### PR TITLE
fix: label observable sandboxes for egress

### DIFF
--- a/services/api-rs/crates/centaur-api-server/src/args.rs
+++ b/services/api-rs/crates/centaur-api-server/src/args.rs
@@ -1041,11 +1041,10 @@ impl SandboxArgs {
             .collect()
     }
 
-    /// Per-sandbox OTLP egress NetworkPolicy target, derived from the OTLP
-    /// endpoint the codex sandbox env will carry. Only in-cluster service DNS
-    /// endpoints (`<service>.<namespace>.svc[...]`) map to a namespace
-    /// selector; anything else gets no rule and a warning, because a silently
-    /// missing rule means harness usage/cost spans never reach the collector.
+    /// Per-sandbox proxy OTLP egress NetworkPolicy target, derived from the
+    /// OTLP endpoint the codex sandbox env will carry. Only in-cluster service
+    /// DNS endpoints (`<service>.<namespace>.svc[...]`) map to a namespace
+    /// selector.
     fn sandbox_otlp_egress_target(&self) -> Result<Option<OtlpEgressTarget>, ServerError> {
         if !matches!(self.workload, SandboxWorkloadKind::CodexAppServer) {
             return Ok(None);
@@ -1070,7 +1069,7 @@ impl SandboxArgs {
                     namespace = %target.namespace,
                     port = target.port,
                     endpoint = %endpoint,
-                    "sandbox OTLP egress enabled"
+                    "sandbox proxy OTLP egress enabled"
                 );
                 Ok(Some(target))
             }
@@ -1078,48 +1077,11 @@ impl SandboxArgs {
                 warn!(
                     endpoint = %endpoint,
                     "sandbox OTLP endpoint is not an in-cluster service DNS name; \
-                     no sandbox egress NetworkPolicy rule will be created for it"
+                     no proxy egress NetworkPolicy rule will be created for it"
                 );
                 Ok(None)
             }
         }
-    }
-
-    fn sandbox_observability_egress_targets(&self) -> Result<Vec<OtlpEgressTarget>, ServerError> {
-        if !matches!(self.workload, SandboxWorkloadKind::CodexAppServer) {
-            return Ok(Vec::new());
-        }
-        let envs = self.codex_app_server_env_template()?;
-        Ok(["VICTORIAMETRICS_URL", "VICTORIALOGS_URL"]
-            .into_iter()
-            .filter_map(|key| {
-                let endpoint = envs
-                    .iter()
-                    .find(|(name, value)| name == key && !value.trim().is_empty())
-                    .map(|(_, value)| value.trim().to_owned())?;
-                match parse_otlp_egress_target(&endpoint) {
-                    Some(target) => {
-                        info!(
-                            env = key,
-                            namespace = %target.namespace,
-                            port = target.port,
-                            endpoint = %endpoint,
-                            "sandbox observability egress enabled"
-                        );
-                        Some(target)
-                    }
-                    None => {
-                        warn!(
-                            env = key,
-                            endpoint = %endpoint,
-                            "sandbox observability endpoint is not an in-cluster service DNS name; \
-                             no sandbox egress NetworkPolicy rule will be created for it"
-                        );
-                        None
-                    }
-                }
-            })
-            .collect())
     }
 
     fn workflow_host_env_template(&self) -> Result<Vec<(String, String)>, ServerError> {
@@ -1353,9 +1315,9 @@ impl TryFrom<&SandboxArgs> for AgentSandboxConfig {
         }
         config.iron_control = args.iron_control.settings();
         config.tools = args.tools_source.to_config();
-        // Direct harness OTLP export needs a per-sandbox egress rule.
+        // The chart label policy handles sandbox OTLP egress; keep the
+        // per-sandbox proxy's own in-cluster OTLP egress explicit.
         config.otlp_egress = args.sandbox_otlp_egress_target()?;
-        config.observability_egress = args.sandbox_observability_egress_targets()?;
         // iron-control is the only proxy mode: a per-sandbox proxy syncs its
         // secrets from the control plane, so configuring iron-proxy without
         // iron-control would produce a non-functional proxy. Fail fast.
@@ -1891,9 +1853,9 @@ fn parse_host_port(value: &str) -> Option<u16> {
     value.rsplit_once(':')?.1.parse().ok()
 }
 
-/// Map an OTLP/observability endpoint URL onto a NetworkPolicy egress target.
-/// Only in-cluster service DNS hosts (`<service>.<namespace>.svc[...]`) are
-/// mapped; the namespace label is the policy's `kubernetes.io/metadata.name`
+/// Map an OTLP endpoint URL onto a NetworkPolicy egress target. Only
+/// in-cluster service DNS hosts (`<service>.<namespace>.svc[...]`) are mapped;
+/// the namespace label is the policy's `kubernetes.io/metadata.name`
 /// selector. Ports default by scheme when absent.
 fn parse_otlp_egress_target(endpoint: &str) -> Option<OtlpEgressTarget> {
     let trimmed = endpoint.trim();
@@ -2533,75 +2495,6 @@ mod tests {
         ])
         .unwrap();
         assert_eq!(mock.sandbox.sandbox_otlp_egress_target().unwrap(), None);
-    }
-
-    #[test]
-    fn sandbox_observability_egress_absent_without_endpoint_env() {
-        let args = Args::try_parse_from([
-            "centaur-api-server",
-            "--database-url",
-            "postgres://postgres:postgres@localhost/centaur",
-            "--session-sandbox-workload",
-            "codex-app-server",
-        ])
-        .unwrap();
-
-        assert!(
-            args.sandbox
-                .sandbox_observability_egress_targets()
-                .unwrap()
-                .is_empty()
-        );
-    }
-
-    #[test]
-    fn sandbox_observability_egress_uses_endpoint_env() {
-        let args = Args::try_parse_from([
-            "centaur-api-server",
-            "--database-url",
-            "postgres://postgres:postgres@localhost/centaur",
-            "--session-sandbox-workload",
-            "codex-app-server",
-            "--session-sandbox-extra-env",
-            r#"[
-                {"name":"VICTORIAMETRICS_URL","value":"http://victoriametrics.telemetry.svc:18428"},
-                {"name":"VICTORIALOGS_URL","value":"https://victorialogs.logs.svc.cluster.local"}
-            ]"#,
-        ])
-        .unwrap();
-
-        assert_eq!(
-            args.sandbox.sandbox_observability_egress_targets().unwrap(),
-            vec![
-                OtlpEgressTarget {
-                    namespace: "telemetry".to_owned(),
-                    port: 18428,
-                },
-                OtlpEgressTarget {
-                    namespace: "logs".to_owned(),
-                    port: 443,
-                },
-            ]
-        );
-    }
-
-    #[test]
-    fn sandbox_observability_egress_absent_for_mock_workload() {
-        let args = Args::try_parse_from([
-            "centaur-api-server",
-            "--database-url",
-            "postgres://postgres:postgres@localhost/centaur",
-            "--session-sandbox-extra-env",
-            r#"[{"name":"VICTORIAMETRICS_URL","value":"http://victoriametrics.telemetry.svc:18428"}]"#,
-        ])
-        .unwrap();
-
-        assert!(
-            args.sandbox
-                .sandbox_observability_egress_targets()
-                .unwrap()
-                .is_empty()
-        );
     }
 
     /// The only test that mutates the process-level OTLP env keys: keeps all

--- a/services/api-rs/crates/centaur-sandbox-agent-k8s/src/iron_proxy.rs
+++ b/services/api-rs/crates/centaur-sandbox-agent-k8s/src/iron_proxy.rs
@@ -339,7 +339,6 @@ impl AgentSandboxBackend {
             iron_proxy,
             &control_target,
             self.config.otlp_egress.as_ref(),
-            &self.config.observability_egress,
             resolved.observability_enabled,
         ) {
             self.network_policies()
@@ -1305,11 +1304,10 @@ fn build_iron_proxy_network_policies(
     iron_proxy: &IronProxyConfig,
     control_target: &ControlPlaneEgressTarget,
     otlp_egress: Option<&OtlpEgressTarget>,
-    observability_egress: &[OtlpEgressTarget],
     observability_enabled: bool,
 ) -> Vec<NetworkPolicy> {
     let sandbox_to_proxy_ports = sandbox_to_proxy_ports(resolved);
-    let mut sandbox_egress = vec![
+    let sandbox_egress = vec![
         egress_to(
             vec![pod_peer(iron_proxy_labels(id))],
             sandbox_to_proxy_ports.clone(),
@@ -1320,23 +1318,6 @@ fn build_iron_proxy_network_policies(
             vec![network_port(8000), network_port(8080)],
         ),
     ];
-    if observability_enabled {
-        sandbox_egress.extend(observability_egress.iter().map(|target| {
-            egress_to(
-                vec![namespace_peer(&target.namespace)],
-                vec![network_port(target.port)],
-            )
-        }));
-    }
-    if observability_enabled && let Some(target) = otlp_egress {
-        // Direct harness OTLP export (codex usage/cost spans). The collector
-        // lives outside this namespace, so the sandbox bypasses iron-proxy for
-        // this one destination (the endpoint host also rides NO_PROXY).
-        sandbox_egress.push(egress_to(
-            vec![namespace_peer(&target.namespace)],
-            vec![network_port(target.port)],
-        ));
-    }
     vec![
         NetworkPolicy {
             metadata: object_meta(
@@ -2023,7 +2004,7 @@ mod tests {
     }
 
     #[test]
-    fn sandbox_egress_policy_allows_otlp_collector_when_configured() {
+    fn sandbox_egress_policy_does_not_inline_otlp_collector_rule() {
         let id = SandboxId::new("asbx-test");
         let iron_proxy = IronProxyConfig::new("proxy:test", "ca-cert", "ca-key");
         let control_target = control_target();
@@ -2031,16 +2012,6 @@ mod tests {
             namespace: "laminar".to_owned(),
             port: 8000,
         };
-        let observability_targets = vec![
-            OtlpEgressTarget {
-                namespace: "observability".to_owned(),
-                port: 8428,
-            },
-            OtlpEgressTarget {
-                namespace: "observability".to_owned(),
-                port: 9428,
-            },
-        ];
 
         let policies = build_iron_proxy_network_policies(
             &id,
@@ -2048,7 +2019,6 @@ mod tests {
             &iron_proxy,
             &control_target,
             Some(&target),
-            &observability_targets,
             true,
         );
         let sandbox_egress = policies[0]
@@ -2060,20 +2030,10 @@ mod tests {
             .unwrap()
             .clone();
         assert!(
-            sandbox_egress
+            !sandbox_egress
                 .iter()
                 .any(|rule| rule_allows_namespace_port(rule, "laminar", 8000))
         );
-        assert!(sandbox_egress.iter().any(|rule| rule_allows_namespace_port(
-            rule,
-            "observability",
-            8428
-        )));
-        assert!(sandbox_egress.iter().any(|rule| rule_allows_namespace_port(
-            rule,
-            "observability",
-            9428
-        )));
         let proxy_egress = policies[1].spec.as_ref().unwrap().egress.as_ref().unwrap();
         assert!(
             proxy_egress
@@ -2088,7 +2048,6 @@ mod tests {
             &iron_proxy,
             &control_target,
             None,
-            &observability_targets,
             true,
         );
         let sandbox_egress = policies[0]
@@ -2115,16 +2074,6 @@ mod tests {
             namespace: "laminar".to_owned(),
             port: 8000,
         };
-        let observability_targets = vec![
-            OtlpEgressTarget {
-                namespace: "observability".to_owned(),
-                port: 8428,
-            },
-            OtlpEgressTarget {
-                namespace: "observability".to_owned(),
-                port: 9428,
-            },
-        ];
 
         let policies = build_iron_proxy_network_policies(
             &id,
@@ -2132,7 +2081,6 @@ mod tests {
             &iron_proxy,
             &control_target,
             Some(&target),
-            &observability_targets,
             false,
         );
         let sandbox_egress = policies[0].spec.as_ref().unwrap().egress.as_ref().unwrap();
@@ -2140,20 +2088,6 @@ mod tests {
             !sandbox_egress
                 .iter()
                 .any(|rule| rule_allows_namespace_port(rule, "laminar", 8000))
-        );
-        assert!(
-            !sandbox_egress.iter().any(|rule| rule_allows_namespace_port(
-                rule,
-                "observability",
-                8428
-            ))
-        );
-        assert!(
-            !sandbox_egress.iter().any(|rule| rule_allows_namespace_port(
-                rule,
-                "observability",
-                9428
-            ))
         );
         assert!(sandbox_egress.iter().any(|rule| {
             rule.to.as_ref().is_some_and(|peers| {
@@ -2262,7 +2196,6 @@ mod tests {
             &iron_proxy,
             &control_target,
             None,
-            &[],
             true,
         );
         let ingress = policies[1]

--- a/services/api-rs/crates/centaur-sandbox-agent-k8s/src/lib.rs
+++ b/services/api-rs/crates/centaur-sandbox-agent-k8s/src/lib.rs
@@ -37,6 +37,7 @@ const BACKEND_NAME: &str = "agent-sandbox-k8s";
 const DEFAULT_CONTAINER_NAME: &str = "agent";
 const MANAGED_BY_LABEL: &str = "centaur.ai/managed-by";
 const SANDBOX_ID_LABEL: &str = "centaur.ai/sandbox-id";
+const OBSERVABILITY_ENABLED_LABEL: &str = "centaur.ai/observability-enabled";
 const MANAGED_BY_VALUE: &str = "api-rs";
 // iron-control principal OID the sandbox's proxy binds to, stamped at create
 // so resume (which has only the sandbox id) can rebind without the spec or any
@@ -64,15 +65,10 @@ pub struct AgentSandboxConfig {
     /// git-clones the tools repo into the agent's `/app/tools`, and `TOOL_DIRS`
     /// is set so the agent's shim installer finds them.
     pub tools: Option<ToolsConfig>,
-    /// In-cluster OTLP collector (e.g. Laminar) the sandbox exports harness
-    /// traces to directly. The per-sandbox egress NetworkPolicy denies all
-    /// destinations except the proxy/control plane, so without this rule the
-    /// harness's usage/cost spans never leave the pod.
+    /// In-cluster OTLP collector (e.g. Laminar) used for observability-capable
+    /// sandboxes. Sandbox pod egress is granted by chart-level label policy;
+    /// the per-sandbox proxy uses this target for its own explicit egress.
     pub otlp_egress: Option<OtlpEgressTarget>,
-    /// Direct in-cluster observability services reached through NO_PROXY by
-    /// tools such as vlogs/vmetrics. Enabled only for observability-capable
-    /// sandboxes.
-    pub observability_egress: Vec<OtlpEgressTarget>,
     pub ready_timeout: Duration,
 }
 
@@ -114,7 +110,6 @@ impl AgentSandboxConfig {
             iron_control: None,
             tools: None,
             otlp_egress: None,
-            observability_egress: Vec::new(),
             ready_timeout: Duration::from_secs(60),
         }
     }
@@ -576,6 +571,9 @@ fn build_agent_sandbox(
     labels.extend(spec.labels.clone());
     labels.insert(MANAGED_BY_LABEL.to_owned(), MANAGED_BY_VALUE.to_owned());
     labels.insert(SANDBOX_ID_LABEL.to_owned(), id.as_str().to_owned());
+    if spec.capabilities.observability_enabled {
+        labels.insert(OBSERVABILITY_ENABLED_LABEL.to_owned(), "true".to_owned());
+    }
 
     let mut pod_labels = labels.clone();
     pod_labels.insert(
@@ -906,6 +904,66 @@ mod tests {
         assert_eq!(container.stdin, Some(true));
         assert_eq!(container.volume_mounts.as_ref().unwrap().len(), 2);
         assert!(container.resources.as_ref().unwrap().limits.is_some());
+    }
+
+    #[test]
+    fn labels_observability_enabled_sandboxes_for_chart_policy() {
+        let spec = SandboxSpec::new("centaur-agent:latest").capabilities(SandboxCapabilities {
+            repo_cache_enabled: true,
+            observability_enabled: true,
+        });
+        let config = AgentSandboxConfig::new("centaur");
+
+        let sandbox = build_agent_sandbox(&SandboxId::new("asbx-test"), &spec, &config).unwrap();
+
+        assert_eq!(
+            sandbox
+                .metadata
+                .labels
+                .as_ref()
+                .and_then(|labels| labels.get(OBSERVABILITY_ENABLED_LABEL))
+                .map(String::as_str),
+            Some("true")
+        );
+        assert_eq!(
+            sandbox
+                .spec
+                .pod_template
+                .metadata
+                .as_ref()
+                .and_then(|metadata| metadata.labels.as_ref())
+                .and_then(|labels| labels.get(OBSERVABILITY_ENABLED_LABEL))
+                .map(String::as_str),
+            Some("true")
+        );
+    }
+
+    #[test]
+    fn omits_observability_enabled_label_for_restricted_sandboxes() {
+        let spec = SandboxSpec::new("centaur-agent:latest").capabilities(SandboxCapabilities {
+            repo_cache_enabled: true,
+            observability_enabled: false,
+        });
+        let config = AgentSandboxConfig::new("centaur");
+
+        let sandbox = build_agent_sandbox(&SandboxId::new("asbx-test"), &spec, &config).unwrap();
+
+        assert!(
+            sandbox
+                .metadata
+                .labels
+                .as_ref()
+                .is_none_or(|labels| !labels.contains_key(OBSERVABILITY_ENABLED_LABEL))
+        );
+        assert!(
+            sandbox
+                .spec
+                .pod_template
+                .metadata
+                .as_ref()
+                .and_then(|metadata| metadata.labels.as_ref())
+                .is_none_or(|labels| !labels.contains_key(OBSERVABILITY_ENABLED_LABEL))
+        );
     }
 
     #[test]


### PR DESCRIPTION
Applies the centaur.ai/observability-enabled label to observability-capable sandboxes so the chart-defined policy can grant observability egress. Removes the code path that parsed observability endpoints and inlined those destinations into each generated sandbox NetworkPolicy, while keeping proxy-level OTLP egress explicit.