### PR TITLE
style: show model before harness and uppercase model names

### DIFF
--- a/services/console/app/controllers/console/threads_controller.rb
+++ b/services/console/app/controllers/console/threads_controller.rb
@@ -571,9 +571,11 @@ class Console::ThreadsController < ApplicationController
   # config files when they are present. Nil (segment omitted) when none of
   # those sources know the model.
   def thread_model_label(session)
-    recorded_model(@latest_executions&.[](session.thread_key)&.metadata) ||
+    model = recorded_model(@latest_executions&.[](session.thread_key)&.metadata) ||
       recorded_model(session.metadata_hash) ||
       default_model_for_harness(session.harness_type.to_s)
+    # Uppercased for display, matching the Slack Console-link context line.
+    model&.upcase
   end
 
   def recorded_model(metadata)

--- a/services/console/app/views/console/threads/_thread_panel.html.erb
+++ b/services/console/app/views/console/threads/_thread_panel.html.erb
@@ -17,12 +17,12 @@
       </a>
       <div class="mt-0.5 flex min-w-0 items-center gap-1.5 truncate text-xs text-zinc-500">
         <span class="truncate"><%= thread_source_label(session) %></span>
-        <span>·</span>
-        <span><%= thread_harness_label(session) %></span>
         <% if (model_label = thread_model_label(session)) %>
           <span>·</span>
           <span class="truncate"><%= model_label %></span>
         <% end %>
+        <span>·</span>
+        <span><%= thread_harness_label(session) %></span>
         <span>·</span>
         <%= local_time(session.updated_at || session.created_at, relative: true, format: :compact) %>
       </div>

--- a/services/console/app/views/console/threads/index.html.erb
+++ b/services/console/app/views/console/threads/index.html.erb
@@ -29,12 +29,12 @@
             <% thread_meta = capture do %>
               <div class="flex min-w-0 items-center gap-2">
                 <span class="truncate"><%= thread_source_label(@selected_session) %></span>
-                <span>·</span>
-                <span><%= thread_harness_label(@selected_session) %></span>
                 <% if (model_label = thread_model_label(@selected_session)) %>
                   <span>·</span>
                   <span class="truncate"><%= model_label %></span>
                 <% end %>
+                <span>·</span>
+                <span><%= thread_harness_label(@selected_session) %></span>
                 <span>·</span>
                 <%= local_time(@selected_session.updated_at || @selected_session.created_at, relative: true, format: :compact) %>
               </div>

--- a/services/console/test/controllers/console/threads_controller_test.rb
+++ b/services/console/test/controllers/console/threads_controller_test.rb
@@ -371,7 +371,7 @@ class Console::ThreadsControllerTest < ActionDispatch::IntegrationTest
     execution = ModelExecution.new(metadata: { "model" => "claude-sonnet-4-6" })
     controller.instance_variable_set(:@latest_executions, { "slack:C1:1" => execution })
 
-    assert_equal "claude-sonnet-4-6", controller.send(:thread_model_label, session)
+    assert_equal "CLAUDE-SONNET-4-6", controller.send(:thread_model_label, session)
   end
 
   test "thread model label reads session metadata before the harness default" do
@@ -381,18 +381,18 @@ class Console::ThreadsControllerTest < ActionDispatch::IntegrationTest
       harness_type: "claudecode"
     )
 
-    assert_equal "claude-fable-5", controller.send(:thread_model_label, session)
+    assert_equal "CLAUDE-FABLE-5", controller.send(:thread_model_label, session)
   end
 
   test "thread model label falls back to the deployment's model env override" do
     controller = Console::ThreadsController.new
 
     with_env("CLAUDE_MODEL" => "claude-fable-5", "CODEX_MODEL" => "gpt-6") do
-      assert_equal "claude-fable-5", controller.send(
+      assert_equal "CLAUDE-FABLE-5", controller.send(
         :thread_model_label,
         TranscriptSession.new(metadata_hash: {}, harness_type: "claudecode")
       )
-      assert_equal "gpt-6", controller.send(
+      assert_equal "GPT-6", controller.send(
         :thread_model_label,
         TranscriptSession.new(metadata_hash: {}, harness_type: "codex")
       )
@@ -412,11 +412,11 @@ class Console::ThreadsControllerTest < ActionDispatch::IntegrationTest
       TOML
 
       with_env("CLAUDE_MODEL" => nil, "CODEX_MODEL" => nil, "CENTAUR_HARNESS_CONFIG_DIR" => dir) do
-        assert_equal "claude-baked-1", controller.send(
+        assert_equal "CLAUDE-BAKED-1", controller.send(
           :thread_model_label,
           TranscriptSession.new(metadata_hash: {}, harness_type: "claudecode")
         )
-        assert_equal "gpt-baked-1", controller.send(
+        assert_equal "GPT-BAKED-1", controller.send(
           :thread_model_label,
           TranscriptSession.new(metadata_hash: {}, harness_type: "codex")
         )

--- a/services/slackbotv2/src/console-session-link.ts
+++ b/services/slackbotv2/src/console-session-link.ts
@@ -98,9 +98,10 @@ export type SlackContextBlock = {
 }
 
 /**
- * Builds the "Open session in Console · {Harness} · {Model}" context block, or
+ * Builds the "Open session in Console · {MODEL} · {Harness}" context block, or
  * undefined when no Console base URL is configured (a bare "Open session in
- * Console" with no link is pointless, so the whole block is skipped).
+ * Console" with no link is pointless, so the whole block is skipped). The
+ * model id is uppercased for display.
  */
 export function buildConsoleSessionContextBlock(params: {
   consoleBaseUrl: string | null | undefined
@@ -111,10 +112,10 @@ export function buildConsoleSessionContextBlock(params: {
   const url = consoleSessionUrl(params.consoleBaseUrl, params.threadKey)
   if (!url) return undefined
   const segments = [`<${url}|Open session in Console>`]
+  const model = params.model?.trim()
+  if (model) segments.push(escapeSlackMrkdwn(model.toUpperCase()))
   const harness = harnessDisplayName(params.harnessType)
   if (harness) segments.push(escapeSlackMrkdwn(harness))
-  const model = params.model?.trim()
-  if (model) segments.push(escapeSlackMrkdwn(model))
   // Middot (U+00B7) with a space on each side, matching the bot's other
   // context lines.
   return {

--- a/services/slackbotv2/test/chat-sdk-emulate.test.ts
+++ b/services/slackbotv2/test/chat-sdk-emulate.test.ts
@@ -477,7 +477,7 @@ describe('slackbotv2', () => {
     )
     expect(firstBlocks[0]).toContain('Open session in Console')
     expect(firstBlocks[0]).toContain('Claude Code')
-    expect(firstBlocks[0]).toContain('claude-opus-4-8')
+    expect(firstBlocks[0]).toContain('CLAUDE-OPUS-4-8')
     expect(firstBlocks[0]).toContain(' · ')
 
     // Explicit --model overrides are recorded in execution metadata so the
@@ -554,7 +554,7 @@ describe('slackbotv2', () => {
     const blocks = consoleBlockTexts(slackApi.calls)
     expect(blocks).toHaveLength(1)
     expect(blocks[0]).toContain('Claude Code')
-    expect(blocks[0]).toContain(claudeSettings.model)
+    expect(blocks[0]).toContain(claudeSettings.model.toUpperCase())
 
     // The effective (default) model is recorded in execution metadata for the
     // Console, but never forwarded to the harness — only explicit overrides

--- a/services/slackbotv2/test/console-session-link.test.ts
+++ b/services/slackbotv2/test/console-session-link.test.ts
@@ -85,7 +85,7 @@ describe('consoleSessionUrl', () => {
 })
 
 describe('buildConsoleSessionContextBlock', () => {
-  test('builds a context block with harness and model separated by middots', () => {
+  test('builds a context block with uppercased model then harness, middot separated', () => {
     const block = buildConsoleSessionContextBlock({
       consoleBaseUrl: 'https://console.centaur.dev',
       threadKey: 'slack:C123:1700000000.000100',
@@ -98,7 +98,7 @@ describe('buildConsoleSessionContextBlock', () => {
         {
           type: 'mrkdwn',
           text:
-            '<https://console.centaur.dev/console/threads?thread=slack%3AC123%3A1700000000.000100|Open session in Console> · Codex · gpt-5.2'
+            '<https://console.centaur.dev/console/threads?thread=slack%3AC123%3A1700000000.000100|Open session in Console> · GPT-5.2 · Codex'
         }
       ]
     })


### PR DESCRIPTION
## Summary
Follow-up to #865:
- The Slack "Open session in Console" context line now reads "Open session in Console · CLAUDE-OPUS-4-8 · Claude Code" (model first, uppercased).
- The Console thread headers (single-panel and split-view panes) match: "Slack · CLAUDE-OPUS-4-8 · Claude Code · 3m ago".
- Uppercasing is display-only; execution metadata keeps the raw model id.

## Tests
- `bun test` in services/slackbotv2 (137 pass) and `bun run check:types` clean; block-builder and emulate assertions updated for the new order/casing.
- Console label tests updated to expect uppercase. Not run here — console Rails tests only run inside the codex-centaur-console-web container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)