### PR TITLE
feat: periodically re-scan for orphaned executions

### DIFF
--- a/services/api-rs/crates/centaur-api-server/src/args.rs
+++ b/services/api-rs/crates/centaur-api-server/src/args.rs
@@ -110,6 +110,11 @@ impl Args {
     pub(crate) fn shutdown_execution_drain_timeout(&self) -> Duration {
         Duration::from_secs(self.server.shutdown_execution_drain_timeout_secs)
     }
+
+    pub(crate) fn execution_adoption_interval(&self) -> Option<Duration> {
+        (self.server.execution_adoption_interval_secs > 0)
+            .then(|| Duration::from_secs(self.server.execution_adoption_interval_secs))
+    }
 }
 
 pub(crate) struct IronControlRuntime {
@@ -463,6 +468,17 @@ pub(crate) struct ServerArgs {
         value_parser = clap::value_parser!(u64).range(0..=600)
     )]
     shutdown_execution_drain_timeout_secs: u64,
+    /// How often to re-run the orphaned-execution adoption scan after the
+    /// startup pass. Executions orphaned while the process is already
+    /// running (e.g. a rolling deploy terminating the previous pod mid-turn
+    /// after this pod's startup scan) are only recovered by these re-scans.
+    /// 0 disables re-scans and keeps the startup-only behavior.
+    #[arg(
+        long = "session-execution-adoption-interval-secs",
+        env = "SESSION_EXECUTION_ADOPTION_INTERVAL_SECS",
+        default_value_t = 60
+    )]
+    execution_adoption_interval_secs: u64,
 }
 
 #[derive(Debug, ClapArgs)]
@@ -2066,6 +2082,35 @@ mod tests {
         assert_eq!(args.sandbox.k8s_namespace, "centaur-test");
         assert_eq!(args.sandbox.ready_timeout_secs, 17);
         assert_eq!(args.sandbox.k8s_context.as_deref(), Some("kind-test"));
+    }
+
+    #[test]
+    fn execution_adoption_rescans_every_minute_by_default() {
+        let args = Args::try_parse_from([
+            "centaur-api-server",
+            "--database-url",
+            "postgres://postgres:postgres@localhost/centaur",
+        ])
+        .unwrap();
+
+        assert_eq!(
+            args.execution_adoption_interval(),
+            Some(Duration::from_secs(60))
+        );
+    }
+
+    #[test]
+    fn execution_adoption_interval_zero_disables_rescans() {
+        let args = Args::try_parse_from([
+            "centaur-api-server",
+            "--database-url",
+            "postgres://postgres:postgres@localhost/centaur",
+            "--session-execution-adoption-interval-secs",
+            "0",
+        ])
+        .unwrap();
+
+        assert_eq!(args.execution_adoption_interval(), None);
     }
 
     #[test]

--- a/services/api-rs/crates/centaur-api-server/src/args.rs
+++ b/services/api-rs/crates/centaur-api-server/src/args.rs
@@ -471,12 +471,15 @@ pub(crate) struct ServerArgs {
     /// How often to re-run the orphaned-execution adoption scan after the
     /// startup pass. Executions orphaned while the process is already
     /// running (e.g. a rolling deploy terminating the previous pod mid-turn
-    /// after this pod's startup scan) are only recovered by these re-scans.
+    /// after this pod's startup scan) are only recovered by these re-scans,
+    /// so the interval bounds how long a handed-off turn stays frozen. A
+    /// steady-state tick is a single SELECT (executions with a live
+    /// stdout-owner lease are skipped before any session or sandbox reads).
     /// 0 disables re-scans and keeps the startup-only behavior.
     #[arg(
         long = "session-execution-adoption-interval-secs",
         env = "SESSION_EXECUTION_ADOPTION_INTERVAL_SECS",
-        default_value_t = 60
+        default_value_t = 15
     )]
     execution_adoption_interval_secs: u64,
 }
@@ -2085,7 +2088,7 @@ mod tests {
     }
 
     #[test]
-    fn execution_adoption_rescans_every_minute_by_default() {
+    fn execution_adoption_rescans_every_fifteen_seconds_by_default() {
         let args = Args::try_parse_from([
             "centaur-api-server",
             "--database-url",
@@ -2095,7 +2098,7 @@ mod tests {
 
         assert_eq!(
             args.execution_adoption_interval(),
-            Some(Duration::from_secs(60))
+            Some(Duration::from_secs(15))
         );
     }
 

--- a/services/api-rs/crates/centaur-api-server/src/main.rs
+++ b/services/api-rs/crates/centaur-api-server/src/main.rs
@@ -108,13 +108,21 @@ async fn initialize_runtime(args: Args, app_state: AppState) -> Result<(), Serve
         .await?,
     );
 
-    // Adopt executions orphaned by the previous process (deploy/crash):
-    // recover finished turns from recorded sandbox output, re-attach still
-    // running sandboxes, and fail the rest so their threads unwedge.
-    let adoption_runtime = runtime.clone();
-    tokio::spawn(async move {
-        adoption_runtime.adopt_orphaned_executions().await;
-    });
+    // Adopt executions orphaned by another control plane process
+    // (deploy/crash): recover finished turns from recorded sandbox output,
+    // re-attach still running sandboxes, and fail the rest so their threads
+    // unwedge. The scan re-runs periodically because executions can be
+    // orphaned after startup — e.g. a rolling deploy terminates the previous
+    // pod mid-turn after this pod's startup scan already ran.
+    match args.execution_adoption_interval() {
+        Some(interval) => runtime.spawn_orphan_adoption(interval),
+        None => {
+            let adoption_runtime = runtime.clone();
+            tokio::spawn(async move {
+                adoption_runtime.adopt_orphaned_executions().await;
+            });
+        }
+    }
 
     app_state.mark_ready(runtime, workflows, Some(pool));
     info!("centaur api-rs runtime initialized");

--- a/services/api-rs/crates/centaur-session-runtime/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-runtime/src/lib.rs
@@ -45,7 +45,7 @@ use tokio::{
     time::{Instant, Interval, MissedTickBehavior, interval_at, sleep, timeout},
 };
 use tokio_util::codec::{FramedRead, FramedWrite, LinesCodec, LinesCodecError};
-use tracing::{Instrument, Span, error, info, info_span, warn};
+use tracing::{Instrument, Span, debug, error, info, info_span, warn};
 use uuid::Uuid;
 
 pub use cleanup::SessionSandboxCleanupConfig;
@@ -66,6 +66,13 @@ const STDOUT_OWNER_LEASE: Duration = Duration::from_secs(45);
 const STDOUT_OWNER_RENEW_INTERVAL: Duration = Duration::from_secs(10);
 const EXECUTION_HANDOFF_POLL_INTERVAL: Duration = Duration::from_millis(500);
 const EXECUTION_HANDOFF_DB_TIMEOUT: Duration = Duration::from_secs(5);
+/// Executions are queued only between `create_execution` and the
+/// running transition a few statements later in `execute_session`, so a
+/// healthy row spends milliseconds in that state. An adoption scan racing a
+/// live `execute_session` (another control plane mid-rollout, or this
+/// process's own request handler) must not fail a young queued row it
+/// happens to observe in that window.
+const QUEUED_ORPHAN_GRACE: Duration = Duration::from_secs(120);
 const COMPONENT_SESSION_RUNTIME: &str = "session_runtime";
 const SANDBOX_REPOS_MOUNT_PATH: &str = "/home/agent/github";
 const OBSERVABILITY_TOOL_BLOCKLIST: &str =
@@ -2799,6 +2806,30 @@ impl SessionRuntime {
     ///    and re-arm the remaining max-duration deadline.
     /// 3. The sandbox is gone: record the failure honestly.
     pub async fn adopt_orphaned_executions(&self) {
+        self.run_orphan_adoption_scan(&mut OrphanAdoptionState::default())
+            .await;
+    }
+
+    /// Re-run the orphan adoption scan every `interval` for the lifetime of
+    /// the process (the first scan runs immediately). A startup-only scan
+    /// misses executions orphaned after it ran — most commonly the previous
+    /// pod of a rolling deploy reaching its termination grace period
+    /// mid-turn after the new pod already scanned — and those stay wedged
+    /// until the next deploy.
+    pub fn spawn_orphan_adoption(&self, interval: Duration) {
+        let runtime = self.clone();
+        tokio::spawn(async move {
+            let mut state = OrphanAdoptionState::default();
+            let mut ticker = interval_at(Instant::now(), interval);
+            ticker.set_missed_tick_behavior(MissedTickBehavior::Delay);
+            loop {
+                ticker.tick().await;
+                runtime.run_orphan_adoption_scan(&mut state).await;
+            }
+        });
+    }
+
+    async fn run_orphan_adoption_scan(&self, state: &mut OrphanAdoptionState) {
         let executions = match self.store.list_active_executions().await {
             Ok(executions) => executions,
             Err(error) => {
@@ -2812,37 +2843,87 @@ impl SessionRuntime {
             }
         };
         if executions.is_empty() {
+            state.deferred.clear();
             return;
         }
-        info!(
-            component = COMPONENT_SESSION_RUNTIME,
-            event = "execution_adoption_scan",
-            orphan_count = executions.len(),
-            "adopting executions orphaned by a previous control plane process"
-        );
+        let mut adopted = 0_usize;
+        let mut failed = 0_usize;
+        let mut skipped = 0_usize;
+        let mut deferred = HashSet::new();
         for execution in executions {
-            if let Err(error) = self.adopt_orphaned_execution(&execution).await {
-                warn!(
-                    component = COMPONENT_SESSION_RUNTIME,
-                    event = "execution_adoption_failed",
-                    thread_key = %execution.thread_key,
-                    execution_id = %execution.execution_id,
-                    %error,
-                    "failed to adopt orphaned execution; will retry on next startup"
-                );
+            let record_deferral = !state.deferred.contains(&execution.execution_id);
+            match self
+                .adopt_orphaned_execution(&execution, record_deferral)
+                .await
+            {
+                Ok(OrphanAdoption::Adopted) => adopted += 1,
+                Ok(OrphanAdoption::Failed) => failed += 1,
+                Ok(OrphanAdoption::Skipped) => skipped += 1,
+                Ok(OrphanAdoption::Deferred) => {
+                    deferred.insert(execution.execution_id);
+                }
+                Err(error) => {
+                    warn!(
+                        component = COMPONENT_SESSION_RUNTIME,
+                        event = "execution_adoption_failed",
+                        thread_key = %execution.thread_key,
+                        execution_id = %execution.execution_id,
+                        %error,
+                        "failed to adopt orphaned execution; will retry on the next scan"
+                    );
+                }
             }
+        }
+        state.deferred = deferred;
+        if adopted > 0 || failed > 0 {
+            info!(
+                component = COMPONENT_SESSION_RUNTIME,
+                event = "execution_adoption_scan",
+                adopted,
+                failed,
+                deferred = state.deferred.len(),
+                skipped,
+                "adopted executions orphaned by a previous control plane process"
+            );
+        } else {
+            debug!(
+                component = COMPONENT_SESSION_RUNTIME,
+                event = "execution_adoption_scan",
+                adopted,
+                failed,
+                deferred = state.deferred.len(),
+                skipped,
+                "orphan adoption scan found nothing adoptable"
+            );
         }
     }
 
     async fn adopt_orphaned_execution(
         &self,
         execution: &SessionExecution,
-    ) -> Result<(), SessionRuntimeError> {
+        record_deferral: bool,
+    ) -> Result<OrphanAdoption, SessionRuntimeError> {
         let thread_key = &execution.thread_key;
         let execution_id = execution.execution_id.as_str();
         if execution.status == ExecutionStatus::Queued {
             // Input is only written after an execution is marked running, so
             // a queued orphan never reached the harness: nothing can come.
+            // Young queued rows are skipped instead of failed: they are most
+            // likely a live execute_session observed mid-transition.
+            let age = SystemTime::now()
+                .duration_since(SystemTime::from(execution.created_at))
+                .unwrap_or_default();
+            if age < QUEUED_ORPHAN_GRACE {
+                debug!(
+                    component = COMPONENT_SESSION_RUNTIME,
+                    event = "execution_adoption_skipped",
+                    thread_key = %thread_key,
+                    execution_id,
+                    age_ms = duration_millis_u64(age),
+                    "skipping young queued execution; a live execute may still claim it"
+                );
+                return Ok(OrphanAdoption::Skipped);
+            }
             self.fail_orphaned_execution(
                 thread_key,
                 execution_id,
@@ -2850,7 +2931,7 @@ impl SessionRuntime {
                 "orphaned before input was sent",
             )
             .await;
-            return Ok(());
+            return Ok(OrphanAdoption::Failed);
         }
         let session = self.store.get_session(thread_key).await?;
         let Some(sandbox_id) = session.sandbox_id.as_deref() else {
@@ -2861,7 +2942,7 @@ impl SessionRuntime {
                 "orphaned with no sandbox assigned",
             )
             .await;
-            return Ok(());
+            return Ok(OrphanAdoption::Failed);
         };
         let id = SandboxId::new(sandbox_id);
         let status = match self.sandbox_runtime.manager.status(&id).await {
@@ -2879,27 +2960,41 @@ impl SessionRuntime {
                 &format!("sandbox no longer accepts io (status {status:?})"),
             )
             .await;
-            return Ok(());
+            return Ok(OrphanAdoption::Failed);
         }
         if !self.claim_expired_stdout_owner(execution_id).await? {
-            info!(
-                component = COMPONENT_SESSION_RUNTIME,
-                event = "execution_adoption_deferred",
-                thread_key = %thread_key,
-                execution_id,
-                sandbox_id,
-                "active stdout owner lease still exists; deferring adoption"
-            );
-            let _ = self
-                .store
-                .append_event(
-                    thread_key,
-                    Some(execution_id),
-                    "session.execution_adoption_deferred",
-                    json!({ "sandbox_id": sandbox_id, "reason": "stdout_owner_lease_active" }),
-                )
-                .await;
-            return Ok(());
+            // Deferrals repeat on every periodic scan while another control
+            // plane pumps the execution; only the first observation is worth
+            // an info log and a durable event.
+            if record_deferral {
+                info!(
+                    component = COMPONENT_SESSION_RUNTIME,
+                    event = "execution_adoption_deferred",
+                    thread_key = %thread_key,
+                    execution_id,
+                    sandbox_id,
+                    "active stdout owner lease still exists; deferring adoption"
+                );
+                let _ = self
+                    .store
+                    .append_event(
+                        thread_key,
+                        Some(execution_id),
+                        "session.execution_adoption_deferred",
+                        json!({ "sandbox_id": sandbox_id, "reason": "stdout_owner_lease_active" }),
+                    )
+                    .await;
+            } else {
+                debug!(
+                    component = COMPONENT_SESSION_RUNTIME,
+                    event = "execution_adoption_deferred",
+                    thread_key = %thread_key,
+                    execution_id,
+                    sandbox_id,
+                    "active stdout owner lease still exists; deferring adoption"
+                );
+            }
+            return Ok(OrphanAdoption::Deferred);
         }
 
         // The turn may have finished while no control plane was attached. An
@@ -2954,7 +3049,7 @@ impl SessionRuntime {
                 terminal,
             )
             .await?;
-            return Ok(());
+            return Ok(OrphanAdoption::Adopted);
         }
 
         // No terminal in the recorded output: treat the turn as still in
@@ -2997,7 +3092,7 @@ impl SessionRuntime {
                 idle_timeout_from_execution(execution),
             );
         }
-        Ok(())
+        Ok(OrphanAdoption::Adopted)
     }
 
     async fn fail_orphaned_execution(
@@ -3150,6 +3245,28 @@ impl SessionRuntime {
             }
         }
     }
+}
+
+/// Outcome of one orphan-adoption attempt.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum OrphanAdoption {
+    /// Terminal output was recovered or a live pump was re-attached.
+    Adopted,
+    /// Another control plane still holds the stdout-owner lease.
+    Deferred,
+    /// The execution was failed as unrecoverable.
+    Failed,
+    /// Too young to judge (freshly queued); revisit on a later scan.
+    Skipped,
+}
+
+/// Scan state carried across periodic orphan-adoption ticks.
+#[derive(Debug, Default)]
+struct OrphanAdoptionState {
+    /// Executions whose deferral was already recorded, so long-lived leases
+    /// do not produce a `session.execution_adoption_deferred` event on every
+    /// tick.
+    deferred: HashSet<String>,
 }
 
 async fn maybe_generate_session_title(
@@ -7393,6 +7510,20 @@ mod adoption_tests {
         execution_id
     }
 
+    /// Ages an execution row past `QUEUED_ORPHAN_GRACE` so adoption treats it
+    /// as a genuine orphan instead of a young row racing a live execute.
+    async fn backdate_execution(store: &PgSessionStore, execution_id: &str, seconds: f64) {
+        sqlx::query(
+            "update session_executions set created_at = created_at - make_interval(secs => $2) \
+             where execution_id = $1",
+        )
+        .bind(execution_id)
+        .bind(seconds)
+        .execute(store.pool())
+        .await
+        .expect("backdate execution");
+    }
+
     async fn wait_for_event(store: &PgSessionStore, thread_key: &ThreadKey, event_type: &str) {
         let deadline = Instant::now() + Duration::from_secs(10);
         loop {
@@ -8426,7 +8557,8 @@ mod adoption_tests {
         let _serial = TEST_LOCK.lock().await;
         let thread_key =
             ThreadKey::parse(format!("test:adopt-queued-{}", uuid::Uuid::new_v4())).unwrap();
-        orphaned_execution(&store, &thread_key, Some("sbx-mock"), false).await;
+        let execution_id = orphaned_execution(&store, &thread_key, Some("sbx-mock"), false).await;
+        backdate_execution(&store, &execution_id, 300.0).await;
 
         let backend = Arc::new(MockBackend::new(SandboxStatus::Running, Vec::new()));
         let runtime = runtime_with(&store, backend.clone());
@@ -8444,6 +8576,141 @@ mod adoption_tests {
             "unexpected error: {error}"
         );
         assert_eq!(backend.opens(), 0);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn skips_young_queued_executions_until_grace_passes() {
+        let Some(store) = test_store().await else {
+            return;
+        };
+        let _serial = TEST_LOCK.lock().await;
+        let thread_key =
+            ThreadKey::parse(format!("test:adopt-young-{}", uuid::Uuid::new_v4())).unwrap();
+        let execution_id = orphaned_execution(&store, &thread_key, Some("sbx-mock"), false).await;
+
+        let backend = Arc::new(MockBackend::new(SandboxStatus::Running, Vec::new()));
+        let runtime = runtime_with(&store, backend.clone());
+        runtime.adopt_orphaned_executions().await;
+
+        // A queued row younger than the grace window may belong to a live
+        // execute_session mid-transition; the scan must leave it alone.
+        let all = events(&store, &thread_key).await;
+        assert!(
+            all.iter()
+                .all(|event| event.event_type != "session.execution_failed"),
+            "young queued execution must not be failed"
+        );
+        let active = store
+            .list_active_executions()
+            .await
+            .expect("list active executions");
+        assert!(
+            active
+                .iter()
+                .any(|execution| execution.execution_id == execution_id),
+            "young queued execution must stay active"
+        );
+
+        // Once the row ages past the grace window, a later scan fails it.
+        backdate_execution(&store, &execution_id, 300.0).await;
+        runtime.adopt_orphaned_executions().await;
+        wait_for_event(&store, &thread_key, "session.execution_failed").await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn adopts_deferred_execution_after_lease_expires() {
+        let Some(store) = test_store().await else {
+            return;
+        };
+        let _serial = TEST_LOCK.lock().await;
+        let thread_key =
+            ThreadKey::parse(format!("test:adopt-deferred-{}", uuid::Uuid::new_v4())).unwrap();
+        let execution_id = orphaned_execution(&store, &thread_key, Some("sbx-mock"), true).await;
+        store
+            .claim_stdout_owner(
+                &execution_id,
+                "other-control-plane",
+                Duration::from_millis(200),
+            )
+            .await
+            .expect("claim lease for other owner");
+
+        let backend = Arc::new(MockBackend::new(
+            SandboxStatus::Running,
+            vec![
+                json!({"type": "item.completed", "item": {"id": "msg-1", "type": "agentMessage", "text": "Done: recovered after handoff.", "phase": "final_answer"}}).to_string(),
+                json!({"type": "turn.completed", "turn": {"id": "turn-1", "status": "completed"}}).to_string(),
+            ],
+        ));
+        let runtime = runtime_with(&store, backend.clone());
+
+        // While another control plane holds the stdout-owner lease the scan
+        // must defer instead of stealing the execution.
+        runtime.adopt_orphaned_executions().await;
+        wait_for_event(&store, &thread_key, "session.execution_adoption_deferred").await;
+        let all = events(&store, &thread_key).await;
+        assert!(
+            all.iter()
+                .all(|event| event.event_type != "session.execution_completed"),
+            "deferred execution must not be terminalized"
+        );
+
+        // Once the lease expires (owner died without releasing), a later
+        // scan adopts the execution and recovers the recorded terminal.
+        sleep(Duration::from_millis(250)).await;
+        runtime.adopt_orphaned_executions().await;
+        wait_for_event(&store, &thread_key, "session.execution_adopted").await;
+        wait_for_event(&store, &thread_key, "session.execution_completed").await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn periodic_scans_record_deferral_once() {
+        let Some(store) = test_store().await else {
+            return;
+        };
+        let _serial = TEST_LOCK.lock().await;
+        let thread_key =
+            ThreadKey::parse(format!("test:adopt-dedup-{}", uuid::Uuid::new_v4())).unwrap();
+        let execution_id = orphaned_execution(&store, &thread_key, Some("sbx-mock"), true).await;
+        store
+            .claim_stdout_owner(
+                &execution_id,
+                "other-control-plane",
+                Duration::from_secs(60),
+            )
+            .await
+            .expect("claim lease for other owner");
+
+        let backend = Arc::new(MockBackend::new(
+            SandboxStatus::Running,
+            vec![
+                json!({"type": "item.completed", "item": {"id": "msg-1", "type": "agentMessage", "text": "Done: recovered after release.", "phase": "final_answer"}}).to_string(),
+                json!({"type": "turn.completed", "turn": {"id": "turn-1", "status": "completed"}}).to_string(),
+            ],
+        ));
+        let runtime = runtime_with(&store, backend.clone());
+
+        // Repeated periodic scans over the same held lease must record the
+        // deferral event only once.
+        let mut state = OrphanAdoptionState::default();
+        runtime.run_orphan_adoption_scan(&mut state).await;
+        runtime.run_orphan_adoption_scan(&mut state).await;
+        let all = events(&store, &thread_key).await;
+        let deferrals = all
+            .iter()
+            .filter(|event| event.event_type == "session.execution_adoption_deferred")
+            .count();
+        assert_eq!(deferrals, 1, "deferral event must be recorded once");
+
+        // Releasing the lease (a clean shutdown handoff) lets the next scan
+        // adopt immediately; this also terminalizes the execution before the
+        // test releases TEST_LOCK.
+        store
+            .release_stdout_owner(&execution_id, "other-control-plane")
+            .await
+            .expect("release lease");
+        runtime.run_orphan_adoption_scan(&mut state).await;
+        wait_for_event(&store, &thread_key, "session.execution_completed").await;
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/services/api-rs/crates/centaur-session-runtime/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-runtime/src/lib.rs
@@ -2806,7 +2806,10 @@ impl SessionRuntime {
     ///    and re-arm the remaining max-duration deadline.
     /// 3. The sandbox is gone: record the failure honestly.
     pub async fn adopt_orphaned_executions(&self) {
-        self.run_orphan_adoption_scan(&mut OrphanAdoptionState::default())
+        // A one-shot scan has no later tick to revisit skipped rows, so
+        // queued orphans are failed immediately regardless of age — the
+        // pre-rescan startup behavior.
+        self.run_orphan_adoption_scan(&mut OrphanAdoptionState::default(), None)
             .await;
     }
 
@@ -2824,13 +2827,22 @@ impl SessionRuntime {
             ticker.set_missed_tick_behavior(MissedTickBehavior::Delay);
             loop {
                 ticker.tick().await;
-                runtime.run_orphan_adoption_scan(&mut state).await;
+                runtime
+                    .run_orphan_adoption_scan(&mut state, Some(QUEUED_ORPHAN_GRACE))
+                    .await;
             }
         });
     }
 
-    async fn run_orphan_adoption_scan(&self, state: &mut OrphanAdoptionState) {
-        let executions = match self.store.list_active_executions().await {
+    /// One pass over all active executions. `queued_grace` is the minimum
+    /// age before a queued row is treated as orphaned; `None` fails queued
+    /// rows immediately and is only correct when no re-scan will follow.
+    async fn run_orphan_adoption_scan(
+        &self,
+        state: &mut OrphanAdoptionState,
+        queued_grace: Option<Duration>,
+    ) {
+        let executions = match self.store.list_active_executions_with_ownership().await {
             Ok(executions) => executions,
             Err(error) => {
                 warn!(
@@ -2849,28 +2861,51 @@ impl SessionRuntime {
         let mut adopted = 0_usize;
         let mut failed = 0_usize;
         let mut skipped = 0_usize;
+        let mut own = 0_usize;
         let mut deferred = HashSet::new();
-        for execution in executions {
-            let record_deferral = !state.deferred.contains(&execution.execution_id);
+        for candidate in executions {
+            let execution_id = candidate.execution.execution_id.clone();
+            // Advisory fast path: a live lease means the execution has an
+            // active pump somewhere. Skip our own executions silently and
+            // defer peers' without touching the session row or the sandbox
+            // backend — the conditional claim below stays the sole authority
+            // on ownership.
+            if candidate.stdout_owner_lease_active {
+                if candidate.stdout_owner_id.as_deref() == Some(self.stdout_owner_id.as_str()) {
+                    own += 1;
+                    continue;
+                }
+                if !state.deferred.contains(&execution_id) {
+                    self.record_adoption_deferral(&candidate.execution).await;
+                }
+                deferred.insert(execution_id);
+                continue;
+            }
+            let record_deferral = !state.deferred.contains(&execution_id);
             match self
-                .adopt_orphaned_execution(&execution, record_deferral)
+                .adopt_orphaned_execution(&candidate.execution, record_deferral, queued_grace)
                 .await
             {
                 Ok(OrphanAdoption::Adopted) => adopted += 1,
                 Ok(OrphanAdoption::Failed) => failed += 1,
                 Ok(OrphanAdoption::Skipped) => skipped += 1,
                 Ok(OrphanAdoption::Deferred) => {
-                    deferred.insert(execution.execution_id);
+                    deferred.insert(execution_id);
                 }
                 Err(error) => {
                     warn!(
                         component = COMPONENT_SESSION_RUNTIME,
                         event = "execution_adoption_failed",
-                        thread_key = %execution.thread_key,
-                        execution_id = %execution.execution_id,
+                        thread_key = %candidate.execution.thread_key,
+                        execution_id = %candidate.execution.execution_id,
                         %error,
                         "failed to adopt orphaned execution; will retry on the next scan"
                     );
+                    // Keep the dedup entry across transient errors so a
+                    // recovered deferral is not re-recorded.
+                    if state.deferred.contains(&execution_id) {
+                        deferred.insert(execution_id);
+                    }
                 }
             }
         }
@@ -2883,6 +2918,7 @@ impl SessionRuntime {
                 failed,
                 deferred = state.deferred.len(),
                 skipped,
+                own,
                 "adopted executions orphaned by a previous control plane process"
             );
         } else {
@@ -2893,36 +2929,60 @@ impl SessionRuntime {
                 failed,
                 deferred = state.deferred.len(),
                 skipped,
+                own,
                 "orphan adoption scan found nothing adoptable"
             );
         }
+    }
+
+    async fn record_adoption_deferral(&self, execution: &SessionExecution) {
+        info!(
+            component = COMPONENT_SESSION_RUNTIME,
+            event = "execution_adoption_deferred",
+            thread_key = %execution.thread_key,
+            execution_id = %execution.execution_id,
+            "active stdout owner lease still exists; deferring adoption"
+        );
+        let _ = self
+            .store
+            .append_event(
+                &execution.thread_key,
+                Some(&execution.execution_id),
+                "session.execution_adoption_deferred",
+                json!({ "reason": "stdout_owner_lease_active" }),
+            )
+            .await;
     }
 
     async fn adopt_orphaned_execution(
         &self,
         execution: &SessionExecution,
         record_deferral: bool,
+        queued_grace: Option<Duration>,
     ) -> Result<OrphanAdoption, SessionRuntimeError> {
         let thread_key = &execution.thread_key;
         let execution_id = execution.execution_id.as_str();
         if execution.status == ExecutionStatus::Queued {
             // Input is only written after an execution is marked running, so
             // a queued orphan never reached the harness: nothing can come.
-            // Young queued rows are skipped instead of failed: they are most
-            // likely a live execute_session observed mid-transition.
-            let age = SystemTime::now()
-                .duration_since(SystemTime::from(execution.created_at))
-                .unwrap_or_default();
-            if age < QUEUED_ORPHAN_GRACE {
-                debug!(
-                    component = COMPONENT_SESSION_RUNTIME,
-                    event = "execution_adoption_skipped",
-                    thread_key = %thread_key,
-                    execution_id,
-                    age_ms = duration_millis_u64(age),
-                    "skipping young queued execution; a live execute may still claim it"
-                );
-                return Ok(OrphanAdoption::Skipped);
+            // On a periodic scan, young queued rows are skipped instead of
+            // failed: they are most likely a live execute_session observed
+            // mid-transition, and a later tick revisits them.
+            if let Some(grace) = queued_grace {
+                let age = SystemTime::now()
+                    .duration_since(SystemTime::from(execution.created_at))
+                    .unwrap_or_default();
+                if age < grace {
+                    debug!(
+                        component = COMPONENT_SESSION_RUNTIME,
+                        event = "execution_adoption_skipped",
+                        thread_key = %thread_key,
+                        execution_id,
+                        age_ms = duration_millis_u64(age),
+                        "skipping young queued execution; a live execute may still claim it"
+                    );
+                    return Ok(OrphanAdoption::Skipped);
+                }
             }
             self.fail_orphaned_execution(
                 thread_key,
@@ -2967,23 +3027,7 @@ impl SessionRuntime {
             // plane pumps the execution; only the first observation is worth
             // an info log and a durable event.
             if record_deferral {
-                info!(
-                    component = COMPONENT_SESSION_RUNTIME,
-                    event = "execution_adoption_deferred",
-                    thread_key = %thread_key,
-                    execution_id,
-                    sandbox_id,
-                    "active stdout owner lease still exists; deferring adoption"
-                );
-                let _ = self
-                    .store
-                    .append_event(
-                        thread_key,
-                        Some(execution_id),
-                        "session.execution_adoption_deferred",
-                        json!({ "sandbox_id": sandbox_id, "reason": "stdout_owner_lease_active" }),
-                    )
-                    .await;
+                self.record_adoption_deferral(execution).await;
             } else {
                 debug!(
                     component = COMPONENT_SESSION_RUNTIME,
@@ -7513,7 +7557,7 @@ mod adoption_tests {
     /// Ages an execution row past `QUEUED_ORPHAN_GRACE` so adoption treats it
     /// as a genuine orphan instead of a young row racing a live execute.
     async fn backdate_execution(store: &PgSessionStore, execution_id: &str, seconds: f64) {
-        sqlx::query(
+        let result = sqlx::query(
             "update session_executions set created_at = created_at - make_interval(secs => $2) \
              where execution_id = $1",
         )
@@ -7522,6 +7566,23 @@ mod adoption_tests {
         .execute(store.pool())
         .await
         .expect("backdate execution");
+        assert_eq!(result.rows_affected(), 1, "expected to backdate one row");
+    }
+
+    /// Expires an execution's stdout-owner lease in place, simulating an
+    /// owner that died without releasing, deterministically (no sleeps
+    /// racing real lease TTLs).
+    async fn expire_stdout_lease(store: &PgSessionStore, execution_id: &str) {
+        let result = sqlx::query(
+            "update session_executions \
+             set stdout_owner_lease_expires_at = now() - interval '1 second' \
+             where execution_id = $1",
+        )
+        .bind(execution_id)
+        .execute(store.pool())
+        .await
+        .expect("expire stdout lease");
+        assert_eq!(result.rows_affected(), 1, "expected to expire one lease");
     }
 
     async fn wait_for_event(store: &PgSessionStore, thread_key: &ThreadKey, event_type: &str) {
@@ -8557,9 +8618,10 @@ mod adoption_tests {
         let _serial = TEST_LOCK.lock().await;
         let thread_key =
             ThreadKey::parse(format!("test:adopt-queued-{}", uuid::Uuid::new_v4())).unwrap();
-        let execution_id = orphaned_execution(&store, &thread_key, Some("sbx-mock"), false).await;
-        backdate_execution(&store, &execution_id, 300.0).await;
+        orphaned_execution(&store, &thread_key, Some("sbx-mock"), false).await;
 
+        // The one-shot scan has no later tick to revisit skipped rows, so it
+        // fails queued orphans immediately regardless of age.
         let backend = Arc::new(MockBackend::new(SandboxStatus::Running, Vec::new()));
         let runtime = runtime_with(&store, backend.clone());
         runtime.adopt_orphaned_executions().await;
@@ -8579,7 +8641,7 @@ mod adoption_tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn skips_young_queued_executions_until_grace_passes() {
+    async fn periodic_scan_skips_young_queued_executions_until_grace_passes() {
         let Some(store) = test_store().await else {
             return;
         };
@@ -8590,10 +8652,14 @@ mod adoption_tests {
 
         let backend = Arc::new(MockBackend::new(SandboxStatus::Running, Vec::new()));
         let runtime = runtime_with(&store, backend.clone());
-        runtime.adopt_orphaned_executions().await;
+        let mut state = OrphanAdoptionState::default();
+        runtime
+            .run_orphan_adoption_scan(&mut state, Some(QUEUED_ORPHAN_GRACE))
+            .await;
 
         // A queued row younger than the grace window may belong to a live
-        // execute_session mid-transition; the scan must leave it alone.
+        // execute_session mid-transition; a periodic scan must leave it
+        // alone and revisit it later.
         let all = events(&store, &thread_key).await;
         assert!(
             all.iter()
@@ -8611,9 +8677,11 @@ mod adoption_tests {
             "young queued execution must stay active"
         );
 
-        // Once the row ages past the grace window, a later scan fails it.
+        // Once the row ages past the grace window, a later tick fails it.
         backdate_execution(&store, &execution_id, 300.0).await;
-        runtime.adopt_orphaned_executions().await;
+        runtime
+            .run_orphan_adoption_scan(&mut state, Some(QUEUED_ORPHAN_GRACE))
+            .await;
         wait_for_event(&store, &thread_key, "session.execution_failed").await;
     }
 
@@ -8630,7 +8698,7 @@ mod adoption_tests {
             .claim_stdout_owner(
                 &execution_id,
                 "other-control-plane",
-                Duration::from_millis(200),
+                Duration::from_secs(60),
             )
             .await
             .expect("claim lease for other owner");
@@ -8656,9 +8724,82 @@ mod adoption_tests {
         );
 
         // Once the lease expires (owner died without releasing), a later
-        // scan adopts the execution and recovers the recorded terminal.
-        sleep(Duration::from_millis(250)).await;
+        // scan adopts the execution and recovers the recorded terminal. The
+        // expiry is forced in the database rather than slept through so slow
+        // test databases cannot turn the first scan into the adopting one.
+        expire_stdout_lease(&store, &execution_id).await;
         runtime.adopt_orphaned_executions().await;
+        wait_for_event(&store, &thread_key, "session.execution_adopted").await;
+        wait_for_event(&store, &thread_key, "session.execution_completed").await;
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn periodic_scan_ignores_executions_owned_by_this_process() {
+        let Some(store) = test_store().await else {
+            return;
+        };
+        let _serial = TEST_LOCK.lock().await;
+        let thread_key =
+            ThreadKey::parse(format!("test:adopt-own-{}", uuid::Uuid::new_v4())).unwrap();
+        let execution_id = orphaned_execution(&store, &thread_key, Some("sbx-mock"), true).await;
+        let backend = Arc::new(MockBackend::new(SandboxStatus::Running, Vec::new()));
+        let runtime = runtime_with(&store, backend.clone());
+        assert!(
+            store
+                .claim_stdout_owner(
+                    &execution_id,
+                    &runtime.stdout_owner_id,
+                    Duration::from_secs(60)
+                )
+                .await
+                .expect("claim as this control plane")
+        );
+
+        // A healthy execution owned by the scanning process must be skipped
+        // silently: no deferral event, no sandbox status probe.
+        let mut state = OrphanAdoptionState::default();
+        runtime
+            .run_orphan_adoption_scan(&mut state, Some(QUEUED_ORPHAN_GRACE))
+            .await;
+        runtime
+            .run_orphan_adoption_scan(&mut state, Some(QUEUED_ORPHAN_GRACE))
+            .await;
+
+        let all = events(&store, &thread_key).await;
+        assert!(
+            all.iter().all(|event| {
+                event.event_type != "session.execution_adoption_deferred"
+                    && event.event_type != "session.execution_adopted"
+                    && event.event_type != "session.execution_failed"
+            }),
+            "self-owned execution must not be touched by the scan"
+        );
+        store
+            .fail_execution_if_active(&execution_id, "test cleanup")
+            .await
+            .expect("terminalize execution");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn spawned_adoption_loop_recovers_orphans() {
+        let Some(store) = test_store().await else {
+            return;
+        };
+        let _serial = TEST_LOCK.lock().await;
+        let thread_key =
+            ThreadKey::parse(format!("test:adopt-loop-{}", uuid::Uuid::new_v4())).unwrap();
+        orphaned_execution(&store, &thread_key, Some("sbx-mock"), true).await;
+
+        let backend = Arc::new(MockBackend::new(
+            SandboxStatus::Running,
+            vec![
+                json!({"type": "item.completed", "item": {"id": "msg-1", "type": "agentMessage", "text": "Done: recovered by the loop.", "phase": "final_answer"}}).to_string(),
+                json!({"type": "turn.completed", "turn": {"id": "turn-1", "status": "completed"}}).to_string(),
+            ],
+        ));
+        let runtime = runtime_with(&store, backend.clone());
+        runtime.spawn_orphan_adoption(Duration::from_millis(50));
+
         wait_for_event(&store, &thread_key, "session.execution_adopted").await;
         wait_for_event(&store, &thread_key, "session.execution_completed").await;
     }
@@ -8693,8 +8834,12 @@ mod adoption_tests {
         // Repeated periodic scans over the same held lease must record the
         // deferral event only once.
         let mut state = OrphanAdoptionState::default();
-        runtime.run_orphan_adoption_scan(&mut state).await;
-        runtime.run_orphan_adoption_scan(&mut state).await;
+        runtime
+            .run_orphan_adoption_scan(&mut state, Some(QUEUED_ORPHAN_GRACE))
+            .await;
+        runtime
+            .run_orphan_adoption_scan(&mut state, Some(QUEUED_ORPHAN_GRACE))
+            .await;
         let all = events(&store, &thread_key).await;
         let deferrals = all
             .iter()
@@ -8709,7 +8854,9 @@ mod adoption_tests {
             .release_stdout_owner(&execution_id, "other-control-plane")
             .await
             .expect("release lease");
-        runtime.run_orphan_adoption_scan(&mut state).await;
+        runtime
+            .run_orphan_adoption_scan(&mut state, Some(QUEUED_ORPHAN_GRACE))
+            .await;
         wait_for_event(&store, &thread_key, "session.execution_completed").await;
     }
 

--- a/services/api-rs/crates/centaur-session-sqlx/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-sqlx/src/lib.rs
@@ -45,6 +45,20 @@ pub struct ReleasedExecution {
     pub thread_key: ThreadKey,
 }
 
+/// An active execution together with its stdout-owner lease state, as
+/// returned by [`PgSessionStore::list_active_executions_with_ownership`].
+/// The lease snapshot is advisory — only the conditional
+/// `claim_expired_stdout_owner` update decides ownership — but it lets an
+/// adoption scan skip executions with a live owner without touching the
+/// session row or the sandbox backend.
+#[derive(Clone, Debug)]
+pub struct ActiveExecutionOwnership {
+    pub execution: SessionExecution,
+    pub stdout_owner_id: Option<String>,
+    /// True when a stdout-owner lease exists and has not expired yet.
+    pub stdout_owner_lease_active: bool,
+}
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct IdleSandboxCandidate {
     pub thread_key: ThreadKey,
@@ -365,6 +379,35 @@ impl PgSessionStore {
         .await?;
 
         rows.into_iter().map(TryInto::try_into).collect()
+    }
+
+    pub async fn list_active_executions_with_ownership(
+        &self,
+    ) -> Result<Vec<ActiveExecutionOwnership>, SessionStoreError> {
+        let rows = sqlx::query_as::<_, ActiveExecutionOwnershipRow>(
+            r#"
+            select execution_id, idempotency_key, thread_key, status, metadata, error, created_at, updated_at, started_at, completed_at,
+                   stdout_owner_id,
+                   coalesce(stdout_owner_lease_expires_at > now(), false) as stdout_owner_lease_active
+            from session_executions
+            where status in ($1, $2)
+            order by created_at, execution_id
+            "#,
+        )
+        .bind(ExecutionStatus::Queued.as_ref())
+        .bind(ExecutionStatus::Running.as_ref())
+        .fetch_all(&self.pool)
+        .await?;
+
+        rows.into_iter()
+            .map(|row| {
+                Ok(ActiveExecutionOwnership {
+                    execution: row.execution.try_into()?,
+                    stdout_owner_id: row.stdout_owner_id,
+                    stdout_owner_lease_active: row.stdout_owner_lease_active,
+                })
+            })
+            .collect()
     }
 
     pub async fn latest_execution_for_thread(
@@ -1588,6 +1631,14 @@ struct SessionExecutionRow {
     updated_at: OffsetDateTime,
     started_at: Option<OffsetDateTime>,
     completed_at: Option<OffsetDateTime>,
+}
+
+#[derive(Debug, FromRow)]
+struct ActiveExecutionOwnershipRow {
+    #[sqlx(flatten)]
+    execution: SessionExecutionRow,
+    stdout_owner_id: Option<String>,
+    stdout_owner_lease_active: bool,
 }
 
 #[derive(Debug, FromRow)]


### PR DESCRIPTION
## Problem

`adopt_orphaned_executions` runs **once at process startup**, and its lease-deferral path retries only "on next startup" — i.e. at the next deploy. That misses the standard rollout race:

1. New pod boots and runs its startup adoption scan.
2. Old pod is still alive mid-turn (stdout-owner lease active), so there is nothing to adopt — or adoption is deferred.
3. Old pod hits its termination grace period and dies mid-turn.
4. The execution is now orphaned, seconds *after* the only scan that could have rescued it. The turn's finished answer sits unread in the sandbox pod logs (exactly what `read_output_since` recovery exists for) until the next deploy.

This exact sequence silently ate a completed turn in stg on 2026-07-02: the deploy of #870 rolled api-rs at 12:37, the new pod scanned at 12:37:06, the old pod died at ~12:37:31 mid-turn, and codex's completed answer (visible in the sandbox pod logs at 12:38:58) was never delivered — the user saw only activity summaries and no reply.

## Change

- **Periodic re-scan**: the adoption scan now re-runs on an interval — `--session-execution-adoption-interval-secs` / `SESSION_EXECUTION_ADOPTION_INTERVAL_SECS`, default 15, `0` restores startup-only. The interval bounds how long a turn handed off by a terminating pod (#872) stays frozen before a peer adopts it; a steady-state tick is a single SELECT because lease-held executions are skipped before any session or sandbox reads. The first scan still runs immediately at startup. Safety against live owners is already provided by the stdout-owner lease (45s TTL, renewed every 10s by a dedicated task): scans defer while a lease is active and claim it atomically (`claim_expired_stdout_owner`) once the owner dies.
- **Queued-row grace window**: queued executions younger than 120s are now skipped instead of failed. Executions are only queued for the instant between `create_execution` and the running transition, but a scan racing a live `execute_session` (periodic tick, or a startup scan overlapping the old pod's in-flight request during a rollout) could observe that window and kill a healthy row.
- **Deferral dedup**: `session.execution_adoption_deferred` (event + info log) is recorded only on the first deferral per execution, so a long turn owned by a live peer doesn't accumulate one event per tick; repeats log at debug.

## Testing

- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings` clean.
- New DB-gated tests (run with `SESSION_RUNTIME_TEST_DATABASE_URL` against ParadeDB): young queued rows are left alone then failed once aged; a lease held by another control plane defers adoption and the recorded terminal is recovered after the lease expires; repeated scans record the deferral event exactly once and adopt immediately after the lease is released.
- Full `centaur-session-runtime` suite: 69/72 pass locally; the 3 failing `stdout_eof_*` tests fail identically on pristine `main` in the same environment (pre-existing, and not exercised in CI since `SESSION_RUNTIME_TEST_DATABASE_URL` is unset there).

Companion PR (separate): graceful SIGTERM drain that releases stdout-owner leases at shutdown, so a replacement pod's re-scan picks orphans up immediately instead of waiting out the 45s lease TTL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)