### PR TITLE
feat: hand off in-flight executions on shutdown

### DIFF
--- a/services/api-rs/crates/centaur-api-server/src/args.rs
+++ b/services/api-rs/crates/centaur-api-server/src/args.rs
@@ -459,7 +459,8 @@ pub(crate) struct ServerArgs {
     #[arg(
         long = "shutdown-execution-drain-timeout-secs",
         env = "SHUTDOWN_EXECUTION_DRAIN_TIMEOUT_SECS",
-        default_value_t = 20
+        default_value_t = 20,
+        value_parser = clap::value_parser!(u64).range(0..=600)
     )]
     shutdown_execution_drain_timeout_secs: u64,
 }

--- a/services/api-rs/crates/centaur-api-server/src/args.rs
+++ b/services/api-rs/crates/centaur-api-server/src/args.rs
@@ -106,6 +106,10 @@ impl Args {
     pub(crate) fn activity_summary_config(&self) -> Option<ActivitySummaryConfig> {
         self.activity_summary.config()
     }
+
+    pub(crate) fn shutdown_execution_drain_timeout(&self) -> Duration {
+        Duration::from_secs(self.server.shutdown_execution_drain_timeout_secs)
+    }
 }
 
 pub(crate) struct IronControlRuntime {
@@ -448,6 +452,16 @@ pub(crate) struct ServerArgs {
     pub(crate) bind_addr: SocketAddr,
     #[arg(long, env = "RUN_MIGRATIONS", default_value_t = false)]
     pub(crate) run_migrations: bool,
+    /// How long shutdown waits for in-flight executions to finish before
+    /// releasing their stdout-owner leases for adoption by a peer. Keep
+    /// below the pod's terminationGracePeriodSeconds (35s in the chart) so
+    /// the release happens before SIGKILL. 0 releases immediately.
+    #[arg(
+        long = "shutdown-execution-drain-timeout-secs",
+        env = "SHUTDOWN_EXECUTION_DRAIN_TIMEOUT_SECS",
+        default_value_t = 20
+    )]
+    shutdown_execution_drain_timeout_secs: u64,
 }
 
 #[derive(Debug, ClapArgs)]
@@ -2051,6 +2065,35 @@ mod tests {
         assert_eq!(args.sandbox.k8s_namespace, "centaur-test");
         assert_eq!(args.sandbox.ready_timeout_secs, 17);
         assert_eq!(args.sandbox.k8s_context.as_deref(), Some("kind-test"));
+    }
+
+    #[test]
+    fn shutdown_drain_defaults_to_twenty_seconds() {
+        let args = Args::try_parse_from([
+            "centaur-api-server",
+            "--database-url",
+            "postgres://postgres:postgres@localhost/centaur",
+        ])
+        .unwrap();
+
+        assert_eq!(
+            args.shutdown_execution_drain_timeout(),
+            Duration::from_secs(20)
+        );
+    }
+
+    #[test]
+    fn shutdown_drain_timeout_is_configurable() {
+        let args = Args::try_parse_from([
+            "centaur-api-server",
+            "--database-url",
+            "postgres://postgres:postgres@localhost/centaur",
+            "--shutdown-execution-drain-timeout-secs",
+            "0",
+        ])
+        .unwrap();
+
+        assert_eq!(args.shutdown_execution_drain_timeout(), Duration::ZERO);
     }
 
     #[test]

--- a/services/api-rs/crates/centaur-api-server/src/error.rs
+++ b/services/api-rs/crates/centaur-api-server/src/error.rs
@@ -57,6 +57,7 @@ impl IntoResponse for ApiError {
             Self::PayloadTooLarge(_) => StatusCode::PAYLOAD_TOO_LARGE,
             Self::ServiceUnavailable(_) => StatusCode::SERVICE_UNAVAILABLE,
             Self::Runtime(SessionRuntimeError::BadRequest(_)) => StatusCode::BAD_REQUEST,
+            Self::Runtime(SessionRuntimeError::ShuttingDown) => StatusCode::SERVICE_UNAVAILABLE,
             Self::Runtime(SessionRuntimeError::Store(SessionStoreError::NotFound { .. })) => {
                 StatusCode::NOT_FOUND
             }

--- a/services/api-rs/crates/centaur-api-server/src/main.rs
+++ b/services/api-rs/crates/centaur-api-server/src/main.rs
@@ -27,9 +27,20 @@ async fn main() -> Result<(), ServerError> {
 
     let app_state = AppState::unready();
     let app = build_router_with_app_state(app_state.clone());
+    let shutdown_state = app_state.clone();
+    let drain_timeout = args.shutdown_execution_drain_timeout();
     let mut server = tokio::spawn(async move {
         axum::serve(listener, app)
-            .with_graceful_shutdown(shutdown_signal())
+            .with_graceful_shutdown(async move {
+                shutdown_signal().await;
+                info!("shutdown signal received; handing off in-flight executions");
+                // Hand off before axum starts draining connections: open SSE
+                // streams can keep the server future alive until SIGKILL, and
+                // the lease release must not be lost to that.
+                if let Some(runtime) = shutdown_state.session_runtime() {
+                    runtime.handoff_owned_executions(drain_timeout).await;
+                }
+            })
             .await
     });
 
@@ -114,8 +125,32 @@ fn init_crypto_provider() {
     let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
 }
 
+/// Resolves on SIGINT (Ctrl-C) or, on Unix, SIGTERM — the signal Kubernetes
+/// sends on pod termination. The binary runs as PID 1 in its container, and
+/// PID 1 ignores signals without installed handlers: without the SIGTERM arm
+/// every rollout burned the full termination grace period and ended in
+/// SIGKILL, never reaching the graceful shutdown path.
 async fn shutdown_signal() {
-    let _ = tokio::signal::ctrl_c().await;
+    #[cfg(unix)]
+    {
+        use tokio::signal::unix::{SignalKind, signal};
+        let mut sigterm = match signal(SignalKind::terminate()) {
+            Ok(sigterm) => sigterm,
+            Err(error) => {
+                tracing::warn!(%error, "failed to install SIGTERM handler; using ctrl-c only");
+                let _ = tokio::signal::ctrl_c().await;
+                return;
+            }
+        };
+        tokio::select! {
+            _ = tokio::signal::ctrl_c() => {}
+            _ = sigterm.recv() => {}
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = tokio::signal::ctrl_c().await;
+    }
 }
 
 #[derive(Debug, Error)]

--- a/services/api-rs/crates/centaur-api-server/src/routes.rs
+++ b/services/api-rs/crates/centaur-api-server/src/routes.rs
@@ -126,6 +126,14 @@ impl AppState {
         self.initialized().is_some()
     }
 
+    /// The session runtime, if initialization completed. Unlike the private
+    /// request-path accessor this does not error while starting; the
+    /// shutdown path uses it to skip the execution handoff when the runtime
+    /// never came up.
+    pub fn session_runtime(&self) -> Option<SessionRuntime> {
+        self.initialized().map(|initialized| initialized.runtime)
+    }
+
     pub(crate) fn runtime(&self) -> Result<SessionRuntime, ApiError> {
         self.initialized()
             .map(|initialized| initialized.runtime)

--- a/services/api-rs/crates/centaur-session-runtime/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-runtime/src/lib.rs
@@ -61,6 +61,7 @@ const SESSION_PIPE_MAX_REATTACH_ATTEMPTS: u32 = 3;
 const SESSION_PIPE_REATTACH_DELAY: Duration = Duration::from_millis(500);
 const STDOUT_OWNER_LEASE: Duration = Duration::from_secs(45);
 const STDOUT_OWNER_RENEW_INTERVAL: Duration = Duration::from_secs(10);
+const EXECUTION_HANDOFF_POLL_INTERVAL: Duration = Duration::from_millis(500);
 const COMPONENT_SESSION_RUNTIME: &str = "session_runtime";
 const SANDBOX_REPOS_MOUNT_PATH: &str = "/home/agent/github";
 const OBSERVABILITY_TOOL_BLOCKLIST: &str =
@@ -3016,6 +3017,99 @@ impl SessionRuntime {
                 error = %record_error,
                 "failed to record orphaned execution failure"
             );
+        }
+    }
+
+    /// Hands off this control plane's in-flight executions before process
+    /// exit. Waits up to `timeout` for owned executions to finish naturally
+    /// (their stdout pumps keep running until the process exits), then
+    /// releases the remaining stdout-owner leases so another control
+    /// plane's adoption scan can claim the executions right away instead of
+    /// waiting out the lease TTL. Turn output produced after the release is
+    /// not lost: adoption replays it from the sandbox backend's recorded
+    /// output.
+    pub async fn handoff_owned_executions(&self, timeout: Duration) {
+        let deadline = Instant::now() + timeout;
+        loop {
+            match self
+                .store
+                .count_executions_with_stdout_owner(&self.stdout_owner_id)
+                .await
+            {
+                Ok(0) => {
+                    info!(
+                        component = COMPONENT_SESSION_RUNTIME,
+                        event = "execution_handoff_idle",
+                        "no in-flight executions to hand off at shutdown"
+                    );
+                    return;
+                }
+                Ok(in_flight) => {
+                    if Instant::now() >= deadline {
+                        break;
+                    }
+                    info!(
+                        component = COMPONENT_SESSION_RUNTIME,
+                        event = "execution_handoff_waiting",
+                        in_flight,
+                        "waiting for in-flight executions to finish before shutdown"
+                    );
+                }
+                Err(error) => {
+                    warn!(
+                        component = COMPONENT_SESSION_RUNTIME,
+                        event = "execution_handoff_count_failed",
+                        %error,
+                        "failed to count in-flight executions; releasing leases now"
+                    );
+                    break;
+                }
+            }
+            sleep(EXECUTION_HANDOFF_POLL_INTERVAL).await;
+        }
+        match self
+            .store
+            .release_stdout_owned_executions(&self.stdout_owner_id)
+            .await
+        {
+            Ok(released) => {
+                for execution in &released {
+                    info!(
+                        component = COMPONENT_SESSION_RUNTIME,
+                        event = "execution_handoff_released",
+                        thread_key = %execution.thread_key,
+                        execution_id = %execution.execution_id,
+                        "released stdout-owner lease at shutdown for adoption by a peer"
+                    );
+                    let _ = self
+                        .store
+                        .append_event(
+                            &execution.thread_key,
+                            Some(&execution.execution_id),
+                            "session.stdout_owner_released",
+                            json!({
+                                "execution_id": execution.execution_id,
+                                "reason": "control_plane_shutdown",
+                            }),
+                        )
+                        .await;
+                }
+                if released.is_empty() {
+                    info!(
+                        component = COMPONENT_SESSION_RUNTIME,
+                        event = "execution_handoff_idle",
+                        "in-flight executions finished during the shutdown drain"
+                    );
+                }
+            }
+            Err(error) => {
+                warn!(
+                    component = COMPONENT_SESSION_RUNTIME,
+                    event = "execution_handoff_release_failed",
+                    %error,
+                    "failed to release stdout-owner leases at shutdown"
+                );
+            }
         }
     }
 }
@@ -8309,5 +8403,90 @@ mod adoption_tests {
             "unexpected error: {error}"
         );
         assert_eq!(backend.opens(), 0);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn shutdown_handoff_releases_owned_leases() {
+        let Some(store) = test_store().await else {
+            return;
+        };
+        let _serial = TEST_LOCK.lock().await;
+        let thread_key =
+            ThreadKey::parse(format!("test:handoff-{}", uuid::Uuid::new_v4())).unwrap();
+        let execution_id = orphaned_execution(&store, &thread_key, Some("sbx-mock"), true).await;
+        let backend = Arc::new(MockBackend::new(SandboxStatus::Running, Vec::new()));
+        let runtime = runtime_with(&store, backend);
+        assert!(
+            store
+                .claim_stdout_owner(
+                    &execution_id,
+                    &runtime.stdout_owner_id,
+                    Duration::from_secs(60)
+                )
+                .await
+                .expect("claim as this control plane")
+        );
+
+        runtime.handoff_owned_executions(Duration::ZERO).await;
+
+        wait_for_event(&store, &thread_key, "session.stdout_owner_released").await;
+        // The lease is immediately claimable by a peer control plane; without
+        // the handoff it would only expire after the lease TTL.
+        assert!(
+            store
+                .claim_stdout_owner(&execution_id, "peer-control-plane", Duration::from_secs(5))
+                .await
+                .expect("peer claims released lease")
+        );
+        store
+            .fail_execution_if_active(&execution_id, "test cleanup")
+            .await
+            .expect("terminalize execution");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn shutdown_handoff_waits_for_executions_to_finish() {
+        let Some(store) = test_store().await else {
+            return;
+        };
+        let _serial = TEST_LOCK.lock().await;
+        let thread_key =
+            ThreadKey::parse(format!("test:handoff-wait-{}", uuid::Uuid::new_v4())).unwrap();
+        let execution_id = orphaned_execution(&store, &thread_key, Some("sbx-mock"), true).await;
+        let backend = Arc::new(MockBackend::new(SandboxStatus::Running, Vec::new()));
+        let runtime = runtime_with(&store, backend);
+        assert!(
+            store
+                .claim_stdout_owner(
+                    &execution_id,
+                    &runtime.stdout_owner_id,
+                    Duration::from_secs(60)
+                )
+                .await
+                .expect("claim as this control plane")
+        );
+
+        // The execution finishes while the drain is waiting; no lease should
+        // be released and no handoff event recorded.
+        let completer_store = store.clone();
+        let completer_id = execution_id.clone();
+        let completer = tokio::spawn(async move {
+            sleep(Duration::from_millis(300)).await;
+            completer_store
+                .complete_execution_if_active(&completer_id)
+                .await
+                .expect("complete execution")
+        });
+        runtime
+            .handoff_owned_executions(Duration::from_secs(5))
+            .await;
+        completer.await.expect("completer task");
+
+        let all = events(&store, &thread_key).await;
+        assert!(
+            all.iter()
+                .all(|event| event.event_type != "session.stdout_owner_released"),
+            "finished execution must not be handed off"
+        );
     }
 }

--- a/services/api-rs/crates/centaur-session-runtime/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-runtime/src/lib.rs
@@ -4,7 +4,10 @@ mod title_generator;
 use std::{
     collections::{BTreeMap, HashMap, HashSet, VecDeque},
     future::Future,
-    sync::Arc,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
     time::{Duration, SystemTime},
 };
 
@@ -62,6 +65,7 @@ const SESSION_PIPE_REATTACH_DELAY: Duration = Duration::from_millis(500);
 const STDOUT_OWNER_LEASE: Duration = Duration::from_secs(45);
 const STDOUT_OWNER_RENEW_INTERVAL: Duration = Duration::from_secs(10);
 const EXECUTION_HANDOFF_POLL_INTERVAL: Duration = Duration::from_millis(500);
+const EXECUTION_HANDOFF_DB_TIMEOUT: Duration = Duration::from_secs(5);
 const COMPONENT_SESSION_RUNTIME: &str = "session_runtime";
 const SANDBOX_REPOS_MOUNT_PATH: &str = "/home/agent/github";
 const OBSERVABILITY_TOOL_BLOCKLIST: &str =
@@ -96,6 +100,10 @@ pub struct SessionRuntime {
     session_title_rerun_requested: SessionTitleThreadSet,
     capacity: Option<Arc<SandboxCapacityController>>,
     stdout_owner_id: String,
+    /// Set once a shutdown handoff begins; fences new stdout-owner claims
+    /// so an execution cannot start on a control plane that is about to
+    /// exit and release its leases.
+    shutting_down: Arc<AtomicBool>,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -743,6 +751,7 @@ impl SessionRuntime {
             session_title_rerun_requested: Arc::new(DashSet::new()),
             capacity: None,
             stdout_owner_id: format!("api-rs-{}", uuid::Uuid::new_v4().simple()),
+            shutting_down: Arc::new(AtomicBool::new(false)),
         }
     }
 
@@ -1092,6 +1101,9 @@ impl SessionRuntime {
     }
 
     async fn claim_stdout_owner(&self, execution_id: &str) -> Result<(), SessionRuntimeError> {
+        if self.shutting_down.load(Ordering::SeqCst) {
+            return Err(SessionRuntimeError::ShuttingDown);
+        }
         let claimed = self
             .store
             .claim_stdout_owner(execution_id, &self.stdout_owner_id, STDOUT_OWNER_LEASE)
@@ -3029,13 +3041,29 @@ impl SessionRuntime {
     /// not lost: adoption replays it from the sandbox backend's recorded
     /// output.
     pub async fn handoff_owned_executions(&self, timeout: Duration) {
-        let deadline = Instant::now() + timeout;
+        // Fence new stdout-owner claims first: an execution accepted after
+        // this point would otherwise claim a lease that outlives the
+        // process, stranding it until the lease TTL expires.
+        self.shutting_down.store(true, Ordering::SeqCst);
+        let deadline = Instant::now()
+            .checked_add(timeout)
+            .unwrap_or_else(|| Instant::now() + Duration::from_secs(3600));
         loop {
-            match self
-                .store
-                .count_executions_with_stdout_owner(&self.stdout_owner_id)
-                .await
-            {
+            let count = tokio::time::timeout(
+                EXECUTION_HANDOFF_DB_TIMEOUT,
+                self.store
+                    .count_executions_with_stdout_owner(&self.stdout_owner_id),
+            )
+            .await;
+            let Ok(count) = count else {
+                warn!(
+                    component = COMPONENT_SESSION_RUNTIME,
+                    event = "execution_handoff_count_timeout",
+                    "timed out counting in-flight executions; releasing leases now"
+                );
+                break;
+            };
+            match count {
                 Ok(0) => {
                     info!(
                         component = COMPONENT_SESSION_RUNTIME,
@@ -3067,11 +3095,21 @@ impl SessionRuntime {
             }
             sleep(EXECUTION_HANDOFF_POLL_INTERVAL).await;
         }
-        match self
-            .store
-            .release_stdout_owned_executions(&self.stdout_owner_id)
-            .await
-        {
+        let released = tokio::time::timeout(
+            EXECUTION_HANDOFF_DB_TIMEOUT,
+            self.store
+                .release_stdout_owned_executions(&self.stdout_owner_id),
+        )
+        .await;
+        let Ok(released) = released else {
+            warn!(
+                component = COMPONENT_SESSION_RUNTIME,
+                event = "execution_handoff_release_timeout",
+                "timed out releasing stdout-owner leases; peers must wait for lease expiry"
+            );
+            return;
+        };
+        match released {
             Ok(released) => {
                 for execution in &released {
                     info!(
@@ -5195,6 +5233,7 @@ fn execution_duration(execution: &SessionExecution) -> Option<Duration> {
 fn runtime_error_failure_class(error: &SessionRuntimeError) -> &'static str {
     match error {
         SessionRuntimeError::BadRequest(_) => "bad_request",
+        SessionRuntimeError::ShuttingDown => "shutting_down",
         SessionRuntimeError::Store(_) => "store",
         SessionRuntimeError::Sandbox(SandboxError::NotFound(_)) => "sandbox_not_found",
         SessionRuntimeError::Sandbox(SandboxError::Unsupported { .. }) => "sandbox_unsupported",
@@ -6070,6 +6109,8 @@ fn terminal_output_from_lines(lines: &[String]) -> Option<TerminalOutput> {
 pub enum SessionRuntimeError {
     #[error("{0}")]
     BadRequest(String),
+    #[error("control plane is shutting down")]
+    ShuttingDown,
     #[error(transparent)]
     Store(#[from] SessionStoreError),
     #[error(transparent)]
@@ -8480,7 +8521,11 @@ mod adoption_tests {
         runtime
             .handoff_owned_executions(Duration::from_secs(5))
             .await;
-        completer.await.expect("completer task");
+        let completed = completer.await.expect("completer task");
+        assert!(
+            completed.is_some(),
+            "the completer, not the handoff, must terminalize the execution"
+        );
 
         let all = events(&store, &thread_key).await;
         assert!(
@@ -8488,5 +8533,35 @@ mod adoption_tests {
                 .all(|event| event.event_type != "session.stdout_owner_released"),
             "finished execution must not be handed off"
         );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn shutdown_fences_new_stdout_claims() {
+        let Some(store) = test_store().await else {
+            return;
+        };
+        let _serial = TEST_LOCK.lock().await;
+        let backend = Arc::new(MockBackend::new(SandboxStatus::Running, Vec::new()));
+        let runtime = runtime_with(&store, backend);
+
+        // Nothing owned: the handoff returns immediately but still flips
+        // the shutdown fence.
+        runtime.handoff_owned_executions(Duration::ZERO).await;
+
+        let thread_key =
+            ThreadKey::parse(format!("test:handoff-fence-{}", uuid::Uuid::new_v4())).unwrap();
+        let execution_id = orphaned_execution(&store, &thread_key, Some("sbx-mock"), true).await;
+        let error = runtime
+            .claim_stdout_owner(&execution_id)
+            .await
+            .expect_err("claims after shutdown must be rejected");
+        assert!(
+            matches!(error, SessionRuntimeError::ShuttingDown),
+            "unexpected error: {error}"
+        );
+        store
+            .fail_execution_if_active(&execution_id, "test cleanup")
+            .await
+            .expect("terminalize execution");
     }
 }

--- a/services/api-rs/crates/centaur-session-sqlx/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-sqlx/src/lib.rs
@@ -37,6 +37,14 @@ pub struct ClaimExecutionResult {
     pub claimed: bool,
 }
 
+/// An active execution whose stdout-owner lease was released by
+/// [`PgSessionStore::release_stdout_owned_executions`].
+#[derive(Clone, Debug)]
+pub struct ReleasedExecution {
+    pub execution_id: String,
+    pub thread_key: ThreadKey,
+}
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct IdleSandboxCandidate {
     pub thread_key: ThreadKey,
@@ -538,6 +546,60 @@ impl PgSessionStore {
         .await?;
 
         Ok(result.rows_affected() > 0)
+    }
+
+    pub async fn count_executions_with_stdout_owner(
+        &self,
+        owner_id: &str,
+    ) -> Result<u64, SessionStoreError> {
+        let count = sqlx::query_scalar::<_, i64>(
+            r#"
+            select count(*)
+            from session_executions
+            where stdout_owner_id = $1 and status in ($2, $3)
+            "#,
+        )
+        .bind(owner_id)
+        .bind(ExecutionStatus::Queued.as_ref())
+        .bind(ExecutionStatus::Running.as_ref())
+        .fetch_one(&self.pool)
+        .await?;
+
+        Ok(u64::try_from(count).unwrap_or_default())
+    }
+
+    /// Releases every active stdout-owner lease held by `owner_id` in one
+    /// statement, returning the affected executions. Used by a clean
+    /// control-plane shutdown so a peer's adoption scan can claim the
+    /// executions immediately instead of waiting out the lease TTL.
+    pub async fn release_stdout_owned_executions(
+        &self,
+        owner_id: &str,
+    ) -> Result<Vec<ReleasedExecution>, SessionStoreError> {
+        let rows = sqlx::query_as::<_, (String, String)>(
+            r#"
+            update session_executions
+            set stdout_owner_id = null,
+                stdout_owner_lease_expires_at = null,
+                updated_at = now()
+            where stdout_owner_id = $1 and status in ($2, $3)
+            returning execution_id, thread_key
+            "#,
+        )
+        .bind(owner_id)
+        .bind(ExecutionStatus::Queued.as_ref())
+        .bind(ExecutionStatus::Running.as_ref())
+        .fetch_all(&self.pool)
+        .await?;
+
+        rows.into_iter()
+            .map(|(execution_id, thread_key)| {
+                Ok(ReleasedExecution {
+                    execution_id,
+                    thread_key: parse_persisted(thread_key)?,
+                })
+            })
+            .collect()
     }
 
     pub async fn complete_execution(
@@ -1961,6 +2023,94 @@ mod tests {
         assert_eq!(
             completed.status,
             centaur_session_core::ExecutionStatus::Completed
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn releases_all_stdout_leases_held_by_one_owner() {
+        let Some(store) = test_store().await else {
+            return;
+        };
+        let owner = format!("owner-{}", Uuid::new_v4().simple());
+        let peer = format!("peer-{}", Uuid::new_v4().simple());
+        let mut owned = Vec::new();
+        for label in ["a", "b"] {
+            let thread_key =
+                ThreadKey::parse(format!("test:handoff-{label}-{}", Uuid::new_v4())).unwrap();
+            store
+                .create_or_get_session(&thread_key, &HarnessType::Codex, None, json!({}))
+                .await
+                .expect("create session");
+            let execution_id = store
+                .create_execution(&thread_key, None, json!({}))
+                .await
+                .expect("create execution")
+                .execution
+                .execution_id;
+            store
+                .mark_execution_running(&execution_id)
+                .await
+                .expect("mark running");
+            assert!(
+                store
+                    .claim_stdout_owner(&execution_id, &owner, Duration::from_secs(60))
+                    .await
+                    .expect("claim stdout owner")
+            );
+            owned.push((execution_id, thread_key));
+        }
+        assert_eq!(
+            store
+                .count_executions_with_stdout_owner(&owner)
+                .await
+                .expect("count owned"),
+            2
+        );
+
+        let released = store
+            .release_stdout_owned_executions(&owner)
+            .await
+            .expect("release owned leases");
+        assert_eq!(released.len(), 2);
+        for (execution_id, thread_key) in &owned {
+            assert!(
+                released.iter().any(|execution| {
+                    execution.execution_id == *execution_id && execution.thread_key == *thread_key
+                }),
+                "released set must include {execution_id}"
+            );
+        }
+        assert_eq!(
+            store
+                .count_executions_with_stdout_owner(&owner)
+                .await
+                .expect("count after release"),
+            0
+        );
+
+        // Released leases are immediately claimable by a peer, without
+        // waiting for expiry.
+        assert!(
+            store
+                .claim_stdout_owner(&owned[0].0, &peer, Duration::from_secs(60))
+                .await
+                .expect("peer claims released lease")
+        );
+
+        // Terminal executions are never part of a release, even if a lease
+        // column is still populated.
+        for (execution_id, _) in &owned {
+            store
+                .fail_execution_if_active(execution_id, "test cleanup")
+                .await
+                .expect("terminalize execution");
+        }
+        assert!(
+            store
+                .release_stdout_owned_executions(&peer)
+                .await
+                .expect("release for peer")
+                .is_empty()
         );
     }
 

--- a/services/api-rs/crates/centaur-session-sqlx/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-sqlx/src/lib.rs
@@ -2059,6 +2059,30 @@ mod tests {
             );
             owned.push((execution_id, thread_key));
         }
+        // A bystander owner's lease must survive the release untouched.
+        let bystander_thread =
+            ThreadKey::parse(format!("test:handoff-bystander-{}", Uuid::new_v4())).unwrap();
+        store
+            .create_or_get_session(&bystander_thread, &HarnessType::Codex, None, json!({}))
+            .await
+            .expect("create bystander session");
+        let bystander_execution = store
+            .create_execution(&bystander_thread, None, json!({}))
+            .await
+            .expect("create bystander execution")
+            .execution
+            .execution_id;
+        store
+            .mark_execution_running(&bystander_execution)
+            .await
+            .expect("mark bystander running");
+        let bystander = format!("bystander-{}", Uuid::new_v4().simple());
+        assert!(
+            store
+                .claim_stdout_owner(&bystander_execution, &bystander, Duration::from_secs(60))
+                .await
+                .expect("claim bystander lease")
+        );
         assert_eq!(
             store
                 .count_executions_with_stdout_owner(&owner)
@@ -2096,6 +2120,19 @@ mod tests {
                 .await
                 .expect("peer claims released lease")
         );
+
+        assert_eq!(
+            store
+                .count_executions_with_stdout_owner(&bystander)
+                .await
+                .expect("count bystander"),
+            1,
+            "release must be scoped to the requested owner"
+        );
+        store
+            .fail_execution_if_active(&bystander_execution, "test cleanup")
+            .await
+            .expect("terminalize bystander");
 
         // Terminal executions are never part of a release, even if a lease
         // column is still populated.


### PR DESCRIPTION
## Problem

Two gaps around pod termination, found while investigating a turn that was silently lost to a rolling deploy in stg (details in #871):

1. **api-rs never sees SIGTERM.** The binary is PID 1 in its container (exec-form ENTRYPOINT, no init) and `shutdown_signal()` only handled Ctrl-C/SIGINT — and PID 1 ignores signals without installed handlers. Every pod termination therefore burned the full 35s `terminationGracePeriodSeconds` and ended in SIGKILL; axum's graceful shutdown never ran.
2. **In-flight executions die holding their stdout-owner leases.** When the process is killed mid-turn, the leases linger until their 45s TTL expires, and (before #871) nothing ever re-scanned to adopt the orphans.

## Change

- Handle **SIGTERM** alongside Ctrl-C as a shutdown signal.
- On shutdown, `handoff_owned_executions` first **fences new stdout-owner claims** (`SessionRuntimeError::ShuttingDown` → 503, so a client retry lands on a healthy pod) — an execution accepted mid-drain would otherwise claim a lease that outlives the process. It then waits up to `--shutdown-execution-drain-timeout-secs` (default 20s, bounded ≤600, under the chart's 35s grace) for in-flight executions to finish naturally — stdout pumps keep running while it waits, so short turns complete normally — and finally **releases the remaining leases in one statement** (`release_stdout_owned_executions`), recording a `session.stdout_owner_released` event per execution. The count/release queries carry 5s timeouts so a hung DB can't push the release past SIGKILL.
- The release lets a peer control plane's adoption scan claim the executions **immediately** instead of waiting out the 45s lease TTL. Output produced after the release is not lost: adoption replays it from the sandbox backend's recorded output (kubelet logs).

## Sequencing note

⚠️ The rescue depends on **#871 (periodic orphan re-scan)** — with a startup-only scan, released executions still wait for the next deploy to be adopted. Merge #871 first (or together). This PR is independently valuable regardless: SIGTERM is currently ignored entirely, so today no rollout exits gracefully, and the drain window lets short turns finish instead of dying mid-stream.

Downstream safety: verified all session-event consumers (slackbotv2, rendering, console) whitelist known event types and ignore unknown ones, so `session.stdout_owner_released` is inert to them.

## Testing

- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings` clean.
- DB-gated tests (ParadeDB): single-statement release returns exactly the owner's executions and leaves a bystander owner's lease untouched (owner scoping mutation-tested); released leases are immediately claimable by a peer; terminal executions are never released; the drain waits for an execution finishing mid-drain and releases nothing; claims after shutdown are rejected with `ShuttingDown`.
- End-to-end: built server, SIGTERM → logs "shutdown signal received; handing off in-flight executions", releases (idle path), exits cleanly in <1s. On main the same signal is ignored until SIGKILL.
- Adversarially reviewed alongside #871 (5 reviewers, 24 verified findings); all confirmed correctness findings addressed in this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)