### PR TITLE
ci: publish images for every main commit

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -4,17 +4,6 @@ on:
   push:
     branches: [main]
     tags: [v*]
-    paths:
-      - .github/workflows/publish-images.yml
-      - services/**
-      - centaur_sdk/**
-      - packages/**
-      - tools/**
-      - scripts/bootstrap-k8s-secrets.sh
-      - package.json
-      - pnpm-lock.yaml
-      - pnpm-workspace.yaml
-      - .agents/skills/**
   pull_request:
   workflow_dispatch:
 


### PR DESCRIPTION
## Summary
- remove path filters from the Publish Images push trigger
- ensure every main commit publishes the expected main-sha image tags for deploys

Prompted by: @goksu

## Testing
- Not run: workflow trigger-only change; actionlint is not installed in the sandbox.