### PR TITLE
fix: retry workflow host database connections

### DIFF
--- a/services/workflow-python/tests/test_workflow_host.py
+++ b/services/workflow-python/tests/test_workflow_host.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import asyncio
 import importlib.util
+import os
 import sys
+import types
 import unittest
 from pathlib import Path
 from unittest.mock import patch
@@ -159,6 +161,43 @@ class WorkflowHostTests(unittest.TestCase):
         result = asyncio.run(ctx.run_agent("draft_summary", text="summarize this"))
 
         self.assertEqual(result, {"name": "draft_summary", "text": "summarize this"})
+
+    def test_create_pool_retries_transient_connection_failure(self) -> None:
+        host = load_workflow_host()
+        calls = []
+        sleeps = []
+        pool = FakePool()
+
+        async def create_pool(database_url):
+            calls.append(database_url)
+            if len(calls) < 3:
+                raise ConnectionRefusedError("postgres is still starting")
+            return pool
+
+        async def sleep(delay):
+            sleeps.append(delay)
+
+        fake_asyncpg = types.SimpleNamespace(create_pool=create_pool)
+
+        with (
+            patch.dict(
+                os.environ,
+                {
+                    "DATABASE_URL": "postgresql://example/db",
+                    "WORKFLOW_HOST_DATABASE_CONNECT_ATTEMPTS": "3",
+                    "WORKFLOW_HOST_DATABASE_CONNECT_BACKOFF_SECONDS": "0.1",
+                    "WORKFLOW_HOST_DATABASE_CONNECT_BACKOFF_MAX_SECONDS": "1.0",
+                },
+                clear=False,
+            ),
+            patch.dict(sys.modules, {"asyncpg": fake_asyncpg}),
+            patch.object(host.asyncio, "sleep", sleep),
+        ):
+            result = asyncio.run(host.create_pool())
+
+        self.assertIs(result, pool)
+        self.assertEqual(calls, ["postgresql://example/db"] * 3)
+        self.assertEqual(sleeps, [0.1, 0.2])
 
     def test_workflow_result_includes_grouping_identifiers(self) -> None:
         host = load_workflow_host()

--- a/services/workflow-python/tests/test_workflow_host.py
+++ b/services/workflow-python/tests/test_workflow_host.py
@@ -180,16 +180,7 @@ class WorkflowHostTests(unittest.TestCase):
         fake_asyncpg = types.SimpleNamespace(create_pool=create_pool)
 
         with (
-            patch.dict(
-                os.environ,
-                {
-                    "DATABASE_URL": "postgresql://example/db",
-                    "WORKFLOW_HOST_DATABASE_CONNECT_ATTEMPTS": "3",
-                    "WORKFLOW_HOST_DATABASE_CONNECT_BACKOFF_SECONDS": "0.1",
-                    "WORKFLOW_HOST_DATABASE_CONNECT_BACKOFF_MAX_SECONDS": "1.0",
-                },
-                clear=False,
-            ),
+            patch.dict(os.environ, {"DATABASE_URL": "postgresql://example/db"}, clear=False),
             patch.dict(sys.modules, {"asyncpg": fake_asyncpg}),
             patch.object(host.asyncio, "sleep", sleep),
         ):
@@ -197,7 +188,7 @@ class WorkflowHostTests(unittest.TestCase):
 
         self.assertIs(result, pool)
         self.assertEqual(calls, ["postgresql://example/db"] * 3)
-        self.assertEqual(sleeps, [0.1, 0.2])
+        self.assertEqual(sleeps, [0.25, 0.5])
 
     def test_workflow_result_includes_grouping_identifiers(self) -> None:
         host = load_workflow_host()

--- a/services/workflow-python/workflow_host.py
+++ b/services/workflow-python/workflow_host.py
@@ -24,12 +24,9 @@ from typing import Any
 from api import metrics
 from api.workflow_engine import WorkflowContext
 
-DATABASE_CONNECT_ATTEMPTS_ENV = "WORKFLOW_HOST_DATABASE_CONNECT_ATTEMPTS"
-DATABASE_CONNECT_BACKOFF_ENV = "WORKFLOW_HOST_DATABASE_CONNECT_BACKOFF_SECONDS"
-DATABASE_CONNECT_BACKOFF_MAX_ENV = "WORKFLOW_HOST_DATABASE_CONNECT_BACKOFF_MAX_SECONDS"
-DEFAULT_DATABASE_CONNECT_ATTEMPTS = 5
-DEFAULT_DATABASE_CONNECT_BACKOFF_SECONDS = 0.25
-DEFAULT_DATABASE_CONNECT_BACKOFF_MAX_SECONDS = 2.0
+DATABASE_CONNECT_ATTEMPTS = 5
+DATABASE_CONNECT_BACKOFF_SECONDS = 0.25
+DATABASE_CONNECT_BACKOFF_MAX_SECONDS = 2.0
 
 
 class ProtocolError(RuntimeError):
@@ -230,26 +227,6 @@ def coerce_input(raw: Any, input_cls: type | None) -> Any:
         return raw
 
 
-def env_int(name: str, default: int, minimum: int = 1) -> int:
-    raw = os.getenv(name, "").strip()
-    if not raw:
-        return default
-    try:
-        return max(minimum, int(raw))
-    except ValueError:
-        return default
-
-
-def env_float(name: str, default: float, minimum: float = 0.0) -> float:
-    raw = os.getenv(name, "").strip()
-    if not raw:
-        return default
-    try:
-        return max(minimum, float(raw))
-    except ValueError:
-        return default
-
-
 async def create_pool() -> Any:
     database_url = os.getenv("DATABASE_URL", "").strip()
     if not database_url:
@@ -259,24 +236,22 @@ async def create_pool() -> Any:
     except ImportError:
         return None
 
-    attempts = env_int(DATABASE_CONNECT_ATTEMPTS_ENV, DEFAULT_DATABASE_CONNECT_ATTEMPTS)
-    backoff = env_float(DATABASE_CONNECT_BACKOFF_ENV, DEFAULT_DATABASE_CONNECT_BACKOFF_SECONDS)
-    max_backoff = env_float(
-        DATABASE_CONNECT_BACKOFF_MAX_ENV,
-        DEFAULT_DATABASE_CONNECT_BACKOFF_MAX_SECONDS,
-    )
     last_error: Exception | None = None
-    for attempt in range(1, attempts + 1):
+    for attempt in range(1, DATABASE_CONNECT_ATTEMPTS + 1):
         try:
             return await asyncpg.create_pool(database_url)
         except Exception as exc:
             last_error = exc
-            if attempt == attempts:
+            if attempt == DATABASE_CONNECT_ATTEMPTS:
                 break
-            delay = min(max_backoff, backoff * (2 ** (attempt - 1)))
+            delay = min(
+                DATABASE_CONNECT_BACKOFF_MAX_SECONDS,
+                DATABASE_CONNECT_BACKOFF_SECONDS * (2 ** (attempt - 1)),
+            )
             print(
                 "workflow_database_connect_retry "
-                f"attempt={attempt} attempts={attempts} delay_seconds={delay} "
+                f"attempt={attempt} attempts={DATABASE_CONNECT_ATTEMPTS} "
+                f"delay_seconds={delay} "
                 f"error={type(exc).__name__}: {exc}",
                 file=sys.stderr,
             )

--- a/services/workflow-python/workflow_host.py
+++ b/services/workflow-python/workflow_host.py
@@ -24,6 +24,13 @@ from typing import Any
 from api import metrics
 from api.workflow_engine import WorkflowContext
 
+DATABASE_CONNECT_ATTEMPTS_ENV = "WORKFLOW_HOST_DATABASE_CONNECT_ATTEMPTS"
+DATABASE_CONNECT_BACKOFF_ENV = "WORKFLOW_HOST_DATABASE_CONNECT_BACKOFF_SECONDS"
+DATABASE_CONNECT_BACKOFF_MAX_ENV = "WORKFLOW_HOST_DATABASE_CONNECT_BACKOFF_MAX_SECONDS"
+DEFAULT_DATABASE_CONNECT_ATTEMPTS = 5
+DEFAULT_DATABASE_CONNECT_BACKOFF_SECONDS = 0.25
+DEFAULT_DATABASE_CONNECT_BACKOFF_MAX_SECONDS = 2.0
+
 
 class ProtocolError(RuntimeError):
     pass
@@ -223,6 +230,26 @@ def coerce_input(raw: Any, input_cls: type | None) -> Any:
         return raw
 
 
+def env_int(name: str, default: int, minimum: int = 1) -> int:
+    raw = os.getenv(name, "").strip()
+    if not raw:
+        return default
+    try:
+        return max(minimum, int(raw))
+    except ValueError:
+        return default
+
+
+def env_float(name: str, default: float, minimum: float = 0.0) -> float:
+    raw = os.getenv(name, "").strip()
+    if not raw:
+        return default
+    try:
+        return max(minimum, float(raw))
+    except ValueError:
+        return default
+
+
 async def create_pool() -> Any:
     database_url = os.getenv("DATABASE_URL", "").strip()
     if not database_url:
@@ -231,7 +258,31 @@ async def create_pool() -> Any:
         import asyncpg  # type: ignore
     except ImportError:
         return None
-    return await asyncpg.create_pool(database_url)
+
+    attempts = env_int(DATABASE_CONNECT_ATTEMPTS_ENV, DEFAULT_DATABASE_CONNECT_ATTEMPTS)
+    backoff = env_float(DATABASE_CONNECT_BACKOFF_ENV, DEFAULT_DATABASE_CONNECT_BACKOFF_SECONDS)
+    max_backoff = env_float(
+        DATABASE_CONNECT_BACKOFF_MAX_ENV,
+        DEFAULT_DATABASE_CONNECT_BACKOFF_MAX_SECONDS,
+    )
+    last_error: Exception | None = None
+    for attempt in range(1, attempts + 1):
+        try:
+            return await asyncpg.create_pool(database_url)
+        except Exception as exc:
+            last_error = exc
+            if attempt == attempts:
+                break
+            delay = min(max_backoff, backoff * (2 ** (attempt - 1)))
+            print(
+                "workflow_database_connect_retry "
+                f"attempt={attempt} attempts={attempts} delay_seconds={delay} "
+                f"error={type(exc).__name__}: {exc}",
+                file=sys.stderr,
+            )
+            await asyncio.sleep(delay)
+    assert last_error is not None
+    raise last_error
 
 
 def jsonable(value: Any) -> Any:


### PR DESCRIPTION
Adds retry and exponential backoff around workflow-host asyncpg pool creation so transient Postgres startup refusals do not fail the workflow immediately. The retry behavior uses fixed conservative constants in the workflow host. Includes focused coverage for a transient connection failure followed by a successful pool creation.