### PR TITLE
fix: grant console Slack thread visibility to Slack SSO identities

### DIFF
--- a/services/console/app/controllers/application_controller.rb
+++ b/services/console/app/controllers/application_controller.rb
@@ -227,7 +227,7 @@ class ApplicationController < ActionController::Base
           .where(oauth_apps: { provider: CONSOLE_SIDEBAR_SLACK_PROVIDER })
           .where(console_sidebar_slack_oauth_credential_owner_sql(subjects: subjects, emails: emails))
 
-        credentials.filter_map do |credential|
+        credential_owners = credentials.filter_map do |credential|
           user_id = console_sidebar_first_present(
             credential.provider_subject,
             *CONSOLE_SIDEBAR_SLACK_CREDENTIAL_USER_LABEL_KEYS.map { |key| credential.labels&.[](key) }
@@ -241,7 +241,18 @@ class ApplicationController < ActionController::Base
               credential.oauth_app&.labels&.[](CONSOLE_SIDEBAR_SLACK_TEAM_LABEL)
             )
           )
-        end.uniq { |owner| [ console_sidebar_normalize_key(owner.user_id), console_sidebar_normalize_key(owner.team_id) ] }
+        end
+
+        # A Slack OIDC sign-in stores the workspace user id (U…) as the
+        # identity subject — the same id slackbotv2 writes into session
+        # metadata — so SSO alone owns those threads even when the user has
+        # not minted a broker credential through the connect flow.
+        identity_owners = subjects.map do |subject|
+          ConsoleSidebarSlackThreadOwner.new(user_id: subject, team_id: nil)
+        end
+
+        (credential_owners + identity_owners)
+          .uniq { |owner| [ console_sidebar_normalize_key(owner.user_id), console_sidebar_normalize_key(owner.team_id) ] }
       end
     end
   end

--- a/services/console/app/controllers/console/threads_controller.rb
+++ b/services/console/app/controllers/console/threads_controller.rb
@@ -278,7 +278,7 @@ class Console::ThreadsController < ApplicationController
             .where(oauth_apps: { provider: SLACK_PROVIDER })
             .where(slack_oauth_credential_owner_sql(subjects: subjects, emails: emails))
 
-          credentials.filter_map do |credential|
+          credential_owners = credentials.filter_map do |credential|
             user_id = first_present(
               credential.provider_subject,
               *SLACK_CREDENTIAL_USER_LABEL_KEYS.map { |key| credential.labels&.[](key) }
@@ -292,7 +292,18 @@ class Console::ThreadsController < ApplicationController
                 credential.oauth_app&.labels&.[](SLACK_TEAM_LABEL)
               )
             )
-          end.uniq { |owner| [ normalize_key(owner.user_id), normalize_key(owner.team_id) ] }
+          end
+
+          # A Slack OIDC sign-in stores the workspace user id (U…) as the
+          # identity subject — the same id slackbotv2 writes into session
+          # metadata — so SSO alone owns those threads even when the user has
+          # not minted a broker credential through the connect flow.
+          identity_owners = subjects.map do |subject|
+            SlackThreadOwner.new(user_id: subject, team_id: nil)
+          end
+
+          (credential_owners + identity_owners)
+            .uniq { |owner| [ normalize_key(owner.user_id), normalize_key(owner.team_id) ] }
         end
       else
         []

--- a/services/console/test/controllers/console/threads_controller_test.rb
+++ b/services/console/test/controllers/console/threads_controller_test.rb
@@ -506,6 +506,62 @@ class Console::ThreadsControllerTest < ActionDispatch::IntegrationTest
     refute_includes sql, "split_part(thread_key, ':', 2)"
   end
 
+  test "visible thread scope matches Slack threads via the SSO identity without a broker credential" do
+    UserIdentity.create!(
+      user: @operator,
+      provider: "slack",
+      subject: "USSOONLY",
+      email: @operator.email,
+      email_verified: true
+    )
+    controller = threads_controller_for(@operator)
+
+    sql = controller.send(:visible_thread_scope).to_sql
+
+    # The Slack OIDC subject is the workspace user id, so signing in with
+    # Slack is enough to own the threads slackbotv2 attributed to that id —
+    # no broker credential required.
+    assert_includes sql, "thread_key LIKE 'slack:%'"
+    assert_includes sql, "metadata ->> 'slack_user_id'"
+    assert_includes sql, "ussoonly"
+    refute_includes sql, "split_part(thread_key, ':', 2)"
+  end
+
+  test "visible thread scope dedupes an SSO identity that matches its broker credential" do
+    app = oauth_apps(:acme_slack)
+    app.update!(client_secret: "slack-secret", labels: {})
+    create_slack_oauth_credential(app, subject: "UOWNER", email: @operator.email, labels: {})
+    UserIdentity.create!(
+      user: @operator,
+      provider: "slack",
+      subject: "UOWNER",
+      email: @operator.email,
+      email_verified: true
+    )
+    controller = threads_controller_for(@operator)
+
+    owners = controller.send(:slack_thread_owners_for_current_user)
+
+    assert_equal [ "UOWNER" ], owners.map { |owner| owner.user_id.upcase }
+  end
+
+  test "sidebar thread scope matches Slack threads via the SSO identity without a broker credential" do
+    UserIdentity.create!(
+      user: @operator,
+      provider: "slack",
+      subject: "USSOONLY",
+      email: @operator.email,
+      email_verified: true
+    )
+    controller = threads_controller_for(@operator)
+
+    sql = controller.send(:console_sidebar_visible_thread_scope).to_sql
+
+    assert_includes sql, "thread_key LIKE 'slack:%'"
+    assert_includes sql, "metadata ->> 'slack_user_id'"
+    assert_includes sql, "ussoonly"
+  end
+
   test "selected session resolves a directly linked thread only within the owner scope" do
     controller = Console::ThreadsController.new
     owned_thread = SelectedSession.new(thread_key: "slack:C123:1782339173.755169")


### PR DESCRIPTION
## Problem

A user who signs into the console with Slack SSO but has never completed the Slack broker connect flow cannot see any of their Slack threads at `/console/threads`. Observed on stg: `sessions.metadata.slack_user_id = U0AANH5QHEF` matched the user's `user_identities.subject` exactly, but the thread list was empty because the visibility scope only derives Slack owners from `broker_credentials` — the SSO identity is used solely as a lookup key to find a credential, never as an owner itself. With no credential row, the entire Slack-ownership clause is dropped from the query.

## Fix

Slack's OIDC `sub` claim is the workspace user id (`U…`) — the same identifier slackbotv2 writes into session metadata. So treat the user's Slack `user_identities.subject` as a thread owner directly, in addition to (not instead of) any matched broker credentials:

- `Console::ThreadsController#slack_thread_owners_for_current_user` appends identity-subject owners (no team scoping, matching slackbotv2's teamless metadata) and dedupes against credential owners.
- The sidebar mirror in `ApplicationController#console_sidebar_slack_thread_owners_for_current_user` gets the identical change.

Broker-credential-based ownership is unchanged, including team scoping when a credential exposes `slack_team_id`.

## Testing

- New tests: SSO-only visibility (threads scope + sidebar scope) and owner dedupe when the identity matches its own credential.
- Full `test/controllers` suite passes in the console test container: 503 runs, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)