### PR TITLE
Restrict console Control and Data Sync sections to admins

### DIFF
--- a/services/console/app/controllers/application_controller.rb
+++ b/services/console/app/controllers/application_controller.rb
@@ -83,9 +83,17 @@ class ApplicationController < ActionController::Base
     end
   end
 
-  # Guard for admin-only controllers (e.g. user management). Not a global gate.
+  # Guard for admin-only controllers (the Control and Data Sync sections, user
+  # management). Not a global gate. Bounces to the threads view rather than root:
+  # root is the admin-only principals page, so redirecting there would loop.
   def require_admin
-    redirect_to root_path, alert: "That page is restricted to admins." unless current_user&.admin?
+    redirect_to console_threads_path, alert: "That page is restricted to admins." unless current_user&.admin?
+  end
+
+  # Where a signed-in user lands when no explicit destination applies: admins get
+  # the Control section, everyone else the threads view (their only section).
+  def default_console_landing_path
+    current_user&.admin? ? console_principals_path : console_threads_path
   end
 
   # Cheap default so every page renders the empty sidebar list without touching
@@ -138,11 +146,11 @@ class ApplicationController < ActionController::Base
 
   def post_login_redirect_path
     path = session.delete(:return_to).to_s
-    return console_principals_path unless path.start_with?("/") && !path.start_with?("//")
+    return default_console_landing_path unless path.start_with?("/") && !path.start_with?("//")
     path
   end
 
-  def safe_console_return_path(default: console_principals_path)
+  def safe_console_return_path(default: default_console_landing_path)
     raw = params[:return_to].presence || params[:next].presence
     return default if raw.blank?
 

--- a/services/console/app/controllers/console/base_secrets_controller.rb
+++ b/services/console/app/controllers/console/base_secrets_controller.rb
@@ -10,6 +10,7 @@ module Console
 
     layout "console"
 
+    before_action :require_admin
     before_action :assign_kind
     before_action :set_secret, only: %i[edit update destroy]
 

--- a/services/console/app/controllers/console/broker_credentials_controller.rb
+++ b/services/console/app/controllers/console/broker_credentials_controller.rb
@@ -10,6 +10,7 @@ module Console
 
     layout "console"
 
+    before_action :require_admin
     before_action :set_credential, only: %i[edit update destroy]
 
     def new

--- a/services/console/app/controllers/console/etls_controller.rb
+++ b/services/console/app/controllers/console/etls_controller.rb
@@ -1,6 +1,8 @@
 class Console::EtlsController < ApplicationController
   layout "console"
 
+  before_action :require_admin
+
   class_attribute :client_factory, default: -> { CentaurApiClient.new }
 
   def index

--- a/services/console/app/controllers/console/oauth_apps_controller.rb
+++ b/services/console/app/controllers/console/oauth_apps_controller.rb
@@ -9,6 +9,7 @@ module Console
 
     layout "console"
 
+    before_action :require_admin
     before_action :set_app, only: %i[edit update]
 
     def new

--- a/services/console/app/controllers/console/principals_controller.rb
+++ b/services/console/app/controllers/console/principals_controller.rb
@@ -8,6 +8,7 @@ module Console
 
     layout "console"
 
+    before_action :require_admin
     before_action :set_principal
 
     def update_sandbox_access

--- a/services/console/app/controllers/console/roles_controller.rb
+++ b/services/console/app/controllers/console/roles_controller.rb
@@ -7,6 +7,7 @@ module Console
 
     layout "console"
 
+    before_action :require_admin
     before_action :set_role, only: %i[show edit update grant_secret revoke_grant]
 
     def index

--- a/services/console/app/controllers/console/secrets_controller.rb
+++ b/services/console/app/controllers/console/secrets_controller.rb
@@ -7,6 +7,7 @@ module Console
 
     layout "console"
 
+    before_action :require_admin
     before_action :set_secret
 
     def grant_role

--- a/services/console/app/controllers/console_controller.rb
+++ b/services/console/app/controllers/console_controller.rb
@@ -1,10 +1,13 @@
 # Operator console: a lightweight, server-rendered HTML view over principals,
 # their effective grants, and secrets. Read-only; gated behind a console session
-# via ApplicationController#require_login. Distinct from the JSON API.
+# (ApplicationController#require_login) and restricted to admins (require_admin),
+# like every Control/Data Sync page. Distinct from the JSON API.
 class ConsoleController < ApplicationController
   include SecretKinds
 
   layout "console"
+
+  before_action :require_admin
 
   # Friendly labels for the source backend (and the gcp_auth credentials_provider
   # type). The secrets table shows only this -- the full reference lives on the

--- a/services/console/app/controllers/sessions_controller.rb
+++ b/services/console/app/controllers/sessions_controller.rb
@@ -20,7 +20,7 @@ class SessionsController < ApplicationController
   # Holding page for a signed-in but not-yet-approved user. Active users have no
   # reason to be here, so send them to the console.
   def pending
-    redirect_to console_principals_path if current_user&.active?
+    redirect_to default_console_landing_path if current_user&.active?
   end
 
   def create

--- a/services/console/app/views/layouts/console.html.erb
+++ b/services/console/app/views/layouts/console.html.erb
@@ -964,12 +964,16 @@
   </head>
 
   <% threads_view = request.path.start_with?("/console/threads") %>
-  <% control_matches = [ "/console/principals", "/console/roles", "/console/secrets", "/console/credentials", "/console/oauth_apps" ] %>
-  <% control_matches << "/console/users" if current_user&.admin? %>
-  <% nav_items = [
-    { label: "Control", icon: "shield-check", path: console_principals_path, matches: control_matches, root_active: true },
-    { label: "Data Sync", icon: "database", path: console_etls_path, matches: [ "/console/etls" ] }
-  ] %>
+  <%# The Control and Data Sync sections are admin-only (each controller enforces
+      require_admin server-side); non-admins only get the Chats view below. %>
+  <% nav_items = [] %>
+  <% if current_user&.admin? %>
+    <% control_matches = [ "/console/principals", "/console/roles", "/console/secrets", "/console/credentials", "/console/oauth_apps", "/console/users" ] %>
+    <% nav_items = [
+      { label: "Control", icon: "shield-check", path: console_principals_path, matches: control_matches, root_active: true },
+      { label: "Data Sync", icon: "database", path: console_etls_path, matches: [ "/console/etls" ] }
+    ] %>
+  <% end %>
 
   <body class="h-full overflow-hidden bg-ink-900 text-zinc-300 font-mono antialiased">
     <div id="console-shell" class="console-shell">

--- a/services/console/test/controllers/console/etls_controller_test.rb
+++ b/services/console/test/controllers/console/etls_controller_test.rb
@@ -60,6 +60,21 @@ class Console::EtlsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to login_path
   end
 
+  test "an active non-admin is redirected away from the Data Sync page" do
+    delete logout_url
+    post login_url, params: { email: users(:member_user).email, password: "password123456" }
+
+    get console_etls_url
+    assert_redirected_to console_threads_path
+    assert_equal "That page is restricted to admins.", flash[:alert]
+    # The gate fires before the action, so the api client is never touched.
+    assert_empty @client.calls
+
+    post console_slack_archive_imports_url, params: { filename: "export.zip" }
+    assert_redirected_to console_threads_path
+    assert_empty @client.calls
+  end
+
   test "renders Slack archive imports on the Data Sync page" do
     @client.imports = [
       {

--- a/services/console/test/controllers/console/threads_controller_test.rb
+++ b/services/console/test/controllers/console/threads_controller_test.rb
@@ -14,6 +14,28 @@ class Console::ThreadsControllerTest < ActionDispatch::IntegrationTest
     post login_url, params: { email: @operator.email, password: "password123456" }
   end
 
+  test "an admin sees the Control and Data Sync nav items" do
+    with_recent_first_error do
+      get console_threads_url
+    end
+
+    assert_response :ok
+    assert_select ".console-nav-link", text: "Control"
+    assert_select ".console-nav-link", text: "Data Sync"
+  end
+
+  test "a non-admin sees no Control or Data Sync nav items" do
+    delete logout_url
+    post login_url, params: { email: users(:member_user).email, password: "password123456" }
+    with_recent_first_error do
+      get console_threads_url
+    end
+
+    assert_response :ok
+    assert_select ".console-nav-link", count: 0
+    assert_select ".console-thread-group-title", text: /Chats/
+  end
+
   test "threads page does not render composer when session database is unavailable" do
     with_recent_first_error do
       get console_threads_url

--- a/services/console/test/controllers/console/users_controller_test.rb
+++ b/services/console/test/controllers/console/users_controller_test.rb
@@ -16,7 +16,7 @@ module Console
     test "an active non-admin is forbidden" do
       sign_in users(:member_user)
       get console_users_url
-      assert_redirected_to root_path
+      assert_redirected_to console_threads_path
       assert_equal "That page is restricted to admins.", flash[:alert]
     end
 
@@ -110,7 +110,7 @@ module Console
       sign_in users(:member_user)
       target = users(:pending_user)
       post approve_console_user_url(target.oid)
-      assert_redirected_to root_path
+      assert_redirected_to console_threads_path
       assert target.reload.pending?
     end
   end

--- a/services/console/test/controllers/console_controller_test.rb
+++ b/services/console/test/controllers/console_controller_test.rb
@@ -12,6 +12,28 @@ class ConsoleControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to login_path
   end
 
+  test "an active non-admin is redirected away from every Control page" do
+    delete logout_url
+    post login_url, params: { email: users(:member_user).email, password: "password123456" }
+
+    [ root_url, console_principals_url, console_roles_url, console_secrets_url,
+      console_credentials_url, console_oauth_apps_url ].each do |url|
+      get url
+      assert_redirected_to console_threads_path
+      assert_equal "That page is restricted to admins.", flash[:alert]
+    end
+  end
+
+  test "a non-admin cannot mutate through the Control form controllers" do
+    delete logout_url
+    post login_url, params: { email: users(:member_user).email, password: "password123456" }
+
+    assert_no_difference -> { Role.count } do
+      post console_roles_url, params: { role: { foreign_id: "sneaky", namespace: "default" } }
+    end
+    assert_redirected_to console_threads_path
+  end
+
   test "secrets table shows backend labels (not refs) and links to detail" do
     secret = static_secrets(:acme_prod_api_key)
     get console_secrets_url

--- a/services/console/test/controllers/sessions_controller_test.rb
+++ b/services/console/test/controllers/sessions_controller_test.rb
@@ -15,6 +15,13 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
     assert_equal @operator.id, session[:user_id]
   end
 
+  test "a non-admin lands on the threads view after login" do
+    member = users(:member_user)
+    post login_url, params: { email: member.email, password: "password123456" }
+    assert_redirected_to console_threads_path
+    assert_equal member.id, session[:user_id]
+  end
+
   test "email match is case-insensitive" do
     post login_url, params: { email: @operator.email.upcase, password: "password123456" }
     assert_equal @operator.id, session[:user_id]


### PR DESCRIPTION
## Summary

The Control (principals, roles, secrets, credentials, oauth apps) and Data Sync (ETLs) sections of the console were reachable by any active console user. This PR makes both admin-only, in the UI and on the server:

- The "Control" and "Data Sync" sidebar nav items only render for `current_user.admin?`; non-admins keep only the Chats view.
- Every controller behind those sections now runs `before_action :require_admin`, so navigating directly to a route (e.g. `/console/secrets`, `/console/etls`) redirects non-admins with the existing "restricted to admins" alert. Covered controllers: `ConsoleController`, `Console::PrincipalsController`, `Console::RolesController`, `Console::SecretsController`, `Console::BaseSecretsController` (all four secret-form controllers), `Console::BrokerCredentialsController`, `Console::OauthAppsController`, `Console::EtlsController`. `Console::UsersController` was already gated; `Console::ThreadsController` stays open to all active users.

## Redirect handling

Root is the admin-only principals page, so `require_admin` now bounces to the threads view instead of `root_path` (which would loop). A new `default_console_landing_path` sends admins to Control and everyone else to Chats after login, on the pending-page bounce, and as the sanitized return-path fallback.

## Testing

Ran the console suite in the `codex-centaur-console-web` container against this branch: 1000 runs, 3 failures — all pre-existing in `CentaurSessionRecordTest` (reproduced identically on pristine `origin/main` in the same environment, unrelated to this change). New coverage: non-admins are redirected from every Control page, from Data Sync reads and mutations (API client never touched), post-login landing, and nav visibility for both roles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)