### PR TITLE
fix: expose full Gmail message content

### DIFF
--- a/tools/productivity/gsuite/client.py
+++ b/tools/productivity/gsuite/client.py
@@ -145,25 +145,28 @@ def gmail_read(message_id: str) -> dict:
         message_id: The message ID
 
     Returns:
-        Dict with id, subject, from, to, date, body (plain text)
+        Dict with id, subject, from, to, date, body, html, and raw RFC822 content
     """
     service = get_gmail_service()
 
     msg = service.users().messages().get(userId="me", id=message_id, format="full").execute()
+    raw_msg = service.users().messages().get(userId="me", id=message_id, format="raw").execute()
 
     headers = {h["name"]: h["value"] for h in msg.get("payload", {}).get("headers", [])}
 
-    def get_body(payload):
-        if payload.get("body", {}).get("data"):
-            return base64.urlsafe_b64decode(payload["body"]["data"]).decode("utf-8")
-        if payload.get("parts"):
-            for part in payload["parts"]:
-                if part.get("mimeType") == "text/plain":
-                    if part.get("body", {}).get("data"):
-                        return base64.urlsafe_b64decode(part["body"]["data"]).decode("utf-8")
-                body = get_body(part)
-                if body:
-                    return body
+    def decode_body(data):
+        padded = data + "=" * (-len(data) % 4)
+        return base64.urlsafe_b64decode(padded.encode()).decode("utf-8", errors="replace")
+
+    def get_body(payload, mime_type):
+        if not isinstance(payload, dict):
+            return ""
+        if payload.get("mimeType") == mime_type and payload.get("body", {}).get("data"):
+            return decode_body(payload["body"]["data"])
+        for part in payload.get("parts") or []:
+            body = get_body(part, mime_type)
+            if body:
+                return body
         return ""
 
     return {
@@ -174,7 +177,9 @@ def gmail_read(message_id: str) -> dict:
         "to": headers.get("To", ""),
         "cc": headers.get("Cc", ""),
         "date": headers.get("Date", ""),
-        "body": get_body(msg.get("payload", {})),
+        "body": get_body(msg.get("payload", {}), "text/plain"),
+        "html": get_body(msg.get("payload", {}), "text/html"),
+        "raw": raw_msg.get("raw", ""),
         "label_ids": msg.get("labelIds", []),
     }
 

--- a/tools/productivity/gsuite/test_client.py
+++ b/tools/productivity/gsuite/test_client.py
@@ -46,6 +46,38 @@ class _FakeDriveService:
         return self.files_api
 
 
+class _FakeGmailMessagesApi:
+    def __init__(self, full_result: dict, raw_result: dict):
+        self.full_result = full_result
+        self.raw_result = raw_result
+        self.get_calls: list[dict] = []
+
+    def get(self, **kwargs):
+        self.get_calls.append(kwargs)
+        if kwargs.get("format") == "full":
+            return _CreateRequest(self.full_result)
+        if kwargs.get("format") == "raw":
+            return _CreateRequest(self.raw_result)
+        raise AssertionError(f"Unexpected Gmail format: {kwargs.get('format')}")
+
+
+class _FakeGmailUsersApi:
+    def __init__(self, messages_api: _FakeGmailMessagesApi):
+        self.messages_api = messages_api
+
+    def messages(self):
+        return self.messages_api
+
+
+class _FakeGmailService:
+    def __init__(self, full_result: dict, raw_result: dict):
+        self.messages_api = _FakeGmailMessagesApi(full_result, raw_result)
+        self.users_api = _FakeGmailUsersApi(self.messages_api)
+
+    def users(self):
+        return self.users_api
+
+
 class _FakeSheetsValuesApi:
     def __init__(self):
         self.update_calls: list[dict] = []
@@ -151,6 +183,56 @@ def _tab(tab_id: str, content: list[dict], *, child_tabs: list[dict] | None = No
         "documentTab": {"body": {"content": content}},
         "childTabs": child_tabs or [],
     }
+
+
+def test_gmail_read_returns_plain_html_and_raw_content(monkeypatch):
+    plain = base64.urlsafe_b64encode(b"Plain body").decode().rstrip("=")
+    html = base64.urlsafe_b64encode(b"<html><body><p>HTML body</p></body></html>").decode().rstrip("=")
+    raw = (
+        b"From: sender@example.com\n"
+        b"To: recipient@example.com\n"
+        b"Subject: Newsletter\n"
+        b"MIME-Version: 1.0\n"
+        b"Content-Type: text/html\n\n"
+        b"<html><body><p>HTML body</p></body></html>"
+    )
+    raw_encoded = base64.urlsafe_b64encode(raw).decode().rstrip("=")
+    full_result = {
+        "id": "msg-1",
+        "threadId": "thread-1",
+        "labelIds": ["INBOX"],
+        "payload": {
+            "headers": [
+                {"name": "Subject", "value": "Newsletter"},
+                {"name": "From", "value": "sender@example.com"},
+                {"name": "To", "value": "recipient@example.com"},
+                {"name": "Date", "value": "Thu, 02 Jul 2026 18:15:51 +0000"},
+            ],
+            "parts": [
+                {
+                    "mimeType": "multipart/alternative",
+                    "parts": [
+                        {"mimeType": "text/plain", "body": {"data": plain}},
+                        {"mimeType": "text/html", "body": {"data": html}},
+                    ],
+                }
+            ],
+        },
+    }
+    fake_service = _FakeGmailService(full_result, {"raw": raw_encoded})
+    monkeypatch.setattr(client, "get_gmail_service", lambda: fake_service)
+
+    result = client.gmail_read("msg-1")
+
+    assert result["id"] == "msg-1"
+    assert result["subject"] == "Newsletter"
+    assert result["body"] == "Plain body"
+    assert result["html"] == "<html><body><p>HTML body</p></body></html>"
+    assert result["raw"] == raw_encoded
+    assert fake_service.messages_api.get_calls == [
+        {"userId": "me", "id": "msg-1", "format": "full"},
+        {"userId": "me", "id": "msg-1", "format": "raw"},
+    ]
 
 
 def test_drive_upload_sets_supports_all_drives(tmp_path, monkeypatch):


### PR DESCRIPTION
This updates gsuite.gmail_get to fetch raw RFC822 alongside the full Gmail payload and return the HTML body in addition to the existing plain-text body. Newsletter ingestion can now archive exact email content instead of relying on Gmail search snippets.