### PR TITLE
fix(console): thread rendering — markdown tables, generated titles, thinking traces

### DIFF
--- a/harness/claude/settings.json
+++ b/harness/claude/settings.json
@@ -1,8 +1,6 @@
 {
   "model": "claude-opus-4-8",
-  "env": {
-    "MAX_THINKING_TOKENS": "8192"
-  },
+  "alwaysThinkingEnabled": true,
   "permissions": {
     "defaultMode": "bypassPermissions",
     "additionalDirectories": [

--- a/harness/claude/settings.json
+++ b/harness/claude/settings.json
@@ -1,5 +1,8 @@
 {
   "model": "claude-opus-4-8",
+  "env": {
+    "MAX_THINKING_TOKENS": "8192"
+  },
   "permissions": {
     "defaultMode": "bypassPermissions",
     "additionalDirectories": [

--- a/services/console/app/controllers/console/threads_controller.rb
+++ b/services/console/app/controllers/console/threads_controller.rb
@@ -451,17 +451,19 @@ class Console::ThreadsController < ApplicationController
   end
 
   # The api-rs stdout pump persists every harness output line verbatim as a
-  # session.output.line event whose payload is a JSON-encoded string. Reasoning
-  # blocks arrive as item/completed notifications with item.type == "reasoning"
-  # carrying the full accumulated thinking text. The SQL LIKE filter keeps the
-  # query from paging through the whole firehose; exact matching happens here.
+  # session.output.line event whose payload is a JSON-encoded string. Codex
+  # reasoning arrives as item/completed notifications with item.type ==
+  # "reasoning" carrying the full accumulated thinking text; Claude Code
+  # stream-json persists each assistant API message whose content can include
+  # "thinking" blocks. The SQL LIKE filter keeps the query from paging through
+  # the whole firehose; exact matching happens here.
   def selected_thinking_items
     return [] unless @selected_session
 
     CentaurSessionEvent
       .where(thread_key: @selected_session.thread_key)
       .where(event_type: "session.output.line")
-      .where("payload::text LIKE '%reasoning%'")
+      .where("payload::text LIKE '%reasoning%' OR payload::text LIKE '%thinking%'")
       .order(event_id: :desc)
       .limit(THINKING_EVENT_LIMIT)
       .to_a
@@ -476,13 +478,7 @@ class Console::ThreadsController < ApplicationController
     value = JSON.parse(line)
     return nil unless value.is_a?(Hash)
 
-    method = (value["method"] || value["type"]).to_s.tr("/", ".")
-    return nil unless method == "item.completed"
-
-    item = value.dig("params", "item") || value["item"]
-    return nil unless item.is_a?(Hash) && item["type"].to_s == "reasoning"
-
-    text = reasoning_item_text(item)
+    text = reasoning_event_text(value) || claude_thinking_text(value)
     return nil if text.blank?
 
     {
@@ -495,6 +491,35 @@ class Console::ThreadsController < ApplicationController
     }
   rescue JSON::ParserError
     nil
+  end
+
+  def reasoning_event_text(value)
+    method = (value["method"] || value["type"]).to_s.tr("/", ".")
+    return nil unless method == "item.completed"
+
+    item = value.dig("params", "item") || value["item"]
+    return nil unless item.is_a?(Hash) && item["type"].to_s == "reasoning"
+
+    reasoning_item_text(item)
+  end
+
+  # Claude Code's stream-json output persists each assistant API message as
+  # {"type":"assistant","message":{"content":[...]}} where extended thinking
+  # arrives in content blocks of type "thinking" (text under the "thinking"
+  # key). Partial stream_event lines never carry type == "assistant", so each
+  # thinking block surfaces exactly once.
+  def claude_thinking_text(value)
+    return nil unless value["type"].to_s == "assistant"
+
+    message = value["message"]
+    content = message.is_a?(Hash) ? message["content"] : value["content"]
+    return nil unless content.is_a?(Array)
+
+    content.filter_map do |part|
+      next unless part.is_a?(Hash) && part["type"].to_s == "thinking"
+
+      part["thinking"].presence || part["text"].presence
+    end.join("\n").strip.presence
   end
 
   # Claude/Amp reasoning lands in content (full text); Codex-native reasoning
@@ -557,6 +582,9 @@ class Console::ThreadsController < ApplicationController
   end
 
   def thread_title(session)
+    stored = stored_session_title(session)
+    return clip_one_line(stored, 80) if stored
+
     metadata = session.metadata_hash
     summary = metadata["summary"]
     title = metadata["title"].presence ||
@@ -575,6 +603,13 @@ class Console::ThreadsController < ApplicationController
     return generated if generated.present?
 
     human_thread_key(session.thread_key)
+  end
+
+  # The title api-rs generates and writes onto sessions.title after a message
+  # append. Guarded because sessions mirrored from a snapshot taken before the
+  # title migration have no such column.
+  def stored_session_title(session)
+    session.title.presence if session.respond_to?(:title)
   end
 
   def thread_source_icon(session)

--- a/services/console/app/helpers/application_helper.rb
+++ b/services/console/app/helpers/application_helper.rb
@@ -2,7 +2,8 @@ require "cgi"
 
 module ApplicationHelper
   MARKDOWN_ALLOWED_TAGS = %w[
-    a blockquote br code del em h1 h2 h3 h4 li ol p pre strong ul
+    a blockquote br code del div em h1 h2 h3 h4 li ol p pre strong
+    table tbody td th thead tr ul
   ].freeze
   MARKDOWN_ALLOWED_ATTRIBUTES = %w[class href rel target].freeze
 
@@ -153,6 +154,12 @@ module ApplicationHelper
   end
 
   def console_sidebar_thread_title(session, latest_message = nil)
+    # sessions.title is the title api-rs generates on message append; prefer it
+    # over metadata heuristics. Guarded because snapshots mirrored before the
+    # title migration have no such column.
+    stored = session.title.presence if session.respond_to?(:title)
+    return console_sidebar_clip_one_line(stored, 48) if stored
+
     metadata = session.metadata_hash
     summary = metadata["summary"]
     title = metadata["title"].presence ||
@@ -304,13 +311,25 @@ module ApplicationHelper
           index += 1
         end
         blocks << %(<blockquote class="mb-3 border-l border-ink-500 pl-3 text-zinc-400 last:mb-0">#{markdown_inline(quoted.join(" "))}</blockquote>)
+      elsif markdown_table_row?(line) && markdown_table_separator?(lines[index + 1])
+        header = markdown_table_cells(line)
+        alignments = markdown_table_alignments(lines[index + 1])
+        index += 2
+        rows = []
+        while index < lines.length && markdown_table_row?(lines[index])
+          rows << markdown_table_cells(lines[index])
+          index += 1
+        end
+        blocks << markdown_table(header, alignments, rows)
       else
         paragraph = []
         while index < lines.length && lines[index].present? && !markdown_block_start?(lines[index])
           paragraph << lines[index]
           index += 1
         end
-        blocks << %(<p class="mb-3 last:mb-0">#{markdown_inline(paragraph.join(" "))}</p>)
+        # Empty when the line is a table row without a separator: the progress
+        # guard below emits it as its own paragraph.
+        blocks << %(<p class="mb-3 last:mb-0">#{markdown_inline(paragraph.join(" "))}</p>) unless paragraph.empty?
       end
 
       # Guarantee forward progress: a block-start marker with no content (e.g.
@@ -331,7 +350,54 @@ module ApplicationHelper
       line.match?(/\A\#{1,4}\s+/) ||
       line.match?(/\A\s*[-*+]\s+/) ||
       line.match?(/\A\s*\d+\.\s+/) ||
-      line.match?(/\A\s*>\s?/)
+      line.match?(/\A\s*>\s?/) ||
+      markdown_table_row?(line)
+  end
+
+  def markdown_table_row?(line)
+    stripped = line.to_s.strip
+    stripped.start_with?("|") && stripped.length > 1
+  end
+
+  def markdown_table_separator?(line)
+    return false unless line && markdown_table_row?(line)
+
+    cells = markdown_table_cells(line)
+    cells.any? && cells.all? { |cell| cell.match?(/\A:?-+:?\z/) }
+  end
+
+  def markdown_table_cells(line)
+    inner = line.strip.delete_prefix("|").delete_suffix("|")
+    inner.split(/(?<!\\)\|/, -1).map { |cell| cell.strip.gsub("\\|", "|") }
+  end
+
+  def markdown_table_alignments(separator_line)
+    markdown_table_cells(separator_line).map do |cell|
+      left = cell.start_with?(":")
+      right = cell.end_with?(":")
+      if left && right
+        "text-center"
+      elsif right
+        "text-right"
+      else
+        "text-left"
+      end
+    end
+  end
+
+  # Extra body cells beyond the header width are dropped and short rows are
+  # padded with empty cells, matching GFM table semantics.
+  def markdown_table(header, alignments, rows)
+    head_cells = header.each_with_index.map do |cell, column|
+      %(<th class="border-b border-ink-700 px-3 py-1.5 font-semibold text-zinc-100 #{alignments[column] || "text-left"}">#{markdown_inline(cell)}</th>)
+    end
+    body_rows = rows.map do |row|
+      cells = Array.new(header.length) do |column|
+        %(<td class="border-b border-ink-800/70 px-3 py-1.5 align-top #{alignments[column] || "text-left"}">#{markdown_inline(row[column].to_s)}</td>)
+      end
+      "<tr>#{cells.join}</tr>"
+    end
+    %(<div class="mb-3 overflow-x-auto last:mb-0"><table class="w-full border-collapse text-sm"><thead><tr>#{head_cells.join}</tr></thead><tbody>#{body_rows.join}</tbody></table></div>)
   end
 
   def markdown_inline(raw_text)

--- a/services/console/test/controllers/console/threads_controller_test.rb
+++ b/services/console/test/controllers/console/threads_controller_test.rb
@@ -3,7 +3,7 @@ require "tmpdir"
 
 class Console::ThreadsControllerTest < ActionDispatch::IntegrationTest
   TranscriptMessage = Struct.new(:role, :parts_array, :metadata_hash, :created_at, keyword_init: true)
-  TranscriptSession = Struct.new(:metadata_hash, :harness_type, keyword_init: true)
+  TranscriptSession = Struct.new(:metadata_hash, :harness_type, :title, keyword_init: true)
   ModelSession = Struct.new(:thread_key, :metadata_hash, :harness_type, keyword_init: true)
   ModelExecution = Struct.new(:metadata, keyword_init: true)
   TranscriptEvent = Struct.new(:event_type, :payload_hash, :created_at, keyword_init: true)
@@ -357,6 +357,28 @@ class Console::ThreadsControllerTest < ActionDispatch::IntegrationTest
     assert title.start_with?("Approach truth-seeking")
     assert_operator title.length, :<=, 80
     assert title.end_with?("...")
+  end
+
+  test "thread title prefers the stored generated title over metadata" do
+    controller = Console::ThreadsController.new
+    session = TranscriptSession.new(
+      metadata_hash: { "summary" => { "title" => "metadata title" } },
+      harness_type: "codex",
+      title: "Fix worker memory leak"
+    )
+
+    assert_equal "Fix worker memory leak", controller.send(:thread_title, session)
+  end
+
+  test "thread title ignores a blank stored title" do
+    controller = Console::ThreadsController.new
+    session = TranscriptSession.new(
+      metadata_hash: { "subject" => "Fallback subject" },
+      harness_type: "codex",
+      title: "  "
+    )
+
+    assert_equal "Fallback subject", controller.send(:thread_title, session)
   end
 
   test "thread title prefers stored summary metadata when present" do
@@ -753,6 +775,56 @@ class Console::ThreadsControllerTest < ActionDispatch::IntegrationTest
     assert_nil controller.send(:thinking_transcript_item, OutputLineEvent.new(payload: tool, created_at: now))
     assert_nil controller.send(:thinking_transcript_item, OutputLineEvent.new(payload: non_json, created_at: now))
     assert_nil controller.send(:thinking_transcript_item, OutputLineEvent.new(payload: non_string, created_at: now))
+  end
+
+  test "thinking transcript item is extracted from a claude stream-json assistant line" do
+    controller = Console::ThreadsController.new
+    line = {
+      type: "assistant",
+      message: {
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "The schema mismatch explains the failure.", signature: "sig" },
+          { type: "text", text: "Here is the fix." }
+        ]
+      }
+    }.to_json
+    event = OutputLineEvent.new(payload: line, created_at: Time.zone.parse("2026-06-26 17:15:58 UTC"))
+
+    item = controller.send(:thinking_transcript_item, event)
+
+    assert_equal "thinking", item[:role]
+    assert_equal :thinking, item[:source]
+    assert_equal "The schema mismatch explains the failure.", item[:text]
+    assert_equal event.created_at, item[:created_at]
+  end
+
+  test "thinking extraction joins multiple claude thinking blocks and skips thinking-free assistant lines" do
+    controller = Console::ThreadsController.new
+    now = Time.zone.now
+
+    multi = {
+      type: "assistant",
+      message: {
+        content: [
+          { type: "thinking", thinking: "First thought." },
+          { type: "thinking", thinking: "Second thought." }
+        ]
+      }
+    }.to_json
+    text_only = {
+      type: "assistant",
+      message: { content: [ { type: "text", text: "No thinking here." } ] }
+    }.to_json
+    stream_event = {
+      type: "stream_event",
+      event: { delta: { type: "thinking_delta", thinking: "partial" } }
+    }.to_json
+
+    item = controller.send(:thinking_transcript_item, OutputLineEvent.new(payload: multi, created_at: now))
+    assert_equal "First thought.\nSecond thought.", item[:text]
+    assert_nil controller.send(:thinking_transcript_item, OutputLineEvent.new(payload: text_only, created_at: now))
+    assert_nil controller.send(:thinking_transcript_item, OutputLineEvent.new(payload: stream_event, created_at: now))
   end
 
   test "requested thread keys are deduped, stripped, and capped at the panel limit" do

--- a/services/console/test/helpers/application_helper_test.rb
+++ b/services/console/test/helpers/application_helper_test.rb
@@ -65,6 +65,76 @@ class ApplicationHelperTest < ActionView::TestCase
                      text: "https://github.com/paradigmxyz/centaur/issues/792"
   end
 
+  test "console_markdown renders gfm tables with alignment" do
+    html = console_markdown(<<~MARKDOWN)
+      Before the table.
+
+      | Name | Count | Status |
+      | :--- | ---: | :---: |
+      | `api-rs` | 12 | **ok** |
+      | console | 3 | pending |
+
+      After the table.
+    MARKDOWN
+
+    assert_select_in html, "table thead tr th", count: 3
+    assert_select_in html, "table tbody tr", count: 2
+    assert_select_in html, "th.text-right", text: "Count"
+    assert_select_in html, "th.text-center", text: "Status"
+    assert_select_in html, "td.text-right", text: "12"
+    assert_select_in html, "tbody code", text: "api-rs"
+    assert_select_in html, "tbody strong", text: "ok"
+    assert_select_in html, "p", text: "Before the table."
+    assert_select_in html, "p", text: "After the table."
+  end
+
+  test "console_markdown pads and truncates ragged table rows to the header width" do
+    html = console_markdown(<<~MARKDOWN)
+      | a | b |
+      | --- | --- |
+      | only |
+      | one | two | three |
+    MARKDOWN
+
+    assert_select_in html, "tbody tr", count: 2
+    assert_select_in html, "tbody tr:first-child td", count: 2
+    assert_select_in html, "tbody tr:last-child td", count: 2
+    refute_includes html, "three"
+  end
+
+  test "console_markdown escapes html inside table cells" do
+    html = console_markdown("| h |\n| --- |\n| <script>alert(1)</script> |")
+
+    refute_includes html, "<script>"
+    assert_select_in html, "tbody td", text: /alert\(1\)/
+  end
+
+  test "console_markdown leaves pipe-prefixed lines without a separator as text" do
+    html = console_markdown("| not a table |\nplain line")
+
+    assert_select_in html, "table", count: 0
+    assert_select_in html, "p", count: 2
+    assert_includes html, "not a table"
+  end
+
+  test "console_sidebar_thread_title prefers the stored generated title" do
+    session = Struct.new(:title, :metadata_hash, keyword_init: true).new(
+      title: "Fix worker memory leak",
+      metadata_hash: { "title" => "metadata title" }
+    )
+
+    assert_equal "Fix worker memory leak", console_sidebar_thread_title(session)
+  end
+
+  test "console_sidebar_thread_title falls back to metadata when no stored title" do
+    session = Struct.new(:title, :metadata_hash, keyword_init: true).new(
+      title: nil,
+      metadata_hash: { "title" => "metadata title" }
+    )
+
+    assert_equal "metadata title", console_sidebar_thread_title(session)
+  end
+
   test "console_markdown escapes unsafe html" do
     html = console_markdown("<script>alert(1)</script> **safe**")
 


### PR DESCRIPTION
Fixes three issues with how console threads render (reported against a stg thread view):

## 1. Markdown tables were dumped as raw pipe text

`console_markdown` is a hand-rolled renderer with no table support, so GFM tables in assistant replies rendered as literal `| a | b |` lines. It now parses GFM tables (header + separator + body rows) with:

- column alignment from the separator row (`:---`, `---:`, `:---:`),
- ragged rows padded/truncated to the header width,
- inline markdown and HTML-escaping inside cells,
- horizontal scroll for wide tables.

Pipe-prefixed lines without a separator row still render as plain text.

## 2. Generated titles were never displayed

api-rs generates a session title on message append and writes it to the `sessions.title` column (`set_session_title_if_empty`), but the console only ever read metadata keys (`metadata.title`, `metadata.summary`, ...) — so the generated titles were sitting in the DB unused. The page header and sidebar now prefer `sessions.title`, falling back to the existing metadata/preview heuristics.

Notes on "are we actually generating them": generation only runs when api-rs has `OPENAI_API_KEY` set, and only fills the title on the *next* message append while `title` is still null — old idle threads stay untitled until they get a new message.

## 3. Thinking traces never appeared

Two stacked causes:

- **Console parsing (fixed here):** the transcript only recognized Codex-protocol `item/completed` notifications with `item.type == "reasoning"`. Claude Code stream-json persists thinking as `{"type":"assistant","message":{"content":[{"type":"thinking",...}]}}` lines, which were silently dropped. Both shapes are now parsed (and the SQL prefilter matches both).
- **Source (fixed here):** nothing ever enabled extended thinking for Claude Code. Codex pins `model_reasoning_effort = "low"` in `harness/codex/config.toml`, but `harness/claude/settings.json` had no thinking enablement, so headless claudecode sessions emitted no thinking blocks at all — the harness-server bridge translates them correctly, there was just nothing to translate. This sets `"alwaysThinkingEnabled": true` in the Claude harness settings (the first-class Claude Code setting, default budget); deployments can override or disable via `CLAUDE_SETTINGS_OVERLAY`.

## Testing

- `test/helpers/application_helper_test.rb` and `test/controllers/console/threads_controller_test.rb` run green in the `codex-centaur-console-web` container (72 runs, 0 failures) with new coverage for tables, stored-title preference, and Claude stream-json thinking extraction.
- rubocop: no offenses on the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
