### PR TITLE
feat: search OAuth Google Docs in company context

### DIFF
--- a/.agents/skills/company-context/SKILL.md
+++ b/.agents/skills/company-context/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: company-context
-description: "Use Centaur's indexed company context together with direct Slack, Linear, Google Drive, or Calendar searches when answering internal company-history, prior-decision, project-context, meeting-context, roadmap/status, or cross-source memory questions. Use for questions like what was discussed, decided, planned, mentioned, or documented internally, especially when the user did not name one exact source."
+description: "Use Centaur's indexed company context together with direct Slack, Linear, Google Docs, Drive, or Calendar searches when answering internal company-history, prior-decision, project-context, meeting-context, roadmap/status, or cross-source memory questions. Indexed context includes Slack channels, user-visible Slack DMs, Google Docs, Google Calendar, and Linear. Use for questions like what was discussed, decided, planned, mentioned, or documented internally, especially when the user did not name one exact source."
 ---
 
 # Company Context
 
-Use `company_context` as the first retrieval step for internal historical context. Its `search` command queries indexed company memory across enabled sources such as Slack, Google Drive/Docs, Google Calendar, and Linear. Always pair indexed results with the relevant direct source tools, then reconcile and collate both evidence sets before answering.
+Use `company_context` as the first retrieval step for internal historical context. Its `search` command queries indexed company memory across enabled sources such as Slack channels, Google Docs (`--source docs`), Google Calendar, and Linear. It also has dedicated commands for user-visible Slack DMs and DM conversations. Always pair indexed results with the relevant direct source tools, then reconcile and collate both evidence sets before answering.
 
 ## Default Workflow
 
@@ -13,6 +13,13 @@ Use `company_context` as the first retrieval step for internal historical contex
 
 ```bash
 company_context search "QUERY" --limit 10 --json
+```
+
+For DM-specific questions, use the dedicated DM search surface:
+
+```bash
+company_context search-dms "QUERY" --limit 10 --json
+company_context search-dm-conversations "PERSON OR QUERY" --limit 10 --json
 ```
 
 2. Read promising documents before answering:
@@ -37,6 +44,7 @@ Use the source-specific tools that match the question. For broad cross-source qu
 ```bash
 company_context latest-date --json
 company_context latest-date --source slack --json
+company_context latest-date --source docs --source-type google_doc --json
 company_context latest-date --source linear --json
 ```
 
@@ -44,9 +52,10 @@ company_context latest-date --source linear --json
 
 ```bash
 company_context search "QUERY" --source slack --limit 10 --json
-company_context search "QUERY" --source google_drive --limit 10 --json
+company_context search "QUERY" --source docs --source-type google_doc --limit 10 --json
 company_context search "QUERY" --source google_calendar --limit 10 --json
 company_context search "QUERY" --source linear --limit 10 --json
+company_context search-dms "QUERY" --limit 10 --json
 ```
 
 6. Collate indexed and live results before answering:

--- a/docs/pages/reference/tool-directory.mdx
+++ b/docs/pages/reference/tool-directory.mdx
@@ -34,7 +34,7 @@ These are broadly useful across most deployments and are good candidates to conf
 | `slack` | Search Slack, read threads, inspect channels/users, and send or upload messages | `SLACK_BOT_TOKEN`; optional: `SLACK_SEARCH_TOKEN`, `SLACK_ETL_TOKEN` |
 | `gsuite` | Use Gmail, Calendar, Drive, Docs, Sheets, Slides, and Google Analytics | `GOOGLE_TOKEN_JSON` |
 | `websearch` | Free web search via Parallel and deep research | None; `PARALLEL_API_KEY` for `deep_research`; `ANTHROPIC_API_KEY` for search synthesis |
-| `company_context` | Search indexed company history across internal sources | None |
+| `company_context` | Search indexed company history, Slack DMs, and Google Docs | None |
 | `grafana` | Query dashboards, alerts, VictoriaMetrics, VictoriaLogs, and annotations | `GRAFANA_URL`, `GRAFANA_API_KEY` |
 | `posthog` | Query product analytics, events, pageviews, breakdowns, and user agents | `POSTHOG_API_KEY`, `POSTHOG_PROJECT_ID` |
 | `attio` | Work with CRM objects, records, lists, notes, tasks, calls, and meetings | `ATTIO_API_KEY` |
@@ -74,7 +74,7 @@ These are broadly useful across most deployments and are good candidates to conf
 | Tool | Use | API key / credential |
 |---|---|---|
 | `airtable` | Bases, schemas, tables, records, views, and URL parsing | `AIRTABLE_API_KEY` |
-| `company_context` | Search indexed company history across internal sources | None |
+| `company_context` | Search indexed company history, Slack DMs, and Google Docs | None |
 | `composio` | Execute tools from third-party services exposed through Composio | `COMPOSIO_API_KEY` |
 | `figma` | Extract Figma files, nodes, components, styles, and variables | `FIGMA_ACCESS_TOKEN` |
 | `granola` | Search and read Granola notes and transcripts | `GRANOLA_API_KEY` |

--- a/docs/public/md/reference/tool-directory.md
+++ b/docs/public/md/reference/tool-directory.md
@@ -34,7 +34,7 @@ These are broadly useful across most deployments and are good candidates to conf
 | `slack` | Search Slack, read threads, inspect channels/users, and send or upload messages | `SLACK_BOT_TOKEN`; optional: `SLACK_SEARCH_TOKEN`, `SLACK_ETL_TOKEN` |
 | `gsuite` | Use Gmail, Calendar, Drive, Docs, Sheets, Slides, and Google Analytics | `GOOGLE_TOKEN_JSON` |
 | `websearch` | Free web search via Parallel and deep research | None; `PARALLEL_API_KEY` for `deep_research`; `ANTHROPIC_API_KEY` for search synthesis |
-| `company_context` | Search indexed company history across internal sources | None |
+| `company_context` | Search indexed company history, Slack DMs, and Google Docs | None |
 | `grafana` | Query dashboards, alerts, VictoriaMetrics, VictoriaLogs, and annotations | `GRAFANA_URL`, `GRAFANA_API_KEY` |
 | `posthog` | Query product analytics, events, pageviews, breakdowns, and user agents | `POSTHOG_API_KEY`, `POSTHOG_PROJECT_ID` |
 | `amplitude` | Query product analytics — event segmentation, funnels, retention, user activity, and taxonomy | `AMPLITUDE_API_KEY`, `AMPLITUDE_SECRET_KEY` |
@@ -76,7 +76,7 @@ These are broadly useful across most deployments and are good candidates to conf
 | Tool | Use | API key / credential |
 |---|---|---|
 | `airtable` | Bases, schemas, tables, records, views, and URL parsing | `AIRTABLE_API_KEY` |
-| `company_context` | Search indexed company history across internal sources | None |
+| `company_context` | Search indexed company history, Slack DMs, and Google Docs | None |
 | `composio` | Execute tools from third-party services exposed through Composio | `COMPOSIO_API_KEY` |
 | `figma` | Extract Figma files, nodes, components, styles, and variables | `FIGMA_ACCESS_TOKEN` |
 | `granola` | Search and read Granola notes and transcripts | `GRANOLA_API_KEY` |

--- a/tools/productivity/company_context/cli.py
+++ b/tools/productivity/company_context/cli.py
@@ -15,7 +15,10 @@ from .client import CompanyContextClient
 
 load_dotenv()
 
-app = typer.Typer(name="company_context", help="Search indexed company history.")
+app = typer.Typer(
+    name="company_context",
+    help="Search indexed company history, Slack DMs, and Google Docs.",
+)
 
 
 @app.command("health")
@@ -69,7 +72,11 @@ def _add_result_rows(table: Table, results: list[dict[str, Any]]) -> None:
 def search(
     query: str = typer.Argument(..., help="Search query."),
     limit: int = typer.Option(10, "--limit", "-n", help="Max results."),
-    source: str | None = typer.Option(None, "--source", help="Filter by source."),
+    source: str | None = typer.Option(
+        None,
+        "--source",
+        help="Filter by source. Use 'docs' for Google Docs.",
+    ),
     source_type: str | None = typer.Option(None, "--source-type", help="Filter by source type."),
     occurred_after: str | None = typer.Option(
         None, "--after", help="Only results on/after this time."
@@ -79,7 +86,7 @@ def search(
     ),
     json_output: bool = typer.Option(False, "--json", help="Output raw JSON."),
 ) -> None:
-    """Search indexed company context documents."""
+    """Search indexed company context documents, including Google Docs with --source docs."""
     result = CompanyContextClient().search(
         query=query,
         limit=limit,
@@ -201,7 +208,11 @@ def search_dms(
 @app.command("list")
 def list_documents(
     limit: int = typer.Option(10, "--limit", "-n", help="Max documents."),
-    source: str | None = typer.Option(None, "--source", help="Filter by source."),
+    source: str | None = typer.Option(
+        None,
+        "--source",
+        help="Filter by source. Use 'docs' for Google Docs.",
+    ),
     source_type: str | None = typer.Option(None, "--source-type", help="Filter by source type."),
     occurred_after: str | None = typer.Option(
         None, "--after", help="Only documents on/after this time."
@@ -211,7 +222,7 @@ def list_documents(
     ),
     json_output: bool = typer.Option(False, "--json", help="Output raw JSON."),
 ) -> None:
-    """List indexed company context documents."""
+    """List indexed company context documents, including Google Docs with --source docs."""
     result = CompanyContextClient().list_documents(
         limit=limit,
         source=source,
@@ -252,7 +263,7 @@ def read_document(
     ),
     json_output: bool = typer.Option(False, "--json", help="Output raw JSON."),
 ) -> None:
-    """Read a company context document."""
+    """Read a company context document returned by search, including Google Docs chunks."""
     result = CompanyContextClient().read_document(
         document_id=document_id,
         max_chars=max_chars,
@@ -277,7 +288,11 @@ def read_document(
 
 @app.command("latest-date")
 def latest_date(
-    source: str | None = typer.Option(None, "--source", help="Filter by source."),
+    source: str | None = typer.Option(
+        None,
+        "--source",
+        help="Filter by source. Use 'docs' for Google Docs.",
+    ),
     source_type: str | None = typer.Option(None, "--source-type", help="Filter by source type."),
 ) -> None:
     """Show the latest indexed timestamp."""

--- a/tools/productivity/company_context/client.py
+++ b/tools/productivity/company_context/client.py
@@ -6,6 +6,7 @@ import asyncio
 import json
 import os
 import re
+from contextlib import suppress
 from datetime import UTC, datetime
 from typing import Any
 from urllib.parse import urlparse, urlunparse
@@ -24,6 +25,9 @@ CHANNEL_DAY_SCORE_MULTIPLIER = 0.75
 DEFAULT_PREVIEW_CHARS = 280
 MAX_RELATED_CHILDREN = 25
 SLACK_DM_SOURCE = "slack_dm"
+DOCS_SOURCE = "docs"
+LEGACY_GOOGLE_DRIVE_SOURCE = "google_drive"
+GOOGLE_DOCS_SOURCE_TYPE = "google_doc"
 COMPANY_CONTEXT_DSN_ENV = "CENTAUR_POSTGRES_DSN"
 COMPANY_CONTEXT_DATABASE_ENV = "COMPANY_CONTEXT_POSTGRES_DATABASE"
 DEFAULT_POSTGRES_DATABASE = "ai_v2"
@@ -243,6 +247,37 @@ def _document_summary(row: Any) -> dict[str, Any]:
     }
 
 
+def _google_doc_summary(row: Any) -> dict[str, Any]:
+    """Return the common result shape for OAuth Google Docs context chunks."""
+    metadata = _as_dict(_row_value(row, "metadata", {}))
+    metadata.update(
+        {
+            "file_id": str(_row_value(row, "file_id", "")),
+            "chunk_id": str(_row_value(row, "chunk_id", "")),
+            "drive_id": str(_row_value(row, "drive_id", "")),
+            "mime_type": str(_row_value(row, "mime_type", "")),
+            "provider_author_id": str(_row_value(row, "provider_author_id", "")),
+        }
+    )
+    return {
+        "document_id": str(_row_value(row, "document_id", "")),
+        "source": DOCS_SOURCE,
+        "source_type": GOOGLE_DOCS_SOURCE_TYPE,
+        "source_document_id": str(_row_value(row, "file_id", "")),
+        "source_chunk_id": str(_row_value(row, "chunk_id", "")),
+        "parent_document_id": None,
+        "title": str(_row_value(row, "title", "")),
+        "url": str(_row_value(row, "url", "")),
+        "author_name": str(_row_value(row, "provider_author_name", "")),
+        "access_scope": "",
+        "occurred_at": _isoformat(
+            _row_value(row, "source_created_at") or _row_value(row, "source_modified_at")
+        ),
+        "source_updated_at": _isoformat(_row_value(row, "source_modified_at")),
+        "metadata": metadata,
+    }
+
+
 def _dm_document_summary(row: Any) -> dict[str, Any]:
     """Return the common metadata we expose for Slack DM context records."""
     metadata = _as_dict(_row_value(row, "metadata", {}))
@@ -296,6 +331,23 @@ def _dm_conversation_summary(row: Any) -> dict[str, Any]:
     }
 
 
+def _include_google_docs_source(source: str | None, source_type: str | None) -> bool:
+    return (source is None or source == DOCS_SOURCE) and source_type in (
+        None,
+        GOOGLE_DOCS_SOURCE_TYPE,
+    )
+
+
+def _company_context_filters_for_source(
+    source: str | None,
+    source_type: str | None,
+) -> tuple[str | None, str | None]:
+    """Map the public docs source to the legacy projected Google Drive rows."""
+    if source == DOCS_SOURCE:
+        return LEGACY_GOOGLE_DRIVE_SOURCE, source_type or GOOGLE_DOCS_SOURCE_TYPE
+    return source, source_type
+
+
 class CompanyContextClient:
     """Query the shared company context document table."""
 
@@ -327,6 +379,12 @@ class CompanyContextClient:
         try:
             terms = _search_terms(query)
             search_terms = [query, *terms]
+            results = []
+            google_docs_error = None
+            company_source, company_source_type = _company_context_filters_for_source(
+                source,
+                source_type,
+            )
             source_param = len(search_terms) + 1
             source_type_param = len(search_terms) + 2
             occurred_after_param = len(search_terms) + 3
@@ -369,13 +427,12 @@ class CompanyContextClient:
                 LIMIT ${limit_param}
                 """,
                 *search_terms,
-                source,
-                source_type,
+                company_source,
+                company_source_type,
                 occurred_after,
                 occurred_before,
                 limit,
             )
-            results = []
             for row in rows:
                 result = _document_summary(row)
                 result["score"] = float(_row_value(row, "score", 0.0) or 0.0)
@@ -387,7 +444,39 @@ class CompanyContextClient:
                 result["result_type"] = str(result["source_type"] or "indexed_document")
                 results.append(result)
 
-            return {
+            if _include_google_docs_source(source, source_type):
+                try:
+                    google_rows = await self._search_google_docs_async(
+                        conn,
+                        search_terms=search_terms,
+                        term_count=len(terms),
+                        limit=limit,
+                        modified_after=occurred_after,
+                        modified_before=occurred_before,
+                    )
+                    for row in google_rows:
+                        result = _google_doc_summary(row)
+                        result["score"] = float(_row_value(row, "score", 0.0) or 0.0)
+                        result["preview"] = _body_preview(
+                            str(_row_value(row, "body", "") or ""),
+                            query=query,
+                        )
+                        result["lane"] = "indexed"
+                        result["result_type"] = GOOGLE_DOCS_SOURCE_TYPE
+                        results.append(result)
+                except asyncpg.UndefinedTableError as exc:
+                    google_docs_error = str(exc)
+
+            results.sort(
+                key=lambda item: (
+                    float(item.get("score") or 0.0),
+                    str(item.get("source_updated_at") or ""),
+                ),
+                reverse=True,
+            )
+            results = results[:limit]
+
+            response = {
                 "status": "ok",
                 "query": query,
                 "source": source,
@@ -398,8 +487,58 @@ class CompanyContextClient:
                 "indexed_count": len(results),
                 "results": results,
             }
+            if google_docs_error:
+                response["google_docs_error"] = google_docs_error
+            return response
         finally:
             await conn.close()
+
+    async def _search_google_docs_async(
+        self,
+        conn: asyncpg.Connection,
+        *,
+        search_terms: list[str],
+        term_count: int,
+        limit: int,
+        modified_after: datetime | None,
+        modified_before: datetime | None,
+    ) -> list[Any]:
+        modified_after_param = len(search_terms) + 1
+        modified_before_param = len(search_terms) + 2
+        limit_param = len(search_terms) + 3
+        return await conn.fetch(
+            f"""
+            SELECT
+                document_id,
+                file_id,
+                chunk_id,
+                title,
+                body,
+                url,
+                provider_author_id,
+                provider_author_name,
+                mime_type,
+                drive_id,
+                source_created_at,
+                source_modified_at,
+                metadata,
+                paradedb.score(document_id) AS score
+            FROM google_docs_context_documents
+            WHERE {_search_where_clause(term_count)}
+              AND (${modified_after_param}::timestamptz IS NULL
+                   OR source_modified_at >= ${modified_after_param})
+              AND (${modified_before_param}::timestamptz IS NULL
+                   OR source_modified_at < ${modified_before_param})
+            ORDER BY paradedb.score(document_id) DESC,
+                     source_modified_at DESC NULLS LAST,
+                     document_id ASC
+            LIMIT ${limit_param}
+            """,
+            *search_terms,
+            modified_after,
+            modified_before,
+            limit,
+        )
 
     async def _latest_date_for_connection(
         self,
@@ -409,6 +548,10 @@ class CompanyContextClient:
         source_type: str | None,
     ) -> dict[str, Any]:
         """Return latest indexed date using an existing DB connection."""
+        company_source, company_source_type = _company_context_filters_for_source(
+            source,
+            source_type,
+        )
         row = await conn.fetchrow(
             """
             SELECT
@@ -420,8 +563,8 @@ class CompanyContextClient:
             WHERE ($1::text IS NULL OR source = $1)
               AND ($2::text IS NULL OR source_type = $2)
             """,
-            source,
-            source_type,
+            company_source,
+            company_source_type,
         )
         if not row or int(row["document_count"] or 0) == 0:
             return {
@@ -441,6 +584,83 @@ class CompanyContextClient:
             "latest_date": _isoformat(row["latest_date"]),
             "latest_source_updated_at": _isoformat(row["latest_source_updated_at"]),
             "latest_occurred_at": _isoformat(row["latest_occurred_at"]),
+        }
+
+    async def _latest_google_docs_for_connection(
+        self,
+        conn: asyncpg.Connection,
+        *,
+        source: str | None,
+        source_type: str | None,
+    ) -> dict[str, Any]:
+        if not _include_google_docs_source(source, source_type):
+            return {
+                "status": "ok",
+                "source": source,
+                "source_type": source_type,
+                "document_count": 0,
+                "latest_date": None,
+                "latest_source_updated_at": None,
+                "latest_occurred_at": None,
+            }
+        row = await conn.fetchrow(
+            """
+            SELECT
+                MAX(COALESCE(source_modified_at, source_created_at)) AS latest_date,
+                MAX(source_modified_at) AS latest_source_updated_at,
+                MAX(source_created_at) AS latest_occurred_at,
+                COUNT(*)::bigint AS document_count
+            FROM google_docs_context_documents
+            """
+        )
+        if not row or int(row["document_count"] or 0) == 0:
+            return {
+                "status": "ok",
+                "source": source,
+                "source_type": source_type,
+                "document_count": 0,
+                "latest_date": None,
+                "latest_source_updated_at": None,
+                "latest_occurred_at": None,
+            }
+        return {
+            "status": "ok",
+            "source": source,
+            "source_type": source_type,
+            "document_count": int(row["document_count"] or 0),
+            "latest_date": _isoformat(row["latest_date"]),
+            "latest_source_updated_at": _isoformat(row["latest_source_updated_at"]),
+            "latest_occurred_at": _isoformat(row["latest_occurred_at"]),
+        }
+
+    def _merge_latest_dates(
+        self,
+        *,
+        source: str | None,
+        source_type: str | None,
+        indexed: dict[str, Any],
+        google_docs: dict[str, Any],
+    ) -> dict[str, Any]:
+        def latest(values: list[str | None]) -> str | None:
+            present = [value for value in values if value]
+            return max(present) if present else None
+
+        return {
+            "status": "ok",
+            "source": source,
+            "source_type": source_type,
+            "document_count": int(indexed.get("document_count") or 0)
+            + int(google_docs.get("document_count") or 0),
+            "latest_date": latest([indexed.get("latest_date"), google_docs.get("latest_date")]),
+            "latest_source_updated_at": latest(
+                [
+                    indexed.get("latest_source_updated_at"),
+                    google_docs.get("latest_source_updated_at"),
+                ]
+            ),
+            "latest_occurred_at": latest(
+                [indexed.get("latest_occurred_at"), google_docs.get("latest_occurred_at")]
+            ),
         }
 
     def search(
@@ -693,6 +913,12 @@ class CompanyContextClient:
     ) -> dict[str, Any]:
         conn = await self._connect()
         try:
+            results = []
+            google_docs_error = None
+            company_source, company_source_type = _company_context_filters_for_source(
+                source,
+                source_type,
+            )
             rows = await conn.fetch(
                 """
                 SELECT
@@ -719,18 +945,42 @@ class CompanyContextClient:
                          document_id ASC
                 LIMIT $5
                 """,
-                source,
-                source_type,
+                company_source,
+                company_source_type,
                 occurred_after,
                 occurred_before,
                 limit,
             )
-            results = []
             for row in rows:
                 result = _document_summary(row)
                 result["preview"] = _body_preview(str(_row_value(row, "body", "") or ""), query="")
                 results.append(result)
-            return {
+            if _include_google_docs_source(source, source_type):
+                try:
+                    google_rows = await self._list_google_docs_async(
+                        conn,
+                        limit=limit,
+                        modified_after=occurred_after,
+                        modified_before=occurred_before,
+                    )
+                    for row in google_rows:
+                        result = _google_doc_summary(row)
+                        result["preview"] = _body_preview(
+                            str(_row_value(row, "body", "") or ""),
+                            query="",
+                        )
+                        results.append(result)
+                except asyncpg.UndefinedTableError as exc:
+                    google_docs_error = str(exc)
+            results.sort(
+                key=lambda item: (
+                    str(item.get("occurred_at") or ""),
+                    str(item.get("source_updated_at") or ""),
+                    str(item.get("document_id") or ""),
+                )
+            )
+            results = results[:limit]
+            response = {
                 "status": "ok",
                 "source": source,
                 "source_type": source_type,
@@ -739,8 +989,47 @@ class CompanyContextClient:
                 "count": len(results),
                 "results": results,
             }
+            if google_docs_error:
+                response["google_docs_error"] = google_docs_error
+            return response
         finally:
             await conn.close()
+
+    async def _list_google_docs_async(
+        self,
+        conn: asyncpg.Connection,
+        *,
+        limit: int,
+        modified_after: datetime | None,
+        modified_before: datetime | None,
+    ) -> list[Any]:
+        return await conn.fetch(
+            """
+            SELECT
+                document_id,
+                file_id,
+                chunk_id,
+                title,
+                body,
+                url,
+                provider_author_id,
+                provider_author_name,
+                mime_type,
+                drive_id,
+                source_created_at,
+                source_modified_at,
+                metadata
+            FROM google_docs_context_documents
+            WHERE ($1::timestamptz IS NULL OR source_modified_at >= $1)
+              AND ($2::timestamptz IS NULL OR source_modified_at < $2)
+            ORDER BY source_modified_at DESC NULLS LAST, source_created_at DESC NULLS LAST,
+                     document_id ASC
+            LIMIT $3
+            """,
+            modified_after,
+            modified_before,
+            limit,
+        )
 
     def list_documents(
         self,
@@ -781,10 +1070,31 @@ class CompanyContextClient:
     ) -> dict[str, Any]:
         conn = await self._connect()
         try:
-            return await self._latest_date_for_connection(
+            indexed = await self._latest_date_for_connection(
                 conn,
                 source=source,
                 source_type=source_type,
+            )
+            google_docs = {
+                "status": "ok",
+                "source": source,
+                "source_type": source_type,
+                "document_count": 0,
+                "latest_date": None,
+                "latest_source_updated_at": None,
+                "latest_occurred_at": None,
+            }
+            with suppress(asyncpg.UndefinedTableError):
+                google_docs = await self._latest_google_docs_for_connection(
+                    conn,
+                    source=source,
+                    source_type=source_type,
+                )
+            return self._merge_latest_dates(
+                source=source,
+                source_type=source_type,
+                indexed=indexed,
+                google_docs=google_docs,
             )
         finally:
             await conn.close()
@@ -898,6 +1208,12 @@ class CompanyContextClient:
                 document_id,
             )
             if not row:
+                try:
+                    google_doc = await self._read_google_doc_async(conn, document_id, max_chars)
+                except asyncpg.UndefinedTableError:
+                    google_doc = None
+                if google_doc is not None:
+                    return google_doc
                 return {
                     "status": "error",
                     "error": f"document not found: {document_id}",
@@ -923,6 +1239,48 @@ class CompanyContextClient:
             return result
         finally:
             await conn.close()
+
+    async def _read_google_doc_async(
+        self,
+        conn: asyncpg.Connection,
+        document_id: str,
+        max_chars: int | None,
+    ) -> dict[str, Any] | None:
+        row = await conn.fetchrow(
+            """
+            SELECT
+                document_id,
+                file_id,
+                chunk_id,
+                title,
+                body,
+                url,
+                provider_author_id,
+                provider_author_name,
+                mime_type,
+                drive_id,
+                source_created_at,
+                source_modified_at,
+                metadata
+            FROM google_docs_context_documents
+            WHERE document_id = $1
+            """,
+            document_id,
+        )
+        if not row:
+            return None
+
+        body = str(row["body"] or "")
+        content = body if max_chars is None else body[:max_chars]
+        truncated = max_chars is not None and len(body) > max_chars
+        return {
+            "status": "ok",
+            **_google_doc_summary(row),
+            "chars": len(content),
+            "total_chars": len(body),
+            "truncated": truncated,
+            "content": content,
+        }
 
     def read_document(
         self,

--- a/tools/productivity/company_context/pyproject.toml
+++ b/tools/productivity/company_context/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "company_context"
-description = "Search indexed company history and user-visible Slack DMs. Prefer this over direct Slack search for historical queries. Current sources: Slack, Slack DMs, Google Drive, Google Calendar, Linear."
+description = "Search indexed company history, user-visible Slack DMs, and Google Docs. Prefer this over direct Slack or Drive search for historical queries. Current sources: Slack, Slack DMs, Google Docs, Google Calendar, Linear."
 version = "0.1.0"
 requires-python = ">=3.11"
 dependencies = [

--- a/tools/productivity/company_context/tests/test_client.py
+++ b/tools/productivity/company_context/tests/test_client.py
@@ -17,9 +17,19 @@ from centaur_sdk.tool_sdk import ToolContext, reset_tool_context, set_tool_conte
 
 
 class _FakeConnection:
-    def __init__(self, *, rows=None, row=None, val=None) -> None:
+    def __init__(
+        self,
+        *,
+        rows=None,
+        fetch_rows=None,
+        row=None,
+        fetchrow_rows=None,
+        val=None,
+    ) -> None:
         self.rows = rows or []
+        self.fetch_rows = list(fetch_rows or [])
         self.row = row
+        self.fetchrow_rows = list(fetchrow_rows or [])
         self.val = val
         self.fetch_calls = []
         self.fetchrow_calls = []
@@ -28,10 +38,14 @@ class _FakeConnection:
 
     async def fetch(self, query, *args):
         self.fetch_calls.append((query, args))
+        if self.fetch_rows:
+            return self.fetch_rows.pop(0)
         return self.rows
 
     async def fetchrow(self, query, *args):
         self.fetchrow_calls.append((query, args))
+        if self.fetchrow_rows:
+            return self.fetchrow_rows.pop(0)
         return self.row
 
     async def fetchval(self, query, *args):
@@ -258,6 +272,119 @@ def test_search_applies_occurred_at_filters(monkeypatch):
         dt.datetime(2026, 5, 8, 12, 30, tzinfo=dt.UTC),
         4,
     )
+
+
+def test_search_docs_source_queries_legacy_drive_and_oauth_docs_indexes(monkeypatch):
+    created_at = dt.datetime(2026, 5, 1, 9, 0, tzinfo=dt.UTC)
+    modified_at = dt.datetime(2026, 5, 8, 12, 0, tzinfo=dt.UTC)
+    fake = _FakeConnection(
+        fetch_rows=[
+            [
+                {
+                    "document_id": "google_drive:doc:legacy-doc-1",
+                    "source": "google_drive",
+                    "source_type": "google_doc",
+                    "source_document_id": "legacy-doc-1",
+                    "source_chunk_id": "",
+                    "parent_document_id": None,
+                    "title": "Legacy roadmap notes",
+                    "body": "Legacy Drive projection mentions launch sequencing.",
+                    "url": "https://docs.google.com/document/d/legacy-doc-1/edit",
+                    "author_name": "Bob",
+                    "access_scope": "",
+                    "occurred_at": created_at,
+                    "source_updated_at": modified_at,
+                    "metadata": {"drive_id": "drive-legacy"},
+                    "score": 1.5,
+                }
+            ],
+            [
+                {
+                    "document_id": "google_docs:doc-123:chunk-0000",
+                    "file_id": "doc-123",
+                    "chunk_id": "chunk-0000",
+                    "title": "Roadmap notes",
+                    "body": "Roadmap notes mention launch sequencing and onboarding.",
+                    "url": "https://docs.google.com/document/d/doc-123/edit",
+                    "provider_author_id": "perm-1",
+                    "provider_author_name": "Alice",
+                    "mime_type": "application/vnd.google-apps.document",
+                    "drive_id": "drive-1",
+                    "source_created_at": created_at,
+                    "source_modified_at": modified_at,
+                    "metadata": {"provider_email": "alice@example.com"},
+                    "score": 2.5,
+                }
+            ],
+        ]
+    )
+
+    async def fake_connect(*args, **kwargs):
+        return fake
+
+    monkeypatch.setattr(company_context_client.asyncpg, "connect", fake_connect)
+
+    result = CompanyContextClient("postgresql://example").search(
+        "roadmap",
+        limit=3,
+        source="docs",
+        source_type="google_doc",
+        occurred_after="2026-05-01",
+        occurred_before="2026-05-09",
+    )
+
+    assert result["status"] == "ok"
+    assert result["source"] == "docs"
+    assert result["source_type"] == "google_doc"
+    assert result["count"] == 2
+    assert result["indexed_count"] == 2
+    assert "google_docs_error" not in result
+    assert result["results"][0]["source"] == "docs"
+    assert result["results"][0]["document_id"] == "google_docs:doc-123:chunk-0000"
+    assert result["results"][1]["source"] == "google_drive"
+    assert result["results"][1]["document_id"] == "google_drive:doc:legacy-doc-1"
+    legacy_query, legacy_args = fake.fetch_calls[0]
+    oauth_query, oauth_args = fake.fetch_calls[1]
+    assert "FROM company_context_documents" in legacy_query
+    assert legacy_args == (
+        "roadmap",
+        "roadmap",
+        "google_drive",
+        "google_doc",
+        dt.datetime(2026, 5, 1, tzinfo=dt.UTC),
+        dt.datetime(2026, 5, 9, tzinfo=dt.UTC),
+        3,
+    )
+    assert "FROM google_docs_context_documents" in oauth_query
+    assert "source_modified_at >= $3" in oauth_query
+    assert "source_modified_at < $4" in oauth_query
+    assert oauth_args == (
+        "roadmap",
+        "roadmap",
+        dt.datetime(2026, 5, 1, tzinfo=dt.UTC),
+        dt.datetime(2026, 5, 9, tzinfo=dt.UTC),
+        3,
+    )
+    assert fake.closed is True
+
+
+def test_search_drive_source_is_not_docs_alias(monkeypatch):
+    fake = _FakeConnection(rows=[])
+
+    async def fake_connect(*args, **kwargs):
+        return fake
+
+    monkeypatch.setattr(company_context_client.asyncpg, "connect", fake_connect)
+
+    result = CompanyContextClient("postgresql://example").search("roadmap", source="drive")
+
+    assert result["status"] == "ok"
+    assert len(fake.fetch_calls) == 1
+    query, args = fake.fetch_calls[0]
+    assert "FROM company_context_documents" in query
+    assert "FROM google_docs_context_documents" not in query
+    assert args == ("roadmap", "roadmap", "drive", None, None, None, 10)
+    assert fake.closed is True
 
 
 def test_search_rejects_invalid_occurred_at_filter():
@@ -721,6 +848,53 @@ def test_read_document_can_return_bounded_content(monkeypatch):
     assert result["metadata"] == {"channel_name": "eng-ai"}
     _, args = fake.fetchrow_calls[0]
     assert args == ("slack:channel_day:C123:2026-05-08",)
+    assert fake.closed is True
+
+
+def test_read_document_falls_back_to_oauth_google_docs_index(monkeypatch):
+    created_at = dt.datetime(2026, 5, 1, 9, 0, tzinfo=dt.UTC)
+    modified_at = dt.datetime(2026, 5, 8, 12, 0, tzinfo=dt.UTC)
+    body = "OAuth Google Doc content"
+    fake = _FakeConnection(
+        fetchrow_rows=[
+            None,
+            {
+                "document_id": "google_docs:doc-123:chunk-0000",
+                "file_id": "doc-123",
+                "chunk_id": "chunk-0000",
+                "title": "Roadmap notes",
+                "body": body,
+                "url": "https://docs.google.com/document/d/doc-123/edit",
+                "provider_author_id": "perm-1",
+                "provider_author_name": "Alice",
+                "mime_type": "application/vnd.google-apps.document",
+                "drive_id": "drive-1",
+                "source_created_at": created_at,
+                "source_modified_at": modified_at,
+                "metadata": {"provider_email": "alice@example.com"},
+            },
+        ]
+    )
+
+    async def fake_connect(*args, **kwargs):
+        return fake
+
+    monkeypatch.setattr(company_context_client.asyncpg, "connect", fake_connect)
+
+    result = CompanyContextClient("postgresql://example").read_document(
+        "google_docs:doc-123:chunk-0000",
+        max_chars=10,
+    )
+
+    assert result["status"] == "ok"
+    assert result["source"] == "docs"
+    assert result["source_type"] == "google_doc"
+    assert result["source_document_id"] == "doc-123"
+    assert result["content"] == "OAuth Goog"
+    assert result["chars"] == 10
+    assert result["total_chars"] == len(body)
+    assert result["truncated"] is True
+    assert len(fake.fetchrow_calls) == 2
     assert fake.closed is True
 
 


### PR DESCRIPTION
## Summary

- Add `docs` as the tool-facing source for Google Docs company-context search.
- Fan out `source=docs` queries to legacy projected `google_drive/google_doc` rows and the new OAuth `google_docs_context_documents` table.
- Allow `company_context read` to resolve OAuth Google Doc chunk ids returned by search.
- Update company-context tool metadata, CLI help, skill guidance, and tool directory docs to mention Slack DMs and Google Docs.

## Validation

- `uv run --with pytest --with asyncpg --with rich pytest tools/productivity/company_context/tests`
- `uv run --with ruff ruff check tools/productivity/company_context`
- `uv run --with asyncpg --with rich --with typer --with python-dotenv python -m py_compile tools/productivity/company_context/cli.py tools/productivity/company_context/client.py`

## Note

- `uv run ... python -m company_context.cli --help` was not used because this package layout hits Hatchling editable-install path rewrite limits in the local smoke environment; `py_compile` covered syntax for the touched CLI/client modules instead.
