### PR TITLE
fix: restore Slack DM context visibility

### DIFF
--- a/services/api-rs/crates/centaur-iron-control/src/principal.rs
+++ b/services/api-rs/crates/centaur-iron-control/src/principal.rs
@@ -70,6 +70,17 @@ pub fn derive_principal(
     actor_user_id: Option<&str>,
     conversation_name: Option<&str>,
 ) -> PrincipalRef {
+    derive_principal_with_slack_team(thread_key, actor_user_id, None, conversation_name)
+}
+
+/// Resolve the principal for a thread, allowing ingress metadata to supply the
+/// Slack team id when legacy DM thread keys omit it.
+pub fn derive_principal_with_slack_team(
+    thread_key: &str,
+    actor_user_id: Option<&str>,
+    slack_team_id: Option<&str>,
+    conversation_name: Option<&str>,
+) -> PrincipalRef {
     let display_name = conversation_name
         .map(str::trim)
         .filter(|name| !name.is_empty());
@@ -144,7 +155,9 @@ pub fn derive_principal(
         };
     }
 
-    let (team_id, conversation_id) = parse_slack_segments(thread_key);
+    let (thread_team_id, conversation_id) = parse_slack_segments(thread_key);
+    let metadata_team_id = slack_team_id.map(str::trim).filter(|team| !team.is_empty());
+    let team_id = thread_team_id.or(metadata_team_id);
     let mut labels = BTreeMap::new();
     if let Some(team) = team_id {
         labels.insert("slack_team_id".to_owned(), team.to_owned());
@@ -324,6 +337,41 @@ mod tests {
         let principal = derive_principal("slack:T123:D9:ts", Some("U07ABC"), None);
         assert_eq!(principal.foreign_id, "slack-user-t123-u07abc");
         assert_eq!(principal.name, "Slack User U07ABC (team T123)");
+    }
+
+    #[test]
+    fn metadata_team_id_is_folded_into_legacy_dm_user_key() {
+        let principal = derive_principal_with_slack_team(
+            "slack:D9:ts",
+            Some("U07ABC"),
+            Some("T123"),
+            Some("Ada Lovelace"),
+        );
+        assert_eq!(principal.foreign_id, "slack-user-t123-u07abc");
+        assert_eq!(principal.name, "Slack DM @Ada Lovelace");
+        assert_eq!(
+            principal.labels.get("slack_team_id").map(String::as_str),
+            Some("T123")
+        );
+        assert_eq!(
+            principal.labels.get("slack_user_id").map(String::as_str),
+            Some("U07ABC")
+        );
+    }
+
+    #[test]
+    fn thread_key_team_id_wins_over_metadata_team_id() {
+        let principal = derive_principal_with_slack_team(
+            "slack:T_FROM_KEY:D9:ts",
+            Some("U07ABC"),
+            Some("T_FROM_METADATA"),
+            None,
+        );
+        assert_eq!(principal.foreign_id, "slack-user-t-from-key-u07abc");
+        assert_eq!(
+            principal.labels.get("slack_team_id").map(String::as_str),
+            Some("T_FROM_KEY")
+        );
     }
 
     #[test]

--- a/services/api-rs/crates/centaur-iron-control/src/session.rs
+++ b/services/api-rs/crates/centaur-iron-control/src/session.rs
@@ -12,11 +12,12 @@ use serde_json::Value;
 use crate::IronControlClient;
 use crate::error::{IronControlError, Result};
 use crate::models::Principal;
-use crate::principal::derive_principal;
+use crate::principal::derive_principal_with_slack_team;
 
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 struct SessionPrincipalMetadata<'a> {
     actor_user_id: Option<&'a str>,
+    slack_team_id: Option<&'a str>,
     conversation_name: Option<&'a str>,
 }
 
@@ -31,6 +32,7 @@ impl<'a> SessionPrincipalMetadata<'a> {
                 .or_else(|| metadata.get("aad_object_id"))
                 .or_else(|| metadata.get("user_id"))
                 .and_then(Value::as_str),
+            slack_team_id: metadata.get("slack_team_id").and_then(Value::as_str),
             conversation_name: metadata
                 .get("slack_conversation_name")
                 .or_else(|| metadata.get("discord_conversation_name"))
@@ -82,9 +84,10 @@ impl SessionRegistrar {
         metadata: Option<&Value>,
     ) -> Result<Principal> {
         let metadata = SessionPrincipalMetadata::from_session_metadata(metadata);
-        let principal = derive_principal(
+        let principal = derive_principal_with_slack_team(
             thread_key,
             metadata.actor_user_id,
+            metadata.slack_team_id,
             metadata.conversation_name,
         );
         let input = principal.to_identity_input(&self.namespace);
@@ -167,6 +170,17 @@ mod tests {
         );
     }
 
+    #[test]
+    fn session_principal_metadata_carries_slack_team_id() {
+        assert_eq!(
+            SessionPrincipalMetadata::from_session_metadata(Some(&json!({
+                "slack_team_id": "T123"
+            })))
+            .slack_team_id,
+            Some("T123")
+        );
+    }
+
     #[tokio::test]
     async fn register_session_seeds_roles_for_new_principal() {
         let (base_url, requests, server) = spawn_iron_control_stub(false).await;
@@ -177,6 +191,7 @@ mod tests {
         );
         let metadata = json!({
             "slack_user_id": "U123",
+            "slack_team_id": "T123",
             "slack_conversation_name": "general"
         });
 
@@ -206,6 +221,7 @@ mod tests {
         );
         let metadata = json!({
             "slack_user_id": "U123",
+            "slack_team_id": "T123",
             "slack_conversation_name": "general"
         });
 

--- a/services/slackbotv2/src/session-api.ts
+++ b/services/slackbotv2/src/session-api.ts
@@ -671,6 +671,7 @@ type RequesterIdentity = {
   githubUnavailableReason?: string
   slackDisplayName?: string
   slackMention?: string
+  slackTeamId?: string
   slackUserId?: string
   slackUserName?: string
 }
@@ -818,14 +819,21 @@ function sessionRequesterMetadata(
   identity?: RequesterIdentity
 ): JsonObject {
   const slackUserId = identity?.slackUserId ?? messageRequesterUserId(message)
+  const slackTeamId = identity?.slackTeamId ?? messageSlackTeamId(message)
   const slackUserName = identity?.slackUserName ?? message?.author.userName
   const slackDisplayName = identity?.slackDisplayName ?? message?.author.fullName
   return {
     ...(slackUserId ? { slack_user_id: slackUserId } : {}),
+    ...(slackTeamId ? { slack_team_id: slackTeamId } : {}),
     ...(slackUserName ? { slack_user_name: slackUserName } : {}),
     ...(slackDisplayName ? { slack_display_name: slackDisplayName } : {}),
     ...(identity?.githubHandle ? { github_handle: identity.githubHandle } : {})
   }
+}
+
+function messageSlackTeamId(message: SlackbotV2ApiMessage | undefined): string | undefined {
+  if (!message) return undefined
+  return message.teamId || slackTeamId(message.raw) || rawSlackString(message.raw, 'team_id')
 }
 
 function messageRequesterUserId(message: SlackbotV2ApiMessage | undefined): string | undefined {
@@ -843,6 +851,7 @@ async function resolveRequesterIdentity(
   const identity: RequesterIdentity = {
     slackDisplayName: stringValue(message.author.fullName),
     slackMention: slackUserId ? `<@${slackUserId}>` : undefined,
+    slackTeamId: messageSlackTeamId(message),
     slackUserId,
     slackUserName: stringValue(message.author.userName)
   }
@@ -915,6 +924,7 @@ function mergeRequesterIdentity(
     ...cached,
     slackDisplayName: cached.slackDisplayName ?? fallback.slackDisplayName,
     slackMention: fallback.slackMention ?? cached.slackMention,
+    slackTeamId: fallback.slackTeamId ?? cached.slackTeamId,
     slackUserId: fallback.slackUserId ?? cached.slackUserId,
     slackUserName: cached.slackUserName ?? fallback.slackUserName
   }

--- a/services/slackbotv2/test/session-api.test.ts
+++ b/services/slackbotv2/test/session-api.test.ts
@@ -719,9 +719,19 @@ describe('session principal display name', () => {
     }
   }
 
-  function createBody(requests: RecordedRequest[]): { metadata?: { slack_conversation_name?: string } } {
+  function createBody(requests: RecordedRequest[]): {
+    metadata?: {
+      slack_conversation_name?: string
+      slack_team_id?: string
+      slack_user_id?: string
+    }
+  } {
     return (requests.find(request => request.url.endsWith('.000100'))?.body ?? {}) as {
-      metadata?: { slack_conversation_name?: string }
+      metadata?: {
+        slack_conversation_name?: string
+        slack_team_id?: string
+        slack_user_id?: string
+      }
     }
   }
 
@@ -871,6 +881,8 @@ describe('session principal display name', () => {
       }
     )
     expect(createBody(requests).metadata?.slack_conversation_name).toBe('Ada Lovelace')
+    expect(createBody(requests).metadata?.slack_team_id).toBe('T1')
+    expect(createBody(requests).metadata?.slack_user_id).toBe('U1')
   })
 
   test('falls back to no name when the channel lookup fails', async () => {

--- a/tools/productivity/company_context/client.py
+++ b/tools/productivity/company_context/client.py
@@ -338,6 +338,16 @@ def _include_google_docs_source(source: str | None, source_type: str | None) -> 
     )
 
 
+def _include_slack_dms_source(source: str | None, source_type: str | None) -> bool:
+    return (source is None or source == SLACK_DM_SOURCE) and source_type in (
+        None,
+        SLACK_DM_SOURCE,
+        "slack_im",
+        "slack_mpim",
+        "slack_dm_conversation",
+    )
+
+
 def _company_context_filters_for_source(
     source: str | None,
     source_type: str | None,
@@ -548,6 +558,8 @@ class CompanyContextClient:
         source_type: str | None,
     ) -> dict[str, Any]:
         """Return latest indexed date using an existing DB connection."""
+        if source == SLACK_DM_SOURCE:
+            return self._empty_latest_date_result(source=source, source_type=source_type)
         company_source, company_source_type = _company_context_filters_for_source(
             source,
             source_type,
@@ -567,15 +579,7 @@ class CompanyContextClient:
             company_source_type,
         )
         if not row or int(row["document_count"] or 0) == 0:
-            return {
-                "status": "ok",
-                "source": source,
-                "source_type": source_type,
-                "document_count": 0,
-                "latest_date": None,
-                "latest_source_updated_at": None,
-                "latest_occurred_at": None,
-            }
+            return self._empty_latest_date_result(source=source, source_type=source_type)
         return {
             "status": "ok",
             "source": source,
@@ -594,15 +598,7 @@ class CompanyContextClient:
         source_type: str | None,
     ) -> dict[str, Any]:
         if not _include_google_docs_source(source, source_type):
-            return {
-                "status": "ok",
-                "source": source,
-                "source_type": source_type,
-                "document_count": 0,
-                "latest_date": None,
-                "latest_source_updated_at": None,
-                "latest_occurred_at": None,
-            }
+            return self._empty_latest_date_result(source=source, source_type=source_type)
         row = await conn.fetchrow(
             """
             SELECT
@@ -614,15 +610,106 @@ class CompanyContextClient:
             """
         )
         if not row or int(row["document_count"] or 0) == 0:
-            return {
-                "status": "ok",
-                "source": source,
-                "source_type": source_type,
-                "document_count": 0,
-                "latest_date": None,
-                "latest_source_updated_at": None,
-                "latest_occurred_at": None,
-            }
+            return self._empty_latest_date_result(source=source, source_type=source_type)
+        return {
+            "status": "ok",
+            "source": source,
+            "source_type": source_type,
+            "document_count": int(row["document_count"] or 0),
+            "latest_date": _isoformat(row["latest_date"]),
+            "latest_source_updated_at": _isoformat(row["latest_source_updated_at"]),
+            "latest_occurred_at": _isoformat(row["latest_occurred_at"]),
+        }
+
+    async def _latest_slack_dms_for_connection(
+        self,
+        conn: asyncpg.Connection,
+        *,
+        source: str | None,
+        source_type: str | None,
+    ) -> dict[str, Any]:
+        if not _include_slack_dms_source(source, source_type):
+            return self._empty_latest_date_result(source=source, source_type=source_type)
+
+        message_conversation_type = None
+        include_messages = source_type in (None, SLACK_DM_SOURCE, "slack_im", "slack_mpim")
+        if source_type in ("slack_im", "slack_mpim"):
+            message_conversation_type = source_type.removeprefix("slack_")
+        include_conversations = source_type in (None, SLACK_DM_SOURCE, "slack_dm_conversation")
+
+        messages = self._empty_latest_date_result(source=source, source_type=source_type)
+        conversations = self._empty_latest_date_result(source=source, source_type=source_type)
+
+        if include_messages:
+            with suppress(asyncpg.UndefinedTableError):
+                row = await conn.fetchrow(
+                    """
+                    SELECT
+                        MAX(COALESCE(source_updated_at, occurred_at)) AS latest_date,
+                        MAX(source_updated_at) AS latest_source_updated_at,
+                        MAX(occurred_at) AS latest_occurred_at,
+                        COUNT(*)::bigint AS document_count
+                    FROM slack_dm_context_documents
+                    WHERE ($1::text IS NULL OR conversation_type = $1)
+                    """,
+                    message_conversation_type,
+                )
+                messages = self._latest_date_result_from_row(
+                    row,
+                    source=source,
+                    source_type=source_type,
+                )
+
+        if include_conversations:
+            with suppress(asyncpg.UndefinedTableError):
+                row = await conn.fetchrow(
+                    """
+                    SELECT
+                        MAX(COALESCE(source_updated_at, last_seen_at)) AS latest_date,
+                        MAX(source_updated_at) AS latest_source_updated_at,
+                        MAX(last_seen_at) AS latest_occurred_at,
+                        COUNT(*)::bigint AS document_count
+                    FROM slack_dm_conversation_context_documents
+                    """,
+                )
+                conversations = self._latest_date_result_from_row(
+                    row,
+                    source=source,
+                    source_type=source_type,
+                )
+
+        return self._merge_latest_dates(
+            source=source,
+            source_type=source_type,
+            indexed=messages,
+            google_docs=conversations,
+        )
+
+    def _empty_latest_date_result(
+        self,
+        *,
+        source: str | None,
+        source_type: str | None,
+    ) -> dict[str, Any]:
+        return {
+            "status": "ok",
+            "source": source,
+            "source_type": source_type,
+            "document_count": 0,
+            "latest_date": None,
+            "latest_source_updated_at": None,
+            "latest_occurred_at": None,
+        }
+
+    def _latest_date_result_from_row(
+        self,
+        row: Any,
+        *,
+        source: str | None,
+        source_type: str | None,
+    ) -> dict[str, Any]:
+        if not row or int(row["document_count"] or 0) == 0:
+            return self._empty_latest_date_result(source=source, source_type=source_type)
         return {
             "status": "ok",
             "source": source,
@@ -640,26 +727,29 @@ class CompanyContextClient:
         source_type: str | None,
         indexed: dict[str, Any],
         google_docs: dict[str, Any],
+        slack_dms: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         def latest(values: list[str | None]) -> str | None:
             present = [value for value in values if value]
             return max(present) if present else None
 
+        latest_results = [indexed, google_docs]
+        if slack_dms is not None:
+            latest_results.append(slack_dms)
+
         return {
             "status": "ok",
             "source": source,
             "source_type": source_type,
-            "document_count": int(indexed.get("document_count") or 0)
-            + int(google_docs.get("document_count") or 0),
-            "latest_date": latest([indexed.get("latest_date"), google_docs.get("latest_date")]),
+            "document_count": sum(
+                int(result.get("document_count") or 0) for result in latest_results
+            ),
+            "latest_date": latest([result.get("latest_date") for result in latest_results]),
             "latest_source_updated_at": latest(
-                [
-                    indexed.get("latest_source_updated_at"),
-                    google_docs.get("latest_source_updated_at"),
-                ]
+                [result.get("latest_source_updated_at") for result in latest_results]
             ),
             "latest_occurred_at": latest(
-                [indexed.get("latest_occurred_at"), google_docs.get("latest_occurred_at")]
+                [result.get("latest_occurred_at") for result in latest_results]
             ),
         }
 
@@ -953,7 +1043,10 @@ class CompanyContextClient:
             )
             for row in rows:
                 result = _document_summary(row)
-                result["preview"] = _body_preview(str(_row_value(row, "body", "") or ""), query="")
+                result["preview"] = _body_preview(
+                    str(_row_value(row, "body", "") or ""),
+                    query="",
+                )
                 results.append(result)
             if _include_google_docs_source(source, source_type):
                 try:
@@ -1075,26 +1168,25 @@ class CompanyContextClient:
                 source=source,
                 source_type=source_type,
             )
-            google_docs = {
-                "status": "ok",
-                "source": source,
-                "source_type": source_type,
-                "document_count": 0,
-                "latest_date": None,
-                "latest_source_updated_at": None,
-                "latest_occurred_at": None,
-            }
+            google_docs = self._empty_latest_date_result(source=source, source_type=source_type)
             with suppress(asyncpg.UndefinedTableError):
                 google_docs = await self._latest_google_docs_for_connection(
                     conn,
                     source=source,
                     source_type=source_type,
                 )
+            slack_dms = self._empty_latest_date_result(source=source, source_type=source_type)
+            slack_dms = await self._latest_slack_dms_for_connection(
+                conn,
+                source=source,
+                source_type=source_type,
+            )
             return self._merge_latest_dates(
                 source=source,
                 source_type=source_type,
                 indexed=indexed,
                 google_docs=google_docs,
+                slack_dms=slack_dms,
             )
         finally:
             await conn.close()

--- a/tools/productivity/company_context/pyproject.toml
+++ b/tools/productivity/company_context/pyproject.toml
@@ -25,3 +25,15 @@ packages = ["."]
 
 [tool.centaur]
 module = "client.py"
+
+[[tool.centaur.secrets]]
+type = "pg_dsn"
+name = "company_context_dsn"
+database = "centaur"
+secret_ref = "CENTAUR_POSTGRES_DSN"
+role = "centaur_slack_reader"
+settings = [
+    { name = "centaur.slack_channel_id", value_from = { principal_label = "slack_channel_id" } },
+    { name = "centaur.slack_team_id", value_from = { principal_label = "slack_team_id" } },
+    { name = "centaur.slack_user_id", value_from = { principal_label = "slack_user_id" } },
+]

--- a/tools/productivity/company_context/tests/test_client.py
+++ b/tools/productivity/company_context/tests/test_client.py
@@ -776,6 +776,77 @@ def test_latest_date_reports_empty_index(monkeypatch):
     assert fake.closed is True
 
 
+def test_latest_date_counts_slack_dm_projection_tables(monkeypatch):
+    fake = _FakeConnection(
+        fetchrow_rows=[
+            {
+                "latest_date": dt.datetime(2026, 5, 9, 15, 30, tzinfo=dt.UTC),
+                "latest_source_updated_at": dt.datetime(2026, 5, 9, 15, 30, tzinfo=dt.UTC),
+                "latest_occurred_at": dt.datetime(2026, 5, 8, 14, 0, tzinfo=dt.UTC),
+                "document_count": 161,
+            },
+            {
+                "latest_date": dt.datetime(2026, 5, 10, 10, 0, tzinfo=dt.UTC),
+                "latest_source_updated_at": dt.datetime(2026, 5, 7, 8, 0, tzinfo=dt.UTC),
+                "latest_occurred_at": dt.datetime(2026, 5, 10, 10, 0, tzinfo=dt.UTC),
+                "document_count": 115,
+            },
+        ]
+    )
+
+    async def fake_connect(*args, **kwargs):
+        return fake
+
+    monkeypatch.setattr(company_context_client.asyncpg, "connect", fake_connect)
+
+    result = CompanyContextClient("postgresql://example").latest_date(source="slack_dm")
+
+    assert result == {
+        "status": "ok",
+        "source": "slack_dm",
+        "source_type": None,
+        "document_count": 276,
+        "latest_date": "2026-05-10T10:00:00+00:00",
+        "latest_source_updated_at": "2026-05-09T15:30:00+00:00",
+        "latest_occurred_at": "2026-05-10T10:00:00+00:00",
+    }
+    assert len(fake.fetchrow_calls) == 2
+    assert "FROM slack_dm_context_documents" in fake.fetchrow_calls[0][0]
+    assert "FROM slack_dm_conversation_context_documents" in fake.fetchrow_calls[1][0]
+    assert fake.closed is True
+
+
+def test_latest_date_can_filter_slack_dm_messages_by_conversation_type(monkeypatch):
+    fake = _FakeConnection(
+        fetchrow_rows=[
+            {
+                "latest_date": dt.datetime(2026, 5, 9, 15, 30, tzinfo=dt.UTC),
+                "latest_source_updated_at": dt.datetime(2026, 5, 9, 15, 30, tzinfo=dt.UTC),
+                "latest_occurred_at": dt.datetime(2026, 5, 8, 14, 0, tzinfo=dt.UTC),
+                "document_count": 31,
+            },
+        ]
+    )
+
+    async def fake_connect(*args, **kwargs):
+        return fake
+
+    monkeypatch.setattr(company_context_client.asyncpg, "connect", fake_connect)
+
+    result = CompanyContextClient("postgresql://example").latest_date(
+        source="slack_dm",
+        source_type="slack_im",
+    )
+
+    assert result["document_count"] == 31
+    assert result["latest_date"] == "2026-05-09T15:30:00+00:00"
+    assert len(fake.fetchrow_calls) == 1
+    query, args = fake.fetchrow_calls[0]
+    assert "FROM slack_dm_context_documents" in query
+    assert args == ("im",)
+    assert fake.closed is True
+
+
 def test_read_document_returns_full_content_by_default(monkeypatch):
     body = "x" * 2_500
     fake = _FakeConnection(


### PR DESCRIPTION
## Summary
- carry Slack team ids from slackbotv2 session metadata into iron-control principal derivation for legacy `slack:D...` DM thread keys
- declare the company_context scoped Postgres DSN settings for Slack channel, team, and user labels so RLS receives the values it needs
- make `company_context latest-date --source slack_dm` read the Slack DM projection tables instead of reporting zero from the generic index only

## Staging Finding
Staging had DM rows indexed in `slack_dm_context_documents` and `slack_dm_conversation_context_documents`, but the live DM sandbox had empty `centaur.slack_user_id`, `centaur.slack_team_id`, and `centaur.slack_channel_id` settings. The principal also only carried `slack_user_id`, while the pg_dsn settings only mapped `slack_channel_id`. That combination made DM RLS filter every DM row out.

## Tests
- `cargo test -p centaur-iron-control principal`
- `cargo test -p centaur-iron-control session`
- `cargo test -p centaur-api-server postgres_listeners_retain_sandbox_env_name_and_database`
- `cargo test -p centaur-perms parses_pg_dsn_secret`
- `cargo test -p centaur-perms translates_pg_dsn_to_input_with_roundtrip_foreign_id`
- `uv run --with pytest --with asyncpg pytest tools/productivity/company_context/tests/test_client.py`
- `bun test test/session-api.test.ts`
- `pnpm --filter slackbotv2 check:types`
- `git diff --check`