### PR TITLE
feat(mcp): scope tool visibility to the principal's granted secrets

### DIFF
--- a/services/api-rs/crates/centaur-api-server/src/mcp.rs
+++ b/services/api-rs/crates/centaur-api-server/src/mcp.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::BTreeMap,
+    collections::{BTreeMap, BTreeSet},
     env, fs,
     path::PathBuf,
     sync::{Mutex, OnceLock},
@@ -117,8 +117,9 @@ pub(crate) async fn mcp_post(
         "ping" => json!({}),
         "tools/list" => {
             ensure_mcp_scope(&principal.scopes, "mcp:tools")?;
+            let visibility = mcp_tool_visibility(&state, &principal).await;
             let mut tools = vec![mcp_whoami_tool()];
-            tools.extend(mcp_centaur_tool_entries()?);
+            tools.extend(mcp_centaur_tool_entries(&visibility)?);
             json!({
                 "tools": tools,
             })
@@ -133,6 +134,18 @@ pub(crate) async fn mcp_post(
                 let Some(tool) = mcp_find_centaur_tool(&params.name)? else {
                     return Ok(mcp_json_error(id, -32602, "unknown tool"));
                 };
+                // Gate the call on the same visibility rule as tools/list so a
+                // principal cannot invoke a tool whose secrets it lacks (which
+                // would only fail later at the proxy with a confusing upstream
+                // error). Re-checked here to close the list -> call window.
+                let visibility = mcp_tool_visibility(&state, &principal).await;
+                if !visibility.allows(&tool) {
+                    return Ok(mcp_json_error(
+                        id,
+                        -32602,
+                        &format!("tool {} is not available to this principal", tool.name),
+                    ));
+                }
                 mcp_centaur_tool_result(&state, &principal, tool, params.arguments).await?
             }
         }
@@ -159,9 +172,93 @@ fn mcp_whoami_tool() -> Value {
     })
 }
 
-fn mcp_centaur_tool_entries() -> Result<Vec<Value>, ApiError> {
+/// Whether MCP tool visibility is scoped to the principal's granted secrets.
+/// Off by default so this is inert until per-tool roles (`tool-<slug>`) are
+/// assigned to the principals that need them; otherwise every secret-backed
+/// tool would vanish for principals that have not been granted anything yet.
+fn mcp_filter_tools_by_grants() -> bool {
+    fn read() -> bool {
+        env::var("CENTAUR_MCP_FILTER_TOOLS_BY_GRANTS")
+            .map(|value| {
+                matches!(
+                    value.trim().to_ascii_lowercase().as_str(),
+                    "1" | "true" | "yes" | "on"
+                )
+            })
+            .unwrap_or(false)
+    }
+    if cfg!(test) {
+        return read();
+    }
+    static CELL: OnceLock<bool> = OnceLock::new();
+    *CELL.get_or_init(read)
+}
+
+/// The set of tool roles a principal may use, used to filter the catalog.
+enum McpToolVisibility {
+    /// Show everything: filtering is disabled, iron-control is not configured,
+    /// or the principal's grants could not be resolved (fail open — the proxy
+    /// still enforces secret access at call time).
+    Unfiltered,
+    /// Show only tools whose `required_tool_role` is in this set (plus tools
+    /// that declare no secrets).
+    Roles(BTreeSet<String>),
+}
+
+impl McpToolVisibility {
+    fn allows(&self, tool: &DiscoveredTool) -> bool {
+        match self {
+            McpToolVisibility::Unfiltered => true,
+            McpToolVisibility::Roles(roles) => match &tool.required_tool_role {
+                None => true,
+                Some(role) => roles.contains(role),
+            },
+        }
+    }
+}
+
+/// Resolve the principal's tool visibility. Returns `Unfiltered` (fail open)
+/// whenever filtering is disabled or the principal's roles cannot be resolved,
+/// since secret access is independently enforced by the per-sandbox proxy at
+/// call time — hiding tools on a transient control-plane error would degrade
+/// UX with no security benefit.
+async fn mcp_tool_visibility(state: &AppState, principal: &McpPrincipal) -> McpToolVisibility {
+    if !mcp_filter_tools_by_grants() {
+        return McpToolVisibility::Unfiltered;
+    }
+    let runtime = match state.runtime() {
+        Ok(runtime) => runtime,
+        Err(error) => {
+            tracing::warn!(
+                %error,
+                "mcp tool filtering: runtime unavailable, showing all tools"
+            );
+            return McpToolVisibility::Unfiltered;
+        }
+    };
+    match runtime
+        .mcp_principal_role_foreign_ids(&principal.principal_id)
+        .await
+    {
+        Ok(Some(roles)) => McpToolVisibility::Roles(roles),
+        Ok(None) => McpToolVisibility::Unfiltered,
+        Err(error) => {
+            tracing::warn!(
+                %error,
+                principal_id = %principal.principal_id,
+                "mcp tool filtering: could not resolve principal roles, showing all tools"
+            );
+            McpToolVisibility::Unfiltered
+        }
+    }
+}
+
+fn mcp_centaur_tool_entries(visibility: &McpToolVisibility) -> Result<Vec<Value>, ApiError> {
     let mut entries = Vec::new();
     for tool in mcp_centaur_tool_catalog()? {
+        if !visibility.allows(&tool) {
+            continue;
+        }
         let methods = mcp_tool_methods(&tool);
         let signatures = methods
             .iter()
@@ -867,7 +964,44 @@ mod mcp_tests {
             description: Some("Demo tool".to_owned()),
             client_module: "client.py".to_owned(),
             project_dir,
+            required_tool_role: None,
         }
+    }
+
+    fn tool_requiring(role: &str) -> DiscoveredTool {
+        DiscoveredTool {
+            name: "demo".to_owned(),
+            package: "demo".to_owned(),
+            description: None,
+            client_module: "client.py".to_owned(),
+            project_dir: PathBuf::from("/tmp/none"),
+            required_tool_role: Some(role.to_owned()),
+        }
+    }
+
+    #[test]
+    fn tool_visibility_unfiltered_shows_everything() {
+        let vis = McpToolVisibility::Unfiltered;
+        assert!(vis.allows(&tool_requiring("tool-github")));
+        assert!(vis.allows(&test_tool(PathBuf::from("/tmp/none"))));
+    }
+
+    #[test]
+    fn tool_visibility_roles_gate_secret_backed_tools() {
+        let vis = McpToolVisibility::Roles(BTreeSet::from(["tool-twitter".to_owned()]));
+        // Granted tool is visible.
+        assert!(vis.allows(&tool_requiring("tool-twitter")));
+        // Un-granted secret-backed tool is hidden.
+        assert!(!vis.allows(&tool_requiring("tool-github")));
+        // A tool that declares no secrets is always visible.
+        assert!(vis.allows(&test_tool(PathBuf::from("/tmp/none"))));
+    }
+
+    #[test]
+    fn tool_visibility_empty_roles_hides_all_secret_backed_tools() {
+        let vis = McpToolVisibility::Roles(BTreeSet::new());
+        assert!(!vis.allows(&tool_requiring("tool-twitter")));
+        assert!(vis.allows(&test_tool(PathBuf::from("/tmp/none"))));
     }
 
     fn test_jwt(secret: &str, claims: Value) -> String {

--- a/services/api-rs/crates/centaur-api-server/src/tool_discovery.rs
+++ b/services/api-rs/crates/centaur-api-server/src/tool_discovery.rs
@@ -65,6 +65,12 @@ pub(crate) struct DiscoveredTool {
     pub(crate) description: Option<String>,
     pub(crate) client_module: String,
     pub(crate) project_dir: PathBuf,
+    /// iron-control role `foreign_id` (`tool-<slug>`) that grants this tool's
+    /// declared secrets, or `None` when the tool declares no secrets (so any
+    /// principal may use it). Mirrors `RoleSpec::tool(<tool dir name>)`, the
+    /// same role `centaur-perms` assigns; used to scope MCP tool visibility to
+    /// the principal's assigned roles.
+    pub(crate) required_tool_role: Option<String>,
 }
 
 #[derive(Debug, Error)]
@@ -164,6 +170,11 @@ pub(crate) fn discover_tool_catalog(
 ) -> Result<DiscoveredToolCatalog, ToolDiscoveryError> {
     let mut tools = Vec::new();
     for tool in collect_plugin_metadata(tool_dirs)?.tools {
+        // A tool's declared secrets are registered under the per-tool role
+        // `tool-<slug of the tool dir name>` (see centaur-perms / RoleSpec::tool).
+        // `tool.name` is the tool directory name, matching that role's slug.
+        let required_tool_role = (!tool.secrets.is_empty())
+            .then(|| centaur_iron_control::RoleSpec::tool(&tool.name).foreign_id);
         for script_name in tool.script_names {
             tools.push(DiscoveredTool {
                 name: script_name,
@@ -171,6 +182,7 @@ pub(crate) fn discover_tool_catalog(
                 description: tool.description.clone(),
                 client_module: tool.client_module.clone(),
                 project_dir: tool.dir.clone(),
+                required_tool_role: required_tool_role.clone(),
             });
         }
     }
@@ -1851,6 +1863,58 @@ secrets = [
     fn write_tool(path: &Path, pyproject: &str) {
         fs::create_dir_all(path).unwrap();
         fs::write(path.join("pyproject.toml"), pyproject).unwrap();
+    }
+
+    #[test]
+    fn catalog_records_per_tool_role_only_for_secret_backed_tools() {
+        let temp = temp_dir("api-rs-tool-role");
+        let base = temp.join("tools");
+        // A secret-backed tool -> requires its `tool-<dir slug>` role.
+        write_tool(
+            &base.join("github"),
+            r#"
+[project]
+name = "centaur-github"
+scripts = { github = "centaur_github.client:main" }
+
+[tool.centaur]
+secrets = [{type = "http", name = "GITHUB_TOKEN", mode = "inject", inject_header = "Authorization", inject_formatter = "Bearer {{ .Value }}", hosts = ["api.github.com"]}]
+"#,
+        );
+        // A tool with no declared secrets -> no required role (public).
+        write_tool(
+            &base.join("calc"),
+            r#"
+[project]
+name = "centaur-calc"
+scripts = { calc = "centaur_calc.client:main" }
+
+[tool.centaur]
+"#,
+        );
+
+        let catalog = discover_tool_catalog(&[base]).unwrap();
+        let github = catalog
+            .tools
+            .iter()
+            .find(|tool| tool.name == "github")
+            .expect("github tool discovered");
+        assert_eq!(
+            github.required_tool_role.as_deref(),
+            Some("tool-github"),
+            "secret-backed tool must require its per-tool role"
+        );
+        let calc = catalog
+            .tools
+            .iter()
+            .find(|tool| tool.name == "calc")
+            .expect("calc tool discovered");
+        assert_eq!(
+            calc.required_tool_role, None,
+            "secretless tool must be public"
+        );
+
+        let _ = fs::remove_dir_all(temp);
     }
 
     fn write_persona(path: &Path, prompt: &str) {

--- a/services/api-rs/crates/centaur-iron-control/src/session.rs
+++ b/services/api-rs/crates/centaur-iron-control/src/session.rs
@@ -116,6 +116,20 @@ impl SessionRegistrar {
     pub async fn get_principal(&self, principal: &str) -> Result<Principal> {
         self.client.get_principal(&self.namespace, principal).await
     }
+
+    /// Role `foreign_id`s currently assigned to a principal (by OID or foreign
+    /// id). Used to scope MCP tool visibility to the tools whose per-tool role
+    /// (`tool-<slug>`) the principal holds.
+    pub async fn principal_role_foreign_ids(
+        &self,
+        principal: &str,
+    ) -> Result<std::collections::BTreeSet<String>> {
+        let roles = self.client.list_principal_roles(principal).await?;
+        Ok(roles
+            .into_iter()
+            .filter_map(|role| role.foreign_id)
+            .collect())
+    }
 }
 
 fn is_status(err: &IronControlError, code: u16) -> bool {

--- a/services/api-rs/crates/centaur-session-runtime/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-runtime/src/lib.rs
@@ -1178,6 +1178,21 @@ impl SessionRuntime {
         Ok(principal_id.to_owned())
     }
 
+    /// Role `foreign_id`s assigned to an MCP principal, or `None` when
+    /// iron-control is not configured. Callers that filter tools by grant
+    /// should treat `None` as "cannot determine — do not filter".
+    pub async fn mcp_principal_role_foreign_ids(
+        &self,
+        principal_id: &str,
+    ) -> Result<Option<std::collections::BTreeSet<String>>, SessionRuntimeError> {
+        let Some(registrar) = &self.iron_control else {
+            return Ok(None);
+        };
+        Ok(Some(
+            registrar.principal_role_foreign_ids(principal_id).await?,
+        ))
+    }
+
     pub fn with_warm_pool(mut self, config: WarmPoolConfig) -> Self {
         if config.target_size == 0 {
             return self;


### PR DESCRIPTION
## What

The MCP `tools/list` showed **every** discovered tool to every authenticated principal, regardless of whether that principal has access to the tool's secrets. A principal without a tool's secret still saw it, and the call then failed later at the proxy with a confusing upstream 401 — exactly what happens today for a freshly OAuth'd, roleless console principal (e.g. `prn_MXythW3X`).

This scopes the MCP catalog to the tools a principal can actually use.

## How

A tool declares the secrets it needs in `[tool.centaur].secrets`; those secrets are registered under a **per-tool iron-control role** `tool-<slug of the tool dir name>` (`RoleSpec::tool`, the same role `centaur-perms` assigns). So the predicate is:

> principal **P** may use tool **T** ⟺ T declares no secrets, **or** P holds role `tool-<slug(T)>`.

- **Discovery** (`tool_discovery.rs`): `DiscoveredTool` now carries `required_tool_role: Option<String>` — `Some("tool-<slug>")` when the tool declares secrets, else `None`.
- **iron-control** (`session.rs`): `SessionRegistrar::principal_role_foreign_ids` returns a principal's assigned role `foreign_id`s; `SessionRuntime::mcp_principal_role_foreign_ids` exposes it (or `None` when iron-control isn't configured).
- **MCP** (`mcp.rs`): `tools/list` is filtered and `tools/call` is gated by `McpToolVisibility`. Tools with no declared secrets are always visible. The whoami tool is unaffected.

## This is a discoverability fix, not a new security boundary

Secret access is **already enforced at runtime** by the per-sandbox iron-proxy: it only injects secrets the principal is granted; an ungranted tool sends the literal placeholder upstream and gets a 401. So nothing leaks today — the problem is phantom tools and confusing failures. Because enforcement is independent, filtering is deliberately **fail-open**: if grants can't be resolved (iron-control unreachable or unconfigured) we show all tools and let the proxy enforce, rather than hide tools on a transient control-plane blip.

## Rollout / safety

Gated behind **`CENTAUR_MCP_FILTER_TOOLS_BY_GRANTS` (default off)**. It's inert until per-tool roles (`tool-<slug>`) are assigned to the principals that need them — enabling it before then would hide every secret-backed tool from everyone. Recommended order: assign roles (via `centaur-perms`) → enable in staging → prod.

## Follow-up (separate PR)

Apply the same predicate to **sandbox** tool installation by computing a per-principal `TOOL_ALLOWLIST` at boot (the plumbing already exists in `install_tool_shims.py`); the sandbox already runs as an `iron_control_principal`.

## Tests

- `tool_discovery`: `catalog_records_per_tool_role_only_for_secret_backed_tools` (secret-backed tool → `tool-<slug>`, secretless → `None`).
- `mcp`: `McpToolVisibility::allows` — unfiltered shows all; `Roles` gates secret-backed tools by membership; empty role set hides all secret-backed tools; secretless tools always visible.
- Full `cargo test` (api-server / iron-control / session-runtime), clippy, and fmt all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)