### PR TITLE
feat: gate sandbox API access by capability

### DIFF
--- a/centaur_sdk/tests/test_tool_sdk.py
+++ b/centaur_sdk/tests/test_tool_sdk.py
@@ -111,6 +111,22 @@ def test_current_session_context_fetches_api_context(monkeypatch: pytest.MonkeyP
         reset_tool_context(token)
 
 
+def test_current_session_context_requires_api_server_capability(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(
+        registry,
+        "_backend",
+        MappingBackend({"CENTAUR_SANDBOX_API_SERVER_ENABLED": "false"}),
+    )
+    token = set_tool_context(ToolContext(name="fake-tool", thread_key="slack:C123:123.456"))
+    try:
+        with pytest.raises(RuntimeError, match="API server sandbox capability"):
+            current_session_context()
+    finally:
+        reset_tool_context(token)
+
+
 def test_current_slack_thread_returns_api_slack_destination(
     monkeypatch: pytest.MonkeyPatch,
 ):
@@ -169,6 +185,23 @@ def test_save_attachment_writes_to_sandbox_uploads_dir(
         "source_url": "https://example.test/report",
         "size_bytes": 5,
     }
+
+
+def test_save_attachment_requires_api_server_capability_without_uploads_dir(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.delenv("CENTAUR_UPLOADS_DIR", raising=False)
+    monkeypatch.setattr(
+        registry,
+        "_backend",
+        MappingBackend({"CENTAUR_SANDBOX_API_SERVER_ENABLED": "false"}),
+    )
+    token = set_tool_context(ToolContext(name="fake-tool", thread_key="slack:C123:123.456"))
+    try:
+        with pytest.raises(RuntimeError, match="API server sandbox capability"):
+            save_attachment(name="report.txt", data=b"hello")
+    finally:
+        reset_tool_context(token)
 
 
 def test_save_attachment_uses_unique_local_name_on_collision(

--- a/centaur_sdk/tool_sdk.py
+++ b/centaur_sdk/tool_sdk.py
@@ -79,6 +79,14 @@ def secret(key: str, default: str | None = None) -> str:
     raise KeyError(f"Missing secret '{key}'{ctx_name}")
 
 
+def _require_api_server_enabled(operation: str) -> None:
+    if secret("CENTAUR_SANDBOX_API_SERVER_ENABLED", "true").strip().lower() == "false":
+        raise RuntimeError(
+            f"{operation} requires the API server sandbox capability, but it is disabled "
+            "for this principal."
+        )
+
+
 def current_thread_key() -> str:
     """Return the active thread key for a tool call."""
     try:
@@ -100,6 +108,7 @@ def current_session_context() -> dict[str, Any]:
     ``slack.thread_ts``. The API remains the source of truth so warm pooled
     sandboxes do not need per-thread environment mutation.
     """
+    _require_api_server_enabled("current_session_context")
     thread_key = current_thread_key()
     base_url = secret("CENTAUR_API_URL", "http://api:8000").rstrip("/")
     headers: dict[str, str] = {}
@@ -188,6 +197,7 @@ def save_attachment(
             uploads_dir=uploads_dir,
         )
 
+    _require_api_server_enabled("save_attachment")
     thread_key = current_thread_key()
     base_url = secret("CENTAUR_API_URL", "http://api:8000").rstrip("/")
     payload = json.dumps(

--- a/contrib/chart/Chart.yaml
+++ b/contrib/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: centaur
 description: Helm chart for the trusted Centaur control plane
 type: application
-version: 0.1.86
+version: 0.1.87
 appVersion: "0.1.0"
 dependencies:
   - name: connect

--- a/contrib/chart/templates/networkpolicy.yaml
+++ b/contrib/chart/templates/networkpolicy.yaml
@@ -189,9 +189,10 @@ spec:
         - podSelector:
             matchLabels:
               centaur.ai/api-server-enabled: "true"
-        # Transitional compatibility: existing sandboxes created before the API
-        # server capability label was introduced still carry only this label.
-        # Keep this until old sandbox pods have aged out.
+        # Transitional compatibility: existing sandbox/proxy pods created
+        # before the API server capability label was introduced still carry only
+        # this label. Remove with the matching egress compatibility policy below
+        # after old api-rs-managed pods have aged out.
         - podSelector:
             matchLabels:
               centaur.ai/managed-by: api-rs
@@ -200,6 +201,32 @@ spec:
             matchLabels:
               kubernetes.io/metadata.name: {{ . | quote }}
 {{- end }}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.apiRs.port }}
+---
+# Transitional compatibility for pre-deploy sandbox/proxy pods. They do not
+# have centaur.ai/api-server-enabled=true, and resume/repair can recreate their
+# per-sandbox policies with the new restricted rule set while the old pods keep
+# running. Remove this with the matching api-rs ingress compatibility selector
+# once old api-rs-managed pods have aged out.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "centaur.fullname" . }}-sandbox-api-server-compat
+  labels:
+{{ include "centaur.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      centaur.ai/managed-by: api-rs
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - podSelector:
+            matchLabels:
+{{ include "centaur.componentSelectorLabels" (dict "root" . "component" "api-rs") | nindent 14 }}
       ports:
         - protocol: TCP
           port: {{ .Values.apiRs.port }}

--- a/contrib/chart/templates/networkpolicy.yaml
+++ b/contrib/chart/templates/networkpolicy.yaml
@@ -184,11 +184,17 @@ spec:
 {{ include "centaur.componentSelectorLabels" (dict "root" . "component" "console-worker") | nindent 14 }}
 {{- end }}
 {{- end }}
-        # Sandboxes call back into the control plane only when their principal
-        # has the API server sandbox capability.
+        # New sandboxes call back into the control plane only when their
+        # principal has the API server sandbox capability.
         - podSelector:
             matchLabels:
               centaur.ai/api-server-enabled: "true"
+        # Transitional compatibility: existing sandboxes created before the API
+        # server capability label was introduced still carry only this label.
+        # Keep this until old sandbox pods have aged out.
+        - podSelector:
+            matchLabels:
+              centaur.ai/managed-by: api-rs
 {{- range .Values.networkPolicy.apiIngressSourceNamespaces }}
         - namespaceSelector:
             matchLabels:

--- a/contrib/chart/templates/networkpolicy.yaml
+++ b/contrib/chart/templates/networkpolicy.yaml
@@ -189,19 +189,16 @@ spec:
         - podSelector:
             matchLabels:
               centaur.ai/api-server-enabled: "true"
-        # Transitional compatibility: pre-deploy sandbox/proxy pods carry
-        # centaur.ai/managed-by=api-rs but no capability stamp. New disabled
-        # pods omit centaur.ai/api-server-enabled but carry the stamp, so they
-        # are excluded from this selector from day one. Remove with the matching
-        # egress compatibility policy below after old api-rs-managed pods have
-        # aged out.
+        # Transitional compatibility: pre-deploy sandbox/proxy pods carry only
+        # centaur.ai/managed-by=api-rs, so this also covers newly-created
+        # API-disabled pods while the rollout policy is present. Remove with the
+        # matching egress compatibility policy below after old api-rs-managed
+        # pods have aged out.
         - podSelector:
             matchLabels:
               centaur.ai/managed-by: api-rs
             matchExpressions:
               - key: centaur.ai/api-server-enabled
-                operator: DoesNotExist
-              - key: centaur.ai/capability-labels-stamped
                 operator: DoesNotExist
 {{- range .Values.networkPolicy.apiIngressSourceNamespaces }}
         - namespaceSelector:
@@ -212,11 +209,11 @@ spec:
         - protocol: TCP
           port: {{ .Values.apiRs.port }}
 ---
-# Transitional compatibility for pre-deploy sandbox/proxy pods. They have
-# centaur.ai/managed-by=api-rs but no capability stamp. New disabled pods omit
-# centaur.ai/api-server-enabled but carry the stamp, so they are excluded from
-# this selector from day one. Remove this with the matching api-rs ingress
-# compatibility selector once old api-rs-managed pods have aged out.
+# Transitional compatibility for pre-deploy sandbox/proxy pods. They carry only
+# centaur.ai/managed-by=api-rs, so this also covers newly-created API-disabled
+# pods while the rollout policy is present. Remove this with the matching
+# api-rs ingress compatibility selector once old api-rs-managed pods have aged
+# out.
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -229,8 +226,6 @@ spec:
       centaur.ai/managed-by: api-rs
     matchExpressions:
       - key: centaur.ai/api-server-enabled
-        operator: DoesNotExist
-      - key: centaur.ai/capability-labels-stamped
         operator: DoesNotExist
   policyTypes:
     - Egress

--- a/contrib/chart/templates/networkpolicy.yaml
+++ b/contrib/chart/templates/networkpolicy.yaml
@@ -150,7 +150,6 @@ spec:
 {{ include "centaur.componentSelectorLabels" (dict "root" . "component" "api-rs") | nindent 6 }}
   policyTypes:
     - Ingress
-    - Egress
   ingress:
     - from:
 {{- if .Values.slackbotv2.enabled }}
@@ -185,12 +184,11 @@ spec:
 {{ include "centaur.componentSelectorLabels" (dict "root" . "component" "console-worker") | nindent 14 }}
 {{- end }}
 {{- end }}
-        # Sandboxes call back into the control plane. agent-k8s labels its pods
-        # centaur.ai/managed-by=api-rs (MANAGED_BY_VALUE in centaur-sandbox-agent-k8s),
-        # which also covers the per-sandbox iron-proxy pods.
+        # Sandboxes call back into the control plane only when their principal
+        # has the API server sandbox capability.
         - podSelector:
             matchLabels:
-              centaur.ai/managed-by: api-rs
+              centaur.ai/api-server-enabled: "true"
 {{- range .Values.networkPolicy.apiIngressSourceNamespaces }}
         - namespaceSelector:
             matchLabels:
@@ -199,6 +197,43 @@ spec:
       ports:
         - protocol: TCP
           port: {{ .Values.apiRs.port }}
+---
+# Sandboxes with the API server capability may call api-rs. The sandbox pod
+# receives this label from api-rs after resolving the principal's capability
+# flags, so default-deny still blocks ordinary sandbox pods.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "centaur.fullname" . }}-sandbox-api-server
+  labels:
+{{ include "centaur.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      centaur.ai/api-server-enabled: "true"
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - podSelector:
+            matchLabels:
+{{ include "centaur.componentSelectorLabels" (dict "root" . "component" "api-rs") | nindent 14 }}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.apiRs.port }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "centaur.componentName" (dict "root" . "component" "api-rs") }}-egress
+  labels:
+{{ include "centaur.componentLabels" (dict "root" . "component" "api-rs") | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+{{ include "centaur.componentSelectorLabels" (dict "root" . "component" "api-rs") | nindent 6 }}
+  policyTypes:
+    - Egress
   egress:
 {{- if .Values.postgres.enabled }}
     - to:

--- a/contrib/chart/templates/networkpolicy.yaml
+++ b/contrib/chart/templates/networkpolicy.yaml
@@ -189,13 +189,18 @@ spec:
         - podSelector:
             matchLabels:
               centaur.ai/api-server-enabled: "true"
-        # Transitional compatibility: existing sandbox/proxy pods created
-        # before the API server capability label was introduced still carry only
-        # this label. Remove with the matching egress compatibility policy below
-        # after old api-rs-managed pods have aged out.
+        # Transitional compatibility: pre-deploy sandbox/proxy pods carry
+        # centaur.ai/managed-by=api-rs but no explicit API server capability
+        # label. New restricted pods carry centaur.ai/api-server-enabled=false
+        # and are excluded from this selector from day one. Remove with the
+        # matching egress compatibility policy below after old api-rs-managed
+        # pods have aged out.
         - podSelector:
             matchLabels:
               centaur.ai/managed-by: api-rs
+            matchExpressions:
+              - key: centaur.ai/api-server-enabled
+                operator: DoesNotExist
 {{- range .Values.networkPolicy.apiIngressSourceNamespaces }}
         - namespaceSelector:
             matchLabels:
@@ -205,11 +210,11 @@ spec:
         - protocol: TCP
           port: {{ .Values.apiRs.port }}
 ---
-# Transitional compatibility for pre-deploy sandbox/proxy pods. They do not
-# have centaur.ai/api-server-enabled=true, and resume/repair can recreate their
-# per-sandbox policies with the new restricted rule set while the old pods keep
-# running. Remove this with the matching api-rs ingress compatibility selector
-# once old api-rs-managed pods have aged out.
+# Transitional compatibility for pre-deploy sandbox/proxy pods. They have
+# centaur.ai/managed-by=api-rs but no explicit API server capability label.
+# New restricted pods carry centaur.ai/api-server-enabled=false and are excluded
+# from this selector from day one. Remove this with the matching api-rs ingress
+# compatibility selector once old api-rs-managed pods have aged out.
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -220,6 +225,9 @@ spec:
   podSelector:
     matchLabels:
       centaur.ai/managed-by: api-rs
+    matchExpressions:
+      - key: centaur.ai/api-server-enabled
+        operator: DoesNotExist
   policyTypes:
     - Egress
   egress:
@@ -231,9 +239,10 @@ spec:
         - protocol: TCP
           port: {{ .Values.apiRs.port }}
 ---
-# Sandboxes with the API server capability may call api-rs. The sandbox pod
-# receives this label from api-rs after resolving the principal's capability
-# flags, so default-deny still blocks ordinary sandbox pods.
+# Sandboxes with the API server capability may call api-rs. New sandbox and
+# proxy pods receive an explicit true/false label from api-rs after resolving
+# the principal's capability flags, so default-deny blocks new pods without the
+# capability.
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/contrib/chart/templates/networkpolicy.yaml
+++ b/contrib/chart/templates/networkpolicy.yaml
@@ -190,16 +190,18 @@ spec:
             matchLabels:
               centaur.ai/api-server-enabled: "true"
         # Transitional compatibility: pre-deploy sandbox/proxy pods carry
-        # centaur.ai/managed-by=api-rs but no explicit API server capability
-        # label. New restricted pods carry centaur.ai/api-server-enabled=false
-        # and are excluded from this selector from day one. Remove with the
-        # matching egress compatibility policy below after old api-rs-managed
-        # pods have aged out.
+        # centaur.ai/managed-by=api-rs but no capability stamp. New disabled
+        # pods omit centaur.ai/api-server-enabled but carry the stamp, so they
+        # are excluded from this selector from day one. Remove with the matching
+        # egress compatibility policy below after old api-rs-managed pods have
+        # aged out.
         - podSelector:
             matchLabels:
               centaur.ai/managed-by: api-rs
             matchExpressions:
               - key: centaur.ai/api-server-enabled
+                operator: DoesNotExist
+              - key: centaur.ai/capability-labels-stamped
                 operator: DoesNotExist
 {{- range .Values.networkPolicy.apiIngressSourceNamespaces }}
         - namespaceSelector:
@@ -211,9 +213,9 @@ spec:
           port: {{ .Values.apiRs.port }}
 ---
 # Transitional compatibility for pre-deploy sandbox/proxy pods. They have
-# centaur.ai/managed-by=api-rs but no explicit API server capability label.
-# New restricted pods carry centaur.ai/api-server-enabled=false and are excluded
-# from this selector from day one. Remove this with the matching api-rs ingress
+# centaur.ai/managed-by=api-rs but no capability stamp. New disabled pods omit
+# centaur.ai/api-server-enabled but carry the stamp, so they are excluded from
+# this selector from day one. Remove this with the matching api-rs ingress
 # compatibility selector once old api-rs-managed pods have aged out.
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -228,6 +230,8 @@ spec:
     matchExpressions:
       - key: centaur.ai/api-server-enabled
         operator: DoesNotExist
+      - key: centaur.ai/capability-labels-stamped
+        operator: DoesNotExist
   policyTypes:
     - Egress
   egress:
@@ -240,9 +244,8 @@ spec:
           port: {{ .Values.apiRs.port }}
 ---
 # Sandboxes with the API server capability may call api-rs. New sandbox and
-# proxy pods receive an explicit true/false label from api-rs after resolving
-# the principal's capability flags, so default-deny blocks new pods without the
-# capability.
+# proxy pods receive centaur.ai/api-server-enabled=true from api-rs only when
+# the principal has the capability, so default-deny blocks new pods without it.
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/services/api-rs/crates/centaur-iron-control/src/models.rs
+++ b/services/api-rs/crates/centaur-iron-control/src/models.rs
@@ -478,6 +478,8 @@ pub struct Principal {
     pub sandbox_repo_cache_enabled: bool,
     #[serde(default = "default_true")]
     pub sandbox_observability_enabled: bool,
+    #[serde(default = "default_true")]
+    pub sandbox_api_server_enabled: bool,
 }
 
 /// A principal's effective config — the same secrets/postgres the principal's

--- a/services/api-rs/crates/centaur-sandbox-agent-k8s/src/iron_proxy.rs
+++ b/services/api-rs/crates/centaur-sandbox-agent-k8s/src/iron_proxy.rs
@@ -20,9 +20,8 @@ use serde_json::{Value, json};
 use tokio::time::{Instant, sleep};
 
 use crate::{
-    API_SERVER_ENABLED_LABEL, AgentSandboxBackend, CAPABILITY_LABELS_STAMPED_LABEL,
-    MANAGED_BY_LABEL, MANAGED_BY_VALUE, OtlpEgressTarget, SANDBOX_ID_LABEL, is_not_found,
-    map_kube_error,
+    API_SERVER_ENABLED_LABEL, AgentSandboxBackend, MANAGED_BY_LABEL, MANAGED_BY_VALUE,
+    OtlpEgressTarget, SANDBOX_ID_LABEL, is_not_found, map_kube_error,
 };
 
 const IRON_PROXY_LABEL: &str = "centaur.ai/iron-proxy";
@@ -1915,10 +1914,6 @@ fn iron_proxy_labels(id: &SandboxId, api_server_enabled: bool) -> BTreeMap<Strin
         (MANAGED_BY_LABEL.to_owned(), MANAGED_BY_VALUE.to_owned()),
         (SANDBOX_ID_LABEL.to_owned(), id.as_str().to_owned()),
         (IRON_PROXY_LABEL.to_owned(), "true".to_owned()),
-        (
-            CAPABILITY_LABELS_STAMPED_LABEL.to_owned(),
-            "true".to_owned(),
-        ),
     ]);
     if api_server_enabled {
         labels.insert(API_SERVER_ENABLED_LABEL.to_owned(), "true".to_owned());
@@ -2063,15 +2058,7 @@ mod tests {
                 .map(String::as_str),
             Some("true")
         );
-        assert!(
-            !iron_proxy_labels(&id, false).contains_key(API_SERVER_ENABLED_LABEL)
-        );
-        assert_eq!(
-            iron_proxy_labels(&id, false)
-                .get(CAPABILITY_LABELS_STAMPED_LABEL)
-                .map(String::as_str),
-            Some("true")
-        );
+        assert!(!iron_proxy_labels(&id, false).contains_key(API_SERVER_ENABLED_LABEL));
     }
 
     #[test]

--- a/services/api-rs/crates/centaur-sandbox-agent-k8s/src/iron_proxy.rs
+++ b/services/api-rs/crates/centaur-sandbox-agent-k8s/src/iron_proxy.rs
@@ -1313,10 +1313,6 @@ fn build_iron_proxy_network_policies(
             sandbox_to_proxy_ports.clone(),
         ),
         dns_egress_rule(),
-        egress_to(
-            vec![pod_peer(iron_proxy.api_pod_labels.clone())],
-            vec![network_port(8000), network_port(8080)],
-        ),
     ];
     vec![
         NetworkPolicy {
@@ -2089,7 +2085,7 @@ mod tests {
                 .iter()
                 .any(|rule| rule_allows_namespace_port(rule, "laminar", 8000))
         );
-        assert!(sandbox_egress.iter().any(|rule| {
+        assert!(!sandbox_egress.iter().any(|rule| {
             rule.to.as_ref().is_some_and(|peers| {
                 peers.iter().any(|peer| {
                     peer.pod_selector.as_ref().is_some_and(|selector| {

--- a/services/api-rs/crates/centaur-sandbox-agent-k8s/src/iron_proxy.rs
+++ b/services/api-rs/crates/centaur-sandbox-agent-k8s/src/iron_proxy.rs
@@ -2064,9 +2064,7 @@ mod tests {
             Some("true")
         );
         assert!(
-            iron_proxy_labels(&id, false)
-                .get(API_SERVER_ENABLED_LABEL)
-                .is_none()
+            !iron_proxy_labels(&id, false).contains_key(API_SERVER_ENABLED_LABEL)
         );
         assert_eq!(
             iron_proxy_labels(&id, false)

--- a/services/api-rs/crates/centaur-sandbox-agent-k8s/src/iron_proxy.rs
+++ b/services/api-rs/crates/centaur-sandbox-agent-k8s/src/iron_proxy.rs
@@ -20,8 +20,8 @@ use serde_json::{Value, json};
 use tokio::time::{Instant, sleep};
 
 use crate::{
-    AgentSandboxBackend, MANAGED_BY_LABEL, MANAGED_BY_VALUE, OtlpEgressTarget, SANDBOX_ID_LABEL,
-    is_not_found, map_kube_error,
+    API_SERVER_ENABLED_LABEL, AgentSandboxBackend, MANAGED_BY_LABEL, MANAGED_BY_VALUE,
+    OtlpEgressTarget, SANDBOX_ID_LABEL, is_not_found, map_kube_error,
 };
 
 const IRON_PROXY_LABEL: &str = "centaur.ai/iron-proxy";
@@ -137,6 +137,7 @@ pub(crate) struct ResolvedIronProxy {
     // env, so it survives api-rs restarts and respects env overrides.
     management_api_key: String,
     observability_enabled: bool,
+    api_server_enabled: bool,
 }
 
 /// The single Postgres listener the proxy multiplexes every upstream through.
@@ -201,6 +202,7 @@ impl AgentSandboxBackend {
             pg,
             replace_placeholders,
             spec.capabilities.observability_enabled,
+            spec.capabilities.api_server_enabled,
         )))
     }
 
@@ -282,12 +284,22 @@ impl AgentSandboxBackend {
                 );
                 true
             });
+        let api_server_enabled = sandbox_api_server_enabled(&sandbox, &self.config.container_name)
+            .unwrap_or_else(|| {
+                tracing::warn!(
+                    sandbox_id = id.as_str(),
+                    container_name = self.config.container_name.as_str(),
+                    "sandbox API server capability env is missing or invalid; defaulting to enabled network policy"
+                );
+                true
+            });
         Ok(Some(self.resolved_iron_proxy_for_principal(
             id,
             principal_id,
             pg,
             replace_placeholders,
             observability_enabled,
+            api_server_enabled,
         )))
     }
 
@@ -298,6 +310,7 @@ impl AgentSandboxBackend {
         pg: Option<ResolvedPg>,
         replace_placeholders: BTreeMap<String, String>,
         observability_enabled: bool,
+        api_server_enabled: bool,
     ) -> ResolvedIronProxy {
         ResolvedIronProxy {
             proxy_host: iron_proxy_service_name(id),
@@ -308,6 +321,7 @@ impl AgentSandboxBackend {
             replace_placeholders,
             management_api_key: new_proxy_management_api_key(),
             observability_enabled,
+            api_server_enabled,
         }
     }
 
@@ -584,12 +598,24 @@ impl AgentSandboxBackend {
                 );
                 true
             });
+        let api_server_enabled = sandbox
+            .as_ref()
+            .and_then(|sandbox| sandbox_api_server_enabled(sandbox, &self.config.container_name))
+            .unwrap_or_else(|| {
+                tracing::warn!(
+                    sandbox_id = id.as_str(),
+                    container_name = self.config.container_name.as_str(),
+                    "sandbox API server capability env is missing or invalid during proxy repair; defaulting to enabled network policy"
+                );
+                true
+            });
         let resolved = self.resolved_iron_proxy_for_principal(
             id,
             principal_id,
             pg,
             replace_placeholders,
             observability_enabled,
+            api_server_enabled,
         );
         self.create_iron_proxy_resources(id, Some(&resolved))
             .await?;
@@ -1128,7 +1154,7 @@ fn build_iron_proxy_pod(
     Pod {
         metadata: object_meta_with_annotations(
             resolved.proxy_pod_name.clone(),
-            iron_proxy_labels(id),
+            iron_proxy_labels(id, resolved.api_server_enabled),
             annotations,
         ),
         spec: Some(PodSpec {
@@ -1288,9 +1314,12 @@ fn build_iron_proxy_service(id: &SandboxId, resolved: &ResolvedIronProxy) -> Ser
         ports.push(service_port("pg", pg.port));
     }
     Service {
-        metadata: object_meta(iron_proxy_service_name(id), iron_proxy_labels(id)),
+        metadata: object_meta(
+            iron_proxy_service_name(id),
+            iron_proxy_labels(id, resolved.api_server_enabled),
+        ),
         spec: Some(ServiceSpec {
-            selector: Some(iron_proxy_labels(id)),
+            selector: Some(iron_proxy_labels(id, resolved.api_server_enabled)),
             ports: Some(ports),
             ..Default::default()
         }),
@@ -1309,7 +1338,7 @@ fn build_iron_proxy_network_policies(
     let sandbox_to_proxy_ports = sandbox_to_proxy_ports(resolved);
     let sandbox_egress = vec![
         egress_to(
-            vec![pod_peer(iron_proxy_labels(id))],
+            vec![pod_peer(iron_proxy_labels(id, resolved.api_server_enabled))],
             sandbox_to_proxy_ports.clone(),
         ),
         dns_egress_rule(),
@@ -1328,9 +1357,15 @@ fn build_iron_proxy_network_policies(
             }),
         },
         NetworkPolicy {
-            metadata: object_meta(iron_proxy_policy_name(id), iron_proxy_labels(id)),
+            metadata: object_meta(
+                iron_proxy_policy_name(id),
+                iron_proxy_labels(id, resolved.api_server_enabled),
+            ),
             spec: Some(NetworkPolicySpec {
-                pod_selector: Some(label_selector(iron_proxy_labels(id))),
+                pod_selector: Some(label_selector(iron_proxy_labels(
+                    id,
+                    resolved.api_server_enabled,
+                ))),
                 policy_types: Some(vec!["Ingress".to_owned(), "Egress".to_owned()]),
                 ingress: Some(vec![
                     NetworkPolicyIngressRule {
@@ -1594,6 +1629,15 @@ fn sandbox_observability_enabled(
     sandbox_env_value(
         sandbox,
         "CENTAUR_SANDBOX_OBSERVABILITY_ENABLED",
+        container_name,
+    )
+    .and_then(|value| value.parse().ok())
+}
+
+fn sandbox_api_server_enabled(sandbox: &crate::crd::Sandbox, container_name: &str) -> Option<bool> {
+    sandbox_env_value(
+        sandbox,
+        "CENTAUR_SANDBOX_API_SERVER_ENABLED",
         container_name,
     )
     .and_then(|value| value.parse().ok())
@@ -1865,11 +1909,15 @@ fn sandbox_labels(id: &SandboxId) -> BTreeMap<String, String> {
     ])
 }
 
-fn iron_proxy_labels(id: &SandboxId) -> BTreeMap<String, String> {
+fn iron_proxy_labels(id: &SandboxId, api_server_enabled: bool) -> BTreeMap<String, String> {
     BTreeMap::from([
         (MANAGED_BY_LABEL.to_owned(), MANAGED_BY_VALUE.to_owned()),
         (SANDBOX_ID_LABEL.to_owned(), id.as_str().to_owned()),
         (IRON_PROXY_LABEL.to_owned(), "true".to_owned()),
+        (
+            API_SERVER_ENABLED_LABEL.to_owned(),
+            api_server_enabled.to_string(),
+        ),
     ])
 }
 
@@ -1895,6 +1943,7 @@ mod tests {
             replace_placeholders: BTreeMap::new(),
             management_api_key: "test-management-key".to_owned(),
             observability_enabled: true,
+            api_server_enabled: true,
         }
     }
 
@@ -1997,6 +2046,24 @@ mod tests {
         assert_eq!(target.port, 3000);
         assert_eq!(peer_namespace(control_peer(&target)), Some("centaur"));
         assert_eq!(peer_component(control_peer(&target)), Some("console"));
+    }
+
+    #[test]
+    fn iron_proxy_labels_api_server_capability_explicitly() {
+        let id = SandboxId::new("asbx-test");
+
+        assert_eq!(
+            iron_proxy_labels(&id, true)
+                .get(API_SERVER_ENABLED_LABEL)
+                .map(String::as_str),
+            Some("true")
+        );
+        assert_eq!(
+            iron_proxy_labels(&id, false)
+                .get(API_SERVER_ENABLED_LABEL)
+                .map(String::as_str),
+            Some("false")
+        );
     }
 
     #[test]

--- a/services/api-rs/crates/centaur-sandbox-agent-k8s/src/iron_proxy.rs
+++ b/services/api-rs/crates/centaur-sandbox-agent-k8s/src/iron_proxy.rs
@@ -20,8 +20,9 @@ use serde_json::{Value, json};
 use tokio::time::{Instant, sleep};
 
 use crate::{
-    API_SERVER_ENABLED_LABEL, AgentSandboxBackend, MANAGED_BY_LABEL, MANAGED_BY_VALUE,
-    OtlpEgressTarget, SANDBOX_ID_LABEL, is_not_found, map_kube_error,
+    API_SERVER_ENABLED_LABEL, AgentSandboxBackend, CAPABILITY_LABELS_STAMPED_LABEL,
+    MANAGED_BY_LABEL, MANAGED_BY_VALUE, OtlpEgressTarget, SANDBOX_ID_LABEL, is_not_found,
+    map_kube_error,
 };
 
 const IRON_PROXY_LABEL: &str = "centaur.ai/iron-proxy";
@@ -1910,15 +1911,19 @@ fn sandbox_labels(id: &SandboxId) -> BTreeMap<String, String> {
 }
 
 fn iron_proxy_labels(id: &SandboxId, api_server_enabled: bool) -> BTreeMap<String, String> {
-    BTreeMap::from([
+    let mut labels = BTreeMap::from([
         (MANAGED_BY_LABEL.to_owned(), MANAGED_BY_VALUE.to_owned()),
         (SANDBOX_ID_LABEL.to_owned(), id.as_str().to_owned()),
         (IRON_PROXY_LABEL.to_owned(), "true".to_owned()),
         (
-            API_SERVER_ENABLED_LABEL.to_owned(),
-            api_server_enabled.to_string(),
+            CAPABILITY_LABELS_STAMPED_LABEL.to_owned(),
+            "true".to_owned(),
         ),
-    ])
+    ]);
+    if api_server_enabled {
+        labels.insert(API_SERVER_ENABLED_LABEL.to_owned(), "true".to_owned());
+    }
+    labels
 }
 
 fn unique_suffix() -> String {
@@ -2049,7 +2054,7 @@ mod tests {
     }
 
     #[test]
-    fn iron_proxy_labels_api_server_capability_explicitly() {
+    fn iron_proxy_labels_api_server_capability_when_enabled() {
         let id = SandboxId::new("asbx-test");
 
         assert_eq!(
@@ -2058,11 +2063,16 @@ mod tests {
                 .map(String::as_str),
             Some("true")
         );
-        assert_eq!(
+        assert!(
             iron_proxy_labels(&id, false)
                 .get(API_SERVER_ENABLED_LABEL)
+                .is_none()
+        );
+        assert_eq!(
+            iron_proxy_labels(&id, false)
+                .get(CAPABILITY_LABELS_STAMPED_LABEL)
                 .map(String::as_str),
-            Some("false")
+            Some("true")
         );
     }
 

--- a/services/api-rs/crates/centaur-sandbox-agent-k8s/src/lib.rs
+++ b/services/api-rs/crates/centaur-sandbox-agent-k8s/src/lib.rs
@@ -39,6 +39,7 @@ const MANAGED_BY_LABEL: &str = "centaur.ai/managed-by";
 const SANDBOX_ID_LABEL: &str = "centaur.ai/sandbox-id";
 const OBSERVABILITY_ENABLED_LABEL: &str = "centaur.ai/observability-enabled";
 const API_SERVER_ENABLED_LABEL: &str = "centaur.ai/api-server-enabled";
+const CAPABILITY_LABELS_STAMPED_LABEL: &str = "centaur.ai/capability-labels-stamped";
 const MANAGED_BY_VALUE: &str = "api-rs";
 // iron-control principal OID the sandbox's proxy binds to, stamped at create
 // so resume (which has only the sandbox id) can rebind without the spec or any
@@ -572,13 +573,16 @@ fn build_agent_sandbox(
     labels.extend(spec.labels.clone());
     labels.insert(MANAGED_BY_LABEL.to_owned(), MANAGED_BY_VALUE.to_owned());
     labels.insert(SANDBOX_ID_LABEL.to_owned(), id.as_str().to_owned());
+    labels.insert(
+        CAPABILITY_LABELS_STAMPED_LABEL.to_owned(),
+        "true".to_owned(),
+    );
     if spec.capabilities.observability_enabled {
         labels.insert(OBSERVABILITY_ENABLED_LABEL.to_owned(), "true".to_owned());
     }
-    labels.insert(
-        API_SERVER_ENABLED_LABEL.to_owned(),
-        spec.capabilities.api_server_enabled.to_string(),
-    );
+    if spec.capabilities.api_server_enabled {
+        labels.insert(API_SERVER_ENABLED_LABEL.to_owned(), "true".to_owned());
+    }
 
     let mut pod_labels = labels.clone();
     pod_labels.insert(
@@ -962,10 +966,19 @@ mod tests {
                 .map(String::as_str),
             Some("true")
         );
+        assert_eq!(
+            sandbox
+                .metadata
+                .labels
+                .as_ref()
+                .and_then(|labels| labels.get(CAPABILITY_LABELS_STAMPED_LABEL))
+                .map(String::as_str),
+            Some("true")
+        );
     }
 
     #[test]
-    fn labels_api_server_disabled_restricted_sandboxes() {
+    fn omits_api_server_label_for_restricted_sandboxes() {
         let spec = SandboxSpec::new("centaur-agent:latest").capabilities(SandboxCapabilities {
             repo_cache_enabled: true,
             observability_enabled: false,
@@ -991,25 +1004,30 @@ mod tests {
                 .and_then(|metadata| metadata.labels.as_ref())
                 .is_none_or(|labels| !labels.contains_key(OBSERVABILITY_ENABLED_LABEL))
         );
-        assert_eq!(
+        assert!(
             sandbox
                 .metadata
                 .labels
                 .as_ref()
-                .and_then(|labels| labels.get(API_SERVER_ENABLED_LABEL))
-                .map(String::as_str),
-            Some("false")
+                .is_none_or(|labels| !labels.contains_key(API_SERVER_ENABLED_LABEL))
         );
-        assert_eq!(
+        assert!(
             sandbox
                 .spec
                 .pod_template
                 .metadata
                 .as_ref()
                 .and_then(|metadata| metadata.labels.as_ref())
-                .and_then(|labels| labels.get(API_SERVER_ENABLED_LABEL))
+                .is_none_or(|labels| !labels.contains_key(API_SERVER_ENABLED_LABEL))
+        );
+        assert_eq!(
+            sandbox
+                .metadata
+                .labels
+                .as_ref()
+                .and_then(|labels| labels.get(CAPABILITY_LABELS_STAMPED_LABEL))
                 .map(String::as_str),
-            Some("false")
+            Some("true")
         );
     }
 

--- a/services/api-rs/crates/centaur-sandbox-agent-k8s/src/lib.rs
+++ b/services/api-rs/crates/centaur-sandbox-agent-k8s/src/lib.rs
@@ -38,6 +38,7 @@ const DEFAULT_CONTAINER_NAME: &str = "agent";
 const MANAGED_BY_LABEL: &str = "centaur.ai/managed-by";
 const SANDBOX_ID_LABEL: &str = "centaur.ai/sandbox-id";
 const OBSERVABILITY_ENABLED_LABEL: &str = "centaur.ai/observability-enabled";
+const API_SERVER_ENABLED_LABEL: &str = "centaur.ai/api-server-enabled";
 const MANAGED_BY_VALUE: &str = "api-rs";
 // iron-control principal OID the sandbox's proxy binds to, stamped at create
 // so resume (which has only the sandbox id) can rebind without the spec or any
@@ -574,6 +575,9 @@ fn build_agent_sandbox(
     if spec.capabilities.observability_enabled {
         labels.insert(OBSERVABILITY_ENABLED_LABEL.to_owned(), "true".to_owned());
     }
+    if spec.capabilities.api_server_enabled {
+        labels.insert(API_SERVER_ENABLED_LABEL.to_owned(), "true".to_owned());
+    }
 
     let mut pod_labels = labels.clone();
     pod_labels.insert(
@@ -911,6 +915,7 @@ mod tests {
         let spec = SandboxSpec::new("centaur-agent:latest").capabilities(SandboxCapabilities {
             repo_cache_enabled: true,
             observability_enabled: true,
+            api_server_enabled: true,
         });
         let config = AgentSandboxConfig::new("centaur");
 
@@ -933,16 +938,37 @@ mod tests {
                 .as_ref()
                 .and_then(|metadata| metadata.labels.as_ref())
                 .and_then(|labels| labels.get(OBSERVABILITY_ENABLED_LABEL))
+                .map(String::as_str),
+            Some("true")
+        );
+        assert_eq!(
+            sandbox
+                .metadata
+                .labels
+                .as_ref()
+                .and_then(|labels| labels.get(API_SERVER_ENABLED_LABEL))
+                .map(String::as_str),
+            Some("true")
+        );
+        assert_eq!(
+            sandbox
+                .spec
+                .pod_template
+                .metadata
+                .as_ref()
+                .and_then(|metadata| metadata.labels.as_ref())
+                .and_then(|labels| labels.get(API_SERVER_ENABLED_LABEL))
                 .map(String::as_str),
             Some("true")
         );
     }
 
     #[test]
-    fn omits_observability_enabled_label_for_restricted_sandboxes() {
+    fn omits_capability_labels_for_restricted_sandboxes() {
         let spec = SandboxSpec::new("centaur-agent:latest").capabilities(SandboxCapabilities {
             repo_cache_enabled: true,
             observability_enabled: false,
+            api_server_enabled: false,
         });
         let config = AgentSandboxConfig::new("centaur");
 
@@ -963,6 +989,22 @@ mod tests {
                 .as_ref()
                 .and_then(|metadata| metadata.labels.as_ref())
                 .is_none_or(|labels| !labels.contains_key(OBSERVABILITY_ENABLED_LABEL))
+        );
+        assert!(
+            sandbox
+                .metadata
+                .labels
+                .as_ref()
+                .is_none_or(|labels| !labels.contains_key(API_SERVER_ENABLED_LABEL))
+        );
+        assert!(
+            sandbox
+                .spec
+                .pod_template
+                .metadata
+                .as_ref()
+                .and_then(|metadata| metadata.labels.as_ref())
+                .is_none_or(|labels| !labels.contains_key(API_SERVER_ENABLED_LABEL))
         );
     }
 
@@ -1021,6 +1063,7 @@ mod tests {
         let spec = SandboxSpec::new("centaur-agent:latest").capabilities(SandboxCapabilities {
             repo_cache_enabled: false,
             observability_enabled: true,
+            api_server_enabled: true,
         });
         let mut tools = ToolsConfig::new("paradigmxyz/centaur", "api:test");
         tools.repo_cache_path = Some("/var/lib/centaur/repos".to_owned());

--- a/services/api-rs/crates/centaur-sandbox-agent-k8s/src/lib.rs
+++ b/services/api-rs/crates/centaur-sandbox-agent-k8s/src/lib.rs
@@ -39,7 +39,6 @@ const MANAGED_BY_LABEL: &str = "centaur.ai/managed-by";
 const SANDBOX_ID_LABEL: &str = "centaur.ai/sandbox-id";
 const OBSERVABILITY_ENABLED_LABEL: &str = "centaur.ai/observability-enabled";
 const API_SERVER_ENABLED_LABEL: &str = "centaur.ai/api-server-enabled";
-const CAPABILITY_LABELS_STAMPED_LABEL: &str = "centaur.ai/capability-labels-stamped";
 const MANAGED_BY_VALUE: &str = "api-rs";
 // iron-control principal OID the sandbox's proxy binds to, stamped at create
 // so resume (which has only the sandbox id) can rebind without the spec or any
@@ -573,10 +572,6 @@ fn build_agent_sandbox(
     labels.extend(spec.labels.clone());
     labels.insert(MANAGED_BY_LABEL.to_owned(), MANAGED_BY_VALUE.to_owned());
     labels.insert(SANDBOX_ID_LABEL.to_owned(), id.as_str().to_owned());
-    labels.insert(
-        CAPABILITY_LABELS_STAMPED_LABEL.to_owned(),
-        "true".to_owned(),
-    );
     if spec.capabilities.observability_enabled {
         labels.insert(OBSERVABILITY_ENABLED_LABEL.to_owned(), "true".to_owned());
     }
@@ -966,15 +961,6 @@ mod tests {
                 .map(String::as_str),
             Some("true")
         );
-        assert_eq!(
-            sandbox
-                .metadata
-                .labels
-                .as_ref()
-                .and_then(|labels| labels.get(CAPABILITY_LABELS_STAMPED_LABEL))
-                .map(String::as_str),
-            Some("true")
-        );
     }
 
     #[test]
@@ -1019,15 +1005,6 @@ mod tests {
                 .as_ref()
                 .and_then(|metadata| metadata.labels.as_ref())
                 .is_none_or(|labels| !labels.contains_key(API_SERVER_ENABLED_LABEL))
-        );
-        assert_eq!(
-            sandbox
-                .metadata
-                .labels
-                .as_ref()
-                .and_then(|labels| labels.get(CAPABILITY_LABELS_STAMPED_LABEL))
-                .map(String::as_str),
-            Some("true")
         );
     }
 

--- a/services/api-rs/crates/centaur-sandbox-agent-k8s/src/lib.rs
+++ b/services/api-rs/crates/centaur-sandbox-agent-k8s/src/lib.rs
@@ -575,9 +575,10 @@ fn build_agent_sandbox(
     if spec.capabilities.observability_enabled {
         labels.insert(OBSERVABILITY_ENABLED_LABEL.to_owned(), "true".to_owned());
     }
-    if spec.capabilities.api_server_enabled {
-        labels.insert(API_SERVER_ENABLED_LABEL.to_owned(), "true".to_owned());
-    }
+    labels.insert(
+        API_SERVER_ENABLED_LABEL.to_owned(),
+        spec.capabilities.api_server_enabled.to_string(),
+    );
 
     let mut pod_labels = labels.clone();
     pod_labels.insert(
@@ -964,7 +965,7 @@ mod tests {
     }
 
     #[test]
-    fn omits_capability_labels_for_restricted_sandboxes() {
+    fn labels_api_server_disabled_restricted_sandboxes() {
         let spec = SandboxSpec::new("centaur-agent:latest").capabilities(SandboxCapabilities {
             repo_cache_enabled: true,
             observability_enabled: false,
@@ -990,21 +991,25 @@ mod tests {
                 .and_then(|metadata| metadata.labels.as_ref())
                 .is_none_or(|labels| !labels.contains_key(OBSERVABILITY_ENABLED_LABEL))
         );
-        assert!(
+        assert_eq!(
             sandbox
                 .metadata
                 .labels
                 .as_ref()
-                .is_none_or(|labels| !labels.contains_key(API_SERVER_ENABLED_LABEL))
+                .and_then(|labels| labels.get(API_SERVER_ENABLED_LABEL))
+                .map(String::as_str),
+            Some("false")
         );
-        assert!(
+        assert_eq!(
             sandbox
                 .spec
                 .pod_template
                 .metadata
                 .as_ref()
                 .and_then(|metadata| metadata.labels.as_ref())
-                .is_none_or(|labels| !labels.contains_key(API_SERVER_ENABLED_LABEL))
+                .and_then(|labels| labels.get(API_SERVER_ENABLED_LABEL))
+                .map(String::as_str),
+            Some("false")
         );
     }
 

--- a/services/api-rs/crates/centaur-sandbox-core/src/spec.rs
+++ b/services/api-rs/crates/centaur-sandbox-core/src/spec.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 pub struct SandboxCapabilities {
     pub repo_cache_enabled: bool,
     pub observability_enabled: bool,
+    pub api_server_enabled: bool,
 }
 
 impl SandboxCapabilities {
@@ -11,11 +12,12 @@ impl SandboxCapabilities {
         Self {
             repo_cache_enabled: true,
             observability_enabled: true,
+            api_server_enabled: true,
         }
     }
 
     pub const fn is_default_enabled(&self) -> bool {
-        self.repo_cache_enabled && self.observability_enabled
+        self.repo_cache_enabled && self.observability_enabled && self.api_server_enabled
     }
 }
 

--- a/services/api-rs/crates/centaur-session-core/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-core/src/lib.rs
@@ -141,6 +141,7 @@ pub enum SessionStatus {
 pub struct SandboxCapabilities {
     pub repo_cache_enabled: bool,
     pub observability_enabled: bool,
+    pub api_server_enabled: bool,
 }
 
 impl SandboxCapabilities {
@@ -148,11 +149,12 @@ impl SandboxCapabilities {
         Self {
             repo_cache_enabled: true,
             observability_enabled: true,
+            api_server_enabled: true,
         }
     }
 
     pub const fn is_default_enabled(&self) -> bool {
-        self.repo_cache_enabled && self.observability_enabled
+        self.repo_cache_enabled && self.observability_enabled && self.api_server_enabled
     }
 }
 

--- a/services/api-rs/crates/centaur-session-runtime/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-runtime/src/lib.rs
@@ -2225,6 +2225,7 @@ impl SessionRuntime {
             sandbox_boot_mode = boot_mode.as_str(),
             sandbox_repo_cache_enabled = desired_capabilities.repo_cache_enabled,
             sandbox_observability_enabled = desired_capabilities.observability_enabled,
+            sandbox_api_server_enabled = desired_capabilities.api_server_enabled,
         );
         let ensure_started = Instant::now();
         let result = async {
@@ -2261,6 +2262,7 @@ impl SessionRuntime {
                         sandbox_id,
                         sandbox_repo_cache_enabled = desired_capabilities.repo_cache_enabled,
                         sandbox_observability_enabled = desired_capabilities.observability_enabled,
+                        sandbox_api_server_enabled = desired_capabilities.api_server_enabled,
                         "replacing existing sandbox whose capabilities do not match"
                     );
                 } else {
@@ -2581,6 +2583,7 @@ impl SessionRuntime {
         Ok(SessionSandboxCapabilities {
             repo_cache_enabled: principal.sandbox_repo_cache_enabled,
             observability_enabled: principal.sandbox_observability_enabled,
+            api_server_enabled: principal.sandbox_api_server_enabled,
         })
     }
 
@@ -5282,6 +5285,7 @@ fn apply_sandbox_capabilities(spec: &mut SandboxSpec, capabilities: &SessionSand
     spec.capabilities = BackendSandboxCapabilities {
         repo_cache_enabled: capabilities.repo_cache_enabled,
         observability_enabled: capabilities.observability_enabled,
+        api_server_enabled: capabilities.api_server_enabled,
     };
     upsert_spec_env(
         spec,
@@ -5292,6 +5296,11 @@ fn apply_sandbox_capabilities(spec: &mut SandboxSpec, capabilities: &SessionSand
         spec,
         "CENTAUR_SANDBOX_OBSERVABILITY_ENABLED",
         capabilities.observability_enabled.to_string(),
+    );
+    upsert_spec_env(
+        spec,
+        "CENTAUR_SANDBOX_API_SERVER_ENABLED",
+        capabilities.api_server_enabled.to_string(),
     );
     if !capabilities.repo_cache_enabled {
         spec.mounts
@@ -7758,6 +7767,7 @@ mod adoption_tests {
         SessionSandboxCapabilities {
             repo_cache_enabled: false,
             observability_enabled: false,
+            api_server_enabled: false,
         }
     }
 
@@ -7853,8 +7863,13 @@ mod adoption_tests {
         let spec = backend.created_specs().pop().expect("created cold spec");
         assert!(!spec.capabilities.repo_cache_enabled);
         assert!(!spec.capabilities.observability_enabled);
+        assert!(!spec.capabilities.api_server_enabled);
         assert_eq!(
             env_value(&spec, "CENTAUR_SANDBOX_OBSERVABILITY_ENABLED"),
+            Some("false")
+        );
+        assert_eq!(
+            env_value(&spec, "CENTAUR_SANDBOX_API_SERVER_ENABLED"),
             Some("false")
         );
         let blocklist = env_value(&spec, "TOOL_BLOCKLIST").unwrap_or("");
@@ -7937,6 +7952,7 @@ mod adoption_tests {
         let spec = backend.created_specs().pop().expect("created cold spec");
         assert!(!spec.capabilities.repo_cache_enabled);
         assert!(!spec.capabilities.observability_enabled);
+        assert!(!spec.capabilities.api_server_enabled);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/services/api-rs/crates/centaur-session-sqlx/migrations/0035_session_sandbox_api_server_capability.sql
+++ b/services/api-rs/crates/centaur-session-sqlx/migrations/0035_session_sandbox_api_server_capability.sql
@@ -1,0 +1,2 @@
+alter table sessions
+    add column if not exists sandbox_api_server_enabled boolean;

--- a/services/api-rs/crates/centaur-session-sqlx/migrations/0035_session_sandbox_api_server_capability.sql
+++ b/services/api-rs/crates/centaur-session-sqlx/migrations/0035_session_sandbox_api_server_capability.sql
@@ -1,5 +1,8 @@
 alter table sessions
-    add column if not exists sandbox_api_server_enabled boolean;
+    add column if not exists sandbox_api_server_enabled boolean default true;
+
+alter table sessions
+    alter column sandbox_api_server_enabled set default true;
 
 update sessions
 set sandbox_api_server_enabled = true

--- a/services/api-rs/crates/centaur-session-sqlx/migrations/0035_session_sandbox_api_server_capability.sql
+++ b/services/api-rs/crates/centaur-session-sqlx/migrations/0035_session_sandbox_api_server_capability.sql
@@ -1,2 +1,7 @@
 alter table sessions
     add column if not exists sandbox_api_server_enabled boolean;
+
+update sessions
+set sandbox_api_server_enabled = true
+where sandbox_observability_enabled is not null
+  and sandbox_api_server_enabled is null;

--- a/services/api-rs/crates/centaur-session-sqlx/migrations/0035_session_sandbox_api_server_capability.sql
+++ b/services/api-rs/crates/centaur-session-sqlx/migrations/0035_session_sandbox_api_server_capability.sql
@@ -1,8 +1,5 @@
 alter table sessions
-    add column if not exists sandbox_api_server_enabled boolean default true;
-
-alter table sessions
-    alter column sandbox_api_server_enabled set default true;
+    add column if not exists sandbox_api_server_enabled boolean;
 
 update sessions
 set sandbox_api_server_enabled = true

--- a/services/api-rs/crates/centaur-session-sqlx/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-sqlx/src/lib.rs
@@ -157,7 +157,7 @@ impl PgSessionStore {
     pub async fn get_session(&self, thread_key: &ThreadKey) -> Result<Session, SessionStoreError> {
         let row = sqlx::query_as::<_, SessionRow>(
             r#"
-            select thread_key, title, sandbox_id, sandbox_repo_cache_enabled, sandbox_observability_enabled, harness_type, harness_thread_id, persona_id, status, iron_control_principal, sandbox_last_active_at, created_at, updated_at
+            select thread_key, title, sandbox_id, sandbox_repo_cache_enabled, sandbox_observability_enabled, sandbox_api_server_enabled, harness_type, harness_thread_id, persona_id, status, iron_control_principal, sandbox_last_active_at, created_at, updated_at
             from sessions
             where thread_key = $1
             "#,
@@ -1120,13 +1120,14 @@ impl PgSessionStore {
                 sandbox_id = $2,
                 sandbox_repo_cache_enabled = null,
                 sandbox_observability_enabled = null,
+                sandbox_api_server_enabled = null,
                 sandbox_last_active_at = case
                     when $2::text is null then null
                     else now()
                 end,
                 updated_at = now()
             where thread_key = $1
-            returning thread_key, title, sandbox_id, sandbox_repo_cache_enabled, sandbox_observability_enabled, harness_type, harness_thread_id, persona_id, status, iron_control_principal, sandbox_last_active_at, created_at, updated_at
+            returning thread_key, title, sandbox_id, sandbox_repo_cache_enabled, sandbox_observability_enabled, sandbox_api_server_enabled, harness_type, harness_thread_id, persona_id, status, iron_control_principal, sandbox_last_active_at, created_at, updated_at
             "#,
         )
         .bind(thread_key.as_str())
@@ -1150,16 +1151,18 @@ impl PgSessionStore {
                 sandbox_id = $2,
                 sandbox_repo_cache_enabled = $3,
                 sandbox_observability_enabled = $4,
+                sandbox_api_server_enabled = $5,
                 sandbox_last_active_at = now(),
                 updated_at = now()
             where thread_key = $1
-            returning thread_key, title, sandbox_id, sandbox_repo_cache_enabled, sandbox_observability_enabled, harness_type, harness_thread_id, persona_id, status, iron_control_principal, sandbox_last_active_at, created_at, updated_at
+            returning thread_key, title, sandbox_id, sandbox_repo_cache_enabled, sandbox_observability_enabled, sandbox_api_server_enabled, harness_type, harness_thread_id, persona_id, status, iron_control_principal, sandbox_last_active_at, created_at, updated_at
             "#,
         )
         .bind(thread_key.as_str())
         .bind(sandbox_id)
         .bind(capabilities.repo_cache_enabled)
         .bind(capabilities.observability_enabled)
+        .bind(capabilities.api_server_enabled)
         .fetch_one(&self.pool)
         .await?;
 
@@ -1178,6 +1181,7 @@ impl PgSessionStore {
                 sandbox_id = null,
                 sandbox_repo_cache_enabled = null,
                 sandbox_observability_enabled = null,
+                sandbox_api_server_enabled = null,
                 sandbox_last_active_at = null,
                 updated_at = now()
             where thread_key = $1 and sandbox_id = $2
@@ -1207,11 +1211,12 @@ impl PgSessionStore {
                 sandbox_id = null,
                 sandbox_repo_cache_enabled = null,
                 sandbox_observability_enabled = null,
+                sandbox_api_server_enabled = null,
                 sandbox_last_active_at = null,
                 status = $3,
                 updated_at = now()
             where thread_key = $1
-            returning thread_key, title, sandbox_id, sandbox_repo_cache_enabled, sandbox_observability_enabled, harness_type, harness_thread_id, persona_id, status, iron_control_principal, sandbox_last_active_at, created_at, updated_at
+            returning thread_key, title, sandbox_id, sandbox_repo_cache_enabled, sandbox_observability_enabled, sandbox_api_server_enabled, harness_type, harness_thread_id, persona_id, status, iron_control_principal, sandbox_last_active_at, created_at, updated_at
             "#,
         )
         .bind(thread_key.as_str())
@@ -1236,7 +1241,7 @@ impl PgSessionStore {
             update sessions
             set iron_control_principal = $2, updated_at = now()
             where thread_key = $1
-            returning thread_key, title, sandbox_id, sandbox_repo_cache_enabled, sandbox_observability_enabled, harness_type, harness_thread_id, persona_id, status, iron_control_principal, sandbox_last_active_at, created_at, updated_at
+            returning thread_key, title, sandbox_id, sandbox_repo_cache_enabled, sandbox_observability_enabled, sandbox_api_server_enabled, harness_type, harness_thread_id, persona_id, status, iron_control_principal, sandbox_last_active_at, created_at, updated_at
             "#,
         )
         .bind(thread_key.as_str())
@@ -1406,7 +1411,7 @@ impl PgSessionStore {
             update sessions
             set harness_thread_id = $2, updated_at = now()
             where thread_key = $1
-            returning thread_key, title, sandbox_id, sandbox_repo_cache_enabled, sandbox_observability_enabled, harness_type, harness_thread_id, persona_id, status, iron_control_principal, sandbox_last_active_at, created_at, updated_at
+            returning thread_key, title, sandbox_id, sandbox_repo_cache_enabled, sandbox_observability_enabled, sandbox_api_server_enabled, harness_type, harness_thread_id, persona_id, status, iron_control_principal, sandbox_last_active_at, created_at, updated_at
             "#,
         )
         .bind(thread_key.as_str())
@@ -1546,6 +1551,7 @@ struct SessionRow {
     sandbox_id: Option<String>,
     sandbox_repo_cache_enabled: Option<bool>,
     sandbox_observability_enabled: Option<bool>,
+    sandbox_api_server_enabled: Option<bool>,
     harness_type: String,
     harness_thread_id: Option<String>,
     persona_id: Option<String>,
@@ -1567,13 +1573,17 @@ impl TryFrom<SessionRow> for Session {
             sandbox_capabilities: match (
                 row.sandbox_repo_cache_enabled,
                 row.sandbox_observability_enabled,
+                row.sandbox_api_server_enabled,
             ) {
-                (Some(repo_cache_enabled), Some(observability_enabled)) => {
-                    Some(SandboxCapabilities {
-                        repo_cache_enabled,
-                        observability_enabled,
-                    })
-                }
+                (
+                    Some(repo_cache_enabled),
+                    Some(observability_enabled),
+                    Some(api_server_enabled),
+                ) => Some(SandboxCapabilities {
+                    repo_cache_enabled,
+                    observability_enabled,
+                    api_server_enabled,
+                }),
                 _ => None,
             },
             harness_type: parse_persisted(row.harness_type)?,

--- a/services/console/app/controllers/api/v1/principals_controller.rb
+++ b/services/console/app/controllers/api/v1/principals_controller.rb
@@ -76,6 +76,7 @@ module Api
           labels: principal.labels,
           sandbox_repo_cache_enabled: principal.sandbox_repo_cache_enabled,
           sandbox_observability_enabled: principal.sandbox_observability_enabled,
+          sandbox_api_server_enabled: principal.sandbox_api_server_enabled,
           created_at: principal.created_at,
           updated_at: principal.updated_at
         }
@@ -86,6 +87,7 @@ module Api
           :name,
           :sandbox_repo_cache_enabled,
           :sandbox_observability_enabled,
+          :sandbox_api_server_enabled,
           labels: {}
         )
       end

--- a/services/console/app/controllers/console/principals_controller.rb
+++ b/services/console/app/controllers/console/principals_controller.rb
@@ -14,7 +14,8 @@ module Console
     def update_sandbox_access
       @principal.update!(
         sandbox_repo_cache_enabled: ActiveModel::Type::Boolean.new.cast(params[:sandbox_repo_cache_enabled]),
-        sandbox_observability_enabled: ActiveModel::Type::Boolean.new.cast(params[:sandbox_observability_enabled])
+        sandbox_observability_enabled: ActiveModel::Type::Boolean.new.cast(params[:sandbox_observability_enabled]),
+        sandbox_api_server_enabled: ActiveModel::Type::Boolean.new.cast(params[:sandbox_api_server_enabled])
       )
       redirect_to console_principal_path(@principal.oid), notice: "Updated sandbox access."
     rescue ActiveRecord::RecordInvalid => e

--- a/services/console/app/views/console/principal.html.erb
+++ b/services/console/app/views/console/principal.html.erb
@@ -56,6 +56,17 @@
           <span class="block text-xs text-zinc-500">Allow sandbox access to logs and metrics surfaces.</span>
         </span>
       </label>
+      <label class="flex items-start gap-3">
+        <%= hidden_field_tag :sandbox_api_server_enabled, "0" %>
+        <%= check_box_tag :sandbox_api_server_enabled,
+                          "1",
+                          @principal.sandbox_api_server_enabled,
+                          class: checkbox_class %>
+        <span>
+          <span class="block text-sm font-medium text-zinc-100">API server</span>
+          <span class="block text-xs text-zinc-500">Allow sandbox access to the api-rs control plane.</span>
+        </span>
+      </label>
       <div>
         <%= submit_tag "Save sandbox access", class: "btn-primary" %>
       </div>

--- a/services/console/db/migrate/20260702000000_add_sandbox_api_server_capability_to_principals.rb
+++ b/services/console/db/migrate/20260702000000_add_sandbox_api_server_capability_to_principals.rb
@@ -1,0 +1,5 @@
+class AddSandboxApiServerCapabilityToPrincipals < ActiveRecord::Migration[8.0]
+  def change
+    add_column :principals, :sandbox_api_server_enabled, :boolean, null: false, default: true
+  end
+end

--- a/services/console/db/migrate/20260702000000_add_sandbox_api_server_capability_to_principals.rb
+++ b/services/console/db/migrate/20260702000000_add_sandbox_api_server_capability_to_principals.rb
@@ -1,4 +1,4 @@
-class AddSandboxApiServerCapabilityToPrincipals < ActiveRecord::Migration[8.0]
+class AddSandboxApiServerCapabilityToPrincipals < ActiveRecord::Migration[8.1]
   def change
     add_column :principals, :sandbox_api_server_enabled, :boolean, null: false, default: true
   end

--- a/services/console/db/schema.rb
+++ b/services/console/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_30_090002) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_02_000000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -310,6 +310,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_30_090002) do
     t.jsonb "labels", default: {}, null: false
     t.string "name"
     t.string "namespace", default: "default", null: false
+    t.boolean "sandbox_api_server_enabled", default: true, null: false
     t.boolean "sandbox_observability_enabled", default: true, null: false
     t.boolean "sandbox_repo_cache_enabled", default: true, null: false
     t.bigint "sync_config_cache_version", default: 0, null: false

--- a/services/console/test/controllers/api/v1/principals_controller_test.rb
+++ b/services/console/test/controllers/api/v1/principals_controller_test.rb
@@ -44,6 +44,7 @@ module Api
         assert_equal({ "kind" => "slack_channel", "team" => "platform" }, data["labels"])
         assert_equal true, data["sandbox_repo_cache_enabled"]
         assert_equal true, data["sandbox_observability_enabled"]
+        assert_equal true, data["sandbox_api_server_enabled"]
       end
 
       test "GET returns 404 for an unknown oid" do
@@ -79,6 +80,7 @@ module Api
         assert_equal({ "kind" => "user", "team" => "platform" }, data["labels"])
         assert_equal true, data["sandbox_repo_cache_enabled"]
         assert_equal true, data["sandbox_observability_enabled"]
+        assert_equal true, data["sandbox_api_server_enabled"]
       end
 
       test "POST creates a Principal with only a human-readable name" do
@@ -99,7 +101,8 @@ module Api
         principal = principals(:acme_channel)
         principal.update!(
           sandbox_repo_cache_enabled: false,
-          sandbox_observability_enabled: false
+          sandbox_observability_enabled: false,
+          sandbox_api_server_enabled: false
         )
         body = { data: { name: "Acme Slack channel" } }
 
@@ -110,6 +113,7 @@ module Api
         assert_equal "Acme Slack channel", principal.name
         assert_equal false, principal.sandbox_repo_cache_enabled
         assert_equal false, principal.sandbox_observability_enabled
+        assert_equal false, principal.sandbox_api_server_enabled
       end
 
       test "PUT updates sandbox access flags" do
@@ -117,7 +121,8 @@ module Api
         body = {
           data: {
             sandbox_repo_cache_enabled: false,
-            sandbox_observability_enabled: false
+            sandbox_observability_enabled: false,
+            sandbox_api_server_enabled: false
           }
         }
 
@@ -127,10 +132,12 @@ module Api
         principal.reload
         assert_equal false, principal.sandbox_repo_cache_enabled
         assert_equal false, principal.sandbox_observability_enabled
+        assert_equal false, principal.sandbox_api_server_enabled
 
         data = json_body.fetch("data")
         assert_equal false, data["sandbox_repo_cache_enabled"]
         assert_equal false, data["sandbox_observability_enabled"]
+        assert_equal false, data["sandbox_api_server_enabled"]
       end
 
       test "POST returns 422 when (namespace, foreign_id) already exists" do

--- a/services/console/test/controllers/console/principals_controller_test.rb
+++ b/services/console/test/controllers/console/principals_controller_test.rb
@@ -17,13 +17,14 @@ module Console
       assert_redirected_to login_path
     end
 
-    test "update_sandbox_access toggles repo cache and observability access" do
+    test "update_sandbox_access toggles sandbox capabilities" do
       principal = principals(:acme_user_bob)
 
       patch console_principal_sandbox_access_url(principal.oid),
             params: {
               sandbox_repo_cache_enabled: "0",
-              sandbox_observability_enabled: "0"
+              sandbox_observability_enabled: "0",
+              sandbox_api_server_enabled: "0"
             }
 
       assert_redirected_to console_principal_path(principal.oid)
@@ -31,6 +32,7 @@ module Console
       principal.reload
       assert_equal false, principal.sandbox_repo_cache_enabled
       assert_equal false, principal.sandbox_observability_enabled
+      assert_equal false, principal.sandbox_api_server_enabled
     end
 
     test "assign_role attaches the role and redirects with a notice" do

--- a/services/console/test/models/principal_test.rb
+++ b/services/console/test/models/principal_test.rb
@@ -56,6 +56,7 @@ class PrincipalTest < ActiveSupport::TestCase
 
     assert_predicate principal, :sandbox_repo_cache_enabled
     assert_predicate principal, :sandbox_observability_enabled
+    assert_predicate principal, :sandbox_api_server_enabled
   end
 
   test "labels accepts arbitrary string map" do

--- a/services/sandbox/entrypoint.sh
+++ b/services/sandbox/entrypoint.sh
@@ -439,6 +439,16 @@ This sandbox does not have Centaur observability access. Do not use vlogs, vmetr
 EOF
 fi
 
+if [ "${CENTAUR_SANDBOX_API_SERVER_ENABLED:-true}" = "false" ] && [ -f "$TARGET_PROMPT" ]; then
+    cat >> "$TARGET_PROMPT" <<'EOF'
+
+---
+
+[API server access]
+This sandbox does not have Centaur API server access. Do not use workflows or tool options that call the api-rs control plane, such as dispatching background agent sessions or downloading Centaur attachment handles.
+EOF
+fi
+
 # Persona prompt injection is done by the API when it writes AGENTS_BASE.md.
 
 # Switch to workspace so the harness reads workspace/AGENTS.md (with persona overlay)

--- a/tools/productivity/gsuite/client.py
+++ b/tools/productivity/gsuite/client.py
@@ -12,10 +12,11 @@ from urllib.parse import quote, urljoin, urlparse, urlsplit
 
 import httplib2
 import socks
-from centaur_sdk import current_thread_key, save_attachment, secret
 from google.auth.credentials import AnonymousCredentials
 from googleapiclient.discovery import build
 from googleapiclient.http import MediaIoBaseDownload, MediaIoBaseUpload
+
+from centaur_sdk import current_thread_key, save_attachment, secret
 
 try:
     from api.integrations.gsuite.http import build_http as _shared_build_http
@@ -288,9 +289,9 @@ def gmail_reply(
         Dict with id, thread_id
     """
     import mimetypes
-    from email.mime.multipart import MIMEMultipart
-    from email.mime.base import MIMEBase
     from email import encoders
+    from email.mime.base import MIMEBase
+    from email.mime.multipart import MIMEMultipart
 
     service = get_gmail_service()
 
@@ -746,6 +747,11 @@ def _download_attachment_bytes(
     attachment_url: str | None = None,
 ) -> bytes:
     """Fetch bytes from Centaur's thread-scoped attachment API."""
+    if secret("CENTAUR_SANDBOX_API_SERVER_ENABLED", "true").strip().lower() == "false":
+        raise RuntimeError(
+            "Drive uploads from Centaur attachments require the API server sandbox capability, "
+            "but it is disabled for this principal."
+        )
     path = attachment_url
     if attachment_id:
         path = f"/agent/attachments/{attachment_id}/download"

--- a/tools/productivity/slack/feedback.py
+++ b/tools/productivity/slack/feedback.py
@@ -20,6 +20,8 @@ from typing import Any
 from slack_sdk import WebClient
 from slack_sdk.errors import SlackApiError
 
+from centaur_sdk import secret
+
 from .client import (
     _retry_on_ratelimit,
     get_slack_client,
@@ -117,6 +119,11 @@ class CentaurAgentClient:
     """Minimal client for starting a background improvement agent session."""
 
     def __init__(self, base_url: str | None = None, api_key: str | None = None):
+        if secret("CENTAUR_SANDBOX_API_SERVER_ENABLED", "true").strip().lower() == "false":
+            raise RuntimeError(
+                "Dispatching feedback improvement runs requires the API server sandbox "
+                "capability, but it is disabled for this principal."
+            )
         self.base_url = (base_url or os.getenv("CENTAUR_API_URL") or "http://api:8000").rstrip("/")
         self.api_key = api_key or _load_centaur_api_key()
         if not self.api_key:


### PR DESCRIPTION
Adds an API server sandbox capability on principals and propagates it through session capability tracking, presence-only sandbox/proxy labels, and Console controls. Updates NetworkPolicies so new sandbox traffic to api-rs is allowed by centaur.ai/api-server-enabled=true, while temporary compatibility policies preserve access for existing api-rs-managed pods until they age out. Existing tracked sessions are backfilled to preserve prior API access semantics, and disabled API access now fails fast in the SDK/tool paths that call the control plane.