### PR TITLE
feat(console): remove SSO approval requirement — users land on the console after login

### DIFF
--- a/services/console/README.md
+++ b/services/console/README.md
@@ -97,6 +97,7 @@ The operator console always supports email and password sign-in. To add Google o
 | `CENTAUR_CONSOLE_SLACK_CLIENT_ID`        | for Slack | Slack OpenID Connect client ID for console login.                                            |
 | `CENTAUR_CONSOLE_SLACK_CLIENT_SECRET`    | for Slack | Slack OpenID Connect client secret for console login.                                        |
 | `CENTAUR_CONSOLE_BOOTSTRAP_ADMINS`       | no       | Comma- or whitespace-separated email allowlist. Matching users become active admins on first SSO login. Other new SSO users are created as pending users. |
+| `CENTAUR_CONSOLE_AUTO_ACTIVATE_DOMAINS`  | no       | Comma- or whitespace-separated email-domain allowlist (for example `acme.com`). Users whose IdP-verified email is on a listed domain are activated on SSO login (without admin) and land on the console directly instead of waiting for approval. Existing pending users on a listed domain are activated on their next login. |
 
 Register these callback URLs with the provider:
 

--- a/services/console/README.md
+++ b/services/console/README.md
@@ -96,8 +96,7 @@ The operator console always supports email and password sign-in. To add Google o
 | `CENTAUR_CONSOLE_GOOGLE_CLIENT_SECRET`   | for Google | Google OAuth client secret for console login.                                                |
 | `CENTAUR_CONSOLE_SLACK_CLIENT_ID`        | for Slack | Slack OpenID Connect client ID for console login.                                            |
 | `CENTAUR_CONSOLE_SLACK_CLIENT_SECRET`    | for Slack | Slack OpenID Connect client secret for console login.                                        |
-| `CENTAUR_CONSOLE_BOOTSTRAP_ADMINS`       | no       | Comma- or whitespace-separated email allowlist. Matching users become active admins on first SSO login. Other new SSO users are created as pending users. |
-| `CENTAUR_CONSOLE_AUTO_ACTIVATE_DOMAINS`  | no       | Comma- or whitespace-separated email-domain allowlist (for example `acme.com`). Users whose IdP-verified email is on a listed domain are activated on SSO login (without admin) and land on the console directly instead of waiting for approval. Existing pending users on a listed domain are activated on their next login. |
+| `CENTAUR_CONSOLE_BOOTSTRAP_ADMINS`       | no       | Comma- or whitespace-separated email allowlist. Matching users become active admins on first SSO login. Other SSO users become active non-admin operators and land on the console directly -- the deployment's network boundary is the access control, there is no approval queue. |
 
 Register these callback URLs with the provider:
 

--- a/services/console/app/models/user.rb
+++ b/services/console/app/models/user.rb
@@ -42,22 +42,26 @@ class User < ApplicationRecord
   # by the stable (provider, subject). A new identity links to an existing user
   # only when the IdP-verified email matches -- an unverified email must never
   # adopt an account -- otherwise a new user is created: active + admin when the
-  # email is on the bootstrap allowlist, pending otherwise. +identity+ is the
+  # email is on the bootstrap allowlist, active when the verified email's domain
+  # is on the auto-activate allowlist, pending otherwise. +identity+ is the
   # provider strategy's { subject:, email:, email_verified:, name: } hash.
   def self.link_or_provision(provider:, identity:)
     transaction do
-      if (existing = UserIdentity.find_by(provider: provider, subject: identity[:subject]))
-        existing.update!(email: identity[:email], email_verified: identity[:email_verified])
-        user = existing.user
-        user.update!(name: identity[:name]) if identity[:name].present? && user.name.blank?
-        next user
-      end
-
-      user = linkable_user(identity) || create!(provisioned_attributes(identity))
-      user.user_identities.create!(
-        provider: provider, subject: identity[:subject],
-        email: identity[:email], email_verified: identity[:email_verified]
-      )
+      user =
+        if (existing = UserIdentity.find_by(provider: provider, subject: identity[:subject]))
+          existing.update!(email: identity[:email], email_verified: identity[:email_verified])
+          existing.user.tap do |u|
+            u.update!(name: identity[:name]) if identity[:name].present? && u.name.blank?
+          end
+        else
+          (linkable_user(identity) || create!(provisioned_attributes(identity))).tap do |u|
+            u.user_identities.create!(
+              provider: provider, subject: identity[:subject],
+              email: identity[:email], email_verified: identity[:email_verified]
+            )
+          end
+        end
+      auto_activate(user, identity)
       user
     end
   end
@@ -71,12 +75,24 @@ class User < ApplicationRecord
   private_class_method :linkable_user
 
   # Attributes for a brand-new SSO user: active + admin when bootstrap-allowlisted
-  # by a verified IdP email, pending otherwise.
+  # by a verified IdP email, pending otherwise (auto_activate then flips
+  # allowlisted domains to active before the login completes).
   def self.provisioned_attributes(identity)
     admin = identity[:email_verified] == true && ConsoleAuth.bootstrap_admin?(identity[:email])
     { email: identity[:email], name: identity[:name], status: admin ? :active : :pending, admin: admin }
   end
   private_class_method :provisioned_attributes
+
+  # A pending user whose IdP-verified email domain is on the auto-activate
+  # allowlist becomes active on login, so allowlisted operators skip the approval
+  # queue -- including users provisioned pending before the domain was listed.
+  # Never touches disabled accounts and never grants admin.
+  def self.auto_activate(user, identity)
+    return unless user.pending?
+    return unless identity[:email_verified] == true && ConsoleAuth.auto_activate?(identity[:email])
+    user.update!(status: :active, approved_at: Time.current)
+  end
+  private_class_method :auto_activate
 
   private
 

--- a/services/console/app/models/user.rb
+++ b/services/console/app/models/user.rb
@@ -14,8 +14,9 @@ class User < ApplicationRecord
   after_update :revoke_mcp_oauth_refresh_tokens_when_disabled,
                if: -> { saved_change_to_status? && disabled? }
 
-  # pending: signed in via SSO but not yet approved -- cannot use the console.
-  # active: approved operator. disabled: access revoked.
+  # active: normal operator (SSO users are provisioned active). pending: legacy
+  # state from the retired approval queue, flipped to active on next SSO login.
+  # disabled: access revoked.
   enum :status, { pending: "pending", active: "active", disabled: "disabled" },
        default: :pending, validate: true
 
@@ -41,10 +42,9 @@ class User < ApplicationRecord
   # as needed, and (re)caches the identity's email/name. A returning login matches
   # by the stable (provider, subject). A new identity links to an existing user
   # only when the IdP-verified email matches -- an unverified email must never
-  # adopt an account -- otherwise a new user is created: active + admin when the
-  # email is on the bootstrap allowlist, active when the verified email's domain
-  # is on the auto-activate allowlist, pending otherwise. +identity+ is the
-  # provider strategy's { subject:, email:, email_verified:, name: } hash.
+  # adopt an account -- otherwise a new active user is created (admin when the
+  # verified email is on the bootstrap allowlist). +identity+ is the provider
+  # strategy's { subject:, email:, email_verified:, name: } hash.
   def self.link_or_provision(provider:, identity:)
     transaction do
       user =
@@ -61,7 +61,7 @@ class User < ApplicationRecord
             )
           end
         end
-      auto_activate(user, identity)
+      activate_on_login(user)
       user
     end
   end
@@ -74,25 +74,24 @@ class User < ApplicationRecord
   end
   private_class_method :linkable_user
 
-  # Attributes for a brand-new SSO user: active + admin when bootstrap-allowlisted
-  # by a verified IdP email, pending otherwise (auto_activate then flips
-  # allowlisted domains to active before the login completes).
+  # Attributes for a brand-new SSO user: everyone is provisioned active -- the
+  # console is only reachable on the internal network, so a completed SSO login
+  # is sufficient and there is no admin-approval queue. Admin additionally
+  # requires a bootstrap-allowlisted, IdP-verified email.
   def self.provisioned_attributes(identity)
     admin = identity[:email_verified] == true && ConsoleAuth.bootstrap_admin?(identity[:email])
-    { email: identity[:email], name: identity[:name], status: admin ? :active : :pending, admin: admin }
+    { email: identity[:email], name: identity[:name], status: :active, admin: admin }
   end
   private_class_method :provisioned_attributes
 
-  # A pending user whose IdP-verified email domain is on the auto-activate
-  # allowlist becomes active on login, so allowlisted operators skip the approval
-  # queue -- including users provisioned pending before the domain was listed.
-  # Never touches disabled accounts and never grants admin.
-  def self.auto_activate(user, identity)
+  # Flips a pending user to active on login: covers accounts provisioned pending
+  # under the old approval-queue policy. Never touches disabled accounts and
+  # never grants admin.
+  def self.activate_on_login(user)
     return unless user.pending?
-    return unless identity[:email_verified] == true && ConsoleAuth.auto_activate?(identity[:email])
     user.update!(status: :active, approved_at: Time.current)
   end
-  private_class_method :auto_activate
+  private_class_method :activate_on_login
 
   private
 

--- a/services/console/lib/console_auth.rb
+++ b/services/console/lib/console_auth.rb
@@ -12,6 +12,12 @@
 # (the first admin needs no existing approver):
 #   CENTAUR_CONSOLE_BOOTSTRAP_ADMINS="me@acme.com, you@acme.com"   (ENV)
 #   credentials.console_auth.bootstrap_admins                   (fallback: string or array)
+#
+# Auto-activate domains skip the admin-approval queue: a user whose IdP-verified
+# email is on a listed domain becomes active (not admin) on login and lands on
+# the console directly. Everyone else is still provisioned pending:
+#   CENTAUR_CONSOLE_AUTO_ACTIVATE_DOMAINS="acme.com, acme.dev"     (ENV)
+#   credentials.console_auth.auto_activate_domains              (fallback: string or array)
 module ConsoleAuth
   # The providers a Login::Providers strategy exists for. A provider must also be
   # `configured?` to actually appear on the login page.
@@ -41,6 +47,18 @@ module ConsoleAuth
     raw = ConsoleEnv["BOOTSTRAP_ADMINS"].presence || credentials_dig(:bootstrap_admins)
     list = raw.is_a?(Array) ? raw : raw.to_s.split(/[,\s]+/)
     list.map { |e| e.to_s.strip.downcase }.reject(&:empty?).uniq
+  end
+
+  def auto_activate?(email)
+    domain = email.to_s.strip.downcase.split("@").last
+    return false if domain.blank?
+    auto_activate_domains.include?(domain)
+  end
+
+  def auto_activate_domains
+    raw = ConsoleEnv["AUTO_ACTIVATE_DOMAINS"].presence || credentials_dig(:auto_activate_domains)
+    list = raw.is_a?(Array) ? raw : raw.to_s.split(/[,\s]+/)
+    list.map { |d| d.to_s.strip.downcase.delete_prefix("@") }.reject(&:empty?).uniq
   end
 
   # ENV first (CENTAUR_CONSOLE_GOOGLE_CLIENT_ID), then credentials

--- a/services/console/lib/console_auth.rb
+++ b/services/console/lib/console_auth.rb
@@ -12,12 +12,6 @@
 # (the first admin needs no existing approver):
 #   CENTAUR_CONSOLE_BOOTSTRAP_ADMINS="me@acme.com, you@acme.com"   (ENV)
 #   credentials.console_auth.bootstrap_admins                   (fallback: string or array)
-#
-# Auto-activate domains skip the admin-approval queue: a user whose IdP-verified
-# email is on a listed domain becomes active (not admin) on login and lands on
-# the console directly. Everyone else is still provisioned pending:
-#   CENTAUR_CONSOLE_AUTO_ACTIVATE_DOMAINS="acme.com, acme.dev"     (ENV)
-#   credentials.console_auth.auto_activate_domains              (fallback: string or array)
 module ConsoleAuth
   # The providers a Login::Providers strategy exists for. A provider must also be
   # `configured?` to actually appear on the login page.
@@ -47,18 +41,6 @@ module ConsoleAuth
     raw = ConsoleEnv["BOOTSTRAP_ADMINS"].presence || credentials_dig(:bootstrap_admins)
     list = raw.is_a?(Array) ? raw : raw.to_s.split(/[,\s]+/)
     list.map { |e| e.to_s.strip.downcase }.reject(&:empty?).uniq
-  end
-
-  def auto_activate?(email)
-    domain = email.to_s.strip.downcase.split("@").last
-    return false if domain.blank?
-    auto_activate_domains.include?(domain)
-  end
-
-  def auto_activate_domains
-    raw = ConsoleEnv["AUTO_ACTIVATE_DOMAINS"].presence || credentials_dig(:auto_activate_domains)
-    list = raw.is_a?(Array) ? raw : raw.to_s.split(/[,\s]+/)
-    list.map { |d| d.to_s.strip.downcase.delete_prefix("@") }.reject(&:empty?).uniq
   end
 
   # ENV first (CENTAUR_CONSOLE_GOOGLE_CLIENT_ID), then credentials

--- a/services/console/test/controllers/session_oauth_controller_test.rb
+++ b/services/console/test/controllers/session_oauth_controller_test.rb
@@ -9,6 +9,7 @@ class SessionOauthControllerTest < ActionDispatch::IntegrationTest
   GOOGLE_CLIENT_ID = "google-login-client-id".freeze
   ENV_KEYS = %w[
     CENTAUR_CONSOLE_GOOGLE_CLIENT_ID CENTAUR_CONSOLE_GOOGLE_CLIENT_SECRET CENTAUR_CONSOLE_BOOTSTRAP_ADMINS
+    CENTAUR_CONSOLE_AUTO_ACTIVATE_DOMAINS
   ].freeze
 
   setup do
@@ -112,6 +113,23 @@ class SessionOauthControllerTest < ActionDispatch::IntegrationTest
     assert_equal "Test User", user.name
     assert_equal user.id, session[:user_id]
     assert_equal [ [ "google", "new-sub" ] ], user.user_identities.pluck(:provider, :subject)
+  end
+
+  test "callback auto-activates an allowlisted email domain and lands on the console" do
+    ENV["CENTAUR_CONSOLE_AUTO_ACTIVATE_DOMAINS"] = "acme.example"
+    run_callback(sub: "team-sub", email: "teammate@acme.example")
+    assert_redirected_to console_threads_path
+    user = User.find_by(email: "teammate@acme.example")
+    assert user.active?
+    assert_not user.admin?
+    assert_equal user.id, session[:user_id]
+  end
+
+  test "callback keeps an unverified email pending even on an allowlisted domain" do
+    ENV["CENTAUR_CONSOLE_AUTO_ACTIVATE_DOMAINS"] = "acme.example"
+    run_callback(sub: "unv-team-sub", email: "impostor@acme.example", email_verified: false)
+    assert_redirected_to pending_path
+    assert User.find_by(email: "impostor@acme.example").pending?
   end
 
   test "callback makes a bootstrap-allowlisted email active and admin" do

--- a/services/console/test/controllers/session_oauth_controller_test.rb
+++ b/services/console/test/controllers/session_oauth_controller_test.rb
@@ -9,7 +9,6 @@ class SessionOauthControllerTest < ActionDispatch::IntegrationTest
   GOOGLE_CLIENT_ID = "google-login-client-id".freeze
   ENV_KEYS = %w[
     CENTAUR_CONSOLE_GOOGLE_CLIENT_ID CENTAUR_CONSOLE_GOOGLE_CLIENT_SECRET CENTAUR_CONSOLE_BOOTSTRAP_ADMINS
-    CENTAUR_CONSOLE_AUTO_ACTIVATE_DOMAINS
   ].freeze
 
   setup do
@@ -102,34 +101,17 @@ class SessionOauthControllerTest < ActionDispatch::IntegrationTest
 
   # --- callback: provisioning ------------------------------------------------
 
-  test "callback provisions a pending user for a non-bootstrap email and signs them in" do
+  test "callback provisions an active user for a non-bootstrap email and lands on the console" do
     assert_difference -> { User.count }, 1 do
       run_callback(sub: "new-sub", email: "newcomer@example.com")
     end
-    assert_redirected_to pending_path
+    assert_redirected_to console_threads_path
     user = User.find_by(email: "newcomer@example.com")
-    assert user.pending?
+    assert user.active?
     assert_not user.admin?
     assert_equal "Test User", user.name
     assert_equal user.id, session[:user_id]
     assert_equal [ [ "google", "new-sub" ] ], user.user_identities.pluck(:provider, :subject)
-  end
-
-  test "callback auto-activates an allowlisted email domain and lands on the console" do
-    ENV["CENTAUR_CONSOLE_AUTO_ACTIVATE_DOMAINS"] = "acme.example"
-    run_callback(sub: "team-sub", email: "teammate@acme.example")
-    assert_redirected_to console_threads_path
-    user = User.find_by(email: "teammate@acme.example")
-    assert user.active?
-    assert_not user.admin?
-    assert_equal user.id, session[:user_id]
-  end
-
-  test "callback keeps an unverified email pending even on an allowlisted domain" do
-    ENV["CENTAUR_CONSOLE_AUTO_ACTIVATE_DOMAINS"] = "acme.example"
-    run_callback(sub: "unv-team-sub", email: "impostor@acme.example", email_verified: false)
-    assert_redirected_to pending_path
-    assert User.find_by(email: "impostor@acme.example").pending?
   end
 
   test "callback makes a bootstrap-allowlisted email active and admin" do
@@ -162,12 +144,12 @@ class SessionOauthControllerTest < ActionDispatch::IntegrationTest
     assert_nil session[:user_id]
   end
 
-  test "callback creates a pending user for an unverified, unrecognized email" do
+  test "callback creates an active user for an unverified, unrecognized email" do
     assert_difference -> { User.count }, 1 do
       run_callback(sub: "unv-sub", email: "stranger@example.com", email_verified: false)
     end
     user = User.find_by(email: "stranger@example.com")
-    assert user.pending?
+    assert user.active?
     assert_not user.user_identities.first.email_verified
   end
 

--- a/services/console/test/models/user_test.rb
+++ b/services/console/test/models/user_test.rb
@@ -103,14 +103,14 @@ class UserTest < ActiveSupport::TestCase
     { subject: "sub-1", email: "newcomer@example.com", email_verified: true, name: "New Comer" }.merge(overrides)
   end
 
-  test "link_or_provision creates a pending user + identity for an unknown email" do
+  test "link_or_provision creates an active user + identity for an unknown email" do
     user = nil
     assert_difference -> { User.count }, 1 do
       assert_difference -> { UserIdentity.count }, 1 do
         user = User.link_or_provision(provider: "google", identity: identity)
       end
     end
-    assert user.pending?
+    assert user.active?
     assert_not user.admin?
     assert_equal "New Comer", user.name
     assert_equal [ [ "google", "sub-1" ] ], user.user_identities.pluck(:provider, :subject)
@@ -160,80 +160,32 @@ class UserTest < ActiveSupport::TestCase
     user = User.link_or_provision(provider: "google",
                                   identity: identity(subject: "boss-sub", email: "boss@example.com",
                                                      email_verified: false))
-    assert user.pending?
+    assert user.active?
     assert_not user.admin?
   ensure
     ENV.delete("CENTAUR_CONSOLE_BOOTSTRAP_ADMINS")
   end
 
-  # --- auto-activate domains -------------------------------------------------
-
-  def with_auto_activate_domains(value)
-    ENV["CENTAUR_CONSOLE_AUTO_ACTIVATE_DOMAINS"] = value
-    yield
-  ensure
-    ENV.delete("CENTAUR_CONSOLE_AUTO_ACTIVATE_DOMAINS")
-  end
-
-  test "link_or_provision auto-activates a verified email on an allowlisted domain" do
-    with_auto_activate_domains("Acme.example, @beta.example") do
-      user = User.link_or_provision(provider: "slack",
-                                    identity: identity(subject: "auto-sub", email: "worker@acme.example"))
-      assert user.active?
-      assert_not user.admin?
-      assert_not_nil user.approved_at
-      assert_nil user.approved_by
-    end
-  end
-
-  test "link_or_provision auto-activate handles @-prefixed and mixed-case domain entries" do
-    with_auto_activate_domains("Acme.example, @beta.example") do
-      user = User.link_or_provision(provider: "slack",
-                                    identity: identity(subject: "beta-sub", email: "Worker@Beta.Example"))
-      assert user.active?
-    end
-  end
-
-  test "link_or_provision keeps an unverified email pending despite an allowlisted domain" do
-    with_auto_activate_domains("acme.example") do
-      user = User.link_or_provision(provider: "slack",
-                                    identity: identity(subject: "unv-sub", email: "worker@acme.example",
-                                                       email_verified: false))
-      assert user.pending?
-    end
-  end
-
-  test "link_or_provision keeps an unlisted domain pending" do
-    with_auto_activate_domains("acme.example") do
-      user = User.link_or_provision(provider: "slack",
-                                    identity: identity(subject: "other-sub", email: "stranger@other.example"))
-      assert user.pending?
-    end
-  end
-
-  test "link_or_provision activates a returning pending user once their domain is allowlisted" do
+  test "link_or_provision activates a returning legacy-pending user" do
     user = User.link_or_provision(provider: "slack",
                                   identity: identity(subject: "late-sub", email: "worker@acme.example"))
-    assert user.pending?
+    user.update!(status: :pending)
 
-    with_auto_activate_domains("acme.example") do
-      returning = User.link_or_provision(provider: "slack",
-                                         identity: identity(subject: "late-sub", email: "worker@acme.example"))
-      assert_equal user, returning
-      assert returning.active?
-      assert_not returning.admin?
-    end
+    returning = User.link_or_provision(provider: "slack",
+                                       identity: identity(subject: "late-sub", email: "worker@acme.example"))
+    assert_equal user, returning
+    assert returning.active?
+    assert_not returning.admin?
+    assert_not_nil returning.approved_at
   end
 
-  test "link_or_provision never reactivates a disabled user via the domain allowlist" do
+  test "link_or_provision never reactivates a disabled user" do
     user = User.link_or_provision(provider: "slack",
                                   identity: identity(subject: "gone-sub", email: "worker@acme.example"))
     user.update!(status: :disabled)
 
-    with_auto_activate_domains("acme.example") do
-      returning = User.link_or_provision(provider: "slack",
-                                         identity: identity(subject: "gone-sub", email: "worker@acme.example"))
-      assert returning.disabled?
-    end
+    returning = User.link_or_provision(provider: "slack",
+                                       identity: identity(subject: "gone-sub", email: "worker@acme.example"))
+    assert returning.disabled?
   end
 end

--- a/services/console/test/models/user_test.rb
+++ b/services/console/test/models/user_test.rb
@@ -165,4 +165,75 @@ class UserTest < ActiveSupport::TestCase
   ensure
     ENV.delete("CENTAUR_CONSOLE_BOOTSTRAP_ADMINS")
   end
+
+  # --- auto-activate domains -------------------------------------------------
+
+  def with_auto_activate_domains(value)
+    ENV["CENTAUR_CONSOLE_AUTO_ACTIVATE_DOMAINS"] = value
+    yield
+  ensure
+    ENV.delete("CENTAUR_CONSOLE_AUTO_ACTIVATE_DOMAINS")
+  end
+
+  test "link_or_provision auto-activates a verified email on an allowlisted domain" do
+    with_auto_activate_domains("Acme.example, @beta.example") do
+      user = User.link_or_provision(provider: "slack",
+                                    identity: identity(subject: "auto-sub", email: "worker@acme.example"))
+      assert user.active?
+      assert_not user.admin?
+      assert_not_nil user.approved_at
+      assert_nil user.approved_by
+    end
+  end
+
+  test "link_or_provision auto-activate handles @-prefixed and mixed-case domain entries" do
+    with_auto_activate_domains("Acme.example, @beta.example") do
+      user = User.link_or_provision(provider: "slack",
+                                    identity: identity(subject: "beta-sub", email: "Worker@Beta.Example"))
+      assert user.active?
+    end
+  end
+
+  test "link_or_provision keeps an unverified email pending despite an allowlisted domain" do
+    with_auto_activate_domains("acme.example") do
+      user = User.link_or_provision(provider: "slack",
+                                    identity: identity(subject: "unv-sub", email: "worker@acme.example",
+                                                       email_verified: false))
+      assert user.pending?
+    end
+  end
+
+  test "link_or_provision keeps an unlisted domain pending" do
+    with_auto_activate_domains("acme.example") do
+      user = User.link_or_provision(provider: "slack",
+                                    identity: identity(subject: "other-sub", email: "stranger@other.example"))
+      assert user.pending?
+    end
+  end
+
+  test "link_or_provision activates a returning pending user once their domain is allowlisted" do
+    user = User.link_or_provision(provider: "slack",
+                                  identity: identity(subject: "late-sub", email: "worker@acme.example"))
+    assert user.pending?
+
+    with_auto_activate_domains("acme.example") do
+      returning = User.link_or_provision(provider: "slack",
+                                         identity: identity(subject: "late-sub", email: "worker@acme.example"))
+      assert_equal user, returning
+      assert returning.active?
+      assert_not returning.admin?
+    end
+  end
+
+  test "link_or_provision never reactivates a disabled user via the domain allowlist" do
+    user = User.link_or_provision(provider: "slack",
+                                  identity: identity(subject: "gone-sub", email: "worker@acme.example"))
+    user.update!(status: :disabled)
+
+    with_auto_activate_domains("acme.example") do
+      returning = User.link_or_provision(provider: "slack",
+                                         identity: identity(subject: "gone-sub", email: "worker@acme.example"))
+      assert returning.disabled?
+    end
+  end
 end


### PR DESCRIPTION
## Summary

New SSO users were provisioned `pending` and held at the "Awaiting approval" page until an admin approved them. The console is deployed on the team's internal Tailnet, so network access is already the access-control boundary — a completed Slack/Google sign-in needs no further approval step.

- New SSO users are provisioned `active` (non-admin) and land directly on the console.
- Legacy `pending` accounts are flipped to `active` on their next SSO login, so nobody stays stuck in the old queue.
- `disabled` accounts are never reactivated and remain the revocation mechanism.
- Admin is unchanged: only via `CENTAUR_CONSOLE_BOOTSTRAP_ADMINS` or an existing admin's promote action; admin-only sections keep their `require_admin` guards.
- The pending page and the Users approve UI are left in place for legacy states; no schema change.

No deployment config needed — this works out of the box.

Note for reviewers: this intentionally relies on the Tailnet as the access boundary. The Slack OIDC flow validates only `iss`/`aud` (no workspace/`team_id` check), so if this console is ever exposed outside the Tailnet, an activation guard needs to come back.

## Testing

```
docker exec -e CENTAUR_CONSOLE_THREADS_READ_ONLY=0 codex-centaur-console-web bin/rails test test/models/user_test.rb test/controllers/session_oauth_controller_test.rb test/controllers/sessions_controller_test.rb test/controllers/console/users_controller_test.rb
```

Full suite: 1015 runs green except 3 pre-existing `CentaurSessionRecordTest` DB-config failures that also fail on unmodified main in that container (environment drift, unrelated). Rubocop clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
