### PR TITLE
fix: capture Slack app message content and unfreeze busy-channel ETL sync

### DIFF
--- a/workflows/slack/backfill.py
+++ b/workflows/slack/backfill.py
@@ -55,6 +55,7 @@ from workflows.slack.shared import (
     record_run_finish,
     record_run_start,
     replace_thread_replies,
+    touch_backfill_job_started,
     upsert_messages,
     workflow_run_id_to_sync_run_id,
 )
@@ -295,6 +296,7 @@ async def handler(inp: Input, ctx: WorkflowContext) -> dict[str, Any]:
         job_type = str(job.get("job_type") or "backfill")
         record_slack_retention_backfill_job(job_type, "claimed")
         try:
+            await touch_backfill_job_started(ctx._pool, job_id)
             if job_type == BACKFILL_JOB_THREAD_REFRESH:
                 payload = _thread_refresh_payload(job)
                 thread_ts = str(payload["thread_ts"])

--- a/workflows/slack/backfill.py
+++ b/workflows/slack/backfill.py
@@ -444,6 +444,7 @@ async def handler(inp: Input, ctx: WorkflowContext) -> dict[str, Any]:
                         run_id=run_id,
                         priority=200,
                         refresh_completed=False,
+                        refresh_pending=False,
                     )
                     record_etl_items_enqueued(
                         "slack", "channel", "thread_refresh_job", 1

--- a/workflows/slack/shared.py
+++ b/workflows/slack/shared.py
@@ -29,6 +29,9 @@ BACKFILL_JOB_CHANNEL_CONTINUATION = "channel_continuation"
 BACKFILL_JOB_CHANNEL_BOOTSTRAP = "channel_bootstrap"
 BACKFILL_JOB_THREAD_REFRESH = "thread_refresh"
 BACKFILL_JOB_PAYLOAD_VERSION = 1
+# Reclaim jobs orphaned in `running` by a dead worker after this long. Must
+# exceed the longest plausible backfill workflow run.
+BACKFILL_JOB_STALE_RUNNING_HOURS = 2
 BACKFILL_JOB_TYPES = (
     BACKFILL_JOB_CHANNEL_BOOTSTRAP,
     BACKFILL_JOB_CHANNEL_CONTINUATION,
@@ -178,6 +181,33 @@ def _attachment_raw_payload(attachment: dict[str, Any]) -> dict[str, Any]:
     return {
         key: value for key, value in attachment.items() if key not in {"content_bytes"}
     }
+
+
+def _attachment_fallback_text(attachments: Any) -> str:
+    """Plain-text stand-in for app messages whose content lives in legacy attachments.
+
+    Bot integrations (GitHub, alerting apps) often post with an empty top-level
+    `text` and put everything in `attachments`; Slack defines `fallback` as the
+    plain-text summary for exactly this case.
+    """
+    if not isinstance(attachments, list):
+        return ""
+    parts: list[str] = []
+    for attachment in attachments:
+        if not isinstance(attachment, dict):
+            continue
+        fallback = str(attachment.get("fallback") or "").strip()
+        if fallback:
+            parts.append(fallback)
+            continue
+        pieces = [
+            str(attachment.get(key) or "").strip()
+            for key in ("pretext", "title", "text")
+        ]
+        joined = "\n".join(piece for piece in pieces if piece)
+        if joined:
+            parts.append(joined)
+    return "\n".join(parts)
 
 
 def _safe_int(value: Any, default: int = 0) -> int:
@@ -1016,10 +1046,13 @@ class SlackEtlClient:
             username = msg.get("bot_profile", {}).get("name", "") or user_id
 
         ts = msg.get("ts", "")
+        text = self._resolve_mentions(msg.get("text", ""), user_cache)
+        if not text.strip():
+            text = _attachment_fallback_text(msg.get("attachments"))
         message = {
             "user": username,
             "user_id": user_id,
-            "text": self._resolve_mentions(msg.get("text", ""), user_cache),
+            "text": text,
             "timestamp": ts,
             "permalink": self._message_permalink(channel_id, ts),
             "channel_id": channel_id,
@@ -1031,6 +1064,8 @@ class SlackEtlClient:
             "subtype": msg.get("subtype"),
             "parent_user_id": msg.get("parent_user_id"),
             "bot_id": msg.get("bot_id"),
+            "attachments": msg.get("attachments") or [],
+            "blocks": msg.get("blocks") or [],
             "files": [
                 normalized
                 for file_obj in msg.get("files", []) or []
@@ -1442,15 +1477,30 @@ async def enqueue_backfill_job(
     run_id: str,
     priority: int = 100,
     refresh_completed: bool = True,
+    refresh_pending: bool = True,
 ) -> None:
-    """Store or refresh a queued backfill job outside the incremental checkpoint."""
+    """Store or refresh a queued backfill job outside the incremental checkpoint.
+
+    `refresh_pending=False` protects in-flight work: the conflict update then
+    only reopens finished (or just failed) jobs and never rewrites the payload,
+    status, or attempt count of a `pending`/`running` row. Periodic enqueuers
+    (the incremental sync) must use it so they cannot clobber the cursor a
+    backfill worker is actively advancing under the same job_key.
+    """
     if not payload:
         return
-    completion_guard = (
-        ""
-        if refresh_completed
-        else " WHERE slack_sync_backfill_jobs.status <> 'completed'"
-    )
+    if refresh_pending:
+        completion_guard = (
+            ""
+            if refresh_completed
+            else " WHERE slack_sync_backfill_jobs.status <> 'completed'"
+        )
+    else:
+        completion_guard = (
+            " WHERE slack_sync_backfill_jobs.status IN ('completed', 'failed')"
+            if refresh_completed
+            else " WHERE slack_sync_backfill_jobs.status = 'failed'"
+        )
     await pool.execute(
         "INSERT INTO slack_sync_backfill_jobs ("
         "job_key, job_type, payload_version, channel_id, status, payload_json, "
@@ -1584,7 +1634,12 @@ async def widen_channel_bootstrap_job(
 
 
 async def claim_backfill_jobs(pool, limit: int) -> list[dict[str, Any]]:
-    """Claim a bounded batch of pending backfill jobs for one workflow run."""
+    """Claim a bounded batch of pending backfill jobs for one workflow run.
+
+    Jobs stuck in `running` past the stale interval are reclaimed too: a worker
+    that died mid-job leaves its row `running` forever, and nothing else may
+    touch in-flight rows (see `enqueue_backfill_job(refresh_pending=False)`).
+    """
     async with pool.acquire() as conn:
         async with conn.transaction():
             rows = await conn.fetch(
@@ -1592,6 +1647,8 @@ async def claim_backfill_jobs(pool, limit: int) -> list[dict[str, Any]]:
                 "    SELECT job_id "
                 "    FROM slack_sync_backfill_jobs "
                 "    WHERE status IN ('pending', 'failed') "
+                "       OR (status = 'running' "
+                f"           AND last_started_at < NOW() - INTERVAL '{BACKFILL_JOB_STALE_RUNNING_HOURS} hours') "
                 "    ORDER BY priority, updated_at, job_id "
                 "    LIMIT $1 "
                 "    FOR UPDATE SKIP LOCKED"

--- a/workflows/slack/shared.py
+++ b/workflows/slack/shared.py
@@ -1048,7 +1048,13 @@ class SlackEtlClient:
         ts = msg.get("ts", "")
         text = self._resolve_mentions(msg.get("text", ""), user_cache)
         if not text.strip():
-            text = _attachment_fallback_text(msg.get("attachments"))
+            text = self._resolve_mentions(
+                _attachment_fallback_text(msg.get("attachments")), user_cache
+            )
+        # Human rich_text blocks just mirror `text`; keep blocks only where they
+        # can carry unique content (app/bot posts or empty-text messages) so
+        # raw_payload doesn't double for every ordinary message.
+        keep_blocks = bool(msg.get("bot_id")) or not (msg.get("text") or "").strip()
         message = {
             "user": username,
             "user_id": user_id,
@@ -1065,7 +1071,7 @@ class SlackEtlClient:
             "parent_user_id": msg.get("parent_user_id"),
             "bot_id": msg.get("bot_id"),
             "attachments": msg.get("attachments") or [],
-            "blocks": msg.get("blocks") or [],
+            "blocks": (msg.get("blocks") or []) if keep_blocks else [],
             "files": [
                 normalized
                 for file_obj in msg.get("files", []) or []
@@ -1396,9 +1402,12 @@ class SlackEtlClient:
 
         latest_seen = watermark
         if page["messages"]:
-            latest_seen = self._format_ts(
-                max(float(message["timestamp"]) for message in page["messages"])
-            )
+            page_max = max(float(message["timestamp"]) for message in page["messages"])
+            # An oldest-anchored page can sit entirely below the prior watermark;
+            # never let the returned watermark regress past it.
+            if watermark is not None:
+                page_max = max(page_max, float(watermark))
+            latest_seen = self._format_ts(page_max)
 
         next_state: dict[str, Any] = {
             "cursor": page["next_cursor"] if page["has_more"] else None,
@@ -1647,8 +1656,8 @@ async def claim_backfill_jobs(pool, limit: int) -> list[dict[str, Any]]:
                 "    SELECT job_id "
                 "    FROM slack_sync_backfill_jobs "
                 "    WHERE status IN ('pending', 'failed') "
-                "       OR (status = 'running' "
-                f"           AND last_started_at < NOW() - INTERVAL '{BACKFILL_JOB_STALE_RUNNING_HOURS} hours') "
+                "       OR (status = 'running' AND last_started_at < "
+                f"           NOW() - INTERVAL '{BACKFILL_JOB_STALE_RUNNING_HOURS} hours') "
                 "    ORDER BY priority, updated_at, job_id "
                 "    LIMIT $1 "
                 "    FOR UPDATE SKIP LOCKED"
@@ -1666,6 +1675,22 @@ async def claim_backfill_jobs(pool, limit: int) -> list[dict[str, Any]]:
                 limit,
             )
     return [dict(row) for row in rows]
+
+
+async def touch_backfill_job_started(pool, job_id: int) -> None:
+    """Re-stamp a claimed job as this worker starts actually processing it.
+
+    A claim batch stamps `last_started_at` once for up to 50 jobs; without the
+    per-job re-stamp, a job at the tail of a slow (rate-limited) but alive run
+    can cross the stale-`running` threshold and be reclaimed by a concurrent
+    run while still owned.
+    """
+    await pool.execute(
+        "UPDATE slack_sync_backfill_jobs "
+        "SET last_started_at = NOW(), updated_at = NOW() "
+        "WHERE job_id = $1 AND status = 'running'",
+        job_id,
+    )
 
 
 async def load_backfill_job_metrics(pool) -> list[dict[str, Any]]:

--- a/workflows/slack/sync.py
+++ b/workflows/slack/sync.py
@@ -522,25 +522,44 @@ async def handler(inp: Input, ctx: WorkflowContext) -> dict[str, Any]:
             record_slack_retention_api_request("fetch_history", "success")
             messages = page.get("messages") or []
             head_page: dict[str, Any] | None = None
-            if page.get("has_more") and inp.latest is None:
+            if (
+                page.get("has_more")
+                and inp.latest is None
+                # Jumping the watermark to the head is only safe when the
+                # continuation jobs that cover the middle actually drain.
+                and env_flag_enabled("SLACK_BACKFILL_ENABLED", default=True)
+            ):
                 # An overflowing window anchors at `oldest`, so this page holds
                 # the oldest slice and the live head stays unfetched — on a busy
                 # channel the watermark would otherwise freeze below the backlog
                 # forever. Probe the head with a default (newest-first) fetch;
-                # the middle is drained by the continuation job.
-                head_page = client._sync_etl_channel_history(
-                    channel_id,
-                    state={
-                        "cursor": None,
-                        "watermark": None,
-                        "oldest": None,
-                        "latest": None,
-                    },
-                    limit=limit,
-                    lookback_days=0,
-                )
-                record_slack_retention_api_request("fetch_history", "success")
-                messages = messages + (head_page.get("messages") or [])
+                # the middle is drained by the continuation job. Best-effort:
+                # a probe failure must not discard the window page already
+                # fetched (the likeliest failure is a rate limit, on exactly
+                # the busy channels that probe every tick).
+                try:
+                    head_page = client._sync_etl_channel_history(
+                        channel_id,
+                        state={
+                            "cursor": None,
+                            "watermark": None,
+                            "oldest": None,
+                            "latest": None,
+                        },
+                        limit=limit,
+                        lookback_days=0,
+                    )
+                except Exception as exc:  # noqa: BLE001 — degrade to window-only
+                    head_page = None
+                    ctx.log(
+                        "slack_sync_head_probe_failed",
+                        channel_id=channel_id,
+                        channel_name=channel_name,
+                        error=str(exc),
+                    )
+                else:
+                    record_slack_retention_api_request("fetch_history", "success")
+                    messages = messages + (head_page.get("messages") or [])
             message_rows = [message_row(msg, run_id) for msg in messages]
             counts["messages_fetched"] += len(message_rows)
             record_slack_retention_messages_processed(
@@ -633,13 +652,24 @@ async def handler(inp: Input, ctx: WorkflowContext) -> dict[str, Any]:
                         window_oldest_ts=desired_oldest,
                     )
             if next_state.get("cursor"):
-                await enqueue_backfill_job(
-                    ctx._pool,
-                    job_key=_continuation_backfill_job_key(
+                # The standing incremental continuation uses ONE stable key per
+                # channel: the window's `oldest` tracks the (now advancing)
+                # watermark, so keying on it would mint a new, almost fully
+                # overlapping job every tick on a persistently busy channel.
+                # With refresh_pending=False a pending/running row keeps its
+                # older (wider) window; a completed/failed row reopens with the
+                # fresh cursor. Explicitly bounded runs keep the windowed key.
+                if inp.oldest is None and inp.latest is None:
+                    continuation_job_key = f"continuation:{channel_id}:incremental"
+                else:
+                    continuation_job_key = _continuation_backfill_job_key(
                         channel_id,
                         oldest_ts=str(next_state.get("oldest") or "") or None,
                         latest_ts=str(next_state.get("latest") or "") or None,
-                    ),
+                    )
+                await enqueue_backfill_job(
+                    ctx._pool,
+                    job_key=continuation_job_key,
                     job_type=BACKFILL_JOB_CHANNEL_CONTINUATION,
                     channel_id=channel_id,
                     payload={
@@ -654,11 +684,6 @@ async def handler(inp: Input, ctx: WorkflowContext) -> dict[str, Any]:
                     # Never clobber a pending/running continuation: the backfill
                     # worker owns its cursor progress under this job_key.
                     refresh_pending=False,
-                )
-                continuation_job_key = _continuation_backfill_job_key(
-                    channel_id,
-                    oldest_ts=str(next_state.get("oldest") or "") or None,
-                    latest_ts=str(next_state.get("latest") or "") or None,
                 )
                 record_etl_items_enqueued(
                     "slack", "channel", "channel_continuation_job", 1

--- a/workflows/slack/sync.py
+++ b/workflows/slack/sync.py
@@ -192,6 +192,23 @@ def _watermark_lag_seconds(ts: str | None) -> float | None:
     return max((dt.datetime.now(dt.timezone.utc) - occurred_at).total_seconds(), 0.0)
 
 
+def _max_slack_ts(*values: Any) -> str | None:
+    """Return the numerically greatest Slack ts string, ignoring empty/invalid."""
+    best: str | None = None
+    best_value = float("-inf")
+    for value in values:
+        if not value:
+            continue
+        try:
+            numeric = float(value)
+        except (TypeError, ValueError):
+            continue
+        if numeric > best_value:
+            best_value = numeric
+            best = str(value)
+    return best
+
+
 async def _upsert_channels(pool, channels: list[dict[str, Any]]) -> None:
     """Refresh public Slack sync channel rows and mark absent channels out of scope."""
     async with pool.acquire() as conn:
@@ -504,6 +521,26 @@ async def handler(inp: Input, ctx: WorkflowContext) -> dict[str, Any]:
             )
             record_slack_retention_api_request("fetch_history", "success")
             messages = page.get("messages") or []
+            head_page: dict[str, Any] | None = None
+            if page.get("has_more") and inp.latest is None:
+                # An overflowing window anchors at `oldest`, so this page holds
+                # the oldest slice and the live head stays unfetched — on a busy
+                # channel the watermark would otherwise freeze below the backlog
+                # forever. Probe the head with a default (newest-first) fetch;
+                # the middle is drained by the continuation job.
+                head_page = client._sync_etl_channel_history(
+                    channel_id,
+                    state={
+                        "cursor": None,
+                        "watermark": None,
+                        "oldest": None,
+                        "latest": None,
+                    },
+                    limit=limit,
+                    lookback_days=0,
+                )
+                record_slack_retention_api_request("fetch_history", "success")
+                messages = messages + (head_page.get("messages") or [])
             message_rows = [message_row(msg, run_id) for msg in messages]
             counts["messages_fetched"] += len(message_rows)
             record_slack_retention_messages_processed(
@@ -555,6 +592,7 @@ async def handler(inp: Input, ctx: WorkflowContext) -> dict[str, Any]:
                     payload={"thread_ts": thread_ts},
                     run_id=run_id,
                     priority=200,
+                    refresh_pending=False,
                 )
                 record_etl_items_enqueued("slack", "channel", "thread_refresh_job", 1)
                 ctx.log(
@@ -613,6 +651,9 @@ async def handler(inp: Input, ctx: WorkflowContext) -> dict[str, Any]:
                     },
                     run_id=run_id,
                     priority=100,
+                    # Never clobber a pending/running continuation: the backfill
+                    # worker owns its cursor progress under this job_key.
+                    refresh_pending=False,
                 )
                 continuation_job_key = _continuation_backfill_job_key(
                     channel_id,
@@ -632,13 +673,21 @@ async def handler(inp: Input, ctx: WorkflowContext) -> dict[str, Any]:
                     latest_ts=next_state.get("latest"),
                     has_cursor=True,
                 )
+            # Monotonic watermark: an oldest-anchored window page can carry a
+            # max ts *below* the stored watermark; never let it regress. The
+            # head probe (when it ran) contributes the true live head.
+            watermark_ts = _max_slack_ts(
+                next_state.get("watermark"),
+                ((head_page or {}).get("sync_state") or {}).get("watermark"),
+                checkpoint_watermark,
+            )
             await _update_checkpoint_success(
                 ctx._pool,
                 channel_id=channel_id,
-                watermark_ts=next_state.get("watermark"),
+                watermark_ts=watermark_ts,
                 run_id=run_id,
             )
-            lag_s = _watermark_lag_seconds(next_state.get("watermark"))
+            lag_s = _watermark_lag_seconds(watermark_ts)
             if lag_s is not None:
                 set_slack_retention_watermark_lag_seconds(mode, lag_s)
             synced.append(channel_ref(channel))

--- a/workflows/slack/tests/test_shared_attachments.py
+++ b/workflows/slack/tests/test_shared_attachments.py
@@ -312,7 +312,7 @@ def test_serialize_message_preserves_bot_attachments_and_blocks():
     client = object.__new__(shared.SlackEtlClient)
     attachments = [
         {
-            "fallback": "Deployment to Preview by lyoungblood",
+            "fallback": "Deployment approved by <@U04ABCDEF>",
             "title": "unused when fallback is present",
             "color": "36a64f",
         }
@@ -328,17 +328,18 @@ def test_serialize_message_preserves_bot_attachments_and_blocks():
             "blocks": blocks,
         },
         "C123",
-        {},
+        {"U04ABCDEF": "artur"},
     )
 
     assert message["attachments"] == attachments
     assert message["blocks"] == blocks
-    assert message["text"] == "Deployment to Preview by lyoungblood"
+    # Fallback text is mention-resolved, same as the primary text path.
+    assert message["text"] == "Deployment approved by @artur"
 
     row = shared.message_row(message, "run_123")
     assert row["raw_payload"]["attachments"] == attachments
     assert row["raw_payload"]["blocks"] == blocks
-    assert row["text"] == "Deployment to Preview by lyoungblood"
+    assert row["text"] == "Deployment approved by @artur"
     # Slack legacy attachments are message content, not file rows.
     assert row["attachments"] == []
 
@@ -352,6 +353,7 @@ def test_serialize_message_keeps_user_text_over_attachment_fallback():
             "text": "see the graph below",
             "ts": "1770000000.000700",
             "attachments": [{"fallback": "graph.png"}],
+            "blocks": [{"type": "rich_text", "elements": []}],
         },
         "C123",
         {"U123": "alice"},
@@ -359,6 +361,8 @@ def test_serialize_message_keeps_user_text_over_attachment_fallback():
 
     assert message["text"] == "see the graph below"
     assert message["attachments"] == [{"fallback": "graph.png"}]
+    # Human rich_text blocks mirror the text; not persisted.
+    assert message["blocks"] == []
 
 
 def test_attachment_fallback_text_prefers_fallback_then_joins_fields():
@@ -574,6 +578,7 @@ def test_backfill_handler_terminally_skips_permanent_slack_errors(monkeypatch):
     monkeypatch.setattr(backfill, "_emit_backfill_job_metrics", fake_noop)
     monkeypatch.setattr(backfill, "emit_slack_checkpoint_metrics", fake_noop)
     monkeypatch.setattr(backfill, "claim_backfill_jobs", fake_claim_jobs)
+    monkeypatch.setattr(backfill, "touch_backfill_job_started", fake_noop)
     monkeypatch.setattr(backfill, "shared_client", lambda **_kwargs: FakeClient())
     monkeypatch.setattr(backfill, "record_run_start", fake_noop)
     monkeypatch.setattr(backfill, "record_run_finish", fake_record_finish)
@@ -797,13 +802,55 @@ def test_claim_backfill_jobs_reclaims_stale_running_rows():
 
     assert result == []
     assert len(conn.fetch_calls) == 1
-    sql = conn.fetch_calls[0][0]
+    sql = " ".join(conn.fetch_calls[0][0].split())
     assert "status IN ('pending', 'failed')" in sql
-    assert "status = 'running'" in sql
     assert (
-        f"last_started_at < NOW() - INTERVAL '{shared.BACKFILL_JOB_STALE_RUNNING_HOURS} hours'"
-        in sql
+        "status = 'running' AND last_started_at < "
+        f"NOW() - INTERVAL '{shared.BACKFILL_JOB_STALE_RUNNING_HOURS} hours'"
+    ) in sql
+
+
+def test_touch_backfill_job_started_restamps_running_row():
+    pool = FakeExecutePool()
+
+    asyncio.run(shared.touch_backfill_job_started(pool, 42))
+
+    assert len(pool.execute_calls) == 1
+    sql, args = pool.execute_calls[0]
+    assert "SET last_started_at = NOW()" in sql
+    assert "status = 'running'" in sql
+    assert args == (42,)
+
+
+def test_sync_etl_channel_history_watermark_never_regresses(monkeypatch):
+    client = object.__new__(shared.SlackEtlClient)
+
+    def fake_page(**kwargs):
+        return {
+            "channel": "busy",
+            "channel_id": "C123",
+            "messages": [{"timestamp": "100.000000"}],
+            "count": 1,
+            "has_more": False,
+            "next_cursor": None,
+            "window": {
+                "oldest": kwargs.get("oldest"),
+                "latest": kwargs.get("latest"),
+                "inclusive": True,
+            },
+            "order": "desc",
+        }
+
+    monkeypatch.setattr(
+        client, "_get_etl_channel_history_page", lambda **kw: fake_page(**kw)
     )
+
+    out = client._sync_etl_channel_history(
+        "C123", state={"watermark": "200.000000"}, limit=10
+    )
+
+    # An oldest-anchored page below the prior watermark must not regress it.
+    assert out["sync_state"]["watermark"] == "200.000000"
 
 
 def test_backfill_handler_drains_continuation_pages_then_completes(monkeypatch):
@@ -900,6 +947,7 @@ def test_backfill_handler_drains_continuation_pages_then_completes(monkeypatch):
     monkeypatch.setattr(backfill, "_emit_backfill_job_metrics", fake_noop)
     monkeypatch.setattr(backfill, "emit_slack_checkpoint_metrics", fake_noop)
     monkeypatch.setattr(backfill, "claim_backfill_jobs", fake_claim_jobs)
+    monkeypatch.setattr(backfill, "touch_backfill_job_started", fake_noop)
     monkeypatch.setattr(backfill, "shared_client", lambda **_kwargs: fake_client)
     monkeypatch.setattr(backfill, "upsert_messages", fake_upsert_messages)
     monkeypatch.setattr(backfill, "enqueue_backfill_job", fake_enqueue)

--- a/workflows/slack/tests/test_shared_attachments.py
+++ b/workflows/slack/tests/test_shared_attachments.py
@@ -308,6 +308,79 @@ def test_serialize_message_skips_oversized_slack_file(monkeypatch):
     assert message["files"][0]["content_bytes"] is None
 
 
+def test_serialize_message_preserves_bot_attachments_and_blocks():
+    client = object.__new__(shared.SlackEtlClient)
+    attachments = [
+        {
+            "fallback": "Deployment to Preview by lyoungblood",
+            "title": "unused when fallback is present",
+            "color": "36a64f",
+        }
+    ]
+    blocks = [{"type": "section", "text": {"type": "mrkdwn", "text": "hi"}}]
+
+    message = client._serialize_message(
+        {
+            "bot_id": "B02T451BQRK",
+            "text": "",
+            "ts": "1770000000.000600",
+            "attachments": attachments,
+            "blocks": blocks,
+        },
+        "C123",
+        {},
+    )
+
+    assert message["attachments"] == attachments
+    assert message["blocks"] == blocks
+    assert message["text"] == "Deployment to Preview by lyoungblood"
+
+    row = shared.message_row(message, "run_123")
+    assert row["raw_payload"]["attachments"] == attachments
+    assert row["raw_payload"]["blocks"] == blocks
+    assert row["text"] == "Deployment to Preview by lyoungblood"
+    # Slack legacy attachments are message content, not file rows.
+    assert row["attachments"] == []
+
+
+def test_serialize_message_keeps_user_text_over_attachment_fallback():
+    client = object.__new__(shared.SlackEtlClient)
+
+    message = client._serialize_message(
+        {
+            "user": "U123",
+            "text": "see the graph below",
+            "ts": "1770000000.000700",
+            "attachments": [{"fallback": "graph.png"}],
+        },
+        "C123",
+        {"U123": "alice"},
+    )
+
+    assert message["text"] == "see the graph below"
+    assert message["attachments"] == [{"fallback": "graph.png"}]
+
+
+def test_attachment_fallback_text_prefers_fallback_then_joins_fields():
+    assert shared._attachment_fallback_text(None) == ""
+    assert shared._attachment_fallback_text("not-a-list") == ""
+    assert (
+        shared._attachment_fallback_text(
+            [
+                "not-a-dict",
+                {"fallback": "  first alert  "},
+                {
+                    "pretext": "PR merged",
+                    "title": "moonwell-fi/mamo",
+                    "text": "fix: handle empty originTx",
+                },
+                {"color": "dddddd"},
+            ]
+        )
+        == "first alert\nPR merged\nmoonwell-fi/mamo\nfix: handle empty originTx"
+    )
+
+
 class FakeConn:
     """Records statements issued inside ``upsert_messages``/attachment batch."""
 
@@ -673,3 +746,178 @@ def test_upsert_messages_dedupes_duplicate_message_keys_last_row_wins():
     assert len(conn.execute_calls) == 1
     _delete_sql, delete_args = conn.execute_calls[0]
     assert delete_args == (["C123"], ["1770000000.000500"], [], [], [])
+
+
+def test_enqueue_backfill_job_refresh_guards():
+    pool = FakeExecutePool()
+    base = {
+        "job_key": "continuation:C123:1770000000.000100:",
+        "job_type": shared.BACKFILL_JOB_CHANNEL_CONTINUATION,
+        "channel_id": "C123",
+        "payload": {"cursor": "abc"},
+        "run_id": "run_123",
+    }
+
+    asyncio.run(shared.enqueue_backfill_job(pool, **base))
+    asyncio.run(shared.enqueue_backfill_job(pool, **base, refresh_completed=False))
+    asyncio.run(shared.enqueue_backfill_job(pool, **base, refresh_pending=False))
+    asyncio.run(
+        shared.enqueue_backfill_job(
+            pool, **base, refresh_completed=False, refresh_pending=False
+        )
+    )
+
+    sqls = [sql for sql, _args in pool.execute_calls]
+    assert len(sqls) == 4
+    # Default: unconditional refresh (the backfill worker saving its progress).
+    assert "WHERE slack_sync_backfill_jobs.status" not in sqls[0]
+    assert sqls[1].endswith("WHERE slack_sync_backfill_jobs.status <> 'completed'")
+    # refresh_pending=False must never touch in-flight pending/running rows.
+    assert sqls[2].endswith(
+        "WHERE slack_sync_backfill_jobs.status IN ('completed', 'failed')"
+    )
+    assert sqls[3].endswith("WHERE slack_sync_backfill_jobs.status = 'failed'")
+
+
+class FakeClaimConn(FakeConn):
+    def __init__(self) -> None:
+        super().__init__()
+        self.fetch_calls: list[tuple] = []
+
+    async def fetch(self, sql, *args):
+        self.fetch_calls.append((sql, args))
+        return []
+
+
+def test_claim_backfill_jobs_reclaims_stale_running_rows():
+    conn = FakeClaimConn()
+    pool = FakePool(conn)
+
+    result = asyncio.run(shared.claim_backfill_jobs(pool, 5))
+
+    assert result == []
+    assert len(conn.fetch_calls) == 1
+    sql = conn.fetch_calls[0][0]
+    assert "status IN ('pending', 'failed')" in sql
+    assert "status = 'running'" in sql
+    assert (
+        f"last_started_at < NOW() - INTERVAL '{shared.BACKFILL_JOB_STALE_RUNNING_HOURS} hours'"
+        in sql
+    )
+
+
+def test_backfill_handler_drains_continuation_pages_then_completes(monkeypatch):
+    monkeypatch.setenv("SLACK_ETL_ENABLED", "true")
+    monkeypatch.setenv("SLACK_BACKFILL_ENABLED", "true")
+    backfill = _load_backfill()
+    calls: dict[str, list] = {"enqueued": [], "completed": [], "upserted": []}
+
+    class FakeClient:
+        def __init__(self) -> None:
+            self.history_calls: list[dict] = []
+
+        def _etl_access_mode(self):
+            return "test"
+
+        def _sync_etl_channel_history(self, channel_id, *, state, limit, lookback_days):
+            self.history_calls.append(dict(state))
+            if state.get("cursor") == "cursor-0":
+                return {
+                    "messages": [
+                        {
+                            "channel_id": channel_id,
+                            "timestamp": "1770000001.000100",
+                            "text": "page one",
+                        }
+                    ],
+                    "sync_state": {
+                        "cursor": "cursor-1",
+                        "watermark": "1770000001.000100",
+                        "oldest": state.get("oldest"),
+                        "latest": None,
+                    },
+                }
+            return {
+                "messages": [
+                    {
+                        "channel_id": channel_id,
+                        "timestamp": "1770000002.000100",
+                        "text": "page two",
+                    }
+                ],
+                "sync_state": {
+                    "cursor": None,
+                    "watermark": "1770000002.000100",
+                    "oldest": None,
+                    "latest": None,
+                },
+            }
+
+    class FakeContext:
+        run_id = "wfr_drain"
+        _pool = object()
+
+        def __init__(self) -> None:
+            self.logs: list[tuple] = []
+
+        def log(self, name, **fields):
+            self.logs.append((name, fields))
+
+    async def fake_claim_jobs(_pool, _limit):
+        return [
+            {
+                "job_id": 586,
+                "job_key": "continuation:C123:1770000000.000100:",
+                "job_type": shared.BACKFILL_JOB_CHANNEL_CONTINUATION,
+                "payload_version": shared.BACKFILL_JOB_PAYLOAD_VERSION,
+                "channel_id": "C123",
+                "payload_json": {
+                    "cursor": "cursor-0",
+                    "oldest": "1770000000.000100",
+                    "latest": None,
+                    "lookback_days": 30,
+                    "thread_lookback_days": 3,
+                },
+                "priority": 100,
+                "attempt_count": 1,
+            }
+        ]
+
+    async def fake_noop(*_args, **_kwargs):
+        return None
+
+    async def fake_upsert_messages(_pool, rows):
+        calls["upserted"].extend(rows)
+        return len(rows)
+
+    async def fake_enqueue(_pool, **kwargs):
+        calls["enqueued"].append(kwargs)
+
+    async def fake_completed(_pool, **kwargs):
+        calls["completed"].append(kwargs)
+
+    fake_client = FakeClient()
+    monkeypatch.setattr(backfill, "_emit_backfill_job_metrics", fake_noop)
+    monkeypatch.setattr(backfill, "emit_slack_checkpoint_metrics", fake_noop)
+    monkeypatch.setattr(backfill, "claim_backfill_jobs", fake_claim_jobs)
+    monkeypatch.setattr(backfill, "shared_client", lambda **_kwargs: fake_client)
+    monkeypatch.setattr(backfill, "upsert_messages", fake_upsert_messages)
+    monkeypatch.setattr(backfill, "enqueue_backfill_job", fake_enqueue)
+    monkeypatch.setattr(backfill, "mark_backfill_job_completed", fake_completed)
+    monkeypatch.setattr(backfill, "record_run_start", fake_noop)
+    monkeypatch.setattr(backfill, "record_run_finish", fake_noop)
+
+    result = asyncio.run(backfill.handler(backfill.Input(channel_batch_limit=1), FakeContext()))
+
+    assert result["status"] == "completed"
+    # The drain advanced through the cursor chain instead of refetching page one.
+    assert [call.get("cursor") for call in fake_client.history_calls] == [
+        "cursor-0",
+        "cursor-1",
+    ]
+    assert len(calls["upserted"]) == 2
+    # Exhausted cursor => the job completes; nothing requeues it.
+    assert calls["enqueued"] == []
+    assert len(calls["completed"]) == 1
+    assert calls["completed"][0]["job_id"] == 586
+    assert calls["completed"][0]["payload"]["cursor"] is None

--- a/workflows/slack/tests/test_sync_head_probe.py
+++ b/workflows/slack/tests/test_sync_head_probe.py
@@ -193,6 +193,7 @@ def _patch_handler_io(monkeypatch, sync, *, checkpoint=None, client=None):
 
 def test_overflowing_window_probes_head_and_advances_watermark(monkeypatch):
     monkeypatch.setenv("SLACK_ETL_ENABLED", "true")
+    monkeypatch.delenv("SLACK_BACKFILL_ENABLED", raising=False)
     sync = _load_sync()
     head_ts = f"{time.time():.6f}"
     client = FakeBusyClient(head_ts=head_ts)
@@ -241,6 +242,10 @@ def test_overflowing_window_probes_head_and_advances_watermark(monkeypatch):
     assert len(continuations) == 1
     assert continuations[0]["payload"]["cursor"] == "cursor-window"
     assert continuations[0]["refresh_pending"] is False
+    # One STABLE key per channel for the standing incremental continuation —
+    # a window-derived key would mint a new overlapping job every tick now
+    # that the watermark advances.
+    assert continuations[0]["job_key"] == "continuation:C123:incremental"
 
     thread_refreshes = [
         c
@@ -252,8 +257,63 @@ def test_overflowing_window_probes_head_and_advances_watermark(monkeypatch):
     assert thread_refreshes[0]["refresh_pending"] is False
 
 
+class FakeProbeFailClient(FakeBusyClient):
+    """Window page succeeds; the head probe raises (e.g. rate limit)."""
+
+    def _sync_etl_channel_history(self, channel_id, **kwargs):
+        if self.history_calls:
+            self.history_calls.append({"channel_id": channel_id, **kwargs})
+            raise RuntimeError("Slack API error: ratelimited")
+        return super()._sync_etl_channel_history(channel_id, **kwargs)
+
+
+def test_head_probe_failure_keeps_window_progress(monkeypatch):
+    monkeypatch.setenv("SLACK_ETL_ENABLED", "true")
+    monkeypatch.delenv("SLACK_BACKFILL_ENABLED", raising=False)
+    sync = _load_sync()
+    client = FakeProbeFailClient(head_ts="unused")
+    calls = _patch_handler_io(
+        monkeypatch,
+        sync,
+        checkpoint={"watermark_ts": "1770000050.000001", "last_error": ""},
+        client=client,
+    )
+
+    ctx = FakeContext()
+    result = asyncio.run(sync.handler(sync.Input(), ctx))
+
+    # The probe is best-effort: its failure must not discard the fetched
+    # window page, the continuation enqueue, or the checkpoint write.
+    assert result["status"] == "completed"
+    assert len(client.history_calls) == 2
+    assert [row["message_ts"] for row in calls["upserted"]] == ["1770000100.000001"]
+    assert calls["checkpoint_success"][0]["watermark_ts"] == "1770000100.000001"
+    assert any(
+        c["job_type"] == sync.BACKFILL_JOB_CHANNEL_CONTINUATION
+        for c in calls["enqueued"]
+    )
+    assert any(name == "slack_sync_head_probe_failed" for name, _ in ctx.logs)
+
+
+def test_head_probe_skipped_when_backfill_disabled(monkeypatch):
+    monkeypatch.setenv("SLACK_ETL_ENABLED", "true")
+    monkeypatch.setenv("SLACK_BACKFILL_ENABLED", "false")
+    sync = _load_sync()
+    client = FakeBusyClient(head_ts="1779999999.000001")
+    calls = _patch_handler_io(monkeypatch, sync, client=client)
+
+    result = asyncio.run(sync.handler(sync.Input(), FakeContext()))
+
+    # Without the backfill worker there is nothing to drain the middle of the
+    # backlog, so jumping the watermark would certify a permanent hole.
+    assert result["status"] == "completed"
+    assert len(client.history_calls) == 1
+    assert calls["checkpoint_success"][0]["watermark_ts"] == "1770000100.000001"
+
+
 def test_head_probe_skipped_for_bounded_manual_runs(monkeypatch):
     monkeypatch.setenv("SLACK_ETL_ENABLED", "true")
+    monkeypatch.delenv("SLACK_BACKFILL_ENABLED", raising=False)
     sync = _load_sync()
     client = FakeBusyClient(head_ts="1779999999.000001")
     _calls = _patch_handler_io(monkeypatch, sync, client=client)
@@ -293,6 +353,7 @@ class FakeQuietClient(FakeBusyClient):
 
 def test_watermark_never_regresses_below_checkpoint(monkeypatch):
     monkeypatch.setenv("SLACK_ETL_ENABLED", "true")
+    monkeypatch.delenv("SLACK_BACKFILL_ENABLED", raising=False)
     sync = _load_sync()
     client = FakeQuietClient(
         head_ts="unused", window_watermark="1770000100.000001"

--- a/workflows/slack/tests/test_sync_head_probe.py
+++ b/workflows/slack/tests/test_sync_head_probe.py
@@ -1,0 +1,328 @@
+"""Busy-channel incremental sync: head probe, watermark monotonicity, enqueue guards.
+
+Regression tests for the deadlock where a channel with more than one page of
+backlog froze forever: the oldest-anchored window page kept the watermark at
+the backlog's density fixed point while the hourly continuation re-enqueue
+clobbered the backfill worker's cursor progress.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+import json
+import sys
+import time
+import types
+from pathlib import Path
+
+
+def _load_sync():
+    repo_root = Path(__file__).resolve().parents[3]
+    if str(repo_root) not in sys.path:
+        sys.path.insert(0, str(repo_root))
+
+    api_module = sys.modules.setdefault("api", types.ModuleType("api"))
+
+    runtime_control = types.ModuleType("api.runtime_control")
+    runtime_control.canonical_json = lambda value: json.dumps(value, sort_keys=True)
+    api_module.runtime_control = runtime_control
+    sys.modules["api.runtime_control"] = runtime_control
+
+    etl_metrics = types.ModuleType("workflows.etl_metrics")
+    for name in (
+        "record_etl_items_enqueued",
+        "record_etl_items_failed",
+        "record_etl_items_seen",
+        "record_etl_items_upserted",
+        "set_etl_active_scopes",
+        "set_etl_failed_scopes",
+        "set_etl_scope_sync_freshness_seconds",
+    ):
+        setattr(etl_metrics, name, lambda *_args, **_kwargs: None)
+    sys.modules["workflows.etl_metrics"] = etl_metrics
+
+    slack_metrics = types.ModuleType("workflows.slack.metrics")
+    for name in (
+        "observe_slack_retention_run_duration",
+        "record_slack_etl_rate_limit",
+        "record_slack_retention_api_rate_limited",
+        "record_slack_retention_api_request",
+        "record_slack_retention_channel_failure",
+        "record_slack_retention_failure",
+        "record_slack_retention_messages_processed",
+        "record_slack_retention_run",
+        "set_slack_retention_last_failure_timestamp",
+        "set_slack_retention_watermark_lag_seconds",
+    ):
+        setattr(slack_metrics, name, lambda *_args, **_kwargs: None)
+    sys.modules["workflows.slack.metrics"] = slack_metrics
+
+    workflow_engine = types.ModuleType("api.workflow_engine")
+    workflow_engine.WorkflowContext = object
+    api_module.workflow_engine = workflow_engine
+    sys.modules["api.workflow_engine"] = workflow_engine
+
+    centaur_sdk = sys.modules.setdefault("centaur_sdk", types.ModuleType("centaur_sdk"))
+    centaur_sdk.secret = lambda _name, default=None: default
+
+    return importlib.import_module("workflows.slack.sync")
+
+
+class FakeContext:
+    run_id = "wfr_test"
+    _pool = object()
+
+    def __init__(self) -> None:
+        self.logs: list[tuple[str, dict]] = []
+
+    def log(self, name: str, **fields):
+        self.logs.append((name, fields))
+
+
+class FakeBusyClient:
+    """First call returns an overflowing oldest-anchored window page; the head
+    probe (no oldest, lookback 0) returns the live newest page."""
+
+    def __init__(self, *, head_ts: str, window_watermark: str = "1770000100.000001") -> None:
+        self.history_calls: list[dict] = []
+        self.head_ts = head_ts
+        self.window_watermark = window_watermark
+
+    def _etl_access_mode(self):
+        return "test"
+
+    def _list_etl_channels(self, *_args, **_kwargs):
+        return [{"id": "C123", "name": "busy"}]
+
+    def _list_etl_users(self, *_args, **_kwargs):
+        return []
+
+    def _sync_etl_channel_history(self, channel_id, **kwargs):
+        self.history_calls.append({"channel_id": channel_id, **kwargs})
+        if len(self.history_calls) == 1:
+            return {
+                "messages": [
+                    {
+                        "channel_id": channel_id,
+                        "timestamp": self.window_watermark,
+                        "text": "stale backlog slice",
+                    }
+                ],
+                "has_more": True,
+                "next_cursor": "cursor-window",
+                "sync_state": {
+                    "cursor": "cursor-window",
+                    "watermark": self.window_watermark,
+                    "oldest": kwargs.get("oldest"),
+                    "latest": None,
+                },
+            }
+        return {
+            "messages": [
+                {
+                    "channel_id": channel_id,
+                    "timestamp": self.head_ts,
+                    "thread_ts": self.head_ts,
+                    "reply_count": 2,
+                    "text": "live head",
+                }
+            ],
+            "has_more": False,
+            "next_cursor": None,
+            "sync_state": {
+                "cursor": None,
+                "watermark": self.head_ts,
+                "oldest": None,
+                "latest": None,
+            },
+        }
+
+
+async def _noop(*_args, **_kwargs):
+    return None
+
+
+async def _zero(*_args, **_kwargs):
+    return 0
+
+
+def _patch_handler_io(monkeypatch, sync, *, checkpoint=None, client=None):
+    calls: dict[str, list] = {
+        "checkpoint_success": [],
+        "enqueued": [],
+        "upserted": [],
+    }
+    fake_client = client
+
+    async def fake_load_checkpoint(_pool, _channel_id):
+        return checkpoint
+
+    async def fake_upsert_messages(_pool, rows):
+        calls["upserted"].extend(rows)
+        return len(rows)
+
+    async def fake_load_thread_refresh_times(*_args, **_kwargs):
+        return {}
+
+    async def fake_update_checkpoint_success(_pool, **kwargs):
+        calls["checkpoint_success"].append(kwargs)
+
+    async def fake_enqueue_backfill_job(_pool, **kwargs):
+        calls["enqueued"].append(kwargs)
+
+    async def fake_widen(_pool, **_kwargs):
+        return False
+
+    monkeypatch.setattr(sync, "_client", lambda: fake_client)
+    monkeypatch.setattr(sync, "_upsert_channels", _noop)
+    monkeypatch.setattr(sync, "_upsert_users", _zero)
+    monkeypatch.setattr(sync, "_load_checkpoint", fake_load_checkpoint)
+    monkeypatch.setattr(sync, "_upsert_messages", fake_upsert_messages)
+    monkeypatch.setattr(sync, "load_thread_refresh_times", fake_load_thread_refresh_times)
+    monkeypatch.setattr(sync, "_update_checkpoint_success", fake_update_checkpoint_success)
+    monkeypatch.setattr(sync, "_update_checkpoint_failure", _noop)
+    monkeypatch.setattr(sync, "enqueue_backfill_job", fake_enqueue_backfill_job)
+    monkeypatch.setattr(sync, "emit_slack_checkpoint_metrics", _noop)
+    monkeypatch.setattr(sync, "record_run_start", _noop)
+    monkeypatch.setattr(sync, "record_run_finish", _noop)
+    monkeypatch.setattr(sync, "widen_channel_bootstrap_job", fake_widen)
+
+    return calls
+
+
+def test_overflowing_window_probes_head_and_advances_watermark(monkeypatch):
+    monkeypatch.setenv("SLACK_ETL_ENABLED", "true")
+    sync = _load_sync()
+    head_ts = f"{time.time():.6f}"
+    client = FakeBusyClient(head_ts=head_ts)
+    calls = _patch_handler_io(
+        monkeypatch,
+        sync,
+        checkpoint={"watermark_ts": "1770000050.000001", "last_error": ""},
+        client=client,
+    )
+
+    result = asyncio.run(sync.handler(sync.Input(), FakeContext()))
+
+    assert result["status"] == "completed"
+    # Window fetch, then the head probe with a default newest-first call.
+    assert len(client.history_calls) == 2
+    head_call = client.history_calls[1]
+    assert head_call["lookback_days"] == 0
+    assert "oldest" not in head_call or head_call.get("oldest") is None
+    assert head_call["state"] == {
+        "cursor": None,
+        "watermark": None,
+        "oldest": None,
+        "latest": None,
+    }
+
+    # Both the stale slice and the live head were upserted.
+    upserted_ts = {row["message_ts"] for row in calls["upserted"]}
+    assert upserted_ts == {"1770000100.000001", head_ts}
+
+    # Watermark jumps to the live head, not the window page max.
+    assert calls["checkpoint_success"] == [
+        {
+            "channel_id": "C123",
+            "watermark_ts": head_ts,
+            "run_id": "slack_sync_wfr_test",
+        }
+    ]
+
+    # The continuation carries the window cursor and must not clobber
+    # in-flight jobs; the head thread refresh gets the same protection.
+    continuations = [
+        c
+        for c in calls["enqueued"]
+        if c["job_type"] == sync.BACKFILL_JOB_CHANNEL_CONTINUATION
+    ]
+    assert len(continuations) == 1
+    assert continuations[0]["payload"]["cursor"] == "cursor-window"
+    assert continuations[0]["refresh_pending"] is False
+
+    thread_refreshes = [
+        c
+        for c in calls["enqueued"]
+        if c["job_type"] == sync.BACKFILL_JOB_THREAD_REFRESH
+    ]
+    assert len(thread_refreshes) == 1
+    assert thread_refreshes[0]["payload"] == {"thread_ts": head_ts}
+    assert thread_refreshes[0]["refresh_pending"] is False
+
+
+def test_head_probe_skipped_for_bounded_manual_runs(monkeypatch):
+    monkeypatch.setenv("SLACK_ETL_ENABLED", "true")
+    sync = _load_sync()
+    client = FakeBusyClient(head_ts="1779999999.000001")
+    _calls = _patch_handler_io(monkeypatch, sync, client=client)
+
+    result = asyncio.run(
+        sync.handler(sync.Input(latest="1770000200.000000"), FakeContext())
+    )
+
+    assert result["status"] == "completed"
+    # An explicit `latest` bound means a deliberate historical window: no probe.
+    assert len(client.history_calls) == 1
+
+
+class FakeQuietClient(FakeBusyClient):
+    """Single page, no backlog, watermark below the stored checkpoint."""
+
+    def _sync_etl_channel_history(self, channel_id, **kwargs):
+        self.history_calls.append({"channel_id": channel_id, **kwargs})
+        return {
+            "messages": [
+                {
+                    "channel_id": channel_id,
+                    "timestamp": self.window_watermark,
+                    "text": "old overlap page",
+                }
+            ],
+            "has_more": False,
+            "next_cursor": None,
+            "sync_state": {
+                "cursor": None,
+                "watermark": self.window_watermark,
+                "oldest": kwargs.get("oldest"),
+                "latest": None,
+            },
+        }
+
+
+def test_watermark_never_regresses_below_checkpoint(monkeypatch):
+    monkeypatch.setenv("SLACK_ETL_ENABLED", "true")
+    sync = _load_sync()
+    client = FakeQuietClient(
+        head_ts="unused", window_watermark="1770000100.000001"
+    )
+    calls = _patch_handler_io(
+        monkeypatch,
+        sync,
+        checkpoint={"watermark_ts": "1775000000.000100", "last_error": ""},
+        client=client,
+    )
+
+    result = asyncio.run(sync.handler(sync.Input(), FakeContext()))
+
+    assert result["status"] == "completed"
+    assert len(client.history_calls) == 1
+    assert calls["checkpoint_success"] == [
+        {
+            "channel_id": "C123",
+            "watermark_ts": "1775000000.000100",
+            "run_id": "slack_sync_wfr_test",
+        }
+    ]
+
+
+def test_max_slack_ts_ignores_invalid_and_orders_numerically():
+    sync = _load_sync()
+    assert sync._max_slack_ts(None, "", "not-a-ts") is None
+    assert (
+        sync._max_slack_ts("1770000000.000100", "1770000000.000099", None)
+        == "1770000000.000100"
+    )
+    # Numeric, not lexicographic: "9.5" > "10" lexicographically but not numerically.
+    assert sync._max_slack_ts("9.5", "10.0") == "10.0"


### PR DESCRIPTION
## Summary

Two coupled defects in the Slack ETL (`workflows/slack/`), both verified on a live deployment where six busy channels had been silently frozen for 2–5 weeks:

### 1. Bot/app message content is never stored

`SlackEtlClient._serialize_message` allowlists message keys and drops `attachments`/`blocks`. Bot integrations (the GitHub app, alerting apps) post with an empty top-level `text` and put all content in legacy attachments — so their messages are stored content-free. On our deployment, **915 of 916 rows** in a GitHub-bot channel had empty `text` and no content in `raw_payload`, making them invisible to the FTS index over `text` and to `company_context_documents`.

**Fix:** pass `attachments` and `blocks` through into `raw_payload`, and synthesize the `text` column from attachment `fallback` (else `pretext`/`title`/`text`) only when top-level text is empty. Human messages are untouched. (The interactive tool client `tools/productivity/slack/client.py` has the same allowlist gap; left as a follow-up since nothing persists its output.)

### 2. Busy channels deadlock: frozen watermark + clobbered continuations

`conversations.history` **anchors at `oldest` when only `oldest` is passed** — the page holds the *oldest* slice of the window, paging forward in time. (Verified empirically against the live API; the code labels the page `"order": "desc"` and assumes the opposite.) Consequences on any channel whose backlog exceeds one page (`limit`, default 100, per tick):

- The incremental tick re-reads the same oldest page forever; `latest_seen = max(page ts)` stabilizes at the channel's *density fixed point* (where ~`limit` messages span `thread_lookback_days`) and can even **regress** the stored watermark. New head messages are never ingested. Six of our channels froze exactly this way, each at its own density fixed point.
- Each tick re-enqueues the channel-continuation job under the same job_key, and `enqueue_backfill_job`'s unconditional `ON CONFLICT` overwrite resets `status` to `pending`, zeroes `attempt_count`, wipes `last_error`, and restores the **stale cursor** — erasing the backfill worker's drain progress seconds after it saves. Live evidence: a continuation job pending for 2 weeks with `attempt_count=0`, `last_started_at` set hourly, `last_completed_at` never, its cursor pointing at the freeze date; the backfill run "completed" hourly upserting exactly the same 656 messages every run.

**Fixes (three small diffs):**

- **Head probe + monotonic watermark** (`sync.py`): when the window page has `has_more` and the run isn't `latest`-bounded, issue one extra `_sync_etl_channel_history` call with no `oldest`/watermark and `lookback_days=0` — a default, unambiguously newest-first fetch — and upsert both pages (idempotent). The checkpoint watermark becomes the numeric max of window page, head page, and previous checkpoint, so it can never regress. Correct under either anchoring behavior; the middle of the backlog is still drained by the continuation job.
- **`refresh_pending=False`** on `enqueue_backfill_job` for periodic enqueuers (sync's continuation + thread refreshes): the conflict update then only reopens `completed`/`failed` jobs (or just `failed` when combined with `refresh_completed=False`) and never rewrites the payload/status/attempts of a `pending`/`running` row. The backfill worker's own progress-save keeps the unconditional default. Continuations now drain to the live head and complete (`latest=None` drains terminate on their own).
- **Stale-`running` rescue** in `claim_backfill_jobs`: the sync clobber accidentally rescued jobs orphaned by a crashed worker; now that in-flight rows are protected, reclaim `running` jobs whose `last_started_at` is older than 2 hours.

No schema changes. Existing frozen checkpoints self-heal on the first post-deploy tick (the head probe jumps the watermark to the live head), and re-ingesting historical pages repairs `raw_payload`/`text` through the existing upsert (`raw_payload = EXCLUDED.raw_payload`).

## Tests

- Serializer: attachments/blocks pass-through + fallback text synthesis; user text never overridden; files-vs-attachments non-conflation regression (`test_shared_attachments.py`).
- Enqueue guard matrix for `refresh_pending` × `refresh_completed`; stale-`running` claim clause; continuation drain advances the cursor chain and completes without requeue (`test_shared_attachments.py`).
- Sync handler: head probe fires only on overflow and never on `latest`-bounded runs; both pages upserted; watermark takes the head value and never regresses below the checkpoint; continuation/thread-refresh enqueues carry `refresh_pending=False` (`test_sync_head_probe.py`).

All 34 tests in `workflows/slack/tests/` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)