### PR TITLE
fix(slackbotv2): rename console link to "Open chat in Console"

### DIFF
--- a/services/slackbotv2/src/console-session-link.ts
+++ b/services/slackbotv2/src/console-session-link.ts
@@ -1,5 +1,5 @@
 /**
- * Slack-only "Open session in Console" context line.
+ * Slack-only "Open chat in Console" context line.
  *
  * On the first assistant message in a Slack thread, slackbotv2 appends a Block
  * Kit `context` block linking to the Console session view. The block is passed
@@ -98,8 +98,8 @@ export type SlackContextBlock = {
 }
 
 /**
- * Builds the "Open session in Console · {MODEL} · {Harness}" context block, or
- * undefined when no Console base URL is configured (a bare "Open session in
+ * Builds the "Open chat in Console · {MODEL} · {Harness}" context block, or
+ * undefined when no Console base URL is configured (a bare "Open chat in
  * Console" with no link is pointless, so the whole block is skipped). The
  * model id is uppercased for display.
  */
@@ -111,7 +111,7 @@ export function buildConsoleSessionContextBlock(params: {
 }): SlackContextBlock | undefined {
   const url = consoleSessionUrl(params.consoleBaseUrl, params.threadKey)
   if (!url) return undefined
-  const segments = [`<${url}|Open session in Console>`]
+  const segments = [`<${url}|Open chat in Console>`]
   const model = params.model?.trim()
   if (model) segments.push(escapeSlackMrkdwn(model.toUpperCase()))
   const harness = harnessDisplayName(params.harnessType)

--- a/services/slackbotv2/src/index.ts
+++ b/services/slackbotv2/src/index.ts
@@ -645,7 +645,7 @@ async function syncThreadMessageToSession(
   setMessageText(serializedMessage, overrides.cleanedText)
   const stickyOverridesUpdate = stickyThreadOverrideUpdate(overrides)
   const effectiveOverrides = resolveStickyThreadOverrides(state, stickyOverridesUpdate)
-  // Slack-only "Open session in Console" link on the FIRST assistant message in
+  // Slack-only "Open chat in Console" link on the FIRST assistant message in
   // a thread (the reply to the first message that starts an execution). The
   // block is undefined when no Console base URL is configured. `thread.id`
   // (`slack:CHANNEL:THREAD_TS`) is the exact value sent to the session API as

--- a/services/slackbotv2/src/types.ts
+++ b/services/slackbotv2/src/types.ts
@@ -108,7 +108,7 @@ export type SlackbotV2Options = {
   /**
    * Public origin of the Console UI (same value the Console itself uses,
    * `CENTAUR_CONSOLE_PUBLIC_URL`). When set, the first assistant message in a
-   * Slack thread gets an "Open session in Console" context link. Unset skips
+   * Slack thread gets an "Open chat in Console" context link. Unset skips
    * the block entirely.
    */
   consolePublicUrl?: string

--- a/services/slackbotv2/test/chat-sdk-emulate.test.ts
+++ b/services/slackbotv2/test/chat-sdk-emulate.test.ts
@@ -441,7 +441,7 @@ describe('slackbotv2', () => {
         .filter(call => call.method === 'chat.stopStream')
         .flatMap(call => (Array.isArray(call.body.blocks) ? (call.body.blocks as unknown[]) : []))
         .map(block => JSON.stringify(block))
-        .filter(text => text.includes('Open session in Console'))
+        .filter(text => text.includes('Open chat in Console'))
 
     const parent = await postUserMessage('Console link thread context.')
     const firstMention = await postUserMessage(
@@ -475,7 +475,7 @@ describe('slackbotv2', () => {
     expect(firstBlocks[0]).toContain(
       `https://console.example.dev/console/threads?thread=${encodedThread}`
     )
-    expect(firstBlocks[0]).toContain('Open session in Console')
+    expect(firstBlocks[0]).toContain('Open chat in Console')
     expect(firstBlocks[0]).toContain('Claude Code')
     expect(firstBlocks[0]).toContain('CLAUDE-OPUS-4-8')
     expect(firstBlocks[0]).toContain(' · ')
@@ -523,7 +523,7 @@ describe('slackbotv2', () => {
         .filter(call => call.method === 'chat.stopStream')
         .flatMap(call => (Array.isArray(call.body.blocks) ? (call.body.blocks as unknown[]) : []))
         .map(block => JSON.stringify(block))
-        .filter(text => text.includes('Open session in Console'))
+        .filter(text => text.includes('Open chat in Console'))
 
     const parent = await postUserMessage('Default model thread context.')
     const mention = await postUserMessage(

--- a/services/slackbotv2/test/console-session-link.test.ts
+++ b/services/slackbotv2/test/console-session-link.test.ts
@@ -98,7 +98,7 @@ describe('buildConsoleSessionContextBlock', () => {
         {
           type: 'mrkdwn',
           text:
-            '<https://console.centaur.dev/console/threads?thread=slack%3AC123%3A1700000000.000100|Open session in Console> · GPT-5.2 · Codex'
+            '<https://console.centaur.dev/console/threads?thread=slack%3AC123%3A1700000000.000100|Open chat in Console> · GPT-5.2 · Codex'
         }
       ]
     })
@@ -111,7 +111,7 @@ describe('buildConsoleSessionContextBlock', () => {
       harnessType: 'claudecode'
     })
     expect(block?.elements[0]?.text).toBe(
-      '<https://console.centaur.dev/console/threads?thread=slack%3AC1%3A1|Open session in Console> · Claude Code'
+      '<https://console.centaur.dev/console/threads?thread=slack%3AC1%3A1|Open chat in Console> · Claude Code'
     )
   })
 


### PR DESCRIPTION
## Summary

The context line slackbotv2 appends to the first assistant message in a Slack thread read "Open session in Console", but the console UI calls these threads chats (the Chats view / sidebar). This renames the link text to "Open chat in Console" so the wordings match. Comments and test assertions updated to the same wording; no behavior change otherwise.

## Testing

```
cd services/slackbotv2 && bun test test
```

137 pass, 0 fail. Typecheck (`bun run check:types`) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)