### PR TITLE
Hard kill harness on stop requests

### DIFF
--- a/crates/harness-server/src/error.rs
+++ b/crates/harness-server/src/error.rs
@@ -49,6 +49,8 @@ pub enum HarnessServerError {
         status: ExitStatus,
         stderr: String,
     },
+    #[error("{kind:?} turn interrupted")]
+    TurnInterrupted { kind: HarnessKind },
     #[error("failed to spawn {bin} app-server: {source}")]
     SpawnCodex {
         bin: String,

--- a/crates/harness-server/src/server.rs
+++ b/crates/harness-server/src/server.rs
@@ -934,7 +934,7 @@ fn handle_active_turn_request<H: HarnessServer, W: Write>(
     normalizer: &mut CodexTurnNormalizer,
     request: JSONRPCRequest,
     stdout: &mut W,
-) -> Result<()> {
+) -> Result<bool> {
     match request.method.as_str() {
         "turn/steer" => {
             let params: TurnSteerParams = request_params(request.params)?;
@@ -945,7 +945,7 @@ fn handle_active_turn_request<H: HarnessServer, W: Write>(
                     -32600,
                     format!("unknown threadId {}", params.thread_id),
                 )?;
-                return Ok(());
+                return Ok(false);
             }
             if params.expected_turn_id != normalizer.turn_id() {
                 write_error(
@@ -958,7 +958,7 @@ fn handle_active_turn_request<H: HarnessServer, W: Write>(
                         normalizer.turn_id()
                     ),
                 )?;
-                return Ok(());
+                return Ok(false);
             }
             process
                 .stdin
@@ -978,9 +978,10 @@ fn handle_active_turn_request<H: HarnessServer, W: Write>(
             {
                 write_value(stdout, &notification_to_wire_value(&notification)?)?;
             }
-            Ok(())
+            Ok(false)
         }
         "turn/interrupt" => {
+            process.kill_and_wait()?;
             write_client_response(
                 stdout,
                 ClientResponse::TurnInterrupt {
@@ -988,7 +989,7 @@ fn handle_active_turn_request<H: HarnessServer, W: Write>(
                     response: TurnInterruptResponse {},
                 },
             )?;
-            Ok(())
+            Ok(true)
         }
         _ => {
             write_error(
@@ -997,7 +998,7 @@ fn handle_active_turn_request<H: HarnessServer, W: Write>(
                 -32600,
                 format!("cannot handle {} while a turn is active", request.method),
             )?;
-            Ok(())
+            Ok(false)
         }
     }
 }
@@ -1033,7 +1034,10 @@ fn run_normalized_turn<H: HarnessServer, W: Write>(
     ) {
         Ok(Some(turn)) => state.completed_turns.push(turn),
         Ok(None) => {}
-        Err(error) => finish_turn_with_error(state, normalizer, stdout, error)?,
+        Err(error) => {
+            state.process = None;
+            finish_turn_with_error(state, normalizer, stdout, error)?;
+        }
     }
     Ok(())
 }
@@ -1076,12 +1080,14 @@ fn run_harness_turn<H: HarnessServer, W: Write>(
     let usage_span_input = usage_span_input_value(input);
     let mut usage_span_output = UsageSpanOutput::default();
     ensure_harness_process(harness, state)?;
-    let process = state
-        .process
-        .as_mut()
-        .ok_or(HarnessServerError::HarnessStdinUnavailable)?;
-    process.stdin.write_all(&harness.stdin_for_turn(input)?)?;
-    process.stdin.flush()?;
+    {
+        let process = state
+            .process
+            .as_mut()
+            .ok_or(HarnessServerError::HarnessStdinUnavailable)?;
+        process.stdin.write_all(&harness.stdin_for_turn(input)?)?;
+        process.stdin.flush()?;
+    }
 
     let mut last_session_id = state.harness_session_id.clone();
     let mut event_normalizer = H::EventNormalizer::default();
@@ -1089,14 +1095,34 @@ fn run_harness_turn<H: HarnessServer, W: Write>(
     let mut latest_usage = None;
     loop {
         while let Ok(request) = request_rx.try_recv() {
-            handle_active_turn_request(harness, process, normalizer, request, stdout)?;
+            let process = state
+                .process
+                .as_mut()
+                .ok_or(HarnessServerError::HarnessStdinUnavailable)?;
+            if handle_active_turn_request(harness, process, normalizer, request, stdout)? {
+                state.process = None;
+                return Err(HarnessServerError::TurnInterrupted {
+                    kind: harness.kind(),
+                });
+            }
         }
 
-        let line = match process.stdout.recv_timeout(Duration::from_millis(50)) {
+        let line = match state
+            .process
+            .as_mut()
+            .ok_or(HarnessServerError::HarnessStdoutUnavailable)?
+            .stdout
+            .recv_timeout(Duration::from_millis(50))
+        {
             Ok(line) => line?,
             Err(RecvTimeoutError::Timeout) => continue,
             Err(RecvTimeoutError::Disconnected) => {
-                let status = process.child.wait()?;
+                let status = state
+                    .process
+                    .as_mut()
+                    .ok_or(HarnessServerError::HarnessStdoutUnavailable)?
+                    .child
+                    .wait()?;
                 return Err(HarnessServerError::HarnessExited {
                     kind: harness.kind(),
                     status,
@@ -1281,8 +1307,11 @@ fn append_usage_span_output(event: &NormalizedEvent, output: &mut UsageSpanOutpu
 }
 
 fn ensure_harness_process<H: HarnessServer>(harness: &H, state: &mut ThreadState) -> Result<()> {
-    if state.process.is_some() {
-        return Ok(());
+    if let Some(process) = state.process.as_mut() {
+        if process.child.try_wait()?.is_none() {
+            return Ok(());
+        }
+        state.process = None;
     }
 
     let mut command = harness.command_for_turn(state);

--- a/crates/harness-server/src/traits.rs
+++ b/crates/harness-server/src/traits.rs
@@ -41,6 +41,13 @@ impl Drop for HarnessChild {
     }
 }
 
+impl HarnessChild {
+    pub fn kill_and_wait(&mut self) -> io::Result<()> {
+        let _ = self.child.kill();
+        self.child.wait().map(|_| ())
+    }
+}
+
 pub trait AppServerRuntime {
     fn run_stdio(&self) -> Result<()>;
 }

--- a/crates/harness-server/tests/app_server_stdio.rs
+++ b/crates/harness-server/tests/app_server_stdio.rs
@@ -618,6 +618,43 @@ fn fake_harness_process_is_started_once_across_two_turns() {
 }
 
 #[test]
+fn turn_interrupt_kills_harness_process_and_finishes_turn() {
+    let start_log = temp_path("harness-interrupt-starts.log");
+    let marker = temp_path("harness-interrupt-marker");
+    let command = format!(
+        "printf 'start\\n' >> {start_log}; \
+         trap 'printf \"killed\\n\" >> {start_log}; exit 143' TERM INT; \
+         printf '%s\\n' '{{\"type\":\"system\",\"subtype\":\"init\",\"session_id\":\"fake-session\"}}'; \
+         if [ -f {marker} ]; then \
+           printf '%s\\n' '{{\"type\":\"assistant\",\"is_partial\":false,\"message\":{{\"id\":\"msg_1\",\"content\":[{{\"type\":\"text\",\"text\":\"fresh turn\"}}]}}}}'; \
+           printf '%s\\n' '{{\"type\":\"result\",\"subtype\":\"success\",\"result\":\"fresh turn\"}}'; \
+           sleep 1; \
+         else \
+           touch {marker}; \
+           while IFS= read -r _; do sleep 60; done; \
+         fi",
+        start_log = shell_quote(start_log.as_path()),
+        marker = shell_quote(marker.as_path())
+    );
+    let mut bridge = BridgeProcess::spawn_harness(Harness::ClaudeCode, Some(command), None);
+    let thread_id =
+        bridge.initialize_and_start_thread(Harness::ClaudeCode, Duration::from_secs(10));
+
+    let interrupted = bridge.run_interrupted_turn(
+        &thread_id,
+        3,
+        4,
+        "hang until stopped",
+        Duration::from_secs(10),
+    );
+    assert_eq!(interrupted.terminal_status.as_deref(), Some("failed"));
+    let _ = bridge.child.kill();
+    let _ = bridge.child.wait();
+    let _ = std::fs::remove_file(start_log);
+    let _ = std::fs::remove_file(marker);
+}
+
+#[test]
 #[ignore = "runs real Claude Code and Codex/Amp-style networked binaries"]
 fn real_claude_code_long_streaming_is_anchored_to_native_cli() {
     require_command("claude", &["--version"]);
@@ -1126,6 +1163,76 @@ impl BridgeProcess {
                     steer_sent = true;
                 }
                 if method == "turn/completed" {
+                    break;
+                }
+            }
+        }
+
+        capture
+    }
+
+    fn run_interrupted_turn(
+        &mut self,
+        thread_id: &str,
+        request_id: i64,
+        interrupt_request_id: i64,
+        prompt: &str,
+        timeout: Duration,
+    ) -> TurnCapture {
+        self.send(json!({
+            "id": request_id,
+            "method": "turn/start",
+            "params": {
+                "threadId": thread_id,
+                "input": [{"type": "text", "text": prompt, "text_elements": []}],
+            },
+        }));
+
+        let deadline = Instant::now() + timeout;
+        let mut capture = TurnCapture::default();
+        let mut interrupt_sent = false;
+        let mut interrupt_acknowledged = false;
+
+        loop {
+            let value = self.read_json(deadline);
+            if let Some(id) = response_id(&value) {
+                if id == request_id {
+                    capture.turn_id = value
+                        .pointer("/result/turn/id")
+                        .and_then(Value::as_str)
+                        .unwrap_or_else(|| panic!("turn/start did not return turn id: {value}"))
+                        .to_string();
+                } else if id == interrupt_request_id {
+                    interrupt_acknowledged = true;
+                }
+                continue;
+            }
+
+            if let Some(method) = value.get("method").and_then(Value::as_str) {
+                assert_notification_thread_id(&value, thread_id);
+                capture.consume_notification(method, &value);
+                if method == "turn/started"
+                    && capture.turn_id.is_empty()
+                    && let Some(turn_id) = value.pointer("/params/turn/id").and_then(Value::as_str)
+                {
+                    capture.turn_id = turn_id.to_string();
+                }
+                if method == "turn/started" && !interrupt_sent {
+                    self.send(json!({
+                        "id": interrupt_request_id,
+                        "method": "turn/interrupt",
+                        "params": {
+                            "threadId": thread_id,
+                            "turnId": capture.turn_id,
+                        },
+                    }));
+                    interrupt_sent = true;
+                }
+                if method == "turn/completed" {
+                    assert!(
+                        interrupt_acknowledged,
+                        "turn completed before interrupt response"
+                    );
                     break;
                 }
             }


### PR DESCRIPTION
## Summary
- hard-kill the active harness child process when `turn/interrupt` is received
- finish the active turn immediately as interrupted instead of waiting on stdout cleanup
- clear dead harness handles before later turns and add interrupt coverage

## Tests
- `cargo test -p harness-server`

Prompted by: @goksu