### PR TITLE
feat(sandbox): install AWS CLI v2 in sandbox image

### DIFF
--- a/services/sandbox/Dockerfile
+++ b/services/sandbox/Dockerfile
@@ -90,6 +90,19 @@ RUN set -eux; \
     chmod +x /usr/local/bin/kubectl; \
     kubectl version --client=true | grep -F "${KUBECTL_VERSION#v}"
 
+# ── AWS CLI v2 ─────────────────────────────────────────────────────────────
+RUN set -eux; \
+    aws_arch="$(case "$(dpkg --print-architecture)" in \
+      amd64) echo x86_64 ;; \
+      arm64) echo aarch64 ;; \
+      *) echo unsupported-architecture >&2; exit 1 ;; \
+    esac)"; \
+    curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-${aws_arch}.zip" -o /tmp/awscliv2.zip; \
+    unzip -q /tmp/awscliv2.zip -d /tmp; \
+    /tmp/aws/install; \
+    rm -rf /tmp/awscliv2.zip /tmp/aws; \
+    aws --version
+
 # ── Nushell ─────────────────────────────────────────────────────────────────
 RUN set -eux; \
     nu_arch="$(case "$(dpkg --print-architecture)" in \


### PR DESCRIPTION
## Summary
- Install AWS CLI v2 in `services/sandbox/Dockerfile`, selecting the `awscliv2` package matching the image's architecture (`amd64` → `x86_64`, `arm64` → `aarch64`), following the same arch-detection pattern already used for `kubectl` and `Nushell` in this file.
- `curl` was already installed in the base package list; no change needed there.

## Test plan
- [x] Validated the new RUN block's shell syntax with `bash -n`
- [ ] CI image build (no outbound network access to Docker Hub in this sandboxed environment to run a full `docker build` locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)