### PR TITLE
Add Slack Block Kit renderer chunks

### DIFF
--- a/packages/rendering/src/chat-sdk.test.ts
+++ b/packages/rendering/src/chat-sdk.test.ts
@@ -40,9 +40,35 @@ describe('ChatSDKRenderer', () => {
     expect(rendererEventTypes).toContain('renderer.status')
     expect(rendererEventTypes).toContain('renderer.message.delta')
     expect(rendererEventTypes).toContain('renderer.message.snapshot')
+    expect(rendererEventTypes).toContain('renderer.blocks')
     expect(rendererEventTypes).toContain('renderer.task.update')
     expect(rendererEventTypes).toContain('renderer.plan.update')
     expect(rendererEventTypes).toContain('renderer.done')
+  })
+
+  it('maps generic Slack Block Kit blocks to Chat SDK block chunks', () => {
+    const renderer = new ChatSDKRenderer()
+    const block = {
+      type: 'data_table',
+      caption: 'Weekly active users',
+      rows: [
+        [{ type: 'raw_text', text: 'Day' }, { type: 'raw_text', text: 'Users' }],
+        [{ type: 'raw_text', text: 'Mon' }, { type: 'raw_number', value: 1200, text: '1,200' }]
+      ]
+    }
+
+    expect(
+      renderer.render('session-1', {
+        type: 'renderer.blocks',
+        blocks: [block],
+        fallbackText: 'Weekly active users table'
+      })
+    ).toEqual([
+      {
+        type: 'chat.stream.append',
+        chunks: [{ type: 'block_kit', blocks: [block], fallbackText: 'Weekly active users table' }]
+      }
+    ])
   })
 
   it('maps generic plan updates to Chat SDK plan chunks', () => {

--- a/packages/rendering/src/chat-sdk.ts
+++ b/packages/rendering/src/chat-sdk.ts
@@ -1,8 +1,15 @@
-import type { RendererEvent, RendererTaskBlock, RendererTaskStatus, RendererTaskUpdate } from './types'
+import type {
+  RendererEvent,
+  RendererSlackBlock,
+  RendererTaskBlock,
+  RendererTaskStatus,
+  RendererTaskUpdate
+} from './types'
 import type { RendererInterface } from './interface'
 
 export type ChatSDKStreamChunk =
   | { type: 'markdown_text'; text: string }
+  | { type: 'block_kit'; blocks: RendererSlackBlock[]; fallbackText?: string }
   | {
       type: 'task_update'
       id: string
@@ -75,6 +82,14 @@ export class ChatSDKRenderer implements RendererInterface<ChatSDKOutput> {
     }
     if (event.type === 'renderer.message.snapshot') {
       return [{ type: 'chat.message.upsert', message: { text: event.markdown } }]
+    }
+    if (event.type === 'renderer.blocks') {
+      return [
+        {
+          type: 'chat.stream.append',
+          chunks: [{ type: 'block_kit', blocks: event.blocks, fallbackText: event.fallbackText }]
+        }
+      ]
     }
     if (event.type === 'renderer.task.update') {
       return [{ type: 'chat.stream.append', chunks: [taskChunk(event.task)] }]

--- a/packages/rendering/src/codex-app-server.test.ts
+++ b/packages/rendering/src/codex-app-server.test.ts
@@ -267,6 +267,45 @@ describe('CodexAppServerRendererEventMapper', () => {
     ])
   })
 
+  it('passes renderer Block Kit events through to Chat SDK block chunks', async () => {
+    async function* source() {
+      yield {
+        type: 'renderer.blocks',
+        fallbackText: 'Weekly active users by platform',
+        blocks: [
+          {
+            type: 'data_visualization',
+            title: 'Weekly active users',
+            chart: {
+              type: 'line',
+              axis_config: {
+                x_axis: { title: 'Day' },
+                y_axis: { title: 'Users' },
+                categories: ['Mon', 'Tue']
+              },
+              series: [{ name: 'Desktop', data: [{ value: 800 }, { value: 920 }] }]
+            }
+          }
+        ]
+      }
+      yield { type: 'turn.completed', result: '' }
+    }
+
+    const chunks = []
+    for await (const chunk of codexAppServerToChatSdkStream(source())) chunks.push(chunk)
+
+    expect(chunks[0]).toMatchObject({
+      type: 'block_kit',
+      fallbackText: 'Weekly active users by platform',
+      blocks: [
+        {
+          type: 'data_visualization',
+          title: 'Weekly active users'
+        }
+      ]
+    })
+  })
+
   it('maps app-server agent message deltas keyed by turnId', () => {
     const mapper = new CodexAppServerRendererEventMapper()
     const events = mapper.process({

--- a/packages/rendering/src/codex-app-server.ts
+++ b/packages/rendering/src/codex-app-server.ts
@@ -168,6 +168,9 @@ export class CodexAppServerRendererEventMapper
     const title = threadTitleUpdate(event)
     if (title) out.push({ type: 'renderer.title.update', title })
 
+    const blocks = rendererBlocks(event)
+    if (blocks) out.push(blocks)
+
     trackAgentMessageLifecycle(event, this.state)
     ensureCommentarySegmentBreak(event, this.state)
 
@@ -888,6 +891,19 @@ function terminalResultText(event: any): string {
     if (resultText) return resultText
   }
   return ''
+}
+
+function rendererBlocks(event: Record<string, unknown>): RendererEvent | null {
+  if (event.type !== 'renderer.blocks') return null
+  const blocks = Array.isArray(event.blocks)
+    ? event.blocks.filter((block): block is Record<string, unknown> & { type: string } => {
+        return Boolean(block) && typeof block === 'object' && !Array.isArray(block)
+          && typeof (block as Record<string, unknown>).type === 'string'
+      })
+    : []
+  if (blocks.length === 0) return null
+  const fallbackText = typeof event.fallbackText === 'string' ? event.fallbackText : undefined
+  return { type: 'renderer.blocks', blocks, fallbackText }
 }
 
 function toolUses(event: any): any[] {

--- a/packages/rendering/src/schema.ts
+++ b/packages/rendering/src/schema.ts
@@ -1,6 +1,7 @@
 export type {
   RendererEvent,
   RendererSessionOpenInput,
+  RendererSlackBlock,
   RendererTask,
   RendererTaskBlock,
   RendererTaskBody,
@@ -13,6 +14,7 @@ export const rendererEventTypes = [
   'renderer.status',
   'renderer.message.delta',
   'renderer.message.snapshot',
+  'renderer.blocks',
   'renderer.task.update',
   'renderer.plan.update',
   'renderer.title.update',

--- a/packages/rendering/src/types.ts
+++ b/packages/rendering/src/types.ts
@@ -6,6 +6,8 @@ export type RendererTaskBlock =
 
 export type RendererTaskBody = RendererTaskBlock[]
 
+export type RendererSlackBlock = Record<string, unknown> & { type: string }
+
 export type RendererTask = {
   id: string
   title: string
@@ -40,6 +42,11 @@ export type RendererEvent =
   | {
       type: 'renderer.message.snapshot'
       markdown: string
+    }
+  | {
+      type: 'renderer.blocks'
+      blocks: RendererSlackBlock[]
+      fallbackText?: string
     }
   | {
       type: 'renderer.task.update'

--- a/patches/@chat-adapter__slack@4.31.0.patch
+++ b/patches/@chat-adapter__slack@4.31.0.patch
@@ -244,7 +244,7 @@ index a7048fd884020cfd96a51c48b7071fa7293f3dc4..e5ff9dc2682a754202102f80d3178818
          isMe
        },
        metadata: {
-@@ -3452,26 +3664,251 @@ var SlackAdapter = class _SlackAdapter {
+@@ -3452,26 +3664,252 @@ var SlackAdapter = class _SlackAdapter {
      }
      this.logger.debug("Slack: starting stream", { channel, threadTs });
      const token = await this.getToken();
@@ -282,6 +282,7 @@ index a7048fd884020cfd96a51c48b7071fa7293f3dc4..e5ff9dc2682a754202102f80d3178818
 +    let provisionalResult;
 +    let sourceConsumed = false;
      let lastAppended = "";
++    let finalBlocks = [...(options?.stopBlocks ?? [])];
 +    let plan;
 +    const taskParts = /* @__PURE__ */ new Map();
 +    const taskSegments = /* @__PURE__ */ new Map();
@@ -505,11 +506,17 @@ index a7048fd884020cfd96a51c48b7071fa7293f3dc4..e5ff9dc2682a754202102f80d3178818
      const sendStructuredChunk = async (chunk) => {
        if (!structuredChunksSupported) {
          return;
-@@ -3481,8 +3918,45 @@ var SlackAdapter = class _SlackAdapter {
+@@ -3481,8 +3919,51 @@ var SlackAdapter = class _SlackAdapter {
        await flushMarkdownDelta(delta);
        lastAppended = committable;
        try {
 -        await streamer.append({ chunks: [chunk], token });
++        if (chunk.type === "block_kit") {
++          if (Array.isArray(chunk.blocks)) {
++            finalBlocks.push(...chunk.blocks);
++          }
++          return;
++        }
 +        if (chunk.type === "plan_update") {
 +          plan = {
 +            ...chunk,
@@ -552,7 +559,7 @@ index a7048fd884020cfd96a51c48b7071fa7293f3dc4..e5ff9dc2682a754202102f80d3178818
          structuredChunksSupported = false;
          this.logger.warn(
            "Structured streaming chunk failed, falling back to text-only streaming. Ensure your Slack app manifest includes assistant_view, assistant:write scope, and @slack/web-api >= 7.14.0",
-@@ -3497,31 +3971,91 @@ var SlackAdapter = class _SlackAdapter {
+@@ -3497,31 +3978,91 @@ var SlackAdapter = class _SlackAdapter {
        await flushMarkdownDelta(delta);
        lastAppended = committable;
      };
@@ -589,7 +596,7 @@ index a7048fd884020cfd96a51c48b7071fa7293f3dc4..e5ff9dc2682a754202102f80d3178818
 +      }
 +      lastResult = await stopSegment(
 +        current,
-+        options?.stopBlocks,
++        finalBlocks.length > 0 ? finalBlocks : void 0,
 +        !provisionalResult
 +      ) ?? provisionalResult;
 +      for (const segment of Array.from(structured)) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,7 +12,7 @@ patchedDependencies:
     hash: fce7a692b030cfe3d325b020a4472b9424b8976aa2f7faded6ad4c83421e9132
     path: patches/@chat-adapter__linear@4.31.0.patch
   '@chat-adapter/slack@4.31.0':
-    hash: 4a13e39aa1f023696e9b930391146ffcb8ac50adfcf394dcf1905e4e445213f7
+    hash: 5cf64283178effabeca0e00909b47d610b05be52bd93cc2a7cf377de16f3f052
     path: patches/@chat-adapter__slack@4.31.0.patch
   '@chat-adapter/state-pg@4.31.0':
     hash: 69262b03c278ca9d4af0bed7b4e05f9d7a5a36d3d79fad31df2a85da4d349274
@@ -171,7 +171,7 @@ importers:
         version: link:../../packages/rendering
       '@chat-adapter/slack':
         specifier: ^4.31.0
-        version: 4.31.0(patch_hash=4a13e39aa1f023696e9b930391146ffcb8ac50adfcf394dcf1905e4e445213f7)(zod@4.4.3)
+        version: 4.31.0(patch_hash=5cf64283178effabeca0e00909b47d610b05be52bd93cc2a7cf377de16f3f052)(zod@4.4.3)
       '@chat-adapter/state-pg':
         specifier: ^4.31.0
         version: 4.31.0(patch_hash=69262b03c278ca9d4af0bed7b4e05f9d7a5a36d3d79fad31df2a85da4d349274)(zod@4.4.3)
@@ -1754,7 +1754,7 @@ snapshots:
       - supports-color
       - zod
 
-  '@chat-adapter/slack@4.31.0(patch_hash=4a13e39aa1f023696e9b930391146ffcb8ac50adfcf394dcf1905e4e445213f7)(zod@4.4.3)':
+  '@chat-adapter/slack@4.31.0(patch_hash=5cf64283178effabeca0e00909b47d610b05be52bd93cc2a7cf377de16f3f052)(zod@4.4.3)':
     dependencies:
       '@chat-adapter/shared': 4.31.0(zod@4.4.3)
       '@slack/socket-mode': 2.0.7

--- a/services/slackbotv2/src/conflate.ts
+++ b/services/slackbotv2/src/conflate.ts
@@ -2,6 +2,7 @@ import type { ChatSDKStreamChunk } from '@centaur/rendering'
 
 type TaskChunk = Extract<ChatSDKStreamChunk, { type: 'task_update' }>
 type PlanChunk = Extract<ChatSDKStreamChunk, { type: 'plan_update' }>
+type BlockKitChunk = Extract<ChatSDKStreamChunk, { type: 'block_kit' }>
 
 /**
  * Conflates a Chat SDK chunk stream for a slow consumer.
@@ -34,6 +35,7 @@ export async function* conflateChatSdkStream(
   // in first-seen order even when they update while pending.
   const pendingTasks = new Map<string, TaskChunk>()
   let pendingPlan: PlanChunk | undefined
+  const pendingBlocks: BlockKitChunk[] = []
   let pendingMarkdown = ''
   let sourceDone = false
   let sourceFailed = false
@@ -51,9 +53,11 @@ export async function* conflateChatSdkStream(
           pendingMarkdown += chunk.text
         } else if (chunk.type === 'plan_update') {
           pendingPlan = chunk
-        } else {
+        } else if (chunk.type === 'task_update') {
           const pending = pendingTasks.get(chunk.id)
           pendingTasks.set(chunk.id, pending ? { ...pending, ...chunk } : chunk)
+        } else {
+          pendingBlocks.push(chunk)
         }
         wake?.()
       }
@@ -85,6 +89,11 @@ export async function* conflateChatSdkStream(
         const text = pendingMarkdown
         pendingMarkdown = ''
         yield { type: 'markdown_text', text }
+        continue
+      }
+      const nextBlock = pendingBlocks.shift()
+      if (nextBlock) {
+        yield nextBlock
         continue
       }
       // Run-to-completion guarantees the pump cannot fold between the checks

--- a/services/slackbotv2/src/index.ts
+++ b/services/slackbotv2/src/index.ts
@@ -1882,7 +1882,7 @@ async function renderExecutionStream(
     // this matches thread.post(StreamingPlan): updateIntervalMs is a no-op
     // (Slack streams server-side) and the recipient context is the message
     // author.
-    const sent = await thread.adapter.stream!(thread.id, visibleStream, {
+    const sent = await thread.adapter.stream!(thread.id, slackAdapterStream(visibleStream), {
       recipientTeamId: message.teamId,
       recipientUserId: message.author.userId,
       ...(taskDisplayMode === 'none' ? {} : { taskDisplayMode }),
@@ -1934,7 +1934,7 @@ async function renderRecoveredExecutionStream(
     if (!visibleStream) return { diverged: false }
     const sent = await thread.adapter.stream!(
       thread.id,
-      visibleStream,
+      slackAdapterStream(visibleStream),
       {
         recipientTeamId: message.teamId,
         recipientUserId: message.author.userId,
@@ -1945,6 +1945,10 @@ async function renderRecoveredExecutionStream(
   } finally {
     await setAssistantStatus(thread, '', options, trace)
   }
+}
+
+function slackAdapterStream(stream: AsyncIterable<ChatSDKStreamChunk>): AsyncIterable<any> {
+  return stream
 }
 
 async function renderPlainTextExecutionStream(
@@ -2014,6 +2018,9 @@ class SlackRenderFallback {
   ): AsyncIterable<ChatSDKStreamChunk> {
     for await (const chunk of stream) {
       if (chunk.type === 'markdown_text') this.markdownText += chunk.text
+      if (chunk.type === 'block_kit' && chunk.fallbackText) {
+        this.markdownText += `${this.markdownText ? '\n' : ''}${chunk.fallbackText}`
+      }
       yield chunk
     }
   }

--- a/services/slackbotv2/test/conflate.test.ts
+++ b/services/slackbotv2/test/conflate.test.ts
@@ -75,6 +75,23 @@ function markdown(text: string): ChatSDKStreamChunk {
   return { type: 'markdown_text', text }
 }
 
+function blockKit(caption: string): ChatSDKStreamChunk {
+  return {
+    type: 'block_kit',
+    fallbackText: caption,
+    blocks: [
+      {
+        type: 'data_table',
+        caption,
+        rows: [
+          [{ type: 'raw_text', text: 'Metric' }, { type: 'raw_text', text: 'Value' }],
+          [{ type: 'raw_text', text: 'Users' }, { type: 'raw_number', value: 12, text: '12' }]
+        ]
+      }
+    ]
+  }
+}
+
 describe('conflateChatSdkStream', () => {
   it('collapses task updates and concatenates markdown while the consumer is busy', async () => {
     const source = manualSource()
@@ -135,6 +152,26 @@ describe('conflateChatSdkStream', () => {
       source.push(chunk)
       expect((await stream.next()).value).toEqual(chunk)
     }
+    source.end()
+    expect((await stream.next()).done).toBe(true)
+  })
+
+  it('preserves Block Kit chunks while conflating task and markdown updates', async () => {
+    const source = manualSource()
+    const stream = conflateChatSdkStream(source.iterable)[Symbol.asyncIterator]()
+    const table = blockKit('Active users')
+
+    source.push(markdown('start'))
+    expect((await stream.next()).value).toEqual(markdown('start'))
+
+    source.push(task('a', 'in_progress'))
+    source.push(table)
+    source.push(markdown('done'))
+    await settle()
+
+    expect((await stream.next()).value).toEqual(task('a', 'in_progress'))
+    expect((await stream.next()).value).toEqual(markdown('done'))
+    expect((await stream.next()).value).toEqual(table)
     source.end()
     expect((await stream.next()).done).toBe(true)
   })


### PR DESCRIPTION
## Summary
- add a generic renderer.blocks event and Chat SDK block_kit chunk for Slack-native Block Kit payloads
- pass renderer.blocks through App Server streams and preserve fallback text in plain-text Slack mode
- teach slackbotv2 conflation and the patched Slack adapter to carry block_kit chunks into final Slack stop blocks

Prompted by: @gakonst

## Tests
- pnpm --filter slackbotv2 test
- pnpm --filter slackbotv2 check:types
- pnpm --filter @centaur/rendering test
- pnpm --filter @centaur/rendering typecheck