### PR TITLE
feat: add principal create and delete UI

### DIFF
--- a/services/console/app/controllers/console/principals_controller.rb
+++ b/services/console/app/controllers/console/principals_controller.rb
@@ -11,6 +11,12 @@ module Console
     before_action :require_admin
     before_action :set_principal
 
+    def destroy
+      label = principal_label(@principal)
+      @principal.destroy!
+      redirect_to console_principals_path, notice: "Deleted principal #{label}."
+    end
+
     def update_sandbox_access
       @principal.update!(
         sandbox_repo_cache_enabled: ActiveModel::Type::Boolean.new.cast(params[:sandbox_repo_cache_enabled]),
@@ -86,6 +92,10 @@ module Console
 
     def secret_label(secret)
       secret.try(:name).presence || secret.foreign_id.presence || secret.oid
+    end
+
+    def principal_label(principal)
+      principal.name.presence || principal.foreign_id.presence || principal.oid
     end
 
     def set_principal

--- a/services/console/app/controllers/console/principals_controller.rb
+++ b/services/console/app/controllers/console/principals_controller.rb
@@ -4,12 +4,27 @@ module Console
   # controller only handles the POST/DELETE actions wired from that page. Gated by
   # the app-wide require_login (not admin -- mirrors the secret/credential forms).
   class PrincipalsController < ApplicationController
+    include KvRowParams
     include SecretKinds
 
     layout "console"
 
     before_action :require_admin
-    before_action :set_principal
+    before_action :set_principal, except: %i[new create]
+
+    def new
+      @principal = Principal.new(namespace: "default")
+    end
+
+    def create
+      @principal = Principal.new(created_by: current_user)
+      assign_form(@principal)
+      if @principal.save
+        redirect_to console_principal_path(@principal.oid), notice: "Principal created."
+      else
+        render :new, status: :unprocessable_entity
+      end
+    end
 
     def destroy
       label = principal_label(@principal)
@@ -70,6 +85,18 @@ module Console
     end
 
     private
+
+    def assign_form(principal)
+      fields = principal_params.permit(:namespace, :foreign_id, :name)
+      fields[:namespace] = fields[:namespace].presence || "default"
+      fields[:foreign_id] = fields[:foreign_id].presence
+      principal.assign_attributes(fields)
+      principal.labels = label_params
+    end
+
+    def principal_params
+      params.fetch(:principal, ActionController::Parameters.new)
+    end
 
     # Parse the "<kind>:<oid>" value from the grant dropdown into a secret record.
     # Returns nil for a blank/unknown selection so the action can flash and bail.

--- a/services/console/app/models/principal.rb
+++ b/services/console/app/models/principal.rb
@@ -12,6 +12,8 @@ class Principal < ApplicationRecord
   has_many :principal_roles, dependent: :destroy
   has_many :roles, through: :principal_roles
   has_many :sync_config_snapshots, class_name: "PrincipalSyncConfigSnapshot", dependent: :destroy
+  has_many :mcp_oauth_authorization_codes, dependent: :destroy
+  has_many :mcp_oauth_refresh_tokens, dependent: :destroy
   belongs_to :created_by, class_name: "User"
 
   after_commit :auto_grant_matching_oauth_credentials, on: %i[create update]

--- a/services/console/app/views/console/principal.html.erb
+++ b/services/console/app/views/console/principal.html.erb
@@ -2,9 +2,16 @@
 
 <div class="mb-8">
   <a href="<%= console_principals_path %>" class="back-link">← back to principals</a>
-  <h1 class="mt-2 page-title">
-    <%= @principal.name.presence || @principal.foreign_id.presence || "Principal" %>
-  </h1>
+  <div class="mt-2 flex flex-wrap items-center gap-3">
+    <h1 class="page-title">
+      <%= @principal.name.presence || @principal.foreign_id.presence || "Principal" %>
+    </h1>
+    <div class="ml-auto">
+      <%= button_to "Delete", console_delete_principal_path(@principal.oid), method: :delete,
+            class: "cursor-pointer rounded border border-red-500/40 px-3 py-1.5 text-sm text-red-300 transition-colors hover:border-red-500/60 hover:bg-red-500/10",
+            data: { turbo_confirm: "Delete this principal? Direct grants, role assignments, MCP tokens, and sync snapshots are removed. Proxies are unassigned. This cannot be undone." } %>
+    </div>
+  </div>
   <div class="mt-2 flex flex-wrap items-center gap-2 text-sm">
     <span class="text-centaur-400 glow"><%= @principal.oid %></span>
     <span class="text-zinc-600">·</span>

--- a/services/console/app/views/console/principals.html.erb
+++ b/services/console/app/views/console/principals.html.erb
@@ -5,7 +5,7 @@
 <%= render "console/page_header",
            title: "Principals",
            subtitle: "#{pluralize(@principals.size, "principal")} across all namespaces. Click a row to inspect its grants.",
-           actions: link_to("Create principal", console_new_principal_path, class: "btn-primary") %>
+           actions: link_to("Add Principal", console_new_principal_path, class: "btn-primary") %>
 
 <div class="console-panel">
   <table class="console-table">

--- a/services/console/app/views/console/principals.html.erb
+++ b/services/console/app/views/console/principals.html.erb
@@ -4,7 +4,8 @@
 
 <%= render "console/page_header",
            title: "Principals",
-           subtitle: "#{pluralize(@principals.size, "principal")} across all namespaces. Click a row to inspect its grants." %>
+           subtitle: "#{pluralize(@principals.size, "principal")} across all namespaces. Click a row to inspect its grants.",
+           actions: link_to("Create principal", console_new_principal_path, class: "btn-primary") %>
 
 <div class="console-panel">
   <table class="console-table">

--- a/services/console/app/views/console/principals/_errors.html.erb
+++ b/services/console/app/views/console/principals/_errors.html.erb
@@ -1,0 +1,10 @@
+<% if principal.errors.any? %>
+  <div class="alert-error">
+    <p class="font-semibold">Principal could not be saved.</p>
+    <ul class="mt-2 list-disc pl-5">
+      <% principal.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>

--- a/services/console/app/views/console/principals/_form.html.erb
+++ b/services/console/app/views/console/principals/_form.html.erb
@@ -42,7 +42,7 @@
   </section>
 
   <div class="flex items-center gap-3">
-    <%= submit_tag "Create principal", class: "btn-primary" %>
+    <%= submit_tag "Add Principal", class: "btn-primary" %>
     <a href="<%= console_principals_path %>" class="btn-secondary">Cancel</a>
   </div>
 <% end %>

--- a/services/console/app/views/console/principals/_form.html.erb
+++ b/services/console/app/views/console/principals/_form.html.erb
@@ -1,0 +1,48 @@
+<%= render "errors", principal: principal %>
+
+<%= form_with url: console_create_principal_path, method: :post, data: { turbo: false }, class: "space-y-6" do %>
+  <section class="form-section">
+    <h2 class="form-section-heading">Identity</h2>
+    <div class="grid gap-5 sm:grid-cols-2">
+      <div>
+        <label class="form-label" for="principal_namespace">Namespace</label>
+        <%= text_field_tag "principal[namespace]", principal.namespace.presence || "default", id: "principal_namespace", class: "form-input #{field_error_class(principal, :namespace)}" %>
+        <%= field_error(principal, :namespace) %>
+      </div>
+      <div>
+        <label class="form-label" for="principal_foreign_id">Foreign ID</label>
+        <%= text_field_tag "principal[foreign_id]", principal.foreign_id, id: "principal_foreign_id", class: "form-input #{field_error_class(principal, :foreign_id)}", placeholder: "slack-channel-T123-C456" %>
+        <%= field_error(principal, :foreign_id) %>
+        <p class="form-hint">Optional. A stable, URL-safe handle for the chat or service identity.</p>
+      </div>
+      <div>
+        <label class="form-label" for="principal_name">Display name</label>
+        <%= text_field_tag "principal[name]", principal.name, id: "principal_name", class: "form-input #{field_error_class(principal, :name)}" %>
+        <%= field_error(principal, :name) %>
+      </div>
+    </div>
+    <%= field_error(principal, :labels) %>
+  </section>
+
+  <section data-controller="nested-fields" class="form-section">
+    <div class="mb-2 flex items-center justify-between">
+      <h2 class="form-section-heading mb-0">Labels</h2>
+      <button type="button" data-action="nested-fields#add" class="btn-secondary">Add label</button>
+    </div>
+
+    <div class="space-y-2" data-nested-fields-target="container">
+      <% (principal.labels.presence || {}).each_with_index do |(k, v), i| %>
+        <%= render "console/base_secrets/label_row", index: i, key: k, value: v %>
+      <% end %>
+    </div>
+
+    <template data-nested-fields-target="template">
+      <%= render "console/base_secrets/label_row", index: "NEW_RECORD", key: "", value: "" %>
+    </template>
+  </section>
+
+  <div class="flex items-center gap-3">
+    <%= submit_tag "Create principal", class: "btn-primary" %>
+    <a href="<%= console_principals_path %>" class="btn-secondary">Cancel</a>
+  </div>
+<% end %>

--- a/services/console/app/views/console/principals/new.html.erb
+++ b/services/console/app/views/console/principals/new.html.erb
@@ -1,0 +1,8 @@
+<% content_for :title, "New Principal · Centaur Console" %>
+
+<div class="mb-8">
+  <a href="<%= console_principals_path %>" class="back-link">← back to principals</a>
+  <h1 class="mt-2 page-title">New Principal</h1>
+</div>
+
+<%= render "form", principal: @principal %>

--- a/services/console/config/routes.rb
+++ b/services/console/config/routes.rb
@@ -54,6 +54,7 @@ Rails.application.routes.draw do
   # extra /roles and /grants path segments keep these clear of the show route above
   # and avoid clobbering the console_principal_path helper.
   namespace :console do
+    delete "principals/:id",                  to: "principals#destroy", as: :delete_principal
     patch  "principals/:id/sandbox_access",   to: "principals#update_sandbox_access", as: :principal_sandbox_access
     post   "principals/:id/roles",            to: "principals#assign_role",   as: :principal_assign_role
     delete "principals/:id/roles/:role_id",   to: "principals#unassign_role", as: :principal_unassign_role

--- a/services/console/config/routes.rb
+++ b/services/console/config/routes.rb
@@ -34,6 +34,10 @@ Rails.application.routes.draw do
   # Operator console (server-rendered HTML UI).
   root "console#principals"
   get "console/principals", to: "console#principals", as: :console_principals
+  namespace :console do
+    get  "principals/new", to: "principals#new",    as: :new_principal
+    post "principals",     to: "principals#create", as: :create_principal
+  end
   get "console/principals/:id", to: "console#principal", as: :console_principal
   namespace :console do
     resources :threads, only: %i[index create]

--- a/services/console/test/controllers/console/principals_controller_test.rb
+++ b/services/console/test/controllers/console/principals_controller_test.rb
@@ -35,6 +35,44 @@ module Console
       assert_equal false, principal.sandbox_api_server_enabled
     end
 
+    test "destroy deletes the principal and dependent access records" do
+      principal = principals(:acme_channel)
+      proxy = proxies(:acme_proxy)
+      client = McpOauthClient.create!(redirect_uris: [ "http://localhost/callback" ])
+      McpOauthAuthorizationCode.create!(
+        mcp_oauth_client: client,
+        user: users(:acme_admin),
+        principal: principal,
+        redirect_uri: "http://localhost/callback",
+        code_challenge: "challenge",
+        resource: "https://api.example.test",
+        scopes: %w[mcp:tools]
+      )
+      McpOauthRefreshToken.create!(
+        mcp_oauth_client: client,
+        user: users(:acme_admin),
+        principal: principal,
+        resource: "https://api.example.test",
+        scopes: %w[mcp:tools]
+      )
+
+      assert_difference -> { Principal.count }, -1 do
+        assert_difference -> { Grant.where(principal: principal).count }, -3 do
+          assert_difference -> { PrincipalRole.where(principal: principal).count }, -1 do
+            assert_difference -> { McpOauthAuthorizationCode.where(principal: principal).count }, -1 do
+              assert_difference -> { McpOauthRefreshToken.where(principal: principal).count }, -1 do
+                delete console_delete_principal_url(principal.oid)
+              end
+            end
+          end
+        end
+      end
+
+      assert_redirected_to console_principals_path
+      assert_equal "Deleted principal #{principal.foreign_id}.", flash[:notice]
+      assert_nil proxy.reload.principal
+    end
+
     test "assign_role attaches the role and redirects with a notice" do
       principal = principals(:acme_user_bob)
       role = roles(:acme_admin_role)

--- a/services/console/test/controllers/console/principals_controller_test.rb
+++ b/services/console/test/controllers/console/principals_controller_test.rb
@@ -25,7 +25,7 @@ module Console
         assert_select "input[name='principal[foreign_id]']"
         assert_select "input[name='principal[name]']"
         assert_select "button", "Add label"
-        assert_select "input[type=submit][value='Create principal']"
+        assert_select "input[type=submit][value='Add Principal']"
       end
     end
 

--- a/services/console/test/controllers/console/principals_controller_test.rb
+++ b/services/console/test/controllers/console/principals_controller_test.rb
@@ -17,6 +17,53 @@ module Console
       assert_redirected_to login_path
     end
 
+    test "new renders the create form" do
+      get console_new_principal_url
+      assert_response :ok
+      assert_select "form[action=?][method=?]", console_create_principal_path, "post" do
+        assert_select "input[name='principal[namespace]'][value=default]"
+        assert_select "input[name='principal[foreign_id]']"
+        assert_select "input[name='principal[name]']"
+        assert_select "button", "Add label"
+        assert_select "input[type=submit][value='Create principal']"
+      end
+    end
+
+    test "create persists a principal and redirects to its detail page" do
+      assert_difference -> { Principal.count }, 1 do
+        post console_create_principal_url,
+             params: {
+               principal: { namespace: "acme", foreign_id: "C-new-console", name: "New console principal" },
+               labels: {
+                 "0" => { key: "kind", value: "slack_channel" },
+                 "1" => { key: "team", value: "platform" }
+               }
+             }
+      end
+
+      principal = Principal.find_by!(namespace: "acme", foreign_id: "C-new-console")
+      assert_redirected_to console_principal_path(principal.oid)
+      assert_equal "Principal created.", flash[:notice]
+      assert_equal "New console principal", principal.name
+      assert_equal({ "kind" => "slack_channel", "team" => "platform" }, principal.labels)
+      assert_equal @operator, principal.created_by
+    end
+
+    test "create re-renders validation errors" do
+      existing = principals(:acme_channel)
+
+      assert_no_difference -> { Principal.count } do
+        post console_create_principal_url,
+             params: {
+               principal: { namespace: existing.namespace, foreign_id: existing.foreign_id, name: "Duplicate" }
+             }
+      end
+
+      assert_response :unprocessable_entity
+      assert_select ".alert-error", text: /Principal could not be saved/
+      assert_select ".field-error", text: /has already been taken/
+    end
+
     test "update_sandbox_access toggles sandbox capabilities" do
       principal = principals(:acme_user_bob)
 

--- a/services/console/test/controllers/console_controller_test.rb
+++ b/services/console/test/controllers/console_controller_test.rb
@@ -143,10 +143,10 @@ class ConsoleControllerTest < ActionDispatch::IntegrationTest
     assert_select "div", text: /#{Regexp.escape(principal.oid)}.*#{Regexp.escape(principal.namespace)}/
   end
 
-  test "principals table links to create principal" do
+  test "principals table links to add principal" do
     get console_principals_url
     assert_response :ok
-    assert_select "a[href=?]", console_new_principal_path, text: "Create principal"
+    assert_select "a[href=?]", console_new_principal_path, text: "Add Principal"
   end
 
   test "principal detail page offers delete" do

--- a/services/console/test/controllers/console_controller_test.rb
+++ b/services/console/test/controllers/console_controller_test.rb
@@ -143,6 +143,16 @@ class ConsoleControllerTest < ActionDispatch::IntegrationTest
     assert_select "div", text: /#{Regexp.escape(principal.oid)}.*#{Regexp.escape(principal.namespace)}/
   end
 
+  test "principal detail page offers delete" do
+    principal = principals(:acme_channel)
+    get console_principal_url(principal.oid)
+    assert_response :ok
+    assert_select "form[action=?][method=?]", console_delete_principal_path(principal.oid), "post" do
+      assert_select "input[name=_method][value=delete]"
+      assert_select "button[type=submit]", "Delete"
+    end
+  end
+
   test "credentials table combines id, shows status, and links to detail" do
     credential = broker_credentials(:acme_managed_gmail)
     get console_credentials_url

--- a/services/console/test/controllers/console_controller_test.rb
+++ b/services/console/test/controllers/console_controller_test.rb
@@ -143,6 +143,12 @@ class ConsoleControllerTest < ActionDispatch::IntegrationTest
     assert_select "div", text: /#{Regexp.escape(principal.oid)}.*#{Regexp.escape(principal.namespace)}/
   end
 
+  test "principals table links to create principal" do
+    get console_principals_url
+    assert_response :ok
+    assert_select "a[href=?]", console_new_principal_path, text: "Create principal"
+  end
+
   test "principal detail page offers delete" do
     principal = principals(:acme_channel)
     get console_principal_url(principal.oid)


### PR DESCRIPTION
Adds console UI for creating principals with namespace, optional foreign ID, display name, and labels. Adds a destructive delete action from the principal detail page that cleans up direct access records and MCP OAuth tokens while leaving proxies unassigned.