### PR TITLE
Add Computer Use: Windows VMs in the sandbox, driven over VNC

### DIFF
--- a/contrib/chart/templates/apirs.yaml
+++ b/contrib/chart/templates/apirs.yaml
@@ -48,6 +48,13 @@
 {{- if and .Values.repoCache.enabled (gt (len $sandboxWorkflowDirList) 0) -}}
 {{- $sandboxWorkflowDirs = join ":" $sandboxWorkflowDirList -}}
 {{- end -}}
+{{- /* Empty apiRs.sandboxKvmDeviceResource auto-follows the KVM device
+plugin: when the DaemonSet is enabled, sandboxes request its canonical
+devices.kubevirt.io/kvm extended resource. */ -}}
+{{- $sandboxKvmDeviceResource := .Values.apiRs.sandboxKvmDeviceResource | default "" -}}
+{{- if and (not $sandboxKvmDeviceResource) .Values.kvmDevicePlugin.enabled -}}
+{{- $sandboxKvmDeviceResource = "devices.kubevirt.io/kvm" -}}
+{{- end -}}
 {{- $apiRsMetricsAnnotations := dict -}}
 {{- if .Values.apiRs.metrics.scrapeAnnotations -}}
 {{- $apiRsMetricsAnnotations = dict "prometheus.io/scrape" "true" "prometheus.io/path" .Values.apiRs.metrics.path "prometheus.io/port" (printf "%v" .Values.apiRs.port) -}}
@@ -293,6 +300,13 @@ spec:
 {{- if .Values.global.imagePullSecrets }}
             - name: SESSION_SANDBOX_IMAGE_PULL_SECRETS
               value: "{{- range $index, $secret := .Values.global.imagePullSecrets }}{{- if $index }},{{ end -}}{{ $secret.name }}{{- end }}"
+{{- end }}
+{{- if $sandboxKvmDeviceResource }}
+            # Extended resource requested on every sandbox agent container so
+            # kubelet injects /dev/kvm (advertised by the KVM device plugin
+            # DaemonSet) without privileged mode.
+            - name: SANDBOX_KVM_DEVICE_RESOURCE
+              value: {{ $sandboxKvmDeviceResource | quote }}
 {{- end }}
             # Sandboxes call back into this control plane via the in-cluster Service.
             - name: SESSION_SANDBOX_CENTAUR_API_URL

--- a/contrib/chart/templates/kvm-device-plugin.yaml
+++ b/contrib/chart/templates/kvm-device-plugin.yaml
@@ -1,0 +1,66 @@
+{{- if .Values.kvmDevicePlugin.enabled }}
+# generic-device-plugin advertising /dev/kvm as the devices.kubevirt.io/kvm
+# extended resource. Sandbox pods request the resource (never privilege) and
+# kubelet injects the device; the privileged/hostPath bits below are confined
+# to this DaemonSet, per the upstream manifest
+# (https://github.com/squat/generic-device-plugin).
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ include "centaur.componentName" (dict "root" . "component" "kvm-device-plugin") }}
+  labels:
+{{ include "centaur.componentLabels" (dict "root" . "component" "kvm-device-plugin") | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+{{ include "centaur.componentSelectorLabels" (dict "root" . "component" "kvm-device-plugin") | nindent 6 }}
+  template:
+    metadata:
+      labels:
+{{ include "centaur.componentSelectorLabels" (dict "root" . "component" "kvm-device-plugin") | nindent 8 }}
+    spec:
+      automountServiceAccountToken: false
+      priorityClassName: system-node-critical
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml . | nindent 8 }}
+      {{- end }}
+{{- with .Values.kvmDevicePlugin.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | nindent 8 }}
+{{- end }}
+{{- with .Values.kvmDevicePlugin.tolerations }}
+      tolerations:
+{{ toYaml . | nindent 8 }}
+{{- end }}
+      containers:
+        - name: generic-device-plugin
+          image: {{ printf "%s:%s" .Values.kvmDevicePlugin.image.repository .Values.kvmDevicePlugin.image.tag | quote }}
+          imagePullPolicy: {{ .Values.kvmDevicePlugin.image.pullPolicy }}
+          args:
+            - --domain
+            - devices.kubevirt.io
+            - --device
+            - '{"name": "kvm", "groups": [{"paths": [{"path": "/dev/kvm"}], "count": {{ int .Values.kvmDevicePlugin.deviceCount }}}]}'
+          ports:
+            - containerPort: 8080
+              name: http
+          # Device-plugin exception: needs /dev and the kubelet device-plugin
+          # socket dir; sandbox pods themselves stay unprivileged.
+          securityContext:
+            privileged: true
+          resources:
+{{ toYaml .Values.kvmDevicePlugin.resources | nindent 12 }}
+          volumeMounts:
+            - name: device-plugin
+              mountPath: /var/lib/kubelet/device-plugins
+            - name: dev
+              mountPath: /dev
+      volumes:
+        - name: device-plugin
+          hostPath:
+            path: /var/lib/kubelet/device-plugins
+        - name: dev
+          hostPath:
+            path: /dev
+{{- end }}

--- a/contrib/chart/values.schema.json
+++ b/contrib/chart/values.schema.json
@@ -240,10 +240,29 @@
         }
       }
     },
+    "kvmDevicePlugin": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "image": {
+          "type": "object",
+          "properties": {
+            "repository": { "type": "string" },
+            "tag": { "type": "string" },
+            "pullPolicy": { "type": "string" }
+          }
+        },
+        "deviceCount": { "type": "integer", "minimum": 1 },
+        "nodeSelector": { "type": "object" },
+        "tolerations": { "type": "array" },
+        "resources": { "type": "object" }
+      }
+    },
     "apiRs": {
       "type": "object",
       "properties": {
         "syncInfraSecrets": { "type": "boolean" },
+        "sandboxKvmDeviceResource": { "type": "string" },
         "mcpPublicUrl": { "type": "string" },
         "sandboxRunningLimit": { "type": "integer", "minimum": 0 },
         "sandboxHotIdleGraceSecs": { "type": "integer", "minimum": 0 },

--- a/contrib/chart/values.yaml
+++ b/contrib/chart/values.yaml
@@ -302,6 +302,27 @@ agentSandbox:
   controller:
     extensions: false
 
+# KVM device plugin (generic-device-plugin DaemonSet) advertising each node's
+# /dev/kvm as the devices.kubevirt.io/kvm extended resource. When enabled,
+# api-rs requests that resource on every sandbox agent container (see
+# apiRs.sandboxKvmDeviceResource) and kubelet injects /dev/kvm, so sandboxes
+# can run hardware-accelerated QEMU VMs while staying unprivileged with all
+# capabilities dropped — only this DaemonSet is privileged.
+kvmDevicePlugin:
+  enabled: false
+  image:
+    repository: ghcr.io/squat/generic-device-plugin
+    tag: latest
+    pullPolicy: IfNotPresent
+  # How many pods may share a node's /dev/kvm concurrently (the advertised
+  # extended-resource capacity; /dev/kvm is safely shareable).
+  deviceCount: 16
+  # Node selector for nodes that actually expose KVM, e.g.
+  # {"feature.node.kubernetes.io/kvm": "true"} with node-feature-discovery.
+  nodeSelector: {}
+  tolerations: []
+  resources: {}
+
 # Rust session control plane (services/api-rs). Owns sessions, agent-k8s
 # sandboxes (via the agents.x-k8s.io Sandbox CRD), and the per-sandbox
 # iron-proxy/firewall.
@@ -319,6 +340,10 @@ apiRs:
   runMigrations: true
   sandboxBackend: agent-k8s
   sandboxWorkload: codex-app-server
+  # Extended-resource name requested (quantity "1", limits and requests) on
+  # every sandbox agent container so kubelet injects /dev/kvm. Empty defaults
+  # to devices.kubevirt.io/kvm when kvmDevicePlugin.enabled, otherwise off.
+  sandboxKvmDeviceResource: ""
   sandboxReadyTimeoutSecs: 90
   sandboxWarmPoolSize: 3
   sandboxWarmPoolReplenishIntervalSecs: 5

--- a/services/api-rs/crates/centaur-api-server/src/args.rs
+++ b/services/api-rs/crates/centaur-api-server/src/args.rs
@@ -626,6 +626,15 @@ struct SandboxArgs {
         value_delimiter = ','
     )]
     passthrough_env: Vec<String>,
+    /// Extended-resource name (canonically `devices.kubevirt.io/kvm`)
+    /// requested with quantity "1" in both limits and requests of every
+    /// sandbox agent container, so the node's KVM device plugin has kubelet
+    /// inject /dev/kvm without privileged mode. Empty/unset disables.
+    #[arg(
+        long = "sandbox-kvm-device-resource",
+        env = "SANDBOX_KVM_DEVICE_RESOURCE"
+    )]
+    sandbox_kvm_device: Option<String>,
     /// Operator-supplied sandbox env as a JSON list of `{"name","value"}`
     /// objects — the chart renders `sandbox.extraEnv` into this (the same
     /// contract as the Python control plane's `KUBERNETES_SANDBOX_EXTRA_ENV`).
@@ -1345,6 +1354,7 @@ impl TryFrom<&SandboxArgs> for AgentSandboxConfig {
         }
         config.iron_control = args.iron_control.settings();
         config.tools = args.tools_source.to_config();
+        config.sandbox_kvm_device = clean_optional_value(args.sandbox_kvm_device.as_deref());
         // The chart label policy handles sandbox OTLP egress; keep the
         // per-sandbox proxy's own in-cluster OTLP egress explicit.
         config.otlp_egress = args.sandbox_otlp_egress_target()?;

--- a/services/api-rs/crates/centaur-sandbox-agent-k8s/src/lib.rs
+++ b/services/api-rs/crates/centaur-sandbox-agent-k8s/src/lib.rs
@@ -70,6 +70,11 @@ pub struct AgentSandboxConfig {
     /// sandboxes. Sandbox pod egress is granted by chart-level label policy;
     /// the per-sandbox proxy uses this target for its own explicit egress.
     pub otlp_egress: Option<OtlpEgressTarget>,
+    /// Extended-resource name (canonically `devices.kubevirt.io/kvm`) requested
+    /// with quantity "1" in both limits and requests of the agent container, so
+    /// a node-local device plugin has kubelet inject /dev/kvm without the pod
+    /// being privileged. Unset disables KVM device access.
+    pub sandbox_kvm_device: Option<String>,
     pub ready_timeout: Duration,
 }
 
@@ -111,6 +116,7 @@ impl AgentSandboxConfig {
             iron_control: None,
             tools: None,
             otlp_egress: None,
+            sandbox_kvm_device: None,
             ready_timeout: Duration::from_secs(60),
         }
     }
@@ -637,7 +643,7 @@ fn build_agent_sandbox(
         }),
     );
     insert_optional(&mut container, "workingDir", spec.working_dir.clone());
-    insert_optional(&mut container, "resources", resources_json(spec));
+    insert_optional(&mut container, "resources", resources_json(spec, config));
 
     let (mut volumes, mut volume_mounts) = mount_json(spec);
     let mut init_containers = Vec::new();
@@ -784,16 +790,35 @@ fn mount_json(spec: &SandboxSpec) -> (Vec<Value>, Vec<Value>) {
     (volumes, mounts)
 }
 
-fn resources_json(spec: &SandboxSpec) -> Option<Value> {
-    let resources = spec.resources.as_ref()?;
+fn resources_json(spec: &SandboxSpec, config: &AgentSandboxConfig) -> Option<Value> {
     let mut limits = serde_json::Map::new();
-    if let Some(cpu_millis) = resources.cpu_millis {
-        limits.insert("cpu".to_owned(), json!(format!("{cpu_millis}m")));
+    if let Some(resources) = spec.resources.as_ref() {
+        if let Some(cpu_millis) = resources.cpu_millis {
+            limits.insert("cpu".to_owned(), json!(format!("{cpu_millis}m")));
+        }
+        if let Some(memory_bytes) = resources.memory_bytes {
+            limits.insert("memory".to_owned(), json!(format!("{memory_bytes}")));
+        }
     }
-    if let Some(memory_bytes) = resources.memory_bytes {
-        limits.insert("memory".to_owned(), json!(format!("{memory_bytes}")));
+    let mut requests = serde_json::Map::new();
+    // Extended resources must be set with equal quantities in both limits and
+    // requests; kubelet then injects the device (e.g. /dev/kvm) advertised by
+    // the node's device plugin into the otherwise-unprivileged container.
+    if let Some(kvm_device) = &config.sandbox_kvm_device {
+        limits.insert(kvm_device.clone(), json!("1"));
+        requests.insert(kvm_device.clone(), json!("1"));
     }
-    (!limits.is_empty()).then(|| json!({ "limits": limits }))
+    if limits.is_empty() && requests.is_empty() {
+        return None;
+    }
+    let mut resources = serde_json::Map::new();
+    if !limits.is_empty() {
+        resources.insert("limits".to_owned(), Value::Object(limits));
+    }
+    if !requests.is_empty() {
+        resources.insert("requests".to_owned(), Value::Object(requests));
+    }
+    Some(Value::Object(resources))
 }
 
 fn state_volume_claim_json(state_volume: &StateVolumeConfig) -> Vec<Value> {
@@ -866,6 +891,7 @@ fn map_kube_error(operation: &str, err: Error) -> SandboxError {
 mod tests {
     use centaur_sandbox_core::{ResourceLimits, SandboxCapabilities, SandboxSpec};
     use k8s_openapi::api::core::v1::{PodCondition, PodStatus};
+    use k8s_openapi::apimachinery::pkg::util::intstr::IntOrString;
 
     use super::*;
 
@@ -908,6 +934,45 @@ mod tests {
         assert_eq!(container.stdin, Some(true));
         assert_eq!(container.volume_mounts.as_ref().unwrap().len(), 2);
         assert!(container.resources.as_ref().unwrap().limits.is_some());
+    }
+
+    #[test]
+    fn requests_kvm_device_in_limits_and_requests_when_configured() {
+        let spec = SandboxSpec::new("centaur-agent:latest")
+            .resources(ResourceLimits::new().cpu_millis(500));
+        let mut config = AgentSandboxConfig::new("centaur");
+        config.sandbox_kvm_device = Some("devices.kubevirt.io/kvm".to_owned());
+
+        let sandbox = build_agent_sandbox(&SandboxId::new("asbx-test"), &spec, &config).unwrap();
+        let resources = sandbox.spec.pod_template.spec.containers[0]
+            .resources
+            .as_ref()
+            .unwrap();
+        let kvm_quantity = IntOrString::String("1".to_owned());
+        let limits = resources.limits.as_ref().unwrap();
+        assert_eq!(limits.get("devices.kubevirt.io/kvm"), Some(&kvm_quantity));
+        assert_eq!(
+            limits.get("cpu"),
+            Some(&IntOrString::String("500m".to_owned()))
+        );
+        let requests = resources.requests.as_ref().unwrap();
+        assert_eq!(requests.get("devices.kubevirt.io/kvm"), Some(&kvm_quantity));
+
+        // Disabled (unset) keeps the previous shape: limits only.
+        let config = AgentSandboxConfig::new("centaur");
+        let sandbox = build_agent_sandbox(&SandboxId::new("asbx-test"), &spec, &config).unwrap();
+        let resources = sandbox.spec.pod_template.spec.containers[0]
+            .resources
+            .as_ref()
+            .unwrap();
+        assert!(resources.requests.is_none());
+        assert!(
+            !resources
+                .limits
+                .as_ref()
+                .unwrap()
+                .contains_key("devices.kubevirt.io/kvm")
+        );
     }
 
     #[test]

--- a/services/sandbox/Dockerfile
+++ b/services/sandbox/Dockerfile
@@ -137,6 +137,16 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
       echo "Skipping browser install: Chrome for Testing does not publish Linux ARM64 builds"; \
     fi
 
+# ── computeruse Windows VM deps (QEMU + TPM emulator; x86 guests only) ──────
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    if [ "$(dpkg --print-architecture)" = "amd64" ]; then \
+      apt-get update && apt-get install -y --no-install-recommends \
+        qemu-system-x86 qemu-utils ovmf swtpm; \
+    else \
+      echo "Skipping QEMU install: Windows x86 guests are not supported on ARM64 nodes"; \
+    fi
+
 USER agent
 WORKDIR /home/agent
 

--- a/tools/README.md
+++ b/tools/README.md
@@ -64,6 +64,8 @@ The open-source tool inventory lives in this `tools/` tree and changes over time
 
 - `centaur_investigator`: parse Centaur Slack thread references and enrich them
   with best-effort vlogs/vmetrics context without exposing message context.
+- `computeruse`: spawn and drive Windows VMs (QEMU) with computer-use actions
+  over VNC; requires `COMPUTERUSE_WINDOWS_IMAGE_URL`.
 - `preqin`: query Preqin Operational API fund and fund-manager data, with
   redacted auth diagnostics for `PREQIN_*` credentials.
 

--- a/tools/infra/computeruse/.env.example
+++ b/tools/infra/computeruse/.env.example
@@ -1,0 +1,1 @@
+COMPUTERUSE_WINDOWS_IMAGE_URL=https URL to prebuilt Windows qcow2 golden image

--- a/tools/infra/computeruse/cli.py
+++ b/tools/infra/computeruse/cli.py
@@ -18,6 +18,17 @@ app = typer.Typer(
 )
 
 
+def _teardown():
+    """Stop vncdotool's non-daemon reactor thread so the CLI process exits.
+
+    Safe no-op when no VNC connection was made; must only run in this one-shot
+    CLI process (a stopped reactor cannot be restarted).
+    """
+    from .client import _shutdown_vnc
+
+    _shutdown_vnc()
+
+
 @app.command("health")
 def health():
     """Assert computeruse readiness with a safe read-only check."""
@@ -247,5 +258,14 @@ def wait(
     _emit(client.wait(seconds))
 
 
+def main():
+    """Console-script entrypoint: run the app, then stop the VNC reactor even on
+    errors so this one-shot process always exits."""
+    try:
+        app()
+    finally:
+        _teardown()
+
+
 if __name__ == "__main__":
-    app()
+    main()

--- a/tools/infra/computeruse/cli.py
+++ b/tools/infra/computeruse/cli.py
@@ -1,0 +1,251 @@
+"""CLI for computeruse — QEMU Windows VMs with computer-use actions over VNC."""
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+import json
+import os
+import shutil
+
+import typer
+from rich.console import Console
+from rich.table import Table
+
+app = typer.Typer(
+    name="computeruse",
+    help="Spawn and drive Windows VMs (QEMU) with computer-use actions over VNC",
+)
+
+
+@app.command("health")
+def health():
+    """Assert computeruse readiness with a safe read-only check."""
+    from .client import QEMU_BINARY, _client
+
+    client = _client()
+    try:
+        details = {
+            "qemu": shutil.which(QEMU_BINARY),
+            "swtpm": shutil.which("swtpm"),
+            "kvm": os.access("/dev/kvm", os.R_OK | os.W_OK),
+            "vms": client.list_vms(),
+        }
+        payload = {"ok": True, "tool": "computeruse", "error": None, "details": details}
+    except Exception as exc:
+        payload = {"ok": False, "tool": "computeruse", "error": str(exc), "details": {}}
+        print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+        raise typer.Exit(1) from exc
+    print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+
+
+console = Console()
+
+
+def get_client():
+    from .client import ComputerUseClient
+
+    return ComputerUseClient()
+
+
+def _emit(data):
+    print(json.dumps(data, indent=2, ensure_ascii=False, default=str))
+
+
+@app.command()
+def spawn(
+    name: str = typer.Option("win", "--name", "-n", help="VM name"),
+    cpus: int = typer.Option(4, "--cpus", help="vCPU count"),
+    memory_gb: int = typer.Option(8, "--memory-gb", "-m", help="RAM in GiB"),
+    image_url: str | None = typer.Option(
+        None, "--image-url", help="Golden qcow2 URL (default: COMPUTERUSE_WINDOWS_IMAGE_URL)"
+    ),
+    display_size: str = typer.Option("1280x800", "--display-size", help="Guest resolution WxH"),
+    fresh: bool = typer.Option(False, "--fresh", help="Recreate the overlay disk from scratch"),
+):
+    """Spawn a Windows VM from the golden image."""
+    client = get_client()
+    result = client.spawn_vm(
+        name=name,
+        cpus=cpus,
+        memory_gb=memory_gb,
+        image_url=image_url,
+        display_size=display_size,
+        fresh=fresh,
+    )
+    _emit(result)
+
+
+@app.command()
+def status(
+    name: str = typer.Option("win", "--name", "-n", help="VM name"),
+    json_output: bool = typer.Option(False, "--json", help="Output as JSON"),
+):
+    """Show status of a named VM."""
+    client = get_client()
+    data = client.vm_status(name)
+    if json_output:
+        _emit(data)
+        return
+    console.print(data)
+
+
+@app.command("list")
+def list_vms(
+    json_output: bool = typer.Option(False, "--json", help="Output as JSON"),
+):
+    """List all known VMs."""
+    client = get_client()
+    vms = client.list_vms()
+    if json_output:
+        _emit(vms)
+        return
+    table = Table(title="computeruse VMs")
+    for col in ("name", "state", "pid", "vnc_port", "rdp_port", "accel"):
+        table.add_column(col)
+    for vm in vms:
+        table.add_row(*(str(vm.get(col, "")) for col in ("name", "state", "pid", "vnc_port", "rdp_port", "accel")))
+    console.print(table)
+
+
+@app.command()
+def stop(
+    name: str = typer.Option("win", "--name", "-n", help="VM name"),
+    force: bool = typer.Option(False, "--force", help="Kill immediately instead of ACPI shutdown"),
+):
+    """Stop a VM (graceful ACPI powerdown, escalating to SIGTERM/SIGKILL)."""
+    client = get_client()
+    _emit(client.stop_vm(name, force=force))
+
+
+@app.command()
+def install(
+    iso_path: str = typer.Argument(..., help="Windows installer ISO path"),
+    name: str = typer.Option("win-install", "--name", "-n", help="VM name"),
+    disk_gb: int = typer.Option(64, "--disk-gb", help="Blank disk size in GiB (sparse)"),
+    cpus: int = typer.Option(4, "--cpus", help="vCPU count"),
+    memory_gb: int = typer.Option(8, "--memory-gb", "-m", help="RAM in GiB"),
+    display_size: str = typer.Option("1280x800", "--display-size", help="Guest resolution WxH"),
+    virtio_iso: str | None = typer.Option(
+        None, "--virtio-iso", help="virtio-win drivers ISO path"
+    ),
+    autounattend: str | None = typer.Option(
+        None,
+        "--autounattend",
+        help="autounattend .xml or prebuilt .iso (see resources/autounattend.xml)",
+    ),
+    fresh: bool = typer.Option(False, "--fresh", help="Recreate the install disk from scratch"),
+):
+    """Boot a Windows installer ISO to build a golden image (one-time helper)."""
+    client = get_client()
+    result = client.install_vm(
+        iso_path=iso_path,
+        name=name,
+        disk_gb=disk_gb,
+        cpus=cpus,
+        memory_gb=memory_gb,
+        display_size=display_size,
+        virtio_iso=virtio_iso,
+        autounattend=autounattend,
+        fresh=fresh,
+    )
+    _emit(result)
+
+
+@app.command()
+def screenshot(
+    name: str = typer.Option("win", "--name", "-n", help="VM name"),
+    output: str | None = typer.Option(None, "--output", "-o", help="PNG output path"),
+    json_output: bool = typer.Option(False, "--json", help="Output as JSON"),
+):
+    """Capture the VM screen to a PNG."""
+    client = get_client()
+    data = client.screenshot(name, output_path=output)
+    if json_output:
+        _emit(data)
+        return
+    console.print(f"[green]{data['path']}[/] ({data['width']}x{data['height']})")
+
+
+@app.command()
+def click(
+    x: int = typer.Argument(..., help="X coordinate"),
+    y: int = typer.Argument(..., help="Y coordinate"),
+    name: str = typer.Option("win", "--name", "-n", help="VM name"),
+    button: str = typer.Option("left", "--button", "-b", help="left, right, or middle"),
+    double: bool = typer.Option(False, "--double", help="Double-click"),
+):
+    """Click at (x, y) in the VM."""
+    client = get_client()
+    _emit(client.click(x, y, name=name, button=button, double=double))
+
+
+@app.command()
+def move(
+    x: int = typer.Argument(..., help="X coordinate"),
+    y: int = typer.Argument(..., help="Y coordinate"),
+    name: str = typer.Option("win", "--name", "-n", help="VM name"),
+):
+    """Move the mouse pointer to (x, y)."""
+    client = get_client()
+    _emit(client.move(x, y, name=name))
+
+
+@app.command()
+def drag(
+    x1: int = typer.Argument(..., help="Start X"),
+    y1: int = typer.Argument(..., help="Start Y"),
+    x2: int = typer.Argument(..., help="End X"),
+    y2: int = typer.Argument(..., help="End Y"),
+    name: str = typer.Option("win", "--name", "-n", help="VM name"),
+):
+    """Drag with the left button from (x1, y1) to (x2, y2)."""
+    client = get_client()
+    _emit(client.drag(x1, y1, x2, y2, name=name))
+
+
+@app.command("type")
+def type_text(
+    text: str = typer.Argument(..., help="Text to type"),
+    name: str = typer.Option("win", "--name", "-n", help="VM name"),
+    interval: float = typer.Option(0.02, "--interval", help="Seconds between keypresses"),
+):
+    """Type text into the VM."""
+    client = get_client()
+    _emit(client.type_text(text, name=name, interval=interval))
+
+
+@app.command()
+def key(
+    combo: str = typer.Argument(..., help="Key or combo, e.g. enter, ctrl-alt-del, win-r"),
+    name: str = typer.Option("win", "--name", "-n", help="VM name"),
+):
+    """Press a key or key combo in the VM."""
+    client = get_client()
+    _emit(client.key(combo, name=name))
+
+
+@app.command()
+def scroll(
+    x: int = typer.Argument(..., help="X coordinate"),
+    y: int = typer.Argument(..., help="Y coordinate"),
+    direction: str = typer.Option("down", "--direction", "-d", help="up or down"),
+    clicks: int = typer.Option(3, "--clicks", "-c", help="Wheel notches"),
+    name: str = typer.Option("win", "--name", "-n", help="VM name"),
+):
+    """Scroll the mouse wheel at (x, y)."""
+    client = get_client()
+    _emit(client.scroll(x, y, direction=direction, clicks=clicks, name=name))
+
+
+@app.command()
+def wait(
+    seconds: float = typer.Argument(..., help="Seconds to sleep (capped at 60)"),
+):
+    """Sleep up to 60 seconds (e.g. while Windows boots)."""
+    client = get_client()
+    _emit(client.wait(seconds))
+
+
+if __name__ == "__main__":
+    app()

--- a/tools/infra/computeruse/client.py
+++ b/tools/infra/computeruse/client.py
@@ -72,6 +72,14 @@ KEY_ALIASES = {
 }
 # Characters that must be sent as named keys when typing text.
 TYPE_KEYS = {"\n": "enter", "\r": "enter", "\t": "tab"}
+# QEMU's VNC server does not synthesize shift for symbol keysyms (uppercase
+# letters work, but '&' arrives as '7'), so shifted US-layout punctuation must
+# be sent as an explicit shift + base-key chord. Verified against QEMU 8.2.
+SHIFTED_KEYS = {
+    "!": "1", "@": "2", "#": "3", "$": "4", "%": "5", "^": "6", "&": "7",
+    "*": "8", "(": "9", ")": "0", "_": "-", "+": "=", "{": "[", "}": "]",
+    "|": "\\", ":": ";", '"': "'", "<": ",", ">": ".", "?": "/", "~": "`",
+}
 
 
 def _build_qemu_cmd(
@@ -403,9 +411,12 @@ class ComputerUseClient:
     def _launch_qemu(self, cmd: list[str], state_dir: Path) -> int:
         result = subprocess.run(cmd, capture_output=True, text=True)
         if result.returncode != 0:
-            raise RuntimeError(
-                f"QEMU failed to start: {result.stderr.strip() or result.stdout.strip()}"
-            )
+            # Fatal errors often land in the -D log rather than stderr.
+            detail = result.stderr.strip() or result.stdout.strip()
+            if not detail:
+                with contextlib.suppress(OSError):
+                    detail = (state_dir / "qemu.log").read_text().strip()[-2000:]
+            raise RuntimeError(f"QEMU failed to start: {detail or '(no output)'}")
         pidfile = state_dir / "qemu.pid"
         for _ in range(50):
             pid = self._pid_from_file(pidfile)
@@ -864,7 +875,15 @@ class ComputerUseClient:
         client = self._vnc_connect(name)
         try:
             for char in text:
-                client.keyPress(TYPE_KEYS.get(char, char))
+                base = SHIFTED_KEYS.get(char)
+                if base is not None:
+                    client.keyDown("shift")
+                    client.pause(0.01)
+                    client.keyPress(base)
+                    client.pause(0.01)
+                    client.keyUp("shift")
+                else:
+                    client.keyPress(TYPE_KEYS.get(char, char))
                 if interval > 0:
                     client.pause(interval)
         finally:
@@ -913,6 +932,15 @@ class ComputerUseClient:
         capped = max(0.0, min(float(seconds), 60.0))
         time.sleep(capped)
         return {"action": "wait", "seconds": capped}
+
+
+def _shutdown_vnc() -> None:
+    """Stop vncdotool's twisted reactor thread (it is non-daemon, so a one-shot
+    process that ran a VNC action would otherwise never exit). Only for
+    short-lived CLI processes — a reactor cannot be restarted, so the
+    long-lived tool-manager process must never call this."""
+    with contextlib.suppress(Exception):
+        vnc_api.shutdown()
 
 
 def _client() -> ComputerUseClient:

--- a/tools/infra/computeruse/client.py
+++ b/tools/infra/computeruse/client.py
@@ -1,0 +1,919 @@
+"""ComputerUse client — QEMU Windows VMs driven with computer-use actions over VNC.
+
+Lifecycle: ``spawn_vm`` boots a copy-on-write overlay of a golden Windows qcow2
+image (downloaded once to ``~/.computeruse/cache/``) and exposes a local VNC
+port. Actions (``click``, ``type_text``, ``key``, ``scroll``, ``drag``) connect
+to that VNC port on demand and disconnect afterwards. Actions are deliberately
+cheap and do not capture the screen — the agent loop is: action → ``screenshot``.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import hashlib
+import json
+import os
+import shutil
+import signal
+import socket
+import subprocess
+import time
+from datetime import UTC, datetime
+from pathlib import Path
+
+import httpx
+from PIL import Image
+from vncdotool import api as vnc_api
+
+from centaur_sdk import secret
+
+BASE_DIR = Path.home() / ".computeruse"
+VMS_DIR = BASE_DIR / "vms"
+CACHE_DIR = BASE_DIR / "cache"
+RESOURCES_DIR = Path(__file__).resolve().parent / "resources"
+
+QEMU_BINARY = "qemu-system-x86_64"
+QEMU_IMG_BINARY = "qemu-img"
+VNC_BASE_PORT = 5900
+# VNC display numbers we allocate from; display 20 -> VNC port 5920.
+DISPLAY_RANGE = range(20, 100)
+# RDP forward port derived from the display so the first VM gets 3390.
+RDP_PORT_OFFSET = 3370
+
+KVM_ACCEL_NOTE = "kvm"
+TCG_ACCEL_NOTE = (
+    "tcg (software emulation — expect a slow VM; ask infra to enable KVM on sandbox pods)"
+)
+
+OVMF_DIR = Path("/usr/share/OVMF")
+# (code, vars-template) pairs, preferred first. The ``.ms`` variants carry the
+# Microsoft secure-boot keys Windows 11 wants.
+OVMF_CANDIDATES = (
+    ("OVMF_CODE_4M.ms.fd", "OVMF_VARS_4M.ms.fd"),
+    ("OVMF_CODE_4M.fd", "OVMF_VARS_4M.fd"),
+    ("OVMF_CODE.ms.fd", "OVMF_VARS.ms.fd"),
+    ("OVMF_CODE.fd", "OVMF_VARS.fd"),
+)
+
+MOUSE_BUTTONS = {"left": 1, "middle": 2, "right": 3}
+SCROLL_BUTTONS = {"up": 4, "down": 5}
+# Friendly aliases -> vncdotool KEYMAP names (see vncdotool.client.KEYMAP).
+KEY_ALIASES = {
+    "win": "super",
+    "windows": "super",
+    "cmd": "super",
+    "control": "ctrl",
+    "option": "alt",
+    "escape": "esc",
+    "backspace": "bsp",
+    "pageup": "pgup",
+    "pagedown": "pgdn",
+    "insert": "ins",
+}
+# Characters that must be sent as named keys when typing text.
+TYPE_KEYS = {"\n": "enter", "\r": "enter", "\t": "tab"}
+
+
+def _build_qemu_cmd(
+    *,
+    name: str,
+    disk_path: str,
+    cpus: int,
+    memory_gb: int,
+    vnc_display: int,
+    rdp_port: int,
+    qmp_sock: str,
+    pidfile: str,
+    serial_log: str,
+    qemu_log: str,
+    accel: str,
+    width: int,
+    height: int,
+    ovmf_code: str | None = None,
+    ovmf_vars: str | None = None,
+    tpm_sock: str | None = None,
+    cdroms: tuple[str, ...] = (),
+    boot_cd: bool = False,
+) -> list[str]:
+    """Build the qemu-system-x86_64 argv (pure — no filesystem side effects).
+
+    ``accel`` is ``"kvm"`` or ``"tcg"``. ``ovmf_code``/``ovmf_vars`` enable UEFI
+    pflash, ``tpm_sock`` wires a swtpm socket TPM, ``cdroms`` attach extra ISO
+    media (installer, virtio drivers, autounattend) and ``boot_cd`` boots from
+    CD once for installs.
+    """
+    cmd = [
+        QEMU_BINARY,
+        "-name",
+        name,
+        "-machine",
+        "q35",
+        "-smp",
+        str(cpus),
+        "-m",
+        f"{memory_gb}G",
+    ]
+    if accel == "kvm":
+        cmd += ["-accel", "kvm", "-cpu", "host"]
+    else:
+        cmd += ["-accel", "tcg,thread=multi", "-cpu", "qemu64"]
+    if ovmf_code and ovmf_vars:
+        cmd += [
+            "-drive",
+            f"if=pflash,format=raw,readonly=on,file={ovmf_code}",
+            "-drive",
+            f"if=pflash,format=raw,file={ovmf_vars}",
+        ]
+    cmd += [
+        "-drive",
+        f"file={disk_path},if=virtio,format=qcow2,discard=unmap",
+        "-netdev",
+        f"user,id=net0,hostfwd=tcp:127.0.0.1:{rdp_port}-:3389",
+        "-device",
+        "virtio-net-pci,netdev=net0",
+        # virtio-vga honors xres/yres as the preferred guest resolution.
+        "-device",
+        f"virtio-vga,xres={width},yres={height}",
+        # usb-tablet gives absolute pointer coordinates so VNC clicks land
+        # exactly where the screenshot says they should.
+        "-usb",
+        "-device",
+        "usb-tablet",
+        "-vnc",
+        f"127.0.0.1:{vnc_display}",
+        "-qmp",
+        f"unix:{qmp_sock},server,nowait",
+        "-pidfile",
+        pidfile,
+        "-serial",
+        f"file:{serial_log}",
+        "-D",
+        qemu_log,
+        "-daemonize",
+    ]
+    if tpm_sock:
+        cmd += [
+            "-chardev",
+            f"socket,id=chrtpm,path={tpm_sock}",
+            "-tpmdev",
+            "emulator,id=tpm0,chardev=chrtpm",
+            "-device",
+            "tpm-tis,tpmdev=tpm0",
+        ]
+    for iso in cdroms:
+        cmd += ["-drive", f"file={iso},media=cdrom,readonly=on"]
+    if boot_cd:
+        cmd += ["-boot", "once=d"]
+    return cmd
+
+
+def _find_ovmf() -> tuple[str, str] | None:
+    """Return (OVMF_CODE, OVMF_VARS template) paths if UEFI firmware exists."""
+    if not OVMF_DIR.is_dir():
+        return None
+    for code, vars_tmpl in OVMF_CANDIDATES:
+        code_path = OVMF_DIR / code
+        vars_path = OVMF_DIR / vars_tmpl
+        if code_path.is_file() and vars_path.is_file():
+            return str(code_path), str(vars_path)
+    return None
+
+
+def _port_free(port: int) -> bool:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        try:
+            sock.bind(("127.0.0.1", port))
+        except OSError:
+            return False
+    return True
+
+
+class ComputerUseClient:
+    """Spawn Windows VMs via QEMU and drive them with computer-use actions over VNC."""
+
+    # ------------------------------------------------------------------
+    # internal helpers
+    # ------------------------------------------------------------------
+
+    def _state_dir(self, name: str, create: bool = False) -> Path:
+        path = VMS_DIR / name
+        if create:
+            path.mkdir(parents=True, exist_ok=True)
+        return path
+
+    def _state_path(self, name: str) -> Path:
+        return self._state_dir(name) / "state.json"
+
+    def _read_state(self, name: str) -> dict | None:
+        path = self._state_path(name)
+        if not path.is_file():
+            return None
+        try:
+            return json.loads(path.read_text())
+        except ValueError:
+            return None
+
+    def _write_state(self, name: str, state: dict) -> None:
+        self._state_path(name).write_text(json.dumps(state, indent=2))
+
+    def _pid_from_file(self, path: Path) -> int | None:
+        try:
+            return int(path.read_text().strip())
+        except (OSError, ValueError):
+            return None
+
+    def _pid_alive(self, pid: int | None) -> bool:
+        if not pid or pid <= 0:
+            return False
+        try:
+            os.kill(pid, 0)
+        except ProcessLookupError:
+            return False
+        except PermissionError:
+            return True
+        return True
+
+    def _qemu_pid(self, name: str) -> int | None:
+        pid = self._pid_from_file(self._state_dir(name) / "qemu.pid")
+        return pid if self._pid_alive(pid) else None
+
+    def _require_qemu(self) -> None:
+        if shutil.which(QEMU_BINARY) is None:
+            raise RuntimeError(
+                f"{QEMU_BINARY} not found on PATH. The sandbox image must include QEMU "
+                "(qemu-system-x86, qemu-utils) for computeruse to spawn Windows VMs."
+            )
+        if shutil.which(QEMU_IMG_BINARY) is None:
+            raise RuntimeError(
+                f"{QEMU_IMG_BINARY} not found on PATH. Install qemu-utils in the sandbox image."
+            )
+
+    def _detect_accel(self) -> tuple[str, str]:
+        """Return (accel flag, human note) — KVM if /dev/kvm is usable, else TCG."""
+        if os.access("/dev/kvm", os.R_OK | os.W_OK):
+            return "kvm", KVM_ACCEL_NOTE
+        return "tcg", TCG_ACCEL_NOTE
+
+    def _find_free_display(self) -> int:
+        used = {
+            state.get("vnc_display")
+            for state in (self._read_state(p.name) for p in self._iter_vm_dirs())
+            if state and self._qemu_pid(state.get("name", "")) is not None
+        }
+        for display in DISPLAY_RANGE:
+            if display in used:
+                continue
+            if _port_free(VNC_BASE_PORT + display) and _port_free(RDP_PORT_OFFSET + display):
+                return display
+        raise RuntimeError("No free VNC display found in range 20-99; stop some VMs first.")
+
+    def _iter_vm_dirs(self) -> list[Path]:
+        if not VMS_DIR.is_dir():
+            return []
+        return sorted(p for p in VMS_DIR.iterdir() if p.is_dir())
+
+    def _resolve_image_url(self, image_url: str | None) -> str:
+        url = image_url or secret("COMPUTERUSE_WINDOWS_IMAGE_URL", "")
+        if not url:
+            raise RuntimeError(
+                "No Windows golden image configured. Pass image_url or set "
+                "COMPUTERUSE_WINDOWS_IMAGE_URL to an https URL of a prebuilt Windows "
+                "qcow2 image (build one with install_vm + resources/autounattend.xml)."
+            )
+        return url
+
+    def _ensure_cached_image(self, url: str) -> Path:
+        """Download the golden qcow2 to the shared cache (idempotent)."""
+        CACHE_DIR.mkdir(parents=True, exist_ok=True)
+        basename = url.split("?")[0].rstrip("/").rsplit("/", 1)[-1] or "image.qcow2"
+        digest = hashlib.sha256(url.encode()).hexdigest()[:12]
+        cached = CACHE_DIR / f"{digest}-{basename}"
+        if cached.is_file() and cached.stat().st_size > 0:
+            return cached
+        partial = cached.with_suffix(cached.suffix + ".part")
+        try:
+            with (
+                httpx.Client(timeout=httpx.Timeout(30.0, read=300.0), follow_redirects=True) as client,
+                client.stream("GET", url) as response,
+            ):
+                response.raise_for_status()
+                with open(partial, "wb") as fh:
+                    for chunk in response.iter_bytes(chunk_size=1 << 20):
+                        fh.write(chunk)
+        except httpx.HTTPStatusError as e:
+            partial.unlink(missing_ok=True)
+            raise RuntimeError(
+                f"Failed to download golden image: {e.response.status_code} from {url}"
+            ) from e
+        except httpx.RequestError as e:
+            partial.unlink(missing_ok=True)
+            raise RuntimeError(f"Failed to download golden image from {url}: {e}") from e
+        partial.rename(cached)
+        return cached
+
+    def _create_overlay(self, backing: Path, disk: Path) -> None:
+        """Create a copy-on-write overlay so the golden image is never mutated."""
+        result = subprocess.run(
+            [
+                QEMU_IMG_BINARY,
+                "create",
+                "-f",
+                "qcow2",
+                "-b",
+                str(backing),
+                "-F",
+                "qcow2",
+                str(disk),
+            ],
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            raise RuntimeError(f"qemu-img create failed: {result.stderr.strip()}")
+
+    def _start_swtpm(self, state_dir: Path) -> str | None:
+        """Start a swtpm socket TPM for the VM; return its socket path or None."""
+        if shutil.which("swtpm") is None:
+            return None
+        tpm_state = state_dir / "tpm"
+        tpm_state.mkdir(parents=True, exist_ok=True)
+        tpm_sock = state_dir / "swtpm.sock"
+        tpm_pidfile = state_dir / "swtpm.pid"
+        result = subprocess.run(
+            [
+                "swtpm",
+                "socket",
+                "--tpm2",
+                "--tpmstate",
+                f"dir={tpm_state}",
+                "--ctrl",
+                f"type=unixio,path={tpm_sock}",
+                "--pid",
+                f"file={tpm_pidfile}",
+                "--log",
+                f"file={state_dir / 'swtpm.log'},level=1",
+                "--daemon",
+            ],
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            return None
+        for _ in range(50):
+            if tpm_sock.exists():
+                return str(tpm_sock)
+            time.sleep(0.1)
+        return None
+
+    def _stop_swtpm(self, name: str) -> None:
+        pidfile = self._state_dir(name) / "swtpm.pid"
+        pid = self._pid_from_file(pidfile)
+        if pid and self._pid_alive(pid):
+            with contextlib.suppress(OSError):
+                os.kill(pid, signal.SIGTERM)
+        pidfile.unlink(missing_ok=True)
+
+    def _qmp(self, name: str, command: str) -> dict | None:
+        """Send a single QMP command to the VM's monitor socket; None if unreachable."""
+        sock_path = self._state_dir(name) / "qmp.sock"
+        if not sock_path.exists():
+            return None
+        try:
+            with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as sock:
+                sock.settimeout(5.0)
+                sock.connect(str(sock_path))
+                stream = sock.makefile("rwb")
+                stream.readline()  # QMP greeting banner
+                reply: dict = {}
+                for payload in ({"execute": "qmp_capabilities"}, {"execute": command}):
+                    stream.write(json.dumps(payload).encode() + b"\n")
+                    stream.flush()
+                    for _ in range(10):  # skip async events until a reply arrives
+                        line = stream.readline()
+                        if not line:
+                            return None
+                        reply = json.loads(line)
+                        if "return" in reply or "error" in reply:
+                            break
+                return reply.get("return", {})
+        except (OSError, ValueError):
+            return None
+
+    def _launch_qemu(self, cmd: list[str], state_dir: Path) -> int:
+        result = subprocess.run(cmd, capture_output=True, text=True)
+        if result.returncode != 0:
+            raise RuntimeError(
+                f"QEMU failed to start: {result.stderr.strip() or result.stdout.strip()}"
+            )
+        pidfile = state_dir / "qemu.pid"
+        for _ in range(50):
+            pid = self._pid_from_file(pidfile)
+            if pid and self._pid_alive(pid):
+                return pid
+            time.sleep(0.1)
+        raise RuntimeError(f"QEMU daemonized but no live pid found in {pidfile}")
+
+    def _running_state(self, name: str) -> dict:
+        """Return the recorded state for a running VM, or raise."""
+        state = self._read_state(name)
+        if state is None:
+            raise RuntimeError(f"No VM named {name!r}. Spawn it first with spawn_vm.")
+        if self._qemu_pid(name) is None:
+            raise RuntimeError(f"VM {name!r} is not running. Spawn it first with spawn_vm.")
+        return state
+
+    def _vnc_connect(self, name: str):
+        state = self._running_state(name)
+        addr = f"127.0.0.1::{state['vnc_port']}"
+        try:
+            return vnc_api.connect(addr, password=None, timeout=30)
+        except Exception as e:  # twisted raises a zoo of connection errors
+            raise RuntimeError(f"Could not connect to VNC for VM {name!r} at {addr}: {e}") from e
+
+    def _vnc_disconnect(self, client) -> None:
+        with contextlib.suppress(Exception):
+            client.disconnect()
+
+    def _normalize_combo(self, combo: str) -> str:
+        parts = [p for p in combo.replace("+", "-").split("-") if p]
+        if not parts:
+            raise RuntimeError(f"Empty key combo: {combo!r}")
+        normalized = []
+        for part in parts:
+            token = part.lower() if len(part) > 1 else part
+            normalized.append(KEY_ALIASES.get(token, token))
+        return "-".join(normalized)
+
+    # ------------------------------------------------------------------
+    # VM lifecycle
+    # ------------------------------------------------------------------
+
+    def spawn_vm(
+        self,
+        name: str = "win",
+        cpus: int = 4,
+        memory_gb: int = 8,
+        image_url: str | None = None,
+        display_size: str = "1280x800",
+        fresh: bool = False,
+    ) -> dict:
+        """Spawn a Windows VM from the golden qcow2 image and expose it over VNC.
+
+        Downloads the golden image (COMPUTERUSE_WINDOWS_IMAGE_URL or image_url) to a
+        shared cache on first use, boots a copy-on-write overlay so the golden image
+        is never mutated, and returns connection details. If a VM with this name is
+        already running and fresh is False, returns its status instead. fresh=True
+        stops any running VM and recreates the overlay disk from the golden image.
+        """
+        self._require_qemu()
+        state_dir = self._state_dir(name, create=True)
+
+        if self._qemu_pid(name) is not None:
+            if not fresh:
+                return self.vm_status(name)
+            self.stop_vm(name, force=True)
+
+        try:
+            width, height = (int(v) for v in display_size.lower().split("x"))
+        except ValueError as e:
+            raise RuntimeError(f"Invalid display_size {display_size!r}; expected WIDTHxHEIGHT") from e
+
+        url = self._resolve_image_url(image_url)
+        golden = self._ensure_cached_image(url)
+        disk = state_dir / "disk.qcow2"
+        if fresh:
+            disk.unlink(missing_ok=True)
+        if not disk.is_file():
+            self._create_overlay(golden, disk)
+
+        display = self._find_free_display()
+        vnc_port = VNC_BASE_PORT + display
+        rdp_port = RDP_PORT_OFFSET + display
+        accel, accel_note = self._detect_accel()
+        notes: list[str] = []
+
+        ovmf = _find_ovmf()
+        ovmf_code = ovmf_vars = None
+        if ovmf:
+            ovmf_code, vars_template = ovmf
+            vars_copy = state_dir / "OVMF_VARS.fd"
+            if fresh or not vars_copy.is_file():
+                shutil.copyfile(vars_template, vars_copy)
+            ovmf_vars = str(vars_copy)
+        else:
+            notes.append("OVMF not found — booting legacy BIOS (Windows 11 images may not boot)")
+
+        tpm_sock = self._start_swtpm(state_dir)
+        if tpm_sock is None:
+            notes.append("swtpm not available — no TPM device (Windows 11 images may complain)")
+
+        cmd = _build_qemu_cmd(
+            name=name,
+            disk_path=str(disk),
+            cpus=cpus,
+            memory_gb=memory_gb,
+            vnc_display=display,
+            rdp_port=rdp_port,
+            qmp_sock=str(state_dir / "qmp.sock"),
+            pidfile=str(state_dir / "qemu.pid"),
+            serial_log=str(state_dir / "serial.log"),
+            qemu_log=str(state_dir / "qemu.log"),
+            accel=accel,
+            width=width,
+            height=height,
+            ovmf_code=ovmf_code,
+            ovmf_vars=ovmf_vars,
+            tpm_sock=tpm_sock,
+        )
+        try:
+            pid = self._launch_qemu(cmd, state_dir)
+        except RuntimeError:
+            self._stop_swtpm(name)
+            raise
+
+        state = {
+            "name": name,
+            "pid": pid,
+            "vnc_display": display,
+            "vnc_port": vnc_port,
+            "rdp_port": rdp_port,
+            "accel": accel,
+            "disk": str(disk),
+            "image_url": url,
+            "display_size": display_size,
+            "cpus": cpus,
+            "memory_gb": memory_gb,
+            "uefi": bool(ovmf),
+            "tpm": bool(tpm_sock),
+            "created_at": datetime.now(UTC).isoformat(),
+        }
+        self._write_state(name, state)
+        return {
+            "name": name,
+            "state": "running",
+            "pid": pid,
+            "vnc_port": vnc_port,
+            "rdp_port": rdp_port,
+            "accel": accel_note,
+            "disk": str(disk),
+            "display_size": display_size,
+            "notes": notes,
+        }
+
+    def vm_status(self, name: str = "win") -> dict:
+        """Report status for a named VM: pid liveness plus QMP query-status if reachable."""
+        state = self._read_state(name)
+        if state is None:
+            return {"name": name, "state": "absent"}
+        pid = self._qemu_pid(name)
+        qmp_status = self._qmp(name, "query-status") if pid else None
+        return {
+            **state,
+            "pid": pid,
+            "state": "running" if pid else "stopped",
+            "qmp_status": (qmp_status or {}).get("status") if qmp_status else None,
+            "accel": TCG_ACCEL_NOTE if state.get("accel") == "tcg" else state.get("accel"),
+        }
+
+    def list_vms(self) -> list[dict]:
+        """List all known VMs (running and stopped) with their status."""
+        return [self.vm_status(path.name) for path in self._iter_vm_dirs()]
+
+    def stop_vm(self, name: str = "win", force: bool = False) -> dict:
+        """Stop a VM: QMP system_powerdown (graceful), falling back to SIGTERM/SIGKILL.
+
+        force=True skips the graceful ACPI shutdown and kills QEMU immediately.
+        Also stops the VM's swtpm process and cleans up pidfiles/sockets.
+        """
+        state_dir = self._state_dir(name)
+        if not state_dir.is_dir():
+            raise RuntimeError(f"No VM named {name!r}.")
+        pid = self._qemu_pid(name)
+        method = "already-stopped"
+        if pid:
+            if not force:
+                self._qmp(name, "system_powerdown")
+                method = "powerdown"
+                deadline = time.time() + 30
+                while time.time() < deadline and self._pid_alive(pid):
+                    time.sleep(0.5)
+            if self._pid_alive(pid):
+                with contextlib.suppress(OSError):
+                    os.kill(pid, signal.SIGTERM)
+                method = "sigterm"
+                deadline = time.time() + 10
+                while time.time() < deadline and self._pid_alive(pid):
+                    time.sleep(0.5)
+            if self._pid_alive(pid):
+                with contextlib.suppress(OSError):
+                    os.kill(pid, signal.SIGKILL)
+                method = "sigkill"
+        self._stop_swtpm(name)
+        (state_dir / "qemu.pid").unlink(missing_ok=True)
+        (state_dir / "qmp.sock").unlink(missing_ok=True)
+        (state_dir / "swtpm.sock").unlink(missing_ok=True)
+        return {"name": name, "state": "stopped", "method": method}
+
+    def install_vm(
+        self,
+        iso_path: str,
+        name: str = "win-install",
+        disk_gb: int = 64,
+        cpus: int = 4,
+        memory_gb: int = 8,
+        display_size: str = "1280x800",
+        virtio_iso: str | None = None,
+        autounattend: str | None = None,
+        fresh: bool = False,
+    ) -> dict:
+        """Boot a Windows installer ISO against a blank disk to build a golden image.
+
+        One-time helper: attach the Windows ISO (and optionally a virtio-win drivers
+        ISO plus an autounattend ISO built from resources/autounattend.xml) to a new
+        sparse qcow2, boot from CD, and watch/drive the install over VNC. When the
+        install finishes, stop the VM and upload the disk as the golden image behind
+        COMPUTERUSE_WINDOWS_IMAGE_URL. autounattend accepts a prebuilt .iso, or a
+        .xml that is wrapped into an ISO if genisoimage/mkisofs/xorrisofs exists.
+        """
+        self._require_qemu()
+        iso = Path(iso_path).expanduser()
+        if not iso.is_file():
+            raise RuntimeError(f"Installer ISO not found: {iso}")
+        state_dir = self._state_dir(name, create=True)
+        if self._qemu_pid(name) is not None:
+            if not fresh:
+                return self.vm_status(name)
+            self.stop_vm(name, force=True)
+
+        try:
+            width, height = (int(v) for v in display_size.lower().split("x"))
+        except ValueError as e:
+            raise RuntimeError(f"Invalid display_size {display_size!r}; expected WIDTHxHEIGHT") from e
+
+        disk = state_dir / "disk.qcow2"
+        if fresh:
+            disk.unlink(missing_ok=True)
+        if not disk.is_file():
+            result = subprocess.run(
+                [QEMU_IMG_BINARY, "create", "-f", "qcow2", str(disk), f"{disk_gb}G"],
+                capture_output=True,
+                text=True,
+            )
+            if result.returncode != 0:
+                raise RuntimeError(f"qemu-img create failed: {result.stderr.strip()}")
+
+        cdroms = [str(iso)]
+        if virtio_iso:
+            virtio = Path(virtio_iso).expanduser()
+            if not virtio.is_file():
+                raise RuntimeError(f"virtio-win ISO not found: {virtio}")
+            cdroms.append(str(virtio))
+        if autounattend:
+            cdroms.append(str(self._autounattend_iso(Path(autounattend).expanduser(), state_dir)))
+
+        display = self._find_free_display()
+        vnc_port = VNC_BASE_PORT + display
+        rdp_port = RDP_PORT_OFFSET + display
+        accel, accel_note = self._detect_accel()
+        notes: list[str] = []
+
+        ovmf = _find_ovmf()
+        ovmf_code = ovmf_vars = None
+        if ovmf:
+            ovmf_code, vars_template = ovmf
+            vars_copy = state_dir / "OVMF_VARS.fd"
+            if fresh or not vars_copy.is_file():
+                shutil.copyfile(vars_template, vars_copy)
+            ovmf_vars = str(vars_copy)
+        else:
+            notes.append("OVMF not found — booting legacy BIOS (Windows 11 setup may refuse)")
+        tpm_sock = self._start_swtpm(state_dir)
+        if tpm_sock is None:
+            notes.append("swtpm not available — no TPM device (Windows 11 setup may refuse)")
+
+        cmd = _build_qemu_cmd(
+            name=name,
+            disk_path=str(disk),
+            cpus=cpus,
+            memory_gb=memory_gb,
+            vnc_display=display,
+            rdp_port=rdp_port,
+            qmp_sock=str(state_dir / "qmp.sock"),
+            pidfile=str(state_dir / "qemu.pid"),
+            serial_log=str(state_dir / "serial.log"),
+            qemu_log=str(state_dir / "qemu.log"),
+            accel=accel,
+            width=width,
+            height=height,
+            ovmf_code=ovmf_code,
+            ovmf_vars=ovmf_vars,
+            tpm_sock=tpm_sock,
+            cdroms=tuple(cdroms),
+            boot_cd=True,
+        )
+        try:
+            pid = self._launch_qemu(cmd, state_dir)
+        except RuntimeError:
+            self._stop_swtpm(name)
+            raise
+        state = {
+            "name": name,
+            "pid": pid,
+            "vnc_display": display,
+            "vnc_port": vnc_port,
+            "rdp_port": rdp_port,
+            "accel": accel,
+            "disk": str(disk),
+            "display_size": display_size,
+            "cpus": cpus,
+            "memory_gb": memory_gb,
+            "uefi": bool(ovmf),
+            "tpm": bool(tpm_sock),
+            "install": True,
+            "created_at": datetime.now(UTC).isoformat(),
+        }
+        self._write_state(name, state)
+        return {
+            "name": name,
+            "state": "running",
+            "pid": pid,
+            "vnc_port": vnc_port,
+            "rdp_port": rdp_port,
+            "accel": accel_note,
+            "disk": str(disk),
+            "cdroms": cdroms,
+            "notes": notes,
+            "next_steps": (
+                "Watch the install with screenshot(); once Windows is installed and "
+                f"configured, stop_vm({name!r}) and publish {disk} as the golden image."
+            ),
+        }
+
+    def _autounattend_iso(self, source: Path, state_dir: Path) -> Path:
+        """Return an ISO carrying autounattend.xml, building one from a .xml if needed."""
+        if not source.is_file():
+            raise RuntimeError(f"autounattend file not found: {source}")
+        if source.suffix.lower() == ".iso":
+            return source
+        tool = next(
+            (t for t in ("genisoimage", "mkisofs", "xorrisofs") if shutil.which(t)), None
+        )
+        if tool is None:
+            raise RuntimeError(
+                "Cannot build autounattend ISO: none of genisoimage/mkisofs/xorrisofs "
+                "found. Provide a prebuilt .iso containing autounattend.xml instead."
+            )
+        staging = state_dir / "autounattend"
+        staging.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(source, staging / "autounattend.xml")
+        iso = state_dir / "autounattend.iso"
+        result = subprocess.run(
+            [tool, "-quiet", "-J", "-r", "-V", "UNATTEND", "-o", str(iso), str(staging)],
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            raise RuntimeError(f"{tool} failed building autounattend ISO: {result.stderr.strip()}")
+        return iso
+
+    # ------------------------------------------------------------------
+    # computer-use actions (loop: action -> screenshot)
+    # ------------------------------------------------------------------
+
+    def screenshot(self, name: str = "win", output_path: str | None = None) -> dict:
+        """Capture the VM screen to a PNG and return its path and dimensions.
+
+        This is the only action that captures the screen; run it after each
+        click/type/key/scroll/drag to observe the result.
+        """
+        state = self._running_state(name)
+        if output_path:
+            path = Path(output_path).expanduser()
+            path.parent.mkdir(parents=True, exist_ok=True)
+        else:
+            shots = self._state_dir(name) / "screenshots"
+            shots.mkdir(parents=True, exist_ok=True)
+            path = shots / f"{datetime.now(UTC).strftime('%Y%m%dT%H%M%S%f')}.png"
+        client = self._vnc_connect(name)
+        try:
+            client.captureScreen(str(path))
+        finally:
+            self._vnc_disconnect(client)
+        with Image.open(path) as img:
+            width, height = img.size
+        return {"name": state["name"], "path": str(path), "width": width, "height": height}
+
+    def click(
+        self,
+        x: int,
+        y: int,
+        name: str = "win",
+        button: str = "left",
+        double: bool = False,
+    ) -> dict:
+        """Click at (x, y). button is left/right/middle; double=True double-clicks.
+
+        Follow with screenshot() to observe the result.
+        """
+        btn = MOUSE_BUTTONS.get(button)
+        if btn is None:
+            raise RuntimeError(f"Unknown button {button!r}; use left, right, or middle.")
+        client = self._vnc_connect(name)
+        try:
+            client.mouseMove(x, y)
+            client.pause(0.05)
+            client.mousePress(btn)
+            if double:
+                client.pause(0.08)
+                client.mousePress(btn)
+        finally:
+            self._vnc_disconnect(client)
+        return {"action": "click", "x": x, "y": y, "button": button, "double": double}
+
+    def move(self, x: int, y: int, name: str = "win") -> dict:
+        """Move the mouse pointer to (x, y) without clicking."""
+        client = self._vnc_connect(name)
+        try:
+            client.mouseMove(x, y)
+        finally:
+            self._vnc_disconnect(client)
+        return {"action": "move", "x": x, "y": y}
+
+    def drag(self, x1: int, y1: int, x2: int, y2: int, name: str = "win") -> dict:
+        """Drag with the left button from (x1, y1) to (x2, y2)."""
+        client = self._vnc_connect(name)
+        try:
+            client.mouseMove(x1, y1)
+            client.pause(0.1)
+            client.mouseDown(1)
+            client.pause(0.1)
+            client.mouseDrag(x2, y2, step=16)
+            client.pause(0.1)
+            client.mouseUp(1)
+        finally:
+            self._vnc_disconnect(client)
+        return {"action": "drag", "from": [x1, y1], "to": [x2, y2]}
+
+    def type_text(self, text: str, name: str = "win", interval: float = 0.02) -> dict:
+        """Type text into the VM, one keypress per character.
+
+        Newlines and tabs are sent as enter/tab. Use key() for shortcuts and
+        follow with screenshot() to observe the result.
+        """
+        client = self._vnc_connect(name)
+        try:
+            for char in text:
+                client.keyPress(TYPE_KEYS.get(char, char))
+                if interval > 0:
+                    client.pause(interval)
+        finally:
+            self._vnc_disconnect(client)
+        return {"action": "type_text", "chars": len(text)}
+
+    def key(self, combo: str, name: str = "win") -> dict:
+        """Press a key or combo, e.g. 'enter', 'ctrl-alt-del', 'win-r', 'alt-f4'.
+
+        Combos join keys with '-' (or '+'); win/cmd map to the Super key.
+        Follow with screenshot() to observe the result.
+        """
+        normalized = self._normalize_combo(combo)
+        client = self._vnc_connect(name)
+        try:
+            client.keyPress(normalized)
+        finally:
+            self._vnc_disconnect(client)
+        return {"action": "key", "combo": combo, "sent": normalized}
+
+    def scroll(
+        self,
+        x: int,
+        y: int,
+        direction: str = "down",
+        clicks: int = 3,
+        name: str = "win",
+    ) -> dict:
+        """Scroll the wheel at (x, y). direction is up or down; clicks is wheel notches."""
+        btn = SCROLL_BUTTONS.get(direction)
+        if btn is None:
+            raise RuntimeError(f"Unknown scroll direction {direction!r}; use up or down.")
+        client = self._vnc_connect(name)
+        try:
+            client.mouseMove(x, y)
+            client.pause(0.05)
+            for _ in range(max(1, clicks)):
+                client.mousePress(btn)
+                client.pause(0.02)
+        finally:
+            self._vnc_disconnect(client)
+        return {"action": "scroll", "x": x, "y": y, "direction": direction, "clicks": clicks}
+
+    def wait(self, seconds: float) -> dict:
+        """Sleep up to 60 seconds (e.g. while Windows boots or an app loads)."""
+        capped = max(0.0, min(float(seconds), 60.0))
+        time.sleep(capped)
+        return {"action": "wait", "seconds": capped}
+
+
+def _client() -> ComputerUseClient:
+    return ComputerUseClient()

--- a/tools/infra/computeruse/pyproject.toml
+++ b/tools/infra/computeruse/pyproject.toml
@@ -1,0 +1,31 @@
+[project]
+name = "computeruse"
+description = "Spawn and drive Windows VMs (QEMU) with computer-use actions over VNC"
+version = "0.1.0"
+requires-python = ">=3.11"
+dependencies = [
+    "python-dotenv>=1.0.0",
+    "httpx>=0.27.0",
+    "typer>=0.12.0",
+    "rich>=13.0.0",
+    "vncdotool>=1.2.0",
+    "pillow>=10.0.0",
+]
+
+[project.scripts]
+computeruse = "centaur_tool_computeruse.cli:app"
+
+[tool.hatch.build.targets.wheel]
+packages = ["."]
+
+[tool.hatch.build.targets.wheel.sources]
+"." = "centaur_tool_computeruse"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.centaur]
+module = "client.py"
+hosts = []
+secrets = []

--- a/tools/infra/computeruse/pyproject.toml
+++ b/tools/infra/computeruse/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
 ]
 
 [project.scripts]
-computeruse = "centaur_tool_computeruse.cli:app"
+computeruse = "centaur_tool_computeruse.cli:main"
 
 [tool.hatch.build.targets.wheel]
 packages = ["."]

--- a/tools/infra/computeruse/resources/autounattend.xml
+++ b/tools/infra/computeruse/resources/autounattend.xml
@@ -1,0 +1,238 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Windows 11 unattended answer file for building the computeruse golden image.
+
+  Usage: computeruse install <win11.iso> with the "virtio-iso" option pointed
+  at a virtio-win drivers ISO and the "autounattend" option pointed at this
+  file (it gets wrapped into a small ISO automatically).
+
+  Before use, replace the AUTOUNATTEND_PASSWORD placeholder with the local
+  admin password you want baked into the image (keep it out of git).
+
+  What this file does:
+    - Wipes disk 0 and lays out a standard UEFI/GPT partition scheme.
+    - Installs Windows 11 Pro (image index 1 of install.wim/install.esd)
+      with a generic KMS client key (never activates — replace if needed).
+    - Skips all OOBE screens (EULA, network, privacy, Microsoft account).
+    - Creates local administrator "agent" with the placeholder password and
+      auto-logs it in.
+    - First-logon commands: enable RDP + firewall rule, disable the lock
+      screen, screensaver, and UAC consent prompts, and never sleep — so a
+      VNC-driven agent is never blocked by a credential or consent dialog.
+    - Sets the display to 1280x800 to match the computeruse default
+      display_size.
+-->
+<unattend xmlns="urn:schemas-microsoft-com:unattend">
+
+  <!-- ============================== windowsPE ============================== -->
+  <settings pass="windowsPE">
+    <component name="Microsoft-Windows-International-Core-WinPE"
+               processorArchitecture="amd64"
+               publicKeyToken="31bf3856ad364e35" language="neutral"
+               versionScope="nonSxS">
+      <SetupUILanguage>
+        <UILanguage>en-US</UILanguage>
+      </SetupUILanguage>
+      <InputLocale>en-US</InputLocale>
+      <SystemLocale>en-US</SystemLocale>
+      <UILanguage>en-US</UILanguage>
+      <UserLocale>en-US</UserLocale>
+    </component>
+
+    <component name="Microsoft-Windows-Setup" processorArchitecture="amd64"
+               publicKeyToken="31bf3856ad364e35" language="neutral"
+               versionScope="nonSxS">
+      <!-- Wipe disk 0 and create a standard UEFI layout: ESP / MSR / OS. -->
+      <DiskConfiguration>
+        <Disk wcm:action="add"
+              xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State">
+          <DiskID>0</DiskID>
+          <WillWipeDisk>true</WillWipeDisk>
+          <CreatePartitions>
+            <CreatePartition wcm:action="add">
+              <Order>1</Order>
+              <Type>EFI</Type>
+              <Size>300</Size>
+            </CreatePartition>
+            <CreatePartition wcm:action="add">
+              <Order>2</Order>
+              <Type>MSR</Type>
+              <Size>16</Size>
+            </CreatePartition>
+            <CreatePartition wcm:action="add">
+              <Order>3</Order>
+              <Type>Primary</Type>
+              <Extend>true</Extend>
+            </CreatePartition>
+          </CreatePartitions>
+          <ModifyPartitions>
+            <ModifyPartition wcm:action="add">
+              <Order>1</Order>
+              <PartitionID>1</PartitionID>
+              <Format>FAT32</Format>
+              <Label>System</Label>
+            </ModifyPartition>
+            <ModifyPartition wcm:action="add">
+              <Order>2</Order>
+              <PartitionID>3</PartitionID>
+              <Format>NTFS</Format>
+              <Label>Windows</Label>
+              <Letter>C</Letter>
+            </ModifyPartition>
+          </ModifyPartitions>
+        </Disk>
+      </DiskConfiguration>
+
+      <ImageInstall>
+        <OSImage>
+          <InstallTo>
+            <DiskID>0</DiskID>
+            <PartitionID>3</PartitionID>
+          </InstallTo>
+        </OSImage>
+      </ImageInstall>
+
+      <UserData>
+        <AcceptEula>true</AcceptEula>
+        <FullName>agent</FullName>
+        <Organization>computeruse</Organization>
+        <ProductKey>
+          <!-- Generic Windows 11 Pro KMS client key; installs but does not activate. -->
+          <Key>W269N-WFGWX-YVC9B-4J6C9-T83GX</Key>
+          <WillShowUI>OnError</WillShowUI>
+        </ProductKey>
+      </UserData>
+    </component>
+  </settings>
+
+  <!-- ============================== specialize ============================= -->
+  <settings pass="specialize">
+    <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64"
+               publicKeyToken="31bf3856ad364e35" language="neutral"
+               versionScope="nonSxS">
+      <ComputerName>computeruse</ComputerName>
+      <TimeZone>UTC</TimeZone>
+    </component>
+
+    <!-- Enable RDP at the service level (firewall opened at first logon). -->
+    <component name="Microsoft-Windows-TerminalServices-LocalSessionManager"
+               processorArchitecture="amd64"
+               publicKeyToken="31bf3856ad364e35" language="neutral"
+               versionScope="nonSxS">
+      <fDenyTSConnections>false</fDenyTSConnections>
+    </component>
+    <component name="Microsoft-Windows-TerminalServices-RDP-WinStationExtensions"
+               processorArchitecture="amd64"
+               publicKeyToken="31bf3856ad364e35" language="neutral"
+               versionScope="nonSxS">
+      <UserAuthentication>0</UserAuthentication>
+    </component>
+  </settings>
+
+  <!-- ============================== oobeSystem ============================= -->
+  <settings pass="oobeSystem">
+    <component name="Microsoft-Windows-International-Core" processorArchitecture="amd64"
+               publicKeyToken="31bf3856ad364e35" language="neutral"
+               versionScope="nonSxS">
+      <InputLocale>en-US</InputLocale>
+      <SystemLocale>en-US</SystemLocale>
+      <UILanguage>en-US</UILanguage>
+      <UserLocale>en-US</UserLocale>
+    </component>
+
+    <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64"
+               publicKeyToken="31bf3856ad364e35" language="neutral"
+               versionScope="nonSxS">
+      <!-- Skip every OOBE screen so the install is fully hands-off. -->
+      <OOBE>
+        <HideEULAPage>true</HideEULAPage>
+        <HideLocalAccountScreen>true</HideLocalAccountScreen>
+        <HideOEMRegistrationScreen>true</HideOEMRegistrationScreen>
+        <HideOnlineAccountScreens>true</HideOnlineAccountScreens>
+        <HideWirelessSetupInOOBE>true</HideWirelessSetupInOOBE>
+        <ProtectYourPC>3</ProtectYourPC>
+        <SkipMachineOOBE>true</SkipMachineOOBE>
+        <SkipUserOOBE>true</SkipUserOOBE>
+      </OOBE>
+
+      <!-- Match computeruse's default display_size of 1280x800. -->
+      <Display>
+        <ColorDepth>32</ColorDepth>
+        <HorizontalResolution>1280</HorizontalResolution>
+        <VerticalResolution>800</VerticalResolution>
+      </Display>
+
+      <!-- Local admin "agent". Replace AUTOUNATTEND_PASSWORD before building. -->
+      <UserAccounts>
+        <LocalAccounts>
+          <LocalAccount wcm:action="add"
+                        xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State">
+            <Name>agent</Name>
+            <DisplayName>agent</DisplayName>
+            <Group>Administrators</Group>
+            <Password>
+              <Value>AUTOUNATTEND_PASSWORD</Value>
+              <PlainText>true</PlainText>
+            </Password>
+          </LocalAccount>
+        </LocalAccounts>
+      </UserAccounts>
+
+      <AutoLogon>
+        <Enabled>true</Enabled>
+        <Username>agent</Username>
+        <Password>
+          <Value>AUTOUNATTEND_PASSWORD</Value>
+          <PlainText>true</PlainText>
+        </Password>
+        <LogonCount>999999</LogonCount>
+      </AutoLogon>
+
+      <!-- Make the desktop automation-friendly on first logon. -->
+      <FirstLogonCommands>
+        <SynchronousCommand wcm:action="add"
+                            xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State">
+          <Order>1</Order>
+          <Description>Enable RDP</Description>
+          <CommandLine>reg add "HKLM\SYSTEM\CurrentControlSet\Control\Terminal Server" /v fDenyTSConnections /t REG_DWORD /d 0 /f</CommandLine>
+        </SynchronousCommand>
+        <SynchronousCommand wcm:action="add"
+                            xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State">
+          <Order>2</Order>
+          <Description>Open RDP firewall rule</Description>
+          <CommandLine>netsh advfirewall firewall set rule group="remote desktop" new enable=Yes</CommandLine>
+        </SynchronousCommand>
+        <SynchronousCommand wcm:action="add"
+                            xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State">
+          <Order>3</Order>
+          <Description>Disable lock screen</Description>
+          <CommandLine>reg add "HKLM\SOFTWARE\Policies\Microsoft\Windows\Personalization" /v NoLockScreen /t REG_DWORD /d 1 /f</CommandLine>
+        </SynchronousCommand>
+        <SynchronousCommand wcm:action="add"
+                            xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State">
+          <Order>4</Order>
+          <Description>Disable screensaver</Description>
+          <CommandLine>reg add "HKCU\Control Panel\Desktop" /v ScreenSaveActive /t REG_SZ /d 0 /f</CommandLine>
+        </SynchronousCommand>
+        <SynchronousCommand wcm:action="add"
+                            xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State">
+          <Order>5</Order>
+          <Description>Disable UAC consent prompts for administrators</Description>
+          <CommandLine>reg add "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System" /v ConsentPromptBehaviorAdmin /t REG_DWORD /d 0 /f</CommandLine>
+        </SynchronousCommand>
+        <SynchronousCommand wcm:action="add"
+                            xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State">
+          <Order>6</Order>
+          <Description>Disable UAC secure desktop prompt</Description>
+          <CommandLine>reg add "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System" /v PromptOnSecureDesktop /t REG_DWORD /d 0 /f</CommandLine>
+        </SynchronousCommand>
+        <SynchronousCommand wcm:action="add"
+                            xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State">
+          <Order>7</Order>
+          <Description>Never sleep or turn off the display</Description>
+          <CommandLine>powercfg /change standby-timeout-ac 0 &amp;&amp; powercfg /change monitor-timeout-ac 0</CommandLine>
+        </SynchronousCommand>
+      </FirstLogonCommands>
+    </component>
+  </settings>
+</unattend>


### PR DESCRIPTION
Adds a `computeruse` tool that spawns a real Windows VM inside the sandbox and drives it with computer-use actions, plus the infra to make it fast.

## Tool — `tools/infra/computeruse`
- `computeruse spawn` boots a Windows VM via QEMU from a golden qcow2 image (`COMPUTERUSE_WINDOWS_IMAGE_URL`): copy-on-write overlay per VM, q35 + virtio + usb-tablet (absolute pointer so clicks match screenshot pixels), OVMF secure-boot firmware + swtpm TPM for Win11, user-mode networking with an RDP host-forward for debugging, VNC bound to localhost. Uses KVM when `/dev/kvm` is present, falls back to TCG software emulation with a loud warning.
- Computer-use actions over VNC (vncdotool): `screenshot`, `click`, `move`, `drag`, `type`, `key`, `scroll`, `wait` — shaped after Anthropic's computer-use action space so the agent loop is action → screenshot.
- `install` + `resources/autounattend.xml` build the golden image unattended from a Windows ISO (local admin `agent`, RDP on, OOBE skipped, 1280x800).
- Lifecycle: `status`, `list`, `stop` (QMP powerdown → SIGTERM → SIGKILL), state under `~/.computeruse/vms/<name>/`.

## Sandbox image — `services/sandbox/Dockerfile`
Installs `qemu-system-x86 qemu-utils ovmf swtpm` (amd64 only).

## KVM opt-in — api-rs + chart
Sandbox pods stay unprivileged: a gated `generic-device-plugin` DaemonSet (`kvmDevicePlugin.enabled`) advertises `devices.kubevirt.io/kvm`, and when `SANDBOX_KVM_DEVICE_RESOURCE` is set the k8s backend requests that extended resource on the agent container so kubelet injects `/dev/kvm`. Auto-wired in the chart when the plugin is enabled.

## Verified
- `cargo check` + `cargo test -p centaur-sandbox-agent-k8s` (38 passed, incl. new resources test)
- `helm template`/`helm lint` render correctly with the flag on and off (validated with the unvendored 1Password dep stripped — pre-existing chart issue)
- Tool: syntax/imports, typer CLI end-to-end (`--help`, `status --json`, `health`), QEMU argv builder dry-runs (KVM/UEFI/TPM and TCG variants), autounattend XML validity
- **End-to-end GUI computer-use, in-sandbox (2026-07-04)**: booted a live Linux desktop ISO (BookwormPup64, TCG software emulation, 8 vCPU / 6 GiB, virtio-vga at 1280x800) via `computeruse install`, then drove it purely with `screenshot`/`click`/`type`/`key` over VNC: dismissed first-run dialogs, launched real Firefox from a desktop icon, typed a URL, and clicked a page link. Network proof: QEMU user-net exposes host loopback as `10.0.2.2`, and a host HTTP server's access log recorded the VM browser's `GET /`, `GET /favicon.ico`, and `GET /page2.html` — real browser, no automation API in the guest. TCG timings: ~2 min to desktop, ~40 s Firefox launch, actions land pixel-exact (usb-tablet).

## Not yet verified (needs cluster + image)
- No end-to-end **Windows** boot yet: a Windows install under TCG takes many hours, so that leg still needs KVM plus a golden image. Rollout needs: (1) enable `kvmDevicePlugin` on KVM-capable nodes (host CPUs already expose AMD-V with nested virt), (2) build the golden image once via `computeruse install` and host the qcow2 (licensing: use our Windows volume licensing / an eval image), (3) allow the image URL through iron-proxy egress, (4) bump sandbox CPU/memory limits for VM-carrying sessions.

Prompted by: georgios
