### PR TITLE
fix: gate sandbox observability egress

### DIFF
--- a/contrib/chart/Chart.yaml
+++ b/contrib/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: centaur
 description: Helm chart for the trusted Centaur control plane
 type: application
-version: 0.1.87
+version: 0.1.88
 appVersion: "0.1.0"
 dependencies:
   - name: connect

--- a/contrib/chart/templates/networkpolicy.yaml
+++ b/contrib/chart/templates/networkpolicy.yaml
@@ -189,51 +189,11 @@ spec:
         - podSelector:
             matchLabels:
               centaur.ai/api-server-enabled: "true"
-        # Transitional compatibility: pre-deploy sandbox/proxy pods carry only
-        # centaur.ai/managed-by=api-rs, so this also covers newly-created
-        # API-disabled pods while the rollout policy is present. Remove with the
-        # matching egress compatibility policy below after old api-rs-managed
-        # pods have aged out.
-        - podSelector:
-            matchLabels:
-              centaur.ai/managed-by: api-rs
-            matchExpressions:
-              - key: centaur.ai/api-server-enabled
-                operator: DoesNotExist
 {{- range .Values.networkPolicy.apiIngressSourceNamespaces }}
         - namespaceSelector:
             matchLabels:
               kubernetes.io/metadata.name: {{ . | quote }}
 {{- end }}
-      ports:
-        - protocol: TCP
-          port: {{ .Values.apiRs.port }}
----
-# Transitional compatibility for pre-deploy sandbox/proxy pods. They carry only
-# centaur.ai/managed-by=api-rs, so this also covers newly-created API-disabled
-# pods while the rollout policy is present. Remove this with the matching
-# api-rs ingress compatibility selector once old api-rs-managed pods have aged
-# out.
-apiVersion: networking.k8s.io/v1
-kind: NetworkPolicy
-metadata:
-  name: {{ include "centaur.fullname" . }}-sandbox-api-server-compat
-  labels:
-{{ include "centaur.labels" . | nindent 4 }}
-spec:
-  podSelector:
-    matchLabels:
-      centaur.ai/managed-by: api-rs
-    matchExpressions:
-      - key: centaur.ai/api-server-enabled
-        operator: DoesNotExist
-  policyTypes:
-    - Egress
-  egress:
-    - to:
-        - podSelector:
-            matchLabels:
-{{ include "centaur.componentSelectorLabels" (dict "root" . "component" "api-rs") | nindent 14 }}
       ports:
         - protocol: TCP
           port: {{ .Values.apiRs.port }}
@@ -244,7 +204,7 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: {{ include "centaur.fullname" . }}-sandbox-api-server
+  name: {{ include "centaur.fullname" . }}-sandbox-api-rs-egress
   labels:
 {{ include "centaur.labels" . | nindent 4 }}
 spec:
@@ -262,6 +222,49 @@ spec:
         - protocol: TCP
           port: {{ .Values.apiRs.port }}
 ---
+{{- if .Values.networkPolicy.observabilityEgress.enabled }}
+{{- if not .Values.networkPolicy.observabilityEgress.destinations }}
+{{- fail "networkPolicy.observabilityEgress.destinations must contain at least one destination when networkPolicy.observabilityEgress.enabled is true" }}
+{{- end }}
+# Sandboxes with the observability capability may call the configured
+# in-cluster observability backends.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "centaur.fullname" . }}-observability-egress
+  labels:
+{{ include "centaur.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      centaur.ai/observability-enabled: "true"
+  policyTypes:
+    - Egress
+  egress:
+{{- range $index, $destination := .Values.networkPolicy.observabilityEgress.destinations }}
+{{- if not $destination.ports }}
+{{- fail (printf "networkPolicy.observabilityEgress.destinations[%d].ports must contain at least one port" $index) }}
+{{- end }}
+    - to:
+        - namespaceSelector:
+{{- if $destination.namespaceSelector }}
+{{ toYaml $destination.namespaceSelector | nindent 12 }}
+{{- else }}
+            matchLabels:
+              kubernetes.io/metadata.name: {{ required (printf "networkPolicy.observabilityEgress.destinations[%d].namespace is required when namespaceSelector is unset" $index) $destination.namespace | quote }}
+{{- end }}
+{{- with $destination.podSelector }}
+          podSelector:
+{{ toYaml . | nindent 12 }}
+{{- end }}
+      ports:
+{{- range $portIndex, $port := $destination.ports }}
+        - protocol: {{ default "TCP" $port.protocol }}
+          port: {{ required (printf "networkPolicy.observabilityEgress.destinations[%d].ports[%d].port is required" $index $portIndex) $port.port }}
+{{- end }}
+{{- end }}
+---
+{{- end }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/contrib/chart/templates/networkpolicy.yaml
+++ b/contrib/chart/templates/networkpolicy.yaml
@@ -204,7 +204,7 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: {{ include "centaur.fullname" . }}-sandbox-api-rs-egress
+  name: {{ include "centaur.fullname" . }}-sandbox-api-server
   labels:
 {{ include "centaur.labels" . | nindent 4 }}
 spec:

--- a/contrib/chart/values.schema.json
+++ b/contrib/chart/values.schema.json
@@ -386,6 +386,54 @@
         "ingressControllerNamespaces": {
           "type": "array",
           "items": { "type": "string" }
+        },
+        "apiServerPort": { "type": "integer" },
+        "otlpEgress": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "namespace": { "type": "string" },
+            "port": { "type": "integer" }
+          }
+        },
+        "observabilityEgress": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "destinations": {
+              "type": "array",
+              "minItems": 0,
+              "items": {
+                "type": "object",
+                "properties": {
+                  "namespace": { "type": "string" },
+                  "namespaceSelector": { "type": "object" },
+                  "podSelector": { "type": "object" },
+                  "ports": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "port": {
+                          "oneOf": [
+                            { "type": "integer" },
+                            { "type": "string" }
+                          ]
+                        },
+                        "protocol": {
+                          "type": "string",
+                          "enum": ["TCP", "UDP", "SCTP"]
+                        }
+                      },
+                      "required": ["port"]
+                    }
+                  }
+                },
+                "required": ["ports"]
+              }
+            }
+          }
         }
       }
     }

--- a/contrib/chart/values.yaml
+++ b/contrib/chart/values.yaml
@@ -566,6 +566,31 @@ networkPolicy:
     # kubernetes.io/metadata.name of the collector's namespace, e.g. "laminar".
     namespace: ""
     port: 8000
+  # Egress to observability backends such as VictoriaLogs or VictoriaMetrics.
+  # This policy selects only pods labeled centaur.ai/observability-enabled=true.
+  # Sandboxes receive that label only when their principal has the observability
+  # sandbox capability.
+  observabilityEgress:
+    enabled: false
+    destinations: []
+    # Example:
+    # destinations:
+    #   - namespace: observability
+    #     podSelector:
+    #       matchLabels:
+    #         app.kubernetes.io/instance: vls
+    #         app.kubernetes.io/name: victoria-logs-single
+    #     ports:
+    #       - port: 9428
+    #         protocol: TCP
+    #   - namespace: observability
+    #     podSelector:
+    #       matchLabels:
+    #         app.kubernetes.io/instance: vms
+    #         app.kubernetes.io/name: victoria-metrics-single
+    #     ports:
+    #       - port: 8428
+    #         protocol: TCP
 
 podSecurityContext:
   fsGroupChangePolicy: OnRootMismatch


### PR DESCRIPTION
Moves sandbox observability egress into the Centaur Helm chart behind the centaur.ai/observability-enabled label, with configurable backend destinations. It also removes the transitional api-rs sandbox compatibility bypass so sandbox access to api-rs is gated by centaur.ai/api-server-enabled and renames the egress policy to match the chart's naming style.