### PR TITLE
fix: handle newline after model override

### DIFF
--- a/services/linearbot/src/overrides.ts
+++ b/services/linearbot/src/overrides.ts
@@ -44,7 +44,15 @@ const MODEL_SHORTCUTS: Record<string, { harnessType: string; model: string }> =
     ]),
   );
 
-const MODEL_FLAG_PATTERN = /(?:^|\s)--model[=\s]+([A-Za-z0-9._/-]+)(?=\s|$)/i;
+// Values are one horizontal-whitespace-delimited token; a newline after the
+// value starts the user's prompt, not part of the model value.
+const MODEL_VALUE_SEPARATOR = String.raw`(?:[^\S\r\n]*=[^\S\r\n]*|[^\S\r\n]+)`;
+const FLAG_VALUE_BOUNDARY = String.raw`(?=[^\S\r\n]|\r?\n|\r|<br\s*/?>|$)`;
+
+const MODEL_FLAG_PATTERN = new RegExp(
+  String.raw`(?:^|\s)--model${MODEL_VALUE_SEPARATOR}([A-Za-z0-9._/-]+)${FLAG_VALUE_BOUNDARY}`,
+  "i",
+);
 
 export function extractMessageOverrides(text: string): MessageOverrides {
   let cleaned = text;
@@ -88,5 +96,11 @@ function flagPattern(flag: string): RegExp {
 }
 
 function stripMatch(text: string, match: RegExpExecArray): string {
-  return `${text.slice(0, match.index)}${text.slice(match.index + match[0].length)}`;
+  const before = text.slice(0, match.index);
+  const after = text
+    .slice(match.index + match[0].length)
+    .replace(/^(?:(?:\r\n?|\n)+|<br\s*\/?>)+/i, "");
+  const separator =
+    before && after && !/\s$/.test(before) && !/^\s/.test(after) ? " " : "";
+  return `${before}${separator}${after}`;
 }

--- a/services/linearbot/test/overrides.test.ts
+++ b/services/linearbot/test/overrides.test.ts
@@ -90,6 +90,33 @@ describe("extractMessageOverrides", () => {
     );
   });
 
+  test("--model accepts a newline immediately after the value", () => {
+    expect(
+      extractMessageOverrides("--claude --model=fable\nwhat model are you"),
+    ).toEqual({
+      cleanedText: "what model are you",
+      harnessType: "claudecode",
+      model: "claude-fable-5",
+    });
+    expect(
+      extractMessageOverrides("@Centaur AI --claude --model=fable\r\nwhat model are you"),
+    ).toEqual({
+      cleanedText: "@Centaur AI what model are you",
+      harnessType: "claudecode",
+      model: "claude-fable-5",
+    });
+  });
+
+  test("--model accepts a rendered line break immediately after the value", () => {
+    expect(
+      extractMessageOverrides("--claude --model=fable<br>what model are you"),
+    ).toEqual({
+      cleanedText: "what model are you",
+      harnessType: "claudecode",
+      model: "claude-fable-5",
+    });
+  });
+
   test("--model passes non-alias values through verbatim", () => {
     expect(
       extractMessageOverrides("--codex --model gpt-5.2-codex go").model,
@@ -129,6 +156,11 @@ describe("extractMessageOverrides", () => {
   test("--model without a value is left untouched", () => {
     expect(extractMessageOverrides("what does --model do?")).toEqual({
       cleanedText: "what does --model do?",
+      harnessType: undefined,
+      model: undefined,
+    });
+    expect(extractMessageOverrides("--model\nwhat model are you")).toEqual({
+      cleanedText: "--model\nwhat model are you",
       harnessType: undefined,
       model: undefined,
     });

--- a/services/slackbotv2/src/overrides.ts
+++ b/services/slackbotv2/src/overrides.ts
@@ -61,11 +61,22 @@ const MODEL_SHORTCUTS: Record<string, { harnessType: string; model: string }> =
     ])
   )
 
-const MODEL_FLAG_PATTERN = /(?:^|\s)--model[=\s]+([A-Za-z0-9._/-]+)(?=\s|$)/i
+// Values are one horizontal-whitespace-delimited token; a newline after the
+// value starts the user's prompt, not part of the model/reasoning value.
+const MODEL_VALUE_SEPARATOR = String.raw`(?:[^\S\r\n]*=[^\S\r\n]*|[^\S\r\n]+)`
+const FLAG_VALUE_BOUNDARY = String.raw`(?=[^\S\r\n]|\r?\n|\r|<br\s*/?>|$)`
+
+const MODEL_FLAG_PATTERN = new RegExp(
+  String.raw`(?:^|\s)--model${MODEL_VALUE_SEPARATOR}([A-Za-z0-9._/-]+)${FLAG_VALUE_BOUNDARY}`,
+  'i'
+)
 
 // Single dash by design: a short per-turn knob (`-rsn high`), so it can't reuse
 // the `--`-prefixed flagPattern() helper. Value-capturing like --model.
-const REASONING_FLAG_PATTERN = /(?:^|\s)-rsn[=\s]+([A-Za-z-]+)(?=\s|$)/i
+const REASONING_FLAG_PATTERN = new RegExp(
+  String.raw`(?:^|\s)-rsn${MODEL_VALUE_SEPARATOR}([A-Za-z-]+)${FLAG_VALUE_BOUNDARY}`,
+  'i'
+)
 
 // Codex reasoning efforts (turn/start `effort`), plus convenience aliases.
 const REASONING_EFFORTS: Record<string, string> = {
@@ -142,5 +153,11 @@ function flagPattern(flag: string): RegExp {
 }
 
 function stripMatch(text: string, match: RegExpExecArray): string {
-  return `${text.slice(0, match.index)}${text.slice(match.index + match[0].length)}`
+  const before = text.slice(0, match.index)
+  const after = text
+    .slice(match.index + match[0].length)
+    .replace(/^(?:(?:\r\n?|\n)+|<br\s*\/?>)+/i, '')
+  const separator =
+    before && after && !/\s$/.test(before) && !/^\s/.test(after) ? ' ' : ''
+  return `${before}${separator}${after}`
 }

--- a/services/slackbotv2/test/chat-sdk-emulate.test.ts
+++ b/services/slackbotv2/test/chat-sdk-emulate.test.ts
@@ -352,7 +352,7 @@ describe('slackbotv2', () => {
 
     const parent = await postUserMessage('Thread default context.')
     const firstMention = await postUserMessage(
-      `<@${BOT_USER_ID}> --claude --model claude-opus-4-8 first pass`,
+      `<@${BOT_USER_ID}> --claude --model=fable\nfirst pass`,
       parent.ts
     )
     const firstWaits: Promise<unknown>[] = []
@@ -367,7 +367,7 @@ describe('slackbotv2', () => {
           team: TEAM_ID,
           ts: firstMention.ts,
           thread_ts: parent.ts,
-          text: `<@${BOT_USER_ID}> --claude --model claude-opus-4-8 first pass`
+          text: `<@${BOT_USER_ID}> --claude --model=fable\nfirst pass`
         }
       }),
       {},
@@ -414,10 +414,11 @@ describe('slackbotv2', () => {
       string,
       unknown
     >
-    expect(firstInput.model).toBe('claude-opus-4-8')
-    expect(secondInput.model).toBe('claude-opus-4-8')
+    expect(firstInput.model).toBe('claude-fable-5')
+    expect(secondInput.model).toBe('claude-fable-5')
     expect(JSON.stringify(firstInput)).not.toContain('--claude')
     expect(JSON.stringify(firstInput)).not.toContain('--model')
+    expect(JSON.stringify(firstInput)).toContain('first pass')
     expect(JSON.stringify(secondInput)).toContain('continue without flags')
 
     const state = await sharedState.get<Record<string, unknown>>(
@@ -426,7 +427,7 @@ describe('slackbotv2', () => {
     expect(state).toEqual(
       expect.objectContaining({
         harnessType: 'claudecode',
-        model: 'claude-opus-4-8'
+        model: 'claude-fable-5'
       })
     )
   })

--- a/services/slackbotv2/test/overrides.test.ts
+++ b/services/slackbotv2/test/overrides.test.ts
@@ -74,6 +74,32 @@ describe('extractMessageOverrides', () => {
     expect(extractMessageOverrides('--model fable go').model).toBe('claude-fable-5')
   })
 
+  test('--model accepts a newline immediately after the value', () => {
+    expect(extractMessageOverrides('--claude --model=fable\nwhat model are you')).toEqual({
+      cleanedText: 'what model are you',
+      harnessType: 'claudecode',
+      model: 'claude-fable-5',
+      reasoning: undefined
+    })
+    expect(
+      extractMessageOverrides('@Centaur AI --claude --model=fable\r\nwhat model are you')
+    ).toEqual({
+      cleanedText: '@Centaur AI what model are you',
+      harnessType: 'claudecode',
+      model: 'claude-fable-5',
+      reasoning: undefined
+    })
+  })
+
+  test('--model accepts a rendered line break immediately after the value', () => {
+    expect(extractMessageOverrides('--claude --model=fable<br>what model are you')).toEqual({
+      cleanedText: 'what model are you',
+      harnessType: 'claudecode',
+      model: 'claude-fable-5',
+      reasoning: undefined
+    })
+  })
+
   test('--model passes non-alias values through verbatim', () => {
     expect(extractMessageOverrides('--codex --model gpt-5.2-codex go').model).toBe('gpt-5.2-codex')
     expect(extractMessageOverrides('--amp --model fast go').model).toBe('fast')
@@ -109,6 +135,12 @@ describe('extractMessageOverrides', () => {
   test('--model without a value is left untouched', () => {
     expect(extractMessageOverrides('what does --model do?')).toEqual({
       cleanedText: 'what does --model do?',
+      harnessType: undefined,
+      model: undefined,
+      reasoning: undefined
+    })
+    expect(extractMessageOverrides('--model\nwhat model are you')).toEqual({
+      cleanedText: '--model\nwhat model are you',
       harnessType: undefined,
       model: undefined,
       reasoning: undefined


### PR DESCRIPTION
Makes Slackbot and Linearbot model override parsing tolerate a newline or rendered line break immediately after the model value. This keeps the value scoped to one token, preserves the following prompt text, and avoids treating a newline-only --model as a value-bearing flag.