### PR TITLE
fix: defer empty Slackbot event streams

### DIFF
--- a/services/slackbotv2/src/index.ts
+++ b/services/slackbotv2/src/index.ts
@@ -32,6 +32,7 @@ import {
   harnessRestartPreamble,
   isRetryableSessionApiError,
   openSessionEventStream,
+  SessionApiError,
   serializeAttachment,
   serializeMessageLinks,
   serializeMessage,
@@ -118,6 +119,7 @@ const RENDER_RECOVERY_THREAD_TIMEOUT_MS = 2 * 60 * 1000
 const RENDER_RECOVERY_MAX_THREAD_FAILURES = 5
 const RENDER_RETRY_INITIAL_DELAY_MS = 250
 const RENDER_RETRY_MAX_DELAY_MS = 5_000
+const EMPTY_EVENT_STREAM_RETRY_MAX_AGE_MS = 10
 const ASSISTANT_STATUS_MAX_CHARS = 50
 const SLACK_TASK_DETAILS_MAX_CHARS = 500
 const SLACK_FALLBACK_TEXT_MAX_CHARS = 35_000
@@ -1064,6 +1066,21 @@ async function renderExecutionAttempt(
     // otherwise be misclassified as retryable session API errors and re-render
     // the whole stream instead of posting the durable final answer.
     const answerLost = slackAnswerLost(error)
+    if (isEmptySessionEventStreamError(error)) {
+      retry = true
+      outcome = 'empty_stream_deferred'
+      traceLog(
+        options,
+        'slackbotv2_render_empty_stream_deferred',
+        trace,
+        {
+          error: errorMessage(error),
+          last_event_id: getLastEventId()
+        },
+        'warn'
+      )
+      return 'complete'
+    }
     if (answerLost === undefined && isRetryableSessionApiError(error)) {
       retry = true
       outcome = 'retry'
@@ -1634,6 +1651,15 @@ async function recoverRenderObligation(
       divergence_reconciled: divergenceReconciled
     })
   } catch (error) {
+    if (isEmptySessionEventStreamError(error)) {
+      renderOutcome = 'empty_stream_deferred'
+      traceLog(options, 'slackbotv2_render_recovery_empty_stream_deferred', trace, {
+        error: errorMessage(error),
+        last_event_id: lastEventId
+      })
+      recordRenderAttempt('recovery', renderOutcome, renderStartedAtMs)
+      return true
+    }
     const answerLost = slackAnswerLost(error)
     if (answerLost === false) {
       // The recovered stream broke only after the final answer became
@@ -1724,10 +1750,18 @@ async function indexRenderObligation(
 }
 
 async function* streamOpenedSession(
-  _input: Pick<ForwardSessionInput, 'threadId' | 'trace'>,
+  input: Pick<ForwardSessionInput, 'threadId' | 'trace'>,
   stream: AsyncIterable<SlackbotV2RendererSource>
 ): AsyncIterable<SlackbotV2RendererSource> {
-  for await (const event of stream) yield event
+  const startedAtMs = nowMs()
+  let yielded = false
+  for await (const event of stream) {
+    yielded = true
+    yield event
+  }
+  if (!yielded && elapsedMs(startedAtMs) <= EMPTY_EVENT_STREAM_RETRY_MAX_AGE_MS) {
+    throw emptySessionEventStreamError(input.threadId)
+  }
 }
 
 function renderRecoveryLeaseKey(threadId: string): string {
@@ -2153,7 +2187,29 @@ async function* streamSessionAfterHandoff(
     return
   }
 
-  for await (const event of stream) yield event
+  const startedAtMs = nowMs()
+  let yielded = false
+  for await (const event of stream) {
+    yielded = true
+    yield event
+  }
+  if (!yielded && elapsedMs(startedAtMs) <= EMPTY_EVENT_STREAM_RETRY_MAX_AGE_MS) {
+    throw emptySessionEventStreamError(input.threadId)
+  }
+}
+
+function emptySessionEventStreamError(threadId: string): SessionApiError {
+  return new SessionApiError({
+    action: 'stream events',
+    body: `empty event stream for ${threadId}`,
+    retryable: true,
+    status: 503,
+    statusText: 'Empty Event Stream'
+  })
+}
+
+function isEmptySessionEventStreamError(error: unknown): boolean {
+  return error instanceof SessionApiError && error.statusText === 'Empty Event Stream'
 }
 
 async function* streamError(error: unknown): AsyncIterable<SlackbotV2RendererSource> {

--- a/services/slackbotv2/src/index.ts
+++ b/services/slackbotv2/src/index.ts
@@ -28,11 +28,12 @@ import { renderSlackDisplayText, slackMessagePromptText } from './slack-display-
 import { slackUserIdForMessage } from './slack-user'
 import {
   collectInitialContext,
+  emptySessionEventStreamError,
   forwardToSessionApi,
   harnessRestartPreamble,
+  isEmptySessionEventStreamError,
   isRetryableSessionApiError,
   openSessionEventStream,
-  SessionApiError,
   serializeAttachment,
   serializeMessageLinks,
   serializeMessage,
@@ -119,7 +120,7 @@ const RENDER_RECOVERY_THREAD_TIMEOUT_MS = 2 * 60 * 1000
 const RENDER_RECOVERY_MAX_THREAD_FAILURES = 5
 const RENDER_RETRY_INITIAL_DELAY_MS = 250
 const RENDER_RETRY_MAX_DELAY_MS = 5_000
-const EMPTY_EVENT_STREAM_RETRY_MAX_AGE_MS = 10
+const EMPTY_EVENT_STREAM_FIRST_EVENT_DEADLINE_MS = 60_000
 const ASSISTANT_STATUS_MAX_CHARS = 50
 const SLACK_TASK_DETAILS_MAX_CHARS = 500
 const SLACK_FALLBACK_TEXT_MAX_CHARS = 35_000
@@ -959,6 +960,7 @@ function scheduleExecutionRender(
     slackbotMetrics.activeLiveRenders.inc()
     try {
       let attempt = 0
+      const firstAttemptStartedAtMs = nowMs()
       while (true) {
         const result = await renderExecutionAttempt(
           thread,
@@ -971,6 +973,26 @@ function scheduleExecutionRender(
           consoleSessionBlock
         )
         if (result === 'complete') return
+        if (
+          result === 'empty_stream'
+          && elapsedMs(firstAttemptStartedAtMs) > EMPTY_EVENT_STREAM_FIRST_EVENT_DEADLINE_MS
+        ) {
+          // The execution produced no events for the entire first-event
+          // window. Stop polling live and leave the preserved obligation to
+          // the recovery sweep instead of spinning on an event stream that
+          // may never fill.
+          traceLog(
+            options,
+            'slackbotv2_render_empty_stream_abandoned',
+            trace,
+            {
+              deadline_ms: EMPTY_EVENT_STREAM_FIRST_EVENT_DEADLINE_MS,
+              last_event_id: getLastEventId()
+            },
+            'error'
+          )
+          return
+        }
         const delayMs = renderRetryDelayMs(attempt)
         attempt += 1
         traceLog(options, 'slackbotv2_render_retry_scheduled', trace, {
@@ -1013,7 +1035,7 @@ async function renderExecutionAttempt(
   assistantStatusVisible: boolean,
   trace?: SlackbotV2Trace,
   consoleSessionBlock?: SlackContextBlock
-): Promise<'complete' | 'retry'> {
+): Promise<'complete' | 'retry' | 'empty_stream'> {
   const renderStartedAtMs = nowMs()
   let outcome = 'failure'
   let rendered = false
@@ -1067,6 +1089,11 @@ async function renderExecutionAttempt(
     // the whole stream instead of posting the durable final answer.
     const answerLost = slackAnswerLost(error)
     if (isEmptySessionEventStreamError(error)) {
+      // The stream closed before the execution's first event existed (for
+      // example a slow-first-token model racing the /events long-poll). Keep
+      // the execution active and let the live loop retry until the
+      // first-event deadline; the render obligation stays preserved for the
+      // recovery sweep as the final backstop.
       retry = true
       outcome = 'empty_stream_deferred'
       traceLog(
@@ -1079,7 +1106,7 @@ async function renderExecutionAttempt(
         },
         'warn'
       )
-      return 'complete'
+      return 'empty_stream'
     }
     if (answerLost === undefined && isRetryableSessionApiError(error)) {
       retry = true
@@ -1618,7 +1645,7 @@ async function recoverRenderObligation(
     })
     const streamResult = await renderRecoveredExecutionStream(
       thread,
-      streamOpenedSession(input, openedStream),
+      throwOnEmptySessionEventStream(input.threadId, openedStream),
       obligation.message,
       options,
       trace
@@ -1652,12 +1679,26 @@ async function recoverRenderObligation(
     })
   } catch (error) {
     if (isEmptySessionEventStreamError(error)) {
+      const obligationAgeMs = renderObligationAgeMs(obligation)
+      if (
+        obligationAgeMs !== undefined
+        && obligationAgeMs > EMPTY_EVENT_STREAM_FIRST_EVENT_DEADLINE_MS
+      ) {
+        // The execution has had the entire first-event window and still has
+        // no events; rethrow so the sweep counts the miss toward the
+        // abandonment budget instead of deferring the obligation forever.
+        renderOutcome = 'empty_stream_stale'
+        throw error
+      }
+      // Too early to give up: the execution may simply not have produced its
+      // first event yet. Defer without burning the failure budget; the finally
+      // below records the attempt and preserves the obligation.
       renderOutcome = 'empty_stream_deferred'
       traceLog(options, 'slackbotv2_render_recovery_empty_stream_deferred', trace, {
         error: errorMessage(error),
-        last_event_id: lastEventId
+        last_event_id: lastEventId,
+        obligation_age_ms: obligationAgeMs
       })
-      recordRenderAttempt('recovery', renderOutcome, renderStartedAtMs)
       return true
     }
     const answerLost = slackAnswerLost(error)
@@ -1749,19 +1790,25 @@ async function indexRenderObligation(
   traceLog(input.options, 'slackbotv2_render_obligation_indexed', input.trace)
 }
 
-async function* streamOpenedSession(
-  input: Pick<ForwardSessionInput, 'threadId' | 'trace'>,
+/**
+ * The /events long-poll is supposed to hold the connection for an active
+ * execution, but the stream can still end before the execution's first event
+ * exists (for example a race between the initial durable read and the notify
+ * subscription, or a proxy that ends idle responses early). Zero events for
+ * an execution this bot accepted means "not ready yet", never a completed
+ * render — regardless of how long the stream took to close — so surface it
+ * as a retryable error instead of a clean end of stream.
+ */
+async function* throwOnEmptySessionEventStream(
+  threadId: string,
   stream: AsyncIterable<SlackbotV2RendererSource>
 ): AsyncIterable<SlackbotV2RendererSource> {
-  const startedAtMs = nowMs()
   let yielded = false
   for await (const event of stream) {
     yielded = true
     yield event
   }
-  if (!yielded && elapsedMs(startedAtMs) <= EMPTY_EVENT_STREAM_RETRY_MAX_AGE_MS) {
-    throw emptySessionEventStreamError(input.threadId)
-  }
+  if (!yielded) throw emptySessionEventStreamError(threadId)
 }
 
 function renderRecoveryLeaseKey(threadId: string): string {
@@ -2187,29 +2234,7 @@ async function* streamSessionAfterHandoff(
     return
   }
 
-  const startedAtMs = nowMs()
-  let yielded = false
-  for await (const event of stream) {
-    yielded = true
-    yield event
-  }
-  if (!yielded && elapsedMs(startedAtMs) <= EMPTY_EVENT_STREAM_RETRY_MAX_AGE_MS) {
-    throw emptySessionEventStreamError(input.threadId)
-  }
-}
-
-function emptySessionEventStreamError(threadId: string): SessionApiError {
-  return new SessionApiError({
-    action: 'stream events',
-    body: `empty event stream for ${threadId}`,
-    retryable: true,
-    status: 503,
-    statusText: 'Empty Event Stream'
-  })
-}
-
-function isEmptySessionEventStreamError(error: unknown): boolean {
-  return error instanceof SessionApiError && error.statusText === 'Empty Event Stream'
+  yield* throwOnEmptySessionEventStream(input.threadId, stream)
 }
 
 async function* streamError(error: unknown): AsyncIterable<SlackbotV2RendererSource> {

--- a/services/slackbotv2/src/session-api.ts
+++ b/services/slackbotv2/src/session-api.ts
@@ -62,6 +62,29 @@ export function isRetryableSessionApiError(error: unknown): boolean {
   return error.name === 'AbortError' || error.name === 'TypeError'
 }
 
+const EMPTY_EVENT_STREAM_STATUS_TEXT = 'Empty Event Stream'
+
+/**
+ * Synthetic retryable error for a session event stream that ended without
+ * producing a single event. An active execution always eventually emits
+ * events, so an empty stream means the /events response ended before the
+ * first event existed and the render must be retried, not treated as
+ * complete.
+ */
+export function emptySessionEventStreamError(threadId: string): SessionApiError {
+  return new SessionApiError({
+    action: 'stream events',
+    body: `empty event stream for ${threadId}`,
+    retryable: true,
+    status: 503,
+    statusText: EMPTY_EVENT_STREAM_STATUS_TEXT
+  })
+}
+
+export function isEmptySessionEventStreamError(error: unknown): boolean {
+  return error instanceof SessionApiError && error.statusText === EMPTY_EVENT_STREAM_STATUS_TEXT
+}
+
 export const DEFAULT_SESSION_IDLE_TIMEOUT_MS = 3 * 60 * 60 * 1000
 const DEFAULT_SESSION_API_TIMEOUT_MS = 30_000
 const DEFAULT_SLACK_API_TIMEOUT_MS = 5_000

--- a/services/slackbotv2/test/chat-sdk-emulate.test.ts
+++ b/services/slackbotv2/test/chat-sdk-emulate.test.ts
@@ -3827,6 +3827,79 @@ describe('slackbotv2', () => {
     expect(Number(recoveredThreadState?.lastEventId)).toBeGreaterThan(0)
   })
 
+  it('retries an empty event stream after execute until the first answer event arrives', async () => {
+    const sharedState = createMemoryState()
+    await sharedState.connect()
+    bot = createTestBot({ state: sharedState })
+    codexApi.autoRespond = false
+    codexApi.endNextEvents = true
+
+    const parent = await postUserMessage('Context before empty stream retry.')
+    const mentionText = `<@${BOT_USER_ID}> wait for a slow first token`
+    const mention = await postUserMessage(mentionText, parent.ts)
+    const key = threadKey(parent.ts)
+    const waits: Promise<unknown>[] = []
+
+    const response = await bot.app.request(
+      '/api/webhooks/slack',
+      signedSlackEvent({
+        event_id: 'Ev-slackbotv2-empty-stream-retry',
+        event: {
+          type: 'app_mention',
+          user: USER_ID,
+          channel: CHANNEL_ID,
+          team: TEAM_ID,
+          ts: mention.ts,
+          thread_ts: parent.ts,
+          text: mentionText
+        }
+      }),
+      {},
+      waitUntilContext(waits)
+    )
+    expect(response.status).toBe(200)
+
+    await waitFor(() => codexApi.executes.length === 1)
+    await waitFor(() => codexApi.eventRequests.length === 1)
+
+    await waitFor(async () => {
+      const threadState = await sharedState.get<Record<string, unknown>>(`thread-state:${key}`)
+      return (
+        threadState?.activeExecution === true
+        && typeof threadState.renderObligation === 'object'
+      )
+    }, 3000)
+    expect(slackApi.calls.some(call => call.method === 'chat.stopStream')).toBe(false)
+
+    codexApi.emitOutputLines(key, sampleCodexOutputLines('Recovered after empty stream.'))
+    bot = createTestBot({ state: sharedState })
+    await waitFor(() => codexApi.eventRequests.length >= 2, 3000)
+    await waitFor(() => slackApi.calls.some(call => call.method === 'chat.stopStream'), 3000)
+    await Promise.all(waits)
+
+    expect(codexApi.executes).toHaveLength(1)
+    expect(codexApi.eventRequests).toEqual([
+      { afterEventId: 0, executionId: 'exe-1', threadKey: key },
+      { afterEventId: 0, executionId: 'exe-1', threadKey: key }
+    ])
+    expect(await threadText(parent.ts)).toContain('Recovered after empty stream.')
+    await waitFor(async () => {
+      const threadState = await sharedState.get<Record<string, unknown>>(`thread-state:${key}`)
+      return threadState?.renderObligation === null
+    }, 2000)
+    const recoveredThreadState = await sharedState.get<Record<string, unknown>>(
+      `thread-state:${key}`
+    )
+    expect(recoveredThreadState).toEqual(
+      expect.objectContaining({
+        activeExecution: false,
+        lastEventId: expect.any(Number),
+        renderObligation: null
+      })
+    )
+    expect(Number(recoveredThreadState?.lastEventId)).toBeGreaterThan(0)
+  })
+
   it('returns 503 for retryable execute failure and lets Slack retry without duplicate append', async () => {
     codexApi.failNextExecute = true
 
@@ -4471,6 +4544,7 @@ type MockSessionApi = {
   emitOutputLines(threadKey: string, lines: string[], executionId?: string): void
   emitSessionEvent(threadKey: string, event: string, data: unknown, executionId?: string): void
   eventRequests: MockSessionEventRequest[]
+  endNextEvents: boolean
   executes: MockSessionRequest<SlackbotV2ExecuteSessionRequest>[]
   failNextEvents: boolean
   failNextExecute: boolean
@@ -4490,6 +4564,7 @@ async function startMockCodexApi(): Promise<MockSessionApi> {
   const idempotentExecutions = new Map<string, string>()
   const streams = new Set<ServerResponse>()
   let autoRespond = true
+  let endNextEvents = false
   let executeHold: Promise<void> | null = null
   let executeHoldRelease: (() => void) | null = null
   let eventId = 0
@@ -4514,6 +4589,9 @@ async function startMockCodexApi(): Promise<MockSessionApi> {
       get executeHold() {
         return executeHold
       },
+      get endNextEvents() {
+        return endNextEvents
+      },
       get failNextExecute() {
         return failNextExecute
       },
@@ -4531,6 +4609,9 @@ async function startMockCodexApi(): Promise<MockSessionApi> {
       port,
       setFailNextEvents(value) {
         failNextEvents = value
+      },
+      setEndNextEvents(value) {
+        endNextEvents = value
       },
       setFailNextExecute(value) {
         failNextExecute = value
@@ -4563,6 +4644,7 @@ async function startMockCodexApi(): Promise<MockSessionApi> {
       executeHoldRelease = null
       closeStreams()
       autoRespond = true
+      endNextEvents = false
       eventId = 0
       failNextEvents = false
       failNextExecute = false
@@ -4578,6 +4660,12 @@ async function startMockCodexApi(): Promise<MockSessionApi> {
     },
     get failNextExecute() {
       return failNextExecute
+    },
+    get endNextEvents() {
+      return endNextEvents
+    },
+    set endNextEvents(value: boolean) {
+      endNextEvents = value
     },
     set failNextExecute(value: boolean) {
       failNextExecute = value
@@ -4649,6 +4737,7 @@ async function handleMockCodexRequest(
     appends: MockSessionRequest<SlackbotV2AppendMessagesRequest>[]
     autoRespond: boolean
     creates: MockSessionRequest<SlackbotV2CreateSessionRequest>[]
+    endNextEvents: boolean
     events: MockSessionEvent[]
     eventRequests: MockSessionEventRequest[]
     executeHold: Promise<void> | null
@@ -4660,6 +4749,7 @@ async function handleMockCodexRequest(
     nextEventId(): number
     port: number
     setFailNextEvents(value: boolean): void
+    setEndNextEvents(value: boolean): void
     setFailNextExecute(value: boolean): void
     setFailNextExecuteAfterAccept(value: boolean): void
     streams: Set<ServerResponse>
@@ -4701,6 +4791,16 @@ async function handleMockCodexRequest(
         res,
         new Response('unavailable', { status: 503, statusText: 'Service Unavailable' })
       )
+      return
+    }
+    if (input.endNextEvents) {
+      input.setEndNextEvents(false)
+      res.writeHead(200, {
+        'cache-control': 'no-cache',
+        connection: 'close',
+        'content-type': 'text/event-stream'
+      })
+      res.end()
       return
     }
     res.writeHead(200, {

--- a/services/slackbotv2/test/chat-sdk-emulate.test.ts
+++ b/services/slackbotv2/test/chat-sdk-emulate.test.ts
@@ -1231,7 +1231,9 @@ describe('slackbotv2', () => {
     expect(steeredText).toContain('Prompted by: @bob-gh')
     expect(steeredText).not.toContain('@alice-gh')
 
-    codexApi.closeStreams()
+    // An empty-closed stream now defers instead of completing the render, so
+    // finish the run with a real answer before draining the background waits.
+    codexApi.emitOutputLines(threadKey(rootMention.ts), sampleCodexOutputLines('Long PR run done.'))
     await Promise.all(rootWaits)
   })
 
@@ -1501,7 +1503,9 @@ describe('slackbotv2', () => {
       'Actually queue this extra constraint.'
     ])
 
-    codexApi.closeStreams()
+    // An empty-closed stream now defers instead of completing the render, so
+    // finish the run with a real answer before draining the background waits.
+    codexApi.emitOutputLines(threadKey(parent.ts), sampleCodexOutputLines('Long run done.'))
     await Promise.all(firstWaits)
   })
 
@@ -1563,7 +1567,9 @@ describe('slackbotv2', () => {
     expect(secondAppendTexts[0]).toContain('# Requester Context')
     expect(secondAppendTexts.at(-1)).toBe(`@${BOT_USER_ID} add this while still running`)
 
-    codexApi.closeStreams()
+    // An empty-closed stream now defers instead of completing the render, so
+    // finish the run with a real answer before draining the background waits.
+    codexApi.emitOutputLines(threadKey(parent.ts), sampleCodexOutputLines('Long mention run done.'))
     await Promise.all(firstWaits)
   })
 
@@ -3211,7 +3217,9 @@ describe('slackbotv2', () => {
     )
     await waitFor(() => codexApi.eventRequests.length === 1)
     await waitFor(() => codexApi.streamCount === 1)
-    codexApi.closeStreams()
+    // An empty-closed stream now defers instead of completing the render, so
+    // finish the run with a real answer before draining the background waits.
+    codexApi.emitOutputLines(threadKey(parent.ts), sampleCodexOutputLines('Slow run done.'))
     await Promise.all(waits)
     expect(
       slackApi.calls
@@ -3827,7 +3835,7 @@ describe('slackbotv2', () => {
     expect(Number(recoveredThreadState?.lastEventId)).toBeGreaterThan(0)
   })
 
-  it('retries an empty event stream after execute until the first answer event arrives', async () => {
+  it('retries an empty event stream in-process until the first answer event arrives', async () => {
     const sharedState = createMemoryState()
     await sharedState.connect()
     bot = createTestBot({ state: sharedState })
@@ -3871,8 +3879,9 @@ describe('slackbotv2', () => {
     }, 3000)
     expect(slackApi.calls.some(call => call.method === 'chat.stopStream')).toBe(false)
 
+    // No bot restart: the live render loop itself must retry the empty
+    // stream, so the answer renders once the execution emits its events.
     codexApi.emitOutputLines(key, sampleCodexOutputLines('Recovered after empty stream.'))
-    bot = createTestBot({ state: sharedState })
     await waitFor(() => codexApi.eventRequests.length >= 2, 3000)
     await waitFor(() => slackApi.calls.some(call => call.method === 'chat.stopStream'), 3000)
     await Promise.all(waits)


### PR DESCRIPTION
## Summary
- Treat immediately closed empty Slackbot session event streams as retryable/deferred instead of successful renders.
- Preserve active render obligations so recovery can replay once answer events arrive.
- Add a Slackbot emulator regression for an empty first event stream followed by delayed output.

Prompted by: mslipper

## Tests
- pnpm --filter slackbotv2 check:types
- pnpm --filter slackbotv2 test -- chat-sdk-emulate.test.ts