### PR TITLE
Cancel weekly usage summary schedule

### DIFF
--- a/services/api-rs/crates/centaur-session-sqlx/migrations/0036_cancel_weekly_usage_summary_schedule.sql
+++ b/services/api-rs/crates/centaur-session-sqlx/migrations/0036_cancel_weekly_usage_summary_schedule.sql
@@ -1,0 +1,29 @@
+-- Cancel the obsolete weekly usage summary workflow that posts
+-- ":centaur: Weekly Centaur Usage Summary :centaur:" into the main Centaur
+-- Slack channel. The workflow definition is persisted as an Absurd schedule
+-- task, not as a checked-in Python workflow.
+
+do $$
+declare
+  v_task_id uuid;
+begin
+  for v_task_id in
+    select task_id
+      from absurd.t_centaur_workflow_schedules
+     where state not in ('completed', 'failed', 'cancelled')
+       and (
+         params::text ilike '%Weekly Centaur Usage Summary%'
+         or (
+           params::text ilike '%C0A82R7S80N%'
+           and (
+             params ->> 'schedule_id' ilike '%usage%'
+             or params ->> 'workflow_name' ilike '%usage%'
+             or params ->> 'name' ilike '%usage%'
+           )
+         )
+       )
+  loop
+    perform absurd.cancel_task('centaur_workflow_schedules', v_task_id);
+  end loop;
+end;
+$$;


### PR DESCRIPTION
## Summary
- diagnose the weekly Slack post as a persisted Centaur workflow schedule rather than a checked-in workflow file
- add a migration that cancels active schedule tasks matching the exact weekly usage summary title or a usage-named schedule scoped to C0A82R7S80N
- use Absurd cancel_task so active runs and wait rows are cancelled consistently

## Verification
- cargo test -p centaur-session-sqlx --no-default-features

Prompted by: storm