### PR TITLE
Trigger image publish for harness-server changes

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -7,6 +7,7 @@ on:
     paths:
       - .github/workflows/publish-images.yml
       - services/**
+      - crates/harness-server/**
       - centaur_sdk/**
       - packages/**
       - tools/**


### PR DESCRIPTION
## Summary
- add `crates/harness-server/**` to the `publish-images` push path filter
- ensures harness-server-only changes rebuild/publish the `centaur-agent` sandbox image

Prompted by: mslipper