### PR TITLE
Fix slackbotv2 handoff wedges

### DIFF
--- a/services/slackbotv2/src/index.ts
+++ b/services/slackbotv2/src/index.ts
@@ -108,6 +108,8 @@ type SlackbotV2RequestContext = {
 }
 
 const requestContext = new AsyncLocalStorage<SlackbotV2RequestContext>()
+const ACTIVE_EXECUTION_TTL_MS = 30 * 60 * 1000
+const WEBHOOK_HANDOFF_TIMEOUT_MS = 30_000
 const RENDER_OBLIGATION_INDEX_KEY = 'slackbotv2:render:index'
 const RENDER_OBLIGATION_INDEX_MAX_LENGTH = 2000
 const RENDER_INDEX_TTL_MS = 30 * 24 * 60 * 60 * 1000
@@ -129,6 +131,13 @@ const LATE_SLACK_FILE_CONSUMED_TTL_MS = 5 * 60_000
 const LATE_SLACK_FILE_IDLE_WAIT_MS = 90_000
 const LATE_SLACK_FILE_IDLE_POLL_MS = 500
 const LATE_SLACK_FILE_MESSAGE_TEXT = 'Late Slack file attachment for the previous message.'
+
+class HandoffTimeoutError extends Error {
+  constructor(timeoutMs: number) {
+    super(`Slack webhook handoff timed out after ${timeoutMs}ms`)
+    this.name = 'AbortError'
+  }
+}
 
 type PendingLateSlackFileMention = {
   channel: string
@@ -266,10 +275,12 @@ export function createSlackbotV2(options: SlackbotV2Options): SlackbotV2 {
       })
       if (awaitHandoff && response.ok) {
         const waitStartedAtMs = nowMs()
+        const timeoutMs = webhookHandoffTimeoutMs(options)
         const waitFields = {
           ...webhookFields,
           response_status: response.status,
-          task_count: handoffTasks.length
+          task_count: handoffTasks.length,
+          timeout_ms: timeoutMs
         }
         traceLog(options, 'slackbotv2_webhook_handoff_wait_started', undefined, waitFields)
         const stopPendingLog = startPendingOperationLog(
@@ -281,7 +292,7 @@ export function createSlackbotV2(options: SlackbotV2Options): SlackbotV2 {
         )
         let waitError: unknown
         try {
-          await Promise.all(handoffTasks)
+          await waitForWebhookHandoff(handoffTasks, timeoutMs)
         } catch (error) {
           waitError = error
           if (isRetryableSessionApiError(error)) context.retryableErrors.push(error)
@@ -529,6 +540,33 @@ function recordFallback(outcome: string, startedAtMs: number): void {
   }
 }
 
+function webhookHandoffTimeoutMs(options: SlackbotV2Options): number {
+  return options.webhookHandoffTimeoutMs ?? WEBHOOK_HANDOFF_TIMEOUT_MS
+}
+
+async function waitForWebhookHandoff(
+  handoffTasks: Promise<unknown>[],
+  timeoutMs: number
+): Promise<void> {
+  const handoff = Promise.all(handoffTasks)
+  let timer: ReturnType<typeof globalThis.setTimeout> | undefined
+  const timeout = new Promise<never>((_, reject) => {
+    timer = globalThis.setTimeout(() => {
+      reject(new HandoffTimeoutError(timeoutMs))
+    }, timeoutMs)
+    const unref = (timer as { unref?: () => void }).unref
+    if (unref) unref.call(timer)
+  })
+  try {
+    await Promise.race([handoff, timeout])
+  } catch (error) {
+    void handoff.catch(() => undefined)
+    throw error
+  } finally {
+    if (timer !== undefined) globalThis.clearTimeout(timer)
+  }
+}
+
 function createDefaultState(options: SlackbotV2Options, logger: Logger): StateAdapter {
   const stateLogger = logger.child('postgres-state')
   // Own the pool so we can attach an error handler. pg.Pool emits 'error' for
@@ -577,6 +615,16 @@ async function ensureStateConnected(state: StateAdapter, options: SlackbotV2Opti
   }
 }
 
+export function hasLiveActiveExecution(
+  state: Pick<SlackbotV2ThreadState, 'activeExecution' | 'activeExecutionStartedAt'>,
+  ttlMs: number,
+  nowEpochMs = Date.now()
+): boolean {
+  if (state.activeExecution !== true) return false
+  if (typeof state.activeExecutionStartedAt !== 'number') return false
+  return nowEpochMs - state.activeExecutionStartedAt <= ttlMs
+}
+
 /**
  * Persists a Slack thread update into the session API. In execute mode the create/append/execute
  * handoff completes before Slack is acknowledged; SSE rendering continues in background.
@@ -596,8 +644,12 @@ async function syncThreadMessageToSession(
   const state = (await thread.state) ?? {}
   const messageIds = new Set(state.forwardedMessageIds ?? [])
   const executedMessageIds = new Set(state.executedMessageIds ?? [])
+  const liveActiveExecution = hasLiveActiveExecution(
+    state,
+    input.options.activeExecutionTtlMs ?? ACTIVE_EXECUTION_TTL_MS
+  )
   const shouldStartExecution =
-    input.mode === 'execute' && state.activeExecution !== true && !executedMessageIds.has(message.id)
+    input.mode === 'execute' && !liveActiveExecution && !executedMessageIds.has(message.id)
   const shouldRefreshThreadContext = shouldStartExecution && isSlackThreadReply(message)
   const shouldIncludeContext =
     shouldStartExecution && (state.historyForwarded !== true || shouldRefreshThreadContext)
@@ -622,6 +674,7 @@ async function syncThreadMessageToSession(
   }
   traceLog(input.options, 'slackbotv2_forward_started', trace, {
     active_execution: state.activeExecution === true,
+    active_execution_live: liveActiveExecution,
     history_forwarded: state.historyForwarded === true
   })
   const assistantStatusVisible = shouldStartExecution
@@ -812,6 +865,7 @@ async function syncThreadMessageToSession(
     await thread.setState({
       ...(stickyOverridesUpdate ?? {}),
       activeExecution: true,
+      activeExecutionStartedAt: Date.now(),
       executedMessageIds: Array.from(latestExecutedMessageIds).slice(-1000),
       lastEventId,
       renderObligation: {
@@ -868,7 +922,10 @@ async function syncThreadMessageToSession(
   }
 
   try {
-    await thread.setState({ activeExecution: true })
+    await thread.setState({
+      activeExecution: true,
+      activeExecutionStartedAt: Date.now()
+    })
     traceLog(input.options, 'slackbotv2_forward_active_execution_marked', trace)
     await forwardToSessionApi(input.options, forwardInput, {
       onExecutionStarted: commitExecutionStarted,
@@ -897,6 +954,7 @@ async function syncThreadMessageToSession(
     const latest = (await thread.state) ?? {}
     await thread.setState({
       activeExecution: false,
+      activeExecutionStartedAt: null,
       lastEventId: Math.max(latest.lastEventId ?? 0, lastEventId)
     })
     if (isRetryableSessionApiError(error)) {
@@ -1149,6 +1207,7 @@ async function renderExecutionAttempt(
     const latest = (await thread.state) ?? {}
     await thread.setState({
       activeExecution: retry,
+      activeExecutionStartedAt: retry ? Date.now() : null,
       lastEventId: Math.max(latest.lastEventId ?? 0, getLastEventId(), fallbackLastEventId),
       ...(rendered ? { renderObligation: null } : {})
     })
@@ -1387,6 +1446,7 @@ async function recoverRenderObligations(
         })
         await thread.setState({
           activeExecution: false,
+          activeExecutionStartedAt: null,
           lastEventId: threadState?.lastEventId ?? 0,
           renderObligation: null
         })
@@ -1412,6 +1472,7 @@ async function recoverRenderObligations(
         )
         await thread.setState({
           activeExecution: false,
+          activeExecutionStartedAt: null,
           lastEventId: threadState?.lastEventId ?? 0,
           renderObligation: null
         })
@@ -1585,6 +1646,7 @@ async function recoverRenderObligation(
     await renderRecoveredExecutionStream(thread, streamError(error), obligation.message, options, trace)
     await thread.setState({
       activeExecution: false,
+      activeExecutionStartedAt: null,
       lastEventId,
       renderObligation: null
     })
@@ -1597,6 +1659,7 @@ async function recoverRenderObligation(
   try {
     await thread.setState({
       activeExecution: true,
+      activeExecutionStartedAt: Date.now(),
       lastEventId
     })
     const streamResult = await renderRecoveredExecutionStream(
@@ -1695,6 +1758,7 @@ async function recoverRenderObligation(
     const latest = (await thread.state) ?? {}
     await thread.setState({
       activeExecution: false,
+      activeExecutionStartedAt: null,
       lastEventId: Math.max(latest.lastEventId ?? 0, lastEventId),
       ...(rendered ? { renderObligation: null } : {})
     })
@@ -2312,7 +2376,11 @@ async function waitForThreadIdle(
   const startedAtMs = nowMs()
   while (elapsedMs(startedAtMs) < LATE_SLACK_FILE_IDLE_WAIT_MS) {
     const latest = (await thread.state) ?? {}
-    if (latest.activeExecution !== true) return true
+    if (
+      !hasLiveActiveExecution(latest, options.activeExecutionTtlMs ?? ACTIVE_EXECUTION_TTL_MS)
+    ) {
+      return true
+    }
     traceLog(options, 'slackbotv2_late_file_repair_waiting_for_idle', trace, {
       waited_ms: elapsedMs(startedAtMs)
     })

--- a/services/slackbotv2/src/server.ts
+++ b/services/slackbotv2/src/server.ts
@@ -25,6 +25,7 @@ const consoleLogger = {
 }
 
 const options: SlackbotV2Options = {
+  activeExecutionTtlMs: optionalNumberEnv('SLACKBOTV2_ACTIVE_EXECUTION_TTL_MS'),
   apiUrl,
   apiKey: optionalEnv('SLACKBOT_API_KEY'),
   assistantStatus: optionalEnv('SLACKBOTV2_ASSISTANT_STATUS'),
@@ -55,6 +56,7 @@ const options: SlackbotV2Options = {
   slackApiTimeoutMs: optionalNumberEnv('SLACKBOTV2_SLACK_API_TIMEOUT_MS'),
   stateKeyPrefix: optionalEnv('SLACKBOTV2_STATE_KEY_PREFIX'),
   userName: stringEnv('SLACKBOTV2_USER_NAME', 'centaur'),
+  webhookHandoffTimeoutMs: optionalNumberEnv('SLACKBOTV2_WEBHOOK_HANDOFF_TIMEOUT_MS'),
   logger: consoleLogger
 }
 

--- a/services/slackbotv2/src/types.ts
+++ b/services/slackbotv2/src/types.ts
@@ -94,6 +94,11 @@ export type SlackbotV2ExecuteSessionResponse = {
 export type SlackbotV2Fetch = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>
 
 export type SlackbotV2Options = {
+  /**
+   * Milliseconds a persisted active-execution marker is trusted. Older markers
+   * are treated as stale so a crash mid-handoff cannot wedge a Slack thread.
+   */
+  activeExecutionTtlMs?: number
   allowedExternalTeamIds?: readonly string[]
   apiKey?: string
   apiUrl: string
@@ -147,6 +152,8 @@ export type SlackbotV2Options = {
   streamTaskDisplayMode?: 'none' | 'plan' | 'timeline'
   triggerBotAllowlist?: readonly string[]
   userName?: string
+  /** Deadline for the Slack webhook's foreground handoff wait. */
+  webhookHandoffTimeoutMs?: number
   mapper?: CodexAppServerToChatStreamOptions
 }
 
@@ -157,6 +164,7 @@ export type SlackbotV2 = {
 
 export type SlackbotV2ThreadState = {
   activeExecution?: boolean
+  activeExecutionStartedAt?: number | null
   executedMessageIds?: string[]
   forwardedMessageIds?: string[]
   /** Last thread-level harness selected by Slack flags. Null clears persisted state. */

--- a/services/slackbotv2/test/chat-sdk-emulate.test.ts
+++ b/services/slackbotv2/test/chat-sdk-emulate.test.ts
@@ -13,6 +13,7 @@ import { createMemoryState } from '@chat-adapter/state-memory'
 import type { ServerNotification } from '@centaur/harness-events'
 import {
   createSlackbotV2,
+  hasLiveActiveExecution,
   normalizeSlackText,
   type SlackbotV2,
   type SlackbotV2AppendMessagesRequest,
@@ -49,6 +50,34 @@ describe('normalizeSlackText', () => {
     expect(normalizeSlackText('<#C0AJ07U8Z1N|eng-centaur>')).toBe(
       '#eng-centaur (C0AJ07U8Z1N)'
     )
+  })
+})
+
+describe('hasLiveActiveExecution', () => {
+  const ttlMs = 30 * 60 * 1000
+
+  it('trusts only fresh active-execution markers', () => {
+    const now = 1_000_000_000
+    expect(hasLiveActiveExecution({}, ttlMs, now)).toBe(false)
+    expect(hasLiveActiveExecution({ activeExecution: false }, ttlMs, now)).toBe(false)
+    expect(
+      hasLiveActiveExecution(
+        { activeExecution: true, activeExecutionStartedAt: now - 1_000 },
+        ttlMs,
+        now
+      )
+    ).toBe(true)
+    expect(
+      hasLiveActiveExecution(
+        { activeExecution: true, activeExecutionStartedAt: now - ttlMs - 1 },
+        ttlMs,
+        now
+      )
+    ).toBe(false)
+    expect(hasLiveActiveExecution({ activeExecution: true }, ttlMs, now)).toBe(false)
+    expect(
+      hasLiveActiveExecution({ activeExecution: true, activeExecutionStartedAt: null }, ttlMs, now)
+    ).toBe(false)
   })
 })
 
@@ -430,6 +459,47 @@ describe('slackbotv2', () => {
         model: 'claude-fable-5'
       })
     )
+  })
+
+  it('does not let a stale activeExecution flag block a new execution', async () => {
+    const sharedState = createMemoryState()
+    await sharedState.connect()
+    bot = createTestBot({ activeExecutionTtlMs: 50, state: sharedState })
+
+    const parent = await postUserMessage('Context before stale active execution.')
+    const mention = await postUserMessage(`<@${BOT_USER_ID}> run despite stale state`, parent.ts)
+    const key = threadKey(parent.ts)
+    await sharedState.set(`thread-state:${key}`, {
+      activeExecution: true,
+      activeExecutionStartedAt: Date.now() - 1_000,
+      forwardedMessageIds: [parent.ts],
+      historyForwarded: true,
+      lastEventId: 0
+    })
+
+    const waits: Promise<unknown>[] = []
+    const response = await bot.app.request(
+      '/api/webhooks/slack',
+      signedSlackEvent({
+        event_id: 'Ev-slackbotv2-stale-active-execution',
+        event: {
+          type: 'app_mention',
+          user: USER_ID,
+          channel: CHANNEL_ID,
+          team: TEAM_ID,
+          ts: mention.ts,
+          thread_ts: parent.ts,
+          text: `<@${BOT_USER_ID}> run despite stale state`
+        }
+      }),
+      {},
+      waitUntilContext(waits)
+    )
+
+    expect(response.status).toBe(200)
+    await Promise.all(waits)
+    expect(codexApi.executes).toHaveLength(1)
+    expect(codexApi.executes[0]?.threadKey).toBe(key)
   })
 
   it('appends an Open-session-in-Console context block to the first assistant message only', async () => {
@@ -3218,6 +3288,63 @@ describe('slackbotv2', () => {
         .filter(call => call.method === 'assistant.threads.setStatus')
         .map(call => stringField(call.body.status))
     ).toEqual(expect.arrayContaining(['Thinking...', '']))
+  })
+
+  it('bounds foreground webhook handoff waits and asks Slack to retry', async () => {
+    const logs: CapturedLog[] = []
+    bot = createTestBot({
+      logger: captureLogger(logs),
+      sessionApiTimeoutMs: 5_000,
+      webhookHandoffTimeoutMs: 25
+    })
+    const releaseExecute = codexApi.holdNextExecute()
+
+    const parent = await postUserMessage('Context before the wedged run.')
+    const mention = await postUserMessage(`<@${BOT_USER_ID}> do not wait forever`, parent.ts)
+    const waits: Promise<unknown>[] = []
+    try {
+      const response = await bot.app.request(
+        '/api/webhooks/slack',
+        signedSlackEvent({
+          event_id: 'Ev-slackbotv2-handoff-timeout',
+          event: {
+            type: 'app_mention',
+            user: USER_ID,
+            channel: CHANNEL_ID,
+            team: TEAM_ID,
+            ts: mention.ts,
+            thread_ts: parent.ts,
+            text: `<@${BOT_USER_ID}> do not wait forever`
+          }
+        }),
+        {},
+        waitUntilContext(waits)
+      )
+
+      expect(response.status).toBe(503)
+      expect(await response.text()).toBe('temporary upstream unavailable')
+      await waitFor(() => hasLog(logs, 'slackbotv2_webhook_handoff_wait_complete'))
+      expect(logData(logs, 'slackbotv2_webhook_handoff_wait_complete')).toEqual(
+        expect.objectContaining({
+          error: 'Slack webhook handoff timed out after 25ms',
+          retryable_error_count: 1,
+          slack_event_id: 'Ev-slackbotv2-handoff-timeout',
+          timeout_ms: 25
+        })
+      )
+      expect(logData(logs, 'slackbotv2_webhook_retry_requested')).toEqual(
+        expect.objectContaining({
+          error: 'Slack webhook handoff timed out after 25ms'
+        })
+      )
+    } finally {
+      releaseExecute()
+    }
+    await waitFor(() => codexApi.executes.length === 1, 3000)
+    await waitFor(() => hasLog(logs, 'slackbotv2_handoff_complete'), 3000)
+    await waitFor(() => codexApi.eventRequests.length === 1, 3000)
+    codexApi.closeStreams()
+    await Promise.all(waits)
   })
 
   it('does not wait for hung assistant status before creating Slack sessions', async () => {


### PR DESCRIPTION
## Summary

- Add a foreground Slack webhook handoff timeout so captured handoff promises cannot keep HTTP requests pending indefinitely.
- Track `activeExecutionStartedAt` for Slackbot thread state and treat old or timestamp-less active-execution markers as stale.
- Clear or refresh the active-execution timestamp consistently across live render, retry, recovery, stale recovery, and late-file idle checks.
- Add emulator coverage for stale active-execution recovery and bounded webhook handoff retries.

## Root Cause

`slackbotv2` waited on captured Chat SDK handoff promises with an unbounded `Promise.all`. If a handoff task wedged, the Slack webhook request stayed open until the process restarted. Separately, Slackbot persisted `activeExecution: true` without a timestamp/TTL, so a crash or stalled render path could make a thread look active forever.

## Validation

- `pnpm --filter slackbotv2 exec bun test test/chat-sdk-emulate.test.ts`
- `pnpm --filter slackbotv2 run check:types`
- `pnpm --filter slackbotv2 test`
