### PR TITLE
Add Slack stop command for active sessions

### DIFF
--- a/services/api-rs/crates/centaur-api-server/src/routes.rs
+++ b/services/api-rs/crates/centaur-api-server/src/routes.rs
@@ -56,7 +56,8 @@ use crate::{
     ApiError,
     mcp::{mcp_get, mcp_post, mcp_protected_resource_metadata},
     types::{
-        AppendMessagesRequest, AppendMessagesResponse, CreateSessionRequest, CreateSessionResponse,
+        AppendMessagesRequest, AppendMessagesResponse, CancelSessionExecutionRequest,
+        CancelSessionExecutionResponse, CreateSessionRequest, CreateSessionResponse,
         EmitWorkflowEventRequest, EventsQuery, ExecuteSessionRequest, ExecuteSessionResponse,
         ListWorkflowRunsQuery, OnHarnessConflict, SessionContextResponse, SessionSseEvent,
         SlackThreadContext, stream_error_sse,
@@ -218,6 +219,10 @@ pub fn build_router_with_app_state(state: AppState) -> Router {
         .route(
             "/api/session/{thread_key}/execute",
             post(execute_session).layer(DefaultBodyLimit::disable()),
+        )
+        .route(
+            "/api/session/{thread_key}/cancel",
+            post(cancel_session_execution),
         )
         .route("/api/session/{thread_key}/events", get(stream_events))
         .route("/api/sandboxes/drain", post(drain_sandboxes))
@@ -511,6 +516,30 @@ async fn execute_session(
         execution_id: execution.execution_id,
         thread_key: execution.thread_key,
         status: execution.status.to_string(),
+    }))
+}
+
+async fn cancel_session_execution(
+    State(state): State<AppState>,
+    Path(raw_thread_key): Path<String>,
+    Json(request): Json<CancelSessionExecutionRequest>,
+) -> Result<Json<CancelSessionExecutionResponse>, ApiError> {
+    let thread_key = ThreadKey::try_from(raw_thread_key)?;
+    let reason = request
+        .reason
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or("Cancelled from Slack");
+    let outcome = state
+        .runtime()?
+        .cancel_active_execution(&thread_key, reason)
+        .await?;
+    Ok(Json(CancelSessionExecutionResponse {
+        ok: true,
+        cancelled: outcome.cancelled,
+        execution_id: outcome.execution_id,
+        thread_key,
     }))
 }
 

--- a/services/api-rs/crates/centaur-api-server/src/types.rs
+++ b/services/api-rs/crates/centaur-api-server/src/types.rs
@@ -77,6 +77,19 @@ pub struct ExecuteSessionResponse {
     pub status: String,
 }
 
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct CancelSessionExecutionRequest {
+    pub reason: Option<String>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct CancelSessionExecutionResponse {
+    pub ok: bool,
+    pub cancelled: bool,
+    pub execution_id: Option<String>,
+    pub thread_key: ThreadKey,
+}
+
 #[derive(Clone, Debug, Deserialize)]
 pub struct EventsQuery {
     pub after_event_id: Option<i64>,

--- a/services/api-rs/crates/centaur-session-runtime/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-runtime/src/lib.rs
@@ -272,6 +272,12 @@ pub struct CreateOrGetSessionOutcome {
     pub harness_switched: bool,
 }
 
+#[derive(Clone, Debug)]
+pub struct CancelExecutionOutcome {
+    pub cancelled: bool,
+    pub execution_id: Option<String>,
+}
+
 /// Outcome of [`SessionRuntime::drain`]: the sandboxes that were stopped and
 /// any that failed to stop (with the backend error text).
 #[derive(Debug, Default)]
@@ -2078,6 +2084,61 @@ impl SessionRuntime {
         {
             warn!(%thread_key, %error, "failed to record steering delivery");
         }
+    }
+
+    pub async fn cancel_active_execution(
+        &self,
+        thread_key: &ThreadKey,
+        reason: &str,
+    ) -> Result<CancelExecutionOutcome, SessionRuntimeError> {
+        let Some(execution) = self.store.active_execution_for_thread(thread_key).await? else {
+            return Ok(CancelExecutionOutcome {
+                cancelled: false,
+                execution_id: None,
+            });
+        };
+        let session = self.store.get_session(thread_key).await?;
+        if let Some(sandbox_id) = session.sandbox_id.as_deref() {
+            self.sandbox_pipes.remove(sandbox_id);
+            match self
+                .sandbox_runtime
+                .manager
+                .stop(&SandboxId::new(sandbox_id))
+                .await
+            {
+                Ok(()) | Err(SandboxError::NotFound(_)) => {}
+                Err(error) => return Err(SessionRuntimeError::Sandbox(error)),
+            }
+            self.store
+                .clear_sandbox_id_if_matches(thread_key, sandbox_id)
+                .await?;
+        }
+        let Some(cancelled) = self
+            .store
+            .cancel_execution_if_active(&execution.execution_id, reason)
+            .await?
+        else {
+            return Ok(CancelExecutionOutcome {
+                cancelled: false,
+                execution_id: Some(execution.execution_id),
+            });
+        };
+        self.store
+            .append_event(
+                thread_key,
+                Some(cancelled.execution_id.as_str()),
+                "session.execution_cancelled",
+                json!({
+                    "execution_id": cancelled.execution_id,
+                    "thread_key": thread_key.as_str(),
+                    "error": reason,
+                }),
+            )
+            .await?;
+        Ok(CancelExecutionOutcome {
+            cancelled: true,
+            execution_id: Some(cancelled.execution_id),
+        })
     }
 
     async fn wait_for_active_steering_pipe(

--- a/services/api-rs/crates/centaur-session-sqlx/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-sqlx/src/lib.rs
@@ -782,6 +782,40 @@ impl PgSessionStore {
         row.try_into().map(Some)
     }
 
+    pub async fn cancel_execution_if_active(
+        &self,
+        execution_id: &str,
+        error: &str,
+    ) -> Result<Option<SessionExecution>, SessionStoreError> {
+        let row = sqlx::query_as::<_, SessionExecutionRow>(
+            r#"
+            update session_executions
+            set status = $2,
+                error = $3,
+                completed_at = coalesce(completed_at, now()),
+                stdout_owner_id = null,
+                stdout_owner_lease_expires_at = null,
+                updated_at = now()
+            where execution_id = $1 and status in ($4, $5)
+            returning execution_id, idempotency_key, thread_key, status, metadata, error, created_at, updated_at, started_at, completed_at
+            "#,
+        )
+        .bind(execution_id)
+        .bind(ExecutionStatus::Cancelled.as_ref())
+        .bind(error)
+        .bind(ExecutionStatus::Queued.as_ref())
+        .bind(ExecutionStatus::Running.as_ref())
+        .fetch_optional(&self.pool)
+        .await?;
+
+        let Some(row) = row else {
+            return Ok(None);
+        };
+        self.set_session_status(&row.thread_key, SessionStatus::Idle)
+            .await?;
+        row.try_into().map(Some)
+    }
+
     pub async fn fail_execution_if_active_and_stdout_owner(
         &self,
         execution_id: &str,

--- a/services/slackbotv2/src/index.ts
+++ b/services/slackbotv2/src/index.ts
@@ -28,6 +28,7 @@ import { renderSlackDisplayText, slackMessagePromptText } from './slack-display-
 import { slackUserIdForMessage } from './slack-user'
 import {
   collectInitialContext,
+  cancelSessionExecution,
   forwardToSessionApi,
   harnessRestartPreamble,
   isRetryableSessionApiError,
@@ -45,6 +46,7 @@ import {
 } from './console-session-link'
 import { extractMessageOverrides } from './overrides'
 import { isAllowedSlackMessage, isAllowedSlackWebhookBody } from './slack-events'
+import { isSlackStopCommand } from './stop-command'
 import type {
   ForwardSessionInput,
   JsonObject,
@@ -205,6 +207,7 @@ export function createSlackbotV2(options: SlackbotV2Options): SlackbotV2 {
 
   chat.onNewMention(async (thread, message) => {
     if (!isAllowedSlackMessage(message, options, logger)) return
+    if (await handleSlackStopCommand(thread, message, options, 'new_mention')) return
     lateSlackFiles.rememberFilelessMention(thread, message)
     await handleSlackMessageHandoff(thread, message, {
       assistantStatusRequested: true,
@@ -218,6 +221,9 @@ export function createSlackbotV2(options: SlackbotV2Options): SlackbotV2 {
 
   chat.onSubscribedMessage(async (thread, message) => {
     if (!isAllowedSlackMessage(message, options, logger)) return
+    if (message.isMention === true) {
+      if (await handleSlackStopCommand(thread, message, options, 'subscribed_message')) return
+    }
     lateSlackFiles.rememberFilelessMention(thread, message)
     await handleSlackMessageHandoff(thread, message, {
       assistantStatusRequested: message.isMention === true,
@@ -329,6 +335,42 @@ export function createSlackbotV2(options: SlackbotV2Options): SlackbotV2 {
   }
 
   return { app, chat }
+}
+
+async function handleSlackStopCommand(
+  thread: Thread<SlackbotV2ThreadState>,
+  message: ChatMessage,
+  options: SlackbotV2Options,
+  trigger: string
+): Promise<boolean> {
+  if (!isSlackStopCommand(message)) return false
+  const trace = createHandoffTrace(thread, message, 'append')
+  traceLog(options, 'slackbotv2_stop_command_started', trace, { trigger })
+  const latest = (await thread.state) ?? {}
+  const reason = `Cancelled from Slack by ${slackUserIdForMessage(message) ?? 'unknown user'}`
+  let cancelled = false
+  try {
+    const response = await cancelSessionExecution(options, thread.id, reason)
+    cancelled = response.cancelled
+    await thread.setState({
+      activeExecution: false,
+      lastEventId: latest.lastEventId ?? latest.renderObligation?.afterEventId ?? 0,
+      renderObligation: null
+    })
+    await setAssistantStatus(thread, '', options, trace)
+    traceLog(options, 'slackbotv2_stop_command_complete', trace, {
+      cancelled,
+      execution_id: response.execution_id,
+      trigger
+    })
+    return true
+  } catch (error) {
+    traceWarn(options, 'slackbotv2_stop_command_failed', trace, {
+      error: errorMessage(error),
+      trigger
+    })
+    throw error
+  }
 }
 
 async function handleSlackMessageHandoff(

--- a/services/slackbotv2/src/session-api.ts
+++ b/services/slackbotv2/src/session-api.ts
@@ -9,6 +9,7 @@ import type {
   SlackbotV2ApiMessageLink,
   SlackbotV2ApiMessage,
   SlackbotV2AppendMessagesRequest,
+  SlackbotV2CancelSessionResponse,
   SlackbotV2CreateSessionRequest,
   SlackbotV2ExecuteSessionRequest,
   SlackbotV2ExecuteSessionResponse,
@@ -555,6 +556,19 @@ export async function openSessionEventStream(
     phase_ms: elapsedMs(streamStartedAtMs)
   })
   return stream
+}
+
+export async function cancelSessionExecution(
+  options: SlackbotV2Options,
+  threadId: string,
+  reason: string
+): Promise<SlackbotV2CancelSessionResponse> {
+  return recordSessionApiOperation(
+    'cancel_session',
+    () => postCancelSessionExecution(options, threadId, reason),
+    sessionApiTimeoutMs(options),
+    'cancel session'
+  )
 }
 
 const RESTART_CONTEXT_MAX_CHARS = 24_000
@@ -1226,6 +1240,27 @@ async function executeSession(
   )
   await ensureApiOk(response, 'execute session')
   return (await response.json()) as SlackbotV2ExecuteSessionResponse
+}
+
+async function postCancelSessionExecution(
+  options: SlackbotV2Options,
+  threadId: string,
+  reason: string
+): Promise<SlackbotV2CancelSessionResponse> {
+  const fetchFn = options.fetch ?? fetch
+  const response = await fetchWithTimeout(
+    fetchFn,
+    apiSessionUrl(options.apiUrl, threadId, 'cancel'),
+    {
+      method: 'POST',
+      headers: apiHeaders(options),
+      body: JSON.stringify({ reason })
+    },
+    sessionApiTimeoutMs(options),
+    'cancel session'
+  )
+  await ensureApiOk(response, 'cancel session')
+  return (await response.json()) as SlackbotV2CancelSessionResponse
 }
 
 async function ensureApiOk(response: Response, action: string): Promise<void> {

--- a/services/slackbotv2/src/stop-command.ts
+++ b/services/slackbotv2/src/stop-command.ts
@@ -1,0 +1,6 @@
+export function isSlackStopCommand(message: { text: string }): boolean {
+  const text = message.text.trim()
+  if (!text) return false
+  const withoutMentions = text.replace(/<@[A-Z0-9]+(?:\|[^>]+)?>/g, ' ').trim()
+  return /\bstop\b/i.test(withoutMentions)
+}

--- a/services/slackbotv2/src/types.ts
+++ b/services/slackbotv2/src/types.ts
@@ -91,6 +91,13 @@ export type SlackbotV2ExecuteSessionResponse = {
   thread_key: string
 }
 
+export type SlackbotV2CancelSessionResponse = {
+  cancelled: boolean
+  execution_id?: string
+  ok: boolean
+  thread_key: string
+}
+
 export type SlackbotV2Fetch = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>
 
 export type SlackbotV2Options = {

--- a/services/slackbotv2/test/session-api.test.ts
+++ b/services/slackbotv2/test/session-api.test.ts
@@ -3,6 +3,7 @@ import {
   clearConversationNameCacheForTests,
   clearRequesterIdentityCacheForTests,
   DEFAULT_SESSION_IDLE_TIMEOUT_MS,
+  cancelSessionExecution,
   forwardToSessionApi,
   harnessRestartPreamble,
   openSessionEventStream,
@@ -80,6 +81,14 @@ function fakeApi(responses: { createSession?: Array<{ body?: unknown; status: nu
         execution_id: 'exec-1',
         ok: true,
         status: 'running',
+        thread_key: 'slack:C1:1700000000.000100'
+      })
+    }
+    if (url.endsWith('/cancel')) {
+      return Response.json({
+        cancelled: true,
+        execution_id: 'exec-1',
+        ok: true,
         thread_key: 'slack:C1:1700000000.000100'
       })
     }
@@ -184,6 +193,25 @@ describe('session event streaming', () => {
       eventKind: 'session.execution_completed'
     })
     expect(seenEventIds).toEqual([1, 2])
+  })
+})
+
+describe('session cancellation', () => {
+  test('posts cancellation reason to the thread cancel endpoint', async () => {
+    const { fetchFn, requests } = fakeApi()
+
+    const response = await cancelSessionExecution(
+      options(fetchFn),
+      'slack:C1:1700000000.000100',
+      'Cancelled from Slack by U1'
+    )
+
+    expect(response.cancelled).toBe(true)
+    const cancel = requests.find(request => request.url.endsWith('/cancel'))
+    expect(cancel?.url).toBe(
+      'http://api.test/api/session/slack%3AC1%3A1700000000.000100/cancel'
+    )
+    expect(cancel?.body).toEqual({ reason: 'Cancelled from Slack by U1' })
   })
 })
 

--- a/services/slackbotv2/test/stop-command.test.ts
+++ b/services/slackbotv2/test/stop-command.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, test } from 'bun:test'
+import { isSlackStopCommand } from '../src/stop-command'
+
+describe('Slack stop command detection', () => {
+  test('matches mention plus stop keyword', () => {
+    expect(isSlackStopCommand({ text: '<@UCENTAUR> stop' })).toBe(true)
+    expect(isSlackStopCommand({ text: 'please <@UCENTAUR> STOP now' })).toBe(true)
+  })
+
+  test('does not match unrelated mentions', () => {
+    expect(isSlackStopCommand({ text: '<@UCENTAUR> status' })).toBe(false)
+    expect(isSlackStopCommand({ text: '<@UCENTAUR> stopping by to ask' })).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary
- add a session cancel API endpoint that marks the active execution cancelled and stops the assigned sandbox
- wire Slack mention messages containing the `stop` keyword to cancel the current thread instead of starting another turn
- add focused Slackbot tests for cancel requests and stop-command detection

## Verification
- `bun test services/slackbotv2/test/session-api.test.ts services/slackbotv2/test/stop-command.test.ts`
- `cargo fmt --check` from `services/api-rs`
- `cargo test -p centaur-session-sqlx -p centaur-session-runtime -p centaur-api-server cancel --manifest-path services/api-rs/Cargo.toml`

Note: `bun run --cwd services/slackbotv2 check:types` is blocked in this checkout because the `tsgo` script binary is not installed.

Prompted by: @DaniPopes