### PR TITLE
Use nightly for Rust fmt and clippy instructions

### DIFF
--- a/services/sandbox/Dockerfile
+++ b/services/sandbox/Dockerfile
@@ -149,11 +149,13 @@ ARG BUN_VERSION=bun-v1.3.13
 
 # ── Agent-scoped toolchains ─────────────────────────────────────────────────
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
-      | sh -s -- -y --profile minimal --component rustfmt --component clippy \
+      | sh -s -- -y --profile minimal --default-toolchain nightly --component rustfmt --component clippy \
+    && rustup toolchain install stable --profile minimal \
     && rustc --version \
     && cargo --version \
-    && rustfmt --version \
-    && clippy-driver --version \
+    && cargo +stable --version \
+    && cargo +nightly fmt --version \
+    && cargo +nightly clippy --version \
     && rm -rf "$HOME/.rustup/toolchains"/*/share/doc "$HOME/.rustup/toolchains"/*/share/man
 RUN --mount=type=cache,target=/home/agent/.cargo/registry,uid=1001,gid=1001,sharing=locked \
     --mount=type=cache,target=/home/agent/.cargo/git,uid=1001,gid=1001,sharing=locked \

--- a/services/sandbox/SYSTEM_PROMPT.md
+++ b/services/sandbox/SYSTEM_PROMPT.md
@@ -70,6 +70,11 @@
 |*NEVER run git commit/push inside* ~/github/ — it is read-only. Always use git-branch first.
 |Prefer `rg` (ripgrep) over `grep` for all codebase operations.
 
+[Rust policy — ALWAYS use nightly for formatting and clippy]
+|ALWAYS install both the Rust stable and nightly toolchains when provisioning Rust tooling, with nightly as the default toolchain.
+|ALWAYS run Rust formatting and clippy through nightly: use `cargo +nightly fmt <args>` and `cargo +nightly clippy <args>` instead of `cargo fmt` or `cargo clippy`.
+|For other cargo commands, prefer the repository's pinned/default toolchain unless the repo or user asks for nightly.
+
 [GitHub PR Attribution]
 |When opening a GitHub PR for a Slack request, attribute the requester in the PR body with one standalone `Prompted by: ...` line.
 |Use the [Requester Context] block when present: prefer the verified GitHub handle resolved from the requester's Slack profile; if none is configured, use the requester's Slack display name or username.


### PR DESCRIPTION
Summary:
- add a Rust policy requiring nightly for formatting and clippy commands
- install nightly as the default sandbox Rust toolchain with rustfmt and clippy

Tests:
- not run (prompt and Dockerfile instruction change only)

Prompted by: @DaniPopes