### PR TITLE
Add sandbox commit-msg hook

### DIFF
--- a/services/sandbox/Dockerfile
+++ b/services/sandbox/Dockerfile
@@ -198,6 +198,7 @@ RUN --mount=type=cache,target=/home/agent/.npm,uid=1001,gid=1001,sharing=locked 
 RUN mkdir -p ~/.amp/bin ~/.config/amp ~/.codex ~/.pi/agent ~/github ~/workspace \
     && git config --global init.defaultBranch main \
     && git config --global push.autoSetupRemote true \
+    && git config --global core.hooksPath /opt/centaur/git-hooks \
     && git config --global --add safe.directory '*' \
     && git config --global user.name "Centaur AI" \
     && git config --global user.email "ai@centaur.local"
@@ -217,6 +218,7 @@ RUN rm -f /etc/sudoers.d/agent
 # Pre-create it as 0755 so the agent user can traverse into it at runtime.
 RUN install -d -m 0755 /etc/centaur /opt/centaur
 COPY --link centaur_sdk/ /opt/centaur/centaur_sdk/
+COPY --link --chmod=0755 services/sandbox/git-hooks/ /opt/centaur/git-hooks/
 COPY --link --chown=1001:1001 tools/ /opt/centaur/tools/
 COPY --link --chmod=644 services/sandbox/codex-auth.json /etc/centaur/codex-auth.default.json
 COPY --link --chmod=644 services/sandbox/claude-credentials.json /etc/centaur/claude-credentials.default.json

--- a/services/sandbox/git-hooks/commit-msg
+++ b/services/sandbox/git-hooks/commit-msg
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+message_file="${1:?commit message file is required}"
+
+if rg -i -q \
+  -e 'generated with (claude|codex|amp)' \
+  -e 'co-authored-by:.*(claude|codex|anthropic|openai|amp)' \
+  "$message_file"; then
+  cat >&2 <<'EOF'
+Commit message contains generated-by or AI co-author attribution.
+
+Remove the generated attribution footer and commit again.
+EOF
+  exit 1
+fi

--- a/services/sandbox/git-hooks/commit-msg
+++ b/services/sandbox/git-hooks/commit-msg
@@ -2,6 +2,19 @@
 set -euo pipefail
 
 message_file="${1:?commit message file is required}"
+subject="$(sed -n '1p' "$message_file")"
+
+if ! [[ "$subject" =~ ^(feat|fix|docs|refactor|test|chore)(\([[:alnum:]_.-]+\))?!?:[[:space:]].+ ]]; then
+  cat >&2 <<'EOF'
+Commit message must use a conventional commit subject:
+
+  feat: add new behavior
+  fix(scope): correct existing behavior
+
+Allowed types: feat, fix, docs, refactor, test, chore.
+EOF
+  exit 1
+fi
 
 if rg -i -q \
   -e 'generated with (claude|codex|amp)' \


### PR DESCRIPTION
## Summary
- add a sandbox commit-msg hook under /opt/centaur/git-hooks
- set global core.hooksPath in the sandbox image
- block generated-by and AI co-author attribution footers in commit messages

## Test
- ran services/sandbox/git-hooks/commit-msg against normal and blocked sample messages
- git diff --check

Prompted by: @Zygimantass