### PR TITLE
Harden harness turn interrupts

### DIFF
--- a/crates/harness-server/src/codex.rs
+++ b/crates/harness-server/src/codex.rs
@@ -1,7 +1,11 @@
 use std::env;
 use std::io::{self, BufRead, Write};
 use std::process::{Child, ChildStdin, Command as ProcessCommand, Stdio};
-use std::sync::mpsc::{self, Receiver};
+use std::sync::{
+    Arc,
+    atomic::{AtomicBool, Ordering},
+    mpsc::{self, Receiver, RecvTimeoutError},
+};
 use std::thread;
 use std::time::Duration;
 
@@ -122,18 +126,57 @@ pub(crate) fn run_codex_blocks_server(config: CodexHarnessServer) -> Result<()> 
     // thread start (the app-server protocol has no per-turn provider), so this
     // lets a later conflicting override be surfaced rather than silently dropped.
     let mut thread_provider: Option<String> = None;
-    let mut blocks_state = BlocksState::default();
+    let (command_tx, command_rx) = mpsc::channel();
+    let (active_turn_tx, active_turn_rx) = mpsc::channel();
+    let turn_active = Arc::new(AtomicBool::new(false));
 
-    let stdin = io::stdin();
-    for raw in stdin.lock().lines() {
-        let line = raw?;
-        let trimmed = line.trim();
-        if trimmed.is_empty() {
-            continue;
-        }
+    {
+        let turn_active = Arc::clone(&turn_active);
+        thread::spawn(move || {
+            let stdin = io::stdin();
+            let mut blocks_state = BlocksState::default();
+            for raw in stdin.lock().lines() {
+                let Ok(line) = raw else {
+                    break;
+                };
+                let trimmed = line.trim();
+                if trimmed.is_empty() {
+                    continue;
+                }
 
-        match parse_blocks_line_with_state(trimmed, &mut blocks_state) {
-            Ok(BlocksCommand::User {
+                match parse_blocks_line_with_state(trimmed, &mut blocks_state) {
+                    Ok(BlocksCommand::Interrupt) if turn_active.load(Ordering::SeqCst) => {
+                        if active_turn_tx
+                            .send(CodexActiveTurnRequest::Interrupt)
+                            .is_err()
+                        {
+                            break;
+                        }
+                    }
+                    Ok(command) => {
+                        if command_tx
+                            .send(CodexBlocksReaderInput::Command(command))
+                            .is_err()
+                        {
+                            break;
+                        }
+                    }
+                    Err(error) => {
+                        if command_tx
+                            .send(CodexBlocksReaderInput::Error(error.to_string()))
+                            .is_err()
+                        {
+                            break;
+                        }
+                    }
+                }
+            }
+        });
+    }
+
+    while let Ok(input) = command_rx.recv() {
+        match input {
+            CodexBlocksReaderInput::Command(BlocksCommand::User {
                 input,
                 client_user_message_id,
                 model,
@@ -142,57 +185,76 @@ pub(crate) fn run_codex_blocks_server(config: CodexHarnessServer) -> Result<()> 
                 trace_context,
             }) => {
                 let traceparent = trace_context.effective_traceparent();
-                if codex.is_none() {
-                    otel::configure_codex_otel_for_startup(&trace_context)?;
-                    let mut child = CodexJsonRpcChild::spawn()?;
-                    initialize_codex(
-                        &mut child,
+                drain_codex_active_turn_requests(&active_turn_rx);
+                turn_active.store(true, Ordering::SeqCst);
+                let result = (|| -> Result<()> {
+                    if codex.is_none() {
+                        otel::configure_codex_otel_for_startup(&trace_context)?;
+                        let mut child = CodexJsonRpcChild::spawn()?;
+                        initialize_codex(
+                            &mut child,
+                            &mut stdout,
+                            &mut request_id,
+                            traceparent.as_deref(),
+                        )?;
+                        codex = Some(child);
+                    }
+                    let model = model.or_else(|| config.default_model());
+                    let model_provider =
+                        config.model_provider_for(provider.as_deref(), model.as_deref());
+                    run_codex_user_turn(
+                        codex.as_mut().expect("codex initialized"),
                         &mut stdout,
                         &mut request_id,
+                        &mut thread_id,
+                        &mut thread_provider,
+                        input,
+                        client_user_message_id,
+                        (model, model_provider),
+                        provider,
+                        reasoning,
+                        &active_turn_rx,
                         traceparent.as_deref(),
-                    )?;
-                    codex = Some(child);
-                }
-                let model = model.or_else(|| config.default_model());
-                let model_provider =
-                    config.model_provider_for(provider.as_deref(), model.as_deref());
-                if let Err(error) = run_codex_user_turn(
-                    codex.as_mut().expect("codex initialized"),
-                    &mut stdout,
-                    &mut request_id,
-                    &mut thread_id,
-                    &mut thread_provider,
-                    input,
-                    client_user_message_id,
-                    (model, model_provider),
-                    provider,
-                    reasoning,
-                    traceparent.as_deref(),
-                ) {
+                    )
+                })();
+                turn_active.store(false, Ordering::SeqCst);
+                drain_codex_active_turn_requests(&active_turn_rx);
+                if let Err(error) = result {
                     let fallback_thread_id = thread_id.as_deref().unwrap_or("codex");
                     eprintln!("Codex blocks turn failed: {error:#}");
                     write_blocks_error(&mut stdout, fallback_thread_id, "turn", error.to_string())?;
                 }
             }
-            Ok(BlocksCommand::Interrupt) => {
-                eprintln!(
-                    "Codex blocks interrupt ignored: no active stdin reader while a turn runs"
-                );
+            CodexBlocksReaderInput::Command(BlocksCommand::Interrupt) => {
+                eprintln!("Codex blocks interrupt ignored: no active turn runs");
             }
-            Ok(BlocksCommand::AttachmentChunk) => {}
-            Err(error) => {
-                eprintln!("invalid Codex blocks input: {error:#}");
+            CodexBlocksReaderInput::Command(BlocksCommand::AttachmentChunk) => {}
+            CodexBlocksReaderInput::Error(error) => {
+                eprintln!("invalid Codex blocks input: {error}");
                 write_blocks_error(
                     &mut stdout,
                     thread_id.as_deref().unwrap_or("codex"),
                     "input",
-                    error.to_string(),
+                    error,
                 )?;
             }
         }
     }
 
     Ok(())
+}
+
+enum CodexBlocksReaderInput {
+    Command(BlocksCommand),
+    Error(String),
+}
+
+enum CodexActiveTurnRequest {
+    Interrupt,
+}
+
+fn drain_codex_active_turn_requests(rx: &Receiver<CodexActiveTurnRequest>) {
+    while rx.try_recv().is_ok() {}
 }
 
 fn initialize_codex<W: Write>(
@@ -231,6 +293,7 @@ fn run_codex_user_turn<W: Write>(
     model_and_provider: (Option<String>, String),
     requested_provider: Option<String>,
     reasoning: Option<String>,
+    active_turn_rx: &Receiver<CodexActiveTurnRequest>,
     traceparent: Option<&str>,
 ) -> Result<()> {
     let (model, model_provider) = model_and_provider;
@@ -306,6 +369,9 @@ fn run_codex_user_turn<W: Write>(
             stdout,
             thread_id.as_deref().unwrap_or_default(),
             &turn_id,
+            active_turn_rx,
+            request_id,
+            traceparent,
         )? {
             TurnTermination::Done => return Ok(()),
             TurnTermination::RetriableEngineError { withheld } => {
@@ -504,12 +570,40 @@ impl CodexJsonRpcChild {
         stdout: &mut W,
         thread_id: &str,
         turn_id: &str,
+        active_turn_rx: &Receiver<CodexActiveTurnRequest>,
+        request_id: &mut i64,
+        traceparent: Option<&str>,
     ) -> Result<TurnTermination> {
         let mut guard = TurnGuard::default();
+        let mut interrupt_request_id = None;
         loop {
-            let value = self.read_value()?;
+            let value = match self.read_value_timeout(Duration::from_millis(50))? {
+                Some(value) => value,
+                None => {
+                    self.forward_pending_interrupt(
+                        active_turn_rx,
+                        &mut interrupt_request_id,
+                        request_id,
+                        thread_id,
+                        turn_id,
+                        traceparent,
+                    )?;
+                    continue;
+                }
+            };
             if is_server_request(&value) {
                 self.send_error_response(&value)?;
+                continue;
+            }
+            if let Some(id) = response_id(&value) {
+                if Some(id) == interrupt_request_id {
+                    if let Some(error) = value.get("error") {
+                        return Err(HarnessServerError::Protocol(format!(
+                            "Codex app-server turn/interrupt request {id} failed: {error}"
+                        )));
+                    }
+                    continue;
+                }
                 continue;
             }
             if notification_method(&value).is_none() {
@@ -532,7 +626,44 @@ impl CodexJsonRpcChild {
                     return Ok(TurnTermination::Done);
                 }
             }
+            self.forward_pending_interrupt(
+                active_turn_rx,
+                &mut interrupt_request_id,
+                request_id,
+                thread_id,
+                turn_id,
+                traceparent,
+            )?;
         }
+    }
+
+    fn forward_pending_interrupt(
+        &mut self,
+        active_turn_rx: &Receiver<CodexActiveTurnRequest>,
+        interrupt_request_id: &mut Option<i64>,
+        request_id: &mut i64,
+        thread_id: &str,
+        turn_id: &str,
+        traceparent: Option<&str>,
+    ) -> Result<()> {
+        while let Ok(CodexActiveTurnRequest::Interrupt) = active_turn_rx.try_recv() {
+            if interrupt_request_id.is_some() {
+                eprintln!("Codex blocks interrupt ignored: interrupt already requested");
+                continue;
+            }
+            let id = next_request_id(request_id);
+            self.send_request(
+                id,
+                "turn/interrupt",
+                json!({
+                    "threadId": thread_id,
+                    "turnId": turn_id,
+                }),
+                traceparent,
+            )?;
+            *interrupt_request_id = Some(id);
+        }
+        Ok(())
     }
 
     fn read_value(&mut self) -> Result<Value> {
@@ -549,6 +680,24 @@ impl CodexJsonRpcChild {
                 continue;
             }
             return Ok(serde_json::from_str(trimmed)?);
+        }
+    }
+
+    fn read_value_timeout(&mut self, timeout: Duration) -> Result<Option<Value>> {
+        loop {
+            let line = match self.stdout.recv_timeout(timeout) {
+                Ok(line) => line?,
+                Err(RecvTimeoutError::Timeout) => return Ok(None),
+                Err(RecvTimeoutError::Disconnected) => {
+                    let status = self.child.wait()?;
+                    return Err(HarnessServerError::CodexExited { status });
+                }
+            };
+            let trimmed = line.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+            return Ok(Some(serde_json::from_str(trimmed)?));
         }
     }
 }

--- a/crates/harness-server/src/codex.rs
+++ b/crates/harness-server/src/codex.rs
@@ -153,6 +153,15 @@ pub(crate) fn run_codex_blocks_server(config: CodexHarnessServer) -> Result<()> 
                             break;
                         }
                     }
+                    Ok(command @ BlocksCommand::User { .. }) => {
+                        turn_active.store(true, Ordering::SeqCst);
+                        if command_tx
+                            .send(CodexBlocksReaderInput::Command(command))
+                            .is_err()
+                        {
+                            break;
+                        }
+                    }
                     Ok(command) => {
                         if command_tx
                             .send(CodexBlocksReaderInput::Command(command))
@@ -185,7 +194,6 @@ pub(crate) fn run_codex_blocks_server(config: CodexHarnessServer) -> Result<()> 
                 trace_context,
             }) => {
                 let traceparent = trace_context.effective_traceparent();
-                drain_codex_active_turn_requests(&active_turn_rx);
                 turn_active.store(true, Ordering::SeqCst);
                 let result = (|| -> Result<()> {
                     if codex.is_none() {

--- a/crates/harness-server/src/error.rs
+++ b/crates/harness-server/src/error.rs
@@ -49,6 +49,8 @@ pub enum HarnessServerError {
         status: ExitStatus,
         stderr: String,
     },
+    #[error("{kind:?} turn interrupted")]
+    TurnInterrupted { kind: HarnessKind },
     #[error("failed to spawn {bin} app-server: {source}")]
     SpawnCodex {
         bin: String,

--- a/crates/harness-server/src/server.rs
+++ b/crates/harness-server/src/server.rs
@@ -105,6 +105,15 @@ pub(crate) fn run_blocks_app_server<H: HarnessServer>(harness: &H) -> Result<()>
                             break;
                         }
                     }
+                    Ok(command @ BlocksCommand::User { .. }) => {
+                        turn_active.store(true, Ordering::SeqCst);
+                        if command_tx
+                            .send(BlocksReaderInput::Command(command))
+                            .is_err()
+                        {
+                            break;
+                        }
+                    }
                     Ok(command) => {
                         if command_tx
                             .send(BlocksReaderInput::Command(command))
@@ -142,7 +151,7 @@ pub(crate) fn run_blocks_app_server<H: HarnessServer>(harness: &H) -> Result<()>
                 if let Some(model) = model {
                     state.model = model;
                 }
-                if let Err(error) = run_blocks_turn(
+                let result = run_blocks_turn(
                     harness,
                     &mut state,
                     input,
@@ -151,7 +160,9 @@ pub(crate) fn run_blocks_app_server<H: HarnessServer>(harness: &H) -> Result<()>
                     &mut stdout,
                     &request_rx,
                     &turn_active,
-                ) {
+                );
+                drain_active_turn_requests(&request_rx);
+                if let Err(error) = result {
                     eprintln!("blocks turn failed: {error:#}");
                     write_blocks_error(&mut stdout, &state.id, "turn", error.to_string())?;
                 }
@@ -263,6 +274,10 @@ enum BlocksReaderInput {
 enum ActiveTurnRequest {
     JsonRpc(JSONRPCRequest),
     BlocksInterrupt,
+}
+
+fn drain_active_turn_requests(rx: &Receiver<ActiveTurnRequest>) {
+    while rx.try_recv().is_ok() {}
 }
 
 #[derive(Debug)]

--- a/crates/harness-server/src/server.rs
+++ b/crates/harness-server/src/server.rs
@@ -981,6 +981,29 @@ fn handle_active_turn_request<H: HarnessServer, W: Write>(
             Ok(false)
         }
         "turn/interrupt" => {
+            let params: TurnInterruptParams = request_params(request.params)?;
+            if params.thread_id != normalizer.thread_id() {
+                write_error(
+                    stdout,
+                    request.id,
+                    -32600,
+                    format!("unknown threadId {}", params.thread_id),
+                )?;
+                return Ok(false);
+            }
+            if params.turn_id != normalizer.turn_id() {
+                write_error(
+                    stdout,
+                    request.id,
+                    -32600,
+                    format!(
+                        "expected active turn id `{}` but found `{}`",
+                        params.turn_id,
+                        normalizer.turn_id()
+                    ),
+                )?;
+                return Ok(false);
+            }
             process.kill_and_wait()?;
             write_client_response(
                 stdout,
@@ -1034,10 +1057,28 @@ fn run_normalized_turn<H: HarnessServer, W: Write>(
     ) {
         Ok(Some(turn)) => state.completed_turns.push(turn),
         Ok(None) => {}
+        Err(HarnessServerError::TurnInterrupted { .. }) => {
+            state.process = None;
+            finish_turn_interrupted(state, normalizer, stdout)?;
+        }
         Err(error) => {
             state.process = None;
             finish_turn_with_error(state, normalizer, stdout, error)?;
         }
+    }
+    Ok(())
+}
+
+fn finish_turn_interrupted<W: Write>(
+    state: &mut ThreadState,
+    normalizer: &mut CodexTurnNormalizer,
+    stdout: &mut W,
+) -> Result<()> {
+    if let Some(notification) = normalizer.finish_turn_interrupted()? {
+        if let ServerNotification::TurnCompleted(completed) = &notification {
+            state.completed_turns.push(completed.turn.clone());
+        }
+        write_value(stdout, &notification_to_wire_value(&notification)?)?;
     }
     Ok(())
 }

--- a/crates/harness-server/src/server.rs
+++ b/crates/harness-server/src/server.rs
@@ -934,7 +934,7 @@ fn handle_active_turn_request<H: HarnessServer, W: Write>(
     normalizer: &mut CodexTurnNormalizer,
     request: JSONRPCRequest,
     stdout: &mut W,
-) -> Result<()> {
+) -> Result<bool> {
     match request.method.as_str() {
         "turn/steer" => {
             let params: TurnSteerParams = request_params(request.params)?;
@@ -945,7 +945,7 @@ fn handle_active_turn_request<H: HarnessServer, W: Write>(
                     -32600,
                     format!("unknown threadId {}", params.thread_id),
                 )?;
-                return Ok(());
+                return Ok(false);
             }
             if params.expected_turn_id != normalizer.turn_id() {
                 write_error(
@@ -958,7 +958,7 @@ fn handle_active_turn_request<H: HarnessServer, W: Write>(
                         normalizer.turn_id()
                     ),
                 )?;
-                return Ok(());
+                return Ok(false);
             }
             process
                 .stdin
@@ -978,9 +978,10 @@ fn handle_active_turn_request<H: HarnessServer, W: Write>(
             {
                 write_value(stdout, &notification_to_wire_value(&notification)?)?;
             }
-            Ok(())
+            Ok(false)
         }
         "turn/interrupt" => {
+            process.kill_and_wait()?;
             write_client_response(
                 stdout,
                 ClientResponse::TurnInterrupt {
@@ -988,7 +989,7 @@ fn handle_active_turn_request<H: HarnessServer, W: Write>(
                     response: TurnInterruptResponse {},
                 },
             )?;
-            Ok(())
+            Ok(true)
         }
         _ => {
             write_error(
@@ -997,7 +998,7 @@ fn handle_active_turn_request<H: HarnessServer, W: Write>(
                 -32600,
                 format!("cannot handle {} while a turn is active", request.method),
             )?;
-            Ok(())
+            Ok(false)
         }
     }
 }
@@ -1033,7 +1034,10 @@ fn run_normalized_turn<H: HarnessServer, W: Write>(
     ) {
         Ok(Some(turn)) => state.completed_turns.push(turn),
         Ok(None) => {}
-        Err(error) => finish_turn_with_error(state, normalizer, stdout, error)?,
+        Err(error) => {
+            state.process = None;
+            finish_turn_with_error(state, normalizer, stdout, error)?;
+        }
     }
     Ok(())
 }
@@ -1076,12 +1080,14 @@ fn run_harness_turn<H: HarnessServer, W: Write>(
     let usage_span_input = usage_span_input_value(input);
     let mut usage_span_output = UsageSpanOutput::default();
     ensure_harness_process(harness, state)?;
-    let process = state
-        .process
-        .as_mut()
-        .ok_or(HarnessServerError::HarnessStdinUnavailable)?;
-    process.stdin.write_all(&harness.stdin_for_turn(input)?)?;
-    process.stdin.flush()?;
+    {
+        let process = state
+            .process
+            .as_mut()
+            .ok_or(HarnessServerError::HarnessStdinUnavailable)?;
+        process.stdin.write_all(&harness.stdin_for_turn(input)?)?;
+        process.stdin.flush()?;
+    }
 
     let mut last_session_id = state.harness_session_id.clone();
     let mut event_normalizer = H::EventNormalizer::default();
@@ -1089,14 +1095,34 @@ fn run_harness_turn<H: HarnessServer, W: Write>(
     let mut latest_usage = None;
     loop {
         while let Ok(request) = request_rx.try_recv() {
-            handle_active_turn_request(harness, process, normalizer, request, stdout)?;
+            let process = state
+                .process
+                .as_mut()
+                .ok_or(HarnessServerError::HarnessStdinUnavailable)?;
+            if handle_active_turn_request(harness, process, normalizer, request, stdout)? {
+                state.process = None;
+                return Err(HarnessServerError::TurnInterrupted {
+                    kind: harness.kind(),
+                });
+            }
         }
 
-        let line = match process.stdout.recv_timeout(Duration::from_millis(50)) {
+        let line = match state
+            .process
+            .as_mut()
+            .ok_or(HarnessServerError::HarnessStdoutUnavailable)?
+            .stdout
+            .recv_timeout(Duration::from_millis(50))
+        {
             Ok(line) => line?,
             Err(RecvTimeoutError::Timeout) => continue,
             Err(RecvTimeoutError::Disconnected) => {
-                let status = process.child.wait()?;
+                let status = state
+                    .process
+                    .as_mut()
+                    .ok_or(HarnessServerError::HarnessStdoutUnavailable)?
+                    .child
+                    .wait()?;
                 return Err(HarnessServerError::HarnessExited {
                     kind: harness.kind(),
                     status,
@@ -1298,8 +1324,11 @@ fn append_usage_span_output(event: &NormalizedEvent, output: &mut UsageSpanOutpu
 }
 
 fn ensure_harness_process<H: HarnessServer>(harness: &H, state: &mut ThreadState) -> Result<()> {
-    if state.process.is_some() {
-        return Ok(());
+    if let Some(process) = state.process.as_mut() {
+        if process.child.try_wait()?.is_none() {
+            return Ok(());
+        }
+        state.process = None;
     }
 
     let mut command = harness.command_for_turn(state);

--- a/crates/harness-server/src/server.rs
+++ b/crates/harness-server/src/server.rs
@@ -4,7 +4,11 @@ use std::fs::OpenOptions;
 use std::io::{self, BufRead, Write};
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
-use std::sync::mpsc::{self, Receiver, RecvTimeoutError};
+use std::sync::{
+    Arc,
+    atomic::{AtomicBool, Ordering},
+    mpsc::{self, Receiver, RecvTimeoutError},
+};
 use std::time::Duration;
 
 use base64::Engine;
@@ -75,21 +79,56 @@ pub fn run_validate_jsonrpc() -> Result<()> {
 }
 
 pub(crate) fn run_blocks_app_server<H: HarnessServer>(harness: &H) -> Result<()> {
-    let stdin = io::stdin();
     let mut stdout = io::stdout().lock();
     let mut state = initial_blocks_thread_state(harness)?;
-    let mut blocks_state = BlocksState::default();
-    let (_request_tx, request_rx) = mpsc::channel();
+    let (command_tx, command_rx) = mpsc::channel();
+    let (request_tx, request_rx) = mpsc::channel();
+    let turn_active = Arc::new(AtomicBool::new(false));
 
-    for raw in stdin.lock().lines() {
-        let line = raw?;
-        let trimmed = line.trim();
-        if trimmed.is_empty() {
-            continue;
-        }
+    {
+        let turn_active = Arc::clone(&turn_active);
+        std::thread::spawn(move || {
+            let stdin = io::stdin();
+            let mut blocks_state = BlocksState::default();
+            for raw in stdin.lock().lines() {
+                let Ok(line) = raw else {
+                    break;
+                };
+                let trimmed = line.trim();
+                if trimmed.is_empty() {
+                    continue;
+                }
 
-        match parse_blocks_line_with_state(trimmed, &mut blocks_state) {
-            Ok(BlocksCommand::User {
+                match parse_blocks_line_with_state(trimmed, &mut blocks_state) {
+                    Ok(BlocksCommand::Interrupt) if turn_active.load(Ordering::SeqCst) => {
+                        if request_tx.send(ActiveTurnRequest::BlocksInterrupt).is_err() {
+                            break;
+                        }
+                    }
+                    Ok(command) => {
+                        if command_tx
+                            .send(BlocksReaderInput::Command(command))
+                            .is_err()
+                        {
+                            break;
+                        }
+                    }
+                    Err(error) => {
+                        if command_tx
+                            .send(BlocksReaderInput::Error(error.to_string()))
+                            .is_err()
+                        {
+                            break;
+                        }
+                    }
+                }
+            }
+        });
+    }
+
+    while let Ok(input) = command_rx.recv() {
+        match input {
+            BlocksReaderInput::Command(BlocksCommand::User {
                 input,
                 client_user_message_id,
                 model,
@@ -111,18 +150,19 @@ pub(crate) fn run_blocks_app_server<H: HarnessServer>(harness: &H) -> Result<()>
                     &trace_context,
                     &mut stdout,
                     &request_rx,
+                    &turn_active,
                 ) {
                     eprintln!("blocks turn failed: {error:#}");
                     write_blocks_error(&mut stdout, &state.id, "turn", error.to_string())?;
                 }
             }
-            Ok(BlocksCommand::Interrupt) => {
-                eprintln!("blocks interrupt ignored: no active stdin reader while a turn runs");
+            BlocksReaderInput::Command(BlocksCommand::Interrupt) => {
+                eprintln!("blocks interrupt ignored: no active turn runs");
             }
-            Ok(BlocksCommand::AttachmentChunk) => {}
-            Err(error) => {
-                eprintln!("invalid blocks input: {error:#}");
-                write_blocks_error(&mut stdout, &state.id, "input", error.to_string())?;
+            BlocksReaderInput::Command(BlocksCommand::AttachmentChunk) => {}
+            BlocksReaderInput::Error(error) => {
+                eprintln!("invalid blocks input: {error}");
+                write_blocks_error(&mut stdout, &state.id, "input", error)?;
             }
         }
     }
@@ -152,7 +192,10 @@ pub(crate) fn run_app_server<H: HarnessServer>(harness: &H) -> Result<()> {
             let JSONRPCMessage::Request(request) = message else {
                 continue;
             };
-            if request_tx.send(request).is_err() {
+            if request_tx
+                .send(ActiveTurnRequest::JsonRpc(request))
+                .is_err()
+            {
                 break;
             }
         }
@@ -162,9 +205,17 @@ pub(crate) fn run_app_server<H: HarnessServer>(harness: &H) -> Result<()> {
     let mut threads: HashMap<String, ThreadState> = HashMap::new();
 
     while let Ok(request) = request_rx.recv() {
-        if let Err(error) = handle_request(harness, request, &request_rx, &mut threads, &mut stdout)
-        {
-            eprintln!("request failed: {error:#}");
+        match request {
+            ActiveTurnRequest::JsonRpc(request) => {
+                if let Err(error) =
+                    handle_request(harness, request, &request_rx, &mut threads, &mut stdout)
+                {
+                    eprintln!("request failed: {error:#}");
+                }
+            }
+            ActiveTurnRequest::BlocksInterrupt => {
+                eprintln!("blocks interrupt ignored: no active turn runs");
+            }
         }
     }
 
@@ -184,11 +235,13 @@ fn run_blocks_turn<H: HarnessServer, W: Write>(
     client_user_message_id: Option<String>,
     trace_context: &TraceContext,
     stdout: &mut W,
-    request_rx: &Receiver<JSONRPCRequest>,
+    request_rx: &Receiver<ActiveTurnRequest>,
+    turn_active: &AtomicBool,
 ) -> Result<()> {
     let turn_id = format!("turn-{}", Uuid::new_v4().simple());
     let mut normalizer = normalizer_for(harness, state, &turn_id);
-    run_normalized_turn(
+    turn_active.store(true, Ordering::SeqCst);
+    let result = run_normalized_turn(
         harness,
         state,
         &input,
@@ -197,7 +250,19 @@ fn run_blocks_turn<H: HarnessServer, W: Write>(
         &mut normalizer,
         stdout,
         request_rx,
-    )
+    );
+    turn_active.store(false, Ordering::SeqCst);
+    result
+}
+
+enum BlocksReaderInput {
+    Command(BlocksCommand),
+    Error(String),
+}
+
+enum ActiveTurnRequest {
+    JsonRpc(JSONRPCRequest),
+    BlocksInterrupt,
 }
 
 #[derive(Debug)]
@@ -707,7 +772,7 @@ fn clean_string(value: Option<&str>) -> Option<String> {
 fn handle_request<H: HarnessServer, W: Write>(
     harness: &H,
     request: JSONRPCRequest,
-    request_rx: &Receiver<JSONRPCRequest>,
+    request_rx: &Receiver<ActiveTurnRequest>,
     threads: &mut HashMap<String, ThreadState>,
     stdout: &mut W,
 ) -> Result<()> {
@@ -932,9 +997,14 @@ fn handle_active_turn_request<H: HarnessServer, W: Write>(
     harness: &H,
     process: &mut HarnessChild,
     normalizer: &mut CodexTurnNormalizer,
-    request: JSONRPCRequest,
+    request: ActiveTurnRequest,
     stdout: &mut W,
 ) -> Result<bool> {
+    let ActiveTurnRequest::JsonRpc(request) = request else {
+        process.kill_and_wait()?;
+        return Ok(true);
+    };
+
     match request.method.as_str() {
         "turn/steer" => {
             let params: TurnSteerParams = request_params(request.params)?;
@@ -1034,7 +1104,7 @@ fn run_normalized_turn<H: HarnessServer, W: Write>(
     trace_context: Option<&TraceContext>,
     normalizer: &mut CodexTurnNormalizer,
     stdout: &mut W,
-    request_rx: &Receiver<JSONRPCRequest>,
+    request_rx: &Receiver<ActiveTurnRequest>,
 ) -> Result<()> {
     for notification in normalizer.start_notifications(!state.thread_started_sent)? {
         if matches!(notification, ServerNotification::ThreadStarted(_)) {
@@ -1112,7 +1182,7 @@ fn run_harness_turn<H: HarnessServer, W: Write>(
     trace_context: Option<&TraceContext>,
     normalizer: &mut CodexTurnNormalizer,
     stdout: &mut W,
-    request_rx: &Receiver<JSONRPCRequest>,
+    request_rx: &Receiver<ActiveTurnRequest>,
 ) -> Result<Option<codex_app_server_protocol::Turn>> {
     let usage_span_start = otel::unix_time_nanos();
     let usage_span_model = state.model.clone();

--- a/crates/harness-server/src/traits.rs
+++ b/crates/harness-server/src/traits.rs
@@ -41,6 +41,13 @@ impl Drop for HarnessChild {
     }
 }
 
+impl HarnessChild {
+    pub fn kill_and_wait(&mut self) -> io::Result<()> {
+        let _ = self.child.kill();
+        self.child.wait().map(|_| ())
+    }
+}
+
 pub trait AppServerRuntime {
     fn run_stdio(&self) -> Result<()>;
 }

--- a/crates/harness-server/src/turn.rs
+++ b/crates/harness-server/src/turn.rs
@@ -237,13 +237,28 @@ impl CodexTurnNormalizer {
         if self.completed {
             return Ok(None);
         }
-        self.completed = true;
         let error = failed.or_else(|| self.last_error.clone());
         let status = if error.is_some() {
             TurnStatus::Failed
         } else {
             TurnStatus::Completed
         };
+        self.finish_turn_with_status(status, error)
+    }
+
+    pub fn finish_turn_interrupted(&mut self) -> Result<Option<ServerNotification>> {
+        self.finish_turn_with_status(TurnStatus::Interrupted, None)
+    }
+
+    fn finish_turn_with_status(
+        &mut self,
+        status: TurnStatus,
+        error: Option<String>,
+    ) -> Result<Option<ServerNotification>> {
+        if self.completed {
+            return Ok(None);
+        }
+        self.completed = true;
         let completed_at = now_secs();
         Ok(Some(ServerNotification::TurnCompleted(
             TurnCompletedNotification {

--- a/crates/harness-server/tests/app_server_stdio.rs
+++ b/crates/harness-server/tests/app_server_stdio.rs
@@ -451,6 +451,73 @@ fn fake_codex_blocks_mode_spawns_app_server_and_translates_user_blocks() {
 }
 
 #[test]
+fn fake_codex_blocks_mode_interrupts_active_turn() {
+    let fake_codex = temp_path("fake-interruptible-codex.sh");
+    let fake_codex_log = temp_path("fake-interruptible-codex-requests.jsonl");
+    let script = fake_codex_interruptible_app_server_script(&fake_codex_log);
+    std::fs::write(&fake_codex, script).expect("write fake codex script");
+    let mut permissions = std::fs::metadata(&fake_codex)
+        .expect("fake codex metadata")
+        .permissions();
+    permissions.set_mode(0o755);
+    std::fs::set_permissions(&fake_codex, permissions).expect("chmod fake codex script");
+
+    let mut bridge = BridgeProcess::spawn_harness_blocks(
+        Harness::Codex,
+        None,
+        Some((
+            "CODEX_BIN",
+            fake_codex.to_str().expect("utf-8 fake codex path"),
+        )),
+    );
+    let turn = bridge.run_blocks_interrupted_turn("hang until stopped", Duration::from_secs(10));
+    let stdout_lines = bridge.finish_successfully();
+
+    assert_eq!(turn.terminal_status.as_deref(), Some("interrupted"));
+    assert!(
+        turn.methods.contains(&"turn/started".to_string()),
+        "missing turn/started; got {:?}",
+        turn.methods
+    );
+    assert!(
+        turn.methods.contains(&"turn/completed".to_string()),
+        "missing turn/completed; got {:?}",
+        turn.methods
+    );
+    assert!(
+        stdout_lines
+            .iter()
+            .all(|line| response_id(&serde_json::from_str(line).expect("JSON stdout")).is_none()),
+        "blocks mode should emit notifications only, not JSON-RPC responses"
+    );
+
+    let requests = std::fs::read_to_string(&fake_codex_log).expect("read fake codex request log");
+    let requests: Vec<Value> = requests
+        .lines()
+        .map(|line| serde_json::from_str(line).expect("fake codex request JSON"))
+        .collect();
+    let interrupt = requests
+        .iter()
+        .find(|value| value.get("method").and_then(Value::as_str) == Some("turn/interrupt"))
+        .unwrap_or_else(|| {
+            panic!("blocks mode did not send turn/interrupt; requests={requests:?}")
+        });
+    assert_eq!(
+        interrupt
+            .pointer("/params/threadId")
+            .and_then(Value::as_str),
+        Some("thread-1")
+    );
+    assert_eq!(
+        interrupt.pointer("/params/turnId").and_then(Value::as_str),
+        Some("turn-1")
+    );
+
+    let _ = std::fs::remove_file(fake_codex);
+    let _ = std::fs::remove_file(fake_codex_log);
+}
+
+#[test]
 fn fake_codex_blocks_mode_forwards_traceparent_to_app_server_requests() {
     let fake_codex = temp_path("fake-codex-trace.sh");
     let fake_codex_log = temp_path("fake-codex-trace-requests.jsonl");
@@ -1490,6 +1557,59 @@ impl BridgeProcess {
         capture
     }
 
+    fn run_blocks_interrupted_turn(&mut self, prompt: &str, timeout: Duration) -> TurnCapture {
+        self.send(json!({
+            "type": "user",
+            "thread_key": "slack:C123:123.456",
+            "trace_metadata": {
+                "source": "slackbotv2",
+                "action": "execute"
+            },
+            "message": {
+                "role": "user",
+                "content": [{"type": "text", "text": prompt}],
+            },
+        }));
+
+        let deadline = Instant::now() + timeout;
+        let mut capture = TurnCapture::default();
+        let mut interrupt_sent = false;
+
+        loop {
+            let value = self.read_json(deadline);
+            assert!(
+                response_id(&value).is_none(),
+                "blocks mode emitted JSON-RPC response: {value}"
+            );
+            if let Some(method) = value.get("method").and_then(Value::as_str) {
+                capture.consume_notification(method, &value);
+                if method == "turn/started"
+                    && capture.turn_id.is_empty()
+                    && let Some(turn_id) = value.pointer("/params/turn/id").and_then(Value::as_str)
+                {
+                    capture.turn_id = turn_id.to_string();
+                }
+                if method == "turn/started" && !interrupt_sent {
+                    self.send(json!({
+                        "type": "interrupt",
+                        "thread_key": "slack:C123:123.456",
+                        "trace_metadata": {
+                            "source": "test",
+                            "action": "interrupt_active_execution"
+                        }
+                    }));
+                    interrupt_sent = true;
+                }
+                if method == "turn/completed" {
+                    assert!(interrupt_sent, "turn completed before interrupt was sent");
+                    break;
+                }
+            }
+        }
+
+        capture
+    }
+
     fn send(&mut self, value: Value) {
         eprintln!("stdin JSON: {value}");
         let stdin = self.stdin.as_mut().expect("stdin still open");
@@ -2015,6 +2135,59 @@ while IFS= read -r line; do
       printf '%s\n' '{"method":"item/agentMessage/delta","params":{"threadId":"thread-1","turnId":"turn-1","itemId":"answer-1","delta":"codex blocks"}}'
       printf '%s\n' '{"method":"item/completed","params":{"threadId":"thread-1","turnId":"turn-1","item":{"type":"agentMessage","id":"answer-1","text":"codex blocks","phase":null,"memoryCitation":null},"completedAtMs":2}}'
       printf '%s\n' '{"method":"turn/completed","params":{"threadId":"thread-1","turn":{"id":"turn-1","items":[{"type":"agentMessage","id":"answer-1","text":"codex blocks","phase":null,"memoryCitation":null}],"itemsView":"full","status":"completed","error":null,"startedAt":1,"completedAt":2,"durationMs":1}}}'
+      ;;
+    *)
+      printf '%s\n' "unexpected request: $line" >&2
+      exit 65
+      ;;
+  esac
+done
+"#,
+    );
+    script
+}
+
+fn fake_codex_interruptible_app_server_script(log_path: &Path) -> String {
+    let mut script = String::new();
+    script.push_str("#!/bin/sh\n");
+    script.push_str("log=");
+    script.push_str(&shell_quote(log_path));
+    script.push_str(
+        r#"
+touch "$log"
+if [ "${1:-}" = "app-server" ] && [ "${2:-}" = "--help" ]; then
+  printf '%s\n' '--listen stdio://'
+  exit 0
+fi
+if [ "${1:-}" != "app-server" ]; then
+  printf '%s\n' 'expected app-server command' >&2
+  exit 64
+fi
+
+request_id() {
+  printf '%s' "$1" | sed -n 's/.*"id":\([0-9][0-9]*\).*/\1/p'
+}
+
+while IFS= read -r line; do
+  printf '%s\n' "$line" >> "$log"
+  case "$line" in
+    *'"method":"initialize"'*)
+      id=$(request_id "$line")
+      printf '{"id":%s,"result":{"userAgent":"fake-codex"}}\n' "$id"
+      ;;
+    *'"method":"thread/start"'*)
+      id=$(request_id "$line")
+      printf '{"id":%s,"result":{"thread":{"id":"thread-1"}}}\n' "$id"
+      ;;
+    *'"method":"turn/start"'*)
+      id=$(request_id "$line")
+      printf '{"id":%s,"result":{"turn":{"id":"turn-1"}}}\n' "$id"
+      printf '%s\n' '{"method":"turn/started","params":{"threadId":"thread-1","turn":{"id":"turn-1","items":[],"itemsView":"full","status":"inProgress","error":null,"startedAt":1,"completedAt":null,"durationMs":null}}}'
+      ;;
+    *'"method":"turn/interrupt"'*)
+      id=$(request_id "$line")
+      printf '{"id":%s,"result":{}}\n' "$id"
+      printf '%s\n' '{"method":"turn/completed","params":{"threadId":"thread-1","turn":{"id":"turn-1","items":[],"itemsView":"full","status":"interrupted","error":null,"startedAt":1,"completedAt":2,"durationMs":1}}}'
       ;;
     *)
       printf '%s\n' "unexpected request: $line" >&2

--- a/crates/harness-server/tests/app_server_stdio.rs
+++ b/crates/harness-server/tests/app_server_stdio.rs
@@ -642,6 +642,43 @@ fn fake_harness_process_is_started_once_across_two_turns() {
 }
 
 #[test]
+fn turn_interrupt_kills_harness_process_and_finishes_turn() {
+    let start_log = temp_path("harness-interrupt-starts.log");
+    let marker = temp_path("harness-interrupt-marker");
+    let command = format!(
+        "printf 'start\\n' >> {start_log}; \
+         trap 'printf \"killed\\n\" >> {start_log}; exit 143' TERM INT; \
+         printf '%s\\n' '{{\"type\":\"system\",\"subtype\":\"init\",\"session_id\":\"fake-session\"}}'; \
+         if [ -f {marker} ]; then \
+           printf '%s\\n' '{{\"type\":\"assistant\",\"is_partial\":false,\"message\":{{\"id\":\"msg_1\",\"content\":[{{\"type\":\"text\",\"text\":\"fresh turn\"}}]}}}}'; \
+           printf '%s\\n' '{{\"type\":\"result\",\"subtype\":\"success\",\"result\":\"fresh turn\"}}'; \
+           sleep 1; \
+         else \
+           touch {marker}; \
+           while IFS= read -r _; do sleep 60; done; \
+         fi",
+        start_log = shell_quote(start_log.as_path()),
+        marker = shell_quote(marker.as_path())
+    );
+    let mut bridge = BridgeProcess::spawn_harness(Harness::ClaudeCode, Some(command), None);
+    let thread_id =
+        bridge.initialize_and_start_thread(Harness::ClaudeCode, Duration::from_secs(10));
+
+    let interrupted = bridge.run_interrupted_turn(
+        &thread_id,
+        3,
+        4,
+        "hang until stopped",
+        Duration::from_secs(10),
+    );
+    assert_eq!(interrupted.terminal_status.as_deref(), Some("failed"));
+    let _ = bridge.child.kill();
+    let _ = bridge.child.wait();
+    let _ = std::fs::remove_file(start_log);
+    let _ = std::fs::remove_file(marker);
+}
+
+#[test]
 #[ignore = "runs real Claude Code and Codex/Amp-style networked binaries"]
 fn real_claude_code_long_streaming_is_anchored_to_native_cli() {
     require_command("claude", &["--version"]);
@@ -1150,6 +1187,76 @@ impl BridgeProcess {
                     steer_sent = true;
                 }
                 if method == "turn/completed" {
+                    break;
+                }
+            }
+        }
+
+        capture
+    }
+
+    fn run_interrupted_turn(
+        &mut self,
+        thread_id: &str,
+        request_id: i64,
+        interrupt_request_id: i64,
+        prompt: &str,
+        timeout: Duration,
+    ) -> TurnCapture {
+        self.send(json!({
+            "id": request_id,
+            "method": "turn/start",
+            "params": {
+                "threadId": thread_id,
+                "input": [{"type": "text", "text": prompt, "text_elements": []}],
+            },
+        }));
+
+        let deadline = Instant::now() + timeout;
+        let mut capture = TurnCapture::default();
+        let mut interrupt_sent = false;
+        let mut interrupt_acknowledged = false;
+
+        loop {
+            let value = self.read_json(deadline);
+            if let Some(id) = response_id(&value) {
+                if id == request_id {
+                    capture.turn_id = value
+                        .pointer("/result/turn/id")
+                        .and_then(Value::as_str)
+                        .unwrap_or_else(|| panic!("turn/start did not return turn id: {value}"))
+                        .to_string();
+                } else if id == interrupt_request_id {
+                    interrupt_acknowledged = true;
+                }
+                continue;
+            }
+
+            if let Some(method) = value.get("method").and_then(Value::as_str) {
+                assert_notification_thread_id(&value, thread_id);
+                capture.consume_notification(method, &value);
+                if method == "turn/started"
+                    && capture.turn_id.is_empty()
+                    && let Some(turn_id) = value.pointer("/params/turn/id").and_then(Value::as_str)
+                {
+                    capture.turn_id = turn_id.to_string();
+                }
+                if method == "turn/started" && !interrupt_sent {
+                    self.send(json!({
+                        "id": interrupt_request_id,
+                        "method": "turn/interrupt",
+                        "params": {
+                            "threadId": thread_id,
+                            "turnId": capture.turn_id,
+                        },
+                    }));
+                    interrupt_sent = true;
+                }
+                if method == "turn/completed" {
+                    assert!(
+                        interrupt_acknowledged,
+                        "turn completed before interrupt response"
+                    );
                     break;
                 }
             }

--- a/crates/harness-server/tests/app_server_stdio.rs
+++ b/crates/harness-server/tests/app_server_stdio.rs
@@ -649,14 +649,14 @@ fn turn_interrupt_kills_harness_process_and_finishes_turn() {
         "printf 'start\\n' >> {start_log}; \
          trap 'printf \"killed\\n\" >> {start_log}; exit 143' TERM INT; \
          printf '%s\\n' '{{\"type\":\"system\",\"subtype\":\"init\",\"session_id\":\"fake-session\"}}'; \
-         if [ -f {marker} ]; then \
-           printf '%s\\n' '{{\"type\":\"assistant\",\"is_partial\":false,\"message\":{{\"id\":\"msg_1\",\"content\":[{{\"type\":\"text\",\"text\":\"fresh turn\"}}]}}}}'; \
-           printf '%s\\n' '{{\"type\":\"result\",\"subtype\":\"success\",\"result\":\"fresh turn\"}}'; \
-           sleep 1; \
-         else \
-           touch {marker}; \
-           while IFS= read -r _; do sleep 60; done; \
-         fi",
+         while IFS= read -r _; do \
+           if [ -f {marker} ]; then \
+             printf '%s\\n' '{{\"type\":\"assistant\",\"is_partial\":false,\"message\":{{\"id\":\"msg_1\",\"content\":[{{\"type\":\"text\",\"text\":\"fresh turn\"}}]}}}}'; \
+             printf '%s\\n' '{{\"type\":\"result\",\"subtype\":\"success\",\"result\":\"fresh turn\"}}'; \
+           else \
+             sleep 60; \
+           fi; \
+         done",
         start_log = shell_quote(start_log.as_path()),
         marker = shell_quote(marker.as_path())
     );
@@ -671,11 +671,57 @@ fn turn_interrupt_kills_harness_process_and_finishes_turn() {
         "hang until stopped",
         Duration::from_secs(10),
     );
-    assert_eq!(interrupted.terminal_status.as_deref(), Some("failed"));
+    assert_eq!(interrupted.terminal_status.as_deref(), Some("interrupted"));
+
+    std::fs::write(&marker, b"fresh turn ready").expect("write fresh-turn marker");
+    let fresh = bridge.run_turn(
+        &thread_id,
+        5,
+        "run after interrupt",
+        None,
+        Duration::from_secs(10),
+    );
+    assert_completed_turn(&fresh);
+    assert_eq!(fresh.text_from_deltas, "fresh turn");
     let _ = bridge.child.kill();
     let _ = bridge.child.wait();
     let _ = std::fs::remove_file(start_log);
     let _ = std::fs::remove_file(marker);
+}
+
+#[test]
+fn turn_interrupt_rejects_wrong_thread_and_turn_without_killing_process() {
+    let start_log = temp_path("harness-rejected-interrupt-starts.log");
+    let command = format!(
+        "printf 'start\\n' >> {start_log}; \
+         printf '%s\\n' '{{\"type\":\"system\",\"subtype\":\"init\",\"session_id\":\"fake-session\"}}'; \
+         while IFS= read -r _; do sleep 60; done",
+        start_log = shell_quote(start_log.as_path()),
+    );
+    let mut bridge = BridgeProcess::spawn_harness(Harness::ClaudeCode, Some(command), None);
+    let thread_id =
+        bridge.initialize_and_start_thread(Harness::ClaudeCode, Duration::from_secs(10));
+
+    let interrupted = bridge.run_turn_with_rejected_interrupts(
+        &thread_id,
+        3,
+        4,
+        5,
+        6,
+        "hang until stopped",
+        Duration::from_secs(10),
+    );
+    assert_eq!(interrupted.terminal_status.as_deref(), Some("interrupted"));
+
+    let starts = std::fs::read_to_string(&start_log).expect("read start log");
+    assert_eq!(
+        starts.lines().count(),
+        1,
+        "rejected interrupts must not kill and restart the harness before the valid interrupt"
+    );
+    let _ = bridge.child.kill();
+    let _ = bridge.child.wait();
+    let _ = std::fs::remove_file(start_log);
 }
 
 #[test]
@@ -1265,6 +1311,128 @@ impl BridgeProcess {
         capture
     }
 
+    fn run_turn_with_rejected_interrupts(
+        &mut self,
+        thread_id: &str,
+        request_id: i64,
+        wrong_thread_interrupt_request_id: i64,
+        wrong_turn_interrupt_request_id: i64,
+        valid_interrupt_request_id: i64,
+        prompt: &str,
+        timeout: Duration,
+    ) -> TurnCapture {
+        self.send(json!({
+            "id": request_id,
+            "method": "turn/start",
+            "params": {
+                "threadId": thread_id,
+                "input": [{"type": "text", "text": prompt, "text_elements": []}],
+            },
+        }));
+
+        let deadline = Instant::now() + timeout;
+        let mut capture = TurnCapture::default();
+        let mut wrong_thread_interrupt_sent = false;
+        let mut wrong_thread_interrupt_rejected = false;
+        let mut wrong_turn_interrupt_sent = false;
+        let mut wrong_turn_interrupt_rejected = false;
+        let mut valid_interrupt_sent = false;
+        let mut valid_interrupt_acknowledged = false;
+
+        loop {
+            let value = self.read_json_allowing_error(deadline);
+            if let Some(id) = response_id(&value) {
+                if id == request_id {
+                    capture.turn_id = value
+                        .pointer("/result/turn/id")
+                        .and_then(Value::as_str)
+                        .unwrap_or_else(|| panic!("turn/start did not return turn id: {value}"))
+                        .to_string();
+                } else if id == wrong_thread_interrupt_request_id {
+                    assert!(
+                        value.get("error").is_some(),
+                        "wrong-thread interrupt should be rejected: {value}"
+                    );
+                    wrong_thread_interrupt_rejected = true;
+                    self.send(json!({
+                        "id": wrong_turn_interrupt_request_id,
+                        "method": "turn/interrupt",
+                        "params": {
+                            "threadId": thread_id,
+                            "turnId": "wrong-turn",
+                        },
+                    }));
+                    wrong_turn_interrupt_sent = true;
+                } else if id == wrong_turn_interrupt_request_id {
+                    assert!(
+                        value.get("error").is_some(),
+                        "wrong-turn interrupt should be rejected: {value}"
+                    );
+                    wrong_turn_interrupt_rejected = true;
+                    self.send(json!({
+                        "id": valid_interrupt_request_id,
+                        "method": "turn/interrupt",
+                        "params": {
+                            "threadId": thread_id,
+                            "turnId": capture.turn_id,
+                        },
+                    }));
+                    valid_interrupt_sent = true;
+                } else if id == valid_interrupt_request_id {
+                    assert!(
+                        value.get("error").is_none(),
+                        "valid interrupt should be acknowledged: {value}"
+                    );
+                    valid_interrupt_acknowledged = true;
+                }
+                continue;
+            }
+
+            if let Some(method) = value.get("method").and_then(Value::as_str) {
+                assert_notification_thread_id(&value, thread_id);
+                capture.consume_notification(method, &value);
+                if method == "turn/started"
+                    && capture.turn_id.is_empty()
+                    && let Some(turn_id) = value.pointer("/params/turn/id").and_then(Value::as_str)
+                {
+                    capture.turn_id = turn_id.to_string();
+                }
+                if method == "turn/started"
+                    && !wrong_thread_interrupt_sent
+                    && !capture.turn_id.is_empty()
+                {
+                    self.send(json!({
+                        "id": wrong_thread_interrupt_request_id,
+                        "method": "turn/interrupt",
+                        "params": {
+                            "threadId": "wrong-thread",
+                            "turnId": capture.turn_id,
+                        },
+                    }));
+                    wrong_thread_interrupt_sent = true;
+                }
+                if method == "turn/completed" {
+                    assert!(
+                        wrong_thread_interrupt_rejected,
+                        "turn completed before wrong-thread interrupt rejection"
+                    );
+                    assert!(
+                        wrong_turn_interrupt_sent && wrong_turn_interrupt_rejected,
+                        "turn completed before wrong-turn interrupt rejection"
+                    );
+                    assert!(valid_interrupt_sent, "valid interrupt was never sent");
+                    assert!(
+                        valid_interrupt_acknowledged,
+                        "turn completed before valid interrupt response"
+                    );
+                    break;
+                }
+            }
+        }
+
+        capture
+    }
+
     fn run_blocks_user_turn(&mut self, prompt: &str, timeout: Duration) -> TurnCapture {
         self.run_blocks_user_turn_with_model(prompt, None, timeout)
     }
@@ -1331,6 +1499,14 @@ impl BridgeProcess {
     }
 
     fn read_json(&mut self, deadline: Instant) -> Value {
+        self.read_json_checked(deadline, false)
+    }
+
+    fn read_json_allowing_error(&mut self, deadline: Instant) -> Value {
+        self.read_json_checked(deadline, true)
+    }
+
+    fn read_json_checked(&mut self, deadline: Instant, allow_error: bool) -> Value {
         loop {
             let now = Instant::now();
             assert!(now < deadline, "timed out waiting for app-server stdout");
@@ -1343,7 +1519,7 @@ impl BridgeProcess {
                     self.stdout_lines.push(line.clone());
                     let value: Value =
                         serde_json::from_str(line.trim()).expect("valid JSON stdout line");
-                    validate_jsonrpc_value(&value);
+                    validate_jsonrpc_value(&value, allow_error);
                     return value;
                 }
                 Ok(Err(error)) => panic!("read app-server stdout: {error}"),
@@ -1652,7 +1828,7 @@ impl RawProcess {
     }
 }
 
-fn validate_jsonrpc_value(value: &Value) {
+fn validate_jsonrpc_value(value: &Value, allow_error: bool) {
     let message: JSONRPCMessage =
         serde_json::from_value(value.clone()).expect("valid JSON-RPC message");
     match message {
@@ -1667,7 +1843,9 @@ fn validate_jsonrpc_value(value: &Value) {
             }
         }
         JSONRPCMessage::Response(_) => {}
-        JSONRPCMessage::Error(error) => panic!("app-server returned JSON-RPC error: {error:?}"),
+        JSONRPCMessage::Error(error) => {
+            assert!(allow_error, "app-server returned JSON-RPC error: {error:?}");
+        }
         JSONRPCMessage::Request(request) => {
             panic!("app-server emitted unexpected request: {request:?}")
         }

--- a/crates/harness-server/tests/app_server_stdio.rs
+++ b/crates/harness-server/tests/app_server_stdio.rs
@@ -386,6 +386,35 @@ fn fake_amp_blocks_mode_accepts_user_blocks_by_default() {
 }
 
 #[test]
+fn fake_claude_blocks_mode_interrupts_back_to_back_stop() {
+    let fake_claude = concat!(
+        "printf '%s\\n' ",
+        "'{\"type\":\"system\",\"subtype\":\"init\",\"session_id\":\"claude-session\"}'; ",
+        "while IFS= read -r _; do sleep 60; done"
+    );
+
+    let mut bridge = BridgeProcess::spawn_harness_blocks(
+        Harness::ClaudeCode,
+        Some(fake_claude.to_string()),
+        None,
+    );
+    let turn = bridge.run_blocks_interrupted_turn("hang until stopped", Duration::from_secs(10));
+    bridge.finish_successfully();
+
+    assert_eq!(turn.terminal_status.as_deref(), Some("interrupted"));
+    assert!(
+        turn.methods.contains(&"turn/started".to_string()),
+        "missing turn/started; got {:?}",
+        turn.methods
+    );
+    assert!(
+        turn.methods.contains(&"turn/completed".to_string()),
+        "missing turn/completed; got {:?}",
+        turn.methods
+    );
+}
+
+#[test]
 fn fake_codex_blocks_mode_spawns_app_server_and_translates_user_blocks() {
     let fake_codex = temp_path("fake-codex.sh");
     let fake_codex_log = temp_path("fake-codex-requests.jsonl");
@@ -1570,10 +1599,17 @@ impl BridgeProcess {
                 "content": [{"type": "text", "text": prompt}],
             },
         }));
+        self.send(json!({
+            "type": "interrupt",
+            "thread_key": "slack:C123:123.456",
+            "trace_metadata": {
+                "source": "test",
+                "action": "interrupt_active_execution"
+            }
+        }));
 
         let deadline = Instant::now() + timeout;
         let mut capture = TurnCapture::default();
-        let mut interrupt_sent = false;
 
         loop {
             let value = self.read_json(deadline);
@@ -1589,19 +1625,7 @@ impl BridgeProcess {
                 {
                     capture.turn_id = turn_id.to_string();
                 }
-                if method == "turn/started" && !interrupt_sent {
-                    self.send(json!({
-                        "type": "interrupt",
-                        "thread_key": "slack:C123:123.456",
-                        "trace_metadata": {
-                            "source": "test",
-                            "action": "interrupt_active_execution"
-                        }
-                    }));
-                    interrupt_sent = true;
-                }
                 if method == "turn/completed" {
-                    assert!(interrupt_sent, "turn completed before interrupt was sent");
                     break;
                 }
             }

--- a/packages/rendering/src/codex-app-server.test.ts
+++ b/packages/rendering/src/codex-app-server.test.ts
@@ -735,6 +735,30 @@ describe('CodexAppServerRendererEventMapper', () => {
       error: 'sandbox exited'
     })
   })
+
+  it('emits interrupted final text for cancelled Rust sessions', async () => {
+    const chunks = await collect(
+      codexAppServerToChatSdkStream(
+        toAsyncIterable([
+          {
+            type: 'item.started',
+            item: { id: 'cmd-1', type: 'commandExecution', command: 'sleep 60' }
+          },
+          {
+            eventKind: 'session.execution_cancelled',
+            data: { error: 'Execution interrupted' }
+          }
+        ])
+      )
+    )
+
+    expect(chunks.filter(chunk => chunk.type === 'markdown_text')).toEqual([
+      {
+        type: 'markdown_text',
+        text: 'Execution interrupted'
+      }
+    ])
+  })
 })
 
 async function collect<T>(source: AsyncIterable<T>): Promise<T[]> {

--- a/packages/rendering/src/codex-app-server.ts
+++ b/packages/rendering/src/codex-app-server.ts
@@ -668,10 +668,17 @@ export function rustSessionEventToServerNotification(source: unknown): RustSessi
     return { kind: 'failed', error: String(data.error ?? 'Execution failed') }
   }
 
-  if (
-    eventKind === 'session.execution_completed' ||
-    eventKind === 'session.execution_cancelled'
-  ) {
+  if (eventKind === 'session.execution_cancelled') {
+    const data = isRecord(source.data) ? source.data : source
+    const resultText =
+      terminalResultText(data).trim() || String(data.error ?? 'Execution interrupted').trim()
+    return {
+      kind: 'completed',
+      ...(resultText ? { resultText } : {})
+    }
+  }
+
+  if (eventKind === 'session.execution_completed') {
     const data = isRecord(source.data) ? source.data : source
     const resultText = terminalResultText(data).trim()
     return {

--- a/packages/rendering/src/index.ts
+++ b/packages/rendering/src/index.ts
@@ -5,7 +5,7 @@ export {
   isTerminalCodexAppServerEvent,
   rustSessionEventToServerNotification
 } from './codex-app-server'
-export { ChatSDKRenderer } from './chat-sdk'
+export { ChatSDKRenderer, EMPTY_FINAL_ANSWER_TEXT } from './chat-sdk'
 export type { CodexAppServerToChatStreamOptions } from './codex-app-server'
 export type { RendererInterface, RendererSession } from './interface'
 export { rendererEventTypes } from './schema'

--- a/services/api-rs/crates/centaur-api-server/src/routes.rs
+++ b/services/api-rs/crates/centaur-api-server/src/routes.rs
@@ -58,8 +58,9 @@ use crate::{
     types::{
         AppendMessagesRequest, AppendMessagesResponse, CreateSessionRequest, CreateSessionResponse,
         EmitWorkflowEventRequest, EventsQuery, ExecuteSessionRequest, ExecuteSessionResponse,
-        ListWorkflowRunsQuery, OnHarnessConflict, SessionContextResponse, SessionSseEvent,
-        SlackThreadContext, stream_error_sse,
+        InterruptSessionExecutionRequest, InterruptSessionExecutionResponse, ListWorkflowRunsQuery,
+        OnHarnessConflict, SessionContextResponse, SessionSseEvent, SlackThreadContext,
+        stream_error_sse,
     },
 };
 
@@ -218,6 +219,10 @@ pub fn build_router_with_app_state(state: AppState) -> Router {
         .route(
             "/api/session/{thread_key}/execute",
             post(execute_session).layer(DefaultBodyLimit::disable()),
+        )
+        .route(
+            "/api/session/{thread_key}/interrupt",
+            post(interrupt_session_execution),
         )
         .route("/api/session/{thread_key}/events", get(stream_events))
         .route("/api/sandboxes/drain", post(drain_sandboxes))
@@ -511,6 +516,30 @@ async fn execute_session(
         execution_id: execution.execution_id,
         thread_key: execution.thread_key,
         status: execution.status.to_string(),
+    }))
+}
+
+async fn interrupt_session_execution(
+    State(state): State<AppState>,
+    Path(raw_thread_key): Path<String>,
+    Json(request): Json<InterruptSessionExecutionRequest>,
+) -> Result<Json<InterruptSessionExecutionResponse>, ApiError> {
+    let thread_key = ThreadKey::try_from(raw_thread_key)?;
+    let reason = request
+        .reason
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or("Interrupted from Slack");
+    let outcome = state
+        .runtime()?
+        .interrupt_active_execution(&thread_key, reason)
+        .await?;
+    Ok(Json(InterruptSessionExecutionResponse {
+        ok: true,
+        interrupted: outcome.interrupted,
+        execution_id: outcome.execution_id,
+        thread_key,
     }))
 }
 

--- a/services/api-rs/crates/centaur-api-server/src/types.rs
+++ b/services/api-rs/crates/centaur-api-server/src/types.rs
@@ -77,6 +77,19 @@ pub struct ExecuteSessionResponse {
     pub status: String,
 }
 
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct InterruptSessionExecutionRequest {
+    pub reason: Option<String>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct InterruptSessionExecutionResponse {
+    pub ok: bool,
+    pub interrupted: bool,
+    pub execution_id: Option<String>,
+    pub thread_key: ThreadKey,
+}
+
 #[derive(Clone, Debug, Deserialize)]
 pub struct EventsQuery {
     pub after_event_id: Option<i64>,

--- a/services/api-rs/crates/centaur-session-runtime/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-runtime/src/lib.rs
@@ -302,6 +302,12 @@ pub struct ExecuteSessionInput {
     pub max_duration_ms: Option<u64>,
 }
 
+#[derive(Clone, Debug)]
+pub struct InterruptExecutionOutcome {
+    pub interrupted: bool,
+    pub execution_id: Option<String>,
+}
+
 #[derive(Debug)]
 pub struct ToolHostCallInput {
     pub principal_id: String,
@@ -2078,6 +2084,63 @@ impl SessionRuntime {
         {
             warn!(%thread_key, %error, "failed to record steering delivery");
         }
+    }
+
+    pub async fn interrupt_active_execution(
+        &self,
+        thread_key: &ThreadKey,
+        reason: &str,
+    ) -> Result<InterruptExecutionOutcome, SessionRuntimeError> {
+        let Some(execution) = self.store.active_execution_for_thread(thread_key).await? else {
+            return Ok(InterruptExecutionOutcome {
+                interrupted: false,
+                execution_id: None,
+            });
+        };
+
+        let execution_span = self
+            .execution_spans
+            .lock()
+            .await
+            .get(&execution.execution_id)
+            .cloned();
+        let trace = SessionTraceContext::new(thread_key, execution_span.as_ref());
+        let input_lines = input_lines_with_session_context(
+            thread_key,
+            &trace,
+            &[interrupt_input_line(thread_key, reason)],
+        );
+
+        let pipe = self
+            .wait_for_active_steering_pipe(thread_key, &execution.execution_id)
+            .await
+            .map_err(SessionRuntimeError::BadRequest)?;
+        write_input_lines(
+            &pipe,
+            &input_lines,
+            thread_key,
+            &execution.execution_id,
+            None,
+        )
+        .await?;
+
+        self.store
+            .append_event(
+                thread_key,
+                Some(&execution.execution_id),
+                "session.interrupt_delivered",
+                json!({
+                    "execution_id": execution.execution_id,
+                    "thread_key": thread_key.as_str(),
+                    "reason": reason,
+                }),
+            )
+            .await?;
+
+        Ok(InterruptExecutionOutcome {
+            interrupted: true,
+            execution_id: Some(execution.execution_id),
+        })
     }
 
     async fn wait_for_active_steering_pipe(
@@ -4893,6 +4956,9 @@ enum TerminalOutput {
         reason: &'static str,
         result_text: Option<String>,
     },
+    Cancelled {
+        reason: &'static str,
+    },
     Failed {
         error: String,
     },
@@ -4937,6 +5003,32 @@ async fn record_terminal_output(
                 )
                 .await?;
             (execution, "completed")
+        }
+        TerminalOutput::Cancelled { reason } => {
+            let Some(execution) = ctx
+                .store
+                .cancel_execution_if_active_and_stdout_owner(
+                    execution_id,
+                    &ctx.stdout_owner_id,
+                    reason,
+                )
+                .await?
+            else {
+                return Ok(());
+            };
+            ctx.store
+                .append_event(
+                    thread_key,
+                    Some(execution_id),
+                    "session.execution_cancelled",
+                    json!({
+                        "execution_id": execution_id,
+                        "thread_key": thread_key.as_str(),
+                        "reason": reason,
+                    }),
+                )
+                .await?;
+            (execution, "cancelled")
         }
         TerminalOutput::Failed { error } => {
             failure_class = Some(terminal_failure_class(&error));
@@ -5506,6 +5598,11 @@ fn completed_turn_terminal_output(value: &Value, prior_final_answer_text: &str) 
                 prior_final_answer_text,
             )
         }
+        Some("interrupted") if prior_final_answer_text.trim().is_empty() => {
+            TerminalOutput::Cancelled {
+                reason: "turn_interrupted",
+            }
+        }
         Some(_status) if !prior_final_answer_text.trim().is_empty() => {
             completed_terminal_output_with_fallback(
                 value,
@@ -5920,6 +6017,19 @@ fn steering_input_line(
         },
     }))
     .ok()
+}
+
+fn interrupt_input_line(thread_key: &ThreadKey, reason: &str) -> String {
+    serde_json::to_string(&json!({
+        "type": "interrupt",
+        "thread_key": thread_key.as_str(),
+        "trace_metadata": {
+            "source": "session.interrupt_active_execution",
+            "action": "interrupt_active_execution",
+            "reason": reason,
+        },
+    }))
+    .expect("interrupt input line serializes")
 }
 
 async fn append_output_line(
@@ -6424,7 +6534,7 @@ mod tests {
     }
 
     #[test]
-    fn interrupted_turn_completed_without_answer_is_failure() {
+    fn interrupted_turn_completed_without_answer_is_cancelled() {
         let event = json!({
             "type": "turn.completed",
             "turn": {"id": "turn-1", "status": "interrupted"},
@@ -6432,8 +6542,8 @@ mod tests {
 
         assert_eq!(
             terminal_output(&event, ""),
-            Some(TerminalOutput::Failed {
-                error: "turn completed with status interrupted before final answer".to_owned()
+            Some(TerminalOutput::Cancelled {
+                reason: "turn_interrupted"
             })
         );
     }

--- a/services/api-rs/crates/centaur-session-sqlx/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-sqlx/src/lib.rs
@@ -820,6 +820,44 @@ impl PgSessionStore {
         row.try_into().map(Some)
     }
 
+    pub async fn cancel_execution_if_active_and_stdout_owner(
+        &self,
+        execution_id: &str,
+        owner_id: &str,
+        reason: &str,
+    ) -> Result<Option<SessionExecution>, SessionStoreError> {
+        let row = sqlx::query_as::<_, SessionExecutionRow>(
+            r#"
+            update session_executions
+            set status = $2,
+                error = $3,
+                completed_at = coalesce(completed_at, now()),
+                stdout_owner_id = null,
+                stdout_owner_lease_expires_at = null,
+                updated_at = now()
+            where execution_id = $1
+              and status in ($4, $5)
+              and stdout_owner_id = $6
+            returning execution_id, idempotency_key, thread_key, status, metadata, error, created_at, updated_at, started_at, completed_at
+            "#,
+        )
+        .bind(execution_id)
+        .bind(ExecutionStatus::Cancelled.as_ref())
+        .bind(reason)
+        .bind(ExecutionStatus::Queued.as_ref())
+        .bind(ExecutionStatus::Running.as_ref())
+        .bind(owner_id)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        let Some(row) = row else {
+            return Ok(None);
+        };
+        self.set_session_status(&row.thread_key, SessionStatus::Idle)
+            .await?;
+        row.try_into().map(Some)
+    }
+
     pub async fn append_event(
         &self,
         thread_key: &ThreadKey,

--- a/services/slackbotv2/src/index.ts
+++ b/services/slackbotv2/src/index.ts
@@ -30,6 +30,7 @@ import {
   collectInitialContext,
   forwardToSessionApi,
   harnessRestartPreamble,
+  interruptSessionExecution,
   isRetryableSessionApiError,
   openSessionEventStream,
   serializeAttachment,
@@ -45,6 +46,7 @@ import {
 } from './console-session-link'
 import { extractMessageOverrides } from './overrides'
 import { isAllowedSlackMessage, isAllowedSlackWebhookBody } from './slack-events'
+import { isSlackStopCommand } from './stop-command'
 import type {
   ForwardSessionInput,
   JsonObject,
@@ -361,6 +363,9 @@ async function handleSlackMessageHandoff(
     backgroundWaitUntil(assistantStatus.then(() => undefined).catch(() => undefined))
   }
   try {
+    if (await handleStopCommand(thread, message, input.options, input.trigger)) {
+      return
+    }
     if (input.subscribe) {
       await subscribeSlackThreadForHandoff(thread, input.options, trace, input.trigger)
     }
@@ -393,6 +398,40 @@ async function handleSlackMessageHandoff(
         .then(() => undefined)
         .catch(() => undefined)
     )
+    throw error
+  }
+}
+
+async function handleStopCommand(
+  thread: Thread<SlackbotV2ThreadState>,
+  message: ChatMessage,
+  options: SlackbotV2Options,
+  trigger: string
+): Promise<boolean> {
+  if (!isSlackStopCommand(message)) return false
+  const trace = createHandoffTrace(thread, message, 'append')
+  traceLog(options, 'slackbotv2_stop_command_started', trace, { trigger })
+  const latest = (await thread.state) ?? {}
+  const reason = `Interrupted from Slack by ${slackUserIdForMessage(message) ?? 'unknown user'}`
+  try {
+    const response = await interruptSessionExecution(options, thread.id, reason)
+    await thread.setState({
+      activeExecution: false,
+      lastEventId: latest.lastEventId ?? latest.renderObligation?.afterEventId ?? 0,
+      renderObligation: null
+    })
+    await setAssistantStatus(thread, '', options, trace)
+    traceLog(options, 'slackbotv2_stop_command_complete', trace, {
+      execution_id: response.execution_id,
+      interrupted: response.interrupted,
+      trigger
+    })
+    return true
+  } catch (error) {
+    traceWarn(options, 'slackbotv2_stop_command_failed', trace, {
+      error: errorMessage(error),
+      trigger
+    })
     throw error
   }
 }

--- a/services/slackbotv2/src/index.ts
+++ b/services/slackbotv2/src/index.ts
@@ -1290,8 +1290,8 @@ async function renderFallbackFinalAnswer(
     for await (const _chunk of chatStream) {
       void _chunk
     }
-    const text = fallback.text()
-    if (!text) {
+    const capturedText = fallback.text()
+    if (!capturedText && !fallback.isInterrupted()) {
       outcome = 'empty'
       traceLog(options, 'slackbotv2_render_fallback_empty', trace, {
         last_event_id: lastEventId,
@@ -1299,6 +1299,7 @@ async function renderFallbackFinalAnswer(
       })
       return null
     }
+    const text = fallback.textOrDefault()
     const fallbackText = truncateSlackText(text, SLACK_FALLBACK_TEXT_MAX_CHARS, 'Slack final answer')
     if (replacement) {
       await thread.adapter.editMessage(thread.id, replacement.replaceMessageId, fallbackText)
@@ -2022,7 +2023,7 @@ async function renderPlainTextExecutionStream(
       void _chunk
     }
     const text = truncateSlackText(
-      fallback.text() || 'Execution completed, but no final text was captured.',
+      fallback.textOrDefault(),
       SLACK_FALLBACK_TEXT_MAX_CHARS,
       'Slack final answer'
     )
@@ -2038,6 +2039,7 @@ async function renderPlainTextExecutionStream(
 class SlackRenderFallback {
   private markdownText = ''
   private terminalText = ''
+  private interrupted = false
 
   async *collectSource(
     stream: AsyncIterable<SlackbotV2RendererSource>
@@ -2061,11 +2063,27 @@ class SlackRenderFallback {
     return (this.terminalText || this.markdownText).trim()
   }
 
+  textOrDefault(): string {
+    return (
+      this.text() ||
+      (this.interrupted
+        ? 'Execution interrupted'
+        : 'Execution completed, but no final text was captured.')
+    )
+  }
+
+  isInterrupted(): boolean {
+    return this.interrupted
+  }
+
   private captureTerminalText(event: SlackbotV2RendererSource): void {
     if (!event || typeof event !== 'object') return
     const eventKind = String(
       'eventKind' in event ? event.eventKind : 'event' in event ? event.event : ''
     )
+    if (eventKind === 'session.execution_cancelled') {
+      this.interrupted = true
+    }
     if (
       eventKind !== 'session.execution_completed' &&
       eventKind !== 'session.execution_cancelled' &&

--- a/services/slackbotv2/src/index.ts
+++ b/services/slackbotv2/src/index.ts
@@ -18,6 +18,7 @@ import { createPostgresState } from '@chat-adapter/state-pg'
 import pg from 'pg'
 import {
   codexAppServerToChatSdkStream,
+  EMPTY_FINAL_ANSWER_TEXT,
   type CodexAppServerToChatStreamOptions,
   type ChatSDKStreamChunk,
   type RendererEvent
@@ -2060,7 +2061,10 @@ class SlackRenderFallback {
   }
 
   text(): string {
-    return (this.terminalText || this.markdownText).trim()
+    const terminalText = this.terminalText.trim()
+    const markdownText = this.markdownText.trim()
+    if (this.interrupted && !terminalText && markdownText === EMPTY_FINAL_ANSWER_TEXT) return ''
+    return terminalText || markdownText
   }
 
   textOrDefault(): string {
@@ -2068,7 +2072,7 @@ class SlackRenderFallback {
       this.text() ||
       (this.interrupted
         ? 'Execution interrupted'
-        : 'Execution completed, but no final text was captured.')
+        : EMPTY_FINAL_ANSWER_TEXT)
     )
   }
 

--- a/services/slackbotv2/src/session-api.ts
+++ b/services/slackbotv2/src/session-api.ts
@@ -1829,7 +1829,7 @@ async function* parseSessionEventStream(
     }
     if (event.event === 'session.execution_cancelled') {
       yield {
-        data: { error: sessionErrorMessage(event, 'Execution cancelled') },
+        data: { error: sessionErrorMessage(event, 'Execution interrupted') },
         event: event.event,
         eventId: event.id,
         eventKind: event.event

--- a/services/slackbotv2/src/session-api.ts
+++ b/services/slackbotv2/src/session-api.ts
@@ -13,6 +13,7 @@ import type {
   SlackbotV2ExecuteSessionRequest,
   SlackbotV2ExecuteSessionResponse,
   SlackbotV2Fetch,
+  SlackbotV2InterruptSessionResponse,
   SlackbotV2Options,
   SlackbotV2RendererSource,
   SlackbotV2SessionMessage
@@ -555,6 +556,19 @@ export async function openSessionEventStream(
     phase_ms: elapsedMs(streamStartedAtMs)
   })
   return stream
+}
+
+export async function interruptSessionExecution(
+  options: SlackbotV2Options,
+  threadId: string,
+  reason: string
+): Promise<SlackbotV2InterruptSessionResponse> {
+  return recordSessionApiOperation(
+    'interrupt_session',
+    () => postInterruptSessionExecution(options, threadId, reason),
+    sessionApiTimeoutMs(options),
+    'interrupt session'
+  )
 }
 
 const RESTART_CONTEXT_MAX_CHARS = 24_000
@@ -1226,6 +1240,27 @@ async function executeSession(
   )
   await ensureApiOk(response, 'execute session')
   return (await response.json()) as SlackbotV2ExecuteSessionResponse
+}
+
+async function postInterruptSessionExecution(
+  options: SlackbotV2Options,
+  threadId: string,
+  reason: string
+): Promise<SlackbotV2InterruptSessionResponse> {
+  const fetchFn = options.fetch ?? fetch
+  const response = await fetchWithTimeout(
+    fetchFn,
+    apiSessionUrl(options.apiUrl, threadId, 'interrupt'),
+    {
+      method: 'POST',
+      headers: apiHeaders(options),
+      body: JSON.stringify({ reason })
+    },
+    sessionApiTimeoutMs(options),
+    'interrupt session'
+  )
+  await ensureApiOk(response, 'interrupt session')
+  return (await response.json()) as SlackbotV2InterruptSessionResponse
 }
 
 async function ensureApiOk(response: Response, action: string): Promise<void> {

--- a/services/slackbotv2/src/session-api.ts
+++ b/services/slackbotv2/src/session-api.ts
@@ -1313,7 +1313,7 @@ async function streamSessionNotifications(
 function apiSessionUrl(
   apiUrl: string,
   threadId: string,
-  suffix?: 'messages' | 'execute' | 'events'
+  suffix?: 'messages' | 'execute' | 'events' | 'interrupt'
 ): string {
   const path = `/api/session/${encodeURIComponent(threadId)}${suffix ? `/${suffix}` : ''}`
   return new URL(path, ensureTrailingSlash(apiUrl)).toString()

--- a/services/slackbotv2/src/stop-command.ts
+++ b/services/slackbotv2/src/stop-command.ts
@@ -1,0 +1,6 @@
+export function isSlackStopCommand(message: { text: string }): boolean {
+  const text = message.text.trim()
+  if (!text) return false
+  const withoutMentions = text.replace(/<@[A-Z0-9]+(?:\|[^>]+)?>/g, ' ').trim()
+  return /\bstop\b/i.test(withoutMentions)
+}

--- a/services/slackbotv2/src/stop-command.ts
+++ b/services/slackbotv2/src/stop-command.ts
@@ -1,6 +1,15 @@
+const STOP_COMMAND_PATTERN = new RegExp(
+  [
+    String.raw`(?:^|[^A-Za-z0-9_-])`,
+    String.raw`(?:stop+|kill(?:ed|ing|s)?|end(?:ed|ing|s)?|cancell?(?:ed|ing|s)?)`,
+    String.raw`(?=$|[^A-Za-z0-9_-])`
+  ].join(''),
+  'i'
+)
+
 export function isSlackStopCommand(message: { text: string }): boolean {
   const text = message.text.trim()
   if (!text) return false
   const withoutMentions = text.replace(/<@[A-Z0-9]+(?:\|[^>]+)?>/g, ' ').trim()
-  return /\bstop\b/i.test(withoutMentions)
+  return STOP_COMMAND_PATTERN.test(withoutMentions)
 }

--- a/services/slackbotv2/src/types.ts
+++ b/services/slackbotv2/src/types.ts
@@ -91,6 +91,13 @@ export type SlackbotV2ExecuteSessionResponse = {
   thread_key: string
 }
 
+export type SlackbotV2InterruptSessionResponse = {
+  execution_id?: string
+  interrupted: boolean
+  ok: boolean
+  thread_key: string
+}
+
 export type SlackbotV2Fetch = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>
 
 export type SlackbotV2Options = {

--- a/services/slackbotv2/test/chat-sdk-emulate.test.ts
+++ b/services/slackbotv2/test/chat-sdk-emulate.test.ts
@@ -1712,6 +1712,83 @@ describe('slackbotv2', () => {
     )
   })
 
+  it('renders interrupted executions with no final answer as interrupted', async () => {
+    codexApi.autoRespond = false
+
+    const parent = await postUserMessage('Context before an interrupt.')
+    const mention = await postUserMessage(`<@${BOT_USER_ID}> run until stopped`, parent.ts)
+    const waits: Promise<unknown>[] = []
+    const response = await bot.app.request(
+      '/api/webhooks/slack',
+      signedSlackEvent({
+        event_id: 'Ev-slackbotv2-interrupted-empty',
+        event: {
+          type: 'app_mention',
+          user: USER_ID,
+          channel: CHANNEL_ID,
+          team: TEAM_ID,
+          ts: mention.ts,
+          thread_ts: parent.ts,
+          text: `<@${BOT_USER_ID}> run until stopped`
+        }
+      }),
+      {},
+      waitUntilContext(waits)
+    )
+
+    expect(response.status).toBe(200)
+    await waitFor(() => codexApi.executes.length === 1)
+    await waitFor(() => codexApi.eventRequests.length === 1)
+    await waitFor(() => codexApi.streamCount === 1)
+
+    codexApi.emitOutputLine(
+      threadKey(parent.ts),
+      JSON.stringify({
+        type: 'item.started',
+        item: {
+          id: 'cmd-1',
+          type: 'commandExecution',
+          command: 'sleep 60',
+          status: 'inProgress'
+        }
+      })
+    )
+    codexApi.emitOutputLine(
+      threadKey(parent.ts),
+      JSON.stringify({
+        type: 'item.completed',
+        item: {
+          id: 'cmd-1',
+          type: 'commandExecution',
+          command: 'sleep 60',
+          status: 'failed',
+          aggregatedOutput: '',
+          exitCode: 130
+        }
+      })
+    )
+    codexApi.emitSessionEvent(threadKey(parent.ts), 'session.execution_cancelled', {
+      execution_id: 'exe-interrupted',
+      status: 'cancelled',
+      reason: 'turn_interrupted'
+    })
+
+    await Promise.all(waits)
+    const transcripts = slackStreamTranscripts(slackApi.calls)
+    expect(transcripts).toHaveLength(1)
+    const markdownChunks = transcripts[0]!.chunks.filter(chunk => chunk.type === 'markdown_text')
+    expect(markdownChunks).toEqual([
+      {
+        type: 'markdown_text',
+        text: 'Execution interrupted'
+      }
+    ])
+    const renderedText = transcripts[0]!.chunks.map(chunkText).filter(Boolean).join('\n')
+    expect(renderedText).toContain('Command execution')
+    expect(renderedText.trim().endsWith('Execution interrupted')).toBe(true)
+    expect(renderedText).not.toContain('Execution completed, but no final text was captured.')
+  })
+
   it('renders api-rs completion result text when no final answer delta streamed', async () => {
     codexApi.autoRespond = false
 

--- a/services/slackbotv2/test/session-api.test.ts
+++ b/services/slackbotv2/test/session-api.test.ts
@@ -5,6 +5,7 @@ import {
   DEFAULT_SESSION_IDLE_TIMEOUT_MS,
   forwardToSessionApi,
   harnessRestartPreamble,
+  interruptSessionExecution,
   openSessionEventStream,
   serializeAttachment,
   serializeMessage
@@ -80,6 +81,14 @@ function fakeApi(responses: { createSession?: Array<{ body?: unknown; status: nu
         execution_id: 'exec-1',
         ok: true,
         status: 'running',
+        thread_key: 'slack:C1:1700000000.000100'
+      })
+    }
+    if (url.endsWith('/interrupt')) {
+      return Response.json({
+        execution_id: 'exec-1',
+        interrupted: true,
+        ok: true,
         thread_key: 'slack:C1:1700000000.000100'
       })
     }
@@ -184,6 +193,25 @@ describe('session event streaming', () => {
       eventKind: 'session.execution_completed'
     })
     expect(seenEventIds).toEqual([1, 2])
+  })
+})
+
+describe('session interruption', () => {
+  test('posts interruption reason to the thread interrupt endpoint', async () => {
+    const { fetchFn, requests } = fakeApi()
+
+    const response = await interruptSessionExecution(
+      options(fetchFn),
+      'slack:C1:1700000000.000100',
+      'Interrupted from Slack by U1'
+    )
+
+    expect(response.interrupted).toBe(true)
+    const interrupt = requests.find(request => request.url.endsWith('/interrupt'))
+    expect(interrupt?.url).toBe(
+      'http://api.test/api/session/slack%3AC1%3A1700000000.000100/interrupt'
+    )
+    expect(interrupt?.body).toEqual({ reason: 'Interrupted from Slack by U1' })
   })
 })
 

--- a/services/slackbotv2/test/session-api.test.ts
+++ b/services/slackbotv2/test/session-api.test.ts
@@ -194,6 +194,47 @@ describe('session event streaming', () => {
     })
     expect(seenEventIds).toEqual([1, 2])
   })
+
+  test('uses interrupted wording for cancelled executions without error text', async () => {
+    const encoded = new TextEncoder().encode(
+      [
+        'id: 1',
+        'event: session.execution_cancelled',
+        'data: {"status":"cancelled","reason":"turn_interrupted"}',
+        '',
+      ].join('\n')
+    )
+    const fetchFn: SlackbotV2Options['fetch'] = async () =>
+      new Response(
+        new ReadableStream({
+          start(controller) {
+            controller.enqueue(encoded)
+            controller.close()
+          }
+        }),
+        { headers: { 'content-type': 'text/event-stream' } }
+      )
+    const seenEventIds: number[] = []
+
+    const stream = await openSessionEventStream(options(fetchFn), {
+      afterEventId: 0,
+      executionId: 'exec-1',
+      onEventId: eventId => seenEventIds.push(eventId),
+      threadId: 'slack:C1:1700000000.000100'
+    })
+    const events = []
+    for await (const event of stream) events.push(event)
+
+    expect(events).toEqual([
+      {
+        data: { error: 'Execution interrupted' },
+        event: 'session.execution_cancelled',
+        eventId: 1,
+        eventKind: 'session.execution_cancelled'
+      }
+    ])
+    expect(seenEventIds).toEqual([1])
+  })
 })
 
 describe('session interruption', () => {

--- a/services/slackbotv2/test/stop-command.test.ts
+++ b/services/slackbotv2/test/stop-command.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, test } from 'bun:test'
+import { isSlackStopCommand } from '../src/stop-command'
+
+describe('Slack stop command detection', () => {
+  test('matches mention plus stop keyword', () => {
+    expect(isSlackStopCommand({ text: '<@UCENTAUR> stop' })).toBe(true)
+    expect(isSlackStopCommand({ text: 'please <@UCENTAUR> STOP now' })).toBe(true)
+  })
+
+  test('does not match unrelated mentions', () => {
+    expect(isSlackStopCommand({ text: '<@UCENTAUR> status' })).toBe(false)
+    expect(isSlackStopCommand({ text: '<@UCENTAUR> stopping by to ask' })).toBe(false)
+  })
+})

--- a/services/slackbotv2/test/stop-command.test.ts
+++ b/services/slackbotv2/test/stop-command.test.ts
@@ -5,10 +5,35 @@ describe('Slack stop command detection', () => {
   test('matches mention plus stop keyword', () => {
     expect(isSlackStopCommand({ text: '<@UCENTAUR> stop' })).toBe(true)
     expect(isSlackStopCommand({ text: 'please <@UCENTAUR> STOP now' })).toBe(true)
+    expect(isSlackStopCommand({ text: '<@UCENTAUR> Stop' })).toBe(true)
+    expect(isSlackStopCommand({ text: '<@UCENTAUR> stoppp' })).toBe(true)
+  })
+
+  test('matches kill, end, cancel, and common variants', () => {
+    for (const text of [
+      'kill',
+      'kill it',
+      'killed',
+      'killing',
+      'end',
+      'end it',
+      'ended',
+      'ending',
+      'cancel',
+      'cancels',
+      'canceled',
+      'cancelled',
+      'canceling',
+      'cancelling'
+    ]) {
+      expect(isSlackStopCommand({ text: `<@UCENTAUR> ${text}` })).toBe(true)
+    }
   })
 
   test('does not match unrelated mentions', () => {
     expect(isSlackStopCommand({ text: '<@UCENTAUR> status' })).toBe(false)
     expect(isSlackStopCommand({ text: '<@UCENTAUR> stopping by to ask' })).toBe(false)
+    expect(isSlackStopCommand({ text: '<@UCENTAUR> run an end-to-end test' })).toBe(false)
+    expect(isSlackStopCommand({ text: '<@UCENTAUR> cancellation policy' })).toBe(false)
   })
 })


### PR DESCRIPTION
## Summary
- keep PR #891's hard-kill behavior, but validate active interrupt thread/turn targets before killing the harness
- complete accepted harness interrupts as `interrupted` and persist textless interrupted turns as cancelled executions instead of failures
- add Slack `stop` parsing from #907, routed through `/api/session/{thread_key}/interrupt` instead of sandbox cancellation
- deliver interrupt lines into active blocks-mode harness turns so Slack stop can interrupt Amp/Claude while they are running

## Tests
- `cargo test -p harness-server`
- `cargo test -p centaur-session-runtime`
- `cargo test -p centaur-api-server`
- `cargo test -p centaur-session-sqlx cancel_execution_if_active_and_stdout_owner --no-default-features`
- `bun test test/stop-command.test.ts test/session-api.test.ts`

## Not run
- `bun run check:types` (fails locally because script `tsgo` is not available)

Closes paradigmxyz/centaur#891
Closes paradigmxyz/centaur#907
