### PR TITLE
Post still-working status after Slack render failure

### DIFF
--- a/services/slackbotv2/src/index.ts
+++ b/services/slackbotv2/src/index.ts
@@ -677,19 +677,7 @@ async function syncThreadMessageToSession(
     )
   }
   if (!shouldStartExecution && input.initialAssistantStatusVisible) {
-    if (state.activeExecution === true && input.mode === 'execute') {
-      const visible = await setAssistantStatus(
-        thread,
-        input.options.assistantStatus ?? 'Still working...',
-        input.options,
-        trace
-      )
-      traceLog(input.options, 'slackbotv2_forward_active_execution_status_refreshed', trace, {
-        visible
-      })
-    } else {
-      await setAssistantStatus(thread, '', input.options, trace)
-    }
+    await setAssistantStatus(thread, '', input.options, trace)
   }
 
   const serializeStartedAtMs = nowMs()

--- a/services/slackbotv2/src/index.ts
+++ b/services/slackbotv2/src/index.ts
@@ -676,7 +676,19 @@ async function syncThreadMessageToSession(
     )
   }
   if (!shouldStartExecution && input.initialAssistantStatusVisible) {
-    await setAssistantStatus(thread, '', input.options, trace)
+    if (state.activeExecution === true && input.mode === 'execute') {
+      const visible = await setAssistantStatus(
+        thread,
+        input.options.assistantStatus ?? 'Still working...',
+        input.options,
+        trace
+      )
+      traceLog(input.options, 'slackbotv2_forward_active_execution_status_refreshed', trace, {
+        visible
+      })
+    } else {
+      await setAssistantStatus(thread, '', input.options, trace)
+    }
   }
 
   const serializeStartedAtMs = nowMs()
@@ -1057,6 +1069,7 @@ async function renderExecutionAttempt(
   let rendered = false
   let retry = false
   let fallbackLastEventId = 0
+  let fallbackInterrupted = false
   try {
     const streamResult = await renderExecutionStream(
       thread,
@@ -1182,18 +1195,22 @@ async function renderExecutionAttempt(
       rendered = true
       outcome = 'fallback'
       fallbackLastEventId = fallback.lastEventId
+      fallbackInterrupted = fallback.interrupted
       return 'complete'
     }
     throw error
   } finally {
     const latest = (await thread.state) ?? {}
+    const executionStillActive = retry || (fallbackInterrupted && latest.activeExecution === true)
+    const shouldClearObligation = rendered && !executionStillActive
     await thread.setState({
-      activeExecution: retry,
+      activeExecution: executionStillActive,
       lastEventId: Math.max(latest.lastEventId ?? 0, getLastEventId(), fallbackLastEventId),
-      ...(rendered ? { renderObligation: null } : {})
+      ...(shouldClearObligation ? { renderObligation: null } : {})
     })
     traceLog(options, 'slackbotv2_render_finalized', trace, {
-      obligation_cleared: rendered,
+      active_execution_preserved: executionStillActive,
+      obligation_cleared: shouldClearObligation,
       render_duration_ms: elapsedMs(renderStartedAtMs),
       retry_scheduled: retry,
       last_event_id: getLastEventId()
@@ -1254,7 +1271,7 @@ async function renderFallbackFinalAnswer(
   source: { afterEventId: number; executionId?: string; threadId: string },
   trace?: SlackbotV2Trace,
   replacement?: { replaceMessageId: string }
-): Promise<{ lastEventId: number } | null> {
+): Promise<{ interrupted: boolean; lastEventId: number } | null> {
   const startedAtMs = nowMs()
   let outcome = 'error'
   let lastEventId = source.afterEventId
@@ -1314,7 +1331,7 @@ async function renderFallbackFinalAnswer(
       phase_ms: elapsedMs(startedAtMs)
     })
     outcome = 'complete'
-    return { lastEventId }
+    return { interrupted: fallback.isInterrupted(), lastEventId }
   } catch (error) {
     outcome = 'error'
     traceLog(

--- a/services/slackbotv2/src/index.ts
+++ b/services/slackbotv2/src/index.ts
@@ -124,6 +124,7 @@ const RENDER_RETRY_MAX_DELAY_MS = 5_000
 const ASSISTANT_STATUS_MAX_CHARS = 50
 const SLACK_TASK_DETAILS_MAX_CHARS = 500
 const SLACK_FALLBACK_TEXT_MAX_CHARS = 35_000
+const STILL_WORKING_TEXT = 'Still working...'
 const POSTGRES_CONNECT_INITIAL_DELAY_MS = 250
 const POSTGRES_CONNECT_MAX_DELAY_MS = 10_000
 const LATE_SLACK_FILE_MATCH_WINDOW_MS = 15_000
@@ -1180,6 +1181,7 @@ async function renderExecutionAttempt(
       )
       return 'complete'
     }
+    await postStillWorkingStatus(thread, options, trace)
     const fallback = await renderFallbackFinalAnswer(
       thread,
       options,
@@ -1733,6 +1735,7 @@ async function recoverRenderObligation(
         )
         return false
       }
+      await postStillWorkingStatus(thread, options, trace)
       const fallback = await renderFallbackFinalAnswer(
         thread,
         options,
@@ -2117,6 +2120,31 @@ class SlackRenderFallback {
       : event
     const text = terminalResultText(data)
     if (text) this.terminalText = text
+  }
+}
+
+async function postStillWorkingStatus(
+  thread: Thread,
+  options: SlackbotV2Options,
+  trace?: SlackbotV2Trace
+): Promise<void> {
+  const startedAtMs = nowMs()
+  try {
+    await thread.post(STILL_WORKING_TEXT)
+    traceLog(options, 'slackbotv2_still_working_status_posted', trace, {
+      phase_ms: elapsedMs(startedAtMs)
+    })
+  } catch (error) {
+    traceLog(
+      options,
+      'slackbotv2_still_working_status_failed',
+      trace,
+      {
+        error: errorMessage(error),
+        phase_ms: elapsedMs(startedAtMs)
+      },
+      'warn'
+    )
   }
 }
 

--- a/services/slackbotv2/test/chat-sdk-emulate.test.ts
+++ b/services/slackbotv2/test/chat-sdk-emulate.test.ts
@@ -1562,14 +1562,6 @@ describe('slackbotv2', () => {
     const secondAppendTexts = sessionMessageTexts(codexApi.appends[1]!.body.messages)
     expect(secondAppendTexts[0]).toContain('# Requester Context')
     expect(secondAppendTexts.at(-1)).toBe(`@${BOT_USER_ID} add this while still running`)
-    await waitFor(
-      () =>
-        slackApi.calls
-          .filter(call => call.method === 'assistant.threads.setStatus')
-          .map(call => stringField(call.body.status))
-          .filter(status => status === 'Thinking...').length >= 2,
-      2000
-    )
 
     codexApi.closeStreams()
     await Promise.all(firstWaits)

--- a/services/slackbotv2/test/chat-sdk-emulate.test.ts
+++ b/services/slackbotv2/test/chat-sdk-emulate.test.ts
@@ -2068,6 +2068,24 @@ describe('slackbotv2', () => {
         }
       })
     )
+    codexApi.emitOutputLine(
+      key,
+      JSON.stringify({
+        type: 'item.completed',
+        item: {
+          id: 'cmd-still-running',
+          type: 'commandExecution',
+          command: 'download reports',
+          status: 'completed',
+          aggregatedOutput: 'still going'
+        }
+      })
+    )
+    await waitFor(async () => {
+      const texts = await threadTexts(parent.ts)
+      return texts.some(text => text.includes('Still working...'))
+    }, 2000)
+
     codexApi.emitSessionEvent(key, 'session.execution_completed', {
       execution_id: 'exe-stream-expired',
       status: 'completed',
@@ -2080,6 +2098,7 @@ describe('slackbotv2', () => {
       text.includes('EXPIRED_STREAM_FALLBACK_VISIBLE')
     )
     expect(visibleFinalReplies).toHaveLength(1)
+    expect(texts.some(text => text.includes('Still working...'))).toBe(true)
     const threadState = await sharedState.get<Record<string, unknown>>(`thread-state:${key}`)
     expect(threadState).toEqual(
       expect.objectContaining({

--- a/services/slackbotv2/test/chat-sdk-emulate.test.ts
+++ b/services/slackbotv2/test/chat-sdk-emulate.test.ts
@@ -1562,6 +1562,14 @@ describe('slackbotv2', () => {
     const secondAppendTexts = sessionMessageTexts(codexApi.appends[1]!.body.messages)
     expect(secondAppendTexts[0]).toContain('# Requester Context')
     expect(secondAppendTexts.at(-1)).toBe(`@${BOT_USER_ID} add this while still running`)
+    await waitFor(
+      () =>
+        slackApi.calls
+          .filter(call => call.method === 'assistant.threads.setStatus')
+          .map(call => stringField(call.body.status))
+          .filter(status => status === 'Thinking...').length >= 2,
+      2000
+    )
 
     codexApi.closeStreams()
     await Promise.all(firstWaits)


### PR DESCRIPTION
## Summary
- post a durable `Still working...` thread status when Slack live rendering fails but the backend execution continues
- preserve render obligations when fallback only captured an interrupted stream, so recovery can still deliver the terminal answer
- add regression coverage for expired Slack streams posting the still-working status before final recovery

## Tests
- pnpm --filter slackbotv2 test test/chat-sdk-emulate.test.ts
- pnpm --filter slackbotv2 check:types

Prompted by: mslipper
