### PR TITLE
fix(console): correct light table dividers

### DIFF
--- a/services/console/app/assets/tailwind/application.css
+++ b/services/console/app/assets/tailwind/application.css
@@ -81,7 +81,11 @@
   }
 
   .console-table {
-    @apply min-w-full divide-y divide-ink-600 text-sm;
+    @apply min-w-full text-sm;
+  }
+
+  .console-table > thead {
+    @apply border-b border-ink-600;
   }
 
   .console-table-head {

--- a/services/console/app/views/layouts/console.html.erb
+++ b/services/console/app/views/layouts/console.html.erb
@@ -1063,8 +1063,9 @@
         color: #7a7f86;
       }
 
-      html[data-console-theme="light"] .console-table > :not(:last-child) {
-        border-color: #e6e5de;
+      html[data-console-theme="light"] .console-table > thead {
+        border-block-end-color: #e6e5de;
+        border-bottom-color: #e6e5de;
       }
 
       html[data-console-theme="light"] .form-input {
@@ -1139,6 +1140,7 @@
 
       html[data-console-theme="light"] .divide-ink-600 > :not([hidden]) ~ :not([hidden]),
       html[data-console-theme="light"] .divide-ink-700 > :not([hidden]) ~ :not([hidden]) {
+        border-block-color: #deded7;
         border-color: #deded7;
       }
 


### PR DESCRIPTION
Summary
- remove the broad .console-table divide selector from the shared console table component
- put the header divider directly on thead and set light-mode logical border colors for table and row dividers

Tests
- BUNDLE_PATH=/private/tmp/centaur-console-bundle PATH=/opt/homebrew/Cellar/ruby@3.4/3.4.10/bin:$PATH bin/rails tailwindcss:build
- BUNDLE_PATH=/private/tmp/centaur-console-bundle PATH=/opt/homebrew/Cellar/ruby@3.4/3.4.10/bin:$PATH bin/rails test test/helpers/application_helper_test.rb (fails: local Postgres is not listening on 127.0.0.1:5432)