### PR TITLE
fix: tighten slack stop command detection

### DIFF
--- a/services/slackbotv2/src/stop-command.ts
+++ b/services/slackbotv2/src/stop-command.ts
@@ -1,8 +1,11 @@
 const STOP_COMMAND_PATTERN = new RegExp(
   [
-    String.raw`(?:^|[^A-Za-z0-9_-])`,
+    String.raw`^`,
+    String.raw`(?:(?:please|pls)\s+)?`,
+    String.raw`(?:(?:can|could|would|will)\s+you\s+)?`,
     String.raw`(?:stop+|kill(?:ed|ing|s)?|end(?:ed|ing|s)?|cancell?(?:ed|ing|s)?)`,
-    String.raw`(?=$|[^A-Za-z0-9_-])`
+    String.raw`(?:\s+(?:it|this|that|now|please|pls|the\s+(?:run|execution|request|job|thread|turn)))*`,
+    String.raw`[.!?]*$`
   ].join(''),
   'i'
 )
@@ -10,6 +13,9 @@ const STOP_COMMAND_PATTERN = new RegExp(
 export function isSlackStopCommand(message: { text: string }): boolean {
   const text = message.text.trim()
   if (!text) return false
-  const withoutMentions = text.replace(/<@[A-Z0-9]+(?:\|[^>]+)?>/g, ' ').trim()
+  const withoutMentions = text
+    .replace(/<@[A-Z0-9]+(?:\|[^>]+)?>/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
   return STOP_COMMAND_PATTERN.test(withoutMentions)
 }

--- a/services/slackbotv2/test/stop-command.test.ts
+++ b/services/slackbotv2/test/stop-command.test.ts
@@ -7,6 +7,7 @@ describe('Slack stop command detection', () => {
     expect(isSlackStopCommand({ text: 'please <@UCENTAUR> STOP now' })).toBe(true)
     expect(isSlackStopCommand({ text: '<@UCENTAUR> Stop' })).toBe(true)
     expect(isSlackStopCommand({ text: '<@UCENTAUR> stoppp' })).toBe(true)
+    expect(isSlackStopCommand({ text: '<@UCENTAUR> could you stop the execution?' })).toBe(true)
   })
 
   test('matches kill, end, cancel, and common variants', () => {
@@ -35,5 +36,9 @@ describe('Slack stop command detection', () => {
     expect(isSlackStopCommand({ text: '<@UCENTAUR> stopping by to ask' })).toBe(false)
     expect(isSlackStopCommand({ text: '<@UCENTAUR> run an end-to-end test' })).toBe(false)
     expect(isSlackStopCommand({ text: '<@UCENTAUR> cancellation policy' })).toBe(false)
+    expect(isSlackStopCommand({ text: '<@UCENTAUR> if so, stop.' })).toBe(false)
+    expect(
+      isSlackStopCommand({ text: '<@UCENTAUR> please check the service; if it is broken, stop.' })
+    ).toBe(false)
   })
 })


### PR DESCRIPTION
Tightens Slack stop-command detection so embedded instructions like "if so, stop." are forwarded as normal prompts instead of interrupting the active execution. Keeps direct stop commands working and adds regression coverage for the misclassification.