### PR TITLE
feat(slackbotv2): gauge open session event stream connections

### DIFF
--- a/services/slackbotv2/src/metrics.ts
+++ b/services/slackbotv2/src/metrics.ts
@@ -321,6 +321,18 @@ export const slackbotMetrics = {
     labelNames: ['operation', 'outcome'],
     name: 'slackbotv2_session_api_operations_total'
   }),
+  sessionEventStreamClosures: counter({
+    help: 'Session API /events stream network connections released, by reason.',
+    labelNames: ['reason'],
+    name: 'slackbotv2_session_event_stream_closures_total'
+  }),
+  sessionEventStreamsOpen: gauge({
+    help:
+      'Session API /events SSE connections Slackbot currently holds open. Each one occupies a '
+      + 'slot in Bun\'s global fetch pool (BUN_CONFIG_MAX_HTTP_REQUESTS, default 256); at the cap '
+      + 'every outbound HTTP request from this process queues forever.',
+    name: 'slackbotv2_session_event_streams_open'
+  }),
   webhookDuration: histogram({
     help: 'Slack webhook request handling duration, in seconds.',
     labelNames: ['route', 'event_type', 'outcome'],

--- a/services/slackbotv2/src/session-api.ts
+++ b/services/slackbotv2/src/session-api.ts
@@ -1850,6 +1850,21 @@ async function* parseSessionEventStream(
 
 async function* parseSseEvents(stream: ReadableStream<Uint8Array>): AsyncIterable<ParsedSessionEvent> {
   const reader = stream.getReader()
+  // Tracks the underlying network connection, NOT this generator's lifetime.
+  // Nothing cancels `reader` when a consumer abandons this generator early
+  // (e.g. parseSessionEventStream returning on a terminal event), so the
+  // connection stays open and keeps holding a slot in Bun's global fetch pool
+  // (BUN_CONFIG_MAX_HTTP_REQUESTS, default 256). A generator-finally here
+  // would hide exactly that leak, so the gauge is only decremented when the
+  // socket actually settles: server EOF or a read error.
+  slackbotMetrics.sessionEventStreamsOpen.inc()
+  let connectionReleased = false
+  const releaseConnection = (reason: 'done' | 'error') => {
+    if (connectionReleased) return
+    connectionReleased = true
+    slackbotMetrics.sessionEventStreamsOpen.dec()
+    slackbotMetrics.sessionEventStreamClosures.inc({ reason })
+  }
   const decoder = new TextDecoder()
   let buffer = ''
   let eventName: string | undefined
@@ -1857,8 +1872,18 @@ async function* parseSseEvents(stream: ReadableStream<Uint8Array>): AsyncIterabl
   let data: string[] = []
 
   while (true) {
-    const { done, value } = await reader.read()
-    if (done) break
+    let done: boolean
+    let value: Uint8Array | undefined
+    try {
+      ;({ done, value } = await reader.read())
+    } catch (error) {
+      releaseConnection('error')
+      throw error
+    }
+    if (done) {
+      releaseConnection('done')
+      break
+    }
     buffer += decoder.decode(value, { stream: true })
     const lines = buffer.split(/\r?\n/)
     buffer = lines.pop() ?? ''


### PR DESCRIPTION
## Summary
- add `slackbotv2_session_event_streams_open` gauge counting GET `/api/session/{key}/events` SSE connections the bot currently holds open, plus `slackbotv2_session_event_stream_closures_total{reason}`
- instrument `parseSseEvents` so the gauge tracks the underlying network connection, not the generator: it only decrements on server EOF or a read error, never in a generator `finally`

## Why

Root-cause instrumentation for the 2026-07-06 slackbot wedge. Every execute turn opens an `/events` SSE stream; when the renderer stops consuming after the terminal event, nothing cancels the reader, so the connection stays open and permanently occupies a slot of Bun's global fetch pool (`BUN_CONFIG_MAX_HTTP_REQUESTS`, default 256, not overridden). At 256 leaked connections every outbound fetch (Slack API and session API alike) queues forever: production logged exactly 256 `slackbotv2_session_events_opened` on the wedged pod, the 256th at 19:35:53Z, and the first outbound timeout 8s later, while api-rs stayed healthy.

A generator-`finally` decrement would fire when the stream is abandoned even though the socket stays open — hiding exactly this leak — so the gauge intentionally tracks socket settlement. Today it is expected to climb ~1 per execute turn until the pod restarts or the leak is fixed; alerting well below 256 gives early warning. The reader-cancel fix (which will bring this gauge back to ~0 with `reason="cancelled"`) comes separately.

Known limit: if the server closes an already-abandoned stream, the slot frees but no read observes it, so the gauge can overcount. api-rs holds these streams open, so in practice the gauge tracks the leak accurately.

## Tests
- `bun test test` (145 pass)
- `bun run check:types`
- local repro (not in this PR): 256 emulated execute turns against the real bot wedge with `handoff_failed="create session timed out"` while this gauge climbs 1-per-turn to 255/256