### PR TITLE
Revert Claude end-turn completion fallback

### DIFF
--- a/crates/harness-server/src/claude.rs
+++ b/crates/harness-server/src/claude.rs
@@ -277,10 +277,6 @@ impl HarnessServer for ClaudeCodeHarness {
     ) -> Result<Vec<NormalizedEvent>> {
         Ok(normalizer.normalize(event))
     }
-
-    fn finish_turn_on_assistant_end_turn(&self) -> bool {
-        true
-    }
 }
 
 #[cfg(test)]

--- a/crates/harness-server/src/server.rs
+++ b/crates/harness-server/src/server.rs
@@ -1263,8 +1263,6 @@ fn run_harness_turn<H: HarnessServer, W: Write>(
         let event = harness.parse_stdout_line(trimmed)?;
         let normalized_events = harness.normalize_events(&mut event_normalizer, event)?;
         let mut terminal = false;
-        let mut native_terminal_in_batch = false;
-        let mut assistant_end_turn_terminal_in_batch = false;
         for normalized in normalized_events {
             if let Some(usage) = normalized.token_usage() {
                 latest_usage = Some(usage.clone());
@@ -1277,26 +1275,11 @@ fn run_harness_turn<H: HarnessServer, W: Write>(
             for notification in normalizer.process_event(&normalized)? {
                 write_value(stdout, &notification_to_wire_value(&notification)?)?;
             }
-            let native_terminal = normalized.is_terminal();
-            let assistant_end_turn_terminal =
-                harness.finish_turn_on_assistant_end_turn() && normalized.is_assistant_end_turn();
-            native_terminal_in_batch |= native_terminal;
-            assistant_end_turn_terminal_in_batch |= assistant_end_turn_terminal;
-            terminal |= native_terminal || assistant_end_turn_terminal;
+            terminal |= normalized.is_terminal()
+                || (harness.finish_turn_on_assistant_end_turn()
+                    && normalized.is_assistant_end_turn());
         }
         if terminal {
-            if assistant_end_turn_terminal_in_batch
-                && !native_terminal_in_batch
-                && matches!(harness.kind(), HarnessKind::ClaudeCode)
-            {
-                eprintln!(
-                    "event=harness_turn_completed_on_assistant_end_turn harness_kind={:?} thread_id={} turn_id={} session_id={}",
-                    harness.kind(),
-                    state.id,
-                    normalizer.turn_id(),
-                    state.harness_session_id.as_deref().unwrap_or("")
-                );
-            }
             export_harness_usage_if_available(
                 trace_context,
                 harness.kind(),

--- a/crates/harness-server/tests/app_server_stdio.rs
+++ b/crates/harness-server/tests/app_server_stdio.rs
@@ -107,30 +107,6 @@ fn fake_claude_app_server_streams_codex_v2_notifications() {
 }
 
 #[test]
-fn fake_claude_app_server_completes_on_final_answer_end_turn_without_result() {
-    let fake_claude = concat!(
-        "printf '%s\\n' ",
-        "'{\"type\":\"system\",\"subtype\":\"init\",\"session_id\":\"claude-session\"}' ",
-        "'{\"type\":\"stream_event\",\"event\":{\"type\":\"message_start\",\"message\":{\"id\":\"msg_1\",\"stop_reason\":null,\"content\":[]}}}' ",
-        "'{\"type\":\"stream_event\",\"event\":{\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}}' ",
-        "'{\"type\":\"stream_event\",\"event\":{\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"cold answer\"}}}' ",
-        "'{\"type\":\"assistant\",\"message\":{\"id\":\"msg_1\",\"stop_reason\":null,\"content\":[{\"type\":\"text\",\"text\":\"cold answer\"}]}}' ",
-        "'{\"type\":\"stream_event\",\"event\":{\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"}}}'"
-    );
-
-    let run = run_bridge_turn(BridgeTurnConfig {
-        harness: Harness::ClaudeCode,
-        command_override: Some(fake_claude.to_string()),
-        prompt: "say hello".to_string(),
-        timeout: Duration::from_secs(10),
-    });
-
-    assert_completed_turn(&run.turn);
-    assert_eq!(run.turn.text_from_deltas, "cold answer");
-    assert_codex_v2_turn(&run.turn);
-}
-
-#[test]
 fn fake_codex_blocks_mode_uses_openrouter_provider_when_model_is_configured() {
     let fake_codex = temp_path("fake-openrouter-codex.sh");
     let fake_codex_log = temp_path("fake-openrouter-codex-requests.jsonl");


### PR DESCRIPTION
## Summary
- Reverts 791bd244 / #903, which completed Claude Code turns on assistant `end_turn` even when the native result event never arrived.
- Intended as a separate rollback candidate for the Fable Slack rendering regression where Slackbot opens the stream, leaves Thinking visible, and never reaches render finalization.

Prompted by: mslipper

## Verification
- cargo test --manifest-path crates/harness-server/Cargo.toml
- cargo test --manifest-path crates/harness-server/Cargo.toml fake_claude_app_server_completes_on_final_answer_end_turn_without_result --test app_server_stdio (0 tests after revert, as the reverted regression test is removed)

## Notes
- cargo +nightly fmt --manifest-path crates/harness-server/Cargo.toml -- --check still reports unrelated formatting drift in crates/harness-server/src/otel.rs, which this revert does not touch.
