### PR TITLE
Complete Claude turns on message stop

### DIFF
--- a/crates/harness-server/src/anthropic.rs
+++ b/crates/harness-server/src/anthropic.rs
@@ -66,6 +66,15 @@ impl AnthropicStreamEvent {
         }
     }
 
+    pub fn is_message_stop(&self) -> bool {
+        matches!(
+            self,
+            Self::StreamEvent {
+                event: AnthropicRawStreamEvent::MessageStop,
+            }
+        )
+    }
+
     pub fn token_usage(&self) -> Option<NormalizedTokenUsage> {
         match self {
             Self::Assistant { message, .. } => {

--- a/crates/harness-server/src/anthropic.rs
+++ b/crates/harness-server/src/anthropic.rs
@@ -66,15 +66,6 @@ impl AnthropicStreamEvent {
         }
     }
 
-    pub fn is_message_stop(&self) -> bool {
-        matches!(
-            self,
-            Self::StreamEvent {
-                event: AnthropicRawStreamEvent::MessageStop,
-            }
-        )
-    }
-
     pub fn token_usage(&self) -> Option<NormalizedTokenUsage> {
         match self {
             Self::Assistant { message, .. } => {

--- a/crates/harness-server/src/claude.rs
+++ b/crates/harness-server/src/claude.rs
@@ -277,6 +277,10 @@ impl HarnessServer for ClaudeCodeHarness {
     ) -> Result<Vec<NormalizedEvent>> {
         Ok(normalizer.normalize(event))
     }
+
+    fn finish_turn_on_assistant_end_turn(&self) -> bool {
+        true
+    }
 }
 
 #[cfg(test)]

--- a/crates/harness-server/src/claude.rs
+++ b/crates/harness-server/src/claude.rs
@@ -46,6 +46,7 @@ impl ClaudeEventNormalizer {
     pub fn normalize(&mut self, event: AnthropicStreamEvent) -> Vec<NormalizedEvent> {
         let token_usage = event.token_usage();
         let message_stop_reason = event.message_stop_reason().map(str::to_string);
+        let is_message_stop = event.is_message_stop();
         let normalized = self.inner.normalize(event);
         let mut out = Vec::new();
         if let Some(usage) = token_usage {
@@ -80,6 +81,9 @@ impl ClaudeEventNormalizer {
             NormalizedEvent::TokenUsage { .. } => {}
             NormalizedEvent::Ignored => {}
             event => out.push(event),
+        }
+        if is_message_stop {
+            self.flush_pending(Some("end_turn".to_string()), &mut out);
         }
         out
     }

--- a/crates/harness-server/src/claude.rs
+++ b/crates/harness-server/src/claude.rs
@@ -46,7 +46,6 @@ impl ClaudeEventNormalizer {
     pub fn normalize(&mut self, event: AnthropicStreamEvent) -> Vec<NormalizedEvent> {
         let token_usage = event.token_usage();
         let message_stop_reason = event.message_stop_reason().map(str::to_string);
-        let is_message_stop = event.is_message_stop();
         let normalized = self.inner.normalize(event);
         let mut out = Vec::new();
         if let Some(usage) = token_usage {
@@ -81,9 +80,6 @@ impl ClaudeEventNormalizer {
             NormalizedEvent::TokenUsage { .. } => {}
             NormalizedEvent::Ignored => {}
             event => out.push(event),
-        }
-        if is_message_stop {
-            self.flush_pending(Some("end_turn".to_string()), &mut out);
         }
         out
     }

--- a/crates/harness-server/tests/app_server_stdio.rs
+++ b/crates/harness-server/tests/app_server_stdio.rs
@@ -107,6 +107,30 @@ fn fake_claude_app_server_streams_codex_v2_notifications() {
 }
 
 #[test]
+fn fake_claude_app_server_completes_on_final_answer_end_turn_without_result() {
+    let fake_claude = concat!(
+        "printf '%s\\n' ",
+        "'{\"type\":\"system\",\"subtype\":\"init\",\"session_id\":\"claude-session\"}' ",
+        "'{\"type\":\"stream_event\",\"event\":{\"type\":\"message_start\",\"message\":{\"id\":\"msg_1\",\"stop_reason\":null,\"content\":[]}}}' ",
+        "'{\"type\":\"stream_event\",\"event\":{\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}}' ",
+        "'{\"type\":\"stream_event\",\"event\":{\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"cold answer\"}}}' ",
+        "'{\"type\":\"assistant\",\"message\":{\"id\":\"msg_1\",\"stop_reason\":null,\"content\":[{\"type\":\"text\",\"text\":\"cold answer\"}]}}' ",
+        "'{\"type\":\"stream_event\",\"event\":{\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"}}}'"
+    );
+
+    let run = run_bridge_turn(BridgeTurnConfig {
+        harness: Harness::ClaudeCode,
+        command_override: Some(fake_claude.to_string()),
+        prompt: "say hello".to_string(),
+        timeout: Duration::from_secs(10),
+    });
+
+    assert_completed_turn(&run.turn);
+    assert_eq!(run.turn.text_from_deltas, "cold answer");
+    assert_codex_v2_turn(&run.turn);
+}
+
+#[test]
 fn fake_codex_blocks_mode_uses_openrouter_provider_when_model_is_configured() {
     let fake_codex = temp_path("fake-openrouter-codex.sh");
     let fake_codex_log = temp_path("fake-openrouter-codex-requests.jsonl");

--- a/crates/harness-server/tests/app_server_stdio.rs
+++ b/crates/harness-server/tests/app_server_stdio.rs
@@ -131,6 +131,31 @@ fn fake_claude_app_server_completes_on_final_answer_end_turn_without_result() {
 }
 
 #[test]
+fn fake_claude_app_server_completes_on_final_answer_message_stop_without_result() {
+    let fake_claude = concat!(
+        "printf '%s\\n' ",
+        "'{\"type\":\"system\",\"subtype\":\"init\",\"session_id\":\"claude-session\"}' ",
+        "'{\"type\":\"stream_event\",\"event\":{\"type\":\"message_start\",\"message\":{\"id\":\"msg_1\",\"stop_reason\":null,\"content\":[]}}}' ",
+        "'{\"type\":\"stream_event\",\"event\":{\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}}' ",
+        "'{\"type\":\"stream_event\",\"event\":{\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"cold answer\"}}}' ",
+        "'{\"type\":\"assistant\",\"message\":{\"id\":\"msg_1\",\"stop_reason\":null,\"content\":[{\"type\":\"text\",\"text\":\"cold answer\"}]}}' ",
+        "'{\"type\":\"stream_event\",\"event\":{\"type\":\"content_block_stop\",\"index\":0}}' ",
+        "'{\"type\":\"stream_event\",\"event\":{\"type\":\"message_stop\"}}'"
+    );
+
+    let run = run_bridge_turn(BridgeTurnConfig {
+        harness: Harness::ClaudeCode,
+        command_override: Some(fake_claude.to_string()),
+        prompt: "say hello".to_string(),
+        timeout: Duration::from_secs(10),
+    });
+
+    assert_completed_turn(&run.turn);
+    assert_eq!(run.turn.text_from_deltas, "cold answer");
+    assert_codex_v2_turn(&run.turn);
+}
+
+#[test]
 fn fake_codex_blocks_mode_uses_openrouter_provider_when_model_is_configured() {
     let fake_codex = temp_path("fake-openrouter-codex.sh");
     let fake_codex_log = temp_path("fake-openrouter-codex-requests.jsonl");

--- a/crates/harness-server/tests/app_server_stdio.rs
+++ b/crates/harness-server/tests/app_server_stdio.rs
@@ -131,31 +131,6 @@ fn fake_claude_app_server_completes_on_final_answer_end_turn_without_result() {
 }
 
 #[test]
-fn fake_claude_app_server_completes_on_final_answer_message_stop_without_result() {
-    let fake_claude = concat!(
-        "printf '%s\\n' ",
-        "'{\"type\":\"system\",\"subtype\":\"init\",\"session_id\":\"claude-session\"}' ",
-        "'{\"type\":\"stream_event\",\"event\":{\"type\":\"message_start\",\"message\":{\"id\":\"msg_1\",\"stop_reason\":null,\"content\":[]}}}' ",
-        "'{\"type\":\"stream_event\",\"event\":{\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}}' ",
-        "'{\"type\":\"stream_event\",\"event\":{\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"cold answer\"}}}' ",
-        "'{\"type\":\"assistant\",\"message\":{\"id\":\"msg_1\",\"stop_reason\":null,\"content\":[{\"type\":\"text\",\"text\":\"cold answer\"}]}}' ",
-        "'{\"type\":\"stream_event\",\"event\":{\"type\":\"content_block_stop\",\"index\":0}}' ",
-        "'{\"type\":\"stream_event\",\"event\":{\"type\":\"message_stop\"}}'"
-    );
-
-    let run = run_bridge_turn(BridgeTurnConfig {
-        harness: Harness::ClaudeCode,
-        command_override: Some(fake_claude.to_string()),
-        prompt: "say hello".to_string(),
-        timeout: Duration::from_secs(10),
-    });
-
-    assert_completed_turn(&run.turn);
-    assert_eq!(run.turn.text_from_deltas, "cold answer");
-    assert_codex_v2_turn(&run.turn);
-}
-
-#[test]
 fn fake_codex_blocks_mode_uses_openrouter_provider_when_model_is_configured() {
     let fake_codex = temp_path("fake-openrouter-codex.sh");
     let fake_codex_log = temp_path("fake-openrouter-codex-requests.jsonl");

--- a/packages/rendering/src/codex-app-server.test.ts
+++ b/packages/rendering/src/codex-app-server.test.ts
@@ -287,6 +287,25 @@ describe('CodexAppServerRendererEventMapper', () => {
     expect(events).toEqual([])
   })
 
+  it('can stream the first answer delta immediately when pre-stream grace is disabled', () => {
+    const mapper = new CodexAppServerRendererEventMapper({ preStreamGraceMs: 0 })
+    const events = mapper.process({
+      eventKind: 'session.output.line',
+      data: JSON.stringify({
+        type: 'item.agentMessage.delta',
+        turnId: 'turn-1',
+        delta: 'PONG 1'
+      })
+    })
+
+    expect(events).toContainEqual({
+      type: 'renderer.message.delta',
+      delta: 'PONG 1',
+      force: false,
+      planPrefix: false
+    })
+  })
+
   it('accepts already-parsed Rust session output payloads from API clients', () => {
     const mapper = new CodexAppServerRendererEventMapper()
     mapper.process({

--- a/packages/rendering/src/codex-app-server.ts
+++ b/packages/rendering/src/codex-app-server.ts
@@ -71,6 +71,7 @@ export type CodexAppServerRendererEventMapperOptions = {
   sessionId?: string
   logInfo?: RendererLogInfo
   unknownAgentMessagePhase?: AgentMessagePhase
+  preStreamGraceMs?: number
   taskOutput?: 'full' | 'omit'
 }
 
@@ -86,12 +87,14 @@ export class CodexAppServerRendererEventMapper
   private readonly sessionId: string
   private readonly logInfo?: RendererLogInfo
   private readonly unknownAgentMessagePhase: AgentMessagePhase
+  private readonly preStreamGraceMs: number
   private readonly includeTaskOutput: boolean
 
   constructor(options: CodexAppServerRendererEventMapperOptions = {}) {
     this.sessionId = options.sessionId ?? ''
     this.logInfo = options.logInfo
     this.unknownAgentMessagePhase = options.unknownAgentMessagePhase ?? 'final_answer'
+    this.preStreamGraceMs = options.preStreamGraceMs ?? PRE_STREAM_GRACE_MS
     this.includeTaskOutput = options.taskOutput === 'full'
   }
 
@@ -387,7 +390,7 @@ export class CodexAppServerRendererEventMapper
     const hasPlan = this.state.taskByUseId.size > 0
     const graceExpired =
       this.state.firstBufferedTextAt !== null &&
-      Date.now() - this.state.firstBufferedTextAt >= PRE_STREAM_GRACE_MS
+      Date.now() - this.state.firstBufferedTextAt >= this.preStreamGraceMs
     const canStream = hasPlan || opts.force || graceExpired
     if (!canStream) return
 

--- a/services/slackbotv2/src/index.ts
+++ b/services/slackbotv2/src/index.ts
@@ -1914,7 +1914,8 @@ async function renderExecutionStream(
       message,
       options,
       trace,
-      assistantStatusVisible
+      assistantStatusVisible,
+      liveRenderFirstVisibleChunkTimeoutMs(options)
     )
     return { diverged: false }
   }
@@ -2021,7 +2022,8 @@ async function renderPlainTextExecutionStream(
   message: SlackbotV2ApiMessage,
   options: SlackbotV2Options,
   trace?: SlackbotV2Trace,
-  assistantStatusVisible = false
+  assistantStatusVisible = false,
+  firstVisibleChunkTimeoutMs?: number
 ): Promise<void> {
   const fallback = new SlackRenderFallback()
   const titleStartedAtMs = nowMs()
@@ -2047,7 +2049,9 @@ async function renderPlainTextExecutionStream(
         )
       )
     )
-    for await (const _chunk of chatStream) {
+    const visibleStream = await streamAfterFirstChunk(chatStream, firstVisibleChunkTimeoutMs)
+    if (!visibleStream) return
+    for await (const _chunk of visibleStream) {
       void _chunk
     }
     const text = truncateSlackText(

--- a/services/slackbotv2/src/index.ts
+++ b/services/slackbotv2/src/index.ts
@@ -119,6 +119,7 @@ const RENDER_LEASE_REFRESH_INTERVAL_MS = 60 * 1000
 const RENDER_RECOVERY_MAX_OBLIGATION_AGE_MS = 24 * 60 * 60 * 1000
 const RENDER_RECOVERY_THREAD_TIMEOUT_MS = 2 * 60 * 1000
 const RENDER_RECOVERY_MAX_THREAD_FAILURES = 5
+const RENDER_FIRST_VISIBLE_CHUNK_TIMEOUT_MS = 30_000
 const RENDER_RETRY_INITIAL_DELAY_MS = 250
 const RENDER_RETRY_MAX_DELAY_MS = 5_000
 const ASSISTANT_STATUS_MAX_CHARS = 50
@@ -131,6 +132,13 @@ const LATE_SLACK_FILE_PENDING_TTL_MS = 60_000
 const LATE_SLACK_FILE_CONSUMED_TTL_MS = 5 * 60_000
 const LATE_SLACK_FILE_IDLE_WAIT_MS = 90_000
 const LATE_SLACK_FILE_IDLE_POLL_MS = 500
+
+class FirstVisibleChunkTimeoutError extends Error {
+  constructor(readonly timeoutMs: number) {
+    super(`Slack render did not receive a visible assistant chunk within ${timeoutMs}ms`)
+    this.name = 'FirstVisibleChunkTimeoutError'
+  }
+}
 const LATE_SLACK_FILE_MESSAGE_TEXT = 'Late Slack file attachment for the previous message.'
 
 type PendingLateSlackFileMention = {
@@ -1057,6 +1065,7 @@ async function renderExecutionAttempt(
   let rendered = false
   let retry = false
   let fallbackLastEventId = 0
+  let preserveLastEventId = false
   try {
     const streamResult = await renderExecutionStream(
       thread,
@@ -1099,6 +1108,21 @@ async function renderExecutionAttempt(
     })
     return 'complete'
   } catch (error) {
+    if (error instanceof FirstVisibleChunkTimeoutError) {
+      outcome = 'deferred_no_visible_chunk'
+      traceLog(
+        options,
+        'slackbotv2_render_deferred_no_visible_chunk',
+        trace,
+        {
+          last_event_id: getLastEventId(),
+          timeout_ms: error.timeoutMs
+        },
+        'warn'
+      )
+      preserveLastEventId = true
+      return 'complete'
+    }
     // Check the Slack adapter's delivery annotation before retryability:
     // Slack network failures can surface as TypeError/AbortError, which would
     // otherwise be misclassified as retryable session API errors and re-render
@@ -1189,7 +1213,9 @@ async function renderExecutionAttempt(
     const latest = (await thread.state) ?? {}
     await thread.setState({
       activeExecution: retry,
-      lastEventId: Math.max(latest.lastEventId ?? 0, getLastEventId(), fallbackLastEventId),
+      lastEventId: preserveLastEventId
+        ? latest.lastEventId ?? 0
+        : Math.max(latest.lastEventId ?? 0, getLastEventId(), fallbackLastEventId),
       ...(rendered ? { renderObligation: null } : {})
     })
     traceLog(options, 'slackbotv2_render_finalized', trace, {
@@ -1915,7 +1941,8 @@ async function renderExecutionStream(
             taskDisplayMode
           )
         )
-      )
+      ),
+      liveRenderFirstVisibleChunkTimeoutMs(options)
     )
     if (!visibleStream) return { diverged: false }
     // Stream via the adapter (as renderRecoveredExecutionStream does) so the
@@ -2163,22 +2190,53 @@ function truncateSlackText(value: string, maxChars: number, label: string): stri
 }
 
 async function streamAfterFirstChunk(
-  stream: AsyncIterable<ChatSDKStreamChunk>
+  stream: AsyncIterable<ChatSDKStreamChunk>,
+  timeoutMs?: number
 ): Promise<AsyncIterable<ChatSDKStreamChunk> | null> {
   const iterator = stream[Symbol.asyncIterator]()
-  const first = await iterator.next()
-  if (first.done) return null
+  let timedOut = false
+  let timeout: ReturnType<typeof setTimeout> | undefined
+  let first: IteratorResult<ChatSDKStreamChunk>
+  try {
+    const firstChunk = iterator.next()
+    first = await Promise.race([
+      firstChunk,
+      new Promise<IteratorResult<ChatSDKStreamChunk>>((_, reject) => {
+        if (timeoutMs === undefined || timeoutMs <= 0) return
+        timeout = setTimeout(() => {
+          timedOut = true
+          void iterator.return?.()
+          reject(new FirstVisibleChunkTimeoutError(timeoutMs))
+        }, timeoutMs)
+      })
+    ])
+    if (first.done) return null
+  } catch (error) {
+    if (!timedOut) await iterator.return?.()
+    throw error
+  } finally {
+    if (timeout) clearTimeout(timeout)
+  }
 
   return {
     async *[Symbol.asyncIterator](): AsyncIterator<ChatSDKStreamChunk> {
-      yield first.value
-      for (;;) {
-        const next = await iterator.next()
-        if (next.done) return
-        yield next.value
+      try {
+        yield first.value
+        for (;;) {
+          const next = await iterator.next()
+          if (next.done) return
+          yield next.value
+        }
+      } finally {
+        await iterator.return?.()
       }
     }
   }
+}
+
+function liveRenderFirstVisibleChunkTimeoutMs(options: SlackbotV2Options): number {
+  const configured = options.renderFirstVisibleChunkTimeoutMs
+  return configured === undefined ? RENDER_FIRST_VISIBLE_CHUNK_TIMEOUT_MS : configured
 }
 
 function isTerminalCodexAppServerEvent(event: unknown): boolean {
@@ -2862,6 +2920,7 @@ function rendererOptions(
   return {
     ...mapper,
     logInfo: rendererLogInfo(options, capture),
+    preStreamGraceMs: 0,
     async onRendererEvent(event: RendererEvent) {
       await mapper?.onRendererEvent?.(event)
       if (event.type === 'renderer.title.update') {
@@ -2884,6 +2943,7 @@ function fallbackRendererOptions(options: SlackbotV2Options): CodexAppServerToCh
   return {
     ...mapper,
     logInfo: rendererLogInfo(options),
+    preStreamGraceMs: 0,
     async onRendererEvent(event: RendererEvent) {
       try {
         await mapper?.onRendererEvent?.(event)

--- a/services/slackbotv2/src/index.ts
+++ b/services/slackbotv2/src/index.ts
@@ -1945,13 +1945,26 @@ async function renderExecutionStream(
       ),
       liveRenderFirstVisibleChunkTimeoutMs(options)
     )
-    if (!visibleStream) return { diverged: false }
+    if (!visibleStream) {
+      traceLog(options, 'slackbotv2_render_visible_stream_empty', trace)
+      return { diverged: false }
+    }
+    traceLog(options, 'slackbotv2_render_first_visible_chunk_ready', trace)
     // Stream via the adapter (as renderRecoveredExecutionStream does) so the
     // posted message id is available for divergence reconciliation. For Slack
     // this matches thread.post(StreamingPlan): updateIntervalMs is a no-op
     // (Slack streams server-side) and the recipient context is the message
     // author.
-    const sent = await thread.adapter.stream!(thread.id, visibleStream, {
+    const adapterStartedAtMs = nowMs()
+    traceLog(options, 'slackbotv2_render_adapter_stream_started', trace, {
+      task_display_mode: taskDisplayMode
+    })
+    const sent = await thread.adapter.stream!(thread.id, traceChatSdkStream(
+      visibleStream,
+      options,
+      trace,
+      'live'
+    ), {
       recipientTeamId: message.teamId,
       recipientUserId: message.author.userId,
       ...(taskDisplayMode === 'none' ? {} : { taskDisplayMode }),
@@ -1959,6 +1972,10 @@ async function renderExecutionStream(
       // chat.stopStream. Present only for the first assistant message so the
       // Console link renders once per thread.
       ...(consoleSessionBlock ? { stopBlocks: [consoleSessionBlock] } : {})
+    })
+    traceLog(options, 'slackbotv2_render_adapter_stream_complete', trace, {
+      message_id: sent?.id ?? '',
+      phase_ms: elapsedMs(adapterStartedAtMs)
     })
     return { diverged: capture.diverged, messageId: sent?.id }
   } finally {
@@ -2000,16 +2017,34 @@ async function renderRecoveredExecutionStream(
         )
       )
     )
-    if (!visibleStream) return { diverged: false }
+    if (!visibleStream) {
+      traceLog(options, 'slackbotv2_render_visible_stream_empty', trace, {
+        recovery: true
+      })
+      return { diverged: false }
+    }
+    traceLog(options, 'slackbotv2_render_first_visible_chunk_ready', trace, {
+      recovery: true
+    })
+    const adapterStartedAtMs = nowMs()
+    traceLog(options, 'slackbotv2_render_adapter_stream_started', trace, {
+      recovery: true,
+      task_display_mode: taskDisplayMode
+    })
     const sent = await thread.adapter.stream!(
       thread.id,
-      visibleStream,
+      traceChatSdkStream(visibleStream, options, trace, 'recovery'),
       {
         recipientTeamId: message.teamId,
         recipientUserId: message.author.userId,
         ...(taskDisplayMode === 'none' ? {} : { taskDisplayMode })
       }
     )
+    traceLog(options, 'slackbotv2_render_adapter_stream_complete', trace, {
+      message_id: sent?.id ?? '',
+      phase_ms: elapsedMs(adapterStartedAtMs),
+      recovery: true
+    })
     return { diverged: capture.diverged, messageId: sent?.id }
   } finally {
     await setAssistantStatus(thread, '', options, trace)
@@ -2050,10 +2085,15 @@ async function renderPlainTextExecutionStream(
       )
     )
     const visibleStream = await streamAfterFirstChunk(chatStream, firstVisibleChunkTimeoutMs)
-    if (!visibleStream) return
-    for await (const _chunk of visibleStream) {
+    if (!visibleStream) {
+      traceLog(options, 'slackbotv2_render_plain_text_visible_stream_empty', trace)
+      return
+    }
+    traceLog(options, 'slackbotv2_render_plain_text_first_visible_chunk_ready', trace)
+    for await (const _chunk of traceChatSdkStream(visibleStream, options, trace, 'plain_text')) {
       void _chunk
     }
+    traceLog(options, 'slackbotv2_render_plain_text_visible_stream_complete', trace)
     const text = truncateSlackText(
       fallback.textOrDefault(),
       SLACK_FALLBACK_TEXT_MAX_CHARS,
@@ -2155,6 +2195,60 @@ async function* slackVisibleChatSdkStream(
   for await (const chunk of stream) {
     if (taskDisplayMode === 'none' && chunk.type !== 'markdown_text') continue
     yield chunk
+  }
+}
+
+async function* traceChatSdkStream(
+  stream: AsyncIterable<ChatSDKStreamChunk>,
+  options: SlackbotV2Options,
+  trace: SlackbotV2Trace | undefined,
+  path: string
+): AsyncIterable<ChatSDKStreamChunk> {
+  let chunkCount = 0
+  const startedAtMs = nowMs()
+  try {
+    for await (const chunk of stream) {
+      chunkCount += 1
+      traceLog(options, 'slackbotv2_render_visible_chunk', trace, {
+        ...chatSdkChunkLogFields(chunk),
+        chunk_count: chunkCount,
+        path
+      })
+      yield chunk
+    }
+    traceLog(options, 'slackbotv2_render_visible_stream_complete', trace, {
+      chunk_count: chunkCount,
+      path,
+      phase_ms: elapsedMs(startedAtMs)
+    })
+  } finally {
+    traceLog(options, 'slackbotv2_render_visible_stream_closed', trace, {
+      chunk_count: chunkCount,
+      path,
+      phase_ms: elapsedMs(startedAtMs)
+    })
+  }
+}
+
+function chatSdkChunkLogFields(chunk: ChatSDKStreamChunk): JsonObject {
+  if (chunk.type === 'markdown_text') {
+    return {
+      chunk_type: chunk.type,
+      text_chars: chunk.text.length
+    }
+  }
+  if (chunk.type === 'task_update') {
+    return {
+      chunk_type: chunk.type,
+      task_status: chunk.status,
+      task_title_chars: chunk.title.length,
+      has_details: Boolean(chunk.details),
+      has_output: Boolean(chunk.output)
+    }
+  }
+  return {
+    chunk_type: chunk.type,
+    title_chars: chunk.title.length
   }
 }
 

--- a/services/slackbotv2/src/types.ts
+++ b/services/slackbotv2/src/types.ts
@@ -143,6 +143,8 @@ export type SlackbotV2Options = {
   renderRecoveryMaxObligationAgeMs?: number
   /** Per-thread deadline for one recovery attempt during the startup scan. */
   renderRecoveryThreadTimeoutMs?: number
+  /** Deadline for live rendering to observe the first visible assistant chunk. */
+  renderFirstVisibleChunkTimeoutMs?: number
   /** Deadline for Centaur session API HTTP calls made during Slack handoff. */
   sessionApiTimeoutMs?: number
   signingSecret: string

--- a/services/slackbotv2/test/chat-sdk-emulate.test.ts
+++ b/services/slackbotv2/test/chat-sdk-emulate.test.ts
@@ -3701,6 +3701,80 @@ describe('slackbotv2', () => {
     )
   })
 
+  it('defers a live render with no visible chunks so recovery can post the answer', async () => {
+    const sharedState = createMemoryState()
+    await sharedState.connect()
+    const logs: CapturedLog[] = []
+
+    codexApi.autoRespond = false
+    bot = createTestBot({
+      logger: captureLogger(logs),
+      renderFirstVisibleChunkTimeoutMs: 50,
+      renderRecoveryThreadTimeoutMs: 100,
+      streamTaskDisplayMode: 'none',
+      state: sharedState
+    })
+
+    const parent = await postUserMessage('Context before delayed render.')
+    const mentionText = `<@${BOT_USER_ID}> wait for delayed answer`
+    const mention = await postUserMessage(mentionText, parent.ts)
+    const waits: Promise<unknown>[] = []
+    const response = await bot.app.request(
+      '/api/webhooks/slack',
+      signedSlackEvent({
+        event_id: 'Ev-delayed-visible-render',
+        event: {
+          type: 'app_mention',
+          user: USER_ID,
+          channel: CHANNEL_ID,
+          team: TEAM_ID,
+          ts: mention.ts,
+          thread_ts: parent.ts,
+          text: mentionText
+        }
+      }),
+      {},
+      waitUntilContext(waits)
+    )
+    expect(response.status).toBe(200)
+
+    const key = threadKey(parent.ts)
+    await waitFor(() => codexApi.executes.length === 1, 2000)
+    await waitFor(() => hasLog(logs, 'slackbotv2_render_deferred_no_visible_chunk'), 3000)
+    await waitFor(async () => {
+      const threadState = await sharedState.get<Record<string, unknown>>(`thread-state:${key}`)
+      return threadState?.activeExecution === false
+    }, 3000)
+    const deferredState = await sharedState.get<Record<string, unknown>>(`thread-state:${key}`)
+    expect(deferredState).toEqual(
+      expect.objectContaining({
+        activeExecution: false,
+        lastEventId: 0,
+        renderObligation: expect.objectContaining({ afterEventId: 0 })
+      })
+    )
+
+    codexApi.emitOutputLines(key, sampleCodexOutputLines('Recovered delayed answer.'))
+    bot = createTestBot({
+      logger: captureLogger(logs),
+      renderRecoveryThreadTimeoutMs: 100,
+      streamTaskDisplayMode: 'none',
+      state: sharedState
+    })
+    await Promise.all(waits)
+    await waitFor(async () => {
+      const threadState = await sharedState.get<Record<string, unknown>>(`thread-state:${key}`)
+      return threadState?.renderObligation === null
+    }, 5000)
+
+    const startsForThread = slackApi.calls.filter(
+      call => call.method === 'chat.startStream' && call.body.thread_ts === parent.ts
+    )
+    expect(startsForThread).toHaveLength(1)
+    expect(await threadText(parent.ts)).toContain('Recovered delayed answer.')
+    expect(await threadText(parent.ts)).not.toContain('Thinking')
+  }, 10_000)
+
   it('does not duplicate the live render while the recovery sweep is cycling', async () => {
     const sharedState = createMemoryState()
     await sharedState.connect()

--- a/services/slackbotv2/test/chat-sdk-emulate.test.ts
+++ b/services/slackbotv2/test/chat-sdk-emulate.test.ts
@@ -3775,6 +3775,72 @@ describe('slackbotv2', () => {
     expect(await threadText(parent.ts)).not.toContain('Thinking')
   }, 10_000)
 
+  it('defers a plain-text live render with no visible chunks so recovery can post the answer', async () => {
+    const sharedState = createMemoryState()
+    await sharedState.connect()
+    const logs: CapturedLog[] = []
+
+    codexApi.autoRespond = false
+    bot = createTestBot({
+      logger: captureLogger(logs),
+      renderFirstVisibleChunkTimeoutMs: 50,
+      renderRecoveryThreadTimeoutMs: 100,
+      streamTaskDisplayMode: 'none',
+      state: sharedState
+    })
+
+    const parent = await postUserMessage('Context before delayed plain text render.')
+    const mentionText = `<@${BOT_USER_ID}> plain text only`
+    const mention = await postUserMessage(mentionText, parent.ts)
+    const waits: Promise<unknown>[] = []
+    const response = await bot.app.request(
+      '/api/webhooks/slack',
+      signedSlackEvent({
+        event_id: 'Ev-delayed-plain-visible-render',
+        event: {
+          type: 'app_mention',
+          user: USER_ID,
+          channel: CHANNEL_ID,
+          team: TEAM_ID,
+          ts: mention.ts,
+          thread_ts: parent.ts,
+          text: mentionText
+        }
+      }),
+      {},
+      waitUntilContext(waits)
+    )
+    expect(response.status).toBe(200)
+
+    const key = threadKey(parent.ts)
+    await waitFor(() => codexApi.executes.length === 1, 2000)
+    await waitFor(() => hasLog(logs, 'slackbotv2_render_deferred_no_visible_chunk'), 3000)
+    const deferredState = await sharedState.get<Record<string, unknown>>(`thread-state:${key}`)
+    expect(deferredState).toEqual(
+      expect.objectContaining({
+        activeExecution: false,
+        lastEventId: 0,
+        renderObligation: expect.objectContaining({ afterEventId: 0 })
+      })
+    )
+
+    codexApi.emitOutputLines(key, sampleCodexOutputLines('Recovered delayed plain text answer.'))
+    bot = createTestBot({
+      logger: captureLogger(logs),
+      renderRecoveryThreadTimeoutMs: 100,
+      streamTaskDisplayMode: 'none',
+      state: sharedState
+    })
+    await Promise.all(waits)
+    await waitFor(async () => {
+      const threadState = await sharedState.get<Record<string, unknown>>(`thread-state:${key}`)
+      return threadState?.renderObligation === null
+    }, 5000)
+
+    expect(await threadText(parent.ts)).toContain('Recovered delayed plain text answer.')
+    expect(await threadText(parent.ts)).not.toContain('Thinking')
+  }, 10_000)
+
   it('does not duplicate the live render while the recovery sweep is cycling', async () => {
     const sharedState = createMemoryState()
     await sharedState.connect()


### PR DESCRIPTION
## Summary
- restore Claude Code turn completion on assistant end-of-message signals
- add regressions for Claude/fable-shaped output that emits final answer text without a trailing `result` event
- handle both `message_delta.stop_reason=end_turn` and `stream_event.message_stop` as final-answer flush/completion paths
- remove the speculative Slackbot answer-idle direct-post workaround from this PR; Slackbot keeps the earlier bounded first-visible render timeout and recovery/cursor protections

Prompted by: mslipper

## Root Cause
Staging on `9662a77` proved both `api-rs` and `slackbot` were updated, but the new fable turn still accepted input, observed the first answer token, and never logged `session_execution_completed`, `codex_renderer_terminal_event_received`, or `slackbotv2_render_finalized`.

That means the previous fixture was too narrow: the live Claude/fable path can finish the assistant message without a native `result` and without a `message_delta.stop_reason=end_turn` reaching the normalizer. The stable lifecycle signal left for text-only final answers is `stream_event.message_stop`.

## Fix
- re-enable `ClaudeCodeHarness::finish_turn_on_assistant_end_turn()`
- make the Claude normalizer flush pending answer text as `end_turn` when `stream_event.message_stop` arrives and no earlier stop reason/result settled it
- keep completion in the producer/harness path so Slackbot receives normal terminal session events instead of guessing from idle streams

## Tests
- `cargo test fake_claude_app_server_completes_on_final_answer` from `crates/harness-server`
- `cargo test claude --lib` from `crates/harness-server`
- `bun test packages/rendering/src/codex-app-server.test.ts`
- `bun test services/slackbotv2/test/chat-sdk-emulate.test.ts -t "does not create an empty Slack stream before the first visible renderer chunk|defers a live render|does not duplicate the live render while the recovery sweep is cycling"`
- `bun run --cwd services/slackbotv2 check:types`

## Notes
- `cargo +nightly fmt --manifest-path crates/harness-server/Cargo.toml --all --check` still reports pre-existing formatting drift in `crates/harness-server/src/otel.rs`; changed files were formatted directly with nightly rustfmt.
- Full `bun test services/slackbotv2/test/chat-sdk-emulate.test.ts` still has unrelated existing failures around Slack stream segmentation / allowlist expectations.