### PR TITLE
fix: release session event stream connections after terminal events

### DIFF
--- a/services/api-rs/crates/centaur-session-runtime/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-runtime/src/lib.rs
@@ -3695,6 +3695,20 @@ fn session_event_stream(
                     if let Some(event) = state.pending.pop_front() {
                         state.after_event_id = event.event_id;
                         state.emitted_count += 1;
+                        // Execution-scoped streams are per-turn: after the
+                        // execution's terminal event nothing else will ever
+                        // arrive, so complete the response instead of parking
+                        // forever. Abandoned client connections otherwise pin
+                        // this stream's dedicated LISTEN connection until the
+                        // TCP peer is proven dead (the 2026-07-06 incident
+                        // exhausted both the Slackbot fetch pool and staging
+                        // Postgres this way). The 30s safety tick makes this
+                        // robust even when the notify is missed.
+                        if state.execution_id.is_some()
+                            && is_terminal_execution_event(&event.event_type)
+                        {
+                            state.done = true;
+                        }
                         return Some((Ok(event), state));
                     }
                     if state.done {
@@ -3747,6 +3761,15 @@ fn session_event_stream(
             }
             .instrument(span)
         },
+    )
+}
+
+/// Terminal event types for a single execution: once one of these is emitted
+/// on an execution-scoped stream, the stream has nothing left to deliver.
+fn is_terminal_execution_event(event_type: &str) -> bool {
+    matches!(
+        event_type,
+        "session.execution_completed" | "session.execution_failed" | "session.execution_cancelled"
     )
 }
 
@@ -7750,6 +7773,84 @@ mod adoption_tests {
             store.clone(),
             SandboxRuntime::backend(backend, SandboxSpec::new("mock")),
         )
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn execution_scoped_event_stream_completes_after_terminal_event() {
+        let Some(store) = test_store().await else {
+            return;
+        };
+        let _serial = TEST_LOCK.lock().await;
+        let thread_key =
+            ThreadKey::parse(format!("test:stream-close-{}", uuid::Uuid::new_v4())).unwrap();
+        let execution_id = orphaned_execution(&store, &thread_key, None, false).await;
+        store
+            .append_event(
+                &thread_key,
+                Some(&execution_id),
+                "session.output.line",
+                json!({ "line": "working" }),
+            )
+            .await
+            .expect("append output event");
+        store
+            .append_event(
+                &thread_key,
+                Some(&execution_id),
+                "session.execution_completed",
+                json!({ "execution_id": execution_id }),
+            )
+            .await
+            .expect("append terminal event");
+
+        // Execution-scoped: the stream must end on its own after emitting the
+        // terminal event, releasing the response and its listener connection.
+        let listener = store.listen_session_events().await.expect("listener");
+        let scoped = session_event_stream(
+            store.clone(),
+            thread_key.clone(),
+            0,
+            Some(execution_id.clone()),
+            listener,
+            tracing::Span::none(),
+        );
+        let emitted = tokio::time::timeout(Duration::from_secs(10), scoped.collect::<Vec<_>>())
+            .await
+            .expect("execution-scoped stream should complete after the terminal event");
+        let kinds: Vec<_> = emitted
+            .into_iter()
+            .map(|result| result.expect("stream event").event_type)
+            .collect();
+        assert_eq!(
+            kinds,
+            vec!["session.output.line", "session.execution_completed"]
+        );
+
+        // Control: an unscoped stream over the same events stays open for
+        // future events instead of completing.
+        let listener = store.listen_session_events().await.expect("listener");
+        let unscoped = session_event_stream(
+            store.clone(),
+            thread_key.clone(),
+            0,
+            None,
+            listener,
+            tracing::Span::none(),
+        );
+        let mut unscoped = std::pin::pin!(unscoped);
+        for _ in 0..2 {
+            unscoped
+                .next()
+                .await
+                .expect("buffered event")
+                .expect("stream event");
+        }
+        assert!(
+            tokio::time::timeout(Duration::from_millis(300), unscoped.next())
+                .await
+                .is_err(),
+            "unscoped stream should stay open after a terminal event"
+        );
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/services/slackbotv2/src/session-api.ts
+++ b/services/slackbotv2/src/session-api.ts
@@ -1850,16 +1850,13 @@ async function* parseSessionEventStream(
 
 async function* parseSseEvents(stream: ReadableStream<Uint8Array>): AsyncIterable<ParsedSessionEvent> {
   const reader = stream.getReader()
-  // Tracks the underlying network connection, NOT this generator's lifetime.
-  // Nothing cancels `reader` when a consumer abandons this generator early
-  // (e.g. parseSessionEventStream returning on a terminal event), so the
-  // connection stays open and keeps holding a slot in Bun's global fetch pool
-  // (BUN_CONFIG_MAX_HTTP_REQUESTS, default 256). A generator-finally here
-  // would hide exactly that leak, so the gauge is only decremented when the
-  // socket actually settles: server EOF or a read error.
+  // Tracks the underlying network connection. Each open stream occupies one
+  // slot of Bun's global fetch pool (BUN_CONFIG_MAX_HTTP_REQUESTS, default
+  // 256); the 2026-07-06 incident wedged Slackbot by leaking one abandoned
+  // stream per completed turn until the pool was exhausted.
   slackbotMetrics.sessionEventStreamsOpen.inc()
   let connectionReleased = false
-  const releaseConnection = (reason: 'done' | 'error') => {
+  const releaseConnection = (reason: 'cancelled' | 'done' | 'error') => {
     if (connectionReleased) return
     connectionReleased = true
     slackbotMetrics.sessionEventStreamsOpen.dec()
@@ -1871,42 +1868,52 @@ async function* parseSseEvents(stream: ReadableStream<Uint8Array>): AsyncIterabl
   let eventId: number | undefined
   let data: string[] = []
 
-  while (true) {
-    let done: boolean
-    let value: Uint8Array | undefined
-    try {
-      ;({ done, value } = await reader.read())
-    } catch (error) {
-      releaseConnection('error')
-      throw error
-    }
-    if (done) {
-      releaseConnection('done')
-      break
-    }
-    buffer += decoder.decode(value, { stream: true })
-    const lines = buffer.split(/\r?\n/)
-    buffer = lines.pop() ?? ''
+  try {
+    while (true) {
+      let done: boolean
+      let value: Uint8Array | undefined
+      try {
+        ;({ done, value } = await reader.read())
+      } catch (error) {
+        releaseConnection('error')
+        throw error
+      }
+      if (done) {
+        releaseConnection('done')
+        break
+      }
+      buffer += decoder.decode(value, { stream: true })
+      const lines = buffer.split(/\r?\n/)
+      buffer = lines.pop() ?? ''
 
-    for (const line of lines) {
-      const emitted = parseSseLine(line, { data, eventId, eventName })
+      for (const line of lines) {
+        const emitted = parseSseLine(line, { data, eventId, eventName })
+        data = emitted.state.data
+        eventId = emitted.state.eventId
+        eventName = emitted.state.eventName
+        if (emitted.event) yield emitted.event
+      }
+    }
+
+    buffer += decoder.decode()
+    if (buffer) {
+      const emitted = parseSseLine(buffer, { data, eventId, eventName })
       data = emitted.state.data
       eventId = emitted.state.eventId
       eventName = emitted.state.eventName
       if (emitted.event) yield emitted.event
     }
-  }
-
-  buffer += decoder.decode()
-  if (buffer) {
-    const emitted = parseSseLine(buffer, { data, eventId, eventName })
-    data = emitted.state.data
-    eventId = emitted.state.eventId
-    eventName = emitted.state.eventName
-    if (emitted.event) yield emitted.event
-  }
-  if (data.length > 0) {
-    yield { data: data.join('\n'), event: eventName, id: eventId }
+    if (data.length > 0) {
+      yield { data: data.join('\n'), event: eventName, id: eventId }
+    }
+  } finally {
+    // Runs when a consumer abandons this generator early — typically
+    // parseSessionEventStream returning on a terminal event. Cancelling the
+    // reader closes the connection, freeing its fetch-pool slot and letting
+    // api-rs drop the stream's server-side resources. Without this, every
+    // completed turn leaked one connection until all outbound HTTP wedged.
+    releaseConnection('cancelled')
+    await reader.cancel().catch(() => {})
   }
 }
 

--- a/services/slackbotv2/test/chat-sdk-emulate.test.ts
+++ b/services/slackbotv2/test/chat-sdk-emulate.test.ts
@@ -22,6 +22,7 @@ import {
   type SlackbotV2SessionMessage
 } from '../src/index'
 import { clearRequesterIdentityCacheForTests } from '../src/session-api'
+import { slackbotMetrics } from '../src/metrics'
 import claudeSettings from '../../../harness/claude/settings.json'
 
 const BOT_TOKEN = 'xoxb-slackbotv2-emulate'
@@ -5666,3 +5667,109 @@ async function isPortOpen(port: number): Promise<boolean> {
     })
   })
 }
+
+// Regression coverage for the 2026-07-06 incident: every execute turn opens a
+// GET /api/session/{key}/events SSE stream; abandoning it after the terminal
+// event without cancelling the reader leaked one connection per turn. At
+// Bun's global fetch cap (BUN_CONFIG_MAX_HTTP_REQUESTS, default 256) every
+// outbound fetch queued forever and all handoffs failed. parseSseEvents now
+// cancels the reader when the consumer stops, so connections are released.
+describe('session event stream connection lifecycle', () => {
+  function openEventStreamGauge(): number {
+    const match = /^slackbotv2_session_event_streams_open (\d+)$/m.exec(slackbotMetrics.expose())
+    return match?.[1] ? Number.parseInt(match[1], 10) : 0
+  }
+
+  function cancelledClosures(): number {
+    const match = /^slackbotv2_session_event_stream_closures_total\{reason="cancelled"\} (\d+)$/m
+      .exec(slackbotMetrics.expose())
+    return match?.[1] ? Number.parseInt(match[1], 10) : 0
+  }
+
+  async function waitForGaugeAtMost(limit: number): Promise<number> {
+    const deadline = Date.now() + 5_000
+    let open = openEventStreamGauge()
+    while (open > limit && Date.now() < deadline) {
+      await new Promise(resolve => setTimeout(resolve, 10))
+      open = openEventStreamGauge()
+    }
+    return open
+  }
+
+  async function deliverMention(bot: SlackbotV2, turn: number, threadTs: string, ts: string) {
+    const waits: Promise<unknown>[] = []
+    const response = await bot.app.request(
+      '/api/webhooks/slack',
+      signedSlackEvent({
+        event_id: `Ev-stream-lifecycle-${threadTs}-${turn}`,
+        event: {
+          type: 'app_mention',
+          user: USER_ID,
+          channel: CHANNEL_ID,
+          team: TEAM_ID,
+          ts,
+          thread_ts: threadTs,
+          text: `<@${BOT_USER_ID}> stream lifecycle turn ${turn}`
+        }
+      }),
+      {},
+      waitUntilContext(waits)
+    )
+    await Promise.all(waits).catch(() => {})
+    return response
+  }
+
+  it('cancels the events connection once a turn reaches its terminal event', async () => {
+    const gaugeBefore = openEventStreamGauge()
+    const closuresBefore = cancelledClosures()
+    const parent = await postUserMessage('Stream lifecycle thread.')
+    const mention = await postUserMessage(`<@${BOT_USER_ID}> stream lifecycle turn 0`, parent.ts)
+
+    const response = await deliverMention(bot, 0, parent.ts, mention.ts)
+    expect(response.status).toBe(200)
+
+    const open = await waitForGaugeAtMost(gaugeBefore)
+    expect(open).toBeLessThanOrEqual(gaugeBefore)
+    expect(cancelledClosures()).toBeGreaterThan(closuresBefore)
+  })
+
+  // Drives past Bun's 256-request cap to prove the wedge is gone. `bun test`
+  // ignores the BUN_CONFIG_MAX_HTTP_REQUESTS override but still enforces the
+  // built-in 256 cap, so crossing 260 turns exercises the real limit. Takes
+  // ~30s, so it is opt-in:
+  //
+  //   SLACKBOTV2_POOL_WEDGE_REPRO=1 bun test test/chat-sdk-emulate.test.ts -t 'pool cap'
+  const runCapCrossing = process.env.SLACKBOTV2_POOL_WEDGE_REPRO === '1' ? it : it.skip
+  runCapCrossing(
+    'keeps handing off past the 256-connection pool cap without wedging',
+    async () => {
+      const poolCap = 256
+      const gaugeBefore = openEventStreamGauge()
+      const repro = createTestBot({
+        sessionApiTimeoutMs: 5_000,
+        slackApiTimeoutMs: 2_000
+      })
+
+      let peak = 0
+      for (let turn = 0; turn < poolCap + 4; turn++) {
+        // One thread per turn, like production traffic: reusing a single
+        // thread makes per-turn context collection grow quadratically.
+        const parent = await postUserMessage(`Pool cap crossing thread ${turn + 1}.`)
+        const mention = await postUserMessage(
+          `<@${BOT_USER_ID}> stream lifecycle turn ${turn + 1}`,
+          parent.ts
+        )
+        const response = await deliverMention(repro, turn + 1, parent.ts, mention.ts)
+        expect(response.status).toBe(200)
+        const open = await waitForGaugeAtMost(gaugeBefore)
+        peak = Math.max(peak, open)
+        if ((turn + 1) % 64 === 0 || turn >= poolCap) {
+          console.log(`turn ${turn + 1}/${poolCap + 4}: ok, open streams settled at ${open}`)
+        }
+        expect(open).toBeLessThanOrEqual(gaugeBefore)
+      }
+      console.log(`peak settled gauge: ${peak}; cancelled closures: ${cancelledClosures()}`)
+    },
+    480_000
+  )
+})


### PR DESCRIPTION
## Summary

Fixes the 2026-07-06 Slackbot wedge at its source, on both sides of the `GET /api/session/{thread_key}/events` SSE stream:

- **slackbotv2**: `parseSseEvents` now cancels its reader in a `finally`, so abandoning the stream after a terminal event actually closes the connection. Previously every completed execute turn leaked one connection; at Bun's global fetch cap (`BUN_CONFIG_MAX_HTTP_REQUESTS`, default 256) every outbound fetch queued forever and all handoffs failed with `create session timed out`. The `slackbotv2_session_event_streams_open` gauge (#916) now decrements with `reason="cancelled"`.
- **api-rs**: execution-scoped event streams complete on their own after emitting that execution's terminal event (`session.execution_completed` / `_failed` / `_cancelled`) instead of parking forever. Every open stream holds a dedicated `PgListener` connection (~2 PG connections each); abandoned streams pinned them until the TCP peer was proven dead — a staging rerun of the incident exhausted Postgres (`max_connections=500`, 483 held by api-rs at 240 leaked streams) through exactly this. The 30s safety tick makes the close robust when the notify is missed. Unscoped streams (no `execution_id`) are unchanged.

Validated end to end before this fix: driving synthesized turns at staging leaked 1-2 connections per turn until `/proc/net/tcp` showed exactly 256 ESTABLISHED sockets to api-rs, at which point every handoff hung (`slackbotv2_webhook_handoff_wait_pending` growing unboundedly) while api-rs itself answered in <1ms — the production incident signature.

## Tests
- `bun test test` (147 tests, includes a new always-on regression test asserting the events connection is cancelled once a turn hits its terminal event)
- `SLACKBOTV2_POOL_WEDGE_REPRO=1 bun test test/chat-sdk-emulate.test.ts -t 'pool cap'` — drives 260 turns through Bun's 256-connection cap: all handoffs succeed, open-stream gauge settles at 0 every turn, 260 `cancelled` closures. Before this fix the same harness wedged at the cap with `handoff_failed="create session timed out"`.
- `bun run check:types`
- `cargo test -p centaur-session-runtime execution_scoped_event_stream` (new test: execution-scoped stream completes after the terminal event; unscoped stream stays open) with a local paradedb
- `cargo test -p centaur-api-server`, `cargo clippy -p centaur-session-runtime --all-targets`, `cargo +nightly fmt --check`

## Not run
- Full `cargo test -p centaur-session-runtime` has 4-5 pre-existing stdout-pump/adoption test failures on my machine that reproduce identically on unmodified `origin/main` (timing-sensitive against a local DB); relying on CI for those.