### PR TITLE
fix: complete harness turns on terminal assistant stops

### DIFF
--- a/crates/harness-server/src/amp.rs
+++ b/crates/harness-server/src/amp.rs
@@ -1,6 +1,7 @@
 use std::collections::HashSet;
 use std::env;
 use std::process::Command as ProcessCommand;
+use std::time::Duration;
 
 use codex_app_server_protocol::UserInput;
 use serde_json::json;
@@ -165,8 +166,11 @@ impl HarnessServer for AmpHarness {
         Ok(normalizer.normalize(event))
     }
 
-    fn finish_turn_on_terminal_assistant_stop(&self) -> bool {
-        true
+    /// Amp's stream has no native `result` event: the terminal assistant stop
+    /// IS the end of the turn, so complete immediately (a settle window would
+    /// add its full length to every turn).
+    fn terminal_assistant_stop_settle(&self) -> Option<Duration> {
+        Some(Duration::ZERO)
     }
 }
 

--- a/crates/harness-server/src/amp.rs
+++ b/crates/harness-server/src/amp.rs
@@ -165,7 +165,7 @@ impl HarnessServer for AmpHarness {
         Ok(normalizer.normalize(event))
     }
 
-    fn finish_turn_on_assistant_end_turn(&self) -> bool {
+    fn finish_turn_on_terminal_assistant_stop(&self) -> bool {
         true
     }
 }

--- a/crates/harness-server/src/anthropic.rs
+++ b/crates/harness-server/src/anthropic.rs
@@ -19,13 +19,19 @@ pub enum AnthropicStreamEvent {
         #[serde(default)]
         is_partial: bool,
         message: AnthropicMessage,
+        #[serde(default)]
+        parent_tool_use_id: Option<String>,
     },
     User {
         message: AnthropicMessage,
         tool_use_result: Option<Value>,
+        #[serde(default)]
+        parent_tool_use_id: Option<String>,
     },
     StreamEvent {
         event: AnthropicRawStreamEvent,
+        #[serde(default)]
+        parent_tool_use_id: Option<String>,
     },
     Result {
         subtype: Option<String>,
@@ -61,9 +67,32 @@ impl AnthropicStreamEvent {
                     AnthropicRawStreamEvent::MessageDelta {
                         delta: Some(delta), ..
                     },
+                ..
             } => delta.stop_reason.as_deref(),
             _ => None,
         }
+    }
+
+    /// The Task tool-use id owning this event when it belongs to a subagent
+    /// sidechain. Sidechain messages stop with their own `end_turn` while the
+    /// parent turn keeps running, so they must never settle the turn.
+    pub fn parent_tool_use_id(&self) -> Option<&str> {
+        match self {
+            Self::Assistant {
+                parent_tool_use_id, ..
+            }
+            | Self::User {
+                parent_tool_use_id, ..
+            }
+            | Self::StreamEvent {
+                parent_tool_use_id, ..
+            } => parent_tool_use_id.as_deref(),
+            _ => None,
+        }
+    }
+
+    pub fn is_sidechain(&self) -> bool {
+        self.parent_tool_use_id().is_some()
     }
 
     pub fn token_usage(&self) -> Option<NormalizedTokenUsage> {
@@ -140,7 +169,7 @@ pub struct AnthropicEventNormalizer {
 impl AnthropicEventNormalizer {
     pub fn normalize(&mut self, event: AnthropicStreamEvent) -> NormalizedEvent {
         match event {
-            AnthropicStreamEvent::StreamEvent { event } => self.normalize_stream_event(event),
+            AnthropicStreamEvent::StreamEvent { event, .. } => self.normalize_stream_event(event),
             event => self.normalize_message_event(event),
         }
     }
@@ -218,6 +247,7 @@ impl AnthropicEventNormalizer {
             AnthropicStreamEvent::Assistant {
                 is_partial,
                 message,
+                ..
             } => NormalizedEvent::AssistantMessage {
                 partial: is_partial,
                 stop_reason: message.stop_reason.clone(),
@@ -226,6 +256,7 @@ impl AnthropicEventNormalizer {
             AnthropicStreamEvent::User {
                 message,
                 tool_use_result,
+                ..
             } => {
                 let tool_use_result = tool_use_result.as_ref();
                 let results = message

--- a/crates/harness-server/src/claude.rs
+++ b/crates/harness-server/src/claude.rs
@@ -1,6 +1,7 @@
 use std::env;
 use std::path::PathBuf;
 use std::process::Command as ProcessCommand;
+use std::time::Duration;
 
 use codex_app_server_protocol::UserInput;
 use serde_json::json;
@@ -275,11 +276,27 @@ impl HarnessServer for ClaudeCodeHarness {
         normalizer: &mut Self::EventNormalizer,
         event: Self::Event,
     ) -> Result<Vec<NormalizedEvent>> {
+        // Subagent sidechains (Task tool) interleave their own messages into
+        // the stream, ending with their own `end_turn` while the parent turn
+        // keeps running. Letting them through corrupts the pending-text state
+        // (their message ids clobber the main chain's) and their stop reasons
+        // would settle — and with the stop fallback, terminate — the parent
+        // turn. The subagent's report reaches the turn through the main
+        // chain's Task tool result.
+        if event.is_sidechain() {
+            return Ok(Vec::new());
+        }
         Ok(normalizer.normalize(event))
     }
 
-    fn finish_turn_on_terminal_assistant_stop(&self) -> bool {
-        true
+    /// Claude Code normally ends a turn with a native `result` line, but
+    /// streams have been observed to stop at `message_delta.stop_reason`
+    /// without one (leaving the execution hung as "thinking" forever). Wait a
+    /// short window for the native result before completing on the stop, so
+    /// the trailing `result` is consumed by this turn instead of instantly
+    /// terminating the next one.
+    fn terminal_assistant_stop_settle(&self) -> Option<Duration> {
+        Some(Duration::from_secs(2))
     }
 }
 

--- a/crates/harness-server/src/claude.rs
+++ b/crates/harness-server/src/claude.rs
@@ -277,6 +277,10 @@ impl HarnessServer for ClaudeCodeHarness {
     ) -> Result<Vec<NormalizedEvent>> {
         Ok(normalizer.normalize(event))
     }
+
+    fn finish_turn_on_terminal_assistant_stop(&self) -> bool {
+        true
+    }
 }
 
 #[cfg(test)]

--- a/crates/harness-server/src/codex.rs
+++ b/crates/harness-server/src/codex.rs
@@ -483,7 +483,10 @@ impl CodexJsonRpcChild {
             .take()
             .ok_or(HarnessServerError::CodexStderrUnavailable)?;
         thread::spawn(move || {
-            let mut parent_stderr = io::stderr().lock();
+            // Unlocked handle on purpose: this child lives across turns, so
+            // holding the StderrLock for the copy's lifetime would block every
+            // eprintln! in the server until the child exits.
+            let mut parent_stderr = io::stderr();
             let _ = io::copy(&mut stderr, &mut parent_stderr);
         });
 

--- a/crates/harness-server/src/server.rs
+++ b/crates/harness-server/src/server.rs
@@ -1276,8 +1276,8 @@ fn run_harness_turn<H: HarnessServer, W: Write>(
                 write_value(stdout, &notification_to_wire_value(&notification)?)?;
             }
             terminal |= normalized.is_terminal()
-                || (harness.finish_turn_on_assistant_end_turn()
-                    && normalized.is_assistant_end_turn());
+                || (harness.finish_turn_on_terminal_assistant_stop()
+                    && normalized.is_terminal_assistant_stop());
         }
         if terminal {
             export_harness_usage_if_available(

--- a/crates/harness-server/src/server.rs
+++ b/crates/harness-server/src/server.rs
@@ -9,7 +9,7 @@ use std::sync::{
     atomic::{AtomicBool, Ordering},
     mpsc::{self, Receiver, RecvTimeoutError},
 };
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use base64::Engine;
 use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
@@ -1211,10 +1211,21 @@ fn run_harness_turn<H: HarnessServer, W: Write>(
             .process
             .as_mut()
             .ok_or(HarnessServerError::HarnessStdinUnavailable)?;
+        // Anything already buffered predates this turn's input: a previous
+        // turn completed via the terminal-stop fallback can leave the CLI's
+        // late `result` (and trailing rate-limit noise) behind, which would
+        // otherwise read as this turn's instant terminal.
+        while process.stdout.try_recv().is_ok() {}
         process.stdin.write_all(&harness.stdin_for_turn(input)?)?;
         process.stdin.flush()?;
     }
 
+    let settle_window = harness.terminal_assistant_stop_settle();
+    // Armed after a terminal assistant stop with no native terminal event yet:
+    // once the stream stays quiet past this deadline the turn completes via
+    // the fallback. Any further output (the native result on its way, trailing
+    // noise, or a continuation of the turn) pushes the deadline back.
+    let mut settle_deadline: Option<Instant> = None;
     let mut last_session_id = state.harness_session_id.clone();
     let mut event_normalizer = H::EventNormalizer::default();
     let mut completed_turn = None;
@@ -1231,17 +1242,60 @@ fn run_harness_turn<H: HarnessServer, W: Write>(
                     kind: harness.kind(),
                 });
             }
+            // A steer re-opens the turn: the harness now owes a response whose
+            // first token can take longer than the settle window, so the
+            // pending fallback completion no longer applies. The response's
+            // own terminal stop re-arms it.
+            settle_deadline = None;
         }
 
-        let line = match state
+        let mut terminal = false;
+        match state
             .process
             .as_mut()
             .ok_or(HarnessServerError::HarnessStdoutUnavailable)?
             .stdout
             .recv_timeout(Duration::from_millis(50))
         {
-            Ok(line) => line?,
-            Err(RecvTimeoutError::Timeout) => continue,
+            Ok(line) => {
+                let line = line?;
+                let trimmed = line.trim();
+                if trimmed.is_empty() {
+                    continue;
+                }
+                let event = harness.parse_stdout_line(trimmed)?;
+                let normalized_events = harness.normalize_events(&mut event_normalizer, event)?;
+                let mut terminal_stop = false;
+                for normalized in normalized_events {
+                    if let Some(usage) = normalized.token_usage() {
+                        latest_usage = Some(usage.clone());
+                    }
+                    append_usage_span_output(&normalized, &mut usage_span_output);
+                    if let Some(session_id) = normalized.session_id() {
+                        last_session_id = Some(session_id.to_string());
+                        state.harness_session_id = Some(session_id.to_string());
+                    }
+                    for notification in normalizer.process_event(&normalized)? {
+                        write_value(stdout, &notification_to_wire_value(&notification)?)?;
+                    }
+                    terminal |= normalized.is_terminal();
+                    terminal_stop |=
+                        settle_window.is_some() && normalized.is_terminal_assistant_stop();
+                }
+                if !terminal {
+                    match settle_window {
+                        Some(window) if terminal_stop && window.is_zero() => terminal = true,
+                        Some(window) if terminal_stop || settle_deadline.is_some() => {
+                            settle_deadline = Some(Instant::now() + window);
+                        }
+                        _ => {}
+                    }
+                }
+            }
+            Err(RecvTimeoutError::Timeout) => match settle_deadline {
+                Some(deadline) if Instant::now() >= deadline => terminal = true,
+                _ => continue,
+            },
             Err(RecvTimeoutError::Disconnected) => {
                 let status = state
                     .process
@@ -1249,35 +1303,20 @@ fn run_harness_turn<H: HarnessServer, W: Write>(
                     .ok_or(HarnessServerError::HarnessStdoutUnavailable)?
                     .child
                     .wait()?;
-                return Err(HarnessServerError::HarnessExited {
-                    kind: harness.kind(),
-                    status,
-                    stderr: String::new(),
-                });
+                // A clean exit while waiting out the settle window means the
+                // native result is never coming: the terminal stop already
+                // seen ends the turn.
+                if settle_deadline.is_some() && status.success() {
+                    state.process = None;
+                    terminal = true;
+                } else {
+                    return Err(HarnessServerError::HarnessExited {
+                        kind: harness.kind(),
+                        status,
+                        stderr: String::new(),
+                    });
+                }
             }
-        };
-        let trimmed = line.trim();
-        if trimmed.is_empty() {
-            continue;
-        }
-        let event = harness.parse_stdout_line(trimmed)?;
-        let normalized_events = harness.normalize_events(&mut event_normalizer, event)?;
-        let mut terminal = false;
-        for normalized in normalized_events {
-            if let Some(usage) = normalized.token_usage() {
-                latest_usage = Some(usage.clone());
-            }
-            append_usage_span_output(&normalized, &mut usage_span_output);
-            if let Some(session_id) = normalized.session_id() {
-                last_session_id = Some(session_id.to_string());
-                state.harness_session_id = Some(session_id.to_string());
-            }
-            for notification in normalizer.process_event(&normalized)? {
-                write_value(stdout, &notification_to_wire_value(&notification)?)?;
-            }
-            terminal |= normalized.is_terminal()
-                || (harness.finish_turn_on_terminal_assistant_stop()
-                    && normalized.is_terminal_assistant_stop());
         }
         if terminal {
             export_harness_usage_if_available(
@@ -1465,7 +1504,12 @@ fn ensure_harness_process<H: HarnessServer>(harness: &H, state: &mut ThreadState
         .take()
         .ok_or(HarnessServerError::HarnessStderrUnavailable)?;
     std::thread::spawn(move || {
-        let mut parent_stderr = io::stderr().lock();
+        // Copy through the unlocked handle (it locks per write): the harness
+        // process outlives each turn, so its stderr never EOFs, and holding
+        // the StderrLock here for the copy's lifetime deadlocks every other
+        // eprintln! in the server — including turn-completion paths, which
+        // then never emit turn/completed.
+        let mut parent_stderr = io::stderr();
         let _ = io::copy(&mut stderr, &mut parent_stderr);
     });
     let (stdout_tx, stdout_rx) = mpsc::channel();

--- a/crates/harness-server/src/traits.rs
+++ b/crates/harness-server/src/traits.rs
@@ -2,6 +2,7 @@ use std::io;
 use std::path::PathBuf;
 use std::process::{Child, ChildStdin, Command as ProcessCommand};
 use std::sync::mpsc::Receiver;
+use std::time::Duration;
 
 use codex_app_server_protocol::{ThreadStartParams, Turn, UserInput};
 use serde_json::Value;
@@ -71,8 +72,17 @@ pub trait HarnessServer {
         normalizer: &mut Self::EventNormalizer,
         event: Self::Event,
     ) -> Result<Vec<NormalizedEvent>>;
-    fn finish_turn_on_terminal_assistant_stop(&self) -> bool {
-        false
+    /// How to treat an assistant message that stops with a terminal stop
+    /// reason (`end_turn`, ...) when no native terminal event has arrived.
+    /// `None` keeps the turn open until a native result/error (the default).
+    /// `Some(window)` completes the turn once the stream stays quiet for
+    /// `window` after the stop: a zero window completes immediately (for
+    /// streams with no native result event), a nonzero window gives the
+    /// harness's own `result` a chance to settle the turn first — and keeps
+    /// that trailing `result` from being read as the *next* turn's terminal —
+    /// while still completing when the result never comes.
+    fn terminal_assistant_stop_settle(&self) -> Option<Duration> {
+        None
     }
 
     fn thread_state(&self, params: &ThreadStartParams, cwd: PathBuf) -> ThreadState {

--- a/crates/harness-server/src/traits.rs
+++ b/crates/harness-server/src/traits.rs
@@ -71,7 +71,7 @@ pub trait HarnessServer {
         normalizer: &mut Self::EventNormalizer,
         event: Self::Event,
     ) -> Result<Vec<NormalizedEvent>>;
-    fn finish_turn_on_assistant_end_turn(&self) -> bool {
+    fn finish_turn_on_terminal_assistant_stop(&self) -> bool {
         false
     }
 
@@ -153,16 +153,23 @@ impl NormalizedEvent {
         }
     }
 
-    pub(crate) fn is_assistant_end_turn(&self) -> bool {
+    pub(crate) fn is_terminal_assistant_stop(&self) -> bool {
         matches!(
             self,
             Self::AssistantMessage {
                 partial: false,
                 stop_reason: Some(stop_reason),
                 ..
-            } if stop_reason == "end_turn"
+            } if is_terminal_assistant_stop_reason(stop_reason)
         )
     }
+}
+
+fn is_terminal_assistant_stop_reason(reason: &str) -> bool {
+    matches!(
+        reason,
+        "end_turn" | "stop_sequence" | "max_tokens" | "refusal"
+    )
 }
 
 #[derive(Debug, Clone)]

--- a/crates/harness-server/tests/app_server_stdio.rs
+++ b/crates/harness-server/tests/app_server_stdio.rs
@@ -107,6 +107,30 @@ fn fake_claude_app_server_streams_codex_v2_notifications() {
 }
 
 #[test]
+fn fake_claude_app_server_completes_on_stop_sequence_without_result() {
+    let fake_claude = concat!(
+        "printf '%s\\n' ",
+        "'{\"type\":\"system\",\"subtype\":\"init\",\"session_id\":\"claude-session\"}' ",
+        "'{\"type\":\"stream_event\",\"event\":{\"type\":\"message_start\",\"message\":{\"id\":\"msg_1\",\"stop_reason\":null,\"content\":[]}}}' ",
+        "'{\"type\":\"stream_event\",\"event\":{\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}}' ",
+        "'{\"type\":\"stream_event\",\"event\":{\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"fable answer\"}}}' ",
+        "'{\"type\":\"assistant\",\"message\":{\"id\":\"msg_1\",\"stop_reason\":null,\"content\":[{\"type\":\"text\",\"text\":\"fable answer\"}]}}' ",
+        "'{\"type\":\"stream_event\",\"event\":{\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"stop_sequence\"}}}'"
+    );
+
+    let run = run_bridge_turn(BridgeTurnConfig {
+        harness: Harness::ClaudeCode,
+        command_override: Some(fake_claude.to_string()),
+        prompt: "say hello".to_string(),
+        timeout: Duration::from_secs(10),
+    });
+
+    assert_completed_turn(&run.turn);
+    assert_eq!(run.turn.text_from_deltas, "fable answer");
+    assert_codex_v2_turn(&run.turn);
+}
+
+#[test]
 fn fake_codex_blocks_mode_uses_openrouter_provider_when_model_is_configured() {
     let fake_codex = temp_path("fake-openrouter-codex.sh");
     let fake_codex_log = temp_path("fake-openrouter-codex-requests.jsonl");

--- a/crates/harness-server/tests/app_server_stdio.rs
+++ b/crates/harness-server/tests/app_server_stdio.rs
@@ -131,6 +131,124 @@ fn fake_claude_app_server_completes_on_stop_sequence_without_result() {
 }
 
 #[test]
+fn fake_claude_completes_on_terminal_stop_while_process_outlives_the_turn() {
+    // The real CLI does not exit after a turn — harness-server keeps it (and
+    // its stdin) alive for the next one. When the stream stops at the
+    // message_delta stop reason with no trailing `result`, the settle window
+    // must complete the turn instead of waiting on the live process forever
+    // (the fable "thinking..." hang).
+    let fake_claude = concat!(
+        "printf '%s\\n' ",
+        "'{\"type\":\"system\",\"subtype\":\"init\",\"session_id\":\"claude-session\"}' ",
+        "'{\"type\":\"stream_event\",\"event\":{\"type\":\"message_start\",\"message\":{\"id\":\"msg_1\",\"stop_reason\":null,\"content\":[]}}}' ",
+        "'{\"type\":\"stream_event\",\"event\":{\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}}' ",
+        "'{\"type\":\"stream_event\",\"event\":{\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"fable answer\"}}}' ",
+        "'{\"type\":\"assistant\",\"message\":{\"id\":\"msg_1\",\"stop_reason\":null,\"content\":[{\"type\":\"text\",\"text\":\"fable answer\"}]}}' ",
+        "'{\"type\":\"stream_event\",\"event\":{\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"}}}'",
+        "; sleep 60"
+    );
+
+    let run = run_bridge_turn(BridgeTurnConfig {
+        harness: Harness::ClaudeCode,
+        command_override: Some(fake_claude.to_string()),
+        prompt: "say hello".to_string(),
+        timeout: Duration::from_secs(10),
+    });
+
+    assert_completed_turn(&run.turn);
+    assert_eq!(run.turn.text_from_deltas, "fable answer");
+    assert_codex_v2_turn(&run.turn);
+}
+
+#[test]
+fn fake_claude_trailing_result_settles_the_turn_and_does_not_poison_the_next() {
+    // The native `result` trails the message_delta stop reason in real CLI
+    // output. The stop must not complete the turn so eagerly that the result
+    // is left buffered, where the next turn would read it as its own instant
+    // terminal and complete with no content.
+    let fake_claude = concat!(
+        "printf '%s\\n' '{\"type\":\"system\",\"subtype\":\"init\",\"session_id\":\"claude-session\"}'; ",
+        "IFS= read -r _; ",
+        "printf '%s\\n' ",
+        "'{\"type\":\"stream_event\",\"event\":{\"type\":\"message_start\",\"message\":{\"id\":\"msg_1\",\"stop_reason\":null,\"content\":[]}}}' ",
+        "'{\"type\":\"stream_event\",\"event\":{\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}}' ",
+        "'{\"type\":\"stream_event\",\"event\":{\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"first answer\"}}}' ",
+        "'{\"type\":\"assistant\",\"message\":{\"id\":\"msg_1\",\"stop_reason\":null,\"content\":[{\"type\":\"text\",\"text\":\"first answer\"}]}}' ",
+        "'{\"type\":\"stream_event\",\"event\":{\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"}}}' ",
+        "'{\"type\":\"stream_event\",\"event\":{\"type\":\"message_stop\"}}' ",
+        "'{\"type\":\"result\",\"subtype\":\"success\",\"result\":\"first answer\"}'; ",
+        "IFS= read -r _; ",
+        "printf '%s\\n' ",
+        "'{\"type\":\"assistant\",\"is_partial\":false,\"message\":{\"id\":\"msg_2\",\"content\":[{\"type\":\"text\",\"text\":\"second answer\"}]}}' ",
+        "'{\"type\":\"result\",\"subtype\":\"success\",\"result\":\"second answer\"}'; ",
+        "sleep 60"
+    );
+
+    let run = run_bridge_two_turns(BridgeTwoTurnConfig {
+        harness: Harness::ClaudeCode,
+        command_override: Some(fake_claude.to_string()),
+        first_prompt: "first".to_string(),
+        second_prompt: "second".to_string(),
+        timeout: Duration::from_secs(10),
+    });
+
+    assert_completed_turn(&run.turns[0]);
+    assert_eq!(run.turns[0].text_from_deltas, "first answer");
+    assert_completed_turn(&run.turns[1]);
+    assert_eq!(run.turns[1].text_from_deltas, "second answer");
+}
+
+#[test]
+fn fake_claude_subagent_sidechain_stop_does_not_complete_the_turn() {
+    // A Task subagent's sidechain messages end with their own end_turn while
+    // the parent turn keeps running (here: 3s of quiet before the main chain
+    // resumes, longer than the settle window). The sidechain stop must not
+    // complete the turn or leak subagent text into it.
+    let fake_claude = concat!(
+        "printf '%s\\n' ",
+        "'{\"type\":\"system\",\"subtype\":\"init\",\"session_id\":\"claude-session\"}' ",
+        "'{\"type\":\"stream_event\",\"event\":{\"type\":\"message_start\",\"message\":{\"id\":\"msg_1\",\"stop_reason\":null,\"content\":[]}}}' ",
+        "'{\"type\":\"stream_event\",\"event\":{\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}}' ",
+        "'{\"type\":\"stream_event\",\"event\":{\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"Delegating.\"}}}' ",
+        "'{\"type\":\"assistant\",\"message\":{\"id\":\"msg_1\",\"stop_reason\":null,\"content\":[{\"type\":\"text\",\"text\":\"Delegating.\"},{\"type\":\"tool_use\",\"id\":\"toolu_task\",\"name\":\"Task\",\"input\":{\"prompt\":\"look it up\"}}]}}' ",
+        "'{\"type\":\"stream_event\",\"event\":{\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"tool_use\"}}}' ",
+        "'{\"type\":\"stream_event\",\"event\":{\"type\":\"message_start\",\"message\":{\"id\":\"msg_sub\",\"stop_reason\":null,\"content\":[]}},\"parent_tool_use_id\":\"toolu_task\"}' ",
+        "'{\"type\":\"stream_event\",\"event\":{\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}},\"parent_tool_use_id\":\"toolu_task\"}' ",
+        "'{\"type\":\"stream_event\",\"event\":{\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"sub answer\"}},\"parent_tool_use_id\":\"toolu_task\"}' ",
+        "'{\"type\":\"assistant\",\"message\":{\"id\":\"msg_sub\",\"stop_reason\":null,\"content\":[{\"type\":\"text\",\"text\":\"sub answer\"}]},\"parent_tool_use_id\":\"toolu_task\"}' ",
+        "'{\"type\":\"stream_event\",\"event\":{\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"}},\"parent_tool_use_id\":\"toolu_task\"}'",
+        "; sleep 3; printf '%s\\n' ",
+        "'{\"type\":\"user\",\"message\":{\"content\":[{\"type\":\"tool_result\",\"tool_use_id\":\"toolu_task\",\"content\":\"sub answer\",\"is_error\":false}]}}' ",
+        "'{\"type\":\"stream_event\",\"event\":{\"type\":\"message_start\",\"message\":{\"id\":\"msg_2\",\"stop_reason\":null,\"content\":[]}}}' ",
+        "'{\"type\":\"stream_event\",\"event\":{\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}}' ",
+        "'{\"type\":\"stream_event\",\"event\":{\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"main answer\"}}}' ",
+        "'{\"type\":\"assistant\",\"message\":{\"id\":\"msg_2\",\"stop_reason\":null,\"content\":[{\"type\":\"text\",\"text\":\"main answer\"}]}}' ",
+        "'{\"type\":\"stream_event\",\"event\":{\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"}}}' ",
+        "'{\"type\":\"result\",\"subtype\":\"success\",\"result\":\"main answer\"}'"
+    );
+
+    let run = run_bridge_turn(BridgeTurnConfig {
+        harness: Harness::ClaudeCode,
+        command_override: Some(fake_claude.to_string()),
+        prompt: "delegate then answer".to_string(),
+        timeout: Duration::from_secs(15),
+    });
+
+    assert_completed_turn(&run.turn);
+    assert!(
+        run.turn.text_from_deltas.contains("main answer"),
+        "main-chain answer missing: {:?}",
+        run.turn.text_from_deltas
+    );
+    assert!(
+        !run.turn.text_from_deltas.contains("sub answer"),
+        "sidechain text leaked into the turn: {:?}",
+        run.turn.text_from_deltas
+    );
+    assert_codex_v2_turn(&run.turn);
+}
+
+#[test]
 fn fake_codex_blocks_mode_uses_openrouter_provider_when_model_is_configured() {
     let fake_codex = temp_path("fake-openrouter-codex.sh");
     let fake_codex_log = temp_path("fake-openrouter-codex-requests.jsonl");


### PR DESCRIPTION
Completes Claude/Amp harness turns when the stream stops at a terminal assistant stop reason, and unblocks the completion path that could leave executions hung after the answer streamed.

Claude turns now wait a short settle window after a terminal stop: the native `result` still completes the turn when it arrives (and is consumed by the turn it belongs to, instead of being left buffered where the next turn would read it as an instant terminal), and the stop completes the turn when the stream goes quiet without one. Amp keeps immediate completion since its stream has no result event. Task subagent sidechain events (`parent_tool_use_id`) are dropped so a subagent's `end_turn` cannot complete or pollute the parent turn.

Also fixes the child-stderr copy thread holding the global stderr lock for the harness process's lifetime (the claude CLI outlives each turn), which deadlocked any `eprintln!` at turn completion — such as an OTLP export failure — before `turn/completed` was written. Overlaps with the fix in #910.