### PR TITLE
fix(slackbotv2): preserve paragraph breaks in Slack plain-text extraction

### DIFF
--- a/patches/@chat-adapter__slack@4.31.0.patch
+++ b/patches/@chat-adapter__slack@4.31.0.patch
@@ -1,5 +1,5 @@
 diff --git a/dist/index.js b/dist/index.js
-index a7048fd884020cfd96a51c48b7071fa7293f3dc4..e5ff9dc2682a754202102f80d3178818ff52ce63 100644
+index a7048fd884020cfd96a51c48b7071fa7293f3dc4..e5bd30bb8f2d41f8f836e7dee742a67f32ccc951 100644
 --- a/dist/index.js
 +++ b/dist/index.js
 @@ -31,6 +31,216 @@ import {
@@ -219,7 +219,41 @@ index a7048fd884020cfd96a51c48b7071fa7293f3dc4..e5ff9dc2682a754202102f80d3178818
  
  // src/cards.ts
  import {
-@@ -2004,7 +2214,10 @@ var SlackAdapter = class _SlackAdapter {
+@@ -352,6 +562,15 @@ import {
+ } from "chat";
+ var BARE_MENTION_PATTERN = /(?<![<\w/])@(\w+)/g;
+ var URL_PATTERN = /\bhttps?:\/\/[^\s<>]+/g;
++function plainTextPreservingBlocks(node) {
++  if (node.type === "root" || node.type === "blockquote") {
++    return getNodeChildren(node).map(plainTextPreservingBlocks).filter(Boolean).join(node.type === "root" ? "\n\n" : "\n");
++  }
++  if (node.type === "list" || node.type === "listItem") {
++    return getNodeChildren(node).map(plainTextPreservingBlocks).filter(Boolean).join("\n");
++  }
++  return toPlainText(node);
++}
+ var SlackFormatConverter = class extends BaseFormatConverter {
+   /**
+    * Render an AST to standard markdown. Slack accepts this directly via
+@@ -366,6 +585,17 @@ var SlackFormatConverter = class extends BaseFormatConverter {
+   toAst(mrkdwn) {
+     return parseMarkdown(slackMrkdwnToMarkdown(mrkdwn));
+   }
++  /**
++   * Extract plain text for incoming `message` events. The base implementation
++   * flattens the whole AST with mdast-util-to-string, which concatenates
++   * sibling block nodes with NO separator: `--model=fable\n\nexamine ...`
++   * became `--model=fableexamine ...`, gluing every paragraph boundary in the
++   * message. Preserve block boundaries instead — paragraphs join with a blank
++   * line, list items and blockquote lines with a newline.
++   */
++  extractPlainText(mrkdwn) {
++    return plainTextPreservingBlocks(this.toAst(mrkdwn));
++  }
+   /**
+    * Build the Slack API payload fields for a message.
+    *
+@@ -2004,7 +2234,10 @@ var SlackAdapter = class _SlackAdapter {
        channel: event.channel,
        threadTs
      });
@@ -231,7 +265,7 @@ index a7048fd884020cfd96a51c48b7071fa7293f3dc4..e5ff9dc2682a754202102f80d3178818
      const factory = async () => {
        const msg = await this.parseSlackMessage(event, threadId);
        if (isMention) {
-@@ -2520,10 +2732,10 @@ var SlackAdapter = class _SlackAdapter {
+@@ -2520,10 +2753,10 @@ var SlackAdapter = class _SlackAdapter {
        formatted: this.formatConverter.toAst(text),
        raw: event,
        author: {
@@ -244,7 +278,7 @@ index a7048fd884020cfd96a51c48b7071fa7293f3dc4..e5ff9dc2682a754202102f80d3178818
          isMe
        },
        metadata: {
-@@ -3452,26 +3664,251 @@ var SlackAdapter = class _SlackAdapter {
+@@ -3452,26 +3685,251 @@ var SlackAdapter = class _SlackAdapter {
      }
      this.logger.debug("Slack: starting stream", { channel, threadTs });
      const token = await this.getToken();
@@ -505,7 +539,7 @@ index a7048fd884020cfd96a51c48b7071fa7293f3dc4..e5ff9dc2682a754202102f80d3178818
      const sendStructuredChunk = async (chunk) => {
        if (!structuredChunksSupported) {
          return;
-@@ -3481,8 +3918,45 @@ var SlackAdapter = class _SlackAdapter {
+@@ -3481,8 +3939,45 @@ var SlackAdapter = class _SlackAdapter {
        await flushMarkdownDelta(delta);
        lastAppended = committable;
        try {
@@ -552,7 +586,7 @@ index a7048fd884020cfd96a51c48b7071fa7293f3dc4..e5ff9dc2682a754202102f80d3178818
          structuredChunksSupported = false;
          this.logger.warn(
            "Structured streaming chunk failed, falling back to text-only streaming. Ensure your Slack app manifest includes assistant_view, assistant:write scope, and @slack/web-api >= 7.14.0",
-@@ -3497,31 +3971,91 @@ var SlackAdapter = class _SlackAdapter {
+@@ -3497,31 +3992,91 @@ var SlackAdapter = class _SlackAdapter {
        await flushMarkdownDelta(delta);
        lastAppended = committable;
      };
@@ -663,7 +697,7 @@ index a7048fd884020cfd96a51c48b7071fa7293f3dc4..e5ff9dc2682a754202102f80d3178818
      };
    }
    /**
-@@ -3798,10 +4332,10 @@ var SlackAdapter = class _SlackAdapter {
+@@ -3798,10 +4353,10 @@ var SlackAdapter = class _SlackAdapter {
        formatted: this.formatConverter.toAst(text),
        raw: event,
        author: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,7 +12,7 @@ patchedDependencies:
     hash: fce7a692b030cfe3d325b020a4472b9424b8976aa2f7faded6ad4c83421e9132
     path: patches/@chat-adapter__linear@4.31.0.patch
   '@chat-adapter/slack@4.31.0':
-    hash: 4a13e39aa1f023696e9b930391146ffcb8ac50adfcf394dcf1905e4e445213f7
+    hash: b005d7fc3498bc499bfd30ff79be29138a48b63944761da6f1b68bec59ef9d68
     path: patches/@chat-adapter__slack@4.31.0.patch
   '@chat-adapter/state-pg@4.31.0':
     hash: 69262b03c278ca9d4af0bed7b4e05f9d7a5a36d3d79fad31df2a85da4d349274
@@ -171,7 +171,7 @@ importers:
         version: link:../../packages/rendering
       '@chat-adapter/slack':
         specifier: ^4.31.0
-        version: 4.31.0(patch_hash=4a13e39aa1f023696e9b930391146ffcb8ac50adfcf394dcf1905e4e445213f7)(zod@4.4.3)
+        version: 4.31.0(patch_hash=b005d7fc3498bc499bfd30ff79be29138a48b63944761da6f1b68bec59ef9d68)(zod@4.4.3)
       '@chat-adapter/state-pg':
         specifier: ^4.31.0
         version: 4.31.0(patch_hash=69262b03c278ca9d4af0bed7b4e05f9d7a5a36d3d79fad31df2a85da4d349274)(zod@4.4.3)
@@ -1754,7 +1754,7 @@ snapshots:
       - supports-color
       - zod
 
-  '@chat-adapter/slack@4.31.0(patch_hash=4a13e39aa1f023696e9b930391146ffcb8ac50adfcf394dcf1905e4e445213f7)(zod@4.4.3)':
+  '@chat-adapter/slack@4.31.0(patch_hash=b005d7fc3498bc499bfd30ff79be29138a48b63944761da6f1b68bec59ef9d68)(zod@4.4.3)':
     dependencies:
       '@chat-adapter/shared': 4.31.0(zod@4.4.3)
       '@slack/socket-mode': 2.0.7

--- a/services/slackbotv2/test/overrides.test.ts
+++ b/services/slackbotv2/test/overrides.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from 'bun:test'
+import { SlackFormatConverter } from '@chat-adapter/slack'
 import { extractMessageOverrides } from '../src/overrides'
 
 describe('extractMessageOverrides', () => {
@@ -221,5 +222,46 @@ describe('extractMessageOverrides', () => {
   test('--bedrock does not match flags embedded in words', () => {
     expect(extractMessageOverrides('--bedrocky hi').provider).toBeUndefined()
     expect(extractMessageOverrides('the --bedrock flag').provider).toBe('amazon-bedrock')
+  })
+})
+
+// The adapter's plain-text extraction feeds extractMessageOverrides. The
+// unpatched @chat-adapter/slack flattened the parsed AST with
+// mdast-util-to-string, which joins sibling paragraphs with NO separator —
+// `--model=fable\n\nexamine ...` reached the parser as `--model=fableexamine
+// ...` and the harness got a nonexistent model. The patched converter
+// preserves block boundaries; these tests exercise the real pipeline.
+describe('SlackFormatConverter.extractPlainText + extractMessageOverrides', () => {
+  const converter = new SlackFormatConverter()
+
+  test('paragraph break after --model survives plain-text extraction', () => {
+    const mrkdwn =
+      '--claude --model=fable\n\nexamine <https://github.com/paradigmxyz/centaur/pull/921|github.com/paradigmxyz/centaur/pull/921>. cross reference that PR.'
+    const text = converter.extractPlainText(mrkdwn)
+    expect(text).toBe(
+      '--claude --model=fable\n\nexamine github.com/paradigmxyz/centaur/pull/921. cross reference that PR.'
+    )
+    expect(extractMessageOverrides(text)).toEqual({
+      cleanedText: 'examine github.com/paradigmxyz/centaur/pull/921. cross reference that PR.',
+      harnessType: 'claudecode',
+      model: 'claude-fable-5',
+      reasoning: undefined
+    })
+  })
+
+  test('single newlines and paragraph breaks are both preserved', () => {
+    expect(converter.extractPlainText('--model=fable\nexamine this')).toBe(
+      '--model=fable\nexamine this'
+    )
+    expect(converter.extractPlainText('line1\n\nline2\nline3')).toBe('line1\n\nline2\nline3')
+  })
+
+  test('list items and blockquotes keep line boundaries', () => {
+    expect(converter.extractPlainText('- item1\n- item2\n\nafter list')).toBe(
+      'item1\nitem2\n\nafter list'
+    )
+    expect(converter.extractPlainText('> quoted line\n\nafter quote')).toBe(
+      'quoted line\n\nafter quote'
+    )
   })
 })


### PR DESCRIPTION
## Problem

`--model=fable` followed by a blank line selected the nonexistent model `fableexamine` ([failing thread](https://paradigm-ops.slack.com/archives/C0BCQMCKJPM/p1783390698045059)). Runtime logs confirm it: the deployed slackbot (sha-d9ef4b7, which already includes the #900 regex fix) logged `slackbotv2_forward_overrides_parsed` with `model=fableexamine`.

## Root cause

Not the overrides regex — #900's newline handling is correct, but it runs on input whose newlines are already gone. `@chat-adapter/slack`'s `SlackFormatConverter.extractPlainText` builds `message.text` by flattening the parsed mrkdwn AST with `mdast-util-to-string`, which joins sibling block nodes with **no separator**:

```
'--claude --model=fable\n\nexamine …'  →  '--claude --model=fableexamine …'
```

A single newline survives (it stays inside one paragraph node), which is why #900's `\n` tests passed while a blank line (paragraph break) still broke. Beyond flags, this glued paragraphs together in *every* Slack message forwarded to the agent.

## Fix

Extend the existing `patches/@chat-adapter__slack@4.31.0.patch` to override `extractPlainText` with a block-aware conversion: top-level blocks join with a blank line, list items and blockquote lines with a newline. Inline behavior is unchanged.

## Verification

- Reproduced the exact corruption against the pristine package, and confirmed the patched package produces `--claude --model=fable\n\nexamine …` → model `claude-fable-5`, cleaned prompt intact.
- New regression tests run the real converter output through `extractMessageOverrides`; full slackbotv2 suite passes (149 pass / 0 fail) and `check:types` is clean.
- `@chat-adapter/linear` is not affected (it uses `raw.comment.body` directly).

Prompted by: mslipper