### PR TITLE
fix(discordbot): port live activity summaries; unstick answer-only streaming

### DIFF
--- a/packages/rendering/src/codex-app-server.ts
+++ b/packages/rendering/src/codex-app-server.ts
@@ -72,6 +72,12 @@ export type CodexAppServerRendererEventMapperOptions = {
   logInfo?: RendererLogInfo
   unknownAgentMessagePhase?: AgentMessagePhase
   taskOutput?: 'full' | 'omit'
+  // How long buffered assistant text waits for plan/tasks to arrive before it
+  // streams anyway. The check is event-driven — with no tasks and no further
+  // events, buffered text sits until the next event or stream end — so
+  // consumers that stream text into their own surface (discordbot) pass 0 to
+  // emit deltas immediately. Default 500ms (Slack card-first rendering).
+  preStreamGraceMs?: number
 }
 
 export type CodexAppServerToChatStreamOptions = CodexAppServerRendererEventMapperOptions & {
@@ -87,12 +93,14 @@ export class CodexAppServerRendererEventMapper
   private readonly logInfo?: RendererLogInfo
   private readonly unknownAgentMessagePhase: AgentMessagePhase
   private readonly includeTaskOutput: boolean
+  private readonly preStreamGraceMs: number
 
   constructor(options: CodexAppServerRendererEventMapperOptions = {}) {
     this.sessionId = options.sessionId ?? ''
     this.logInfo = options.logInfo
     this.unknownAgentMessagePhase = options.unknownAgentMessagePhase ?? 'final_answer'
     this.includeTaskOutput = options.taskOutput === 'full'
+    this.preStreamGraceMs = options.preStreamGraceMs ?? PRE_STREAM_GRACE_MS
   }
 
   process(source: ServerNotification | RustSessionStreamEvent | unknown): RendererEvent[] {
@@ -387,7 +395,7 @@ export class CodexAppServerRendererEventMapper
     const hasPlan = this.state.taskByUseId.size > 0
     const graceExpired =
       this.state.firstBufferedTextAt !== null &&
-      Date.now() - this.state.firstBufferedTextAt >= PRE_STREAM_GRACE_MS
+      Date.now() - this.state.firstBufferedTextAt >= this.preStreamGraceMs
     const canStream = hasPlan || opts.force || graceExpired
     if (!canStream) return
 

--- a/services/discordbot/src/discord-narrator.ts
+++ b/services/discordbot/src/discord-narrator.ts
@@ -62,6 +62,7 @@ export class DiscordNarrator {
   // concatenate; a commentary item re-uses its id and replaces its body.
   private pendingParts = new Map<string, string>();
   private queuedBlurbs: string[] = [];
+  private lastStatus = "";
   private postedCount = 0;
   private droppedBlurbs = 0;
   private lastPostAtMs = 0;
@@ -99,6 +100,23 @@ export class DiscordNarrator {
     const narrator = new DiscordNarrator(thread, message, botOptions, options);
     narrator.enqueueReaction("PUT", REACTION_WORKING);
     return narrator;
+  }
+
+  /**
+   * Server-side activity summaries (renderer.status events) — the Discord
+   * analog of Slack's assistant status. Discord has no ephemeral status
+   * surface, so summaries post as append-only subtext blurbs, like thoughts
+   * did before reasoning synthesis moved out of the renderer. Empty statuses
+   * (the end-of-run clear) and consecutive repeats are dropped.
+   */
+  status(text: string): void {
+    if (this.finished) return;
+    const trimmed = text.trim();
+    if (!trimmed || trimmed === this.lastStatus) return;
+    this.lastStatus = trimmed;
+    if (trimmed.length < NARRATOR_MIN_BLURB_CHARS) return;
+    this.queuedBlurbs.push(truncateBlurb(trimmed));
+    this.schedulePost();
   }
 
   update(chunk: DiscordNarratorChunk): void {

--- a/services/discordbot/src/index.ts
+++ b/services/discordbot/src/index.ts
@@ -1246,7 +1246,7 @@ async function renderSplitExecutionStreams(
   try {
     for await (const chunk of codexAppServerToChatSdkStream(
       stream,
-      rendererOptions(options),
+      rendererOptions(options, narrator),
     )) {
       if (chunk.type === "markdown_text") {
         if (!answerPost) {
@@ -1613,17 +1613,29 @@ function backgroundWaitUntil(promise: Promise<unknown>): void {
   void promise.catch(() => undefined);
 }
 
-// Vestigial wrapper kept so call sites diff cleanly against slackbotv2, whose
-// rendererOptions hooks onRendererEvent to update the Slack assistant title
-// (no Discord analog). Today it only forwards the configured mapper.
+// Mirrors slackbotv2's rendererOptions: forwards the configured mapper and
+// hooks onRendererEvent. Slack routes renderer.status (server-side activity
+// summaries) to its native assistant status; Discord has no such surface, so
+// they post as the narrator's append-only subtext blurbs. Paths without a
+// narrator (plain-text runs) drop status events by design.
 function rendererOptions(
   options: DiscordbotOptions,
+  narrator?: DiscordNarrator,
 ): CodexAppServerToChatStreamOptions {
   const mapper = options.mapper;
   return {
     ...mapper,
+    // Discord streams answer text into its own append-only messages, so
+    // there is no card to wait for: stream deltas immediately. Non-zero
+    // grace here can strand an answer-only turn's deltas entirely — the
+    // grace check is event-driven, and with no tasks and no later events
+    // the buffered text only flushes at stream end.
+    preStreamGraceMs: 0,
     async onRendererEvent(event: RendererEvent) {
       await mapper?.onRendererEvent?.(event);
+      if (event.type === "renderer.status") {
+        narrator?.status(event.status);
+      }
     },
   };
 }

--- a/services/discordbot/src/session-api.ts
+++ b/services/discordbot/src/session-api.ts
@@ -763,6 +763,15 @@ async function* parseSessionEventStream(
       if (isTerminalCodexOutputLine(event.data)) return;
       continue;
     }
+    if (event.event === "session.activity_summary") {
+      yield {
+        data: sessionEventData(event),
+        event: event.event,
+        eventId: event.id,
+        eventKind: event.event,
+      } satisfies RustSessionStreamEvent;
+      continue;
+    }
     if (
       event.event === "session.execution_failed" ||
       event.event === "session.stream_error"

--- a/services/discordbot/test/chat-sdk-emulate.test.ts
+++ b/services/discordbot/test/chat-sdk-emulate.test.ts
@@ -180,17 +180,15 @@ describe("discordbot", () => {
       JSON.stringify(JSON.parse(secondExecute.body.input_lines[0]!)),
     ).toContain("now execute with the latest");
 
-    // Append-only narration: reasoning blurbs as `-# ` subtext messages.
-    // Thoughts that complete close together may merge into one blurb, so
-    // assert the contents and the per-line subtext prefix, not boundaries.
-    const blurbText = blurbPostsIn(threadId).join("\n");
-    expect(blurbText).toContain("Checking the command output");
-    expect(blurbText).toContain("Inspecting the event stream");
-    for (const blurb of blurbPostsIn(threadId)) {
-      for (const line of blurb.split("\n")) {
-        if (line.trim()) expect(line.startsWith("-# ")).toBe(true);
-      }
-    }
+    // Reasoning synthesis moved server-side (live activity summaries): raw
+    // commentary/reasoning deltas no longer render as blurbs or anywhere
+    // else. Summaries arrive as session.activity_summary events instead —
+    // covered by the dedicated activity-summary test below.
+    expect(blurbPostsIn(threadId)).toEqual([]);
+    const allPosts = botPostsIn(threadId).join("\n");
+    expect(allPosts).not.toContain("Checking the command output");
+    expect(allPosts).not.toContain("Inspecting the event stream");
+    expect(allPosts).not.toContain("Thinking");
 
     // The final answers land as their own lazily-created messages.
     const answers = answerPostsIn(threadId);
@@ -635,7 +633,7 @@ describe("discordbot", () => {
       thread: { id: threadId, parentId: CHANNEL_ID },
     });
     await waitFor(() => codexApi.executes.length === 1);
-    await waitFor(() => codexApi.streamCount === 1);
+    await waitFor(() => codexApi.hasStream(key));
 
     codexApi.emitOutputLine(
       key,
@@ -656,6 +654,12 @@ describe("discordbot", () => {
         itemId: "answer-1",
         delta: "partial answer ",
       }),
+    );
+    // Wait for the first message post so the tail must land as an edit —
+    // emitting both deltas back to back can coalesce into the initial post,
+    // which would never exercise the failing-edit path under test.
+    await waitFor(() =>
+      botPostsIn(threadId).some((content) => content.includes("partial answer")),
     );
     codexApi.emitOutputLine(
       key,
@@ -684,6 +688,88 @@ describe("discordbot", () => {
       ),
     ).toBe(true);
     expect(hasReaction(threadId, mentionId, "PUT", "❌")).toBe(false);
+  });
+
+  it("posts session activity summaries as subtext blurbs", async () => {
+    codexApi.autoRespond = false;
+
+    const threadId = discordApi.nextId();
+    discordApi.seedThreadChannel(threadId, CHANNEL_ID);
+    const key = threadKey(threadId);
+    const mentionId = await dispatchMessage({
+      channelId: threadId,
+      content: `<@${APP_ID}> summarize activity`,
+      mention: true,
+      thread: { id: threadId, parentId: CHANNEL_ID },
+    });
+    await waitFor(() => codexApi.executes.length === 1);
+    await waitFor(() => codexApi.eventRequests.length === 1);
+    await waitFor(() => codexApi.hasStream(key));
+
+    const firstSummary = "Checking the benchmark page and related logs.";
+    const secondSummary = "Comparing the chart against the raw data.";
+    codexApi.emitSessionEvent(key, "session.activity_summary", {
+      execution_id: "exe-activity-summary",
+      summary: firstSummary,
+    });
+    // A consecutive repeat is dropped instead of posting a duplicate blurb.
+    codexApi.emitSessionEvent(key, "session.activity_summary", {
+      execution_id: "exe-activity-summary",
+      summary: firstSummary,
+    });
+    await waitFor(() =>
+      blurbPostsIn(threadId).some((content) => content.includes(firstSummary)),
+    );
+    codexApi.emitSessionEvent(key, "session.activity_summary", {
+      execution_id: "exe-activity-summary",
+      summary: secondSummary,
+    });
+    codexApi.emitOutputLine(
+      key,
+      JSON.stringify({
+        type: "item.started",
+        item: {
+          id: "answer-1",
+          type: "agentMessage",
+          text: "",
+          phase: "final_answer",
+        },
+      }),
+    );
+    codexApi.emitOutputLine(
+      key,
+      JSON.stringify({
+        type: "item.agentMessage.delta",
+        itemId: "answer-1",
+        delta: "Done with status.",
+      }),
+    );
+    codexApi.emitOutputLine(
+      key,
+      JSON.stringify({
+        type: "turn.completed",
+        turn: { id: "turn-1", items: [] },
+      }),
+    );
+
+    await waitForSettle(threadId, mentionId);
+    // finish() flushes the second summary even inside the min-post-gap window.
+    const blurbs = blurbPostsIn(threadId);
+    expect(blurbs.join("\n")).toContain(firstSummary);
+    expect(blurbs.join("\n")).toContain(secondSummary);
+    expect(
+      blurbs.join("\n").split(`-# ${firstSummary}`),
+    ).toHaveLength(2);
+    for (const blurb of blurbs) {
+      for (const line of blurb.split("\n")) {
+        if (line.trim()) expect(line.startsWith("-# ")).toBe(true);
+      }
+    }
+    // Summaries stay in the subtext lane; the answer stays summary-free.
+    const answers = answerPostsIn(threadId);
+    expect(answers.join("\n")).toContain("Done with status.");
+    expect(answers.join("\n")).not.toContain(firstSummary);
+    expect(hasReaction(threadId, mentionId, "PUT", "✅")).toBe(true);
   });
 
   // Regression (g) — transient create/append failure is retried in place.
@@ -2016,6 +2102,7 @@ type MockSessionApi = {
   failNextEvents: boolean;
   failNextExecute: boolean;
   failNextExecuteAfterAccept: boolean;
+  hasStream(threadKey: string): boolean;
   holdNextExecute(): () => void;
   reset(): void;
   streamCount: number;
@@ -2030,6 +2117,7 @@ async function startMockCodexApi(): Promise<MockSessionApi> {
   const executes: MockSessionRequest<DiscordbotExecuteSessionRequest>[] = [];
   const idempotentExecutions = new Map<string, string>();
   const streams = new Set<ServerResponse>();
+  const streamThreadKeys = new Map<ServerResponse, string>();
   let autoRespond = true;
   let executeHold: Promise<void> | null = null;
   let executeHoldRelease: (() => void) | null = null;
@@ -2043,6 +2131,7 @@ async function startMockCodexApi(): Promise<MockSessionApi> {
   const closeStreams = () => {
     for (const stream of streams) stream.end();
     streams.clear();
+    streamThreadKeys.clear();
   };
   const server = createServer((req, res) => {
     void handleMockCodexRequest(req, res, {
@@ -2091,6 +2180,7 @@ async function startMockCodexApi(): Promise<MockSessionApi> {
         failNextExecuteAfterAccept = value;
       },
       streams,
+      streamThreadKeys,
     }).catch((error) => {
       res.writeHead(500, { "content-type": "application/json" });
       res.end(JSON.stringify({ error: String(error) }));
@@ -2175,6 +2265,12 @@ async function startMockCodexApi(): Promise<MockSessionApi> {
     get streamCount() {
       return streams.size;
     },
+    // streamCount counts LIVE streams across all threads; a stream from the
+    // previous test that has not closed yet can satisfy a bare count wait.
+    // Order-sensitive tests wait for THEIR thread's stream instead.
+    hasStream(threadKey: string) {
+      return Array.from(streamThreadKeys.values()).includes(threadKey);
+    },
     emitOutputLine(threadKey: string, line: string, executionId?: string) {
       emitMockSessionEvent({
         data: line,
@@ -2238,6 +2334,7 @@ async function handleMockCodexRequest(
     setFailNextExecute(value: boolean): void;
     setFailNextExecuteAfterAccept(value: boolean): void;
     streams: Set<ServerResponse>;
+    streamThreadKeys: Map<ServerResponse, string>;
   },
 ): Promise<void> {
   const url = new URL(req.url ?? "/", `http://127.0.0.1:${input.port}`);
@@ -2302,6 +2399,7 @@ async function handleMockCodexRequest(
       "content-type": "text/event-stream",
     });
     input.streams.add(res);
+    input.streamThreadKeys.set(res, threadKey);
     for (const event of input.events) {
       if (
         event.threadKey === threadKey &&
@@ -2315,6 +2413,7 @@ async function handleMockCodexRequest(
     }
     req.once("close", () => {
       input.streams.delete(res);
+      input.streamThreadKeys.delete(res);
     });
     return;
   }


### PR DESCRIPTION
## Problem

`4c17d8b8` ("feat: add live activity summaries") moved reasoning→"Thinking" task synthesis out of the shared renderer (server-side now, surfaced as `session.activity_summary` → `renderer.status`) and adapted slackbotv2 and linearbot — but not discordbot. It also landed without a PR CI run, and the discordbot test job is path-filtered, so `main` has had 2 failing discordbot tests since. Any PR that touches shared paths (e.g. #923/#924, which touch `pnpm-lock.yaml`) un-skips the job and goes red on these.

Two real regressions in discordbot, not just stale tests:

1. **No narration.** Discord's narrator built its `-#` subtext reasoning blurbs from the removed Thinking tasks — runs stopped narrating entirely. Discordbot's SSE parser also drops `session.activity_summary` events (whitelist), so the replacement signal never reached the renderer.
2. **Answer-only turns don't stream.** The synthetic starting item no longer primes the renderer's task state, and the pre-stream grace check is event-driven — with no tasks and no later events, buffered answer deltas sit until stream end.

## Fix

- Forward `session.activity_summary` through discordbot's SSE whitelist (mirrors slackbotv2).
- Route `renderer.status` to a new `DiscordNarrator.status()` — the Discord analog of Slack's assistant status: summaries post as append-only `-#` subtext blurbs; consecutive repeats and the end-of-run clear are dropped.
- `packages/rendering`: make the pre-stream grace configurable (`preStreamGraceMs`, default 500ms — unchanged for slackbotv2); discordbot passes 0 since it streams answer text into its own append-only messages and has no card to wait for.

## Tests

- New end-to-end test: activity summaries → `-#` blurbs, dedupe, answer stays summary-free.
- Stale expectations updated: raw commentary/reasoning deltas no longer render anywhere.
- The failing-edit test now waits for the first post before sending the tail, so the tail must land as an edit (deltas could previously coalesce into the initial post, skipping the path under test).
- Mock session API gains `hasStream(threadKey)` — `streamCount` counts live streams across all threads, so a lingering stream from the previous test could satisfy a bare count wait (the original order-dependence that hid half of this).

## Verification

- discordbot: 140 pass / 0 fail (was 138/2 on `main`); typecheck clean.
- packages/rendering: 27 pass / 0 fail, `tsc --noEmit` clean.
- slackbotv2 150/0, linearbot 94/0, teamsbot 52/0 (shared renderer change is behavior-neutral at the default).

Unblocks #923 / #924.

Prompted by: mslipper