### PR TITLE
fix(slackbotv2): release the events connection when a live render is abandoned mid-turn

### DIFF
--- a/services/slackbotv2/src/index.ts
+++ b/services/slackbotv2/src/index.ts
@@ -38,7 +38,8 @@ import {
   serializeMessageLinks,
   serializeMessage,
   sessionStreamError,
-  withSlackApiTimeout
+  withSlackApiTimeout,
+  type SessionEventStream
 } from './session-api'
 import {
   buildConsoleSessionContextBlock,
@@ -1057,10 +1058,11 @@ async function renderExecutionAttempt(
   let rendered = false
   let retry = false
   let fallbackLastEventId = 0
+  const eventsConnection: { close?: () => void } = {}
   try {
     const streamResult = await renderExecutionStream(
       thread,
-      streamSessionAfterHandoff(options, input),
+      streamSessionAfterHandoff(options, input, eventsConnection),
       message,
       options,
       trace,
@@ -1099,6 +1101,13 @@ async function renderExecutionAttempt(
     })
     return 'complete'
   } catch (error) {
+    // The live render is over the moment it throws: release its events
+    // connection before anything else. The retry and fallback paths below
+    // open their own streams — and the fallback blocks until the execution's
+    // terminal event, which is exactly how long an unreleased connection
+    // would otherwise stay parked, holding a fetch-pool slot and buffering
+    // the rest of the turn with no consumer.
+    eventsConnection.close?.()
     // Check the Slack adapter's delivery annotation before retryability:
     // Slack network failures can surface as TypeError/AbortError, which would
     // otherwise be misclassified as retryable session API errors and re-render
@@ -1186,6 +1195,8 @@ async function renderExecutionAttempt(
     }
     throw error
   } finally {
+    // Idempotent backstop for the non-throwing exits.
+    eventsConnection.close?.()
     const latest = (await thread.state) ?? {}
     await thread.setState({
       activeExecution: retry,
@@ -1608,7 +1619,7 @@ async function recoverRenderObligation(
   const renderStartedAtMs = nowMs()
   let renderOutcome = 'failure'
 
-  let openedStream: AsyncIterable<SlackbotV2RendererSource>
+  let openedStream: SessionEventStream
   try {
     openedStream = await openSessionEventStream(options, input)
   } catch (error) {
@@ -1733,6 +1744,9 @@ async function recoverRenderObligation(
       lastEventId = Math.max(lastEventId, fallback.lastEventId)
     }
   } finally {
+    // Same connection release as the live path: an abandoned recovery render
+    // must not hold its events connection until the turn's terminal event.
+    openedStream.close()
     const latest = (await thread.state) ?? {}
     await thread.setState({
       activeExecution: false,
@@ -2171,11 +2185,21 @@ async function streamAfterFirstChunk(
 
   return {
     async *[Symbol.asyncIterator](): AsyncIterator<ChatSDKStreamChunk> {
-      yield first.value
-      for (;;) {
-        const next = await iterator.next()
-        if (next.done) return
-        yield next.value
+      try {
+        yield first.value
+        for (;;) {
+          const next = await iterator.next()
+          if (next.done) return
+          yield next.value
+        }
+      } finally {
+        // A consumer that stops early (a failed Slack stream call tears down
+        // the live render) closes this wrapper, not the iterator it drives.
+        // Forward the close so the conflate layer can stop its pump and
+        // cancel the underlying events connection instead of pulling — and
+        // buffering — the rest of the turn with no consumer. Do not await
+        // it: a silent source keeps the close unsettled until its next event.
+        void Promise.resolve(iterator.return?.()).catch(() => undefined)
       }
     }
   }
@@ -2200,9 +2224,10 @@ function terminalResultText(event: unknown): string {
 
 async function* streamSessionAfterHandoff(
   options: SlackbotV2Options,
-  input: ForwardSessionInput
+  input: ForwardSessionInput,
+  connection?: { close?: () => void }
 ): AsyncIterable<SlackbotV2RendererSource> {
-  let stream: AsyncIterable<SlackbotV2RendererSource>
+  let stream: SessionEventStream
   try {
     stream = await openSessionEventStream(options, input)
   } catch (error) {
@@ -2213,6 +2238,9 @@ async function* streamSessionAfterHandoff(
     yield sessionStreamError(error)
     return
   }
+  // Hand the caller the connection release: it owns the render attempt and is
+  // the only scope that still runs when the render is torn down mid-turn.
+  if (connection) connection.close = () => stream.close()
 
   for await (const event of stream) yield event
 }

--- a/services/slackbotv2/src/session-api.ts
+++ b/services/slackbotv2/src/session-api.ts
@@ -537,7 +537,7 @@ export async function forwardToSessionApi(
 export async function openSessionEventStream(
   options: SlackbotV2Options,
   input: Pick<ForwardSessionInput, 'afterEventId' | 'executionId' | 'onEventId' | 'threadId' | 'trace'>
-): Promise<AsyncIterable<SlackbotV2RendererSource>> {
+): Promise<SessionEventStream> {
   const streamStartedAtMs = nowMs()
   const stream = await recordSessionApiOperation('open_event_stream', () =>
     streamSessionNotifications(
@@ -1284,13 +1284,30 @@ function isRetryableApiStatus(status: number): boolean {
   return status === 408 || status === 425 || status === 429 || status >= 500
 }
 
+/**
+ * An events stream whose underlying connection can be released out of band.
+ * Generator teardown alone cannot do that mid-execution: every layer of the
+ * render chain is parked on an internal await, and a queued `return()` waits
+ * for the next event — which never comes once the render is abandoned.
+ * `close()` settles the connection's pending read immediately (idempotent).
+ */
+export type SessionEventStream = AsyncIterable<SlackbotV2RendererSource> & {
+  close(): void
+}
+
+type SessionEventConnection = {
+  reader: ReadableStreamDefaultReader<Uint8Array>
+  /** True once close() settled the connection: its end is a cancellation, not stream completion. */
+  wasClosed: () => boolean
+}
+
 async function streamSessionNotifications(
   options: SlackbotV2Options,
   threadId: string,
   afterEventId: number,
   executionId: string | undefined,
   onEventId: (eventId: number) => void
-): Promise<AsyncIterable<SlackbotV2RendererSource>> {
+): Promise<SessionEventStream> {
   const fetchFn = options.fetch ?? fetch
   const url = new URL(apiSessionUrl(options.apiUrl, threadId, 'events'))
   url.searchParams.set('after_event_id', String(afterEventId))
@@ -1306,8 +1323,20 @@ async function streamSessionNotifications(
     'stream events'
   )
   await ensureApiOk(response, 'stream events')
-  if (!response.body) return toAsyncIterable([])
-  return parseSessionEventStream(response.body, onEventId)
+  if (!response.body) {
+    return Object.assign(toAsyncIterable<SlackbotV2RendererSource>([]), { close: () => {} })
+  }
+  const reader = response.body.getReader()
+  let closed = false
+  return Object.assign(
+    parseSessionEventStream({ reader, wasClosed: () => closed }, onEventId),
+    {
+      close: () => {
+        closed = true
+        void reader.cancel().catch(() => undefined)
+      }
+    }
+  )
 }
 
 function apiSessionUrl(
@@ -1794,10 +1823,10 @@ type ParsedSessionEvent = {
 }
 
 async function* parseSessionEventStream(
-  stream: ReadableStream<Uint8Array>,
+  connection: SessionEventConnection,
   onEventId: (eventId: number) => void
 ): AsyncIterable<SlackbotV2RendererSource> {
-  for await (const event of parseSseEvents(stream)) {
+  for await (const event of parseSseEvents(connection)) {
     if (typeof event.id === 'number') onEventId(event.id)
     if (event.event === 'session.output.line') {
       yield {
@@ -1848,8 +1877,10 @@ async function* parseSessionEventStream(
   }
 }
 
-async function* parseSseEvents(stream: ReadableStream<Uint8Array>): AsyncIterable<ParsedSessionEvent> {
-  const reader = stream.getReader()
+async function* parseSseEvents(
+  connection: SessionEventConnection
+): AsyncIterable<ParsedSessionEvent> {
+  const { reader } = connection
   // Tracks the underlying network connection. Each open stream occupies one
   // slot of Bun's global fetch pool (BUN_CONFIG_MAX_HTTP_REQUESTS, default
   // 256); the 2026-07-06 incident wedged Slackbot by leaking one abandoned
@@ -1879,7 +1910,9 @@ async function* parseSseEvents(stream: ReadableStream<Uint8Array>): AsyncIterabl
         throw error
       }
       if (done) {
-        releaseConnection('done')
+        // A read settled by close() ends the stream from the consumer side —
+        // record it as a cancellation, not as the execution's own completion.
+        releaseConnection(connection.wasClosed() ? 'cancelled' : 'done')
         break
       }
       buffer += decoder.decode(value, { stream: true })

--- a/services/slackbotv2/test/chat-sdk-emulate.test.ts
+++ b/services/slackbotv2/test/chat-sdk-emulate.test.ts
@@ -5733,6 +5733,93 @@ describe('session event stream connection lifecycle', () => {
     expect(cancelledClosures()).toBeGreaterThan(closuresBefore)
   })
 
+  it('cancels the events connection when the Slack stream fails mid-render', async () => {
+    // Abandoning the live render must also release the connection while the
+    // execution is still producing output. The render wrapper drives the
+    // conflated stream manually, so an adapter.stream teardown has to forward
+    // the close down the chain — otherwise the conflate pump keeps the SSE
+    // connection open (and buffers every remaining chunk) until the turn ends.
+    const gaugeBefore = openEventStreamGauge()
+    const closuresBefore = cancelledClosures()
+    codexApi.autoRespond = false
+    // First append succeeds, then Slack expires the streaming message and the
+    // next append tears down the live render mid-turn.
+    slackApi.failStreamAppendsAfter(1, 'message_not_in_streaming_state')
+
+    const parent = await postUserMessage('Stream abandoned mid-render.')
+    const mention = await postUserMessage(`<@${BOT_USER_ID}> stream lifecycle turn 0`, parent.ts)
+    const key = threadKey(parent.ts)
+    const waits: Promise<unknown>[] = []
+    const response = await bot.app.request(
+      '/api/webhooks/slack',
+      signedSlackEvent({
+        event_id: `Ev-stream-lifecycle-midrender-${parent.ts}`,
+        event: {
+          type: 'app_mention',
+          user: USER_ID,
+          channel: CHANNEL_ID,
+          team: TEAM_ID,
+          ts: mention.ts,
+          thread_ts: parent.ts,
+          text: `<@${BOT_USER_ID}> stream lifecycle turn 0`
+        }
+      }),
+      {},
+      waitUntilContext(waits)
+    )
+    expect(response.status).toBe(200)
+    await waitFor(() => codexApi.executes.length === 1)
+    await waitFor(() => codexApi.eventRequests.length === 1)
+    await waitFor(() => codexApi.streamCount === 1)
+
+    codexApi.emitOutputLine(
+      key,
+      JSON.stringify({
+        type: 'item.completed',
+        item: {
+          id: 'cmd-midrender-1',
+          type: 'commandExecution',
+          // Large enough to flush the Slack SDK's client-side stream buffer
+          // so the first append carries content.
+          command: `sleep 1 # ${'x'.repeat(300)}`,
+          status: 'completed',
+          aggregatedOutput: 'first'
+        }
+      })
+    )
+    await waitFor(() => slackApi.calls.some(call => call.method === 'chat.startStream'))
+    codexApi.emitOutputLine(
+      key,
+      JSON.stringify({
+        type: 'item.completed',
+        item: {
+          id: 'cmd-midrender-2',
+          type: 'commandExecution',
+          command: `sleep 1 # ${'y'.repeat(300)}`,
+          status: 'completed',
+          aggregatedOutput: 'second'
+        }
+      })
+    )
+
+    // The execution has not completed: the abandoned render must cancel its
+    // events connection now instead of holding it (and buffering the rest of
+    // the turn) until the terminal event. The gauge is churned by render
+    // recovery reopening a fresh stream, so assert on the monotonic
+    // cancelled-closures counter, which only the abandoned render increments.
+    await waitFor(() => cancelledClosures() > closuresBefore, 5_000)
+    expect(cancelledClosures()).toBeGreaterThan(closuresBefore)
+
+    codexApi.emitSessionEvent(key, 'session.execution_completed', {
+      execution_id: 'exe-midrender-cancel',
+      status: 'completed',
+      result_text: 'MIDRENDER_CANCEL_FINAL'
+    })
+    await Promise.all(waits).catch(() => {})
+    const open = await waitForGaugeAtMost(gaugeBefore)
+    expect(open).toBeLessThanOrEqual(gaugeBefore)
+  })
+
   // Drives past Bun's 256-request cap to prove the wedge is gone. `bun test`
   // ignores the BUN_CONFIG_MAX_HTTP_REQUESTS override but still enforces the
   // built-in 256 cap, so crossing 260 turns exercises the real limit. Takes


### PR DESCRIPTION

## Problem

#920 releases the `GET /api/session/{key}/events` connection when its consumer stops — but only through async-iterator teardown, and teardown cannot fire mid-execution. Every layer of the live render chain is parked on an internal await (the conflate pump on `iterator.next()`, the SSE parser on `reader.read()`), and a queued `.return()` waits for the pending operation to settle — which only the stream's next event does. Once the render is abandoned, that event never comes.

So when `adapter.stream` fails mid-render (Slack stream expiry, `msg_too_long`, rate limit, network error), the abandoned render's connection stays open until the execution's terminal event:

- one slot of Bun's global fetch pool (`BUN_CONFIG_MAX_HTTP_REQUESTS`, default 256) held for the rest of the turn,
- the conflate pump keeps pulling and buffering every remaining chunk with no consumer — the tens-of-thousands-of-chunks volume conflation exists to absorb,
- the retry and recovery paths open fresh streams while the old ones are still parked, so repeated Slack failures accumulate held connections — the same accumulation shape as the 2026-07-06 incident.

There is also a propagation break above all this: `streamAfterFirstChunk` drives the conflated stream with a manual `iterator.next()` loop and no try/finally, so a consumer close never even reaches the conflate layer. (Contrast `renderFallbackFinalAnswer`, which drains the identical chain with plain `for await` and closes cleanly.)

## Change

- **session-api**: the events stream now carries an out-of-band `close()` that cancels its reader, settling the parked read immediately instead of waiting for the next event. A read settled by `close()` is recorded as `reason="cancelled"`, not `done` — the execution didn't finish, the consumer let go.
- **index**: a failed render attempt releases its events connection first thing in the catch — the fallback that follows blocks on a fresh stream until the terminal event, which is exactly how long the dead connection would otherwise stay parked. The recovery render closes its stream the same way, and `streamAfterFirstChunk` now forwards protocol closes to the layers below instead of silently dropping them.

## Testing

- New always-on regression test: a mid-render Slack stream failure while the execution is still emitting output must close the abandoned connection with `reason="cancelled"` *before* the terminal event, and the open-streams gauge must settle at baseline afterward. Fails on `main` (times out waiting for the cancelled closure), passes with this change.
- `bun test test`: 147 pass / 0 fail.
- `bun run check:types` clean.
