### PR TITLE
fix(harness-server): keep the settle fallback armed across rejected mid-turn requests

### DIFF
--- a/crates/harness-server/src/server.rs
+++ b/crates/harness-server/src/server.rs
@@ -1008,16 +1008,27 @@ fn apply_resume_overrides(state: &mut ThreadState, params: &ThreadResumeParams) 
     Ok(())
 }
 
+/// What handling a mid-turn JSON-RPC request did to the harness.
+enum ActiveTurnRequestOutcome {
+    /// The harness process was killed; the turn is over.
+    Interrupted,
+    /// Steer input was written to the harness, which now owes a response.
+    Steered,
+    /// The request was rejected without reaching the harness: the turn's
+    /// state is untouched.
+    Rejected,
+}
+
 fn handle_active_turn_request<H: HarnessServer, W: Write>(
     harness: &H,
     process: &mut HarnessChild,
     normalizer: &mut CodexTurnNormalizer,
     request: ActiveTurnRequest,
     stdout: &mut W,
-) -> Result<bool> {
+) -> Result<ActiveTurnRequestOutcome> {
     let ActiveTurnRequest::JsonRpc(request) = request else {
         process.kill_and_wait()?;
-        return Ok(true);
+        return Ok(ActiveTurnRequestOutcome::Interrupted);
     };
 
     match request.method.as_str() {
@@ -1030,7 +1041,7 @@ fn handle_active_turn_request<H: HarnessServer, W: Write>(
                     -32600,
                     format!("unknown threadId {}", params.thread_id),
                 )?;
-                return Ok(false);
+                return Ok(ActiveTurnRequestOutcome::Rejected);
             }
             if params.expected_turn_id != normalizer.turn_id() {
                 write_error(
@@ -1043,7 +1054,7 @@ fn handle_active_turn_request<H: HarnessServer, W: Write>(
                         normalizer.turn_id()
                     ),
                 )?;
-                return Ok(false);
+                return Ok(ActiveTurnRequestOutcome::Rejected);
             }
             process
                 .stdin
@@ -1063,7 +1074,7 @@ fn handle_active_turn_request<H: HarnessServer, W: Write>(
             {
                 write_value(stdout, &notification_to_wire_value(&notification)?)?;
             }
-            Ok(false)
+            Ok(ActiveTurnRequestOutcome::Steered)
         }
         "turn/interrupt" => {
             let params: TurnInterruptParams = request_params(request.params)?;
@@ -1074,7 +1085,7 @@ fn handle_active_turn_request<H: HarnessServer, W: Write>(
                     -32600,
                     format!("unknown threadId {}", params.thread_id),
                 )?;
-                return Ok(false);
+                return Ok(ActiveTurnRequestOutcome::Rejected);
             }
             if params.turn_id != normalizer.turn_id() {
                 write_error(
@@ -1087,7 +1098,7 @@ fn handle_active_turn_request<H: HarnessServer, W: Write>(
                         normalizer.turn_id()
                     ),
                 )?;
-                return Ok(false);
+                return Ok(ActiveTurnRequestOutcome::Rejected);
             }
             process.kill_and_wait()?;
             write_client_response(
@@ -1097,7 +1108,7 @@ fn handle_active_turn_request<H: HarnessServer, W: Write>(
                     response: TurnInterruptResponse {},
                 },
             )?;
-            Ok(true)
+            Ok(ActiveTurnRequestOutcome::Interrupted)
         }
         _ => {
             write_error(
@@ -1106,7 +1117,7 @@ fn handle_active_turn_request<H: HarnessServer, W: Write>(
                 -32600,
                 format!("cannot handle {} while a turn is active", request.method),
             )?;
-            Ok(false)
+            Ok(ActiveTurnRequestOutcome::Rejected)
         }
     }
 }
@@ -1236,17 +1247,24 @@ fn run_harness_turn<H: HarnessServer, W: Write>(
                 .process
                 .as_mut()
                 .ok_or(HarnessServerError::HarnessStdinUnavailable)?;
-            if handle_active_turn_request(harness, process, normalizer, request, stdout)? {
-                state.process = None;
-                return Err(HarnessServerError::TurnInterrupted {
-                    kind: harness.kind(),
-                });
+            match handle_active_turn_request(harness, process, normalizer, request, stdout)? {
+                ActiveTurnRequestOutcome::Interrupted => {
+                    state.process = None;
+                    return Err(HarnessServerError::TurnInterrupted {
+                        kind: harness.kind(),
+                    });
+                }
+                // A steer re-opens the turn: the harness now owes a response
+                // whose first token can take longer than the settle window, so
+                // the pending fallback completion no longer applies. The
+                // response's own terminal stop re-arms it.
+                ActiveTurnRequestOutcome::Steered => settle_deadline = None,
+                // A rejected request never reached the harness: no response is
+                // owed, so a pending fallback completion must survive it —
+                // with the stream already quiet, disarming here would leave
+                // nothing to complete the turn.
+                ActiveTurnRequestOutcome::Rejected => {}
             }
-            // A steer re-opens the turn: the harness now owes a response whose
-            // first token can take longer than the settle window, so the
-            // pending fallback completion no longer applies. The response's
-            // own terminal stop re-arms it.
-            settle_deadline = None;
         }
 
         let mut terminal = false;

--- a/crates/harness-server/tests/app_server_stdio.rs
+++ b/crates/harness-server/tests/app_server_stdio.rs
@@ -199,6 +199,42 @@ fn fake_claude_trailing_result_settles_the_turn_and_does_not_poison_the_next() {
 }
 
 #[test]
+fn fake_claude_rejected_steer_during_settle_window_does_not_hang_the_turn() {
+    // A steer racing the turn boundary carries a stale turn id and is
+    // rejected without any input reaching the harness. With the stream
+    // already quiet after the terminal stop, the rejection must leave the
+    // settle fallback armed — it is the only thing left that can complete
+    // the turn.
+    let fake_claude = concat!(
+        "printf '%s\\n' ",
+        "'{\"type\":\"system\",\"subtype\":\"init\",\"session_id\":\"claude-session\"}' ",
+        "'{\"type\":\"stream_event\",\"event\":{\"type\":\"message_start\",\"message\":{\"id\":\"msg_1\",\"stop_reason\":null,\"content\":[]}}}' ",
+        "'{\"type\":\"stream_event\",\"event\":{\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}}' ",
+        "'{\"type\":\"stream_event\",\"event\":{\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"fable answer\"}}}' ",
+        "'{\"type\":\"assistant\",\"message\":{\"id\":\"msg_1\",\"stop_reason\":null,\"content\":[{\"type\":\"text\",\"text\":\"fable answer\"}]}}' ",
+        "'{\"type\":\"stream_event\",\"event\":{\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"}}}'",
+        "; sleep 60"
+    );
+
+    let mut bridge =
+        BridgeProcess::spawn_harness(Harness::ClaudeCode, Some(fake_claude.to_string()), None);
+    let thread_id =
+        bridge.initialize_and_start_thread(Harness::ClaudeCode, Duration::from_secs(10));
+    let turn = bridge.run_turn_with_rejected_steers_during_settle(
+        &thread_id,
+        3,
+        4,
+        5,
+        "say hello",
+        Duration::from_secs(10),
+    );
+    bridge.finish_successfully();
+
+    assert_completed_turn(&turn);
+    assert_eq!(turn.text_from_deltas, "fable answer");
+}
+
+#[test]
 fn fake_claude_subagent_sidechain_stop_does_not_complete_the_turn() {
     // A Task subagent's sidechain messages end with their own end_turn while
     // the parent turn keeps running (here: 3s of quiet before the main chain
@@ -1638,6 +1674,107 @@ impl BridgeProcess {
                     assert!(
                         valid_interrupt_acknowledged,
                         "turn completed before valid interrupt response"
+                    );
+                    break;
+                }
+            }
+        }
+
+        capture
+    }
+
+    fn run_turn_with_rejected_steers_during_settle(
+        &mut self,
+        thread_id: &str,
+        request_id: i64,
+        wrong_thread_steer_request_id: i64,
+        wrong_turn_steer_request_id: i64,
+        prompt: &str,
+        timeout: Duration,
+    ) -> TurnCapture {
+        self.send(json!({
+            "id": request_id,
+            "method": "turn/start",
+            "params": {
+                "threadId": thread_id,
+                "input": [{"type": "text", "text": prompt, "text_elements": []}],
+            },
+        }));
+
+        let deadline = Instant::now() + timeout;
+        let mut capture = TurnCapture::default();
+        let mut steers_sent = false;
+        let mut wrong_thread_steer_rejected = false;
+        let mut wrong_turn_steer_rejected = false;
+
+        loop {
+            let value = self.read_json_allowing_error(deadline);
+            if let Some(id) = response_id(&value) {
+                if id == request_id {
+                    capture.turn_id = value
+                        .pointer("/result/turn/id")
+                        .and_then(Value::as_str)
+                        .unwrap_or_else(|| panic!("turn/start did not return turn id: {value}"))
+                        .to_string();
+                } else if id == wrong_thread_steer_request_id {
+                    assert!(
+                        value.get("error").is_some(),
+                        "wrong-thread steer should be rejected: {value}"
+                    );
+                    wrong_thread_steer_rejected = true;
+                } else if id == wrong_turn_steer_request_id {
+                    assert!(
+                        value.get("error").is_some(),
+                        "wrong-turn steer should be rejected: {value}"
+                    );
+                    wrong_turn_steer_rejected = true;
+                }
+                continue;
+            }
+
+            if let Some(method) = value.get("method").and_then(Value::as_str) {
+                assert_notification_thread_id(&value, thread_id);
+                capture.consume_notification(method, &value);
+                if method == "turn/started"
+                    && capture.turn_id.is_empty()
+                    && let Some(turn_id) = value.pointer("/params/turn/id").and_then(Value::as_str)
+                {
+                    capture.turn_id = turn_id.to_string();
+                }
+                if method == "item/completed" && !steers_sent && !capture.turn_id.is_empty() {
+                    // The terminal stop trails the completed message by one
+                    // line; give the server time to process it so the steers
+                    // land inside the armed settle window, not before it.
+                    thread::sleep(Duration::from_millis(500));
+                    self.send(json!({
+                        "id": wrong_thread_steer_request_id,
+                        "method": "turn/steer",
+                        "params": {
+                            "threadId": "wrong-thread",
+                            "expectedTurnId": capture.turn_id,
+                            "input": [{"type": "text", "text": "steer astray", "text_elements": []}],
+                        },
+                    }));
+                    self.send(json!({
+                        "id": wrong_turn_steer_request_id,
+                        "method": "turn/steer",
+                        "params": {
+                            "threadId": thread_id,
+                            "expectedTurnId": "wrong-turn",
+                            "input": [{"type": "text", "text": "steer astray", "text_elements": []}],
+                        },
+                    }));
+                    steers_sent = true;
+                }
+                if method == "turn/completed" {
+                    assert!(steers_sent, "steers were never sent");
+                    assert!(
+                        wrong_thread_steer_rejected,
+                        "turn completed before wrong-thread steer rejection"
+                    );
+                    assert!(
+                        wrong_turn_steer_rejected,
+                        "turn completed before wrong-turn steer rejection"
                     );
                     break;
                 }


### PR DESCRIPTION

Hardens the settle machinery from #921. A `turn/steer` or `turn/interrupt` that arrives with a stale turn id — a client racing the turn boundary — is rejected with a JSON-RPC error and never reaches the harness, but the drain loop cleared `settle_deadline` unconditionally after every request. If the turn had already stopped at a terminal assistant stop with no native `result` (the case the settle fallback exists to complete), the rejection disarmed the only remaining completion path and the turn hung with the stream quiet.

`handle_active_turn_request` now reports what it did — `Interrupted`, `Steered`, or `Rejected` — and only a delivered steer disarms the pending fallback, since only then does the harness owe a response. Rejections (stale steer, stale interrupt, unknown method) leave the turn's state untouched.

To be direct about reachability: this path only fires in jsonrpc mode, and production sandboxes run blocks mode, whose only mid-turn request kills the process. So this is a latent defect in the settle state machine plus a regression test pinning the invariant, not a live production hang.

## Testing

- New regression test: a wrong-thread steer and a stale-turn-id steer land inside the armed settle window; both must be rejected with `-32600` and the turn must still complete through the fallback. Fails on `main` (the turn never completes), passes with this change.
- `cargo test -p harness-server`: 21 pass / 0 fail (4 ignored: real-CLI tests).
- `cargo +nightly fmt --check` clean; `cargo clippy --all-targets` introduces no new warnings.
