### PR TITLE
fix(console): serve stale proxy sync snapshots while one session rebuilds

### DIFF
--- a/services/console/app/models/principal_sync_config_snapshot.rb
+++ b/services/console/app/models/principal_sync_config_snapshot.rb
@@ -10,12 +10,25 @@ class PrincipalSyncConfigSnapshot < ApplicationRecord
   validates :principal_cache_version, presence: true
   validates :principal_id, uniqueness: { scope: :principal_cache_version }
 
+  # Returns the freshest usable snapshot, stale-while-revalidate style. When
+  # the current-version snapshot is stale or missing, exactly one caller
+  # rebuilds it (non-blocking row lock on the principal); concurrent callers
+  # are served the stale snapshot immediately instead of queuing behind the
+  # rebuild. Config invalidations fan out to every proxy of a principal at
+  # once (cache-version bumps, TTL expiry), so blocking here previously
+  # stampeded all of them onto one row lock, each holding a request thread
+  # and DB connection for the full rebuild.
+  #
+  # Serving a stale snapshot is safe: iron-proxy treats the config hash as an
+  # ETag and re-applies on its next 5s poll once the rebuild lands. Only a
+  # cold start (no snapshot at any version) blocks until the build finishes,
+  # because there is nothing stale to serve.
   def self.fetch_for(principal)
     version = principal.sync_config_cache_version
     snapshot = find_by(principal: principal, principal_cache_version: version)
     return snapshot if snapshot&.fresh?
 
-    build_for(principal)
+    try_build_for(principal) || snapshot || latest_for(principal) || build_for(principal)
   end
 
   def self.prune_expired!
@@ -26,19 +39,48 @@ class PrincipalSyncConfigSnapshot < ApplicationRecord
     updated_at >= TTL.ago
   end
 
-  def self.build_for(principal)
-    principal.with_lock do
-      principal.reload
-      version = principal.sync_config_cache_version
-      snapshot = find_or_initialize_by(principal: principal, principal_cache_version: version)
-      return snapshot if snapshot.persisted? && snapshot.fresh?
+  # Most recent snapshot at any cache version; the stale fallback while
+  # another session rebuilds. Old versions survive until prune_expired!
+  # (RETENTION), which comfortably covers a rebuild.
+  def self.latest_for(principal)
+    where(principal: principal).order(updated_at: :desc).first
+  end
 
-      config = principal.effective_config(redact_secrets: false)
-      snapshot.payload = config
-      snapshot.save!
-      snapshot
+  def self.build_for(principal)
+    principal.with_lock { build_within_lock(principal) }
+  rescue ActiveRecord::RecordNotUnique
+    retry
+  end
+
+  # Non-blocking variant of build_for: acquires the principal row lock with
+  # SKIP LOCKED and returns nil when another session already holds it.
+  def self.try_build_for(principal)
+    transaction do
+      locked = Principal.lock("FOR UPDATE SKIP LOCKED").find_by(id: principal.id)
+      next nil unless locked
+
+      build_within_lock(locked)
     end
   rescue ActiveRecord::RecordNotUnique
     retry
+  end
+
+  # Assumes the caller holds the principal's row lock and passes the freshly
+  # locked (reloaded) record, so sync_config_cache_version is current.
+  def self.build_within_lock(principal)
+    version = principal.sync_config_cache_version
+    snapshot = find_or_initialize_by(principal: principal, principal_cache_version: version)
+    return snapshot if snapshot.persisted? && snapshot.fresh?
+
+    snapshot.payload = principal.effective_config(redact_secrets: false)
+    if snapshot.changed?
+      snapshot.save!
+    else
+      # A rebuild that yields an identical payload must still restart the TTL,
+      # or the snapshot stays permanently stale and every poll re-runs the
+      # expensive effective_config rebuild.
+      snapshot.touch
+    end
+    snapshot
   end
 end

--- a/services/console/test/models/principal_sync_config_snapshot_test.rb
+++ b/services/console/test/models/principal_sync_config_snapshot_test.rb
@@ -1,0 +1,112 @@
+require "test_helper"
+
+class PrincipalSyncConfigSnapshotTest < ActiveSupport::TestCase
+  setup do
+    @principal = principals(:acme_channel)
+  end
+
+  # Simulates losing the non-blocking rebuild race: another session holds the
+  # principal row lock, so try_build_for's SKIP LOCKED select comes back empty.
+  # (Real cross-session lock contention is not reproducible under transactional
+  # tests, where all sessions share one connection.)
+  def while_rebuild_lock_held
+    singleton = PrincipalSyncConfigSnapshot.singleton_class
+    original = PrincipalSyncConfigSnapshot.method(:try_build_for)
+    singleton.define_method(:try_build_for) { |_principal| nil }
+    yield
+  ensure
+    singleton.define_method(:try_build_for, original)
+  end
+
+  test "fetch_for builds a snapshot on cold start" do
+    assert_difference -> { PrincipalSyncConfigSnapshot.count }, 1 do
+      snapshot = PrincipalSyncConfigSnapshot.fetch_for(@principal)
+      assert_equal @principal.sync_config_cache_version, snapshot.principal_cache_version
+      assert_equal @principal.effective_config(redact_secrets: false), snapshot.payload
+    end
+  end
+
+  test "fetch_for returns the fresh snapshot without rebuilding" do
+    snapshot = PrincipalSyncConfigSnapshot.fetch_for(@principal)
+
+    assert_no_difference -> { PrincipalSyncConfigSnapshot.count } do
+      assert_equal snapshot, PrincipalSyncConfigSnapshot.fetch_for(@principal)
+    end
+    assert_equal snapshot.updated_at, snapshot.reload.updated_at
+  end
+
+  test "fetch_for rebuilds a snapshot stale past TTL" do
+    snapshot = PrincipalSyncConfigSnapshot.fetch_for(@principal)
+    stale_time = (PrincipalSyncConfigSnapshot::TTL + 1.minute).ago
+    snapshot.update_columns(updated_at: stale_time)
+
+    refreshed = PrincipalSyncConfigSnapshot.fetch_for(@principal)
+    assert_equal snapshot.id, refreshed.id
+    assert refreshed.fresh?
+  end
+
+  test "fetch_for builds a new snapshot after a cache version bump" do
+    old = PrincipalSyncConfigSnapshot.fetch_for(@principal)
+    Principal.bump_sync_config_cache_versions(@principal.id)
+    @principal.reload
+
+    fresh = PrincipalSyncConfigSnapshot.fetch_for(@principal)
+    refute_equal old.id, fresh.id
+    assert_equal @principal.sync_config_cache_version, fresh.principal_cache_version
+  end
+
+  # The stampede regression: when another session holds the rebuild lock,
+  # fetch_for must serve the stale current-version snapshot instead of
+  # queuing behind the row lock.
+  test "fetch_for serves the stale snapshot while another session rebuilds" do
+    snapshot = PrincipalSyncConfigSnapshot.fetch_for(@principal)
+    stale_time = (PrincipalSyncConfigSnapshot::TTL + 1.minute).ago
+    snapshot.update_columns(updated_at: stale_time)
+
+    while_rebuild_lock_held do
+      assert_no_difference -> { PrincipalSyncConfigSnapshot.count } do
+        served = PrincipalSyncConfigSnapshot.fetch_for(@principal)
+        assert_equal snapshot.id, served.id
+        refute served.fresh?
+      end
+    end
+  end
+
+  test "fetch_for serves the previous-version snapshot while another session rebuilds after a bump" do
+    old = PrincipalSyncConfigSnapshot.fetch_for(@principal)
+    Principal.bump_sync_config_cache_versions(@principal.id)
+    @principal.reload
+
+    while_rebuild_lock_held do
+      assert_no_difference -> { PrincipalSyncConfigSnapshot.count } do
+        served = PrincipalSyncConfigSnapshot.fetch_for(@principal)
+        assert_equal old.id, served.id
+        refute_equal @principal.sync_config_cache_version, served.principal_cache_version
+      end
+    end
+  end
+
+  test "fetch_for falls back to a blocking build on cold start when the non-blocking build loses" do
+    while_rebuild_lock_held do
+      assert_difference -> { PrincipalSyncConfigSnapshot.count }, 1 do
+        snapshot = PrincipalSyncConfigSnapshot.fetch_for(@principal)
+        assert_equal @principal.sync_config_cache_version, snapshot.principal_cache_version
+      end
+    end
+  end
+
+  test "try_build_for builds when the principal row lock is free" do
+    assert_difference -> { PrincipalSyncConfigSnapshot.count }, 1 do
+      snapshot = PrincipalSyncConfigSnapshot.try_build_for(@principal)
+      assert_equal @principal.sync_config_cache_version, snapshot.principal_cache_version
+    end
+  end
+
+  test "try_build_for returns the existing snapshot when already fresh" do
+    snapshot = PrincipalSyncConfigSnapshot.fetch_for(@principal)
+
+    assert_no_difference -> { PrincipalSyncConfigSnapshot.count } do
+      assert_equal snapshot, PrincipalSyncConfigSnapshot.try_build_for(@principal)
+    end
+  end
+end


### PR DESCRIPTION
## Problem

centaur-console in prd-centaur-na was crash-looping today (~30 restarts/hour at peak): all 6 replicas were repeatedly SIGTERM'd by kubelet after failing `/up` liveness probes.

Root cause: every iron-proxy polls `POST /api/v1/proxy/sync` on a 5s cadence. When a principal's config snapshot goes stale (10min TTL) or its cache version is bumped — broker credential refreshes (Google OAuth, ~every 30min) bump **every** referencing principal at once — all of that principal's proxies stampede into `PrincipalSyncConfigSnapshot.build_for`, which takes `principal.with_lock` (`SELECT … FOR UPDATE`). Each waiter holds a Puma thread and DB connection for the duration of the winner's `effective_config` rebuild.

One busy Slack channel principal is currently shared by 30+ sandbox proxies. Console capacity is 6 pods × 3 Puma threads = 18 slots. Each invalidation wave saturated every thread with lock-queued sync requests, starved the `/up` probe (5s timeout × 6 failures), and kubelet killed all replicas simultaneously. Smoking-gun cycle: Google token refresh 14:19:00 UTC → mass snapshot rebuild 14:20:02–14:20:23 → liveness kills 14:21.

## Fix

`fetch_for` is now stale-while-revalidate:

- Exactly one caller rebuilds, acquiring the principal row lock with **`FOR UPDATE SKIP LOCKED`** (`try_build_for`).
- Concurrent callers are served the stale current-version snapshot, or the newest previous-version snapshot after a cache bump (old versions survive until the 1h `RETENTION` prune), in ~ms instead of queuing.
- Only a cold start (no snapshot at any version) still blocks on the original `with_lock` path.

Serving stale is safe: iron-proxy treats the config hash as an ETag and re-applies on its next 5s poll once the rebuild lands.

## Bonus bug the new tests exposed

A rebuild that produced a byte-identical payload no-op'd on `save!`, so `updated_at` never advanced — the snapshot stayed **permanently stale** and every poll re-ran the expensive `effective_config` rebuild. This matches the constant ~3s sync requests observed in prod even between invalidation waves. `build_within_lock` now `touch`es the row in that case to restart the TTL.

## Testing

- New `PrincipalSyncConfigSnapshotTest` covering cold start, fresh hit, TTL-stale rebuild, version-bump rebuild, and the lock-contention fallbacks (stale current-version, previous-version after bump, blocking cold start). Real cross-session lock contention isn't reproducible under transactional tests (shared connection), so losing the rebuild race is simulated at the `try_build_for` seam.
- Full console suite green in ruby:3.4.8 + Postgres 17 (matching CI): 1044 runs, 0 failures.
- `rubocop` clean.