### PR TITLE
feat(console): grant oauth credentials and user-mcp role to console-user MCP principals

### DIFF
--- a/services/console/Gemfile.lock
+++ b/services/console/Gemfile.lock
@@ -369,6 +369,7 @@ PLATFORMS
   arm-linux-musl
   arm64-darwin-23
   arm64-darwin-24
+  arm64-darwin-25
   x86_64-linux
   x86_64-linux-gnu
   x86_64-linux-musl

--- a/services/console/app/controllers/mcp/oauth_controller.rb
+++ b/services/console/app/controllers/mcp/oauth_controller.rb
@@ -437,23 +437,33 @@ module Mcp
       nil
     end
 
+    # Principal creation and role seeding share a transaction: seeding is
+    # create-only, so a principal that committed without its role would stay
+    # unseeded forever. The RecordNotUnique retry sits outside the transaction
+    # because a unique violation aborts the enclosing Postgres transaction;
+    # every violation source (principal, role, or assignment race) converges
+    # to the find path on the next pass.
     def principal_for_current_user
-      foreign_id = principal_foreign_id(current_user.email)
-      principal = Principal.find_or_initialize_by(
-        namespace: mcp_principal_namespace, foreign_id: foreign_id
-      )
-      newly_created = principal.new_record?
-      principal.created_by ||= current_user
-      principal.name = current_user.name.presence || current_user.email
-      principal.labels = principal.labels.merge(
-        "managed-by" => "centaur",
-        "kind" => "console_user",
-        "console-user-id" => current_user.oid,
-        "email" => current_user.email
-      )
-      principal.save!
-      assign_user_mcp_role(principal) if newly_created
-      principal
+      Principal.transaction do
+        foreign_id = principal_foreign_id(current_user.email)
+        principal = Principal.find_or_initialize_by(
+          namespace: mcp_principal_namespace, foreign_id: foreign_id
+        )
+        newly_created = principal.new_record?
+        principal.created_by ||= current_user
+        principal.name = current_user.name.presence || current_user.email
+        principal.labels = principal.labels.merge(
+          "managed-by" => "centaur",
+          "kind" => "console_user",
+          "console-user-id" => current_user.oid,
+          "email" => current_user.email
+        )
+        principal.save!
+        assign_user_mcp_role(principal) if newly_created
+        principal
+      end
+    rescue ActiveRecord::RecordNotUnique
+      retry
     end
 
     # New console-user principals start with the shared user-mcp role. Seeded
@@ -472,10 +482,6 @@ module Mcp
           foreign_id: USER_MCP_ROLE_FOREIGN_ID
         )
       principal.principal_roles.find_or_create_by!(role: role)
-    rescue ActiveRecord::RecordNotUnique
-      # Concurrent authorize requests raced the role or assignment into
-      # existence; the requested end state is true.
-      retry
     end
 
     def principal_foreign_id(email)

--- a/services/console/app/controllers/mcp/oauth_controller.rb
+++ b/services/console/app/controllers/mcp/oauth_controller.rb
@@ -12,6 +12,10 @@ module Mcp
 
     ACCESS_TOKEN_TTL_SECONDS = 1.hour.to_i
 
+    # The shared role seeded onto new console-user principals. Admins attach
+    # tool secrets to this role to define what every MCP user gets by default.
+    USER_MCP_ROLE_FOREIGN_ID = "user-mcp"
+
     # GET /.well-known/oauth-authorization-server
     def metadata
       render json: {
@@ -435,19 +439,43 @@ module Mcp
 
     def principal_for_current_user
       foreign_id = principal_foreign_id(current_user.email)
-      Principal
-        .find_or_initialize_by(namespace: mcp_principal_namespace, foreign_id: foreign_id)
-        .tap do |principal|
-        principal.created_by ||= current_user
-        principal.name = current_user.name.presence || current_user.email
-        principal.labels = principal.labels.merge(
-          "managed-by" => "centaur",
-          "kind" => "console_user",
-          "console-user-id" => current_user.oid,
-          "email" => current_user.email
+      principal = Principal.find_or_initialize_by(
+        namespace: mcp_principal_namespace, foreign_id: foreign_id
+      )
+      newly_created = principal.new_record?
+      principal.created_by ||= current_user
+      principal.name = current_user.name.presence || current_user.email
+      principal.labels = principal.labels.merge(
+        "managed-by" => "centaur",
+        "kind" => "console_user",
+        "console-user-id" => current_user.oid,
+        "email" => current_user.email
+      )
+      principal.save!
+      assign_user_mcp_role(principal) if newly_created
+      principal
+    end
+
+    # New console-user principals start with the shared user-mcp role. Seeded
+    # only at creation so an operator removing the role from a principal
+    # sticks, mirroring SessionRegistrar's seeding of the infra role for
+    # session principals.
+    def assign_user_mcp_role(principal)
+      role = Role
+        .create_with(
+          name: "User MCP",
+          labels: { "managed-by" => "centaur" },
+          created_by: current_user
         )
-        principal.save!
-      end
+        .find_or_create_by!(
+          namespace: principal.namespace,
+          foreign_id: USER_MCP_ROLE_FOREIGN_ID
+        )
+      principal.principal_roles.find_or_create_by!(role: role)
+    rescue ActiveRecord::RecordNotUnique
+      # Concurrent authorize requests raced the role or assignment into
+      # existence; the requested end state is true.
+      retry
     end
 
     def principal_foreign_id(email)

--- a/services/console/app/services/principal_credential_reconciliation.rb
+++ b/services/console/app/services/principal_credential_reconciliation.rb
@@ -164,6 +164,17 @@ class PrincipalCredentialReconciliation
     )
   end
 
+  # TODO(perf): this loads every oauth-flow credential in the system -- O(C)
+  # rows per Principal create/update, since apply_for_principal runs in an
+  # after_commit. Negligible while C is in the hundreds. Add the optimization
+  # when oauth-flow credential count reaches the low thousands or principal
+  # writes show up in latency traces, whichever comes first: replace the
+  # single-principal path with a candidate query (namespace-scoped
+  # `LOWER(provider_email) IN (...) OR provider_subject IN (...)`, backed by
+  # indexes on (namespace, LOWER(provider_email)) and (namespace,
+  # provider_subject)), which is O(K) in the credentials of the one matched
+  # human. Keep the SQL normalization identical to normalize_email /
+  # normalize_key. entries/apply_all legitimately need the full load.
   def credential_indexes
     providers.index_with do |provider|
       credentials = provider_credentials(provider)

--- a/services/console/app/services/principal_credential_reconciliation.rb
+++ b/services/console/app/services/principal_credential_reconciliation.rb
@@ -1,17 +1,19 @@
-# Finds Slack/Google OAuth-flow credentials that appear to belong to the same
-# human as an existing user principal, then automatically grants their wrapper
-# static secrets to that principal.
+# Finds OAuth-flow credentials (Slack/Google/GitHub/...) that appear to belong
+# to the same human as an existing user principal, then automatically grants
+# their wrapper static secrets to that principal.
 class PrincipalCredentialReconciliation
   Entry = Struct.new(
     :principal,
-    :slack_credentials,
-    :google_credentials,
-    :slack_grants,
-    :google_grants,
+    :credentials_by_provider,
+    :granted_by_credential_id,
     keyword_init: true
   ) do
     def credentials
-      slack_credentials + google_credentials
+      credentials_by_provider.values.flatten
+    end
+
+    def credentials_for(provider)
+      credentials_by_provider[provider] || []
     end
 
     def actionable_credentials
@@ -19,38 +21,32 @@ class PrincipalCredentialReconciliation
     end
 
     def granted?(credential)
-      slack_grants[credential.id] || google_grants[credential.id] || false
+      granted_by_credential_id[credential.id] || false
     end
   end
 
   USER_KIND = "user"
+  # Minted by the MCP OAuth flow (Mcp::OauthController#principal_for_current_user)
+  # for a console user connecting an MCP client.
+  CONSOLE_USER_KIND = "console_user"
+  CONSOLE_USER_ID_LABEL = "console-user-id"
   SLACK_PROVIDER = Oauth::Providers::Slack::KEY
   GOOGLE_PROVIDER = Oauth::Providers::Google::KEY
   EMAIL_LABELS = %w[email google_email slack_email].freeze
-  SLACK_USER_LABELS = %w[slack_user_id].freeze
-  GOOGLE_SUBJECT_LABELS = %w[google_subject].freeze
+  # Principal labels carrying a provider-native identity. When a principal has
+  # one for a provider, it takes precedence over email matching for that
+  # provider's credentials. Providers without an entry (for example github)
+  # match by email only.
   PROVIDER_SUBJECT_LABELS = {
-    SLACK_PROVIDER => SLACK_USER_LABELS,
-    GOOGLE_PROVIDER => GOOGLE_SUBJECT_LABELS
+    SLACK_PROVIDER => %w[slack_user_id],
+    GOOGLE_PROVIDER => %w[google_subject]
   }.freeze
   SLACK_TEAM_LABEL = "slack_team_id"
 
   def entries
-    slack = provider_credentials(SLACK_PROVIDER)
-    google = provider_credentials(GOOGLE_PROVIDER)
-    slack_by_subject = credentials_by_subject(slack)
-    google_by_subject = credentials_by_subject(google)
-    slack_by_email = credentials_by_email(slack)
-    google_by_email = credentials_by_email(google)
-
+    indexes = credential_indexes
     user_principals.select { |principal| user_principal?(principal) }.filter_map do |principal|
-      entry_for(
-        principal,
-        slack_by_subject: slack_by_subject,
-        slack_by_email: slack_by_email,
-        google_by_subject: google_by_subject,
-        google_by_email: google_by_email
-      )
+      entry_for(principal, indexes: indexes)
     end.sort_by do |entry|
       [ entry.principal.namespace, entry.principal.name.to_s, entry.principal.foreign_id.to_s ]
     end
@@ -89,6 +85,13 @@ class PrincipalCredentialReconciliation
 
   private
 
+  # Every registered OAuth-flow provider participates: a provider without
+  # subject labels still reconciles by email, so new registry entries get
+  # matching for free.
+  def providers
+    Oauth::Providers.keys
+  end
+
   def apply_entry(entry)
     return { requested: 0, created: 0 } unless entry
 
@@ -96,7 +99,7 @@ class PrincipalCredentialReconciliation
     created = entry.actionable_credentials.count do |credential|
       grant_credential(entry.principal, credential)
     end
-    sync_principal_provider_labels(entry.principal, entry.google_credentials)
+    sync_principal_provider_labels(entry.principal, entry.credentials)
     { requested: requested, created: created }
   end
 
@@ -129,47 +132,35 @@ class PrincipalCredentialReconciliation
     false
   end
 
-  def entry_for(
-    principal,
-    slack_by_subject: nil,
-    slack_by_email: nil,
-    google_by_subject: nil,
-    google_by_email: nil
-  )
+  def entry_for(principal, indexes: nil)
     return nil unless user_principal?(principal)
 
-    slack_by_subject ||= credentials_by_subject(provider_credentials(SLACK_PROVIDER))
-    slack_by_email ||= credentials_by_email(provider_credentials(SLACK_PROVIDER))
-    google_by_subject ||= credentials_by_subject(provider_credentials(GOOGLE_PROVIDER))
-    google_by_email ||= credentials_by_email(provider_credentials(GOOGLE_PROVIDER))
-
+    indexes ||= credential_indexes
     emails = principal_emails(principal)
-    slack_credentials = provider_credentials_for(
-      principal,
-      subject_label_keys: SLACK_USER_LABELS,
-      credentials_by_subject: slack_by_subject,
-      credentials_by_email: slack_by_email,
-      emails: emails,
-      provider: SLACK_PROVIDER
-    )
-    google_credentials = provider_credentials_for(
-      principal,
-      subject_label_keys: GOOGLE_SUBJECT_LABELS,
-      credentials_by_subject: google_by_subject,
-      credentials_by_email: google_by_email,
-      emails: emails,
-      provider: GOOGLE_PROVIDER
-    )
-
-    return nil if slack_credentials.empty? && google_credentials.empty?
+    credentials_by_provider = providers.each_with_object({}) do |provider, acc|
+      matched = provider_credentials_for(
+        principal,
+        provider: provider,
+        subject_index: indexes[provider][:subjects],
+        email_index: indexes[provider][:emails],
+        emails: emails
+      )
+      acc[provider] = matched if matched.any?
+    end
+    return nil if credentials_by_provider.empty?
 
     Entry.new(
       principal: principal,
-      slack_credentials: slack_credentials,
-      google_credentials: google_credentials,
-      slack_grants: grant_status(principal, slack_credentials),
-      google_grants: grant_status(principal, google_credentials)
+      credentials_by_provider: credentials_by_provider,
+      granted_by_credential_id: grant_status(principal, credentials_by_provider.values.flatten)
     )
+  end
+
+  def credential_indexes
+    providers.index_with do |provider|
+      credentials = provider_credentials(provider)
+      { subjects: index_by_subject(credentials), emails: index_by_email(credentials) }
+    end
   end
 
   def provider_credentials(provider)
@@ -187,57 +178,46 @@ class PrincipalCredentialReconciliation
 
   def user_principal?(principal)
     labels = principal.labels || {}
-    labels["kind"] == USER_KIND ||
-      (EMAIL_LABELS + SLACK_USER_LABELS + GOOGLE_SUBJECT_LABELS).any? do |key|
-        labels[key].present?
-      end
+    return true if [ USER_KIND, CONSOLE_USER_KIND ].include?(labels["kind"])
+
+    (EMAIL_LABELS + PROVIDER_SUBJECT_LABELS.values.flatten).any? do |key|
+      labels[key].present?
+    end
   end
 
-  def credentials_by_subject(credentials)
+  def index_by_subject(credentials)
     credentials.each_with_object(Hash.new { |hash, key| hash[key] = [] }) do |credential, acc|
       subject = normalize_key(credential.provider_subject)
       acc[subject] << credential if subject
     end
   end
 
-  def credentials_by_email(credentials)
+  def index_by_email(credentials)
     credentials.each_with_object(Hash.new { |hash, key| hash[key] = [] }) do |credential, acc|
       email = normalize_email(credential.provider_email)
       acc[email] << credential if email
     end
   end
 
-  def provider_credentials_for(
-    principal,
-    subject_label_keys:,
-    credentials_by_subject:,
-    credentials_by_email:,
-    emails:,
-    provider:
-  )
-    native = credentials_for_subject_labels(
-      principal,
-      subject_label_keys,
-      credentials_by_subject,
-      provider
-    )
+  def provider_credentials_for(principal, provider:, subject_index:, email_index:, emails:)
+    native = credentials_for_subject_labels(principal, provider, subject_index)
     return native if native.any?
 
-    credentials_for_emails(principal, emails, credentials_by_email, provider)
+    credentials_for_emails(principal, emails, email_index, provider)
   end
 
-  def credentials_for_subject_labels(principal, label_keys, credentials_by_subject, provider)
+  def credentials_for_subject_labels(principal, provider, subject_index)
     labels = principal.labels || {}
-    subjects = label_keys.filter_map { |key| normalize_key(labels[key]) }.uniq
+    subjects = subject_label_keys(provider).filter_map { |key| normalize_key(labels[key]) }.uniq
     subjects
-      .flat_map { |subject| credentials_by_subject[subject] || [] }
+      .flat_map { |subject| subject_index[subject] || [] }
       .select { |credential| credential_matches_principal?(principal, credential, provider) }
       .uniq
   end
 
-  def credentials_for_emails(principal, emails, credentials_by_email, provider)
+  def credentials_for_emails(principal, emails, email_index, provider)
     emails
-      .flat_map { |email| credentials_by_email[email] || [] }
+      .flat_map { |email| email_index[email] || [] }
       .select { |credential| credential_matches_principal?(principal, credential, provider) }
       .uniq
   end
@@ -248,7 +228,7 @@ class PrincipalCredentialReconciliation
     return false unless credential.namespace == principal.namespace
     return false if provider == SLACK_PROVIDER && !slack_team_matches?(principal, credential)
 
-    subjects = PROVIDER_SUBJECT_LABELS.fetch(provider)
+    subjects = subject_label_keys(provider)
       .filter_map { |key| normalize_key(principal.labels&.[](key)) }
       .uniq
     if subjects.any?
@@ -258,8 +238,12 @@ class PrincipalCredentialReconciliation
     end
   end
 
+  def subject_label_keys(provider)
+    PROVIDER_SUBJECT_LABELS.fetch(provider, [])
+  end
+
   def supported_provider?(credential)
-    PROVIDER_SUBJECT_LABELS.key?(credential.oauth_app&.provider)
+    providers.include?(credential.oauth_app&.provider)
   end
 
   # Slack user ids are workspace-scoped. If either side carries a team label,
@@ -276,9 +260,31 @@ class PrincipalCredentialReconciliation
 
   def principal_emails(principal)
     labels = principal.labels || {}
-    EMAIL_LABELS.map { |key| labels[key] }
+    label_emails = EMAIL_LABELS.map { |key| labels[key] }
+    (label_emails + console_user_emails(principal))
       .filter_map { |email| normalize_email(email) }
       .uniq
+  end
+
+  # Console-user principals carry the console user's oid, so every verified
+  # identity email of that user participates in matching -- a credential
+  # registered under a secondary verified email still reaches the principal.
+  # Unverified emails are excluded: an unverified address must not adopt
+  # someone else's credentials.
+  def console_user_emails(principal)
+    user_oid = principal.labels&.[](CONSOLE_USER_ID_LABEL)
+    return [] if user_oid.blank?
+
+    @console_user_emails ||= {}
+    @console_user_emails.fetch(user_oid) do
+      user = User.find_by_oid(user_oid)
+      emails = if user
+        [ user.email ] + user.user_identities.where(email_verified: true).pluck(:email)
+      else
+        []
+      end
+      @console_user_emails[user_oid] = emails
+    end
   end
 
   def grant_status(principal, credentials)

--- a/services/console/app/services/principal_credential_reconciliation.rb
+++ b/services/console/app/services/principal_credential_reconciliation.rb
@@ -27,7 +27,11 @@ class PrincipalCredentialReconciliation
 
   USER_KIND = "user"
   # Minted by the MCP OAuth flow (Mcp::OauthController#principal_for_current_user)
-  # for a console user connecting an MCP client.
+  # for a console user connecting an MCP client. These principals match
+  # credentials only through their console User record (primary email plus
+  # verified identity emails) -- never through mutable principal labels or
+  # provider-subject labels, which would widen the trust boundary beyond the
+  # authenticated user.
   CONSOLE_USER_KIND = "console_user"
   CONSOLE_USER_ID_LABEL = "console-user-id"
   SLACK_PROVIDER = Oauth::Providers::Slack::KEY
@@ -104,6 +108,10 @@ class PrincipalCredentialReconciliation
   end
 
   def sync_principal_provider_labels(principal, credentials)
+    # Console-user principals never match by label, so stamping provider
+    # identity labels on them would only create stale, unused inputs.
+    return if console_user_principal?(principal)
+
     google_credentials = credentials.select do |credential|
       credential.oauth_app&.provider == GOOGLE_PROVIDER
     end
@@ -207,6 +215,8 @@ class PrincipalCredentialReconciliation
   end
 
   def credentials_for_subject_labels(principal, provider, subject_index)
+    return [] if console_user_principal?(principal)
+
     labels = principal.labels || {}
     subjects = subject_label_keys(provider).filter_map { |key| normalize_key(labels[key]) }.uniq
     subjects
@@ -227,6 +237,9 @@ class PrincipalCredentialReconciliation
     return false unless supported_provider?(credential)
     return false unless credential.namespace == principal.namespace
     return false if provider == SLACK_PROVIDER && !slack_team_matches?(principal, credential)
+    if console_user_principal?(principal)
+      return principal_emails(principal).include?(normalize_email(credential.provider_email))
+    end
 
     subjects = subject_label_keys(provider)
       .filter_map { |key| normalize_key(principal.labels&.[](key)) }
@@ -258,10 +271,17 @@ class PrincipalCredentialReconciliation
     principal_team.present? && principal_team == credential_team
   end
 
+  def console_user_principal?(principal)
+    (principal.labels || {})["kind"] == CONSOLE_USER_KIND
+  end
+
   def principal_emails(principal)
+    if console_user_principal?(principal)
+      return console_user_emails(principal).filter_map { |email| normalize_email(email) }.uniq
+    end
+
     labels = principal.labels || {}
-    label_emails = EMAIL_LABELS.map { |key| labels[key] }
-    (label_emails + console_user_emails(principal))
+    EMAIL_LABELS.map { |key| labels[key] }
       .filter_map { |email| normalize_email(email) }
       .uniq
   end

--- a/services/console/test/controllers/mcp/oauth_controller_test.rb
+++ b/services/console/test/controllers/mcp/oauth_controller_test.rb
@@ -157,6 +157,47 @@ module Mcp
       assert_equal "mcp:tools", jwt_payload.fetch("scope")
     end
 
+    test "authorization approval seeds new console principals with the user-mcp role" do
+      client = create_client
+
+      code = authorize_code(client)
+
+      principal = McpOauthAuthorizationCode.find_usable(code).principal
+      role = Role.find_by(namespace: principal.namespace, foreign_id: "user-mcp")
+      assert role, "expected the user-mcp role to be created"
+      assert_equal "User MCP", role.name
+      assert_equal "centaur", role.labels["managed-by"]
+      assert_includes principal.roles, role
+    end
+
+    test "authorization approval reuses an existing user-mcp role" do
+      existing = Role.create!(
+        namespace: "default",
+        foreign_id: "user-mcp",
+        name: "Custom user role",
+        created_by: @operator
+      )
+      client = create_client
+
+      assert_no_difference -> { Role.count } do
+        code = authorize_code(client)
+        principal = McpOauthAuthorizationCode.find_usable(code).principal
+        assert_includes principal.roles, existing
+      end
+    end
+
+    test "authorization approval does not restore a removed user-mcp role on existing principals" do
+      client = create_client
+      code = authorize_code(client)
+      principal = McpOauthAuthorizationCode.find_usable(code).principal
+      principal.principal_roles.destroy_all
+
+      post "/mcp/oauth/authorize", params: authorize_params(client).merge(decision: "approve")
+
+      assert_response :redirect
+      assert_empty principal.reload.roles
+    end
+
     test "authorization code exchange rejects users disabled after consent" do
       client = create_client
       code = authorize_code(client)

--- a/services/console/test/services/principal_credential_reconciliation_test.rb
+++ b/services/console/test/services/principal_credential_reconciliation_test.rb
@@ -26,8 +26,8 @@ class PrincipalCredentialReconciliationTest < ActiveSupport::TestCase
       candidate.principal == principal
     end
     assert_not_nil entry
-    assert_equal [ slack ], entry.slack_credentials
-    assert_equal [ google ], entry.google_credentials
+    assert_equal [ slack ], entry.credentials_for("slack")
+    assert_equal [ google ], entry.credentials_for("google")
     assert_empty entry.actionable_credentials
   end
 
@@ -74,8 +74,8 @@ class PrincipalCredentialReconciliationTest < ActiveSupport::TestCase
     end
 
     assert_not_nil entry
-    assert_equal [ slack ], entry.slack_credentials
-    assert_equal [ google ], entry.google_credentials
+    assert_equal [ slack ], entry.credentials_for("slack")
+    assert_equal [ google ], entry.credentials_for("google")
     assert principal.grants.exists?(static_secret: slack.static_secret)
     assert principal.grants.exists?(static_secret: google.static_secret)
     assert_equal "google-sub-alice", principal.reload.labels["google_subject"]
@@ -163,7 +163,82 @@ class PrincipalCredentialReconciliationTest < ActiveSupport::TestCase
     end
   end
 
+  test "console user principal is granted matching credentials across providers on create" do
+    slack = create_credential(oauth_apps(:acme_slack), "slack-sub-carol", "carol@acme.example")
+    google = create_credential(oauth_apps(:acme_google), "google-sub-carol", "carol@acme.example")
+    github = create_credential(oauth_apps(:acme_github), "12345", "carol@acme.example")
+    secrets = [ slack, google, github ].map { |credential| wrap(credential) }
+
+    principal = create_console_user_principal(
+      users(:member_user),
+      email: "carol@acme.example",
+      foreign_id: "console-user-carol"
+    )
+
+    secrets.each do |secret|
+      assert principal.grants.exists?(static_secret: secret),
+             "expected grant for #{secret.name}"
+    end
+  end
+
+  test "console user principal matches credentials via verified identity emails" do
+    user = users(:member_user)
+    user.user_identities.create!(
+      provider: "google", subject: "google-sub-member",
+      email: "member.alt@acme.example", email_verified: true
+    )
+    credential = create_credential(oauth_apps(:acme_slack), "slack-sub-alt", "member.alt@acme.example")
+    secret = wrap(credential)
+
+    principal = create_console_user_principal(user, foreign_id: "console-user-member")
+
+    assert principal.grants.exists?(static_secret: secret)
+  end
+
+  test "console user principal ignores unverified identity emails" do
+    user = users(:member_user)
+    user.user_identities.create!(
+      provider: "google", subject: "google-sub-unverified",
+      email: "victim@acme.example", email_verified: false
+    )
+    credential = create_credential(oauth_apps(:acme_slack), "slack-sub-victim", "victim@acme.example")
+    secret = wrap(credential)
+
+    principal = create_console_user_principal(user, foreign_id: "console-user-member-2")
+
+    refute principal.grants.exists?(static_secret: secret)
+  end
+
+  test "github credential identity enrichment grants an existing wrapper when it becomes a match" do
+    principal = principals(:acme_user_alice)
+    principal.update!(labels: principal.labels.merge("email" => "alice@example.com"))
+    credential = create_credential(oauth_apps(:acme_github), "gh-pending", nil)
+    secret = wrap(credential)
+    refute principal.grants.exists?(static_secret: secret)
+
+    assert_difference -> { principal.grants.count }, 1 do
+      credential.update!(provider_email: "alice@example.com")
+    end
+    assert principal.grants.exists?(static_secret: secret)
+  end
+
   private
+
+  # Mirrors the principal shape minted by Mcp::OauthController#principal_for_current_user.
+  def create_console_user_principal(user, foreign_id:, email: nil)
+    Principal.create!(
+      namespace: "acme",
+      foreign_id: foreign_id,
+      name: user.name.presence || user.email,
+      labels: {
+        "managed-by" => "centaur",
+        "kind" => "console_user",
+        "console-user-id" => user.oid,
+        "email" => email || user.email
+      },
+      created_by: user
+    )
+  end
 
   def create_credential(app, subject, email)
     BrokerCredential.create!(

--- a/services/console/test/services/principal_credential_reconciliation_test.rb
+++ b/services/console/test/services/principal_credential_reconciliation_test.rb
@@ -164,21 +164,53 @@ class PrincipalCredentialReconciliationTest < ActiveSupport::TestCase
   end
 
   test "console user principal is granted matching credentials across providers on create" do
-    slack = create_credential(oauth_apps(:acme_slack), "slack-sub-carol", "carol@acme.example")
-    google = create_credential(oauth_apps(:acme_google), "google-sub-carol", "carol@acme.example")
-    github = create_credential(oauth_apps(:acme_github), "12345", "carol@acme.example")
+    slack = create_credential(oauth_apps(:acme_slack), "slack-sub-member", "member@acme.example")
+    google = create_credential(oauth_apps(:acme_google), "google-sub-member", "member@acme.example")
+    github = create_credential(oauth_apps(:acme_github), "12345", "member@acme.example")
     secrets = [ slack, google, github ].map { |credential| wrap(credential) }
 
-    principal = create_console_user_principal(
-      users(:member_user),
-      email: "carol@acme.example",
-      foreign_id: "console-user-carol"
-    )
+    principal = create_console_user_principal(users(:member_user), foreign_id: "console-user-member-0")
 
     secrets.each do |secret|
       assert principal.grants.exists?(static_secret: secret),
              "expected grant for #{secret.name}"
     end
+  end
+
+  test "console user principal ignores a spoofed email label" do
+    credential = create_credential(oauth_apps(:acme_slack), "slack-sub-carol", "carol@acme.example")
+    secret = wrap(credential)
+
+    principal = create_console_user_principal(
+      users(:member_user),
+      email: "carol@acme.example",
+      foreign_id: "console-user-spoofed-email"
+    )
+
+    refute principal.grants.exists?(static_secret: secret)
+  end
+
+  test "console user principal ignores provider subject labels" do
+    credential = create_credential(oauth_apps(:acme_google), "google-sub-carol", "carol@acme.example")
+    secret = wrap(credential)
+
+    principal = create_console_user_principal(
+      users(:member_user),
+      extra_labels: { "google_subject" => "google-sub-carol" },
+      foreign_id: "console-user-spoofed-subject"
+    )
+
+    refute principal.grants.exists?(static_secret: secret)
+  end
+
+  test "console user principal does not accumulate provider labels from matched credentials" do
+    create_credential(oauth_apps(:acme_google), "google-sub-member", "member@acme.example")
+
+    principal = create_console_user_principal(users(:member_user), foreign_id: "console-user-labels")
+
+    labels = principal.reload.labels
+    assert_nil labels["google_subject"]
+    assert_nil labels["google_email"]
   end
 
   test "console user principal matches credentials via verified identity emails" do
@@ -225,7 +257,9 @@ class PrincipalCredentialReconciliationTest < ActiveSupport::TestCase
   private
 
   # Mirrors the principal shape minted by Mcp::OauthController#principal_for_current_user.
-  def create_console_user_principal(user, foreign_id:, email: nil)
+  # The email/extra_labels overrides simulate tampered or stale labels, which
+  # matching must ignore for console-user principals.
+  def create_console_user_principal(user, foreign_id:, email: nil, extra_labels: {})
     Principal.create!(
       namespace: "acme",
       foreign_id: foreign_id,
@@ -235,7 +269,7 @@ class PrincipalCredentialReconciliationTest < ActiveSupport::TestCase
         "kind" => "console_user",
         "console-user-id" => user.oid,
         "email" => email || user.email
-      },
+      }.merge(extra_labels),
       created_by: user
     )
   end


### PR DESCRIPTION
## Why

MCP is now scoped per user, but console-user principals minted by the MCP OAuth flow received no roles or credentials automatically, so a fresh MCP user had access to nothing.

## What

**OAuth credential auto-grant** — `PrincipalCredentialReconciliation`:
- Generalized from Google-only to all `Oauth::Providers`.
- Console-user principals (`labels.kind == console_user`) now match OAuth credentials against the user's verified identity emails (loaded via `console-user-id`), so a user's own OAuth credentials are granted to their MCP principal automatically. Existing runs via `after_commit` on both `Principal` and `BrokerCredential`, so it applies whichever side is created first.

**`user-mcp` role seeding** — `Mcp::OauthController`:
- Newly minted console-user principals get a shared `user-mcp` role (find-or-created in the principal's namespace, labeled `managed-by: centaur`).
- Admins attach tool secrets to this role to define the default toolset every MCP user gets.
- Seeded on **create only**: removing the role from a principal sticks across re-auths, mirroring `SessionRegistrar`'s infra-role semantics for session principals.

## Notes

- The role is lazily created on first OAuth approval rather than upserted at api-rs boot; no api-rs changes.
- Pre-existing console-user principals (minted before this ships) need the role attached once manually.

## Testing

- `rails test`: 1035 runs, 0 failures (3 new OAuth controller tests: role seeded on create, existing role reused without duplicates, removed role not restored on re-auth; 11 reconciliation tests).
- `rubocop` clean on changed files.