### PR TITLE
fix(slackbotv2): retry retryable handoff failures in-process instead of relying on Slack redelivery (reland)

### DIFF
--- a/services/slackbotv2/src/index.ts
+++ b/services/slackbotv2/src/index.ts
@@ -106,7 +106,6 @@ type SlackAssistantAdapter = {
 const MAX_SLACK_MESSAGE_ATTACHMENTS = 20
 
 type SlackbotV2RequestContext = {
-  retryableErrors: unknown[]
   waitUntil(promise: Promise<unknown>): void
 }
 
@@ -126,6 +125,7 @@ const SLACK_TASK_DETAILS_MAX_CHARS = 500
 const SLACK_FALLBACK_TEXT_MAX_CHARS = 35_000
 const POSTGRES_CONNECT_INITIAL_DELAY_MS = 250
 const POSTGRES_CONNECT_MAX_DELAY_MS = 10_000
+const HANDOFF_RETRY_DELAYS_MS: readonly number[] = [5_000, 30_000, 120_000]
 const LATE_SLACK_FILE_MATCH_WINDOW_MS = 15_000
 const LATE_SLACK_FILE_PENDING_TTL_MS = 60_000
 const LATE_SLACK_FILE_CONSUMED_TTL_MS = 5 * 60_000
@@ -253,7 +253,6 @@ export function createSlackbotV2(options: SlackbotV2Options): SlackbotV2 {
       const webhookFields = slackWebhookLogFields(rawBody)
       const handoffTasks: Promise<unknown>[] = []
       const context: SlackbotV2RequestContext = {
-        retryableErrors: [],
         waitUntil: promise => waitUntil(c, promise)
       }
       const response = await requestContext.run(context, () => {
@@ -287,23 +286,13 @@ export function createSlackbotV2(options: SlackbotV2Options): SlackbotV2 {
           await Promise.all(handoffTasks)
         } catch (error) {
           waitError = error
-          if (isRetryableSessionApiError(error)) context.retryableErrors.push(error)
         } finally {
           stopPendingLog()
           traceLog(options, 'slackbotv2_webhook_handoff_wait_complete', undefined, {
             ...waitFields,
             error: waitError ? errorMessage(waitError) : undefined,
-            phase_ms: elapsedMs(waitStartedAtMs),
-            retryable_error_count: context.retryableErrors.length
+            phase_ms: elapsedMs(waitStartedAtMs)
           })
-        }
-        if (context.retryableErrors.length > 0) {
-          outcome = 'retry_requested'
-          slackbotMetrics.webhookRetryRequests.inc()
-          traceLog(options, 'slackbotv2_webhook_retry_requested', undefined, {
-            error: errorMessage(context.retryableErrors[0])
-          })
-          return new globalThis.Response('temporary upstream unavailable', { status: 503 })
         }
       }
       const lateFileTask = lateSlackFiles.repairFromWebhook(rawBody)
@@ -617,6 +606,68 @@ async function ensureStateConnected(state: StateAdapter, options: SlackbotV2Opti
   }
 }
 
+type SyncThreadMessageInput = {
+  initialAssistantStatusRequested?: boolean
+  initialAssistantStatusVisible?: boolean
+  mode: SlackbotV2MessageMode
+  options: SlackbotV2Options
+  /** Number of in-process retries already spent on this message's handoff. */
+  retryAttempt?: number
+  state: StateAdapter
+}
+
+/**
+ * Schedules an in-process retry of a Slack→session handoff after a retryable
+ * session API failure. Slack's own webhook redelivery cannot drive retries:
+ * Slack times deliveries out after ~3s, so its redelivery races the
+ * still-running original attempt, is deduped by the chat SDK, and is
+ * acknowledged before the original attempt fails. Retrying locally keeps the
+ * dedupe intact and never depends on Slack redelivering.
+ *
+ * Returns false when the retry budget is exhausted; the caller then surfaces
+ * the failure instead of retrying.
+ */
+function scheduleHandoffRetry(
+  thread: Thread<SlackbotV2ThreadState>,
+  message: ChatMessage,
+  input: SyncThreadMessageInput,
+  error: unknown,
+  trace: SlackbotV2Trace
+): boolean {
+  const delays = input.options.handoffRetryDelaysMs ?? HANDOFF_RETRY_DELAYS_MS
+  const attempt = input.retryAttempt ?? 0
+  if (attempt >= delays.length) return false
+  const delayMs = delays[attempt] ?? 0
+  slackbotMetrics.handoffRetries.inc({ outcome: 'scheduled' })
+  traceLog(input.options, 'slackbotv2_handoff_retry_scheduled', trace, {
+    attempt: attempt + 1,
+    delay_ms: delayMs,
+    error: errorMessage(error),
+    max_attempts: delays.length
+  })
+  backgroundWaitUntil(
+    (async () => {
+      await sleep(delayMs)
+      await syncThreadMessageToSession(thread, message, { ...input, retryAttempt: attempt + 1 })
+    })().catch(async retryError => {
+      traceWarn(input.options, 'slackbotv2_handoff_retry_failed', trace, {
+        attempt: attempt + 1,
+        error: errorMessage(retryError)
+      })
+      // A retry chain that dies outside the normal failure paths (which clear
+      // the status themselves) must not leave "Thinking..." stuck on the thread.
+      if (input.mode === 'execute') {
+        try {
+          await setAssistantStatus(thread, '', input.options, trace)
+        } catch {
+          // Best-effort; the original failure is already logged.
+        }
+      }
+    })
+  )
+  return true
+}
+
 /**
  * Persists a Slack thread update into the session API. In execute mode the create/append/execute
  * handoff completes before Slack is acknowledged; SSE rendering continues in background.
@@ -624,13 +675,7 @@ async function ensureStateConnected(state: StateAdapter, options: SlackbotV2Opti
 async function syncThreadMessageToSession(
   thread: Thread<SlackbotV2ThreadState>,
   message: ChatMessage,
-  input: {
-    initialAssistantStatusRequested?: boolean
-    initialAssistantStatusVisible?: boolean
-    mode: SlackbotV2MessageMode
-    options: SlackbotV2Options
-    state: StateAdapter
-  }
+  input: SyncThreadMessageInput
 ): Promise<void> {
   const traceStartedAtMs = nowMs()
   const state = (await thread.state) ?? {}
@@ -880,30 +925,21 @@ async function syncThreadMessageToSession(
       }
     } catch (error) {
       if (isRetryableSessionApiError(error)) {
-        const context = requestContext.getStore()
-        if (context) {
-          context.retryableErrors.push(error)
-          try {
-            await input.state.delete(`dedupe:slack:${message.id}`)
-          } catch (deleteError) {
-            traceLog(input.options, 'slackbotv2_webhook_retry_dedupe_clear_failed', trace, {
-              error: errorMessage(deleteError)
-            })
-          }
-          traceLog(input.options, 'slackbotv2_webhook_retry_marked', trace, {
-            error: errorMessage(error)
-          })
+        if (scheduleHandoffRetry(thread, message, input, error, trace)) {
+          recordForward(input.mode, 'retry_scheduled', traceStartedAtMs)
+          return
         }
+        slackbotMetrics.handoffRetries.inc({ outcome: 'exhausted' })
+        traceWarn(input.options, 'slackbotv2_handoff_retry_exhausted', trace, {
+          error: errorMessage(error)
+        })
       }
-      recordForward(
-        input.mode,
-        isRetryableSessionApiError(error) ? 'retry_requested' : 'error',
-        traceStartedAtMs
-      )
+      recordForward(input.mode, 'error', traceStartedAtMs)
       throw error
     }
     traceLog(input.options, 'slackbotv2_forward_complete', trace)
     recordForward(input.mode, 'complete', traceStartedAtMs)
+    if (input.retryAttempt) slackbotMetrics.handoffRetries.inc({ outcome: 'succeeded' })
     return
   }
 
@@ -930,6 +966,7 @@ async function syncThreadMessageToSession(
       last_event_id: lastEventId
     })
     recordForward(input.mode, 'complete', traceStartedAtMs)
+    if (input.retryAttempt) slackbotMetrics.handoffRetries.inc({ outcome: 'succeeded' })
   } catch (error) {
     // The live render is not happening; let the recovery sweep claim the
     // obligation (if one was committed) as soon as it scans.
@@ -940,23 +977,24 @@ async function syncThreadMessageToSession(
       lastEventId: Math.max(latest.lastEventId ?? 0, lastEventId)
     })
     if (isRetryableSessionApiError(error)) {
-      const context = requestContext.getStore()
-      if (context) {
-        context.retryableErrors.push(error)
-        try {
-          await input.state.delete(`dedupe:slack:${message.id}`)
-        } catch (deleteError) {
-          traceLog(input.options, 'slackbotv2_webhook_retry_dedupe_clear_failed', trace, {
-            error: errorMessage(deleteError)
-          })
-        }
-        traceLog(input.options, 'slackbotv2_webhook_retry_marked', trace, {
-          error: errorMessage(error)
-        })
-        if (assistantStatusVisible) await setAssistantStatus(thread, '', input.options, trace)
-        recordForward(input.mode, 'retry_requested', traceStartedAtMs)
-        throw error
+      // The assistant status stays visible through the retry window; a
+      // successful retry replaces it with the live render, and exhaustion
+      // falls through to the visible error notice below (which clears it).
+      //
+      // If another mention starts an execution before the retry fires, the
+      // retry recomputes eligibility and downgrades to append/no-op. That is
+      // intentional: this message was already appended (or will be appended)
+      // to the session, so the newer execution sees it — the same conflation
+      // that happens when two mentions arrive seconds apart on a healthy
+      // system. The thread is never left silent in that case.
+      if (scheduleHandoffRetry(thread, message, input, error, trace)) {
+        recordForward(input.mode, 'retry_scheduled', traceStartedAtMs)
+        return
       }
+      slackbotMetrics.handoffRetries.inc({ outcome: 'exhausted' })
+      traceWarn(input.options, 'slackbotv2_handoff_retry_exhausted', trace, {
+        error: errorMessage(error)
+      })
     }
     try {
       await renderExecutionStream(

--- a/services/slackbotv2/src/metrics.ts
+++ b/services/slackbotv2/src/metrics.ts
@@ -249,6 +249,11 @@ export const slackbotMetrics = {
     labelNames: ['mode', 'outcome'],
     name: 'slackbotv2_forward_messages_total'
   }),
+  handoffRetries: counter({
+    help: 'In-process Slack handoff retries after retryable session API failures.',
+    labelNames: ['outcome'],
+    name: 'slackbotv2_handoff_retries_total'
+  }),
   info: gauge({
     help: 'Static Slackbot v2 service info.',
     name: 'slackbotv2_info'
@@ -342,10 +347,6 @@ export const slackbotMetrics = {
     help: 'Slack webhook requests handled by Slackbot.',
     labelNames: ['route', 'event_type', 'outcome'],
     name: 'slackbotv2_slack_webhook_requests_total'
-  }),
-  webhookRetryRequests: counter({
-    help: 'Slack webhook requests answered with a retryable error so Slack retries delivery.',
-    name: 'slackbotv2_webhook_retry_requests_total'
   })
 }
 

--- a/services/slackbotv2/src/types.ts
+++ b/services/slackbotv2/src/types.ts
@@ -133,6 +133,15 @@ export type SlackbotV2Options = {
    * harness config files (see console-session-link.ts).
    */
   harnessDefaultModels?: Record<string, string>
+  /**
+   * Backoff delays between in-process retries of a Slack handoff after a
+   * retryable session API failure. Slack's own webhook redelivery cannot
+   * drive these retries: Slack times deliveries out after ~3s, so its
+   * redelivery races the still-running original attempt, is deduped, and is
+   * acknowledged before the original attempt fails. The bot retries locally
+   * instead and posts a visible error once the delays are exhausted.
+   */
+  handoffRetryDelaysMs?: readonly number[]
   /** Milliseconds before an idle execution pauses its sandbox. Defaults to up to 3h. */
   idleTimeoutMs?: number
   logger?: Logger

--- a/services/slackbotv2/test/chat-sdk-emulate.test.ts
+++ b/services/slackbotv2/test/chat-sdk-emulate.test.ts
@@ -3286,7 +3286,6 @@ describe('slackbotv2', () => {
     expect(logData(logs, 'slackbotv2_webhook_handoff_wait_complete')).toEqual(
       expect.objectContaining({
         phase_ms: expect.any(Number),
-        retryable_error_count: 0,
         slack_event_id: 'Ev-slackbotv2-slow-execute'
       })
     )
@@ -3908,7 +3907,8 @@ describe('slackbotv2', () => {
     expect(Number(recoveredThreadState?.lastEventId)).toBeGreaterThan(0)
   })
 
-  it('returns 503 for retryable execute failure and lets Slack retry without duplicate append', async () => {
+  it('locally retries a retryable execute failure without duplicate append', async () => {
+    bot = createTestBot({ handoffRetryDelaysMs: [50] })
     codexApi.failNextExecute = true
 
     const parent = await postUserMessage('History that must not be lost.')
@@ -3925,40 +3925,46 @@ describe('slackbotv2', () => {
         text: `<@${BOT_USER_ID}> first try`
       }
     })
-    const failedWaits: Promise<unknown>[] = []
-    const failedResponse = await bot.app.request(
+    const waits: Promise<unknown>[] = []
+    const response = await bot.app.request(
       '/api/webhooks/slack',
       retryableEvent,
       {},
-      waitUntilContext(failedWaits)
+      waitUntilContext(waits)
     )
-    expect(failedResponse.status).toBe(503)
-    await Promise.all(failedWaits)
+    // The retryable failure is retried in-process; Slack is acknowledged so
+    // its own redelivery (which would be deduped anyway) is never needed.
+    expect(response.status).toBe(200)
     expect(codexApi.appends).toHaveLength(1)
     expect(codexApi.executes).toHaveLength(1)
     expect(codexApi.eventRequests).toHaveLength(0)
-    expect(slackApi.calls.some(call => call.method === 'chat.startStream')).toBe(false)
 
-    const retryWaits: Promise<unknown>[] = []
-    const retryResponse = await bot.app.request(
-      '/api/webhooks/slack',
-      retryableEvent,
-      {},
-      waitUntilContext(retryWaits)
-    )
-    expect(retryResponse.status).toBe(200)
-    await Promise.all(retryWaits)
+    await waitFor(() => codexApi.executes.length === 2, 3000)
+    await waitFor(async () => (await threadText(parent.ts)).includes('Executed request 1.'), 3000)
+    await Promise.all(waits)
 
-    expect(codexApi.executes).toHaveLength(2)
     expect(codexApi.appends).toHaveLength(1)
     const retryContextTexts = sessionMessageTexts(codexApi.appends[0]?.body.messages ?? [])
     expect(retryContextTexts).toContain('History that must not be lost.')
     expect(retryContextTexts.some(text => text.includes('first try'))).toBe(true)
     expect(codexApi.eventRequests).toHaveLength(1)
-    expect(await threadText(parent.ts)).toContain('Executed request 1.')
+
+    // A late Slack redelivery of the same event stays deduped and adds no work.
+    const redeliveryWaits: Promise<unknown>[] = []
+    const redeliveryResponse = await bot.app.request(
+      '/api/webhooks/slack',
+      retryableEvent,
+      {},
+      waitUntilContext(redeliveryWaits)
+    )
+    expect(redeliveryResponse.status).toBe(200)
+    await Promise.all(redeliveryWaits)
+    expect(codexApi.executes).toHaveLength(2)
+    expect(codexApi.appends).toHaveLength(1)
   })
 
-  it('reuses an accepted execution when Slack retries after a lost execute response', async () => {
+  it('reuses an accepted execution when the local retry follows a lost execute response', async () => {
+    bot = createTestBot({ handoffRetryDelaysMs: [50] })
     codexApi.failNextExecuteAfterAccept = true
 
     const parent = await postUserMessage('History before response loss.')
@@ -3975,38 +3981,141 @@ describe('slackbotv2', () => {
         text: `<@${BOT_USER_ID}> first try accepted`
       }
     })
-    const failedWaits: Promise<unknown>[] = []
-    const failedResponse = await bot.app.request(
+    const waits: Promise<unknown>[] = []
+    const response = await bot.app.request(
       '/api/webhooks/slack',
       retryableEvent,
       {},
-      waitUntilContext(failedWaits)
+      waitUntilContext(waits)
     )
-    expect(failedResponse.status).toBe(503)
-    await Promise.all(failedWaits)
+    expect(response.status).toBe(200)
     expect(codexApi.executes).toHaveLength(1)
     expect(codexApi.eventRequests).toHaveLength(0)
-    expect(slackApi.calls.some(call => call.method === 'chat.startStream')).toBe(false)
 
-    const retryWaits: Promise<unknown>[] = []
-    const retryResponse = await bot.app.request(
-      '/api/webhooks/slack',
-      retryableEvent,
-      {},
-      waitUntilContext(retryWaits)
-    )
-    expect(retryResponse.status).toBe(200)
-    await Promise.all(retryWaits)
+    await waitFor(() => codexApi.executes.length === 2, 3000)
+    await waitFor(async () => (await threadText(parent.ts)).includes('Executed request 1.'), 3000)
+    await Promise.all(waits)
 
-    expect(codexApi.executes).toHaveLength(2)
     expect(codexApi.executes.map(execute => execute.body.idempotency_key)).toEqual([
       mention.ts,
       mention.ts
     ])
     expect(codexApi.appends).toHaveLength(1)
     expect(codexApi.eventRequests).toHaveLength(1)
-    expect(await threadText(parent.ts)).toContain('Executed request 1.')
     expect(await threadText(parent.ts)).not.toContain('Executed request 2.')
+  })
+
+  it('conflates a pending execute retry into an execution started meanwhile', async () => {
+    bot = createTestBot({ handoffRetryDelaysMs: [300] })
+    codexApi.failNextExecute = true
+
+    const parent = await postUserMessage('History before conflation.')
+    const firstMention = await postUserMessage(`<@${BOT_USER_ID}> first conflated mention`, parent.ts)
+    const firstWaits: Promise<unknown>[] = []
+    const firstResponse = await bot.app.request(
+      '/api/webhooks/slack',
+      signedSlackEvent({
+        event_id: 'Ev-slackbotv2-conflate-1',
+        event: {
+          type: 'app_mention',
+          user: USER_ID,
+          channel: CHANNEL_ID,
+          team: TEAM_ID,
+          ts: firstMention.ts,
+          thread_ts: parent.ts,
+          text: `<@${BOT_USER_ID}> first conflated mention`
+        }
+      }),
+      {},
+      waitUntilContext(firstWaits)
+    )
+    expect(firstResponse.status).toBe(200)
+    expect(codexApi.executes).toHaveLength(1)
+
+    // A second mention lands while the first message's retry is still pending
+    // and starts the thread's execution. Keep it running (no auto response)
+    // across the retry window.
+    codexApi.autoRespond = false
+    const secondMention = await postUserMessage(
+      `<@${BOT_USER_ID}> second conflated mention`,
+      parent.ts
+    )
+    const secondWaits: Promise<unknown>[] = []
+    const secondResponse = await bot.app.request(
+      '/api/webhooks/slack',
+      signedSlackEvent({
+        event_id: 'Ev-slackbotv2-conflate-2',
+        event: {
+          type: 'app_mention',
+          user: USER_ID,
+          channel: CHANNEL_ID,
+          team: TEAM_ID,
+          ts: secondMention.ts,
+          thread_ts: parent.ts,
+          text: `<@${BOT_USER_ID}> second conflated mention`
+        }
+      }),
+      {},
+      waitUntilContext(secondWaits)
+    )
+    expect(secondResponse.status).toBe(200)
+    expect(codexApi.executes).toHaveLength(2)
+
+    // The first message's retry fires into the active execution and must not
+    // start a third execution; its text is already in the session, so the
+    // running execution sees it.
+    await sleep(500)
+    expect(codexApi.executes).toHaveLength(2)
+    const appendedTexts = codexApi.appends.flatMap(append =>
+      sessionMessageTexts(append.body.messages ?? [])
+    )
+    expect(appendedTexts.some(text => text.includes('first conflated mention'))).toBe(true)
+    expect(appendedTexts.some(text => text.includes('second conflated mention'))).toBe(true)
+
+    codexApi.emitOutputLines(threadKey(parent.ts), sampleCodexOutputLines('Conflated answer.'))
+    await Promise.all([...firstWaits, ...secondWaits])
+    expect(await threadText(parent.ts)).toContain('Conflated answer.')
+    expect(await threadText(parent.ts)).not.toContain(BROKEN_STREAM_TEXT)
+  })
+
+  it('renders a visible error once local retries are exhausted', async () => {
+    bot = createTestBot({ handoffRetryDelaysMs: [200] })
+    codexApi.failNextExecute = true
+
+    const parent = await postUserMessage('History before exhaustion.')
+    const mention = await postUserMessage(`<@${BOT_USER_ID}> exhaust retries`, parent.ts)
+    const waits: Promise<unknown>[] = []
+    const response = await bot.app.request(
+      '/api/webhooks/slack',
+      signedSlackEvent({
+        event_id: 'Ev-slackbotv2-retry-exhausted',
+        event: {
+          type: 'app_mention',
+          user: USER_ID,
+          channel: CHANNEL_ID,
+          team: TEAM_ID,
+          ts: mention.ts,
+          thread_ts: parent.ts,
+          text: `<@${BOT_USER_ID}> exhaust retries`
+        }
+      }),
+      {},
+      waitUntilContext(waits)
+    )
+    expect(response.status).toBe(200)
+    expect(codexApi.executes).toHaveLength(1)
+
+    // Fail the scheduled retry too so the budget of one retry is exhausted.
+    codexApi.failNextExecute = true
+    await waitFor(() => codexApi.executes.length === 2, 3000)
+    await waitFor(async () => (await threadText(parent.ts)).includes('Execution failed'), 3000)
+    await Promise.all(waits)
+
+    expect(codexApi.eventRequests).toHaveLength(0)
+    const threadState = await bot.chat
+      .thread(threadKey(parent.ts))
+      .state
+    expect(threadState).toEqual(expect.objectContaining({ activeExecution: false }))
   })
 
   it('keeps v1 external org and trigger-bot allowlist behavior', async () => {


### PR DESCRIPTION
Reland of #931, which was reverted in #934 because an unrelated `fix(console)` commit had been pushed onto the branch before merge. This PR contains **only** the slackbotv2 change (single cherry-picked commit, 4 files under `services/slackbotv2`).

## Problem

Investigated from https://tempoxyz.slack.com/archives/C0A87C21805/p1783430357408879?thread_ts=1783430270.895689&cid=C0A87C21805 — a prompt got no response.

The prompt was ingested, but session create/load was slow during centaur-console instability and the execute handoff failed with a retryable session API error. The old design handled this by returning **503 + clearing the event dedupe key**, expecting Slack to redeliver the event. Slack only retries webhook events that fail within ~3s of delivery — any handler that runs longer than that gets no redelivery. Result: the failure path was a silent drop.

## Fix

Retryable handoff failures are now retried **in-process** (delays: 5s / 30s / 120s, configurable via `handoffRetryDelaysMs`) while Slack gets an immediate 200:

- The assistant "Thinking..." status stays visible through the retry window; a successful retry replaces it with the live render.
- Retry exhaustion renders the existing visible error notice (no more silent drops).
- Execute idempotency keys make retries safe when the first execute was accepted server-side but the response was lost.
- If another mention starts an execution before a retry fires, the retry conflates into it: the message was already appended to the session, so the newer execution sees it — the same semantics as two mentions arriving seconds apart on a healthy system. The thread is never left silent.
- A retry chain that dies unexpectedly best-effort clears the assistant status so "Thinking..." can't stick.

Metrics: `slackbotv2_webhook_retry_requests_total` (dead with the 503 path) is replaced by `slackbotv2_handoff_retries_total{outcome=scheduled|succeeded|exhausted}`.

## Tests

- `locally retries a retryable execute failure without duplicate append`
- `reuses an accepted execution when the local retry follows a lost execute response`
- `conflates a pending execute retry into an execution started meanwhile` (regression for the concurrent-mention race)
- `renders a visible error once local retries are exhausted`

Re-validated after the cherry-pick onto post-revert main: `bun run check:types` ✅ · full suite 147 pass / 1 skip / 4 fail — the 4 failures are pre-existing on clean main (sticky harness/model flags + three plain-text extraction tests).