### PR TITLE
feat(console): admin self-descope to operator permissions

### DIFF
--- a/services/console/app/controllers/application_controller.rb
+++ b/services/console/app/controllers/application_controller.rb
@@ -9,7 +9,7 @@ class ApplicationController < ActionController::Base
   # controllers don't each hand-roll a rescue. Mirrors Api::BaseController.
   rescue_from ActiveRecord::RecordNotFound, with: :render_not_found
 
-  helper_method :current_user
+  helper_method :current_user, :acting_admin?, :descoped?
   helper_method :public_base_url, :oauth_callback_redirect_uri
 
   # The public origin the console is reached at. Derived from the request by
@@ -65,6 +65,24 @@ class ApplicationController < ActionController::Base
     @current_user ||= User.find_by(id: session[:user_id]) if session[:user_id]
   end
 
+  # Whether this admin has temporarily descoped themselves to operator
+  # permissions ("view as operator"). Self-healing: the flag is dropped if the
+  # user is no longer an admin, so it can never outlive the privileges it pauses.
+  def descoped?
+    return false unless session[:descoped]
+    return true if current_user&.admin?
+
+    session.delete(:descoped)
+    false
+  end
+
+  # The permission check console gates use instead of current_user.admin?: a
+  # real admin who is not currently descoped. Keeping current_user untouched
+  # means audit trails and data displays still see the true account.
+  def acting_admin?
+    current_user&.admin? && !descoped?
+  end
+
   # before_action gate for console pages: bounce anonymous requests to the login
   # form rather than rendering the page.
   def require_login
@@ -87,13 +105,13 @@ class ApplicationController < ActionController::Base
   # management). Not a global gate. Bounces to the threads view rather than root:
   # root is the admin-only principals page, so redirecting there would loop.
   def require_admin
-    redirect_to console_threads_path, alert: "That page is restricted to admins." unless current_user&.admin?
+    redirect_to console_threads_path, alert: "That page is restricted to admins." unless acting_admin?
   end
 
   # Where a signed-in user lands when no explicit destination applies: admins get
   # the Control section, everyone else the threads view (their only section).
   def default_console_landing_path
-    current_user&.admin? ? console_principals_path : console_threads_path
+    acting_admin? ? console_principals_path : console_threads_path
   end
 
   # Cheap default so every page renders the empty sidebar list without touching

--- a/services/console/app/controllers/console/descopes_controller.rb
+++ b/services/console/app/controllers/console/descopes_controller.rb
@@ -1,0 +1,28 @@
+module Console
+  # Admin "view as operator" support: an admin can temporarily pause their own
+  # admin permissions to see the console as a regular operator would. The flag
+  # lives in the cookie session; acting_admin? (the check every admin gate uses)
+  # is false while it's set, and ApplicationController drops it automatically if
+  # the user is no longer an admin.
+  #
+  # create is admin-gated. destroy is deliberately not: while descoped, the user
+  # fails require_admin, but they must always be able to restore themselves.
+  class DescopesController < ApplicationController
+    before_action :require_admin, only: :create
+
+    def create
+      session[:descoped] = true
+      Rails.logger.info("console_descope_started admin=#{current_user.email}")
+      # No flash: the persistent descope banner already announces the state.
+      redirect_to console_threads_path
+    end
+
+    def destroy
+      return redirect_to default_console_landing_path unless descoped?
+
+      session.delete(:descoped)
+      Rails.logger.info("console_descope_stopped admin=#{current_user.email}")
+      redirect_to console_principals_path, notice: "Admin permissions restored."
+    end
+  end
+end

--- a/services/console/app/views/console/_control_tabs.html.erb
+++ b/services/console/app/views/console/_control_tabs.html.erb
@@ -5,7 +5,7 @@
   { label: "Credentials", path: console_credentials_path, match: "/console/credentials" },
   { label: "Apps", path: console_oauth_apps_path, match: "/console/oauth_apps" }
 ] %>
-<% control_tabs << { label: "Users", path: console_users_path, match: "/console/users" } if current_user&.admin? %>
+<% control_tabs << { label: "Users", path: console_users_path, match: "/console/users" } if acting_admin? %>
 
 <nav class="console-control-tabs" aria-label="Control sections">
   <% control_tabs.each do |tab| %>

--- a/services/console/app/views/console/base_secrets/edit.html.erb
+++ b/services/console/app/views/console/base_secrets/edit.html.erb
@@ -10,7 +10,7 @@
 </div>
 
 <% if (cred = managed_credential(@secret)) %>
-  <div class="mb-6 rounded-lg border border-amber-500/40 bg-amber-500/[0.06] px-4 py-3 text-sm text-amber-200/90">
+  <div class="console-amber-note mb-6 rounded-lg border border-amber-500/40 bg-amber-500/[0.06] px-4 py-3 text-sm text-amber-200/90">
     <span class="font-semibold">Managed secret.</span>
     Maintained by the
     <% if cred.oauth_app %><%= cred.oauth_app.slug %> <% end %>OAuth integration (broker credential <%= cred.oid %>).

--- a/services/console/app/views/console/threads/index.html.erb
+++ b/services/console/app/views/console/threads/index.html.erb
@@ -1,7 +1,7 @@
 <% content_for :title, "Chats · Centaur Console" %>
 
 <% if @thread_db_unavailable %>
-  <div class="mb-4 shrink-0 rounded border border-amber-500/30 bg-amber-500/[0.08] px-4 py-3 text-sm text-amber-200">
+  <div class="console-amber-note mb-4 shrink-0 rounded border border-amber-500/30 bg-amber-500/[0.08] px-4 py-3 text-sm text-amber-200">
     Chat database is unavailable. Set <span class="font-semibold">CENTAUR_CONSOLE_CENTAUR_DATABASE_URL</span>
     so Console can read the API session database.
   </div>

--- a/services/console/app/views/layouts/console.html.erb
+++ b/services/console/app/views/layouts/console.html.erb
@@ -97,6 +97,47 @@
         background: #050506;
       }
 
+      /* While descoped, the body becomes a column: banner on top, shell
+         filling the rest. Scoped so the normal layout is untouched. */
+      .console-descoped {
+        display: flex;
+        flex-direction: column;
+      }
+
+      .console-descoped .console-shell {
+        flex: 1 1 auto;
+        min-height: 0;
+        height: auto;
+      }
+
+      .console-descope-banner {
+        flex: 0 0 auto;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 1rem;
+        padding: 0.5rem 1rem;
+        font-size: 0.75rem;
+        font-weight: 700;
+        color: #1c1205;
+        background: #f59e0b;
+      }
+
+      .console-descope-restore {
+        cursor: pointer;
+        border-radius: 0.25rem;
+        border: 1px solid #1c1205;
+        padding: 0.125rem 0.625rem;
+        font-weight: 700;
+        color: #fbbf24;
+        background: #1c1205;
+        transition: opacity 120ms ease;
+      }
+
+      .console-descope-restore:hover {
+        opacity: 0.85;
+      }
+
       .console-sidebar {
         width: 18rem;
         flex: 0 0 auto;
@@ -839,6 +880,16 @@
         background: #fbfbf8;
       }
 
+      /* Amber notice boxes (thread-DB unavailable, managed secret) keep their
+         translucent amber-on-dark look in dark mode, but that washes out on the
+         light background; match the solid descope-banner treatment instead. */
+      html[data-console-theme="light"] .console-amber-note {
+        background: #f59e0b;
+        border-color: #b45309;
+        color: #1c1205;
+        font-weight: 600;
+      }
+
       html[data-console-theme="light"] .console-sidebar-account {
         border-top-color: #deded7;
       }
@@ -1199,7 +1250,7 @@
   <%# The Control and Data Sync sections are admin-only (each controller enforces
       require_admin server-side); non-admins only get the Chats view below. %>
   <% nav_items = [] %>
-  <% if current_user&.admin? %>
+  <% if acting_admin? %>
     <% control_matches = [ "/console/principals", "/console/roles", "/console/secrets", "/console/credentials", "/console/oauth_apps", "/console/users" ] %>
     <% nav_items = [
       { label: "Control", icon: "shield-check", path: console_principals_path, matches: control_matches, root_active: true },
@@ -1207,7 +1258,14 @@
     ] %>
   <% end %>
 
-  <body class="h-full overflow-hidden bg-ink-900 text-zinc-300 font-mono antialiased">
+  <body class="h-full overflow-hidden bg-ink-900 text-zinc-300 font-mono antialiased <%= "console-descoped" if descoped? %>">
+    <% if descoped? %>
+      <div class="console-descope-banner" role="status">
+        <span>Admin permissions paused — viewing the console as an operator</span>
+        <%= button_to "Restore admin", console_descope_path, method: :delete,
+              class: "console-descope-restore" %>
+      </div>
+    <% end %>
     <div id="console-shell" class="console-shell">
       <aside class="console-sidebar" aria-label="Console navigation">
         <div class="console-sidebar-top">
@@ -1236,7 +1294,7 @@
             <% end %>
           </nav>
 
-          <% if current_user&.admin? %>
+          <% if acting_admin? %>
             <div class="console-thread-group">
               <a href="<%= console_workflows_path %>"
                  class="console-thread-group-title <%= "console-thread-group-title-active" if workflows_view %>"
@@ -1309,6 +1367,18 @@
                 <span data-console-theme-action-icon="dark" hidden><%= console_icon("moon", classes: "size-4") %></span>
                 <span data-console-theme-label>Light mode</span>
               </button>
+              <% if acting_admin? %>
+                <%= button_to console_descope_path,
+                      method: :post,
+                      class: "console-signout-button",
+                      form: { class: "console-signout-form" },
+                      role: "menuitem",
+                      title: "Temporarily pause your admin permissions",
+                      aria: { label: "View as operator" } do %>
+                  <%= console_icon("user-circle", classes: "size-4") %>
+                  <span class="console-signout-label">View as operator</span>
+                <% end %>
+              <% end %>
               <%= button_to logout_path,
                     method: :delete,
                     class: "console-signout-button",

--- a/services/console/config/routes.rb
+++ b/services/console/config/routes.rb
@@ -119,6 +119,9 @@ Rails.application.routes.draw do
         post :promote
       end
     end
+    # Admin self-descope ("view as operator"): pause (admin-only) and restore
+    # admin permissions. A singular resource because it's a per-session flag.
+    resource :descope, only: %i[create destroy]
   end
 
   namespace :api do

--- a/services/console/test/controllers/console/descopes_controller_test.rb
+++ b/services/console/test/controllers/console/descopes_controller_test.rb
@@ -1,0 +1,76 @@
+require "test_helper"
+
+module Console
+  # Covers admin self-descope ("view as operator"): who can start it, that admin
+  # gates and admin chrome disappear while descoped, how it's restored, and the
+  # self-healing session cleanup when the user is no longer an admin.
+  class DescopesControllerTest < ActionDispatch::IntegrationTest
+    def sign_in(user)
+      post login_url, params: { email: user.email, password: "password123456" }
+    end
+
+    test "a non-admin cannot descope" do
+      sign_in users(:member_user)
+      post console_descope_url
+      assert_redirected_to console_threads_path
+      assert_equal "That page is restricted to admins.", flash[:alert]
+    end
+
+    test "a descoped admin loses admin pages and chrome, and sees the banner" do
+      sign_in users(:acme_admin)
+      post console_descope_url
+      assert_redirected_to console_threads_path
+
+      get console_users_url
+      assert_redirected_to console_threads_path
+      assert_equal "That page is restricted to admins.", flash[:alert]
+
+      get console_threads_url
+      assert_response :ok
+      assert_select ".console-descope-banner", /Admin permissions paused/
+      assert_select ".console-nav-link", text: "Control", count: 0
+      assert_select "form[action=?]", console_descope_path do
+        assert_select "button", text: /Restore admin/
+      end
+    end
+
+    test "restore brings back admin permissions" do
+      sign_in users(:acme_admin)
+      post console_descope_url
+
+      delete console_descope_url
+      assert_redirected_to console_principals_path
+
+      get console_users_url
+      assert_response :ok
+      assert_select ".console-descope-banner", count: 0
+    end
+
+    test "descope ends automatically when the user is no longer an admin" do
+      admin = users(:acme_admin)
+      sign_in admin
+      post console_descope_url
+
+      admin.update!(admin: false)
+      get console_threads_url
+      assert_response :ok
+      assert_select ".console-descope-banner", count: 0
+    end
+
+    test "restore is a no-op redirect when not descoped" do
+      sign_in users(:acme_admin)
+      delete console_descope_url
+      assert_redirected_to console_principals_path
+    end
+
+    test "the account menu offers descope only to acting admins" do
+      sign_in users(:acme_admin)
+      get console_threads_url
+      assert_select ".console-signout-label", text: "View as operator"
+
+      sign_in users(:member_user)
+      get console_threads_url
+      assert_select ".console-signout-label", text: "View as operator", count: 0
+    end
+  end
+end


### PR DESCRIPTION
## What

Adds a **View as operator** toggle so admins can temporarily pause their own admin permissions and see the console exactly as an operator does.

- `session[:descoped]` flag with `acting_admin?` / `descoped?` helpers on `ApplicationController`; `require_admin` and the default landing path now go through `acting_admin?`
- `Console::DescopesController`: `POST /console/descope` pauses admin perms (admin-only), `DELETE` restores them
- Admin-only nav (Control, Data Sync, Workflows, the Users control tab) hides while descoped
- Account menu gains a **View as operator** item
- Persistent high-contrast amber banner while descoped — *Admin permissions paused — viewing the console as an operator* — with a **Restore admin** button
- Light mode only: existing amber notice boxes (thread-DB unavailable, managed secret) get the same solid amber treatment via a shared `.console-amber-note` class

Descope is self-healing: the flag is dropped automatically if the user is no longer an admin, so it can never outlive the privileges it pauses.

## Testing

- rubocop clean on touched files
- Full console suite in Docker: **1044 runs, 3769 assertions, 0 failures, 0 errors**
- Manually verified descope/restore flow, banner rendering, and nav hiding in a local dev instance