### PR TITLE
feat(console): redirect OAuth callback to Integrations and show connected state

### DIFF
--- a/services/console/app/controllers/console/integrations_controller.rb
+++ b/services/console/app/controllers/console/integrations_controller.rb
@@ -11,5 +11,13 @@ class Console::IntegrationsController < ApplicationController
 
   def index
     @oauth_apps = OauthApp.where(enabled: true).order(:slug)
+    # The user's existing connections, matched by the email the IdP reported
+    # during consent (the flow itself is unauthenticated, so provider_email is
+    # the only link back to a console user). Newest wins if the user somehow
+    # consented with several provider accounts sharing the email.
+    @credentials_by_app_id = BrokerCredential
+      .where(oauth_app_id: @oauth_apps.select(:id), provider_email: current_user.email)
+      .order(:updated_at)
+      .index_by(&:oauth_app_id)
   end
 end

--- a/services/console/app/controllers/oauth/flows_controller.rb
+++ b/services/console/app/controllers/oauth/flows_controller.rb
@@ -6,8 +6,8 @@ module Oauth
   # The OAuth consent flow, keyed by an app's well-known slug:
   # /oauth/:slug/start sends a team member to the IdP's consent screen, and
   # /oauth/:slug/callback turns the returned authorization code into a managed
-  # BrokerCredential linked to the OauthApp, then renders an centaur-console result
-  # page.
+  # BrokerCredential linked to the OauthApp, then sends the user back to the
+  # console Integrations page (or renders a result page on failure).
   #
   # Deliberately unauthenticated -- a team member connects an integration by
   # clicking a well-known link; there is no external app to integrate with, so
@@ -91,7 +91,10 @@ module Oauth
       @credential = upsert_credential(state, result, identity)
       enqueue_identity_enrichment(@credential)
 
-      render_result(:success, identity: identity)
+      # Back to the Integrations page the user started from; failures below
+      # still render the standalone result page, which offers a retry link.
+      connected_as = " as #{identity[:email]}" if identity[:email].present?
+      redirect_to console_integrations_path, notice: "#{@app.slug} connected#{connected_as}."
     rescue Broker::ExchangeError => e
       render_result(:error, message: "Connecting the integration failed (#{e.reason}).")
     rescue ActiveRecord::RecordInvalid => e
@@ -242,14 +245,13 @@ module Oauth
       nil
     end
 
-    # Renders the team-facing result page. +kind+ is :success, :denied, or
-    # :error; the matching HTTP status defaults sensibly but callers override it
-    # for the 4xx pre-consent rejections.
-    def render_result(kind, status: nil, message: nil, identity: nil, **)
+    # Renders the team-facing failure page. +kind+ is :denied or :error; the
+    # status defaults to 422 but callers override it for the 4xx pre-consent
+    # rejections. Success does not come through here -- the happy path
+    # redirects back to the console Integrations page.
+    def render_result(kind, status: :unprocessable_entity, message: nil)
       @kind = kind
       @message = message
-      @identity = identity
-      status ||= (kind == :success ? :ok : :unprocessable_entity)
       render :result, status: status
     end
   end

--- a/services/console/app/views/console/integrations/index.html.erb
+++ b/services/console/app/views/console/integrations/index.html.erb
@@ -26,8 +26,17 @@
         <% if app.description.present? %>
           <p class="line-clamp-2 text-xs text-zinc-500" title="<%= app.description %>"><%= app.description %></p>
         <% end %>
-        <div class="mt-auto pt-1">
-          <a href="<%= start_url %>" class="btn-primary inline-block">Connect</a>
+        <div class="mt-auto flex items-center justify-between gap-3 pt-1">
+          <% credential = @credentials_by_app_id[app.id] %>
+          <% if credential %>
+            <a href="<%= start_url %>" class="btn-secondary inline-block">Reconnect</a>
+            <span class="flex items-center gap-1.5 text-xs <%= credential.dead? ? "text-amber-300" : "text-emerald-300" %>">
+              <span class="size-1.5 rounded-full <%= credential.dead? ? "bg-amber-400" : "bg-emerald-400" %>"></span>
+              <%= credential.dead? ? "Needs reconnecting" : "Connected" %>
+            </span>
+          <% else %>
+            <a href="<%= start_url %>" class="btn-primary inline-block">Connect</a>
+          <% end %>
         </div>
       </div>
     <% end %>

--- a/services/console/app/views/oauth/flows/result.html.erb
+++ b/services/console/app/views/oauth/flows/result.html.erb
@@ -1,11 +1,9 @@
 <%
   heading, accent =
     case @kind
-    when :success then [ "Connected", "text-emerald-300" ]
-    when :denied  then [ "Not connected", "text-amber-300" ]
-    else               [ "Something went wrong", "text-red-300" ]
+    when :denied then [ "Not connected", "text-amber-300" ]
+    else              [ "Something went wrong", "text-red-300" ]
     end
-  app_name = @app&.slug
 %>
 <% content_for :title, "#{heading} · Centaur Console" %>
 
@@ -15,19 +13,8 @@
   </div>
   <h1 class="text-lg font-bold <%= accent %>"><%= heading %></h1>
 
-  <% if @kind == :success %>
-    <p class="mt-3 text-sm text-zinc-400">
-      <%= app_name %> is connected<%= " as #{@identity[:email]}" if @identity && @identity[:email].present? %>.
-    </p>
-    <% if @credential %>
-      <p class="mt-3 text-xs text-zinc-500">Credential</p>
-      <p class="break-all font-mono text-xs text-centaur-300"><%= @credential.oid %></p>
-    <% end %>
-    <p class="mt-4 text-xs text-zinc-600">Your access is being managed automatically. You can close this tab.</p>
-  <% else %>
-    <p class="mt-3 text-sm text-zinc-400"><%= @message %></p>
-    <% if @app&.enabled? %>
-      <a href="<%= oauth_start_path(slug: @app.slug) %>" class="mt-4 inline-block text-sm console-link">Try again</a>
-    <% end %>
+  <p class="mt-3 text-sm text-zinc-400"><%= @message %></p>
+  <% if @app&.enabled? %>
+    <a href="<%= oauth_start_path(slug: @app.slug) %>" class="mt-4 inline-block text-sm console-link">Try again</a>
   <% end %>
 </div>

--- a/services/console/test/controllers/console/integrations_controller_test.rb
+++ b/services/console/test/controllers/console/integrations_controller_test.rb
@@ -24,6 +24,55 @@ class Console::IntegrationsControllerTest < ActionDispatch::IntegrationTest
     assert_select "svg path[fill='#E01E5A']" # Slack
   end
 
+  test "an app already connected under the user's email shows Reconnect and its status" do
+    post login_url, params: { email: users(:member_user).email, password: "password123456" }
+
+    credential = BrokerCredential.create!(
+      oauth_app: oauth_apps(:acme_google),
+      namespace: "acme",
+      foreign_id: "google-google-member-sub",
+      name: "Google – Member",
+      token_endpoint: "https://oauth2.googleapis.com/token",
+      client_id: "google-client-id",
+      provider_subject: "member-sub",
+      provider_email: users(:member_user).email,
+      external_user_key: "member-key"
+    )
+
+    get console_integrations_url
+    assert_response :ok
+    assert_select "a.btn-secondary[href=?]", "http://www.example.com/oauth/google/start", text: "Reconnect"
+    assert_match "Connected", response.body
+    # The other apps are still unconnected.
+    assert_select "a.btn-primary[href=?]", "http://www.example.com/oauth/slack/start", text: "Connect"
+
+    # A dead credential asks the user to reconnect rather than claiming success.
+    credential.update!(dead: true, dead_reason: "invalid_grant")
+    get console_integrations_url
+    assert_match "Needs reconnecting", response.body
+  end
+
+  test "a credential minted for someone else's email does not mark the app connected" do
+    post login_url, params: { email: users(:member_user).email, password: "password123456" }
+
+    BrokerCredential.create!(
+      oauth_app: oauth_apps(:acme_google),
+      namespace: "acme",
+      foreign_id: "google-google-other-sub",
+      name: "Google – Other",
+      token_endpoint: "https://oauth2.googleapis.com/token",
+      client_id: "google-client-id",
+      provider_subject: "other-sub",
+      provider_email: users(:acme_admin).email,
+      external_user_key: "other-key"
+    )
+
+    get console_integrations_url
+    assert_response :ok
+    assert_select "a.btn-primary[href=?]", "http://www.example.com/oauth/google/start", text: "Connect"
+    assert_no_match "Reconnect", response.body
+  end
+
   test "an admin sees the same page" do
     post login_url, params: { email: users(:acme_admin).email, password: "password123456" }
 

--- a/services/console/test/controllers/oauth/flows_controller_test.rb
+++ b/services/console/test/controllers/oauth/flows_controller_test.rb
@@ -195,16 +195,15 @@ module Oauth
 
     # --- callback -------------------------------------------------------------
 
-    test "callback happy path mints a live credential and renders a success page" do
+    test "callback happy path mints a live credential and redirects to the Integrations page" do
       state = start_flow
       stub_exchange(status: 200, body: token_body)
 
       assert_difference -> { BrokerCredential.count } => 1 do
         get oauth_callback_url(slug: "google"), params: { state: state, code: "auth-code" }
       end
-      assert_response :ok
-      assert_match "Connected", response.body
-      assert_match "user@example.com", response.body
+      assert_redirected_to console_integrations_path
+      assert_equal "google connected as user@example.com.", flash[:notice]
 
       cred = BrokerCredential.find_by(oauth_app: @app, provider_subject: "google-sub-1")
       assert_equal "acme", cred.namespace
@@ -218,7 +217,6 @@ module Oauth
       assert_equal "RT", cred.refresh_token
       assert cred.next_attempt_at.present?
       assert_nil cred.created_by
-      assert_includes response.body, cred.oid
     end
 
     test "callback happy path supports Slack user tokens" do
@@ -228,8 +226,8 @@ module Oauth
       assert_difference -> { BrokerCredential.count } => 1 do
         get oauth_callback_url(slug: "slack"), params: { state: state, code: "auth-code" }
       end
-      assert_response :ok
-      assert_match "Connected", response.body
+      assert_redirected_to console_integrations_path
+      assert_match(/\Aslack connected/, flash[:notice])
 
       app = oauth_apps(:acme_slack)
       cred = BrokerCredential.find_by(oauth_app: app, provider_subject: "U0R7MFMJM")
@@ -254,8 +252,8 @@ module Oauth
           get oauth_callback_url(slug: "github"), params: { state: state, code: "auth-code" }
         end
       end
-      assert_response :ok
-      assert_match "Connected", response.body
+      assert_redirected_to console_integrations_path
+      assert_match(/\Agithub connected/, flash[:notice])
 
       app = oauth_apps(:acme_github)
       cred = BrokerCredential.find_by(oauth_app: app)
@@ -324,8 +322,8 @@ module Oauth
         get oauth_callback_url(slug: "google"), params: { state: state, code: "auth-code" }
       end
 
-      assert_response :ok
-      assert_match "Connected", response.body
+      assert_redirected_to console_integrations_path
+      assert_match(/connected/, flash[:notice])
       assert_equal user.id, session[:user_id]
     end
 


### PR DESCRIPTION
## Summary

Follow-up to #937, two improvements to the Integrations flow:

**1. Callback redirects back to the Integrations page.** A successful OAuth consent now redirects the user to `/console/integrations` with a flash notice (`<slug> connected as <email>.`) instead of rendering the standalone result page — the user lands where they started. Denied and error outcomes keep the standalone result page with its "Try again" link, since those can occur outside a console session. The now-dead success branch is removed from the result view.

**2. Cards reflect existing connections.** An integration whose `BrokerCredential` carries the signed-in user's email (`provider_email` — the only link the unauthenticated consent flow records back to a console user) shows a **Connected** badge and a secondary **Reconnect** button instead of **Connect**. Dead credentials show **Needs reconnecting** so a broken connection is not presented as healthy.

## Testing

- `bundle exec rails test` — 1058 runs, 3834 assertions, 0 failures, 0 errors, 16 skips
- `bundle exec rubocop` on touched files — no offenses
- New tests cover: redirect + flash on successful consent, Connected/Reconnect rendering, dead-credential state, and that someone else's credential does not mark an app connected
