### PR TITLE
fix(console): hide admin redirect alert

### DIFF
--- a/services/console/app/controllers/application_controller.rb
+++ b/services/console/app/controllers/application_controller.rb
@@ -102,10 +102,11 @@ class ApplicationController < ActionController::Base
   end
 
   # Guard for admin-only controllers (the Control and Data Sync sections, user
-  # management). Not a global gate. Bounces to the threads view rather than root:
-  # root is the admin-only principals page, so redirecting there would loop.
+  # management). Not a global gate. Bounces non-admins to their only available
+  # section. Keep this redirect silent: direct/admin-default URLs are not
+  # actionable errors for non-admin operators, especially on a fresh visit.
   def require_admin
-    redirect_to console_threads_path, alert: "That page is restricted to admins." unless acting_admin?
+    redirect_to console_threads_path unless acting_admin?
   end
 
   # Where a signed-in user lands when no explicit destination applies: admins get

--- a/services/console/test/controllers/console/descopes_controller_test.rb
+++ b/services/console/test/controllers/console/descopes_controller_test.rb
@@ -13,7 +13,7 @@ module Console
       sign_in users(:member_user)
       post console_descope_url
       assert_redirected_to console_threads_path
-      assert_equal "That page is restricted to admins.", flash[:alert]
+      assert_nil flash[:alert]
     end
 
     test "a descoped admin loses admin pages and chrome, and sees the banner" do
@@ -23,7 +23,7 @@ module Console
 
       get console_users_url
       assert_redirected_to console_threads_path
-      assert_equal "That page is restricted to admins.", flash[:alert]
+      assert_nil flash[:alert]
 
       get console_threads_url
       assert_response :ok

--- a/services/console/test/controllers/console/etls_controller_test.rb
+++ b/services/console/test/controllers/console/etls_controller_test.rb
@@ -66,7 +66,7 @@ class Console::EtlsControllerTest < ActionDispatch::IntegrationTest
 
     get console_etls_url
     assert_redirected_to console_threads_path
-    assert_equal "That page is restricted to admins.", flash[:alert]
+    assert_nil flash[:alert]
     # The gate fires before the action, so the api client is never touched.
     assert_empty @client.calls
 

--- a/services/console/test/controllers/console/users_controller_test.rb
+++ b/services/console/test/controllers/console/users_controller_test.rb
@@ -17,7 +17,7 @@ module Console
       sign_in users(:member_user)
       get console_users_url
       assert_redirected_to console_threads_path
-      assert_equal "That page is restricted to admins.", flash[:alert]
+      assert_nil flash[:alert]
     end
 
     test "an admin sees the index with pending users listed" do

--- a/services/console/test/controllers/console/workflows_controller_test.rb
+++ b/services/console/test/controllers/console/workflows_controller_test.rb
@@ -54,7 +54,7 @@ class Console::WorkflowsControllerTest < ActionDispatch::IntegrationTest
     get console_workflows_url
 
     assert_redirected_to console_threads_path
-    assert_equal "That page is restricted to admins.", flash[:alert]
+    assert_nil flash[:alert]
   end
 
   test "a non-admin does not see the workflows tab" do

--- a/services/console/test/controllers/console_controller_test.rb
+++ b/services/console/test/controllers/console_controller_test.rb
@@ -20,7 +20,7 @@ class ConsoleControllerTest < ActionDispatch::IntegrationTest
       console_credentials_url, console_oauth_apps_url ].each do |url|
       get url
       assert_redirected_to console_threads_path
-      assert_equal "That page is restricted to admins.", flash[:alert]
+      assert_nil flash[:alert]
     end
   end
 


### PR DESCRIPTION
## Summary
- Redirect non-admins from admin-only console pages without a flash alert.
- Update admin-gate controller tests to assert the redirect stays silent.

## Tests
- bin/rails test test/controllers/console_controller_test.rb test/controllers/console/users_controller_test.rb test/controllers/console/etls_controller_test.rb