### PR TITLE
fix(console): recolor first divide-y divider in light mode

### DIFF
--- a/services/console/app/views/layouts/console.html.erb
+++ b/services/console/app/views/layouts/console.html.erb
@@ -1189,8 +1189,11 @@
         --tw-ring-color: #d8d8d0;
       }
 
-      html[data-console-theme="light"] .divide-ink-600 > :not([hidden]) ~ :not([hidden]),
-      html[data-console-theme="light"] .divide-ink-700 > :not([hidden]) ~ :not([hidden]) {
+      /* Tailwind v4 puts divide-y borders on `> :not(:last-child)` (border-bottom),
+         not on the v3 `~` sibling selector — the first child carries a divider too,
+         so the recolor must cover it or the first row's border stays ink-dark. */
+      html[data-console-theme="light"] .divide-ink-600 > :not(:last-child),
+      html[data-console-theme="light"] .divide-ink-700 > :not(:last-child) {
         border-block-color: #deded7;
         border-color: #deded7;
       }


### PR DESCRIPTION
## Summary

In light mode, the divider under the first row of every console `divide-y` panel (workflow detail dl, Historical Runs table, Data Sync table, etc.) rendered near-black instead of light gray.

Tailwind v4 emits `divide-y` borders as `border-bottom` on `:where(& > :not(:last-child))` — the first child carries a divider. The light-theme recolor in the console layout still used the Tailwind v3 sibling selector (`> :not([hidden]) ~ :not([hidden])`), which only matches the second child onward, so the first row's divider kept its dark `ink-700` color.

This updates the two override selectors to `> :not(:last-child)` to match what Tailwind v4 actually generates. Verified by compiling a probe with the same tailwindcss version the console pins (4.3.0): both the divide width and color rules land on `:where(& > :not(:last-child))`, and the zero-specificity `:where()` wrapper means the themed override cleanly wins.

## Test plan

- Open any console table (e.g. Workflows detail page or Data Sync) in light mode and confirm the divider under the first row matches the rest (#deded7) instead of near-black.
- Confirm dark mode is unchanged (overrides are scoped to `html[data-console-theme="light"]`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)