### PR TITLE
fix(console): reflect fresh connections on Integrations after the callback redirect

### DIFF
--- a/services/console/app/controllers/console/integrations_controller.rb
+++ b/services/console/app/controllers/console/integrations_controller.rb
@@ -11,12 +11,14 @@ class Console::IntegrationsController < ApplicationController
 
   def index
     @oauth_apps = OauthApp.where(enabled: true).order(:slug)
-    # The user's existing connections, matched by the email the IdP reported
-    # during consent (the flow itself is unauthenticated, so provider_email is
-    # the only link back to a console user). Newest wins if the user somehow
-    # consented with several provider accounts sharing the email.
-    @credentials_by_app_id = BrokerCredential
-      .where(oauth_app_id: @oauth_apps.select(:id), provider_email: current_user.email)
+    # The user's existing connections: credentials they minted while signed in
+    # (created_by, recorded by the consent callback) plus any whose IdP-reported
+    # email matches their console login -- the fallback for consents made
+    # without a console session. Newest wins if several match one app.
+    mine = BrokerCredential.where(created_by: current_user)
+      .or(BrokerCredential.where(provider_email: current_user.email))
+    @credentials_by_app_id = mine
+      .where(oauth_app_id: @oauth_apps.select(:id))
       .order(:updated_at)
       .index_by(&:oauth_app_id)
   end

--- a/services/console/app/controllers/oauth/flows_controller.rb
+++ b/services/console/app/controllers/oauth/flows_controller.rb
@@ -163,6 +163,12 @@ module Oauth
     def upsert_credential(state, result, identity)
       BrokerCredential.transaction do
         credential = BrokerCredential.find_or_initialize_by(oauth_app: @app, provider_subject: identity[:subject])
+        # When the consenting browser carries a signed-in console session,
+        # remember which user connected this account. The Integrations page
+        # matches on it, so the card flips to "Connected" even when the
+        # provider account's email differs from the console login email.
+        # Never overwritten: the first linked user keeps the credential.
+        credential.created_by ||= current_user
         if credential.new_record?
           credential.namespace = @app.credential_namespace
           credential.foreign_id = "#{@app.provider}-#{@app.slug}-#{identity[:subject].downcase}"
@@ -217,8 +223,8 @@ module Oauth
     #
     # Created once per credential (keyed on the broker_credential association, which
     # a unique index enforces) and left untouched on re-consent, so any operator
-    # edits -- a different header, extra rules -- survive. Has no created_by: the
-    # unauthenticated flow has no current user, like the credential it wraps. Left
+    # edits -- a different header, extra rules -- survive. Has no created_by:
+    # unlike the credential, no console feature keys off the secret's owner. Left
     # without a foreign_id: it is found by association, and copying the credential's
     # would risk colliding with an operator-created secret.
     def ensure_wrapping_secret(credential)

--- a/services/console/test/controllers/console/integrations_controller_test.rb
+++ b/services/console/test/controllers/console/integrations_controller_test.rb
@@ -52,6 +52,27 @@ class Console::IntegrationsControllerTest < ActionDispatch::IntegrationTest
     assert_match "Needs reconnecting", response.body
   end
 
+  test "a credential the user minted shows connected even when the provider email differs" do
+    post login_url, params: { email: users(:member_user).email, password: "password123456" }
+
+    BrokerCredential.create!(
+      oauth_app: oauth_apps(:acme_google),
+      namespace: "acme",
+      foreign_id: "google-google-personal-sub",
+      name: "Google – Personal",
+      token_endpoint: "https://oauth2.googleapis.com/token",
+      client_id: "google-client-id",
+      provider_subject: "personal-sub",
+      provider_email: "personal@gmail.example",
+      external_user_key: "personal-key",
+      created_by: users(:member_user)
+    )
+
+    get console_integrations_url
+    assert_response :ok
+    assert_select "a.btn-secondary[href=?]", "http://www.example.com/oauth/google/start", text: "Reconnect"
+  end
+
   test "a credential minted for someone else's email does not mark the app connected" do
     post login_url, params: { email: users(:member_user).email, password: "password123456" }
 

--- a/services/console/test/controllers/oauth/flows_controller_test.rb
+++ b/services/console/test/controllers/oauth/flows_controller_test.rb
@@ -330,6 +330,24 @@ module Oauth
       assert_equal user, cred.reload.created_by
     end
 
+    test "a Slack consent with no email in the token response still shows connected on Integrations" do
+      user = users(:member_user)
+      sign_in user
+      state = start_flow(slug: "slack", scopes: "chat:write")
+      stub_exchange(status: 200, body: slack_token_body)
+      get oauth_callback_url(slug: "slack"), params: { state: state, code: "auth-code" }
+      assert_redirected_to console_integrations_path
+
+      # Slack's token response carries no email (enrichment fills it in later),
+      # so the connected state must come from the created_by link.
+      cred = BrokerCredential.find_by(oauth_app: oauth_apps(:acme_slack), provider_subject: "U0R7MFMJM")
+      assert_nil cred.provider_email
+      assert_equal user, cred.created_by
+
+      get console_integrations_url
+      assert_select "a.btn-secondary[href=?]", "http://www.example.com/oauth/slack/start", text: "Reconnect"
+    end
+
     test "callback works with a disabled console session" do
       user = users(:member_user)
       sign_in user

--- a/services/console/test/controllers/oauth/flows_controller_test.rb
+++ b/services/console/test/controllers/oauth/flows_controller_test.rb
@@ -311,6 +311,25 @@ module Oauth
       assert_equal "operator-renamed", secret.reload.name
     end
 
+    test "callback records the signed-in user on the credential and keeps the original owner on re-consent" do
+      user = users(:member_user)
+      sign_in user
+      state = start_flow
+      stub_exchange(status: 200, body: token_body)
+      get oauth_callback_url(slug: "google"), params: { state: state, code: "auth-code" }
+
+      cred = BrokerCredential.find_by(oauth_app: @app, provider_subject: "google-sub-1")
+      assert_equal user, cred.created_by
+
+      # Someone else re-consenting for the same provider account does not steal
+      # the credential.
+      sign_in users(:acme_admin)
+      state = start_flow
+      stub_exchange(status: 200, body: token_body)
+      get oauth_callback_url(slug: "google"), params: { state: state, code: "auth-code" }
+      assert_equal user, cred.reload.created_by
+    end
+
     test "callback works with a disabled console session" do
       user = users(:member_user)
       sign_in user


### PR DESCRIPTION
## Summary

Fixes the Integrations page not reflecting a fresh connection after the callback redirects back (follow-up to #938).

**Root cause:** the page matched credentials only by `provider_email` — but for Slack and GitHub that field is **nil at mint time**. Slack's OAuth v2 token response carries no email in `authed_user` (it is filled in later by `Oauth::EnrichCredentialIdentityJob` via `users.info`, and only when the `users:read.email` scope was granted), and the GitHub strategy explicitly mints with `email: nil` pending its own enrichment job. So even when the console login and the provider account share the same email, the card stayed on "Connect" after the redirect. (Google, whose id_token does carry the email, could still miss when the provider account's email differs from the console login.)

**Fix:** stop depending on the provider reporting an email at consent time.
- The callback now records `created_by` from the browser's console session when one exists — synchronously, before the redirect. Never overwritten: the first linked user keeps the credential, so someone else re-consenting for the same provider account does not steal it.
- The Integrations page matches `created_by` first, with `provider_email` kept as the fallback for consents made without a console session.

## Testing

- `bundle exec rails test` — 1060 runs, 3841 assertions, 0 failures, 0 errors, 16 skips
- `bundle exec rubocop` on touched files — no offenses
- New tests: callback records the signed-in user and preserves the original owner on re-consent; a user's credential shows Connected even when the provider email differs (which for Slack/GitHub means "is still nil")
