### PR TITLE
fix(proxy): allowlist Datadog auth headers for the agent Datadog tool

### DIFF
--- a/services/iron-proxy/iron-proxy.yaml
+++ b/services/iron-proxy/iron-proxy.yaml
@@ -82,6 +82,13 @@ transforms:
         - "addepar-firm"
         - "clientid"
         - "x-as-user-email"
+        # Datadog static-key auth for the agent-facing Datadog tool/CLI: it
+        # authenticates to api.datadoghq.com with these two headers (Datadog does
+        # not accept Authorization: Bearer for static API/app keys). Neither is
+        # matched by the x-* catch-all below, so both must be listed to survive
+        # egress filtering — same per-integration pattern as the headers above.
+        - "dd-api-key"
+        - "dd-application-key"
         - "/^x-codex-.*$/"
         - "/^x-openai-.*$/"
         # AWS SigV4 request headers (x-amz-target, x-amz-date,


### PR DESCRIPTION
## Summary

Add `dd-api-key` / `dd-application-key` to iron-proxy's `header_allowlist` (2 lines in `services/iron-proxy/iron-proxy.yaml`) so agent tools can authenticate **read-only** to the Datadog REST API through the per-sandbox proxy.

## Why

Datadog authenticates with two static-key headers — `DD-API-KEY` (org API key) and `DD-APPLICATION-KEY` (application key). It does **not** accept `Authorization: Bearer <key>` for static-key auth. Neither `dd-`-prefixed header matches the `^x-…(api-key|token|auth|key)$` catch-all, so iron-proxy strips them before egress and requests to `api.datadoghq.com` return `403`.

This is the same **per-integration header addition** already present in the allowlist for `notion-version`, `x-github-api-version`, `x-as-user-email`, `project-access-token`, `fx-access-*`, `x-cb-access-*`, etc. Datadog just needs its two.

## Scope — please note (re: #476)

This enables **agent-tool access to Datadog as a read-only observability data source** (root-cause analysis, PR investigation) — the same shape as the other third-party API tools under `tools/`. It is **not** about Centaur's own telemetry or the OTEL logging pipeline; nothing here changes how Centaur emits or ingests its own logs.

#476 proposed the identical change and was closed as orthogonal to the OTEL logging design. I believe that was a scope misread of the use case, so I'm reopening with the framing above.

## Concretely unblocks #811

#811 ("Add Datadog observability tool" — read-only logs / metrics / monitors / hosts / dashboards) wires the DD API/app keys through tool metadata but does not touch the allowlist, so at runtime its `DD-API-KEY` / `DD-APPLICATION-KEY` headers are stripped and every request `403`s. This PR is the enabling primitive for that tool. cc @decofe @Zygimantass

cc @mslipper @goksu — small `header_allowlist` addition in your area; happy to adjust framing or placement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
