### PR TITLE
fix: label company context lookup metrics

### DIFF
--- a/tools/productivity/company_context/client.py
+++ b/tools/productivity/company_context/client.py
@@ -154,8 +154,12 @@ def _first_nonempty_env(names: list[str]) -> str | None:
 
 def _metric_runtime_labels() -> dict[str, str]:
     labels: dict[str, str] = {}
-    environment = _first_nonempty_env(["CENTAUR_ENVIRONMENT", "DEPLOY_ENV", "ENVIRONMENT"])
-    namespace = _first_nonempty_env(["CENTAUR_NAMESPACE", "POD_NAMESPACE", "NAMESPACE"])
+    environment = _first_nonempty_env(
+        ["METRICS_ENVIRONMENT", "CENTAUR_ENVIRONMENT", "DEPLOY_ENV", "ENVIRONMENT"]
+    )
+    namespace = _first_nonempty_env(
+        ["METRICS_NAMESPACE", "CENTAUR_NAMESPACE", "POD_NAMESPACE", "NAMESPACE"]
+    )
     if environment:
         labels["environment"] = environment
     if namespace:

--- a/tools/productivity/company_context/tests/test_client.py
+++ b/tools/productivity/company_context/tests/test_client.py
@@ -346,6 +346,48 @@ def test_search_emits_error_lookup_metric(monkeypatch):
     )
 
 
+def test_lookup_metrics_use_metrics_runtime_labels(monkeypatch):
+    monkeypatch.setenv("METRICS_ENVIRONMENT", "staging")
+    monkeypatch.setenv("METRICS_NAMESPACE", "stg-centaur-system")
+    pushed_lines = []
+    monkeypatch.setattr(
+        company_context_client,
+        "_push_company_context_lookup_metric_lines",
+        lambda lines: pushed_lines.extend(lines),
+    )
+
+    company_context_client._emit_company_context_lookup_metrics(
+        status="ok",
+        requested_source="slack",
+        requested_source_type=None,
+        occurred_after=None,
+        occurred_before=None,
+        results=[
+            {
+                "source": "slack",
+                "source_type": "slack_thread",
+                "lane": "indexed",
+            }
+        ],
+    )
+
+    assert any(
+        line.startswith(
+            'company_context_lookup_requests{environment="staging",namespace="stg-centaur-system",'
+            'requested_source="slack",requested_source_type="all",status="ok",'
+            'time_window="false"} 1 '
+        )
+        for line in pushed_lines
+    )
+    assert any(
+        line.startswith(
+            'company_context_lookup_results{environment="staging",lane="indexed",'
+            'namespace="stg-centaur-system",source="slack",source_type="slack_thread"} 1 '
+        )
+        for line in pushed_lines
+    )
+
+
 def test_search_uses_or_terms_and_drops_stop_words(monkeypatch):
     fake = _FakeConnection(rows=[])
 


### PR DESCRIPTION
## Summary
- include `METRICS_ENVIRONMENT` and `METRICS_NAMESPACE` in company context lookup metric labels
- add coverage that emitted lookup samples carry the staging namespace/environment labels

## Root Cause
Staging sets `METRICS_ENVIRONMENT=staging` and `METRICS_NAMESPACE=stg-centaur-system`, but the lookup metric helper only read `CENTAUR_ENVIRONMENT`/`DEPLOY_ENV`/`ENVIRONMENT` and `CENTAUR_NAMESPACE`/`POD_NAMESPACE`/`NAMESPACE`. The metrics were emitted, but without namespace labels, so dashboard queries filtered them out.

## Validation
- `uv run --project /Users/akshaan/Desktop/centaur-company-context-metric-labels/tools/productivity/company_context --no-editable --python 3.11 --with pytest pytest tests/test_client.py`
- `uvx ruff check tools/productivity/company_context/client.py tools/productivity/company_context/tests/test_client.py`
