### PR TITLE
feat: add native Flue harness

### DIFF
--- a/crates/harness-server/src/flue.rs
+++ b/crates/harness-server/src/flue.rs
@@ -1,0 +1,266 @@
+use std::env;
+use std::io::{self, BufRead, Write};
+use std::path::PathBuf;
+use std::process::Command as ProcessCommand;
+
+use codex_app_server_protocol::UserInput;
+use serde_json::{Value, json};
+use uuid::Uuid;
+
+use crate::server::{BlocksCommand, BlocksState, parse_blocks_line_with_state, write_blocks_error};
+use crate::util::{user_input_to_anthropic_content, write_value};
+use crate::{AppServerRuntime, HarnessServerError, Result};
+
+/// Runs Flue as a Centaur harness.
+///
+/// Centaur already owns durable sessions and workflow orchestration. This
+/// adapter therefore treats Flue as a finite per-turn executor: every Centaur
+/// user turn becomes one `flue run` invocation, and the JSON result is projected
+/// back onto the existing Centaur app-server event stream.
+#[derive(Debug, Default)]
+pub struct FlueHarnessServer;
+
+impl AppServerRuntime for FlueHarnessServer {
+    fn run_stdio(&self) -> Result<()> {
+        run_flue_blocks_server()
+    }
+}
+
+pub fn run_flue_blocks_server() -> Result<()> {
+    let stdin = io::stdin();
+    let mut stdout = io::stdout().lock();
+    let mut blocks_state = BlocksState::default();
+    let thread_id = env::var("CENTAUR_THREAD_KEY")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or_else(|| format!("flue-{}", Uuid::new_v4().simple()));
+
+    write_value(
+        &mut stdout,
+        &json!({"type": "thread.started", "thread_id": thread_id}),
+    )?;
+
+    for raw in stdin.lock().lines() {
+        let line = raw?;
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+
+        match parse_blocks_line_with_state(trimmed, &mut blocks_state) {
+            Ok(BlocksCommand::User {
+                input,
+                client_user_message_id: _,
+                model: _,
+                provider: _,
+                reasoning: _,
+                trace_context: _,
+            }) => {
+                let turn_id = format!("turn-{}", Uuid::new_v4().simple());
+                match run_flue_turn(&input, &thread_id, &turn_id) {
+                    Ok(result_text) => {
+                        write_flue_success(&mut stdout, &thread_id, &turn_id, result_text)?
+                    }
+                    Err(error) => {
+                        eprintln!("Flue turn failed: {error:#}");
+                        write_blocks_error(&mut stdout, &thread_id, &turn_id, error.to_string())?;
+                    }
+                }
+            }
+            Ok(BlocksCommand::Interrupt) => {
+                eprintln!(
+                    "Flue blocks interrupt ignored: flue run is per-turn and non-interactive"
+                );
+            }
+            Ok(BlocksCommand::AttachmentChunk) => {}
+            Err(error) => {
+                eprintln!("invalid Flue blocks input: {error:#}");
+                write_blocks_error(&mut stdout, &thread_id, "input", error.to_string())?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn run_flue_turn(input: &[UserInput], thread_id: &str, turn_id: &str) -> Result<String> {
+    let workflow = env::var("CENTAUR_FLUE_WORKFLOW")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or_else(|| "agent-turn".to_string());
+    let target = env::var("CENTAUR_FLUE_TARGET")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or_else(|| "node".to_string());
+    let input_json = flue_input_json(input, thread_id, turn_id)?;
+    let project_dir = env::var_os("CENTAUR_FLUE_PROJECT_DIR").map(PathBuf::from);
+
+    let mut command = ProcessCommand::new(flue_bin());
+    command.args([
+        "run",
+        &workflow,
+        "--target",
+        &target,
+        "--input",
+        &input_json,
+    ]);
+    if let Some(project_dir) = project_dir {
+        command.current_dir(project_dir);
+    }
+
+    let output = command
+        .output()
+        .map_err(|source| HarnessServerError::SpawnHarness {
+            cwd: env::current_dir().unwrap_or_else(|_| "/".into()),
+            source,
+        })?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        let detail = [stderr, stdout]
+            .into_iter()
+            .filter(|value| !value.is_empty())
+            .collect::<Vec<_>>()
+            .join("\n");
+        return Err(HarnessServerError::InvalidBlocksInput {
+            message: if detail.is_empty() {
+                format!("flue run exited with status {}", output.status)
+            } else {
+                format!("flue run exited with status {}: {detail}", output.status)
+            },
+        });
+    }
+
+    Ok(extract_flue_result_text(&String::from_utf8_lossy(
+        &output.stdout,
+    )))
+}
+
+fn flue_input_json(input: &[UserInput], thread_id: &str, turn_id: &str) -> Result<String> {
+    let text = input
+        .iter()
+        .map(user_input_text)
+        .collect::<Vec<_>>()
+        .join("\n");
+    let value = json!({
+        "text": text,
+        "thread_key": thread_id,
+        "turn_id": turn_id,
+        "content": user_input_to_anthropic_content(input),
+    });
+    Ok(serde_json::to_string(&value)?)
+}
+
+/// Preserve Centaur's canonical input surface while giving Flue a simple text
+/// field for ordinary workflows and the original Anthropic-style content blocks
+/// for richer workflows that want attachment/image metadata.
+fn user_input_text(input: &UserInput) -> String {
+    match input {
+        UserInput::Text { text, .. } => text.clone(),
+        UserInput::Image { url, .. } => format!("[image: {url}]"),
+        UserInput::LocalImage { path, .. } => format!("[local image: {}]", path.display()),
+        UserInput::Skill { name, path } => format!("[skill: {name} at {}]", path.display()),
+        UserInput::Mention { name, path } => format!("[mention: {name} at {path}]"),
+    }
+}
+
+fn extract_flue_result_text(stdout: &str) -> String {
+    for line in stdout.lines().rev() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        if let Ok(value) = serde_json::from_str::<Value>(trimmed) {
+            if let Some(text) = value.pointer("/result/text").and_then(Value::as_str) {
+                return text.to_string();
+            }
+            if let Some(text) = value.get("text").and_then(Value::as_str) {
+                return text.to_string();
+            }
+            if let Some(result) = value.get("result") {
+                return result
+                    .as_str()
+                    .map(ToOwned::to_owned)
+                    .unwrap_or_else(|| result.to_string());
+            }
+            return value.to_string();
+        }
+    }
+    stdout.trim().to_string()
+}
+
+fn write_flue_success<W: Write>(
+    stdout: &mut W,
+    thread_id: &str,
+    turn_id: &str,
+    result_text: String,
+) -> Result<()> {
+    let item_id = format!("msg-{}", Uuid::new_v4().simple());
+    // Session runtime already understands these event shapes from the other
+    // harnesses. Emitting them here avoids adding a Flue-specific event parser
+    // in Centaur's durable execution layer.
+    write_value(
+        stdout,
+        &json!({
+            "type": "assistant",
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "text", "text": result_text}]
+            },
+            "thread_id": thread_id,
+            "turn_id": turn_id
+        }),
+    )?;
+    write_value(
+        stdout,
+        &json!({
+            "type": "item.completed",
+            "item": {
+                "id": item_id,
+                "type": "agentMessage",
+                "phase": "final_answer",
+                "text": result_text
+            },
+            "thread_id": thread_id,
+            "turn_id": turn_id
+        }),
+    )?;
+    write_value(
+        stdout,
+        &json!({"type": "turn.done", "thread_id": thread_id, "turn_id": turn_id, "result": result_text}),
+    )
+}
+
+fn flue_bin() -> String {
+    env::var("FLUE_BIN")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or_else(|| "flue".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn flue_input_includes_text_and_anthropic_content() {
+        let input = vec![UserInput::Text {
+            text: "hello".to_string(),
+            text_elements: Vec::new(),
+        }];
+        let value: Value =
+            serde_json::from_str(&flue_input_json(&input, "thread:1", "turn-1").unwrap()).unwrap();
+
+        assert_eq!(value["text"], "hello");
+        assert_eq!(value["thread_key"], "thread:1");
+        assert_eq!(value["turn_id"], "turn-1");
+        assert_eq!(value["content"][0]["text"], "hello");
+    }
+
+    #[test]
+    fn extracts_last_json_result_text() {
+        let stdout = "event line\n{\"result\":{\"text\":\"done\"}}\n";
+        assert_eq!(extract_flue_result_text(stdout), "done");
+    }
+}

--- a/crates/harness-server/src/lib.rs
+++ b/crates/harness-server/src/lib.rs
@@ -3,6 +3,7 @@ pub mod anthropic;
 pub mod claude;
 pub mod codex;
 mod error;
+pub mod flue;
 mod otel;
 mod server;
 mod traits;

--- a/crates/harness-server/src/main.rs
+++ b/crates/harness-server/src/main.rs
@@ -21,6 +21,7 @@ enum CliCommand {
     #[command(alias = "claude")]
     ClaudeCode(HarnessCommand),
     Amp(HarnessCommand),
+    Flue(HarnessCommand),
     ValidateJsonrpc,
     ValidateAgentDeltas,
 }
@@ -53,6 +54,7 @@ fn run() -> Result<()> {
         CliCommand::Codex(command) => run_mode(HarnessKind::Codex, command.mode),
         CliCommand::ClaudeCode(command) => run_mode(HarnessKind::ClaudeCode, command.mode),
         CliCommand::Amp(command) => run_mode(HarnessKind::Amp, command.mode),
+        CliCommand::Flue(command) => run_mode(HarnessKind::Flue, command.mode),
         CliCommand::ValidateJsonrpc => run_validate_jsonrpc(),
         CliCommand::ValidateAgentDeltas => run_validate_agent_deltas(),
     }

--- a/crates/harness-server/src/server.rs
+++ b/crates/harness-server/src/server.rs
@@ -23,6 +23,7 @@ use uuid::Uuid;
 use crate::amp::AmpHarness;
 use crate::claude::ClaudeCodeHarness;
 use crate::codex::CodexHarnessServer;
+use crate::flue::FlueHarnessServer;
 use crate::otel::TraceContext;
 use crate::traits::{
     AppServerNormalizer, AppServerRuntime, HarnessChild, HarnessKind, HarnessServer,
@@ -38,6 +39,7 @@ pub fn server_for(kind: HarnessKind) -> Box<dyn AppServerRuntime> {
         HarnessKind::Codex => Box::new(CodexHarnessServer::codex()),
         HarnessKind::ClaudeCode => Box::new(AppServerNormalizer::new(ClaudeCodeHarness)),
         HarnessKind::Amp => Box::new(AppServerNormalizer::new(AmpHarness)),
+        HarnessKind::Flue => Box::new(FlueHarnessServer),
     }
 }
 
@@ -50,6 +52,7 @@ pub fn run_blocks_server(kind: HarnessKind) -> Result<()> {
         HarnessKind::Codex => crate::codex::run_codex_blocks_server(CodexHarnessServer::codex()),
         HarnessKind::ClaudeCode => run_blocks_app_server(&ClaudeCodeHarness),
         HarnessKind::Amp => run_blocks_app_server(&AmpHarness),
+        HarnessKind::Flue => crate::flue::run_flue_blocks_server(),
     }
 }
 

--- a/crates/harness-server/src/traits.rs
+++ b/crates/harness-server/src/traits.rs
@@ -14,6 +14,7 @@ pub enum HarnessKind {
     Codex,
     ClaudeCode,
     Amp,
+    Flue,
 }
 
 pub struct ThreadState {

--- a/services/api-rs/crates/centaur-api-integration-test/src/main.rs
+++ b/services/api-rs/crates/centaur-api-integration-test/src/main.rs
@@ -222,6 +222,7 @@ async fn test_harness_wire_values(http: &HttpClient, base_url: &str) -> Result<(
         (HarnessType::Codex, "codex"),
         (HarnessType::Amp, "amp"),
         (HarnessType::ClaudeCode, "claudecode"),
+        (HarnessType::Flue, "flue"),
     ];
 
     for (harness_type, expected_wire_value) in cases {

--- a/services/api-rs/crates/centaur-api-server/src/args.rs
+++ b/services/api-rs/crates/centaur-api-server/src/args.rs
@@ -1723,6 +1723,7 @@ impl IronProxyHarnessArgs {
             HarnessType::Codex,
             HarnessType::ClaudeCode,
             HarnessType::Amp,
+            HarnessType::Flue,
         ] {
             if engine == self.engine {
                 continue;
@@ -1803,6 +1804,7 @@ fn harness_fragment_engine_name(engine: &HarnessType) -> &'static str {
         HarnessType::Codex => "codex",
         HarnessType::Amp => "amp",
         HarnessType::ClaudeCode => "claude-code",
+        HarnessType::Flue => "flue",
     }
 }
 
@@ -1820,6 +1822,7 @@ fn harness_auth_mode_env(engine: &HarnessType) -> Option<String> {
         HarnessType::Codex => env::var("CODEX_AUTH_MODE").ok(),
         HarnessType::ClaudeCode => env::var("CLAUDE_CODE_AUTH_MODE").ok(),
         HarnessType::Amp => None,
+        HarnessType::Flue => None,
     }
 }
 

--- a/services/api-rs/crates/centaur-session-cli/src/main.rs
+++ b/services/api-rs/crates/centaur-session-cli/src/main.rs
@@ -573,6 +573,7 @@ impl FromStr for ThreadKeyArg {
 enum HarnessTypeArg {
     Codex,
     Amp,
+    Flue,
     #[value(name = "claudecode")]
     ClaudeCode,
 }
@@ -582,6 +583,7 @@ impl From<HarnessTypeArg> for HarnessType {
         match value {
             HarnessTypeArg::Codex => Self::Codex,
             HarnessTypeArg::Amp => Self::Amp,
+            HarnessTypeArg::Flue => Self::Flue,
             HarnessTypeArg::ClaudeCode => Self::ClaudeCode,
         }
     }

--- a/services/api-rs/crates/centaur-session-core/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-core/src/lib.rs
@@ -124,6 +124,7 @@ pub enum HarnessType {
     Codex,
     Amp,
     ClaudeCode,
+    Flue,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, AsRefStr, Display, EnumString)]
@@ -253,6 +254,7 @@ mod tests {
     fn harness_type_accepts_supported_values() {
         assert_eq!(HarnessType::from_str("codex").unwrap(), HarnessType::Codex);
         assert_eq!(HarnessType::from_str("amp").unwrap(), HarnessType::Amp);
+        assert_eq!(HarnessType::from_str("flue").unwrap(), HarnessType::Flue);
         assert_eq!(
             HarnessType::from_str("claudecode").unwrap(),
             HarnessType::ClaudeCode
@@ -268,6 +270,10 @@ mod tests {
         assert_eq!(
             serde_json::from_value::<HarnessType>(serde_json::json!("codex")).unwrap(),
             HarnessType::Codex
+        );
+        assert_eq!(
+            serde_json::to_value(HarnessType::Flue).unwrap(),
+            serde_json::json!("flue")
         );
     }
 

--- a/services/api-rs/crates/centaur-session-runtime/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-runtime/src/lib.rs
@@ -1854,6 +1854,7 @@ fn harness_server_subcommand(harness: &HarnessType) -> &'static str {
         HarnessType::Codex => "codex",
         HarnessType::ClaudeCode => "claude-code",
         HarnessType::Amp => "amp",
+        HarnessType::Flue => "flue",
     }
 }
 
@@ -4633,10 +4634,12 @@ mod tests {
         let codex_spec = workload.spec(&thread_key, &HarnessType::Codex);
         let claude_spec = workload.spec(&thread_key, &HarnessType::ClaudeCode);
         let amp_spec = workload.spec(&thread_key, &HarnessType::Amp);
+        let flue_spec = workload.spec(&thread_key, &HarnessType::Flue);
 
         assert_eq!(codex_spec.args, vec!["harness-server", "codex"]);
         assert_eq!(claude_spec.args, vec!["harness-server", "claude-code"]);
         assert_eq!(amp_spec.args, vec!["harness-server", "amp"]);
+        assert_eq!(flue_spec.args, vec!["harness-server", "flue"]);
         // The image entrypoint must be preserved: only CMD is overridden.
         assert_eq!(codex_spec.command, None);
     }

--- a/services/api-rs/crates/centaur-session-sqlx/migrations/0026_session_flue_harness.sql
+++ b/services/api-rs/crates/centaur-session-sqlx/migrations/0026_session_flue_harness.sql
@@ -1,0 +1,6 @@
+alter table sessions
+    drop constraint if exists sessions_harness_type_supported;
+
+alter table sessions
+    add constraint sessions_harness_type_supported
+    check (harness_type in ('codex', 'amp', 'claudecode', 'flue'));

--- a/services/sandbox/Dockerfile
+++ b/services/sandbox/Dockerfile
@@ -63,6 +63,7 @@ RUN useradd -m -s /bin/bash -u 1001 agent \
 
 ARG CLAUDE_CODE_VERSION=2.1.154
 ARG CODEX_VERSION=0.139.0
+ARG FLUE_CLI_VERSION=1.0.0-beta.9
 ARG PI_CODING_AGENT_VERSION=0.67.2
 ARG NUSHELL_VERSION=0.112.2
 ARG KUBECTL_VERSION=v1.34.2
@@ -107,12 +108,14 @@ RUN --mount=type=cache,target=/root/.npm,sharing=locked \
     npm install -g --prefer-online --force \
       "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}" \
       "@openai/codex@${CODEX_VERSION}" \
+      "@flue/cli@${FLUE_CLI_VERSION}" \
       "@mariozechner/pi-coding-agent@${PI_CODING_AGENT_VERSION}" \
       "pnpm@${PNPM_VERSION}" \
       agent-browser@0.26.0 \
     && find /usr/lib/node_modules -type f \( -name '*.map' -o -name '*.tsbuildinfo' \) -delete \
     && claude --version | grep -F "${CLAUDE_CODE_VERSION}" \
     && codex --version | grep -F "${CODEX_VERSION}" \
+    && flue --version | grep -F "${FLUE_CLI_VERSION}" \
     && pnpm --version | grep -F "${PNPM_VERSION}"
 
 # ── agent-browser system deps (must run as root before USER agent) ───────────


### PR DESCRIPTION
## Summary

Adds a native Centaur `flue` harness path instead of routing Flue only through the overlay bridge.

This is intentionally a draft PR for review/architecture discussion before merge.

## What changed

- Adds `HarnessType::Flue` to the session control-plane type.
- Adds `harness-server flue` as a native harness-server subcommand.
- Adds a Flue harness adapter that maps each Centaur turn to one finite `flue run` invocation.
- Projects Flue results back onto Centaur's existing assistant/result/turn event shapes.
- Adds a DB migration allowing `sessions.harness_type = 'flue'`.
- Bakes `@flue/cli@1.0.0-beta.9` into the sandbox image.
- Updates CLI/runtime/integration harness wire-value coverage.

## Validation

- `cargo check --offline` in `crates/harness-server`
- `cargo check --offline -p centaur-session-core -p centaur-session-runtime -p centaur-session-cli` in `services/api-rs`

## Notes

Centaur still owns durable workflows and sessions. Flue is treated as the finite per-turn executor, not as the Centaur workflow engine.
