### PR TITLE
fix(slackbotv2): compose personas with harness flags

### DIFF
--- a/services/slackbotv2/src/index.ts
+++ b/services/slackbotv2/src/index.ts
@@ -142,7 +142,10 @@ type PendingLateSlackFileMention = {
   user: string
 }
 
-type StickyThreadOverrides = Pick<SlackbotV2ThreadState, 'harnessType' | 'model' | 'provider'>
+type StickyThreadOverrides = Pick<
+  SlackbotV2ThreadState,
+  'harnessType' | 'model' | 'personaId' | 'provider'
+>
 
 function stickyThreadOverrideUpdate(
   overrides: StickyThreadOverrides
@@ -154,6 +157,7 @@ function stickyThreadOverrideUpdate(
     if (!overrides.provider) update.provider = null
   }
   if (overrides.model) update.model = overrides.model
+  if (overrides.personaId) update.personaId = overrides.personaId
   if (overrides.provider) {
     update.provider = overrides.provider
     if (!overrides.model) update.model = null
@@ -168,10 +172,12 @@ function resolveStickyThreadOverrides(
   harnessType?: string
   model?: string
   provider?: string
+  personaId?: string
 } {
   return {
     harnessType: stickyOverrideValue(state, update, 'harnessType'),
     model: stickyOverrideValue(state, update, 'model'),
+    personaId: stickyOverrideValue(state, update, 'personaId'),
     provider: stickyOverrideValue(state, update, 'provider')
   }
 }
@@ -752,10 +758,17 @@ async function syncThreadMessageToSession(
         model: effectiveModel
       })
     : undefined
-  if (overrides.harnessType || overrides.model || overrides.provider || overrides.reasoning) {
+  if (
+    overrides.harnessType ||
+    overrides.model ||
+    overrides.personaId ||
+    overrides.provider ||
+    overrides.reasoning
+  ) {
     traceLog(input.options, 'slackbotv2_forward_overrides_parsed', trace, {
       harness_type: overrides.harnessType,
       model: overrides.model,
+      persona_id: overrides.personaId,
       provider: overrides.provider,
       reasoning: overrides.reasoning
     })
@@ -821,6 +834,7 @@ async function syncThreadMessageToSession(
     messages: messagesToAppend,
     model: shouldStartExecution ? effectiveOverrides.model : undefined,
     metadataModel: shouldStartExecution ? effectiveModel : undefined,
+    personaId: shouldStartExecution ? effectiveOverrides.personaId : undefined,
     provider: shouldStartExecution ? effectiveOverrides.provider : undefined,
     reasoning: overrides.reasoning,
     onEventId: eventId => {

--- a/services/slackbotv2/src/overrides.ts
+++ b/services/slackbotv2/src/overrides.ts
@@ -3,6 +3,8 @@
  *   --claude | --claude-code | --amp | --codex   pick the harness for the thread
  *   --bedrock                                    codex via the AWS Bedrock provider
  *   --meta                                       codex via Meta AI direct
+ *   --persona <id> (or --persona=<id>)           pick the persona independently
+ *   --invest                                     shortcut for --persona=invest
  *   --model <name> (or --model=<name>)           pick the model within that harness
  *   -rsn <effort> (or -rsn=<effort>)             per-turn reasoning effort (codex)
  *   --fable | --opus | --sonnet | --haiku        model shortcuts (imply claude-code)
@@ -24,6 +26,7 @@ export type MessageOverrides = {
   cleanedText: string
   harnessType?: string
   model?: string
+  personaId?: string
   provider?: string
   reasoning?: string
 }
@@ -72,6 +75,15 @@ const MODEL_FLAG_PATTERN = new RegExp(
   'i'
 )
 
+const PERSONA_FLAG_PATTERN = new RegExp(
+  String.raw`(?:^|\s)--persona${MODEL_VALUE_SEPARATOR}([A-Za-z0-9._-]+)${FLAG_VALUE_BOUNDARY}`,
+  'i'
+)
+
+const PERSONA_SHORTCUTS: Record<string, string> = {
+  invest: 'invest'
+}
+
 // Single dash by design: a short per-turn knob (`-rsn high`), so it can't reuse
 // the `--`-prefixed flagPattern() helper. Value-capturing like --model.
 const REASONING_FLAG_PATTERN = new RegExp(
@@ -98,8 +110,15 @@ export function extractMessageOverrides(text: string): MessageOverrides {
   let cleaned = text
   let harnessType: string | undefined
   let model: string | undefined
+  let personaId: string | undefined
   let provider: string | undefined
   let reasoning: string | undefined
+
+  const personaMatch = PERSONA_FLAG_PATTERN.exec(cleaned)
+  if (personaMatch) {
+    personaId = personaMatch[1]!
+    cleaned = stripMatch(cleaned, personaMatch)
+  }
 
   const modelMatch = MODEL_FLAG_PATTERN.exec(cleaned)
   if (modelMatch) {
@@ -140,10 +159,18 @@ export function extractMessageOverrides(text: string): MessageOverrides {
     cleaned = stripMatch(cleaned, match)
   }
 
+  for (const [flag, persona] of Object.entries(PERSONA_SHORTCUTS)) {
+    const match = flagPattern(flag).exec(cleaned)
+    if (!match) continue
+    personaId ??= persona
+    cleaned = stripMatch(cleaned, match)
+  }
+
   return {
     cleanedText: cleaned === text ? text : cleaned.trim(),
     harnessType,
     model,
+    personaId,
     provider,
     reasoning
   }

--- a/services/slackbotv2/src/session-api.ts
+++ b/services/slackbotv2/src/session-api.ts
@@ -475,6 +475,7 @@ export async function forwardToSessionApi(
       options,
       input.threadId,
       input.harnessType,
+      input.personaId,
       sessionRequesterMessage(input)
     ),
     sessionApiTimeoutMs(options),
@@ -725,6 +726,7 @@ async function createSession(
   options: SlackbotV2Options,
   threadId: string,
   harnessType?: string,
+  personaId?: string,
   message?: SlackbotV2ApiMessage
 ): Promise<CreateSessionOutcome> {
   const requested = harnessType ?? options.defaultHarnessType ?? DEFAULT_HARNESS_TYPE
@@ -734,8 +736,9 @@ async function createSession(
     options,
     threadId,
     requested,
+    personaId,
     message,
-    harnessType ? 'restart' : undefined
+    harnessType || personaId ? 'restart' : undefined
   )
   if (response.ok) {
     return { harnessSwitched: await harnessSwitchedFromResponse(response) }
@@ -753,7 +756,7 @@ async function createSession(
   // harness instead of failing the message.
   const existing = response.status === 409 ? existingHarnessFromConflict(body) : undefined
   if (existing && existing !== requested) {
-    const retry = await postCreateSession(options, threadId, existing, message)
+    const retry = await postCreateSession(options, threadId, existing, personaId, message)
     await ensureApiOk(retry, 'create session')
     return { harnessSwitched: false }
   }
@@ -770,6 +773,7 @@ async function postCreateSession(
   options: SlackbotV2Options,
   threadId: string,
   harnessType: string,
+  personaId?: string,
   message?: SlackbotV2ApiMessage,
   onHarnessConflict?: 'reject' | 'restart'
 ): Promise<Response> {
@@ -787,6 +791,7 @@ async function postCreateSession(
       ...sessionRequesterMetadata(message),
       ...(conversationName ? { slack_conversation_name: conversationName } : {})
     },
+    ...(personaId ? { persona_id: personaId } : {}),
     ...(onHarnessConflict ? { on_harness_conflict: onHarnessConflict } : {})
   }
   return fetchWithTimeout(

--- a/services/slackbotv2/src/types.ts
+++ b/services/slackbotv2/src/types.ts
@@ -74,6 +74,8 @@ export type SlackbotV2CreateSessionRequest = {
   metadata: JsonObject
   /** 'restart': switch the thread to harness_type if it's pinned to another harness. */
   on_harness_conflict?: 'reject' | 'restart'
+  /** Persona id selected independently from harness/model. */
+  persona_id?: string
 }
 
 export type SlackbotV2ExecuteSessionRequest = {
@@ -181,6 +183,8 @@ export type SlackbotV2ThreadState = {
   lastEventId?: number
   /** Last thread-level model selected by Slack flags. Null clears persisted state. */
   model?: string | null
+  /** Last thread-level persona selected by Slack flags. Null clears persisted state. */
+  personaId?: string | null
   /** Last thread-level model provider selected by Slack flags. Null clears persisted state. */
   provider?: string | null
   renderObligation?: SlackbotV2RenderObligation | null
@@ -230,6 +234,8 @@ export type ForwardSessionInput = {
   metadataModel?: string
   /** Effective model provider selected by sticky thread flags (--bedrock); codex only. */
   provider?: string
+  /** Effective persona selected by sticky thread flags (--persona/--invest). */
+  personaId?: string
   /** Per-turn reasoning effort parsed from the `-rsn` flag (codex only). */
   reasoning?: string
   onEventId(eventId: number): void

--- a/services/slackbotv2/test/chat-sdk-emulate.test.ts
+++ b/services/slackbotv2/test/chat-sdk-emulate.test.ts
@@ -349,14 +349,14 @@ describe('slackbotv2', () => {
   // The paragraph break (`\n\n`) after the model value is deliberate: the
   // unpatched chat SDK dropped it, gluing the value to the next word
   // (`fablefirst`); this exercises the patched extractPlainText end to end.
-  it('keeps harness and model flags sticky within a Slack thread', async () => {
+  it('keeps persona, harness, and model flags sticky within a Slack thread', async () => {
     const sharedState = createMemoryState()
     await sharedState.connect()
     bot = createTestBot({ state: sharedState })
 
     const parent = await postUserMessage('Thread default context.')
     const firstMention = await postUserMessage(
-      `<@${BOT_USER_ID}> --claude --model=fable\n\nfirst pass`,
+      `<@${BOT_USER_ID}> --invest --claude --model=fable\n\nfirst pass`,
       parent.ts
     )
     const firstWaits: Promise<unknown>[] = []
@@ -371,7 +371,7 @@ describe('slackbotv2', () => {
           team: TEAM_ID,
           ts: firstMention.ts,
           thread_ts: parent.ts,
-          text: `<@${BOT_USER_ID}> --claude --model=fable\n\nfirst pass`
+          text: `<@${BOT_USER_ID}> --invest --claude --model=fable\n\nfirst pass`
         }
       }),
       {},
@@ -409,6 +409,10 @@ describe('slackbotv2', () => {
       'claudecode',
       'claudecode'
     ])
+    expect(codexApi.creates.map(create => create.body.persona_id)).toEqual([
+      'invest',
+      'invest'
+    ])
     expect(codexApi.executes).toHaveLength(2)
     const firstInput = JSON.parse(codexApi.executes[0]!.body.input_lines.at(-1)!) as Record<
       string,
@@ -420,6 +424,7 @@ describe('slackbotv2', () => {
     >
     expect(firstInput.model).toBe('claude-fable-5')
     expect(secondInput.model).toBe('claude-fable-5')
+    expect(JSON.stringify(firstInput)).not.toContain('--invest')
     expect(JSON.stringify(firstInput)).not.toContain('--claude')
     expect(JSON.stringify(firstInput)).not.toContain('--model')
     expect(JSON.stringify(firstInput)).toContain('first pass')
@@ -431,7 +436,8 @@ describe('slackbotv2', () => {
     expect(state).toEqual(
       expect.objectContaining({
         harnessType: 'claudecode',
-        model: 'claude-fable-5'
+        model: 'claude-fable-5',
+        personaId: 'invest'
       })
     )
   })

--- a/services/slackbotv2/test/overrides.test.ts
+++ b/services/slackbotv2/test/overrides.test.ts
@@ -53,6 +53,26 @@ describe('extractMessageOverrides', () => {
     })
   })
 
+  test('parses persona independently from harness and model', () => {
+    expect(extractMessageOverrides('--invest --claude --model=fable reason through this')).toEqual({
+      cleanedText: 'reason through this',
+      harnessType: 'claudecode',
+      model: 'claude-fable-5',
+      personaId: 'invest',
+      reasoning: undefined
+    })
+    expect(extractMessageOverrides('--persona eng --codex debug this')).toEqual({
+      cleanedText: 'debug this',
+      harnessType: 'codex',
+      model: undefined,
+      personaId: 'eng',
+      reasoning: undefined
+    })
+    expect(extractMessageOverrides('--persona=legal --sonnet review this').personaId).toBe(
+      'legal'
+    )
+  })
+
   test('model shortcuts set model and imply claude-code', () => {
     expect(extractMessageOverrides('--opus fix it')).toEqual({
       cleanedText: 'fix it',

--- a/services/slackbotv2/test/session-api.test.ts
+++ b/services/slackbotv2/test/session-api.test.ts
@@ -532,6 +532,25 @@ describe('forwardToSessionApi overrides', () => {
     expect((create?.body as { harness_type?: string }).harness_type).toBe('claudecode')
   })
 
+  test('creates session with persona independent from harness override', async () => {
+    const { fetchFn, requests } = fakeApi()
+    await forwardToSessionApi(
+      options(fetchFn),
+      forwardInput(apiMessage('review this'), {
+        harnessType: 'claudecode',
+        personaId: 'invest'
+      })
+    )
+    const create = requests.find(request => request.url.endsWith('.000100'))
+    expect(create?.body).toEqual(
+      expect.objectContaining({
+        harness_type: 'claudecode',
+        on_harness_conflict: 'restart',
+        persona_id: 'invest'
+      })
+    )
+  })
+
   test('includes model override on the execute input line', async () => {
     const { fetchFn, requests } = fakeApi()
     await forwardToSessionApi(


### PR DESCRIPTION
## Summary
- parse persona directives independently from harness/model flags
- forward `persona_id` during session creation so runtime persona prompts/env apply across harnesses
- keep persona sticky in Slack threads and cover `--invest --claude --model=fable` with regression tests

## Tests
- `bun test services/slackbotv2/test/overrides.test.ts services/slackbotv2/test/session-api.test.ts services/slackbotv2/test/chat-sdk-emulate.test.ts`
- `bun run --cwd services/slackbotv2 check:types`

Prompted by: arjun