### PR TITLE
fix(harness): make codex attach Responses item ids for the Meta (--meta) provider

### DIFF
--- a/harness/codex/config.toml
+++ b/harness/codex/config.toml
@@ -32,7 +32,17 @@ wire_api = "responses"
 requires_openai_auth = false
 
 [model_providers.responses]
-name = "Meta AI direct"
+# The name "azure" is load-bearing, not cosmetic: codex strips the `id` field
+# from Responses input items (`#[serde(skip_serializing)]` on ResponseItem ids)
+# and only re-attaches them via `attach_item_ids` when
+# `is_azure_responses_provider(name, base_url)` matches — i.e. name == "azure"
+# or an Azure base URL. Meta's Responses endpoint, like Azure's, rejects
+# replayed history items without ids (`input[N] missing required field id`),
+# so long --meta turns fail once the model round-trips its own prior
+# reasoning/tool items. Rename back to a display name once we're on
+# codex >= 0.142.0 with `[features] item_ids = true`, which preserves ids for
+# all Responses providers.
+name = "azure"
 base_url = "https://api.ai.meta.com/v1"
 env_key = "META_AI_API_KEY"
 wire_api = "responses"


### PR DESCRIPTION
## Problem

```
Execution failed: {"error":{"code":null,"message":"`input[66]` missing required field `id`","param":"input[66]","type":"invalid_request_error"}}
```

## Root cause

- codex serializes Responses-API input items with their `id` fields stripped (`#[serde(skip_serializing)]` on `ResponseItem` ids, [protocol/src/models.rs](https://github.com/openai/codex/blob/rust-v0.139.0/codex-rs/protocol/src/models.rs)).
- It only re-attaches ids via `attach_item_ids` when the provider is detected as Azure — `is_azure_responses_provider(name, base_url)` matches `name == "azure"` or an Azure base URL ([codex-api/src/endpoint/responses.rs#L86](https://github.com/openai/codex/blob/rust-v0.139.0/codex-rs/codex-api/src/endpoint/responses.rs#L86), [codex-api/src/provider.rs#L88](https://github.com/openai/codex/blob/rust-v0.139.0/codex-rs/codex-api/src/provider.rs#L88)).
- Our Meta provider (`[model_providers.responses]`, base_url `api.ai.meta.com`) is not detected as Azure, so ids stay stripped. Meta's Responses endpoint — like Azure's — requires `id` on replayed history items, so any turn long enough for the model to round-trip its own prior reasoning/tool items 400s (`input[66]` here = 67th history item within the memo turn).

## Fix

Rename the provider to `azure` in `harness/codex/config.toml`. The name is codex's opt-in switch for the Azure Responses workaround (`store: true` + `attach_item_ids`); the `--meta` flag mapping keys off the table key `responses` and is unchanged, as are base URL and auth.

## Caveats / follow-up

- `name == "azure"` also flips `supports_remote_compaction` on, so codex will try remote compaction against Meta at context pressure — unverified whether Meta supports that endpoint.
- Items restored from a rollout on `thread/resume` never had ids persisted (same `skip_serializing`), so a `--meta` thread resumed after sandbox recycling may still hit this on its first post-resume turn.
- The durable fix for both caveats is bumping codex to >= 0.142.0 (currently pinned 0.139.0 in `services/sandbox/Dockerfile`) and enabling `[features] item_ids = true`, which preserves/assigns item ids for all Responses providers ([openai/codex#28814](https://github.com/openai/codex/pull/28814), merged 2026-06-19). That bump also needs the `codex-*` crate revs in `crates/harness-server/Cargo.toml` moved in lockstep, so it's left out of this minimal mitigation.

Prompted by: mslipper