### PR TITLE
ci: rebuild images for harness config changes

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -8,6 +8,7 @@ on:
       - .github/workflows/publish-images.yml
       - services/**
       - crates/harness-server/**
+      - harness/**
       - centaur_sdk/**
       - packages/**
       - tools/**


### PR DESCRIPTION
Adds the harness config directory to the publish-images path filter so changes to Codex harness config trigger the image build workflow. This ensures the centaur-agent image is rebuilt when harness/codex/config.toml changes.