### PR TITLE
chore: bump iron-proxy to v0.46.0

### DIFF
--- a/services/iron-proxy/Dockerfile
+++ b/services/iron-proxy/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.7
 
-FROM ironsh/iron-proxy:0.46.0-rc.1@sha256:8d78eb486e4298078fe0fa19803094dd6cf1b8ca12d956ae5e1cdfcac0f5e5c2
+FROM ironsh/iron-proxy:0.46.0@sha256:2561948695928b0fa4b78835ae2b437c9915f209a59442a5807a86c0d70e950d
 
 USER root
 RUN --mount=type=cache,target=/var/cache/apk,sharing=locked \


### PR DESCRIPTION
Bumps the iron-proxy base image from the v0.46.0 release candidate to the final v0.46.0 image, keeping the Dockerfile pinned to the published multi-arch digest.