### PR TITLE
fix(iron-proxy): bump base image to 0.46.0

### DIFF
--- a/services/iron-proxy/Dockerfile
+++ b/services/iron-proxy/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.7
 
-FROM ironsh/iron-proxy:0.46.0-rc.1@sha256:8d78eb486e4298078fe0fa19803094dd6cf1b8ca12d956ae5e1cdfcac0f5e5c2
+FROM ironsh/iron-proxy:0.46.0@sha256:ce65e5efe68635b0867005d7b7b730f58b5aa112433b418a28d254682706a2fb
 
 USER root
 RUN --mount=type=cache,target=/var/cache/apk,sharing=locked \


### PR DESCRIPTION
## Summary
- bump `services/iron-proxy/Dockerfile` from `ironsh/iron-proxy:0.46.0-rc.1` to the final `ironsh/iron-proxy:0.46.0` image digest

Prompted by: mslipper

## Verification
- `docker manifest inspect ironsh/iron-proxy:0.46.0`
- `git diff --check`
