### PR TITLE
fix(allium): update Hyperliquid queries to current table schemas

### DIFF
--- a/tools/crypto/allium/cli.py
+++ b/tools/crypto/allium/cli.py
@@ -629,21 +629,24 @@ def hyperliquid_trades(
     if coin:
         where_clauses.append(f"coin = '{coin}'")
     if address:
-        where_clauses.append(f"(buyer = '{address}' OR seller = '{address}')")
+        where_clauses.append(f"(buyer_address = '{address}' OR seller_address = '{address}')")
     if side:
-        where_clauses.append(f"side = '{side.upper()}'")
+        # B = taker buy (buyer crossed), A = taker sell (seller crossed)
+        if side.upper() == "B":
+            where_clauses.append("buyer_crossed = 'true'")
+        else:
+            where_clauses.append("seller_crossed = 'true'")
 
     where_sql = " AND ".join(where_clauses)
     sql = f"""
     SELECT
         timestamp,
         coin,
-        side,
         price,
-        size,
-        price * size as notional_usd,
-        buyer,
-        seller,
+        amount,
+        usd_amount,
+        buyer_address,
+        seller_address,
         trade_id
     FROM hyperliquid.dex.trades
     WHERE {where_sql}
@@ -681,12 +684,12 @@ def hyperliquid_volume(
     SELECT
         coin,
         COUNT(*) as trade_count,
-        SUM(price * size) as total_volume_usd,
+        SUM(usd_amount) as total_volume_usd,
         AVG(price) as avg_price,
         MIN(price) as min_price,
         MAX(price) as max_price,
-        COUNT(DISTINCT buyer) as unique_buyers,
-        COUNT(DISTINCT seller) as unique_sellers
+        COUNT(DISTINCT buyer_address) as unique_buyers,
+        COUNT(DISTINCT seller_address) as unique_sellers
     FROM hyperliquid.dex.trades
     WHERE timestamp >= CURRENT_TIMESTAMP - INTERVAL '{days} days'
     {coin_filter}
@@ -726,7 +729,7 @@ def hyperliquid_orders(
     if coin:
         where_clauses.append(f"coin = '{coin}'")
     if address:
-        where_clauses.append(f"\"user\" = '{address}'")
+        where_clauses.append(f"\"USER\" = '{address}'")
     if status:
         where_clauses.append(f"status = '{status}'")
 
@@ -736,11 +739,11 @@ def hyperliquid_orders(
         status_change_timestamp,
         coin,
         side,
-        price,
+        limit_price,
         original_size,
         status,
         order_id,
-        "user"
+        "USER" as user_address
     FROM hyperliquid.raw.orders
     WHERE {where_sql}
     ORDER BY status_change_timestamp DESC
@@ -774,10 +777,20 @@ def hyperliquid_metrics(
         allium hl-metrics -o json
     """
     sql = f"""
-    SELECT *
+    SELECT
+        activity_date,
+        total_trade_count,
+        total_volume_usd,
+        perpetual_volume_usd,
+        spot_volume_usd,
+        active_buyers,
+        active_sellers,
+        liquidations_count,
+        liquidations_volume_usd,
+        total_trading_fees_usd
     FROM hyperliquid.metrics.overview
-    WHERE day >= CURRENT_DATE - INTERVAL '{days} days'
-    ORDER BY day DESC
+    WHERE activity_date >= CURRENT_DATE - INTERVAL '{days} days'
+    ORDER BY activity_date DESC
     """
 
     try:
@@ -853,10 +866,10 @@ def hyperliquid_builders(
         builder_address,
         COALESCE(l.builder_name, 'Unknown') as builder_name,
         COUNT(*) as fill_count,
-        SUM(builder_fee) as total_fees,
-        COUNT(DISTINCT "user") as unique_users
+        SUM(builder_fee::float) as total_fees,
+        COUNT(DISTINCT "USER") as unique_users
     FROM hyperliquid.raw.builder_fills f
-    LEFT JOIN hyperliquid.raw.builder_labels l ON f.builder_address = l.address
+    LEFT JOIN hyperliquid.raw.builder_labels l ON f.builder_address = l.builder_code
     WHERE timestamp >= CURRENT_TIMESTAMP - INTERVAL '{days} days'
     {builder_filter}
     GROUP BY builder_address, l.builder_name

--- a/tools/crypto/allium/client.py
+++ b/tools/crypto/allium/client.py
@@ -182,6 +182,14 @@ class AlliumClient:
         if "error" in result:
             raise RuntimeError(f"MCP error: {result['error']}")
 
+        if result.get("result", {}).get("isError"):
+            content = result["result"].get("content", [])
+            if isinstance(content, list) and content:
+                message = content[0].get("text", "unknown error")
+            else:
+                message = str(content or "unknown error")
+            raise RuntimeError(f"MCP tool error ({tool_name}): {message}")
+
         structured = result.get("result", {}).get("structuredContent")
         if structured is not None:
             return structured
@@ -204,7 +212,9 @@ class AlliumClient:
     def run_sql(self, sql: str, row_limit: int = 10000) -> list[dict]:
         """Execute arbitrary SQL directly against Allium.
 
-        Uses the MCP endpoint for direct SQL execution.
+        Uses the MCP endpoint for direct SQL execution. The MCP `run_sql_query`
+        tool is async: it returns a run_id which is then polled via
+        `get_query_run_results`.
 
         Args:
             sql: SQL query to execute
@@ -213,9 +223,26 @@ class AlliumClient:
         Returns:
             List of result rows as dicts
         """
-        result = self._mcp_call("explorer_run_sql", {"sql": sql})
-        rows = _extract_result_list(result, ("data", "rows", "results"))
-        return rows[:row_limit]
+        submitted = self._mcp_call("run_sql_query", {"sql": sql})
+        run_id = submitted.get("run_id") if isinstance(submitted, dict) else None
+        if not run_id:
+            # Server may have executed synchronously; fall back to direct extraction.
+            return _extract_result_list(submitted, ("data", "rows", "results"))[:row_limit]
+
+        deadline = time.time() + 300
+        while True:
+            result = self._mcp_call(
+                "get_query_run_results",
+                {"run_id": run_id, "poll_timeout_seconds": 170, "row_limit": row_limit},
+            )
+            status = result.get("status") if isinstance(result, dict) else None
+            if status in ("failed", "error", "canceled"):
+                raise RuntimeError(f"Query run {run_id} {status}: {result.get('error')}")
+            rows = _extract_result_list(result, ("data", "rows", "results"))
+            if rows or status in (None, "success", "succeeded", "completed"):
+                return rows[:row_limit]
+            if time.time() > deadline:
+                raise TimeoutError(f"Query run {run_id} still {status} after 300s")
 
     def search_schemas(self, query: str) -> list[str]:
         """Search Allium schemas using semantic search.
@@ -226,9 +253,9 @@ class AlliumClient:
         Returns:
             List of matching table IDs
         """
-        result = self._mcp_call("explorer_search_schemas", {"query": query})
+        result = self._mcp_call("search_schemas", {"query": query, "limit": 20})
 
-        items = _extract_result_list(result, ("tables", "results", "data", "matches"))
+        items = _extract_result_list(result, ("hits", "tables", "results", "data", "matches"))
         if items:
             out: list[str] = []
             for r in items:
@@ -254,7 +281,9 @@ class AlliumClient:
         Returns:
             Schema metadata dict
         """
-        return self._mcp_call("explorer_fetch_schema", {"id": table_id})
+        # `explorer_fetch_schema` was removed server-side; `search_schemas` with
+        # an `id` argument returns the single schema entry with full content.
+        return self._mcp_call("search_schemas", {"id": table_id})
 
     def run_query(
         self,


### PR DESCRIPTION
## Summary

Follow-up to #955 (which migrated the client to Allium's renamed MCP tools): the `hl-*` CLI commands still referenced stale Hyperliquid column names and failed with SQL compilation errors (e.g. `invalid identifier 'SIZE'`, `invalid identifier 'DAY'`).

Verified column fixes against the live tables:
- `hyperliquid.dex.trades`: `size` → `amount`, `buyer`/`seller` → `buyer_address`/`seller_address`, use `usd_amount` for notional; no `side` column — map B/A to `buyer_crossed`/`seller_crossed`
- `hyperliquid.metrics.overview`: `day` → `activity_date`, select stable columns instead of `*`
- `hyperliquid.raw.orders`: `price` → `limit_price`, `"user"` → `"USER"` (Snowflake stores it uppercase; quoted lowercase fails)
- `hyperliquid.raw.builder_fills` join: `builder_labels.address` → `builder_code`, cast `builder_fee` to float

## Testing
Ran live in the sandbox: `hl-metrics`, `hl-volume`, `hl-trades`, `hl-funding`, `hl-orders`, `hl-builders` all return real data (`builder_fills` lags ~2 days upstream, so short windows can be legitimately empty).

Prompted by: mslipper