### PR TITLE
feat(console): workflows dashboard cleanup — grouping, filters, pagination, force-start, debugging

### DIFF
--- a/services/console/app/controllers/console/workflows_controller.rb
+++ b/services/console/app/controllers/console/workflows_controller.rb
@@ -2,6 +2,8 @@ class Console::WorkflowsController < ApplicationController
   layout "console"
   before_action :require_admin
 
+  class_attribute :client_factory, default: -> { CentaurApiClient.new }
+
   PER_PAGE = 50
 
   def index
@@ -69,6 +71,8 @@ class Console::WorkflowsController < ApplicationController
       status: @status,
       queue: @queue
     )
+
+    load_workflow_api_details
   rescue ActiveRecord::ActiveRecordError, PG::Error => e
     Rails.logger.warn("console_workflow_load_failed workflow=#{@workflow_name} error=#{e.class}: #{e.message}")
     @workflow_db_unavailable = true
@@ -76,7 +80,69 @@ class Console::WorkflowsController < ApplicationController
     @latest_run = nil
   end
 
+  # Enqueue a run through the workflows API. Scheduled workflows are started
+  # with their registered schedule input so a forced run matches a normal tick.
+  def force_start
+    workflow_name = params[:id].to_s
+    schedule = workflow_schedules_for(workflow_name).first
+    result = api_client.create_workflow_run(
+      workflow_name: workflow_name,
+      input: schedule&.dig("input")
+    )
+    notice =
+      if result["created"] == false
+        "A run with this idempotency key is already queued (#{result["run_id"]})."
+      else
+        "Run queued (#{result["run_id"]})."
+      end
+    redirect_to console_workflow_path(workflow_name), notice: notice
+  rescue StandardError => e
+    Rails.logger.warn("console_workflow_force_start_failed workflow=#{workflow_name} error=#{e.class}: #{e.message}")
+    redirect_to console_workflow_path(workflow_name), alert: "Could not start workflow: #{e.message}"
+  end
+
   private
+
+  # Best-effort enrichment from the workflows API: the registered schedule
+  # (cron/interval, source path for the GitHub link) and the latest run's
+  # input/result/failure for debugging. The page renders without any of it
+  # when the API is unreachable.
+  def load_workflow_api_details
+    @workflow_schedules = workflow_schedules_for(@workflow_name)
+    @latest_run_detail = fetch_run_detail(@latest_run&.run_id)
+
+    return if @latest_run_detail.blank? && @workflow_schedules.blank?
+    return if @latest_run&.display_status == "failed"
+    return unless @status_counts["failed"].to_i.positive?
+
+    failed_run = CentaurWorkflowRun.for_workflow(@workflow_name, limit: 1, status: "failed").first
+    @latest_failure_detail = fetch_run_detail(failed_run&.run_id)
+  end
+
+  def workflow_schedules_for(workflow_name)
+    response = api_client.list_workflow_schedules
+    Array(response["schedules"]).select do |schedule|
+      schedule.is_a?(Hash) && schedule["workflow_name"] == workflow_name
+    end
+  rescue StandardError => e
+    Rails.logger.warn("console_workflow_schedules_failed error=#{e.class}: #{e.message}")
+    []
+  end
+
+  def fetch_run_detail(run_id)
+    return nil if run_id.blank?
+
+    response = api_client.get_workflow_run(run_id)
+    detail = response["run"]
+    detail.is_a?(Hash) ? detail : nil
+  rescue StandardError => e
+    Rails.logger.warn("console_workflow_run_detail_failed run=#{run_id} error=#{e.class}: #{e.message}")
+    nil
+  end
+
+  def api_client
+    @api_client ||= self.class.client_factory.call
+  end
 
   def page_param
     page = Integer(params[:page].to_s, 10, exception: false) || 1

--- a/services/console/app/controllers/console/workflows_controller.rb
+++ b/services/console/app/controllers/console/workflows_controller.rb
@@ -2,45 +2,84 @@ class Console::WorkflowsController < ApplicationController
   layout "console"
   before_action :require_admin
 
-  WORKFLOW_LIMIT = 200
-  WORKFLOW_HISTORY_LIMIT = 1_000
+  PER_PAGE = 50
 
   def index
     @workflow_db_unavailable = false
     @workflow_runs = []
+    @queue_breakdown = {}
+    @page = page_param
+    @total_pages = 1
 
     unless CentaurWorkflowRun.available?
       @workflow_db_unavailable = true
       return
     end
 
-    @workflow_runs = CentaurWorkflowRun.recent(limit: WORKFLOW_LIMIT)
+    @total_workflows = CentaurWorkflowRun.workflow_count
+    @total_pages = [ (@total_workflows.to_f / PER_PAGE).ceil, 1 ].max
+    @page = [ @page, @total_pages ].min
+
+    @workflow_runs = CentaurWorkflowRun.latest_per_workflow(
+      limit: PER_PAGE,
+      offset: (@page - 1) * PER_PAGE
+    )
+    @queue_breakdown = CentaurWorkflowRun.latest_per_queue(@workflow_runs.map(&:workflow_key))
   rescue ActiveRecord::ActiveRecordError, PG::Error => e
     Rails.logger.warn("console_workflows_load_failed error=#{e.class}: #{e.message}")
     @workflow_db_unavailable = true
     @workflow_runs = []
+    @queue_breakdown = {}
   end
 
   def show
     @workflow_db_unavailable = false
     @workflow_name = params[:id].to_s
     @workflow_runs = []
+    @status_counts = {}
+    @queue_names = []
+    @status = params[:status].presence
+    @queue = params[:queue].presence
+    @page = page_param
+    @total_pages = 1
 
     unless CentaurWorkflowRun.available?
       @workflow_db_unavailable = true
       return
     end
 
+    @latest_run = CentaurWorkflowRun.for_workflow(@workflow_name, limit: 1).first
+    if @latest_run.blank?
+      response.status = :not_found
+      return
+    end
+
+    @status_counts = CentaurWorkflowRun.status_counts(@workflow_name)
+    @total_runs = @status_counts.values.sum
+    @queue_names = CentaurWorkflowRun.queue_names(@workflow_name)
+
+    @filtered_count = CentaurWorkflowRun.run_count(@workflow_name, status: @status, queue: @queue)
+    @total_pages = [ (@filtered_count.to_f / PER_PAGE).ceil, 1 ].max
+    @page = [ @page, @total_pages ].min
+
     @workflow_runs = CentaurWorkflowRun.for_workflow(
       @workflow_name,
-      limit: WORKFLOW_HISTORY_LIMIT
+      limit: PER_PAGE,
+      offset: (@page - 1) * PER_PAGE,
+      status: @status,
+      queue: @queue
     )
-    @latest_run = @workflow_runs.first
-    response.status = :not_found if @latest_run.blank?
   rescue ActiveRecord::ActiveRecordError, PG::Error => e
     Rails.logger.warn("console_workflow_load_failed workflow=#{@workflow_name} error=#{e.class}: #{e.message}")
     @workflow_db_unavailable = true
     @workflow_runs = []
     @latest_run = nil
+  end
+
+  private
+
+  def page_param
+    page = Integer(params[:page].to_s, 10, exception: false) || 1
+    page < 1 ? 1 : page
   end
 end

--- a/services/console/app/helpers/application_helper.rb
+++ b/services/console/app/helpers/application_helper.rb
@@ -42,6 +42,57 @@ module ApplicationHelper
     end
   end
 
+  # Engine names rendered the way the Chats page renders harness types
+  # (Console::ThreadsController#thread_harness_label): known harnesses get
+  # their product names, anything else is capitalized word-wise.
+  def workflow_engine_label(harness_type)
+    case harness_type.to_s
+    when "codex" then "Codex"
+    when "claudecode" then "Claude Code"
+    when "amp" then "Amp"
+    when "" then nil
+    else harness_type.to_s.tr("_-", " ").squish.split.map(&:capitalize).join(" ")
+    end
+  end
+
+  # GitHub URL for a workflow source path reported by the workflow host.
+  # Paths are repo-relative; an overlay-repo prefix ("centaur-tempo/...") maps
+  # to the tempo overlay repo, everything else to the main centaur repo.
+  def workflow_source_url(source_path)
+    path = source_path.to_s
+    return nil if path.blank?
+
+    if path.start_with?("centaur-tempo/")
+      "https://github.com/tempoxyz/centaur-tempo/blob/main/#{path.delete_prefix("centaur-tempo/")}"
+    else
+      "https://github.com/paradigmxyz/centaur/blob/main/#{path}"
+    end
+  end
+
+  # Human label for a workflow schedule from the workflows API, e.g.
+  # "cron */5 * * * *" or "every 5m". The kind is the serde-tagged enum
+  # {"type":"cron","cron":...} | {"type":"interval","interval_seconds":...}.
+  def workflow_schedule_label(schedule)
+    kind = schedule.is_a?(Hash) ? schedule["kind"] : nil
+    return nil unless kind.is_a?(Hash)
+
+    case kind["type"]
+    when "cron"
+      "cron #{kind["cron"]}"
+    when "interval"
+      seconds = kind["interval_seconds"].to_i
+      "every #{seconds % 60 == 0 && seconds >= 60 ? "#{seconds / 60}m" : "#{seconds}s"}"
+    end
+  end
+
+  # Pretty-printed JSON for workflow run payloads (input/result/failure).
+  # Falls back to to_s for values the generator refuses.
+  def workflow_debug_json(value)
+    JSON.pretty_generate(value)
+  rescue JSON::GeneratorError
+    value.to_s
+  end
+
   def workflow_duration_label(run)
     started_at = run.started_or_created_at
     finished_at = run.terminal_at

--- a/services/console/app/helpers/application_helper.rb
+++ b/services/console/app/helpers/application_helper.rb
@@ -36,7 +36,7 @@ module ApplicationHelper
     when "completed" then "border-centaur-500/30 bg-centaur-500/10 text-centaur-300"
     when "running" then "border-sky-500/40 bg-sky-500/10 text-sky-300"
     when "failed" then "border-red-500/40 bg-red-500/10 text-red-300"
-    when "cancelled" then "border-zinc-600 bg-zinc-700/40 text-zinc-400"
+    when "cancelled" then "border-ink-600 bg-ink-800/80 text-zinc-400"
     when "pending", "sleeping" then "border-amber-500/40 bg-amber-500/10 text-amber-300"
     else "border-ink-600 bg-ink-800/80 text-zinc-400"
     end

--- a/services/console/app/models/centaur_workflow_run.rb
+++ b/services/console/app/models/centaur_workflow_run.rb
@@ -2,10 +2,28 @@ class CentaurWorkflowRun < CentaurSessionRecord
   self.table_name = "centaur_readonly_workflow_runs"
   self.primary_key = "run_id"
 
-  RECENT_ORDER = Arel.sql(
+  RECENCY_SQL =
     "coalesce(completed_at, failed_at, cancelled_at, started_at, " \
-      "first_started_at, available_at, created_at) desc, task_id desc"
-  )
+      "first_started_at, available_at, created_at)".freeze
+
+  RECENT_ORDER = Arel.sql("#{RECENCY_SQL} desc, task_id desc")
+
+  # Mirrors #workflow_key: runs are grouped under their workflow name, falling
+  # back to the task name for runs enqueued before workflow names were recorded.
+  WORKFLOW_KEY_SQL =
+    "coalesce(nullif(workflow_name, ''), nullif(task_name, ''))".freeze
+
+  # SQL twin of #display_status so status filters and tab counts agree with the
+  # badge rendered for each row.
+  DISPLAY_STATUS_SQL = <<~SQL.squish.freeze
+    CASE
+      WHEN cancelled_at IS NOT NULL THEN 'cancelled'
+      WHEN failed_at IS NOT NULL THEN 'failed'
+      WHEN completed_at IS NOT NULL THEN 'completed'
+      WHEN claimed OR state = 'running' THEN 'running'
+      ELSE coalesce(nullif(state, ''), 'unknown')
+    END
+  SQL
 
   scope :recent_first, -> { order(RECENT_ORDER) }
 
@@ -18,12 +36,88 @@ class CentaurWorkflowRun < CentaurSessionRecord
       recent_first.limit(limit).to_a
     end
 
-    def for_workflow(workflow_name, limit:)
-      where(
+    # The most recent run of each distinct workflow, newest activity first.
+    def latest_per_workflow(limit:, offset: 0)
+      find_by_sql([ <<~SQL, { limit: limit, offset: offset } ])
+        SELECT * FROM (
+          SELECT DISTINCT ON (#{WORKFLOW_KEY_SQL}) *
+          FROM #{table_name}
+          ORDER BY #{WORKFLOW_KEY_SQL}, #{RECENCY_SQL} DESC, task_id DESC
+        ) latest_runs
+        ORDER BY #{RECENCY_SQL} DESC, task_id DESC
+        LIMIT :limit OFFSET :offset
+      SQL
+    end
+
+    def workflow_count
+      count_by_sql(
+        "SELECT COUNT(*) FROM " \
+          "(SELECT DISTINCT #{WORKFLOW_KEY_SQL} FROM #{table_name}) workflow_keys"
+      )
+    end
+
+    # The most recent run per (workflow, queue) for the given workflow keys,
+    # grouped by workflow key. Each run carries a queue_run_count attribute with
+    # that queue's total run count. Feeds the per-queue lines on the index.
+    def latest_per_queue(workflow_keys)
+      keys = workflow_keys.compact.uniq
+      return {} if keys.empty?
+
+      runs = find_by_sql([ <<~SQL, { keys: keys } ])
+        SELECT DISTINCT ON (#{WORKFLOW_KEY_SQL}, queue_name) *,
+          COUNT(*) OVER (PARTITION BY #{WORKFLOW_KEY_SQL}, queue_name) AS queue_run_count
+        FROM #{table_name}
+        WHERE #{WORKFLOW_KEY_SQL} IN (:keys)
+        ORDER BY #{WORKFLOW_KEY_SQL}, queue_name, #{RECENCY_SQL} DESC, task_id DESC
+      SQL
+
+      runs
+        .group_by(&:workflow_key)
+        .transform_values { |queue_runs| queue_runs.sort_by { |run| run.recency_at&.to_time.to_i }.reverse }
+    end
+
+    def for_workflow(workflow_name, limit:, offset: 0, status: nil, queue: nil)
+      workflow_scope(workflow_name, status: status, queue: queue)
+        .recent_first
+        .limit(limit)
+        .offset(offset)
+        .to_a
+    end
+
+    def run_count(workflow_name, status: nil, queue: nil)
+      workflow_scope(workflow_name, status: status, queue: queue).count
+    end
+
+    # { "completed" => 12, "running" => 1, ... } for one workflow's runs.
+    def status_counts(workflow_name)
+      workflow_scope(workflow_name)
+        .group(Arel.sql(DISPLAY_STATUS_SQL))
+        .count
+    end
+
+    def queue_names(workflow_name)
+      workflow_scope(workflow_name)
+        .distinct
+        .order(:queue_name)
+        .pluck(:queue_name)
+    end
+
+    def queue_label_for(queue_name)
+      suffix = queue_name.to_s.delete_prefix("centaur_workflows").delete_prefix("_")
+      suffix.presence&.tr("_", " ") || "default"
+    end
+
+    private
+
+    def workflow_scope(workflow_name, status: nil, queue: nil)
+      scope = where(
         "workflow_name = :workflow_name OR " \
           "((workflow_name IS NULL OR workflow_name = '') AND task_name = :workflow_name)",
         workflow_name: workflow_name
-      ).recent_first.limit(limit).to_a
+      )
+      scope = scope.where("#{DISPLAY_STATUS_SQL} = ?", status) if status.present?
+      scope = scope.where(queue_name: queue) if queue.present?
+      scope
     end
   end
 
@@ -38,8 +132,7 @@ class CentaurWorkflowRun < CentaurSessionRecord
   end
 
   def queue_label
-    suffix = queue_name.to_s.delete_prefix("centaur_workflows").delete_prefix("_")
-    suffix.presence&.tr("_", " ") || "default"
+    self.class.queue_label_for(queue_name)
   end
 
   def display_status
@@ -57,5 +150,9 @@ class CentaurWorkflowRun < CentaurSessionRecord
 
   def terminal_at
     completed_at || failed_at || cancelled_at
+  end
+
+  def recency_at
+    terminal_at || started_at || first_started_at || available_at || created_at
   end
 end

--- a/services/console/app/services/centaur_api_client.rb
+++ b/services/console/app/services/centaur_api_client.rb
@@ -95,6 +95,21 @@ class CentaurApiClient
     post("/api/session/#{escape_path(thread_key)}/execute", payload)
   end
 
+  def list_workflow_schedules
+    get("/api/workflows/schedules")
+  end
+
+  def get_workflow_run(run_id)
+    get("/api/workflows/runs/#{escape_path(run_id)}")
+  end
+
+  def create_workflow_run(workflow_name:, input: nil)
+    payload = { workflow_name: workflow_name }
+    payload[:input] = input unless input.nil?
+
+    post("/api/workflows/runs", payload)
+  end
+
   private
 
   def get(path, params = {})

--- a/services/console/app/views/console/workflows/_pagination.html.erb
+++ b/services/console/app/views/console/workflows/_pagination.html.erb
@@ -1,0 +1,25 @@
+<%# Prev/next pager footer. Locals: page, total_pages, total_count, unit.
+    Preserves the current query params (filters) while swapping the page. %>
+<% page_url = ->(n) { "#{request.path}?#{request.query_parameters.merge("page" => n).to_query}" } %>
+<div class="flex items-center justify-between gap-4 border-t border-ink-700 px-5 py-3 text-xs text-zinc-500">
+  <div>
+    <%= number_with_delimiter(total_count) %> <%= unit.pluralize(total_count) %>
+    <% if total_pages > 1 %>
+      <span class="text-zinc-600">· page <%= page %> of <%= number_with_delimiter(total_pages) %></span>
+    <% end %>
+  </div>
+  <% if total_pages > 1 %>
+    <div class="flex items-center gap-2">
+      <% if page > 1 %>
+        <%= link_to "Previous", page_url.call(page - 1), class: "btn-secondary px-2.5 py-1 text-xs" %>
+      <% else %>
+        <span class="rounded border border-ink-700 px-2.5 py-1 text-zinc-600 opacity-60">Previous</span>
+      <% end %>
+      <% if page < total_pages %>
+        <%= link_to "Next", page_url.call(page + 1), class: "btn-secondary px-2.5 py-1 text-xs" %>
+      <% else %>
+        <span class="rounded border border-ink-700 px-2.5 py-1 text-zinc-600 opacity-60">Next</span>
+      <% end %>
+    </div>
+  <% end %>
+</div>

--- a/services/console/app/views/console/workflows/index.html.erb
+++ b/services/console/app/views/console/workflows/index.html.erb
@@ -12,7 +12,7 @@
       <tr>
         <th class="console-th">Workflow</th>
         <th class="console-th">Status</th>
-        <th class="console-th">Queue</th>
+        <th class="console-th">Queues</th>
         <th class="console-th">Attempts</th>
         <th class="console-th">Started</th>
         <th class="console-th">Finished</th>
@@ -31,6 +31,7 @@
       <% @workflow_runs.each do |run| %>
         <% status = run.display_status %>
         <% workflow_key = run.workflow_key %>
+        <% queue_runs = @queue_breakdown[workflow_key].presence || [ run ] %>
         <tr class="console-row-hover align-top">
           <td class="console-td">
             <% if workflow_key.present? %>
@@ -53,7 +54,25 @@
           </td>
 
           <td class="console-td-nowrap text-xs text-zinc-400">
-            <%= run.queue_label %>
+            <% if queue_runs.size == 1 %>
+              <%= run.queue_label %>
+            <% else %>
+              <div class="space-y-1.5">
+                <% queue_runs.each_with_index do |queue_run, index| %>
+                  <div class="flex items-center gap-2">
+                    <span class="text-zinc-600"><%= index == queue_runs.size - 1 ? "└" : "├" %></span>
+                    <span><%= queue_run.queue_label %></span>
+                    <span class="inline-flex rounded border px-1.5 py-px text-[11px] font-medium <%= workflow_status_classes(queue_run.display_status) %>">
+                      <%= queue_run.display_status.tr("_", " ") %>
+                    </span>
+                    <span class="text-zinc-600">
+                      <%= local_time(queue_run.recency_at, relative: true, format: :compact) %>
+                      · <%= queue_run.queue_run_count.to_i %> runs
+                    </span>
+                  </div>
+                <% end %>
+              </div>
+            <% end %>
           </td>
 
           <td class="console-td-nowrap text-xs text-zinc-400">
@@ -79,4 +98,12 @@
       <% end %>
     </tbody>
   </table>
+
+  <% unless @workflow_db_unavailable %>
+    <%= render "pagination",
+               page: @page,
+               total_pages: @total_pages,
+               total_count: @total_workflows.to_i,
+               unit: "workflow" %>
+  <% end %>
 </section>

--- a/services/console/app/views/console/workflows/index.html.erb
+++ b/services/console/app/views/console/workflows/index.html.erb
@@ -52,7 +52,7 @@
             <% if queue_runs.size == 1 %>
               <div class="mt-1.5 text-zinc-500"><%= run.queue_label %></div>
             <% else %>
-              <div class="mt-1.5 space-y-1.5">
+              <div class="mt-2 space-y-2.5">
                 <% queue_runs.each_with_index do |queue_run, index| %>
                   <div class="flex items-center gap-2">
                     <span class="text-zinc-600"><%= index == queue_runs.size - 1 ? "└" : "├" %></span>

--- a/services/console/app/views/console/workflows/index.html.erb
+++ b/services/console/app/views/console/workflows/index.html.erb
@@ -12,17 +12,15 @@
       <tr>
         <th class="console-th">Workflow</th>
         <th class="console-th">Status</th>
-        <th class="console-th">Queues</th>
         <th class="console-th">Attempts</th>
         <th class="console-th">Started</th>
         <th class="console-th">Finished</th>
-        <th class="console-th">Run</th>
       </tr>
     </thead>
     <tbody class="divide-y divide-ink-700">
       <% if @workflow_runs.empty? %>
         <tr>
-          <td colspan="7" class="px-5 py-10 text-center text-zinc-600">
+          <td colspan="5" class="px-5 py-10 text-center text-zinc-600">
             <%= @workflow_db_unavailable ? "No workflow runs available." : "No workflow runs yet." %>
           </td>
         </tr>
@@ -47,17 +45,14 @@
             <div class="mt-1 text-xs text-zinc-600"><%= run.task_name.presence || "workflow" %></div>
           </td>
 
-          <td class="console-td-nowrap">
+          <td class="console-td-nowrap text-xs text-zinc-400">
             <span class="inline-flex rounded border px-2 py-0.5 text-xs font-medium <%= workflow_status_classes(status) %>">
               <%= status.tr("_", " ") %>
             </span>
-          </td>
-
-          <td class="console-td-nowrap text-xs text-zinc-400">
             <% if queue_runs.size == 1 %>
-              <%= run.queue_label %>
+              <div class="mt-1.5 text-zinc-500"><%= run.queue_label %></div>
             <% else %>
-              <div class="space-y-1.5">
+              <div class="mt-1.5 space-y-1.5">
                 <% queue_runs.each_with_index do |queue_run, index| %>
                   <div class="flex items-center gap-2">
                     <span class="text-zinc-600"><%= index == queue_runs.size - 1 ? "└" : "├" %></span>
@@ -88,11 +83,6 @@
 
           <td class="console-td-nowrap text-xs text-zinc-400">
             <%= local_time(run.terminal_at, relative: true) %>
-          </td>
-
-          <td class="console-td text-xs text-zinc-500">
-            <div title="<%= run.run_id %>"><%= truncate_middle(run.run_id, max: 34) %></div>
-            <div class="mt-1 text-zinc-600" title="<%= run.task_id %>"><%= truncate_middle(run.task_id, max: 34) %></div>
           </td>
         </tr>
       <% end %>

--- a/services/console/app/views/console/workflows/show.html.erb
+++ b/services/console/app/views/console/workflows/show.html.erb
@@ -17,6 +17,9 @@
   </div>
 <% else %>
   <% status = @latest_run.display_status %>
+  <% schedule = @workflow_schedules&.first %>
+  <% source_path = schedule&.dig("source_path").presence %>
+  <% source_url = workflow_source_url(source_path) %>
   <div class="mb-8">
     <a href="<%= console_workflows_path %>" class="back-link">← back to workflows</a>
     <div class="mt-2 flex flex-wrap items-center gap-3">
@@ -26,25 +29,46 @@
       <span class="inline-flex rounded border px-2 py-0.5 text-xs font-medium <%= workflow_status_classes(status) %>">
         <%= status.tr("_", " ") %>
       </span>
+      <div class="ml-auto">
+        <%= button_to "Run now", run_console_workflow_path(@workflow_name), method: :post,
+              class: "btn-primary",
+              data: { turbo_confirm: "Queue a #{@workflow_name} run now?#{schedule ? " It starts with the registered schedule input." : ""}" } %>
+      </div>
     </div>
     <div class="mt-2 flex flex-wrap items-center gap-2 text-sm">
       <span class="text-zinc-400"><%= @latest_run.task_name.presence || "workflow" %></span>
       <span class="text-zinc-600">·</span>
       <span class="text-zinc-400"><%= pluralize(number_with_delimiter(@total_runs), "run") %></span>
+      <% if source_url %>
+        <span class="text-zinc-600">·</span>
+        <a href="<%= source_url %>" target="_blank" rel="noopener noreferrer" class="console-link" title="<%= source_path %>">
+          <%= source_path %> ↗
+        </a>
+      <% end %>
     </div>
   </div>
 
   <section class="mb-8">
-    <h2 class="mb-3 text-xs font-semibold uppercase tracking-wider text-zinc-500">Latest Run</h2>
+    <h2 class="mb-3 text-xs font-semibold uppercase tracking-wider text-zinc-500">Overview</h2>
+    <% schedule_text = nil %>
+    <% if schedule %>
+      <% kind = schedule["kind"].is_a?(Hash) ? schedule["kind"] : {} %>
+      <% schedule_text = [
+           workflow_schedule_label(schedule),
+           (schedule["timezone"].presence if kind["type"] == "cron"),
+           ("disabled" if schedule["enabled"] == false)
+         ].compact.join(" · ") %>
+    <% end %>
     <dl class="console-panel divide-y divide-ink-700">
       <% [
         [ "Queue", @queue_names.map { |queue_name| CentaurWorkflowRun.queue_label_for(queue_name) }.join(", ").presence || @latest_run.queue_label ],
-        [ "Engine", @latest_run.harness_type.presence ],
+        [ "Engine", workflow_engine_label(@latest_run.harness_type) ],
+        ([ "Schedule", schedule_text ] if schedule_text.present?),
         [ "Started", local_time(@latest_run.started_or_created_at) ],
         [ "Duration", workflow_duration_label(@latest_run) ],
         [ "Attempts", safe_join([ (@latest_run.attempts || 0).to_s, tag.span(" / #{@latest_run.max_attempts.presence || "unlimited"}", class: "text-zinc-600") ]) ],
         [ "Runs", pluralize(number_with_delimiter(@total_runs), "run") ]
-      ].each do |label, value| %>
+      ].compact.each do |label, value| %>
         <div class="flex flex-col gap-1 px-5 py-3 sm:flex-row sm:gap-4">
           <dt class="w-48 shrink-0 text-xs uppercase tracking-wider text-zinc-500"><%= label %></dt>
           <dd class="min-w-0 text-xs text-zinc-200"><%= value.presence || tag.span("—", class: "text-zinc-600") %></dd>
@@ -52,6 +76,35 @@
       <% end %>
     </dl>
   </section>
+
+  <% debug_rows = [] %>
+  <% if @latest_run_detail.present? %>
+    <% input = @latest_run_detail["input"] %>
+    <% debug_rows << [ "Input", input, nil ] unless input.nil? || input == {} || input == "" %>
+    <% debug_rows << [ "Result", @latest_run_detail["result"], nil ] unless @latest_run_detail["result"].nil? %>
+    <% debug_rows << [ "Failure", @latest_run_detail["failure"], @latest_run_detail["run_id"] ] unless @latest_run_detail["failure"].nil? %>
+  <% end %>
+  <% if @latest_failure_detail.present? && @latest_failure_detail["failure"].present? %>
+    <% debug_rows << [ "Last failure", @latest_failure_detail["failure"], @latest_failure_detail["run_id"] ] %>
+  <% end %>
+  <% if debug_rows.any? %>
+    <section class="mb-8">
+      <h2 class="mb-3 text-xs font-semibold uppercase tracking-wider text-zinc-500">Debugging</h2>
+      <dl class="console-panel divide-y divide-ink-700">
+        <% debug_rows.each do |label, value, run_id| %>
+          <div class="flex flex-col gap-1 px-5 py-3 sm:flex-row sm:gap-4">
+            <dt class="w-48 shrink-0 text-xs uppercase tracking-wider <%= label.include?("ailure") ? "text-red-400" : "text-zinc-500" %>"><%= label %></dt>
+            <dd class="min-w-0 flex-1 text-xs text-zinc-200">
+              <% if run_id.present? %>
+                <div class="mb-1 text-zinc-500">run <%= run_id %></div>
+              <% end %>
+              <pre class="max-h-64 overflow-auto rounded bg-ink-900/80 p-3 leading-5"><%= workflow_debug_json(value) %></pre>
+            </dd>
+          </div>
+        <% end %>
+      </dl>
+    </section>
+  <% end %>
 
   <h2 class="mb-3 text-xs font-semibold uppercase tracking-wider text-zinc-500">Historical Runs</h2>
 

--- a/services/console/app/views/console/workflows/show.html.erb
+++ b/services/console/app/views/console/workflows/show.html.erb
@@ -30,9 +30,9 @@
         <%= status.tr("_", " ") %>
       </span>
       <div class="ml-auto">
-        <%= button_to "Run now", run_console_workflow_path(@workflow_name), method: :post,
+        <%= button_to "Manually Trigger", run_console_workflow_path(@workflow_name), method: :post,
               class: "btn-primary",
-              data: { turbo_confirm: "Queue a #{@workflow_name} run now?#{schedule ? " It starts with the registered schedule input." : ""}" } %>
+              data: { turbo_confirm: "Manually trigger a #{@workflow_name} run?#{schedule ? " It starts with the registered schedule input." : ""}" } %>
       </div>
     </div>
     <div class="mt-2 flex flex-wrap items-center gap-2 text-sm">

--- a/services/console/app/views/console/workflows/show.html.erb
+++ b/services/console/app/views/console/workflows/show.html.erb
@@ -1,71 +1,59 @@
 <% title = @latest_run&.workflow_name_label || @workflow_name %>
 <% content_for :title, "#{title} · Centaur Console" %>
 
-<div class="mb-5">
-  <%= link_to "Back to Workflows", console_workflows_path, class: "back-link" %>
-</div>
-
 <% if @workflow_db_unavailable %>
+  <div class="mb-8">
+    <a href="<%= console_workflows_path %>" class="back-link">← back to workflows</a>
+  </div>
   <div class="mb-4 rounded border border-amber-500/30 bg-amber-500/[0.08] px-4 py-3 text-sm text-amber-200">
     Workflow database is unavailable. Console needs the API workflow read-only views to show runs.
   </div>
 <% elsif @latest_run.blank? %>
+  <div class="mb-8">
+    <a href="<%= console_workflows_path %>" class="back-link">← back to workflows</a>
+  </div>
   <div class="empty-state">
     No workflow runs found for <span class="text-zinc-300"><%= @workflow_name %></span>.
   </div>
 <% else %>
   <% status = @latest_run.display_status %>
-  <section class="mb-6 grid gap-6 lg:grid-cols-2">
-    <dl class="divide-y divide-ink-700 border-y border-ink-700">
-      <div class="flex gap-5 px-5 py-4">
-        <dt class="w-36 shrink-0 text-xs uppercase tracking-wider text-zinc-500">Workflow</dt>
-        <dd class="min-w-0 text-zinc-100" title="<%= @latest_run.workflow_name_label %>">
-          <%= truncate_middle(@latest_run.workflow_name_label, max: 72) %>
-        </dd>
-      </div>
-      <div class="flex gap-5 px-5 py-4">
-        <dt class="w-36 shrink-0 text-xs uppercase tracking-wider text-zinc-500">Queue</dt>
-        <dd class="min-w-0 text-zinc-100">
-          <%= @queue_names.map { |queue_name| CentaurWorkflowRun.queue_label_for(queue_name) }.join(", ").presence || @latest_run.queue_label %>
-        </dd>
-      </div>
-      <div class="flex gap-5 px-5 py-4">
-        <dt class="w-36 shrink-0 text-xs uppercase tracking-wider text-zinc-500">Duration</dt>
-        <dd class="min-w-0 text-zinc-100"><%= workflow_duration_label(@latest_run) %></dd>
-      </div>
-      <div class="flex gap-5 px-5 py-4">
-        <dt class="w-36 shrink-0 text-xs uppercase tracking-wider text-zinc-500">Engine</dt>
-        <dd class="min-w-0 text-zinc-100"><%= @latest_run.harness_type.presence || "—" %></dd>
-      </div>
-    </dl>
+  <div class="mb-8">
+    <a href="<%= console_workflows_path %>" class="back-link">← back to workflows</a>
+    <div class="mt-2 flex flex-wrap items-center gap-3">
+      <h1 class="page-title" title="<%= @latest_run.workflow_name_label %>">
+        <%= truncate_middle(@latest_run.workflow_name_label, max: 72) %>
+      </h1>
+      <span class="inline-flex rounded border px-2 py-0.5 text-xs font-medium <%= workflow_status_classes(status) %>">
+        <%= status.tr("_", " ") %>
+      </span>
+    </div>
+    <div class="mt-2 flex flex-wrap items-center gap-2 text-sm">
+      <span class="text-zinc-400"><%= @latest_run.task_name.presence || "workflow" %></span>
+      <span class="text-zinc-600">·</span>
+      <span class="text-zinc-400"><%= pluralize(number_with_delimiter(@total_runs), "run") %></span>
+    </div>
+  </div>
 
-    <dl class="divide-y divide-ink-700 border-y border-ink-700">
-      <div class="flex gap-5 px-5 py-4">
-        <dt class="w-36 shrink-0 text-xs uppercase tracking-wider text-zinc-500">Status</dt>
-        <dd class="min-w-0">
-          <span class="inline-flex rounded border px-2 py-0.5 text-xs font-medium <%= workflow_status_classes(status) %>">
-            <%= status.tr("_", " ") %>
-          </span>
-        </dd>
-      </div>
-      <div class="flex gap-5 px-5 py-4">
-        <dt class="w-36 shrink-0 text-xs uppercase tracking-wider text-zinc-500">Started</dt>
-        <dd class="min-w-0 text-zinc-100"><%= local_time(@latest_run.started_or_created_at) %></dd>
-      </div>
-      <div class="flex gap-5 px-5 py-4">
-        <dt class="w-36 shrink-0 text-xs uppercase tracking-wider text-zinc-500">Attempts</dt>
-        <dd class="min-w-0 text-zinc-100">
-          <%= @latest_run.attempts || 0 %><span class="text-zinc-600"> / <%= @latest_run.max_attempts.presence || "unlimited" %></span>
-        </dd>
-      </div>
-      <div class="flex gap-5 px-5 py-4">
-        <dt class="w-36 shrink-0 text-xs uppercase tracking-wider text-zinc-500">Runs</dt>
-        <dd class="min-w-0 text-zinc-100"><%= pluralize(number_with_delimiter(@total_runs), "run") %></dd>
-      </div>
+  <section class="mb-8">
+    <h2 class="mb-3 text-xs font-semibold uppercase tracking-wider text-zinc-500">Latest Run</h2>
+    <dl class="console-panel divide-y divide-ink-700">
+      <% [
+        [ "Queue", @queue_names.map { |queue_name| CentaurWorkflowRun.queue_label_for(queue_name) }.join(", ").presence || @latest_run.queue_label ],
+        [ "Engine", @latest_run.harness_type.presence ],
+        [ "Started", local_time(@latest_run.started_or_created_at) ],
+        [ "Duration", workflow_duration_label(@latest_run) ],
+        [ "Attempts", safe_join([ (@latest_run.attempts || 0).to_s, tag.span(" / #{@latest_run.max_attempts.presence || "unlimited"}", class: "text-zinc-600") ]) ],
+        [ "Runs", pluralize(number_with_delimiter(@total_runs), "run") ]
+      ].each do |label, value| %>
+        <div class="flex flex-col gap-1 px-5 py-3 sm:flex-row sm:gap-4">
+          <dt class="w-48 shrink-0 text-xs uppercase tracking-wider text-zinc-500"><%= label %></dt>
+          <dd class="min-w-0 text-xs text-zinc-200"><%= value.presence || tag.span("—", class: "text-zinc-600") %></dd>
+        </div>
+      <% end %>
     </dl>
   </section>
 
-  <h1 class="mb-3 text-xs font-semibold uppercase tracking-wider text-zinc-500">Historical Runs</h1>
+  <h2 class="mb-3 text-xs font-semibold uppercase tracking-wider text-zinc-500">Historical Runs</h2>
 
   <%# Filter tabs. Changing a filter resets to page 1; the pager keeps filters. %>
   <% filter_url = ->(status: @status, queue: @queue) {

--- a/services/console/app/views/console/workflows/show.html.erb
+++ b/services/console/app/views/console/workflows/show.html.erb
@@ -25,7 +25,9 @@
       </div>
       <div class="flex gap-5 px-5 py-4">
         <dt class="w-36 shrink-0 text-xs uppercase tracking-wider text-zinc-500">Queue</dt>
-        <dd class="min-w-0 text-zinc-100"><%= @latest_run.queue_label %></dd>
+        <dd class="min-w-0 text-zinc-100">
+          <%= @queue_names.map { |queue_name| CentaurWorkflowRun.queue_label_for(queue_name) }.join(", ").presence || @latest_run.queue_label %>
+        </dd>
       </div>
       <div class="flex gap-5 px-5 py-4">
         <dt class="w-36 shrink-0 text-xs uppercase tracking-wider text-zinc-500">Duration</dt>
@@ -58,12 +60,42 @@
       </div>
       <div class="flex gap-5 px-5 py-4">
         <dt class="w-36 shrink-0 text-xs uppercase tracking-wider text-zinc-500">Runs</dt>
-        <dd class="min-w-0 text-zinc-100"><%= pluralize(@workflow_runs.size, "run") %></dd>
+        <dd class="min-w-0 text-zinc-100"><%= pluralize(number_with_delimiter(@total_runs), "run") %></dd>
       </div>
     </dl>
   </section>
 
   <h1 class="mb-3 text-xs font-semibold uppercase tracking-wider text-zinc-500">Historical Runs</h1>
+
+  <%# Filter tabs. Changing a filter resets to page 1; the pager keeps filters. %>
+  <% filter_url = ->(status: @status, queue: @queue) {
+       query = { status: status, queue: queue }.compact
+       query.empty? ? request.path : "#{request.path}?#{query.to_query}"
+     } %>
+  <% status_order = %w[running pending sleeping completed failed cancelled] %>
+  <% status_tabs = (status_order & @status_counts.keys) + (@status_counts.keys - status_order).sort %>
+  <div class="mb-3 flex flex-wrap items-center gap-1.5">
+    <%= link_to filter_url.call(status: nil), class: "chip #{'chip-on' if @status.blank?}" do %>
+      all <span class="ml-1 text-zinc-500"><%= number_with_delimiter(@total_runs) %></span>
+    <% end %>
+    <% status_tabs.each do |status_tab| %>
+      <%= link_to filter_url.call(status: status_tab), class: "chip #{'chip-on' if @status == status_tab}" do %>
+        <%= status_tab.tr("_", " ") %> <span class="ml-1 text-zinc-500"><%= number_with_delimiter(@status_counts[status_tab]) %></span>
+      <% end %>
+    <% end %>
+  </div>
+
+  <% if @queue_names.size > 1 %>
+    <div class="mb-3 flex flex-wrap items-center gap-1.5">
+      <span class="mr-1 text-xs uppercase tracking-wider text-zinc-500">Queue</span>
+      <%= link_to "all", filter_url.call(queue: nil), class: "chip #{'chip-on' if @queue.blank?}" %>
+      <% @queue_names.each do |queue_name| %>
+        <%= link_to CentaurWorkflowRun.queue_label_for(queue_name),
+                    filter_url.call(queue: queue_name),
+                    class: "chip #{'chip-on' if @queue == queue_name}" %>
+      <% end %>
+    </div>
+  <% end %>
 
   <section class="console-scroll-panel">
     <table class="console-table">
@@ -78,6 +110,14 @@
         </tr>
       </thead>
       <tbody class="divide-y divide-ink-700">
+        <% if @workflow_runs.empty? %>
+          <tr>
+            <td colspan="6" class="px-5 py-10 text-center text-zinc-600">
+              No runs match the selected filters.
+            </td>
+          </tr>
+        <% end %>
+
         <% @workflow_runs.each do |run| %>
           <% run_status = run.display_status %>
           <tr class="console-row-hover align-top">
@@ -114,5 +154,11 @@
         <% end %>
       </tbody>
     </table>
+
+    <%= render "pagination",
+               page: @page,
+               total_pages: @total_pages,
+               total_count: @filtered_count.to_i,
+               unit: "run" %>
   </section>
 <% end %>

--- a/services/console/app/views/layouts/console.html.erb
+++ b/services/console/app/views/layouts/console.html.erb
@@ -1136,6 +1136,14 @@
         color: #5f656c;
       }
 
+      html[data-console-theme="light"] .page-title {
+        color: #303438;
+      }
+
+      html[data-console-theme="light"] .page-subtitle {
+        color: #6f757c;
+      }
+
       /* Toggle chips (filter tabs, HTTP methods): the component's @apply'd
          ink colors compile to raw values, so the utility-class remaps above
          don't reach them -- restyle the component classes directly. */

--- a/services/console/app/views/layouts/console.html.erb
+++ b/services/console/app/views/layouts/console.html.erb
@@ -1136,6 +1136,27 @@
         color: #5f656c;
       }
 
+      /* Toggle chips (filter tabs, HTTP methods): the component's @apply'd
+         ink colors compile to raw values, so the utility-class remaps above
+         don't reach them -- restyle the component classes directly. */
+      html[data-console-theme="light"] .chip {
+        border-color: #d2d3cc;
+        background: #ffffff;
+        color: #5f656c;
+      }
+
+      html[data-console-theme="light"] .chip:hover {
+        border-color: #168f4a80;
+        color: #303438;
+      }
+
+      html[data-console-theme="light"] .chip-on,
+      html[data-console-theme="light"] .chip-on:hover {
+        border-color: #168f4a;
+        background: rgba(22, 143, 74, 0.08);
+        color: #168f4a;
+      }
+
       html[data-console-theme="light"] .empty-state {
         border-color: #d8d8d0;
         background: #f0f0eb;

--- a/services/console/config/routes.rb
+++ b/services/console/config/routes.rb
@@ -41,7 +41,11 @@ Rails.application.routes.draw do
   get "console/principals/:id", to: "console#principal", as: :console_principal
   namespace :console do
     resources :threads, only: %i[index create]
-    resources :workflows, only: %i[index show]
+    resources :workflows, only: %i[index show] do
+      member do
+        post :run, action: :force_start
+      end
+    end
     # Lazily-loaded sidebar thread list (Turbo Frame src). Kept off the main
     # page render so the unindexed cross-database sessions query does not block
     # every console page. See ApplicationController#load_console_sidebar_threads.

--- a/services/console/test/controllers/console/workflows_controller_test.rb
+++ b/services/console/test/controllers/console/workflows_controller_test.rb
@@ -33,9 +33,47 @@ class Console::WorkflowsControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
+  # Stands in for CentaurApiClient: schedules/run details for show-page
+  # enrichment, plus a capture of force-started runs.
+  class FakeApiClient
+    attr_reader :created_runs
+
+    def initialize(schedules: [], run_details: {}, create_result: nil, create_error: nil)
+      @schedules = schedules
+      @run_details = run_details
+      @create_result = create_result || { "ok" => true, "run_id" => "run-new", "created" => true }
+      @create_error = create_error
+      @created_runs = []
+    end
+
+    def list_workflow_schedules
+      { "ok" => true, "schedules" => @schedules }
+    end
+
+    def get_workflow_run(run_id)
+      detail = @run_details[run_id]
+      raise CentaurApiClient::Error, "run not found" unless detail
+
+      { "ok" => true, "run" => detail }
+    end
+
+    def create_workflow_run(workflow_name:, input: nil)
+      raise CentaurApiClient::Error, @create_error if @create_error
+
+      @created_runs << { workflow_name: workflow_name, input: input }
+      @create_result
+    end
+  end
+
   setup do
+    @original_client_factory = Console::WorkflowsController.client_factory
+    with_api_client(FakeApiClient.new)
     @operator = users(:acme_admin)
     post login_url, params: { email: @operator.email, password: "password123456" }
+  end
+
+  teardown do
+    Console::WorkflowsController.client_factory = @original_client_factory
   end
 
   test "an admin sees one row per workflow" do
@@ -72,6 +110,18 @@ class Console::WorkflowsControllerTest < ActionDispatch::IntegrationTest
     assert_match "├", response.body
     assert_match "└", response.body
     assert_match "7 runs", response.body
+  end
+
+  test "the workflow index does not show run ids" do
+    run = fake_run(workflow_name: "slack_sync")
+
+    with_workflow_index(runs: [ run ]) do
+      get console_workflows_url
+    end
+
+    assert_response :ok
+    assert_no_match run.run_id, response.body
+    assert_no_match run.task_id, response.body
   end
 
   test "the workflow index is paginated" do
@@ -121,9 +171,10 @@ class Console::WorkflowsControllerTest < ActionDispatch::IntegrationTest
     assert_response :ok
     assert_select "h1.page-title", text: /slack_sync/
     assert_select "dt", text: "Engine"
-    assert_select "dd", text: "codex"
+    assert_select "dd", text: "Codex"
     assert_select "h2", "Historical Runs"
     assert_select "tbody tr", count: 1
+    assert_select "form[action=?]", run_console_workflow_path("slack_sync")
   end
 
   test "workflow show page renders status filter tabs with counts" do
@@ -190,6 +241,109 @@ class Console::WorkflowsControllerTest < ActionDispatch::IntegrationTest
     assert_match "page 2 of 3", response.body
   end
 
+  test "workflow show page shows the schedule and source link when registered" do
+    run = fake_run(workflow_name: "slack_sync", harness_type: "codex")
+    with_api_client(FakeApiClient.new(schedules: [ slack_sync_schedule ]))
+
+    with_workflow_history("slack_sync", runs: [ run ]) do
+      get console_workflow_url("slack_sync")
+    end
+
+    assert_response :ok
+    assert_select "dt", text: "Schedule"
+    assert_select "dd", text: /cron \*\/5 \* \* \* \* · America\/Los_Angeles/
+    assert_select "a[href=?]",
+                  "https://github.com/paradigmxyz/centaur/blob/main/workflows/slack/sync.py",
+                  text: /workflows\/slack\/sync\.py/
+  end
+
+  test "workflow show page links overlay-repo workflow sources to the overlay repo" do
+    run = fake_run(workflow_name: "consensus_ci_triage")
+    schedule = slack_sync_schedule.merge(
+      "workflow_name" => "consensus_ci_triage",
+      "source_path" => "centaur-tempo/workflows/consensus_ci_triage.py"
+    )
+    with_api_client(FakeApiClient.new(schedules: [ schedule ]))
+
+    with_workflow_history("consensus_ci_triage", runs: [ run ]) do
+      get console_workflow_url("consensus_ci_triage")
+    end
+
+    assert_response :ok
+    assert_select "a[href=?]",
+                  "https://github.com/tempoxyz/centaur-tempo/blob/main/workflows/consensus_ci_triage.py"
+  end
+
+  test "workflow show page surfaces the latest run's input and failure for debugging" do
+    run = fake_run(workflow_name: "slack_sync", display_status: "failed")
+    with_api_client(
+      FakeApiClient.new(
+        run_details: {
+          run.run_id => {
+            "run_id" => run.run_id,
+            "input" => { "mode" => "full" },
+            "failure" => { "error" => "boom exploded" }
+          }
+        }
+      )
+    )
+
+    with_workflow_history("slack_sync", runs: [ run ]) do
+      get console_workflow_url("slack_sync")
+    end
+
+    assert_response :ok
+    assert_select "h2", text: "Debugging"
+    assert_select "dt", text: "Input"
+    assert_select "dt", text: "Failure"
+    assert_match "boom exploded", response.body
+  end
+
+  test "workflow show page renders without api enrichment when the api is down" do
+    run = fake_run(workflow_name: "slack_sync")
+    with_api_client(FakeApiClient.new(run_details: {}))
+
+    with_workflow_history("slack_sync", runs: [ run ]) do
+      get console_workflow_url("slack_sync")
+    end
+
+    assert_response :ok
+    assert_select "h2", text: "Debugging", count: 0
+    assert_select "dt", text: "Schedule", count: 0
+  end
+
+  test "force starting a workflow queues a run with the schedule input" do
+    client = FakeApiClient.new(schedules: [ slack_sync_schedule ])
+    with_api_client(client)
+
+    post run_console_workflow_url("slack_sync")
+
+    assert_redirected_to console_workflow_path("slack_sync")
+    assert_match(/Run queued \(run-new\)/, flash[:notice])
+    assert_equal [ { workflow_name: "slack_sync", input: { "mode" => "incremental" } } ], client.created_runs
+  end
+
+  test "force starting a workflow surfaces api errors" do
+    with_api_client(FakeApiClient.new(create_error: "workflow runtime is not enabled"))
+
+    post run_console_workflow_url("slack_sync")
+
+    assert_redirected_to console_workflow_path("slack_sync")
+    assert_match(/workflow runtime is not enabled/, flash[:alert])
+  end
+
+  test "a non-admin cannot force start a workflow" do
+    delete logout_url
+    post login_url, params: { email: users(:member_user).email, password: "password123456" }
+    client = FakeApiClient.new
+    with_api_client(client)
+
+    post run_console_workflow_url("slack_sync")
+
+    assert_redirected_to console_threads_path
+    assert_empty client.created_runs
+  end
+
   test "workflow show page returns not found for unknown workflow" do
     with_workflow_history("missing") do
       get console_workflow_url("missing")
@@ -210,6 +364,23 @@ class Console::WorkflowsControllerTest < ActionDispatch::IntegrationTest
   end
 
   private
+
+  def with_api_client(client)
+    Console::WorkflowsController.client_factory = -> { client }
+  end
+
+  def slack_sync_schedule
+    {
+      "schedule_id" => "slack_sync",
+      "workflow_name" => "slack_sync",
+      "source_path" => "workflows/slack/sync.py",
+      "kind" => { "type" => "cron", "cron" => "*/5 * * * *" },
+      "timezone" => "America/Los_Angeles",
+      "input" => { "mode" => "incremental" },
+      "enabled" => true,
+      "no_delivery" => false
+    }
+  end
 
   def fake_run(attrs = {})
     now = Time.zone.parse("2026-07-06 12:00:00 UTC")

--- a/services/console/test/controllers/console/workflows_controller_test.rb
+++ b/services/console/test/controllers/console/workflows_controller_test.rb
@@ -6,15 +6,18 @@ class Console::WorkflowsControllerTest < ActionDispatch::IntegrationTest
     :workflow_name_label,
     :task_name,
     :display_status,
+    :queue_name,
     :queue_label,
     :attempts,
     :max_attempts,
     :started_or_created_at,
     :created_at,
     :terminal_at,
+    :recency_at,
     :run_id,
     :task_id,
     :harness_type,
+    :queue_run_count,
     keyword_init: true
   ) do
     def workflow_name_label
@@ -24,6 +27,10 @@ class Console::WorkflowsControllerTest < ActionDispatch::IntegrationTest
     def workflow_key
       workflow_name.presence || task_name.presence
     end
+
+    def recency_at
+      self[:recency_at] || terminal_at || started_or_created_at
+    end
   end
 
   setup do
@@ -31,10 +38,10 @@ class Console::WorkflowsControllerTest < ActionDispatch::IntegrationTest
     post login_url, params: { email: @operator.email, password: "password123456" }
   end
 
-  test "an admin sees workflow runs" do
+  test "an admin sees one row per workflow" do
     run = fake_run(workflow_name: "slack_sync", display_status: "running")
 
-    with_workflow_runs(run) do
+    with_workflow_index(runs: [ run ]) do
       get console_workflows_url
     end
 
@@ -45,6 +52,40 @@ class Console::WorkflowsControllerTest < ActionDispatch::IntegrationTest
     assert_select "span", text: "running"
     assert_select "a[href=?]", console_workflows_path
     assert response.body.index('href="/console/workflows"') < response.body.index('href="/console/threads"')
+  end
+
+  test "a workflow with runs in several queues lists each queue on its own line" do
+    run = fake_run(workflow_name: "slack_backfill", queue_name: "centaur_workflows_etl_backfill", queue_label: "etl backfill")
+    queue_runs = [
+      fake_run(workflow_name: "slack_backfill", queue_name: "centaur_workflows_etl_backfill", queue_label: "etl backfill", queue_run_count: 7),
+      fake_run(workflow_name: "slack_backfill", queue_name: "centaur_workflows_slack_live", queue_label: "slack live", display_status: "running", queue_run_count: 2)
+    ]
+
+    with_workflow_index(runs: [ run ], queue_breakdown: { "slack_backfill" => queue_runs }) do
+      get console_workflows_url
+    end
+
+    assert_response :ok
+    assert_select "tbody tr", count: 1
+    assert_match "etl backfill", response.body
+    assert_match "slack live", response.body
+    assert_match "├", response.body
+    assert_match "└", response.body
+    assert_match "7 runs", response.body
+  end
+
+  test "the workflow index is paginated" do
+    runs = 3.times.map { |i| fake_run(workflow_name: "wf_#{i}") }
+
+    with_workflow_index(runs: runs, workflow_count: 120) do
+      get console_workflows_url, params: { page: 2 }
+    end
+
+    assert_response :ok
+    assert_match "120 workflows", response.body
+    assert_match "page 2 of 3", response.body
+    assert_select "a", text: "Previous"
+    assert_select "a", text: "Next"
   end
 
   test "a non-admin is redirected away from the workflow dashboard" do
@@ -73,7 +114,7 @@ class Console::WorkflowsControllerTest < ActionDispatch::IntegrationTest
   test "workflow show page lists core metadata and historical runs" do
     run = fake_run(workflow_name: "slack_sync", display_status: "completed", harness_type: "codex")
 
-    with_workflow_history("slack_sync", run) do
+    with_workflow_history("slack_sync", runs: [ run ]) do
       get console_workflow_url("slack_sync")
     end
 
@@ -84,6 +125,70 @@ class Console::WorkflowsControllerTest < ActionDispatch::IntegrationTest
     assert_select "dd", text: "codex"
     assert_select "h1", "Historical Runs"
     assert_select "tbody tr", count: 1
+  end
+
+  test "workflow show page renders status filter tabs with counts" do
+    run = fake_run(workflow_name: "slack_sync", display_status: "completed")
+
+    with_workflow_history(
+      "slack_sync",
+      runs: [ run ],
+      status_counts: { "completed" => 9, "failed" => 1 }
+    ) do
+      get console_workflow_url("slack_sync")
+    end
+
+    assert_response :ok
+    assert_select "a.chip", text: /all\s*10/
+    assert_select "a.chip", text: /completed\s*9/
+    assert_select "a.chip", text: /failed\s*1/
+    assert_select "dd", text: /10 runs/
+  end
+
+  test "workflow show page marks the active status tab and passes the filter through" do
+    run = fake_run(workflow_name: "slack_sync", display_status: "failed")
+    seen = {}
+
+    with_workflow_history(
+      "slack_sync",
+      runs: [ run ],
+      status_counts: { "completed" => 9, "failed" => 1 },
+      capture: seen
+    ) do
+      get console_workflow_url("slack_sync"), params: { status: "failed" }
+    end
+
+    assert_response :ok
+    assert_equal "failed", seen[:status]
+    assert_select "a.chip-on", text: /failed\s*1/
+  end
+
+  test "workflow show page renders queue tabs when several queues exist" do
+    run = fake_run(workflow_name: "slack_sync")
+
+    with_workflow_history(
+      "slack_sync",
+      runs: [ run ],
+      queue_names: %w[centaur_workflows_etl centaur_workflows_slack_live]
+    ) do
+      get console_workflow_url("slack_sync"), params: { queue: "centaur_workflows_slack_live" }
+    end
+
+    assert_response :ok
+    assert_select "a.chip", text: "etl"
+    assert_select "a.chip-on", text: "slack live"
+  end
+
+  test "workflow show page paginates historical runs" do
+    runs = 2.times.map { |i| fake_run(workflow_name: "slack_sync", run_id: "run-#{i}") }
+
+    with_workflow_history("slack_sync", runs: runs, run_count: 130) do
+      get console_workflow_url("slack_sync"), params: { page: 2 }
+    end
+
+    assert_response :ok
+    assert_match "130 runs", response.body
+    assert_match "page 2 of 3", response.body
   end
 
   test "workflow show page returns not found for unknown workflow" do
@@ -114,35 +219,43 @@ class Console::WorkflowsControllerTest < ActionDispatch::IntegrationTest
       workflow_name_label: nil,
       task_name: "centaur_workflow",
       display_status: "completed",
+      queue_name: "centaur_workflows",
       queue_label: "default",
       attempts: 1,
       max_attempts: 3,
       started_or_created_at: now,
       created_at: now,
       terminal_at: now + 2.minutes,
+      recency_at: nil,
       run_id: "00000000-0000-0000-0000-000000000001",
       task_id: "00000000-0000-0000-0000-000000000002",
-      harness_type: nil
+      harness_type: nil,
+      queue_run_count: 1
     }.merge(attrs))
   end
 
-  def with_workflow_runs(*runs)
+  def with_workflow_index(runs:, queue_breakdown: {}, workflow_count: nil)
     with_centaur_workflow_run_methods(
       available?: -> { true },
-      recent: ->(limit:) {
-        runs
-      }
+      workflow_count: -> { workflow_count || runs.size },
+      latest_per_workflow: ->(limit:, offset: 0) { runs },
+      latest_per_queue: ->(keys) { queue_breakdown }
     ) do
       yield
     end
   end
 
-  def with_workflow_history(workflow_name, *runs)
+  def with_workflow_history(workflow_name, runs: [], status_counts: nil, queue_names: [], run_count: nil, capture: nil)
+    status_counts ||= runs.group_by(&:display_status).transform_values(&:size)
     with_centaur_workflow_run_methods(
       available?: -> { true },
-      for_workflow: ->(name, limit:) {
+      for_workflow: ->(name, limit:, offset: 0, status: nil, queue: nil) {
+        capture&.merge!(status: status, queue: queue, offset: offset)
         name == workflow_name && limit.positive? ? runs : []
-      }
+      },
+      status_counts: ->(name) { name == workflow_name ? status_counts : {} },
+      queue_names: ->(name) { name == workflow_name ? queue_names : [] },
+      run_count: ->(name, status: nil, queue: nil) { run_count || runs.size }
     ) do
       yield
     end

--- a/services/console/test/controllers/console/workflows_controller_test.rb
+++ b/services/console/test/controllers/console/workflows_controller_test.rb
@@ -119,11 +119,10 @@ class Console::WorkflowsControllerTest < ActionDispatch::IntegrationTest
     end
 
     assert_response :ok
-    assert_select "dt", text: "Workflow"
-    assert_select "dd", text: /slack_sync/
+    assert_select "h1.page-title", text: /slack_sync/
     assert_select "dt", text: "Engine"
     assert_select "dd", text: "codex"
-    assert_select "h1", "Historical Runs"
+    assert_select "h2", "Historical Runs"
     assert_select "tbody tr", count: 1
   end
 

--- a/services/console/test/models/centaur_workflow_run_test.rb
+++ b/services/console/test/models/centaur_workflow_run_test.rb
@@ -4,6 +4,7 @@ class CentaurWorkflowRunTest < ActiveSupport::TestCase
   setup do
     ensure_workflow_runs_table
     CentaurWorkflowRun.reset_column_information
+    CentaurWorkflowRun.delete_all
   end
 
   test "workflow runs are read only" do
@@ -29,6 +30,86 @@ class CentaurWorkflowRunTest < ActiveSupport::TestCase
     run = workflow_run(queue_name: "centaur_workflows_etl_backfill")
 
     assert_equal "etl backfill", run.queue_label
+  end
+
+  test "latest_per_workflow returns one row per workflow, newest activity first" do
+    insert_run(workflow_name: "alpha", completed_at: 3.hours.ago)
+    insert_run(workflow_name: "alpha", completed_at: 1.hour.ago)
+    insert_run(workflow_name: "beta", completed_at: 2.hours.ago)
+
+    runs = CentaurWorkflowRun.latest_per_workflow(limit: 10)
+
+    assert_equal %w[alpha beta], runs.map(&:workflow_key)
+    assert_in_delta 1.hour.ago.to_i, runs.first.completed_at.to_i, 5
+    assert_equal 2, CentaurWorkflowRun.workflow_count
+  end
+
+  test "latest_per_workflow groups blank workflow names under the task name" do
+    insert_run(workflow_name: nil, task_name: "legacy_task", completed_at: 1.hour.ago)
+    insert_run(workflow_name: "", task_name: "legacy_task", completed_at: 2.hours.ago)
+
+    runs = CentaurWorkflowRun.latest_per_workflow(limit: 10)
+
+    assert_equal [ "legacy_task" ], runs.map(&:workflow_key)
+    assert_equal 1, CentaurWorkflowRun.workflow_count
+  end
+
+  test "latest_per_workflow paginates" do
+    insert_run(workflow_name: "alpha", completed_at: 1.hour.ago)
+    insert_run(workflow_name: "beta", completed_at: 2.hours.ago)
+    insert_run(workflow_name: "gamma", completed_at: 3.hours.ago)
+
+    page_two = CentaurWorkflowRun.latest_per_workflow(limit: 2, offset: 2)
+
+    assert_equal %w[gamma], page_two.map(&:workflow_key)
+  end
+
+  test "latest_per_queue returns the newest run per queue with run counts" do
+    insert_run(workflow_name: "alpha", queue_name: "centaur_workflows_etl", completed_at: 3.hours.ago)
+    insert_run(workflow_name: "alpha", queue_name: "centaur_workflows_etl", completed_at: 2.hours.ago)
+    insert_run(workflow_name: "alpha", queue_name: "centaur_workflows_live", completed_at: 1.hour.ago)
+    insert_run(workflow_name: "beta", queue_name: "centaur_workflows_etl", completed_at: 1.hour.ago)
+
+    breakdown = CentaurWorkflowRun.latest_per_queue(%w[alpha])
+
+    assert_equal %w[alpha], breakdown.keys
+    queue_runs = breakdown["alpha"]
+    assert_equal %w[centaur_workflows_live centaur_workflows_etl], queue_runs.map(&:queue_name)
+    assert_equal [ 1, 2 ], queue_runs.map { |run| run.queue_run_count.to_i }
+  end
+
+  test "for_workflow filters by status and queue and paginates" do
+    insert_run(workflow_name: "alpha", queue_name: "centaur_workflows_etl", completed_at: 1.hour.ago)
+    insert_run(workflow_name: "alpha", queue_name: "centaur_workflows_etl", failed_at: 2.hours.ago)
+    insert_run(workflow_name: "alpha", queue_name: "centaur_workflows_live", completed_at: 3.hours.ago)
+
+    completed = CentaurWorkflowRun.for_workflow("alpha", limit: 10, status: "completed")
+    assert_equal 2, completed.size
+    assert completed.all? { |run| run.display_status == "completed" }
+
+    live_only = CentaurWorkflowRun.for_workflow("alpha", limit: 10, queue: "centaur_workflows_live")
+    assert_equal 1, live_only.size
+
+    page_two = CentaurWorkflowRun.for_workflow("alpha", limit: 2, offset: 2)
+    assert_equal 1, page_two.size
+
+    assert_equal 2, CentaurWorkflowRun.run_count("alpha", status: "completed")
+    assert_equal 3, CentaurWorkflowRun.run_count("alpha")
+  end
+
+  test "status_counts and queue_names summarize a workflow's runs" do
+    insert_run(workflow_name: "alpha", queue_name: "centaur_workflows_etl", completed_at: 1.hour.ago)
+    insert_run(workflow_name: "alpha", queue_name: "centaur_workflows_live", failed_at: 2.hours.ago)
+    insert_run(workflow_name: "alpha", queue_name: "centaur_workflows_live", claimed: true, state: "running")
+
+    assert_equal(
+      { "completed" => 1, "failed" => 1, "running" => 1 },
+      CentaurWorkflowRun.status_counts("alpha")
+    )
+    assert_equal(
+      %w[centaur_workflows_etl centaur_workflows_live],
+      CentaurWorkflowRun.queue_names("alpha")
+    )
   end
 
   private
@@ -62,12 +143,30 @@ class CentaurWorkflowRunTest < ActiveSupport::TestCase
   end
 
   def workflow_run(attrs = {})
-    CentaurWorkflowRun.new({
+    CentaurWorkflowRun.new(default_run_attributes.merge(attrs))
+  end
+
+  def insert_run(attrs = {})
+    @run_sequence = (@run_sequence || 0) + 1
+    CentaurWorkflowRun.insert_all!(
+      [
+        default_run_attributes.merge(
+          run_id: format("00000000-0000-0000-0000-%012d", @run_sequence),
+          task_id: format("11111111-0000-0000-0000-%012d", @run_sequence),
+          created_at: 1.day.ago
+        ).merge(attrs)
+      ],
+      returning: false
+    )
+  end
+
+  def default_run_attributes
+    {
       queue_name: "centaur_workflows",
       workflow_name: "echo",
       task_name: "centaur_workflow",
       state: "pending",
       claimed: false
-    }.merge(attrs))
+    }
   end
 end

--- a/services/console/test/services/centaur_api_client_test.rb
+++ b/services/console/test/services/centaur_api_client_test.rb
@@ -162,4 +162,36 @@ class CentaurApiClientTest < ActiveSupport::TestCase
     assert_equal [ '{"type":"user"}' ], body["input_lines"]
     assert_equal "idem-1", body["idempotency_key"]
   end
+
+  test "lists workflow schedules and fetches run details" do
+    http = StubHTTP.new(status: 200, body: { ok: true, schedules: [] }.to_json)
+    client = CentaurApiClient.new(base_url: "http://api.internal:8080", http: http)
+
+    client.list_workflow_schedules
+    client.get_workflow_run("run:1")
+
+    schedules = http.requests.first
+    assert_equal :get, schedules[:method]
+    assert_equal "http://api.internal:8080/api/workflows/schedules", schedules[:url]
+
+    run = http.requests.second
+    assert_equal :get, run[:method]
+    assert_equal "http://api.internal:8080/api/workflows/runs/run%3A1", run[:url]
+  end
+
+  test "creates workflow runs with optional input" do
+    http = StubHTTP.new(status: 200, body: { ok: true, run_id: "r1" }.to_json)
+    client = CentaurApiClient.new(base_url: "http://api.internal:8080", http: http)
+
+    client.create_workflow_run(workflow_name: "slack_sync")
+    client.create_workflow_run(workflow_name: "slack_sync", input: { "mode" => "full" })
+
+    bare = http.requests.first
+    assert_equal :post, bare[:method]
+    assert_equal "http://api.internal:8080/api/workflows/runs", bare[:url]
+    assert_equal({ "workflow_name" => "slack_sync" }, JSON.parse(bare[:body]))
+
+    with_input = http.requests.second
+    assert_equal({ "workflow_name" => "slack_sync", "input" => { "mode" => "full" } }, JSON.parse(with_input[:body]))
+  end
 end


### PR DESCRIPTION
## Summary

Reworks the console Workflows tab into a proper operational dashboard.

### Index
- One row per unique workflow (its latest run) instead of a raw run feed; workflows spanning several queues get per-queue tree lines with each queue's latest status, last-run time, and run count
- Status and Queue merged into one column and the run/task id column removed, so the table stays informative at narrow widths
- Server-side pagination (50/page) replacing the 200-run hard limit

### Workflow detail page
- Header restyled to the console detail-page idiom: back-link, page-title with inline status badge, task-name / run-count / source-link meta line, compact Overview panel
- Status filter tabs with counts and queue tabs over Historical Runs; filters compose and survive pagination (50/page, replacing the 1,000-run limit)
- **Manually Trigger** button (admin-only, confirmed) that queues a run via `POST /api/workflows/runs`, reusing the registered schedule input so a forced run matches a normal tick
- **Debugging** section with the latest run's input/result/failure and the most recent failure payload (with run id), fetched from the workflows API
- Schedule row (cron/interval, timezone, disabled flag) and a GitHub source link — overlay paths (`centaur-tempo/...`) map to `tempoxyz/centaur-tempo`, everything else to `paradigmxyz/centaur`
- Engine rendered like the Chats page harness labels (`codex` → Codex)

All API-backed data is best-effort: when api-rs is unreachable the page renders from the read-only view alone.

### Fixes along the way
- Light theme: `.chip`, `.page-title`, `.page-subtitle` component classes compiled raw dark colors the light-mode utility remaps never reach (white-on-white titles on every detail page); they now have explicit light overrides. The cancelled badge moved to remapped ink classes.

### Deployment note
Schedules/debugging/force-start need `CENTAUR_CONSOLE_CENTAUR_API_URL` (+ `CENTAUR_CONSOLE_CENTAUR_API_KEY` if gated) pointing at api-rs; without it those sections quietly degrade.

## Testing

```
docker exec -e CENTAUR_CONSOLE_THREADS_READ_ONLY=0 codex-centaur-console-web bin/rails test test/controllers/console/workflows_controller_test.rb test/services/centaur_api_client_test.rb test/models/centaur_workflow_run_test.rb
```
41 runs, 0 failures. Full controllers/models/services suite: 989 runs, only the 3 known env-only `CentaurSessionRecordTest` DB-config failures on the local container. Rubocop clean. Browser-verified in light and dark at 1600px/1100px/1000px with seeded multi-queue fixture data, including a live Manually Trigger click against a mocked workflows API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)