### PR TITLE
fix: limit default infra secrets to model providers

### DIFF
--- a/services/api-rs/crates/centaur-api-server/src/args.rs
+++ b/services/api-rs/crates/centaur-api-server/src/args.rs
@@ -956,9 +956,9 @@ impl SandboxArgs {
 
         // Inject the infra/harness placeholder credentials so env-based
         // consumers send the proxy_value iron-proxy replaces with the real
-        // secret: codex's OPENAI_API_KEY (api_key mode → codex logs in and
+        // secret: codex's OPENAI_API_KEY (api_key mode -> codex logs in and
         // hits api.openai.com instead of falling back to the ChatGPT
-        // auth.json), git's GITHUB_TOKEN, and the rest of the infra set.
+        // auth.json), and the rest of the model-provider infra set.
         for (name, value) in self.iron_proxy.sandbox_placeholder_env()? {
             if !envs.iter().any(|(existing, _)| existing == &name) {
                 envs.push((name, value));
@@ -1671,7 +1671,7 @@ impl IronProxyArgs {
 
     /// Placeholder env (`PLACEHOLDER=PLACEHOLDER`) for the infra/harness
     /// secrets, whose consumers read credentials straight from the environment
-    /// (codex's `OPENAI_API_KEY`, git's `GITHUB_TOKEN`, …). Discovered tool
+    /// (for example codex's `OPENAI_API_KEY`). Discovered tool
     /// secrets contribute nothing here: tools read credentials through the SDK,
     /// whose `StubBackend` already returns the key name iron-proxy matches on,
     /// and the cloudwatch tool embeds its own throwaway SigV4 credentials.

--- a/services/api-rs/crates/centaur-iron-proxy/src/fragment.rs
+++ b/services/api-rs/crates/centaur-iron-proxy/src/fragment.rs
@@ -250,10 +250,10 @@ fn normalize_auth_mode(value: &str) -> String {
 }
 
 /// The `PLACEHOLDER=PLACEHOLDER` env for replace-mode secrets whose consumers
-/// read credentials straight from the environment (codex's `OPENAI_API_KEY`,
-/// git's `GITHUB_TOKEN`, …) rather than through the tool SDK, whose
-/// `StubBackend` already hands back the key name. Only the infra/harness
-/// fragments have such consumers; tool fragments are excluded at the call site.
+/// read credentials straight from the environment (for example codex's
+/// `OPENAI_API_KEY`) rather than through the tool SDK, whose `StubBackend`
+/// already hands back the key name. Only the infra/harness fragments have such
+/// consumers; tool fragments are excluded at the call site.
 pub fn placeholder_env(fragments: &[ProxyFragment]) -> BTreeMap<String, String> {
     fragments
         .iter()

--- a/services/api-rs/crates/centaur-iron-proxy/src/infra.yaml
+++ b/services/api-rs/crates/centaur-iron-proxy/src/infra.yaml
@@ -3,20 +3,3 @@ proxy:
   # default 30s response-header timeout. Keep model-provider calls from being
   # cut off while OpenAI is still computing the first response byte.
   upstream_response_header_timeout: "120s"
-
-transforms:
-  - name: secrets
-    config:
-      secrets:
-        - replace:
-            proxy_value: XAI_API_KEY
-            match_headers: ["Authorization"]
-          rules: [{ host: api.x.ai }]
-        - replace:
-            proxy_value: GEMINI_API_KEY
-            match_headers: ["X-Goog-Api-Key"]
-          rules: [{ host: generativelanguage.googleapis.com }]
-        - replace:
-            proxy_value: AMP_API_KEY
-            match_headers: ["Authorization"]
-          rules: [{ host: ampcode.com }]

--- a/services/api-rs/crates/centaur-iron-proxy/src/infra.yaml
+++ b/services/api-rs/crates/centaur-iron-proxy/src/infra.yaml
@@ -20,13 +20,3 @@ transforms:
             proxy_value: AMP_API_KEY
             match_headers: ["Authorization"]
           rules: [{ host: ampcode.com }]
-        - replace:
-            proxy_value: GITHUB_TOKEN
-            match_headers: ["Authorization"]
-          rules:
-            - { host: github.com }
-            - { host: api.github.com }
-        - replace:
-            proxy_value: SLACK_BOT_TOKEN
-            match_headers: ["Authorization"]
-          rules: [{ host: "*.slack.com" }]

--- a/services/api-rs/crates/centaur-iron-proxy/src/tests.rs
+++ b/services/api-rs/crates/centaur-iron-proxy/src/tests.rs
@@ -46,8 +46,11 @@ fn harness_auth_fragments_are_baked_in() {
         Some("120s")
     );
     let placeholders = placeholder_env(&[infra]);
-    for name in ["AMP_API_KEY", "GITHUB_TOKEN", "SLACK_BOT_TOKEN"] {
+    for name in ["XAI_API_KEY", "GEMINI_API_KEY", "AMP_API_KEY"] {
         assert_eq!(placeholders.get(name).map(String::as_str), Some(name));
+    }
+    for name in ["GITHUB_TOKEN", "SLACK_BOT_TOKEN"] {
+        assert!(!placeholders.contains_key(name));
     }
 }
 

--- a/services/api-rs/crates/centaur-iron-proxy/src/tests.rs
+++ b/services/api-rs/crates/centaur-iron-proxy/src/tests.rs
@@ -38,6 +38,17 @@ fn harness_auth_fragments_are_baked_in() {
         Some("META_AI_API_KEY")
     );
 
+    let claude_code = harness_auth_fragment("claude-code", "api_key")
+        .unwrap()
+        .unwrap();
+    let claude_code_placeholders = placeholder_env(&[claude_code]);
+    assert_eq!(
+        claude_code_placeholders
+            .get("ANTHROPIC_API_KEY")
+            .map(String::as_str),
+        Some("ANTHROPIC_API_KEY")
+    );
+
     assert!(harness_auth_fragment("codex", "bogus").unwrap().is_none());
 
     let infra = infra_fragment().unwrap();
@@ -46,12 +57,7 @@ fn harness_auth_fragments_are_baked_in() {
         Some("120s")
     );
     let placeholders = placeholder_env(&[infra]);
-    for name in ["XAI_API_KEY", "GEMINI_API_KEY", "AMP_API_KEY"] {
-        assert_eq!(placeholders.get(name).map(String::as_str), Some(name));
-    }
-    for name in ["GITHUB_TOKEN", "SLACK_BOT_TOKEN"] {
-        assert!(!placeholders.contains_key(name));
-    }
+    assert!(placeholders.is_empty());
 }
 
 #[test]


### PR DESCRIPTION
Limits the default infra role to model-provider credentials by removing non-model secret transforms from the static infra fragment. Existing model access remains registered through baked harness fragments for OpenAI, Anthropic, OpenRouter, Meta, and opt-in Bedrock.