### PR TITLE
feat: add Slack file proxy API

### DIFF
--- a/services/api-rs/Cargo.lock
+++ b/services/api-rs/Cargo.lock
@@ -186,6 +186,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
 dependencies = [
  "aws-lc-sys",
+ "untrusted 0.7.1",
  "zeroize",
 ]
 
@@ -814,6 +815,7 @@ dependencies = [
  "futures-util",
  "hex",
  "hmac 0.12.1",
+ "jsonwebtoken",
  "kube",
  "reqwest",
  "rustls 0.23.40",
@@ -2533,6 +2535,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonwebtoken"
+version = "10.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eba32bfb4ffdeaca3e34431072faf01745c9b26d25504aa7a6cf5684334fc4fc"
+dependencies = [
+ "aws-lc-rs",
+ "base64",
+ "getrandom 0.2.17",
+ "js-sys",
+ "serde",
+ "serde_json",
+ "signature",
+ "zeroize",
+]
+
+[[package]]
 name = "k8s-openapi"
 version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3672,7 +3690,7 @@ dependencies = [
  "cfg-if",
  "getrandom 0.2.17",
  "libc",
- "untrusted",
+ "untrusted 0.9.0",
  "windows-sys 0.52.0",
 ]
 
@@ -3808,7 +3826,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
  "ring",
- "untrusted",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -3820,7 +3838,7 @@ dependencies = [
  "aws-lc-rs",
  "ring",
  "rustls-pki-types",
- "untrusted",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -3897,7 +3915,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
 dependencies = [
  "ring",
- "untrusted",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -5050,6 +5068,12 @@ checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
+name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
@@ -5840,6 +5864,20 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zerotrie"

--- a/services/api-rs/Cargo.lock
+++ b/services/api-rs/Cargo.lock
@@ -3656,6 +3656,7 @@ dependencies = [
  "rustls-platform-verifier",
  "serde",
  "serde_json",
+ "serde_urlencoded",
  "sync_wrapper",
  "tokio",
  "tokio-rustls 0.26.4",

--- a/services/api-rs/Cargo.toml
+++ b/services/api-rs/Cargo.toml
@@ -74,7 +74,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.9"
 sha2 = "0.10"
-reqwest = { version = "0.13.4", default-features = false, features = ["form", "json", "query", "rustls", "stream"] }
+reqwest = { version = "0.13.4", default-features = false, features = ["form", "json", "rustls", "stream"] }
 ratatui = "0.29"
 rustls = "0.23"
 opentelemetry = "0.32.0"

--- a/services/api-rs/Cargo.toml
+++ b/services/api-rs/Cargo.toml
@@ -67,6 +67,7 @@ futures-util = { version = "0.3", features = ["sink"] }
 hmac = "0.12"
 hex = "0.4"
 jiff = "0.2"
+jsonwebtoken = { version = "10.4.0", default-features = false, features = ["aws_lc_rs"] }
 k8s-openapi = { version = "0.27.1", features = ["latest"] }
 kube = "3.1.0"
 serde = { version = "1", features = ["derive"] }

--- a/services/api-rs/Cargo.toml
+++ b/services/api-rs/Cargo.toml
@@ -74,7 +74,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.9"
 sha2 = "0.10"
-reqwest = { version = "0.13.4", default-features = false, features = ["form", "json", "rustls", "stream"] }
+reqwest = { version = "0.13.4", default-features = false, features = ["form", "json", "query", "rustls", "stream"] }
 ratatui = "0.29"
 rustls = "0.23"
 opentelemetry = "0.32.0"

--- a/services/api-rs/Cargo.toml
+++ b/services/api-rs/Cargo.toml
@@ -74,7 +74,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.9"
 sha2 = "0.10"
-reqwest = { version = "0.13.4", default-features = false, features = ["json", "rustls", "stream"] }
+reqwest = { version = "0.13.4", default-features = false, features = ["form", "json", "rustls", "stream"] }
 ratatui = "0.29"
 rustls = "0.23"
 opentelemetry = "0.32.0"

--- a/services/api-rs/crates/centaur-api-server/Cargo.toml
+++ b/services/api-rs/crates/centaur-api-server/Cargo.toml
@@ -27,6 +27,7 @@ eventsource-stream.workspace = true
 futures-util.workspace = true
 hmac.workspace = true
 hex.workspace = true
+jsonwebtoken.workspace = true
 kube.workspace = true
 reqwest.workspace = true
 rustls.workspace = true

--- a/services/api-rs/crates/centaur-api-server/src/lib.rs
+++ b/services/api-rs/crates/centaur-api-server/src/lib.rs
@@ -2,7 +2,7 @@ pub mod client;
 mod error;
 mod mcp;
 mod routes;
-mod slack_file_proxy;
+mod slack_proxy;
 mod tool_discovery;
 pub mod types;
 

--- a/services/api-rs/crates/centaur-api-server/src/lib.rs
+++ b/services/api-rs/crates/centaur-api-server/src/lib.rs
@@ -2,6 +2,7 @@ pub mod client;
 mod error;
 mod mcp;
 mod routes;
+mod slack_file_proxy;
 mod tool_discovery;
 pub mod types;
 

--- a/services/api-rs/crates/centaur-api-server/src/mcp.rs
+++ b/services/api-rs/crates/centaur-api-server/src/mcp.rs
@@ -751,7 +751,7 @@ fn static_env(cell: &'static OnceLock<Option<String>>, name: &str) -> Option<Str
     cell.get_or_init(|| env::var(name).ok()).clone()
 }
 
-fn jwt_signing_secret() -> Option<String> {
+pub(crate) fn jwt_signing_secret() -> Option<String> {
     static CELL: OnceLock<Option<String>> = OnceLock::new();
     static_env(&CELL, "CENTAUR_JWT_SIGNING_SECRET")
 }

--- a/services/api-rs/crates/centaur-api-server/src/routes.rs
+++ b/services/api-rs/crates/centaur-api-server/src/routes.rs
@@ -55,6 +55,7 @@ use uuid::Uuid;
 use crate::{
     ApiError,
     mcp::{mcp_get, mcp_post, mcp_protected_resource_metadata},
+    slack_file_proxy::slack_file_proxy_router,
     types::{
         AppendMessagesRequest, AppendMessagesResponse, CreateSessionRequest, CreateSessionResponse,
         EmitWorkflowEventRequest, EventsQuery, ExecuteSessionRequest, ExecuteSessionResponse,
@@ -226,6 +227,7 @@ pub fn build_router_with_app_state(state: AppState) -> Router {
         )
         .route("/api/session/{thread_key}/events", get(stream_events))
         .route("/api/sandboxes/drain", post(drain_sandboxes))
+        .merge(slack_file_proxy_router())
         .route("/api/workflows/schedules", get(list_workflow_schedules))
         .route(
             "/api/workflows/runs",

--- a/services/api-rs/crates/centaur-api-server/src/routes.rs
+++ b/services/api-rs/crates/centaur-api-server/src/routes.rs
@@ -55,7 +55,7 @@ use uuid::Uuid;
 use crate::{
     ApiError,
     mcp::{mcp_get, mcp_post, mcp_protected_resource_metadata},
-    slack_file_proxy::slack_file_proxy_router,
+    slack_proxy::slack_proxy_router,
     types::{
         AppendMessagesRequest, AppendMessagesResponse, CreateSessionRequest, CreateSessionResponse,
         EmitWorkflowEventRequest, EventsQuery, ExecuteSessionRequest, ExecuteSessionResponse,
@@ -227,7 +227,7 @@ pub fn build_router_with_app_state(state: AppState) -> Router {
         )
         .route("/api/session/{thread_key}/events", get(stream_events))
         .route("/api/sandboxes/drain", post(drain_sandboxes))
-        .merge(slack_file_proxy_router())
+        .merge(slack_proxy_router())
         .route("/api/workflows/schedules", get(list_workflow_schedules))
         .route(
             "/api/workflows/runs",

--- a/services/api-rs/crates/centaur-api-server/src/routes.rs
+++ b/services/api-rs/crates/centaur-api-server/src/routes.rs
@@ -2331,14 +2331,14 @@ fn slack_archive_upload_config() -> Result<SlackArchiveUploadConfig, ApiError> {
     })
 }
 
-fn non_empty_env(name: &str) -> Option<String> {
+pub(crate) fn non_empty_env(name: &str) -> Option<String> {
     env::var(name)
         .ok()
         .map(|value| value.trim().to_owned())
         .filter(|value| !value.is_empty())
 }
 
-fn positive_env_u64(name: &str, default: u64) -> u64 {
+pub(crate) fn positive_env_u64(name: &str, default: u64) -> u64 {
     env::var(name)
         .ok()
         .and_then(|value| value.parse::<u64>().ok())

--- a/services/api-rs/crates/centaur-api-server/src/slack_file_proxy.rs
+++ b/services/api-rs/crates/centaur-api-server/src/slack_file_proxy.rs
@@ -43,6 +43,10 @@ struct SlackFileUploadQuery {
     initial_comment: Option<String>,
     #[serde(default)]
     content_type: Option<String>,
+    #[serde(default)]
+    alt_txt: Option<String>,
+    #[serde(default)]
+    snippet_type: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -92,7 +96,15 @@ async fn upload_slack_file(
     let content_length = content_length(&headers)?;
     ensure_upload_size(content_length, config.max_upload_bytes)?;
     let client = reqwest::Client::new();
-    let upload_ticket = get_upload_url(&client, &config, &query.filename, content_length).await?;
+    let upload_ticket = get_upload_url(
+        &client,
+        &config,
+        &query.filename,
+        content_length,
+        query.alt_txt.as_deref(),
+        query.snippet_type.as_deref(),
+    )
+    .await?;
     upload_file_bytes(
         &client,
         &upload_ticket.upload_url,
@@ -220,21 +232,31 @@ async fn get_upload_url(
     config: &SlackFileProxyConfig,
     filename: &str,
     length: u64,
+    alt_txt: Option<&str>,
+    snippet_type: Option<&str>,
 ) -> Result<SlackUploadTicket, ApiError> {
-    let value = slack_api_post_form(
-        client,
-        config,
-        "files.getUploadURLExternal",
-        &[
-            ("filename", filename.to_owned()),
-            ("length", length.to_string()),
-        ],
-    )
-    .await?;
+    let form = slack_get_upload_url_form(filename, length, alt_txt, snippet_type);
+    let value = slack_api_post_form(client, config, "files.getUploadURLExternal", &form).await?;
     Ok(SlackUploadTicket {
         upload_url: required_slack_string(&value, "upload_url")?,
         file_id: required_slack_string(&value, "file_id")?,
     })
+}
+
+fn slack_get_upload_url_form(
+    filename: &str,
+    length: u64,
+    alt_txt: Option<&str>,
+    snippet_type: Option<&str>,
+) -> Vec<(&'static str, String)> {
+    let mut form = vec![
+        ("filename", filename.to_owned()),
+        ("length", length.to_string()),
+        ("alt_txt", alt_txt.unwrap_or("").to_owned()),
+        ("snippet_type", snippet_type.unwrap_or("").to_owned()),
+    ];
+    form.retain(|(_, value)| !value.is_empty());
+    form
 }
 
 async fn upload_file_bytes(
@@ -318,11 +340,7 @@ async fn slack_api_post_form(
     let response = client
         .post(format!("{}/{}", config.api_url, method))
         .bearer_auth(&config.bot_token)
-        .header(
-            header::CONTENT_TYPE,
-            "application/x-www-form-urlencoded; charset=utf-8",
-        )
-        .body(form_urlencoded(form))
+        .form(form)
         .send()
         .await
         .map_err(|error| ApiError::Internal(format!("Slack API request failed: {error}")))?;
@@ -341,19 +359,6 @@ async fn slack_api_post_form(
         )));
     }
     Ok(value)
-}
-
-fn form_urlencoded(form: &[(&str, String)]) -> String {
-    form.iter()
-        .map(|(key, value)| {
-            format!(
-                "{}={}",
-                urlencoding::encode(key),
-                urlencoding::encode(value)
-            )
-        })
-        .collect::<Vec<_>>()
-        .join("&")
 }
 
 fn authorize_slack_file_proxy(headers: &HeaderMap) -> Result<SlackFileProxyClaims, ApiError> {
@@ -756,5 +761,28 @@ mod tests {
         let mut headers = HeaderMap::new();
         headers.insert(header::CONTENT_LENGTH, "42".parse().unwrap());
         assert_eq!(content_length(&headers).unwrap(), 42);
+    }
+
+    #[test]
+    fn upload_url_form_includes_alt_text_and_snippet_type() {
+        let form = slack_get_upload_url_form("notes.txt", 42, Some("Release notes"), Some("text"));
+        assert_eq!(
+            form,
+            vec![
+                ("filename", "notes.txt".to_owned()),
+                ("length", "42".to_owned()),
+                ("alt_txt", "Release notes".to_owned()),
+                ("snippet_type", "text".to_owned()),
+            ]
+        );
+
+        let form = slack_get_upload_url_form("notes.txt", 42, None, None);
+        assert_eq!(
+            form,
+            vec![
+                ("filename", "notes.txt".to_owned()),
+                ("length", "42".to_owned()),
+            ]
+        );
     }
 }

--- a/services/api-rs/crates/centaur-api-server/src/slack_file_proxy.rs
+++ b/services/api-rs/crates/centaur-api-server/src/slack_file_proxy.rs
@@ -170,6 +170,7 @@ async fn download_slack_file(
         )));
     }
 
+    let upstream_headers = upstream.headers().clone();
     let mut response = Body::from_stream(upstream.bytes_stream()).into_response();
     let headers = response.headers_mut();
     if let Some(value) = file
@@ -179,10 +180,8 @@ async fn download_slack_file(
     {
         headers.insert(header::CONTENT_TYPE, value);
     }
-    if let Some(value) = file.get("size").and_then(Value::as_u64) {
-        if let Ok(value) = value.to_string().parse() {
-            headers.insert(header::CONTENT_LENGTH, value);
-        }
+    if let Some(value) = upstream_headers.get(header::CONTENT_LENGTH).cloned() {
+        headers.insert(header::CONTENT_LENGTH, value);
     }
     if let Some(filename) = file
         .get("name")
@@ -206,7 +205,7 @@ struct SlackFileProxyConfig {
 impl SlackFileProxyConfig {
     fn from_env() -> Result<Self, ApiError> {
         let bot_token = non_empty_env("SLACK_BOT_TOKEN")
-            .ok_or_else(|| ApiError::BadRequest("SLACK_BOT_TOKEN is not configured".to_owned()))?;
+            .ok_or_else(|| ApiError::Internal("SLACK_BOT_TOKEN is not configured".to_owned()))?;
         Ok(Self {
             api_url: non_empty_env("SLACK_API_URL")
                 .unwrap_or_else(|| DEFAULT_SLACK_API_URL.to_owned())
@@ -363,9 +362,8 @@ async fn slack_api_post_form(
 
 fn authorize_slack_file_proxy(headers: &HeaderMap) -> Result<SlackFileProxyClaims, ApiError> {
     let token = bearer_token(headers)?;
-    let secret = non_empty_env("CENTAUR_API_JWT_SECRET").ok_or_else(|| {
-        ApiError::BadRequest("CENTAUR_API_JWT_SECRET is not configured".to_owned())
-    })?;
+    let secret = non_empty_env("CENTAUR_API_JWT_SECRET")
+        .ok_or_else(|| ApiError::Internal("CENTAUR_API_JWT_SECRET is not configured".to_owned()))?;
     let audience = non_empty_env("CENTAUR_API_JWT_AUDIENCE")
         .unwrap_or_else(|| DEFAULT_API_JWT_AUDIENCE.to_owned());
     verify_hs256_jwt(token, secret.as_bytes(), &audience)

--- a/services/api-rs/crates/centaur-api-server/src/slack_file_proxy.rs
+++ b/services/api-rs/crates/centaur-api-server/src/slack_file_proxy.rs
@@ -29,6 +29,8 @@ pub(crate) fn slack_file_proxy_router() -> Router<AppState> {
             "/api/slack/files/{file_id}/download",
             get(download_slack_file),
         )
+        .route("/api/slack/search/messages", get(search_slack_messages))
+        .route("/api/slack/search/files", get(search_slack_files))
 }
 
 #[derive(Debug, Deserialize)]
@@ -55,6 +57,27 @@ struct SlackFileDownloadQuery {
 }
 
 #[derive(Debug, Deserialize)]
+struct SlackSearchQuery {
+    query: String,
+    #[serde(default)]
+    channel_id: Option<String>,
+    #[serde(default)]
+    count: Option<u32>,
+    #[serde(default)]
+    highlight: Option<bool>,
+    #[serde(default)]
+    page: Option<u32>,
+    #[serde(default)]
+    cursor: Option<String>,
+    #[serde(default)]
+    sort: Option<String>,
+    #[serde(default)]
+    sort_dir: Option<String>,
+    #[serde(default)]
+    team_id: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
 struct SlackFileProxyClaims {
     iat: i64,
     iss: String,
@@ -69,6 +92,8 @@ struct SlackProxyClaims {
     upload_channels: Vec<String>,
     #[serde(default)]
     download_channels: Vec<String>,
+    #[serde(default)]
+    search_channels: Vec<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -193,6 +218,57 @@ async fn download_slack_file(
         headers.insert(header::CONTENT_DISPOSITION, filename);
     }
     Ok(response)
+}
+
+async fn search_slack_messages(
+    headers: HeaderMap,
+    Query(query): Query<SlackSearchQuery>,
+) -> Result<Json<Value>, ApiError> {
+    search_slack(headers, query, SlackSearchKind::Messages).await
+}
+
+async fn search_slack_files(
+    headers: HeaderMap,
+    Query(query): Query<SlackSearchQuery>,
+) -> Result<Json<Value>, ApiError> {
+    search_slack(headers, query, SlackSearchKind::Files).await
+}
+
+#[derive(Clone, Copy, Debug)]
+enum SlackSearchKind {
+    Messages,
+    Files,
+}
+
+impl SlackSearchKind {
+    fn method(self) -> &'static str {
+        match self {
+            Self::Messages => "search.messages",
+            Self::Files => "search.files",
+        }
+    }
+
+    fn result_key(self) -> &'static str {
+        match self {
+            Self::Messages => "messages",
+            Self::Files => "files",
+        }
+    }
+}
+
+async fn search_slack(
+    headers: HeaderMap,
+    query: SlackSearchQuery,
+    kind: SlackSearchKind,
+) -> Result<Json<Value>, ApiError> {
+    let claims = authorize_slack_file_proxy(&headers)?;
+    let channels = search_channels(&claims, query.channel_id.as_deref())?;
+    let config = SlackFileProxyConfig::from_env()?;
+    let client = reqwest::Client::new();
+    let form = slack_search_form(&query, &channels)?;
+    let mut response = slack_api_get_form(&client, &config, kind.method(), &form).await?;
+    filter_search_response(&mut response, kind, &channels);
+    Ok(Json(response))
 }
 
 #[derive(Debug)]
@@ -360,6 +436,36 @@ async fn slack_api_post_form(
     Ok(value)
 }
 
+async fn slack_api_get_form(
+    client: &reqwest::Client,
+    config: &SlackFileProxyConfig,
+    method: &str,
+    form: &[(&str, String)],
+) -> Result<Value, ApiError> {
+    let response = client
+        .get(format!("{}/{}", config.api_url, method))
+        .bearer_auth(&config.bot_token)
+        .query(form)
+        .send()
+        .await
+        .map_err(|error| ApiError::Internal(format!("Slack API request failed: {error}")))?;
+    let status = response.status();
+    let value = response
+        .json::<Value>()
+        .await
+        .map_err(|error| ApiError::Internal(format!("Slack API response was not JSON: {error}")))?;
+    if !status.is_success() || value.get("ok") != Some(&Value::Bool(true)) {
+        let slack_error = value
+            .get("error")
+            .and_then(Value::as_str)
+            .unwrap_or("unknown_error");
+        return Err(ApiError::BadRequest(format!(
+            "Slack {method} failed: {slack_error}"
+        )));
+    }
+    Ok(value)
+}
+
 fn authorize_slack_file_proxy(headers: &HeaderMap) -> Result<SlackFileProxyClaims, ApiError> {
     let token = bearer_token(headers)?;
     let secret = non_empty_env("CENTAUR_API_JWT_SECRET")
@@ -435,6 +541,34 @@ fn ensure_download_channel_allowed(
     )
 }
 
+fn search_channels(
+    claims: &SlackFileProxyClaims,
+    requested_channel_id: Option<&str>,
+) -> Result<Vec<String>, ApiError> {
+    if let Some(channel_id) = requested_channel_id {
+        validate_slack_channel_id(channel_id)?;
+        ensure_channel_allowed(
+            &claims.slack.search_channels,
+            channel_id,
+            "JWT is not authorized to search this Slack channel",
+        )?;
+        return Ok(vec![channel_id.to_owned()]);
+    }
+
+    let mut channels = claims.slack.search_channels.clone();
+    channels.sort();
+    channels.dedup();
+    for channel in &channels {
+        validate_slack_channel_id(channel)?;
+    }
+    if channels.is_empty() {
+        return Err(ApiError::Forbidden(
+            "JWT is not authorized to search any Slack channels".to_owned(),
+        ));
+    }
+    Ok(channels)
+}
+
 fn ensure_channel_allowed(
     allowed_channels: &[String],
     channel_id: &str,
@@ -444,6 +578,106 @@ fn ensure_channel_allowed(
         return Ok(());
     }
     Err(ApiError::Forbidden(message.to_owned()))
+}
+
+fn slack_search_form(
+    query: &SlackSearchQuery,
+    channels: &[String],
+) -> Result<Vec<(&'static str, String)>, ApiError> {
+    let locked_query = locked_search_query(&query.query, channels)?;
+    let mut form = vec![
+        ("query", locked_query),
+        (
+            "count",
+            query
+                .count
+                .map(|value| value.to_string())
+                .unwrap_or_default(),
+        ),
+        (
+            "highlight",
+            query
+                .highlight
+                .map(|value| value.to_string())
+                .unwrap_or_default(),
+        ),
+        (
+            "page",
+            query
+                .page
+                .map(|value| value.to_string())
+                .unwrap_or_default(),
+        ),
+        ("cursor", query.cursor.clone().unwrap_or_default()),
+        ("sort", query.sort.clone().unwrap_or_default()),
+        ("sort_dir", query.sort_dir.clone().unwrap_or_default()),
+        ("team_id", query.team_id.clone().unwrap_or_default()),
+    ];
+    form.retain(|(_, value)| !value.is_empty());
+    Ok(form)
+}
+
+fn locked_search_query(query: &str, channels: &[String]) -> Result<String, ApiError> {
+    let query = query.trim();
+    if query.is_empty() {
+        return Err(ApiError::BadRequest("query must not be empty".to_owned()));
+    }
+    if channels.is_empty() {
+        return Err(ApiError::Forbidden(
+            "JWT is not authorized to search any Slack channels".to_owned(),
+        ));
+    }
+    let filters = channels
+        .iter()
+        .map(|channel| format!("in:<#{channel}>"))
+        .collect::<Vec<_>>();
+    if filters.len() == 1 {
+        Ok(format!("{query} {}", filters[0]))
+    } else {
+        Ok(format!("{query} ({})", filters.join(" OR ")))
+    }
+}
+
+fn filter_search_response(response: &mut Value, kind: SlackSearchKind, channels: &[String]) {
+    let allowed = channels.iter().cloned().collect::<BTreeSet<_>>();
+    let Some(container) = response
+        .get_mut(kind.result_key())
+        .and_then(Value::as_object_mut)
+    else {
+        return;
+    };
+    let Some(matches) = container.get_mut("matches").and_then(Value::as_array_mut) else {
+        return;
+    };
+    matches.retain(|entry| search_match_in_allowed_channels(entry, kind, &allowed));
+    let filtered_count = u64::try_from(matches.len()).unwrap_or(u64::MAX);
+    container.insert("total".to_owned(), json!(filtered_count));
+    if let Some(pagination) = container
+        .get_mut("pagination")
+        .and_then(Value::as_object_mut)
+    {
+        pagination.insert("total_count".to_owned(), json!(filtered_count));
+    }
+    if let Some(paging) = container.get_mut("paging").and_then(Value::as_object_mut) {
+        paging.insert("total".to_owned(), json!(filtered_count));
+    }
+}
+
+fn search_match_in_allowed_channels(
+    entry: &Value,
+    kind: SlackSearchKind,
+    allowed: &BTreeSet<String>,
+) -> bool {
+    match kind {
+        SlackSearchKind::Messages => entry
+            .get("channel")
+            .and_then(|channel| channel.get("id"))
+            .and_then(Value::as_str)
+            .is_some_and(|channel_id| allowed.contains(channel_id)),
+        SlackSearchKind::Files => slack_file_channel_ids(entry)
+            .iter()
+            .any(|channel_id| allowed.contains(channel_id)),
+    }
 }
 
 fn slack_file_in_channel(file: &Value, channel_id: &str) -> bool {
@@ -602,19 +836,28 @@ mod tests {
                 "exp": 4_102_444_800i64,
                 "slack": {
                     "upload_channels": ["C123456789"],
-                    "download_channels": ["C987654321"]
+                    "download_channels": ["C987654321"],
+                    "search_channels": ["G123456789"]
                 }
             }),
         );
         let claims = verify_hs256_jwt(&token, b"secret", "centaur-api").unwrap();
         ensure_upload_channel_allowed(&claims, "C123456789").unwrap();
         ensure_download_channel_allowed(&claims, "C987654321").unwrap();
+        assert_eq!(
+            search_channels(&claims, Some("G123456789")).unwrap(),
+            vec!["G123456789".to_owned()]
+        );
         assert!(matches!(
             ensure_upload_channel_allowed(&claims, "C987654321").unwrap_err(),
             ApiError::Forbidden(_)
         ));
         assert!(matches!(
             ensure_download_channel_allowed(&claims, "C123456789").unwrap_err(),
+            ApiError::Forbidden(_)
+        ));
+        assert!(matches!(
+            search_channels(&claims, Some("C123456789")).unwrap_err(),
             ApiError::Forbidden(_)
         ));
     }
@@ -782,5 +1025,122 @@ mod tests {
                 ("length", "42".to_owned()),
             ]
         );
+    }
+
+    #[test]
+    fn search_form_locks_query_to_allowed_channels() {
+        let query = SlackSearchQuery {
+            query: "release notes".to_owned(),
+            channel_id: None,
+            count: Some(10),
+            highlight: Some(true),
+            page: None,
+            cursor: Some("cursor-1".to_owned()),
+            sort: Some("timestamp".to_owned()),
+            sort_dir: Some("desc".to_owned()),
+            team_id: Some("T12345678".to_owned()),
+        };
+        let form =
+            slack_search_form(&query, &["C123456789".to_owned(), "G123456789".to_owned()]).unwrap();
+        assert_eq!(
+            form,
+            vec![
+                (
+                    "query",
+                    "release notes (in:<#C123456789> OR in:<#G123456789>)".to_owned(),
+                ),
+                ("count", "10".to_owned()),
+                ("highlight", "true".to_owned()),
+                ("cursor", "cursor-1".to_owned()),
+                ("sort", "timestamp".to_owned()),
+                ("sort_dir", "desc".to_owned()),
+                ("team_id", "T12345678".to_owned()),
+            ]
+        );
+    }
+
+    #[test]
+    fn search_channels_uses_requested_channel_or_full_claim_list() {
+        let claims = SlackFileProxyClaims {
+            iat: 1,
+            iss: "centaur-console".to_owned(),
+            slack: SlackProxyClaims {
+                upload_channels: vec![],
+                download_channels: vec![],
+                search_channels: vec![
+                    "G123456789".to_owned(),
+                    "C123456789".to_owned(),
+                    "C123456789".to_owned(),
+                ],
+            },
+            sub: Some("user_123".to_owned()),
+        };
+
+        assert_eq!(
+            search_channels(&claims, Some("G123456789")).unwrap(),
+            vec!["G123456789".to_owned()]
+        );
+        assert_eq!(
+            search_channels(&claims, None).unwrap(),
+            vec!["C123456789".to_owned(), "G123456789".to_owned()]
+        );
+        assert!(matches!(
+            search_channels(&claims, Some("D123456789")).unwrap_err(),
+            ApiError::Forbidden(_)
+        ));
+    }
+
+    #[test]
+    fn search_response_filter_removes_disallowed_message_matches() {
+        let mut response = json!({
+            "ok": true,
+            "messages": {
+                "matches": [
+                    {"channel": {"id": "C123456789"}, "text": "allowed"},
+                    {"channel": {"id": "C987654321"}, "text": "denied"}
+                ],
+                "pagination": {"total_count": 2},
+                "paging": {"total": 2},
+                "total": 2
+            }
+        });
+
+        filter_search_response(
+            &mut response,
+            SlackSearchKind::Messages,
+            &["C123456789".to_owned()],
+        );
+
+        assert_eq!(response["messages"]["matches"].as_array().unwrap().len(), 1);
+        assert_eq!(response["messages"]["matches"][0]["text"], "allowed");
+        assert_eq!(response["messages"]["total"], json!(1));
+        assert_eq!(response["messages"]["pagination"]["total_count"], json!(1));
+        assert_eq!(response["messages"]["paging"]["total"], json!(1));
+    }
+
+    #[test]
+    fn search_response_filter_removes_disallowed_file_matches() {
+        let mut response = json!({
+            "ok": true,
+            "files": {
+                "matches": [
+                    {"id": "F123456789", "channels": ["C123456789"]},
+                    {"id": "F987654321", "groups": ["G987654321"]}
+                ],
+                "pagination": {"total_count": 2},
+                "paging": {"total": 2},
+                "total": 2
+            }
+        });
+
+        filter_search_response(
+            &mut response,
+            SlackSearchKind::Files,
+            &["C123456789".to_owned()],
+        );
+
+        assert_eq!(response["files"]["matches"].as_array().unwrap().len(), 1);
+        assert_eq!(response["files"]["matches"][0]["id"], "F123456789");
+        assert_eq!(response["files"]["total"], json!(1));
     }
 }

--- a/services/api-rs/crates/centaur-api-server/src/slack_file_proxy.rs
+++ b/services/api-rs/crates/centaur-api-server/src/slack_file_proxy.rs
@@ -1,0 +1,760 @@
+use std::{collections::BTreeSet, env};
+
+use axum::{
+    Json, Router,
+    body::Body,
+    extract::{DefaultBodyLimit, Path, Query},
+    http::{HeaderMap, header},
+    response::{IntoResponse, Response},
+    routing::{get, post},
+};
+use jsonwebtoken::{Algorithm, DecodingKey, Validation, decode};
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+
+use crate::{ApiError, routes::AppState};
+
+const DEFAULT_SLACK_API_URL: &str = "https://slack.com/api";
+const DEFAULT_API_JWT_AUDIENCE: &str = "centaur-api";
+const DEFAULT_MAX_UPLOAD_BYTES: u64 = 100 * 1024 * 1024;
+const JWT_CLOCK_SKEW_SECONDS: i64 = 30;
+
+pub(crate) fn slack_file_proxy_router() -> Router<AppState> {
+    Router::new()
+        .route(
+            "/api/slack/files/upload",
+            post(upload_slack_file).layer(DefaultBodyLimit::disable()),
+        )
+        .route(
+            "/api/slack/files/{file_id}/download",
+            get(download_slack_file),
+        )
+}
+
+#[derive(Debug, Deserialize)]
+struct SlackFileUploadQuery {
+    channel_id: String,
+    filename: String,
+    #[serde(default)]
+    thread_ts: Option<String>,
+    #[serde(default)]
+    title: Option<String>,
+    #[serde(default)]
+    initial_comment: Option<String>,
+    #[serde(default)]
+    content_type: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct SlackFileDownloadQuery {
+    channel_id: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct SlackFileProxyClaims {
+    iat: i64,
+    iss: String,
+    slack: SlackProxyClaims,
+    #[serde(default)]
+    sub: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct SlackProxyClaims {
+    #[serde(default)]
+    upload_channels: Vec<String>,
+    #[serde(default)]
+    download_channels: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct SlackFileUploadResponse {
+    ok: bool,
+    file_id: String,
+    channel_id: String,
+    thread_ts: Option<String>,
+    file: Value,
+}
+
+async fn upload_slack_file(
+    headers: HeaderMap,
+    Query(query): Query<SlackFileUploadQuery>,
+    body: Body,
+) -> Result<Json<SlackFileUploadResponse>, ApiError> {
+    let claims = authorize_slack_file_proxy(&headers)?;
+    ensure_upload_channel_allowed(&claims, &query.channel_id)?;
+    validate_slack_channel_id(&query.channel_id)?;
+    validate_filename(&query.filename)?;
+    if let Some(thread_ts) = query.thread_ts.as_deref() {
+        validate_slack_thread_ts(thread_ts)?;
+    }
+    let config = SlackFileProxyConfig::from_env()?;
+    let content_length = content_length(&headers)?;
+    ensure_upload_size(content_length, config.max_upload_bytes)?;
+    let client = reqwest::Client::new();
+    let upload_ticket = get_upload_url(&client, &config, &query.filename, content_length).await?;
+    upload_file_bytes(
+        &client,
+        &upload_ticket.upload_url,
+        body,
+        content_length,
+        query.content_type.as_deref(),
+    )
+    .await?;
+    let file = complete_upload(
+        &client,
+        &config,
+        &upload_ticket.file_id,
+        &query.channel_id,
+        query.thread_ts.as_deref(),
+        query.title.as_deref().unwrap_or(&query.filename),
+        query.initial_comment.as_deref(),
+    )
+    .await?;
+
+    Ok(Json(SlackFileUploadResponse {
+        ok: true,
+        file_id: upload_ticket.file_id,
+        channel_id: query.channel_id,
+        thread_ts: query.thread_ts,
+        file,
+    }))
+}
+
+async fn download_slack_file(
+    headers: HeaderMap,
+    Path(file_id): Path<String>,
+    Query(query): Query<SlackFileDownloadQuery>,
+) -> Result<Response, ApiError> {
+    let claims = authorize_slack_file_proxy(&headers)?;
+    ensure_download_channel_allowed(&claims, &query.channel_id)?;
+    validate_slack_channel_id(&query.channel_id)?;
+    validate_slack_file_id(&file_id)?;
+
+    let config = SlackFileProxyConfig::from_env()?;
+    let client = reqwest::Client::new();
+    let file = slack_file_info(&client, &config, &file_id).await?;
+    if !slack_file_in_channel(&file, &query.channel_id) {
+        return Err(ApiError::Forbidden(
+            "file is not shared in an allowed Slack channel".to_owned(),
+        ));
+    }
+    let download_url = file
+        .get("url_private_download")
+        .or_else(|| file.get("url_private"))
+        .and_then(Value::as_str)
+        .ok_or_else(|| ApiError::BadRequest("Slack file has no download URL".to_owned()))?;
+
+    let upstream = client
+        .get(download_url)
+        .bearer_auth(&config.bot_token)
+        .send()
+        .await
+        .map_err(|error| ApiError::Internal(format!("Slack file download failed: {error}")))?;
+    if !upstream.status().is_success() {
+        return Err(ApiError::BadRequest(format!(
+            "Slack file download failed with status {}",
+            upstream.status().as_u16()
+        )));
+    }
+
+    let mut response = Body::from_stream(upstream.bytes_stream()).into_response();
+    let headers = response.headers_mut();
+    if let Some(value) = file
+        .get("mimetype")
+        .and_then(Value::as_str)
+        .and_then(|value| value.parse().ok())
+    {
+        headers.insert(header::CONTENT_TYPE, value);
+    }
+    if let Some(value) = file.get("size").and_then(Value::as_u64) {
+        if let Ok(value) = value.to_string().parse() {
+            headers.insert(header::CONTENT_LENGTH, value);
+        }
+    }
+    if let Some(filename) = file
+        .get("name")
+        .or_else(|| file.get("title"))
+        .and_then(Value::as_str)
+        .map(content_disposition_filename)
+        .and_then(|value| value.parse().ok())
+    {
+        headers.insert(header::CONTENT_DISPOSITION, filename);
+    }
+    Ok(response)
+}
+
+#[derive(Debug)]
+struct SlackFileProxyConfig {
+    api_url: String,
+    bot_token: String,
+    max_upload_bytes: u64,
+}
+
+impl SlackFileProxyConfig {
+    fn from_env() -> Result<Self, ApiError> {
+        let bot_token = non_empty_env("SLACK_BOT_TOKEN")
+            .ok_or_else(|| ApiError::BadRequest("SLACK_BOT_TOKEN is not configured".to_owned()))?;
+        Ok(Self {
+            api_url: non_empty_env("SLACK_API_URL")
+                .unwrap_or_else(|| DEFAULT_SLACK_API_URL.to_owned())
+                .trim_end_matches('/')
+                .to_owned(),
+            bot_token,
+            max_upload_bytes: positive_env_u64(
+                "SLACK_FILE_PROXY_MAX_UPLOAD_BYTES",
+                DEFAULT_MAX_UPLOAD_BYTES,
+            ),
+        })
+    }
+}
+
+#[derive(Debug)]
+struct SlackUploadTicket {
+    upload_url: String,
+    file_id: String,
+}
+
+async fn get_upload_url(
+    client: &reqwest::Client,
+    config: &SlackFileProxyConfig,
+    filename: &str,
+    length: u64,
+) -> Result<SlackUploadTicket, ApiError> {
+    let value = slack_api_post_form(
+        client,
+        config,
+        "files.getUploadURLExternal",
+        &[
+            ("filename", filename.to_owned()),
+            ("length", length.to_string()),
+        ],
+    )
+    .await?;
+    Ok(SlackUploadTicket {
+        upload_url: required_slack_string(&value, "upload_url")?,
+        file_id: required_slack_string(&value, "file_id")?,
+    })
+}
+
+async fn upload_file_bytes(
+    client: &reqwest::Client,
+    upload_url: &str,
+    body: Body,
+    content_length: u64,
+    content_type: Option<&str>,
+) -> Result<(), ApiError> {
+    let response = client
+        .post(upload_url)
+        .header(
+            header::CONTENT_TYPE,
+            content_type.unwrap_or("application/octet-stream"),
+        )
+        .header(header::CONTENT_LENGTH, content_length)
+        .body(reqwest::Body::wrap_stream(body.into_data_stream()))
+        .send()
+        .await
+        .map_err(|error| ApiError::Internal(format!("Slack upload failed: {error}")))?;
+    if !response.status().is_success() {
+        return Err(ApiError::BadRequest(format!(
+            "Slack upload failed with status {}",
+            response.status().as_u16()
+        )));
+    }
+    Ok(())
+}
+
+async fn complete_upload(
+    client: &reqwest::Client,
+    config: &SlackFileProxyConfig,
+    file_id: &str,
+    channel_id: &str,
+    thread_ts: Option<&str>,
+    title: &str,
+    initial_comment: Option<&str>,
+) -> Result<Value, ApiError> {
+    let files = json!([{ "id": file_id, "title": title }]).to_string();
+    let mut form = vec![
+        ("files", files),
+        ("channel_id", channel_id.to_owned()),
+        ("thread_ts", thread_ts.unwrap_or("").to_owned()),
+        ("initial_comment", initial_comment.unwrap_or("").to_owned()),
+    ];
+    form.retain(|(_, value)| !value.is_empty());
+    let value = slack_api_post_form(client, config, "files.completeUploadExternal", &form).await?;
+    value
+        .get("files")
+        .and_then(Value::as_array)
+        .and_then(|files| files.first())
+        .cloned()
+        .ok_or_else(|| {
+            ApiError::BadRequest("Slack upload response did not include file".to_owned())
+        })
+}
+
+async fn slack_file_info(
+    client: &reqwest::Client,
+    config: &SlackFileProxyConfig,
+    file_id: &str,
+) -> Result<Value, ApiError> {
+    let value = slack_api_post_form(
+        client,
+        config,
+        "files.info",
+        &[("file", file_id.to_owned())],
+    )
+    .await?;
+    value.get("file").cloned().ok_or_else(|| {
+        ApiError::BadRequest("Slack file info response did not include file".to_owned())
+    })
+}
+
+async fn slack_api_post_form(
+    client: &reqwest::Client,
+    config: &SlackFileProxyConfig,
+    method: &str,
+    form: &[(&str, String)],
+) -> Result<Value, ApiError> {
+    let response = client
+        .post(format!("{}/{}", config.api_url, method))
+        .bearer_auth(&config.bot_token)
+        .header(
+            header::CONTENT_TYPE,
+            "application/x-www-form-urlencoded; charset=utf-8",
+        )
+        .body(form_urlencoded(form))
+        .send()
+        .await
+        .map_err(|error| ApiError::Internal(format!("Slack API request failed: {error}")))?;
+    let status = response.status();
+    let value = response
+        .json::<Value>()
+        .await
+        .map_err(|error| ApiError::Internal(format!("Slack API response was not JSON: {error}")))?;
+    if !status.is_success() || value.get("ok") != Some(&Value::Bool(true)) {
+        let slack_error = value
+            .get("error")
+            .and_then(Value::as_str)
+            .unwrap_or("unknown_error");
+        return Err(ApiError::BadRequest(format!(
+            "Slack {method} failed: {slack_error}"
+        )));
+    }
+    Ok(value)
+}
+
+fn form_urlencoded(form: &[(&str, String)]) -> String {
+    form.iter()
+        .map(|(key, value)| {
+            format!(
+                "{}={}",
+                urlencoding::encode(key),
+                urlencoding::encode(value)
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("&")
+}
+
+fn authorize_slack_file_proxy(headers: &HeaderMap) -> Result<SlackFileProxyClaims, ApiError> {
+    let token = bearer_token(headers)?;
+    let secret = non_empty_env("CENTAUR_API_JWT_SECRET").ok_or_else(|| {
+        ApiError::BadRequest("CENTAUR_API_JWT_SECRET is not configured".to_owned())
+    })?;
+    let audience = non_empty_env("CENTAUR_API_JWT_AUDIENCE")
+        .unwrap_or_else(|| DEFAULT_API_JWT_AUDIENCE.to_owned());
+    verify_hs256_jwt(token, secret.as_bytes(), &audience)
+}
+
+fn bearer_token(headers: &HeaderMap) -> Result<&str, ApiError> {
+    let value = headers
+        .get(header::AUTHORIZATION)
+        .and_then(|value| value.to_str().ok())
+        .ok_or_else(|| ApiError::Unauthorized("missing bearer token".to_owned()))?;
+    value
+        .strip_prefix("Bearer ")
+        .filter(|token| !token.trim().is_empty())
+        .ok_or_else(|| ApiError::Unauthorized("missing bearer token".to_owned()))
+}
+
+fn verify_hs256_jwt(
+    token: &str,
+    secret: &[u8],
+    expected_audience: &str,
+) -> Result<SlackFileProxyClaims, ApiError> {
+    let mut validation = Validation::new(Algorithm::HS256);
+    validation.leeway = JWT_CLOCK_SKEW_SECONDS as u64;
+    validation.validate_nbf = true;
+    validation.set_audience(&[expected_audience]);
+    validation.set_required_spec_claims(&["exp", "iss", "sub", "aud"]);
+    let token_data =
+        decode::<SlackFileProxyClaims>(token, &DecodingKey::from_secret(secret), &validation)
+            .map_err(|_| ApiError::Unauthorized("invalid JWT".to_owned()))?;
+    validate_claims(&token_data.claims)?;
+    Ok(token_data.claims)
+}
+
+fn validate_claims(claims: &SlackFileProxyClaims) -> Result<(), ApiError> {
+    let now = time::OffsetDateTime::now_utc().unix_timestamp();
+    if claims.iat > now + JWT_CLOCK_SKEW_SECONDS {
+        return Err(ApiError::Unauthorized(
+            "JWT issued-at is in the future".to_owned(),
+        ));
+    }
+    if claims.iss.trim().is_empty() {
+        return Err(ApiError::Unauthorized("JWT issuer is required".to_owned()));
+    }
+    if claims.sub.as_deref().unwrap_or_default().trim().is_empty() {
+        return Err(ApiError::Unauthorized("JWT subject is required".to_owned()));
+    }
+    Ok(())
+}
+
+fn ensure_upload_channel_allowed(
+    claims: &SlackFileProxyClaims,
+    channel_id: &str,
+) -> Result<(), ApiError> {
+    ensure_channel_allowed(
+        &claims.slack.upload_channels,
+        channel_id,
+        "JWT is not authorized to upload to this Slack channel",
+    )
+}
+
+fn ensure_download_channel_allowed(
+    claims: &SlackFileProxyClaims,
+    channel_id: &str,
+) -> Result<(), ApiError> {
+    ensure_channel_allowed(
+        &claims.slack.download_channels,
+        channel_id,
+        "JWT is not authorized to download from this Slack channel",
+    )
+}
+
+fn ensure_channel_allowed(
+    allowed_channels: &[String],
+    channel_id: &str,
+    message: &str,
+) -> Result<(), ApiError> {
+    if allowed_channels.iter().any(|allowed| allowed == channel_id) {
+        return Ok(());
+    }
+    Err(ApiError::Forbidden(message.to_owned()))
+}
+
+fn slack_file_in_channel(file: &Value, channel_id: &str) -> bool {
+    slack_file_channel_ids(file).contains(channel_id)
+}
+
+fn slack_file_channel_ids(file: &Value) -> BTreeSet<String> {
+    let mut channels = BTreeSet::new();
+    for key in ["channels", "groups", "ims"] {
+        if let Some(values) = file.get(key).and_then(Value::as_array) {
+            for value in values {
+                if let Some(channel) = value.as_str() {
+                    channels.insert(channel.to_owned());
+                }
+            }
+        }
+    }
+    if let Some(shares) = file.get("shares").and_then(Value::as_object) {
+        for share_type in shares.values().filter_map(Value::as_object) {
+            for (channel, _shares) in share_type {
+                channels.insert(channel.to_owned());
+            }
+        }
+    }
+    channels
+}
+
+fn required_slack_string(value: &Value, field: &str) -> Result<String, ApiError> {
+    value
+        .get(field)
+        .and_then(Value::as_str)
+        .map(str::to_owned)
+        .ok_or_else(|| ApiError::BadRequest(format!("Slack response missing {field}")))
+}
+
+fn content_length(headers: &HeaderMap) -> Result<u64, ApiError> {
+    headers
+        .get(header::CONTENT_LENGTH)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.parse::<u64>().ok())
+        .ok_or_else(|| ApiError::BadRequest("Content-Length header is required".to_owned()))
+}
+
+fn ensure_upload_size(len: u64, max: u64) -> Result<(), ApiError> {
+    if len == 0 {
+        return Err(ApiError::BadRequest(
+            "file body must not be empty".to_owned(),
+        ));
+    }
+    if len > max {
+        return Err(ApiError::PayloadTooLarge(format!(
+            "file body exceeds {max} byte limit"
+        )));
+    }
+    Ok(())
+}
+
+fn validate_slack_channel_id(channel_id: &str) -> Result<(), ApiError> {
+    if channel_id.len() >= 9
+        && matches!(channel_id.as_bytes().first(), Some(b'C' | b'D' | b'G'))
+        && channel_id
+            .bytes()
+            .all(|byte| byte.is_ascii_uppercase() || byte.is_ascii_digit())
+    {
+        return Ok(());
+    }
+    Err(ApiError::BadRequest("invalid Slack channel ID".to_owned()))
+}
+
+fn validate_slack_file_id(file_id: &str) -> Result<(), ApiError> {
+    if file_id.len() >= 9
+        && file_id.starts_with('F')
+        && file_id
+            .bytes()
+            .all(|byte| byte.is_ascii_uppercase() || byte.is_ascii_digit())
+    {
+        return Ok(());
+    }
+    Err(ApiError::BadRequest("invalid Slack file ID".to_owned()))
+}
+
+fn validate_slack_thread_ts(thread_ts: &str) -> Result<(), ApiError> {
+    let Some((seconds, micros)) = thread_ts.split_once('.') else {
+        return Err(ApiError::BadRequest("invalid Slack thread_ts".to_owned()));
+    };
+    if !seconds.is_empty()
+        && !micros.is_empty()
+        && seconds.bytes().all(|byte| byte.is_ascii_digit())
+        && micros.bytes().all(|byte| byte.is_ascii_digit())
+    {
+        return Ok(());
+    }
+    Err(ApiError::BadRequest("invalid Slack thread_ts".to_owned()))
+}
+
+fn validate_filename(filename: &str) -> Result<(), ApiError> {
+    let filename = filename.trim();
+    if filename.is_empty() || filename.contains('/') || filename.contains('\\') {
+        return Err(ApiError::BadRequest("invalid filename".to_owned()));
+    }
+    Ok(())
+}
+
+fn content_disposition_filename(filename: &str) -> String {
+    let sanitized = filename
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || matches!(ch, '.' | '_' | '-') {
+                ch
+            } else {
+                '_'
+            }
+        })
+        .collect::<String>();
+    format!("attachment; filename=\"{sanitized}\"")
+}
+
+fn non_empty_env(name: &str) -> Option<String> {
+    env::var(name)
+        .ok()
+        .map(|value| value.trim().to_owned())
+        .filter(|value| !value.is_empty())
+}
+
+fn positive_env_u64(name: &str, default: u64) -> u64 {
+    env::var(name)
+        .ok()
+        .and_then(|value| value.parse::<u64>().ok())
+        .filter(|value| *value > 0)
+        .unwrap_or(default)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use jsonwebtoken::{EncodingKey, Header, encode};
+
+    fn test_jwt(secret: &[u8], claims: Value) -> String {
+        encode(
+            &Header::new(Algorithm::HS256),
+            &claims,
+            &EncodingKey::from_secret(secret),
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn verifies_hs256_jwt_and_separate_slack_channel_claims() {
+        let token = test_jwt(
+            b"secret",
+            json!({
+                "iss": "centaur-console",
+                "sub": "user_123",
+                "aud": "centaur-api",
+                "iat": 1_700_000_000i64,
+                "exp": 4_102_444_800i64,
+                "slack": {
+                    "upload_channels": ["C123456789"],
+                    "download_channels": ["C987654321"]
+                }
+            }),
+        );
+        let claims = verify_hs256_jwt(&token, b"secret", "centaur-api").unwrap();
+        ensure_upload_channel_allowed(&claims, "C123456789").unwrap();
+        ensure_download_channel_allowed(&claims, "C987654321").unwrap();
+        assert!(matches!(
+            ensure_upload_channel_allowed(&claims, "C987654321").unwrap_err(),
+            ApiError::Forbidden(_)
+        ));
+        assert!(matches!(
+            ensure_download_channel_allowed(&claims, "C123456789").unwrap_err(),
+            ApiError::Forbidden(_)
+        ));
+    }
+
+    #[test]
+    fn rejects_invalid_jwt_signature() {
+        let token = test_jwt(
+            b"secret",
+            json!({
+                "iss": "centaur-console",
+                "sub": "user_123",
+                "aud": "centaur-api",
+                "iat": 1_700_000_000i64,
+                "exp": 4_102_444_800i64,
+                "slack": {
+                    "upload_channels": ["C123456789"],
+                    "download_channels": ["C123456789"]
+                }
+            }),
+        );
+        assert!(matches!(
+            verify_hs256_jwt(&token, b"other-secret", "centaur-api").unwrap_err(),
+            ApiError::Unauthorized(_)
+        ));
+    }
+
+    #[test]
+    fn rejects_expired_jwt() {
+        let token = test_jwt(
+            b"secret",
+            json!({
+                "iss": "centaur-console",
+                "sub": "user_123",
+                "aud": "centaur-api",
+                "iat": 1i64,
+                "exp": 1i64,
+                "slack": {
+                    "upload_channels": ["C123456789"],
+                    "download_channels": ["C123456789"]
+                }
+            }),
+        );
+        assert!(matches!(
+            verify_hs256_jwt(&token, b"secret", "centaur-api").unwrap_err(),
+            ApiError::Unauthorized(_)
+        ));
+    }
+
+    #[test]
+    fn rejects_wrong_jwt_audience() {
+        let token = test_jwt(
+            b"secret",
+            json!({
+                "iss": "centaur-console",
+                "sub": "user_123",
+                "aud": "other-api",
+                "iat": 1_700_000_000i64,
+                "exp": 4_102_444_800i64,
+                "slack": {
+                    "upload_channels": ["C123456789"],
+                    "download_channels": ["C123456789"]
+                }
+            }),
+        );
+        assert!(matches!(
+            verify_hs256_jwt(&token, b"secret", "centaur-api").unwrap_err(),
+            ApiError::Unauthorized(_)
+        ));
+    }
+
+    #[test]
+    fn accepts_jwt_audience_array() {
+        let token = test_jwt(
+            b"secret",
+            json!({
+                "iss": "centaur-console",
+                "sub": "user_123",
+                "aud": ["other-api", "centaur-api"],
+                "iat": 1_700_000_000i64,
+                "exp": 4_102_444_800i64,
+                "slack": {
+                    "upload_channels": ["C123456789"],
+                    "download_channels": ["C123456789"]
+                }
+            }),
+        );
+        let claims = verify_hs256_jwt(&token, b"secret", "centaur-api").unwrap();
+        ensure_upload_channel_allowed(&claims, "C123456789").unwrap();
+        ensure_download_channel_allowed(&claims, "C123456789").unwrap();
+    }
+
+    #[test]
+    fn rejects_missing_standard_jwt_claims() {
+        let token = test_jwt(
+            b"secret",
+            json!({
+                "aud": "centaur-api",
+                "exp": 4_102_444_800i64,
+                "slack": {
+                    "upload_channels": ["C123456789"],
+                    "download_channels": ["C123456789"]
+                }
+            }),
+        );
+        assert!(matches!(
+            verify_hs256_jwt(&token, b"secret", "centaur-api").unwrap_err(),
+            ApiError::Unauthorized(_)
+        ));
+    }
+
+    #[test]
+    fn extracts_channels_from_file_metadata() {
+        let file = json!({
+            "channels": ["C111111111"],
+            "groups": ["G111111111"],
+            "ims": ["D111111111"],
+            "shares": {
+                "public": {
+                    "C222222222": [{"ts": "1.000001"}]
+                },
+                "private": {
+                    "G222222222": [{"ts": "1.000002"}]
+                }
+            }
+        });
+        let channels = slack_file_channel_ids(&file);
+        assert!(channels.contains("C111111111"));
+        assert!(channels.contains("G111111111"));
+        assert!(channels.contains("D111111111"));
+        assert!(channels.contains("C222222222"));
+        assert!(channels.contains("G222222222"));
+    }
+
+    #[test]
+    fn upload_requires_content_length() {
+        let headers = HeaderMap::new();
+        assert!(matches!(
+            content_length(&headers).unwrap_err(),
+            ApiError::BadRequest(_)
+        ));
+
+        let mut headers = HeaderMap::new();
+        headers.insert(header::CONTENT_LENGTH, "42".parse().unwrap());
+        assert_eq!(content_length(&headers).unwrap(), 42);
+    }
+}

--- a/services/api-rs/crates/centaur-api-server/src/slack_proxy.rs
+++ b/services/api-rs/crates/centaur-api-server/src/slack_proxy.rs
@@ -1,10 +1,10 @@
-use std::{collections::BTreeSet, env};
+use std::{collections::BTreeSet, sync::OnceLock, time::Duration};
 
 use axum::{
     Json, Router,
     body::Body,
     extract::{DefaultBodyLimit, Path, Query},
-    http::{HeaderMap, header},
+    http::{HeaderMap, HeaderValue, header},
     response::{IntoResponse, Response},
     routing::{get, post},
 };
@@ -12,12 +12,30 @@ use jsonwebtoken::{Algorithm, DecodingKey, Validation, decode};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 
-use crate::{ApiError, routes::AppState};
+use crate::{
+    ApiError,
+    mcp::jwt_signing_secret,
+    routes::{AppState, non_empty_env, positive_env_u64},
+};
 
 const DEFAULT_SLACK_API_URL: &str = "https://slack.com/api";
 const DEFAULT_API_JWT_AUDIENCE: &str = "centaur-api";
+const DEFAULT_API_JWT_ISSUER: &str = "centaur-console";
 const DEFAULT_MAX_UPLOAD_BYTES: u64 = 100 * 1024 * 1024;
 const JWT_CLOCK_SKEW_SECONDS: i64 = 30;
+const HTTP_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+const HTTP_READ_TIMEOUT: Duration = Duration::from_secs(60);
+
+fn http_client() -> &'static reqwest::Client {
+    static CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
+    CLIENT.get_or_init(|| {
+        reqwest::Client::builder()
+            .connect_timeout(HTTP_CONNECT_TIMEOUT)
+            .read_timeout(HTTP_READ_TIMEOUT)
+            .build()
+            .expect("reqwest client configuration is valid")
+    })
+}
 
 pub(crate) fn slack_proxy_router() -> Router<AppState> {
     Router::new()
@@ -29,8 +47,6 @@ pub(crate) fn slack_proxy_router() -> Router<AppState> {
             "/api/slack/files/{file_id}/download",
             get(download_slack_file),
         )
-        .route("/api/slack/search/messages", get(search_slack_messages))
-        .route("/api/slack/search/files", get(search_slack_files))
 }
 
 #[derive(Debug, Deserialize)]
@@ -57,30 +73,8 @@ struct SlackFileDownloadQuery {
 }
 
 #[derive(Debug, Deserialize)]
-struct SlackSearchQuery {
-    query: String,
-    #[serde(default)]
-    channel_id: Option<String>,
-    #[serde(default)]
-    count: Option<u32>,
-    #[serde(default)]
-    highlight: Option<bool>,
-    #[serde(default)]
-    page: Option<u32>,
-    #[serde(default)]
-    cursor: Option<String>,
-    #[serde(default)]
-    sort: Option<String>,
-    #[serde(default)]
-    sort_dir: Option<String>,
-    #[serde(default)]
-    team_id: Option<String>,
-}
-
-#[derive(Debug, Deserialize)]
 struct SlackFileProxyClaims {
     iat: i64,
-    iss: String,
     slack: SlackProxyClaims,
     #[serde(default)]
     sub: Option<String>,
@@ -92,8 +86,6 @@ struct SlackProxyClaims {
     upload_channels: Vec<String>,
     #[serde(default)]
     download_channels: Vec<String>,
-    #[serde(default)]
-    search_channels: Vec<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -117,13 +109,16 @@ async fn upload_slack_file(
     if let Some(thread_ts) = query.thread_ts.as_deref() {
         validate_slack_thread_ts(thread_ts)?;
     }
-    let config = SlackFileProxyConfig::from_env()?;
+    if let Some(content_type) = query.content_type.as_deref() {
+        validate_content_type(content_type)?;
+    }
+    let config = slack_proxy_config()?;
     let content_length = content_length(&headers)?;
     ensure_upload_size(content_length, config.max_upload_bytes)?;
-    let client = reqwest::Client::new();
+    let client = http_client();
     let upload_ticket = get_upload_url(
-        &client,
-        &config,
+        client,
+        config,
         &query.filename,
         content_length,
         query.alt_txt.as_deref(),
@@ -131,7 +126,7 @@ async fn upload_slack_file(
     )
     .await?;
     upload_file_bytes(
-        &client,
+        client,
         &upload_ticket.upload_url,
         body,
         content_length,
@@ -139,8 +134,8 @@ async fn upload_slack_file(
     )
     .await?;
     let file = complete_upload(
-        &client,
-        &config,
+        client,
+        config,
         &upload_ticket.file_id,
         &query.channel_id,
         query.thread_ts.as_deref(),
@@ -168,9 +163,9 @@ async fn download_slack_file(
     validate_slack_channel_id(&query.channel_id)?;
     validate_slack_file_id(&file_id)?;
 
-    let config = SlackFileProxyConfig::from_env()?;
-    let client = reqwest::Client::new();
-    let file = slack_file_info(&client, &config, &file_id).await?;
+    let config = slack_proxy_config()?;
+    let client = http_client();
+    let file = slack_file_info(client, config, &file_id).await?;
     if !slack_file_in_channel(&file, &query.channel_id) {
         return Err(ApiError::Forbidden(
             "file is not shared in an allowed Slack channel".to_owned(),
@@ -195,87 +190,71 @@ async fn download_slack_file(
         )));
     }
 
-    let upstream_headers = upstream.headers().clone();
+    let file_mimetype = file.get("mimetype").and_then(Value::as_str);
+    // Slack's file host serves login/error pages with a 200 status; without this
+    // check they would stream through labeled as the file's real mimetype.
+    let upstream_content_type = upstream
+        .headers()
+        .get(header::CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok());
+    if upstream_body_is_unexpected_html(upstream_content_type, file_mimetype) {
+        return Err(ApiError::Internal(
+            "Slack file download returned an HTML page instead of the file contents".to_owned(),
+        ));
+    }
+
+    let upstream_content_length = upstream.headers().get(header::CONTENT_LENGTH).cloned();
     let mut response = Body::from_stream(upstream.bytes_stream()).into_response();
     let headers = response.headers_mut();
-    if let Some(value) = file
-        .get("mimetype")
-        .and_then(Value::as_str)
-        .and_then(|value| value.parse().ok())
-    {
+    if let Some(value) = file_mimetype.and_then(|value| value.parse().ok()) {
         headers.insert(header::CONTENT_TYPE, value);
     }
-    if let Some(value) = upstream_headers.get(header::CONTENT_LENGTH).cloned() {
+    if let Some(value) = upstream_content_length {
         headers.insert(header::CONTENT_LENGTH, value);
     }
-    if let Some(filename) = file
+    headers.insert(
+        header::X_CONTENT_TYPE_OPTIONS,
+        HeaderValue::from_static("nosniff"),
+    );
+    let filename = file
         .get("name")
         .or_else(|| file.get("title"))
         .and_then(Value::as_str)
-        .map(content_disposition_filename)
-        .and_then(|value| value.parse().ok())
-    {
-        headers.insert(header::CONTENT_DISPOSITION, filename);
+        .unwrap_or(&file_id);
+    if let Ok(value) = content_disposition_filename(filename).parse::<HeaderValue>() {
+        headers.insert(header::CONTENT_DISPOSITION, value);
     }
     Ok(response)
 }
 
-async fn search_slack_messages(
-    headers: HeaderMap,
-    Query(query): Query<SlackSearchQuery>,
-) -> Result<Json<Value>, ApiError> {
-    search_slack(headers, query, SlackSearchKind::Messages).await
+fn upstream_body_is_unexpected_html(
+    upstream_content_type: Option<&str>,
+    file_mimetype: Option<&str>,
+) -> bool {
+    let upstream_is_html = upstream_content_type.is_some_and(|value| {
+        value
+            .trim_start()
+            .to_ascii_lowercase()
+            .starts_with("text/html")
+    });
+    let file_is_html = file_mimetype.is_some_and(|value| value.eq_ignore_ascii_case("text/html"));
+    upstream_is_html && !file_is_html
 }
 
-async fn search_slack_files(
-    headers: HeaderMap,
-    Query(query): Query<SlackSearchQuery>,
-) -> Result<Json<Value>, ApiError> {
-    search_slack(headers, query, SlackSearchKind::Files).await
-}
-
-#[derive(Clone, Copy, Debug)]
-enum SlackSearchKind {
-    Messages,
-    Files,
-}
-
-impl SlackSearchKind {
-    fn method(self) -> &'static str {
-        match self {
-            Self::Messages => "search.messages",
-            Self::Files => "search.files",
-        }
-    }
-
-    fn result_key(self) -> &'static str {
-        match self {
-            Self::Messages => "messages",
-            Self::Files => "files",
-        }
-    }
-}
-
-async fn search_slack(
-    headers: HeaderMap,
-    query: SlackSearchQuery,
-    kind: SlackSearchKind,
-) -> Result<Json<Value>, ApiError> {
-    let claims = authorize_slack_file_proxy(&headers)?;
-    let channels = search_channels(&claims, query.channel_id.as_deref())?;
-    let config = SlackFileProxyConfig::from_env()?;
-    let client = reqwest::Client::new();
-    let form = slack_search_form(&query, &channels)?;
-    let mut response = slack_api_get_form(&client, &config, kind.method(), &form).await?;
-    filter_search_response(&mut response, kind, &channels);
-    Ok(Json(response))
-}
-
-#[derive(Debug)]
+// No Debug derive: bot_token must not end up in logs via {:?} formatting.
 struct SlackFileProxyConfig {
     api_url: String,
     bot_token: String,
     max_upload_bytes: u64,
+}
+
+fn slack_proxy_config() -> Result<&'static SlackFileProxyConfig, ApiError> {
+    static CELL: OnceLock<SlackFileProxyConfig> = OnceLock::new();
+    if let Some(config) = CELL.get() {
+        return Ok(config);
+    }
+    let config = SlackFileProxyConfig::from_env()?;
+    Ok(CELL.get_or_init(|| config))
 }
 
 impl SlackFileProxyConfig {
@@ -436,43 +415,16 @@ async fn slack_api_post_form(
     Ok(value)
 }
 
-async fn slack_api_get_form(
-    client: &reqwest::Client,
-    config: &SlackFileProxyConfig,
-    method: &str,
-    form: &[(&str, String)],
-) -> Result<Value, ApiError> {
-    let response = client
-        .get(format!("{}/{}", config.api_url, method))
-        .bearer_auth(&config.bot_token)
-        .query(form)
-        .send()
-        .await
-        .map_err(|error| ApiError::Internal(format!("Slack API request failed: {error}")))?;
-    let status = response.status();
-    let value = response
-        .json::<Value>()
-        .await
-        .map_err(|error| ApiError::Internal(format!("Slack API response was not JSON: {error}")))?;
-    if !status.is_success() || value.get("ok") != Some(&Value::Bool(true)) {
-        let slack_error = value
-            .get("error")
-            .and_then(Value::as_str)
-            .unwrap_or("unknown_error");
-        return Err(ApiError::BadRequest(format!(
-            "Slack {method} failed: {slack_error}"
-        )));
-    }
-    Ok(value)
-}
-
 fn authorize_slack_file_proxy(headers: &HeaderMap) -> Result<SlackFileProxyClaims, ApiError> {
     let token = bearer_token(headers)?;
-    let secret = non_empty_env("CENTAUR_API_JWT_SECRET")
-        .ok_or_else(|| ApiError::Internal("CENTAUR_API_JWT_SECRET is not configured".to_owned()))?;
+    let secret = jwt_signing_secret().ok_or_else(|| {
+        ApiError::Internal("CENTAUR_JWT_SIGNING_SECRET is not configured".to_owned())
+    })?;
     let audience = non_empty_env("CENTAUR_API_JWT_AUDIENCE")
         .unwrap_or_else(|| DEFAULT_API_JWT_AUDIENCE.to_owned());
-    verify_hs256_jwt(token, secret.as_bytes(), &audience)
+    let issuer = non_empty_env("CENTAUR_API_JWT_ISSUER")
+        .unwrap_or_else(|| DEFAULT_API_JWT_ISSUER.to_owned());
+    verify_hs256_jwt(token, secret.as_bytes(), &audience, &issuer)
 }
 
 fn bearer_token(headers: &HeaderMap) -> Result<&str, ApiError> {
@@ -481,8 +433,10 @@ fn bearer_token(headers: &HeaderMap) -> Result<&str, ApiError> {
         .and_then(|value| value.to_str().ok())
         .ok_or_else(|| ApiError::Unauthorized("missing bearer token".to_owned()))?;
     value
-        .strip_prefix("Bearer ")
-        .filter(|token| !token.trim().is_empty())
+        .split_once(' ')
+        .filter(|(scheme, _)| scheme.eq_ignore_ascii_case("Bearer"))
+        .map(|(_, token)| token.trim())
+        .filter(|token| !token.is_empty())
         .ok_or_else(|| ApiError::Unauthorized("missing bearer token".to_owned()))
 }
 
@@ -490,11 +444,13 @@ fn verify_hs256_jwt(
     token: &str,
     secret: &[u8],
     expected_audience: &str,
+    expected_issuer: &str,
 ) -> Result<SlackFileProxyClaims, ApiError> {
     let mut validation = Validation::new(Algorithm::HS256);
     validation.leeway = JWT_CLOCK_SKEW_SECONDS as u64;
     validation.validate_nbf = true;
     validation.set_audience(&[expected_audience]);
+    validation.set_issuer(&[expected_issuer]);
     validation.set_required_spec_claims(&["exp", "iss", "sub", "aud"]);
     let token_data =
         decode::<SlackFileProxyClaims>(token, &DecodingKey::from_secret(secret), &validation)
@@ -509,9 +465,6 @@ fn validate_claims(claims: &SlackFileProxyClaims) -> Result<(), ApiError> {
         return Err(ApiError::Unauthorized(
             "JWT issued-at is in the future".to_owned(),
         ));
-    }
-    if claims.iss.trim().is_empty() {
-        return Err(ApiError::Unauthorized("JWT issuer is required".to_owned()));
     }
     if claims.sub.as_deref().unwrap_or_default().trim().is_empty() {
         return Err(ApiError::Unauthorized("JWT subject is required".to_owned()));
@@ -541,34 +494,6 @@ fn ensure_download_channel_allowed(
     )
 }
 
-fn search_channels(
-    claims: &SlackFileProxyClaims,
-    requested_channel_id: Option<&str>,
-) -> Result<Vec<String>, ApiError> {
-    if let Some(channel_id) = requested_channel_id {
-        validate_slack_channel_id(channel_id)?;
-        ensure_channel_allowed(
-            &claims.slack.search_channels,
-            channel_id,
-            "JWT is not authorized to search this Slack channel",
-        )?;
-        return Ok(vec![channel_id.to_owned()]);
-    }
-
-    let mut channels = claims.slack.search_channels.clone();
-    channels.sort();
-    channels.dedup();
-    for channel in &channels {
-        validate_slack_channel_id(channel)?;
-    }
-    if channels.is_empty() {
-        return Err(ApiError::Forbidden(
-            "JWT is not authorized to search any Slack channels".to_owned(),
-        ));
-    }
-    Ok(channels)
-}
-
 fn ensure_channel_allowed(
     allowed_channels: &[String],
     channel_id: &str,
@@ -578,106 +503,6 @@ fn ensure_channel_allowed(
         return Ok(());
     }
     Err(ApiError::Forbidden(message.to_owned()))
-}
-
-fn slack_search_form(
-    query: &SlackSearchQuery,
-    channels: &[String],
-) -> Result<Vec<(&'static str, String)>, ApiError> {
-    let locked_query = locked_search_query(&query.query, channels)?;
-    let mut form = vec![
-        ("query", locked_query),
-        (
-            "count",
-            query
-                .count
-                .map(|value| value.to_string())
-                .unwrap_or_default(),
-        ),
-        (
-            "highlight",
-            query
-                .highlight
-                .map(|value| value.to_string())
-                .unwrap_or_default(),
-        ),
-        (
-            "page",
-            query
-                .page
-                .map(|value| value.to_string())
-                .unwrap_or_default(),
-        ),
-        ("cursor", query.cursor.clone().unwrap_or_default()),
-        ("sort", query.sort.clone().unwrap_or_default()),
-        ("sort_dir", query.sort_dir.clone().unwrap_or_default()),
-        ("team_id", query.team_id.clone().unwrap_or_default()),
-    ];
-    form.retain(|(_, value)| !value.is_empty());
-    Ok(form)
-}
-
-fn locked_search_query(query: &str, channels: &[String]) -> Result<String, ApiError> {
-    let query = query.trim();
-    if query.is_empty() {
-        return Err(ApiError::BadRequest("query must not be empty".to_owned()));
-    }
-    if channels.is_empty() {
-        return Err(ApiError::Forbidden(
-            "JWT is not authorized to search any Slack channels".to_owned(),
-        ));
-    }
-    let filters = channels
-        .iter()
-        .map(|channel| format!("in:<#{channel}>"))
-        .collect::<Vec<_>>();
-    if filters.len() == 1 {
-        Ok(format!("{query} {}", filters[0]))
-    } else {
-        Ok(format!("{query} ({})", filters.join(" OR ")))
-    }
-}
-
-fn filter_search_response(response: &mut Value, kind: SlackSearchKind, channels: &[String]) {
-    let allowed = channels.iter().cloned().collect::<BTreeSet<_>>();
-    let Some(container) = response
-        .get_mut(kind.result_key())
-        .and_then(Value::as_object_mut)
-    else {
-        return;
-    };
-    let Some(matches) = container.get_mut("matches").and_then(Value::as_array_mut) else {
-        return;
-    };
-    matches.retain(|entry| search_match_in_allowed_channels(entry, kind, &allowed));
-    let filtered_count = u64::try_from(matches.len()).unwrap_or(u64::MAX);
-    container.insert("total".to_owned(), json!(filtered_count));
-    if let Some(pagination) = container
-        .get_mut("pagination")
-        .and_then(Value::as_object_mut)
-    {
-        pagination.insert("total_count".to_owned(), json!(filtered_count));
-    }
-    if let Some(paging) = container.get_mut("paging").and_then(Value::as_object_mut) {
-        paging.insert("total".to_owned(), json!(filtered_count));
-    }
-}
-
-fn search_match_in_allowed_channels(
-    entry: &Value,
-    kind: SlackSearchKind,
-    allowed: &BTreeSet<String>,
-) -> bool {
-    match kind {
-        SlackSearchKind::Messages => entry
-            .get("channel")
-            .and_then(|channel| channel.get("id"))
-            .and_then(Value::as_str)
-            .is_some_and(|channel_id| allowed.contains(channel_id)),
-        SlackSearchKind::Files => slack_file_channel_ids(entry)
-            .iter()
-            .any(|channel_id| allowed.contains(channel_id)),
-    }
 }
 
 fn slack_file_in_channel(file: &Value, channel_id: &str) -> bool {
@@ -781,6 +606,13 @@ fn validate_filename(filename: &str) -> Result<(), ApiError> {
     Ok(())
 }
 
+fn validate_content_type(content_type: &str) -> Result<(), ApiError> {
+    if content_type.trim().is_empty() || content_type.parse::<HeaderValue>().is_err() {
+        return Err(ApiError::BadRequest("invalid content_type".to_owned()));
+    }
+    Ok(())
+}
+
 fn content_disposition_filename(filename: &str) -> String {
     let sanitized = filename
         .chars()
@@ -793,21 +625,6 @@ fn content_disposition_filename(filename: &str) -> String {
         })
         .collect::<String>();
     format!("attachment; filename=\"{sanitized}\"")
-}
-
-fn non_empty_env(name: &str) -> Option<String> {
-    env::var(name)
-        .ok()
-        .map(|value| value.trim().to_owned())
-        .filter(|value| !value.is_empty())
-}
-
-fn positive_env_u64(name: &str, default: u64) -> u64 {
-    env::var(name)
-        .ok()
-        .and_then(|value| value.parse::<u64>().ok())
-        .filter(|value| *value > 0)
-        .unwrap_or(default)
 }
 
 #[cfg(test)]
@@ -836,28 +653,19 @@ mod tests {
                 "exp": 4_102_444_800i64,
                 "slack": {
                     "upload_channels": ["C123456789"],
-                    "download_channels": ["C987654321"],
-                    "search_channels": ["G123456789"]
+                    "download_channels": ["C987654321"]
                 }
             }),
         );
-        let claims = verify_hs256_jwt(&token, b"secret", "centaur-api").unwrap();
+        let claims = verify_hs256_jwt(&token, b"secret", "centaur-api", "centaur-console").unwrap();
         ensure_upload_channel_allowed(&claims, "C123456789").unwrap();
         ensure_download_channel_allowed(&claims, "C987654321").unwrap();
-        assert_eq!(
-            search_channels(&claims, Some("G123456789")).unwrap(),
-            vec!["G123456789".to_owned()]
-        );
         assert!(matches!(
             ensure_upload_channel_allowed(&claims, "C987654321").unwrap_err(),
             ApiError::Forbidden(_)
         ));
         assert!(matches!(
             ensure_download_channel_allowed(&claims, "C123456789").unwrap_err(),
-            ApiError::Forbidden(_)
-        ));
-        assert!(matches!(
-            search_channels(&claims, Some("C123456789")).unwrap_err(),
             ApiError::Forbidden(_)
         ));
     }
@@ -879,7 +687,8 @@ mod tests {
             }),
         );
         assert!(matches!(
-            verify_hs256_jwt(&token, b"other-secret", "centaur-api").unwrap_err(),
+            verify_hs256_jwt(&token, b"other-secret", "centaur-api", "centaur-console")
+                .unwrap_err(),
             ApiError::Unauthorized(_)
         ));
     }
@@ -901,7 +710,7 @@ mod tests {
             }),
         );
         assert!(matches!(
-            verify_hs256_jwt(&token, b"secret", "centaur-api").unwrap_err(),
+            verify_hs256_jwt(&token, b"secret", "centaur-api", "centaur-console").unwrap_err(),
             ApiError::Unauthorized(_)
         ));
     }
@@ -923,7 +732,7 @@ mod tests {
             }),
         );
         assert!(matches!(
-            verify_hs256_jwt(&token, b"secret", "centaur-api").unwrap_err(),
+            verify_hs256_jwt(&token, b"secret", "centaur-api", "centaur-console").unwrap_err(),
             ApiError::Unauthorized(_)
         ));
     }
@@ -944,7 +753,7 @@ mod tests {
                 }
             }),
         );
-        let claims = verify_hs256_jwt(&token, b"secret", "centaur-api").unwrap();
+        let claims = verify_hs256_jwt(&token, b"secret", "centaur-api", "centaur-console").unwrap();
         ensure_upload_channel_allowed(&claims, "C123456789").unwrap();
         ensure_download_channel_allowed(&claims, "C123456789").unwrap();
     }
@@ -963,7 +772,7 @@ mod tests {
             }),
         );
         assert!(matches!(
-            verify_hs256_jwt(&token, b"secret", "centaur-api").unwrap_err(),
+            verify_hs256_jwt(&token, b"secret", "centaur-api", "centaur-console").unwrap_err(),
             ApiError::Unauthorized(_)
         ));
     }
@@ -1005,6 +814,76 @@ mod tests {
     }
 
     #[test]
+    fn rejects_wrong_jwt_issuer() {
+        let token = test_jwt(
+            b"secret",
+            json!({
+                "iss": "other-issuer",
+                "sub": "user_123",
+                "aud": "centaur-api",
+                "iat": 1_700_000_000i64,
+                "exp": 4_102_444_800i64,
+                "slack": {
+                    "upload_channels": ["C123456789"],
+                    "download_channels": ["C123456789"]
+                }
+            }),
+        );
+        assert!(matches!(
+            verify_hs256_jwt(&token, b"secret", "centaur-api", "centaur-console").unwrap_err(),
+            ApiError::Unauthorized(_)
+        ));
+    }
+
+    #[test]
+    fn bearer_token_scheme_is_case_insensitive() {
+        for value in ["Bearer token-1", "bearer token-1", "BEARER token-1"] {
+            let mut headers = HeaderMap::new();
+            headers.insert(header::AUTHORIZATION, value.parse().unwrap());
+            assert_eq!(bearer_token(&headers).unwrap(), "token-1");
+        }
+
+        for value in ["Bearer ", "token-1", "Basic token-1"] {
+            let mut headers = HeaderMap::new();
+            headers.insert(header::AUTHORIZATION, value.parse().unwrap());
+            assert!(matches!(
+                bearer_token(&headers).unwrap_err(),
+                ApiError::Unauthorized(_)
+            ));
+        }
+    }
+
+    #[test]
+    fn detects_unexpected_html_download_body() {
+        assert!(upstream_body_is_unexpected_html(
+            Some("text/html; charset=utf-8"),
+            Some("image/png"),
+        ));
+        assert!(upstream_body_is_unexpected_html(Some("TEXT/HTML"), None));
+        assert!(!upstream_body_is_unexpected_html(
+            Some("text/html"),
+            Some("text/html"),
+        ));
+        assert!(!upstream_body_is_unexpected_html(
+            Some("image/png"),
+            Some("image/png"),
+        ));
+        assert!(!upstream_body_is_unexpected_html(None, Some("image/png")));
+    }
+
+    #[test]
+    fn validates_content_type() {
+        validate_content_type("application/pdf").unwrap();
+        validate_content_type("text/plain; charset=utf-8").unwrap();
+        for content_type in ["", " ", "a\nb", "a\rb", "a\0b"] {
+            assert!(matches!(
+                validate_content_type(content_type).unwrap_err(),
+                ApiError::BadRequest(_)
+            ));
+        }
+    }
+
+    #[test]
     fn upload_url_form_includes_alt_text_and_snippet_type() {
         let form = slack_get_upload_url_form("notes.txt", 42, Some("Release notes"), Some("text"));
         assert_eq!(
@@ -1025,122 +904,5 @@ mod tests {
                 ("length", "42".to_owned()),
             ]
         );
-    }
-
-    #[test]
-    fn search_form_locks_query_to_allowed_channels() {
-        let query = SlackSearchQuery {
-            query: "release notes".to_owned(),
-            channel_id: None,
-            count: Some(10),
-            highlight: Some(true),
-            page: None,
-            cursor: Some("cursor-1".to_owned()),
-            sort: Some("timestamp".to_owned()),
-            sort_dir: Some("desc".to_owned()),
-            team_id: Some("T12345678".to_owned()),
-        };
-        let form =
-            slack_search_form(&query, &["C123456789".to_owned(), "G123456789".to_owned()]).unwrap();
-        assert_eq!(
-            form,
-            vec![
-                (
-                    "query",
-                    "release notes (in:<#C123456789> OR in:<#G123456789>)".to_owned(),
-                ),
-                ("count", "10".to_owned()),
-                ("highlight", "true".to_owned()),
-                ("cursor", "cursor-1".to_owned()),
-                ("sort", "timestamp".to_owned()),
-                ("sort_dir", "desc".to_owned()),
-                ("team_id", "T12345678".to_owned()),
-            ]
-        );
-    }
-
-    #[test]
-    fn search_channels_uses_requested_channel_or_full_claim_list() {
-        let claims = SlackFileProxyClaims {
-            iat: 1,
-            iss: "centaur-console".to_owned(),
-            slack: SlackProxyClaims {
-                upload_channels: vec![],
-                download_channels: vec![],
-                search_channels: vec![
-                    "G123456789".to_owned(),
-                    "C123456789".to_owned(),
-                    "C123456789".to_owned(),
-                ],
-            },
-            sub: Some("user_123".to_owned()),
-        };
-
-        assert_eq!(
-            search_channels(&claims, Some("G123456789")).unwrap(),
-            vec!["G123456789".to_owned()]
-        );
-        assert_eq!(
-            search_channels(&claims, None).unwrap(),
-            vec!["C123456789".to_owned(), "G123456789".to_owned()]
-        );
-        assert!(matches!(
-            search_channels(&claims, Some("D123456789")).unwrap_err(),
-            ApiError::Forbidden(_)
-        ));
-    }
-
-    #[test]
-    fn search_response_filter_removes_disallowed_message_matches() {
-        let mut response = json!({
-            "ok": true,
-            "messages": {
-                "matches": [
-                    {"channel": {"id": "C123456789"}, "text": "allowed"},
-                    {"channel": {"id": "C987654321"}, "text": "denied"}
-                ],
-                "pagination": {"total_count": 2},
-                "paging": {"total": 2},
-                "total": 2
-            }
-        });
-
-        filter_search_response(
-            &mut response,
-            SlackSearchKind::Messages,
-            &["C123456789".to_owned()],
-        );
-
-        assert_eq!(response["messages"]["matches"].as_array().unwrap().len(), 1);
-        assert_eq!(response["messages"]["matches"][0]["text"], "allowed");
-        assert_eq!(response["messages"]["total"], json!(1));
-        assert_eq!(response["messages"]["pagination"]["total_count"], json!(1));
-        assert_eq!(response["messages"]["paging"]["total"], json!(1));
-    }
-
-    #[test]
-    fn search_response_filter_removes_disallowed_file_matches() {
-        let mut response = json!({
-            "ok": true,
-            "files": {
-                "matches": [
-                    {"id": "F123456789", "channels": ["C123456789"]},
-                    {"id": "F987654321", "groups": ["G987654321"]}
-                ],
-                "pagination": {"total_count": 2},
-                "paging": {"total": 2},
-                "total": 2
-            }
-        });
-
-        filter_search_response(
-            &mut response,
-            SlackSearchKind::Files,
-            &["C123456789".to_owned()],
-        );
-
-        assert_eq!(response["files"]["matches"].as_array().unwrap().len(), 1);
-        assert_eq!(response["files"]["matches"][0]["id"], "F123456789");
-        assert_eq!(response["files"]["total"], json!(1));
     }
 }

--- a/services/api-rs/crates/centaur-api-server/src/slack_proxy.rs
+++ b/services/api-rs/crates/centaur-api-server/src/slack_proxy.rs
@@ -19,7 +19,7 @@ const DEFAULT_API_JWT_AUDIENCE: &str = "centaur-api";
 const DEFAULT_MAX_UPLOAD_BYTES: u64 = 100 * 1024 * 1024;
 const JWT_CLOCK_SKEW_SECONDS: i64 = 30;
 
-pub(crate) fn slack_file_proxy_router() -> Router<AppState> {
+pub(crate) fn slack_proxy_router() -> Router<AppState> {
     Router::new()
         .route(
             "/api/slack/files/upload",


### PR DESCRIPTION
Adds authenticated API routes for uploading files to Slack threads and downloading Slack files through api-rs. The proxy validates HS256 API JWTs with nested Slack upload/download channel grants, streams file bodies, and uses Slack's external upload flow.