### PR TITLE
feat(harness): first-class omp (oh-my-pi) harness

### DIFF
--- a/.github/workflows/darkmatter-images.yml
+++ b/.github/workflows/darkmatter-images.yml
@@ -1,0 +1,86 @@
+name: darkmatter images
+
+# Build + push the darkmatter Centaur images (api-rs control plane + the omp
+# sandbox agent) in CI — never locally, so deployed images always match the
+# committed source. Runs on the darkmatter fork only.
+on:
+  push:
+    branches: [feat/omp-harness, main]
+    paths:
+      - "services/api-rs/**"
+      - "services/sandbox/**"
+      - "services/workflow-python/**"
+      - "crates/**"
+      - "harness/**"
+      - "tools/**"
+      - "workflows/**"
+      - ".github/workflows/darkmatter-images.yml"
+  workflow_dispatch: {}
+
+concurrency:
+  group: darkmatter-images-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  api-rs:
+    if: github.repository_owner == 'darkmatter'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/centaur-api-rs
+          tags: |
+            type=sha,format=long
+            type=raw,value=latest,enable={{is_default_branch}}
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: services/api-rs/Dockerfile
+          platforms: linux/amd64 # k3s nodes
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=api-rs
+          cache-to: type=gha,mode=max,scope=api-rs
+
+  agent:
+    if: github.repository_owner == 'darkmatter'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/centaur-agent
+          tags: |
+            type=sha,format=long
+            type=raw,value=latest,enable={{is_default_branch}}
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: services/sandbox/Dockerfile
+          target: sandbox
+          platforms: linux/amd64 # k3s nodes
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=agent
+          cache-to: type=gha,mode=max,scope=agent

--- a/contrib/chart/values.yaml
+++ b/contrib/chart/values.yaml
@@ -222,12 +222,13 @@ sandbox:
   #                  subscription token (proxy injects the brokered credential).
   codexAuthMode: api_key
   claudeCodeAuthMode: api_key
-  # The deployment's default harness: codex | amp | claudecode. Decides what
-  # warm sandboxes boot (SESSION_SANDBOX_HARNESS) and which harness auth
-  # fragment is required at startup (the other harnesses' fragments are
-  # registered too when available, so per-session --claude/--amp/--codex
-  # overrides keep working credentials). Per-session sandboxes always run
-  # their session's harness via container args; the sandbox image CMD only
+  # The deployment's default harness: codex | amp | claudecode | omp. Decides
+  # what warm sandboxes boot (SESSION_SANDBOX_HARNESS) and which harness auth
+  # fragment is required at startup (engines with no auth-mode source — amp,
+  # omp — require none; the other harnesses' fragments are registered too when
+  # available, so per-session --claude/--amp/--codex/--omp overrides keep
+  # working credentials). Per-session sandboxes always run their session's
+  # harness via container args; the sandbox image CMD only
   # matters for containers started outside api-rs.
   harnessEngine: codex
   # Copied into every sandbox pod. CLAUDE_MODEL / CODEX_MODEL set here (the

--- a/crates/harness-server/src/amp.rs
+++ b/crates/harness-server/src/amp.rs
@@ -116,33 +116,35 @@ impl HarnessServer for AmpHarness {
         "amp"
     }
 
-    fn command_for_turn(&self, state: &ThreadState, _input: &[UserInput]) -> ProcessCommand { if let Some(command) = command_from_override("CENTAUR_AMP_APP_BRIDGE_COMMAND") {
-        return command;
+    fn command_for_turn(&self, state: &ThreadState, _input: &[UserInput]) -> ProcessCommand {
+        if let Some(command) = command_from_override("CENTAUR_AMP_APP_BRIDGE_COMMAND") {
+            return command;
+        }
+
+        let bin = env::var("AMP_BIN").unwrap_or_else(|_| "amp".to_string());
+        let mut command = ProcessCommand::new(bin);
+        command.args([
+            "--no-ide",
+            "--no-notifications",
+            "--no-color",
+            "--dangerously-allow-all",
+            "--execute",
+            "--stream-json",
+            "--stream-json-input",
+            "--stream-json-thinking",
+            "--mode",
+            &state.model,
+        ]);
+        if let Ok(visibility) = env::var("AMP_THREAD_VISIBILITY")
+            && !visibility.trim().is_empty()
+        {
+            command.args(["--visibility", visibility.trim()]);
+        }
+        if let Some(session_id) = &state.harness_session_id {
+            command.args(["threads", "continue", session_id]);
+        }
+        command
     }
-    
-    let bin = env::var("AMP_BIN").unwrap_or_else(|_| "amp".to_string());
-    let mut command = ProcessCommand::new(bin);
-    command.args([
-        "--no-ide",
-        "--no-notifications",
-        "--no-color",
-        "--dangerously-allow-all",
-        "--execute",
-        "--stream-json",
-        "--stream-json-input",
-        "--stream-json-thinking",
-        "--mode",
-        &state.model,
-    ]);
-    if let Ok(visibility) = env::var("AMP_THREAD_VISIBILITY")
-        && !visibility.trim().is_empty()
-    {
-        command.args(["--visibility", visibility.trim()]);
-    }
-    if let Some(session_id) = &state.harness_session_id {
-        command.args(["threads", "continue", session_id]);
-    }
-    command }
 
     fn stdin_for_turn(&self, input: &[UserInput]) -> Result<Vec<u8>> {
         amp_user_stdin(input, false)

--- a/crates/harness-server/src/amp.rs
+++ b/crates/harness-server/src/amp.rs
@@ -116,35 +116,33 @@ impl HarnessServer for AmpHarness {
         "amp"
     }
 
-    fn command_for_turn(&self, state: &ThreadState) -> ProcessCommand {
-        if let Some(command) = command_from_override("CENTAUR_AMP_APP_BRIDGE_COMMAND") {
-            return command;
-        }
-
-        let bin = env::var("AMP_BIN").unwrap_or_else(|_| "amp".to_string());
-        let mut command = ProcessCommand::new(bin);
-        command.args([
-            "--no-ide",
-            "--no-notifications",
-            "--no-color",
-            "--dangerously-allow-all",
-            "--execute",
-            "--stream-json",
-            "--stream-json-input",
-            "--stream-json-thinking",
-            "--mode",
-            &state.model,
-        ]);
-        if let Ok(visibility) = env::var("AMP_THREAD_VISIBILITY")
-            && !visibility.trim().is_empty()
-        {
-            command.args(["--visibility", visibility.trim()]);
-        }
-        if let Some(session_id) = &state.harness_session_id {
-            command.args(["threads", "continue", session_id]);
-        }
-        command
+    fn command_for_turn(&self, state: &ThreadState, _input: &[UserInput]) -> ProcessCommand { if let Some(command) = command_from_override("CENTAUR_AMP_APP_BRIDGE_COMMAND") {
+        return command;
     }
+    
+    let bin = env::var("AMP_BIN").unwrap_or_else(|_| "amp".to_string());
+    let mut command = ProcessCommand::new(bin);
+    command.args([
+        "--no-ide",
+        "--no-notifications",
+        "--no-color",
+        "--dangerously-allow-all",
+        "--execute",
+        "--stream-json",
+        "--stream-json-input",
+        "--stream-json-thinking",
+        "--mode",
+        &state.model,
+    ]);
+    if let Ok(visibility) = env::var("AMP_THREAD_VISIBILITY")
+        && !visibility.trim().is_empty()
+    {
+        command.args(["--visibility", visibility.trim()]);
+    }
+    if let Some(session_id) = &state.harness_session_id {
+        command.args(["threads", "continue", session_id]);
+    }
+    command }
 
     fn stdin_for_turn(&self, input: &[UserInput]) -> Result<Vec<u8>> {
         amp_user_stdin(input, false)

--- a/crates/harness-server/src/claude.rs
+++ b/crates/harness-server/src/claude.rs
@@ -221,36 +221,38 @@ impl HarnessServer for ClaudeCodeHarness {
         "anthropic"
     }
 
-    fn command_for_turn(&self, state: &ThreadState, _input: &[UserInput]) -> ProcessCommand { if let Some(command) = command_from_override("CENTAUR_CLAUDE_APP_BRIDGE_COMMAND") {
-        return command;
+    fn command_for_turn(&self, state: &ThreadState, _input: &[UserInput]) -> ProcessCommand {
+        if let Some(command) = command_from_override("CENTAUR_CLAUDE_APP_BRIDGE_COMMAND") {
+            return command;
+        }
+
+        let bin = env::var("CLAUDE_BIN").unwrap_or_else(|_| "claude".to_string());
+        let mut command = ProcessCommand::new(bin);
+        command.args([
+            "--print",
+            "--input-format",
+            "stream-json",
+            "--output-format",
+            "stream-json",
+            "--verbose",
+            "--include-partial-messages",
+            "--dangerously-skip-permissions",
+            "--permission-mode",
+            "bypassPermissions",
+        ]);
+        if !state.model.is_empty() {
+            command.args(["--model", &state.model]);
+        }
+        if PathBuf::from("AGENTS.md").is_file() {
+            command.args(["--append-system-prompt-file", "AGENTS.md"]);
+        }
+        if let Some(session_id) = &state.harness_session_id {
+            command.args(["--resume", session_id]);
+        } else {
+            command.args(["--session-id", &state.id]);
+        }
+        command
     }
-    
-    let bin = env::var("CLAUDE_BIN").unwrap_or_else(|_| "claude".to_string());
-    let mut command = ProcessCommand::new(bin);
-    command.args([
-        "--print",
-        "--input-format",
-        "stream-json",
-        "--output-format",
-        "stream-json",
-        "--verbose",
-        "--include-partial-messages",
-        "--dangerously-skip-permissions",
-        "--permission-mode",
-        "bypassPermissions",
-    ]);
-    if !state.model.is_empty() {
-        command.args(["--model", &state.model]);
-    }
-    if PathBuf::from("AGENTS.md").is_file() {
-        command.args(["--append-system-prompt-file", "AGENTS.md"]);
-    }
-    if let Some(session_id) = &state.harness_session_id {
-        command.args(["--resume", session_id]);
-    } else {
-        command.args(["--session-id", &state.id]);
-    }
-    command }
 
     fn stdin_for_turn(&self, input: &[UserInput]) -> Result<Vec<u8>> {
         let payload = json!({

--- a/crates/harness-server/src/claude.rs
+++ b/crates/harness-server/src/claude.rs
@@ -221,38 +221,36 @@ impl HarnessServer for ClaudeCodeHarness {
         "anthropic"
     }
 
-    fn command_for_turn(&self, state: &ThreadState) -> ProcessCommand {
-        if let Some(command) = command_from_override("CENTAUR_CLAUDE_APP_BRIDGE_COMMAND") {
-            return command;
-        }
-
-        let bin = env::var("CLAUDE_BIN").unwrap_or_else(|_| "claude".to_string());
-        let mut command = ProcessCommand::new(bin);
-        command.args([
-            "--print",
-            "--input-format",
-            "stream-json",
-            "--output-format",
-            "stream-json",
-            "--verbose",
-            "--include-partial-messages",
-            "--dangerously-skip-permissions",
-            "--permission-mode",
-            "bypassPermissions",
-        ]);
-        if !state.model.is_empty() {
-            command.args(["--model", &state.model]);
-        }
-        if PathBuf::from("AGENTS.md").is_file() {
-            command.args(["--append-system-prompt-file", "AGENTS.md"]);
-        }
-        if let Some(session_id) = &state.harness_session_id {
-            command.args(["--resume", session_id]);
-        } else {
-            command.args(["--session-id", &state.id]);
-        }
-        command
+    fn command_for_turn(&self, state: &ThreadState, _input: &[UserInput]) -> ProcessCommand { if let Some(command) = command_from_override("CENTAUR_CLAUDE_APP_BRIDGE_COMMAND") {
+        return command;
     }
+    
+    let bin = env::var("CLAUDE_BIN").unwrap_or_else(|_| "claude".to_string());
+    let mut command = ProcessCommand::new(bin);
+    command.args([
+        "--print",
+        "--input-format",
+        "stream-json",
+        "--output-format",
+        "stream-json",
+        "--verbose",
+        "--include-partial-messages",
+        "--dangerously-skip-permissions",
+        "--permission-mode",
+        "bypassPermissions",
+    ]);
+    if !state.model.is_empty() {
+        command.args(["--model", &state.model]);
+    }
+    if PathBuf::from("AGENTS.md").is_file() {
+        command.args(["--append-system-prompt-file", "AGENTS.md"]);
+    }
+    if let Some(session_id) = &state.harness_session_id {
+        command.args(["--resume", session_id]);
+    } else {
+        command.args(["--session-id", &state.id]);
+    }
+    command }
 
     fn stdin_for_turn(&self, input: &[UserInput]) -> Result<Vec<u8>> {
         let payload = json!({

--- a/crates/harness-server/src/lib.rs
+++ b/crates/harness-server/src/lib.rs
@@ -3,6 +3,7 @@ pub mod anthropic;
 pub mod claude;
 pub mod codex;
 mod error;
+pub mod omp;
 mod otel;
 mod server;
 mod traits;

--- a/crates/harness-server/src/main.rs
+++ b/crates/harness-server/src/main.rs
@@ -21,6 +21,7 @@ enum CliCommand {
     #[command(alias = "claude")]
     ClaudeCode(HarnessCommand),
     Amp(HarnessCommand),
+    Omp(HarnessCommand),
     ValidateJsonrpc,
     ValidateAgentDeltas,
 }
@@ -53,6 +54,7 @@ fn run() -> Result<()> {
         CliCommand::Codex(command) => run_mode(HarnessKind::Codex, command.mode),
         CliCommand::ClaudeCode(command) => run_mode(HarnessKind::ClaudeCode, command.mode),
         CliCommand::Amp(command) => run_mode(HarnessKind::Amp, command.mode),
+        CliCommand::Omp(command) => run_mode(HarnessKind::Omp, command.mode),
         CliCommand::ValidateJsonrpc => run_validate_jsonrpc(),
         CliCommand::ValidateAgentDeltas => run_validate_agent_deltas(),
     }

--- a/crates/harness-server/src/omp.rs
+++ b/crates/harness-server/src/omp.rs
@@ -1,0 +1,542 @@
+use std::env;
+use std::path::PathBuf;
+use std::process::Command as ProcessCommand;
+use std::time::Duration;
+
+use codex_app_server_protocol::UserInput;
+use serde::Deserialize;
+use serde_json::Value;
+
+use crate::{
+    HarnessKind, HarnessServer, NormalizedContent, NormalizedEvent, NormalizedTokenUsage,
+    NormalizedToolResult, Result, ThreadState, command_from_override, stable_id,
+    user_input_to_anthropic_content,
+};
+
+#[derive(Debug, Default)]
+pub struct OmpHarness;
+
+/// One line of `omp -p --mode json` output. omp runs one agent turn per
+/// process: the first line is always `session` (carrying the durable session
+/// id, echoed verbatim on `-r` resume), tool loops produce several
+/// `turn_start`/`turn_end` pairs, and `agent_end` is the final line before the
+/// process exits.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum OmpStreamEvent {
+    Session {
+        id: String,
+    },
+    AgentStart,
+    TurnStart,
+    MessageStart,
+    MessageUpdate {
+        #[serde(rename = "assistantMessageEvent")]
+        assistant_message_event: OmpAssistantMessageEvent,
+        message: OmpMessageId,
+    },
+    MessageEnd {
+        message: OmpMessage,
+    },
+    ToolExecutionStart,
+    ToolExecutionUpdate,
+    ToolExecutionEnd {
+        #[serde(rename = "toolCallId")]
+        tool_call_id: String,
+        result: Option<OmpToolExecutionResult>,
+        #[serde(default, rename = "isError")]
+        is_error: bool,
+    },
+    TurnEnd,
+    AgentEnd,
+    Error {
+        message: Option<String>,
+        error: Option<Value>,
+    },
+    #[serde(other)]
+    Unknown,
+}
+
+impl OmpStreamEvent {
+    pub fn parse_json_line(line: &str) -> Result<Self> {
+        Ok(serde_json::from_str(line)?)
+    }
+}
+
+/// The streaming `assistantMessageEvent` payload inside `message_update`.
+/// Only text and thinking deltas are consumed; frame boundaries and tool-call
+/// streaming carry nothing the normalized events need (the authoritative tool
+/// call arrives with the message's `message_end`).
+#[derive(Debug, Clone, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum OmpAssistantMessageEvent {
+    TextStart,
+    TextDelta {
+        delta: String,
+    },
+    TextEnd,
+    ThinkingStart,
+    ThinkingDelta {
+        #[serde(rename = "contentIndex")]
+        content_index: usize,
+        delta: String,
+    },
+    ThinkingEnd,
+    ToolcallStart,
+    ToolcallDelta,
+    ToolcallEnd,
+    #[serde(other)]
+    Unknown,
+}
+
+/// The slice of a `message_update`'s partial message the normalizer needs:
+/// the provider response id keying text deltas to their message item. The
+/// full partial (repeated content, usage, cost) is deliberately not parsed —
+/// it is re-sent on every delta line.
+#[derive(Debug, Clone, Deserialize)]
+pub struct OmpMessageId {
+    #[serde(default, rename = "responseId")]
+    pub response_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct OmpMessage {
+    pub role: String,
+    #[serde(default)]
+    pub content: Vec<OmpContentBlock>,
+    #[serde(default)]
+    pub model: Option<String>,
+    #[serde(default)]
+    pub usage: Option<OmpUsage>,
+    #[serde(default, rename = "stopReason")]
+    pub stop_reason: Option<String>,
+    #[serde(default, rename = "responseId")]
+    pub response_id: Option<String>,
+}
+
+impl OmpMessage {
+    fn token_usage(&self) -> Option<NormalizedTokenUsage> {
+        let usage = self.usage.as_ref()?;
+        let normalized = NormalizedTokenUsage {
+            model: self.model.clone(),
+            input_tokens: usage.input,
+            output_tokens: usage.output,
+            cache_creation_input_tokens: usage.cache_write,
+            cache_read_input_tokens: usage.cache_read,
+            reasoning_output_tokens: None,
+            total_tokens: usage.total_tokens,
+        };
+        normalized.has_counts().then_some(normalized)
+    }
+
+    fn into_normalized_content(self) -> Vec<NormalizedContent> {
+        let item_id = assistant_item_id(self.response_id.as_deref());
+        self.content
+            .into_iter()
+            .enumerate()
+            .filter_map(|(index, block)| match block {
+                OmpContentBlock::Text { text } => Some(NormalizedContent::AgentText {
+                    item_id: item_id.clone(),
+                    text,
+                }),
+                OmpContentBlock::Thinking { thinking } => Some(NormalizedContent::ReasoningText {
+                    item_id: reasoning_item_id(&item_id, index),
+                    text: thinking,
+                }),
+                OmpContentBlock::ToolCall {
+                    id,
+                    name,
+                    arguments,
+                } => Some(NormalizedContent::ToolUse {
+                    raw_id: id,
+                    tool: name,
+                    arguments,
+                }),
+                OmpContentBlock::Unknown => None,
+            })
+            .collect()
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(tag = "type")]
+pub enum OmpContentBlock {
+    #[serde(rename = "text")]
+    Text { text: String },
+    #[serde(rename = "thinking")]
+    Thinking { thinking: String },
+    #[serde(rename = "toolCall")]
+    ToolCall {
+        id: String,
+        name: String,
+        #[serde(default)]
+        arguments: Value,
+    },
+    #[serde(other)]
+    Unknown,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct OmpUsage {
+    #[serde(default)]
+    pub input: Option<i64>,
+    #[serde(default)]
+    pub output: Option<i64>,
+    #[serde(default, rename = "cacheRead")]
+    pub cache_read: Option<i64>,
+    #[serde(default, rename = "cacheWrite")]
+    pub cache_write: Option<i64>,
+    #[serde(default, rename = "totalTokens")]
+    pub total_tokens: Option<i64>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct OmpToolExecutionResult {
+    #[serde(default)]
+    pub content: Vec<OmpContentBlock>,
+}
+
+impl OmpToolExecutionResult {
+    fn text(&self) -> String {
+        let mut out = String::new();
+        for block in &self.content {
+            if let OmpContentBlock::Text { text } = block {
+                if !out.is_empty() {
+                    out.push('\n');
+                }
+                out.push_str(text);
+            }
+        }
+        out
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct OmpEventNormalizer;
+
+impl OmpEventNormalizer {
+    fn normalize(&mut self, event: OmpStreamEvent) -> Vec<NormalizedEvent> {
+        match event {
+            OmpStreamEvent::Session { id } => vec![NormalizedEvent::SessionStarted {
+                session_id: Some(id),
+            }],
+            OmpStreamEvent::MessageUpdate {
+                assistant_message_event,
+                message,
+            } => {
+                let item_id = assistant_item_id(message.response_id.as_deref());
+                match assistant_message_event {
+                    OmpAssistantMessageEvent::TextDelta { delta } if !delta.is_empty() => {
+                        vec![NormalizedEvent::AgentTextDelta { item_id, delta }]
+                    }
+                    OmpAssistantMessageEvent::ThinkingDelta {
+                        content_index,
+                        delta,
+                    } if !delta.is_empty() => {
+                        vec![NormalizedEvent::ReasoningTextDelta {
+                            item_id: reasoning_item_id(&item_id, content_index),
+                            delta,
+                        }]
+                    }
+                    OmpAssistantMessageEvent::Unknown => {
+                        eprintln!("omp: ignoring unknown assistantMessageEvent kind");
+                        Vec::new()
+                    }
+                    _ => Vec::new(),
+                }
+            }
+            OmpStreamEvent::MessageEnd { message } if message.role == "assistant" => {
+                let mut out = Vec::new();
+                if let Some(usage) = message.token_usage() {
+                    out.push(NormalizedEvent::TokenUsage { usage });
+                }
+                let stop_reason = message.stop_reason.as_deref().map(normalized_stop_reason);
+                out.push(NormalizedEvent::AssistantMessage {
+                    partial: false,
+                    stop_reason,
+                    content: message.into_normalized_content(),
+                });
+                out
+            }
+            // user echoes and toolResult messages: the tool result is taken
+            // from `tool_execution_end` (which also carries `isError`), so the
+            // duplicate toolResult message would double-emit it.
+            OmpStreamEvent::MessageEnd { .. } => Vec::new(),
+            OmpStreamEvent::ToolExecutionEnd {
+                tool_call_id,
+                result,
+                is_error,
+            } => vec![NormalizedEvent::ToolResults(vec![NormalizedToolResult {
+                tool_use_id: tool_call_id,
+                content: result.as_ref().map(OmpToolExecutionResult::text).unwrap_or_default(),
+                is_error,
+                exit_code: None,
+            }])],
+            OmpStreamEvent::AgentEnd => vec![NormalizedEvent::Result { error: None }],
+            OmpStreamEvent::Error { message, error } => {
+                let message = message
+                    .or_else(|| error.as_ref().map(ToString::to_string))
+                    .unwrap_or_else(|| "harness error".to_string());
+                vec![NormalizedEvent::Error { message }]
+            }
+            OmpStreamEvent::AgentStart
+            | OmpStreamEvent::TurnStart
+            | OmpStreamEvent::TurnEnd
+            | OmpStreamEvent::MessageStart
+            | OmpStreamEvent::ToolExecutionStart
+            | OmpStreamEvent::ToolExecutionUpdate => Vec::new(),
+            OmpStreamEvent::Unknown => {
+                eprintln!("omp: ignoring unknown event type");
+                Vec::new()
+            }
+        }
+    }
+}
+
+impl HarnessServer for OmpHarness {
+    type Event = OmpStreamEvent;
+    type EventNormalizer = OmpEventNormalizer;
+
+    fn kind(&self) -> HarnessKind {
+        HarnessKind::Omp
+    }
+
+    fn cli_version(&self) -> &'static str {
+        "omp"
+    }
+
+    /// Empty when no explicit override exists: the model is owned by the
+    /// in-image harness config (harness/omp/config.yml modelRoles), mirroring
+    /// how claude reads harness/claude/settings.json. An empty model means
+    /// `command_for_turn` omits `--model` so the CLI falls through to the
+    /// agent config dir.
+    fn default_model(&self) -> String {
+        env::var("OMP_MODEL").unwrap_or_default()
+    }
+
+    fn default_model_provider(&self) -> &'static str {
+        "omp"
+    }
+
+    fn command_for_turn(&self, state: &ThreadState, input: &[UserInput]) -> ProcessCommand {
+        if let Some(command) = command_from_override("CENTAUR_OMP_APP_BRIDGE_COMMAND") {
+            return command;
+        }
+
+        let bin = env::var("OMP_BIN").unwrap_or_else(|_| "omp".to_string());
+        let mut command = ProcessCommand::new(bin);
+        command.args(["-p", "--mode", "json", "--auto-approve", "--session-dir"]);
+        command.arg(omp_session_dir());
+        if let Some(session_id) = &state.harness_session_id {
+            command.args(["-r", session_id]);
+        }
+        if !state.model.is_empty() {
+            command.args(["--model", &state.model]);
+        }
+        // The prompt rides argv, not stdin; `--` keeps prompts that start
+        // with a dash from being read as flags.
+        command.arg("--");
+        command.arg(prompt_text(input));
+        command
+    }
+
+    /// omp takes the prompt as a command argument and never reads stdin in
+    /// `-p` mode, so there is nothing to write (an empty write is a no-op).
+    fn stdin_for_turn(&self, _input: &[UserInput]) -> Result<Vec<u8>> {
+        Ok(Vec::new())
+    }
+
+    fn parse_stdout_line(&self, line: &str) -> Result<Self::Event> {
+        OmpStreamEvent::parse_json_line(line)
+    }
+
+    fn normalize_events(
+        &self,
+        normalizer: &mut Self::EventNormalizer,
+        event: Self::Event,
+    ) -> Result<Vec<NormalizedEvent>> {
+        Ok(normalizer.normalize(event))
+    }
+
+    /// omp's native terminal event (`agent_end`) is the last line before the
+    /// process exits, so waiting for it after the final assistant stop only
+    /// adds the process's shutdown time to every turn: complete immediately
+    /// (amp pattern). The trailing `turn_end`/`agent_end` lines die with the
+    /// per-turn process — the next turn spawns a fresh one.
+    fn terminal_assistant_stop_settle(&self) -> Option<Duration> {
+        Some(Duration::ZERO)
+    }
+}
+
+fn assistant_item_id(raw_id: Option<&str>) -> String {
+    stable_id(raw_id.unwrap_or("assistant"), "msg")
+}
+
+fn reasoning_item_id(message_id: &str, index: usize) -> String {
+    format!("{message_id}-reasoning-{index}")
+}
+
+/// Map omp stop reasons onto the anthropic-style values the shared
+/// terminal-stop logic understands (`stop` ends the agent run, `toolUse`
+/// continues the tool loop). Unrecognized reasons pass through and never
+/// settle the turn — `agent_end` (or process exit) ends it instead.
+fn normalized_stop_reason(reason: &str) -> String {
+    match reason {
+        "stop" => "end_turn",
+        "toolUse" => "tool_use",
+        "length" => "max_tokens",
+        other => other,
+    }
+    .to_string()
+}
+
+fn omp_session_dir() -> PathBuf {
+    env::var_os("OMP_SESSION_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| {
+            env::var_os("HOME")
+                .map(PathBuf::from)
+                .unwrap_or_else(|| PathBuf::from("/tmp"))
+                .join(".omp-harness-sessions")
+        })
+}
+
+fn prompt_text(input: &[UserInput]) -> String {
+    let mut prompt = String::new();
+    for part in user_input_to_anthropic_content(input) {
+        if let Some(text) = part.get("text").and_then(Value::as_str) {
+            if !prompt.is_empty() {
+                prompt.push_str("\n\n");
+            }
+            prompt.push_str(text);
+        }
+    }
+    prompt
+}
+
+#[cfg(test)]
+mod tests {
+    use codex_app_server_protocol::UserInput;
+
+    use crate::{HarnessServer, NormalizedContent, NormalizedEvent};
+
+    use super::{OmpEventNormalizer, OmpHarness};
+
+    fn normalize(normalizer: &mut OmpEventNormalizer, line: &str) -> Vec<NormalizedEvent> {
+        let event = OmpHarness.parse_stdout_line(line).unwrap();
+        OmpHarness.normalize_events(normalizer, event).unwrap()
+    }
+
+    #[test]
+    fn session_line_yields_harness_session_id() {
+        let mut normalizer = OmpEventNormalizer::default();
+        let events = normalize(
+            &mut normalizer,
+            r#"{"type":"session","version":3,"id":"019f3bb2-40aa-7000-b7e7-5414136e3b18","timestamp":"2026-07-07T08:29:25.547Z","cwd":"/tmp/omp-p03-test"}"#,
+        );
+        assert_eq!(events.len(), 1);
+        assert_eq!(
+            events[0].session_id(),
+            Some("019f3bb2-40aa-7000-b7e7-5414136e3b18")
+        );
+    }
+
+    #[test]
+    fn text_delta_streams_agent_text_keyed_by_response_id() {
+        let mut normalizer = OmpEventNormalizer::default();
+        let events = normalize(
+            &mut normalizer,
+            r#"{"type":"message_update","assistantMessageEvent":{"type":"text_delta","contentIndex":0,"delta":"ONE"},"message":{"role":"assistant","content":[{"type":"text","text":"DONE"}],"responseId":"msg_011CcnPBnPUWzpXCn7915U1v"}}"#,
+        );
+        assert!(matches!(
+            events.as_slice(),
+            [NormalizedEvent::AgentTextDelta { item_id, delta }]
+                if item_id == "msg_011CcnPBnPUWzpXCn7915U1v" && delta == "ONE"
+        ));
+    }
+
+    #[test]
+    fn assistant_message_end_emits_usage_and_tool_use() {
+        let mut normalizer = OmpEventNormalizer::default();
+        let events = normalize(
+            &mut normalizer,
+            r#"{"type":"message_end","message":{"role":"assistant","content":[{"type":"toolCall","id":"toolu_01CnTRcRztUD24oiuqg4wQq8","name":"bash","arguments":{"command":"echo centaur-tool-test","i":"Running test echo"}}],"provider":"anthropic","model":"claude-opus-4-8","usage":{"input":2,"output":80,"cacheRead":0,"cacheWrite":41021,"totalTokens":41103},"stopReason":"toolUse","responseId":"msg_011CcnPBYXnmZhM1otcyNfq5"}}"#,
+        );
+        assert!(matches!(
+            &events[0],
+            NormalizedEvent::TokenUsage { usage }
+                if usage.input_tokens == Some(2)
+                    && usage.output_tokens == Some(80)
+                    && usage.total_tokens == Some(41103)
+                    && usage.model.as_deref() == Some("claude-opus-4-8")
+        ));
+        assert!(matches!(
+            &events[1],
+            NormalizedEvent::AssistantMessage { partial: false, stop_reason: Some(reason), content }
+                if reason == "tool_use"
+                    && matches!(
+                        content.as_slice(),
+                        [NormalizedContent::ToolUse { raw_id, tool, .. }]
+                            if raw_id == "toolu_01CnTRcRztUD24oiuqg4wQq8" && tool == "bash"
+                    )
+        ));
+    }
+
+    #[test]
+    fn tool_execution_end_maps_tool_result() {
+        let mut normalizer = OmpEventNormalizer::default();
+        let events = normalize(
+            &mut normalizer,
+            r#"{"type":"tool_execution_end","toolCallId":"toolu_01CnTRcRztUD24oiuqg4wQq8","toolName":"bash","result":{"content":[{"type":"text","text":"centaur-tool-test\n\n\nWall time: 0.07 seconds"}],"details":{"timeoutSeconds":300,"wallTimeMs":70.62383399999817}},"isError":false}"#,
+        );
+        assert!(matches!(
+            events.as_slice(),
+            [NormalizedEvent::ToolResults(results)]
+                if results.len() == 1
+                    && results[0].tool_use_id == "toolu_01CnTRcRztUD24oiuqg4wQq8"
+                    && results[0].content.starts_with("centaur-tool-test")
+                    && !results[0].is_error
+        ));
+    }
+
+    #[test]
+    fn final_assistant_stop_is_terminal_and_agent_end_yields_result() {
+        let mut normalizer = OmpEventNormalizer::default();
+        let events = normalize(
+            &mut normalizer,
+            r#"{"type":"message_end","message":{"role":"assistant","content":[{"type":"text","text":"DONE"}],"usage":{"input":2,"output":5,"cacheRead":0,"cacheWrite":41333,"totalTokens":41340},"stopReason":"stop","responseId":"msg_011CcnPBnPUWzpXCn7915U1v"}}"#,
+        );
+        let assistant = events
+            .iter()
+            .find(|event| matches!(event, NormalizedEvent::AssistantMessage { .. }))
+            .expect("assistant message");
+        assert!(assistant.is_terminal_assistant_stop());
+
+        let events = normalize(&mut normalizer, r#"{"type":"agent_end","messages":[]}"#);
+        assert!(matches!(
+            events.as_slice(),
+            [NormalizedEvent::Result { error: None }]
+        ));
+    }
+
+    #[test]
+    fn tool_result_message_end_is_ignored_to_avoid_double_emission() {
+        let mut normalizer = OmpEventNormalizer::default();
+        let events = normalize(
+            &mut normalizer,
+            r#"{"type":"message_end","message":{"role":"toolResult","toolCallId":"toolu_01CnTRcRztUD24oiuqg4wQq8","toolName":"bash","content":[{"type":"text","text":"centaur-tool-test"}],"isError":false}}"#,
+        );
+        assert!(events.is_empty());
+    }
+
+    #[test]
+    fn turn_stdin_is_empty() {
+        let bytes = OmpHarness
+            .stdin_for_turn(&[UserInput::Text {
+                text: "hello".to_string(),
+                text_elements: Vec::new(),
+            }])
+            .unwrap();
+        assert!(bytes.is_empty());
+    }
+}

--- a/crates/harness-server/src/omp.rs
+++ b/crates/harness-server/src/omp.rs
@@ -268,7 +268,10 @@ impl OmpEventNormalizer {
                 is_error,
             } => vec![NormalizedEvent::ToolResults(vec![NormalizedToolResult {
                 tool_use_id: tool_call_id,
-                content: result.as_ref().map(OmpToolExecutionResult::text).unwrap_or_default(),
+                content: result
+                    .as_ref()
+                    .map(OmpToolExecutionResult::text)
+                    .unwrap_or_default(),
                 is_error,
                 exit_code: None,
             }])],

--- a/crates/harness-server/src/otel.rs
+++ b/crates/harness-server/src/otel.rs
@@ -827,6 +827,7 @@ fn harness_name(kind: HarnessKind) -> &'static str {
         HarnessKind::Codex => "codex",
         HarnessKind::ClaudeCode => "claude",
         HarnessKind::Amp => "amp",
+        HarnessKind::Omp => "omp",
     }
 }
 
@@ -838,6 +839,8 @@ fn gen_ai_system(kind: HarnessKind, model_provider: &str) -> &'static str {
         "openai"
     } else if provider.contains("amp") || matches!(kind, HarnessKind::Amp) {
         "amp"
+    } else if provider.contains("omp") || matches!(kind, HarnessKind::Omp) {
+        "omp"
     } else {
         "unknown"
     }

--- a/crates/harness-server/src/server.rs
+++ b/crates/harness-server/src/server.rs
@@ -27,6 +27,7 @@ use uuid::Uuid;
 use crate::amp::AmpHarness;
 use crate::claude::ClaudeCodeHarness;
 use crate::codex::CodexHarnessServer;
+use crate::omp::OmpHarness;
 use crate::otel::{self, HarnessUsageSpan, TraceContext};
 use crate::traits::{
     AppServerNormalizer, AppServerRuntime, HarnessChild, HarnessKind, HarnessServer,
@@ -42,6 +43,7 @@ pub fn server_for(kind: HarnessKind) -> Box<dyn AppServerRuntime> {
         HarnessKind::Codex => Box::new(CodexHarnessServer::codex()),
         HarnessKind::ClaudeCode => Box::new(AppServerNormalizer::new(ClaudeCodeHarness)),
         HarnessKind::Amp => Box::new(AppServerNormalizer::new(AmpHarness)),
+        HarnessKind::Omp => Box::new(AppServerNormalizer::new(OmpHarness)),
     }
 }
 
@@ -54,6 +56,7 @@ pub fn run_blocks_server(kind: HarnessKind) -> Result<()> {
         HarnessKind::Codex => crate::codex::run_codex_blocks_server(CodexHarnessServer::codex()),
         HarnessKind::ClaudeCode => run_blocks_app_server(&ClaudeCodeHarness),
         HarnessKind::Amp => run_blocks_app_server(&AmpHarness),
+        HarnessKind::Omp => run_blocks_app_server(&OmpHarness),
     }
 }
 
@@ -1205,7 +1208,7 @@ fn run_harness_turn<H: HarnessServer, W: Write>(
     let usage_span_turn_id = normalizer.turn_id().to_string();
     let usage_span_input = usage_span_input_value(input);
     let mut usage_span_output = UsageSpanOutput::default();
-    ensure_harness_process(harness, state)?;
+    ensure_harness_process(harness, state, input)?;
     {
         let process = state
             .process
@@ -1471,7 +1474,11 @@ fn append_usage_span_output(event: &NormalizedEvent, output: &mut UsageSpanOutpu
     }
 }
 
-fn ensure_harness_process<H: HarnessServer>(harness: &H, state: &mut ThreadState) -> Result<()> {
+fn ensure_harness_process<H: HarnessServer>(
+    harness: &H,
+    state: &mut ThreadState,
+    input: &[UserInput],
+) -> Result<()> {
     if let Some(process) = state.process.as_mut() {
         if process.child.try_wait()?.is_none() {
             return Ok(());
@@ -1479,7 +1486,7 @@ fn ensure_harness_process<H: HarnessServer>(harness: &H, state: &mut ThreadState
         state.process = None;
     }
 
-    let mut command = harness.command_for_turn(state);
+    let mut command = harness.command_for_turn(state, input);
     let mut child = command
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())

--- a/crates/harness-server/src/traits.rs
+++ b/crates/harness-server/src/traits.rs
@@ -15,6 +15,7 @@ pub enum HarnessKind {
     Codex,
     ClaudeCode,
     Amp,
+    Omp,
 }
 
 pub struct ThreadState {
@@ -61,7 +62,11 @@ pub trait HarnessServer {
     fn cli_version(&self) -> &'static str;
     fn default_model(&self) -> String;
     fn default_model_provider(&self) -> &'static str;
-    fn command_for_turn(&self, state: &ThreadState) -> ProcessCommand;
+    /// The process to spawn for a turn. `input` is this turn's user input:
+    /// one-shot harnesses that take the prompt as a command argument (omp)
+    /// build it into the argv; stream-stdin harnesses (claude, amp) ignore it
+    /// and receive the input through `stdin_for_turn`.
+    fn command_for_turn(&self, state: &ThreadState, input: &[UserInput]) -> ProcessCommand;
     fn stdin_for_turn(&self, input: &[UserInput]) -> Result<Vec<u8>>;
     fn stdin_for_steer(&self, input: &[UserInput]) -> Result<Vec<u8>> {
         self.stdin_for_turn(input)

--- a/harness/omp/config.yml
+++ b/harness/omp/config.yml
@@ -1,15 +1,13 @@
 # Baked omp (oh-my-pi) agent config. Copied to $PI_CODING_AGENT_DIR/config.yml
 # at container start by entrypoint.sh, which substitutes __OMP_LITELLM_BASE_URL__
-# (default https://litellm.drkmttr.dev/v1) so in-cluster deployments can point
-# at a local LiteLLM Service.
+# (default https://litellm.drkmttr.dev/v1) so deployments can point elsewhere.
 #
-# Model roles default to the gateway's `glm-local` alias (hosted_vllm
-# glm-5.2-fp8 on the dedicated LiteLLM instance). Deliberately NOT
-# `glm-5.2-fp8`: omp's discovery fuzzy-merges gateway model ids against the
-# live models.dev catalog, and that id collides with the fireworks-ai
-# `glm-5p2-fp8` entry — the SDK then puts the catalog's canonical wire id in
-# the request body, which LiteLLM 400s. `glm-local` matches nothing in the
-# catalog, so the alias goes on the wire unchanged (diagnosed 2026-07-06).
+# Model id is glm-5.2-fp8 — the gateway name with a working OpenRouter fallback
+# when the hosted_vllm upstream is down (the `glm-local` alias has NO fallback;
+# verified during the 2026-07-07 vLLM outage). The models.dev fuzzy-merge trap
+# that motivated the alias (skills presets/omp, 2026-07-06) only affects
+# DISCOVERY-based registries; models.yml here defines the model STATICALLY, and
+# the id goes on the wire unchanged (verified empirically both ways).
 providers:
   litellm:
     baseUrl: __OMP_LITELLM_BASE_URL__
@@ -18,16 +16,16 @@ providers:
     api: openai-completions
 
 modelRoles:
-  default: "litellm/glm-local"
-  smol: "litellm/glm-local"
-  commit: "litellm/glm-local"
-  task: "litellm/glm-local"
+  default: "litellm/glm-5.2-fp8"
+  smol: "litellm/glm-5.2-fp8"
+  commit: "litellm/glm-5.2-fp8"
+  task: "litellm/glm-5.2-fp8"
   # v1 posture: EVERY role stays on the internal gateway — sandboxes carry no
   # frontier-provider keys (credential-safe injection via iron-proxy is the
   # tracked follow-up). Point slow/plan/advisor at a frontier model only in
   # deployments that actually inject its key.
-  slow: "litellm/glm-local"
-  plan: "litellm/glm-local"
-  advisor: "litellm/glm-local"
+  slow: "litellm/glm-5.2-fp8"
+  plan: "litellm/glm-5.2-fp8"
+  advisor: "litellm/glm-5.2-fp8"
 
 defaultThinkingLevel: medium

--- a/harness/omp/config.yml
+++ b/harness/omp/config.yml
@@ -1,0 +1,29 @@
+# Baked omp (oh-my-pi) agent config. Copied to $PI_CODING_AGENT_DIR/config.yml
+# at container start by entrypoint.sh, which substitutes __OMP_LITELLM_BASE_URL__
+# (default https://litellm.drkmttr.dev/v1) so in-cluster deployments can point
+# at a local LiteLLM Service.
+#
+# Model roles default to the gateway's `glm-local` alias (hosted_vllm
+# glm-5.2-fp8 on the dedicated LiteLLM instance). Deliberately NOT
+# `glm-5.2-fp8`: omp's discovery fuzzy-merges gateway model ids against the
+# live models.dev catalog, and that id collides with the fireworks-ai
+# `glm-5p2-fp8` entry — the SDK then puts the catalog's canonical wire id in
+# the request body, which LiteLLM 400s. `glm-local` matches nothing in the
+# catalog, so the alias goes on the wire unchanged (diagnosed 2026-07-06).
+providers:
+  litellm:
+    baseUrl: __OMP_LITELLM_BASE_URL__
+    apiKey: LITELLM_API_KEY
+    auth: apiKey
+    api: openai-completions
+
+modelRoles:
+  default: "litellm/glm-local"
+  smol: "litellm/glm-local"
+  commit: "litellm/glm-local"
+  task: "litellm/glm-local"
+  slow: "anthropic/claude-fable-5"
+  plan: "anthropic/claude-fable-5"
+  advisor: "anthropic/claude-fable-5"
+
+defaultThinkingLevel: medium

--- a/harness/omp/config.yml
+++ b/harness/omp/config.yml
@@ -22,8 +22,12 @@ modelRoles:
   smol: "litellm/glm-local"
   commit: "litellm/glm-local"
   task: "litellm/glm-local"
-  slow: "anthropic/claude-fable-5"
-  plan: "anthropic/claude-fable-5"
-  advisor: "anthropic/claude-fable-5"
+  # v1 posture: EVERY role stays on the internal gateway — sandboxes carry no
+  # frontier-provider keys (credential-safe injection via iron-proxy is the
+  # tracked follow-up). Point slow/plan/advisor at a frontier model only in
+  # deployments that actually inject its key.
+  slow: "litellm/glm-local"
+  plan: "litellm/glm-local"
+  advisor: "litellm/glm-local"
 
 defaultThinkingLevel: medium

--- a/harness/omp/models.yml
+++ b/harness/omp/models.yml
@@ -1,13 +1,20 @@
 # Baked omp (oh-my-pi) model-provider registry. Copied next to config.yml by
-# entrypoint.sh (same __OMP_LITELLM_BASE_URL__ substitution). `discovery:
-# litellm` probes the proxy's management endpoints (/model_group/info,
-# /v2/model/info, then /models) so the gateway's model list, context windows,
-# and reasoning flags load automatically. Requires LITELLM_API_KEY in the
-# environment.
+# entrypoint.sh (same __OMP_LITELLM_BASE_URL__ substitution).
+#
+# The gateway model is defined STATICALLY, not via discovery: omp resolves
+# model roles once per process, and on a cold cache LiteLLM discovery races
+# that resolution — the session then silently falls back to the built-in
+# default provider (the github-executor learned this the hard way; its
+# warm-models.mjs exists solely to work around it). A static definition
+# resolves immediately and deterministically on first boot.
 providers:
   litellm:
     baseUrl: __OMP_LITELLM_BASE_URL__
     apiKey: LITELLM_API_KEY
     api: openai-completions
-    discovery:
-      type: litellm
+    models:
+      - id: glm-local
+        name: GLM 5.2 (darkmatter gateway)
+        reasoning: true
+        contextWindow: 1048576
+        maxTokens: 131072

--- a/harness/omp/models.yml
+++ b/harness/omp/models.yml
@@ -1,20 +1,22 @@
 # Baked omp (oh-my-pi) model-provider registry. Copied next to config.yml by
 # entrypoint.sh (same __OMP_LITELLM_BASE_URL__ substitution).
 #
-# The gateway model is defined STATICALLY, not via discovery: omp resolves
-# model roles once per process, and on a cold cache LiteLLM discovery races
-# that resolution — the session then silently falls back to the built-in
-# default provider (the github-executor learned this the hard way; its
-# warm-models.mjs exists solely to work around it). A static definition
-# resolves immediately and deterministically on first boot.
+# The gateway model is defined STATICALLY, not via discovery, for two reasons:
+# (1) omp resolves model roles once per process and cold-cache discovery races
+#     that resolution (silent fallback to the built-in default provider — the
+#     github-executor's warm-models.mjs exists solely to work around it);
+# (2) discovery fuzzy-merges gateway ids against the live models.dev catalog,
+#     where glm-5.2-fp8 collides with fireworks glm-5p2-fp8 and gets a wire id
+#     the gateway 400s. Static definitions bypass the merge — the id goes on
+#     the wire unchanged (verified 2026-07-07).
 providers:
   litellm:
     baseUrl: __OMP_LITELLM_BASE_URL__
     apiKey: LITELLM_API_KEY
     api: openai-completions
     models:
-      - id: glm-local
-        name: GLM 5.2 (darkmatter gateway)
+      - id: glm-5.2-fp8
+        name: GLM 5.2 fp8 (darkmatter gateway)
         reasoning: true
         contextWindow: 1048576
         maxTokens: 131072

--- a/harness/omp/models.yml
+++ b/harness/omp/models.yml
@@ -1,0 +1,13 @@
+# Baked omp (oh-my-pi) model-provider registry. Copied next to config.yml by
+# entrypoint.sh (same __OMP_LITELLM_BASE_URL__ substitution). `discovery:
+# litellm` probes the proxy's management endpoints (/model_group/info,
+# /v2/model/info, then /models) so the gateway's model list, context windows,
+# and reasoning flags load automatically. Requires LITELLM_API_KEY in the
+# environment.
+providers:
+  litellm:
+    baseUrl: __OMP_LITELLM_BASE_URL__
+    apiKey: LITELLM_API_KEY
+    api: openai-completions
+    discovery:
+      type: litellm

--- a/services/api-rs/crates/centaur-api-integration-test/src/main.rs
+++ b/services/api-rs/crates/centaur-api-integration-test/src/main.rs
@@ -222,6 +222,7 @@ async fn test_harness_wire_values(http: &HttpClient, base_url: &str) -> Result<(
         (HarnessType::Codex, "codex"),
         (HarnessType::Amp, "amp"),
         (HarnessType::ClaudeCode, "claudecode"),
+        (HarnessType::Omp, "omp"),
     ];
 
     for (harness_type, expected_wire_value) in cases {

--- a/services/api-rs/crates/centaur-api-server/src/args.rs
+++ b/services/api-rs/crates/centaur-api-server/src/args.rs
@@ -1774,7 +1774,14 @@ impl IronProxyHarnessArgs {
     /// so sessions restarted onto another harness still get working
     /// credentials through the proxy.
     fn fragments(&self) -> Result<Vec<ProxyFragment>, ServerError> {
-        let mut fragments = vec![self.fragment()?];
+        let mut fragments = Vec::new();
+        // Engines with no auth-mode source (amp, omp — credentials reach the
+        // sandbox as plain env, not proxy-injected) have no infra fragment to
+        // require. An explicit KUBERNETES_IRON_PROXY_HARNESS_AUTH_MODE still
+        // forces resolution (and fails loudly on an unknown pair).
+        if self.auth_mode.is_some() || harness_auth_mode_env(&self.engine).is_some() {
+            fragments.push(self.fragment()?);
+        }
         for engine in [
             HarnessType::Codex,
             HarnessType::ClaudeCode,

--- a/services/api-rs/crates/centaur-api-server/src/args.rs
+++ b/services/api-rs/crates/centaur-api-server/src/args.rs
@@ -1779,6 +1779,7 @@ impl IronProxyHarnessArgs {
             HarnessType::Codex,
             HarnessType::ClaudeCode,
             HarnessType::Amp,
+            HarnessType::Omp,
         ] {
             if engine == self.engine {
                 continue;
@@ -1859,6 +1860,7 @@ fn harness_fragment_engine_name(engine: &HarnessType) -> &'static str {
         HarnessType::Codex => "codex",
         HarnessType::Amp => "amp",
         HarnessType::ClaudeCode => "claude-code",
+        HarnessType::Omp => "omp",
     }
 }
 
@@ -1876,6 +1878,9 @@ fn harness_auth_mode_env(engine: &HarnessType) -> Option<String> {
         HarnessType::Codex => env::var("CODEX_AUTH_MODE").ok(),
         HarnessType::ClaudeCode => env::var("CLAUDE_CODE_AUTH_MODE").ok(),
         HarnessType::Amp => None,
+        // omp gets its upstream key through the plain sandbox env (LiteLLM
+        // gateway), not an iron-proxy auth fragment — the amp pattern.
+        HarnessType::Omp => None,
     }
 }
 

--- a/services/api-rs/crates/centaur-session-cli/src/main.rs
+++ b/services/api-rs/crates/centaur-session-cli/src/main.rs
@@ -575,6 +575,7 @@ enum HarnessTypeArg {
     Amp,
     #[value(name = "claudecode")]
     ClaudeCode,
+    Omp,
 }
 
 impl From<HarnessTypeArg> for HarnessType {
@@ -583,6 +584,7 @@ impl From<HarnessTypeArg> for HarnessType {
             HarnessTypeArg::Codex => Self::Codex,
             HarnessTypeArg::Amp => Self::Amp,
             HarnessTypeArg::ClaudeCode => Self::ClaudeCode,
+            HarnessTypeArg::Omp => Self::Omp,
         }
     }
 }

--- a/services/api-rs/crates/centaur-session-core/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-core/src/lib.rs
@@ -124,6 +124,7 @@ pub enum HarnessType {
     Codex,
     Amp,
     ClaudeCode,
+    Omp,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, AsRefStr, Display, EnumString)]
@@ -295,6 +296,7 @@ mod tests {
             HarnessType::from_str("claudecode").unwrap(),
             HarnessType::ClaudeCode
         );
+        assert_eq!(HarnessType::from_str("omp").unwrap(), HarnessType::Omp);
     }
 
     #[test]
@@ -306,6 +308,10 @@ mod tests {
         assert_eq!(
             serde_json::from_value::<HarnessType>(serde_json::json!("codex")).unwrap(),
             HarnessType::Codex
+        );
+        assert_eq!(
+            serde_json::to_value(HarnessType::Omp).unwrap(),
+            serde_json::json!("omp")
         );
     }
 

--- a/services/api-rs/crates/centaur-session-runtime/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-runtime/src/lib.rs
@@ -3626,6 +3626,7 @@ fn harness_server_subcommand(harness: &HarnessType) -> &'static str {
         HarnessType::Codex => "codex",
         HarnessType::ClaudeCode => "claude-code",
         HarnessType::Amp => "amp",
+        HarnessType::Omp => "omp",
     }
 }
 
@@ -7210,10 +7211,12 @@ mod tests {
         let codex_spec = workload.spec(&thread_key, &HarnessType::Codex, None);
         let claude_spec = workload.spec(&thread_key, &HarnessType::ClaudeCode, None);
         let amp_spec = workload.spec(&thread_key, &HarnessType::Amp, None);
+        let omp_spec = workload.spec(&thread_key, &HarnessType::Omp, None);
 
         assert_eq!(codex_spec.args, vec!["harness-server", "codex"]);
         assert_eq!(claude_spec.args, vec!["harness-server", "claude-code"]);
         assert_eq!(amp_spec.args, vec!["harness-server", "amp"]);
+        assert_eq!(omp_spec.args, vec!["harness-server", "omp"]);
         // The image entrypoint must be preserved: only CMD is overridden.
         assert_eq!(codex_spec.command, None);
     }

--- a/services/api-rs/crates/centaur-session-sqlx/migrations/0036_session_harness_type_omp.sql
+++ b/services/api-rs/crates/centaur-session-sqlx/migrations/0036_session_harness_type_omp.sql
@@ -1,0 +1,5 @@
+alter table sessions
+    drop constraint sessions_harness_type_supported;
+alter table sessions
+    add constraint sessions_harness_type_supported
+    check (harness_type in ('codex', 'amp', 'claudecode', 'omp'));

--- a/services/sandbox/Dockerfile
+++ b/services/sandbox/Dockerfile
@@ -67,6 +67,7 @@ RUN useradd -m -s /bin/bash -u 1001 agent \
 ARG CLAUDE_CODE_VERSION=2.1.154
 ARG CODEX_VERSION=0.139.0
 ARG PI_CODING_AGENT_VERSION=0.67.2
+ARG OMP_VERSION=16.3.5
 ARG NUSHELL_VERSION=0.112.2
 ARG KUBECTL_VERSION=v1.34.2
 ARG KACHE_VERSION=v0.7.0
@@ -112,6 +113,7 @@ RUN --mount=type=cache,target=/root/.npm,sharing=locked \
       "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}" \
       "@openai/codex@${CODEX_VERSION}" \
       "@mariozechner/pi-coding-agent@${PI_CODING_AGENT_VERSION}" \
+      "@oh-my-pi/pi-coding-agent@${OMP_VERSION}" \
       "pnpm@${PNPM_VERSION}" \
       agent-browser@0.26.0 \
     && find /usr/lib/node_modules -type f \( -name '*.map' -o -name '*.tsbuildinfo' \) -delete \
@@ -145,7 +147,9 @@ ENV PATH="/home/agent/.cargo/bin:/home/agent/.local/bin:/home/agent/.foundry/bin
 ARG FOUNDRY_VERSION=v1.7.0
 ARG AMP_CLI_VERSION=0.0.1774529752-g94f44d
 ARG MANIM_VERSION=0.20.1
-ARG BUN_VERSION=bun-v1.3.13
+# omp (@oh-my-pi/pi-coding-agent) requires bun >= 1.3.14 (its bin shim is a
+# `#!/usr/bin/env bun` script); keep this pin at or above that.
+ARG BUN_VERSION=bun-v1.3.14
 
 # ── Agent-scoped toolchains ─────────────────────────────────────────────────
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
@@ -165,6 +169,9 @@ RUN --mount=type=cache,target=/home/agent/.cargo/registry,uid=1001,gid=1001,shar
     && kache --version
 RUN curl -LsSf https://astral.sh/uv/install.sh | sh
 RUN curl -fsSL https://bun.sh/install | bash -s "${BUN_VERSION}"
+# omp's npm bin shim runs dist/cli.js under bun (shebang), so it can only be
+# verified once bun is on PATH — not in the root npm install layer above.
+RUN omp --version | grep -F "${OMP_VERSION}"
 RUN --mount=type=cache,target=/home/agent/.cache/uv,uid=1001,gid=1001,sharing=locked \
     uv tool install "manim==${MANIM_VERSION}" \
     && manim --version
@@ -197,7 +204,7 @@ RUN if [ "$(dpkg --print-architecture)" = "amd64" ]; then \
 # ── Agent skills + workspace setup (rarely changes) ─────────────────────────
 RUN --mount=type=cache,target=/home/agent/.npm,uid=1001,gid=1001,sharing=locked \
     npx -y skills add vercel-labs/agent-browser
-RUN mkdir -p ~/.amp/bin ~/.config/amp ~/.codex ~/.pi/agent ~/github ~/workspace \
+RUN mkdir -p ~/.amp/bin ~/.config/amp ~/.codex ~/.pi/agent ~/.omp/agent ~/github ~/workspace \
     && git config --global init.defaultBranch main \
     && git config --global push.autoSetupRemote true \
     && git config --global --add safe.directory '*' \

--- a/services/sandbox/Dockerfile
+++ b/services/sandbox/Dockerfile
@@ -237,6 +237,7 @@ COPY --link --chmod=755 services/sandbox/install_tool_shims.py /usr/local/bin/in
 COPY --link --chmod=755 services/sandbox/centaur_tool_host.py /usr/local/bin/centaur-tool-host
 COPY --link --chmod=755 services/sandbox/repo_cache_sync.py /usr/local/bin/repo-cache-sync
 COPY --link --chmod=755 services/sandbox/repo_cache_watch.py /usr/local/bin/repo-cache-watch
+COPY --link --chmod=755 services/sandbox/mint-github-token.mjs /usr/local/bin/mint-github-token.mjs
 COPY --link --chmod=755 services/sandbox/entrypoint.sh /entrypoint.sh
 COPY --link --chown=1001:1001 crates/harness-server/ /opt/centaur/harness-server-src/
 

--- a/services/sandbox/entrypoint.sh
+++ b/services/sandbox/entrypoint.sh
@@ -369,6 +369,26 @@ for omp_cfg in config.yml models.yml; do
     fi
 done
 
+# ── GitHub App installation token (darkmatter deployments) ──────────────────
+# When the App credentials are passed through, mint a short-lived installation
+# token at boot so the agent can clone/push and reply on GitHub — legacy
+# github-executor parity (the App key lived in the agent's trust domain there
+# too). Fail-soft: a mint failure leaves GITHUB_TOKEN as whatever stub the
+# runtime provided.
+if [ -n "${GITHUB_APP_ID:-}" ] && [ -n "${GITHUB_APP_PRIVATE_KEY:-}" ]; then
+    if minted_token="$(bun /usr/local/bin/mint-github-token.mjs 2>/tmp/mint-github-token.err)"; then
+        export GITHUB_TOKEN="$minted_token"
+        export GH_TOKEN="$minted_token"
+        # Scoped to github.com, kept out of URLs/reflog (legacy configureGit).
+        printf 'https://x-access-token:%s@github.com\n' "$minted_token" > "$HOME_DIR/.git-credentials"
+        chmod 600 "$HOME_DIR/.git-credentials"
+        git config --global credential.helper store
+        echo "github installation token minted"
+    else
+        echo "github token mint failed: $(head -c 200 /tmp/mint-github-token.err 2>/dev/null)" >&2
+    fi
+fi
+
 # ── Per-session workspace clone (no shared worktree metadata) ────────────────
 if [ "${CENTAUR_PERSISTENT_STATE:-0}" = "1" ]; then
     WORKSPACE_DIR="$STATE_DIR/workspace"

--- a/services/sandbox/entrypoint.sh
+++ b/services/sandbox/entrypoint.sh
@@ -355,6 +355,20 @@ cat > "$HOME_DIR/.pi/agent/settings.json" <<EOF
 }
 EOF
 
+# ── omp (oh-my-pi) settings ──────────────────────────────────────────────────
+# Baked harness/omp/{config.yml,models.yml} land in $PI_CODING_AGENT_DIR with
+# the LiteLLM base URL substituted (OMP_LITELLM_BASE_URL, default the public
+# darkmatter gateway) so in-cluster deployments can point at a local Service.
+export PI_CODING_AGENT_DIR="${PI_CODING_AGENT_DIR:-$HOME_DIR/.omp/agent}"
+mkdir -p "$PI_CODING_AGENT_DIR"
+OMP_LITELLM_BASE_URL="${OMP_LITELLM_BASE_URL:-https://litellm.drkmttr.dev/v1}"
+for omp_cfg in config.yml models.yml; do
+    if [ -f "$HARNESS_CONFIG_DIR/omp/$omp_cfg" ]; then
+        sed "s|__OMP_LITELLM_BASE_URL__|$OMP_LITELLM_BASE_URL|g" \
+            "$HARNESS_CONFIG_DIR/omp/$omp_cfg" > "$PI_CODING_AGENT_DIR/$omp_cfg"
+    fi
+done
+
 # ── Per-session workspace clone (no shared worktree metadata) ────────────────
 if [ "${CENTAUR_PERSISTENT_STATE:-0}" = "1" ]; then
     WORKSPACE_DIR="$STATE_DIR/workspace"

--- a/services/sandbox/mint-github-token.mjs
+++ b/services/sandbox/mint-github-token.mjs
@@ -1,0 +1,61 @@
+// Mint a GitHub App installation token from GITHUB_APP_ID +
+// GITHUB_APP_PRIVATE_KEY (PEM) in the environment. Self-contained (node:crypto
+// only); runs under bun at sandbox boot (entrypoint.sh) so agents get a
+// short-lived GITHUB_TOKEN instead of any long-lived credential.
+//
+// Installation selection: prefer the account whose login matches
+// GITHUB_APP_INSTALLATION_OWNER (default "darkmatter"); deprioritize
+// enterprise-typed installations — an empty enterprise install with no login
+// once shadowed the org install and every clone failed "Repository not found"
+// (effect-github-app 20ed762).
+import { createSign } from "node:crypto";
+
+const appId = process.env.GITHUB_APP_ID;
+const pem = process.env.GITHUB_APP_PRIVATE_KEY;
+if (!appId || !pem) {
+  console.error("mint-github-token: GITHUB_APP_ID / GITHUB_APP_PRIVATE_KEY unset");
+  process.exit(2);
+}
+
+const b64u = (buf) => Buffer.from(buf).toString("base64url");
+const now = Math.floor(Date.now() / 1000);
+const header = b64u(JSON.stringify({ alg: "RS256", typ: "JWT" }));
+const payload = b64u(JSON.stringify({ iat: now - 60, exp: now + 540, iss: appId }));
+const signer = createSign("RSA-SHA256");
+signer.update(`${header}.${payload}`);
+const jwt = `${header}.${payload}.${signer.sign(pem, "base64url")}`;
+
+const gh = (path, init = {}) =>
+  fetch(`https://api.github.com${path}`, {
+    ...init,
+    headers: {
+      accept: "application/vnd.github+json",
+      "user-agent": "centaur-sandbox-token-mint",
+      authorization: `Bearer ${jwt}`,
+      ...init.headers,
+    },
+  });
+
+const owner = (process.env.GITHUB_APP_INSTALLATION_OWNER ?? "darkmatter").toLowerCase();
+const resp = await gh("/app/installations?per_page=100");
+if (!resp.ok) {
+  console.error(`mint-github-token: installations ${resp.status}: ${(await resp.text()).slice(0, 200)}`);
+  process.exit(1);
+}
+const installations = await resp.json();
+const score = (i) =>
+  (i.account?.login?.toLowerCase() === owner ? 2 : 0) +
+  (i.target_type !== "Enterprise" && i.account?.type !== "Enterprise" ? 1 : 0);
+const pick = installations.sort((a, b) => score(b) - score(a))[0];
+if (!pick) {
+  console.error("mint-github-token: no installations for this App");
+  process.exit(1);
+}
+
+const tok = await gh(`/app/installations/${pick.id}/access_tokens`, { method: "POST" });
+if (!tok.ok) {
+  console.error(`mint-github-token: access_tokens ${tok.status}: ${(await tok.text()).slice(0, 200)}`);
+  process.exit(1);
+}
+const { token } = await tok.json();
+console.log(token);

--- a/workflows/restart_survival_demo.py
+++ b/workflows/restart_survival_demo.py
@@ -1,0 +1,104 @@
+"""Restart-survival demo workflow — proves durable resume across api-rs restarts.
+
+Runs ``steps`` (default 3) checkpointed steps separated by explicit durable
+sleeps (default 90s each, ~3 min total wall time). Each step records a marker
+(UTC timestamp, workflow-host process id, hostname, pid, Absurd run id) as its
+``ctx.step`` return value, so every marker is persisted as an Absurd checkpoint
+in Postgres the moment the step completes.
+
+Because ``ctx.sleep`` suspends the Absurd task (the workflow-host process exits
+and the handler replays from the top on wake), a marker whose
+``host_process_id`` differs from its neighbours proves the run resumed in a new
+host process, while a marker that is byte-identical before and after an api-rs
+pod restart proves the step was NOT re-executed.
+
+Trigger a run:
+
+    POST /api/workflows/runs
+    {"workflow_name": "restart_survival_demo", "input": {"steps": 3, "sleep_seconds": 90}}
+
+Read durable step markers mid-run (task_id from the create response):
+
+    select checkpoint_name, state, updated_at
+    from absurd.c_centaur_workflows
+    where task_id = '<TASK_ID>'::uuid
+    order by updated_at;
+
+Pass criteria for a mid-run api-rs restart: markers checkpointed before the
+restart are unchanged afterwards, later steps still execute exactly once, and
+the final result lists every step with monotonically increasing timestamps.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import os
+import socket
+import uuid
+from dataclasses import dataclass
+from typing import Any
+
+from api.workflow_engine import WorkflowContext
+
+WORKFLOW_NAME = "restart_survival_demo"
+
+MAX_STEPS = 10
+MAX_SLEEP_SECONDS = 600.0
+
+# Regenerated on every module import, i.e. once per workflow-host process.
+# Each suspend/resume cycle (every durable sleep, and any api-rs restart)
+# spawns a fresh host process, so completed-step markers keep the process id
+# of the process that actually executed them.
+_HOST_PROCESS_ID = uuid.uuid4().hex[:12]
+
+
+@dataclass
+class Input:
+    steps: int = 3
+    sleep_seconds: float = 90.0
+
+
+def _utc_now_iso() -> str:
+    return dt.datetime.now(dt.timezone.utc).isoformat()
+
+
+async def handler(inp: Input, ctx: WorkflowContext) -> dict[str, Any]:
+    steps = max(1, min(int(inp.steps), MAX_STEPS))
+    sleep_seconds = max(0.0, min(float(inp.sleep_seconds), MAX_SLEEP_SECONDS))
+
+    ctx.log(
+        "restart_survival_demo_pass",
+        host_process_id=_HOST_PROCESS_ID,
+        hostname=socket.gethostname(),
+        steps=steps,
+        sleep_seconds=sleep_seconds,
+    )
+
+    markers: list[dict[str, Any]] = []
+    for index in range(1, steps + 1):
+
+        async def record_marker(step_index: int = index) -> dict[str, Any]:
+            return {
+                "step": step_index,
+                "executed_at": _utc_now_iso(),
+                "host_process_id": _HOST_PROCESS_ID,
+                "hostname": socket.gethostname(),
+                "pid": os.getpid(),
+                "absurd_run_id": ctx.run_id,
+            }
+
+        marker = await ctx.step(f"step_{index}_marker", record_marker)
+        markers.append(marker)
+        if index < steps:
+            await ctx.sleep(f"pause_after_step_{index}", sleep_seconds)
+
+    host_processes = sorted({marker["host_process_id"] for marker in markers})
+    return {
+        "workflow_name": WORKFLOW_NAME,
+        "steps": markers,
+        "completed_at": _utc_now_iso(),
+        "completed_by_host_process_id": _HOST_PROCESS_ID,
+        "step_host_processes": host_processes,
+        "resumed_across_host_processes": len(host_processes) > 1
+        or (bool(markers) and markers[-1]["host_process_id"] != _HOST_PROCESS_ID),
+    }

--- a/workflows/tests/test_restart_survival_demo.py
+++ b/workflows/tests/test_restart_survival_demo.py
@@ -1,0 +1,182 @@
+"""Replay/resume semantics for the restart_survival_demo workflow.
+
+Runs the real workflow handler through the real workflow-host
+``WorkflowContext`` against an in-memory stand-in for the Absurd checkpoint
+store. Every durable sleep suspends (the host process dies and the handler
+replays from the top in a fresh process), mirroring what api-rs does in
+production — including across an api-rs pod restart, where the checkpoint
+store survives in Postgres while every process is replaced.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW_PATH = REPO_ROOT / "workflows" / "restart_survival_demo.py"
+
+sys.path.insert(0, str(REPO_ROOT / "services" / "workflow-python"))
+
+import workflow_host  # noqa: E402
+
+
+class SimulatedSuspend(BaseException):
+    """Models the workflow-host process dying on a durable sleep suspend."""
+
+
+class DurableCheckpointRpc:
+    """In-memory Absurd stand-in: checkpoints survive, processes do not."""
+
+    def __init__(self) -> None:
+        self.checkpoints: dict[str, object] = {}
+        self.step_executions: dict[str, int] = {}
+        self.notifications: list[dict[str, object]] = []
+
+    def notify(self, payload: dict[str, object]) -> None:
+        self.notifications.append(payload)
+
+    async def request(self, payload: dict[str, object]) -> object:
+        message_type = payload["type"]
+        if message_type == "ctx.step.get":
+            step = payload["step"]
+            if step in self.checkpoints:
+                return {
+                    "done": True,
+                    "checkpoint_name": step,
+                    "value": self.checkpoints[step],
+                }
+            return {"done": False, "checkpoint_name": step}
+        if message_type == "ctx.step.put":
+            name = payload["checkpoint_name"]
+            self.checkpoints[name] = payload["value"]
+            self.step_executions[name] = self.step_executions.get(name, 0) + 1
+            return payload["value"]
+        if message_type == "ctx.sleep":
+            step = payload["step"]
+            if step in self.checkpoints:
+                return {"slept": True}
+            self.checkpoints[step] = {"wake_at": "recorded"}
+            raise SimulatedSuspend(step)
+        raise AssertionError(f"unexpected request {payload}")
+
+
+class RestartSurvivalDemoTests(unittest.TestCase):
+    def _load_workflow(self) -> workflow_host.RegisteredWorkflow:
+        registered = workflow_host.load_workflow_file(WORKFLOW_PATH)
+        assert registered is not None
+        return registered
+
+    def test_discovered_with_expected_contract(self) -> None:
+        registered = self._load_workflow()
+        self.assertEqual(registered.workflow_name, "restart_survival_demo")
+        self.assertIsNotNone(registered.input_cls)
+        self.assertIsNone(registered.webhooks)
+        self.assertIsNone(registered.schedule)
+
+    def test_steps_resume_from_checkpoints_across_host_processes(self) -> None:
+        rpc = DurableCheckpointRpc()
+        raw_input = {"steps": 3, "sleep_seconds": 5}
+        passes = 0
+        result = None
+
+        while result is None:
+            passes += 1
+            self.assertLessEqual(passes, 10, "workflow never completed")
+            # Fresh module load per pass: a new host process with a new
+            # _HOST_PROCESS_ID, exactly like a post-suspend or post-restart
+            # replay in production.
+            registered = self._load_workflow()
+            ctx = workflow_host.WorkflowContext(
+                rpc,
+                run_id=f"run-pass-{passes}",
+                task_id="task-1",
+                workflow_name=registered.workflow_name,
+            )
+            inp = workflow_host.coerce_input(raw_input, registered.input_cls)
+
+            async def run_pass(handler=registered.handler, inp=inp, ctx=ctx):
+                try:
+                    return await handler(inp, ctx)
+                except SimulatedSuspend:
+                    return None
+
+            result = asyncio.run(run_pass())
+
+        # 3 steps + 2 sleeps, each sleep suspends once: 3 passes total.
+        self.assertEqual(passes, 3)
+        markers = result["steps"]
+        self.assertEqual([marker["step"] for marker in markers], [1, 2, 3])
+
+        # Every step executed exactly once despite the handler replaying
+        # from the top on each pass.
+        self.assertEqual(
+            rpc.step_executions,
+            {"step_1_marker": 1, "step_2_marker": 1, "step_3_marker": 1},
+        )
+
+        # Markers checkpointed in earlier passes came back verbatim: each
+        # pass ran in a distinct host process, and each marker retains the
+        # process that actually executed it.
+        host_processes = [marker["host_process_id"] for marker in markers]
+        self.assertEqual(len(set(host_processes)), 3)
+        run_ids = [marker["absurd_run_id"] for marker in markers]
+        self.assertEqual(run_ids, ["run-pass-1", "run-pass-2", "run-pass-3"])
+        self.assertTrue(result["resumed_across_host_processes"])
+        self.assertNotEqual(
+            markers[0]["host_process_id"], result["completed_by_host_process_id"]
+        )
+
+    def test_completed_markers_survive_simulated_pod_restart(self) -> None:
+        rpc = DurableCheckpointRpc()
+        raw_input = {"steps": 3, "sleep_seconds": 5}
+
+        registered = self._load_workflow()
+        ctx = workflow_host.WorkflowContext(
+            rpc,
+            run_id="run-before-restart",
+            task_id="task-1",
+            workflow_name=registered.workflow_name,
+        )
+        inp = workflow_host.coerce_input(raw_input, registered.input_cls)
+
+        async def first_pass():
+            try:
+                return await registered.handler(inp, ctx)
+            except SimulatedSuspend:
+                return None
+
+        self.assertIsNone(asyncio.run(first_pass()))
+        marker_before = rpc.checkpoints["step_1_marker"]
+
+        # "Pod restart": every process is gone; only the checkpoint rows
+        # (rpc.checkpoints) survive, exactly like absurd.c_centaur_workflows
+        # surviving an api-rs pod kill.
+        result = None
+        while result is None:
+            registered = self._load_workflow()
+            ctx = workflow_host.WorkflowContext(
+                rpc,
+                run_id="run-after-restart",
+                task_id="task-1",
+                workflow_name=registered.workflow_name,
+            )
+            inp = workflow_host.coerce_input(raw_input, registered.input_cls)
+
+            async def next_pass(handler=registered.handler, inp=inp, ctx=ctx):
+                try:
+                    return await handler(inp, ctx)
+                except SimulatedSuspend:
+                    return None
+
+            result = asyncio.run(next_pass())
+
+        self.assertEqual(result["steps"][0], marker_before)
+        self.assertEqual(rpc.step_executions["step_1_marker"], 1)
+        self.assertEqual(result["steps"][1]["absurd_run_id"], "run-after-restart")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds `HarnessType::Omp` as a first-class harness: registration across the enum/DB constraint (migration 0036), container-arg mapping, and an `OmpHarness` server implementation (`crates/harness-server/src/omp.rs`) driving the omp CLI (`@oh-my-pi/pi-coding-agent`, a pi-mono fork) per turn in JSON mode — argv prompt with `--` guard, `-r <id>` session resume, model fall-through to the agent config dir, amp-style terminal settle on `agent_end`, and a normalizer mapping omp's event stream (message_update deltas, toolcall start/delta/end, usage) onto the blocks protocol.

Also included:
- sandbox image: omp + bun (>= 1.3.14) installed in the agent image; `harness/omp/` config fragments (LiteLLM-first static model registry; see the models.yml comment on discovery races)
- `workflows/restart_survival_demo.py`: checkpointed steps + durable sleeps proving restart resume (validated live: api-rs killed mid-sleep resumes at scheduled wake, pre-kill checkpoints byte-identical, attempts=1)
- fix: engines with no auth-mode env (the amp pattern — omp too) no longer force a harness auth fragment, so iron-proxy deployments boot without a placeholder fragment for engines whose credentials arrive as plain env or proxy replace rules
- chart: `sandbox.harnessEngine` docs mention omp; rustfmt pass over harness-server

Running in production on our k3s cluster (sessions, GitHub-bot jobs, PR auto-reviews all drive this harness through the session API). Disclosure: developed with AI assistance; validated by the crate's test suite (84 passing in harness-server incl. 26 omp normalizer/adapter tests) and live E2E turns.

Happy to split the workflow demo or the fragment fix into separate PRs if preferred.