### PR TITLE
fix(console): stop POST / and tokenless CSRF from raising unhandled errors

### DIFF
--- a/services/console/app/controllers/application_controller.rb
+++ b/services/console/app/controllers/application_controller.rb
@@ -9,6 +9,15 @@ class ApplicationController < ActionController::Base
   # controllers don't each hand-roll a rescue. Mirrors Api::BaseController.
   rescue_from ActiveRecord::RecordNotFound, with: :render_not_found
 
+  # A tokenless or stale-CSRF POST is an expected 4xx on a public, cookie-session
+  # UI: bots probing form endpoints, or a user submitting a login form after
+  # their session (and CSRF token) rotated. Handle it as a normal bad request
+  # instead of letting it bubble up as an unhandled exception — which Rails logs
+  # at error level and trips error tracking. CSRF protection is unchanged — the
+  # request is still rejected; we only stop treating an expected rejection as an
+  # error.
+  rescue_from ActionController::InvalidAuthenticityToken, with: :handle_invalid_authenticity_token
+
   helper_method :current_user, :acting_admin?, :descoped?
   helper_method :public_base_url, :oauth_callback_redirect_uri
 
@@ -186,6 +195,18 @@ class ApplicationController < ActionController::Base
 
   def render_not_found(e)
     render plain: e.message, status: :not_found
+  end
+
+  # Reject the request (CSRF protection is preserved) but log at warn, not error,
+  # so an expected tokenless POST does not page. HTML callers are bounced to a
+  # fresh login form (the usual cause is an expired session); anything else gets
+  # a bare 422.
+  def handle_invalid_authenticity_token
+    Rails.logger.warn("invalid_authenticity_token path=#{request.path} method=#{request.request_method}")
+    respond_to do |format|
+      format.html { redirect_to login_path, alert: "Your session expired. Please sign in again." }
+      format.any { head :unprocessable_entity }
+    end
   end
 
   def console_sidebar_visible_thread_scope

--- a/services/console/config/routes.rb
+++ b/services/console/config/routes.rb
@@ -201,5 +201,10 @@ Rails.application.routes.draw do
   get "oauth/:slug/callback", to: "oauth/flows#callback", as: :oauth_callback
 
   # Render a JSON 404 for any unmatched route instead of the static error page.
-  match "*path", to: "errors#not_found", via: :all
+  # The `(*path)` glob is optional so it also matches the site root: a non-GET
+  # request to "/" (e.g. a bot POSTing "/") falls through here for a clean 404
+  # instead of raising ActionController::RoutingError. A bare "*path" glob does
+  # not match the empty root path, so those POSTs used to raise an unhandled
+  # RoutingError — logged at error level, and noise for any error tracker.
+  match "(*path)", to: "errors#not_found", via: :all
 end

--- a/services/console/test/integration/error_routing_test.rb
+++ b/services/console/test/integration/error_routing_test.rb
@@ -1,0 +1,52 @@
+require "test_helper"
+
+# Regression coverage for the two expected-4xx conditions that used to raise and
+# get logged at error level: a non-GET request to the site root, and a
+# tokenless/stale-CSRF form POST.
+class ErrorRoutingTest < ActionDispatch::IntegrationTest
+  test "POST to the site root returns a JSON 404 instead of raising RoutingError" do
+    post "/"
+    assert_response :not_found
+    assert_equal({ "error" => { "message" => "not found" } }, response.parsed_body)
+  end
+
+  test "other verbs on the root also resolve to the JSON 404 fallback" do
+    put "/"
+    assert_response :not_found
+  end
+
+  test "unmatched non-root paths still return the JSON 404 fallback" do
+    post "/definitely/not/a/route"
+    assert_response :not_found
+    assert_equal({ "error" => { "message" => "not found" } }, response.parsed_body)
+  end
+
+  test "GET on the root is still served by the console, not the 404 fallback" do
+    get "/"
+    # Not signed in, so require_login bounces to the login form. The point is
+    # that the root is NOT swallowed by the unmatched-route 404 fallback.
+    assert_redirected_to login_path
+  end
+end
+
+class InvalidAuthenticityTokenTest < ActionDispatch::IntegrationTest
+  setup do
+    @original_forgery_protection = ActionController::Base.allow_forgery_protection
+    ActionController::Base.allow_forgery_protection = true
+  end
+
+  teardown do
+    ActionController::Base.allow_forgery_protection = @original_forgery_protection
+  end
+
+  test "a tokenless HTML form POST is rejected without raising, bounced to login" do
+    post login_path, params: { email: "someone@example.com", password: "nope" }
+    assert_redirected_to login_path
+    assert_equal "Your session expired. Please sign in again.", flash[:alert]
+  end
+
+  test "a tokenless non-HTML POST is rejected with a 422" do
+    post login_path, headers: { "Accept" => "application/json" }
+    assert_response :unprocessable_entity
+  end
+end


### PR DESCRIPTION
## Summary

Two expected 4xx conditions on the public, cookie-session console were **raising and getting logged at error level** (so they trip error tracking / alerting). Both fire on ordinary internet traffic — a bot probing the app, or a user submitting a stale login form — so treating them as errors is noise.

**`ActionController::RoutingError (No route matches [POST] "/")`** — the unmatched-route catch-all used a bare `*path` glob, which does not match the empty root path. So a non-GET request to `/` (e.g. a bot POSTing `/`) fell through to a raised `RoutingError` instead of the intended JSON 404. Making the glob optional (`(*path)`) lets the root fall through to `errors#not_found` like every other unmatched path. `GET /` is still served by `root` (declared earlier, so it wins).

**`ActionController::InvalidAuthenticityToken (Can't verify CSRF token authenticity.)`** — a tokenless or stale-CSRF form POST raised and bubbled up as an unhandled exception. `ApplicationController` now rescues it: the request is still rejected (CSRF protection is unchanged), but it logs at `warn` — HTML callers are bounced to a fresh login (the usual cause is an expired session), everything else gets a `422`.

## Testing

- `bin/rails test test/integration/error_routing_test.rb` — 6 runs, 13 assertions, 0 failures (POST/PUT `/` → JSON 404; unmatched non-root still 404; `GET /` still routed to the console; tokenless HTML POST → login bounce; tokenless non-HTML POST → 422)
- `bin/rails test test/controllers/sessions_controller_test.rb test/controllers/mcp/oauth_controller_test.rb` — 24 runs, 147 assertions, 0 failures (no regression through `ApplicationController`)
- `bin/rubocop` on the changed files — no offenses
