### PR TITLE
fix(iron-proxy): restore GITHUB_TOKEN and SLACK_BOT_TOKEN infra secrets

### DIFF
--- a/services/api-rs/crates/centaur-api-server/src/args.rs
+++ b/services/api-rs/crates/centaur-api-server/src/args.rs
@@ -958,7 +958,8 @@ impl SandboxArgs {
         // consumers send the proxy_value iron-proxy replaces with the real
         // secret: codex's OPENAI_API_KEY (api_key mode -> codex logs in and
         // hits api.openai.com instead of falling back to the ChatGPT
-        // auth.json), and the rest of the model-provider infra set.
+        // auth.json), git/gh's GITHUB_TOKEN, the slack tool's
+        // SLACK_BOT_TOKEN, and the rest of the infra set.
         for (name, value) in self.iron_proxy.sandbox_placeholder_env()? {
             if !envs.iter().any(|(existing, _)| existing == &name) {
                 envs.push((name, value));

--- a/services/api-rs/crates/centaur-iron-proxy/src/fragment.rs
+++ b/services/api-rs/crates/centaur-iron-proxy/src/fragment.rs
@@ -250,10 +250,10 @@ fn normalize_auth_mode(value: &str) -> String {
 }
 
 /// The `PLACEHOLDER=PLACEHOLDER` env for replace-mode secrets whose consumers
-/// read credentials straight from the environment (for example codex's
-/// `OPENAI_API_KEY`) rather than through the tool SDK, whose `StubBackend`
-/// already hands back the key name. Only the infra/harness fragments have such
-/// consumers; tool fragments are excluded at the call site.
+/// read credentials straight from the environment (codex's `OPENAI_API_KEY`,
+/// git's `GITHUB_TOKEN`, …) rather than through the tool SDK, whose
+/// `StubBackend` already hands back the key name. Only the infra/harness
+/// fragments have such consumers; tool fragments are excluded at the call site.
 pub fn placeholder_env(fragments: &[ProxyFragment]) -> BTreeMap<String, String> {
     fragments
         .iter()

--- a/services/api-rs/crates/centaur-iron-proxy/src/infra.yaml
+++ b/services/api-rs/crates/centaur-iron-proxy/src/infra.yaml
@@ -3,3 +3,23 @@ proxy:
   # default 30s response-header timeout. Keep model-provider calls from being
   # cut off while OpenAI is still computing the first response byte.
   upstream_response_header_timeout: "120s"
+
+transforms:
+  - name: secrets
+    config:
+      secrets:
+        # gh/git read GITHUB_TOKEN straight from the environment, so sandboxes
+        # need the replace-mode placeholder env (`GITHUB_TOKEN=GITHUB_TOKEN`)
+        # that placeholder_env derives from this entry; iron-proxy swaps the
+        # placeholder for the real token at the edge. Same placeholder-swap
+        # contract for the slack tool's SLACK_BOT_TOKEN.
+        - replace:
+            proxy_value: GITHUB_TOKEN
+            match_headers: ["Authorization"]
+          rules:
+            - { host: github.com }
+            - { host: api.github.com }
+        - replace:
+            proxy_value: SLACK_BOT_TOKEN
+            match_headers: ["Authorization"]
+          rules: [{ host: "*.slack.com" }]

--- a/services/api-rs/crates/centaur-iron-proxy/src/tests.rs
+++ b/services/api-rs/crates/centaur-iron-proxy/src/tests.rs
@@ -57,7 +57,9 @@ fn harness_auth_fragments_are_baked_in() {
         Some("120s")
     );
     let placeholders = placeholder_env(&[infra]);
-    assert!(placeholders.is_empty());
+    for name in ["GITHUB_TOKEN", "SLACK_BOT_TOKEN"] {
+        assert_eq!(placeholders.get(name).map(String::as_str), Some(name));
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Problem

#960 removed all non-model secret transforms from the static infra fragment. The sandbox placeholder env is derived from that same fragment (`sandbox_placeholder_env()` → `placeholder_env()`), so sandboxes created after the `main-sha-53f9545` rollout (2026-07-08 13:07 UTC) stopped receiving `GITHUB_TOKEN=GITHUB_TOKEN` and `SLACK_BOT_TOKEN` placeholders, and per-sandbox proxies lost the corresponding replace rules.

Since `gh`/git decide they are unauthenticated from local env alone, they never send the Authorization header iron-proxy would rewrite — so `gh auth status` fails without making a network request. Broke `gh`, git-over-HTTPS, and the slack tool in every new sandbox.

Verified in production: in a post-rollout sandbox, `gh auth status` fails, while `GITHUB_TOKEN=GITHUB_TOKEN gh api user` succeeds once a replace rule is present at the proxy — confirming only the env/rule halves were missing, exactly what this fragment provides.

## Fix

Restore the replace-mode entries for:
- `GITHUB_TOKEN` (github.com, api.github.com)
- `SLACK_BOT_TOKEN` (*.slack.com)

The other #960 removals (`XAI_API_KEY`, `GEMINI_API_KEY`, `AMP_API_KEY`) stay removed, keeping the rest of the least-privilege intent.

Partial revert of #960 — cc @mslipper

## Testing

- `cargo test -p centaur-iron-proxy` (updated `harness_auth_fragments_are_baked_in` to assert the two placeholders)
- `cargo fmt --check`