### PR TITLE
fix: inject sandbox token placeholders outside fragments

### DIFF
--- a/services/api-rs/crates/centaur-api-server/src/args.rs
+++ b/services/api-rs/crates/centaur-api-server/src/args.rs
@@ -40,6 +40,8 @@ use tracing::{info, warn};
 use crate::{ServerError, activity_summary::ActivitySummaryConfig};
 
 const SANDBOX_REPOS_MOUNT_PATH: &str = "/home/agent/github";
+const GITHUB_TOKEN_ENV: &str = "GITHUB_TOKEN";
+const SLACK_BOT_TOKEN_ENV: &str = "SLACK_BOT_TOKEN";
 
 /// OTLP env always forwarded from the api-rs process into codex sandboxes,
 /// mirroring the Python control plane's `_SANDBOX_PASSTHROUGH_ENV_KEYS`. The
@@ -1677,9 +1679,12 @@ impl IronProxyArgs {
     /// whose `StubBackend` already returns the key name iron-proxy matches on,
     /// and the cloudwatch tool embeds its own throwaway SigV4 credentials.
     fn sandbox_placeholder_env(&self) -> Result<BTreeMap<String, String>, ServerError> {
-        Ok(centaur_iron_proxy::placeholder_env(&[
-            self.infra_fragment()?
-        ]))
+        let mut env = centaur_iron_proxy::placeholder_env(&[self.infra_fragment()?]);
+        env.entry(GITHUB_TOKEN_ENV.to_owned())
+            .or_insert_with(|| GITHUB_TOKEN_ENV.to_owned());
+        env.entry(SLACK_BOT_TOKEN_ENV.to_owned())
+            .or_insert_with(|| SLACK_BOT_TOKEN_ENV.to_owned());
+        Ok(env)
     }
 
     fn env_from_secret_names(&self) -> Vec<String> {
@@ -2513,6 +2518,20 @@ mod tests {
                 .map(|env| env.value.as_str()),
             Some("true")
         );
+        assert_eq!(
+            spec.env
+                .iter()
+                .find(|env| env.name == GITHUB_TOKEN_ENV)
+                .map(|env| env.value.as_str()),
+            Some(GITHUB_TOKEN_ENV)
+        );
+        assert_eq!(
+            spec.env
+                .iter()
+                .find(|env| env.name == SLACK_BOT_TOKEN_ENV)
+                .map(|env| env.value.as_str()),
+            Some(SLACK_BOT_TOKEN_ENV)
+        );
     }
 
     #[test]
@@ -2546,6 +2565,14 @@ mod tests {
         assert!(
             env.iter()
                 .any(|(name, value)| name == "OPENAI_API_KEY" && value == "OPENAI_API_KEY")
+        );
+        assert!(
+            env.iter()
+                .any(|(name, value)| name == GITHUB_TOKEN_ENV && value == GITHUB_TOKEN_ENV)
+        );
+        assert!(
+            env.iter()
+                .any(|(name, value)| name == SLACK_BOT_TOKEN_ENV && value == SLACK_BOT_TOKEN_ENV)
         );
         assert!(
             env.iter()

--- a/services/api-rs/crates/centaur-iron-proxy/src/infra.yaml
+++ b/services/api-rs/crates/centaur-iron-proxy/src/infra.yaml
@@ -3,23 +3,3 @@ proxy:
   # default 30s response-header timeout. Keep model-provider calls from being
   # cut off while OpenAI is still computing the first response byte.
   upstream_response_header_timeout: "120s"
-
-transforms:
-  - name: secrets
-    config:
-      secrets:
-        # gh/git read GITHUB_TOKEN straight from the environment, so sandboxes
-        # need the replace-mode placeholder env (`GITHUB_TOKEN=GITHUB_TOKEN`)
-        # that placeholder_env derives from this entry; iron-proxy swaps the
-        # placeholder for the real token at the edge. Same placeholder-swap
-        # contract for the slack tool's SLACK_BOT_TOKEN.
-        - replace:
-            proxy_value: GITHUB_TOKEN
-            match_headers: ["Authorization"]
-          rules:
-            - { host: github.com }
-            - { host: api.github.com }
-        - replace:
-            proxy_value: SLACK_BOT_TOKEN
-            match_headers: ["Authorization"]
-          rules: [{ host: "*.slack.com" }]

--- a/services/api-rs/crates/centaur-iron-proxy/src/tests.rs
+++ b/services/api-rs/crates/centaur-iron-proxy/src/tests.rs
@@ -58,7 +58,7 @@ fn harness_auth_fragments_are_baked_in() {
     );
     let placeholders = placeholder_env(&[infra]);
     for name in ["GITHUB_TOKEN", "SLACK_BOT_TOKEN"] {
-        assert_eq!(placeholders.get(name).map(String::as_str), Some(name));
+        assert_eq!(placeholders.get(name).map(String::as_str), None);
     }
 }
 


### PR DESCRIPTION
Moves the GitHub and Slack sandbox placeholder defaults into api-rs sandbox env construction so they are present regardless of proxy fragments. Removes their static replace-secret entries from the bundled iron-proxy infra fragment and updates regression coverage for the new ownership.