### PR TITLE
fix(slackbotv2): detect stop commands in Chat-SDK-normalized mention text

### DIFF
--- a/services/slackbotv2/src/stop-command.ts
+++ b/services/slackbotv2/src/stop-command.ts
@@ -13,8 +13,14 @@ const STOP_COMMAND_PATTERN = new RegExp(
 export function isSlackStopCommand(message: { text: string }): boolean {
   const text = message.text.trim()
   if (!text) return false
+  // The Chat SDK normalizes Slack mention tokens before handlers run:
+  // <@U123|name> becomes @name and the bot's own <@U123> becomes @U123, so
+  // message.text never contains raw <@...> tokens. Strip both raw tokens
+  // (defensive) and normalized standalone @mentions; mid-word @ (emails
+  // like user@example.com) is left alone.
   const withoutMentions = text
     .replace(/<@[A-Z0-9]+(?:\|[^>]+)?>/g, ' ')
+    .replace(/(^|\s)@[A-Za-z0-9._-]+/g, '$1')
     .replace(/\s+/g, ' ')
     .trim()
   return STOP_COMMAND_PATTERN.test(withoutMentions)

--- a/services/slackbotv2/test/stop-command.test.ts
+++ b/services/slackbotv2/test/stop-command.test.ts
@@ -31,6 +31,26 @@ describe('Slack stop command detection', () => {
     }
   })
 
+  test('matches Chat-SDK-normalized mentions plus stop keyword', () => {
+    // The Chat SDK rewrites <@U123|name> to @name and the bot's own <@U123>
+    // to @U123 before handlers run, so live message.text carries these forms.
+    expect(isSlackStopCommand({ text: '@centaur_ai stop' })).toBe(true)
+    expect(isSlackStopCommand({ text: '@U08TEST123 stop' })).toBe(true)
+    expect(isSlackStopCommand({ text: 'please @centaur_ai STOP now' })).toBe(true)
+    expect(isSlackStopCommand({ text: '@centaur_ai could you stop the execution?' })).toBe(true)
+    expect(isSlackStopCommand({ text: '@centaur_ai cancel' })).toBe(true)
+  })
+
+  test('does not match unrelated normalized mentions', () => {
+    expect(isSlackStopCommand({ text: '@centaur_ai status' })).toBe(false)
+    expect(isSlackStopCommand({ text: '@centaur_ai stopping by to ask' })).toBe(false)
+    expect(isSlackStopCommand({ text: '@centaur_ai if so, stop.' })).toBe(false)
+    expect(
+      isSlackStopCommand({ text: '@centaur_ai please check the service; if it is broken, stop.' })
+    ).toBe(false)
+    expect(isSlackStopCommand({ text: 'cancel the invite for user@example.com' })).toBe(false)
+  })
+
   test('does not match unrelated mentions', () => {
     expect(isSlackStopCommand({ text: '<@UCENTAUR> status' })).toBe(false)
     expect(isSlackStopCommand({ text: '<@UCENTAUR> stopping by to ask' })).toBe(false)


### PR DESCRIPTION
## Problem

`@centaur_ai stop` no longer interrupts active executions — the message is forwarded to the session as a normal prompt (logs show a normal handoff with no `slackbotv2_stop_command_started`).

## Root cause

`isSlackStopCommand` strips raw Slack mention tokens (`<@U123>`, `<@U123|name>`) before matching, but the Chat SDK normalizes mentions before slackbotv2 handlers ever run: `<@U123|name>` becomes `@name` and the bot's own mention (skipped from display-name resolution) becomes `@U123`. Live `message.text` therefore never contains raw tokens, and the strip is a no-op.

This was latent in #911: its unanchored pattern matched the stop keyword anywhere, so the un-stripped `@centaur_ai ` prefix didn't matter. #915 anchored the pattern (`^...$`) to stop misclassifying embedded instructions like "if it is broken, stop." — correct fix, but it made the dead mention-strip load-bearing and silently broke every mention-prefixed stop command. Existing tests kept passing because they feed the raw `<@UCENTAUR> stop` format production never delivers.

## Fix

Strip normalized standalone `@mentions` (both `@displayname` and the bot's own `@U0BOTID` form) in addition to raw tokens before applying the anchored pattern. Mid-word `@` (emails like user@example.com) is left alone. Keeps #915's false-positive fix intact.

## Testing

- New regression tests using the normalized text forms (`@centaur_ai stop`, `@U08TEST123 stop`, negative cases including embedded "if so, stop." and an email address)
- Full slackbotv2 suite: 157 pass, 0 fail
- `bun run check:types` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)