### PR TITLE
feat: generate API server JWTs for sandbox proxy sync

### DIFF
--- a/services/console/app/models/principal.rb
+++ b/services/console/app/models/principal.rb
@@ -234,6 +234,8 @@ class Principal < ApplicationRecord
   end
 
   def api_server_jwt_secret
+    return nil unless sandbox_api_server_enabled?
+
     channel_id = labels.to_h[SLACK_CHANNEL_ID_LABEL].to_s.strip
     return nil unless channel_id.match?(SLACK_CHANNEL_ID_FORMAT)
 

--- a/services/console/app/models/principal.rb
+++ b/services/console/app/models/principal.rb
@@ -1,3 +1,5 @@
+require "uri"
+
 class Principal < ApplicationRecord
   oid_prefix "prn"
 
@@ -32,8 +34,10 @@ class Principal < ApplicationRecord
   # reports that a control_plane source carries a value without revealing it.
   REDACTED = "[redacted]".freeze
   SANDBOX_REPO_CACHE_LABEL = "centaur.sandbox_repo_cache".freeze
+  SLACK_CHANNEL_ID_LABEL = "slack_channel_id".freeze
   SANDBOX_REPO_CACHE_VALUES = %w[none public all].freeze
   SANDBOX_REPO_CACHE_ALIASES = { "pub" => "public" }.freeze
+  SLACK_CHANNEL_ID_FORMAT = /\A[CDG][A-Z0-9]{8,}\z/
 
   # The config of a principal with no effective grants; also what an unassigned
   # proxy resolves to.
@@ -121,7 +125,7 @@ class Principal < ApplicationRecord
   def effective_config(redact_secrets: true)
     served = served_credentials
     config = {
-      "secrets" => proxy_secrets_for(served),
+      "secrets" => proxy_secrets_for(served) + generated_proxy_secrets,
       "transforms" => proxy_transforms_for(served),
       "postgres" => sync_postgres
     }
@@ -224,6 +228,37 @@ class Principal < ApplicationRecord
     served[:static].map(&:to_proxy_secret)
   end
 
+  def generated_proxy_secrets
+    secret = api_server_jwt_secret
+    secret ? [ secret ] : []
+  end
+
+  def api_server_jwt_secret
+    channel_id = labels.to_h[SLACK_CHANNEL_ID_LABEL].to_s.strip
+    return nil unless channel_id.match?(SLACK_CHANNEL_ID_FORMAT)
+
+    token = ApiServer::Jwt.encode_for_principal(self)
+    return nil if token.blank?
+
+    rules = api_server_hosts.map { |host| { "host" => host } }
+    return nil if rules.empty?
+
+    {
+      "source" => { "type" => "control_plane", "value" => token },
+      "inject" => { "header" => "Authorization", "formatter" => "Bearer {{ .Value }}" },
+      "rules" => rules
+    }
+  end
+
+  def api_server_hosts
+    configured = ENV["CENTAUR_API_SERVER_PROXY_HOSTS"].to_s.split(",")
+    from_url = self.class.host_from_url(ENV["CENTAUR_API_URL"])
+    (configured + [ from_url, "centaur-api-rs", "api" ])
+      .map { |host| host.to_s.strip.downcase.delete_suffix(".") }
+      .reject(&:blank?)
+      .uniq
+  end
+
   def proxy_transforms_for(served)
     transforms = served[:gcp_auth].map(&:to_proxy_transform)
     transforms += served[:gcp_id_token].map(&:to_proxy_transform)
@@ -234,6 +269,12 @@ class Principal < ApplicationRecord
     transforms << { "name" => "oauth_token", "config" => { "tokens" => oauth_entries } } if oauth_entries.any?
 
     transforms
+  end
+
+  def self.host_from_url(value)
+    URI.parse(value.to_s).host
+  rescue URI::InvalidURIError
+    nil
   end
 
   # Cross-type conflict resolution. The wire protocol applies the `secrets` array

--- a/services/console/app/models/principal_sync_config_snapshot.rb
+++ b/services/console/app/models/principal_sync_config_snapshot.rb
@@ -89,6 +89,8 @@ class PrincipalSyncConfigSnapshot < ApplicationRecord
   end
 
   def api_server_jwt_window_stale?(principal)
+    return false unless principal.sandbox_api_server_enabled?
+
     channel_id = principal.labels.to_h[Principal::SLACK_CHANNEL_ID_LABEL].to_s.strip
     return false unless channel_id.match?(Principal::SLACK_CHANNEL_ID_FORMAT)
     return false if ENV["CENTAUR_JWT_SIGNING_SECRET"].to_s.blank?

--- a/services/console/app/models/principal_sync_config_snapshot.rb
+++ b/services/console/app/models/principal_sync_config_snapshot.rb
@@ -26,7 +26,7 @@ class PrincipalSyncConfigSnapshot < ApplicationRecord
   def self.fetch_for(principal)
     version = principal.sync_config_cache_version
     snapshot = find_by(principal: principal, principal_cache_version: version)
-    return snapshot if snapshot&.fresh?
+    return snapshot if snapshot&.fresh_for?(principal)
 
     try_build_for(principal) || snapshot || latest_for(principal) || build_for(principal)
   end
@@ -37,6 +37,10 @@ class PrincipalSyncConfigSnapshot < ApplicationRecord
 
   def fresh?
     updated_at >= TTL.ago
+  end
+
+  def fresh_for?(principal)
+    fresh? && !api_server_jwt_window_stale?(principal)
   end
 
   # Most recent snapshot at any cache version; the stale fallback while
@@ -70,7 +74,7 @@ class PrincipalSyncConfigSnapshot < ApplicationRecord
   def self.build_within_lock(principal)
     version = principal.sync_config_cache_version
     snapshot = find_or_initialize_by(principal: principal, principal_cache_version: version)
-    return snapshot if snapshot.persisted? && snapshot.fresh?
+    return snapshot if snapshot.persisted? && snapshot.fresh_for?(principal)
 
     snapshot.payload = principal.effective_config(redact_secrets: false)
     if snapshot.changed?
@@ -82,5 +86,13 @@ class PrincipalSyncConfigSnapshot < ApplicationRecord
       snapshot.touch
     end
     snapshot
+  end
+
+  def api_server_jwt_window_stale?(principal)
+    channel_id = principal.labels.to_h[Principal::SLACK_CHANNEL_ID_LABEL].to_s.strip
+    return false unless channel_id.match?(Principal::SLACK_CHANNEL_ID_FORMAT)
+    return false if ENV["CENTAUR_JWT_SIGNING_SECRET"].to_s.blank?
+
+    updated_at.to_i < ApiServer::Jwt.window_start(Time.current.to_i)
   end
 end

--- a/services/console/app/models/principal_sync_config_snapshot.rb
+++ b/services/console/app/models/principal_sync_config_snapshot.rb
@@ -93,6 +93,6 @@ class PrincipalSyncConfigSnapshot < ApplicationRecord
     return false unless channel_id.match?(Principal::SLACK_CHANNEL_ID_FORMAT)
     return false if ENV["CENTAUR_JWT_SIGNING_SECRET"].to_s.blank?
 
-    updated_at.to_i < ApiServer::Jwt.window_start(Time.current.to_i)
+    updated_at.to_i < ApiServer::Jwt.window_start_for(principal, Time.current.to_i)
   end
 end

--- a/services/console/lib/api_server/jwt.rb
+++ b/services/console/lib/api_server/jwt.rb
@@ -1,0 +1,47 @@
+module ApiServer
+  module Jwt
+    DEFAULT_AUDIENCE = "centaur-api".freeze
+    DEFAULT_ISSUER = "centaur-console".freeze
+    DEFAULT_WINDOW_SECONDS = 15.minutes.to_i
+    DEFAULT_TTL_SECONDS = 1.hour.to_i
+
+    module_function
+
+    def encode_for_principal(principal, now: Time.current)
+      channel_id = principal.labels.to_h[Principal::SLACK_CHANNEL_ID_LABEL].to_s.strip
+      return nil if channel_id.blank?
+
+      signing_secret = ENV["CENTAUR_JWT_SIGNING_SECRET"].to_s
+      return nil if signing_secret.blank?
+
+      issued_at = window_start(now.to_i)
+      expires_at = issued_at + DEFAULT_TTL_SECONDS
+      CentaurJwt::Hs256.encode(
+        {
+          "iss" => issuer,
+          "sub" => principal.oid,
+          "aud" => audience,
+          "iat" => issued_at,
+          "exp" => expires_at,
+          "slack" => {
+            "upload_channels" => [ channel_id ],
+            "download_channels" => [ channel_id ]
+          }
+        },
+        signing_secret: signing_secret
+      )
+    end
+
+    def window_start(timestamp)
+      timestamp - (timestamp % DEFAULT_WINDOW_SECONDS)
+    end
+
+    def audience
+      ENV["CENTAUR_API_JWT_AUDIENCE"].presence || DEFAULT_AUDIENCE
+    end
+
+    def issuer
+      ENV["CENTAUR_API_JWT_ISSUER"].presence || DEFAULT_ISSUER
+    end
+  end
+end

--- a/services/console/lib/api_server/jwt.rb
+++ b/services/console/lib/api_server/jwt.rb
@@ -1,3 +1,5 @@
+require "zlib"
+
 module ApiServer
   module Jwt
     DEFAULT_AUDIENCE = "centaur-api".freeze
@@ -14,7 +16,7 @@ module ApiServer
       signing_secret = ENV["CENTAUR_JWT_SIGNING_SECRET"].to_s
       return nil if signing_secret.blank?
 
-      issued_at = window_start(now.to_i)
+      issued_at = window_start_for(principal, now.to_i)
       expires_at = issued_at + DEFAULT_TTL_SECONDS
       CentaurJwt::Hs256.encode(
         {
@@ -32,8 +34,16 @@ module ApiServer
       )
     end
 
-    def window_start(timestamp)
-      timestamp - (timestamp % DEFAULT_WINDOW_SECONDS)
+    # Rotation boundaries are offset per principal (deterministically, from
+    # the oid) so the fleet's tokens don't all roll over — and force snapshot
+    # rebuilds — at the same instant.
+    def window_start_for(principal, timestamp)
+      offset = rotation_offset(principal)
+      timestamp - ((timestamp - offset) % DEFAULT_WINDOW_SECONDS)
+    end
+
+    def rotation_offset(principal)
+      Zlib.crc32(principal.oid.to_s) % DEFAULT_WINDOW_SECONDS
     end
 
     def audience

--- a/services/console/lib/centaur_jwt/hs256.rb
+++ b/services/console/lib/centaur_jwt/hs256.rb
@@ -8,7 +8,7 @@ module CentaurJwt
 
     def encode(payload, signing_secret:)
       signing_secret = signing_secret.to_s
-      raise KeyError, "CENTAUR_JWT_SIGNING_SECRET is not configured" if signing_secret.empty?
+      raise KeyError, "CENTAUR_JWT_SIGNING_SECRET is not configured" if signing_secret.blank?
 
       header = { "alg" => "HS256", "typ" => "JWT" }
       signing_input = [ base64url_json(header), base64url_json(payload) ].join(".")

--- a/services/console/lib/centaur_jwt/hs256.rb
+++ b/services/console/lib/centaur_jwt/hs256.rb
@@ -1,0 +1,23 @@
+require "base64"
+require "json"
+require "openssl"
+
+module CentaurJwt
+  module Hs256
+    module_function
+
+    def encode(payload, signing_secret:)
+      signing_secret = signing_secret.to_s
+      raise KeyError, "CENTAUR_JWT_SIGNING_SECRET is not configured" if signing_secret.empty?
+
+      header = { "alg" => "HS256", "typ" => "JWT" }
+      signing_input = [ base64url_json(header), base64url_json(payload) ].join(".")
+      signature = OpenSSL::HMAC.digest("SHA256", signing_secret, signing_input)
+      "#{signing_input}.#{Base64.urlsafe_encode64(signature, padding: false)}"
+    end
+
+    def base64url_json(value)
+      Base64.urlsafe_encode64(JSON.generate(value), padding: false)
+    end
+  end
+end

--- a/services/console/lib/mcp/jwt.rb
+++ b/services/console/lib/mcp/jwt.rb
@@ -1,23 +1,10 @@
-require "base64"
-require "json"
-require "openssl"
-
 module Mcp
   module Jwt
     module_function
 
     def encode(payload)
       signing_secret = ENV["CENTAUR_JWT_SIGNING_SECRET"].to_s
-      raise KeyError, "CENTAUR_JWT_SIGNING_SECRET is not configured" if signing_secret.blank?
-
-      header = { "alg" => "HS256", "typ" => "JWT" }
-      signing_input = [ base64url_json(header), base64url_json(payload) ].join(".")
-      signature = OpenSSL::HMAC.digest("SHA256", signing_secret, signing_input)
-      "#{signing_input}.#{Base64.urlsafe_encode64(signature, padding: false)}"
-    end
-
-    def base64url_json(value)
-      Base64.urlsafe_encode64(JSON.generate(value), padding: false)
+      CentaurJwt::Hs256.encode(payload, signing_secret: signing_secret)
     end
   end
 end

--- a/services/console/test/lib/centaur_jwt/hs256_test.rb
+++ b/services/console/test/lib/centaur_jwt/hs256_test.rb
@@ -1,0 +1,19 @@
+require "test_helper"
+
+class CentaurJwtHs256Test < ActiveSupport::TestCase
+  test "encode raises when the signing secret is missing or whitespace" do
+    assert_raises(KeyError) { CentaurJwt::Hs256.encode({ "sub" => "x" }, signing_secret: nil) }
+    assert_raises(KeyError) { CentaurJwt::Hs256.encode({ "sub" => "x" }, signing_secret: "") }
+    assert_raises(KeyError) { CentaurJwt::Hs256.encode({ "sub" => "x" }, signing_secret: "   ") }
+  end
+
+  test "encode signs with HS256" do
+    token = CentaurJwt::Hs256.encode({ "sub" => "x" }, signing_secret: "test-secret")
+    header, payload, signature = token.split(".")
+
+    assert_equal({ "alg" => "HS256", "typ" => "JWT" }, JSON.parse(Base64.urlsafe_decode64(header)))
+    assert_equal({ "sub" => "x" }, JSON.parse(Base64.urlsafe_decode64(payload)))
+    expected = OpenSSL::HMAC.digest("SHA256", "test-secret", "#{header}.#{payload}")
+    assert_equal Base64.urlsafe_encode64(expected, padding: false), signature
+  end
+end

--- a/services/console/test/models/principal_sync_config_snapshot_test.rb
+++ b/services/console/test/models/principal_sync_config_snapshot_test.rb
@@ -50,8 +50,9 @@ class PrincipalSyncConfigSnapshotTest < ActiveSupport::TestCase
   test "fetch_for rebuilds api server JWT snapshots when the jwt window advances" do
     with_env("CENTAUR_JWT_SIGNING_SECRET" => "test-secret") do
       @principal.update!(labels: { Principal::SLACK_CHANNEL_ID_LABEL => "C0123456789" })
-      current_time = Time.zone.at(1_700_001_060)
-      previous_window_time = Time.zone.at(1_700_000_940)
+      boundary = 1_700_001_000 + ApiServer::Jwt.rotation_offset(@principal)
+      current_time = Time.zone.at(boundary + 60)
+      previous_window_time = Time.zone.at(boundary - 60)
       proxy = proxies(:acme_proxy)
 
       snapshot = PrincipalSyncConfigSnapshot.fetch_for(@principal)

--- a/services/console/test/models/principal_sync_config_snapshot_test.rb
+++ b/services/console/test/models/principal_sync_config_snapshot_test.rb
@@ -76,6 +76,27 @@ class PrincipalSyncConfigSnapshotTest < ActiveSupport::TestCase
     end
   end
 
+  test "fetch_for does not rebuild api server JWT snapshots when sandbox api access is disabled" do
+    with_env("CENTAUR_JWT_SIGNING_SECRET" => "test-secret") do
+      @principal.update!(
+        labels: { Principal::SLACK_CHANNEL_ID_LABEL => "C0123456789" },
+        sandbox_api_server_enabled: false
+      )
+      boundary = 1_700_001_000 + ApiServer::Jwt.rotation_offset(@principal)
+      current_time = Time.zone.at(boundary + 60)
+      previous_window_time = Time.zone.at(boundary - 60)
+
+      snapshot = PrincipalSyncConfigSnapshot.fetch_for(@principal)
+      snapshot.update_columns(updated_at: previous_window_time)
+
+      travel_to current_time do
+        assert_no_changes -> { snapshot.reload.updated_at } do
+          assert_equal snapshot, PrincipalSyncConfigSnapshot.fetch_for(@principal)
+        end
+      end
+    end
+  end
+
   test "fetch_for builds a new snapshot after a cache version bump" do
     old = PrincipalSyncConfigSnapshot.fetch_for(@principal)
     Principal.bump_sync_config_cache_versions(@principal.id)

--- a/services/console/test/models/principal_sync_config_snapshot_test.rb
+++ b/services/console/test/models/principal_sync_config_snapshot_test.rb
@@ -1,6 +1,8 @@
 require "test_helper"
 
 class PrincipalSyncConfigSnapshotTest < ActiveSupport::TestCase
+  include ActiveSupport::Testing::TimeHelpers
+
   setup do
     @principal = principals(:acme_channel)
   end
@@ -43,6 +45,34 @@ class PrincipalSyncConfigSnapshotTest < ActiveSupport::TestCase
     refreshed = PrincipalSyncConfigSnapshot.fetch_for(@principal)
     assert_equal snapshot.id, refreshed.id
     assert refreshed.fresh?
+  end
+
+  test "fetch_for rebuilds api server JWT snapshots when the jwt window advances" do
+    with_env("CENTAUR_JWT_SIGNING_SECRET" => "test-secret") do
+      @principal.update!(labels: { Principal::SLACK_CHANNEL_ID_LABEL => "C0123456789" })
+      current_time = Time.zone.at(1_700_001_060)
+      previous_window_time = Time.zone.at(1_700_000_940)
+      proxy = proxies(:acme_proxy)
+
+      snapshot = PrincipalSyncConfigSnapshot.fetch_for(@principal)
+      original_hash = proxy.sync_config_snapshot.fetch(:config_hash)
+      original_token = snapshot.payload.fetch("secrets").find do |secret|
+        secret.dig("inject", "header") == "Authorization"
+      end.dig("source", "value")
+      snapshot.update_columns(updated_at: previous_window_time)
+
+      travel_to current_time do
+        refreshed = PrincipalSyncConfigSnapshot.fetch_for(@principal)
+        refreshed_token = refreshed.payload.fetch("secrets").find do |secret|
+          secret.dig("inject", "header") == "Authorization"
+        end.dig("source", "value")
+
+        assert_equal snapshot.id, refreshed.id
+        assert refreshed.fresh?
+        refute_equal original_token, refreshed_token
+        refute_equal original_hash, proxy.reload.sync_config_snapshot.fetch(:config_hash)
+      end
+    end
   end
 
   test "fetch_for builds a new snapshot after a cache version bump" do
@@ -107,6 +137,18 @@ class PrincipalSyncConfigSnapshotTest < ActiveSupport::TestCase
 
     assert_no_difference -> { PrincipalSyncConfigSnapshot.count } do
       assert_equal snapshot, PrincipalSyncConfigSnapshot.try_build_for(@principal)
+    end
+  end
+
+  def with_env(values)
+    previous = values.keys.to_h { |key| [ key, ENV[key] ] }
+    values.each do |key, value|
+      value.nil? ? ENV.delete(key) : ENV[key] = value
+    end
+    yield
+  ensure
+    previous.each do |key, value|
+      value.nil? ? ENV.delete(key) : ENV[key] = value
     end
   end
 end

--- a/services/console/test/models/principal_test.rb
+++ b/services/console/test/models/principal_test.rb
@@ -133,7 +133,8 @@ class PrincipalTest < ActiveSupport::TestCase
       assert_equal [ "C0123456789" ], claims.dig("slack", "upload_channels")
       assert_equal [ "C0123456789" ], claims.dig("slack", "download_channels")
       assert_equal 1.hour.to_i, claims.fetch("exp") - claims.fetch("iat")
-      assert_equal 0, claims.fetch("iat") % 15.minutes.to_i
+      assert_equal ApiServer::Jwt.rotation_offset(principal),
+                   claims.fetch("iat") % ApiServer::Jwt::DEFAULT_WINDOW_SECONDS
     end
   end
 
@@ -142,17 +143,20 @@ class PrincipalTest < ActiveSupport::TestCase
       principal = principals(:acme_channel)
       principal.update!(labels: { Principal::SLACK_CHANNEL_ID_LABEL => "C0123456789" })
 
+      window = ApiServer::Jwt::DEFAULT_WINDOW_SECONDS
+      boundary = 1_700_000_100 + ApiServer::Jwt.rotation_offset(principal)
+
       first = ApiServer::Jwt.encode_for_principal(
         principal,
-        now: Time.zone.at(1_700_000_123)
+        now: Time.zone.at(boundary + 23)
       )
       second = ApiServer::Jwt.encode_for_principal(
         principal,
-        now: Time.zone.at(1_700_000_899)
+        now: Time.zone.at(boundary + window - 1)
       )
       third = ApiServer::Jwt.encode_for_principal(
         principal,
-        now: Time.zone.at(1_700_001_000)
+        now: Time.zone.at(boundary + window)
       )
 
       assert_equal first, second

--- a/services/console/test/models/principal_test.rb
+++ b/services/console/test/models/principal_test.rb
@@ -107,6 +107,59 @@ class PrincipalTest < ActiveSupport::TestCase
     assert_equal({ "env" => "prod", "team" => "platform" }, principal.reload.labels)
   end
 
+  test "effective_config adds api server JWT for slack channel principals" do
+    with_env(
+      "CENTAUR_JWT_SIGNING_SECRET" => "test-secret",
+      "CENTAUR_API_URL" => "http://api.internal:8080",
+      "CENTAUR_API_SERVER_PROXY_HOSTS" => nil
+    ) do
+      principal = principals(:acme_channel)
+      principal.update!(labels: { Principal::SLACK_CHANNEL_ID_LABEL => "C0123456789" })
+
+      config = principal.effective_config(redact_secrets: false)
+      entry = config.fetch("secrets").find do |secret|
+        secret.dig("inject", "header") == "Authorization" &&
+          secret.dig("source", "type") == "control_plane"
+      end
+
+      refute_nil entry
+      assert_equal "Bearer {{ .Value }}", entry.dig("inject", "formatter")
+      assert_includes entry.fetch("rules"), { "host" => "api.internal" }
+
+      claims = jwt_payload(entry.dig("source", "value"))
+      assert_equal "centaur-console", claims.fetch("iss")
+      assert_equal "centaur-api", claims.fetch("aud")
+      assert_equal principal.oid, claims.fetch("sub")
+      assert_equal [ "C0123456789" ], claims.dig("slack", "upload_channels")
+      assert_equal [ "C0123456789" ], claims.dig("slack", "download_channels")
+      assert_equal 1.hour.to_i, claims.fetch("exp") - claims.fetch("iat")
+      assert_equal 0, claims.fetch("iat") % 15.minutes.to_i
+    end
+  end
+
+  test "api server JWT is deterministic inside the rotation window" do
+    with_env("CENTAUR_JWT_SIGNING_SECRET" => "test-secret") do
+      principal = principals(:acme_channel)
+      principal.update!(labels: { Principal::SLACK_CHANNEL_ID_LABEL => "C0123456789" })
+
+      first = ApiServer::Jwt.encode_for_principal(
+        principal,
+        now: Time.zone.at(1_700_000_123)
+      )
+      second = ApiServer::Jwt.encode_for_principal(
+        principal,
+        now: Time.zone.at(1_700_000_899)
+      )
+      third = ApiServer::Jwt.encode_for_principal(
+        principal,
+        now: Time.zone.at(1_700_001_000)
+      )
+
+      assert_equal first, second
+      refute_equal first, third
+    end
+  end
+
   test "namespace is immutable after creation" do
     principal = principals(:acme_channel)
     assert_raises(ActiveRecord::ReadonlyAttributeError) do
@@ -505,5 +558,22 @@ class PrincipalTest < ActiveSupport::TestCase
     live = principal.effective_config(redact_secrets: false)
                     .fetch("secrets").find { |s| s.dig("source", "type") == "control_plane" }
     assert_equal "s3cr3t", live.dig("source", "value")
+  end
+
+  def jwt_payload(token)
+    _header, payload, _signature = token.split(".")
+    JSON.parse(Base64.urlsafe_decode64(payload))
+  end
+
+  def with_env(values)
+    previous = values.keys.to_h { |key| [ key, ENV[key] ] }
+    values.each do |key, value|
+      value.nil? ? ENV.delete(key) : ENV[key] = value
+    end
+    yield
+  ensure
+    previous.each do |key, value|
+      value.nil? ? ENV.delete(key) : ENV[key] = value
+    end
   end
 end

--- a/services/console/test/models/principal_test.rb
+++ b/services/console/test/models/principal_test.rb
@@ -138,6 +138,24 @@ class PrincipalTest < ActiveSupport::TestCase
     end
   end
 
+  test "effective_config omits api server JWT when sandbox api access is disabled" do
+    with_env("CENTAUR_JWT_SIGNING_SECRET" => "test-secret") do
+      principal = principals(:acme_channel)
+      principal.update!(
+        labels: { Principal::SLACK_CHANNEL_ID_LABEL => "C0123456789" },
+        sandbox_api_server_enabled: false
+      )
+
+      config = principal.effective_config(redact_secrets: false)
+      entry = config.fetch("secrets").find do |secret|
+        secret.dig("inject", "header") == "Authorization" &&
+          secret.dig("source", "type") == "control_plane"
+      end
+
+      assert_nil entry
+    end
+  end
+
   test "api server JWT is deterministic inside the rotation window" do
     with_env("CENTAUR_JWT_SIGNING_SECRET" => "test-secret") do
       principal = principals(:acme_channel)


### PR DESCRIPTION
Generates short-lived API server JWTs in proxy sync config for Slack channel principals, scoped from the principal's Slack channel label. Refactors HS256 signing into a shared console JWT helper while keeping MCP token generation on the shared signer, and refreshes sync snapshots when the JWT rotation window advances so proxy config hashes change correctly.