### PR TITLE
fix: read workflow output watermark

### DIFF
--- a/workflows/company_context_documents.py
+++ b/workflows/company_context_documents.py
@@ -191,6 +191,8 @@ async def _latest_successful_watermark(pool, current_run_id: str) -> dt.datetime
     if not row:
         return None
     output = decode_jsonb(row["completed_payload"], {})
+    if isinstance(output, dict) and isinstance(output.get("output"), dict):
+        output = output["output"]
     return _parse_datetime(str(output.get("watermark") or ""))
 
 

--- a/workflows/tests/test_company_context_documents_attachments.py
+++ b/workflows/tests/test_company_context_documents_attachments.py
@@ -79,8 +79,12 @@ class FakeWatermarkPool:
         self.args = args
         return {
             "completed_payload": {
-                "status": "completed",
-                "watermark": "2026-06-18T22:59:36+00:00",
+                "steps": ["python_host"],
+                "output": {
+                    "status": "completed",
+                    "watermark": "2026-06-18T22:59:36+00:00",
+                },
+                "workflow_name": "company_context_documents",
             }
         }
 


### PR DESCRIPTION
## Summary
- read company context projection watermarks from the workflow output payload shape emitted by Absurd
- keep compatibility with the previous top-level watermark shape
- update the regression fixture to match observed staging/prod completed payloads

## Root cause
`company_context_documents` looked for `completed_payload.watermark`, but completed Absurd workflow tasks store the handler return under `completed_payload.output.watermark`. The projection therefore missed its previous successful watermark and retried oversized projection batches.

## Validation
- `uv run --with pytest python -m pytest workflows/tests/test_company_context_documents_attachments.py`
- `just build-one api-rs`

## Notes
Reproduced read-only against staging and prod before this PR. Both environments had fresh raw Slack rows but stale projected thread documents, consistent with the missed watermark.