### PR TITLE
feat: expose slack client jwt on healthz

### DIFF
--- a/services/api-rs/crates/centaur-api-server/src/api_jwt.rs
+++ b/services/api-rs/crates/centaur-api-server/src/api_jwt.rs
@@ -1,0 +1,204 @@
+use std::{env, sync::OnceLock};
+
+use axum::http::{HeaderMap, header};
+use base64::{Engine as _, engine::general_purpose};
+use jsonwebtoken::{Algorithm, DecodingKey, Validation, decode};
+use serde::de::DeserializeOwned;
+use serde_json::Value;
+
+use crate::ApiError;
+
+const DEFAULT_API_JWT_AUDIENCE: &str = "centaur-api";
+const DEFAULT_API_JWT_ISSUER: &str = "centaur-console";
+const JWT_CLOCK_SKEW_SECONDS: i64 = 30;
+
+pub(crate) fn bearer_token(headers: &HeaderMap) -> Result<&str, ApiError> {
+    let value = headers
+        .get(header::AUTHORIZATION)
+        .and_then(|value| value.to_str().ok())
+        .ok_or_else(|| ApiError::Unauthorized("missing bearer token".to_owned()))?;
+    value
+        .split_once(' ')
+        .filter(|(scheme, _)| scheme.eq_ignore_ascii_case("Bearer"))
+        .map(|(_, token)| token.trim())
+        .filter(|token| !token.is_empty())
+        .ok_or_else(|| ApiError::Unauthorized("missing bearer token".to_owned()))
+}
+
+pub(crate) fn bearer_jwt_from_headers(headers: &HeaderMap) -> Option<&str> {
+    let token = bearer_token(headers).ok()?;
+    if token.matches('.').count() == 2 {
+        Some(token)
+    } else {
+        None
+    }
+}
+
+pub(crate) fn decode_jwt_payload(token: &str) -> Result<Value, String> {
+    let mut parts = token.split('.');
+    let _header = parts.next();
+    let payload = parts
+        .next()
+        .ok_or_else(|| "JWT payload is missing".to_owned())?;
+    if parts.next().is_none() || parts.next().is_some() {
+        return Err("JWT must have three segments".to_owned());
+    }
+    let decoded = general_purpose::URL_SAFE_NO_PAD
+        .decode(payload)
+        .or_else(|_| general_purpose::URL_SAFE.decode(payload))
+        .map_err(|_| "JWT payload is not valid base64url".to_owned())?;
+    serde_json::from_slice(&decoded).map_err(|_| "JWT payload is not valid JSON".to_owned())
+}
+
+pub(crate) fn verify_console_jwt<T>(token: &str) -> Result<T, ApiError>
+where
+    T: DeserializeOwned,
+{
+    let secret = jwt_signing_secret().ok_or_else(|| {
+        ApiError::Internal("CENTAUR_JWT_SIGNING_SECRET is not configured".to_owned())
+    })?;
+    let audience = non_empty_env("CENTAUR_API_JWT_AUDIENCE")
+        .unwrap_or_else(|| DEFAULT_API_JWT_AUDIENCE.to_owned());
+    let issuer = non_empty_env("CENTAUR_API_JWT_ISSUER")
+        .unwrap_or_else(|| DEFAULT_API_JWT_ISSUER.to_owned());
+    verify_hs256_jwt(token, secret.as_bytes(), &audience, &issuer)
+}
+
+pub(crate) fn verify_hs256_jwt<T>(
+    token: &str,
+    secret: &[u8],
+    expected_audience: &str,
+    expected_issuer: &str,
+) -> Result<T, ApiError>
+where
+    T: DeserializeOwned,
+{
+    let mut validation = Validation::new(Algorithm::HS256);
+    validation.leeway = JWT_CLOCK_SKEW_SECONDS as u64;
+    validation.validate_nbf = true;
+    validation.set_audience(&[expected_audience]);
+    validation.set_issuer(&[expected_issuer]);
+    validation.set_required_spec_claims(&["exp", "iss", "sub", "aud"]);
+    let token_data = decode::<T>(token, &DecodingKey::from_secret(secret), &validation)
+        .map_err(|_| ApiError::Unauthorized("invalid JWT".to_owned()))?;
+    let payload =
+        decode_jwt_payload(token).map_err(|_| ApiError::Unauthorized("invalid JWT".to_owned()))?;
+    validate_standard_claims(&payload)?;
+    Ok(token_data.claims)
+}
+
+fn validate_standard_claims(claims: &Value) -> Result<(), ApiError> {
+    let now = time::OffsetDateTime::now_utc().unix_timestamp();
+    let iat = claims
+        .get("iat")
+        .and_then(Value::as_i64)
+        .ok_or_else(|| ApiError::Unauthorized("JWT issued-at is required".to_owned()))?;
+    if iat > now + JWT_CLOCK_SKEW_SECONDS {
+        return Err(ApiError::Unauthorized(
+            "JWT issued-at is in the future".to_owned(),
+        ));
+    }
+    if claims
+        .get("sub")
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .trim()
+        .is_empty()
+    {
+        return Err(ApiError::Unauthorized("JWT subject is required".to_owned()));
+    }
+    Ok(())
+}
+
+// Deployment JWT configuration is static, so it is resolved once per process.
+// Tests mutate env per-case, so cfg!(test) reads live.
+fn static_env(cell: &'static OnceLock<Option<String>>, name: &str) -> Option<String> {
+    if cfg!(test) {
+        return env::var(name).ok();
+    }
+    cell.get_or_init(|| env::var(name).ok()).clone()
+}
+
+pub(crate) fn jwt_signing_secret() -> Option<String> {
+    static CELL: OnceLock<Option<String>> = OnceLock::new();
+    static_env(&CELL, "CENTAUR_JWT_SIGNING_SECRET")
+}
+
+fn non_empty_env(name: &str) -> Option<String> {
+    env::var(name)
+        .ok()
+        .map(|value| value.trim().to_owned())
+        .filter(|value| !value.is_empty())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::http::HeaderValue;
+    use jsonwebtoken::{EncodingKey, Header, encode};
+    use serde_json::json;
+
+    fn test_jwt(secret: &[u8], claims: Value) -> String {
+        encode(
+            &Header::new(Algorithm::HS256),
+            &claims,
+            &EncodingKey::from_secret(secret),
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn bearer_token_scheme_is_case_insensitive() {
+        for value in ["Bearer token-1", "bearer token-1", "BEARER token-1"] {
+            let mut headers = HeaderMap::new();
+            headers.insert(header::AUTHORIZATION, value.parse().unwrap());
+            assert_eq!(bearer_token(&headers).unwrap(), "token-1");
+        }
+
+        for value in ["Bearer ", "token-1", "Basic token-1"] {
+            let mut headers = HeaderMap::new();
+            headers.insert(header::AUTHORIZATION, value.parse().unwrap());
+            assert!(matches!(
+                bearer_token(&headers).unwrap_err(),
+                ApiError::Unauthorized(_)
+            ));
+        }
+    }
+
+    #[test]
+    fn bearer_jwt_from_headers_requires_jwt_shape() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            header::AUTHORIZATION,
+            HeaderValue::from_static("Bearer not-a-jwt"),
+        );
+        assert!(bearer_jwt_from_headers(&headers).is_none());
+
+        headers.insert(
+            header::AUTHORIZATION,
+            HeaderValue::from_static("Bearer header.payload.signature"),
+        );
+        assert_eq!(
+            bearer_jwt_from_headers(&headers),
+            Some("header.payload.signature")
+        );
+    }
+
+    #[test]
+    fn verify_console_jwt_rejects_missing_issued_at() {
+        let token = test_jwt(
+            b"secret",
+            json!({
+                "iss": "centaur-console",
+                "sub": "principal_123",
+                "aud": "centaur-api",
+                "exp": 4_102_444_800i64,
+            }),
+        );
+        assert!(matches!(
+            verify_hs256_jwt::<Value>(&token, b"secret", "centaur-api", "centaur-console")
+                .unwrap_err(),
+            ApiError::Unauthorized(_)
+        ));
+    }
+}

--- a/services/api-rs/crates/centaur-api-server/src/lib.rs
+++ b/services/api-rs/crates/centaur-api-server/src/lib.rs
@@ -1,3 +1,4 @@
+mod api_jwt;
 pub mod client;
 mod error;
 mod mcp;
@@ -35,6 +36,8 @@ mod tests {
     };
     use centaur_session_runtime::SandboxRuntime;
     use centaur_session_sqlx::PgSessionStore;
+    use jsonwebtoken::{Algorithm, EncodingKey, Header, encode};
+    use serde_json::{Value, json};
     use sqlx::PgPool;
     use tower::ServiceExt;
 
@@ -110,6 +113,58 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn healthz_decodes_slack_client_bearer_jwt_when_present() {
+        let app = build_router_with_app_state(AppState::unready());
+        let token = encode(
+            &Header::new(Algorithm::HS256),
+            &json!({
+                "iss": "centaur-console",
+                "sub": "principal_123",
+                "aud": "centaur-api",
+                "iat": 1_700_000_000i64,
+                "exp": 4_102_444_800i64,
+                "slack": {
+                    "upload_channels": ["C123456789"],
+                    "download_channels": ["C987654321"]
+                }
+            }),
+            &EncodingKey::from_secret(b"test-secret"),
+        )
+        .unwrap();
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/healthz")
+                    .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let body: Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(body.get("ok").and_then(Value::as_bool), Some(true));
+        assert_eq!(
+            body.pointer("/slack_client_jwt/claims/sub")
+                .and_then(Value::as_str),
+            Some("principal_123")
+        );
+        assert_eq!(
+            body.pointer("/slack_client_jwt/claims/slack/upload_channels/0")
+                .and_then(Value::as_str),
+            Some("C123456789")
+        );
+        assert_eq!(
+            body.pointer("/slack_client_jwt/claims/slack/download_channels/0")
+                .and_then(Value::as_str),
+            Some("C987654321")
+        );
     }
 
     #[tokio::test]

--- a/services/api-rs/crates/centaur-api-server/src/mcp.rs
+++ b/services/api-rs/crates/centaur-api-server/src/mcp.rs
@@ -22,6 +22,7 @@ use time::OffsetDateTime;
 
 use crate::{
     ApiError,
+    api_jwt::jwt_signing_secret,
     routes::{AppState, header_value},
     tool_discovery::{DiscoveredTool, ToolDiscoveryConfig, discover_tool_catalog},
 };
@@ -749,11 +750,6 @@ fn static_env(cell: &'static OnceLock<Option<String>>, name: &str) -> Option<Str
         return env::var(name).ok();
     }
     cell.get_or_init(|| env::var(name).ok()).clone()
-}
-
-pub(crate) fn jwt_signing_secret() -> Option<String> {
-    static CELL: OnceLock<Option<String>> = OnceLock::new();
-    static_env(&CELL, "CENTAUR_JWT_SIGNING_SECRET")
 }
 
 fn mcp_public_url_env() -> Option<String> {

--- a/services/api-rs/crates/centaur-api-server/src/routes.rs
+++ b/services/api-rs/crates/centaur-api-server/src/routes.rs
@@ -54,6 +54,7 @@ use uuid::Uuid;
 
 use crate::{
     ApiError,
+    api_jwt::{bearer_jwt_from_headers, decode_jwt_payload, verify_console_jwt},
     mcp::{mcp_get, mcp_post, mcp_protected_resource_metadata},
     slack_proxy::slack_proxy_router,
     types::{
@@ -336,8 +337,30 @@ pub fn build_router_with_app_state(state: AppState) -> Router {
         .with_state(state)
 }
 
-async fn healthz() -> Json<Value> {
-    Json(json!({"ok": true}))
+async fn healthz(headers: HeaderMap) -> Json<Value> {
+    let mut body = json!({"ok": true});
+    if let Some(token) = bearer_jwt_from_headers(&headers) {
+        body["slack_client_jwt"] = match decode_jwt_payload(token) {
+            Ok(claims) => {
+                let mut jwt = json!({ "claims": claims });
+                match verify_console_jwt::<Value>(token) {
+                    Ok(_) => {
+                        jwt["valid"] = json!(true);
+                    }
+                    Err(error) => {
+                        jwt["valid"] = json!(false);
+                        jwt["error"] = json!(error.to_string());
+                    }
+                }
+                jwt
+            }
+            Err(error) => json!({
+                "valid": false,
+                "error": error,
+            }),
+        };
+    }
+    Json(body)
 }
 
 async fn readyz(State(state): State<AppState>) -> impl IntoResponse {

--- a/services/api-rs/crates/centaur-api-server/src/slack_proxy.rs
+++ b/services/api-rs/crates/centaur-api-server/src/slack_proxy.rs
@@ -8,21 +8,17 @@ use axum::{
     response::{IntoResponse, Response},
     routing::{get, post},
 };
-use jsonwebtoken::{Algorithm, DecodingKey, Validation, decode};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 
 use crate::{
     ApiError,
-    mcp::jwt_signing_secret,
+    api_jwt::{bearer_token, verify_console_jwt},
     routes::{AppState, non_empty_env, positive_env_u64},
 };
 
 const DEFAULT_SLACK_API_URL: &str = "https://slack.com/api";
-const DEFAULT_API_JWT_AUDIENCE: &str = "centaur-api";
-const DEFAULT_API_JWT_ISSUER: &str = "centaur-console";
 const DEFAULT_MAX_UPLOAD_BYTES: u64 = 100 * 1024 * 1024;
-const JWT_CLOCK_SKEW_SECONDS: i64 = 30;
 const HTTP_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
 const HTTP_READ_TIMEOUT: Duration = Duration::from_secs(60);
 
@@ -74,10 +70,7 @@ struct SlackFileDownloadQuery {
 
 #[derive(Debug, Deserialize)]
 struct SlackFileProxyClaims {
-    iat: i64,
     slack: SlackProxyClaims,
-    #[serde(default)]
-    sub: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -417,59 +410,7 @@ async fn slack_api_post_form(
 
 fn authorize_slack_file_proxy(headers: &HeaderMap) -> Result<SlackFileProxyClaims, ApiError> {
     let token = bearer_token(headers)?;
-    let secret = jwt_signing_secret().ok_or_else(|| {
-        ApiError::Internal("CENTAUR_JWT_SIGNING_SECRET is not configured".to_owned())
-    })?;
-    let audience = non_empty_env("CENTAUR_API_JWT_AUDIENCE")
-        .unwrap_or_else(|| DEFAULT_API_JWT_AUDIENCE.to_owned());
-    let issuer = non_empty_env("CENTAUR_API_JWT_ISSUER")
-        .unwrap_or_else(|| DEFAULT_API_JWT_ISSUER.to_owned());
-    verify_hs256_jwt(token, secret.as_bytes(), &audience, &issuer)
-}
-
-fn bearer_token(headers: &HeaderMap) -> Result<&str, ApiError> {
-    let value = headers
-        .get(header::AUTHORIZATION)
-        .and_then(|value| value.to_str().ok())
-        .ok_or_else(|| ApiError::Unauthorized("missing bearer token".to_owned()))?;
-    value
-        .split_once(' ')
-        .filter(|(scheme, _)| scheme.eq_ignore_ascii_case("Bearer"))
-        .map(|(_, token)| token.trim())
-        .filter(|token| !token.is_empty())
-        .ok_or_else(|| ApiError::Unauthorized("missing bearer token".to_owned()))
-}
-
-fn verify_hs256_jwt(
-    token: &str,
-    secret: &[u8],
-    expected_audience: &str,
-    expected_issuer: &str,
-) -> Result<SlackFileProxyClaims, ApiError> {
-    let mut validation = Validation::new(Algorithm::HS256);
-    validation.leeway = JWT_CLOCK_SKEW_SECONDS as u64;
-    validation.validate_nbf = true;
-    validation.set_audience(&[expected_audience]);
-    validation.set_issuer(&[expected_issuer]);
-    validation.set_required_spec_claims(&["exp", "iss", "sub", "aud"]);
-    let token_data =
-        decode::<SlackFileProxyClaims>(token, &DecodingKey::from_secret(secret), &validation)
-            .map_err(|_| ApiError::Unauthorized("invalid JWT".to_owned()))?;
-    validate_claims(&token_data.claims)?;
-    Ok(token_data.claims)
-}
-
-fn validate_claims(claims: &SlackFileProxyClaims) -> Result<(), ApiError> {
-    let now = time::OffsetDateTime::now_utc().unix_timestamp();
-    if claims.iat > now + JWT_CLOCK_SKEW_SECONDS {
-        return Err(ApiError::Unauthorized(
-            "JWT issued-at is in the future".to_owned(),
-        ));
-    }
-    if claims.sub.as_deref().unwrap_or_default().trim().is_empty() {
-        return Err(ApiError::Unauthorized("JWT subject is required".to_owned()));
-    }
-    Ok(())
+    verify_console_jwt(token)
 }
 
 fn ensure_upload_channel_allowed(
@@ -630,7 +571,7 @@ fn content_disposition_filename(filename: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use jsonwebtoken::{EncodingKey, Header, encode};
+    use jsonwebtoken::{Algorithm, EncodingKey, Header, encode};
 
     fn test_jwt(secret: &[u8], claims: Value) -> String {
         encode(
@@ -657,7 +598,13 @@ mod tests {
                 }
             }),
         );
-        let claims = verify_hs256_jwt(&token, b"secret", "centaur-api", "centaur-console").unwrap();
+        let claims = crate::api_jwt::verify_hs256_jwt::<SlackFileProxyClaims>(
+            &token,
+            b"secret",
+            "centaur-api",
+            "centaur-console",
+        )
+        .unwrap();
         ensure_upload_channel_allowed(&claims, "C123456789").unwrap();
         ensure_download_channel_allowed(&claims, "C987654321").unwrap();
         assert!(matches!(
@@ -687,8 +634,13 @@ mod tests {
             }),
         );
         assert!(matches!(
-            verify_hs256_jwt(&token, b"other-secret", "centaur-api", "centaur-console")
-                .unwrap_err(),
+            crate::api_jwt::verify_hs256_jwt::<SlackFileProxyClaims>(
+                &token,
+                b"other-secret",
+                "centaur-api",
+                "centaur-console"
+            )
+            .unwrap_err(),
             ApiError::Unauthorized(_)
         ));
     }
@@ -710,7 +662,13 @@ mod tests {
             }),
         );
         assert!(matches!(
-            verify_hs256_jwt(&token, b"secret", "centaur-api", "centaur-console").unwrap_err(),
+            crate::api_jwt::verify_hs256_jwt::<SlackFileProxyClaims>(
+                &token,
+                b"secret",
+                "centaur-api",
+                "centaur-console"
+            )
+            .unwrap_err(),
             ApiError::Unauthorized(_)
         ));
     }
@@ -732,7 +690,13 @@ mod tests {
             }),
         );
         assert!(matches!(
-            verify_hs256_jwt(&token, b"secret", "centaur-api", "centaur-console").unwrap_err(),
+            crate::api_jwt::verify_hs256_jwt::<SlackFileProxyClaims>(
+                &token,
+                b"secret",
+                "centaur-api",
+                "centaur-console"
+            )
+            .unwrap_err(),
             ApiError::Unauthorized(_)
         ));
     }
@@ -753,7 +717,13 @@ mod tests {
                 }
             }),
         );
-        let claims = verify_hs256_jwt(&token, b"secret", "centaur-api", "centaur-console").unwrap();
+        let claims = crate::api_jwt::verify_hs256_jwt::<SlackFileProxyClaims>(
+            &token,
+            b"secret",
+            "centaur-api",
+            "centaur-console",
+        )
+        .unwrap();
         ensure_upload_channel_allowed(&claims, "C123456789").unwrap();
         ensure_download_channel_allowed(&claims, "C123456789").unwrap();
     }
@@ -772,7 +742,13 @@ mod tests {
             }),
         );
         assert!(matches!(
-            verify_hs256_jwt(&token, b"secret", "centaur-api", "centaur-console").unwrap_err(),
+            crate::api_jwt::verify_hs256_jwt::<SlackFileProxyClaims>(
+                &token,
+                b"secret",
+                "centaur-api",
+                "centaur-console"
+            )
+            .unwrap_err(),
             ApiError::Unauthorized(_)
         ));
     }
@@ -830,27 +806,15 @@ mod tests {
             }),
         );
         assert!(matches!(
-            verify_hs256_jwt(&token, b"secret", "centaur-api", "centaur-console").unwrap_err(),
+            crate::api_jwt::verify_hs256_jwt::<SlackFileProxyClaims>(
+                &token,
+                b"secret",
+                "centaur-api",
+                "centaur-console"
+            )
+            .unwrap_err(),
             ApiError::Unauthorized(_)
         ));
-    }
-
-    #[test]
-    fn bearer_token_scheme_is_case_insensitive() {
-        for value in ["Bearer token-1", "bearer token-1", "BEARER token-1"] {
-            let mut headers = HeaderMap::new();
-            headers.insert(header::AUTHORIZATION, value.parse().unwrap());
-            assert_eq!(bearer_token(&headers).unwrap(), "token-1");
-        }
-
-        for value in ["Bearer ", "token-1", "Basic token-1"] {
-            let mut headers = HeaderMap::new();
-            headers.insert(header::AUTHORIZATION, value.parse().unwrap());
-            assert!(matches!(
-                bearer_token(&headers).unwrap_err(),
-                ApiError::Unauthorized(_)
-            ));
-        }
     }
 
     #[test]


### PR DESCRIPTION
Adds shared api-rs JWT helpers for console-issued bearer tokens and uses them from the health endpoint, Slack file proxy, and MCP signing-secret lookup. The health endpoint now includes decoded Slack client JWT claims when a JWT-shaped bearer token is present while preserving the unauthenticated health response.