### PR TITLE
feat(sandbox): make iron-proxy pod ServiceAccount configurable

### DIFF
--- a/services/api-rs/crates/centaur-api-server/src/args.rs
+++ b/services/api-rs/crates/centaur-api-server/src/args.rs
@@ -1589,6 +1589,14 @@ struct IronProxyArgs {
         env = "KUBERNETES_IRON_PROXY_IMAGE_PULL_POLICY"
     )]
     image_pull_policy: Option<String>,
+    /// ServiceAccount for proxy pods. Bind it to a cloud identity (e.g. GKE
+    /// Workload Identity) to enable ambient-credential transforms; unset keeps
+    /// the namespace default (no cloud identity).
+    #[arg(
+        long = "kubernetes-iron-proxy-service-account-name",
+        env = "KUBERNETES_IRON_PROXY_SERVICE_ACCOUNT_NAME"
+    )]
+    service_account_name: Option<String>,
     #[arg(
         long = "kubernetes-iron-proxy-upstream-deny-cidrs",
         env = "KUBERNETES_IRON_PROXY_UPSTREAM_DENY_CIDRS",
@@ -1631,6 +1639,7 @@ impl IronProxyArgs {
         let mut config =
             IronProxyConfig::new(self.image.clone(), ca_cert_secret_name, ca_key_secret_name);
         config.image_pull_policy = self.image_pull_policy.clone();
+        config.service_account_name = self.service_account_name.clone();
         config.upstream_deny_cidrs = self
             .upstream_deny_cidrs
             .iter()

--- a/services/api-rs/crates/centaur-sandbox-agent-k8s/src/iron_proxy.rs
+++ b/services/api-rs/crates/centaur-sandbox-agent-k8s/src/iron_proxy.rs
@@ -75,6 +75,16 @@ const PROXY_REASSIGN_FALLBACK_DELAY: Duration = Duration::from_secs(6);
 pub struct IronProxyConfig {
     pub image: String,
     pub image_pull_policy: Option<String>,
+    /// Kubernetes ServiceAccount the proxy pod runs under. `None` (the default)
+    /// leaves the pod on the namespace default ServiceAccount, holding no cloud
+    /// identity. Set this to a ServiceAccount bound to a cloud identity — e.g.
+    /// via GKE Workload Identity — so credential-minting transforms that resolve
+    /// ambient credentials (such as `gcp_auth` / `gcp_id_token` with
+    /// `credentials_provider: workload_identity`) can mint tokens. The
+    /// ServiceAccount token is still never mounted (`automountServiceAccountToken`
+    /// stays `false`): Workload Identity resolves through the node metadata
+    /// server keyed on the pod's ServiceAccount, not a mounted token.
+    pub service_account_name: Option<String>,
     pub fragments: Vec<ProxyFragment>,
     pub source_policy: SourcePolicy,
     pub ca_cert_secret_name: String,
@@ -97,6 +107,7 @@ impl IronProxyConfig {
         Self {
             image: image.into(),
             image_pull_policy: None,
+            service_account_name: None,
             fragments: Vec::new(),
             source_policy: SourcePolicy::default(),
             ca_cert_secret_name: ca_cert_secret_name.into(),
@@ -1161,7 +1172,13 @@ fn build_iron_proxy_pod(
             annotations,
         ),
         spec: Some(PodSpec {
+            // Never mount the ServiceAccount token: the proxy has no need for
+            // the Kubernetes API, and Workload Identity resolves through the
+            // node metadata server (keyed on `service_account_name`), not this
+            // token. Setting one without the other keeps the pod's cloud
+            // identity ambient-only.
             automount_service_account_token: Some(false),
+            service_account_name: iron_proxy.service_account_name.clone(),
             restart_policy: Some("Never".to_owned()),
             containers: vec![iron_proxy_container(iron_proxy, resolved, sync)],
             volumes: Some(iron_proxy_volumes(iron_proxy)),
@@ -2258,6 +2275,49 @@ mod tests {
             deny_cidrs,
             Some("169.254.169.254/32,127.0.0.0/8,10.42.0.0/16,10.43.0.0/16")
         );
+    }
+
+    #[test]
+    fn proxy_pod_service_account_defaults_to_none() {
+        let id = SandboxId::new("asbx-test");
+        let iron_proxy = IronProxyConfig::new("proxy:test", "ca-cert", "ca-key");
+        let sync = ProxySyncEnv {
+            proxy_id: "proxy-id".to_owned(),
+            control_url: "http://iron-control".to_owned(),
+            token: "proxy-token".to_owned(),
+        };
+
+        let spec = build_iron_proxy_pod(&id, &iron_proxy, &resolved(), &sync)
+            .spec
+            .expect("pod spec");
+
+        assert_eq!(spec.service_account_name, None);
+        assert_eq!(spec.automount_service_account_token, Some(false));
+    }
+
+    #[test]
+    fn proxy_pod_runs_under_configured_service_account_without_mounting_token() {
+        let id = SandboxId::new("asbx-test");
+        let mut iron_proxy = IronProxyConfig::new("proxy:test", "ca-cert", "ca-key");
+        iron_proxy.service_account_name = Some("iron-proxy-egress".to_owned());
+        let sync = ProxySyncEnv {
+            proxy_id: "proxy-id".to_owned(),
+            control_url: "http://iron-control".to_owned(),
+            token: "proxy-token".to_owned(),
+        };
+
+        let spec = build_iron_proxy_pod(&id, &iron_proxy, &resolved(), &sync)
+            .spec
+            .expect("pod spec");
+
+        assert_eq!(
+            spec.service_account_name.as_deref(),
+            Some("iron-proxy-egress")
+        );
+        // Workload Identity keys off the pod's ServiceAccount through the
+        // metadata server, so the token stays unmounted even when a SA is set:
+        // the proxy gets an ambient cloud identity, never a Kubernetes API token.
+        assert_eq!(spec.automount_service_account_token, Some(false));
     }
 
     #[test]


### PR DESCRIPTION
## What

Adds `KUBERNETES_IRON_PROXY_SERVICE_ACCOUNT_NAME` (`IronProxyConfig::service_account_name`) so operators can run sandbox iron-proxy pods under a named Kubernetes ServiceAccount instead of the namespace default. Unset keeps today's behavior exactly.

## Why

`gcp_auth`'s `credentials_provider: workload_identity` (and any future keyless `gcp_id_token`) resolves Application Default Credentials from **inside the proxy pod**. On GKE that requires the pod to run under a ServiceAccount bound to a GCP service account via Workload Identity. Today the proxy pod runs on the namespace **default** ServiceAccount with no such binding, so those keyless transforms have no ambient identity to mint from — the only working GCP credential path is a keyfile secret. This lets operators give the proxy a dedicated, narrowly-scoped cloud identity instead.

It must be a **dedicated** ServiceAccount for the proxy, not the shared namespace default: the sandbox/agent pod also runs on the default SA, so binding an identity there would hand it to the untrusted workload itself. Setting it only on the proxy pod keeps the identity on the trusted egress proxy.

## Security posture

- The ServiceAccount token is still **never mounted** (`automountServiceAccountToken: false`). GKE Workload Identity resolves through the node metadata server keyed on the pod's ServiceAccount, so the proxy gains an *ambient* cloud identity without ever holding a Kubernetes API token.
- Unset (the default) is a no-op: default ServiceAccount, no cloud identity, byte-identical pod spec to today.
- The proxy already denies sandbox egress to the metadata server (`169.254.169.254/32` in `upstream_deny_cidrs`), so this does not open an identity path for sandboxes themselves.

## Changes

- `IronProxyConfig::service_account_name: Option<String>`, threaded onto the proxy `PodSpec`.
- `--kubernetes-iron-proxy-service-account-name` / `KUBERNETES_IRON_PROXY_SERVICE_ACCOUNT_NAME` arg.
- Unit tests: defaults to `None`; when set, the pod runs under the SA with the token still unmounted.

## Validation

- `cargo test -p centaur-sandbox-agent-k8s` — pass (incl. new tests)
- `cargo clippy -p centaur-sandbox-agent-k8s -p centaur-api-server --all-targets -- -D warnings` — clean
- `cargo fmt` — clean

> ⚠️ **Draft — not yet validated on a live stack.** Before ready-for-review, per `AGENTS.md`: exercise on the local k8s stack, and verify end-to-end on a real GKE cluster that a Workload-Identity-bound proxy SA mints a token (`gcp_auth` `workload_identity`) through the metadata server with the token unmounted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
