### PR TITLE
fix: batch company context projection windows

### DIFF
--- a/contrib/chart/Chart.yaml
+++ b/contrib/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: centaur
 description: Helm chart for the trusted Centaur control plane
 type: application
-version: 0.1.92
+version: 0.1.93
 appVersion: "0.1.0"
 dependencies:
   - name: connect

--- a/contrib/chart/templates/apirs.yaml
+++ b/contrib/chart/templates/apirs.yaml
@@ -94,6 +94,7 @@
   (dict "name" "GOOGLE_CALENDAR_SYNC_INTERVAL_SECONDS" "value" (dig "googleCalendar" "syncIntervalSeconds" 14400 $apiRsEtl))
   (dict "name" "COMPANY_CONTEXT_DOCUMENTS_ENABLED" "value" (dig "companyContextDocuments" "enabled" true $apiRsEtl))
   (dict "name" "COMPANY_CONTEXT_DOCUMENTS_INTERVAL_SECONDS" "value" (dig "companyContextDocuments" "intervalSeconds" 14400 $apiRsEtl))
+  (dict "name" "COMPANY_CONTEXT_DOCUMENTS_MAX_WINDOW_SECONDS" "value" (dig "companyContextDocuments" "maxWindowSeconds" 21600 $apiRsEtl))
 -}}
 {{- $apiRsEtlPassthroughNames := list -}}
 {{- range $env := $apiRsEtlEnv -}}

--- a/contrib/chart/values.schema.json
+++ b/contrib/chart/values.schema.json
@@ -330,7 +330,8 @@
               "type": "object",
               "properties": {
                 "enabled": { "type": "boolean" },
-                "intervalSeconds": { "type": "integer" }
+                "intervalSeconds": { "type": "integer" },
+                "maxWindowSeconds": { "type": "integer" }
               }
             }
           }

--- a/contrib/chart/values.yaml
+++ b/contrib/chart/values.yaml
@@ -397,6 +397,7 @@ apiRs:
     companyContextDocuments:
       enabled: true
       intervalSeconds: 14400
+      maxWindowSeconds: 21600
   # Reaper: stop sandboxes older than the max lifetime, regardless of whether
   # they are running or suspended. 0 disables the sweep. Interval must be >= 1.
   sandboxMaxLifetimeSecs: 259200 # 3 days

--- a/docs/pages/operate/slack-etl.mdx
+++ b/docs/pages/operate/slack-etl.mdx
@@ -89,6 +89,7 @@ apiRs:
 | `SLACK_DM_RETENTION_DAYS` | `0` | Deletes Slack DM messages, stale empty DM conversations, and terminal DM run/job rows older than this many days. `0` disables DM retention. |
 | `COMPANY_CONTEXT_DOCUMENTS_ENABLED` | `true` | Enables projection from Slack sync rows into company context documents. |
 | `COMPANY_CONTEXT_DOCUMENTS_INTERVAL_SECONDS` | `14400` | How often to project changed Slack rows into documents. |
+| `COMPANY_CONTEXT_DOCUMENTS_MAX_WINDOW_SECONDS` | `21600` | Maximum source `updated_at` window projected by one company context documents run. |
 
 Example exclusion list:
 

--- a/docs/pages/reference/configuration.mdx
+++ b/docs/pages/reference/configuration.mdx
@@ -233,6 +233,7 @@ Slack ETL workflows:
 | `SLACK_BACKFILL_ENABLED`, `SLACK_BACKFILL_CHANNEL_BATCH_LIMIT`, `SLACK_BACKFILL_CHANNEL_PAGES_PER_JOB` | `apiRs.etl.slack.backfill.*`. | Backfill enablement and batch sizing. |
 | `SLACK_RETENTION_ENABLED`, `SLACK_RETENTION_INTERVAL_MINUTES`, `SLACK_ETL_RETENTION_DAYS`, `SLACK_DM_RETENTION_DAYS` | `apiRs.etl.slack.retention.*`. | Slack retention enablement, cadence, and separate public ETL/DM TTLs. |
 | `COMPANY_CONTEXT_DOCUMENTS_ENABLED` | `apiRs.etl.companyContextDocuments.enabled`. | Enables company-context projection when any ETL is on. |
+| `COMPANY_CONTEXT_DOCUMENTS_MAX_WINDOW_SECONDS` | `apiRs.etl.companyContextDocuments.maxWindowSeconds`. | Maximum source `updated_at` window projected by one company-context documents run. |
 
 Google Workspace ETL workflows:
 

--- a/docs/public/md/operate/slack-etl.md
+++ b/docs/public/md/operate/slack-etl.md
@@ -89,6 +89,7 @@ apiRs:
 | `SLACK_DM_RETENTION_DAYS` | `0` | Deletes Slack DM messages, stale empty DM conversations, and terminal DM run/job rows older than this many days. `0` disables DM retention. |
 | `COMPANY_CONTEXT_DOCUMENTS_ENABLED` | `true` | Enables projection from Slack sync rows into company context documents. |
 | `COMPANY_CONTEXT_DOCUMENTS_INTERVAL_SECONDS` | `14400` | How often to project changed Slack rows into documents. |
+| `COMPANY_CONTEXT_DOCUMENTS_MAX_WINDOW_SECONDS` | `21600` | Maximum source `updated_at` window projected by one company context documents run. |
 
 Example exclusion list:
 

--- a/docs/public/md/reference/configuration.md
+++ b/docs/public/md/reference/configuration.md
@@ -236,6 +236,7 @@ Slack ETL workflows:
 | `SLACK_BACKFILL_ENABLED`, `SLACK_BACKFILL_CHANNEL_BATCH_LIMIT`, `SLACK_BACKFILL_CHANNEL_PAGES_PER_JOB` | `apiRs.etl.slack.backfill.*`. | Backfill enablement and batch sizing. |
 | `SLACK_RETENTION_ENABLED`, `SLACK_RETENTION_INTERVAL_MINUTES`, `SLACK_ETL_RETENTION_DAYS`, `SLACK_DM_RETENTION_DAYS` | `apiRs.etl.slack.retention.*`. | Slack retention enablement, cadence, and separate public ETL/DM TTLs. |
 | `COMPANY_CONTEXT_DOCUMENTS_ENABLED` | `apiRs.etl.companyContextDocuments.enabled`. | Enables company-context projection when any ETL is on. |
+| `COMPANY_CONTEXT_DOCUMENTS_MAX_WINDOW_SECONDS` | `apiRs.etl.companyContextDocuments.maxWindowSeconds`. | Maximum source `updated_at` window projected by one company-context documents run. |
 
 Google Workspace ETL workflows:
 

--- a/workflows/company_context_documents.py
+++ b/workflows/company_context_documents.py
@@ -26,6 +26,7 @@ WORKFLOW_NAME = "company_context_documents"
 
 DEFAULT_SYNC_INTERVAL_SECONDS = 4 * 60 * 60
 DEFAULT_WATERMARK_OVERLAP_SECONDS = 60
+DEFAULT_MAX_WINDOW_SECONDS = 6 * 60 * 60
 MIN_THREAD_MESSAGES = 5
 FALSE_ENV_VALUES = {"0", "false", "no", "off"}
 SLACK_MENTION_RE = re.compile(r"<@([A-Z0-9]+)>")
@@ -95,6 +96,7 @@ class Input:
 
     since: str | None = None
     watermark_overlap_seconds: int = DEFAULT_WATERMARK_OVERLAP_SECONDS
+    max_window_seconds: int | None = None
     metadata: dict[str, Any] = field(default_factory=dict)
 
 
@@ -110,6 +112,58 @@ def _parse_datetime(value: str | None) -> dt.datetime | None:
     if parsed.tzinfo is None:
         parsed = parsed.replace(tzinfo=dt.timezone.utc)
     return parsed.astimezone(dt.timezone.utc)
+
+
+def _updated_at_bounds_clause(
+    column: str,
+    since: dt.datetime | None,
+    until: dt.datetime | None,
+) -> tuple[str, list[Any]]:
+    args: list[Any] = []
+    clauses: list[str] = []
+    if since is not None:
+        args.append(since)
+        clauses.append(f"{column} > ${len(args)}")
+    if until is not None:
+        args.append(until)
+        clauses.append(f"{column} <= ${len(args)}")
+    return " AND ".join(clauses), args
+
+
+def _updated_at_where(
+    column: str,
+    since: dt.datetime | None,
+    until: dt.datetime | None,
+    *,
+    base_clauses: tuple[str, ...] = (),
+) -> tuple[str, list[Any]]:
+    bounds_clause, args = _updated_at_bounds_clause(column, since, until)
+    clauses = [*base_clauses]
+    if bounds_clause:
+        clauses.append(bounds_clause)
+    return (f"WHERE {' AND '.join(clauses)}" if clauses else ""), args
+
+
+def _max_window_seconds(value: int | str | None = None) -> int:
+    configured = (
+        value
+        if value is not None
+        else os.getenv("COMPANY_CONTEXT_DOCUMENTS_MAX_WINDOW_SECONDS")
+    )
+    return _positive_int(configured, DEFAULT_MAX_WINDOW_SECONDS)
+
+
+def _batch_until(
+    since: dt.datetime | None,
+    now: dt.datetime,
+    max_window_seconds: int,
+) -> dt.datetime | None:
+    if since is None:
+        return None
+    return min(
+        now.astimezone(dt.timezone.utc),
+        since + dt.timedelta(seconds=max_window_seconds),
+    )
 
 
 def _format_time(value: dt.datetime | None) -> str:
@@ -301,16 +355,14 @@ async def _load_slack_lookup_maps(pool) -> tuple[dict[str, str], dict[str, str]]
     return users_by_id, channels_by_id
 
 
-async def _load_changed_message_keys(pool, since: dt.datetime | None) -> dict[str, Any]:
+async def _load_changed_message_keys(
+    pool,
+    since: dt.datetime | None,
+    until: dt.datetime | None = None,
+) -> dict[str, Any]:
     """Find channel/day and thread aggregates affected by changed Slack rows."""
-    if since is None:
-        where_sql = ""
-        args: list[Any] = []
-        attachment_where_sql = ""
-    else:
-        where_sql = "WHERE updated_at > $1"
-        attachment_where_sql = "WHERE a.updated_at > $1"
-        args = [since]
+    where_sql, args = _updated_at_where("updated_at", since, until)
+    attachment_where_sql, _ = _updated_at_where("a.updated_at", since, until)
 
     channel_day_rows = await pool.fetch(
         "SELECT DISTINCT channel_id, (occurred_at AT TIME ZONE 'UTC')::date AS day "
@@ -380,14 +432,18 @@ async def _load_changed_message_keys(pool, since: dt.datetime | None) -> dict[st
     }
 
 
-async def _load_changed_drive_files(pool, since: dt.datetime | None) -> dict[str, Any]:
+async def _load_changed_drive_files(
+    pool,
+    since: dt.datetime | None,
+    until: dt.datetime | None = None,
+) -> dict[str, Any]:
     """Find Google Drive files whose synced content changed."""
-    if since is None:
-        where_sql = "WHERE last_error = '' AND trashed = FALSE"
-        args: list[Any] = []
-    else:
-        where_sql = "WHERE last_error = '' AND trashed = FALSE AND updated_at > $1"
-        args = [since]
+    where_sql, args = _updated_at_where(
+        "updated_at",
+        since,
+        until,
+        base_clauses=("last_error = ''", "trashed = FALSE"),
+    )
 
     rows = await pool.fetch(
         "SELECT file_id, name, mime_type, web_view_link, drive_id, parent_ids, owners, "
@@ -415,14 +471,15 @@ async def _load_changed_drive_files(pool, since: dt.datetime | None) -> dict[str
 async def _load_changed_calendar_events(
     pool,
     since: dt.datetime | None,
+    until: dt.datetime | None = None,
 ) -> dict[str, Any]:
     """Find Google Calendar events whose synced content changed."""
-    if since is None:
-        where_sql = "WHERE e.last_error = ''"
-        args: list[Any] = []
-    else:
-        where_sql = "WHERE e.last_error = '' AND e.updated_at > $1"
-        args = [since]
+    where_sql, args = _updated_at_where(
+        "e.updated_at",
+        since,
+        until,
+        base_clauses=("e.last_error = ''",),
+    )
 
     rows = await pool.fetch(
         "SELECT e.calendar_id, c.summary AS calendar_summary, c.time_zone, "
@@ -457,24 +514,30 @@ async def _load_changed_calendar_events(
 async def _load_changed_linear_issues(
     pool,
     since: dt.datetime | None,
+    until: dt.datetime | None = None,
 ) -> dict[str, Any]:
     """Find Linear issues whose issue row or embedded comments changed."""
-    if since is None:
+    bounds_clause, args = _updated_at_bounds_clause("i.updated_at", since, until)
+    comment_bounds_clause, _ = _updated_at_bounds_clause(
+        "c.updated_at",
+        since,
+        until,
+    )
+    if not bounds_clause:
         args: list[Any] = []
         where_sql = "WHERE i.last_error = ''"
         comment_where_sql = ""
     else:
-        args = [since]
         where_sql = (
             "WHERE i.last_error = '' "
-            "AND (i.updated_at > $1 OR EXISTS ("
+            f"AND ({bounds_clause} OR EXISTS ("
             "  SELECT 1 FROM linear_sync_comments c "
             "  WHERE c.issue_id = i.issue_id "
             "    AND c.last_error = '' "
-            "    AND c.updated_at > $1"
+            f"    AND {comment_bounds_clause}"
             "))"
         )
-        comment_where_sql = "WHERE c.last_error = '' AND c.updated_at > $1"
+        comment_where_sql = f"WHERE c.last_error = '' AND {comment_bounds_clause}"
 
     rows = await pool.fetch(
         "SELECT i.issue_id, i.identifier, i.issue_number, i.title, i.description, "
@@ -1300,6 +1363,9 @@ async def handler(inp: Input, ctx: WorkflowContext) -> dict[str, Any]:
         if last_watermark is not None
         else None
     )
+    now = dt.datetime.now(dt.timezone.utc)
+    max_window_seconds = _max_window_seconds(inp.max_window_seconds)
+    batch_until = _batch_until(since, now, max_window_seconds)
 
     slack_enabled = _env_flag_enabled("SLACK_ETL_ENABLED")
     google_drive_enabled = _env_flag_enabled("GOOGLE_DRIVE_ETL_ENABLED")
@@ -1328,28 +1394,32 @@ async def handler(inp: Input, ctx: WorkflowContext) -> dict[str, Any]:
     channels_by_id: dict[str, str] = {}
     if slack_enabled:
         users_by_id, channels_by_id = await _load_slack_lookup_maps(ctx._pool)
-        changed = await _load_changed_message_keys(ctx._pool, since)
+        changed = await _load_changed_message_keys(ctx._pool, since, batch_until)
     drive_changed = {
         "files": [],
         "changed_files": 0,
         "max_updated_at": None,
     }
     if google_drive_enabled:
-        drive_changed = await _load_changed_drive_files(ctx._pool, since)
+        drive_changed = await _load_changed_drive_files(ctx._pool, since, batch_until)
     calendar_changed = {
         "events": [],
         "changed_events": 0,
         "max_updated_at": None,
     }
     if google_calendar_enabled:
-        calendar_changed = await _load_changed_calendar_events(ctx._pool, since)
+        calendar_changed = await _load_changed_calendar_events(
+            ctx._pool, since, batch_until
+        )
     linear_changed = {
         "issues": [],
         "changed_issues": 0,
         "max_updated_at": None,
     }
     if linear_enabled:
-        linear_changed = await _load_changed_linear_issues(ctx._pool, since)
+        linear_changed = await _load_changed_linear_issues(
+            ctx._pool, since, batch_until
+        )
 
     documents_upserted = 0
     documents_deleted = 0
@@ -1508,24 +1578,38 @@ async def handler(inp: Input, ctx: WorkflowContext) -> dict[str, Any]:
         if action in {"inserted", "updated"}:
             documents_upserted += 1
 
-    watermark_candidates = [
-        value
-        for value in (
-            changed["max_updated_at"],
-            drive_changed["max_updated_at"],
-            calendar_changed["max_updated_at"],
-            linear_changed["max_updated_at"],
-            last_watermark,
-        )
-        if value is not None
-    ]
-    watermark = max(watermark_candidates) if watermark_candidates else None
+    if batch_until is not None:
+        watermark = batch_until
+    else:
+        watermark_candidates = [
+            value
+            for value in (
+                changed["max_updated_at"],
+                drive_changed["max_updated_at"],
+                calendar_changed["max_updated_at"],
+                linear_changed["max_updated_at"],
+                last_watermark,
+            )
+            if value is not None
+        ]
+        watermark = max(watermark_candidates) if watermark_candidates else None
     source_watermarks = {
-        "slack": changed["max_updated_at"] or last_watermark,
-        "google_drive": drive_changed["max_updated_at"] or last_watermark,
-        "google_calendar": calendar_changed["max_updated_at"] or last_watermark,
-        "linear": linear_changed["max_updated_at"] or last_watermark,
+        "slack": watermark
+        if batch_until is not None
+        else changed["max_updated_at"] or last_watermark,
+        "google_drive": watermark
+        if batch_until is not None
+        else drive_changed["max_updated_at"] or last_watermark,
+        "google_calendar": watermark
+        if batch_until is not None
+        else calendar_changed["max_updated_at"] or last_watermark,
+        "linear": watermark
+        if batch_until is not None
+        else linear_changed["max_updated_at"] or last_watermark,
     }
+    remaining_lag_seconds = (
+        max((now - watermark).total_seconds(), 0.0) if watermark is not None else None
+    )
     _emit_company_context_projection_lag(enabled_sources, source_watermarks)
     await _emit_etl_scope_metrics(ctx._pool, enabled_sources)
     await _emit_company_context_document_size_snapshot(ctx._pool, enabled_sources)
@@ -1544,6 +1628,10 @@ async def handler(inp: Input, ctx: WorkflowContext) -> dict[str, Any]:
         "linear_issue_documents": len(linear_changed["issues"]),
         "documents_upserted": documents_upserted,
         "documents_deleted": documents_deleted,
+        "since": since.isoformat() if since else None,
+        "batch_until": batch_until.isoformat() if batch_until else None,
+        "max_window_seconds": max_window_seconds,
+        "remaining_lag_seconds": remaining_lag_seconds,
         "watermark": watermark.isoformat() if watermark else None,
     }
     ctx.log("company_context_documents_completed", **result)

--- a/workflows/tests/test_company_context_documents_attachments.py
+++ b/workflows/tests/test_company_context_documents_attachments.py
@@ -89,6 +89,34 @@ class FakeWatermarkPool:
         }
 
 
+class FakeChangedRowsPool:
+    def __init__(self) -> None:
+        self.fetch_calls: list[tuple[str, tuple]] = []
+        self.fetchrow_calls: list[tuple[str, tuple]] = []
+
+    async def fetch(self, query, *args):
+        self.fetch_calls.append((query, args))
+        return []
+
+    async def fetchrow(self, query, *args):
+        self.fetchrow_calls.append((query, args))
+        return {
+            "changed_messages": 0,
+            "changed_attachments": 0,
+            "max_updated_at": None,
+        }
+
+
+class FakeWorkflowContext:
+    def __init__(self) -> None:
+        self.run_id = "run_123"
+        self._pool = object()
+        self.logs: list[tuple[str, dict]] = []
+
+    def log(self, message, **fields):
+        self.logs.append((message, fields))
+
+
 def test_latest_successful_watermark_reads_absurd_etl_queue():
     pool = FakeWatermarkPool()
 
@@ -112,6 +140,87 @@ def test_latest_successful_watermark_reads_absurd_etl_queue():
     )
 
 
+def test_load_changed_message_keys_applies_upper_batch_bound():
+    pool = FakeChangedRowsPool()
+    since = dt.datetime(2026, 6, 18, 22, 58, 36, tzinfo=dt.UTC)
+    until = dt.datetime(2026, 6, 19, 4, 58, 36, tzinfo=dt.UTC)
+
+    result = asyncio.run(projection._load_changed_message_keys(pool, since, until))
+
+    assert result["changed_messages"] == 0
+    assert pool.fetch_calls
+    assert pool.fetchrow_calls
+    queries = [query for query, _args in (*pool.fetch_calls, *pool.fetchrow_calls)]
+    assert any("updated_at > $1" in query for query in queries)
+    assert any("updated_at <= $2" in query for query in queries)
+    assert any("a.updated_at > $1" in query for query in queries)
+    assert any("a.updated_at <= $2" in query for query in queries)
+    for _query, args in (*pool.fetch_calls, *pool.fetchrow_calls):
+        assert args == (since, until)
+
+
+def test_handler_advances_empty_bounded_window(monkeypatch):
+    last_watermark = dt.datetime(2026, 6, 18, 22, 59, 36, tzinfo=dt.UTC)
+    seen_bounds: dict[str, dt.datetime | None] = {}
+
+    async def latest_watermark(_pool, _run_id):
+        return last_watermark
+
+    async def load_slack_lookup_maps(_pool):
+        return {}, {}
+
+    async def load_changed_message_keys(_pool, since, until=None):
+        seen_bounds["since"] = since
+        seen_bounds["until"] = until
+        return {
+            "channel_days": [],
+            "threads": [],
+            "attachments": [],
+            "changed_messages": 0,
+            "changed_attachments": 0,
+            "max_updated_at": None,
+        }
+
+    async def noop_async(*_args, **_kwargs):
+        return None
+
+    monkeypatch.setenv("SLACK_ETL_ENABLED", "true")
+    monkeypatch.setenv("GOOGLE_DRIVE_ETL_ENABLED", "false")
+    monkeypatch.setenv("GOOGLE_CALENDAR_ETL_ENABLED", "false")
+    monkeypatch.setenv("LINEAR_ETL_ENABLED", "false")
+    monkeypatch.setenv("COMPANY_CONTEXT_DOCUMENTS_ENABLED", "true")
+    monkeypatch.setattr(projection, "_latest_successful_watermark", latest_watermark)
+    monkeypatch.setattr(projection, "_load_slack_lookup_maps", load_slack_lookup_maps)
+    monkeypatch.setattr(
+        projection,
+        "_load_changed_message_keys",
+        load_changed_message_keys,
+    )
+    monkeypatch.setattr(
+        projection,
+        "_emit_company_context_document_size_snapshot",
+        noop_async,
+    )
+    monkeypatch.setattr(projection, "_emit_etl_scope_metrics", noop_async)
+
+    ctx = FakeWorkflowContext()
+    result = asyncio.run(
+        projection.handler(
+            projection.Input(max_window_seconds=3600),
+            ctx,
+        )
+    )
+
+    expected_since = dt.datetime(2026, 6, 18, 22, 58, 36, tzinfo=dt.UTC)
+    expected_until = dt.datetime(2026, 6, 18, 23, 58, 36, tzinfo=dt.UTC)
+    assert seen_bounds == {"since": expected_since, "until": expected_until}
+    assert result["changed_messages"] == 0
+    assert result["batch_until"] == expected_until.isoformat()
+    assert result["watermark"] == expected_until.isoformat()
+    assert result["remaining_lag_seconds"] is not None
+    assert ctx.logs[-1][0] == "company_context_documents_completed"
+
+
 def test_etl_scope_metrics_no_longer_emit_slack_scope_gauges(monkeypatch):
     calls: list[tuple] = []
     monkeypatch.setattr(
@@ -131,9 +240,7 @@ def test_etl_scope_metrics_no_longer_emit_slack_scope_gauges(monkeypatch):
     )
     pool = FakeScopeMetricsPool()
 
-    asyncio.run(
-        projection._emit_etl_scope_metrics(pool, ["slack", "google_drive"])
-    )
+    asyncio.run(projection._emit_etl_scope_metrics(pool, ["slack", "google_drive"]))
 
     assert len(pool.fetchrow_calls) == 1
     assert "google_drive_sync_checkpoints" in pool.fetchrow_calls[0]


### PR DESCRIPTION
## Summary

- bound `company_context_documents` source scans to a configurable `updated_at` window
- advance the existing workflow payload watermark to `batch_until` after a bounded slice completes, including empty/no-op slices
- pass `COMPANY_CONTEXT_DOCUMENTS_MAX_WINDOW_SECONDS` through the Helm chart and document the new knob

## Why

Staging recovered the prior checkpoint, but the next projection still had to process a large stale range in one workflow attempt. Failed attempts can persist partial document writes, but they do not advance the successful watermark, so the same oversized range repeats. This makes catch-up unreliable.

## Validation

- `uv run --with ruff ruff format workflows/company_context_documents.py workflows/tests/test_company_context_documents_attachments.py`
- `uv run --with ruff ruff check workflows/company_context_documents.py workflows/tests/test_company_context_documents_attachments.py`
- `uv run --with pytest python -m pytest workflows/tests/test_company_context_documents_attachments.py`
- `just build-one api-rs`
- `helm template centaur contrib/chart -n centaur`
- `just deploy`
- `kubectl exec -n centaur deploy/centaur-centaur-api-rs -- curl -fsS http://localhost:8080/readyz`
- verified local API env renders `COMPANY_CONTEXT_DOCUMENTS_MAX_WINDOW_SECONDS=21600` and includes it in `SESSION_SANDBOX_PASSTHROUGH_ENV`
