### PR TITLE
chore: update iron-proxy to 0.47.0

### DIFF
--- a/services/iron-proxy/Dockerfile
+++ b/services/iron-proxy/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.7
 
-FROM ironsh/iron-proxy:0.46.0@sha256:ce65e5efe68635b0867005d7b7b730f58b5aa112433b418a28d254682706a2fb
+FROM ironsh/iron-proxy:0.47.0@sha256:dc13ff78c9e2c83389dc540c8f51cf551edc543900855200a49ccf7ca6fd9666
 
 USER root
 RUN --mount=type=cache,target=/var/cache/apk,sharing=locked \


### PR DESCRIPTION
Updates the bundled iron-proxy base image from 0.46.0 to 0.47.0 and refreshes the pinned amd64 digest.