### PR TITLE
fix(slack): resolve user IDs and @usernames to DM channels in read paths

### DIFF
--- a/tools/productivity/slack/client.py
+++ b/tools/productivity/slack/client.py
@@ -382,7 +382,21 @@ class SlackClient:
         return items, next_cursor, bool(next_cursor)
 
     def _resolve_channel(self, channel: str) -> str:
-        """Resolve a channel name to its ID using cached channel list."""
+        """Resolve a channel name, channel ID, user ID, or @user DM to a conversation ID.
+
+        User references (``U123``, ``<@U123>``, or ``@username``) resolve to the
+        bot's one-on-one DM channel with that user, opening it if needed.
+        """
+        raw = str(channel).strip()
+        if self._looks_like_user_id(raw):
+            return self._open_dm_channel(raw)
+        if raw.startswith("@"):
+            username = raw[1:].strip()
+            user_cache = self._get_user_cache()
+            for user_id, name in user_cache.items():
+                if name == username:
+                    return self._open_dm_channel(user_id)
+            raise RuntimeError(f"User '{channel}' not found in workspace")
         normalized = self._clean_channel_ref(channel)
         if self._looks_like_channel_id(normalized):
             return normalized.upper()

--- a/tools/productivity/slack/tests/test_client.py
+++ b/tools/productivity/slack/tests/test_client.py
@@ -197,6 +197,45 @@ def test_send_dm_opens_dm_and_posts_message() -> None:
     assert fake_web_client.last_kwargs["unfurl_links"] is False
 
 
+def _restore_real_resolve_channel(client: SlackClient) -> None:
+    client._resolve_channel = SlackClient._resolve_channel.__get__(client)  # type: ignore[method-assign]
+
+
+def test_resolve_channel_opens_dm_for_user_id() -> None:
+    client, fake_web_client = _make_client()
+    _restore_real_resolve_channel(client)
+
+    assert client._resolve_channel("<@U123ABC>") == "D123"
+    assert fake_web_client.open_calls == [{"users": "U123ABC"}]
+
+
+def test_resolve_channel_opens_dm_for_at_username() -> None:
+    client, fake_web_client = _make_client()
+    _restore_real_resolve_channel(client)
+    client._get_user_cache = lambda: {"U123ABC": "georgios"}  # type: ignore[method-assign]
+
+    assert client._resolve_channel("@georgios") == "D123"
+    assert fake_web_client.open_calls == [{"users": "U123ABC"}]
+
+
+def test_resolve_channel_rejects_unknown_at_username() -> None:
+    client, _ = _make_client()
+    _restore_real_resolve_channel(client)
+    client._get_user_cache = lambda: {"U123ABC": "georgios"}  # type: ignore[method-assign]
+
+    with pytest.raises(RuntimeError, match="not found in workspace"):
+        client._resolve_channel("@nobody")
+
+
+def test_resolve_channel_still_resolves_channel_names() -> None:
+    client, fake_web_client = _make_client()
+    _restore_real_resolve_channel(client)
+
+    assert client._resolve_channel("paradigm-pulse") == "C123"
+    assert client._resolve_channel("C456DEF") == "C456DEF"
+    assert fake_web_client.open_calls == []
+
+
 def test_retry_on_ratelimit_honors_retry_after(monkeypatch: pytest.MonkeyPatch) -> None:
     client, _ = _make_client()
     now = {"value": 100.0}


### PR DESCRIPTION
## Summary

`SlackClient._resolve_channel` only matched channel IDs and channel names from `list_bot_channels` (which never includes IMs), so read methods like `get_channel_history`, `get_thread_replies`, and `get_channel_members` could not read the bot's DMs — `get_channel_history("@user")` failed with "Channel not found or bot not a member" even though `send_message`/`send_dm` could already open DMs via `conversations.open`.

This wires the existing `_open_dm_channel` logic into `_resolve_channel`:

- `U123…` / `<@U123…>` → opens/reuses the bot's IM with that user
- `@username` → exact-match lookup against the cached user list, then opens the IM
- channel names and `C…`/`D…` IDs resolve exactly as before

`_resolve_message_destination` keeps its own user-ID check since the test harness stubs `_resolve_channel` directly.

## Testing

Added 4 tests covering user-ID DM resolution, `@username` DM resolution, unknown `@username` error, and unchanged channel-name/ID resolution. All 37 tests in `tools/productivity/slack/tests/test_client.py` pass (ran with `uv run --no-project --python 3.12` due to a pre-existing hatchling editable-install failure on Python 3.14).

Note: reading DM history at runtime also requires the injected bot token to have `im:history`.