### PR TITLE
feat(console): chat composer — start and continue chats from the console

### DIFF
--- a/services/console/app/controllers/application_controller.rb
+++ b/services/console/app/controllers/application_controller.rb
@@ -11,6 +11,7 @@ class ApplicationController < ActionController::Base
 
   helper_method :current_user, :acting_admin?, :descoped?
   helper_method :public_base_url, :oauth_callback_redirect_uri
+  helper_method :console_threads_read_only?
 
   # The public origin the console is reached at. Derived from the request by
   # default; CENTAUR_CONSOLE_PUBLIC_URL overrides it for deployments behind
@@ -57,7 +58,21 @@ class ApplicationController < ActionController::Base
   CONSOLE_SIDEBAR_THREAD_OWNER_METADATA_KEYS = %w[actor_email user_email].freeze
   ConsoleSidebarSlackThreadOwner = Struct.new(:user_id, :team_id, keyword_init: true)
 
+  # Env values that switch chats out of the read-only default.
+  CONSOLE_THREADS_WRITABLE_ENV_VALUES = %w[0 false off no].freeze
+
   private
+
+  # Whether chats are read-only. Defaults to read-only — deployments that browse
+  # a mirrored snapshot of the sessions DB (or have no reachable Centaur API)
+  # must not render a composer that cannot work. Deployments wired to a live
+  # api-rs opt in to posting by setting CENTAUR_CONSOLE_THREADS_READ_ONLY=0.
+  # Rendered into the global sidebar (New chat affordance), hence defined here
+  # rather than on Console::ThreadsController.
+  def console_threads_read_only?
+    value = ConsoleEnv["THREADS_READ_ONLY"].to_s.strip.downcase
+    !CONSOLE_THREADS_WRITABLE_ENV_VALUES.include?(value)
+  end
 
   # The signed-in operator for cookie-session (console) requests, or nil. Distinct
   # from Api::BaseController#current_user, which resolves a User from an API key.

--- a/services/console/app/controllers/application_controller.rb
+++ b/services/console/app/controllers/application_controller.rb
@@ -11,7 +11,6 @@ class ApplicationController < ActionController::Base
 
   helper_method :current_user, :acting_admin?, :descoped?
   helper_method :public_base_url, :oauth_callback_redirect_uri
-  helper_method :console_threads_read_only?
 
   # The public origin the console is reached at. Derived from the request by
   # default; CENTAUR_CONSOLE_PUBLIC_URL overrides it for deployments behind
@@ -58,21 +57,7 @@ class ApplicationController < ActionController::Base
   CONSOLE_SIDEBAR_THREAD_OWNER_METADATA_KEYS = %w[actor_email user_email].freeze
   ConsoleSidebarSlackThreadOwner = Struct.new(:user_id, :team_id, keyword_init: true)
 
-  # Env values that switch chats out of the read-only default.
-  CONSOLE_THREADS_WRITABLE_ENV_VALUES = %w[0 false off no].freeze
-
   private
-
-  # Whether chats are read-only. Defaults to read-only — deployments that browse
-  # a mirrored snapshot of the sessions DB (or have no reachable Centaur API)
-  # must not render a composer that cannot work. Deployments wired to a live
-  # api-rs opt in to posting by setting CENTAUR_CONSOLE_THREADS_READ_ONLY=0.
-  # Rendered into the global sidebar (New chat affordance), hence defined here
-  # rather than on Console::ThreadsController.
-  def console_threads_read_only?
-    value = ConsoleEnv["THREADS_READ_ONLY"].to_s.strip.downcase
-    !CONSOLE_THREADS_WRITABLE_ENV_VALUES.include?(value)
-  end
 
   # The signed-in operator for cookie-session (console) requests, or nil. Distinct
   # from Api::BaseController#current_user, which resolves a User from an API key.

--- a/services/console/app/controllers/console/threads_controller.rb
+++ b/services/console/app/controllers/console/threads_controller.rb
@@ -81,27 +81,41 @@ class Console::ThreadsController < ApplicationController
 
   SlackThreadOwner = Struct.new(:user_id, :team_id, keyword_init: true)
 
-  # The composer's single model selector, in display order. Each entry pins
-  # the harness the choice runs on (wire values match api-rs's HarnessType
-  # enum, serde lowercase); the model ids are the ones the bots' --model flags
+  # The composer's model selector, in display order. Each entry pins the
+  # harness the choice runs on (wire values match api-rs's HarnessType enum,
+  # serde lowercase); the model ids are the ones the bots' --model flags
   # expand to (services/slackbotv2/src/overrides.ts). Amp appears as a plain
-  # entry with no model: it picks its own model per turn.
-  ComposerAgent = Struct.new(:value, :label, :harness, :model, keyword_init: true)
+  # entry with no model: it picks its own model per turn. `efforts` are the
+  # per-turn reasoning efforts the harness accepts for the model (codex only —
+  # harness-server discards `reasoning` for claude/amp; enum per
+  # crates/harness-server/src/codex.rs, `max` being 5.6-specific).
+  ComposerAgent = Struct.new(:value, :label, :harness, :model, :efforts, keyword_init: true)
+  CODEX_EFFORTS = [
+    %w[minimal Minimal],
+    %w[low Low],
+    %w[medium Medium],
+    %w[high High],
+    [ "xhigh", "Extra High" ]
+  ].freeze
   # First entry doubles as the default pick (unless the deploy's default-model
   # resolution for its harness names another listed model).
   COMPOSER_AGENTS = [
+    ComposerAgent.new(value: "gpt-5.6-sol", label: "GPT-5.6 Sol",
+                      harness: "codex", model: "gpt-5.6-sol",
+                      efforts: CODEX_EFFORTS + [ %w[max Max] ]),
     ComposerAgent.new(value: "gpt-5.5", label: "GPT-5.5",
-                      harness: "codex", model: "gpt-5.5"),
+                      harness: "codex", model: "gpt-5.5",
+                      efforts: CODEX_EFFORTS),
     ComposerAgent.new(value: "claude-opus-4-8", label: "Claude Opus 4.8",
-                      harness: "claudecode", model: "claude-opus-4-8"),
+                      harness: "claudecode", model: "claude-opus-4-8", efforts: []),
     ComposerAgent.new(value: "claude-sonnet-4-6", label: "Claude Sonnet 4.6",
-                      harness: "claudecode", model: "claude-sonnet-4-6"),
+                      harness: "claudecode", model: "claude-sonnet-4-6", efforts: []),
     ComposerAgent.new(value: "claude-haiku-4-5", label: "Claude Haiku 4.5",
-                      harness: "claudecode", model: "claude-haiku-4-5"),
+                      harness: "claudecode", model: "claude-haiku-4-5", efforts: []),
     ComposerAgent.new(value: "claude-fable-5", label: "Claude Fable 5",
-                      harness: "claudecode", model: "claude-fable-5"),
+                      harness: "claudecode", model: "claude-fable-5", efforts: []),
     ComposerAgent.new(value: "amp", label: "Amp",
-                      harness: "amp", model: nil)
+                      harness: "amp", model: nil, efforts: [])
   ].freeze
 
   helper_method :thread_title,
@@ -115,6 +129,7 @@ class Console::ThreadsController < ApplicationController
                 :thread_status_classes,
                 :composer_agent_choices,
                 :composer_default_agent_value,
+                :composer_agents_json,
                 :thread_execution_active?
 
   def index
@@ -196,6 +211,21 @@ class Console::ThreadsController < ApplicationController
       COMPOSER_AGENTS.first.value
   end
 
+  # Per-agent metadata the picker script needs to rebuild the effort submenu
+  # when the model changes: { value => { label:, efforts: [[value, label]] } }.
+  def composer_agents_json
+    COMPOSER_AGENTS.to_h do |agent|
+      [ agent.value, { label: agent.label, efforts: agent.efforts } ]
+    end.to_json
+  end
+
+  def composer_effort_param(agent)
+    effort = params[:effort].to_s.strip
+    return nil if effort.blank?
+
+    agent.efforts.map(&:first).include?(effort) ? effort : nil
+  end
+
   def composer_agent_for(raw)
     value = raw.to_s.strip
     value = composer_default_agent_value if value.blank?
@@ -216,7 +246,7 @@ class Console::ThreadsController < ApplicationController
       harness_type: agent.harness,
       metadata: console_actor_metadata.merge(agent.model.present? ? { model: agent.model } : {})
     )
-    send_prompt(thread_key, prompt, model: agent.model)
+    send_prompt(thread_key, prompt, model: agent.model, effort: composer_effort_param(agent))
     redirect_to console_threads_path(thread: thread_key)
   rescue CentaurApiClient::Error => e
     redirect_to console_threads_path(new: 1), alert: "Could not start the chat: #{e.message}"
@@ -244,7 +274,7 @@ class Console::ThreadsController < ApplicationController
   # Append persists the turn in conversation history; execute runs it. The
   # shared client_message_id lets api-rs dedupe the copy of the message the
   # harness echoes back.
-  def send_prompt(thread_key, prompt, model: nil)
+  def send_prompt(thread_key, prompt, model: nil, effort: nil)
     message_id = SecureRandom.uuid
 
     api_client.append_session_messages(
@@ -261,18 +291,26 @@ class Console::ThreadsController < ApplicationController
 
     execute_metadata = console_actor_metadata.merge(action: "execute")
     execute_metadata[:model] = model if model.present?
+    execute_metadata[:reasoning] = effort if effort.present?
     api_client.execute_session(
       thread_key: thread_key,
       idempotency_key: SecureRandom.uuid,
       metadata: execute_metadata,
-      input_lines: [ composer_input_line(thread_key, prompt, model: model, client_message_id: message_id) ]
+      input_lines: [
+        composer_input_line(
+          thread_key, prompt,
+          model: model, effort: effort, client_message_id: message_id
+        )
+      ]
     )
   end
 
   # One blocks-protocol user line, the shape harness-server parses from
   # execute's input_lines. `model` is honored by every harness; omitted (e.g.
-  # for Amp) the harness runs its own default.
-  def composer_input_line(thread_key, prompt, model:, client_message_id:)
+  # for Amp) the harness runs its own default. `reasoning` is the per-turn
+  # codex effort; other harnesses discard it, and validation upstream only
+  # accepts it for codex models anyway.
+  def composer_input_line(thread_key, prompt, model:, effort:, client_message_id:)
     line = {
       type: "user",
       thread_key: thread_key,
@@ -281,6 +319,7 @@ class Console::ThreadsController < ApplicationController
       message: { role: "user", content: [ { type: "text", text: prompt } ] }
     }
     line[:model] = model if model.present?
+    line[:reasoning] = effort if effort.present?
     line.to_json
   end
 

--- a/services/console/app/controllers/console/threads_controller.rb
+++ b/services/console/app/controllers/console/threads_controller.rb
@@ -1,6 +1,9 @@
 class Console::ThreadsController < ApplicationController
   layout "console"
 
+  # Injectable for tests, mirroring Console::WorkflowsController.
+  class_attribute :client_factory, default: -> { CentaurApiClient.new }
+
   THREAD_LIMIT = 250
   MESSAGE_LIMIT = 80
   EXECUTION_LIMIT = 8
@@ -80,6 +83,32 @@ class Console::ThreadsController < ApplicationController
 
   SlackThreadOwner = Struct.new(:user_id, :team_id, keyword_init: true)
 
+  # Harnesses the composer can start a chat on, in display order. Wire values
+  # match api-rs's HarnessType enum (serde lowercase).
+  COMPOSER_HARNESSES = [
+    [ "claudecode", "Claude Code" ],
+    [ "codex", "Codex" ],
+    [ "amp", "Amp" ]
+  ].freeze
+  COMPOSER_DEFAULT_HARNESS = "claudecode".freeze
+  # Models offered per harness. The blocks-protocol user line carries `model`
+  # and every harness honors it; the ids here are the ones the bots' --model
+  # flags expand to (services/slackbotv2/src/overrides.ts). Amp maps to an
+  # empty list on purpose: it manages its own model per turn, so the composer
+  # shows a note instead of a selector.
+  COMPOSER_MODELS = {
+    "claudecode" => [
+      [ "claude-opus-4-8", "Claude Opus 4.8" ],
+      [ "claude-sonnet-4-6", "Claude Sonnet 4.6" ],
+      [ "claude-haiku-4-5", "Claude Haiku 4.5" ],
+      [ "claude-fable-5", "Claude Fable 5" ]
+    ],
+    "codex" => [
+      [ "gpt-5.5", "GPT-5.5" ]
+    ],
+    "amp" => []
+  }.freeze
+
   helper_method :thread_title,
                 :thread_source_icon,
                 :thread_source_label,
@@ -88,7 +117,11 @@ class Console::ThreadsController < ApplicationController
                 :thread_user_label,
                 :thread_message_text,
                 :thread_text_preview,
-                :thread_status_classes
+                :thread_status_classes,
+                :composer_harness_choices,
+                :composer_default_harness,
+                :composer_model_choices,
+                :composer_model_choices_by_harness
 
   def index
     @query = params[:q].to_s.strip
@@ -111,11 +144,28 @@ class Console::ThreadsController < ApplicationController
     @thread_db_unavailable = true
   end
 
+  # Composer submit: no thread_key starts a new chat (create session + first
+  # message + execute), a thread_key sends a follow-up into an existing chat.
+  # Both paths talk to api-rs through CentaurApiClient; the transcript itself
+  # is still read from the sessions DB by #index after the redirect.
   def create
-    redirect_to(
-      console_threads_path(thread: params[:thread_key].presence),
-      alert: READ_ONLY_REASON
-    )
+    thread_key = params[:thread_key].to_s.strip.presence
+
+    if console_threads_read_only?
+      redirect_to(console_threads_path(thread: thread_key), alert: READ_ONLY_REASON)
+      return
+    end
+
+    prompt = params[:prompt].to_s.strip
+    if prompt.blank?
+      redirect_to(
+        thread_key ? console_threads_path(thread: reply_redirect_keys(thread_key)) : console_threads_path(new: 1),
+        alert: "Type a message first."
+      )
+      return
+    end
+
+    thread_key ? reply_to_thread(thread_key, prompt) : start_thread(prompt)
   end
 
   # Lazily-loaded sidebar thread list, requested by the Turbo Frame in
@@ -128,6 +178,157 @@ class Console::ThreadsController < ApplicationController
   end
 
   private
+
+  def api_client
+    @api_client ||= client_factory.call
+  end
+
+  def composer_harness_choices
+    COMPOSER_HARNESSES
+  end
+
+  def composer_default_harness
+    COMPOSER_DEFAULT_HARNESS
+  end
+
+  # Model options for one harness, default first and annotated. The default
+  # comes from the same env/config resolution the thread header uses, so the
+  # composer never claims a default the sandbox would not actually run.
+  def composer_model_choices(harness)
+    options = COMPOSER_MODELS.fetch(harness, [])
+    default = default_model_for_harness(harness)
+    return options if default.blank?
+
+    default_label = options.find { |value, _label| value == default }&.last || default
+    [ [ default, "#{default_label} (default)" ] ] +
+      options.reject { |value, _label| value == default }
+  end
+
+  def composer_model_choices_by_harness
+    COMPOSER_HARNESSES.to_h { |value, _label| [ value, composer_model_choices(value) ] }
+  end
+
+  def start_thread(prompt)
+    harness = params[:harness_type].to_s.strip.presence || composer_default_harness
+    unless COMPOSER_MODELS.key?(harness)
+      redirect_to console_threads_path(new: 1), alert: "Unknown harness #{harness.inspect}."
+      return
+    end
+
+    model = composer_model_param(harness)
+    thread_key = "console:#{SecureRandom.uuid}"
+
+    api_client.create_session(
+      thread_key: thread_key,
+      harness_type: harness,
+      metadata: console_actor_metadata.merge(model.present? ? { model: model } : {})
+    )
+    send_prompt(thread_key, prompt, model: model)
+    redirect_to console_threads_path(thread: thread_key)
+  rescue CentaurApiClient::Error => e
+    redirect_to console_threads_path(new: 1), alert: "Could not start the chat: #{e.message}"
+  end
+
+  def reply_to_thread(thread_key, prompt)
+    # Resolve through the owner scope so a crafted thread_key cannot post into
+    # another user's chat — same rule the read side applies to ?thread=.
+    session = visible_thread_scope.where(thread_key: thread_key).first
+    if session.nil?
+      redirect_to console_threads_path, alert: "Chat not found."
+      return
+    end
+
+    send_prompt(session.thread_key, prompt, model: reply_model_for(session))
+    redirect_to console_threads_path(thread: reply_redirect_keys(session.thread_key))
+  rescue CentaurApiClient::Error => e
+    redirect_to console_threads_path(thread: reply_redirect_keys(thread_key)),
+                alert: "Could not send the message: #{e.message}"
+  rescue ActiveRecord::ActiveRecordError, PG::Error => e
+    Rails.logger.warn("console_threads_reply_lookup_failed error=#{e.class}: #{e.message}")
+    redirect_to console_threads_path, alert: "Chat database is unavailable."
+  end
+
+  # Append persists the turn in conversation history; execute runs it. The
+  # shared client_message_id lets api-rs dedupe the copy of the message the
+  # harness echoes back.
+  def send_prompt(thread_key, prompt, model: nil)
+    message_id = SecureRandom.uuid
+
+    api_client.append_session_messages(
+      thread_key: thread_key,
+      messages: [
+        {
+          client_message_id: message_id,
+          role: "user",
+          parts: [ { type: "text", text: prompt } ],
+          metadata: console_actor_metadata
+        }
+      ]
+    )
+
+    execute_metadata = console_actor_metadata.merge(action: "execute")
+    execute_metadata[:model] = model if model.present?
+    api_client.execute_session(
+      thread_key: thread_key,
+      idempotency_key: SecureRandom.uuid,
+      metadata: execute_metadata,
+      input_lines: [ composer_input_line(thread_key, prompt, model: model, client_message_id: message_id) ]
+    )
+  end
+
+  # One blocks-protocol user line, the shape harness-server parses from
+  # execute's input_lines. `model` is honored by every harness; omitted (e.g.
+  # for Amp) the harness runs its own default.
+  def composer_input_line(thread_key, prompt, model:, client_message_id:)
+    line = {
+      type: "user",
+      thread_key: thread_key,
+      client_user_message_id: client_message_id,
+      trace_metadata: { action: "execute", source: "console" },
+      message: { role: "user", content: [ { type: "text", text: prompt } ] }
+    }
+    line[:model] = model if model.present?
+    line.to_json
+  end
+
+  # Follow-ups reuse the model the chat has been running on (mirrors the
+  # display resolution in thread_model_label, minus the upcasing): last
+  # execution's recorded model, session metadata, then the deploy default.
+  def reply_model_for(session)
+    recorded_model(latest_executions_for([ session.thread_key ])[session.thread_key]&.metadata) ||
+      recorded_model(session.metadata_hash) ||
+      default_model_for_harness(session.harness_type.to_s)
+  end
+
+  # An unknown model falls back to the harness default rather than erroring:
+  # the select is populated from the same list, so mismatches only come from
+  # hand-crafted posts.
+  def composer_model_param(harness)
+    model = params[:model].to_s.strip
+    return nil if model.blank?
+
+    allowed = COMPOSER_MODELS.fetch(harness, []).map(&:first) +
+      [ default_model_for_harness(harness) ]
+    allowed.compact.include?(model) ? model : nil
+  end
+
+  # Keeps split-view panes open across a composer submit: the form carries the
+  # page's full ?thread= list, and the redirect re-orders it so the posted
+  # thread stays primary. Unowned keys are filtered again by #index on render.
+  def reply_redirect_keys(thread_key)
+    open_keys = params[:open_threads].to_s.split(",").map(&:strip).reject(&:blank?)
+    ([ thread_key ] + open_keys).uniq.first(PANEL_LIMIT).join(",")
+  end
+
+  def console_actor_metadata
+    email = current_user&.email.to_s
+    {
+      platform: "console",
+      source: "console",
+      user_email: email,
+      actor_email: email
+    }
+  end
 
   def load_threads
     session_scope = visible_thread_scope

--- a/services/console/app/controllers/console/threads_controller.rb
+++ b/services/console/app/controllers/console/threads_controller.rb
@@ -177,18 +177,14 @@ class Console::ThreadsController < ApplicationController
   end
 
   # Selector options as [label, value] pairs, the deploy's default model
-  # annotated and listed first. The default comes from the same env/config
-  # resolution the thread header uses, so the composer never claims a default
-  # the sandbox would not actually run.
+  # first (pre-checked in the menu). The default comes from the same
+  # env/config resolution the thread header uses, so the composer never
+  # claims a default the sandbox would not actually run.
   def composer_agent_choices
     default_value = composer_default_agent_value
-    sorted = COMPOSER_AGENTS.sort_by.with_index do |agent, index|
-      agent.value == default_value ? -1 : index
-    end
-    sorted.map do |agent|
-      label = agent.value == default_value ? "#{agent.label} (default)" : agent.label
-      [ label, agent.value ]
-    end
+    COMPOSER_AGENTS
+      .sort_by.with_index { |agent, index| agent.value == default_value ? -1 : index }
+      .map { |agent| [ agent.label, agent.value ] }
   end
 
   def composer_default_agent_value

--- a/services/console/app/controllers/console/threads_controller.rb
+++ b/services/console/app/controllers/console/threads_controller.rb
@@ -89,7 +89,11 @@ class Console::ThreadsController < ApplicationController
   # expand to (services/slackbotv2/src/overrides.ts). Amp appears as a plain
   # entry with no model: it picks its own model per turn.
   ComposerAgent = Struct.new(:value, :label, :harness, :model, keyword_init: true)
+  # First entry doubles as the default pick (unless the deploy's default-model
+  # resolution for its harness names another listed model).
   COMPOSER_AGENTS = [
+    ComposerAgent.new(value: "gpt-5.5", label: "GPT-5.5",
+                      harness: "codex", model: "gpt-5.5"),
     ComposerAgent.new(value: "claude-opus-4-8", label: "Claude Opus 4.8",
                       harness: "claudecode", model: "claude-opus-4-8"),
     ComposerAgent.new(value: "claude-sonnet-4-6", label: "Claude Sonnet 4.6",
@@ -98,8 +102,6 @@ class Console::ThreadsController < ApplicationController
                       harness: "claudecode", model: "claude-haiku-4-5"),
     ComposerAgent.new(value: "claude-fable-5", label: "Claude Fable 5",
                       harness: "claudecode", model: "claude-fable-5"),
-    ComposerAgent.new(value: "gpt-5.5", label: "GPT-5.5",
-                      harness: "codex", model: "gpt-5.5"),
     ComposerAgent.new(value: "amp", label: "Amp",
                       harness: "amp", model: nil)
   ].freeze

--- a/services/console/app/controllers/console/threads_controller.rb
+++ b/services/console/app/controllers/console/threads_controller.rb
@@ -81,6 +81,9 @@ class Console::ThreadsController < ApplicationController
 
   SlackThreadOwner = Struct.new(:user_id, :team_id, keyword_init: true)
 
+  # Pseudo thread key that opens a new-chat composer pane in the split view.
+  NEW_PANE_KEY = "new".freeze
+
   # The composer's model selector, in display order. Each entry pins the
   # harness the choice runs on (wire values match api-rs's HarnessType enum,
   # serde lowercase); the model ids are the ones the bots' --model flags
@@ -135,9 +138,14 @@ class Console::ThreadsController < ApplicationController
   def index
     @query = params[:q].to_s.strip
     requested_keys = requested_thread_keys
-    @selected_thread_key = requested_keys.first.to_s
-    @pane_thread_keys = requested_keys.drop(1)
-    @starting_new_thread = params[:new].present?
+    # "new" is a sentinel pane key: Cmd-clicking the sidebar's New chat adds a
+    # composer pane to the split view the same way thread keys add threads. On
+    # its own it is just the full-page new-chat screen.
+    @new_chat_pane_index = requested_keys.index(NEW_PANE_KEY) if requested_keys.size > 1
+    thread_keys = requested_keys - [ NEW_PANE_KEY ]
+    @selected_thread_key = thread_keys.first.to_s
+    @pane_thread_keys = thread_keys.drop(1)
+    @starting_new_thread = params[:new].present? || requested_keys == [ NEW_PANE_KEY ]
     @thread_db_unavailable = false
     @thread_not_found = false
 
@@ -247,7 +255,12 @@ class Console::ThreadsController < ApplicationController
       metadata: console_actor_metadata.merge(agent.model.present? ? { model: agent.model } : {})
     )
     send_prompt(thread_key, prompt, model: agent.model, effort: composer_effort_param(agent))
-    redirect_to console_threads_path(thread: thread_key)
+    # A new-chat pane in a split view swaps the sentinel for the created
+    # thread so the other panes stay open.
+    open_keys = params[:open_threads].to_s.split(",").map(&:strip).reject(&:blank?)
+    redirect_keys = open_keys.include?(NEW_PANE_KEY) ?
+      open_keys.map { |key| key == NEW_PANE_KEY ? thread_key : key } : [ thread_key ]
+    redirect_to console_threads_path(thread: redirect_keys.uniq.first(PANEL_LIMIT).join(","))
   rescue CentaurApiClient::Error => e
     redirect_to console_threads_path(new: 1), alert: "Could not start the chat: #{e.message}"
   end
@@ -451,12 +464,23 @@ class Console::ThreadsController < ApplicationController
     sessions = ([ @selected_session ] + Array(@pane_sessions)).compact
       .uniq(&:thread_key)
       .first(PANEL_LIMIT)
-    return [] if sessions.empty?
+    panels = if sessions.empty?
+      []
+    else
+      # Build the primary panel last so the @selected_* thread state (used by
+      # the page header and mention-resolution memos) ends on the primary
+      # thread.
+      extra_panels = sessions.drop(1).map { |session| thread_panel_for(session) }
+      [ thread_panel_for(sessions.first) ] + extra_panels
+    end
 
-    # Build the primary panel last so the @selected_* thread state (used by the
-    # page header and mention-resolution memos) ends on the primary thread.
-    extra_panels = sessions.drop(1).map { |session| thread_panel_for(session) }
-    [ thread_panel_for(sessions.first) ] + extra_panels
+    if @new_chat_pane_index && panels.any?
+      panels.insert(
+        [ @new_chat_pane_index, panels.size ].min,
+        { new_chat: true, thread_key: NEW_PANE_KEY, session: nil, transcript_items: [] }
+      )
+    end
+    panels
   end
 
   def thread_panel_for(session)

--- a/services/console/app/controllers/console/threads_controller.rb
+++ b/services/console/app/controllers/console/threads_controller.rb
@@ -83,31 +83,26 @@ class Console::ThreadsController < ApplicationController
 
   SlackThreadOwner = Struct.new(:user_id, :team_id, keyword_init: true)
 
-  # Harnesses the composer can start a chat on, in display order. Wire values
-  # match api-rs's HarnessType enum (serde lowercase).
-  COMPOSER_HARNESSES = [
-    [ "claudecode", "Claude Code" ],
-    [ "codex", "Codex" ],
-    [ "amp", "Amp" ]
+  # The composer's single model selector, in display order. Each entry pins
+  # the harness the choice runs on (wire values match api-rs's HarnessType
+  # enum, serde lowercase); the model ids are the ones the bots' --model flags
+  # expand to (services/slackbotv2/src/overrides.ts). Amp appears as a plain
+  # entry with no model: it picks its own model per turn.
+  ComposerAgent = Struct.new(:value, :label, :harness, :model, keyword_init: true)
+  COMPOSER_AGENTS = [
+    ComposerAgent.new(value: "claude-opus-4-8", label: "Claude Opus 4.8",
+                      harness: "claudecode", model: "claude-opus-4-8"),
+    ComposerAgent.new(value: "claude-sonnet-4-6", label: "Claude Sonnet 4.6",
+                      harness: "claudecode", model: "claude-sonnet-4-6"),
+    ComposerAgent.new(value: "claude-haiku-4-5", label: "Claude Haiku 4.5",
+                      harness: "claudecode", model: "claude-haiku-4-5"),
+    ComposerAgent.new(value: "claude-fable-5", label: "Claude Fable 5",
+                      harness: "claudecode", model: "claude-fable-5"),
+    ComposerAgent.new(value: "gpt-5.5", label: "GPT-5.5",
+                      harness: "codex", model: "gpt-5.5"),
+    ComposerAgent.new(value: "amp", label: "Amp",
+                      harness: "amp", model: nil)
   ].freeze
-  COMPOSER_DEFAULT_HARNESS = "claudecode".freeze
-  # Models offered per harness. The blocks-protocol user line carries `model`
-  # and every harness honors it; the ids here are the ones the bots' --model
-  # flags expand to (services/slackbotv2/src/overrides.ts). Amp maps to an
-  # empty list on purpose: it manages its own model per turn, so the composer
-  # shows a note instead of a selector.
-  COMPOSER_MODELS = {
-    "claudecode" => [
-      [ "claude-opus-4-8", "Claude Opus 4.8" ],
-      [ "claude-sonnet-4-6", "Claude Sonnet 4.6" ],
-      [ "claude-haiku-4-5", "Claude Haiku 4.5" ],
-      [ "claude-fable-5", "Claude Fable 5" ]
-    ],
-    "codex" => [
-      [ "gpt-5.5", "GPT-5.5" ]
-    ],
-    "amp" => []
-  }.freeze
 
   helper_method :thread_title,
                 :thread_source_icon,
@@ -118,10 +113,8 @@ class Console::ThreadsController < ApplicationController
                 :thread_message_text,
                 :thread_text_preview,
                 :thread_status_classes,
-                :composer_harness_choices,
-                :composer_default_harness,
-                :composer_model_choices,
-                :composer_model_choices_by_harness
+                :composer_agent_choices,
+                :composer_default_agent_value
 
   def index
     @query = params[:q].to_s.strip
@@ -183,47 +176,48 @@ class Console::ThreadsController < ApplicationController
     @api_client ||= client_factory.call
   end
 
-  def composer_harness_choices
-    COMPOSER_HARNESSES
+  # Selector options as [label, value] pairs, the deploy's default model
+  # annotated and listed first. The default comes from the same env/config
+  # resolution the thread header uses, so the composer never claims a default
+  # the sandbox would not actually run.
+  def composer_agent_choices
+    default_value = composer_default_agent_value
+    sorted = COMPOSER_AGENTS.sort_by.with_index do |agent, index|
+      agent.value == default_value ? -1 : index
+    end
+    sorted.map do |agent|
+      label = agent.value == default_value ? "#{agent.label} (default)" : agent.label
+      [ label, agent.value ]
+    end
   end
 
-  def composer_default_harness
-    COMPOSER_DEFAULT_HARNESS
+  def composer_default_agent_value
+    default = default_model_for_harness(COMPOSER_AGENTS.first.harness)
+    COMPOSER_AGENTS.find { |agent| agent.value == default }&.value ||
+      COMPOSER_AGENTS.first.value
   end
 
-  # Model options for one harness, default first and annotated. The default
-  # comes from the same env/config resolution the thread header uses, so the
-  # composer never claims a default the sandbox would not actually run.
-  def composer_model_choices(harness)
-    options = COMPOSER_MODELS.fetch(harness, [])
-    default = default_model_for_harness(harness)
-    return options if default.blank?
-
-    default_label = options.find { |value, _label| value == default }&.last || default
-    [ [ default, "#{default_label} (default)" ] ] +
-      options.reject { |value, _label| value == default }
-  end
-
-  def composer_model_choices_by_harness
-    COMPOSER_HARNESSES.to_h { |value, _label| [ value, composer_model_choices(value) ] }
+  def composer_agent_for(raw)
+    value = raw.to_s.strip
+    value = composer_default_agent_value if value.blank?
+    COMPOSER_AGENTS.find { |agent| agent.value == value }
   end
 
   def start_thread(prompt)
-    harness = params[:harness_type].to_s.strip.presence || composer_default_harness
-    unless COMPOSER_MODELS.key?(harness)
-      redirect_to console_threads_path(new: 1), alert: "Unknown harness #{harness.inspect}."
+    agent = composer_agent_for(params[:model])
+    if agent.nil?
+      redirect_to console_threads_path(new: 1),
+                  alert: "Unknown model #{params[:model].to_s.inspect}."
       return
     end
 
-    model = composer_model_param(harness)
     thread_key = "console:#{SecureRandom.uuid}"
-
     api_client.create_session(
       thread_key: thread_key,
-      harness_type: harness,
-      metadata: console_actor_metadata.merge(model.present? ? { model: model } : {})
+      harness_type: agent.harness,
+      metadata: console_actor_metadata.merge(agent.model.present? ? { model: agent.model } : {})
     )
-    send_prompt(thread_key, prompt, model: model)
+    send_prompt(thread_key, prompt, model: agent.model)
     redirect_to console_threads_path(thread: thread_key)
   rescue CentaurApiClient::Error => e
     redirect_to console_threads_path(new: 1), alert: "Could not start the chat: #{e.message}"
@@ -298,18 +292,6 @@ class Console::ThreadsController < ApplicationController
     recorded_model(latest_executions_for([ session.thread_key ])[session.thread_key]&.metadata) ||
       recorded_model(session.metadata_hash) ||
       default_model_for_harness(session.harness_type.to_s)
-  end
-
-  # An unknown model falls back to the harness default rather than erroring:
-  # the select is populated from the same list, so mismatches only come from
-  # hand-crafted posts.
-  def composer_model_param(harness)
-    model = params[:model].to_s.strip
-    return nil if model.blank?
-
-    allowed = COMPOSER_MODELS.fetch(harness, []).map(&:first) +
-      [ default_model_for_harness(harness) ]
-    allowed.compact.include?(model) ? model : nil
   end
 
   # Keeps split-view panes open across a composer submit: the form carries the

--- a/services/console/app/controllers/console/threads_controller.rb
+++ b/services/console/app/controllers/console/threads_controller.rb
@@ -62,8 +62,6 @@ class Console::ThreadsController < ApplicationController
   CONSOLE_THREAD_OWNER_METADATA_KEYS = %w[actor_email user_email].freeze
   SLACK_USER_ID_PATTERN = /\A[UW][A-Z0-9]+\z/.freeze
   SLACK_MENTION_PATTERN = /<@([UW][A-Z0-9]+)(?:\|([^>]+))?>|@([UW][A-Z0-9]+)/.freeze
-  READ_ONLY_REASON =
-    "Chats are read-only while browsing a mirrored production snapshot.".freeze
   # Deploy-time default-model overrides: the same env vars deployers set in
   # sandbox.extraEnv to change the harness model, mirrored onto the Console by
   # the chart. Amp has no fixed default model, so it is intentionally absent.
@@ -145,11 +143,6 @@ class Console::ThreadsController < ApplicationController
   # is still read from the sessions DB by #index after the redirect.
   def create
     thread_key = params[:thread_key].to_s.strip.presence
-
-    if console_threads_read_only?
-      redirect_to(console_threads_path(thread: thread_key), alert: READ_ONLY_REASON)
-      return
-    end
 
     prompt = params[:prompt].to_s.strip
     if prompt.blank?

--- a/services/console/app/controllers/console/threads_controller.rb
+++ b/services/console/app/controllers/console/threads_controller.rb
@@ -114,7 +114,8 @@ class Console::ThreadsController < ApplicationController
                 :thread_text_preview,
                 :thread_status_classes,
                 :composer_agent_choices,
-                :composer_default_agent_value
+                :composer_default_agent_value,
+                :thread_execution_active?
 
   def index
     @query = params[:q].to_s.strip
@@ -169,6 +170,13 @@ class Console::ThreadsController < ApplicationController
 
   def api_client
     @api_client ||= client_factory.call
+  end
+
+  # Whether the thread's newest execution is still running — drives the
+  # transcript's thinking indicator and the while-running auto-refresh.
+  def thread_execution_active?(thread_key)
+    execution = @latest_executions&.[](thread_key)
+    execution.present? && %w[queued running executing].include?(execution.status.to_s)
   end
 
   # Selector options as [label, value] pairs, the deploy's default model

--- a/services/console/app/helpers/application_helper.rb
+++ b/services/console/app/helpers/application_helper.rb
@@ -179,6 +179,8 @@ module ApplicationHelper
       outline_icon(classes, "M12 4.5v15m7.5-7.5h-15")
     when "chevron-right"
       outline_icon(classes, "m8.25 4.5 7.5 7.5-7.5 7.5")
+    when "check"
+      outline_icon(classes, "m4.5 12.75 6 6 9-13.5")
     when "x-mark"
       outline_icon(classes, "M6 18 18 6M6 6l12 12")
     when "shield-check"

--- a/services/console/app/javascript/controllers/localtime_controller.js
+++ b/services/console/app/javascript/controllers/localtime_controller.js
@@ -8,20 +8,34 @@ import { Controller } from "@hotwired/stimulus"
 //                                            local time as a hover tooltip.
 //   data-localtime-format-value="compact" -> "4d", with the absolute local time
 //                                            as a hover tooltip.
+//
+// Relative displays re-render every 30s so "now" ages into "1m" without a
+// page visit, and truncate toward zero so 90s reads as 1m, not 2m.
 export default class extends Controller {
   static values = { datetime: String, format: String, relative: Boolean }
 
   connect() {
-    const date = new Date(this.datetimeValue)
-    if (isNaN(date.getTime())) return
+    this.date = new Date(this.datetimeValue)
+    if (isNaN(this.date.getTime())) return
 
-    const absolute = this.formatAbsolute(date)
+    this.render()
+    if (this.formatValue === "compact" || this.relativeValue) {
+      this.timer = setInterval(() => this.render(), 30000)
+    }
+  }
+
+  disconnect() {
+    if (this.timer) clearInterval(this.timer)
+  }
+
+  render() {
+    const absolute = this.formatAbsolute(this.date)
 
     if (this.formatValue === "compact") {
-      this.element.textContent = this.compactRelativeFrom(date)
+      this.element.textContent = this.compactRelativeFrom(this.date)
       this.element.title = absolute
     } else if (this.relativeValue) {
-      this.element.textContent = this.relativeFrom(date)
+      this.element.textContent = this.relativeFrom(this.date)
       this.element.title = absolute
     } else {
       this.element.textContent = absolute
@@ -38,26 +52,26 @@ export default class extends Controller {
   }
 
   relativeFrom(date) {
-    const seconds = Math.round((date.getTime() - Date.now()) / 1000)
+    const seconds = Math.trunc((date.getTime() - Date.now()) / 1000)
     const rtf = new Intl.RelativeTimeFormat(undefined, { numeric: "auto" })
     const units = [
       ["year", 31536000], ["month", 2592000], ["day", 86400],
       ["hour", 3600], ["minute", 60]
     ]
     for (const [unit, secs] of units) {
-      if (Math.abs(seconds) >= secs) return rtf.format(Math.round(seconds / secs), unit)
+      if (Math.abs(seconds) >= secs) return rtf.format(Math.trunc(seconds / secs), unit)
     }
     return rtf.format(seconds, "second")
   }
 
   compactRelativeFrom(date) {
-    const seconds = Math.abs(Math.round((Date.now() - date.getTime()) / 1000))
+    const seconds = Math.abs(Math.trunc((Date.now() - date.getTime()) / 1000))
     const units = [
       ["y", 31536000], ["mo", 2592000], ["w", 604800],
       ["d", 86400], ["h", 3600], ["m", 60]
     ]
     for (const [unit, secs] of units) {
-      if (seconds >= secs) return `${Math.max(1, Math.round(seconds / secs))}${unit}`
+      if (seconds >= secs) return `${Math.floor(seconds / secs)}${unit}`
     }
     return "now"
   }

--- a/services/console/app/views/console/threads/_composer.html.erb
+++ b/services/console/app/views/console/threads/_composer.html.erb
@@ -18,7 +18,7 @@
   <div class="console-composer-box">
     <%= form.text_area :prompt,
                        rows: thread_mode ? 1 : 3,
-                       placeholder: thread_mode ? "Reply…" : "What are we working on?",
+                       placeholder: thread_mode ? "Ask a follow-up" : "Do anything",
                        required: true,
                        autofocus: !thread_mode,
                        class: "console-composer-input",

--- a/services/console/app/views/console/threads/_composer.html.erb
+++ b/services/console/app/views/console/threads/_composer.html.erb
@@ -27,30 +27,56 @@
       <span class="console-composer-spacer"></span>
       <% unless thread_mode %>
         <% default_value = composer_default_agent_value %>
-        <% default_label = composer_agent_choices.find { |_label, value| value == default_value }&.first %>
-        <div class="console-composer-model" data-console-model-picker>
+        <% default_agent = Console::ThreadsController::COMPOSER_AGENTS.find { |agent| agent.value == default_value } %>
+        <div class="console-composer-model"
+             data-console-model-picker
+             data-agents="<%= composer_agents_json %>">
           <%= form.hidden_field :model, value: default_value, data: { console_model_input: true } %>
+          <%= form.hidden_field :effort, value: "", data: { console_effort_input: true } %>
           <button type="button"
                   class="console-composer-model-trigger"
                   aria-haspopup="menu"
                   aria-expanded="false"
-                  aria-label="Model">
-            <span data-console-model-label><%= default_label %></span>
+                  aria-label="Model and effort">
+            <span data-console-model-label><%= default_agent&.label %></span>
             <span class="console-composer-model-chevron" aria-hidden="true"><%= console_icon("chevron-right", classes: "size-3") %></span>
           </button>
           <div class="console-account-menu console-composer-model-menu" role="menu" hidden>
-            <div class="console-account-menu-line console-account-menu-muted">Model</div>
-            <% composer_agent_choices.each do |label, value| %>
-              <button type="button"
-                      class="console-account-menu-button"
-                      role="menuitemradio"
-                      aria-checked="<%= value == default_value %>"
-                      data-console-model-option
-                      data-value="<%= value %>">
-                <span class="console-composer-model-option-label"><%= label %></span>
-                <span class="console-composer-model-check" <%= "hidden" unless value == default_value %>><%= console_icon("check", classes: "size-4") %></span>
+            <%# Root level: one row per setting, current value on the right,
+                mirroring the codex app's composer menu. %>
+            <div data-picker-level="root">
+              <button type="button" class="console-account-menu-button console-composer-menu-row" data-picker-open="model">
+                <span>Model</span>
+                <span class="console-composer-menu-value" data-picker-current="model"><%= default_agent&.label %></span>
+                <span class="console-composer-menu-chevron" aria-hidden="true"><%= console_icon("chevron-right", classes: "size-3") %></span>
               </button>
-            <% end %>
+              <button type="button" class="console-account-menu-button console-composer-menu-row" data-picker-open="effort"
+                      <%= "hidden" if default_agent&.efforts.blank? %>>
+                <span>Effort</span>
+                <span class="console-composer-menu-value" data-picker-current="effort">Default</span>
+                <span class="console-composer-menu-chevron" aria-hidden="true"><%= console_icon("chevron-right", classes: "size-3") %></span>
+              </button>
+            </div>
+            <div data-picker-level="model" hidden>
+              <div class="console-account-menu-line console-account-menu-muted">Model</div>
+              <% composer_agent_choices.each do |label, value| %>
+                <button type="button"
+                        class="console-account-menu-button"
+                        role="menuitemradio"
+                        aria-checked="<%= value == default_value %>"
+                        data-console-model-option
+                        data-value="<%= value %>">
+                  <span class="console-composer-model-option-label"><%= label %></span>
+                  <span class="console-composer-model-check" <%= "hidden" unless value == default_value %>><%= console_icon("check", classes: "size-4") %></span>
+                </button>
+              <% end %>
+            </div>
+            <div data-picker-level="effort" hidden>
+              <div class="console-account-menu-line console-account-menu-muted">Effort</div>
+              <%# Options are rebuilt by the picker script per selected model
+                  (efforts differ between models). %>
+              <div data-picker-effort-options></div>
+            </div>
           </div>
         </div>
       <% end %>
@@ -137,42 +163,112 @@
       event.target.closest("form")?.requestSubmit();
     });
 
+    const pickerAgents = (picker) => {
+      try { return JSON.parse(picker.dataset.agents || "{}"); } catch { return {}; }
+    };
+
+    const showLevel = (picker, name) => {
+      picker.querySelectorAll("[data-picker-level]").forEach((level) => {
+        level.hidden = level.dataset.pickerLevel !== name;
+      });
+    };
+
     function closePicker(picker) {
       const menu = picker.querySelector("[role=menu]");
       const trigger = picker.querySelector("[aria-haspopup=menu]");
       if (menu) menu.hidden = true;
       if (trigger) trigger.setAttribute("aria-expanded", "false");
+      showLevel(picker, "root");
     }
 
-    document.addEventListener("click", (event) => {
-      const trigger = event.target.closest?.("[data-console-model-picker] [aria-haspopup=menu]");
-      const option = event.target.closest?.("[data-console-model-option]");
+    // The pill reads "<model>" or "<model> · <effort>"; the root rows carry
+    // the same current values on their right edge.
+    const syncPickerLabels = (picker) => {
+      const agents = pickerAgents(picker);
+      const model = picker.querySelector("[data-console-model-input]").value;
+      const effort = picker.querySelector("[data-console-effort-input]").value;
+      const agent = agents[model] || { label: model, efforts: [] };
+      const effortLabel = (agent.efforts.find(([value]) => value === effort) || [])[1];
 
-      if (option) {
-        const picker = option.closest("[data-console-model-picker]");
-        picker.querySelector("[data-console-model-input]").value = option.dataset.value;
-        picker.querySelector("[data-console-model-label]").textContent =
-          option.querySelector(".console-composer-model-option-label").textContent;
+      picker.querySelector("[data-console-model-label]").textContent =
+        effortLabel ? `${agent.label} · ${effortLabel}` : agent.label;
+      picker.querySelector("[data-picker-current='model']").textContent = agent.label;
+      picker.querySelector("[data-picker-current='effort']").textContent = effortLabel || "Default";
+      picker.querySelector("[data-picker-open='effort']").hidden = agent.efforts.length === 0;
+    };
+
+    // Effort options depend on the picked model (5.6 adds Max); "Default"
+    // posts an empty effort so the harness config decides.
+    const rebuildEffortOptions = (picker) => {
+      const agents = pickerAgents(picker);
+      const model = picker.querySelector("[data-console-model-input]").value;
+      const effort = picker.querySelector("[data-console-effort-input]").value;
+      const container = picker.querySelector("[data-picker-effort-options]");
+      const template = picker.querySelector("[data-console-model-option]");
+      container.replaceChildren();
+
+      const choices = [["", "Default"], ...((agents[model] || {}).efforts || [])];
+      for (const [value, label] of choices) {
+        const option = template.cloneNode(true);
+        option.removeAttribute("data-console-model-option");
+        option.setAttribute("data-console-effort-option", "");
+        option.dataset.value = value;
+        option.querySelector(".console-composer-model-option-label").textContent = label;
+        const selected = value === effort;
+        option.setAttribute("aria-checked", String(selected));
+        option.querySelector(".console-composer-model-check").hidden = !selected;
+        container.appendChild(option);
+      }
+    };
+
+    document.addEventListener("click", (event) => {
+      const picker = event.target.closest?.("[data-console-model-picker]");
+
+      if (!picker) {
+        document.querySelectorAll("[data-console-model-picker]").forEach(closePicker);
+        return;
+      }
+
+      const trigger = event.target.closest("[aria-haspopup=menu]");
+      if (trigger) {
+        const menu = picker.querySelector("[role=menu]");
+        const expanded = trigger.getAttribute("aria-expanded") === "true";
+        menu.hidden = expanded;
+        trigger.setAttribute("aria-expanded", String(!expanded));
+        showLevel(picker, "root");
+        return;
+      }
+
+      const opener = event.target.closest("[data-picker-open]");
+      if (opener) {
+        if (opener.dataset.pickerOpen === "effort") rebuildEffortOptions(picker);
+        showLevel(picker, opener.dataset.pickerOpen);
+        return;
+      }
+
+      const modelOption = event.target.closest("[data-console-model-option]");
+      if (modelOption) {
+        picker.querySelector("[data-console-model-input]").value = modelOption.dataset.value;
+        // A model switch resets effort: the lists differ per model.
+        picker.querySelector("[data-console-effort-input]").value = "";
         picker.querySelectorAll("[data-console-model-option]").forEach((other) => {
-          const selected = other === option;
+          const selected = other === modelOption;
           other.setAttribute("aria-checked", String(selected));
           other.querySelector(".console-composer-model-check").hidden = !selected;
         });
+        syncPickerLabels(picker);
         closePicker(picker);
         picker.closest("form")?.querySelector("[data-console-composer-input]")?.focus();
         return;
       }
 
-      if (trigger) {
-        const picker = trigger.closest("[data-console-model-picker]");
-        const menu = picker.querySelector("[role=menu]");
-        const expanded = trigger.getAttribute("aria-expanded") === "true";
-        menu.hidden = expanded;
-        trigger.setAttribute("aria-expanded", String(!expanded));
-        return;
+      const effortOption = event.target.closest("[data-console-effort-option]");
+      if (effortOption) {
+        picker.querySelector("[data-console-effort-input]").value = effortOption.dataset.value;
+        syncPickerLabels(picker);
+        closePicker(picker);
+        picker.closest("form")?.querySelector("[data-console-composer-input]")?.focus();
       }
-
-      document.querySelectorAll("[data-console-model-picker]").forEach(closePicker);
     });
   })();
 </script>

--- a/services/console/app/views/console/threads/_composer.html.erb
+++ b/services/console/app/views/console/threads/_composer.html.erb
@@ -1,0 +1,112 @@
+<%# Chat composer, shared by the full-page New-chat view (mode: :new — harness
+    and model pickers) and open chats (mode: :thread, session: — follow-ups on
+    the session's existing harness/model). Enter sends, Shift+Enter breaks a
+    line; the script below is idempotent across Turbo visits. Amp exposes no
+    model choice, so selecting it swaps the model select for a note. %>
+<% thread_mode = defined?(mode) && mode == :thread %>
+<% composer_session = thread_mode ? session : nil %>
+<%= form_with url: console_threads_path,
+              method: :post,
+              class: "console-composer #{thread_mode ? "console-composer--thread" : "console-composer--new"}",
+              data: { console_composer: thread_mode ? "thread" : "new" } do |form| %>
+  <% if thread_mode %>
+    <%= form.hidden_field :thread_key, value: composer_session.thread_key %>
+    <%= form.hidden_field :open_threads, value: params[:thread].to_s.presence %>
+  <% end %>
+  <div class="console-composer-box">
+    <%= form.text_area :prompt,
+                       rows: thread_mode ? 1 : 3,
+                       placeholder: thread_mode ? "Reply…" : "What are we working on?",
+                       required: true,
+                       autofocus: !thread_mode,
+                       class: "console-composer-input",
+                       data: { console_composer_input: true } %>
+    <div class="console-composer-controls">
+      <% if thread_mode %>
+        <span class="console-composer-meta">
+          <%= thread_harness_label(composer_session) %><% if (model_label = thread_model_label(composer_session)) %> · <%= model_label %><% end %>
+        </span>
+      <% else %>
+        <label class="console-composer-control">
+          <span class="console-composer-control-label">Harness</span>
+          <%= form.select :harness_type,
+                          options_for_select(composer_harness_choices.map(&:reverse), composer_default_harness),
+                          {},
+                          class: "console-composer-select",
+                          data: { console_composer_harness: true } %>
+        </label>
+        <label class="console-composer-control"
+               data-console-composer-model-wrap
+               <%= "hidden" if composer_model_choices(composer_default_harness).empty? %>>
+          <span class="console-composer-control-label">Model</span>
+          <select name="model"
+                  class="console-composer-select"
+                  data-console-composer-model
+                  data-model-options="<%= composer_model_choices_by_harness.to_json %>">
+            <% composer_model_choices(composer_default_harness).each do |value, label| %>
+              <option value="<%= value %>"><%= label %></option>
+            <% end %>
+          </select>
+        </label>
+        <span class="console-composer-note"
+              data-console-composer-amp-note
+              <%= "hidden" unless composer_model_choices(composer_default_harness).empty? %>>
+          Model chosen by Amp per turn
+        </span>
+      <% end %>
+      <span class="console-composer-spacer"></span>
+      <button type="submit" class="console-composer-send" aria-label="Send message" title="Send">
+        <%= console_icon("arrow-up", classes: "size-4") %>
+      </button>
+    </div>
+  </div>
+<% end %>
+
+<script>
+  (() => {
+    if (window.__consoleComposerWired) return;
+    window.__consoleComposerWired = true;
+
+    // Repopulate the model select for the picked harness. An empty option list
+    // (Amp) hides the control — the harness manages its own model — and shows
+    // the explanatory note instead; the disabled select stays out of the post.
+    const syncModels = (form) => {
+      const harness = form.querySelector("[data-console-composer-harness]");
+      const model = form.querySelector("[data-console-composer-model]");
+      if (!harness || !model) return;
+      let optionsByHarness = {};
+      try { optionsByHarness = JSON.parse(model.dataset.modelOptions || "{}"); } catch {}
+      const choices = optionsByHarness[harness.value] || [];
+      model.innerHTML = "";
+      for (const [value, label] of choices) {
+        const option = document.createElement("option");
+        option.value = value;
+        option.textContent = label;
+        model.appendChild(option);
+      }
+      const hasChoices = choices.length > 0;
+      model.disabled = !hasChoices;
+      const wrap = form.querySelector("[data-console-composer-model-wrap]");
+      if (wrap) wrap.hidden = !hasChoices;
+      const note = form.querySelector("[data-console-composer-amp-note]");
+      if (note) note.hidden = hasChoices;
+    };
+
+    document.addEventListener("change", (event) => {
+      if (!event.target.matches?.("[data-console-composer-harness]")) return;
+      syncModels(event.target.closest("form"));
+    });
+
+    document.addEventListener("keydown", (event) => {
+      if (event.key !== "Enter" || event.shiftKey || event.isComposing) return;
+      if (!event.target.matches?.("[data-console-composer-input]")) return;
+      event.preventDefault();
+      event.target.closest("form")?.requestSubmit();
+    });
+
+    // Re-sync selects Turbo restored from a cached page snapshot.
+    document.addEventListener("turbo:load", () => {
+      document.querySelectorAll("[data-console-composer]").forEach(syncModels);
+    });
+  })();
+</script>

--- a/services/console/app/views/console/threads/_composer.html.erb
+++ b/services/console/app/views/console/threads/_composer.html.erb
@@ -1,8 +1,10 @@
 <%# Chat composer, shared by the full-page New-chat view (mode: :new — a
-    single model selector; each choice pins its harness, and Amp is simply one
-    of the options) and open chats (mode: :thread, session: — follow-ups on
-    the session's existing harness/model). Enter sends, Shift+Enter breaks a
-    line; the script below is idempotent across Turbo visits. %>
+    model picker where each choice pins its harness, and Amp is simply one of
+    the options) and open chats (mode: :thread, session: — follow-ups on the
+    session's existing harness/model). The picker is a custom menu mirroring
+    the account dropdown (same panel/item classes), not a native select.
+    Enter sends, Shift+Enter breaks a line; the script below is idempotent
+    across Turbo visits. %>
 <% thread_mode = defined?(mode) && mode == :thread %>
 <% composer_session = thread_mode ? session : nil %>
 <%= form_with url: console_threads_path,
@@ -27,11 +29,33 @@
           <%= thread_harness_label(composer_session) %><% if (model_label = thread_model_label(composer_session)) %> · <%= model_label %><% end %>
         </span>
       <% else %>
-        <%= form.select :model,
-                        options_for_select(composer_agent_choices, composer_default_agent_value),
-                        {},
-                        class: "console-composer-select",
-                        aria: { label: "Model" } %>
+        <% default_value = composer_default_agent_value %>
+        <% default_label = composer_agent_choices.find { |_label, value| value == default_value }&.first %>
+        <div class="console-composer-model" data-console-model-picker>
+          <%= form.hidden_field :model, value: default_value, data: { console_model_input: true } %>
+          <button type="button"
+                  class="console-composer-model-trigger"
+                  aria-haspopup="menu"
+                  aria-expanded="false"
+                  aria-label="Model">
+            <span data-console-model-label><%= default_label %></span>
+            <span class="console-composer-model-chevron" aria-hidden="true"><%= console_icon("chevron-right", classes: "size-3") %></span>
+          </button>
+          <div class="console-account-menu console-composer-model-menu" role="menu" hidden>
+            <div class="console-account-menu-line console-account-menu-muted">Model</div>
+            <% composer_agent_choices.each do |label, value| %>
+              <button type="button"
+                      class="console-account-menu-button"
+                      role="menuitemradio"
+                      aria-checked="<%= value == default_value %>"
+                      data-console-model-option
+                      data-value="<%= value %>">
+                <span class="console-composer-model-option-label"><%= label %></span>
+                <span class="console-composer-model-check" <%= "hidden" unless value == default_value %>><%= console_icon("check", classes: "size-4") %></span>
+              </button>
+            <% end %>
+          </div>
+        </div>
       <% end %>
       <span class="console-composer-spacer"></span>
       <button type="submit" class="console-composer-send" aria-label="Send message" title="Send">
@@ -47,10 +71,52 @@
     window.__consoleComposerWired = true;
 
     document.addEventListener("keydown", (event) => {
+      if (event.key === "Escape") {
+        document.querySelectorAll("[data-console-model-picker]").forEach(closePicker);
+        return;
+      }
       if (event.key !== "Enter" || event.shiftKey || event.isComposing) return;
       if (!event.target.matches?.("[data-console-composer-input]")) return;
       event.preventDefault();
       event.target.closest("form")?.requestSubmit();
+    });
+
+    function closePicker(picker) {
+      const menu = picker.querySelector("[role=menu]");
+      const trigger = picker.querySelector("[aria-haspopup=menu]");
+      if (menu) menu.hidden = true;
+      if (trigger) trigger.setAttribute("aria-expanded", "false");
+    }
+
+    document.addEventListener("click", (event) => {
+      const trigger = event.target.closest?.("[data-console-model-picker] [aria-haspopup=menu]");
+      const option = event.target.closest?.("[data-console-model-option]");
+
+      if (option) {
+        const picker = option.closest("[data-console-model-picker]");
+        picker.querySelector("[data-console-model-input]").value = option.dataset.value;
+        picker.querySelector("[data-console-model-label]").textContent =
+          option.querySelector(".console-composer-model-option-label").textContent;
+        picker.querySelectorAll("[data-console-model-option]").forEach((other) => {
+          const selected = other === option;
+          other.setAttribute("aria-checked", String(selected));
+          other.querySelector(".console-composer-model-check").hidden = !selected;
+        });
+        closePicker(picker);
+        picker.closest("form")?.querySelector("[data-console-composer-input]")?.focus();
+        return;
+      }
+
+      if (trigger) {
+        const picker = trigger.closest("[data-console-model-picker]");
+        const menu = picker.querySelector("[role=menu]");
+        const expanded = trigger.getAttribute("aria-expanded") === "true";
+        menu.hidden = expanded;
+        trigger.setAttribute("aria-expanded", String(!expanded));
+        return;
+      }
+
+      document.querySelectorAll("[data-console-model-picker]").forEach(closePicker);
     });
   })();
 </script>

--- a/services/console/app/views/console/threads/_composer.html.erb
+++ b/services/console/app/views/console/threads/_composer.html.erb
@@ -7,6 +7,9 @@
     across Turbo visits. %>
 <% thread_mode = defined?(mode) && mode == :thread %>
 <% composer_session = thread_mode ? session : nil %>
+<%# compact: single-row textarea for new-chat composers docked in a pane,
+    matching the thread composer's height. %>
+<% compact_mode = defined?(compact) && compact %>
 <%= form_with url: console_threads_path,
               method: :post,
               class: "console-composer #{thread_mode ? "console-composer--thread" : "console-composer--new"}",
@@ -20,7 +23,7 @@
   <%= form.hidden_field :open_threads, value: params[:thread].to_s.presence %>
   <div class="console-composer-box">
     <%= form.text_area :prompt,
-                       rows: thread_mode ? 1 : 3,
+                       rows: thread_mode || compact_mode ? 1 : 3,
                        placeholder: thread_mode ? "Follow up" : "Do anything",
                        required: true,
                        autofocus: !thread_mode,
@@ -135,24 +138,27 @@
       const text = (input?.value || "").trim();
       if (!text) return;
 
-      if (form.dataset.consoleComposer === "new") {
-        // The form stays in the DOM (hidden) so the in-flight submission is
-        // undisturbed; the heading gives way to the painted conversation.
-        const container = form.closest(".console-new-chat");
-        if (!container) return;
+      // Full-page new chat: the form stays in the DOM (hidden) so the
+      // in-flight submission is undisturbed; the heading gives way to the
+      // painted conversation.
+      const container = form.dataset.consoleComposer === "new" && form.closest(".console-new-chat");
+      if (container) {
         const column = document.createElement("div");
         column.className = "flex w-full flex-col gap-6";
         column.append(userBubble(text), thinkingRow());
         container.querySelector(".console-new-chat-title")?.setAttribute("hidden", "");
         container.insertBefore(column, form);
         form.hidden = true;
-      } else {
-        const transcript = form.closest("section")?.querySelector(".console-transcript-scroll > div");
-        if (!transcript) return;
-        transcript.querySelector("[data-console-thinking-indicator]")?.remove();
-        transcript.append(userBubble(text), thinkingRow());
-        input.value = "";
+        return;
       }
+
+      // Docked composers (thread panes and new-chat panes) paint into their
+      // pane's transcript.
+      const transcript = form.closest("section")?.querySelector(".console-transcript-scroll > div");
+      if (!transcript) return;
+      transcript.querySelector("[data-console-thinking-indicator]")?.remove();
+      transcript.append(userBubble(text), thinkingRow());
+      input.value = "";
     });
 
     document.addEventListener("keydown", (event) => {

--- a/services/console/app/views/console/threads/_composer.html.erb
+++ b/services/console/app/views/console/threads/_composer.html.erb
@@ -28,7 +28,9 @@
         <span class="console-composer-meta">
           <%= thread_harness_label(composer_session) %><% if (model_label = thread_model_label(composer_session)) %> · <%= model_label %><% end %>
         </span>
-      <% else %>
+      <% end %>
+      <span class="console-composer-spacer"></span>
+      <% unless thread_mode %>
         <% default_value = composer_default_agent_value %>
         <% default_label = composer_agent_choices.find { |_label, value| value == default_value }&.first %>
         <div class="console-composer-model" data-console-model-picker>
@@ -57,7 +59,6 @@
           </div>
         </div>
       <% end %>
-      <span class="console-composer-spacer"></span>
       <button type="submit" class="console-composer-send" aria-label="Send message" title="Send">
         <%= console_icon("arrow-up", classes: "size-4") %>
       </button>

--- a/services/console/app/views/console/threads/_composer.html.erb
+++ b/services/console/app/views/console/threads/_composer.html.erb
@@ -13,8 +13,11 @@
               data: { console_composer: thread_mode ? "thread" : "new" } do |form| %>
   <% if thread_mode %>
     <%= form.hidden_field :thread_key, value: composer_session.thread_key %>
-    <%= form.hidden_field :open_threads, value: params[:thread].to_s.presence %>
   <% end %>
+  <%# Both modes carry the page's open panes: replies re-open them after the
+      redirect, and a new-chat pane swaps its "new" sentinel for the created
+      thread key. %>
+  <%= form.hidden_field :open_threads, value: params[:thread].to_s.presence %>
   <div class="console-composer-box">
     <%= form.text_area :prompt,
                        rows: thread_mode ? 1 : 3,

--- a/services/console/app/views/console/threads/_composer.html.erb
+++ b/services/console/app/views/console/threads/_composer.html.erb
@@ -18,7 +18,7 @@
   <div class="console-composer-box">
     <%= form.text_area :prompt,
                        rows: thread_mode ? 1 : 3,
-                       placeholder: thread_mode ? "Ask a follow-up" : "Do anything",
+                       placeholder: thread_mode ? "Follow up" : "Do anything",
                        required: true,
                        autofocus: !thread_mode,
                        class: "console-composer-input",

--- a/services/console/app/views/console/threads/_composer.html.erb
+++ b/services/console/app/views/console/threads/_composer.html.erb
@@ -1,8 +1,8 @@
-<%# Chat composer, shared by the full-page New-chat view (mode: :new — harness
-    and model pickers) and open chats (mode: :thread, session: — follow-ups on
+<%# Chat composer, shared by the full-page New-chat view (mode: :new — a
+    single model selector; each choice pins its harness, and Amp is simply one
+    of the options) and open chats (mode: :thread, session: — follow-ups on
     the session's existing harness/model). Enter sends, Shift+Enter breaks a
-    line; the script below is idempotent across Turbo visits. Amp exposes no
-    model choice, so selecting it swaps the model select for a note. %>
+    line; the script below is idempotent across Turbo visits. %>
 <% thread_mode = defined?(mode) && mode == :thread %>
 <% composer_session = thread_mode ? session : nil %>
 <%= form_with url: console_threads_path,
@@ -27,32 +27,11 @@
           <%= thread_harness_label(composer_session) %><% if (model_label = thread_model_label(composer_session)) %> · <%= model_label %><% end %>
         </span>
       <% else %>
-        <label class="console-composer-control">
-          <span class="console-composer-control-label">Harness</span>
-          <%= form.select :harness_type,
-                          options_for_select(composer_harness_choices.map(&:reverse), composer_default_harness),
-                          {},
-                          class: "console-composer-select",
-                          data: { console_composer_harness: true } %>
-        </label>
-        <label class="console-composer-control"
-               data-console-composer-model-wrap
-               <%= "hidden" if composer_model_choices(composer_default_harness).empty? %>>
-          <span class="console-composer-control-label">Model</span>
-          <select name="model"
-                  class="console-composer-select"
-                  data-console-composer-model
-                  data-model-options="<%= composer_model_choices_by_harness.to_json %>">
-            <% composer_model_choices(composer_default_harness).each do |value, label| %>
-              <option value="<%= value %>"><%= label %></option>
-            <% end %>
-          </select>
-        </label>
-        <span class="console-composer-note"
-              data-console-composer-amp-note
-              <%= "hidden" unless composer_model_choices(composer_default_harness).empty? %>>
-          Model chosen by Amp per turn
-        </span>
+        <%= form.select :model,
+                        options_for_select(composer_agent_choices, composer_default_agent_value),
+                        {},
+                        class: "console-composer-select",
+                        aria: { label: "Model" } %>
       <% end %>
       <span class="console-composer-spacer"></span>
       <button type="submit" class="console-composer-send" aria-label="Send message" title="Send">
@@ -67,46 +46,11 @@
     if (window.__consoleComposerWired) return;
     window.__consoleComposerWired = true;
 
-    // Repopulate the model select for the picked harness. An empty option list
-    // (Amp) hides the control — the harness manages its own model — and shows
-    // the explanatory note instead; the disabled select stays out of the post.
-    const syncModels = (form) => {
-      const harness = form.querySelector("[data-console-composer-harness]");
-      const model = form.querySelector("[data-console-composer-model]");
-      if (!harness || !model) return;
-      let optionsByHarness = {};
-      try { optionsByHarness = JSON.parse(model.dataset.modelOptions || "{}"); } catch {}
-      const choices = optionsByHarness[harness.value] || [];
-      model.innerHTML = "";
-      for (const [value, label] of choices) {
-        const option = document.createElement("option");
-        option.value = value;
-        option.textContent = label;
-        model.appendChild(option);
-      }
-      const hasChoices = choices.length > 0;
-      model.disabled = !hasChoices;
-      const wrap = form.querySelector("[data-console-composer-model-wrap]");
-      if (wrap) wrap.hidden = !hasChoices;
-      const note = form.querySelector("[data-console-composer-amp-note]");
-      if (note) note.hidden = hasChoices;
-    };
-
-    document.addEventListener("change", (event) => {
-      if (!event.target.matches?.("[data-console-composer-harness]")) return;
-      syncModels(event.target.closest("form"));
-    });
-
     document.addEventListener("keydown", (event) => {
       if (event.key !== "Enter" || event.shiftKey || event.isComposing) return;
       if (!event.target.matches?.("[data-console-composer-input]")) return;
       event.preventDefault();
       event.target.closest("form")?.requestSubmit();
-    });
-
-    // Re-sync selects Turbo restored from a cached page snapshot.
-    document.addEventListener("turbo:load", () => {
-      document.querySelectorAll("[data-console-composer]").forEach(syncModels);
     });
   })();
 </script>

--- a/services/console/app/views/console/threads/_composer.html.erb
+++ b/services/console/app/views/console/threads/_composer.html.erb
@@ -24,11 +24,6 @@
                        class: "console-composer-input",
                        data: { console_composer_input: true } %>
     <div class="console-composer-controls">
-      <% if thread_mode %>
-        <span class="console-composer-meta">
-          <%= thread_harness_label(composer_session) %><% if (model_label = thread_model_label(composer_session)) %> · <%= model_label %><% end %>
-        </span>
-      <% end %>
       <span class="console-composer-spacer"></span>
       <% unless thread_mode %>
         <% default_value = composer_default_agent_value %>
@@ -70,6 +65,66 @@
   (() => {
     if (window.__consoleComposerWired) return;
     window.__consoleComposerWired = true;
+
+    // Optimistic send: paint the outgoing message and a thinking placeholder
+    // the moment the form submits, so the seconds the server spends creating
+    // the session and dispatching the turn never look like a hang. The real
+    // transcript replaces all of it when the redirect lands. Markup mirrors
+    // the transcript partial's user bubble and _thinking_indicator.
+    const userBubble = (text) => {
+      const row = document.createElement("div");
+      row.className = "group flex justify-end";
+      const stack = document.createElement("div");
+      stack.className = "console-message-stack flex flex-col max-w-[72%] items-end";
+      const bubble = document.createElement("div");
+      bubble.className = "w-full rounded-[24px] bg-ink-700 px-4 py-3 text-zinc-100";
+      const body = document.createElement("div");
+      body.className = "console-markdown text-sm leading-6";
+      body.style.whiteSpace = "pre-wrap";
+      body.textContent = text;
+      bubble.appendChild(body);
+      stack.appendChild(bubble);
+      row.appendChild(stack);
+      return row;
+    };
+
+    const thinkingRow = () => {
+      const row = document.createElement("div");
+      row.className = "flex justify-start";
+      row.setAttribute("data-console-thinking-indicator", "");
+      const pending = document.createElement("div");
+      pending.className = "console-thinking-pending";
+      pending.textContent = "Thinking…";
+      row.appendChild(pending);
+      return row;
+    };
+
+    document.addEventListener("submit", (event) => {
+      const form = event.target;
+      if (!form.matches?.("[data-console-composer]")) return;
+      const input = form.querySelector("[data-console-composer-input]");
+      const text = (input?.value || "").trim();
+      if (!text) return;
+
+      if (form.dataset.consoleComposer === "new") {
+        // The form stays in the DOM (hidden) so the in-flight submission is
+        // undisturbed; the heading gives way to the painted conversation.
+        const container = form.closest(".console-new-chat");
+        if (!container) return;
+        const column = document.createElement("div");
+        column.className = "flex w-full flex-col gap-6";
+        column.append(userBubble(text), thinkingRow());
+        container.querySelector(".console-new-chat-title")?.setAttribute("hidden", "");
+        container.insertBefore(column, form);
+        form.hidden = true;
+      } else {
+        const transcript = form.closest("section")?.querySelector(".console-transcript-scroll > div");
+        if (!transcript) return;
+        transcript.querySelector("[data-console-thinking-indicator]")?.remove();
+        transcript.append(userBubble(text), thinkingRow());
+        input.value = "";
+      }
+    });
 
     document.addEventListener("keydown", (event) => {
       if (event.key === "Escape") {

--- a/services/console/app/views/console/threads/_thinking_indicator.html.erb
+++ b/services/console/app/views/console/threads/_thinking_indicator.html.erb
@@ -1,0 +1,6 @@
+<%# Pulsing placeholder shown while a turn is executing and the reply has not
+    landed yet. The composer's optimistic-submit JS builds this same markup
+    client-side (see _composer.html.erb) — keep the two in sync. %>
+<div class="flex justify-start" data-console-thinking-indicator>
+  <div class="console-thinking-pending">Thinking…</div>
+</div>

--- a/services/console/app/views/console/threads/_thread_panel.html.erb
+++ b/services/console/app/views/console/threads/_thread_panel.html.erb
@@ -39,4 +39,9 @@
       <%= render "console/threads/transcript", items: panel[:transcript_items] %>
     </div>
   </div>
+  <% unless console_threads_read_only? %>
+    <div class="console-composer-dock console-composer-dock--panel">
+      <%= render "console/threads/composer", mode: :thread, session: session %>
+    </div>
+  <% end %>
 </section>

--- a/services/console/app/views/console/threads/_thread_panel.html.erb
+++ b/services/console/app/views/console/threads/_thread_panel.html.erb
@@ -20,10 +20,14 @@
         <%= console_icon("x-mark", classes: "size-4") %>
       </a>
     </header>
-    <div class="flex min-h-0 flex-1 items-start justify-center overflow-y-auto px-4">
-      <div class="console-new-chat console-new-chat--panel">
-        <%= render "console/threads/composer", mode: :new %>
-      </div>
+    <%# Mirrors the thread-panel structure 1:1 — empty transcript scroll in
+        the middle, composer docked at the bottom — so a new-chat pane sizes
+        exactly like its conversation siblings. %>
+    <div class="console-transcript-scroll min-h-0 flex-1 overflow-y-auto px-4 py-4">
+      <div class="flex flex-col gap-5"></div>
+    </div>
+    <div class="console-composer-dock console-composer-dock--panel">
+      <%= render "console/threads/composer", mode: :new, compact: true %>
     </div>
   </section>
 <% else %>

--- a/services/console/app/views/console/threads/_thread_panel.html.erb
+++ b/services/console/app/views/console/threads/_thread_panel.html.erb
@@ -37,6 +37,7 @@
   <div class="console-transcript-scroll min-h-0 flex-1 overflow-y-auto px-4 py-4">
     <div class="flex flex-col gap-5">
       <%= render "console/threads/transcript", items: panel[:transcript_items] %>
+      <%= render "console/threads/thinking_indicator" if thread_execution_active?(session.thread_key) %>
     </div>
   </div>
   <div class="console-composer-dock console-composer-dock--panel">

--- a/services/console/app/views/console/threads/_thread_panel.html.erb
+++ b/services/console/app/views/console/threads/_thread_panel.html.erb
@@ -1,10 +1,32 @@
 <%# One panel of the split-view grid. panel: {session:, thread_key:,
-    transcript_items:}; panels: all panels, used to build the close link that
-    drops this panel and promotes the first remaining thread to primary. The
-    thread param carries all open keys comma-separated, primary first. %>
+    transcript_items:} — or {new_chat: true} for a composer pane; panels: all
+    panels, used to build the close link that drops this panel and promotes
+    the first remaining thread to primary. The thread param carries all open
+    keys comma-separated, primary first. %>
 <% session = panel[:session] %>
 <% remaining_keys = panels.map { |other| other[:thread_key] } - [ panel[:thread_key] ] %>
 <% close_path = console_threads_path(thread: remaining_keys.join(",")) %>
+<% if panel[:new_chat] %>
+  <section class="flex min-h-0 min-w-0 flex-col overflow-hidden rounded-xl border border-ink-700 bg-ink-900/35"
+           data-thread-panel="<%= panel[:thread_key] %>">
+    <header class="flex shrink-0 items-center gap-2 border-b border-ink-700 px-4 py-2.5">
+      <div class="min-w-0 flex-1">
+        <span class="block truncate text-sm font-semibold text-zinc-100">New chat</span>
+      </div>
+      <a href="<%= close_path %>"
+         class="console-panel-close"
+         aria-label="Close panel"
+         title="Close panel">
+        <%= console_icon("x-mark", classes: "size-4") %>
+      </a>
+    </header>
+    <div class="flex min-h-0 flex-1 items-start justify-center overflow-y-auto px-4">
+      <div class="console-new-chat console-new-chat--panel">
+        <%= render "console/threads/composer", mode: :new %>
+      </div>
+    </div>
+  </section>
+<% else %>
 <section class="flex min-h-0 min-w-0 flex-col overflow-hidden rounded-xl border border-ink-700 bg-ink-900/35"
          data-thread-panel="<%= session.thread_key %>">
   <header class="flex shrink-0 items-center gap-2 border-b border-ink-700 px-4 py-2.5">
@@ -44,3 +66,4 @@
     <%= render "console/threads/composer", mode: :thread, session: session %>
   </div>
 </section>
+<% end %>

--- a/services/console/app/views/console/threads/_thread_panel.html.erb
+++ b/services/console/app/views/console/threads/_thread_panel.html.erb
@@ -39,9 +39,7 @@
       <%= render "console/threads/transcript", items: panel[:transcript_items] %>
     </div>
   </div>
-  <% unless console_threads_read_only? %>
-    <div class="console-composer-dock console-composer-dock--panel">
-      <%= render "console/threads/composer", mode: :thread, session: session %>
-    </div>
-  <% end %>
+  <div class="console-composer-dock console-composer-dock--panel">
+    <%= render "console/threads/composer", mode: :thread, session: session %>
+  </div>
 </section>

--- a/services/console/app/views/console/threads/index.html.erb
+++ b/services/console/app/views/console/threads/index.html.erb
@@ -51,7 +51,11 @@
       </div>
       <% end %>
 
-      <% if @starting_new_thread && !console_threads_read_only? %>
+      <%# With posting enabled, an empty selection IS the new-chat screen —
+          both the explicit ?new=1 entry point and the nothing-selected /
+          no-chats-yet cases. Read-only keeps the plain empty states below;
+          an unresolvable ?thread= still renders as not-found. %>
+      <% if (@starting_new_thread || @selected_session.nil?) && !@thread_not_found && !console_threads_read_only? %>
         <div class="flex min-h-0 flex-1 items-start justify-center overflow-y-auto px-6">
           <div class="console-new-chat">
             <h1 class="console-new-chat-title">Start a new chat</h1>
@@ -83,11 +87,6 @@
               <p class="text-sm leading-6 text-zinc-500">
                 Chats you start — from Slack or the Console — will show up here.
               </p>
-              <% unless console_threads_read_only? %>
-                <a href="<%= console_threads_path(new: 1) %>" class="console-new-chat-cta">
-                  Start a chat
-                </a>
-              <% end %>
             </div>
           </div>
         <% else %>

--- a/services/console/app/views/console/threads/index.html.erb
+++ b/services/console/app/views/console/threads/index.html.erb
@@ -51,6 +51,15 @@
       </div>
       <% end %>
 
+      <% if @starting_new_thread && !console_threads_read_only? %>
+        <div class="flex min-h-0 flex-1 items-center justify-center overflow-y-auto px-6">
+          <div class="console-new-chat">
+            <h1 class="console-new-chat-title">Start a new chat</h1>
+            <p class="console-new-chat-subtitle">Pick a harness, choose a model where it applies, and send your first message.</p>
+            <%= render "console/threads/composer", mode: :new %>
+          </div>
+        </div>
+      <% else %>
       <div id="thread-transcript-scroll" class="console-transcript-scroll min-h-0 flex-1 overflow-y-auto py-6">
         <% if @selected_session %>
           <div class="console-thread-content flex flex-col gap-6">
@@ -75,6 +84,11 @@
               <p class="text-sm leading-6 text-zinc-500">
                 Chats you start — from Slack or the Console — will show up here.
               </p>
+              <% unless console_threads_read_only? %>
+                <a href="<%= console_threads_path(new: 1) %>" class="console-new-chat-cta">
+                  Start a chat
+                </a>
+              <% end %>
             </div>
           </div>
         <% else %>
@@ -88,6 +102,38 @@
           </div>
         <% end %>
       </div>
+
+      <% if @selected_session && !console_threads_read_only? %>
+        <div class="console-composer-dock">
+          <div class="console-thread-content">
+            <%= render "console/threads/composer", mode: :thread, session: @selected_session %>
+          </div>
+        </div>
+        <% latest_execution = @latest_executions&.[](@selected_session.thread_key) %>
+        <% if latest_execution && %w[queued running executing].include?(latest_execution.status.to_s) %>
+          <%# The console has no event stream; while a turn is running, refresh
+              the transcript every few seconds. Skipped whenever the composer
+              holds a draft so a reload never eats typed text. %>
+          <script>
+            (() => {
+              const refresh = () => {
+                const input = document.querySelector("[data-console-composer-input]");
+                if (input && (input.value.trim() !== "" || document.activeElement === input)) {
+                  setTimeout(refresh, 4000);
+                  return;
+                }
+                if (window.Turbo) {
+                  window.Turbo.visit(window.location.href, { action: "replace" });
+                } else {
+                  window.location.reload();
+                }
+              };
+              setTimeout(refresh, 4000);
+            })();
+          </script>
+        <% end %>
+      <% end %>
+      <% end %>
     </section>
   <% end %>
 </div>

--- a/services/console/app/views/console/threads/index.html.erb
+++ b/services/console/app/views/console/threads/index.html.erb
@@ -66,6 +66,7 @@
         <% if @selected_session %>
           <div class="console-thread-content flex flex-col gap-6">
             <%= render "console/threads/transcript", items: @selected_transcript_items %>
+            <%= render "console/threads/thinking_indicator" if thread_execution_active?(@selected_session.thread_key) %>
           </div>
         <% else %>
           <div class="flex h-full items-center justify-center px-6">
@@ -85,31 +86,32 @@
             <%= render "console/threads/composer", mode: :thread, session: @selected_session %>
           </div>
         </div>
-        <% latest_execution = @latest_executions&.[](@selected_session.thread_key) %>
-        <% if latest_execution && %w[queued running executing].include?(latest_execution.status.to_s) %>
-          <%# The console has no event stream; while a turn is running, refresh
-              the transcript every few seconds. Skipped whenever the composer
-              holds a draft so a reload never eats typed text. %>
-          <script>
-            (() => {
-              const refresh = () => {
-                const input = document.querySelector("[data-console-composer-input]");
-                if (input && (input.value.trim() !== "" || document.activeElement === input)) {
-                  setTimeout(refresh, 4000);
-                  return;
-                }
-                if (window.Turbo) {
-                  window.Turbo.visit(window.location.href, { action: "replace" });
-                } else {
-                  window.location.reload();
-                }
-              };
-              setTimeout(refresh, 4000);
-            })();
-          </script>
-        <% end %>
       <% end %>
       <% end %>
     </section>
+  <% end %>
+
+  <% if @thread_panels.any? { |panel| thread_execution_active?(panel[:thread_key]) } %>
+    <%# The console has no event stream; while a turn is running in any open
+        pane, refresh the transcript every few seconds. Skipped whenever a
+        composer holds a draft so a reload never eats typed text. %>
+    <script>
+      (() => {
+        const refresh = () => {
+          const drafting = Array.from(document.querySelectorAll("[data-console-composer-input]"))
+            .some((input) => input.value.trim() !== "" || document.activeElement === input);
+          if (drafting) {
+            setTimeout(refresh, 4000);
+            return;
+          }
+          if (window.Turbo) {
+            window.Turbo.visit(window.location.href, { action: "replace" });
+          } else {
+            window.location.reload();
+          }
+        };
+        setTimeout(refresh, 4000);
+      })();
+    </script>
   <% end %>
 </div>

--- a/services/console/app/views/console/threads/index.html.erb
+++ b/services/console/app/views/console/threads/index.html.erb
@@ -52,10 +52,9 @@
       <% end %>
 
       <% if @starting_new_thread && !console_threads_read_only? %>
-        <div class="flex min-h-0 flex-1 items-center justify-center overflow-y-auto px-6">
+        <div class="flex min-h-0 flex-1 items-start justify-center overflow-y-auto px-6">
           <div class="console-new-chat">
             <h1 class="console-new-chat-title">Start a new chat</h1>
-            <p class="console-new-chat-subtitle">Pick a harness, choose a model where it applies, and send your first message.</p>
             <%= render "console/threads/composer", mode: :new %>
           </div>
         </div>

--- a/services/console/app/views/console/threads/index.html.erb
+++ b/services/console/app/views/console/threads/index.html.erb
@@ -51,11 +51,10 @@
       </div>
       <% end %>
 
-      <%# With posting enabled, an empty selection IS the new-chat screen —
-          both the explicit ?new=1 entry point and the nothing-selected /
-          no-chats-yet cases. Read-only keeps the plain empty states below;
-          an unresolvable ?thread= still renders as not-found. %>
-      <% if (@starting_new_thread || @selected_session.nil?) && !@thread_not_found && !console_threads_read_only? %>
+      <%# An empty selection IS the new-chat screen — both the explicit ?new=1
+          entry point and the nothing-selected / no-chats-yet cases. An
+          unresolvable ?thread= still renders as not-found. %>
+      <% if (@starting_new_thread || @selected_session.nil?) && !@thread_not_found %>
         <div class="flex min-h-0 flex-1 items-start justify-center overflow-y-auto px-6">
           <div class="console-new-chat">
             <h1 class="console-new-chat-title">Start a new chat</h1>
@@ -68,7 +67,7 @@
           <div class="console-thread-content flex flex-col gap-6">
             <%= render "console/threads/transcript", items: @selected_transcript_items %>
           </div>
-        <% elsif @thread_not_found %>
+        <% else %>
           <div class="flex h-full items-center justify-center px-6">
             <div class="flex max-w-sm flex-col items-center gap-3 text-center">
               <div class="flex size-12 items-center justify-center rounded-full border border-ink-700 bg-ink-850/60 text-zinc-500">
@@ -77,31 +76,10 @@
               <div class="text-sm font-semibold text-zinc-200">Chat not found</div>
             </div>
           </div>
-        <% elsif @sessions.empty? %>
-          <div class="flex h-full items-center justify-center px-6">
-            <div class="flex max-w-sm flex-col items-center gap-3 text-center">
-              <div class="flex size-12 items-center justify-center rounded-full border border-ink-700 bg-ink-850/60 text-zinc-500">
-                <%= console_icon("message-square", classes: "size-5") %>
-              </div>
-              <div class="text-sm font-semibold text-zinc-200">No chats yet</div>
-              <p class="text-sm leading-6 text-zinc-500">
-                Chats you start — from Slack or the Console — will show up here.
-              </p>
-            </div>
-          </div>
-        <% else %>
-          <div class="flex h-full items-center justify-center px-6">
-            <div class="flex max-w-sm flex-col items-center gap-3 text-center">
-              <div class="flex size-12 items-center justify-center rounded-full border border-ink-700 bg-ink-850/60 text-zinc-500">
-                <%= console_icon("message-square", classes: "size-5") %>
-              </div>
-              <div class="text-sm font-semibold text-zinc-200">Select a chat from the sidebar</div>
-            </div>
-          </div>
         <% end %>
       </div>
 
-      <% if @selected_session && !console_threads_read_only? %>
+      <% if @selected_session %>
         <div class="console-composer-dock">
           <div class="console-thread-content">
             <%= render "console/threads/composer", mode: :thread, session: @selected_session %>

--- a/services/console/app/views/layouts/console.html.erb
+++ b/services/console/app/views/layouts/console.html.erb
@@ -240,6 +240,12 @@
         font-weight: 500;
       }
 
+      /* Keep stacked group tabs (Workflows / New chat / Chats) on the same
+         0.125rem rhythm as the nav rows above them. */
+      .console-thread-group + .console-thread-group {
+        margin-top: 0.125rem;
+      }
+
       .console-thread-group-title {
         display: flex;
         height: 2.35rem;
@@ -977,26 +983,6 @@
         text-align: center;
       }
 
-      .console-new-chat-link {
-        color: #a1a1aa;
-      }
-
-      /* New chat is an action row, not a nav destination: hover brightens the
-         text instead of drawing a pill, so it never stacks against the active
-         Chats pill right below it. */
-      .console-new-chat-link:hover {
-        background: transparent;
-        color: #f4f4f5;
-      }
-
-      .console-new-chat-link .console-nav-icon {
-        position: absolute;
-        left: 0.95rem;
-        top: 50%;
-        transform: translateY(-50%);
-        display: grid;
-        place-items: center;
-      }
 
       .console-control-tabs {
         display: flex;
@@ -1486,15 +1472,6 @@
         color: #1c1f23;
       }
 
-      html[data-console-theme="light"] .console-new-chat-link {
-        color: #565c63;
-      }
-
-      html[data-console-theme="light"] .console-new-chat-link:hover {
-        background: transparent;
-        color: #1c1f23;
-      }
-
       @media (max-width: 760px) {
         .console-sidebar {
           width: 11rem;
@@ -1588,16 +1565,19 @@
             </div>
           <% end %>
 
-          <div class="console-thread-group">
-            <% unless console_threads_read_only? %>
+          <% unless console_threads_read_only? %>
+            <div class="console-thread-group">
               <a href="<%= console_threads_path(new: 1) %>"
-                 class="console-thread-link console-new-chat-link"
+                 class="console-thread-group-title"
                  aria-label="New chat"
                  title="New chat">
                 <span class="console-nav-icon"><%= console_icon("plus", classes: "size-4") %></span>
-                <span class="console-thread-title">New chat</span>
+                <span class="console-nav-label">New chat</span>
               </a>
-            <% end %>
+            </div>
+          <% end %>
+
+          <div class="console-thread-group">
             <a href="<%= console_threads_path %>"
                class="console-thread-group-title <%= "console-thread-group-title-active" if threads_view %>"
                title="Chats">

--- a/services/console/app/views/layouts/console.html.erb
+++ b/services/console/app/views/layouts/console.html.erb
@@ -884,7 +884,7 @@
         gap: 0.4rem;
         max-width: 16rem;
         border-radius: 999px;
-        background: rgba(255, 255, 255, 0.05);
+        background: transparent;
         padding: 0.3rem 0.75rem;
         color: #a1a1aa;
         font-size: 0.8125rem;
@@ -1466,7 +1466,7 @@
       }
 
       html[data-console-theme="light"] .console-composer-model-trigger {
-        background: rgba(15, 18, 20, 0.06);
+        background: transparent;
         color: #565c63;
       }
 

--- a/services/console/app/views/layouts/console.html.erb
+++ b/services/console/app/views/layouts/console.html.erb
@@ -818,6 +818,159 @@
         opacity: 1;
       }
 
+      /* Chat composer — the full-page New-chat card and the dock pinned under
+         open transcripts share one box; the dock only adds placement. */
+      .console-composer-dock {
+        flex: 0 0 auto;
+        padding: 0.75rem 0 1rem;
+        border-top: 1px solid rgba(255, 255, 255, 0.08);
+      }
+
+      .console-composer-dock--panel {
+        padding: 0.6rem 0.75rem 0.75rem;
+      }
+
+      .console-composer-box {
+        display: flex;
+        flex-direction: column;
+        gap: 0.4rem;
+        border: 1px solid rgba(255, 255, 255, 0.1);
+        border-radius: 1.25rem;
+        background: rgba(255, 255, 255, 0.035);
+        padding: 0.75rem 0.875rem 0.625rem;
+        transition: border-color 120ms ease;
+      }
+
+      .console-composer-box:focus-within {
+        border-color: rgba(255, 255, 255, 0.22);
+      }
+
+      .console-composer-input {
+        width: 100%;
+        resize: none;
+        border: 0;
+        background: transparent;
+        color: #f4f4f5;
+        font-size: 0.875rem;
+        line-height: 1.5;
+        outline: none;
+      }
+
+      .console-composer-input::placeholder {
+        color: #71717a;
+      }
+
+      .console-composer-controls {
+        display: flex;
+        align-items: center;
+        gap: 0.75rem;
+        min-width: 0;
+      }
+
+      .console-composer-spacer {
+        flex: 1;
+      }
+
+      .console-composer-control {
+        display: flex;
+        align-items: center;
+        gap: 0.4rem;
+        min-width: 0;
+      }
+
+      .console-composer-control-label {
+        color: #71717a;
+        font-size: 0.75rem;
+        font-weight: 500;
+      }
+
+      .console-composer-select {
+        max-width: 14rem;
+        border: 1px solid rgba(255, 255, 255, 0.1);
+        border-radius: 0.625rem;
+        background: rgba(11, 11, 13, 0.45);
+        color: #d4d4d8;
+        font-size: 0.8125rem;
+        padding: 0.3rem 0.5rem;
+      }
+
+      .console-composer-note,
+      .console-composer-meta {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        color: #71717a;
+        font-size: 0.75rem;
+      }
+
+      .console-composer-send {
+        display: grid;
+        height: 2rem;
+        width: 2rem;
+        flex: 0 0 auto;
+        place-items: center;
+        border-radius: 999px;
+        background: #28c26a;
+        color: #0b0b0d;
+        transition: background 120ms ease;
+      }
+
+      .console-composer-send:hover {
+        background: #3ace79;
+      }
+
+      /* Full-page New-chat composer: centered column, chat-app style. */
+      .console-new-chat {
+        width: 100%;
+        max-width: 42rem;
+        display: flex;
+        flex-direction: column;
+        gap: 0.5rem;
+      }
+
+      .console-new-chat-title {
+        color: #f4f4f5;
+        font-size: 1.375rem;
+        font-weight: 600;
+        text-align: center;
+      }
+
+      .console-new-chat-subtitle {
+        margin-bottom: 1rem;
+        color: #71717a;
+        font-size: 0.875rem;
+        text-align: center;
+      }
+
+      .console-new-chat-link {
+        color: #a1a1aa;
+      }
+
+      .console-new-chat-cta {
+        border-radius: 999px;
+        padding: 0.375rem 1rem;
+        background: rgba(40, 194, 106, 0.12);
+        box-shadow: inset 0 0 0 1px rgba(40, 194, 106, 0.3);
+        color: #3ace79;
+        font-size: 0.875rem;
+        font-weight: 500;
+        text-decoration: none;
+        transition: background 120ms ease;
+      }
+
+      .console-new-chat-cta:hover {
+        background: rgba(40, 194, 106, 0.2);
+      }
+
+      .console-new-chat-link .console-nav-icon {
+        position: absolute;
+        left: 0.95rem;
+        top: 50%;
+        transform: translateY(-50%);
+        display: grid;
+        place-items: center;
+      }
+
       .console-control-tabs {
         display: flex;
         gap: 0.25rem;
@@ -1256,6 +1409,57 @@
         color: #8c9198;
       }
 
+      /* Composer: plain-CSS component classes, so the utility-class remaps
+         above never reach them — they need their own light overrides. */
+      html[data-console-theme="light"] .console-composer-dock {
+        border-top-color: rgba(15, 18, 20, 0.08);
+      }
+
+      html[data-console-theme="light"] .console-composer-box {
+        border-color: rgba(15, 18, 20, 0.14);
+        background: #ffffff;
+      }
+
+      html[data-console-theme="light"] .console-composer-box:focus-within {
+        border-color: rgba(15, 18, 20, 0.3);
+      }
+
+      html[data-console-theme="light"] .console-composer-input {
+        color: #1c1f23;
+      }
+
+      html[data-console-theme="light"] .console-composer-input::placeholder {
+        color: #8c9198;
+      }
+
+      html[data-console-theme="light"] .console-composer-select {
+        border-color: rgba(15, 18, 20, 0.14);
+        background: #f4f5f6;
+        color: #30343a;
+      }
+
+      html[data-console-theme="light"] .console-composer-control-label,
+      html[data-console-theme="light"] .console-composer-note,
+      html[data-console-theme="light"] .console-composer-meta {
+        color: #6f757c;
+      }
+
+      html[data-console-theme="light"] .console-composer-send {
+        color: #ffffff;
+      }
+
+      html[data-console-theme="light"] .console-new-chat-title {
+        color: #1c1f23;
+      }
+
+      html[data-console-theme="light"] .console-new-chat-subtitle {
+        color: #6f757c;
+      }
+
+      html[data-console-theme="light"] .console-new-chat-link {
+        color: #565c63;
+      }
+
       @media (max-width: 760px) {
         .console-sidebar {
           width: 11rem;
@@ -1356,6 +1560,15 @@
               <span class="console-nav-icon"><%= console_icon("message-square", classes: "size-4") %></span>
               <span class="console-nav-label">Chats</span>
             </a>
+            <% unless console_threads_read_only? %>
+              <a href="<%= console_threads_path(new: 1) %>"
+                 class="console-thread-link console-new-chat-link <%= "console-thread-link-active" if threads_view && params[:new].present? %>"
+                 aria-label="New chat"
+                 title="New chat">
+                <span class="console-nav-icon"><%= console_icon("plus", classes: "size-4") %></span>
+                <span class="console-thread-title">New chat</span>
+              </a>
+            <% end %>
             <%# The thread list is loaded lazily via a Turbo Frame so the
                 unindexed cross-database sessions query never blocks the primary
                 page render. See ApplicationController#init_console_sidebar_threads

--- a/services/console/app/views/layouts/console.html.erb
+++ b/services/console/app/views/layouts/console.html.erb
@@ -871,14 +871,65 @@
         flex: 1;
       }
 
-      .console-composer-select {
-        max-width: 14rem;
-        border: 1px solid rgba(255, 255, 255, 0.1);
-        border-radius: 0.625rem;
-        background: rgba(11, 11, 13, 0.45);
-        color: #d4d4d8;
+      /* Model picker: a pill trigger opening a popover that reuses the
+         account-menu panel/item classes, so both dropdowns share one design. */
+      .console-composer-model {
+        position: relative;
+        min-width: 0;
+      }
+
+      .console-composer-model-trigger {
+        display: flex;
+        align-items: center;
+        gap: 0.4rem;
+        max-width: 16rem;
+        border-radius: 999px;
+        background: rgba(255, 255, 255, 0.05);
+        padding: 0.3rem 0.75rem;
+        color: #a1a1aa;
         font-size: 0.8125rem;
-        padding: 0.3rem 0.5rem;
+        font-weight: 500;
+        transition: background 120ms ease, color 120ms ease;
+      }
+
+      .console-composer-model-trigger:hover,
+      .console-composer-model-trigger[aria-expanded="true"] {
+        background: rgba(255, 255, 255, 0.09);
+        color: #f4f4f5;
+      }
+
+      .console-composer-model-chevron {
+        display: grid;
+        place-items: center;
+        transform: rotate(90deg);
+        transition: transform 120ms ease;
+      }
+
+      .console-composer-model-trigger[aria-expanded="true"] .console-composer-model-chevron {
+        transform: rotate(-90deg);
+      }
+
+      .console-composer-model-menu {
+        top: calc(100% + 0.4rem);
+        right: auto;
+        bottom: auto;
+        left: 0;
+        width: 15rem;
+      }
+
+      .console-composer-model-option-label {
+        min-width: 0;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        flex: 1;
+        text-align: left;
+      }
+
+      .console-composer-model-check {
+        display: grid;
+        place-items: center;
+        color: #3ace79;
       }
 
       .console-composer-meta {
@@ -1414,10 +1465,19 @@
         color: #8c9198;
       }
 
-      html[data-console-theme="light"] .console-composer-select {
-        border-color: rgba(15, 18, 20, 0.14);
-        background: #f4f5f6;
-        color: #30343a;
+      html[data-console-theme="light"] .console-composer-model-trigger {
+        background: rgba(15, 18, 20, 0.06);
+        color: #565c63;
+      }
+
+      html[data-console-theme="light"] .console-composer-model-trigger:hover,
+      html[data-console-theme="light"] .console-composer-model-trigger[aria-expanded="true"] {
+        background: rgba(15, 18, 20, 0.1);
+        color: #1c1f23;
+      }
+
+      html[data-console-theme="light"] .console-composer-model-check {
+        color: #1f9d55;
       }
 
       html[data-console-theme="light"] .console-composer-meta {

--- a/services/console/app/views/layouts/console.html.erb
+++ b/services/console/app/views/layouts/console.html.erb
@@ -1002,11 +1002,6 @@
         gap: 1rem;
       }
 
-      /* Inside a split-view pane the composer sits higher: panes are short. */
-      .console-new-chat--panel {
-        margin-top: 10vh;
-      }
-
       .console-new-chat-title {
         color: #f4f4f5;
         font-size: 1.25rem;

--- a/services/console/app/views/layouts/console.html.erb
+++ b/services/console/app/views/layouts/console.html.erb
@@ -926,6 +926,25 @@
         width: 15rem;
       }
 
+      /* Root rows of the picker menu: setting name left, current value and a
+         chevron on the right (codex-app style). */
+      .console-composer-menu-value {
+        margin-left: auto;
+        min-width: 0;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        color: #71717a;
+        font-weight: 400;
+      }
+
+      .console-composer-menu-chevron {
+        display: grid;
+        flex: 0 0 auto;
+        place-items: center;
+        color: #71717a;
+      }
+
       .console-composer-model-option-label {
         min-width: 0;
         overflow: hidden;
@@ -1461,6 +1480,11 @@
 
       html[data-console-theme="light"] .console-composer-model-check {
         color: #1f9d55;
+      }
+
+      html[data-console-theme="light"] .console-composer-menu-value,
+      html[data-console-theme="light"] .console-composer-menu-chevron {
+        color: #8c9198;
       }
 
       html[data-console-theme="light"] .console-thinking-pending {

--- a/services/console/app/views/layouts/console.html.erb
+++ b/services/console/app/views/layouts/console.html.erb
@@ -825,11 +825,12 @@
       }
 
       /* Chat composer — the full-page New-chat card and the dock pinned under
-         open transcripts share one box; the dock only adds placement. */
+         open transcripts share one box; the dock only adds placement. No
+         separator rule: the rounded box already reads as the boundary, and a
+         full-bleed hairline over the narrower transcript column looks off. */
       .console-composer-dock {
         flex: 0 0 auto;
-        padding: 0.75rem 0 1rem;
-        border-top: 1px solid rgba(255, 255, 255, 0.08);
+        padding: 0.25rem 0 1rem;
       }
 
       .console-composer-dock--panel {
@@ -1424,10 +1425,6 @@
 
       /* Composer: plain-CSS component classes, so the utility-class remaps
          above never reach them — they need their own light overrides. */
-      html[data-console-theme="light"] .console-composer-dock {
-        border-top-color: rgba(15, 18, 20, 0.08);
-      }
-
       html[data-console-theme="light"] .console-composer-box {
         border-color: rgba(15, 18, 20, 0.14);
         background: #ffffff;
@@ -1830,7 +1827,56 @@
           });
         };
 
-        document.addEventListener("turbo:load", syncSidebarActiveThreads);
+        // A chat the turbo-permanent list has never seen (just started from
+        // the composer, or older than the list window) appears immediately as
+        // an optimistic row, then the frame refetches so the server's row,
+        // title, and ordering replace it.
+        const SIDEBAR_THREADS_PATH = "<%= console_sidebar_threads_path %>";
+
+        const ensureActiveThreadRow = () => {
+          const url = new URL(window.location.href);
+          if (!url.pathname.startsWith(THREADS_PATH)) return;
+          const openKeys = (url.searchParams.get("thread") || "").split(",").filter(Boolean);
+          const primary = openKeys[0];
+          if (!primary) return;
+
+          const frame = document.getElementById("console_sidebar_threads");
+          if (!frame) return;
+          // Still on the lazy-load placeholder: the initial fetch carries the
+          // thread param and will include this chat on its own.
+          if (!frame.querySelector("[data-console-thread-link], .console-thread-empty")) return;
+
+          const known = Array.from(frame.querySelectorAll("[data-console-thread-link]")).some((link) =>
+            new URL(link.href, window.location.origin).searchParams.get("thread") === primary
+          );
+          if (known) return;
+
+          frame.querySelector(".console-thread-empty")?.remove();
+          const title = document.querySelector(".console-thread-detail-header h1")?.textContent?.trim() || primary;
+          const link = document.createElement("a");
+          link.href = `${THREADS_PATH}?thread=${encodeURIComponent(primary)}`;
+          link.className = "console-thread-link";
+          link.setAttribute("data-console-thread-link", "true");
+          link.title = title;
+          const titleSpan = document.createElement("span");
+          titleSpan.className = "console-thread-title";
+          titleSpan.textContent = title;
+          const timeSpan = document.createElement("span");
+          timeSpan.className = "console-thread-time";
+          timeSpan.textContent = "now";
+          link.append(titleSpan, timeSpan);
+          frame.prepend(link);
+          syncSidebarActiveThreads();
+
+          const src = new URL(SIDEBAR_THREADS_PATH, window.location.origin);
+          src.searchParams.set("thread", openKeys.join(","));
+          frame.setAttribute("src", src.toString());
+        };
+
+        document.addEventListener("turbo:load", () => {
+          syncSidebarActiveThreads();
+          ensureActiveThreadRow();
+        });
         document.addEventListener("turbo:frame-load", (event) => {
           if (event.target && event.target.id === "console_sidebar_threads") syncSidebarActiveThreads();
         });

--- a/services/console/app/views/layouts/console.html.erb
+++ b/services/console/app/views/layouts/console.html.erb
@@ -1577,12 +1577,6 @@
           <% end %>
 
           <div class="console-thread-group">
-            <a href="<%= console_threads_path %>"
-               class="console-thread-group-title <%= "console-thread-group-title-active" if threads_view %>"
-               title="Chats">
-              <span class="console-nav-icon"><%= console_icon("message-square", classes: "size-4") %></span>
-              <span class="console-nav-label">Chats</span>
-            </a>
             <% unless console_threads_read_only? %>
               <a href="<%= console_threads_path(new: 1) %>"
                  class="console-thread-link console-new-chat-link"
@@ -1592,6 +1586,12 @@
                 <span class="console-thread-title">New chat</span>
               </a>
             <% end %>
+            <a href="<%= console_threads_path %>"
+               class="console-thread-group-title <%= "console-thread-group-title-active" if threads_view %>"
+               title="Chats">
+              <span class="console-nav-icon"><%= console_icon("message-square", classes: "size-4") %></span>
+              <span class="console-nav-label">Chats</span>
+            </a>
             <%# The thread list is loaded lazily via a Turbo Frame so the
                 unindexed cross-database sessions query never blocks the primary
                 page render. See ApplicationController#init_console_sidebar_threads

--- a/services/console/app/views/layouts/console.html.erb
+++ b/services/console/app/views/layouts/console.html.erb
@@ -909,11 +909,13 @@
         transform: rotate(-90deg);
       }
 
+      /* The picker sits just left of the send button, so the popover hangs
+         from its right edge. */
       .console-composer-model-menu {
         top: calc(100% + 0.4rem);
-        right: auto;
+        right: 0;
         bottom: auto;
-        left: 0;
+        left: auto;
         width: 15rem;
       }
 
@@ -979,21 +981,6 @@
         color: #a1a1aa;
       }
 
-      .console-new-chat-cta {
-        border-radius: 999px;
-        padding: 0.375rem 1rem;
-        background: rgba(40, 194, 106, 0.12);
-        box-shadow: inset 0 0 0 1px rgba(40, 194, 106, 0.3);
-        color: #3ace79;
-        font-size: 0.875rem;
-        font-weight: 500;
-        text-decoration: none;
-        transition: background 120ms ease;
-      }
-
-      .console-new-chat-cta:hover {
-        background: rgba(40, 194, 106, 0.2);
-      }
 
       .console-new-chat-link .console-nav-icon {
         position: absolute;
@@ -1598,7 +1585,7 @@
             </a>
             <% unless console_threads_read_only? %>
               <a href="<%= console_threads_path(new: 1) %>"
-                 class="console-thread-link console-new-chat-link <%= "console-thread-link-active" if threads_view && params[:new].present? %>"
+                 class="console-thread-link console-new-chat-link"
                  aria-label="New chat"
                  title="New chat">
                 <span class="console-nav-icon"><%= console_icon("plus", classes: "size-4") %></span>

--- a/services/console/app/views/layouts/console.html.erb
+++ b/services/console/app/views/layouts/console.html.erb
@@ -941,12 +941,18 @@
         color: #3ace79;
       }
 
-      .console-composer-meta {
-        overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
-        color: #71717a;
-        font-size: 0.75rem;
+      /* "Thinking…" placeholder while a turn is executing, painted both by
+         the server (_thinking_indicator) and the composer's optimistic JS. */
+      .console-thinking-pending {
+        color: #8b8b94;
+        font-size: 0.875rem;
+        line-height: 1.5;
+        animation: console-thinking-pulse 1.6s ease-in-out infinite;
+      }
+
+      @keyframes console-thinking-pulse {
+        0%, 100% { opacity: 0.45; }
+        50% { opacity: 1; }
       }
 
       .console-composer-send {
@@ -1457,7 +1463,7 @@
         color: #1f9d55;
       }
 
-      html[data-console-theme="light"] .console-composer-meta {
+      html[data-console-theme="light"] .console-thinking-pending {
         color: #6f757c;
       }
 

--- a/services/console/app/views/layouts/console.html.erb
+++ b/services/console/app/views/layouts/console.html.erb
@@ -1002,6 +1002,11 @@
         gap: 1rem;
       }
 
+      /* Inside a split-view pane the composer sits higher: panes are short. */
+      .console-new-chat--panel {
+        margin-top: 10vh;
+      }
+
       .console-new-chat-title {
         color: #f4f4f5;
         font-size: 1.25rem;
@@ -1592,11 +1597,17 @@
             </div>
           <% end %>
 
+          <%# New chat rides the thread-link machinery with the "new" sentinel
+              key: plain click opens the full-page composer, Cmd/Ctrl-click
+              adds a composer pane to the split view (and re-clicking an open
+              one closes it). %>
           <div class="console-thread-group">
-            <a href="<%= console_threads_path(new: 1) %>"
+            <a href="<%= console_threads_path(thread: Console::ThreadsController::NEW_PANE_KEY) %>"
                class="console-thread-group-title"
                aria-label="New chat"
-               title="New chat">
+               title="New chat"
+               data-console-thread-link
+               data-console-new-chat>
               <span class="console-nav-icon"><%= console_icon("plus", classes: "size-4") %></span>
               <span class="console-nav-label">New chat</span>
             </a>
@@ -1837,6 +1848,9 @@
             : [];
 
           document.querySelectorAll("[data-console-thread-link]").forEach((link) => {
+            // The New chat tab participates in open/close clicks but is not a
+            // thread row: no open-dot or pane-number decoration.
+            if (link.dataset.consoleNewChat !== undefined) return;
             const key = new URL(link.href, window.location.origin).searchParams.get("thread");
             const paneIndex = openKeys.indexOf(key);
             const open = paneIndex !== -1;
@@ -1866,7 +1880,8 @@
           if (!url.pathname.startsWith(THREADS_PATH)) return;
           const openKeys = (url.searchParams.get("thread") || "").split(",").filter(Boolean);
           const primary = openKeys[0];
-          if (!primary) return;
+          // "new" is the composer-pane sentinel, not a thread.
+          if (!primary || primary === "new") return;
 
           const frame = document.getElementById("console_sidebar_threads");
           if (!frame) return;

--- a/services/console/app/views/layouts/console.html.erb
+++ b/services/console/app/views/layouts/console.html.erb
@@ -871,19 +871,6 @@
         flex: 1;
       }
 
-      .console-composer-control {
-        display: flex;
-        align-items: center;
-        gap: 0.4rem;
-        min-width: 0;
-      }
-
-      .console-composer-control-label {
-        color: #71717a;
-        font-size: 0.75rem;
-        font-weight: 500;
-      }
-
       .console-composer-select {
         max-width: 14rem;
         border: 1px solid rgba(255, 255, 255, 0.1);
@@ -894,7 +881,6 @@
         padding: 0.3rem 0.5rem;
       }
 
-      .console-composer-note,
       .console-composer-meta {
         overflow: hidden;
         text-overflow: ellipsis;
@@ -919,26 +905,22 @@
         background: #3ace79;
       }
 
-      /* Full-page New-chat composer: centered column, chat-app style. */
+      /* Full-page New-chat composer. Sits a bit above vertical center (the
+         claude.ai-style resting height) and matches the transcript column
+         width so it reads as an empty chat, not a separate page. */
       .console-new-chat {
         width: 100%;
-        max-width: 42rem;
+        max-width: 48rem;
+        margin-top: 28vh;
         display: flex;
         flex-direction: column;
-        gap: 0.5rem;
+        gap: 1rem;
       }
 
       .console-new-chat-title {
         color: #f4f4f5;
-        font-size: 1.375rem;
+        font-size: 1.25rem;
         font-weight: 600;
-        text-align: center;
-      }
-
-      .console-new-chat-subtitle {
-        margin-bottom: 1rem;
-        color: #71717a;
-        font-size: 0.875rem;
         text-align: center;
       }
 
@@ -1438,8 +1420,6 @@
         color: #30343a;
       }
 
-      html[data-console-theme="light"] .console-composer-control-label,
-      html[data-console-theme="light"] .console-composer-note,
       html[data-console-theme="light"] .console-composer-meta {
         color: #6f757c;
       }
@@ -1450,10 +1430,6 @@
 
       html[data-console-theme="light"] .console-new-chat-title {
         color: #1c1f23;
-      }
-
-      html[data-console-theme="light"] .console-new-chat-subtitle {
-        color: #6f757c;
       }
 
       html[data-console-theme="light"] .console-new-chat-link {

--- a/services/console/app/views/layouts/console.html.erb
+++ b/services/console/app/views/layouts/console.html.erb
@@ -1562,17 +1562,15 @@
             </div>
           <% end %>
 
-          <% unless console_threads_read_only? %>
-            <div class="console-thread-group">
-              <a href="<%= console_threads_path(new: 1) %>"
-                 class="console-thread-group-title"
-                 aria-label="New chat"
-                 title="New chat">
-                <span class="console-nav-icon"><%= console_icon("plus", classes: "size-4") %></span>
-                <span class="console-nav-label">New chat</span>
-              </a>
-            </div>
-          <% end %>
+          <div class="console-thread-group">
+            <a href="<%= console_threads_path(new: 1) %>"
+               class="console-thread-group-title"
+               aria-label="New chat"
+               title="New chat">
+              <span class="console-nav-icon"><%= console_icon("plus", classes: "size-4") %></span>
+              <span class="console-nav-label">New chat</span>
+            </a>
+          </div>
 
           <div class="console-thread-group">
             <a href="<%= console_threads_path %>"

--- a/services/console/app/views/layouts/console.html.erb
+++ b/services/console/app/views/layouts/console.html.erb
@@ -981,6 +981,13 @@
         color: #a1a1aa;
       }
 
+      /* New chat is an action row, not a nav destination: hover brightens the
+         text instead of drawing a pill, so it never stacks against the active
+         Chats pill right below it. */
+      .console-new-chat-link:hover {
+        background: transparent;
+        color: #f4f4f5;
+      }
 
       .console-new-chat-link .console-nav-icon {
         position: absolute;
@@ -1481,6 +1488,11 @@
 
       html[data-console-theme="light"] .console-new-chat-link {
         color: #565c63;
+      }
+
+      html[data-console-theme="light"] .console-new-chat-link:hover {
+        background: transparent;
+        color: #1c1f23;
       }
 
       @media (max-width: 760px) {

--- a/services/console/test/controllers/console/threads_controller_test.rb
+++ b/services/console/test/controllers/console/threads_controller_test.rb
@@ -738,6 +738,36 @@ class Console::ThreadsControllerTest < ActionDispatch::IntegrationTest
     assert_equal "gpt-5.5", create[:metadata][:model]
   end
 
+  test "a codex chat carries the picked reasoning effort" do
+    client = RecordingApiClient.new
+    with_composer(client: client) do
+      post console_threads_url,
+           params: { prompt: "Reply with PONG.", model: "gpt-5.6-sol", effort: "max" }
+    end
+
+    execute = client.calls[2].last
+    assert_equal "max", execute[:metadata][:reasoning]
+    line = JSON.parse(execute[:input_lines].first)
+    assert_equal "max", line["reasoning"]
+  end
+
+  test "an effort the model does not offer is dropped" do
+    client = RecordingApiClient.new
+    with_composer(client: client) do
+      # max is 5.6-only; claude models take no effort at all.
+      post console_threads_url,
+           params: { prompt: "Reply with PONG.", model: "gpt-5.5", effort: "max" }
+      post console_threads_url,
+           params: { prompt: "Reply with PONG.", model: "claude-opus-4-8", effort: "high" }
+    end
+
+    [ 2, 5 ].each do |index|
+      execute = client.calls[index].last
+      assert_not execute[:metadata].key?(:reasoning)
+      assert_not JSON.parse(execute[:input_lines].first).key?("reasoning")
+    end
+  end
+
   test "a blank prompt asks for a message" do
     client = RecordingApiClient.new
     with_composer(client: client) do

--- a/services/console/test/controllers/console/threads_controller_test.rb
+++ b/services/console/test/controllers/console/threads_controller_test.rb
@@ -675,6 +675,18 @@ class Console::ThreadsControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test "writable mode shows the new chat screen when nothing is selected" do
+    with_composer do
+      with_recent_first_error do
+        get console_threads_url
+      end
+    end
+
+    assert_response :ok
+    assert_select "textarea[name=prompt]", count: 1
+    assert_select "body", text: /No chats yet/, count: 0
+  end
+
   test "writable mode renders a follow-up composer on an open chat" do
     skip_unless_session_table
     insert_console_session("console:composer-open")

--- a/services/console/test/controllers/console/threads_controller_test.rb
+++ b/services/console/test/controllers/console/threads_controller_test.rb
@@ -667,9 +667,11 @@ class Console::ThreadsControllerTest < ActionDispatch::IntegrationTest
     assert_select "a[aria-label=?]", "New chat", count: 1
     assert_select "form[action=?]", console_threads_path do
       assert_select "textarea[name=prompt]", count: 1
-      assert_select "select[name=model]", count: 1
-      assert_select "select[name=model] option[value=?]", "amp"
-      assert_select "select[name=harness_type]", count: 0
+      # The model picker is a custom menu (account-dropdown style) posting
+      # through a hidden field, not a native select.
+      assert_select "input[type=hidden][name=model]", count: 1
+      assert_select "[data-console-model-option][data-value=?]", "amp"
+      assert_select "select", count: 0
     end
   end
 
@@ -686,7 +688,7 @@ class Console::ThreadsControllerTest < ActionDispatch::IntegrationTest
       assert_select "input[type=hidden][name=thread_key][value=?]", "console:composer-open"
       assert_select "textarea[name=prompt]", count: 1
       # Follow-ups stay on the chat's existing harness/model: no picker.
-      assert_select "select[name=model]", count: 0
+      assert_select "[data-console-model-picker]", count: 0
     end
   end
 

--- a/services/console/test/controllers/console/threads_controller_test.rb
+++ b/services/console/test/controllers/console/threads_controller_test.rb
@@ -37,8 +37,10 @@ class Console::ThreadsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "threads page does not render composer when session database is unavailable" do
-    with_recent_first_error do
-      get console_threads_url
+    with_threads_read_only do
+      with_recent_first_error do
+        get console_threads_url
+      end
     end
 
     assert_response :ok
@@ -57,15 +59,19 @@ class Console::ThreadsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "blank prompt is blocked by read only mode" do
-    post console_threads_url, params: { prompt: " " }
+    with_threads_read_only do
+      post console_threads_url, params: { prompt: " " }
+    end
 
     assert_redirected_to console_threads_path
     assert_equal "Chats are read-only while browsing a mirrored production snapshot.", flash[:alert]
   end
 
   test "threads page hides composer controls" do
-    with_recent_first_error do
-      get console_threads_url
+    with_threads_read_only do
+      with_recent_first_error do
+        get console_threads_url
+      end
     end
 
     assert_response :ok
@@ -77,7 +83,9 @@ class Console::ThreadsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "posts are blocked without calling the session api" do
-    post console_threads_url, params: { prompt: "Do not run this." }
+    with_threads_read_only do
+      post console_threads_url, params: { prompt: "Do not run this." }
+    end
 
     assert_redirected_to console_threads_path
     assert_equal "Chats are read-only while browsing a mirrored production snapshot.", flash[:alert]
@@ -626,22 +634,179 @@ class Console::ThreadsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "starting a thread is blocked without calling the session api" do
-    post console_threads_url, params: { prompt: "Reply with PONG.", harness_type: "amp" }
+    with_threads_read_only do
+      post console_threads_url, params: { prompt: "Reply with PONG.", harness_type: "amp" }
+    end
 
     assert_redirected_to console_threads_path
     assert_equal "Chats are read-only while browsing a mirrored production snapshot.", flash[:alert]
   end
 
   test "posting to an existing thread is blocked without calling the session api" do
-    post console_threads_url,
-         params: {
-           prompt: "Continue from here.",
-           thread_key: "console:existing",
-           harness_type: "codex"
-         }
+    with_threads_read_only do
+      post console_threads_url,
+           params: {
+             prompt: "Continue from here.",
+             thread_key: "console:existing",
+             harness_type: "codex"
+           }
+    end
 
     assert_redirected_to console_threads_path(thread: "console:existing")
     assert_equal "Chats are read-only while browsing a mirrored production snapshot.", flash[:alert]
+  end
+
+  test "writable mode renders the sidebar New chat link and the full-page composer" do
+    with_composer do
+      with_recent_first_error do
+        get console_threads_url(new: 1)
+      end
+    end
+
+    assert_response :ok
+    assert_select "a[aria-label=?]", "New chat", count: 1
+    assert_select "form[action=?]", console_threads_path do
+      assert_select "textarea[name=prompt]", count: 1
+      assert_select "select[name=harness_type]", count: 1
+      assert_select "select[name=model]", count: 1
+    end
+  end
+
+  test "writable mode renders a follow-up composer on an open chat" do
+    skip_unless_session_table
+    insert_console_session("console:composer-open")
+
+    with_composer do
+      get console_threads_url(thread: "console:composer-open")
+    end
+
+    assert_response :ok
+    assert_select "form[action=?]", console_threads_path do
+      assert_select "input[type=hidden][name=thread_key][value=?]", "console:composer-open"
+      assert_select "textarea[name=prompt]", count: 1
+      # Follow-ups stay on the chat's existing harness/model: no pickers.
+      assert_select "select[name=harness_type]", count: 0
+    end
+  end
+
+  test "starting a chat creates a session, appends the prompt, and executes it" do
+    client = RecordingApiClient.new
+    with_composer(client: client) do
+      post console_threads_url,
+           params: { prompt: "Reply with PONG.", harness_type: "claudecode", model: "claude-opus-4-8" }
+    end
+
+    assert_equal %i[create_session append_session_messages execute_session], client.calls.map(&:first)
+
+    create = client.calls[0].last
+    assert create[:thread_key].start_with?("console:"), "expected a console:-namespaced thread key"
+    assert_equal "claudecode", create[:harness_type]
+    assert_equal "console", create[:metadata][:platform]
+    assert_equal "console", create[:metadata][:source]
+    assert_equal @operator.email, create[:metadata][:actor_email]
+    assert_equal "claude-opus-4-8", create[:metadata][:model]
+
+    append = client.calls[1].last
+    assert_equal create[:thread_key], append[:thread_key]
+    message = append[:messages].first
+    assert_equal "user", message[:role]
+    assert_equal "Reply with PONG.", message[:parts].first[:text]
+    assert_equal @operator.email, message[:metadata][:user_email]
+
+    execute = client.calls[2].last
+    assert_equal create[:thread_key], execute[:thread_key]
+    assert execute[:idempotency_key].present?
+    assert_equal "claude-opus-4-8", execute[:metadata][:model]
+    line = JSON.parse(execute[:input_lines].first)
+    assert_equal "user", line["type"]
+    assert_equal create[:thread_key], line["thread_key"]
+    assert_equal "claude-opus-4-8", line["model"]
+    assert_equal message[:client_message_id], line["client_user_message_id"]
+    assert_equal "Reply with PONG.", line.dig("message", "content", 0, "text")
+
+    assert_redirected_to console_threads_path(thread: create[:thread_key])
+  end
+
+  test "starting an amp chat sends no model" do
+    client = RecordingApiClient.new
+    with_composer(client: client) do
+      post console_threads_url,
+           params: { prompt: "Reply with PONG.", harness_type: "amp", model: "claude-opus-4-8" }
+    end
+
+    create = client.calls[0].last
+    assert_equal "amp", create[:harness_type]
+    assert_not create[:metadata].key?(:model)
+
+    execute = client.calls[2].last
+    assert_not execute[:metadata].key?(:model)
+    line = JSON.parse(execute[:input_lines].first)
+    assert_not line.key?("model")
+  end
+
+  test "starting a chat with an unknown harness is rejected" do
+    client = RecordingApiClient.new
+    with_composer(client: client) do
+      post console_threads_url, params: { prompt: "Reply with PONG.", harness_type: "hal9000" }
+    end
+
+    assert_empty client.calls
+    assert_redirected_to console_threads_path(new: 1)
+    assert_match(/Unknown harness/, flash[:alert])
+  end
+
+  test "a blank prompt in writable mode asks for a message" do
+    client = RecordingApiClient.new
+    with_composer(client: client) do
+      post console_threads_url, params: { prompt: "   " }
+    end
+
+    assert_empty client.calls
+    assert_redirected_to console_threads_path(new: 1)
+    assert_equal "Type a message first.", flash[:alert]
+  end
+
+  test "replying appends and executes on an owned chat without creating a session" do
+    skip_unless_session_table
+    insert_console_session("console:composer-reply")
+
+    client = RecordingApiClient.new
+    with_composer(client: client) do
+      post console_threads_url,
+           params: {
+             prompt: "Continue from here.",
+             thread_key: "console:composer-reply",
+             open_threads: "console:composer-reply,console:other"
+           }
+    end
+
+    assert_equal %i[append_session_messages execute_session], client.calls.map(&:first)
+    assert_equal "console:composer-reply", client.calls[0].last[:thread_key]
+    assert_redirected_to console_threads_path(thread: "console:composer-reply,console:other")
+  end
+
+  test "replying into a chat outside the owner scope is rejected" do
+    skip_unless_session_table
+
+    client = RecordingApiClient.new
+    with_composer(client: client) do
+      post console_threads_url,
+           params: { prompt: "Continue from here.", thread_key: "console:not-mine" }
+    end
+
+    assert_empty client.calls
+    assert_redirected_to console_threads_path
+    assert_equal "Chat not found.", flash[:alert]
+  end
+
+  test "a session api error surfaces as a flash alert" do
+    client = RecordingApiClient.new(error: CentaurApiClient::Error.new("boom"))
+    with_composer(client: client) do
+      post console_threads_url, params: { prompt: "Reply with PONG.", harness_type: "codex" }
+    end
+
+    assert_redirected_to console_threads_path(new: 1)
+    assert_match(/boom/, flash[:alert])
   end
 
   # Fix 6: the sidebar thread list is loaded lazily via a Turbo Frame so the
@@ -1152,6 +1317,46 @@ class Console::ThreadsControllerTest < ActionDispatch::IntegrationTest
   end
 
   private
+
+  # Fake CentaurApiClient recording every composer call; raises `error` from
+  # each method instead when given, to exercise the failure paths.
+  class RecordingApiClient
+    attr_reader :calls
+
+    def initialize(error: nil)
+      @calls = []
+      @error = error
+    end
+
+    def create_session(**kwargs) = record(:create_session, kwargs)
+    def append_session_messages(**kwargs) = record(:append_session_messages, kwargs)
+    def execute_session(**kwargs) = record(:execute_session, kwargs)
+
+    private
+
+    def record(name, kwargs)
+      raise @error if @error
+
+      @calls << [ name, kwargs ]
+      {}
+    end
+  end
+
+  # Read-only is the unset-env default; pinned explicitly so the suite is
+  # deterministic when the runner exports CENTAUR_CONSOLE_THREADS_READ_ONLY=0
+  # (the local dev container does).
+  def with_threads_read_only(&block)
+    with_env("CENTAUR_CONSOLE_THREADS_READ_ONLY" => nil, "IRON_CONTROL_THREADS_READ_ONLY" => nil, &block)
+  end
+
+  # Runs the block with chats writable and the injected fake session client.
+  def with_composer(client: RecordingApiClient.new)
+    original_factory = Console::ThreadsController.client_factory
+    Console::ThreadsController.client_factory = -> { client }
+    with_env("CENTAUR_CONSOLE_THREADS_READ_ONLY" => "0") { yield client }
+  ensure
+    Console::ThreadsController.client_factory = original_factory
+  end
 
   # Sets each env var for the block (nil deletes) and restores the previous
   # values afterwards.

--- a/services/console/test/controllers/console/threads_controller_test.rb
+++ b/services/console/test/controllers/console/threads_controller_test.rb
@@ -667,8 +667,9 @@ class Console::ThreadsControllerTest < ActionDispatch::IntegrationTest
     assert_select "a[aria-label=?]", "New chat", count: 1
     assert_select "form[action=?]", console_threads_path do
       assert_select "textarea[name=prompt]", count: 1
-      assert_select "select[name=harness_type]", count: 1
       assert_select "select[name=model]", count: 1
+      assert_select "select[name=model] option[value=?]", "amp"
+      assert_select "select[name=harness_type]", count: 0
     end
   end
 
@@ -684,8 +685,8 @@ class Console::ThreadsControllerTest < ActionDispatch::IntegrationTest
     assert_select "form[action=?]", console_threads_path do
       assert_select "input[type=hidden][name=thread_key][value=?]", "console:composer-open"
       assert_select "textarea[name=prompt]", count: 1
-      # Follow-ups stay on the chat's existing harness/model: no pickers.
-      assert_select "select[name=harness_type]", count: 0
+      # Follow-ups stay on the chat's existing harness/model: no picker.
+      assert_select "select[name=model]", count: 0
     end
   end
 
@@ -693,7 +694,7 @@ class Console::ThreadsControllerTest < ActionDispatch::IntegrationTest
     client = RecordingApiClient.new
     with_composer(client: client) do
       post console_threads_url,
-           params: { prompt: "Reply with PONG.", harness_type: "claudecode", model: "claude-opus-4-8" }
+           params: { prompt: "Reply with PONG.", model: "claude-opus-4-8" }
     end
 
     assert_equal %i[create_session append_session_messages execute_session], client.calls.map(&:first)
@@ -727,11 +728,10 @@ class Console::ThreadsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to console_threads_path(thread: create[:thread_key])
   end
 
-  test "starting an amp chat sends no model" do
+  test "picking Amp starts an amp chat and sends no model" do
     client = RecordingApiClient.new
     with_composer(client: client) do
-      post console_threads_url,
-           params: { prompt: "Reply with PONG.", harness_type: "amp", model: "claude-opus-4-8" }
+      post console_threads_url, params: { prompt: "Reply with PONG.", model: "amp" }
     end
 
     create = client.calls[0].last
@@ -744,15 +744,26 @@ class Console::ThreadsControllerTest < ActionDispatch::IntegrationTest
     assert_not line.key?("model")
   end
 
-  test "starting a chat with an unknown harness is rejected" do
+  test "starting a chat with an unknown model is rejected" do
     client = RecordingApiClient.new
     with_composer(client: client) do
-      post console_threads_url, params: { prompt: "Reply with PONG.", harness_type: "hal9000" }
+      post console_threads_url, params: { prompt: "Reply with PONG.", model: "hal9000" }
     end
 
     assert_empty client.calls
     assert_redirected_to console_threads_path(new: 1)
-    assert_match(/Unknown harness/, flash[:alert])
+    assert_match(/Unknown model/, flash[:alert])
+  end
+
+  test "a gpt model pick starts a codex chat" do
+    client = RecordingApiClient.new
+    with_composer(client: client) do
+      post console_threads_url, params: { prompt: "Reply with PONG.", model: "gpt-5.5" }
+    end
+
+    create = client.calls[0].last
+    assert_equal "codex", create[:harness_type]
+    assert_equal "gpt-5.5", create[:metadata][:model]
   end
 
   test "a blank prompt in writable mode asks for a message" do

--- a/services/console/test/controllers/console/threads_controller_test.rb
+++ b/services/console/test/controllers/console/threads_controller_test.rb
@@ -36,59 +36,18 @@ class Console::ThreadsControllerTest < ActionDispatch::IntegrationTest
     assert_select ".console-thread-group-title", text: /Chats/
   end
 
-  test "threads page does not render composer when session database is unavailable" do
-    with_threads_read_only do
-      with_recent_first_error do
-        get console_threads_url
-      end
+  test "threads page falls back to the new chat screen when session database is unavailable" do
+    with_recent_first_error do
+      get console_threads_url
     end
 
     assert_response :ok
-    assert_select "input[name=q]", count: 0
-    assert_select ".console-main-thread-frame aside", count: 0
-    # No chat selected: like the not-found state, the page renders only the
-    # centered empty state — no detail header.
+    # No chat selected: the new-chat composer renders (posting goes through
+    # the API, not the sessions DB), alongside the unavailability note.
     assert_select ".console-thread-detail-header", count: 0
-    assert_select "a[aria-label=?]", "New chat", count: 0
-    assert_select "span[aria-label=?]", "New chat disabled", count: 0
-    assert_select "textarea[name=prompt]", count: 0
-    assert_select "select[name=harness_type]", count: 0
-    assert_select "form[action=?]", console_threads_path, count: 0
-    assert_select "body", text: /No chats yet/
+    assert_select "a[aria-label=?]", "New chat", count: 1
+    assert_select "textarea[name=prompt]", count: 1
     assert_select "body", text: /Chat database is unavailable/
-  end
-
-  test "blank prompt is blocked by read only mode" do
-    with_threads_read_only do
-      post console_threads_url, params: { prompt: " " }
-    end
-
-    assert_redirected_to console_threads_path
-    assert_equal "Chats are read-only while browsing a mirrored production snapshot.", flash[:alert]
-  end
-
-  test "threads page hides composer controls" do
-    with_threads_read_only do
-      with_recent_first_error do
-        get console_threads_url
-      end
-    end
-
-    assert_response :ok
-    assert_select "textarea[name=prompt]", count: 0
-    assert_select "form[action=?]", console_threads_path, count: 0
-    assert_select "body", text: /Read-only snapshot/, count: 0
-    assert_select "span[aria-label=?]", "New chat disabled", count: 0
-    assert_select "a[aria-label=?]", "New chat", count: 0
-  end
-
-  test "posts are blocked without calling the session api" do
-    with_threads_read_only do
-      post console_threads_url, params: { prompt: "Do not run this." }
-    end
-
-    assert_redirected_to console_threads_path
-    assert_equal "Chats are read-only while browsing a mirrored production snapshot.", flash[:alert]
   end
 
   test "plain threads page redirects to first visible thread" do
@@ -633,30 +592,7 @@ class Console::ThreadsControllerTest < ActionDispatch::IntegrationTest
     assert_nil controller.send(:selected_session, scoped_relation, [])
   end
 
-  test "starting a thread is blocked without calling the session api" do
-    with_threads_read_only do
-      post console_threads_url, params: { prompt: "Reply with PONG.", harness_type: "amp" }
-    end
-
-    assert_redirected_to console_threads_path
-    assert_equal "Chats are read-only while browsing a mirrored production snapshot.", flash[:alert]
-  end
-
-  test "posting to an existing thread is blocked without calling the session api" do
-    with_threads_read_only do
-      post console_threads_url,
-           params: {
-             prompt: "Continue from here.",
-             thread_key: "console:existing",
-             harness_type: "codex"
-           }
-    end
-
-    assert_redirected_to console_threads_path(thread: "console:existing")
-    assert_equal "Chats are read-only while browsing a mirrored production snapshot.", flash[:alert]
-  end
-
-  test "writable mode renders the sidebar New chat link and the full-page composer" do
+  test "renders the sidebar New chat link and the full-page composer" do
     with_composer do
       with_recent_first_error do
         get console_threads_url(new: 1)
@@ -675,7 +611,7 @@ class Console::ThreadsControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
-  test "writable mode shows the new chat screen when nothing is selected" do
+  test "shows the new chat screen when nothing is selected" do
     with_composer do
       with_recent_first_error do
         get console_threads_url
@@ -687,7 +623,7 @@ class Console::ThreadsControllerTest < ActionDispatch::IntegrationTest
     assert_select "body", text: /No chats yet/, count: 0
   end
 
-  test "writable mode renders a follow-up composer on an open chat" do
+  test "renders a follow-up composer on an open chat" do
     skip_unless_session_table
     insert_console_session("console:composer-open")
 
@@ -780,7 +716,7 @@ class Console::ThreadsControllerTest < ActionDispatch::IntegrationTest
     assert_equal "gpt-5.5", create[:metadata][:model]
   end
 
-  test "a blank prompt in writable mode asks for a message" do
+  test "a blank prompt asks for a message" do
     client = RecordingApiClient.new
     with_composer(client: client) do
       post console_threads_url, params: { prompt: "   " }
@@ -1367,18 +1303,11 @@ class Console::ThreadsControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
-  # Read-only is the unset-env default; pinned explicitly so the suite is
-  # deterministic when the runner exports CENTAUR_CONSOLE_THREADS_READ_ONLY=0
-  # (the local dev container does).
-  def with_threads_read_only(&block)
-    with_env("CENTAUR_CONSOLE_THREADS_READ_ONLY" => nil, "IRON_CONTROL_THREADS_READ_ONLY" => nil, &block)
-  end
-
-  # Runs the block with chats writable and the injected fake session client.
+  # Runs the block with the injected fake session client.
   def with_composer(client: RecordingApiClient.new)
     original_factory = Console::ThreadsController.client_factory
     Console::ThreadsController.client_factory = -> { client }
-    with_env("CENTAUR_CONSOLE_THREADS_READ_ONLY" => "0") { yield client }
+    yield client
   ensure
     Console::ThreadsController.client_factory = original_factory
   end

--- a/services/console/test/controllers/console/threads_controller_test.rb
+++ b/services/console/test/controllers/console/threads_controller_test.rb
@@ -623,6 +623,28 @@ class Console::ThreadsControllerTest < ActionDispatch::IntegrationTest
     assert_select "body", text: /No chats yet/, count: 0
   end
 
+  test "an active execution renders a thinking indicator" do
+    skip_unless_session_table
+    insert_console_session("console:thinking-active")
+    insert_session_execution("console:thinking-active", status: "running")
+
+    get console_threads_url(thread: "console:thinking-active")
+
+    assert_response :ok
+    assert_select "[data-console-thinking-indicator]", count: 1
+  end
+
+  test "a completed execution renders no thinking indicator" do
+    skip_unless_session_table
+    insert_console_session("console:thinking-done")
+    insert_session_execution("console:thinking-done", status: "completed")
+
+    get console_threads_url(thread: "console:thinking-done")
+
+    assert_response :ok
+    assert_select "[data-console-thinking-indicator]", count: 0
+  end
+
   test "renders a follow-up composer on an open chat" do
     skip_unless_session_table
     insert_console_session("console:composer-open")
@@ -1372,6 +1394,21 @@ class Console::ThreadsControllerTest < ActionDispatch::IntegrationTest
       slack_user_name: slack_user_name
     }.to_json
     insert_session(thread_key, metadata)
+  end
+
+  def insert_session_execution(thread_key, status:)
+    connection = CentaurSession.connection
+    connection.execute(<<~SQL.squish)
+      insert into session_executions (execution_id, thread_key, status, metadata, created_at, updated_at)
+      values (
+        #{connection.quote("#{thread_key}-exec")},
+        #{connection.quote(thread_key)},
+        #{connection.quote(status)},
+        '{}'::jsonb,
+        now(),
+        now()
+      )
+    SQL
   end
 
   def insert_session_message(thread_key, index:)

--- a/services/console/test/controllers/console/threads_controller_test.rb
+++ b/services/console/test/controllers/console/threads_controller_test.rb
@@ -645,6 +645,48 @@ class Console::ThreadsControllerTest < ActionDispatch::IntegrationTest
     assert_select "[data-console-thinking-indicator]", count: 0
   end
 
+  test "a new sentinel pane opens a composer panel alongside a thread" do
+    skip_unless_session_table
+    insert_console_session("console:with-new-pane")
+
+    with_composer do
+      get console_threads_url(thread: "console:with-new-pane,new")
+    end
+
+    assert_response :ok
+    assert_select "[data-thread-panel]", count: 2
+    assert_select "[data-thread-panel=new]", count: 1
+    assert_select "[data-thread-panel=new] textarea[name=prompt]", count: 1
+    assert_select "[data-thread-panel=new] [data-console-model-picker]", count: 1
+  end
+
+  test "the new sentinel alone renders the full-page new chat screen" do
+    with_composer do
+      with_recent_first_error do
+        get console_threads_url(thread: "new")
+      end
+    end
+
+    assert_response :ok
+    assert_select "[data-thread-panel]", count: 0
+    assert_select "textarea[name=prompt]", count: 1
+  end
+
+  test "starting a chat from a pane swaps the sentinel for the created thread" do
+    client = RecordingApiClient.new
+    with_composer(client: client) do
+      post console_threads_url,
+           params: {
+             prompt: "Reply with PONG.",
+             model: "gpt-5.5",
+             open_threads: "console:other,new"
+           }
+    end
+
+    thread_key = client.calls[0].last[:thread_key]
+    assert_redirected_to console_threads_path(thread: "console:other,#{thread_key}")
+  end
+
   test "renders a follow-up composer on an open chat" do
     skip_unless_session_table
     insert_console_session("console:composer-open")


### PR DESCRIPTION
## What

Adds a chat composer to the Console threads view, so chats can be started and continued directly from the Console instead of only via Slack.

- **New chat**: a sidebar tab (above Chats, standard tab geometry/spacing) opens a full-page composer — heading + input box sitting slightly above vertical center, at the transcript column width. The no-selection / no-chats states render this screen directly; only an unresolvable `?thread=` still shows not-found.
- **Model + effort picker**: a two-level menu (codex-app style) — root rows show Model and Effort with current values; submenus check the active choice. Each model pins its harness (Claude Opus/Sonnet/Haiku/Fable → `claudecode`, GPT-5.6 Sol / GPT-5.5 → `codex`, and Amp as a plain entry with no model, since Amp picks its own per turn). GPT-5.6 Sol is the default. Reasoning efforts are per-model (`max` is 5.6-only), apply to codex picks only, and ride the blocks line as `reasoning` — Default sends none so the harness config decides. The popover reuses the account dropdown's panel/item classes and posts through hidden `model`/`effort` fields.
- **Follow-ups**: open chats and split-view panes get a docked composer (prompt only; meta line shows the chat's harness · model). Enter sends, Shift+Enter breaks a line. While a turn is running the page re-visits every 4s — skipped whenever the composer holds a draft.
- **Optimistic sidebar**: a chat the turbo-permanent sidebar list has never seen gets an inserted row immediately (title from the thread header, "now"), then the frame refetches so the server row/ordering replaces it.

## Backend

`POST /console/threads` (previously a read-only stub) now drives api-rs through the existing `CentaurApiClient` — chats are writable unconditionally; the old read-only mode and its `CENTAUR_CONSOLE_THREADS_READ_ONLY` env are removed:

- New thread: `console:<uuid>` key → `create_session` (metadata `platform`/`source=console` + `user_email`/`actor_email`, matching the existing owner scope) → `append_session_messages` → `execute_session` with a blocks-protocol user line carrying the chosen model (omitted for Amp). The same UUID rides as `client_message_id` / `client_user_message_id` so api-rs dedupes the harness echo.
- Reply: the thread key resolves through `visible_thread_scope`, so nobody can post into another user's chat; the recorded model (execution metadata → session metadata → deploy default) is reused. Split-view panes survive the redirect via an `open_threads` field.
- The client is injectable (`client_factory`), mirroring the workflows controller. Note for deployers: the console needs `CENTAUR_CONSOLE_CENTAUR_API_URL` pointed at a live api-rs; posting into a snapshot-only deployment will surface API errors as flash alerts.

## Testing

```
docker exec codex-centaur-console-web bin/rails test test/controllers/console/threads_controller_test.rb
```

68 runs green (composer rendering, start/reply/Amp/unknown-model/error paths, owner-scope rejection, DB-unavailable fallback to the new-chat screen); full controllers suite 577/577; rubocop clean. Verified end-to-end in a browser against a local api-rs (thread started from the composer, reply ran on the picked model/harness, both themes screenshotted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

