### PR TITLE
feat: index private Slack channels behind flag

### DIFF
--- a/contrib/chart/Chart.yaml
+++ b/contrib/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: centaur
 description: Helm chart for the trusted Centaur control plane
 type: application
-version: 0.1.94
+version: 0.1.95
 appVersion: "0.1.0"
 dependencies:
   - name: connect

--- a/contrib/chart/templates/apirs.yaml
+++ b/contrib/chart/templates/apirs.yaml
@@ -75,6 +75,7 @@
   (dict "name" "SLACK_SYNC_INTERVAL_SECONDS" "value" (dig "slack" "syncIntervalSeconds" 3600 $apiRsEtl))
   (dict "name" "SLACK_SYNC_BACKFILL_LOOKBACK_DAYS" "value" (dig "slack" "syncBackfillLookbackDays" 30 $apiRsEtl))
   (dict "name" "SLACK_SYNC_THREAD_LOOKBACK_DAYS" "value" (dig "slack" "syncThreadLookbackDays" 3 $apiRsEtl))
+  (dict "name" "SLACK_SYNC_INDEX_PRIVATE_CHANNELS" "value" (dig "slack" "indexPrivateChannels" false $apiRsEtl))
   (dict "name" "SLACK_ETL_EXCLUDED_CHANNEL_PATTERNS" "value" (dig "slack" "excludedChannelPatterns" "" $apiRsEtl))
   (dict "name" "SLACK_ETL_ATTACHMENTS_ENABLED" "value" (dig "slack" "attachments" "enabled" true $apiRsEtl))
   (dict "name" "SLACK_ETL_ATTACHMENT_MAX_BYTES" "value" (dig "slack" "attachments" "maxBytes" 10485760 $apiRsEtl))

--- a/contrib/chart/values.schema.json
+++ b/contrib/chart/values.schema.json
@@ -277,6 +277,7 @@
                 "syncIntervalSeconds": { "type": "integer" },
                 "syncBackfillLookbackDays": { "type": "integer" },
                 "syncThreadLookbackDays": { "type": "integer" },
+                "indexPrivateChannels": { "type": "boolean" },
                 "excludedChannelPatterns": { "type": "string" },
                 "attachments": {
                   "type": "object",

--- a/contrib/chart/values.yaml
+++ b/contrib/chart/values.yaml
@@ -371,6 +371,7 @@ apiRs:
       syncIntervalSeconds: 3600
       syncBackfillLookbackDays: 30
       syncThreadLookbackDays: 3
+      indexPrivateChannels: false
       excludedChannelPatterns: ""
       attachments:
         enabled: true

--- a/docs/pages/operate/slack-etl.mdx
+++ b/docs/pages/operate/slack-etl.mdx
@@ -12,7 +12,7 @@ token, channel scope, exclusion patterns, and data boundary they want agents to
 use.
 :::
 
-Slack ETL keeps an indexed, queryable copy of public Slack history in Postgres
+Slack ETL keeps an indexed, queryable copy of Slack channel history in Postgres
 for agent context and operator workflows. It runs as scheduled Centaur
 workflows: one workflow keeps recent channel history fresh, one drains deferred
 historical backfill work, and one turns synced messages into company context
@@ -27,7 +27,7 @@ token and writes durable rows into Postgres.
 
 | Workflow | Default cadence | Role |
 |----------|-----------------|------|
-| `slack_sync` | 1 hour | Lists public channels, refreshes users, syncs recent root messages, advances per-channel checkpoints, and enqueues backfill jobs. |
+| `slack_sync` | 1 hour | Lists channels, refreshes users, syncs recent root messages, advances per-channel checkpoints, and enqueues backfill jobs. |
 | `slack_backfill` | 10 minutes | Claims queued backfill jobs and drains Slack cursors without slowing the incremental sync. |
 | `company_context_documents` | 4 hours | Projects changed Slack rows into `company_context_documents` for retrieval. |
 
@@ -46,15 +46,17 @@ The token must be able to call:
 
 | Slack API | Used for |
 |-----------|----------|
-| `conversations.list` | Discover public channels. |
+| `conversations.list` | Discover public channels, and private channels when explicitly enabled. |
 | `conversations.history` | Read channel root messages. |
 | `conversations.replies` | Refresh thread replies. |
 | `users.list` | Resolve Slack user metadata for documents. |
 | `files:read` / file URL access | Download message attachment bytes from `files.slack.com`. |
 
-Slack ETL currently syncs public channels visible to the configured ETL user
-token. It does not sync private channels, DMs, or Slackbot-only live thread
-events.
+Slack ETL syncs public channels visible to the configured ETL user token.
+Set `SLACK_SYNC_INDEX_PRIVATE_CHANNELS=true` to also sync private channels
+visible to that token. It does not sync DMs or Slackbot-only live thread events.
+Private channel rows are protected by RLS: `centaur_readonly` sees public
+channel data and the channel in `centaur.slack_channel_id`.
 
 ## Enable the schedules
 
@@ -80,12 +82,13 @@ apiRs:
 | `SLACK_BACKFILL_CHANNEL_PAGES_PER_JOB` | `5` | Maximum Slack history pages drained before a job is requeued. |
 | `SLACK_SYNC_BACKFILL_LOOKBACK_DAYS` | `30` | Historical window seeded for first-time channel backfills. |
 | `SLACK_SYNC_THREAD_LOOKBACK_DAYS` | `3` | Recent thread window eligible for reply refresh. |
+| `SLACK_SYNC_INDEX_PRIVATE_CHANNELS` | `false` | Includes private channels visible to the ETL token in Slack sync and backfill. |
 | `SLACK_ETL_ATTACHMENTS_ENABLED` | `true` | Download Slack message attachment bytes into Postgres. Metadata rows are still written when downloads are disabled. |
 | `SLACK_ETL_ATTACHMENT_MAX_BYTES` | `10485760` | Per-file byte cap for Slack attachment downloads. Oversized files keep metadata with `skipped_too_large` status. |
 | `SLACK_ETL_EXCLUDED_CHANNEL_PATTERNS` | empty | Comma-separated channel-name globs to skip, without needing the leading `#`. |
 | `SLACK_RETENTION_ENABLED` | `true` | Allows the `slack_retention` schedule to run when at least one Slack retention TTL is positive. |
 | `SLACK_RETENTION_INTERVAL_MINUTES` | `60` | How often to prune Slack retention-managed rows. |
-| `SLACK_ETL_RETENTION_DAYS` | `0` | Deletes public Slack ETL messages, derived Slack documents, and terminal ETL run/job rows older than this many days. `0` disables public ETL retention. |
+| `SLACK_ETL_RETENTION_DAYS` | `0` | Deletes Slack ETL messages, derived Slack documents, and terminal ETL run/job rows older than this many days. `0` disables ETL retention. |
 | `SLACK_DM_RETENTION_DAYS` | `0` | Deletes Slack DM messages, stale empty DM conversations, and terminal DM run/job rows older than this many days. `0` disables DM retention. |
 | `COMPANY_CONTEXT_DOCUMENTS_ENABLED` | `true` | Enables projection from Slack sync rows into company context documents. |
 | `COMPANY_CONTEXT_DOCUMENTS_INTERVAL_SECONDS` | `14400` | How often to project changed Slack rows into documents. |
@@ -103,7 +106,7 @@ Slack ETL writes normalized Slack data into dedicated tables:
 
 | Table | Contents |
 |-------|----------|
-| `slack_sync_channels` | Public channels visible to the ETL token and whether they are currently syncable. |
+| `slack_sync_channels` | Channels visible to the ETL token, channel privacy, and whether they are currently syncable. |
 | `slack_sync_users` | Slack user display metadata used when rendering documents. |
 | `slack_sync_runs` | One row per incremental or backfill workflow run, with counts and channel outcomes. |
 | `slack_sync_messages` | Root messages and replies keyed by `(channel_id, message_ts)`. |
@@ -255,7 +258,7 @@ setting alerts.
 |---------|---------------|
 | Schedules are missing | Confirm `WORKFLOW_DIRS` includes `/app/workflows` and the API restarted after the workflow files were deployed. |
 | Schedules exist but are disabled | Confirm Helm values set `apiRs.etl.slack.enabled=true` and the API pod was restarted. |
-| `slack_sync` skips with `no_public_channels` | Confirm the ETL user token can see the expected public channels. |
+| `slack_sync` skips with `no_channels` | Confirm the ETL user token can see the expected public channels, or enable private channel sync when only private channels are in scope. |
 | Channels are all skipped | Check `SLACK_ETL_EXCLUDED_CHANNEL_PATTERNS` for broad globs. |
 | Checkpoints show `missing_scope` or `not_allowed_token_type` | Add the missing Slack OAuth scope or use the expected user-token class. |
 | Backfill jobs keep failing | Inspect `slack_sync_backfill_jobs.last_error` and the corresponding `slack_sync_runs` row. |

--- a/docs/pages/reference/configuration.mdx
+++ b/docs/pages/reference/configuration.mdx
@@ -230,6 +230,7 @@ Slack ETL workflows:
 | `SLACK_ETL_ENABLED` | `apiRs.etl.slack.enabled`. | Master switch for Slack sync/backfill/context schedules. |
 | `SLACK_SYNC_INTERVAL_SECONDS`, `SLACK_BACKFILL_INTERVAL_SECONDS`, `COMPANY_CONTEXT_DOCUMENTS_INTERVAL_SECONDS` | `apiRs.etl.slack.syncIntervalSeconds`, `apiRs.etl.slack.backfill.intervalSeconds`, `apiRs.etl.companyContextDocuments.intervalSeconds`. | Slack ETL schedule intervals. |
 | `SLACK_SYNC_BACKFILL_LOOKBACK_DAYS`, `SLACK_SYNC_THREAD_LOOKBACK_DAYS` | `apiRs.etl.slack.syncBackfillLookbackDays`, `apiRs.etl.slack.syncThreadLookbackDays`. | Slack history/thread lookback windows. |
+| `SLACK_SYNC_INDEX_PRIVATE_CHANNELS` | `apiRs.etl.slack.indexPrivateChannels`. | Includes private channels visible to the ETL token. |
 | `SLACK_ETL_EXCLUDED_CHANNEL_PATTERNS` | `apiRs.etl.slack.excludedChannelPatterns`. | Comma-separated channel-name globs to skip. |
 | `SLACK_BACKFILL_ENABLED`, `SLACK_BACKFILL_CHANNEL_BATCH_LIMIT`, `SLACK_BACKFILL_CHANNEL_PAGES_PER_JOB` | `apiRs.etl.slack.backfill.*`. | Backfill enablement and batch sizing. |
 | `SLACK_RETENTION_ENABLED`, `SLACK_RETENTION_INTERVAL_MINUTES`, `SLACK_ETL_RETENTION_DAYS`, `SLACK_DM_RETENTION_DAYS` | `apiRs.etl.slack.retention.*`. | Slack retention enablement, cadence, and separate public ETL/DM TTLs. |

--- a/docs/public/md/operate/slack-etl.md
+++ b/docs/public/md/operate/slack-etl.md
@@ -12,7 +12,7 @@ token, channel scope, exclusion patterns, and data boundary they want agents to
 use.
 :::
 
-Slack ETL keeps an indexed, queryable copy of public Slack history in Postgres
+Slack ETL keeps an indexed, queryable copy of Slack channel history in Postgres
 for agent context and operator workflows. It runs as scheduled Centaur
 workflows: one workflow keeps recent channel history fresh, one drains deferred
 historical backfill work, and one turns synced messages into company context
@@ -27,7 +27,7 @@ token and writes durable rows into Postgres.
 
 | Workflow | Default cadence | Role |
 |----------|-----------------|------|
-| `slack_sync` | 1 hour | Lists public channels, refreshes users, syncs recent root messages, advances per-channel checkpoints, and enqueues backfill jobs. |
+| `slack_sync` | 1 hour | Lists channels, refreshes users, syncs recent root messages, advances per-channel checkpoints, and enqueues backfill jobs. |
 | `slack_backfill` | 10 minutes | Claims queued backfill jobs and drains Slack cursors without slowing the incremental sync. |
 | `company_context_documents` | 4 hours | Projects changed Slack rows into `company_context_documents` for retrieval. |
 
@@ -46,15 +46,17 @@ The token must be able to call:
 
 | Slack API | Used for |
 |-----------|----------|
-| `conversations.list` | Discover public channels. |
+| `conversations.list` | Discover public channels, and private channels when explicitly enabled. |
 | `conversations.history` | Read channel root messages. |
 | `conversations.replies` | Refresh thread replies. |
 | `users.list` | Resolve Slack user metadata for documents. |
 | `files:read` / file URL access | Download message attachment bytes from `files.slack.com`. |
 
-Slack ETL currently syncs public channels visible to the configured ETL user
-token. It does not sync private channels, DMs, or Slackbot-only live thread
-events.
+Slack ETL syncs public channels visible to the configured ETL user token.
+Set `SLACK_SYNC_INDEX_PRIVATE_CHANNELS=true` to also sync private channels
+visible to that token. It does not sync DMs or Slackbot-only live thread events.
+Private channel rows are protected by RLS: `centaur_readonly` sees public
+channel data and the channel in `centaur.slack_channel_id`.
 
 ## Enable the schedules
 
@@ -80,12 +82,13 @@ apiRs:
 | `SLACK_BACKFILL_CHANNEL_PAGES_PER_JOB` | `5` | Maximum Slack history pages drained before a job is requeued. |
 | `SLACK_SYNC_BACKFILL_LOOKBACK_DAYS` | `30` | Historical window seeded for first-time channel backfills. |
 | `SLACK_SYNC_THREAD_LOOKBACK_DAYS` | `3` | Recent thread window eligible for reply refresh. |
+| `SLACK_SYNC_INDEX_PRIVATE_CHANNELS` | `false` | Includes private channels visible to the ETL token in Slack sync and backfill. |
 | `SLACK_ETL_ATTACHMENTS_ENABLED` | `true` | Download Slack message attachment bytes into Postgres. Metadata rows are still written when downloads are disabled. |
 | `SLACK_ETL_ATTACHMENT_MAX_BYTES` | `10485760` | Per-file byte cap for Slack attachment downloads. Oversized files keep metadata with `skipped_too_large` status. |
 | `SLACK_ETL_EXCLUDED_CHANNEL_PATTERNS` | empty | Comma-separated channel-name globs to skip, without needing the leading `#`. |
 | `SLACK_RETENTION_ENABLED` | `true` | Allows the `slack_retention` schedule to run when at least one Slack retention TTL is positive. |
 | `SLACK_RETENTION_INTERVAL_MINUTES` | `60` | How often to prune Slack retention-managed rows. |
-| `SLACK_ETL_RETENTION_DAYS` | `0` | Deletes public Slack ETL messages, derived Slack documents, and terminal ETL run/job rows older than this many days. `0` disables public ETL retention. |
+| `SLACK_ETL_RETENTION_DAYS` | `0` | Deletes Slack ETL messages, derived Slack documents, and terminal ETL run/job rows older than this many days. `0` disables ETL retention. |
 | `SLACK_DM_RETENTION_DAYS` | `0` | Deletes Slack DM messages, stale empty DM conversations, and terminal DM run/job rows older than this many days. `0` disables DM retention. |
 | `COMPANY_CONTEXT_DOCUMENTS_ENABLED` | `true` | Enables projection from Slack sync rows into company context documents. |
 | `COMPANY_CONTEXT_DOCUMENTS_INTERVAL_SECONDS` | `14400` | How often to project changed Slack rows into documents. |
@@ -103,7 +106,7 @@ Slack ETL writes normalized Slack data into dedicated tables:
 
 | Table | Contents |
 |-------|----------|
-| `slack_sync_channels` | Public channels visible to the ETL token and whether they are currently syncable. |
+| `slack_sync_channels` | Channels visible to the ETL token, channel privacy, and whether they are currently syncable. |
 | `slack_sync_users` | Slack user display metadata used when rendering documents. |
 | `slack_sync_runs` | One row per incremental or backfill workflow run, with counts and channel outcomes. |
 | `slack_sync_messages` | Root messages and replies keyed by `(channel_id, message_ts)`. |
@@ -255,7 +258,7 @@ setting alerts.
 |---------|---------------|
 | Schedules are missing | Confirm `WORKFLOW_DIRS` includes `/app/workflows` and the API restarted after the workflow files were deployed. |
 | Schedules exist but are disabled | Confirm Helm values set `apiRs.etl.slack.enabled=true` and the API pod was restarted. |
-| `slack_sync` skips with `no_public_channels` | Confirm the ETL user token can see the expected public channels. |
+| `slack_sync` skips with `no_channels` | Confirm the ETL user token can see the expected public channels, or enable private channel sync when only private channels are in scope. |
 | Channels are all skipped | Check `SLACK_ETL_EXCLUDED_CHANNEL_PATTERNS` for broad globs. |
 | Checkpoints show `missing_scope` or `not_allowed_token_type` | Add the missing Slack OAuth scope or use the expected user-token class. |
 | Backfill jobs keep failing | Inspect `slack_sync_backfill_jobs.last_error` and the corresponding `slack_sync_runs` row. |

--- a/docs/public/md/reference/configuration.md
+++ b/docs/public/md/reference/configuration.md
@@ -233,6 +233,7 @@ Slack ETL workflows:
 | `SLACK_ETL_ENABLED` | `apiRs.etl.slack.enabled`. | Master switch for Slack sync/backfill/context schedules. |
 | `SLACK_SYNC_INTERVAL_SECONDS`, `SLACK_BACKFILL_INTERVAL_SECONDS`, `COMPANY_CONTEXT_DOCUMENTS_INTERVAL_SECONDS` | `apiRs.etl.slack.syncIntervalSeconds`, `apiRs.etl.slack.backfill.intervalSeconds`, `apiRs.etl.companyContextDocuments.intervalSeconds`. | Slack ETL schedule intervals. |
 | `SLACK_SYNC_BACKFILL_LOOKBACK_DAYS`, `SLACK_SYNC_THREAD_LOOKBACK_DAYS` | `apiRs.etl.slack.syncBackfillLookbackDays`, `apiRs.etl.slack.syncThreadLookbackDays`. | Slack history/thread lookback windows. |
+| `SLACK_SYNC_INDEX_PRIVATE_CHANNELS` | `apiRs.etl.slack.indexPrivateChannels`. | Includes private channels visible to the ETL token. |
 | `SLACK_ETL_EXCLUDED_CHANNEL_PATTERNS` | `apiRs.etl.slack.excludedChannelPatterns`. | Comma-separated channel-name globs to skip. |
 | `SLACK_BACKFILL_ENABLED`, `SLACK_BACKFILL_CHANNEL_BATCH_LIMIT`, `SLACK_BACKFILL_CHANNEL_PAGES_PER_JOB` | `apiRs.etl.slack.backfill.*`. | Backfill enablement and batch sizing. |
 | `SLACK_RETENTION_ENABLED`, `SLACK_RETENTION_INTERVAL_MINUTES`, `SLACK_ETL_RETENTION_DAYS`, `SLACK_DM_RETENTION_DAYS` | `apiRs.etl.slack.retention.*`. | Slack retention enablement, cadence, and separate public ETL/DM TTLs. |

--- a/services/api-rs/crates/centaur-session-sqlx/migrations/0038_slack_private_channels.sql
+++ b/services/api-rs/crates/centaur-session-sqlx/migrations/0038_slack_private_channels.sql
@@ -1,0 +1,73 @@
+alter table slack_sync_channels
+    add column if not exists is_private boolean not null default false;
+
+create index if not exists idx_slack_sync_channels_private
+    on slack_sync_channels (is_private, channel_id);
+
+drop policy if exists centaur_readonly_slack_sync_channels_select
+    on slack_sync_channels;
+create policy centaur_readonly_slack_sync_channels_select
+    on slack_sync_channels
+    for select
+    to centaur_readonly
+    using (
+        not is_private
+        or channel_id = centaur_current_slack_channel_id()
+    );
+
+drop policy if exists centaur_readonly_slack_sync_message_attachments_select
+    on slack_sync_message_attachments;
+create policy centaur_readonly_slack_sync_message_attachments_select
+    on slack_sync_message_attachments
+    for select
+    to centaur_readonly
+    using (
+        exists (
+            select 1
+            from slack_sync_channels channels
+            where channels.channel_id = slack_sync_message_attachments.channel_id
+        )
+    );
+
+drop policy if exists centaur_readonly_slack_sync_messages_select
+    on slack_sync_messages;
+create policy centaur_readonly_slack_sync_messages_select
+    on slack_sync_messages
+    for select
+    to centaur_readonly
+    using (
+        exists (
+            select 1
+            from slack_sync_channels channels
+            where channels.channel_id = slack_sync_messages.channel_id
+        )
+    );
+
+drop policy if exists centaur_readonly_slack_sync_users_select
+    on slack_sync_users;
+create policy centaur_readonly_slack_sync_users_select
+    on slack_sync_users
+    for select
+    to centaur_readonly
+    using (
+        exists (
+            select 1
+            from slack_sync_messages messages
+            where messages.user_id = slack_sync_users.user_id
+        )
+    );
+
+drop policy if exists centaur_readonly_company_context_documents_select
+    on company_context_documents;
+create policy centaur_readonly_company_context_documents_select
+    on company_context_documents
+    for select
+    to centaur_readonly
+    using (
+        source <> 'slack'
+        or exists (
+            select 1
+            from slack_sync_channels channels
+            where channels.channel_id = metadata ->> 'channel_id'
+        )
+    );

--- a/services/api-rs/crates/centaur-session-sqlx/migrations/0038_slack_private_channels.sql
+++ b/services/api-rs/crates/centaur-session-sqlx/migrations/0038_slack_private_channels.sql
@@ -43,20 +43,6 @@ create policy centaur_readonly_slack_sync_messages_select
         )
     );
 
-drop policy if exists centaur_readonly_slack_sync_users_select
-    on slack_sync_users;
-create policy centaur_readonly_slack_sync_users_select
-    on slack_sync_users
-    for select
-    to centaur_readonly
-    using (
-        exists (
-            select 1
-            from slack_sync_messages messages
-            where messages.user_id = slack_sync_users.user_id
-        )
-    );
-
 drop policy if exists centaur_readonly_company_context_documents_select
     on company_context_documents;
 create policy centaur_readonly_company_context_documents_select

--- a/services/api-rs/crates/centaur-session-sqlx/tests/etl_context_rls.rs
+++ b/services/api-rs/crates/centaur-session-sqlx/tests/etl_context_rls.rs
@@ -732,47 +732,11 @@ fn public_visible_rows() -> VisibleRows {
 }
 
 fn public_and_private_visible_rows() -> VisibleRows {
-    VisibleRows {
-        slack_channels: vec![
-            "C_ADMIN".to_owned(),
-            "C_ALPHA".to_owned(),
-            "C_BETA".to_owned(),
-            "G_PRIVATE".to_owned(),
-        ],
-        slack_users: vec![
-            "U_ALPHA".to_owned(),
-            "U_BETA".to_owned(),
-            "U_PRIVATE".to_owned(),
-        ],
-        slack_messages: vec![
-            "C_ALPHA:1000.000001".to_owned(),
-            "C_BETA:1000.000002".to_owned(),
-            "G_PRIVATE:1000.000003".to_owned(),
-        ],
-        slack_attachments: vec![
-            "C_ALPHA:1000.000001:F_ALPHA".to_owned(),
-            "C_BETA:1000.000002:F_BETA".to_owned(),
-            "G_PRIVATE:1000.000003:F_PRIVATE".to_owned(),
-        ],
-        context_docs: vec![
-            "doc_gcal".to_owned(),
-            "doc_gdrive".to_owned(),
-            "doc_linear".to_owned(),
-            "doc_slack_alpha".to_owned(),
-            "doc_slack_beta".to_owned(),
-            "doc_slack_private".to_owned(),
-        ],
-        google_drive_runs: 1,
-        google_drive_files: 1,
-        google_drive_checkpoints: 1,
-        google_calendar_runs: 1,
-        google_calendar_calendars: 1,
-        google_calendar_events: 1,
-        google_calendar_checkpoints: 1,
-        linear_runs: 1,
-        linear_projects: 1,
-        linear_issues: 1,
-        linear_comments: 1,
-        linear_checkpoints: 1,
-    }
+    let mut rows = public_visible_rows();
+    rows.slack_channels.push("G_PRIVATE".to_owned());
+    rows.slack_messages.push("G_PRIVATE:1000.000003".to_owned());
+    rows.slack_attachments
+        .push("G_PRIVATE:1000.000003:F_PRIVATE".to_owned());
+    rows.context_docs.push("doc_slack_private".to_owned());
+    rows
 }

--- a/services/api-rs/crates/centaur-session-sqlx/tests/etl_context_rls.rs
+++ b/services/api-rs/crates/centaur-session-sqlx/tests/etl_context_rls.rs
@@ -18,6 +18,8 @@ const DROP_SLACK_CONTEXT_ADMIN_CHANNELS_SQL: &str =
     include_str!("../migrations/0022_drop_slack_context_rls_admin_channels.sql");
 const CENTAUR_READONLY_RLS_POLICIES_SQL: &str =
     include_str!("../migrations/0023_centaur_readonly_rls_policies.sql");
+const SLACK_PRIVATE_CHANNELS_SQL: &str =
+    include_str!("../migrations/0038_slack_private_channels.sql");
 
 const RLS_TABLES: &[&str] = &[
     "slack_sync_channels",
@@ -84,6 +86,7 @@ async fn run_rls_assertions(conn: &mut PgConnection, schema: &str) -> Result<(),
     execute_migration(conn, ETL_CONTEXT_RLS_SQL).await?;
     execute_migration(conn, DROP_SLACK_CONTEXT_ADMIN_CHANNELS_SQL).await?;
     execute_migration(conn, CENTAUR_READONLY_RLS_POLICIES_SQL).await?;
+    execute_migration(conn, SLACK_PRIVATE_CHANNELS_SQL).await?;
     grant_schema_usage(conn, schema).await?;
 
     assert_rls_enabled(conn).await?;
@@ -173,7 +176,11 @@ async fn run_rls_assertions(conn: &mut PgConnection, schema: &str) -> Result<(),
     );
 
     let readonly_role = visible_rows(conn, schema, "centaur_readonly", None).await?;
-    assert_eq!(readonly_role, all_visible_rows());
+    assert_eq!(readonly_role, public_visible_rows());
+
+    let readonly_private_channel =
+        visible_rows(conn, schema, "centaur_readonly", Some("G_PRIVATE")).await?;
+    assert_eq!(readonly_private_channel, public_and_private_visible_rows());
 
     Ok(())
 }
@@ -260,6 +267,7 @@ async fn create_minimal_etl_tables(conn: &mut PgConnection) -> Result<(), sqlx::
         create table slack_sync_messages (
             channel_id text not null references slack_sync_channels(channel_id) on delete cascade,
             message_ts text not null,
+            user_id text not null default '',
             text text not null default '',
             primary key (channel_id, message_ts)
         );
@@ -527,28 +535,34 @@ async fn assert_legacy_admin_state_is_removed(conn: &mut PgConnection) -> Result
 async fn insert_fixture_rows(conn: &mut PgConnection) -> Result<(), sqlx::Error> {
     sqlx::raw_sql(
         r#"
-        insert into slack_sync_channels (channel_id, channel_name) values
-            ('C_ALPHA', 'alpha'),
-            ('C_BETA', 'beta'),
-            ('C_ADMIN', 'admin');
+        insert into slack_sync_channels (channel_id, channel_name, is_private) values
+            ('C_ALPHA', 'alpha', false),
+            ('C_BETA', 'beta', false),
+            ('C_ADMIN', 'admin', false),
+            ('G_PRIVATE', 'private', true);
 
         insert into slack_sync_users (user_id, user_name) values
             ('U_ALPHA', 'alpha user'),
-            ('U_BETA', 'beta user');
+            ('U_BETA', 'beta user'),
+            ('U_PRIVATE', 'private user');
 
-        insert into slack_sync_messages (channel_id, message_ts, text) values
-            ('C_ALPHA', '1000.000001', 'alpha channel message'),
-            ('C_BETA', '1000.000002', 'beta channel message');
+        insert into slack_sync_messages (channel_id, message_ts, user_id, text) values
+            ('C_ALPHA', '1000.000001', 'U_ALPHA', 'alpha channel message'),
+            ('C_BETA', '1000.000002', 'U_BETA', 'beta channel message'),
+            ('G_PRIVATE', '1000.000003', 'U_PRIVATE', 'private channel message');
 
         insert into slack_sync_message_attachments
             (channel_id, message_ts, slack_file_id, name)
         values
             ('C_ALPHA', '1000.000001', 'F_ALPHA', 'alpha.pdf'),
-            ('C_BETA', '1000.000002', 'F_BETA', 'beta.pdf');
+            ('C_BETA', '1000.000002', 'F_BETA', 'beta.pdf'),
+            ('G_PRIVATE', '1000.000003', 'F_PRIVATE', 'private.pdf');
 
         insert into company_context_documents (document_id, source, source_type, metadata) values
             ('doc_slack_alpha', 'slack', 'slack_thread', '{"channel_id": "C_ALPHA"}'),
             ('doc_slack_beta', 'slack', 'slack_thread', '{"channel_id": "C_BETA"}'),
+            ('doc_slack_private', 'slack', 'slack_thread', '{"channel_id": "G_PRIVATE"}'),
+            ('doc_slack_unknown_channel', 'slack', 'slack_thread', '{}'),
             ('doc_gdrive', 'google_drive', 'google_doc', '{}'),
             ('doc_gcal', 'google_calendar', 'calendar_event', '{}'),
             ('doc_linear', 'linear', 'linear_issue', '{}');
@@ -675,7 +689,7 @@ fn empty_visible_rows() -> VisibleRows {
     }
 }
 
-fn all_visible_rows() -> VisibleRows {
+fn public_visible_rows() -> VisibleRows {
     VisibleRows {
         slack_channels: vec![
             "C_ADMIN".to_owned(),
@@ -697,6 +711,52 @@ fn all_visible_rows() -> VisibleRows {
             "doc_linear".to_owned(),
             "doc_slack_alpha".to_owned(),
             "doc_slack_beta".to_owned(),
+        ],
+        google_drive_runs: 1,
+        google_drive_files: 1,
+        google_drive_checkpoints: 1,
+        google_calendar_runs: 1,
+        google_calendar_calendars: 1,
+        google_calendar_events: 1,
+        google_calendar_checkpoints: 1,
+        linear_runs: 1,
+        linear_projects: 1,
+        linear_issues: 1,
+        linear_comments: 1,
+        linear_checkpoints: 1,
+    }
+}
+
+fn public_and_private_visible_rows() -> VisibleRows {
+    VisibleRows {
+        slack_channels: vec![
+            "C_ADMIN".to_owned(),
+            "C_ALPHA".to_owned(),
+            "C_BETA".to_owned(),
+            "G_PRIVATE".to_owned(),
+        ],
+        slack_users: vec![
+            "U_ALPHA".to_owned(),
+            "U_BETA".to_owned(),
+            "U_PRIVATE".to_owned(),
+        ],
+        slack_messages: vec![
+            "C_ALPHA:1000.000001".to_owned(),
+            "C_BETA:1000.000002".to_owned(),
+            "G_PRIVATE:1000.000003".to_owned(),
+        ],
+        slack_attachments: vec![
+            "C_ALPHA:1000.000001:F_ALPHA".to_owned(),
+            "C_BETA:1000.000002:F_BETA".to_owned(),
+            "G_PRIVATE:1000.000003:F_PRIVATE".to_owned(),
+        ],
+        context_docs: vec![
+            "doc_gcal".to_owned(),
+            "doc_gdrive".to_owned(),
+            "doc_linear".to_owned(),
+            "doc_slack_alpha".to_owned(),
+            "doc_slack_beta".to_owned(),
+            "doc_slack_private".to_owned(),
         ],
         google_drive_runs: 1,
         google_drive_files: 1,

--- a/services/api-rs/crates/centaur-session-sqlx/tests/etl_context_rls.rs
+++ b/services/api-rs/crates/centaur-session-sqlx/tests/etl_context_rls.rs
@@ -696,7 +696,11 @@ fn public_visible_rows() -> VisibleRows {
             "C_ALPHA".to_owned(),
             "C_BETA".to_owned(),
         ],
-        slack_users: vec!["U_ALPHA".to_owned(), "U_BETA".to_owned()],
+        slack_users: vec![
+            "U_ALPHA".to_owned(),
+            "U_BETA".to_owned(),
+            "U_PRIVATE".to_owned(),
+        ],
         slack_messages: vec![
             "C_ALPHA:1000.000001".to_owned(),
             "C_BETA:1000.000002".to_owned(),

--- a/workflows/slack/retention.py
+++ b/workflows/slack/retention.py
@@ -81,7 +81,7 @@ async def _count_or_delete(
 
 
 async def prune_slack_etl(pool, *, retention_days: int, dry_run: bool = False) -> dict[str, int]:
-    """Delete public Slack ETL rows older than the configured retention window."""
+    """Delete Slack ETL rows older than the configured retention window."""
     if retention_days <= 0:
         return {
             "company_context_documents": 0,

--- a/workflows/slack/shared.py
+++ b/workflows/slack/shared.py
@@ -80,7 +80,10 @@ class SlackSyncClient(Protocol):
     def _etl_access_mode(self) -> str: ...
 
     def _list_etl_channels(
-        self, limit: int = 200, force_refresh: bool = False
+        self,
+        limit: int = 200,
+        force_refresh: bool = False,
+        include_private_channels: bool = False,
     ) -> list[dict]: ...
 
     def _list_etl_users(self, limit: int = 200) -> list[dict]: ...
@@ -1169,16 +1172,25 @@ class SlackEtlClient:
         self,
         limit: int = 500,
         force_refresh: bool = False,
+        include_private_channels: bool | None = None,
     ) -> list[dict]:
         channels = []
         cursor = None
+        include_private = (
+            env_flag_enabled("SLACK_SYNC_INDEX_PRIVATE_CHANNELS", default=False)
+            if include_private_channels is None
+            else include_private_channels
+        )
+        conversation_types = (
+            "public_channel,private_channel" if include_private else "public_channel"
+        )
 
         while len(channels) < limit:
             try:
                 response = self._retry_on_ratelimit(
                     self._client.conversations_list,
                     method_key="etl.conversations.list",
-                    types="public_channel",
+                    types=conversation_types,
                     limit=min(limit - len(channels), self._MAX_PAGE_SIZE),
                     cursor=cursor,
                     exclude_archived=True,
@@ -1192,7 +1204,8 @@ class SlackEtlClient:
                 )
 
             for channel in response.get("channels", []):
-                if channel.get("is_private", False):
+                is_private = bool(channel.get("is_private", False))
+                if is_private and not include_private:
                     continue
                 channels.append(
                     {
@@ -1203,7 +1216,7 @@ class SlackEtlClient:
                         "topic": channel.get("topic", {}).get("value", ""),
                         "member_count": channel.get("num_members", 0),
                         "is_archived": channel.get("is_archived", False),
-                        "is_private": channel.get("is_private", False),
+                        "is_private": is_private,
                         "is_member": channel.get("is_member", False),
                     }
                 )

--- a/workflows/slack/sync.py
+++ b/workflows/slack/sync.py
@@ -1,4 +1,4 @@
-"""Workflow: sync recent public Slack channel history into Postgres."""
+"""Workflow: sync recent Slack channel history into Postgres."""
 
 from __future__ import annotations
 
@@ -57,6 +57,7 @@ DEFAULT_CHANNEL_PAGE_LIMIT = 100
 DEFAULT_THREAD_REPLY_PAGE_LIMIT = 200
 DEFAULT_SYNC_INTERVAL_SECONDS = 3_600
 EXCLUDED_CHANNELS_ENV = "SLACK_ETL_EXCLUDED_CHANNEL_PATTERNS"
+INDEX_PRIVATE_CHANNELS_ENV = "SLACK_SYNC_INDEX_PRIVATE_CHANNELS"
 
 
 def _env_flag_enabled(name: str, default: bool = False) -> bool:
@@ -210,7 +211,7 @@ def _max_slack_ts(*values: Any) -> str | None:
 
 
 async def _upsert_channels(pool, channels: list[dict[str, Any]]) -> None:
-    """Refresh public Slack sync channel rows and mark absent channels out of scope."""
+    """Refresh Slack sync channel rows and mark absent channels out of scope."""
     async with pool.acquire() as conn:
         async with conn.transaction():
             await conn.execute(
@@ -222,12 +223,13 @@ async def _upsert_channels(pool, channels: list[dict[str, Any]]) -> None:
                     continue
                 await conn.execute(
                     "INSERT INTO slack_sync_channels ("
-                    "channel_id, channel_name, is_archived, is_syncable, topic, purpose, "
-                    "member_count, raw_payload, last_seen_at, updated_at"
-                    ") VALUES ($1, $2, $3, TRUE, $4, $5, $6, $7::jsonb, NOW(), NOW()) "
+                    "channel_id, channel_name, is_archived, is_private, is_syncable, "
+                    "topic, purpose, member_count, raw_payload, last_seen_at, updated_at"
+                    ") VALUES ($1, $2, $3, $4, TRUE, $5, $6, $7, $8::jsonb, NOW(), NOW()) "
                     "ON CONFLICT (channel_id) DO UPDATE SET "
                     "channel_name = EXCLUDED.channel_name, "
                     "is_archived = EXCLUDED.is_archived, "
+                    "is_private = EXCLUDED.is_private, "
                     "is_syncable = TRUE, "
                     "topic = EXCLUDED.topic, "
                     "purpose = EXCLUDED.purpose, "
@@ -238,6 +240,7 @@ async def _upsert_channels(pool, channels: list[dict[str, Any]]) -> None:
                     channel_id,
                     str(channel.get("name") or ""),
                     bool(channel.get("is_archived")),
+                    bool(channel.get("is_private")),
                     str(channel.get("topic") or ""),
                     str(channel.get("purpose") or ""),
                     int(channel.get("member_count") or 0),
@@ -349,7 +352,7 @@ async def _update_checkpoint_failure(
 
 
 async def handler(inp: Input, ctx: WorkflowContext) -> dict[str, Any]:
-    """Sync public Slack channels visible through the configured ETL user token."""
+    """Sync Slack channels visible through the configured ETL user token."""
     started_at = time.monotonic()
     mode = "incremental"
     record_slack_retention_run(WORKFLOW_NAME, "started", mode)
@@ -378,8 +381,13 @@ async def handler(inp: Input, ctx: WorkflowContext) -> dict[str, Any]:
     limit = positive_int(inp.limit, DEFAULT_CHANNEL_PAGE_LIMIT)
     client = _client()
     access_mode = client._etl_access_mode()
+    include_private_channels = _env_flag_enabled(INDEX_PRIVATE_CHANNELS_ENV)
     try:
-        public_channels = client._list_etl_channels(limit=10_000, force_refresh=True)
+        channels = client._list_etl_channels(
+            limit=10_000,
+            force_refresh=True,
+            include_private_channels=include_private_channels,
+        )
         record_slack_retention_api_request("list_channels", "success")
     except Exception as exc:
         reason = failure_reason(str(exc))
@@ -391,10 +399,10 @@ async def handler(inp: Input, ctx: WorkflowContext) -> dict[str, Any]:
             WORKFLOW_NAME, dt.datetime.now(dt.timezone.utc).timestamp()
         )
         raise
-    record_etl_items_seen("slack", "channel", "channel", len(public_channels))
+    record_etl_items_seen("slack", "channel", "channel", len(channels))
     exclusion_patterns = _channel_exclusion_patterns(os.getenv(EXCLUDED_CHANNELS_ENV))
     channels_to_sync, excluded_channels = _filter_excluded_channels(
-        public_channels,
+        channels,
         exclusion_patterns,
     )
     if excluded_channels:
@@ -407,11 +415,12 @@ async def handler(inp: Input, ctx: WorkflowContext) -> dict[str, Any]:
     await _upsert_channels(ctx._pool, channels_to_sync)
     record_etl_items_upserted("slack", "channel", "channel", len(channels_to_sync))
 
-    if not public_channels:
-        reason = "no_public_channels"
+    if not channels:
+        reason = "no_channels"
         ctx.log(
-            "slack_sync_skipped_no_public_channels",
+            "slack_sync_skipped_no_channels",
             access_mode=access_mode,
+            include_private_channels=include_private_channels,
             reason=reason,
         )
         await emit_slack_checkpoint_metrics(ctx._pool)
@@ -472,6 +481,7 @@ async def handler(inp: Input, ctx: WorkflowContext) -> dict[str, Any]:
         metadata={
             **inp.metadata,
             "slack_access_mode": access_mode,
+            "index_private_channels": include_private_channels,
             "users_upserted": users_upserted,
             "excluded_channel_patterns": exclusion_patterns,
         },

--- a/workflows/slack/tests/test_shared_attachments.py
+++ b/workflows/slack/tests/test_shared_attachments.py
@@ -183,13 +183,15 @@ def test_retry_on_ratelimit_records_failed_fast_by_workflow(monkeypatch):
 def test_list_etl_channels_preserves_slack_created_timestamp():
     client = object.__new__(shared.SlackEtlClient)
     client._workflow_name = "slack_sync"
+    retry_calls = []
 
     def fake_conversations_list(**_kwargs):
         raise AssertionError("wrapped Slack client call should not be used directly")
 
     client._client = types.SimpleNamespace(conversations_list=fake_conversations_list)
 
-    def fake_retry(_func, **_kwargs):
+    def fake_retry(_func, **kwargs):
+        retry_calls.append(kwargs)
         return {
             "channels": [
                 {
@@ -217,6 +219,7 @@ def test_list_etl_channels_preserves_slack_created_timestamp():
 
     channels = client._list_etl_channels()
 
+    assert retry_calls[0]["types"] == "public_channel"
     assert channels == [
         {
             "id": "C123",
@@ -230,6 +233,46 @@ def test_list_etl_channels_preserves_slack_created_timestamp():
             "is_member": True,
         }
     ]
+
+
+def test_list_etl_channels_can_include_private_channels():
+    client = object.__new__(shared.SlackEtlClient)
+    client._workflow_name = "slack_sync"
+    retry_calls = []
+
+    def fake_conversations_list(**_kwargs):
+        raise AssertionError("wrapped Slack client call should not be used directly")
+
+    client._client = types.SimpleNamespace(conversations_list=fake_conversations_list)
+
+    def fake_retry(_func, **kwargs):
+        retry_calls.append(kwargs)
+        return {
+            "channels": [
+                {
+                    "id": "C123",
+                    "name": "eng-infra",
+                    "is_archived": False,
+                    "is_private": False,
+                },
+                {
+                    "id": "G123",
+                    "name": "private-room",
+                    "is_archived": False,
+                    "is_private": True,
+                    "is_member": True,
+                },
+            ],
+            "response_metadata": {},
+        }
+
+    client._retry_on_ratelimit = fake_retry
+
+    channels = client._list_etl_channels(include_private_channels=True)
+
+    assert retry_calls[0]["types"] == "public_channel,private_channel"
+    assert [channel["id"] for channel in channels] == ["C123", "G123"]
+    assert channels[1]["is_private"] is True
 
 
 def test_serialize_message_downloads_slack_file_bytes(monkeypatch):

--- a/workflows/slack/tests/test_sync_cold_start.py
+++ b/workflows/slack/tests/test_sync_cold_start.py
@@ -74,12 +74,14 @@ class FakeContext:
 class FakeClient:
     def __init__(self, *, cursor: str | None = None) -> None:
         self.history_calls: list[dict] = []
+        self.channel_calls: list[dict] = []
         self.cursor = cursor
 
     def _etl_access_mode(self):
         return "test"
 
-    def _list_etl_channels(self, *_args, **_kwargs):
+    def _list_etl_channels(self, *_args, **kwargs):
+        self.channel_calls.append(kwargs)
         return [{"id": "C123", "name": "cold-start"}]
 
     def _list_etl_users(self, *_args, **_kwargs):
@@ -118,6 +120,7 @@ def _patch_handler_io(monkeypatch, sync, *, checkpoint=None, client=None):
         "checkpoint_success": [],
         "enqueued": [],
         "finish": [],
+        "run_start": [],
         "widened": [],
     }
     fake_client = client or FakeClient()
@@ -140,6 +143,9 @@ def _patch_handler_io(monkeypatch, sync, *, checkpoint=None, client=None):
     async def fake_record_run_finish(_pool, **kwargs):
         calls["finish"].append(kwargs)
 
+    async def fake_record_run_start(_pool, **kwargs):
+        calls["run_start"].append(kwargs)
+
     async def fake_widen_channel_bootstrap_job(_pool, **kwargs):
         calls["widened"].append(kwargs)
         return False
@@ -154,7 +160,7 @@ def _patch_handler_io(monkeypatch, sync, *, checkpoint=None, client=None):
     monkeypatch.setattr(sync, "_update_checkpoint_failure", _noop)
     monkeypatch.setattr(sync, "enqueue_backfill_job", fake_enqueue_backfill_job)
     monkeypatch.setattr(sync, "emit_slack_checkpoint_metrics", _noop)
-    monkeypatch.setattr(sync, "record_run_start", _noop)
+    monkeypatch.setattr(sync, "record_run_start", fake_record_run_start)
     monkeypatch.setattr(sync, "record_run_finish", fake_record_run_finish)
     monkeypatch.setattr(
         sync,
@@ -175,7 +181,9 @@ def test_cold_start_channel_uses_full_lookback_window(monkeypatch):
     result = asyncio.run(sync.handler(sync.Input(), FakeContext()))
 
     assert result["status"] == "completed"
+    assert client.channel_calls[0]["include_private_channels"] is False
     assert client.history_calls[0]["oldest"] == "days:30"
+    assert calls["run_start"][0]["metadata"]["index_private_channels"] is False
     assert calls["checkpoint_success"] == [
         {
             "channel_id": "C123",
@@ -217,3 +225,18 @@ def test_watermarked_channel_keeps_incremental_overlap(monkeypatch):
             "priority": 150,
         }
     ]
+
+
+def test_private_channel_flag_is_passed_to_discovery(monkeypatch):
+    monkeypatch.setenv("SLACK_ETL_ENABLED", "true")
+    monkeypatch.setenv("SLACK_SYNC_INDEX_PRIVATE_CHANNELS", "true")
+    sync = _load_sync()
+    client, calls = _patch_handler_io(monkeypatch, sync)
+
+    monkeypatch.setattr(sync, "_ts_now_minus_days", lambda days: f"days:{days}")
+
+    result = asyncio.run(sync.handler(sync.Input(), FakeContext()))
+
+    assert result["status"] == "completed"
+    assert client.channel_calls[0]["include_private_channels"] is True
+    assert calls["run_start"][0]["metadata"]["index_private_channels"] is True


### PR DESCRIPTION
Adds a Slack sync feature flag, `SLACK_SYNC_INDEX_PRIVATE_CHANNELS`, to include private channels visible to the ETL token. Persists channel privacy metadata and tightens read-only RLS so public Slack data remains broadly visible while private channel data is only visible for the current Slack channel. Updates Helm values and Slack ETL docs for the new flag.