### PR TITLE
Add Granola sync workflow

### DIFF
--- a/services/api-rs/Dockerfile
+++ b/services/api-rs/Dockerfile
@@ -29,9 +29,10 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     apt-get update && apt-get install -y --no-install-recommends ca-certificates curl python3 python3-pip
 COPY --from=builder /usr/local/bin/centaur-api-server /usr/local/bin/centaur-api-server
 WORKDIR /app
+COPY centaur_sdk/ /app/centaur_sdk/
 COPY services/workflow-python/ /app/workflow-python/
 RUN --mount=type=cache,target=/root/.cache/pip,sharing=locked \
-    pip3 install --break-system-packages --no-compile /app/workflow-python \
+    pip3 install --break-system-packages --no-compile /app/centaur_sdk /app/workflow-python \
     && python3 -c "import boto3, botocore" \
     && rm -rf /usr/share/doc /usr/share/man /usr/share/info
 # api-rs discovers tool secret metadata from pyproject.toml at startup so it can

--- a/services/api-rs/crates/centaur-session-sqlx/migrations/0040_granola_sync_tables.sql
+++ b/services/api-rs/crates/centaur-session-sqlx/migrations/0040_granola_sync_tables.sql
@@ -1,0 +1,277 @@
+create extension if not exists pg_search;
+
+create table if not exists granola_sync_runs (
+    run_id text primary key,
+    workflow_run_id text,
+    mode text not null default 'incremental',
+    status text not null,
+    scopes_requested jsonb not null default '[]'::jsonb,
+    scopes_synced jsonb not null default '[]'::jsonb,
+    scopes_failed jsonb not null default '[]'::jsonb,
+    notes_seen integer not null default 0,
+    notes_upserted integer not null default 0,
+    transcripts_seen integer not null default 0,
+    transcripts_upserted integer not null default 0,
+    started_at timestamptz not null default now(),
+    finished_at timestamptz,
+    error_text text not null default '',
+    metadata jsonb not null default '{}'::jsonb
+);
+
+create index if not exists idx_granola_sync_runs_started
+    on granola_sync_runs (started_at desc);
+
+create table if not exists granola_sync_notes (
+    note_id text primary key,
+    title text not null default '',
+    owner_id text not null default '',
+    owner_email text not null default '',
+    owner_name text not null default '',
+    attendees jsonb not null default '[]'::jsonb,
+    access_emails text[] not null default array[]::text[],
+    calendar_event jsonb not null default '{}'::jsonb,
+    summary_markdown text not null default '',
+    summary_text text not null default '',
+    transcript_text text not null default '',
+    transcript_payload jsonb not null default '[]'::jsonb,
+    url text not null default '',
+    content_text text not null default '',
+    content_hash text not null default '',
+    source_created_at timestamptz,
+    source_updated_at timestamptz,
+    raw_payload jsonb not null default '{}'::jsonb,
+    source_run_id text references granola_sync_runs(run_id) on delete set null,
+    first_seen_at timestamptz not null default now(),
+    last_seen_at timestamptz not null default now(),
+    last_error text not null default '',
+    updated_at timestamptz not null default now()
+);
+
+create index if not exists idx_granola_sync_notes_source_updated
+    on granola_sync_notes (source_updated_at desc);
+
+create index if not exists idx_granola_sync_notes_owner
+    on granola_sync_notes (owner_email, source_created_at desc);
+
+create index if not exists idx_granola_sync_notes_access_emails
+    on granola_sync_notes using gin (access_emails);
+
+create index if not exists idx_granola_sync_notes_text
+    on granola_sync_notes
+    using gin (to_tsvector('english', coalesce(content_text, '')));
+
+create table if not exists granola_context_documents (
+    document_id text primary key,
+    note_id text not null references granola_sync_notes(note_id) on delete cascade,
+    title text not null default '',
+    body text not null default '',
+    url text not null default '',
+    owner_id text not null default '',
+    owner_email text not null default '',
+    owner_name text not null default '',
+    access_emails text[] not null default array[]::text[],
+    attendee_labels text[] not null default array[]::text[],
+    occurred_at timestamptz,
+    source_updated_at timestamptz,
+    content_hash text not null default '',
+    metadata jsonb not null default '{}'::jsonb,
+    created_at timestamptz not null default now(),
+    updated_at timestamptz not null default now(),
+    unique (note_id),
+    check (document_id <> ''),
+    check (note_id <> '')
+);
+
+create index if not exists idx_granola_context_documents_note_time
+    on granola_context_documents (note_id, occurred_at desc);
+
+create index if not exists idx_granola_context_documents_owner_time
+    on granola_context_documents (owner_email, occurred_at desc);
+
+create index if not exists idx_granola_context_documents_access_emails
+    on granola_context_documents using gin (access_emails);
+
+create index if not exists idx_granola_context_documents_metadata
+    on granola_context_documents using gin (metadata);
+
+drop index if exists idx_granola_context_documents_bm25;
+
+create index idx_granola_context_documents_bm25
+    on granola_context_documents
+    using bm25 (
+        document_id,
+        note_id,
+        title,
+        body,
+        url,
+        owner_id,
+        owner_email,
+        owner_name,
+        occurred_at,
+        source_updated_at,
+        metadata
+    )
+    with (
+        key_field = 'document_id',
+        text_fields = '{
+            "document_id": {
+                "tokenizer": {"type": "keyword"}
+            },
+            "note_id": {
+                "tokenizer": {"type": "keyword"}
+            },
+            "owner_id": {
+                "tokenizer": {"type": "keyword"}
+            },
+            "owner_email": {
+                "tokenizer": {"type": "keyword"}
+            }
+        }'
+    );
+
+create table if not exists granola_sync_checkpoints (
+    scope_id text primary key,
+    watermark_time timestamptz,
+    last_run_id text references granola_sync_runs(run_id) on delete set null,
+    last_success_at timestamptz,
+    last_error text not null default '',
+    created_at timestamptz not null default now(),
+    updated_at timestamptz not null default now()
+);
+
+do $$
+declare
+    role_name text;
+begin
+    foreach role_name in array array[
+        'centaur_slack_reader',
+        'centaur_slack_admin',
+        'centaur_readonly'
+    ] loop
+        if exists (select 1 from pg_roles where rolname = role_name) then
+            execute format(
+                'grant select on %s to %I',
+                'granola_sync_runs, granola_sync_notes, granola_context_documents, granola_sync_checkpoints',
+                role_name
+            );
+        end if;
+    end loop;
+end $$;
+
+alter table granola_sync_runs enable row level security;
+alter table granola_sync_notes enable row level security;
+alter table granola_context_documents enable row level security;
+alter table granola_sync_checkpoints enable row level security;
+
+create or replace function centaur_current_slack_user_email()
+returns text
+language sql
+stable
+security definer
+set search_path = public
+as $$
+    select coalesce(
+        lower(nullif(current_setting('centaur.user_email', true), '')),
+        (
+            select lower(nullif(coalesce(
+                users.raw_payload #>> '{profile,email}',
+                users.raw_payload ->> 'email'
+            ), ''))
+            from slack_sync_users users
+            where users.team_id = centaur_current_slack_team_id()
+              and users.user_id = centaur_current_slack_user_id()
+            limit 1
+        )
+    )
+$$;
+
+create or replace function centaur_granola_current_user_can_read(
+    p_access_emails text[]
+)
+returns boolean
+language sql
+stable
+as $$
+    select coalesce(
+        centaur_current_slack_user_email() = any(coalesce(p_access_emails, array[]::text[])),
+        false
+    )
+$$;
+
+do $$
+declare
+    role_name text;
+begin
+    foreach role_name in array array[
+        'centaur_slack_reader',
+        'centaur_slack_admin',
+        'centaur_readonly'
+    ] loop
+        if exists (select 1 from pg_roles where rolname = role_name) then
+            execute format(
+                'grant execute on function centaur_current_slack_user_email() to %I',
+                role_name
+            );
+            execute format(
+                'grant execute on function centaur_granola_current_user_can_read(text[]) to %I',
+                role_name
+            );
+        end if;
+    end loop;
+end $$;
+
+drop policy if exists centaur_granola_runs_admin_select on granola_sync_runs;
+drop policy if exists centaur_granola_runs_reader_select on granola_sync_runs;
+create policy centaur_granola_runs_reader_select
+    on granola_sync_runs for select to centaur_slack_reader
+    using (false);
+drop policy if exists centaur_readonly_granola_sync_runs_select on granola_sync_runs;
+create policy centaur_readonly_granola_sync_runs_select
+    on granola_sync_runs for select to centaur_readonly using (false);
+
+drop policy if exists centaur_granola_notes_admin_select on granola_sync_notes;
+drop policy if exists centaur_granola_notes_reader_select on granola_sync_notes;
+create policy centaur_granola_notes_reader_select
+    on granola_sync_notes for select to centaur_slack_reader
+    using (centaur_granola_current_user_can_read(access_emails));
+drop policy if exists centaur_readonly_granola_sync_notes_select on granola_sync_notes;
+create policy centaur_readonly_granola_sync_notes_select
+    on granola_sync_notes for select to centaur_readonly using (false);
+
+drop policy if exists centaur_granola_context_documents_admin_select
+    on granola_context_documents;
+drop policy if exists centaur_granola_context_documents_reader_select
+    on granola_context_documents;
+create policy centaur_granola_context_documents_reader_select
+    on granola_context_documents for select to centaur_slack_reader
+    using (centaur_granola_current_user_can_read(access_emails));
+drop policy if exists centaur_readonly_granola_context_documents_select
+    on granola_context_documents;
+create policy centaur_readonly_granola_context_documents_select
+    on granola_context_documents for select to centaur_readonly using (false);
+
+drop policy if exists centaur_granola_checkpoints_admin_select
+    on granola_sync_checkpoints;
+drop policy if exists centaur_granola_checkpoints_reader_select
+    on granola_sync_checkpoints;
+create policy centaur_granola_checkpoints_reader_select
+    on granola_sync_checkpoints for select to centaur_slack_reader
+    using (false);
+drop policy if exists centaur_readonly_granola_sync_checkpoints_select
+    on granola_sync_checkpoints;
+create policy centaur_readonly_granola_sync_checkpoints_select
+    on granola_sync_checkpoints for select to centaur_readonly using (false);
+
+do $$
+begin
+    if exists (select 1 from pg_roles where rolname = 'centaur_slack_admin') then
+        create policy centaur_granola_runs_admin_select
+            on granola_sync_runs for select to centaur_slack_admin using (true);
+        create policy centaur_granola_notes_admin_select
+            on granola_sync_notes for select to centaur_slack_admin using (true);
+        create policy centaur_granola_context_documents_admin_select
+            on granola_context_documents for select to centaur_slack_admin using (true);
+        create policy centaur_granola_checkpoints_admin_select
+            on granola_sync_checkpoints for select to centaur_slack_admin using (true);
+    end if;
+end $$;

--- a/tools/productivity/company_context/client.py
+++ b/tools/productivity/company_context/client.py
@@ -28,6 +28,8 @@ CHANNEL_DAY_SCORE_MULTIPLIER = 0.75
 DEFAULT_PREVIEW_CHARS = 280
 MAX_RELATED_CHILDREN = 25
 SLACK_DM_SOURCE = "slack_dm"
+GRANOLA_SOURCE = "granola"
+GRANOLA_SOURCE_TYPE = "granola_note"
 DOCS_SOURCE = "docs"
 LEGACY_GOOGLE_DRIVE_SOURCE = "google_drive"
 GOOGLE_DOCS_SOURCE_TYPE = "google_doc"
@@ -421,6 +423,38 @@ def _google_doc_summary(row: Any) -> dict[str, Any]:
     }
 
 
+def _granola_doc_summary(row: Any) -> dict[str, Any]:
+    """Return the common result shape for user-visible Granola notes."""
+    metadata = _as_dict(_row_value(row, "metadata", {}))
+    metadata.update(
+        {
+            "note_id": str(_row_value(row, "note_id", "")),
+            "owner_id": str(_row_value(row, "owner_id", "")),
+            "owner_email": str(_row_value(row, "owner_email", "")),
+            "attendee_labels": list(_row_value(row, "attendee_labels", []) or []),
+        }
+    )
+    return {
+        "document_id": str(_row_value(row, "document_id", "")),
+        "source": GRANOLA_SOURCE,
+        "source_type": GRANOLA_SOURCE_TYPE,
+        "source_document_id": str(_row_value(row, "note_id", "")),
+        "source_chunk_id": "",
+        "parent_document_id": None,
+        "title": str(_row_value(row, "title", "")),
+        "url": str(_row_value(row, "url", "")),
+        "author_name": str(
+            _row_value(row, "owner_name", "")
+            or _row_value(row, "owner_email", "")
+            or _row_value(row, "owner_id", "")
+        ),
+        "access_scope": "granola_note",
+        "occurred_at": _isoformat(_row_value(row, "occurred_at")),
+        "source_updated_at": _isoformat(_row_value(row, "source_updated_at")),
+        "metadata": metadata,
+    }
+
+
 def _dm_document_summary(row: Any) -> dict[str, Any]:
     """Return the common metadata we expose for Slack DM context records."""
     metadata = _as_dict(_row_value(row, "metadata", {}))
@@ -491,6 +525,14 @@ def _include_slack_dms_source(source: str | None, source_type: str | None) -> bo
     )
 
 
+def _include_granola_source(source: str | None, source_type: str | None) -> bool:
+    return (source is None or source == GRANOLA_SOURCE) and source_type in (
+        None,
+        GRANOLA_SOURCE,
+        GRANOLA_SOURCE_TYPE,
+    )
+
+
 def _company_context_filters_for_source(
     source: str | None,
     source_type: str | None,
@@ -534,6 +576,7 @@ class CompanyContextClient:
             search_terms = [query, *terms]
             results = []
             google_docs_error = None
+            granola_error = None
             company_source, company_source_type = _company_context_filters_for_source(
                 source,
                 source_type,
@@ -620,6 +663,29 @@ class CompanyContextClient:
                 except asyncpg.UndefinedTableError as exc:
                     google_docs_error = str(exc)
 
+            if _include_granola_source(source, source_type):
+                try:
+                    granola_rows = await self._search_granola_async(
+                        conn,
+                        search_terms=search_terms,
+                        term_count=len(terms),
+                        limit=limit,
+                        occurred_after=occurred_after,
+                        occurred_before=occurred_before,
+                    )
+                    for row in granola_rows:
+                        result = _granola_doc_summary(row)
+                        result["score"] = float(_row_value(row, "score", 0.0) or 0.0)
+                        result["preview"] = _body_preview(
+                            str(_row_value(row, "body", "") or ""),
+                            query=query,
+                        )
+                        result["lane"] = "indexed"
+                        result["result_type"] = GRANOLA_SOURCE_TYPE
+                        results.append(result)
+                except asyncpg.UndefinedTableError as exc:
+                    granola_error = str(exc)
+
             results.sort(
                 key=lambda item: (
                     float(item.get("score") or 0.0),
@@ -651,6 +717,8 @@ class CompanyContextClient:
             }
             if google_docs_error:
                 response["google_docs_error"] = google_docs_error
+            if granola_error:
+                response["granola_error"] = granola_error
             return response
         finally:
             await conn.close()
@@ -699,6 +767,54 @@ class CompanyContextClient:
             *search_terms,
             modified_after,
             modified_before,
+            limit,
+        )
+
+    async def _search_granola_async(
+        self,
+        conn: asyncpg.Connection,
+        *,
+        search_terms: list[str],
+        term_count: int,
+        limit: int,
+        occurred_after: datetime | None,
+        occurred_before: datetime | None,
+    ) -> list[Any]:
+        occurred_after_param = len(search_terms) + 1
+        occurred_before_param = len(search_terms) + 2
+        limit_param = len(search_terms) + 3
+        return await conn.fetch(
+            f"""
+            SELECT
+                document_id,
+                note_id,
+                title,
+                body,
+                url,
+                owner_id,
+                owner_email,
+                owner_name,
+                access_emails,
+                attendee_labels,
+                occurred_at,
+                source_updated_at,
+                metadata,
+                paradedb.score(document_id) AS score
+            FROM granola_context_documents
+            WHERE {_search_where_clause(term_count)}
+              AND (${occurred_after_param}::timestamptz IS NULL
+                   OR occurred_at >= ${occurred_after_param})
+              AND (${occurred_before_param}::timestamptz IS NULL
+                   OR occurred_at < ${occurred_before_param})
+            ORDER BY paradedb.score(document_id) DESC,
+                     occurred_at DESC NULLS LAST,
+                     source_updated_at DESC NULLS LAST,
+                     document_id ASC
+            LIMIT ${limit_param}
+            """,
+            *search_terms,
+            occurred_after,
+            occurred_before,
             limit,
         )
 
@@ -772,6 +888,31 @@ class CompanyContextClient:
             "latest_source_updated_at": _isoformat(row["latest_source_updated_at"]),
             "latest_occurred_at": _isoformat(row["latest_occurred_at"]),
         }
+
+    async def _latest_granola_for_connection(
+        self,
+        conn: asyncpg.Connection,
+        *,
+        source: str | None,
+        source_type: str | None,
+    ) -> dict[str, Any]:
+        if not _include_granola_source(source, source_type):
+            return self._empty_latest_date_result(source=source, source_type=source_type)
+        row = await conn.fetchrow(
+            """
+            SELECT
+                MAX(COALESCE(source_updated_at, occurred_at)) AS latest_date,
+                MAX(source_updated_at) AS latest_source_updated_at,
+                MAX(occurred_at) AS latest_occurred_at,
+                COUNT(*)::bigint AS document_count
+            FROM granola_context_documents
+            """
+        )
+        return self._latest_date_result_from_row(
+            row,
+            source=source,
+            source_type=source_type,
+        )
 
     async def _latest_slack_dms_for_connection(
         self,
@@ -880,6 +1021,7 @@ class CompanyContextClient:
         indexed: dict[str, Any],
         google_docs: dict[str, Any],
         slack_dms: dict[str, Any] | None = None,
+        granola: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         def latest(values: list[str | None]) -> str | None:
             present = [value for value in values if value]
@@ -888,6 +1030,8 @@ class CompanyContextClient:
         latest_results = [indexed, google_docs]
         if slack_dms is not None:
             latest_results.append(slack_dms)
+        if granola is not None:
+            latest_results.append(granola)
 
         return {
             "status": "ok",
@@ -1167,6 +1311,7 @@ class CompanyContextClient:
         try:
             results = []
             google_docs_error = None
+            granola_error = None
             company_source, company_source_type = _company_context_filters_for_source(
                 source,
                 source_type,
@@ -1227,6 +1372,23 @@ class CompanyContextClient:
                         results.append(result)
                 except asyncpg.UndefinedTableError as exc:
                     google_docs_error = str(exc)
+            if _include_granola_source(source, source_type):
+                try:
+                    granola_rows = await self._list_granola_async(
+                        conn,
+                        limit=limit,
+                        occurred_after=occurred_after,
+                        occurred_before=occurred_before,
+                    )
+                    for row in granola_rows:
+                        result = _granola_doc_summary(row)
+                        result["preview"] = _body_preview(
+                            str(_row_value(row, "body", "") or ""),
+                            query="",
+                        )
+                        results.append(result)
+                except asyncpg.UndefinedTableError as exc:
+                    granola_error = str(exc)
             results.sort(
                 key=lambda item: (
                     str(item.get("occurred_at") or ""),
@@ -1246,6 +1408,8 @@ class CompanyContextClient:
             }
             if google_docs_error:
                 response["google_docs_error"] = google_docs_error
+            if granola_error:
+                response["granola_error"] = granola_error
             return response
         finally:
             await conn.close()
@@ -1283,6 +1447,42 @@ class CompanyContextClient:
             """,
             modified_after,
             modified_before,
+            limit,
+        )
+
+    async def _list_granola_async(
+        self,
+        conn: asyncpg.Connection,
+        *,
+        limit: int,
+        occurred_after: datetime | None,
+        occurred_before: datetime | None,
+    ) -> list[Any]:
+        return await conn.fetch(
+            """
+            SELECT
+                document_id,
+                note_id,
+                title,
+                body,
+                url,
+                owner_id,
+                owner_email,
+                owner_name,
+                access_emails,
+                attendee_labels,
+                occurred_at,
+                source_updated_at,
+                metadata
+            FROM granola_context_documents
+            WHERE ($1::timestamptz IS NULL OR occurred_at >= $1)
+              AND ($2::timestamptz IS NULL OR occurred_at < $2)
+            ORDER BY occurred_at DESC NULLS LAST, source_updated_at DESC NULLS LAST,
+                     document_id ASC
+            LIMIT $3
+            """,
+            occurred_after,
+            occurred_before,
             limit,
         )
 
@@ -1343,12 +1543,20 @@ class CompanyContextClient:
                 source=source,
                 source_type=source_type,
             )
+            granola = self._empty_latest_date_result(source=source, source_type=source_type)
+            with suppress(asyncpg.UndefinedTableError):
+                granola = await self._latest_granola_for_connection(
+                    conn,
+                    source=source,
+                    source_type=source_type,
+                )
             return self._merge_latest_dates(
                 source=source,
                 source_type=source_type,
                 indexed=indexed,
                 google_docs=google_docs,
                 slack_dms=slack_dms,
+                granola=granola,
             )
         finally:
             await conn.close()
@@ -1468,6 +1676,16 @@ class CompanyContextClient:
                     google_doc = None
                 if google_doc is not None:
                     return google_doc
+                try:
+                    granola_doc = await self._read_granola_doc_async(
+                        conn,
+                        document_id,
+                        max_chars,
+                    )
+                except asyncpg.UndefinedTableError:
+                    granola_doc = None
+                if granola_doc is not None:
+                    return granola_doc
                 return {
                     "status": "error",
                     "error": f"document not found: {document_id}",
@@ -1530,6 +1748,48 @@ class CompanyContextClient:
         return {
             "status": "ok",
             **_google_doc_summary(row),
+            "chars": len(content),
+            "total_chars": len(body),
+            "truncated": truncated,
+            "content": content,
+        }
+
+    async def _read_granola_doc_async(
+        self,
+        conn: asyncpg.Connection,
+        document_id: str,
+        max_chars: int | None,
+    ) -> dict[str, Any] | None:
+        row = await conn.fetchrow(
+            """
+            SELECT
+                document_id,
+                note_id,
+                title,
+                body,
+                url,
+                owner_id,
+                owner_email,
+                owner_name,
+                access_emails,
+                attendee_labels,
+                occurred_at,
+                source_updated_at,
+                metadata
+            FROM granola_context_documents
+            WHERE document_id = $1
+            """,
+            document_id,
+        )
+        if not row:
+            return None
+
+        body = str(row["body"] or "")
+        content = body if max_chars is None else body[:max_chars]
+        truncated = max_chars is not None and len(body) > max_chars
+        return {
+            "status": "ok",
+            **_granola_doc_summary(row),
             "chars": len(content),
             "total_chars": len(body),
             "truncated": truncated,

--- a/tools/productivity/company_context/tests/test_client.py
+++ b/tools/productivity/company_context/tests/test_client.py
@@ -252,6 +252,7 @@ def test_search_emits_grouped_lookup_metrics(monkeypatch):
     pushed_lines = []
     monkeypatch.setattr(company_context_client.asyncpg, "connect", fake_connect)
     monkeypatch.setattr(company_context_client, "_include_google_docs_source", lambda *_args: False)
+    monkeypatch.setattr(company_context_client, "_include_granola_source", lambda *_args: False)
     monkeypatch.setattr(
         company_context_client,
         "_push_company_context_lookup_metric_lines",
@@ -571,6 +572,78 @@ def test_search_drive_source_is_not_docs_alias(monkeypatch):
     assert "FROM company_context_documents" in query
     assert "FROM google_docs_context_documents" not in query
     assert args == ("roadmap", "roadmap", "drive", None, None, None, 10)
+    assert fake.closed is True
+
+
+def test_search_granola_source_queries_private_note_projection(monkeypatch):
+    occurred_at = dt.datetime(2026, 7, 1, 10, 0, tzinfo=dt.UTC)
+    source_updated_at = dt.datetime(2026, 7, 1, 10, 30, tzinfo=dt.UTC)
+    fake = _FakeConnection(
+        fetch_rows=[
+            [],
+            [
+                {
+                    "document_id": "granola:note:not_123",
+                    "note_id": "not_123",
+                    "title": "Launch review",
+                    "body": "We agreed to ship.",
+                    "url": "https://app.granola.ai/notes/not_123",
+                    "owner_id": "usr_1",
+                    "owner_email": "alice@example.com",
+                    "owner_name": "Alice",
+                    "access_emails": ["alice@example.com", "bob@example.com"],
+                    "attendee_labels": ["Bob <bob@example.com>"],
+                    "occurred_at": occurred_at,
+                    "source_updated_at": source_updated_at,
+                    "metadata": {"note_id": "not_123"},
+                    "score": 3.0,
+                }
+            ],
+        ]
+    )
+
+    async def fake_connect(*args, **kwargs):
+        return fake
+
+    monkeypatch.setattr(company_context_client.asyncpg, "connect", fake_connect)
+
+    result = CompanyContextClient("postgresql://example").search(
+        "launch review",
+        source="granola",
+        occurred_after="2026-07-01",
+        occurred_before="2026-07-02",
+    )
+
+    assert result["status"] == "ok"
+    assert result["count"] == 1
+    assert result["results"][0]["source"] == "granola"
+    assert result["results"][0]["source_type"] == "granola_note"
+    assert result["results"][0]["source_document_id"] == "not_123"
+    assert result["results"][0]["author_name"] == "Alice"
+    legacy_query, legacy_args = fake.fetch_calls[0]
+    granola_query, granola_args = fake.fetch_calls[1]
+    assert "FROM company_context_documents" in legacy_query
+    assert legacy_args == (
+        "launch review",
+        "launch",
+        "review",
+        "granola",
+        None,
+        dt.datetime(2026, 7, 1, tzinfo=dt.UTC),
+        dt.datetime(2026, 7, 2, tzinfo=dt.UTC),
+        10,
+    )
+    assert "FROM granola_context_documents" in granola_query
+    assert "occurred_at >= $4" in granola_query
+    assert "occurred_at < $5" in granola_query
+    assert granola_args == (
+        "launch review",
+        "launch",
+        "review",
+        dt.datetime(2026, 7, 1, tzinfo=dt.UTC),
+        dt.datetime(2026, 7, 2, tzinfo=dt.UTC),
+        10,
+    )
     assert fake.closed is True
 
 
@@ -1153,6 +1226,54 @@ def test_read_document_falls_back_to_oauth_google_docs_index(monkeypatch):
     assert result["total_chars"] == len(body)
     assert result["truncated"] is True
     assert len(fake.fetchrow_calls) == 2
+    assert fake.closed is True
+
+
+def test_read_document_falls_back_to_granola_note_projection(monkeypatch):
+    body = "Granola note content"
+    fake = _FakeConnection(
+        fetchrow_rows=[
+            None,
+            None,
+            {
+                "document_id": "granola:note:not_123",
+                "note_id": "not_123",
+                "title": "Launch review",
+                "body": body,
+                "url": "https://app.granola.ai/notes/not_123",
+                "owner_id": "usr_1",
+                "owner_email": "alice@example.com",
+                "owner_name": "Alice",
+                "access_emails": ["alice@example.com", "bob@example.com"],
+                "attendee_labels": ["Bob <bob@example.com>"],
+                "occurred_at": dt.datetime(2026, 7, 1, 10, 0, tzinfo=dt.UTC),
+                "source_updated_at": dt.datetime(2026, 7, 1, 10, 30, tzinfo=dt.UTC),
+                "metadata": {"note_id": "not_123"},
+            },
+        ]
+    )
+
+    async def fake_connect(*args, **kwargs):
+        return fake
+
+    monkeypatch.setattr(company_context_client.asyncpg, "connect", fake_connect)
+
+    result = CompanyContextClient("postgresql://example").read_document(
+        "granola:note:not_123",
+        max_chars=7,
+    )
+
+    assert result["status"] == "ok"
+    assert result["source"] == "granola"
+    assert result["source_type"] == "granola_note"
+    assert result["source_document_id"] == "not_123"
+    assert result["author_name"] == "Alice"
+    assert result["content"] == "Granola"
+    assert result["chars"] == 7
+    assert result["total_chars"] == len(body)
+    assert result["truncated"] is True
+    assert len(fake.fetchrow_calls) == 3
+    assert "FROM granola_context_documents" in fake.fetchrow_calls[2][0]
     assert fake.closed is True
 
 

--- a/workflows/granola_sync.py
+++ b/workflows/granola_sync.py
@@ -1,0 +1,757 @@
+"""Workflow: sync Granola notes and transcripts into Postgres."""
+
+from __future__ import annotations
+
+import datetime as dt
+import hashlib
+import os
+from dataclasses import dataclass, field
+from typing import Any, Protocol
+
+from api.runtime_control import canonical_json
+from workflows.etl_metrics import (
+    record_etl_items_failed,
+    record_etl_items_seen,
+    record_etl_items_upserted,
+    set_etl_active_scopes,
+    set_etl_failed_scopes,
+    set_etl_scope_sync_freshness_seconds,
+)
+from api.workflow_engine import WorkflowContext
+from workflows.slack.shared import env_flag_enabled, positive_int
+
+WORKFLOW_NAME = "granola_sync"
+DEFAULT_SYNC_INTERVAL_SECONDS = 4 * 60 * 60
+DEFAULT_PAGE_SIZE = 30
+DEFAULT_WATERMARK_OVERLAP_SECONDS = 5 * 60
+WORKSPACE_SCOPE = "workspace"
+
+
+SCHEDULE = {
+    "schedule_id": "granola_sync",
+    "interval_seconds": positive_int(
+        os.getenv("GRANOLA_SYNC_INTERVAL_SECONDS"),
+        DEFAULT_SYNC_INTERVAL_SECONDS,
+    ),
+    "enabled": env_flag_enabled("GRANOLA_ETL_ENABLED", default=False),
+    "no_delivery": True,
+}
+
+
+@dataclass
+class Input:
+    """Runtime options for a manual Granola sync workflow run."""
+
+    since: str | None = None
+    limit: int = DEFAULT_PAGE_SIZE
+    max_notes: int | None = None
+    include_transcripts: bool = True
+    watermark_overlap_seconds: int = DEFAULT_WATERMARK_OVERLAP_SECONDS
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+class GranolaSyncClient(Protocol):
+    """Small adapter protocol used by the Granola ETL workflow."""
+
+    async def list_notes(
+        self,
+        page_size: int = DEFAULT_PAGE_SIZE,
+        cursor: str | None = None,
+        created_before: str | None = None,
+        created_after: str | None = None,
+        updated_after: str | None = None,
+    ) -> dict[str, Any]: ...
+
+    async def get_note(
+        self, note_id: str, include_transcript: bool = False
+    ) -> dict[str, Any]: ...
+
+
+class GranolaToolClient:
+    """Granola client backed by the workflow tool bridge."""
+
+    def __init__(self, ctx: WorkflowContext) -> None:
+        self._ctx = ctx
+
+    async def list_notes(
+        self,
+        page_size: int = DEFAULT_PAGE_SIZE,
+        cursor: str | None = None,
+        created_before: str | None = None,
+        created_after: str | None = None,
+        updated_after: str | None = None,
+    ) -> dict[str, Any]:
+        result = await self._ctx.call_tool(
+            "granola",
+            "list_notes",
+            {
+                "page_size": page_size,
+                "cursor": cursor,
+                "created_before": created_before,
+                "created_after": created_after,
+                "updated_after": updated_after,
+            },
+        )
+        return result if isinstance(result, dict) else {}
+
+    async def get_note(
+        self, note_id: str, include_transcript: bool = False
+    ) -> dict[str, Any]:
+        result = await self._ctx.call_tool(
+            "granola",
+            "get_note",
+            {"note_id": note_id, "include_transcript": include_transcript},
+        )
+        return result if isinstance(result, dict) else {}
+
+
+def _client(ctx: WorkflowContext) -> GranolaSyncClient:
+    return GranolaToolClient(ctx)
+
+
+def _parse_datetime(value: str | None) -> dt.datetime | None:
+    if not value:
+        return None
+    try:
+        parsed = dt.datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=dt.timezone.utc)
+    return parsed.astimezone(dt.timezone.utc)
+
+
+def _source_datetime(payload: dict[str, Any], *keys: str) -> dt.datetime | None:
+    for key in keys:
+        parsed = _parse_datetime(str(payload.get(key) or ""))
+        if parsed is not None:
+            return parsed
+    return None
+
+
+def _rfc3339(value: dt.datetime) -> str:
+    return value.astimezone(dt.timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _text_value(value: Any) -> str:
+    return str(value or "")
+
+
+def _note_url(note: dict[str, Any]) -> str:
+    return _text_value(note.get("url") or note.get("permalink") or note.get("web_url"))
+
+
+def _normalized_email(value: Any) -> str:
+    return str(value or "").strip().lower()
+
+
+def _access_emails(owner: dict[str, Any], attendees: list[Any]) -> list[str]:
+    emails: list[str] = []
+
+    def add(value: Any) -> None:
+        email = _normalized_email(value)
+        if email and email not in emails:
+            emails.append(email)
+
+    add(owner.get("email"))
+    for attendee in attendees:
+        if isinstance(attendee, dict):
+            add(attendee.get("email"))
+    return emails
+
+
+def _json_object(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _json_array(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _format_time(value: dt.datetime | None) -> str:
+    if not value:
+        return "unknown time"
+    return value.astimezone(dt.timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
+
+
+def _named_entry(value: Any) -> str:
+    if isinstance(value, dict):
+        name = _text_value(value.get("name") or value.get("display_name")).strip()
+        email = _text_value(value.get("email")).strip()
+        if name and email:
+            return f"{name} <{email}>"
+        return name or email
+    return _text_value(value).strip()
+
+
+def _named_entries(value: Any) -> list[str]:
+    labels: list[str] = []
+    for entry in _json_array(value):
+        label = _named_entry(entry)
+        if label and label not in labels:
+            labels.append(label)
+    return labels
+
+
+def _content_hash(*parts: Any) -> str:
+    return hashlib.sha256(canonical_json(parts).encode("utf-8")).hexdigest()
+
+
+def _workflow_run_id_to_sync_run_id(workflow_run_id: str) -> str:
+    safe_run_id = "".join(char if char.isalnum() else "_" for char in workflow_run_id)
+    return f"granola_sync_{safe_run_id}"
+
+
+def _scope_ref(scope_id: str, reason: str | None = None) -> dict[str, str]:
+    result = {"scope_id": scope_id}
+    if reason:
+        result["reason"] = reason
+    return result
+
+
+def _failure_reason(error: str) -> str:
+    lowered = error.lower()
+    if "rate" in lowered or "429" in lowered:
+        return "rate_limited"
+    if (
+        "401" in lowered
+        or "403" in lowered
+        or "auth" in lowered
+        or "permission" in lowered
+    ):
+        return "permission_error"
+    if "database" in lowered or "postgres" in lowered:
+        return "write_error"
+    return "api_error"
+
+
+def _transcript_text(transcript: Any) -> str:
+    lines: list[str] = []
+    for utterance in _json_array(transcript):
+        if not isinstance(utterance, dict):
+            continue
+        speaker = _json_object(utterance.get("speaker"))
+        speaker_name = (
+            _text_value(speaker.get("name"))
+            or _text_value(speaker.get("email"))
+            or _text_value(speaker.get("source"))
+            or "Unknown"
+        )
+        text = _text_value(utterance.get("text")).strip()
+        if text:
+            lines.append(f"{speaker_name}: {text}")
+    return "\n".join(lines)
+
+
+def _granola_context_document(
+    *,
+    note: dict[str, Any],
+    note_id: str,
+    title: str,
+    owner: dict[str, Any],
+    attendees: list[Any],
+    access_emails: list[str],
+    calendar_event: dict[str, Any],
+    transcript: list[Any],
+    transcript_text: str,
+    summary_markdown: str,
+    summary_text: str,
+    source_created_at: dt.datetime | None,
+    source_updated_at: dt.datetime | None,
+) -> dict[str, Any]:
+    owner_id = _text_value(owner.get("id") or owner.get("user_id"))
+    owner_email = _text_value(owner.get("email"))
+    owner_name = _text_value(owner.get("name") or owner.get("display_name"))
+    owner_label = _named_entry(owner)
+    attendee_labels = _named_entries(attendees)
+    document_title = title.strip() or "Untitled Granola note"
+    url = _note_url(note)
+    summary = summary_markdown.strip() or summary_text.strip()
+
+    lines = [
+        f"# {document_title}",
+        "",
+        "- Source: Granola",
+        f"- Created: {_format_time(source_created_at)}",
+        f"- Updated: {_format_time(source_updated_at)}",
+    ]
+    if owner_label:
+        lines.append(f"- Owner: {owner_label}")
+    if attendee_labels:
+        lines.append(f"- Attendees: {', '.join(attendee_labels)}")
+    if url:
+        lines.append(f"- URL: {url}")
+    if summary:
+        lines.extend(["", "## Summary", summary])
+    if transcript_text.strip():
+        lines.extend(["", "## Transcript", transcript_text.strip()])
+
+    body = "\n".join(lines).strip()
+    metadata = {
+        "source": "granola",
+        "note_id": note_id,
+        "owner_id": owner_id,
+        "owner_email": owner_email,
+        "owner_name": owner_name,
+        "access_emails": access_emails,
+        "attendees": attendees,
+        "attendee_labels": attendee_labels,
+        "calendar_event": calendar_event,
+        "transcript_payload": transcript,
+        "has_summary": bool(summary),
+        "has_transcript": bool(transcript_text.strip()),
+        "raw_payload": note,
+    }
+    return {
+        "document_id": f"granola:note:{note_id}",
+        "note_id": note_id,
+        "title": document_title,
+        "body": body,
+        "url": url,
+        "owner_id": owner_id,
+        "owner_email": owner_email,
+        "owner_name": owner_name,
+        "access_emails": access_emails,
+        "attendee_labels": attendee_labels,
+        "occurred_at": source_created_at or source_updated_at,
+        "source_updated_at": source_updated_at,
+        "content_hash": _content_hash(document_title, body, url, metadata),
+        "metadata": metadata,
+    }
+
+
+async def _load_checkpoint(pool, scope_id: str) -> dict[str, Any] | None:
+    row = await pool.fetchrow(
+        "SELECT watermark_time, last_error FROM granola_sync_checkpoints "
+        "WHERE scope_id = $1",
+        scope_id,
+    )
+    return dict(row) if row else None
+
+
+async def _update_checkpoint_success(
+    pool,
+    *,
+    scope_id: str,
+    watermark_time: dt.datetime | None,
+    run_id: str,
+) -> None:
+    await pool.execute(
+        "INSERT INTO granola_sync_checkpoints ("
+        "scope_id, watermark_time, last_run_id, last_success_at, last_error, updated_at"
+        ") VALUES ($1, $2, $3, NOW(), '', NOW()) "
+        "ON CONFLICT (scope_id) DO UPDATE SET "
+        "watermark_time = COALESCE(EXCLUDED.watermark_time, "
+        "granola_sync_checkpoints.watermark_time), "
+        "last_run_id = EXCLUDED.last_run_id, "
+        "last_success_at = NOW(), "
+        "last_error = '', "
+        "updated_at = NOW()",
+        scope_id,
+        watermark_time,
+        run_id,
+    )
+
+
+async def _update_checkpoint_failure(
+    pool,
+    *,
+    scope_id: str,
+    run_id: str,
+    error: str,
+) -> None:
+    await pool.execute(
+        "INSERT INTO granola_sync_checkpoints ("
+        "scope_id, last_run_id, last_error, updated_at"
+        ") VALUES ($1, $2, $3, NOW()) "
+        "ON CONFLICT (scope_id) DO UPDATE SET "
+        "last_run_id = EXCLUDED.last_run_id, "
+        "last_error = EXCLUDED.last_error, "
+        "updated_at = NOW()",
+        scope_id,
+        run_id,
+        error,
+    )
+
+
+async def _emit_checkpoint_metrics(pool) -> None:
+    """Publish Granola workspace checkpoint health for the ETL overview."""
+    row = await pool.fetchrow(
+        "SELECT COUNT(*) AS active_scopes, "
+        "COUNT(*) FILTER (WHERE last_error <> '') AS failed_scopes, "
+        "COALESCE("
+        "  EXTRACT(EPOCH FROM NOW() - MIN(last_success_at) "
+        "    FILTER (WHERE last_success_at IS NOT NULL)"
+        "  ), "
+        "  0"
+        ") AS freshness_seconds "
+        "FROM granola_sync_checkpoints"
+    )
+    set_etl_active_scopes("granola", int(row["active_scopes"] or 0) if row else 0)
+    set_etl_failed_scopes("granola", int(row["failed_scopes"] or 0) if row else 0)
+    set_etl_scope_sync_freshness_seconds(
+        "granola",
+        float(row["freshness_seconds"] or 0.0) if row else 0.0,
+    )
+
+
+async def _record_run_start(
+    pool,
+    *,
+    run_id: str,
+    workflow_run_id: str,
+    scopes_requested: list[dict[str, str]],
+    metadata: dict[str, Any],
+) -> None:
+    await pool.execute(
+        "INSERT INTO granola_sync_runs ("
+        "run_id, workflow_run_id, mode, status, scopes_requested, metadata"
+        ") VALUES ($1, $2, 'incremental', 'running', $3::jsonb, $4::jsonb) "
+        "ON CONFLICT (run_id) DO UPDATE SET "
+        "workflow_run_id = EXCLUDED.workflow_run_id, "
+        "status = 'running', "
+        "scopes_requested = EXCLUDED.scopes_requested, "
+        "scopes_synced = '[]'::jsonb, "
+        "scopes_failed = '[]'::jsonb, "
+        "notes_seen = 0, "
+        "notes_upserted = 0, "
+        "transcripts_seen = 0, "
+        "transcripts_upserted = 0, "
+        "finished_at = NULL, "
+        "error_text = '', "
+        "metadata = EXCLUDED.metadata",
+        run_id,
+        workflow_run_id,
+        canonical_json(scopes_requested),
+        canonical_json(metadata),
+    )
+
+
+async def _record_run_finish(
+    pool,
+    *,
+    run_id: str,
+    status: str,
+    scopes_synced: list[dict[str, str]],
+    scopes_failed: list[dict[str, str]],
+    counts: dict[str, int],
+    error_text: str = "",
+) -> None:
+    await pool.execute(
+        "UPDATE granola_sync_runs SET "
+        "status = $2, scopes_synced = $3::jsonb, scopes_failed = $4::jsonb, "
+        "notes_seen = $5, notes_upserted = $6, transcripts_seen = $7, "
+        "transcripts_upserted = $8, finished_at = NOW(), error_text = $9 "
+        "WHERE run_id = $1",
+        run_id,
+        status,
+        canonical_json(scopes_synced),
+        canonical_json(scopes_failed),
+        counts.get("notes_seen", 0),
+        counts.get("notes_upserted", 0),
+        counts.get("transcripts_seen", 0),
+        counts.get("transcripts_upserted", 0),
+        error_text,
+    )
+
+
+async def _upsert_context_document(pool, document: dict[str, Any]) -> None:
+    await pool.execute(
+        "INSERT INTO granola_context_documents ("
+        "document_id, note_id, title, body, url, owner_id, owner_email, owner_name, "
+        "access_emails, attendee_labels, occurred_at, source_updated_at, content_hash, "
+        "metadata, updated_at"
+        ") VALUES ("
+        "$1, $2, $3, $4, $5, $6, $7, $8, $9::text[], $10::text[], $11, $12, $13, "
+        "$14::jsonb, NOW()"
+        ") ON CONFLICT (document_id) DO UPDATE SET "
+        "note_id = EXCLUDED.note_id, "
+        "title = EXCLUDED.title, "
+        "body = EXCLUDED.body, "
+        "url = EXCLUDED.url, "
+        "owner_id = EXCLUDED.owner_id, "
+        "owner_email = EXCLUDED.owner_email, "
+        "owner_name = EXCLUDED.owner_name, "
+        "access_emails = EXCLUDED.access_emails, "
+        "attendee_labels = EXCLUDED.attendee_labels, "
+        "occurred_at = EXCLUDED.occurred_at, "
+        "source_updated_at = EXCLUDED.source_updated_at, "
+        "content_hash = EXCLUDED.content_hash, "
+        "metadata = EXCLUDED.metadata, "
+        "updated_at = NOW()",
+        document["document_id"],
+        document["note_id"],
+        document["title"],
+        document["body"],
+        document["url"],
+        document["owner_id"],
+        document["owner_email"],
+        document["owner_name"],
+        document["access_emails"],
+        document["attendee_labels"],
+        document["occurred_at"],
+        document["source_updated_at"],
+        document["content_hash"],
+        canonical_json(document["metadata"]),
+    )
+
+
+async def _upsert_note(
+    pool,
+    *,
+    note: dict[str, Any],
+    run_id: str,
+) -> tuple[dt.datetime | None, bool]:
+    note_id = _text_value(note.get("id") or note.get("note_id"))
+    owner = _json_object(note.get("owner"))
+    attendees = _json_array(note.get("attendees"))
+    access_emails = _access_emails(owner, attendees)
+    calendar_event = _json_object(note.get("calendar_event"))
+    transcript = _json_array(note.get("transcript"))
+    transcript_text = _transcript_text(transcript)
+    summary_markdown = _text_value(note.get("summary_markdown"))
+    summary_text = _text_value(note.get("summary_text"))
+    title = _text_value(note.get("title"))
+    content_text = "\n".join(
+        part
+        for part in (title, summary_markdown, summary_text, transcript_text)
+        if part.strip()
+    )
+    source_created_at = _source_datetime(note, "created_at", "createdAt")
+    source_updated_at = (
+        _source_datetime(note, "updated_at", "updatedAt") or source_created_at
+    )
+    context_document = _granola_context_document(
+        note=note,
+        note_id=note_id,
+        title=title,
+        owner=owner,
+        attendees=attendees,
+        access_emails=access_emails,
+        calendar_event=calendar_event,
+        transcript=transcript,
+        transcript_text=transcript_text,
+        summary_markdown=summary_markdown,
+        summary_text=summary_text,
+        source_created_at=source_created_at,
+        source_updated_at=source_updated_at,
+    )
+    await pool.execute(
+        "INSERT INTO granola_sync_notes ("
+        "note_id, title, owner_id, owner_email, owner_name, attendees, access_emails, "
+        "calendar_event, summary_markdown, summary_text, transcript_text, transcript_payload, "
+        "url, content_text, content_hash, source_created_at, source_updated_at, raw_payload, "
+        "source_run_id, last_seen_at, last_error, updated_at"
+        ") VALUES ("
+        "$1, $2, $3, $4, $5, $6::jsonb, $7::text[], $8::jsonb, $9, $10, "
+        "$11, $12::jsonb, $13, $14, $15, $16, $17, $18::jsonb, $19, NOW(), '', NOW()"
+        ") ON CONFLICT (note_id) DO UPDATE SET "
+        "title = EXCLUDED.title, "
+        "owner_id = EXCLUDED.owner_id, "
+        "owner_email = EXCLUDED.owner_email, "
+        "owner_name = EXCLUDED.owner_name, "
+        "attendees = EXCLUDED.attendees, "
+        "access_emails = EXCLUDED.access_emails, "
+        "calendar_event = EXCLUDED.calendar_event, "
+        "summary_markdown = EXCLUDED.summary_markdown, "
+        "summary_text = EXCLUDED.summary_text, "
+        "transcript_text = EXCLUDED.transcript_text, "
+        "transcript_payload = EXCLUDED.transcript_payload, "
+        "url = EXCLUDED.url, "
+        "content_text = EXCLUDED.content_text, "
+        "content_hash = EXCLUDED.content_hash, "
+        "source_created_at = EXCLUDED.source_created_at, "
+        "source_updated_at = EXCLUDED.source_updated_at, "
+        "raw_payload = EXCLUDED.raw_payload, "
+        "source_run_id = EXCLUDED.source_run_id, "
+        "last_seen_at = NOW(), "
+        "last_error = '', "
+        "updated_at = NOW()",
+        note_id,
+        title,
+        _text_value(owner.get("id") or owner.get("user_id")),
+        _text_value(owner.get("email")),
+        _text_value(owner.get("name") or owner.get("display_name")),
+        canonical_json(attendees),
+        access_emails,
+        canonical_json(calendar_event),
+        summary_markdown,
+        summary_text,
+        transcript_text,
+        canonical_json(transcript),
+        _text_value(note.get("url") or note.get("permalink")),
+        content_text,
+        _content_hash(content_text),
+        source_created_at,
+        source_updated_at,
+        canonical_json(note),
+        run_id,
+    )
+    await _upsert_context_document(pool, context_document)
+    return source_updated_at, bool(transcript)
+
+
+async def _sync_workspace(
+    *,
+    client: GranolaSyncClient,
+    pool,
+    page_size: int,
+    updated_after: dt.datetime | None,
+    max_notes: int | None,
+    include_transcripts: bool,
+    run_id: str,
+) -> tuple[int, int, int, int, dt.datetime | None]:
+    seen = 0
+    upserted = 0
+    transcripts_seen = 0
+    transcripts_upserted = 0
+    watermark: dt.datetime | None = None
+    cursor: str | None = None
+    updated_after_arg = _rfc3339(updated_after) if updated_after else None
+
+    while True:
+        page = await client.list_notes(
+            page_size=page_size,
+            cursor=cursor,
+            updated_after=updated_after_arg,
+        )
+        notes = [
+            note
+            for note in page.get("notes", []) or []
+            if isinstance(note, dict) and (note.get("id") or note.get("note_id"))
+        ]
+        if max_notes is not None:
+            notes = notes[: max(max_notes - seen, 0)]
+        seen += len(notes)
+        record_etl_items_seen("granola", WORKSPACE_SCOPE, "note", len(notes))
+
+        for note_ref in notes:
+            note_id = _text_value(note_ref.get("id") or note_ref.get("note_id"))
+            note = (
+                await client.get_note(note_id, include_transcript=include_transcripts)
+                if note_id
+                else note_ref
+            )
+            if not isinstance(note, dict):
+                note = note_ref
+            note.setdefault("id", note_id)
+            source_updated_at, has_transcript = await _upsert_note(
+                pool, note=note, run_id=run_id
+            )
+            upserted += 1
+            record_etl_items_upserted("granola", WORKSPACE_SCOPE, "note", 1)
+            if include_transcripts:
+                transcripts_seen += 1
+                if has_transcript:
+                    transcripts_upserted += 1
+                    record_etl_items_upserted(
+                        "granola", WORKSPACE_SCOPE, "transcript", 1
+                    )
+            if source_updated_at and (
+                watermark is None or source_updated_at > watermark
+            ):
+                watermark = source_updated_at
+
+        if max_notes is not None and seen >= max_notes:
+            break
+        cursor = (
+            _text_value(page.get("cursor") or page.get("next_cursor")).strip() or None
+        )
+        if not page.get("hasMore") or not cursor:
+            break
+
+    return seen, upserted, transcripts_seen, transcripts_upserted, watermark
+
+
+async def handler(inp: Input, ctx: WorkflowContext) -> dict[str, Any]:
+    """Sync changed Granola notes into raw sync tables."""
+    if not env_flag_enabled("GRANOLA_ETL_ENABLED", default=False):
+        ctx.log("granola_sync_skipped_disabled")
+        return {"status": "skipped", "reason": "granola_etl_disabled"}
+
+    page_size = min(positive_int(inp.limit, DEFAULT_PAGE_SIZE), DEFAULT_PAGE_SIZE)
+    overlap_seconds = max(int(inp.watermark_overlap_seconds), 0)
+    run_id = _workflow_run_id_to_sync_run_id(ctx.run_id)
+    scopes_requested = [_scope_ref(WORKSPACE_SCOPE)]
+
+    await _record_run_start(
+        ctx._pool,
+        run_id=run_id,
+        workflow_run_id=ctx.run_id,
+        scopes_requested=scopes_requested,
+        metadata={
+            **inp.metadata,
+            "page_size": page_size,
+            "max_notes": inp.max_notes,
+            "include_transcripts": inp.include_transcripts,
+        },
+    )
+
+    client = _client(ctx)
+    explicit_since = _parse_datetime(inp.since)
+    checkpoint = await _load_checkpoint(ctx._pool, WORKSPACE_SCOPE)
+    watermark = explicit_since
+    if watermark is None and checkpoint and checkpoint.get("watermark_time"):
+        watermark = checkpoint["watermark_time"].astimezone(dt.timezone.utc)
+    if watermark is not None:
+        watermark = watermark - dt.timedelta(seconds=overlap_seconds)
+
+    synced: list[dict[str, str]] = []
+    failed: list[dict[str, str]] = []
+    counts = {
+        "notes_seen": 0,
+        "notes_upserted": 0,
+        "transcripts_seen": 0,
+        "transcripts_upserted": 0,
+    }
+    try:
+        (
+            counts["notes_seen"],
+            counts["notes_upserted"],
+            counts["transcripts_seen"],
+            counts["transcripts_upserted"],
+            successful_watermark,
+        ) = await _sync_workspace(
+            client=client,
+            pool=ctx._pool,
+            page_size=page_size,
+            updated_after=watermark,
+            max_notes=inp.max_notes,
+            include_transcripts=inp.include_transcripts,
+            run_id=run_id,
+        )
+        await _update_checkpoint_success(
+            ctx._pool,
+            scope_id=WORKSPACE_SCOPE,
+            watermark_time=successful_watermark,
+            run_id=run_id,
+        )
+        synced.append(_scope_ref(WORKSPACE_SCOPE))
+    except Exception as exc:
+        error = str(exc)
+        failed.append(_scope_ref(WORKSPACE_SCOPE, error))
+        record_etl_items_failed(
+            "granola", WORKSPACE_SCOPE, "scope", _failure_reason(error)
+        )
+        await _update_checkpoint_failure(
+            ctx._pool,
+            scope_id=WORKSPACE_SCOPE,
+            run_id=run_id,
+            error=error,
+        )
+        ctx.log("granola_sync_scope_failed", scope_id=WORKSPACE_SCOPE, error=error)
+
+    status = "completed" if not failed else "failed"
+    error_text = "" if not failed else "Granola workspace sync failed"
+    await _record_run_finish(
+        ctx._pool,
+        run_id=run_id,
+        status=status,
+        scopes_synced=synced,
+        scopes_failed=failed,
+        counts=counts,
+        error_text=error_text,
+    )
+    await _emit_checkpoint_metrics(ctx._pool)
+
+    return {"status": status, "run_id": run_id, **counts}

--- a/workflows/tests/test_granola_sync.py
+++ b/workflows/tests/test_granola_sync.py
@@ -1,0 +1,219 @@
+from __future__ import annotations
+
+import asyncio
+import datetime as dt
+import importlib
+import json
+import sys
+import types
+from pathlib import Path
+
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+
+def _install_workflow_stubs() -> None:
+    api_module = sys.modules.get("api") or types.ModuleType("api")
+    runtime_control = sys.modules.get("api.runtime_control") or types.ModuleType(
+        "api.runtime_control"
+    )
+    runtime_control.canonical_json = lambda value: json.dumps(value, sort_keys=True)
+
+    etl_metrics = types.ModuleType("workflows.etl_metrics")
+    for name in (
+        "record_etl_items_failed",
+        "record_etl_items_seen",
+        "record_etl_items_upserted",
+        "set_etl_active_scopes",
+        "set_etl_failed_scopes",
+        "set_etl_scope_sync_freshness_seconds",
+    ):
+        setattr(etl_metrics, name, lambda *_args, **_kwargs: None)
+
+    workflow_engine = types.ModuleType("api.workflow_engine")
+    workflow_engine.WorkflowContext = object
+
+    slack_shared = types.ModuleType("workflows.slack.shared")
+    slack_shared.env_flag_enabled = lambda _name, default=True: default
+    slack_shared.positive_int = lambda value, default: (
+        int(value) if value is not None and int(value) > 0 else default
+    )
+
+    api_module.runtime_control = runtime_control
+    api_module.workflow_engine = workflow_engine
+    sys.modules.setdefault("api", api_module)
+    sys.modules["api.runtime_control"] = runtime_control
+    sys.modules["api.workflow_engine"] = workflow_engine
+    sys.modules["workflows.etl_metrics"] = etl_metrics
+    sys.modules["workflows.slack.shared"] = slack_shared
+
+
+def _load(name: str):
+    _install_workflow_stubs()
+    return importlib.import_module(name)
+
+
+def test_granola_transcript_text_uses_speaker_identity():
+    granola = _load("workflows.granola_sync")
+
+    text = granola._transcript_text(
+        [
+            {"speaker": {"name": "Alice"}, "text": "Hello"},
+            {"speaker": {"email": "bob@example.com"}, "text": "Ship it"},
+            {"speaker": {}, "text": ""},
+        ]
+    )
+
+    assert text == "Alice: Hello\nbob@example.com: Ship it"
+
+
+def test_granola_access_emails_include_owner_and_attendees_once():
+    granola = _load("workflows.granola_sync")
+
+    emails = granola._access_emails(
+        {"email": "Alice@Example.com "},
+        [
+            {"email": "bob@example.com"},
+            {"email": "alice@example.com"},
+            {"name": "No Email"},
+        ],
+    )
+
+    assert emails == ["alice@example.com", "bob@example.com"]
+
+
+def test_granola_context_document_is_user_scoped_to_owner_and_attendees():
+    granola = _load("workflows.granola_sync")
+    note = {
+        "id": "not_123",
+        "title": "Launch review",
+        "web_url": "https://app.granola.ai/notes/not_123",
+        "owner": {"id": "usr_1", "name": "Alice", "email": "Alice@Example.com"},
+        "attendees": [
+            {"name": "Bob", "email": "bob@example.com"},
+            {"name": "Alice", "email": "alice@example.com"},
+        ],
+        "summary_markdown": "We agreed to ship.",
+        "transcript": [
+            {"speaker": {"name": "Alice"}, "text": "Let's ship."},
+        ],
+        "created_at": "2026-07-01T10:00:00Z",
+        "updated_at": "2026-07-01T10:30:00Z",
+    }
+    owner = granola._json_object(note["owner"])
+    attendees = granola._json_array(note["attendees"])
+    transcript = granola._json_array(note["transcript"])
+    access_emails = granola._access_emails(owner, attendees)
+
+    document = granola._granola_context_document(
+        note=note,
+        note_id="not_123",
+        title="Launch review",
+        owner=owner,
+        attendees=attendees,
+        access_emails=access_emails,
+        calendar_event={},
+        transcript=transcript,
+        transcript_text=granola._transcript_text(transcript),
+        summary_markdown="We agreed to ship.",
+        summary_text="",
+        source_created_at=dt.datetime(2026, 7, 1, 10, tzinfo=dt.UTC),
+        source_updated_at=dt.datetime(2026, 7, 1, 10, 30, tzinfo=dt.UTC),
+    )
+
+    assert document["document_id"] == "granola:note:not_123"
+    assert document["note_id"] == "not_123"
+    assert document["url"] == "https://app.granola.ai/notes/not_123"
+    assert document["access_emails"] == ["alice@example.com", "bob@example.com"]
+    assert document["attendee_labels"] == [
+        "Bob <bob@example.com>",
+        "Alice <alice@example.com>",
+    ]
+    assert "## Summary\nWe agreed to ship." in document["body"]
+    assert "## Transcript\nAlice: Let's ship." in document["body"]
+    assert document["metadata"]["access_emails"] == [
+        "alice@example.com",
+        "bob@example.com",
+    ]
+    assert document["metadata"]["has_transcript"] is True
+
+
+def test_granola_checkpoint_metrics_use_workspace_checkpoint_health(monkeypatch):
+    granola = _load("workflows.granola_sync")
+    calls: dict[str, list[tuple]] = {
+        "active": [],
+        "failed": [],
+        "freshness": [],
+    }
+    monkeypatch.setattr(
+        granola,
+        "set_etl_active_scopes",
+        lambda *args: calls["active"].append(args),
+    )
+    monkeypatch.setattr(
+        granola,
+        "set_etl_failed_scopes",
+        lambda *args: calls["failed"].append(args),
+    )
+    monkeypatch.setattr(
+        granola,
+        "set_etl_scope_sync_freshness_seconds",
+        lambda *args: calls["freshness"].append(args),
+    )
+
+    class FakePool:
+        def __init__(self) -> None:
+            self.fetchrow_calls: list[tuple[str, tuple]] = []
+
+        async def fetchrow(self, query, *args):
+            self.fetchrow_calls.append((query, args))
+            return {
+                "active_scopes": 1,
+                "failed_scopes": 1,
+                "freshness_seconds": 123.5,
+            }
+
+    pool = FakePool()
+    asyncio.run(granola._emit_checkpoint_metrics(pool))
+
+    assert len(pool.fetchrow_calls) == 1
+    assert "FROM granola_sync_checkpoints" in pool.fetchrow_calls[0][0]
+    assert calls == {
+        "active": [("granola", 1)],
+        "failed": [("granola", 1)],
+        "freshness": [("granola", 123.5)],
+    }
+
+
+def test_granola_sync_emits_checkpoint_metrics_after_a_failed_attempt(monkeypatch):
+    granola = _load("workflows.granola_sync")
+    monkeypatch.setattr(granola, "env_flag_enabled", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(granola, "_client", lambda _ctx: object())
+
+    async def noop(*_args, **_kwargs):
+        return None
+
+    async def fail_sync(*_args, **_kwargs):
+        raise RuntimeError("Granola API unavailable")
+
+    emitted: list[object] = []
+
+    async def record_metrics(pool):
+        emitted.append(pool)
+
+    monkeypatch.setattr(granola, "_record_run_start", noop)
+    monkeypatch.setattr(granola, "_load_checkpoint", noop)
+    monkeypatch.setattr(granola, "_sync_workspace", fail_sync)
+    monkeypatch.setattr(granola, "_update_checkpoint_failure", noop)
+    monkeypatch.setattr(granola, "_record_run_finish", noop)
+    monkeypatch.setattr(granola, "_emit_checkpoint_metrics", record_metrics)
+
+    pool = object()
+    context = types.SimpleNamespace(
+        run_id="run-123", _pool=pool, log=lambda *_args, **_kwargs: None
+    )
+
+    result = asyncio.run(granola.handler(granola.Input(), context))
+
+    assert result["status"] == "failed"
+    assert emitted == [pool]


### PR DESCRIPTION
## Summary

Adds a scheduled Granola sync workflow that writes notes/transcripts into dedicated Postgres sync tables with run metadata and checkpoints.

Adds a separate `granola_context_documents` projection, searched by the company-context tool as `source=granola`, instead of mixing user-scoped Granola notes into shared `company_context_documents`.

Adds the standard ETL health gauges for Granola: active scopes, failed scopes, and checkpoint freshness.

## Access model

- `GRANOLA_ETL_ENABLED` gates the new schedule; disabled runs skip cleanly.
- Synced notes and context documents store normalized `access_emails` from the note owner and attendees.
- `centaur_slack_reader` can read Granola rows only when the current user email, resolved from `centaur.user_email` or the current Slack user's synced profile email, appears in `access_emails`.
- `company_context_documents` is no longer modified for Granola; Granola follows the Slack-DM-style separate-table model.
- `centaur_readonly` returns no Granola rows; `centaur_slack_admin` keeps explicit admin visibility when that optional database role exists.

## Runtime fixes

- The migration now conditionally grants function execution to optional RLS roles, so a fresh database without `centaur_slack_admin` migrates successfully.
- `centaur_sdk` is installed in the `api-rs` image so Python ETLs, including Granola, load in the workflow host.

## Validation

- `uvx --from pytest pytest workflows/tests/test_granola_sync.py`
- `uvx ruff check workflows/granola_sync.py workflows/tests/test_granola_sync.py`
- `uvx ruff format --check workflows/granola_sync.py workflows/tests/test_granola_sync.py`
- `git diff --check`
- `just build-one api-rs` and `just build-one agent`
- Fresh local Kubernetes namespace: applied `0038_granola_sync_tables.sql`, loaded the enabled Granola schedule, and ran `granola_sync` end-to-end through the workflow sandbox. The credentialless local run returned the expected 401 and verified the failed checkpoint plus `etl_active_scopes`, `etl_failed_scopes`, `etl_scope_sync_freshness_seconds`, and `etl_items_failed_total` metrics.