### PR TITLE
fix(slack): populate channel member emails

### DIFF
--- a/tools/productivity/slack/client.py
+++ b/tools/productivity/slack/client.py
@@ -1261,6 +1261,49 @@ class SlackClient:
 
         return sorted(users[:limit], key=lambda x: x["name"])
 
+    def _users_by_id(self, user_ids: list[str]) -> dict[str, dict[str, Any]]:
+        """Fetch Slack user profiles for a known set of user IDs."""
+        wanted = {user_id for user_id in user_ids if user_id}
+        users: dict[str, dict[str, Any]] = {}
+        cursor = None
+
+        while wanted:
+            try:
+                kwargs: dict[str, Any] = {"limit": self._MAX_PAGE_SIZE}
+                if cursor:
+                    kwargs["cursor"] = cursor
+                response = self._retry_on_ratelimit(
+                    self._client.users_list,
+                    method_key="users.list",
+                    **kwargs,
+                )
+            except (SlackApiError, SlackRateLimitError):
+                return users
+
+            for user in response.get("members", []):
+                user_id = user.get("id", "")
+                if user_id not in wanted:
+                    continue
+                profile = user.get("profile", {}) or {}
+                users[user_id] = {
+                    "id": user_id,
+                    "name": user.get("name", ""),
+                    "real_name": user.get("real_name", ""),
+                    "display_name": profile.get("display_name", ""),
+                    "email": profile.get("email", ""),
+                    "title": profile.get("title", ""),
+                    "is_bot": user.get("is_bot", False),
+                    "is_deleted": user.get("deleted", False),
+                    "team_id": user.get("team_id", "") or user.get("team", ""),
+                }
+                wanted.remove(user_id)
+
+            cursor = response.get("response_metadata", {}).get("next_cursor")
+            if not cursor:
+                break
+
+        return users
+
     def get_channel_members(self, channel: str) -> list[dict]:
         """Get all members of a Slack channel with their user info.
 
@@ -1297,19 +1340,15 @@ class SlackClient:
             if not cursor:
                 break
 
-        # Use bulk user cache instead of fresh API call
-        user_cache = self._get_user_cache()
+        users_by_id = self._users_by_id(member_ids)
 
         members = []
         for member_id in member_ids:
-            name = user_cache.get(member_id)
-            if name:
-                members.append(
-                    {
-                        "id": member_id,
-                        "name": name,
-                    }
-                )
+            member = users_by_id.get(member_id)
+            if member:
+                members.append(member)
+            else:
+                members.append({"id": member_id, "name": member_id})
 
         return members
 

--- a/tools/productivity/slack/tests/test_client.py
+++ b/tools/productivity/slack/tests/test_client.py
@@ -22,6 +22,8 @@ class _FakeWebClient:
         self.history_pages: list[dict] = []
         self.reply_calls: list[dict] = []
         self.reply_pages: list[dict] = []
+        self.member_calls: list[dict] = []
+        self.member_pages: list[dict] = []
         self.open_calls: list[dict] = []
         self.open_response: dict = {"channel": {"id": "D123"}}
         self.users_calls: list[dict] = []
@@ -55,6 +57,10 @@ class _FakeWebClient:
     def conversations_replies(self, **kwargs):
         self.reply_calls.append(kwargs)
         return self.reply_pages.pop(0)
+
+    def conversations_members(self, **kwargs):
+        self.member_calls.append(kwargs)
+        return self.member_pages.pop(0)
 
     def conversations_open(self, **kwargs):
         self.open_calls.append(kwargs)
@@ -544,6 +550,39 @@ def test_get_thread_replies_page_uses_bounded_default() -> None:
     assert fake_web_client.reply_calls[0]["limit"] == 50
     assert result["effective_limit"] == 50
     assert result["continuation_available"] is False
+
+
+def test_get_channel_member_emails_uses_member_profiles() -> None:
+    client, fake_web_client = _make_client()
+    fake_web_client.member_pages = [
+        {
+            "members": ["U1", "U2"],
+            "response_metadata": {"next_cursor": ""},
+        }
+    ]
+    fake_web_client.users_pages = [
+        {
+            "members": [
+                {
+                    "id": "U1",
+                    "name": "alice",
+                    "real_name": "Alice Example",
+                    "profile": {"email": "alice@example.com"},
+                },
+                {
+                    "id": "U2",
+                    "name": "bob",
+                    "real_name": "Bob Example",
+                    "profile": {},
+                },
+            ],
+            "response_metadata": {"next_cursor": ""},
+        }
+    ]
+
+    assert client.get_channel_member_emails("paradigm-pulse") == ["alice@example.com"]
+    assert fake_web_client.member_calls == [{"channel": "C123", "limit": 200}]
+    assert fake_web_client.users_calls == [{"limit": 200}]
 
 
 def test_dump_channel_with_threads_limits_thread_expansion() -> None:


### PR DESCRIPTION
## Summary
- Enrich Slack channel members with profile data from `users.list` keyed by the IDs returned by `conversations.members`.
- Preserve the existing fallback when profile lookup is unavailable.
- Add regression coverage for `get_channel_member_emails`, which backs the `channel-emails` CLI used by downstream GSuite permission helpers.

## Why
`get_channel_member_emails()` expected `get_channel_members()` entries to include `email`, but `get_channel_members()` only returned `id` and `name` from the user-name cache. That made email export return an empty list even when Slack user profiles included emails.

## Tests
- `python3 -m ruff check tools/productivity/slack/client.py tools/productivity/slack/tests/test_client.py`
- `PYTHONPATH=tools/productivity /tmp/centaur-slack-venv/bin/python -m pytest tools/productivity/slack/tests/test_client.py -q`
- `python3 -m py_compile tools/productivity/slack/client.py tools/productivity/slack/tests/test_client.py`