### PR TITLE
ci(docs): fail the build when public/md mirrors drift from pages; resync

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -45,6 +45,17 @@ jobs:
         with:
           persist-credentials: false
 
+      # The build regenerates public/md on the fly, so the deployed site never
+      # drifts — only the committed copies agents curl from the repo do.
+      - name: Check committed md mirrors are in sync
+        run: |
+          bash scripts/build-md.sh
+          if ! git diff --exit-code --stat -- public/md; then
+            echo "docs/public/md is out of sync with docs/pages;" \
+              "run 'bash docs/scripts/build-md.sh' and commit the result." >&2
+            exit 1
+          fi
+
       - name: Set up Node
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -50,6 +50,9 @@ jobs:
       - name: Check committed md mirrors are in sync
         run: |
           bash scripts/build-md.sh
+          # Intent-add so mirrors for newly added pages (untracked files)
+          # also register as drift; git diff ignores untracked paths.
+          git add -N public/md
           if ! git diff --exit-code --stat -- public/md; then
             echo "docs/public/md is out of sync with docs/pages;" \
               "run 'bash docs/scripts/build-md.sh' and commit the result." >&2

--- a/docs/public/md/extend/acme-example.md
+++ b/docs/public/md/extend/acme-example.md
@@ -87,12 +87,8 @@ git -C centaur-acme rev-parse --short HEAD
 The Centaur chart's repo-cache DaemonSet checks out the overlay repo on each
 node, so changing tools, workflows, or skills is a Git push — no API, sandbox,
 or overlay image rebuild is required for overlay-only changes. New sandboxes see
-the latest cached checkout. Repo-cache-enabled running sandboxes auto-refresh
-their local tool shims and copied skills from the latest cached checkout; use
-`centaur-tools refresh` only when you need a manual refresh. This only updates
-the runtime catalog and local source copy. Secret grants and proxy credentials
-are reconciled separately, so a newly visible tool may still fail normally until
-its credential path is available.
+the latest cached checkout; existing sandboxes can run `centaur-tools refresh`
+when they need to refresh tool shims from the current repo-cache checkout.
 
 Configure the ordered overlay sources in Helm values:
 

--- a/docs/public/md/extend/apps.md
+++ b/docs/public/md/extend/apps.md
@@ -58,8 +58,8 @@ enabled = true
 [[tools]]
 name = "research-tool"
 description = "Search private research data"
-methods = [
-  { name = "search", path = "/tools/research-tool/search" },
+scripts = [
+  { name = "research-tool", command = "research-tool" },
 ]
 
 [[skills]]
@@ -109,7 +109,7 @@ The app plane keeps the API as the registry, auth boundary, and router:
 | Logs | `GET /apps/{name}/logs` |
 | Restart | `POST /apps/{name}/restart` |
 | Delete | `DELETE /apps/{name}` |
-| Tool method | Existing `/tools/{tool}/{method}` route proxies to the app |
+| Tool capability | Registered as a sandbox-visible tool script or workflow-host bridge |
 | Skills | Listed through app skill discovery and fetched lazily |
 | Workflows | Started through the existing workflow run API |
 

--- a/docs/public/md/operate/slack-etl.md
+++ b/docs/public/md/operate/slack-etl.md
@@ -216,7 +216,7 @@ kubectl exec -n centaur deploy/centaur-centaur-api-rs -- curl -s \
 Check sync health:
 
 ```bash
-kubectl exec -n centaur deploy/centaur-centaur-api -- \
+kubectl exec -n centaur deploy/centaur-centaur-api-rs -- \
   psql "$DATABASE_URL" -c \
   "SELECT channel_id, watermark_ts, last_success_at, last_error
    FROM slack_sync_checkpoints
@@ -227,7 +227,7 @@ kubectl exec -n centaur deploy/centaur-centaur-api -- \
 Check backfill pressure:
 
 ```bash
-kubectl exec -n centaur deploy/centaur-centaur-api -- \
+kubectl exec -n centaur deploy/centaur-centaur-api-rs -- \
   psql "$DATABASE_URL" -c \
   "SELECT job_type, status, count(*), min(updated_at) AS oldest_updated_at
    FROM slack_sync_backfill_jobs
@@ -238,7 +238,7 @@ kubectl exec -n centaur deploy/centaur-centaur-api -- \
 Check document projection:
 
 ```bash
-kubectl exec -n centaur deploy/centaur-centaur-api -- \
+kubectl exec -n centaur deploy/centaur-centaur-api-rs -- \
   psql "$DATABASE_URL" -c \
   "SELECT source_type, count(*), max(source_updated_at)
    FROM company_context_documents

--- a/docs/public/md/reference/configuration.md
+++ b/docs/public/md/reference/configuration.md
@@ -179,6 +179,7 @@ Kubernetes backend:
 | `KUBERNETES_SANDBOX_RUNTIME_CLASS_NAME`, `KUBERNETES_SANDBOX_SERVICE_ACCOUNT_NAME` | `sandbox.runtimeClassName`, `api.extraEnv`. | Pod runtime class and service account. |
 | `KUBERNETES_SANDBOX_CPU_LIMIT`, `KUBERNETES_SANDBOX_MEMORY_LIMIT`, `KUBERNETES_SANDBOX_CPU_REQUEST`, `KUBERNETES_SANDBOX_MEMORY_REQUEST` | `sandbox.resources.*`. | Sandbox pod resources. |
 | `KUBERNETES_SANDBOX_READY_TIMEOUT_S`, `KUBERNETES_ATTACH_LOG_TAIL_LINES` | `api.extraEnv`. | Sandbox readiness and attach diagnostics. |
+| `SESSION_SANDBOX_RUNNING_LIMIT`, `SESSION_SANDBOX_HOT_IDLE_GRACE_SECS` | `apiRs.sandboxRunningLimit`, `apiRs.sandboxHotIdleGraceSecs`. | Capacity admission for running-like sandboxes; discards ready warm sandboxes first, then pauses least-recently-active idle sessions outside the grace window. |
 | `SESSION_SANDBOX_CLEANUP_INTERVAL_SECS`, `SESSION_SANDBOX_IDLE_CLEANUP_BACKSTOP_SECS` | `apiRs.sandboxCleanupIntervalSecs`, `apiRs.sandboxIdleCleanupBackstopSecs`. | DB-aware cleanup of unreferenced sandboxes and restart recovery for idle pauses. Persisted `idle_timeout_ms` is honored after restart; the backstop is the fallback for older execution rows without that metadata. |
 | `KUBERNETES_SANDBOX_EXTRA_ENV` | `sandbox.extraEnv`. | JSON list copied into each sandbox. |
 | `KUBERNETES_WORKFLOW_DIRS` | Chart-rendered from `overlays.sources[*].workflowsSubdir` (default `workflows`) using the sandbox repo-cache mount prefix. | Workflow-host sandbox discovery paths. |
@@ -199,8 +200,6 @@ Sandbox entrypoint and wrappers:
 | --- | --- | --- |
 | `CENTAUR_HARNESS_CONFIG_DIR`, `CENTAUR_HARNESS_ADAPTER` | Sandbox image or `sandbox.extraEnv`. | Harness config directory and optional adapter executable. |
 | `CENTAUR_SKILL_DIRS` | Chart-rendered from `overlays.sources[*].skillsSubdir` (default `.agents/skills`) through `SESSION_SANDBOX_EXTRA_ENV`. | Ordered skill directories copied into the agent workspace. |
-| `CENTAUR_TOOLS_AUTO_RELOAD` | `repoCache.autoReload` via api-rs tools config; defaults to `true`. | Enables repo-cache-backed auto-refresh of local tool shims and copied skills in running sandboxes. Runtime catalog only; secret grants/proxy credentials reconcile separately. |
-| `CENTAUR_TOOLS_RELOAD_INTERVAL_SECONDS` | `sandbox.extraEnv`. | Poll interval for the repo-cache checkout watchdog. |
 | `AGENT_REPO`, `AGENT_PERSONA` | Runtime assignment metadata. | Workspace repo clone and persona prompt. |
 | `GOOGLE_APPLICATION_CREDENTIALS` | Sandbox entrypoint or `sandbox.extraEnv`. | Google ADC path; entrypoint creates a local stub when unset. |
 | `CODEX_API_KEY`, `CODEX_HOME`, `CODEX_CONTINUE_THREAD_ID` | `sandbox.extraEnv` or runtime resume. | Codex auth/config/resume behavior. |
@@ -208,8 +207,6 @@ Sandbox entrypoint and wrappers:
 | `META_AI_API_KEY` | Secret mounted into api-rs. | Meta AI direct credential for Codex provider `responses` and Slack or Linear `--meta` selection. |
 | `CODEX_MODEL_REASONING_SUMMARY` | `sandbox.extraEnv`. | Sets `model_reasoning_summary` in the Codex config (`auto`, `concise`, `detailed`, `none`). Codex >= 0.139 emits no reasoning summaries unless this is set, so renderers show no thinking trace. |
 | `CODEX_MODEL_REASONING_EFFORT` | `sandbox.extraEnv`. | Overrides the codex `model_reasoning_effort` (baked into `harness/codex/config.toml`) by patching the per-sandbox `~/.codex/config.toml` at boot, without forking the image. One of `none`, `minimal`, `low`, `medium`, `high`, `xhigh`; an unknown value is ignored (the config default stands). |
-| `CODEX_BEDROCK_REGION` | `sandbox.extraEnv`. | Opt-in switch and single source of truth for the Bedrock region. When set, the control plane registers the AWS SigV4 re-signing credential (scoped to the `bedrock` service and this region, upstream `bedrock-mantle.<region>.api.aws`), injects the placeholder `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` env so codex can sign requests iron-proxy re-signs with the real IAM keys, and pins codex's `amazon-bedrock` provider to this region at sandbox boot (so the in-sandbox client and the proxy agree). Unset disables Bedrock; defaults to `us-east-1`. See [Codex with Amazon Bedrock](/deploying-in-production#codex-with-amazon-bedrock). |
-| `CODEX_BEDROCK_SESSION_TOKEN` | `sandbox.extraEnv`. | Set truthy when the Bedrock IAM credentials are temporary (STS) and carry a session token, so the `AWS_SESSION_TOKEN` placeholder is declared and injected. Omit for long-term IAM user keys. |
 | `CLAUDE_MODEL`, `CLAUDE_CONTINUE_SESSION_ID` | `sandbox.extraEnv` or runtime resume. | Claude model and resume behavior. |
 | `CLAUDE_CODE_AUTH_MODE` | `sandbox.extraEnv`. | Claude Code auth flow: `api_key` (default, uses `ANTHROPIC_API_KEY`) or `access_token` (Claude.ai Pro or Max via the brokered OAuth login). See [Claude Auth Modes](/deploying-in-production#claude-auth-modes). |
 | `DEPLOY_ENV`, `ENVIRONMENT`, `TRACEPARENT` | Deployment env or wrapper-generated. | Runtime environment and trace context. |

--- a/docs/public/md/reference/tool-directory.md
+++ b/docs/public/md/reference/tool-directory.md
@@ -12,13 +12,13 @@ Centaur ships with a set of tool integrations under `tools/`. Deployments can en
 The repo inventory is not the same as a live deployment. To see what an agent can use in a running sandbox, ask it to run:
 
 ```bash
-call tools
+centaur-tools list
 ```
 
-To inspect a specific tool's methods and parameters:
+To inspect a specific tool's CLI:
 
 ```bash
-call discover linear
+linear --help
 ```
 
 The `API key / credential` column uses the secret names declared by each tool's `[tool.centaur]` config. `None` means the base tool declares no required tool-specific credential; optional credentials are called out separately.
@@ -37,7 +37,6 @@ These are broadly useful across most deployments and are good candidates to conf
 | `company_context` | Search indexed company history, Slack DMs, and Google Docs | None |
 | `grafana` | Query dashboards, alerts, VictoriaMetrics, VictoriaLogs, and annotations | `GRAFANA_URL`, `GRAFANA_API_KEY` |
 | `posthog` | Query product analytics, events, pageviews, breakdowns, and user agents | `POSTHOG_API_KEY`, `POSTHOG_PROJECT_ID` |
-| `amplitude` | Query product analytics — event segmentation, funnels, retention, user activity, and taxonomy | `AMPLITUDE_API_KEY`, `AMPLITUDE_SECRET_KEY` |
 | `attio` | Work with CRM objects, records, lists, notes, tasks, calls, and meetings | `ATTIO_API_KEY` |
 | `pylon` | Read and manage support issues, accounts, contacts, teams, tags, and users | `PYLON_API_KEY` |
 
@@ -64,7 +63,6 @@ These are broadly useful across most deployments and are good candidates to conf
 | `demo` | Test tool hot-reload and basic tool plumbing | None |
 | `grafana` | Grafana dashboards, alerts, VictoriaMetrics, VictoriaLogs, and annotations | `GRAFANA_URL`, `GRAFANA_API_KEY` |
 | `posthog` | Product analytics through HogQL, events, pageviews, and breakdowns | `POSTHOG_API_KEY`, `POSTHOG_PROJECT_ID` |
-| `amplitude` | Amplitude event segmentation, funnels, retention, user activity, realtime, and taxonomy | `AMPLITUDE_API_KEY`, `AMPLITUDE_SECRET_KEY` |
 | `profslice` | Extract Firefox Profiler data for analysis | None |
 | `reth` | Reth execution timing and performance metrics | None |
 | `reth-log-analyzer` | Parse Reth logs and generate performance graphs | None |

--- a/docs/public/md/secrets/environment.md
+++ b/docs/public/md/secrets/environment.md
@@ -90,7 +90,7 @@ endpoint, and inject a short-lived bearer token for matching API hosts.
 Check the API pod environment:
 
 ```bash
-kubectl exec -n centaur-system deploy/centaur-centaur-api -- env | \
+kubectl exec -n centaur-system deploy/centaur-centaur-api-rs -- env | \
   grep -E 'FIREWALL_MANAGER_SECRET_SOURCE|WAREHOUSE_API_KEY'
 ```
 

--- a/docs/public/md/secrets/onepassword.md
+++ b/docs/public/md/secrets/onepassword.md
@@ -122,7 +122,7 @@ Each item should live in `OP_VAULT` with its value in `credential`.
 Check that the API and [iron-proxy](https://docs.iron.sh) received the expected source mode:
 
 ```bash
-kubectl exec -n centaur-system deploy/centaur-centaur-api -- env | \
+kubectl exec -n centaur-system deploy/centaur-centaur-api-rs -- env | \
   grep -E 'FIREWALL_MANAGER_SECRET_SOURCE|OP_VAULT'
 ```
 

--- a/docs/public/md/what-is-centaur.md
+++ b/docs/public/md/what-is-centaur.md
@@ -23,7 +23,9 @@ Sandboxes speak a stable Anthropic-style message format with the API. Harness-sp
 
 ## Approved Tools
 
-Agents call tools through Centaur's API, not through ad hoc local credentials. Tool plugins expose typed REST endpoints, are discovered by the API, and can be extended without changing the core control plane.
+Agents call approved tool CLIs inside the sandbox, not ad hoc local
+credentials. Tool plugins are discovered by api-rs for metadata and secret
+grants, then installed in sandboxes as local CLI shims by `centaur-tools`.
 
 This creates a narrow and auditable boundary for agent capabilities. Teams decide which tools exist, how they authenticate, and what methods are available.
 
@@ -33,9 +35,15 @@ Sandboxes only ever see placeholder strings for upstream credentials. Real value
 
 ## Durable Workflows
 
-Centaur includes a Python workflow engine for long-running automation. Workflow handlers checkpoint each step, sleep or wait for external events, start child workflows, and run agent turns as part of larger processes.
+Centaur includes a durable workflow runtime for long-running automation:
+api-rs owns the Absurd-backed state machine, while `services/workflow-python`
+runs Python workflow handlers. Handlers checkpoint each step, sleep or wait for
+external events, start child workflows, and run agent turns as part of larger
+processes.
 
-This lets teams move beyond one-off prompts. A workflow can poll, branch, retry, call tools, wait for a signal, delegate to an agent turn, and resume after process restarts without rebuilding orchestration from scratch.
+This lets teams move beyond one-off prompts. A workflow can poll, branch,
+retry, invoke tools, wait for a signal, delegate to an agent turn, and resume
+after process restarts without rebuilding orchestration from scratch.
 
 ## Slack And API Surfaces
 


### PR DESCRIPTION
Closes #999

The committed `docs/public/md` mirrors only stay in sync with `docs/pages` when authors remember to rerun `build-md.sh`. The Docs workflow regenerates them at build time for the deployed site but never verifies the committed copies, so drift is invisible on the website and accumulates in the repo — eight files on current main.

- Add a step to the Docs workflow (before node setup; the script is a plain `cp` loop needing no deps): run `scripts/build-md.sh`, fail on `git diff --exit-code -- public/md` with a message telling the author to rerun the script and commit.
- Resync the eight currently stale mirrors in the same commit so the check starts green. Pure `mdx → md` copies; no source content changes.

The workflow already triggers on `docs/**` for both PRs and pushes to main, so the check runs exactly where mirror edits can land. Verified locally: the check fails on unmodified main and passes after the resync.

Note: #997 / #998 also touch mdx pages and their mirrors; whichever lands after this needs at most a trivial `build-md.sh` rerun — and this check will catch it if forgotten.
