### PR TITLE
feat: proxy Slack history and files

### DIFF
--- a/services/api-rs/crates/centaur-api-server/src/lib.rs
+++ b/services/api-rs/crates/centaur-api-server/src/lib.rs
@@ -128,7 +128,8 @@ mod tests {
                 "exp": 4_102_444_800i64,
                 "slack": {
                     "upload_channels": ["C123456789"],
-                    "download_channels": ["C987654321"]
+                    "download_channels": ["C987654321"],
+                    "history_channels": ["C111111111"]
                 }
             }),
             &EncodingKey::from_secret(b"test-secret"),
@@ -164,6 +165,11 @@ mod tests {
             body.pointer("/slack_client_jwt/claims/slack/download_channels/0")
                 .and_then(Value::as_str),
             Some("C987654321")
+        );
+        assert_eq!(
+            body.pointer("/slack_client_jwt/claims/slack/history_channels/0")
+                .and_then(Value::as_str),
+            Some("C111111111")
         );
     }
 

--- a/services/api-rs/crates/centaur-api-server/src/slack_proxy.rs
+++ b/services/api-rs/crates/centaur-api-server/src/slack_proxy.rs
@@ -43,6 +43,10 @@ pub(crate) fn slack_proxy_router() -> Router<AppState> {
             "/api/slack/files/{file_id}/download",
             get(download_slack_file),
         )
+        .route(
+            "/api/slack/channels/{channel_id}/history",
+            get(get_slack_channel_history),
+        )
 }
 
 #[derive(Debug, Deserialize)]
@@ -69,6 +73,22 @@ struct SlackFileDownloadQuery {
 }
 
 #[derive(Debug, Deserialize)]
+struct SlackChannelHistoryQuery {
+    #[serde(default)]
+    latest: Option<String>,
+    #[serde(default)]
+    oldest: Option<String>,
+    #[serde(default)]
+    inclusive: Option<bool>,
+    #[serde(default)]
+    include_all_metadata: Option<bool>,
+    #[serde(default)]
+    limit: Option<u16>,
+    #[serde(default)]
+    cursor: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
 struct SlackFileProxyClaims {
     slack: SlackProxyClaims,
 }
@@ -79,6 +99,8 @@ struct SlackProxyClaims {
     upload_channels: Vec<String>,
     #[serde(default)]
     download_channels: Vec<String>,
+    #[serde(default)]
+    history_channels: Vec<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -218,6 +240,21 @@ async fn download_slack_file(
         headers.insert(header::CONTENT_DISPOSITION, value);
     }
     Ok(response)
+}
+
+async fn get_slack_channel_history(
+    headers: HeaderMap,
+    Path(channel_id): Path<String>,
+    Query(query): Query<SlackChannelHistoryQuery>,
+) -> Result<Json<Value>, ApiError> {
+    let claims = authorize_slack_file_proxy(&headers)?;
+    ensure_history_channel_allowed(&claims, &channel_id)?;
+    validate_slack_channel_id(&channel_id)?;
+    validate_slack_channel_history_query(&query)?;
+
+    let config = slack_proxy_config()?;
+    let value = slack_channel_history(http_client(), config, &channel_id, &query).await?;
+    Ok(Json(value))
 }
 
 fn upstream_body_is_unexpected_html(
@@ -378,6 +415,51 @@ async fn slack_file_info(
     })
 }
 
+async fn slack_channel_history(
+    client: &reqwest::Client,
+    config: &SlackFileProxyConfig,
+    channel_id: &str,
+    query: &SlackChannelHistoryQuery,
+) -> Result<Value, ApiError> {
+    let form = slack_channel_history_form(channel_id, query);
+    slack_api_post_form(client, config, "conversations.history", &form).await
+}
+
+fn slack_channel_history_form(
+    channel_id: &str,
+    query: &SlackChannelHistoryQuery,
+) -> Vec<(&'static str, String)> {
+    let mut form = vec![
+        ("channel", channel_id.to_owned()),
+        ("latest", query.latest.clone().unwrap_or_default()),
+        ("oldest", query.oldest.clone().unwrap_or_default()),
+        (
+            "inclusive",
+            query
+                .inclusive
+                .map(|value| value.to_string())
+                .unwrap_or_default(),
+        ),
+        (
+            "include_all_metadata",
+            query
+                .include_all_metadata
+                .map(|value| value.to_string())
+                .unwrap_or_default(),
+        ),
+        (
+            "limit",
+            query
+                .limit
+                .map(|value| value.to_string())
+                .unwrap_or_default(),
+        ),
+        ("cursor", query.cursor.clone().unwrap_or_default()),
+    ];
+    form.retain(|(_, value)| !value.is_empty());
+    form
+}
+
 async fn slack_api_post_form(
     client: &reqwest::Client,
     config: &SlackFileProxyConfig,
@@ -432,6 +514,17 @@ fn ensure_download_channel_allowed(
         &claims.slack.download_channels,
         channel_id,
         "JWT is not authorized to download from this Slack channel",
+    )
+}
+
+fn ensure_history_channel_allowed(
+    claims: &SlackFileProxyClaims,
+    channel_id: &str,
+) -> Result<(), ApiError> {
+    ensure_channel_allowed(
+        &claims.slack.history_channels,
+        channel_id,
+        "JWT is not authorized to read history from this Slack channel",
     )
 }
 
@@ -525,6 +618,26 @@ fn validate_slack_file_id(file_id: &str) -> Result<(), ApiError> {
     Err(ApiError::BadRequest("invalid Slack file ID".to_owned()))
 }
 
+fn validate_slack_channel_history_query(query: &SlackChannelHistoryQuery) -> Result<(), ApiError> {
+    if let Some(latest) = query.latest.as_deref() {
+        validate_slack_timestamp(latest)?;
+    }
+    if let Some(oldest) = query.oldest.as_deref() {
+        validate_slack_timestamp(oldest)?;
+    }
+    if let Some(limit) = query.limit
+        && !(1..=999).contains(&limit)
+    {
+        return Err(ApiError::BadRequest(
+            "Slack history limit must be between 1 and 999".to_owned(),
+        ));
+    }
+    if let Some(cursor) = query.cursor.as_deref() {
+        validate_slack_cursor(cursor)?;
+    }
+    Ok(())
+}
+
 fn validate_slack_thread_ts(thread_ts: &str) -> Result<(), ApiError> {
     let Some((seconds, micros)) = thread_ts.split_once('.') else {
         return Err(ApiError::BadRequest("invalid Slack thread_ts".to_owned()));
@@ -537,6 +650,30 @@ fn validate_slack_thread_ts(thread_ts: &str) -> Result<(), ApiError> {
         return Ok(());
     }
     Err(ApiError::BadRequest("invalid Slack thread_ts".to_owned()))
+}
+
+fn validate_slack_timestamp(timestamp: &str) -> Result<(), ApiError> {
+    if !timestamp.is_empty()
+        && timestamp
+            .split_once('.')
+            .map(|(seconds, micros)| {
+                !seconds.is_empty()
+                    && !micros.is_empty()
+                    && seconds.bytes().all(|byte| byte.is_ascii_digit())
+                    && micros.bytes().all(|byte| byte.is_ascii_digit())
+            })
+            .unwrap_or_else(|| timestamp.bytes().all(|byte| byte.is_ascii_digit()))
+    {
+        return Ok(());
+    }
+    Err(ApiError::BadRequest("invalid Slack timestamp".to_owned()))
+}
+
+fn validate_slack_cursor(cursor: &str) -> Result<(), ApiError> {
+    if cursor.is_empty() || cursor.len() > 4096 || cursor.chars().any(|ch| ch.is_ascii_control()) {
+        return Err(ApiError::BadRequest("invalid Slack cursor".to_owned()));
+    }
+    Ok(())
 }
 
 fn validate_filename(filename: &str) -> Result<(), ApiError> {
@@ -594,7 +731,8 @@ mod tests {
                 "exp": 4_102_444_800i64,
                 "slack": {
                     "upload_channels": ["C123456789"],
-                    "download_channels": ["C987654321"]
+                    "download_channels": ["C987654321"],
+                    "history_channels": ["C111111111"]
                 }
             }),
         );
@@ -607,12 +745,17 @@ mod tests {
         .unwrap();
         ensure_upload_channel_allowed(&claims, "C123456789").unwrap();
         ensure_download_channel_allowed(&claims, "C987654321").unwrap();
+        ensure_history_channel_allowed(&claims, "C111111111").unwrap();
         assert!(matches!(
             ensure_upload_channel_allowed(&claims, "C987654321").unwrap_err(),
             ApiError::Forbidden(_)
         ));
         assert!(matches!(
             ensure_download_channel_allowed(&claims, "C123456789").unwrap_err(),
+            ApiError::Forbidden(_)
+        ));
+        assert!(matches!(
+            ensure_history_channel_allowed(&claims, "C123456789").unwrap_err(),
             ApiError::Forbidden(_)
         ));
     }
@@ -866,6 +1009,81 @@ mod tests {
             vec![
                 ("filename", "notes.txt".to_owned()),
                 ("length", "42".to_owned()),
+            ]
+        );
+    }
+
+    #[test]
+    fn validates_slack_channel_history_query() {
+        validate_slack_channel_history_query(&SlackChannelHistoryQuery {
+            latest: Some("1700000000.000002".to_owned()),
+            oldest: Some("0".to_owned()),
+            inclusive: Some(true),
+            include_all_metadata: Some(true),
+            limit: Some(999),
+            cursor: Some("next_cursor".to_owned()),
+        })
+        .unwrap();
+
+        assert!(matches!(
+            validate_slack_channel_history_query(&SlackChannelHistoryQuery {
+                latest: None,
+                oldest: None,
+                inclusive: None,
+                include_all_metadata: None,
+                limit: Some(1000),
+                cursor: None,
+            })
+            .unwrap_err(),
+            ApiError::BadRequest(_)
+        ));
+        assert!(matches!(
+            validate_slack_channel_history_query(&SlackChannelHistoryQuery {
+                latest: Some("not-a-ts".to_owned()),
+                oldest: None,
+                inclusive: None,
+                include_all_metadata: None,
+                limit: None,
+                cursor: None,
+            })
+            .unwrap_err(),
+            ApiError::BadRequest(_)
+        ));
+        assert!(matches!(
+            validate_slack_channel_history_query(&SlackChannelHistoryQuery {
+                latest: None,
+                oldest: None,
+                inclusive: None,
+                include_all_metadata: None,
+                limit: None,
+                cursor: Some("bad\ncursor".to_owned()),
+            })
+            .unwrap_err(),
+            ApiError::BadRequest(_)
+        ));
+    }
+
+    #[test]
+    fn channel_history_form_omits_empty_query_params() {
+        let form = slack_channel_history_form(
+            "C123456789",
+            &SlackChannelHistoryQuery {
+                latest: Some("1700000000.000002".to_owned()),
+                oldest: None,
+                inclusive: Some(false),
+                include_all_metadata: Some(true),
+                limit: Some(15),
+                cursor: None,
+            },
+        );
+        assert_eq!(
+            form,
+            vec![
+                ("channel", "C123456789".to_owned()),
+                ("latest", "1700000000.000002".to_owned()),
+                ("inclusive", "false".to_owned()),
+                ("include_all_metadata", "true".to_owned()),
+                ("limit", "15".to_owned()),
             ]
         );
     }

--- a/services/console/lib/api_server/jwt.rb
+++ b/services/console/lib/api_server/jwt.rb
@@ -27,7 +27,8 @@ module ApiServer
           "exp" => expires_at,
           "slack" => {
             "upload_channels" => [ channel_id ],
-            "download_channels" => [ channel_id ]
+            "download_channels" => [ channel_id ],
+            "history_channels" => [ channel_id ]
           }
         },
         signing_secret: signing_secret

--- a/services/console/test/models/principal_test.rb
+++ b/services/console/test/models/principal_test.rb
@@ -132,6 +132,7 @@ class PrincipalTest < ActiveSupport::TestCase
       assert_equal principal.oid, claims.fetch("sub")
       assert_equal [ "C0123456789" ], claims.dig("slack", "upload_channels")
       assert_equal [ "C0123456789" ], claims.dig("slack", "download_channels")
+      assert_equal [ "C0123456789" ], claims.dig("slack", "history_channels")
       assert_equal 1.hour.to_i, claims.fetch("exp") - claims.fetch("iat")
       assert_equal ApiServer::Jwt.rotation_offset(principal),
                    claims.fetch("iat") % ApiServer::Jwt::DEFAULT_WINDOW_SECONDS

--- a/tools/productivity/slack/cli.py
+++ b/tools/productivity/slack/cli.py
@@ -215,7 +215,7 @@ def channel(
         )
     except (RuntimeError, ValueError) as e:
         stderr_console.print(f"[red]Error: {e}[/]")
-        raise typer.Exit(1)
+        raise typer.Exit(1) from e
 
     messages = page["messages"]
 
@@ -244,6 +244,74 @@ def channel(
 
         thread_info = f" [dim]({msg['reply_count']} replies)[/]" if msg.get("reply_count") else ""
         console.print(f"[green]{msg['user']}[/]{thread_info}: {text}")
+
+
+@app.command("channel-proxy")
+def channel_proxy(
+    channel_id: str = typer.Argument(..., help="Slack channel ID, e.g. C1234567890"),
+    limit: int = typer.Option(50, "--limit", "-n", help="Max messages"),
+    cursor: str = typer.Option(None, "--cursor", help="Slack pagination cursor for the next page"),
+    oldest: str = typer.Option(None, "--oldest", help="Oldest Slack timestamp boundary"),
+    latest: str = typer.Option(None, "--latest", help="Latest Slack timestamp boundary"),
+    inclusive: bool | None = typer.Option(
+        None,
+        "--inclusive/--exclusive",
+        help="Include messages exactly on the oldest/latest boundary",
+    ),
+    include_all_metadata: bool | None = typer.Option(
+        None,
+        "--include-all-metadata/--metadata-default",
+        help="Ask Slack to return all message metadata",
+    ),
+    full: bool = typer.Option(False, "--full", "-f", help="Show full message text"),
+    json_output: bool = typer.Option(False, "--json", help="Output raw proxy response as JSON"),
+):
+    """Get channel history through the Centaur API server proxy."""
+    import sys
+
+    from .client import get_channel_history_proxy
+
+    try:
+        page = get_channel_history_proxy(
+            channel_id,
+            cursor=cursor,
+            include_all_metadata=include_all_metadata,
+            inclusive=inclusive,
+            latest=latest,
+            limit=limit,
+            oldest=oldest,
+        )
+    except (RuntimeError, ValueError) as e:
+        stderr_console.print(f"[red]Error: {e}[/]")
+        raise typer.Exit(1) from e
+
+    if json_output:
+        print(json.dumps(page, indent=2, ensure_ascii=False), file=sys.stdout)
+        raise typer.Exit()
+
+    messages = page.get("messages", [])
+    if not messages:
+        console.print("[yellow]No messages found.[/]")
+        raise typer.Exit()
+
+    header = f"[bold]#{channel_id}[/] - {len(messages)} messages"
+    if page.get("has_more"):
+        header += " [dim](more available)[/]"
+    console.print(f"{header}\n")
+
+    next_cursor = page.get("response_metadata", {}).get("next_cursor")
+    if next_cursor:
+        console.print(f"[dim]next_cursor={next_cursor}[/]\n")
+
+    for msg in messages:
+        user = msg.get("user") or msg.get("bot_id") or msg.get("username") or "unknown"
+        text = str(msg.get("text") or "")
+        if not full:
+            text = text[:120].replace("\n", " ")
+            if len(str(msg.get("text") or "")) > 120:
+                text += "..."
+        thread_info = f" [dim]({msg['reply_count']} replies)[/]" if msg.get("reply_count") else ""
+        console.print(f"[green]{user}[/]{thread_info}: {text}")
 
 
 @app.command()
@@ -570,6 +638,62 @@ def upload(
         except (RuntimeError, ValueError) as e:
             console.print(f"[red]Error uploading {path.name}: {e}[/]")
             raise typer.Exit(1)
+
+
+@app.command("upload-proxy")
+def upload_proxy(
+    channel_id: str = typer.Argument(
+        ..., help="Slack channel/conversation ID to upload into, e.g. C123 or D123"
+    ),
+    files: list[str] = typer.Argument(..., help="File path(s) to upload"),  # noqa: B008
+    comment: str = typer.Option(None, "--comment", "-c", help="Comment to post with files"),
+    thread: str = typer.Option(None, "--thread", "-t", help="Slack thread timestamp to reply to"),
+    content_type: str = typer.Option(
+        None, "--content-type", help="Content-Type to send for all files"
+    ),
+    alt_text: str = typer.Option(None, "--alt-text", help="Alt text for all files"),
+    snippet_type: str = typer.Option(None, "--snippet-type", help="Slack snippet type"),
+):
+    """Upload file(s) through the Centaur API server Slack proxy."""
+    import base64
+    import mimetypes
+    from pathlib import Path
+
+    from .client import upload_file_proxy
+
+    if not _channel_arg_is_id(channel_id):
+        console.print(
+            "[red]Error: upload-proxy channel must be a Slack conversation ID like C123 or D123[/]"
+        )
+        raise typer.Exit(1)
+
+    first_upload_path = files[0] if files else None
+    for file_path in files:
+        path = Path(file_path)
+        if not path.exists():
+            console.print(f"[red]File not found: {file_path}[/]")
+            raise typer.Exit(1)
+
+        effective_content_type = content_type or mimetypes.guess_type(path.name)[0]
+        try:
+            result = upload_file_proxy(
+                channel_id=channel_id,
+                content_base64=base64.b64encode(path.read_bytes()).decode(),
+                filename=path.name,
+                title=path.name,
+                initial_comment=comment if file_path == first_upload_path else None,
+                thread_ts=thread,
+                content_type=effective_content_type,
+                alt_txt=alt_text,
+                snippet_type=snippet_type,
+            )
+            console.print(f"[green]✓ Uploaded {path.name}[/]")
+            console.print(
+                f"[dim]{result.get('file_id') or result.get('file', {}).get('id', '')}[/]"
+            )
+        except (RuntimeError, ValueError) as e:
+            console.print(f"[red]Error uploading {path.name}: {e}[/]")
+            raise typer.Exit(1) from e
 
 
 @app.command()
@@ -908,6 +1032,41 @@ def files(
             size_kb = f["size"] / 1024
             console.print(f"[cyan]{f['name']}[/] ({f['filetype']}, {size_kb:.1f} KB)")
             console.print(f"  [dim]{f['url_private']}[/]")
+
+
+@app.command("download-proxy")
+def download_proxy(
+    file_id: str = typer.Argument(..., help="Slack file ID, e.g. F1234567890"),
+    channel_id: str = typer.Argument(
+        ..., help="Slack channel/conversation ID that the file is shared in"
+    ),
+    output: str = typer.Option(".", "--output", "-o", help="Output directory for downloads"),
+    json_output: bool = typer.Option(False, "--json", help="Print metadata as JSON"),
+):
+    """Download a Slack file through the Centaur API server Slack proxy."""
+    import base64
+    import sys
+    from pathlib import Path
+
+    from .client import download_file_proxy
+
+    try:
+        result = download_file_proxy(file_id=file_id, channel_id=channel_id)
+    except (RuntimeError, ValueError) as e:
+        console.print(f"[red]Error downloading Slack file: {e}[/]")
+        raise typer.Exit(1) from e
+
+    if json_output:
+        metadata = {key: value for key, value in result.items() if key != "content_base64"}
+        print(json.dumps(metadata, indent=2, ensure_ascii=False), file=sys.stdout)
+        raise typer.Exit()
+
+    output_dir = Path(output)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    out_path = output_dir / result["filename"]
+    out_path.write_bytes(base64.b64decode(result["content_base64"]))
+    console.print(f"[green]✓ Downloaded {result['filename']}[/] ({result['size_bytes']} bytes)")
+    console.print(f"[dim]{out_path.absolute()}[/]")
 
 
 # === Feedback Commands ===

--- a/tools/productivity/slack/client.py
+++ b/tools/productivity/slack/client.py
@@ -1,11 +1,14 @@
 """Slack API client for bot-token Slack tool operations."""
 
 import base64
+import binascii
 import json
 import mimetypes
 import os
 import re
 import time
+import urllib.error
+import urllib.parse
 import urllib.request
 from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -84,6 +87,7 @@ class SlackClient:
     _CHANNEL_CACHE_TTL = 300  # 5 minutes
     _USER_CACHE_TTL = 600  # 10 minutes
     _MAX_PAGE_SIZE = 200
+    _MAX_SLACK_HISTORY_PROXY_PAGE_SIZE = 999
     _DEFAULT_THREAD_REPLY_LIMIT = 50
     _DEFAULT_DUMP_MESSAGE_LIMIT = 100
     _DEFAULT_DUMP_THREAD_LIMIT = 25
@@ -92,6 +96,7 @@ class SlackClient:
     _DATE_ONLY_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
     _NUMERIC_TS_RE = re.compile(r"^\d+(?:\.\d+)?$")
     _CHANNEL_ID_RE = re.compile(r"^[CGD][A-Z0-9]+$")
+    _FILE_ID_RE = re.compile(r"^F[A-Z0-9]+$")
     _USER_ID_RE = re.compile(r"^[UW][A-Z0-9]+$")
     _AUTH_ERROR_CODES: ClassVar[frozenset[str]] = frozenset(
         {
@@ -301,6 +306,119 @@ class SlackClient:
             parsed = parsed.replace(tzinfo=UTC)
         return self._format_ts(parsed.timestamp())
 
+    def _centaur_api_url(self) -> str:
+        """Return the Centaur API base URL available inside agent sandboxes."""
+        return secret("CENTAUR_API_URL", "http://api:8000").rstrip("/")
+
+    def _centaur_api_headers(self) -> dict[str, str]:
+        """Return headers for API-server calls.
+
+        In sandboxes, iron-proxy injects the principal-scoped Authorization
+        header for the API host. A local bearer can be supplied for tests or
+        manual CLI use.
+        """
+        headers = {"Accept": "application/json"}
+        bearer = secret("CENTAUR_API_BEARER_TOKEN", "").strip()
+        if bearer:
+            headers["Authorization"] = f"Bearer {bearer}"
+        return headers
+
+    def _centaur_api_query_value(self, value: Any) -> str:
+        """Format query values for axum/serde query extraction."""
+        if isinstance(value, bool):
+            return "true" if value else "false"
+        return str(value)
+
+    def _centaur_api_url_for(self, path: str, params: dict[str, Any]) -> str:
+        """Build a Centaur API URL with query parameters."""
+        query = urllib.parse.urlencode(
+            {
+                key: self._centaur_api_query_value(value)
+                for key, value in params.items()
+                if value is not None
+            }
+        )
+        url = f"{self._centaur_api_url()}{path}"
+        if query:
+            url = f"{url}?{query}"
+        return url
+
+    def _centaur_api_get_json(self, path: str, params: dict[str, Any]) -> dict[str, Any]:
+        """GET a Centaur API JSON endpoint."""
+        url = self._centaur_api_url_for(path, params)
+        request = urllib.request.Request(url, headers=self._centaur_api_headers(), method="GET")
+        try:
+            with urllib.request.urlopen(request, timeout=self._api_timeout_seconds()) as response:
+                raw = response.read().decode("utf-8")
+        except urllib.error.HTTPError as exc:
+            raw = exc.read().decode("utf-8", errors="replace")
+            detail = raw
+            try:
+                body = json.loads(raw)
+                detail = body.get("message") or body.get("detail") or raw
+            except json.JSONDecodeError:
+                pass
+            raise RuntimeError(f"Centaur API error {exc.code} on {path}: {detail}") from exc
+        except urllib.error.URLError as exc:
+            raise RuntimeError(f"Centaur API request failed on {path}: {exc.reason}") from exc
+        return json.loads(raw) if raw else {}
+
+    def _centaur_api_post_bytes_json(
+        self,
+        path: str,
+        params: dict[str, Any],
+        body: bytes,
+        content_type: str = "application/octet-stream",
+    ) -> dict[str, Any]:
+        """POST bytes to a Centaur API endpoint and parse a JSON response."""
+        url = self._centaur_api_url_for(path, params)
+        headers = self._centaur_api_headers()
+        headers["Content-Type"] = content_type
+        request = urllib.request.Request(url, data=body, headers=headers, method="POST")
+        try:
+            with urllib.request.urlopen(request, timeout=self._api_timeout_seconds()) as response:
+                raw = response.read().decode("utf-8")
+        except urllib.error.HTTPError as exc:
+            raw = exc.read().decode("utf-8", errors="replace")
+            detail = raw
+            try:
+                error_body = json.loads(raw)
+                detail = error_body.get("message") or error_body.get("detail") or raw
+            except json.JSONDecodeError:
+                pass
+            raise RuntimeError(f"Centaur API error {exc.code} on {path}: {detail}") from exc
+        except urllib.error.URLError as exc:
+            raise RuntimeError(f"Centaur API request failed on {path}: {exc.reason}") from exc
+        return json.loads(raw) if raw else {}
+
+    def _centaur_api_get_bytes(
+        self,
+        path: str,
+        params: dict[str, Any],
+        max_bytes: int,
+    ) -> tuple[bytes, dict[str, str]]:
+        """GET bytes from a Centaur API endpoint."""
+        url = self._centaur_api_url_for(path, params)
+        request = urllib.request.Request(url, headers=self._centaur_api_headers(), method="GET")
+        try:
+            with urllib.request.urlopen(request, timeout=self._api_timeout_seconds()) as response:
+                body = response.read(max_bytes + 1)
+                headers = {key.lower(): value for key, value in response.headers.items()}
+        except urllib.error.HTTPError as exc:
+            raw = exc.read().decode("utf-8", errors="replace")
+            detail = raw
+            try:
+                error_body = json.loads(raw)
+                detail = error_body.get("message") or error_body.get("detail") or raw
+            except json.JSONDecodeError:
+                pass
+            raise RuntimeError(f"Centaur API error {exc.code} on {path}: {detail}") from exc
+        except urllib.error.URLError as exc:
+            raise RuntimeError(f"Centaur API request failed on {path}: {exc.reason}") from exc
+        if len(body) > max_bytes:
+            raise ValueError(f"Slack file exceeds the {max_bytes}-byte download limit")
+        return body, headers
+
     def _message_permalink(self, channel_id: str, ts: str) -> str:
         """Build a Slack permalink from channel and timestamp."""
         return f"https://slack.com/archives/{channel_id}/p{ts.replace('.', '')}"
@@ -317,6 +435,34 @@ class SlackClient:
             if item["id"] == channel_id:
                 return item["name"]
         return channel_id
+
+    def _normalize_explicit_channel_id(self, channel_id: str) -> str:
+        """Normalize and validate an explicit Slack conversation ID."""
+        normalized_channel_id = self._clean_channel_ref(channel_id).upper()
+        if len(normalized_channel_id) < 9 or not self._looks_like_channel_id(
+            normalized_channel_id
+        ):
+            raise ValueError("channel_id must be a Slack conversation ID like C123456789")
+        return normalized_channel_id
+
+    def _normalize_file_id(self, file_id: str) -> str:
+        """Normalize and validate a Slack file ID."""
+        normalized_file_id = str(file_id).strip().upper()
+        if len(normalized_file_id) < 9 or not self._FILE_ID_RE.fullmatch(normalized_file_id):
+            raise ValueError("file_id must be a Slack file ID like F123456789")
+        return normalized_file_id
+
+    def _content_disposition_filename(self, value: str | None) -> str | None:
+        """Extract a simple filename value from Content-Disposition."""
+        if not value:
+            return None
+        match = re.search(r'filename="([^"]+)"', value)
+        if match:
+            return match.group(1)
+        match = re.search(r"filename=([^;]+)", value)
+        if match:
+            return match.group(1).strip()
+        return None
 
     def _serialize_message(
         self,
@@ -986,6 +1132,53 @@ class SlackClient:
             },
             "order": "desc",
         }
+
+    def get_channel_history_proxy(
+        self,
+        channel_id: str,
+        cursor: str | None = None,
+        include_all_metadata: bool | None = None,
+        inclusive: bool | None = None,
+        latest: str | int | float | None = None,
+        limit: int | None = None,
+        oldest: str | int | float | None = None,
+    ) -> dict[str, Any]:
+        """Fetch Slack channel history through the Centaur API server proxy.
+
+        This maps to Slack's documented `conversations.history` arguments,
+        except `token` is intentionally omitted because the API server supplies
+        Slack credentials. `channel_id` must be an explicit Slack conversation
+        ID authorized by the principal's `slack.history_channels` claim.
+        """
+        if secret("CENTAUR_SANDBOX_API_SERVER_ENABLED", "true").strip().lower() == "false":
+            raise RuntimeError(
+                "Slack channel history proxy requires the API server sandbox capability, "
+                "but it is disabled for this principal."
+            )
+
+        normalized_channel_id = self._clean_channel_ref(channel_id).upper()
+        if len(normalized_channel_id) < 9 or not self._looks_like_channel_id(normalized_channel_id):
+            raise ValueError("channel_id must be a Slack conversation ID like C123456789")
+
+        params: dict[str, Any] = {
+            "cursor": cursor,
+            "include_all_metadata": include_all_metadata,
+            "inclusive": inclusive,
+            "latest": self._normalize_ts(latest),
+            "limit": None,
+            "oldest": self._normalize_ts(oldest),
+        }
+        if limit is not None:
+            requested_limit = int(limit)
+            if not 1 <= requested_limit <= self._MAX_SLACK_HISTORY_PROXY_PAGE_SIZE:
+                raise ValueError("limit must be between 1 and 999")
+            params["limit"] = requested_limit
+
+        channel_path = urllib.parse.quote(normalized_channel_id, safe="")
+        return self._centaur_api_get_json(
+            f"/api/slack/channels/{channel_path}/history",
+            params,
+        )
 
     def get_channel_history(
         self,
@@ -1682,6 +1875,88 @@ class SlackClient:
                 resolved_channel=resolved_channel,
             )
 
+    def upload_file_proxy(
+        self,
+        channel_id: str,
+        content_base64: str,
+        filename: str,
+        thread_ts: str | None = None,
+        title: str | None = None,
+        initial_comment: str | None = None,
+        content_type: str | None = None,
+        alt_txt: str | None = None,
+        snippet_type: str | None = None,
+    ) -> dict[str, Any]:
+        """Upload a file through the Centaur API server Slack proxy.
+
+        This maps to `/api/slack/files/upload`. The caller supplies file bytes
+        as base64, and the API server handles Slack credentials and channel
+        authorization through the principal-scoped JWT.
+        """
+        if secret("CENTAUR_SANDBOX_API_SERVER_ENABLED", "true").strip().lower() == "false":
+            raise RuntimeError(
+                "Slack file upload proxy requires the API server sandbox capability, "
+                "but it is disabled for this principal."
+            )
+        normalized_channel_id = self._normalize_explicit_channel_id(channel_id)
+        effective_filename = str(filename).strip()
+        if not effective_filename:
+            raise ValueError("filename is required")
+        try:
+            body = base64.b64decode(content_base64, validate=True)
+        except (binascii.Error, ValueError) as exc:
+            raise ValueError("content_base64 must be valid base64") from exc
+        if not body:
+            raise ValueError("content_base64 must not be empty")
+
+        params = {
+            "channel_id": normalized_channel_id,
+            "filename": effective_filename,
+            "thread_ts": self._normalize_ts(thread_ts),
+            "title": title,
+            "initial_comment": initial_comment,
+            "content_type": content_type,
+            "alt_txt": alt_txt,
+            "snippet_type": snippet_type,
+        }
+        return self._centaur_api_post_bytes_json(
+            "/api/slack/files/upload",
+            params,
+            body,
+            content_type or "application/octet-stream",
+        )
+
+    def download_file_proxy(self, file_id: str, channel_id: str) -> dict[str, Any]:
+        """Download a Slack file through the Centaur API server Slack proxy.
+
+        Returns base64-encoded file bytes plus filename, content type, and size.
+        """
+        if secret("CENTAUR_SANDBOX_API_SERVER_ENABLED", "true").strip().lower() == "false":
+            raise RuntimeError(
+                "Slack file download proxy requires the API server sandbox capability, "
+                "but it is disabled for this principal."
+            )
+        normalized_file_id = self._normalize_file_id(file_id)
+        normalized_channel_id = self._normalize_explicit_channel_id(channel_id)
+        body, headers = self._centaur_api_get_bytes(
+            f"/api/slack/files/{urllib.parse.quote(normalized_file_id, safe='')}/download",
+            {"channel_id": normalized_channel_id},
+            self._MAX_DOWNLOAD_BYTES,
+        )
+        filename = (
+            self._content_disposition_filename(headers.get("content-disposition"))
+            or normalized_file_id
+        )
+        content_type = headers.get("content-type") or "application/octet-stream"
+        return {
+            "file_id": normalized_file_id,
+            "channel_id": normalized_channel_id,
+            "filename": filename,
+            "content_type": content_type,
+            "size_bytes": len(body),
+            "content_base64": base64.b64encode(body).decode(),
+        }
+
     def list_usergroups(self) -> list[dict]:
         """List all user groups in the workspace."""
         try:
@@ -2059,6 +2334,10 @@ def get_channel_history_page(*args, **kwargs):
     return _client().get_channel_history_page(*args, **kwargs)
 
 
+def get_channel_history_proxy(*args, **kwargs):
+    return _client().get_channel_history_proxy(*args, **kwargs)
+
+
 def get_channel_history(*args, **kwargs):
     return _client().get_channel_history(*args, **kwargs)
 
@@ -2105,6 +2384,14 @@ def send_dm(*args, **kwargs):
 
 def upload_file(*args, **kwargs):
     return _client().upload_file(*args, **kwargs)
+
+
+def upload_file_proxy(*args, **kwargs):
+    return _client().upload_file_proxy(*args, **kwargs)
+
+
+def download_file_proxy(*args, **kwargs):
+    return _client().download_file_proxy(*args, **kwargs)
 
 
 def list_usergroups(*args, **kwargs):

--- a/tools/productivity/slack/tests/test_cli.py
+++ b/tools/productivity/slack/tests/test_cli.py
@@ -1,10 +1,10 @@
+import base64
 import sys
 import types
 from pathlib import Path
 
-from typer.testing import CliRunner
-
 from slack.cli import _channel_arg_is_id, app
+from typer.testing import CliRunner
 
 
 def test_channel_arg_is_id_accepts_channel_id_forms() -> None:
@@ -78,3 +78,72 @@ def test_upload_rejects_channel_name(monkeypatch, tmp_path: Path) -> None:
 
     assert result.exit_code == 1
     assert "must be a Slack conversation ID" in result.output
+
+
+def test_upload_proxy_calls_proxy_client(monkeypatch, tmp_path: Path) -> None:
+    upload = tmp_path / "chart.png"
+    upload.write_bytes(b"png")
+    calls = []
+
+    def fake_upload_file_proxy(**kwargs):
+        calls.append(kwargs)
+        return {"file_id": "F1234567890"}
+
+    fake_client = types.SimpleNamespace(upload_file_proxy=fake_upload_file_proxy)
+    monkeypatch.setitem(sys.modules, "slack.client", fake_client)
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "upload-proxy",
+            "C1234567890",
+            str(upload),
+            "--thread",
+            "1780000000.000000",
+            "--comment",
+            "chart",
+            "--content-type",
+            "image/png",
+            "--alt-text",
+            "chart alt",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert calls == [
+        {
+            "channel_id": "C1234567890",
+            "content_base64": "cG5n",
+            "filename": "chart.png",
+            "title": "chart.png",
+            "initial_comment": "chart",
+            "thread_ts": "1780000000.000000",
+            "content_type": "image/png",
+            "alt_txt": "chart alt",
+            "snippet_type": None,
+        }
+    ]
+
+
+def test_download_proxy_writes_file(monkeypatch, tmp_path: Path) -> None:
+    calls = []
+
+    def fake_download_file_proxy(**kwargs):
+        calls.append(kwargs)
+        return {
+            "filename": "report.pdf",
+            "content_base64": base64.b64encode(b"%PDF").decode(),
+            "size_bytes": 4,
+        }
+
+    fake_client = types.SimpleNamespace(download_file_proxy=fake_download_file_proxy)
+    monkeypatch.setitem(sys.modules, "slack.client", fake_client)
+
+    result = CliRunner().invoke(
+        app,
+        ["download-proxy", "F1234567890", "C1234567890", "--output", str(tmp_path)],
+    )
+
+    assert result.exit_code == 0
+    assert calls == [{"file_id": "F1234567890", "channel_id": "C1234567890"}]
+    assert (tmp_path / "report.pdf").read_bytes() == b"%PDF"

--- a/tools/productivity/slack/tests/test_client.py
+++ b/tools/productivity/slack/tests/test_client.py
@@ -1,3 +1,4 @@
+import base64
 import email.message
 import json
 
@@ -410,6 +411,184 @@ def test_get_channel_history_page_preserves_non_auth_error_shape() -> None:
         client.get_channel_history_page("paradigm-pulse")
 
 
+def test_get_channel_history_proxy_calls_centaur_api(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import urllib.parse
+    import urllib.request
+
+    client, _ = _make_client()
+    request_info: dict[str, str | None] = {}
+
+    def fake_urlopen(req, *args, **kwargs):
+        request_info["url"] = req.full_url
+        request_info["authorization"] = req.get_header("Authorization")
+        body = json.dumps(
+            {
+                "ok": True,
+                "messages": [{"type": "message", "ts": "1700000000.000001"}],
+                "has_more": False,
+            }
+        ).encode()
+        return _FakeHTTPResponse(body, "application/json")
+
+    monkeypatch.setenv("CENTAUR_API_URL", "http://api.internal:8080")
+    monkeypatch.setenv("CENTAUR_API_BEARER_TOKEN", "test-jwt")
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+
+    result = client.get_channel_history_proxy(
+        "<#C123456789|general>",
+        cursor="next",
+        include_all_metadata=True,
+        inclusive=False,
+        latest="1700000000.000002",
+        limit=999,
+        oldest=0,
+    )
+
+    assert result["ok"] is True
+    assert request_info["authorization"] == "Bearer test-jwt"
+    parsed = urllib.parse.urlparse(request_info["url"])
+    assert parsed.scheme == "http"
+    assert parsed.netloc == "api.internal:8080"
+    assert parsed.path == "/api/slack/channels/C123456789/history"
+    query = urllib.parse.parse_qs(parsed.query)
+    assert query == {
+        "cursor": ["next"],
+        "include_all_metadata": ["true"],
+        "inclusive": ["false"],
+        "latest": ["1700000000.000002"],
+        "limit": ["999"],
+        "oldest": ["0.000000"],
+    }
+
+
+def test_get_channel_history_proxy_validates_inputs() -> None:
+    client, _ = _make_client()
+
+    with pytest.raises(ValueError, match="channel_id"):
+        client.get_channel_history_proxy("general")
+
+    with pytest.raises(ValueError, match="between 1 and 999"):
+        client.get_channel_history_proxy("C123456789", limit=1000)
+
+
+def test_upload_file_proxy_posts_file_bytes_to_centaur_api(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import urllib.parse
+    import urllib.request
+
+    client, _ = _make_client()
+    request_info: dict[str, object] = {}
+
+    def fake_urlopen(req, *args, **kwargs):
+        request_info["url"] = req.full_url
+        request_info["headers"] = {key.lower(): value for key, value in req.header_items()}
+        request_info["data"] = req.data
+        body = json.dumps(
+            {
+                "ok": True,
+                "file_id": "F123456789",
+                "channel_id": "C123456789",
+                "file": {"id": "F123456789"},
+            }
+        ).encode()
+        return _FakeHTTPResponse(body, "application/json")
+
+    monkeypatch.setenv("CENTAUR_API_URL", "http://api.internal:8080")
+    monkeypatch.setenv("CENTAUR_API_BEARER_TOKEN", "test-jwt")
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+
+    result = client.upload_file_proxy(
+        channel_id="C123456789",
+        content_base64=base64.b64encode(b"hello").decode(),
+        filename="hello.txt",
+        thread_ts="1700000000.000001",
+        title="Hello",
+        initial_comment="uploaded",
+        content_type="text/plain",
+        alt_txt="hello file",
+        snippet_type="text",
+    )
+
+    assert result["file_id"] == "F123456789"
+    assert request_info["data"] == b"hello"
+    headers = request_info["headers"]
+    assert isinstance(headers, dict)
+    assert headers["authorization"] == "Bearer test-jwt"
+    assert headers["content-type"] == "text/plain"
+    parsed = urllib.parse.urlparse(request_info["url"])
+    assert parsed.path == "/api/slack/files/upload"
+    assert urllib.parse.parse_qs(parsed.query) == {
+        "channel_id": ["C123456789"],
+        "filename": ["hello.txt"],
+        "thread_ts": ["1700000000.000001"],
+        "title": ["Hello"],
+        "initial_comment": ["uploaded"],
+        "content_type": ["text/plain"],
+        "alt_txt": ["hello file"],
+        "snippet_type": ["text"],
+    }
+
+
+def test_download_file_proxy_returns_base64_file(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import urllib.parse
+    import urllib.request
+
+    client, _ = _make_client()
+    request_info: dict[str, str | None] = {}
+
+    def fake_urlopen(req, *args, **kwargs):
+        request_info["url"] = req.full_url
+        request_info["authorization"] = req.get_header("Authorization")
+        return _FakeHTTPResponse(
+            b"%PDF",
+            "application/pdf",
+            {"Content-Disposition": 'attachment; filename="report.pdf"'},
+        )
+
+    monkeypatch.setenv("CENTAUR_API_URL", "http://api.internal:8080")
+    monkeypatch.setenv("CENTAUR_API_BEARER_TOKEN", "test-jwt")
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+
+    result = client.download_file_proxy(file_id="F123456789", channel_id="C123456789")
+
+    assert result == {
+        "file_id": "F123456789",
+        "channel_id": "C123456789",
+        "filename": "report.pdf",
+        "content_type": "application/pdf",
+        "size_bytes": 4,
+        "content_base64": base64.b64encode(b"%PDF").decode(),
+    }
+    assert request_info["authorization"] == "Bearer test-jwt"
+    parsed = urllib.parse.urlparse(request_info["url"])
+    assert parsed.path == "/api/slack/files/F123456789/download"
+    assert urllib.parse.parse_qs(parsed.query) == {"channel_id": ["C123456789"]}
+
+
+def test_file_proxy_methods_validate_inputs() -> None:
+    client, _ = _make_client()
+
+    with pytest.raises(ValueError, match="filename"):
+        client.upload_file_proxy(
+            channel_id="C123456789",
+            content_base64=base64.b64encode(b"hello").decode(),
+            filename=" ",
+        )
+    with pytest.raises(ValueError, match="valid base64"):
+        client.upload_file_proxy(
+            channel_id="C123456789",
+            content_base64="not base64",
+            filename="hello.txt",
+        )
+    with pytest.raises(ValueError, match="file_id"):
+        client.download_file_proxy(file_id="bad", channel_id="C123456789")
+
+
 def test_search_messages_with_channel_ids_scans_history_without_listing() -> None:
     client, fake_web_client = _make_client()
     client._get_user_cache = lambda: {"UGZCSQTPE": "matt", "U1": "alice"}  # type: ignore[method-assign]
@@ -790,9 +969,12 @@ def test_upload_file_requires_a_content_source() -> None:
 class _FakeHTTPResponse:
     """Minimal stand-in for urllib's HTTPResponse context manager."""
 
-    def __init__(self, body: bytes, content_type: str) -> None:
+    def __init__(
+        self, body: bytes, content_type: str, headers: dict[str, str] | None = None
+    ) -> None:
         self._body = body
         self._content_type = content_type
+        self._headers = headers or {}
 
     def __enter__(self) -> "_FakeHTTPResponse":
         return self
@@ -807,6 +989,8 @@ class _FakeHTTPResponse:
     def headers(self) -> "email.message.Message":
         msg = email.message.Message()
         msg["Content-Type"] = self._content_type
+        for key, value in self._headers.items():
+            msg[key] = value
         return msg
 
 


### PR DESCRIPTION
Adds API-server Slack proxy endpoints for channel history and issues channel-scoped JWT claims from console. Updates the Slack tool with proxy-backed history, upload, and download helpers plus CLI commands.