### PR TITLE
chore: change codex default model to gpt-5.6-sol

### DIFF
--- a/harness/codex/config.toml
+++ b/harness/codex/config.toml
@@ -1,4 +1,4 @@
-model = "gpt-5.5"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "low"
 personality = "pragmatic"
 model_verbosity = "low"


### PR DESCRIPTION
## Summary
- Change the baked Codex default model from `gpt-5.5` to `gpt-5.6-sol`.
- Keep the default reasoning effort at `low`.

## Testing
- Not run; static config-only change.

Prompted by: @Zygimantass