### PR TITLE
feat: add MPP service discovery

### DIFF
--- a/docs/pages/reference/tool-directory.mdx
+++ b/docs/pages/reference/tool-directory.mdx
@@ -136,7 +136,7 @@ These tools ship in the base repo because many Centaur users need onchain or mar
 | `kalshi` | Prediction market events, markets, trades, and candlesticks | None |
 | `karma` | DAO delegate reputation, activity, scores, and governance analytics | None |
 | `messari` | Crypto asset prices, metrics, profiles, markets, news, and timeseries | `MESSARI_API_KEY` |
-| `mpp` | Paid market-data and web-search requests through Machine Payments Protocol | None |
+| `mpp` | Paid MPP requests | None |
 | `nansen` | Wallet labels, smart-money activity, token flows, holders, and PnL | `NANSEN_API_KEY` |
 | `polymarket` | Prediction market events, markets, prices, books, and trades | None |
 | `snapshot` | Offchain governance spaces, proposals, votes, and voting power | `SNAPSHOT_API_KEY` |

--- a/docs/public/md/reference/tool-directory.md
+++ b/docs/public/md/reference/tool-directory.md
@@ -138,7 +138,7 @@ These tools ship in the base repo because many Centaur users need onchain or mar
 | `kalshi` | Prediction market events, markets, trades, and candlesticks | None |
 | `karma` | DAO delegate reputation, activity, scores, and governance analytics | None |
 | `messari` | Crypto asset prices, metrics, profiles, markets, news, and timeseries | `MESSARI_API_KEY` |
-| `mpp` | Paid market-data and web-search requests through Machine Payments Protocol | None |
+| `mpp` | Paid MPP requests | None |
 | `nansen` | Wallet labels, smart-money activity, token flows, holders, and PnL | `NANSEN_API_KEY` |
 | `polymarket` | Prediction market events, markets, prices, books, and trades | None |
 | `snapshot` | Offchain governance spaces, proposals, votes, and voting power | `SNAPSHOT_API_KEY` |

--- a/tools/crypto/mpp/cli.py
+++ b/tools/crypto/mpp/cli.py
@@ -1,16 +1,31 @@
 """CLI for Market data via MPP (Machine Payments Protocol)."""
 
+import json
+from collections.abc import Callable
+
+import typer
 from dotenv import load_dotenv
 
 load_dotenv()
 
-import json
-import typer
-
 app = typer.Typer(
     name="mpp",
-    help="Market data via MPP (Machine Payments Protocol) — token prices, web search, on-chain data, trending tokens, wallet balances, and Dune SQL queries. Paid per-query with Tempo stablecoins.",
+    help="Market data and live service discovery via MPP (Machine Payments Protocol).",
 )
+services_app = typer.Typer(help="Discover public MPP services without making a payment.")
+app.add_typer(services_app, name="services")
+
+
+def _print_json(payload: object) -> None:
+    typer.echo(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+
+
+def _run_discovery(operation: Callable[[], object]) -> None:
+    try:
+        _print_json(operation())
+    except (RuntimeError, ValueError) as exc:
+        _print_json({"error": str(exc)})
+        raise typer.Exit(1) from exc
 
 
 @app.callback()
@@ -29,13 +44,66 @@ def health():
         payload = {"ok": True, "tool": "mpp", "error": None, "details": details}
     except Exception as exc:
         payload = {"ok": False, "tool": "mpp", "error": str(exc), "details": {}}
-        print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+        _print_json(payload)
         raise typer.Exit(1) from exc
     finally:
         close = getattr(client, "close", None)
         if callable(close):
             close()
-    print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+    _print_json(payload)
+
+
+@services_app.command("list")
+def list_services(
+    query: str | None = typer.Option(
+        None, "--query", "-q", help="Text to match in catalog metadata"
+    ),
+    category: str | None = typer.Option(None, help="Exact service category"),
+    tag: str | None = typer.Option(None, help="Exact service tag"),
+    limit: int = typer.Option(20, min=1, max=100, help="Maximum services to return"),
+) -> None:
+    """List public MPP services with optional catalog filters."""
+    from .client import _client
+
+    client = _client()
+    _run_discovery(
+        lambda: {
+            "services": client.list_services(query=query, category=category, tag=tag, limit=limit),
+            "filters": {"query": query, "category": category, "tag": tag, "limit": limit},
+        }
+    )
+
+
+@services_app.command("search")
+def search_services(
+    query: str = typer.Argument(..., help="Text to match in catalog metadata"),
+    category: str | None = typer.Option(None, help="Exact service category"),
+    tag: str | None = typer.Option(None, help="Exact service tag"),
+    limit: int = typer.Option(20, min=1, max=100, help="Maximum services to return"),
+) -> None:
+    """Search public MPP services by id, name, description, category, or tag."""
+    from .client import _client
+
+    client = _client()
+    _run_discovery(
+        lambda: {
+            "services": client.search_services(
+                query=query, category=category, tag=tag, limit=limit
+            ),
+            "filters": {"query": query, "category": category, "tag": tag, "limit": limit},
+        }
+    )
+
+
+@services_app.command("show")
+def show_service(
+    service: str = typer.Argument(..., help="Exact service id or unambiguous service name"),
+) -> None:
+    """Show one complete public MPP service record."""
+    from .client import _client
+
+    client = _client()
+    _run_discovery(lambda: client.get_service(service))
 
 
 if __name__ == "__main__":

--- a/tools/crypto/mpp/client.py
+++ b/tools/crypto/mpp/client.py
@@ -9,11 +9,21 @@ Ported from gtmskill's mpp-client.ts, mpp-search.ts, and mpp-onchain.ts.
 from __future__ import annotations
 
 import time
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from typing import Any
 
 import httpx
+
 from centaur_sdk.tool_sdk import secret
+
+MPP_SERVICE_CATALOG_URL = "https://mpp.dev/api/services"
+MPP_SERVICE_CATALOG_TIMEOUT_SECONDS = 15
+DEFAULT_SERVICE_LIMIT = 20
+MAX_SERVICE_LIMIT = 100
+
+
+class MppCatalogError(RuntimeError):
+    """Raised when the public MPP service catalog cannot be used safely."""
 
 # --- Token name normalization ---
 
@@ -69,8 +79,154 @@ class MppClient:
         self._private_key: str | None = None
         self._daily_spend = 0.0
         self._daily_cap = 10.0
-        self._last_reset = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+        self._last_reset = datetime.now(UTC).strftime("%Y-%m-%d")
         self._coingecko_id_cache: dict[str, str] = {}
+        self._catalog_http: httpx.Client | None = None
+
+    def _fetch_service_catalog(self) -> list[dict[str, Any]]:
+        """Fetch and validate the public MPP service catalog without using a wallet."""
+        client = self._catalog_http
+        owns_client = client is None
+        if client is None:
+            client = httpx.Client(timeout=MPP_SERVICE_CATALOG_TIMEOUT_SECONDS)
+
+        try:
+            try:
+                response = client.get(MPP_SERVICE_CATALOG_URL)
+                response.raise_for_status()
+            except httpx.HTTPStatusError as exc:
+                raise MppCatalogError(
+                    f"MPP service catalog returned HTTP {exc.response.status_code}"
+                ) from exc
+            except httpx.HTTPError as exc:
+                raise MppCatalogError("could not fetch MPP service catalog") from exc
+
+            try:
+                payload = response.json()
+            except ValueError as exc:
+                raise MppCatalogError("MPP service catalog returned invalid JSON") from exc
+
+            services = payload.get("services") if isinstance(payload, dict) else None
+            if not isinstance(services, list) or not all(
+                isinstance(service, dict) for service in services
+            ):
+                raise MppCatalogError("MPP service catalog has an invalid services list")
+            return services
+        finally:
+            if owns_client:
+                client.close()
+
+    @staticmethod
+    def _validate_service_limit(limit: int) -> None:
+        if not 1 <= limit <= MAX_SERVICE_LIMIT:
+            raise ValueError(f"limit must be between 1 and {MAX_SERVICE_LIMIT}")
+
+    @staticmethod
+    def _matches_service(
+        service: dict[str, Any], query: str | None, category: str | None, tag: str | None
+    ) -> bool:
+        if category is not None:
+            categories = service.get("categories") or []
+            if not any(str(value).casefold() == category.casefold() for value in categories):
+                return False
+
+        if tag is not None:
+            tags = service.get("tags") or []
+            if not any(str(value).casefold() == tag.casefold() for value in tags):
+                return False
+
+        if query is None:
+            return True
+
+        haystack = [
+            service.get("id"),
+            service.get("name"),
+            service.get("description"),
+            *(service.get("categories") or []),
+            *(service.get("tags") or []),
+        ]
+        normalized_query = query.casefold()
+        return any(
+            normalized_query in str(value).casefold() for value in haystack if value is not None
+        )
+
+    @staticmethod
+    def _service_summary(service: dict[str, Any]) -> dict[str, Any]:
+        endpoints = service.get("endpoints") or []
+        paid_endpoints = service.get("paidEndpoints")
+        if not isinstance(paid_endpoints, int):
+            paid_endpoints = sum(
+                isinstance(endpoint, dict) and endpoint.get("payment") is not None
+                for endpoint in endpoints
+            )
+        return {
+            "id": service.get("id", ""),
+            "name": service.get("name", ""),
+            "description": service.get("description", ""),
+            "service_url": service.get("serviceUrl") or service.get("url") or "",
+            "categories": service.get("categories") or [],
+            "tags": service.get("tags") or [],
+            "status": service.get("status", ""),
+            "paid_endpoints": paid_endpoints,
+        }
+
+    def list_services(
+        self,
+        query: str | None = None,
+        category: str | None = None,
+        tag: str | None = None,
+        limit: int = DEFAULT_SERVICE_LIMIT,
+    ) -> list[dict[str, Any]]:
+        """List public MPP services, optionally filtered by catalog metadata."""
+        self._validate_service_limit(limit)
+        normalized_query = query.strip() if query is not None else None
+        normalized_category = category.strip() if category is not None else None
+        normalized_tag = tag.strip() if tag is not None else None
+        if normalized_query == "":
+            normalized_query = None
+        if normalized_category == "":
+            normalized_category = None
+        if normalized_tag == "":
+            normalized_tag = None
+
+        return [
+            self._service_summary(service)
+            for service in self._fetch_service_catalog()
+            if self._matches_service(service, normalized_query, normalized_category, normalized_tag)
+        ][:limit]
+
+    def search_services(
+        self,
+        query: str,
+        category: str | None = None,
+        tag: str | None = None,
+        limit: int = DEFAULT_SERVICE_LIMIT,
+    ) -> list[dict[str, Any]]:
+        """Search public MPP services by text and optional exact catalog filters."""
+        return self.list_services(query=query, category=category, tag=tag, limit=limit)
+
+    def get_service(self, service: str) -> dict[str, Any]:
+        """Return one complete public MPP service record by id or unambiguous name."""
+        identifier = service.strip()
+        if not identifier:
+            raise ValueError("service id or name is required")
+
+        services = self._fetch_service_catalog()
+        exact_ids = [item for item in services if item.get("id") == identifier]
+        if exact_ids:
+            return exact_ids[0]
+
+        name_matches = [
+            item
+            for item in services
+            if isinstance(item.get("name"), str)
+            and item["name"].casefold() == identifier.casefold()
+        ]
+        if len(name_matches) == 1:
+            return name_matches[0]
+        if len(name_matches) > 1:
+            raise ValueError(f"MPP service name {identifier!r} is ambiguous; use its id")
+        raise ValueError(f"MPP service {identifier!r} was not found")
 
     def _get_private_key(self) -> str:
         """Lazy-load MPP_PRIVATE_KEY from secrets on first use."""
@@ -84,7 +240,7 @@ class MppClient:
         return self._private_key
 
     def _check_budget(self, needed: float = 0) -> bool:
-        today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+        today = datetime.now(UTC).strftime("%Y-%m-%d")
         if today != self._last_reset:
             self._daily_spend = 0.0
             self._last_reset = today
@@ -287,9 +443,9 @@ class MppClient:
             return [
                 {
                     "date": (
-                        datetime.fromtimestamp(p[0] / 1000, tz=timezone.utc).strftime("%Y-%m-%d %H:%M")
+                        datetime.fromtimestamp(p[0] / 1000, tz=UTC).strftime("%Y-%m-%d %H:%M")
                         if days <= 7
-                        else datetime.fromtimestamp(p[0] / 1000, tz=timezone.utc).strftime("%Y-%m-%d")
+                        else datetime.fromtimestamp(p[0] / 1000, tz=UTC).strftime("%Y-%m-%d")
                     ),
                     "price": p[1],
                 }
@@ -330,7 +486,7 @@ class MppClient:
                 return []
             return [
                 {
-                    "date": datetime.fromtimestamp(c[0] / 1000, tz=timezone.utc).strftime("%Y-%m-%d"),
+                    "date": datetime.fromtimestamp(c[0] / 1000, tz=UTC).strftime("%Y-%m-%d"),
                     "open": c[1],
                     "high": c[2],
                     "low": c[3],

--- a/tools/crypto/mpp/tests/conftest.py
+++ b/tools/crypto/mpp/tests/conftest.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[4]
+sys.path.insert(0, str(ROOT / "tools" / "crypto"))
+sys.path.insert(0, str(ROOT))

--- a/tools/crypto/mpp/tests/test_cli.py
+++ b/tools/crypto/mpp/tests/test_cli.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import json
+
+from mpp import cli
+from typer.testing import CliRunner
+
+
+class FakeClient:
+    def list_services(self, **kwargs):
+        assert kwargs == {"query": None, "category": "search", "tag": None, "limit": 5}
+        return [{"id": "exa"}]
+
+    def search_services(self, **kwargs):
+        assert kwargs == {"query": "image", "category": None, "tag": None, "limit": 20}
+        return [{"id": "fal"}]
+
+    def get_service(self, service: str):
+        assert service == "fal"
+        return {"id": "fal", "endpoints": [{"payment": {"intent": "charge"}}]}
+
+
+def test_service_commands_emit_json(monkeypatch) -> None:
+    monkeypatch.setattr("mpp.client._client", lambda: FakeClient())
+    runner = CliRunner()
+
+    listed = runner.invoke(cli.app, ["services", "list", "--category", "search", "--limit", "5"])
+    searched = runner.invoke(cli.app, ["services", "search", "image"])
+    shown = runner.invoke(cli.app, ["services", "show", "fal"])
+
+    assert listed.exit_code == 0, listed.output
+    assert json.loads(listed.output)["services"] == [{"id": "exa"}]
+    assert searched.exit_code == 0, searched.output
+    assert json.loads(searched.output)["services"] == [{"id": "fal"}]
+    assert shown.exit_code == 0, shown.output
+    assert json.loads(shown.output)["endpoints"][0]["payment"] == {"intent": "charge"}
+
+
+def test_service_commands_return_a_json_error(monkeypatch) -> None:
+    class FailingClient:
+        def get_service(self, service: str):
+            raise ValueError(f"MPP service {service!r} was not found")
+
+    monkeypatch.setattr("mpp.client._client", lambda: FailingClient())
+
+    result = CliRunner().invoke(cli.app, ["services", "show", "missing"])
+
+    assert result.exit_code == 1
+    assert json.loads(result.output) == {"error": "MPP service 'missing' was not found"}

--- a/tools/crypto/mpp/tests/test_client.py
+++ b/tools/crypto/mpp/tests/test_client.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import httpx
+import pytest
+from mpp import client as client_module
+from mpp.client import MppCatalogError, MppClient
+
+CATALOG = {
+    "services": [
+        {
+            "id": "fal",
+            "name": "Fal AI",
+            "description": "Image generation models",
+            "serviceUrl": "https://fal.mpp.example",
+            "categories": ["AI", "media"],
+            "tags": ["image", "generation"],
+            "status": "active",
+            "paidEndpoints": 2,
+            "endpoints": [
+                {
+                    "method": "POST",
+                    "path": "/generate",
+                    "payment": {"intent": "charge", "method": "tempo", "amount": "100"},
+                }
+            ],
+        },
+        {
+            "id": "exa",
+            "name": "Exa",
+            "description": "Web search API",
+            "url": "https://exa.example",
+            "categories": ["search"],
+            "tags": ["web", "research"],
+            "status": "active",
+            "endpoints": [{"method": "POST", "path": "/search", "payment": {"intent": "charge"}}],
+        },
+        {
+            "id": "exa-archive",
+            "name": "Exa",
+            "description": "Archived Exa service",
+            "serviceUrl": "https://archive.example",
+            "categories": ["search"],
+            "tags": ["archive"],
+            "status": "inactive",
+            "endpoints": [],
+        },
+    ]
+}
+
+
+def make_client(handler) -> MppClient:
+    client = MppClient()
+    client._catalog_http = httpx.Client(transport=httpx.MockTransport(handler))
+    return client
+
+
+def test_list_services_filters_summarizes_and_never_loads_a_private_key(monkeypatch) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert str(request.url) == "https://mpp.dev/api/services"
+        return httpx.Response(200, json=CATALOG)
+
+    monkeypatch.setattr(
+        client_module,
+        "secret",
+        lambda _: pytest.fail("service discovery must not load MPP_PRIVATE_KEY"),
+    )
+    client = make_client(handler)
+
+    assert client.list_services(query="image", category="ai", tag="generation") == [
+        {
+            "id": "fal",
+            "name": "Fal AI",
+            "description": "Image generation models",
+            "service_url": "https://fal.mpp.example",
+            "categories": ["AI", "media"],
+            "tags": ["image", "generation"],
+            "status": "active",
+            "paid_endpoints": 2,
+        }
+    ]
+
+
+def test_search_matches_all_supported_metadata_and_honors_limit() -> None:
+    client = make_client(lambda _: httpx.Response(200, json=CATALOG))
+
+    assert [service["id"] for service in client.search_services("web", limit=1)] == ["exa"]
+    assert [service["id"] for service in client.list_services(query="media")] == ["fal"]
+    assert [service["id"] for service in client.list_services(query="exa")] == [
+        "exa",
+        "exa-archive",
+    ]
+
+
+def test_get_service_returns_raw_endpoint_and_payment_metadata() -> None:
+    client = make_client(lambda _: httpx.Response(200, json=CATALOG))
+
+    assert client.get_service("fal") == CATALOG["services"][0]
+
+
+def test_get_service_resolves_an_unambiguous_name_and_rejects_ambiguous_or_unknown_names() -> None:
+    single = {"services": [CATALOG["services"][0], CATALOG["services"][1]]}
+    client = make_client(lambda _: httpx.Response(200, json=single))
+    assert client.get_service("fal ai")["id"] == "fal"
+
+    ambiguous = make_client(lambda _: httpx.Response(200, json=CATALOG))
+    with pytest.raises(ValueError, match="ambiguous"):
+        ambiguous.get_service("Exa")
+
+    with pytest.raises(ValueError, match="was not found"):
+        client.get_service("missing")
+
+
+@pytest.mark.parametrize("payload", [{}, {"services": {}}, {"services": ["not-a-service"]}])
+def test_catalog_rejects_invalid_shapes(payload) -> None:
+    client = make_client(lambda _: httpx.Response(200, json=payload))
+
+    with pytest.raises(MppCatalogError, match="invalid services list"):
+        client.list_services()
+
+
+def test_catalog_errors_are_concise() -> None:
+    def http_error(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(503, request=request)
+
+    client = make_client(http_error)
+    with pytest.raises(MppCatalogError, match="HTTP 503"):
+        client.list_services()
+
+    malformed = make_client(lambda _: httpx.Response(200, content=b"not-json"))
+    with pytest.raises(MppCatalogError, match="invalid JSON"):
+        malformed.list_services()
+
+
+@pytest.mark.parametrize("limit", [0, 101])
+def test_list_services_rejects_unsafe_limits(limit: int) -> None:
+    client = MppClient()
+
+    with pytest.raises(ValueError, match="between 1 and 100"):
+        client.list_services(limit=limit)


### PR DESCRIPTION
## Motivation

Expose the public MPP service catalog to Centaur agents without changing payment behavior.

## Summary

- Add list, search, and full-record lookup commands to the MPP tool.
- Validate catalog responses and retain payment metadata for discovered services.
- Cover client and CLI behavior with fixture-based tests.

## Key design considerations

- Discovery is read-only and does not access `MPP_PRIVATE_KEY`.
- Catalog metadata is fetched live and remains advisory.