### PR TITLE
fix: sync slack labels for mcp principals

### DIFF
--- a/services/console/app/controllers/oauth/flows_controller.rb
+++ b/services/console/app/controllers/oauth/flows_controller.rb
@@ -183,6 +183,7 @@ module Oauth
           provider_email: identity[:email],
           # Store exactly what the IdP granted, so the refresh POST re-requests it.
           scopes: granted_scopes(result, state),
+          labels: credential_labels(credential, identity),
           refresh_token: result.refresh_token,
           access_token: result.access_token,
           expires_at: now + expires_in,
@@ -199,6 +200,14 @@ module Oauth
     def granted_scopes(result, state)
       return Array(state["scopes"]) if result.scope.blank?
       @provider.parse_granted_scopes(result.scope)
+    end
+
+    def credential_labels(credential, identity)
+      labels = credential.labels || {}
+      return labels unless @app.provider == Oauth::Providers::Slack::KEY
+      return labels if identity[:team_id].blank?
+
+      labels.merge("slack_team_id" => identity[:team_id])
     end
 
     def identity_display_name(identity)

--- a/services/console/app/services/principal_credential_reconciliation.rb
+++ b/services/console/app/services/principal_credential_reconciliation.rb
@@ -108,9 +108,10 @@ class PrincipalCredentialReconciliation
   end
 
   def sync_principal_provider_labels(principal, credentials)
-    # Console-user principals never match by label, so stamping provider
-    # identity labels on them would only create stale, unused inputs.
-    return if console_user_principal?(principal)
+    if console_user_principal?(principal)
+      sync_console_user_slack_labels(principal, credentials)
+      return
+    end
 
     google_credentials = credentials.select do |credential|
       credential.oauth_app&.provider == GOOGLE_PROVIDER
@@ -277,9 +278,35 @@ class PrincipalCredentialReconciliation
     principal_team = normalize_key(principal.labels&.[](SLACK_TEAM_LABEL))
     credential_team = normalize_key(credential.labels&.[](SLACK_TEAM_LABEL)) ||
                       normalize_key(credential.oauth_app&.labels&.[](SLACK_TEAM_LABEL))
+    return true if console_user_principal?(principal) && principal_team.blank?
     return true if principal_team.blank? && credential_team.blank?
 
     principal_team.present? && principal_team == credential_team
+  end
+
+  def sync_console_user_slack_labels(principal, credentials)
+    slack_credentials = credentials.select do |credential|
+      credential.oauth_app&.provider == SLACK_PROVIDER
+    end
+    return if slack_credentials.empty?
+
+    slack_user_id = unique_present_value(slack_credentials.map(&:provider_subject))
+    slack_team_id = unique_present_value(slack_credentials.map { |credential| slack_team_for(credential) })
+    return unless slack_user_id && slack_team_id
+
+    labels = principal.labels || {}
+    updates = {
+      "slack_user_id" => slack_user_id,
+      SLACK_TEAM_LABEL => slack_team_id
+    }
+    return if updates.all? { |key, value| labels[key] == value }
+
+    principal.update!(labels: labels.merge(updates))
+  end
+
+  def slack_team_for(credential)
+    credential.labels&.[](SLACK_TEAM_LABEL).presence ||
+      credential.oauth_app&.labels&.[](SLACK_TEAM_LABEL).presence
   end
 
   def console_user_principal?(principal)

--- a/services/console/lib/oauth/providers/slack.rb
+++ b/services/console/lib/oauth/providers/slack.rb
@@ -36,7 +36,8 @@ module Oauth
           return {
             subject: user_id,
             email: result.response.dig("authed_user", "email"),
-            name: slack_user_name(result.response)
+            name: slack_user_name(result.response),
+            team_id: slack_team_id(result.response)
           }
         end
 
@@ -50,6 +51,11 @@ module Oauth
       def slack_user_name(response)
         response.dig("authed_user", "name").presence ||
           response.dig("authed_user", "user").presence
+      end
+
+      def slack_team_id(response)
+        response.dig("team", "id").presence ||
+          response.dig("authed_user", "team_id").presence
       end
     end
   end

--- a/services/console/test/controllers/oauth/flows_controller_test.rb
+++ b/services/console/test/controllers/oauth/flows_controller_test.rb
@@ -62,6 +62,7 @@ module Oauth
         ok: true, access_token: "xoxe.xoxb-1-bot", refresh_token: "xoxe-1-bot-refresh",
         expires_in: 43_200, token_type: "bot", scope: "commands",
         id_token: id_token_value,
+        team: { id: "TACME", name: "Acme" },
         authed_user: {
           id: sub,
           user: "grace",
@@ -295,6 +296,7 @@ module Oauth
       assert_equal %w[chat:write], cred.scopes
       assert_equal "xoxe.xoxp-1-user", cred.access_token
       assert_equal "xoxe-1-refresh", cred.refresh_token
+      assert_equal "TACME", cred.labels["slack_team_id"]
       assert_equal [ "slack.com" ], cred.static_secret.rules.map(&:host)
       assert_equal "Slack – grace token", cred.static_secret.name
     end

--- a/services/console/test/lib/oauth/providers/slack_test.rb
+++ b/services/console/test/lib/oauth/providers/slack_test.rb
@@ -31,11 +31,15 @@ module Oauth
         result = result_with(
           claims: valid_claims,
           id_token: nil,
-          response: { "authed_user" => { "id" => "U12345" } }
+          response: {
+            "team" => { "id" => "T12345" },
+            "authed_user" => { "id" => "U12345" }
+          }
         )
 
         identity = strategy.identity_from(result, client_id: CLIENT_ID)
         assert_equal "U12345", identity[:subject]
+        assert_equal "T12345", identity[:team_id]
         assert_nil identity[:email]
         assert_nil identity[:name]
       end

--- a/services/console/test/services/principal_credential_reconciliation_test.rb
+++ b/services/console/test/services/principal_credential_reconciliation_test.rb
@@ -177,6 +177,19 @@ class PrincipalCredentialReconciliationTest < ActiveSupport::TestCase
     end
   end
 
+  test "console user principal syncs Slack labels from a matched admin credential" do
+    app = oauth_apps(:acme_slack)
+    app.update!(labels: app.labels.merge("slack_team_id" => "TACME"))
+    credential = create_credential(app, "U-MEMBER", "member@acme.example")
+    secret = wrap(credential)
+
+    principal = create_console_user_principal(users(:member_user), foreign_id: "console-user-slack")
+
+    assert principal.grants.exists?(static_secret: secret)
+    assert_equal "U-MEMBER", principal.reload.labels["slack_user_id"]
+    assert_equal "TACME", principal.labels["slack_team_id"]
+  end
+
   test "console user principal ignores a spoofed email label" do
     credential = create_credential(oauth_apps(:acme_slack), "slack-sub-carol", "carol@acme.example")
     secret = wrap(credential)


### PR DESCRIPTION
## Summary
- sync Slack user/team labels onto Console MCP principals after a trusted credential match
- persist Slack workspace team IDs from Slack OAuth responses onto broker credentials
- cover admin-created credential matching, verified Console identity matching, and Slack OAuth team extraction

## Why
company_context RLS needs slack_user_id and slack_team_id on the active principal. Console MCP principals already match credentials through the trusted Console user, but they did not receive the Slack labels needed for RLS.

## Validation
- docker run --rm -v /Users/akshaan/Desktop/centaur-pr-mcp-labels/services/console:/rails -w /rails -v centaur_console_pr_bundle:/usr/local/bundle -e RAILS_ENV=test -e DATABASE_URL=postgres://postgres:postgres@host.docker.internal:55432/iron_control_test centaur-console-dev-ruby:3.4.8 bin/rails test test/services/principal_credential_reconciliation_test.rb test/lib/oauth/providers/slack_test.rb test/controllers/oauth/flows_controller_test.rb
- 51 runs, 354 assertions, 0 failures, 0 errors
