### PR TITLE
fix: default slack file and thread tools to api routes

### DIFF
--- a/services/api-rs/crates/centaur-api-server/src/slack_proxy.rs
+++ b/services/api-rs/crates/centaur-api-server/src/slack_proxy.rs
@@ -47,6 +47,10 @@ pub(crate) fn slack_proxy_router() -> Router<AppState> {
             "/api/slack/channels/{channel_id}/history",
             get(get_slack_channel_history),
         )
+        .route(
+            "/api/slack/channels/{channel_id}/threads/{thread_ts}/replies",
+            get(get_slack_thread_replies),
+        )
 }
 
 #[derive(Debug, Deserialize)]
@@ -257,6 +261,23 @@ async fn get_slack_channel_history(
     Ok(Json(value))
 }
 
+async fn get_slack_thread_replies(
+    headers: HeaderMap,
+    Path((channel_id, thread_ts)): Path<(String, String)>,
+    Query(query): Query<SlackChannelHistoryQuery>,
+) -> Result<Json<Value>, ApiError> {
+    let claims = authorize_slack_file_proxy(&headers)?;
+    ensure_history_channel_allowed(&claims, &channel_id)?;
+    validate_slack_channel_id(&channel_id)?;
+    validate_slack_thread_ts(&thread_ts)?;
+    validate_slack_channel_history_query(&query)?;
+
+    let config = slack_proxy_config()?;
+    let value =
+        slack_thread_replies(http_client(), config, &channel_id, &thread_ts, &query).await?;
+    Ok(Json(value))
+}
+
 fn upstream_body_is_unexpected_html(
     upstream_content_type: Option<&str>,
     file_mimetype: Option<&str>,
@@ -425,6 +446,17 @@ async fn slack_channel_history(
     slack_api_post_form(client, config, "conversations.history", &form).await
 }
 
+async fn slack_thread_replies(
+    client: &reqwest::Client,
+    config: &SlackFileProxyConfig,
+    channel_id: &str,
+    thread_ts: &str,
+    query: &SlackChannelHistoryQuery,
+) -> Result<Value, ApiError> {
+    let form = slack_thread_replies_form(channel_id, thread_ts, query);
+    slack_api_post_form(client, config, "conversations.replies", &form).await
+}
+
 fn slack_channel_history_form(
     channel_id: &str,
     query: &SlackChannelHistoryQuery,
@@ -457,6 +489,16 @@ fn slack_channel_history_form(
         ("cursor", query.cursor.clone().unwrap_or_default()),
     ];
     form.retain(|(_, value)| !value.is_empty());
+    form
+}
+
+fn slack_thread_replies_form(
+    channel_id: &str,
+    thread_ts: &str,
+    query: &SlackChannelHistoryQuery,
+) -> Vec<(&'static str, String)> {
+    let mut form = slack_channel_history_form(channel_id, query);
+    form.push(("ts", thread_ts.to_owned()));
     form
 }
 
@@ -1084,6 +1126,33 @@ mod tests {
                 ("inclusive", "false".to_owned()),
                 ("include_all_metadata", "true".to_owned()),
                 ("limit", "15".to_owned()),
+            ]
+        );
+    }
+
+    #[test]
+    fn thread_replies_form_includes_thread_ts() {
+        let form = slack_thread_replies_form(
+            "C123456789",
+            "1700000000.000001",
+            &SlackChannelHistoryQuery {
+                latest: None,
+                oldest: Some("0".to_owned()),
+                inclusive: Some(true),
+                include_all_metadata: None,
+                limit: Some(25),
+                cursor: Some("next".to_owned()),
+            },
+        );
+        assert_eq!(
+            form,
+            vec![
+                ("channel", "C123456789".to_owned()),
+                ("oldest", "0".to_owned()),
+                ("inclusive", "true".to_owned()),
+                ("limit", "25".to_owned()),
+                ("cursor", "next".to_owned()),
+                ("ts", "1700000000.000001".to_owned()),
             ]
         );
     }

--- a/services/sandbox/SYSTEM_PROMPT.md
+++ b/services/sandbox/SYSTEM_PROMPT.md
@@ -152,7 +152,7 @@
 |
 [Common Tool CLIs]
 |NEVER call external APIs directly via curl unless you are downloading a file the prompt explicitly told you to fetch that way.
-|Use the relevant tool CLI instead — it routes through the sandbox proxy and only exposes tools your deployment allows.
+|Use the relevant tool CLI instead; it only exposes tools your deployment allows.
 |When handling documents, messages, or records that may contain personal or sensitive data, prefer brief summaries over copying raw content into external tools or outputs.
 |Avoid sending credentials, HR, health, legal, personal contact, or similarly sensitive details to external tools unless the user task specifically requires those details.
 |Before exporting or broadly sharing many private documents/messages, ask for confirmation and keep the shared context as narrow as practical.
@@ -182,6 +182,7 @@
 |Treat explicit Slack channel IDs as authoritative. If a user refers to a channel as `#name (C123...)`, `<#C123...|name>`, `#C123...`, or otherwise provides a channel ID, use that exact ID for Slack history/search/file operations.
 |When fetching or summarizing a specific Slack channel, verify that the fetched `channel_id` matches the requested channel ID before using the results. If it does not match, stop and report the mismatch.
 |Never substitute a search-derived or semantically similar channel for an explicitly requested Slack channel ID. If both a human-readable channel name and ID are present, the ID wins.
+|For Slack thread history, use `slack thread <permalink|channel_id:timestamp>` first. If that fails, retry once with `slack thread-direct <permalink|channel_id:timestamp>`.
 
 [Slack files and attachments]
 |Files attached to the current user message are not always preloaded on disk. Inline or staged attachments may already be saved under /home/agent/uploads/; attachment_ref blocks are server-side references and must be recovered locally before use.
@@ -190,9 +191,9 @@
 |When uploading or sending a file "back", "here", "to this channel", or "into this thread", the destination is the current Slack channel ID plus the current thread timestamp.
 |For Slack uploads, always pass the API-owned Slack channel ID and thread timestamp explicitly. Read them from the current user turn's `session_context.slack.channel_id` and `session_context.slack.thread_ts` fields, or from `thread_key` when it has the form `slack:<team_id>:<channel_id>:<thread_ts>`. Never call `slack upload` with only a file path.
 |For Slack uploads, always resolve the actual Slack conversation ID before calling the upload tool: use a channel ID for channel/thread uploads, and if the user explicitly asks for a DM, open or resolve the DM and use its DM conversation ID. Never use a Slack user ID like `U123...` as an upload destination.
-|For Slack file uploads from a thread, call the upload tool with the channel ID and thread timestamp, for example `slack upload C123... /path/file --thread 1234567890.123456`; never call `slack upload U123... ...` for a threaded reply. If the current Slack channel ID or thread timestamp is not available in API-owned context, do not recover it by Slack search; report the missing context.
-|For Slack file downloads, use the Slack CLI file surface. Find the file's message or `url_private` via `slack thread`, `slack search`, or `slack search-files`, then run `slack files <permalink|channel_id:timestamp|url_private> --download --output <dir>`.
-|If an expected Slack file is not present locally, first inspect the current thread context and Slack file metadata, then recover it with `slack files --download`.
+|For Slack file uploads from a thread, call the upload tool with the channel ID and thread timestamp, for example `slack upload C123... /path/file --thread 1234567890.123456`; if that upload fails, retry once with `slack upload-direct C123... /path/file --thread 1234567890.123456`. Never call `slack upload U123... ...` for a threaded reply. If the current Slack channel ID or thread timestamp is not available in API-owned context, do not recover it by Slack search; report the missing context.
+|For Slack file downloads, find the file ID and channel ID via `slack thread`, `slack search`, or `slack search-files`, then run `slack download <file_id> <channel_id> --output <dir>`. Use `slack download-direct <permalink|channel_id:timestamp|url_private> --output <dir>` only when `slack download` is unavailable.
+|If an expected Slack file is not present locally, first inspect the current thread context and Slack file metadata, then recover it with `slack download`.
 |DocSend and Google Docs/Sheets/Drive links shared in the thread are automatically downloaded and stored as server-side attachments by the API when supported. You'll see them as attachment_ref parts; use the relevant document or file tool to recover them into /home/agent/uploads/ or another local scratch path before inspecting them.
 |Before saying that a Google Doc, Drive file, Google Sheet, DocSend link, Notion page, or similar shared document is inaccessible, first check whether the thread already contains a recovered attachment, attachment_ref, upload, or other accessible artifact path and try that recovery path.
 |Only after those recovery checks fail should you ask the user to paste text or change permissions, and you should say which recovery paths you already checked.

--- a/tools/productivity/slack/cli.py
+++ b/tools/productivity/slack/cli.py
@@ -314,7 +314,25 @@ def channel_proxy(
         console.print(f"[green]{user}[/]{thread_info}: {text}")
 
 
-@app.command()
+def _parse_thread_ref(permalink: str) -> tuple[str, str]:
+    import re
+
+    if permalink.startswith("https://"):
+        match = re.search(r"/archives/([A-Z0-9]+)/p(\d+)", permalink)
+        if not match:
+            console.print("[red]Invalid permalink format[/]")
+            raise typer.Exit(1)
+        channel_id = match.group(1)
+        ts_raw = match.group(2)
+        return channel_id, f"{ts_raw[:10]}.{ts_raw[10:]}"
+    if ":" in permalink:
+        channel_id, thread_ts = permalink.split(":", 1)
+        return channel_id, thread_ts
+    console.print("[red]Provide a Slack permalink or 'channel_id:timestamp'[/]")
+    raise typer.Exit(1)
+
+
+@app.command("thread")
 def thread(
     permalink: str = typer.Argument(..., help="Slack permalink or 'channel_id:timestamp'"),
     limit: int = typer.Option(100, "--limit", "-n", help="Max messages to return from the thread"),
@@ -341,24 +359,84 @@ def thread(
         slack thread "C01234567:1234567890.123456"
         slack thread "https://..." --json
     """
-    import re
+    import sys
+
+    from .client import get_thread_replies_proxy
+
+    channel_id, thread_ts = _parse_thread_ref(permalink)
+
+    try:
+        page = get_thread_replies_proxy(
+            channel_id,
+            thread_ts,
+            limit=limit,
+            cursor=cursor,
+            oldest=oldest,
+            latest=latest,
+            inclusive=inclusive,
+        )
+    except (RuntimeError, ValueError) as e:
+        stderr_console.print(f"[red]Error: {e}[/]")
+        raise typer.Exit(1) from e
+
+    messages = page.get("messages", [])
+
+    if not messages:
+        console.print("[yellow]No messages found in thread.[/]")
+        raise typer.Exit()
+
+    if json_output:
+        print(json.dumps(page, indent=2, ensure_ascii=False), file=sys.stdout)
+        raise typer.Exit()
+
+    header = f"\n[bold]Thread ({len(messages)} messages)[/]"
+    if page.get("has_more"):
+        header += " [dim](more available)[/]"
+    console.print(f"{header}\n")
+
+    next_cursor = page.get("response_metadata", {}).get("next_cursor")
+    if next_cursor:
+        console.print(f"[dim]next_cursor={next_cursor}[/]\n")
+
+    for i, msg in enumerate(messages):
+        prefix = "[bold]>[/]" if i == 0 else "  "
+        user = msg.get("user") or msg.get("bot_id") or msg.get("username") or "unknown"
+        text = str(msg.get("text") or "").replace("\n", "\n     ")
+        console.print(f"{prefix} [cyan]@{user}[/]: {text}\n")
+
+
+@app.command("thread-direct")
+def thread_direct(
+    permalink: str = typer.Argument(..., help="Slack permalink or 'channel_id:timestamp'"),
+    limit: int = typer.Option(100, "--limit", "-n", help="Max messages to return from the thread"),
+    cursor: str = typer.Option(None, "--cursor", help="Slack pagination cursor for the next page"),
+    oldest: str = typer.Option(
+        None,
+        "--oldest",
+        help="Oldest timestamp boundary: Slack ts, epoch, ISO datetime, or YYYY-MM-DD",
+    ),
+    latest: str = typer.Option(
+        None,
+        "--latest",
+        help="Latest timestamp boundary: Slack ts, epoch, ISO datetime, or YYYY-MM-DD",
+    ),
+    inclusive: bool = typer.Option(
+        True, "--inclusive/--exclusive", help="Include the boundary timestamps"
+    ),
+    json_output: bool = typer.Option(False, "--json", help="Output as JSON"),
+):
+    """Get all replies in a thread directly with the Slack SDK.
+
+    Examples:
+        slack thread-direct "https://slack.com/archives/C01234567/p1234567890123456"
+        slack thread-direct "C01234567:1234567890.123456"
+        slack thread-direct "https://..." --json
+    """
     import sys
 
     from .client import get_thread_replies_page
 
-    if permalink.startswith("https://"):
-        match = re.search(r"/archives/([A-Z0-9]+)/p(\d+)", permalink)
-        if not match:
-            console.print("[red]Invalid permalink format[/]")
-            raise typer.Exit(1)
-        channel_id = match.group(1)
-        ts_raw = match.group(2)
-        thread_ts = f"{ts_raw[:10]}.{ts_raw[10:]}"
-    elif ":" in permalink:
-        channel_id, thread_ts = permalink.split(":", 1)
-    else:
-        console.print("[red]Provide a Slack permalink or 'channel_id:timestamp'[/]")
-        raise typer.Exit(1)
+    channel_id, thread_ts = _parse_thread_ref(permalink)
 
     try:
         page = get_thread_replies_page(
@@ -372,7 +450,7 @@ def thread(
         )
     except (RuntimeError, ValueError) as e:
         stderr_console.print(f"[red]Error: {e}[/]")
-        raise typer.Exit(1)
+        raise typer.Exit(1) from e
 
     messages = page["messages"]
 
@@ -586,8 +664,8 @@ def users(
     console.print(table)
 
 
-@app.command()
-def upload(
+@app.command("upload-direct")
+def upload_direct(
     channel: str = typer.Argument(
         ..., help="Slack channel/conversation ID to upload into, e.g. C123 or D123"
     ),
@@ -595,11 +673,11 @@ def upload(
     comment: str = typer.Option(None, "--comment", "-c", help="Comment to post with files"),
     thread: str = typer.Option(..., "--thread", "-t", help="Slack thread timestamp to reply to"),
 ):
-    """Upload file(s) to Slack.
+    """Upload file(s) directly with the Slack SDK.
 
     Examples:
-        slack upload C123 screenshot.png --thread 1234567890.123456
-        slack upload C123 file1.png file2.jpg --thread 1234567890.123456 -c "Here are the files"
+        slack upload-direct C123 screenshot.png --thread 1234567890.123456
+        slack upload-direct C123 file1.png file2.jpg --thread 1234567890.123456 -c "Here are the files"
     """
     import base64
     from pathlib import Path
@@ -608,7 +686,7 @@ def upload(
 
     if not _channel_arg_is_id(channel):
         console.print(
-            "[red]Error: upload channel must be a Slack conversation ID like C123 or D123[/]"
+            "[red]Error: upload-direct channel must be a Slack conversation ID like C123 or D123[/]"
         )
         raise typer.Exit(1)
 
@@ -637,11 +715,12 @@ def upload(
             console.print(f"[dim]{result['permalink']}[/]")
         except (RuntimeError, ValueError) as e:
             console.print(f"[red]Error uploading {path.name}: {e}[/]")
-            raise typer.Exit(1)
+            raise typer.Exit(1) from e
 
 
 @app.command("upload-proxy")
-def upload_proxy(
+@app.command("upload")
+def upload(
     channel_id: str = typer.Argument(
         ..., help="Slack channel/conversation ID to upload into, e.g. C123 or D123"
     ),
@@ -663,7 +742,7 @@ def upload_proxy(
 
     if not _channel_arg_is_id(channel_id):
         console.print(
-            "[red]Error: upload-proxy channel must be a Slack conversation ID like C123 or D123[/]"
+            "[red]Error: upload channel must be a Slack conversation ID like C123 or D123[/]"
         )
         raise typer.Exit(1)
 
@@ -966,27 +1045,16 @@ def files(
         slack files "https://..." -d -o /tmp/slack-files
     """
     import re
-    from pathlib import Path
     from urllib.parse import urlparse
 
-    from .client import _fetch_slack_file, get_message_files
+    from .client import get_message_files
 
     parsed = urlparse(permalink)
     if parsed.scheme == "https" and (parsed.hostname or "").lower() == "files.slack.com":
         if not download:
             console.print("[red]Pass --download to download a direct Slack file URL[/]")
             raise typer.Exit(1)
-        output_dir = Path(output)
-        output_dir.mkdir(parents=True, exist_ok=True)
-        try:
-            filename, _mime_type, body = _fetch_slack_file(permalink)
-            out_path = output_dir / filename
-            out_path.write_bytes(body)
-            console.print(f"[green]✓ Downloaded {filename}[/] ({len(body)} bytes)")
-            console.print(f"[dim]{out_path.absolute()}[/]")
-        except Exception as e:
-            console.print(f"[red]Error downloading Slack file: {e}[/]")
-            raise typer.Exit(1)
+        _download_direct_url(permalink, output)
         return
 
     if permalink.startswith("https://"):
@@ -1010,22 +1078,12 @@ def files(
         raise typer.Exit()
 
     if download:
-        output_dir = Path(output)
-        output_dir.mkdir(parents=True, exist_ok=True)
-
         for f in files_list:
             if not f["url_private"]:
                 console.print(f"[yellow]⚠ No download URL for {f['name']}[/]")
                 continue
 
-            out_path = output_dir / f["name"]
-            try:
-                _filename, _mime_type, body = _fetch_slack_file(f["url_private"])
-                out_path.write_bytes(body)
-                console.print(f"[green]✓ Downloaded {f['name']}[/] ({len(body)} bytes)")
-                console.print(f"[dim]{out_path.absolute()}[/]")
-            except Exception as e:
-                console.print(f"[red]Error downloading {f['name']}: {e}[/]")
+            _download_direct_url(f["url_private"], output, display_name=f["name"])
     else:
         console.print(f"[bold]Files ({len(files_list)})[/]\n")
         for f in files_list:
@@ -1034,8 +1092,75 @@ def files(
             console.print(f"  [dim]{f['url_private']}[/]")
 
 
+def _download_direct_url(url: str, output: str, display_name: str | None = None) -> None:
+    from pathlib import Path
+
+    from .client import _fetch_slack_file
+
+    output_dir = Path(output)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    try:
+        filename, _mime_type, body = _fetch_slack_file(url)
+        out_path = output_dir / (display_name or filename)
+        out_path.write_bytes(body)
+        console.print(f"[green]✓ Downloaded {out_path.name}[/] ({len(body)} bytes)")
+        console.print(f"[dim]{out_path.absolute()}[/]")
+    except Exception as e:
+        console.print(f"[red]Error downloading Slack file: {e}[/]")
+        raise typer.Exit(1) from e
+
+
+@app.command("download-direct")
+def download_direct(
+    permalink: str = typer.Argument(
+        ..., help="Slack message permalink, channel:timestamp, or url_private"
+    ),
+    output: str = typer.Option(".", "--output", "-o", help="Output directory for downloads"),
+):
+    """Download Slack files directly with the Slack bot token."""
+    _download_direct(permalink, output)
+
+
+def _download_direct(permalink: str, output: str) -> None:
+    import re
+    from urllib.parse import urlparse
+
+    from .client import get_message_files
+
+    parsed = urlparse(permalink)
+    if parsed.scheme == "https" and (parsed.hostname or "").lower() == "files.slack.com":
+        _download_direct_url(permalink, output)
+        return
+
+    if permalink.startswith("https://"):
+        match = re.search(r"/archives/([A-Z0-9]+)/p(\d+)", permalink)
+        if not match:
+            console.print("[red]Invalid permalink format[/]")
+            raise typer.Exit(1)
+        channel_id = match.group(1)
+        ts_raw = match.group(2)
+        message_ts = f"{ts_raw[:10]}.{ts_raw[10:]}"
+    elif ":" in permalink:
+        channel_id, message_ts = permalink.split(":", 1)
+    else:
+        console.print("[red]Provide a Slack permalink, 'channel_id:timestamp', or url_private[/]")
+        raise typer.Exit(1)
+
+    files_list = get_message_files(channel_id, message_ts)
+    if not files_list:
+        console.print("[yellow]No files attached to this message.[/]")
+        raise typer.Exit()
+
+    for f in files_list:
+        if not f["url_private"]:
+            console.print(f"[yellow]⚠ No download URL for {f['name']}[/]")
+            continue
+        _download_direct_url(f["url_private"], output, display_name=f["name"])
+
+
 @app.command("download-proxy")
-def download_proxy(
+@app.command("download")
+def download(
     file_id: str = typer.Argument(..., help="Slack file ID, e.g. F1234567890"),
     channel_id: str = typer.Argument(
         ..., help="Slack channel/conversation ID that the file is shared in"

--- a/tools/productivity/slack/client.py
+++ b/tools/productivity/slack/client.py
@@ -1180,6 +1180,48 @@ class SlackClient:
             params,
         )
 
+    def get_thread_replies_proxy(
+        self,
+        channel_id: str,
+        thread_ts: str,
+        cursor: str | None = None,
+        inclusive: bool | None = None,
+        latest: str | int | float | None = None,
+        limit: int | None = None,
+        oldest: str | int | float | None = None,
+    ) -> dict[str, Any]:
+        """Fetch Slack thread replies through the Centaur API server."""
+        if secret("CENTAUR_SANDBOX_API_SERVER_ENABLED", "true").strip().lower() == "false":
+            raise RuntimeError(
+                "Slack thread replies require the API server sandbox capability, "
+                "but it is disabled for this principal."
+            )
+
+        normalized_channel_id = self._normalize_explicit_channel_id(channel_id)
+        normalized_thread_ts = self._normalize_ts(thread_ts)
+        if normalized_thread_ts is None:
+            raise ValueError("thread_ts is required")
+
+        params: dict[str, Any] = {
+            "cursor": cursor,
+            "inclusive": inclusive,
+            "latest": self._normalize_ts(latest),
+            "limit": None,
+            "oldest": self._normalize_ts(oldest),
+        }
+        if limit is not None:
+            requested_limit = int(limit)
+            if not 1 <= requested_limit <= self._MAX_SLACK_HISTORY_PROXY_PAGE_SIZE:
+                raise ValueError("limit must be between 1 and 999")
+            params["limit"] = requested_limit
+
+        channel_path = urllib.parse.quote(normalized_channel_id, safe="")
+        thread_path = urllib.parse.quote(normalized_thread_ts, safe="")
+        return self._centaur_api_get_json(
+            f"/api/slack/channels/{channel_path}/threads/{thread_path}/replies",
+            params,
+        )
+
     def get_channel_history(
         self,
         channel: str,
@@ -2336,6 +2378,10 @@ def get_channel_history_page(*args, **kwargs):
 
 def get_channel_history_proxy(*args, **kwargs):
     return _client().get_channel_history_proxy(*args, **kwargs)
+
+
+def get_thread_replies_proxy(*args, **kwargs):
+    return _client().get_thread_replies_proxy(*args, **kwargs)
 
 
 def get_channel_history(*args, **kwargs):

--- a/tools/productivity/slack/tests/test_cli.py
+++ b/tools/productivity/slack/tests/test_cli.py
@@ -18,7 +18,24 @@ def test_channel_arg_is_id_rejects_names() -> None:
     assert not _channel_arg_is_id("#eng-centaur")
 
 
-def test_upload_requires_explicit_channel_and_thread(monkeypatch, tmp_path: Path) -> None:
+def test_upload_direct_requires_explicit_channel_and_thread(
+    monkeypatch, tmp_path: Path
+) -> None:
+    upload = tmp_path / "chart.png"
+    upload.write_bytes(b"png")
+
+    fake_client = types.SimpleNamespace(upload_file=lambda **_: {})
+    monkeypatch.setitem(sys.modules, "slack.client", fake_client)
+
+    result = CliRunner().invoke(
+        app,
+        ["upload-direct", "C1234567890", str(upload)],
+    )
+
+    assert result.exit_code != 0
+
+
+def test_upload_direct_calls_direct_client(monkeypatch, tmp_path: Path) -> None:
     upload = tmp_path / "chart.png"
     upload.write_bytes(b"png")
     calls = []
@@ -33,7 +50,7 @@ def test_upload_requires_explicit_channel_and_thread(monkeypatch, tmp_path: Path
     result = CliRunner().invoke(
         app,
         [
-            "upload",
+            "upload-direct",
             "C1234567890",
             str(upload),
             "--thread",
@@ -65,7 +82,7 @@ def test_upload_rejects_file_only_form(tmp_path: Path) -> None:
     assert result.exit_code != 0
 
 
-def test_upload_rejects_channel_name(monkeypatch, tmp_path: Path) -> None:
+def test_upload_direct_rejects_channel_name(monkeypatch, tmp_path: Path) -> None:
     upload = tmp_path / "chart.png"
     upload.write_bytes(b"png")
     fake_client = types.SimpleNamespace(upload_file=lambda **_: {})
@@ -73,14 +90,14 @@ def test_upload_rejects_channel_name(monkeypatch, tmp_path: Path) -> None:
 
     result = CliRunner().invoke(
         app,
-        ["upload", "#eng-ai", str(upload), "--thread", "1780000000.000000"],
+        ["upload-direct", "#eng-ai", str(upload), "--thread", "1780000000.000000"],
     )
 
     assert result.exit_code == 1
-    assert "must be a Slack conversation ID" in result.output
+    assert "upload-direct channel must be a Slack conversation ID" in result.output
 
 
-def test_upload_proxy_calls_proxy_client(monkeypatch, tmp_path: Path) -> None:
+def test_upload_calls_proxy_client(monkeypatch, tmp_path: Path) -> None:
     upload = tmp_path / "chart.png"
     upload.write_bytes(b"png")
     calls = []
@@ -95,7 +112,7 @@ def test_upload_proxy_calls_proxy_client(monkeypatch, tmp_path: Path) -> None:
     result = CliRunner().invoke(
         app,
         [
-            "upload-proxy",
+            "upload",
             "C1234567890",
             str(upload),
             "--thread",
@@ -125,7 +142,7 @@ def test_upload_proxy_calls_proxy_client(monkeypatch, tmp_path: Path) -> None:
     ]
 
 
-def test_download_proxy_writes_file(monkeypatch, tmp_path: Path) -> None:
+def test_download_writes_file_with_proxy(monkeypatch, tmp_path: Path) -> None:
     calls = []
 
     def fake_download_file_proxy(**kwargs):
@@ -141,9 +158,89 @@ def test_download_proxy_writes_file(monkeypatch, tmp_path: Path) -> None:
 
     result = CliRunner().invoke(
         app,
-        ["download-proxy", "F1234567890", "C1234567890", "--output", str(tmp_path)],
+        ["download", "F1234567890", "C1234567890", "--output", str(tmp_path)],
     )
 
     assert result.exit_code == 0
     assert calls == [{"file_id": "F1234567890", "channel_id": "C1234567890"}]
     assert (tmp_path / "report.pdf").read_bytes() == b"%PDF"
+
+
+def test_thread_calls_api_server_client(monkeypatch) -> None:
+    calls = []
+
+    def fake_get_thread_replies_proxy(*args, **kwargs):
+        calls.append((args, kwargs))
+        return {
+            "ok": True,
+            "messages": [{"user": "U123", "text": "root"}],
+            "has_more": False,
+        }
+
+    fake_client = types.SimpleNamespace(get_thread_replies_proxy=fake_get_thread_replies_proxy)
+    monkeypatch.setitem(sys.modules, "slack.client", fake_client)
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "thread",
+            "C1234567890:1780000000.000000",
+            "--limit",
+            "10",
+            "--cursor",
+            "next",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert calls == [
+        (
+            ("C1234567890", "1780000000.000000"),
+            {
+                "limit": 10,
+                "cursor": "next",
+                "oldest": None,
+                "latest": None,
+                "inclusive": True,
+            },
+        )
+    ]
+
+
+def test_thread_direct_calls_direct_client(monkeypatch) -> None:
+    calls = []
+
+    def fake_get_thread_replies_page(*args, **kwargs):
+        calls.append((args, kwargs))
+        return {
+            "messages": [{"user": "alice", "text": "root"}],
+            "has_more": False,
+            "window": {"oldest": None, "latest": None, "inclusive": True},
+        }
+
+    fake_client = types.SimpleNamespace(get_thread_replies_page=fake_get_thread_replies_page)
+    monkeypatch.setitem(sys.modules, "slack.client", fake_client)
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "thread-direct",
+            "C1234567890:1780000000.000000",
+            "--limit",
+            "10",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert calls == [
+        (
+            ("C1234567890", "1780000000.000000"),
+            {
+                "limit": 10,
+                "cursor": None,
+                "oldest": None,
+                "latest": None,
+                "inclusive": True,
+            },
+        )
+    ]

--- a/tools/productivity/slack/tests/test_client.py
+++ b/tools/productivity/slack/tests/test_client.py
@@ -473,6 +473,70 @@ def test_get_channel_history_proxy_validates_inputs() -> None:
         client.get_channel_history_proxy("C123456789", limit=1000)
 
 
+def test_get_thread_replies_proxy_calls_centaur_api(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import urllib.parse
+    import urllib.request
+
+    client, _ = _make_client()
+    request_info: dict[str, str | None] = {}
+
+    def fake_urlopen(req, *args, **kwargs):
+        request_info["url"] = req.full_url
+        request_info["authorization"] = req.get_header("Authorization")
+        body = json.dumps(
+            {
+                "ok": True,
+                "messages": [{"type": "message", "ts": "1700000000.000001"}],
+                "has_more": False,
+            }
+        ).encode()
+        return _FakeHTTPResponse(body, "application/json")
+
+    monkeypatch.setenv("CENTAUR_API_URL", "http://api.internal:8080")
+    monkeypatch.setenv("CENTAUR_API_BEARER_TOKEN", "test-jwt")
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+
+    result = client.get_thread_replies_proxy(
+        "<#C123456789|general>",
+        "1700000000.000001",
+        cursor="next",
+        inclusive=False,
+        latest="1700000000.000002",
+        limit=999,
+        oldest=0,
+    )
+
+    assert result["ok"] is True
+    assert request_info["authorization"] == "Bearer test-jwt"
+    parsed = urllib.parse.urlparse(request_info["url"])
+    assert parsed.scheme == "http"
+    assert parsed.netloc == "api.internal:8080"
+    assert parsed.path == "/api/slack/channels/C123456789/threads/1700000000.000001/replies"
+    query = urllib.parse.parse_qs(parsed.query)
+    assert query == {
+        "cursor": ["next"],
+        "inclusive": ["false"],
+        "latest": ["1700000000.000002"],
+        "limit": ["999"],
+        "oldest": ["0.000000"],
+    }
+
+
+def test_get_thread_replies_proxy_validates_inputs() -> None:
+    client, _ = _make_client()
+
+    with pytest.raises(ValueError, match="channel_id"):
+        client.get_thread_replies_proxy("general", "1700000000.000001")
+
+    with pytest.raises(ValueError, match="thread_ts"):
+        client.get_thread_replies_proxy("C123456789", "")
+
+    with pytest.raises(ValueError, match="between 1 and 999"):
+        client.get_thread_replies_proxy("C123456789", "1700000000.000001", limit=1000)
+
+
 def test_upload_file_proxy_posts_file_bytes_to_centaur_api(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/workflows/slack/shared.py
+++ b/workflows/slack/shared.py
@@ -75,7 +75,7 @@ def attachment_max_bytes() -> int:
 
 
 class SlackSyncClient(Protocol):
-    """Small protocol for the Slack client methods used by Slack ETL workflows."""
+    """Small protocol for the direct Slack client used by Slack ETL workflows."""
 
     def _etl_access_mode(self) -> str: ...
 
@@ -713,7 +713,7 @@ class SlackEtlRateLimitError(RuntimeError):
 
 
 class SlackEtlClient:
-    """Slack user-token client used only by Slack ETL workflows."""
+    """Direct Slack user-token client used only by Slack ETL workflows."""
 
     _MAX_PAGE_SIZE = 200
     _DEFAULT_API_TIMEOUT_SECONDS = 8

--- a/workflows/slack/tests/test_shared_attachments.py
+++ b/workflows/slack/tests/test_shared_attachments.py
@@ -275,6 +275,146 @@ def test_list_etl_channels_can_include_private_channels():
     assert channels[1]["is_private"] is True
 
 
+def test_etl_channel_history_uses_direct_slack_client():
+    client = object.__new__(shared.SlackEtlClient)
+    client._workflow_name = "slack_sync"
+    client._user_cache = {"U123": "alice"}
+    direct_history = object()
+    client._client = types.SimpleNamespace(conversations_history=direct_history)
+    retry_calls = []
+
+    def fake_retry(func, **kwargs):
+        retry_calls.append((func, kwargs))
+        return {
+            "messages": [
+                {
+                    "user": "U123",
+                    "text": "hello",
+                    "ts": "1770000000.000100",
+                }
+            ],
+            "response_metadata": {},
+        }
+
+    client._retry_on_ratelimit = fake_retry
+
+    page = client._get_etl_channel_history_page("C123", limit=25)
+
+    assert page["messages"][0]["text"] == "hello"
+    assert retry_calls == [
+        (
+            direct_history,
+            {
+                "method_key": "etl.conversations.history",
+                "channel": "C123",
+                "limit": 25,
+            },
+        )
+    ]
+
+
+def test_etl_thread_replies_use_direct_slack_client():
+    client = object.__new__(shared.SlackEtlClient)
+    client._workflow_name = "slack_backfill"
+    client._user_cache = {"U123": "alice"}
+    direct_replies = object()
+    client._client = types.SimpleNamespace(conversations_replies=direct_replies)
+    retry_calls = []
+
+    def fake_retry(func, **kwargs):
+        retry_calls.append((func, kwargs))
+        return {
+            "messages": [
+                {
+                    "user": "U123",
+                    "text": "root",
+                    "ts": "1770000000.000100",
+                },
+                {
+                    "user": "U123",
+                    "text": "reply",
+                    "ts": "1770000001.000100",
+                    "thread_ts": "1770000000.000100",
+                },
+            ],
+            "response_metadata": {},
+        }
+
+    client._retry_on_ratelimit = fake_retry
+
+    page = client._get_etl_thread_replies_page(
+        "C123",
+        "1770000000.000100",
+        limit=25,
+    )
+
+    assert [message["text"] for message in page["messages"]] == ["root", "reply"]
+    assert retry_calls == [
+        (
+            direct_replies,
+            {
+                "method_key": "etl.conversations.replies",
+                "channel": "C123",
+                "ts": "1770000000.000100",
+                "limit": 25,
+                "inclusive": True,
+            },
+        )
+    ]
+
+
+def test_etl_file_download_uses_direct_slack_file_url(monkeypatch):
+    client = object.__new__(shared.SlackEtlClient)
+    client.token = "xoxp-etl"
+    requests = []
+
+    class FakeHeaders:
+        def get_content_type(self):
+            return "text/plain"
+
+    class FakeResponse:
+        headers = FakeHeaders()
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return None
+
+        def read(self, _limit):
+            return b"hello"
+
+    def fake_urlopen(request, *, timeout):
+        requests.append(
+            {
+                "url": request.full_url,
+                "authorization": request.get_header("Authorization"),
+                "method": request.get_method(),
+                "timeout": timeout,
+            }
+        )
+        return FakeResponse()
+
+    monkeypatch.setattr(shared.urllib_request, "urlopen", fake_urlopen)
+    monkeypatch.setattr(client, "_api_timeout_seconds", lambda: 8)
+
+    mime_type, body = client._download_slack_file_bytes(
+        "https://files.slack.com/files-pri/T/F123/report.txt",
+        max_bytes=100,
+    )
+
+    assert mime_type == "text/plain"
+    assert body == b"hello"
+    assert requests == [
+        {
+            "url": "https://files.slack.com/files-pri/T/F123/report.txt",
+            "authorization": "Bearer xoxp-etl",
+            "method": "GET",
+            "timeout": 8,
+        }
+    ]
+
+
 def test_serialize_message_downloads_slack_file_bytes(monkeypatch):
     monkeypatch.setenv("SLACK_ETL_ATTACHMENTS_ENABLED", "true")
     monkeypatch.setenv("SLACK_ETL_ATTACHMENT_MAX_BYTES", "100")


### PR DESCRIPTION
Updates the Slack CLI so upload, download, and thread history use API-backed routes by default, while retaining direct fallbacks as explicit commands. Adds the thread replies API route and refreshes sandbox guidance to use the default commands first before retrying direct variants.