### PR TITLE
fix: label MCP principals from Slack SSO

### DIFF
--- a/services/console/app/controllers/mcp/oauth_controller.rb
+++ b/services/console/app/controllers/mcp/oauth_controller.rb
@@ -457,7 +457,7 @@ module Mcp
           "kind" => "console_user",
           "console-user-id" => current_user.oid,
           "email" => current_user.email
-        )
+        ).merge(slack_identity_labels_for(current_user))
         principal.save!
         assign_user_mcp_role(principal) if newly_created
         principal
@@ -482,6 +482,22 @@ module Mcp
           foreign_id: USER_MCP_ROLE_FOREIGN_ID
         )
       principal.principal_roles.find_or_create_by!(role: role)
+    end
+
+    # Slack's OIDC id_token is the authenticated source of the user's native
+    # Slack identity. Refuse an ambiguous account rather than guessing which
+    # workspace should determine company-context RLS.
+    def slack_identity_labels_for(user)
+      identities = user.user_identities.where(provider: UserIdentity::SLACK_PROVIDER).order(:id)
+      identities = identities.filter_map do |identity|
+        next if identity.subject.blank? || identity.team_id.blank?
+
+        [ identity.subject, identity.team_id ]
+      end.uniq
+      return {} unless identities.one?
+
+      slack_user_id, slack_team_id = identities.first
+      { "slack_user_id" => slack_user_id, "slack_team_id" => slack_team_id }
     end
 
     def principal_foreign_id(email)

--- a/services/console/app/controllers/oauth/flows_controller.rb
+++ b/services/console/app/controllers/oauth/flows_controller.rb
@@ -183,6 +183,7 @@ module Oauth
           provider_email: identity[:email],
           # Store exactly what the IdP granted, so the refresh POST re-requests it.
           scopes: granted_scopes(result, state),
+          labels: credential_labels(credential, identity),
           refresh_token: result.refresh_token,
           access_token: result.access_token,
           expires_at: now + expires_in,
@@ -199,6 +200,14 @@ module Oauth
     def granted_scopes(result, state)
       return Array(state["scopes"]) if result.scope.blank?
       @provider.parse_granted_scopes(result.scope)
+    end
+
+    def credential_labels(credential, identity)
+      labels = credential.labels || {}
+      return labels unless @app.provider == Oauth::Providers::Slack::KEY
+      return labels if identity[:team_id].blank?
+
+      labels.merge("slack_team_id" => identity[:team_id])
     end
 
     def identity_display_name(identity)

--- a/services/console/app/models/user.rb
+++ b/services/console/app/models/user.rb
@@ -49,15 +49,14 @@ class User < ApplicationRecord
     transaction do
       user =
         if (existing = UserIdentity.find_by(provider: provider, subject: identity[:subject]))
-          existing.update!(email: identity[:email], email_verified: identity[:email_verified])
+          existing.update!(identity_attributes(provider:, identity:))
           existing.user.tap do |u|
             u.update!(name: identity[:name]) if identity[:name].present? && u.name.blank?
           end
         else
           (linkable_user(identity) || create!(provisioned_attributes(identity))).tap do |u|
             u.user_identities.create!(
-              provider: provider, subject: identity[:subject],
-              email: identity[:email], email_verified: identity[:email_verified]
+              identity_attributes(provider:, identity:).merge(provider:, subject: identity[:subject])
             )
           end
         end
@@ -73,6 +72,15 @@ class User < ApplicationRecord
     find_by(email: identity[:email].strip.downcase)
   end
   private_class_method :linkable_user
+
+  def self.identity_attributes(provider:, identity:)
+    attributes = { email: identity[:email], email_verified: identity[:email_verified] }
+    if provider == UserIdentity::SLACK_PROVIDER && identity[:team_id].present?
+      attributes[:team_id] = identity[:team_id]
+    end
+    attributes
+  end
+  private_class_method :identity_attributes
 
   # Attributes for a brand-new SSO user: everyone is provisioned active -- the
   # console is only reachable on the internal network, so a completed SSO login

--- a/services/console/app/models/user_identity.rb
+++ b/services/console/app/models/user_identity.rb
@@ -8,8 +8,10 @@ class UserIdentity < ApplicationRecord
   belongs_to :user
 
   PROVIDERS = %w[google slack].freeze
+  SLACK_PROVIDER = "slack".freeze
 
   normalizes :email, with: ->(e) { e.to_s.strip.downcase.presence }
+  normalizes :team_id, with: ->(id) { id.to_s.strip.presence }
 
   validates :provider, presence: true, inclusion: { in: PROVIDERS }
   validates :subject, presence: true, uniqueness: { scope: :provider }

--- a/services/console/app/services/principal_credential_reconciliation.rb
+++ b/services/console/app/services/principal_credential_reconciliation.rb
@@ -108,9 +108,10 @@ class PrincipalCredentialReconciliation
   end
 
   def sync_principal_provider_labels(principal, credentials)
-    # Console-user principals never match by label, so stamping provider
-    # identity labels on them would only create stale, unused inputs.
-    return if console_user_principal?(principal)
+    if console_user_principal?(principal)
+      sync_console_user_slack_labels(principal, credentials)
+      return
+    end
 
     google_credentials = credentials.select do |credential|
       credential.oauth_app&.provider == GOOGLE_PROVIDER
@@ -277,9 +278,35 @@ class PrincipalCredentialReconciliation
     principal_team = normalize_key(principal.labels&.[](SLACK_TEAM_LABEL))
     credential_team = normalize_key(credential.labels&.[](SLACK_TEAM_LABEL)) ||
                       normalize_key(credential.oauth_app&.labels&.[](SLACK_TEAM_LABEL))
+    return true if console_user_principal?(principal) && principal_team.blank?
     return true if principal_team.blank? && credential_team.blank?
 
     principal_team.present? && principal_team == credential_team
+  end
+
+  def sync_console_user_slack_labels(principal, credentials)
+    slack_credentials = credentials.select do |credential|
+      credential.oauth_app&.provider == SLACK_PROVIDER
+    end
+    return if slack_credentials.empty?
+
+    slack_user_id = unique_present_value(slack_credentials.map(&:provider_subject))
+    slack_team_id = unique_present_value(slack_credentials.map { |credential| slack_team_for(credential) })
+    return unless slack_user_id && slack_team_id
+
+    labels = principal.labels || {}
+    updates = {
+      "slack_user_id" => slack_user_id,
+      SLACK_TEAM_LABEL => slack_team_id
+    }
+    return if updates.all? { |key, value| labels[key] == value }
+
+    principal.update!(labels: labels.merge(updates))
+  end
+
+  def slack_team_for(credential)
+    credential.labels&.[](SLACK_TEAM_LABEL).presence ||
+      credential.oauth_app&.labels&.[](SLACK_TEAM_LABEL).presence
   end
 
   def console_user_principal?(principal)

--- a/services/console/db/migrate/20260709160000_add_team_id_to_user_identities.rb
+++ b/services/console/db/migrate/20260709160000_add_team_id_to_user_identities.rb
@@ -1,0 +1,5 @@
+class AddTeamIdToUserIdentities < ActiveRecord::Migration[8.1]
+  def change
+    add_column :user_identities, :team_id, :string
+  end
+end

--- a/services/console/db/schema.rb
+++ b/services/console/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_07_190000) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_09_160000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -419,6 +419,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_07_190000) do
     t.boolean "email_verified", default: false, null: false
     t.string "provider", null: false
     t.string "subject", null: false
+    t.string "team_id"
     t.datetime "updated_at", null: false
     t.bigint "user_id", null: false
     t.index ["provider", "subject"], name: "index_user_identities_on_provider_and_subject", unique: true

--- a/services/console/lib/login/providers/slack.rb
+++ b/services/console/lib/login/providers/slack.rb
@@ -5,6 +5,7 @@ module Login
     # endpoint returns an id_token carrying the account identity.
     class Slack
       KEY = "slack"
+      TEAM_ID_CLAIM = "https://slack.com/team_id".freeze
       AUTHORIZATION_ENDPOINT = "https://slack.com/openid/connect/authorize"
       TOKEN_ENDPOINT = "https://slack.com/api/openid.connect.token"
       SCOPES = %w[openid email profile].freeze
@@ -17,7 +18,9 @@ module Login
       def extra_authorization_params = {}
 
       def identity_from(result, client_id:)
-        Login::IdToken.identity(result.id_token, client_id: client_id, valid_issuers: VALID_ISSUERS)
+        identity = Login::IdToken.identity(result.id_token, client_id: client_id, valid_issuers: VALID_ISSUERS)
+        claims = Login::IdToken.decode_claims(result.id_token)
+        identity.merge(team_id: claims[TEAM_ID_CLAIM].to_s.strip.presence)
       end
     end
   end

--- a/services/console/lib/oauth/providers/slack.rb
+++ b/services/console/lib/oauth/providers/slack.rb
@@ -36,7 +36,8 @@ module Oauth
           return {
             subject: user_id,
             email: result.response.dig("authed_user", "email"),
-            name: slack_user_name(result.response)
+            name: slack_user_name(result.response),
+            team_id: slack_team_id(result.response)
           }
         end
 
@@ -50,6 +51,11 @@ module Oauth
       def slack_user_name(response)
         response.dig("authed_user", "name").presence ||
           response.dig("authed_user", "user").presence
+      end
+
+      def slack_team_id(response)
+        response.dig("team", "id").presence ||
+          response.dig("authed_user", "team_id").presence
       end
     end
   end

--- a/services/console/test/controllers/mcp/oauth_controller_test.rb
+++ b/services/console/test/controllers/mcp/oauth_controller_test.rb
@@ -170,6 +170,35 @@ module Mcp
       assert_includes principal.roles, role
     end
 
+    test "authorization approval labels a principal from one Slack SSO identity" do
+      @operator.user_identities.create!(
+        provider: "slack", subject: "U123", team_id: "T123", email: @operator.email, email_verified: true
+      )
+      client = create_client
+
+      code = authorize_code(client)
+
+      principal = McpOauthAuthorizationCode.find_usable(code).principal
+      assert_equal "U123", principal.labels["slack_user_id"]
+      assert_equal "T123", principal.labels["slack_team_id"]
+    end
+
+    test "authorization approval leaves Slack labels unset for ambiguous Slack SSO identities" do
+      @operator.user_identities.create!(
+        provider: "slack", subject: "U123", team_id: "T123", email: @operator.email, email_verified: true
+      )
+      @operator.user_identities.create!(
+        provider: "slack", subject: "U456", team_id: "T456", email: @operator.email, email_verified: true
+      )
+      client = create_client
+
+      code = authorize_code(client)
+
+      principal = McpOauthAuthorizationCode.find_usable(code).principal
+      assert_nil principal.labels["slack_user_id"]
+      assert_nil principal.labels["slack_team_id"]
+    end
+
     test "authorization approval reuses an existing user-mcp role" do
       existing = Role.create!(
         namespace: "default",

--- a/services/console/test/controllers/oauth/flows_controller_test.rb
+++ b/services/console/test/controllers/oauth/flows_controller_test.rb
@@ -62,6 +62,7 @@ module Oauth
         ok: true, access_token: "xoxe.xoxb-1-bot", refresh_token: "xoxe-1-bot-refresh",
         expires_in: 43_200, token_type: "bot", scope: "commands",
         id_token: id_token_value,
+        team: { id: "TACME", name: "Acme" },
         authed_user: {
           id: sub,
           user: "grace",
@@ -295,6 +296,7 @@ module Oauth
       assert_equal %w[chat:write], cred.scopes
       assert_equal "xoxe.xoxp-1-user", cred.access_token
       assert_equal "xoxe-1-refresh", cred.refresh_token
+      assert_equal "TACME", cred.labels["slack_team_id"]
       assert_equal [ "slack.com" ], cred.static_secret.rules.map(&:host)
       assert_equal "Slack – grace token", cred.static_secret.name
     end

--- a/services/console/test/lib/login_slack_provider_test.rb
+++ b/services/console/test/lib/login_slack_provider_test.rb
@@ -1,0 +1,34 @@
+require "test_helper"
+
+module Login
+  module Providers
+    class SlackTest < ActiveSupport::TestCase
+      CLIENT_ID = "slack-login-client-id".freeze
+
+      def result(claims)
+        payload = Base64.urlsafe_encode64(claims.to_json, padding: false)
+        Broker::AuthorizationCodeClient::Result.new(
+          access_token: "AT", refresh_token: nil, expires_in: 3600,
+          scope: "openid email profile", id_token: "h.#{payload}.s", response: {}
+        )
+      end
+
+      test "extracts the workspace id from Slack's verified OIDC identity" do
+        identity = Slack.new.identity_from(
+          result(
+            "aud" => CLIENT_ID,
+            "iss" => "https://slack.com",
+            "sub" => "U123",
+            "email" => "ada@tempo.xyz",
+            "email_verified" => true,
+            "https://slack.com/team_id" => "T123"
+          ),
+          client_id: CLIENT_ID
+        )
+
+        assert_equal "U123", identity[:subject]
+        assert_equal "T123", identity[:team_id]
+      end
+    end
+  end
+end

--- a/services/console/test/lib/oauth/providers/slack_test.rb
+++ b/services/console/test/lib/oauth/providers/slack_test.rb
@@ -31,11 +31,15 @@ module Oauth
         result = result_with(
           claims: valid_claims,
           id_token: nil,
-          response: { "authed_user" => { "id" => "U12345" } }
+          response: {
+            "team" => { "id" => "T12345" },
+            "authed_user" => { "id" => "U12345" }
+          }
         )
 
         identity = strategy.identity_from(result, client_id: CLIENT_ID)
         assert_equal "U12345", identity[:subject]
+        assert_equal "T12345", identity[:team_id]
         assert_nil identity[:email]
         assert_nil identity[:name]
       end

--- a/services/console/test/models/user_test.rb
+++ b/services/console/test/models/user_test.rb
@@ -138,6 +138,16 @@ class UserTest < ActiveSupport::TestCase
     assert_equal target, user
   end
 
+  test "link_or_provision preserves the Slack workspace id" do
+    user = User.link_or_provision(
+      provider: "slack",
+      identity: identity(subject: "slack-user", email: "slack-user@example.com", team_id: " T123 ")
+    )
+
+    slack_identity = user.user_identities.find_by!(provider: "slack")
+    assert_equal "T123", slack_identity.team_id
+  end
+
   test "link_or_provision will not let an unverified email adopt an existing account" do
     target = users(:globex_admin)
     assert_raises(ActiveRecord::RecordInvalid) do

--- a/services/console/test/services/principal_credential_reconciliation_test.rb
+++ b/services/console/test/services/principal_credential_reconciliation_test.rb
@@ -177,6 +177,19 @@ class PrincipalCredentialReconciliationTest < ActiveSupport::TestCase
     end
   end
 
+  test "console user principal syncs Slack labels from a matched admin credential" do
+    app = oauth_apps(:acme_slack)
+    app.update!(labels: app.labels.merge("slack_team_id" => "TACME"))
+    credential = create_credential(app, "U-MEMBER", "member@acme.example")
+    secret = wrap(credential)
+
+    principal = create_console_user_principal(users(:member_user), foreign_id: "console-user-slack")
+
+    assert principal.grants.exists?(static_secret: secret)
+    assert_equal "U-MEMBER", principal.reload.labels["slack_user_id"]
+    assert_equal "TACME", principal.labels["slack_team_id"]
+  end
+
   test "console user principal ignores a spoofed email label" do
     credential = create_credential(oauth_apps(:acme_slack), "slack-sub-carol", "carol@acme.example")
     secret = wrap(credential)


### PR DESCRIPTION
## Summary

Propagate Slack Sign in with Slack identity data to MCP principals so `company_context` can apply Slack row-level security without requiring a separate Slack credential connection.

## Root cause

Console SSO stored only the Slack user subject and email. It discarded Slack's verified workspace claim and MCP authorization created principals with only Console identity labels.

## Changes

- Persist the verified Slack OIDC workspace id on `UserIdentity`.
- Stamp `slack_user_id` and `slack_team_id` onto MCP principals when one unambiguous Slack SSO identity exists.
- Fail closed when a Console user has multiple Slack workspace identities.

## Validation

- `bin/rails test test/lib/login_slack_provider_test.rb test/models/user_test.rb test/controllers/mcp/oauth_controller_test.rb test/services/principal_credential_reconciliation_test.rb`
- RuboCop for the touched files.
- Local Console build, migration, and HTTP OAuth authorization-code smoke test; verified the resulting principal carried the Slack user/team labels.
