### PR TITLE
fix: gate readonly DM access by Slack identity

### DIFF
--- a/services/api-rs/crates/centaur-session-sqlx/migrations/0042_centaur_readonly_slack_dm_rls.sql
+++ b/services/api-rs/crates/centaur-session-sqlx/migrations/0042_centaur_readonly_slack_dm_rls.sql
@@ -1,0 +1,139 @@
+-- Keep centaur_readonly useful for public channel context while allowing a
+-- principal that carries Slack identity settings to see only its own DMs.
+
+drop policy if exists centaur_readonly_slack_dm_sync_conversations_select
+    on slack_dm_sync_conversations;
+create policy centaur_readonly_slack_dm_sync_conversations_select
+    on slack_dm_sync_conversations
+    for select
+    to centaur_readonly
+    using (
+        exists (
+            select 1
+            from slack_dm_sync_conversation_members members
+            where members.home_team_id = slack_dm_sync_conversations.home_team_id
+              and members.home_team_id = centaur_current_slack_team_id()
+              and members.conversation_id = slack_dm_sync_conversations.conversation_id
+              and members.user_id = centaur_current_slack_user_id()
+              and members.is_current_member
+        )
+    );
+
+drop policy if exists centaur_readonly_slack_dm_sync_conversation_members_select
+    on slack_dm_sync_conversation_members;
+create policy centaur_readonly_slack_dm_sync_conversation_members_select
+    on slack_dm_sync_conversation_members
+    for select
+    to centaur_readonly
+    using (
+        home_team_id = centaur_current_slack_team_id()
+        and user_id = centaur_current_slack_user_id()
+        and is_current_member
+    );
+
+drop policy if exists centaur_readonly_slack_dm_sync_messages_select
+    on slack_dm_sync_messages;
+create policy centaur_readonly_slack_dm_sync_messages_select
+    on slack_dm_sync_messages
+    for select
+    to centaur_readonly
+    using (
+        exists (
+            select 1
+            from slack_dm_sync_conversation_members members
+            where members.home_team_id = slack_dm_sync_messages.home_team_id
+              and members.home_team_id = centaur_current_slack_team_id()
+              and members.conversation_id = slack_dm_sync_messages.conversation_id
+              and members.user_id = centaur_current_slack_user_id()
+              and members.is_current_member
+        )
+    );
+
+drop policy if exists centaur_readonly_slack_dm_sync_message_attachments_select
+    on slack_dm_sync_message_attachments;
+create policy centaur_readonly_slack_dm_sync_message_attachments_select
+    on slack_dm_sync_message_attachments
+    for select
+    to centaur_readonly
+    using (
+        exists (
+            select 1
+            from slack_dm_sync_conversation_members members
+            where members.home_team_id = slack_dm_sync_message_attachments.home_team_id
+              and members.home_team_id = centaur_current_slack_team_id()
+              and members.conversation_id = slack_dm_sync_message_attachments.conversation_id
+              and members.user_id = centaur_current_slack_user_id()
+              and members.is_current_member
+        )
+    );
+
+drop policy if exists centaur_readonly_slack_dm_sync_checkpoints_select
+    on slack_dm_sync_checkpoints;
+create policy centaur_readonly_slack_dm_sync_checkpoints_select
+    on slack_dm_sync_checkpoints
+    for select
+    to centaur_readonly
+    using (
+        exists (
+            select 1
+            from slack_dm_sync_conversation_members members
+            where members.home_team_id = slack_dm_sync_checkpoints.home_team_id
+              and members.home_team_id = centaur_current_slack_team_id()
+              and members.conversation_id = slack_dm_sync_checkpoints.conversation_id
+              and members.user_id = centaur_current_slack_user_id()
+              and members.is_current_member
+        )
+    );
+
+-- Operational rows never belong in user-visible company context.
+drop policy if exists centaur_readonly_slack_dm_sync_runs_select
+    on slack_dm_sync_runs;
+create policy centaur_readonly_slack_dm_sync_runs_select
+    on slack_dm_sync_runs
+    for select
+    to centaur_readonly
+    using (false);
+
+drop policy if exists centaur_readonly_slack_dm_sync_backfill_jobs_select
+    on slack_dm_sync_backfill_jobs;
+create policy centaur_readonly_slack_dm_sync_backfill_jobs_select
+    on slack_dm_sync_backfill_jobs
+    for select
+    to centaur_readonly
+    using (false);
+
+drop policy if exists centaur_readonly_slack_dm_context_documents_select
+    on slack_dm_context_documents;
+create policy centaur_readonly_slack_dm_context_documents_select
+    on slack_dm_context_documents
+    for select
+    to centaur_readonly
+    using (
+        exists (
+            select 1
+            from slack_dm_sync_conversation_members members
+            where members.home_team_id = slack_dm_context_documents.home_team_id
+              and members.home_team_id = centaur_current_slack_team_id()
+              and members.conversation_id = slack_dm_context_documents.conversation_id
+              and members.user_id = centaur_current_slack_user_id()
+              and members.is_current_member
+        )
+    );
+
+drop policy if exists centaur_readonly_slack_dm_conversation_context_documents_select
+    on slack_dm_conversation_context_documents;
+create policy centaur_readonly_slack_dm_conversation_context_documents_select
+    on slack_dm_conversation_context_documents
+    for select
+    to centaur_readonly
+    using (
+        exists (
+            select 1
+            from slack_dm_sync_conversation_members members
+            where members.home_team_id = slack_dm_conversation_context_documents.home_team_id
+              and members.home_team_id = centaur_current_slack_team_id()
+              and members.conversation_id = slack_dm_conversation_context_documents.conversation_id
+              and members.user_id = centaur_current_slack_user_id()
+              and members.is_current_member
+        )
+    );

--- a/services/api-rs/crates/centaur-session-sqlx/tests/slack_dm_context_rls.rs
+++ b/services/api-rs/crates/centaur-session-sqlx/tests/slack_dm_context_rls.rs
@@ -12,6 +12,8 @@ const SLACK_DM_CONTEXT_DOCUMENTS_SQL: &str =
     include_str!("../migrations/0028_slack_dm_context_documents.sql");
 const SLACK_DM_CONVERSATION_CONTEXT_DOCUMENTS_SQL: &str =
     include_str!("../migrations/0029_slack_dm_conversation_context_documents.sql");
+const READONLY_DM_RLS_SQL: &str =
+    include_str!("../migrations/0042_centaur_readonly_slack_dm_rls.sql");
 
 const RLS_TABLES: &[&str] = &[
     "slack_dm_sync_conversations",
@@ -58,6 +60,7 @@ async fn run_rls_assertions(conn: &mut PgConnection, schema: &str) -> Result<(),
     execute_migration(conn, SLACK_DM_SYNC_SQL).await?;
     execute_slack_dm_context_documents_migration(conn).await?;
     execute_slack_dm_conversation_context_documents_migration(conn).await?;
+    execute_migration(conn, READONLY_DM_RLS_SQL).await?;
     grant_schema_usage(conn, schema).await?;
 
     assert_rls_enabled(conn).await?;
@@ -178,7 +181,11 @@ async fn run_rls_assertions(conn: &mut PgConnection, schema: &str) -> Result<(),
         Some("U_A"),
     )
     .await?;
-    assert_eq!(readonly, empty_visible_dm_rows());
+    assert_eq!(readonly, user_a);
+
+    let readonly_missing_user =
+        visible_rows(conn, schema, "centaur_readonly", Some("T_HOME"), None).await?;
+    assert_eq!(readonly_missing_user, empty_visible_dm_rows());
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

Keep MCP users on the channel-capable `centaur_readonly` route while allowing their Slack SSO identity to gate access to their own DM context.

## Why

`centaur_readonly` preserves public channel visibility but previously denied every DM table. The separate `centaur_slack_reader` route supports DM RLS but requires a channel id for channel context, so selecting it for MCP users would hide channels.

## Changes

- Make `centaur_readonly` DM policies enforce active Slack conversation membership from session team/user settings.
- Keep operational DM tables denied and preserve public-channel policies unchanged.

## Rollout

Configure `centaur_readonly_dsn` manually with `centaur.slack_team_id` and `centaur.slack_user_id` sourced from principal labels before relying on MCP DM access.

## Validation

- `SESSION_SQLX_TEST_DATABASE_URL=postgres://postgres:postgres@127.0.0.1:55432/postgres cargo test -p centaur-session-sqlx slack_dm_rls -- --nocapture`
