### PR TITLE
fix: avoid stale api-rs build artifacts

### DIFF
--- a/services/api-rs/Dockerfile
+++ b/services/api-rs/Dockerfile
@@ -16,7 +16,6 @@ COPY services/api-rs/ ./
 ARG RUST_BUILD_PROFILE=release
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
-    --mount=type=cache,target=/build/target,sharing=locked \
     case "$RUST_BUILD_PROFILE" in \
       release) cargo build --release -p centaur-api-server && cp target/release/centaur-api-server /usr/local/bin/centaur-api-server ;; \
       debug|dev) cargo build -p centaur-api-server && cp target/debug/centaur-api-server /usr/local/bin/centaur-api-server ;; \


### PR DESCRIPTION
## Summary
- remove the shared BuildKit cache mount for the api-rs Cargo target directory
- retain Cargo registry and git caches for dependency download performance
- force production image builds to derive the binary from the current source tree

## Validation
- `git diff --check`
- confirmed the api-rs Dockerfile no longer mounts `/build/target`

Prompted by: mslipper