### PR TITLE
feat: add slack proxy endpoints

### DIFF
--- a/services/api-rs/crates/centaur-api-server/src/slack_proxy.rs
+++ b/services/api-rs/crates/centaur-api-server/src/slack_proxy.rs
@@ -48,9 +48,23 @@ pub(crate) fn slack_proxy_router() -> Router<AppState> {
             get(get_slack_channel_history),
         )
         .route(
+            "/api/slack/channels/{channel_id}/members",
+            get(get_slack_channel_members),
+        )
+        .route(
+            "/api/slack/channels/{channel_id}/files",
+            get(list_slack_channel_files),
+        )
+        .route(
+            "/api/slack/channels/{channel_id}/files/{file_id}",
+            get(get_slack_channel_file_info),
+        )
+        .route(
             "/api/slack/channels/{channel_id}/threads/{thread_ts}/replies",
             get(get_slack_thread_replies),
         )
+        .route("/api/slack/users", get(list_slack_users))
+        .route("/api/slack/users/{user_id}/info", get(get_slack_user_info))
 }
 
 #[derive(Debug, Deserialize)]
@@ -90,6 +104,32 @@ struct SlackChannelHistoryQuery {
     limit: Option<u16>,
     #[serde(default)]
     cursor: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct SlackCursorLimitQuery {
+    #[serde(default)]
+    limit: Option<u16>,
+    #[serde(default)]
+    cursor: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct SlackFilesListQuery {
+    #[serde(default)]
+    limit: Option<u16>,
+    #[serde(default)]
+    page: Option<u16>,
+    #[serde(default)]
+    ts_from: Option<String>,
+    #[serde(default)]
+    ts_to: Option<String>,
+    #[serde(default)]
+    types: Option<String>,
+    #[serde(default)]
+    user: Option<String>,
+    #[serde(default)]
+    show_files_hidden_by_limit: Option<bool>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -278,6 +318,96 @@ async fn get_slack_thread_replies(
     Ok(Json(value))
 }
 
+async fn get_slack_channel_members(
+    headers: HeaderMap,
+    Path(channel_id): Path<String>,
+    Query(query): Query<SlackCursorLimitQuery>,
+) -> Result<Json<Value>, ApiError> {
+    let claims = authorize_slack_file_proxy(&headers)?;
+    ensure_history_channel_allowed(&claims, &channel_id)?;
+    validate_slack_channel_id(&channel_id)?;
+    validate_slack_cursor_limit_query(&query)?;
+
+    let config = slack_proxy_config()?;
+    let value = slack_channel_members(http_client(), config, &channel_id, &query).await?;
+    Ok(Json(value))
+}
+
+async fn list_slack_channel_files(
+    headers: HeaderMap,
+    Path(channel_id): Path<String>,
+    Query(query): Query<SlackFilesListQuery>,
+) -> Result<Json<Value>, ApiError> {
+    let claims = authorize_slack_file_proxy(&headers)?;
+    ensure_download_channel_allowed(&claims, &channel_id)?;
+    validate_slack_channel_id(&channel_id)?;
+    validate_slack_files_list_query(&query)?;
+
+    let config = slack_proxy_config()?;
+    let value = slack_channel_files(http_client(), config, &channel_id, &query).await?;
+    let files = value
+        .get("files")
+        .and_then(Value::as_array)
+        .ok_or_else(|| {
+            ApiError::BadRequest("Slack files.list response missing files".to_owned())
+        })?;
+    if files
+        .iter()
+        .any(|file| !slack_file_in_channel(file, &channel_id))
+    {
+        return Err(ApiError::Forbidden(
+            "Slack files.list returned a file outside the allowed channel".to_owned(),
+        ));
+    }
+    Ok(Json(value))
+}
+
+async fn get_slack_channel_file_info(
+    headers: HeaderMap,
+    Path((channel_id, file_id)): Path<(String, String)>,
+) -> Result<Json<Value>, ApiError> {
+    let claims = authorize_slack_file_proxy(&headers)?;
+    ensure_download_channel_allowed(&claims, &channel_id)?;
+    validate_slack_channel_id(&channel_id)?;
+    validate_slack_file_id(&file_id)?;
+
+    let config = slack_proxy_config()?;
+    let value = slack_file_info_response(http_client(), config, &file_id).await?;
+    let file = value.get("file").ok_or_else(|| {
+        ApiError::BadRequest("Slack file info response did not include file".to_owned())
+    })?;
+    if !slack_file_in_channel(file, &channel_id) {
+        return Err(ApiError::Forbidden(
+            "file is not shared in an allowed Slack channel".to_owned(),
+        ));
+    }
+    Ok(Json(value))
+}
+
+async fn list_slack_users(
+    headers: HeaderMap,
+    Query(query): Query<SlackCursorLimitQuery>,
+) -> Result<Json<Value>, ApiError> {
+    let _claims = authorize_slack_file_proxy(&headers)?;
+    validate_slack_cursor_limit_query(&query)?;
+
+    let config = slack_proxy_config()?;
+    let value = slack_users_list(http_client(), config, &query).await?;
+    Ok(Json(value))
+}
+
+async fn get_slack_user_info(
+    headers: HeaderMap,
+    Path(user_id): Path<String>,
+) -> Result<Json<Value>, ApiError> {
+    let _claims = authorize_slack_file_proxy(&headers)?;
+    validate_slack_user_id(&user_id)?;
+
+    let config = slack_proxy_config()?;
+    let value = slack_user_info(http_client(), config, &user_id).await?;
+    Ok(Json(value))
+}
+
 fn upstream_body_is_unexpected_html(
     upstream_content_type: Option<&str>,
     file_mimetype: Option<&str>,
@@ -424,16 +554,24 @@ async fn slack_file_info(
     config: &SlackFileProxyConfig,
     file_id: &str,
 ) -> Result<Value, ApiError> {
-    let value = slack_api_post_form(
+    let value = slack_file_info_response(client, config, file_id).await?;
+    value.get("file").cloned().ok_or_else(|| {
+        ApiError::BadRequest("Slack file info response did not include file".to_owned())
+    })
+}
+
+async fn slack_file_info_response(
+    client: &reqwest::Client,
+    config: &SlackFileProxyConfig,
+    file_id: &str,
+) -> Result<Value, ApiError> {
+    slack_api_post_form(
         client,
         config,
         "files.info",
         &[("file", file_id.to_owned())],
     )
-    .await?;
-    value.get("file").cloned().ok_or_else(|| {
-        ApiError::BadRequest("Slack file info response did not include file".to_owned())
-    })
+    .await
 }
 
 async fn slack_channel_history(
@@ -455,6 +593,49 @@ async fn slack_thread_replies(
 ) -> Result<Value, ApiError> {
     let form = slack_thread_replies_form(channel_id, thread_ts, query);
     slack_api_post_form(client, config, "conversations.replies", &form).await
+}
+
+async fn slack_channel_members(
+    client: &reqwest::Client,
+    config: &SlackFileProxyConfig,
+    channel_id: &str,
+    query: &SlackCursorLimitQuery,
+) -> Result<Value, ApiError> {
+    let form = slack_channel_members_form(channel_id, query);
+    slack_api_post_form(client, config, "conversations.members", &form).await
+}
+
+async fn slack_channel_files(
+    client: &reqwest::Client,
+    config: &SlackFileProxyConfig,
+    channel_id: &str,
+    query: &SlackFilesListQuery,
+) -> Result<Value, ApiError> {
+    let form = slack_files_list_form(channel_id, query);
+    slack_api_post_form(client, config, "files.list", &form).await
+}
+
+async fn slack_users_list(
+    client: &reqwest::Client,
+    config: &SlackFileProxyConfig,
+    query: &SlackCursorLimitQuery,
+) -> Result<Value, ApiError> {
+    let form = slack_users_list_form(query);
+    slack_api_post_form(client, config, "users.list", &form).await
+}
+
+async fn slack_user_info(
+    client: &reqwest::Client,
+    config: &SlackFileProxyConfig,
+    user_id: &str,
+) -> Result<Value, ApiError> {
+    slack_api_post_form(
+        client,
+        config,
+        "users.info",
+        &[("user", user_id.to_owned())],
+    )
+    .await
 }
 
 fn slack_channel_history_form(
@@ -499,6 +680,76 @@ fn slack_thread_replies_form(
 ) -> Vec<(&'static str, String)> {
     let mut form = slack_channel_history_form(channel_id, query);
     form.push(("ts", thread_ts.to_owned()));
+    form
+}
+
+fn slack_channel_members_form(
+    channel_id: &str,
+    query: &SlackCursorLimitQuery,
+) -> Vec<(&'static str, String)> {
+    let mut form = vec![
+        ("channel", channel_id.to_owned()),
+        (
+            "limit",
+            query
+                .limit
+                .map(|value| value.to_string())
+                .unwrap_or_default(),
+        ),
+        ("cursor", query.cursor.clone().unwrap_or_default()),
+    ];
+    form.retain(|(_, value)| !value.is_empty());
+    form
+}
+
+fn slack_files_list_form(
+    channel_id: &str,
+    query: &SlackFilesListQuery,
+) -> Vec<(&'static str, String)> {
+    let mut form = vec![
+        ("channel", channel_id.to_owned()),
+        (
+            "count",
+            query
+                .limit
+                .map(|value| value.to_string())
+                .unwrap_or_default(),
+        ),
+        (
+            "page",
+            query
+                .page
+                .map(|value| value.to_string())
+                .unwrap_or_default(),
+        ),
+        ("ts_from", query.ts_from.clone().unwrap_or_default()),
+        ("ts_to", query.ts_to.clone().unwrap_or_default()),
+        ("types", query.types.clone().unwrap_or_default()),
+        ("user", query.user.clone().unwrap_or_default()),
+        (
+            "show_files_hidden_by_limit",
+            query
+                .show_files_hidden_by_limit
+                .map(|value| value.to_string())
+                .unwrap_or_default(),
+        ),
+    ];
+    form.retain(|(_, value)| !value.is_empty());
+    form
+}
+
+fn slack_users_list_form(query: &SlackCursorLimitQuery) -> Vec<(&'static str, String)> {
+    let mut form = vec![
+        (
+            "limit",
+            query
+                .limit
+                .map(|value| value.to_string())
+                .unwrap_or_default(),
+        ),
+        ("cursor", query.cursor.clone().unwrap_or_default()),
+    ];
+    form.retain(|(_, value)| !value.is_empty());
     form
 }
 
@@ -660,6 +911,18 @@ fn validate_slack_file_id(file_id: &str) -> Result<(), ApiError> {
     Err(ApiError::BadRequest("invalid Slack file ID".to_owned()))
 }
 
+fn validate_slack_user_id(user_id: &str) -> Result<(), ApiError> {
+    if user_id.len() >= 9
+        && matches!(user_id.as_bytes().first(), Some(b'U' | b'W'))
+        && user_id
+            .bytes()
+            .all(|byte| byte.is_ascii_uppercase() || byte.is_ascii_digit())
+    {
+        return Ok(());
+    }
+    Err(ApiError::BadRequest("invalid Slack user ID".to_owned()))
+}
+
 fn validate_slack_channel_history_query(query: &SlackChannelHistoryQuery) -> Result<(), ApiError> {
     if let Some(latest) = query.latest.as_deref() {
         validate_slack_timestamp(latest)?;
@@ -680,6 +943,50 @@ fn validate_slack_channel_history_query(query: &SlackChannelHistoryQuery) -> Res
     Ok(())
 }
 
+fn validate_slack_cursor_limit_query(query: &SlackCursorLimitQuery) -> Result<(), ApiError> {
+    if let Some(limit) = query.limit
+        && !(1..=999).contains(&limit)
+    {
+        return Err(ApiError::BadRequest(
+            "Slack limit must be between 1 and 999".to_owned(),
+        ));
+    }
+    if let Some(cursor) = query.cursor.as_deref() {
+        validate_slack_cursor(cursor)?;
+    }
+    Ok(())
+}
+
+fn validate_slack_files_list_query(query: &SlackFilesListQuery) -> Result<(), ApiError> {
+    if let Some(limit) = query.limit
+        && !(1..=999).contains(&limit)
+    {
+        return Err(ApiError::BadRequest(
+            "Slack files.list limit must be between 1 and 999".to_owned(),
+        ));
+    }
+    if let Some(page) = query.page
+        && page == 0
+    {
+        return Err(ApiError::BadRequest(
+            "Slack files.list page must be at least 1".to_owned(),
+        ));
+    }
+    if let Some(ts_from) = query.ts_from.as_deref() {
+        validate_slack_timestamp(ts_from)?;
+    }
+    if let Some(ts_to) = query.ts_to.as_deref() {
+        validate_slack_timestamp(ts_to)?;
+    }
+    if let Some(types) = query.types.as_deref() {
+        validate_slack_file_types(types)?;
+    }
+    if let Some(user) = query.user.as_deref() {
+        validate_slack_user_id(user)?;
+    }
+    Ok(())
+}
+
 fn validate_slack_thread_ts(thread_ts: &str) -> Result<(), ApiError> {
     let Some((seconds, micros)) = thread_ts.split_once('.') else {
         return Err(ApiError::BadRequest("invalid Slack thread_ts".to_owned()));
@@ -692,6 +999,17 @@ fn validate_slack_thread_ts(thread_ts: &str) -> Result<(), ApiError> {
         return Ok(());
     }
     Err(ApiError::BadRequest("invalid Slack thread_ts".to_owned()))
+}
+
+fn validate_slack_file_types(types: &str) -> Result<(), ApiError> {
+    if !types.is_empty()
+        && types
+            .bytes()
+            .all(|byte| byte.is_ascii_lowercase() || matches!(byte, b',' | b'_'))
+    {
+        return Ok(());
+    }
+    Err(ApiError::BadRequest("invalid Slack file types".to_owned()))
 }
 
 fn validate_slack_timestamp(timestamp: &str) -> Result<(), ApiError> {
@@ -959,6 +1277,86 @@ mod tests {
         assert!(channels.contains("D111111111"));
         assert!(channels.contains("C222222222"));
         assert!(channels.contains("G222222222"));
+    }
+
+    #[test]
+    fn files_list_form_maps_proxy_limit_to_slack_count() {
+        let query = SlackFilesListQuery {
+            limit: Some(25),
+            page: Some(2),
+            ts_from: Some("1700000000.000001".to_owned()),
+            ts_to: Some("1700000001.000001".to_owned()),
+            types: Some("pdfs,images".to_owned()),
+            user: Some("U123456789".to_owned()),
+            show_files_hidden_by_limit: Some(true),
+        };
+        assert_eq!(
+            slack_files_list_form("C123456789", &query),
+            vec![
+                ("channel", "C123456789".to_owned()),
+                ("count", "25".to_owned()),
+                ("page", "2".to_owned()),
+                ("ts_from", "1700000000.000001".to_owned()),
+                ("ts_to", "1700000001.000001".to_owned()),
+                ("types", "pdfs,images".to_owned()),
+                ("user", "U123456789".to_owned()),
+                ("show_files_hidden_by_limit", "true".to_owned()),
+            ]
+        );
+    }
+
+    #[test]
+    fn validates_new_slack_proxy_query_shapes() {
+        validate_slack_cursor_limit_query(&SlackCursorLimitQuery {
+            limit: Some(999),
+            cursor: Some("cursor".to_owned()),
+        })
+        .unwrap();
+        assert!(matches!(
+            validate_slack_cursor_limit_query(&SlackCursorLimitQuery {
+                limit: Some(1000),
+                cursor: None,
+            })
+            .unwrap_err(),
+            ApiError::BadRequest(_)
+        ));
+
+        validate_slack_files_list_query(&SlackFilesListQuery {
+            limit: Some(1),
+            page: Some(1),
+            ts_from: Some("1700000000.000001".to_owned()),
+            ts_to: Some("1700000001".to_owned()),
+            types: Some("pdfs,images".to_owned()),
+            user: Some("U123456789".to_owned()),
+            show_files_hidden_by_limit: Some(false),
+        })
+        .unwrap();
+        assert!(matches!(
+            validate_slack_files_list_query(&SlackFilesListQuery {
+                limit: None,
+                page: Some(0),
+                ts_from: None,
+                ts_to: None,
+                types: None,
+                user: None,
+                show_files_hidden_by_limit: None,
+            })
+            .unwrap_err(),
+            ApiError::BadRequest(_)
+        ));
+        assert!(matches!(
+            validate_slack_files_list_query(&SlackFilesListQuery {
+                limit: None,
+                page: None,
+                ts_from: None,
+                ts_to: None,
+                types: Some("pdfs;images".to_owned()),
+                user: None,
+                show_files_hidden_by_limit: None,
+            })
+            .unwrap_err(),
+            ApiError::BadRequest(_)
+        ));
     }
 
     #[test]

--- a/tools/productivity/slack/cli.py
+++ b/tools/productivity/slack/cli.py
@@ -596,13 +596,49 @@ def channel_members_cmd(
         slack channel-members eng-ai
         slack channel-members eng-ai --emails
     """
+    from .client import get_channel_members_via_proxy
+
+    try:
+        members = get_channel_members_via_proxy(channel)
+    except RuntimeError as e:
+        console.print(f"[red]Error: {e}[/]")
+        raise typer.Exit(1) from e
+
+    if not members:
+        console.print("[yellow]No members found.[/]")
+        raise typer.Exit()
+
+    if emails_only:
+        for m in members:
+            if m.get("email"):
+                console.print(m["email"])
+    else:
+        table = Table(title=f"#{channel} Members ({len(members)})")
+        table.add_column("Name", style="cyan", max_width=20)
+        table.add_column("Real Name", style="white", max_width=25)
+        table.add_column("Email", style="green", max_width=35)
+
+        for m in members:
+            table.add_row(f"@{m['name']}", m.get("real_name", ""), m.get("email", ""))
+
+        console.print(table)
+
+
+@app.command("channel-members-direct")
+def channel_members_direct_cmd(
+    channel: str = typer.Argument(..., help="Channel name (without #) or channel ID"),
+    emails_only: bool = typer.Option(
+        False, "--emails", "-e", help="Output only email addresses (one per line)"
+    ),
+):
+    """List all members of a Slack channel directly with the Slack SDK."""
     from .client import get_channel_members
 
     try:
         members = get_channel_members(channel)
     except RuntimeError as e:
         console.print(f"[red]Error: {e}[/]")
-        raise typer.Exit(1)
+        raise typer.Exit(1) from e
 
     if not members:
         console.print("[yellow]No members found.[/]")
@@ -631,6 +667,46 @@ def users(
     bots: bool = typer.Option(False, "--bots", "-b", help="Include bots"),
 ):
     """List all Slack workspace members."""
+    from .client import list_users_via_proxy
+
+    results = list_users_via_proxy(limit=limit)
+
+    if not bots:
+        results = [u for u in results if not u["is_bot"]]
+
+    if query:
+        query_lower = query.lower()
+        results = [
+            u
+            for u in results
+            if query_lower in u["name"].lower()
+            or query_lower in u["real_name"].lower()
+            or query_lower in u["email"].lower()
+        ]
+
+    if not results:
+        console.print("[yellow]No users found.[/]")
+        raise typer.Exit()
+
+    table = Table(title=f"Users ({len(results)})")
+    table.add_column("Name", style="cyan", max_width=20)
+    table.add_column("Real Name", style="white", max_width=25)
+    table.add_column("Title", style="dim", max_width=30)
+
+    for u in results:
+        bot = " [dim]🤖[/]" if u["is_bot"] else ""
+        table.add_row(f"@{u['name']}{bot}", u["real_name"], u["title"][:30])
+
+    console.print(table)
+
+
+@app.command("users-direct")
+def users_direct(
+    limit: int = typer.Option(100, "--limit", "-n", help="Max users"),
+    query: str = typer.Option(None, "--query", "-q", help="Filter by name/email"),
+    bots: bool = typer.Option(False, "--bots", "-b", help="Include bots"),
+):
+    """List all Slack workspace members directly with the Slack SDK."""
     from .client import list_users
 
     results = list_users(limit=limit)
@@ -905,21 +981,24 @@ def usergroup_update(
 @app.command("search-files")
 def search_files_cmd(
     query: str = typer.Argument(..., help="Search query for files"),
+    channel_id: str = typer.Option(
+        ..., "--channel-id", "-c", help="Allowed Slack channel/conversation ID"
+    ),
     limit: int = typer.Option(20, "--limit", "-n", help="Max results"),
 ):
-    """Search files shared across the workspace.
+    """Search files shared in an allowed Slack channel through the proxy.
 
     Examples:
-        slack search-files "quarterly report"
-        slack search-files "architecture diagram" -n 10
+        slack search-files "quarterly report" --channel-id C123456789
+        slack search-files "architecture diagram" -c C123456789 -n 10
     """
-    from .client import search_files
+    from .client import search_files_via_proxy
 
     try:
-        results = search_files(query, max_results=limit)
-    except RuntimeError as e:
+        results = search_files_via_proxy(query, channel_id=channel_id, max_results=limit)
+    except (RuntimeError, ValueError) as e:
         console.print(f"[red]Error: {e}[/]")
-        raise typer.Exit(1)
+        raise typer.Exit(1) from e
 
     if not results:
         console.print("[yellow]No files found.[/]")
@@ -944,6 +1023,102 @@ def search_files_cmd(
     console.print(table)
 
 
+@app.command("search-files-direct")
+def search_files_direct_cmd(
+    query: str = typer.Argument(..., help="Search query for files"),
+    limit: int = typer.Option(20, "--limit", "-n", help="Max results"),
+):
+    """Search files directly with the Slack SDK."""
+    from .client import search_files
+
+    try:
+        results = search_files(query, max_results=limit)
+    except RuntimeError as e:
+        console.print(f"[red]Error: {e}[/]")
+        raise typer.Exit(1) from e
+
+    if not results:
+        console.print("[yellow]No files found.[/]")
+        raise typer.Exit()
+
+    table = Table(title=f"Files matching '{query}' ({len(results)})")
+    table.add_column("Name", style="cyan", max_width=30)
+    table.add_column("Type", style="dim", max_width=8)
+    table.add_column("User", style="green", max_width=15)
+    table.add_column("Size", style="dim", justify="right", max_width=10)
+
+    for f in results:
+        size = f["size"]
+        if size > 1_000_000:
+            size_str = f"{size / 1_000_000:.1f}MB"
+        elif size > 1000:
+            size_str = f"{size / 1000:.0f}KB"
+        else:
+            size_str = f"{size}B"
+        table.add_row(f["name"], f["filetype"], f["user"], size_str)
+
+    console.print(table)
+
+
+@app.command("file-info")
+def file_info_cmd(
+    file_id: str = typer.Argument(..., help="Slack file ID, e.g. F1234567890"),
+    channel_id: str = typer.Argument(..., help="Allowed Slack channel/conversation ID"),
+    json_output: bool = typer.Option(False, "--json", help="Output raw file metadata as JSON"),
+):
+    """Get Slack file metadata through the Centaur API server proxy."""
+    import sys
+
+    from .client import get_file_info_via_proxy
+
+    try:
+        file = get_file_info_via_proxy(file_id=file_id, channel_id=channel_id)
+    except (RuntimeError, ValueError) as e:
+        console.print(f"[red]Error: {e}[/]")
+        raise typer.Exit(1) from e
+
+    if json_output:
+        print(json.dumps(file, indent=2, ensure_ascii=False), file=sys.stdout)
+        raise typer.Exit()
+
+    size = file.get("size", 0)
+    console.print(f"[bold]{file.get('name') or file.get('title') or file_id}[/]")
+    console.print(f"ID: {file.get('id', file_id)}")
+    console.print(f"Type: {file.get('filetype', '') or file.get('mimetype', '')}")
+    console.print(f"Size: {size} bytes")
+    if file.get("permalink"):
+        console.print(f"[dim]{file['permalink']}[/]")
+
+
+@app.command("file-info-direct")
+def file_info_direct_cmd(
+    file_id: str = typer.Argument(..., help="Slack file ID, e.g. F1234567890"),
+    json_output: bool = typer.Option(False, "--json", help="Output raw file metadata as JSON"),
+):
+    """Get Slack file metadata directly with the Slack SDK."""
+    import sys
+
+    from .client import get_file_info
+
+    try:
+        file = get_file_info(file_id=file_id)
+    except (RuntimeError, ValueError) as e:
+        console.print(f"[red]Error: {e}[/]")
+        raise typer.Exit(1) from e
+
+    if json_output:
+        print(json.dumps(file, indent=2, ensure_ascii=False), file=sys.stdout)
+        raise typer.Exit()
+
+    size = file.get("size", 0)
+    console.print(f"[bold]{file.get('name') or file.get('title') or file_id}[/]")
+    console.print(f"ID: {file.get('id', file_id)}")
+    console.print(f"Type: {file.get('filetype', '') or file.get('mimetype', '')}")
+    console.print(f"Size: {size} bytes")
+    if file.get("permalink"):
+        console.print(f"[dim]{file['permalink']}[/]")
+
+
 @app.command("search-users")
 def search_users_cmd(
     query: str = typer.Argument(..., help="Search by name, email, or title"),
@@ -956,13 +1131,43 @@ def search_users_cmd(
         slack search-users "@paradigm.xyz"
         slack search-users "engineer"
     """
+    from .client import search_users_via_proxy
+
+    try:
+        results = search_users_via_proxy(query, max_results=limit)
+    except RuntimeError as e:
+        console.print(f"[red]Error: {e}[/]")
+        raise typer.Exit(1) from e
+
+    if not results:
+        console.print("[yellow]No users found.[/]")
+        raise typer.Exit()
+
+    table = Table(title=f"Users matching '{query}' ({len(results)})")
+    table.add_column("Name", style="cyan", max_width=20)
+    table.add_column("Real Name", style="white", max_width=25)
+    table.add_column("Email", style="green", max_width=35)
+    table.add_column("Title", style="dim", max_width=30)
+
+    for u in results:
+        table.add_row(f"@{u['name']}", u["real_name"], u["email"], u["title"][:30])
+
+    console.print(table)
+
+
+@app.command("search-users-direct")
+def search_users_direct_cmd(
+    query: str = typer.Argument(..., help="Search by name, email, or title"),
+    limit: int = typer.Option(20, "--limit", "-n", help="Max results"),
+):
+    """Search workspace users directly with the Slack SDK."""
     from .client import search_users
 
     try:
         results = search_users(query, max_results=limit)
     except RuntimeError as e:
         console.print(f"[red]Error: {e}[/]")
-        raise typer.Exit(1)
+        raise typer.Exit(1) from e
 
     if not results:
         console.print("[yellow]No users found.[/]")
@@ -1466,7 +1671,30 @@ def channel_emails(
         slack channel-emails eng-ai
         slack channel-emails #general -o json
     """
-    import json
+    from .client import get_channel_member_emails_via_proxy
+
+    try:
+        emails = get_channel_member_emails_via_proxy(channel)
+        if output == "json":
+            print(json.dumps({"channel": channel, "emails": emails, "count": len(emails)}))
+        else:
+            if emails:
+                console.print(f"[bold]Members of #{channel} ({len(emails)}):[/]")
+                for email in emails:
+                    console.print(f"  {email}")
+            else:
+                console.print(f"[yellow]No members with emails found in #{channel}[/]")
+    except Exception as e:
+        console.print(f"[red]Error: {e}[/]")
+        raise typer.Exit(1) from e
+
+
+@app.command("channel-emails-direct")
+def channel_emails_direct(
+    channel: str = typer.Argument(..., help="Channel name (with or without #)"),
+    output: str = typer.Option("text", "-o", "--output", help="Output format: text or json"),
+):
+    """Get channel member emails directly with the Slack SDK."""
     from .client import get_channel_member_emails
 
     try:
@@ -1482,7 +1710,7 @@ def channel_emails(
                 console.print(f"[yellow]No members with emails found in #{channel}[/]")
     except Exception as e:
         console.print(f"[red]Error: {e}[/]")
-        raise typer.Exit(1)
+        raise typer.Exit(1) from e
 
 
 @app.command("user-info")
@@ -1496,7 +1724,47 @@ def user_info(
         slack user-info U123ABC
         slack user-info U123ABC -o json
     """
-    import json
+    from .client import get_user_profile_via_proxy
+
+    try:
+        profile = get_user_profile_via_proxy(user_id)
+
+        if output == "json":
+            print(json.dumps(profile, indent=2, ensure_ascii=False))
+        else:
+            console.print(f"[bold]Name:[/] {profile['real_name'] or profile['name']}")
+            if profile["display_name"]:
+                console.print(f"[bold]Display Name:[/] {profile['display_name']}")
+            if profile["title"]:
+                console.print(f"[bold]Title:[/] {profile['title']}")
+            if profile["email"]:
+                console.print(f"[bold]Email:[/] {profile['email']}")
+            else:
+                console.print("[yellow]No email found[/]")
+            if profile["phone"]:
+                console.print(f"[bold]Phone:[/] {profile['phone']}")
+            if profile["status_text"]:
+                console.print(
+                    f"[bold]Status:[/] {profile['status_emoji']} {profile['status_text']}"
+                )
+            if profile["timezone"]:
+                console.print(f"[bold]Timezone:[/] {profile['tz_label']} ({profile['timezone']})")
+            if profile["skype"]:
+                console.print(f"[bold]Skype:[/] {profile['skype']}")
+            if profile["custom_fields"]:
+                for label, value in profile["custom_fields"].items():
+                    console.print(f"[bold]{label}:[/] {value}")
+    except Exception as e:
+        console.print(f"[red]Error: {e}[/]")
+        raise typer.Exit(1) from e
+
+
+@app.command("user-info-direct")
+def user_info_direct(
+    user_id: str = typer.Argument(..., help="Slack user ID (e.g., U123ABC)"),
+    output: str = typer.Option("text", "-o", "--output", help="Output format: text or json"),
+):
+    """Get full user profile directly with the Slack SDK."""
     from .client import get_user_profile
 
     try:
@@ -1529,7 +1797,7 @@ def user_info(
                     console.print(f"[bold]{label}:[/] {value}")
     except Exception as e:
         console.print(f"[red]Error: {e}[/]")
-        raise typer.Exit(1)
+        raise typer.Exit(1) from e
 
 
 if __name__ == "__main__":

--- a/tools/productivity/slack/client.py
+++ b/tools/productivity/slack/client.py
@@ -439,9 +439,7 @@ class SlackClient:
     def _normalize_explicit_channel_id(self, channel_id: str) -> str:
         """Normalize and validate an explicit Slack conversation ID."""
         normalized_channel_id = self._clean_channel_ref(channel_id).upper()
-        if len(normalized_channel_id) < 9 or not self._looks_like_channel_id(
-            normalized_channel_id
-        ):
+        if len(normalized_channel_id) < 9 or not self._looks_like_channel_id(normalized_channel_id):
             raise ValueError("channel_id must be a Slack conversation ID like C123456789")
         return normalized_channel_id
 
@@ -451,6 +449,13 @@ class SlackClient:
         if len(normalized_file_id) < 9 or not self._FILE_ID_RE.fullmatch(normalized_file_id):
             raise ValueError("file_id must be a Slack file ID like F123456789")
         return normalized_file_id
+
+    def _normalize_user_id(self, user_id: str) -> str:
+        """Normalize and validate a Slack user ID."""
+        normalized_user_id = self._clean_user_ref(user_id).upper()
+        if len(normalized_user_id) < 9 or not self._USER_ID_RE.fullmatch(normalized_user_id):
+            raise ValueError("user_id must be a Slack user ID like U123456789")
+        return normalized_user_id
 
     def _content_disposition_filename(self, value: str | None) -> str | None:
         """Extract a simple filename value from Content-Disposition."""
@@ -498,6 +503,21 @@ class SlackClient:
         if channel_name is not None:
             message["channel"] = channel_name
         return message
+
+    def _serialize_user(self, user: dict[str, Any]) -> dict[str, Any]:
+        """Normalize Slack API user payloads into a stable shape."""
+        profile = user.get("profile", {}) or {}
+        return {
+            "id": user.get("id", ""),
+            "name": user.get("name", ""),
+            "real_name": user.get("real_name", ""),
+            "display_name": profile.get("display_name", ""),
+            "email": profile.get("email", ""),
+            "title": profile.get("title", ""),
+            "is_bot": user.get("is_bot", False),
+            "is_deleted": user.get("deleted", False),
+            "team_id": user.get("team_id", "") or user.get("team", ""),
+        }
 
     def _collect_cursor_pages(
         self,
@@ -1222,6 +1242,111 @@ class SlackClient:
             params,
         )
 
+    def get_channel_members_proxy(
+        self,
+        channel_id: str,
+        limit: int = 200,
+        cursor: str | None = None,
+    ) -> dict[str, Any]:
+        """Fetch a page of Slack channel members through the Centaur API server."""
+        if secret("CENTAUR_SANDBOX_API_SERVER_ENABLED", "true").strip().lower() == "false":
+            raise RuntimeError(
+                "Slack channel members proxy requires the API server sandbox capability, "
+                "but it is disabled for this principal."
+            )
+
+        normalized_channel_id = self._normalize_explicit_channel_id(channel_id)
+        requested_limit = int(limit)
+        if not 1 <= requested_limit <= self._MAX_SLACK_HISTORY_PROXY_PAGE_SIZE:
+            raise ValueError("limit must be between 1 and 999")
+        channel_path = urllib.parse.quote(normalized_channel_id, safe="")
+        return self._centaur_api_get_json(
+            f"/api/slack/channels/{channel_path}/members",
+            {"limit": requested_limit, "cursor": cursor},
+        )
+
+    def list_users_proxy(
+        self,
+        limit: int = 200,
+        cursor: str | None = None,
+    ) -> dict[str, Any]:
+        """Fetch a page of Slack workspace users through the Centaur API server."""
+        if secret("CENTAUR_SANDBOX_API_SERVER_ENABLED", "true").strip().lower() == "false":
+            raise RuntimeError(
+                "Slack users.list proxy requires the API server sandbox capability, "
+                "but it is disabled for this principal."
+            )
+        requested_limit = int(limit)
+        if not 1 <= requested_limit <= self._MAX_SLACK_HISTORY_PROXY_PAGE_SIZE:
+            raise ValueError("limit must be between 1 and 999")
+        return self._centaur_api_get_json(
+            "/api/slack/users",
+            {"limit": requested_limit, "cursor": cursor},
+        )
+
+    def get_user_info_proxy(self, user_id: str) -> dict[str, Any]:
+        """Fetch Slack users.info through the Centaur API server."""
+        if secret("CENTAUR_SANDBOX_API_SERVER_ENABLED", "true").strip().lower() == "false":
+            raise RuntimeError(
+                "Slack users.info proxy requires the API server sandbox capability, "
+                "but it is disabled for this principal."
+            )
+        normalized_user_id = self._normalize_user_id(user_id)
+        user_path = urllib.parse.quote(normalized_user_id, safe="")
+        return self._centaur_api_get_json(f"/api/slack/users/{user_path}/info", {})
+
+    def list_files_proxy(
+        self,
+        channel_id: str,
+        limit: int = 100,
+        page: int | None = None,
+        ts_from: str | int | float | None = None,
+        ts_to: str | int | float | None = None,
+        types: str | None = None,
+        user: str | None = None,
+        show_files_hidden_by_limit: bool | None = None,
+    ) -> dict[str, Any]:
+        """Fetch Slack files.list for one allowed channel through the API server."""
+        if secret("CENTAUR_SANDBOX_API_SERVER_ENABLED", "true").strip().lower() == "false":
+            raise RuntimeError(
+                "Slack files.list proxy requires the API server sandbox capability, "
+                "but it is disabled for this principal."
+            )
+        normalized_channel_id = self._normalize_explicit_channel_id(channel_id)
+        requested_limit = int(limit)
+        if not 1 <= requested_limit <= self._MAX_SLACK_HISTORY_PROXY_PAGE_SIZE:
+            raise ValueError("limit must be between 1 and 999")
+        normalized_user = self._normalize_user_id(user) if user else None
+        channel_path = urllib.parse.quote(normalized_channel_id, safe="")
+        return self._centaur_api_get_json(
+            f"/api/slack/channels/{channel_path}/files",
+            {
+                "limit": requested_limit,
+                "page": page,
+                "ts_from": self._normalize_ts(ts_from),
+                "ts_to": self._normalize_ts(ts_to),
+                "types": types,
+                "user": normalized_user,
+                "show_files_hidden_by_limit": show_files_hidden_by_limit,
+            },
+        )
+
+    def get_file_info_proxy(self, file_id: str, channel_id: str) -> dict[str, Any]:
+        """Fetch Slack files.info through the API server and channel allowlist."""
+        if secret("CENTAUR_SANDBOX_API_SERVER_ENABLED", "true").strip().lower() == "false":
+            raise RuntimeError(
+                "Slack files.info proxy requires the API server sandbox capability, "
+                "but it is disabled for this principal."
+            )
+        normalized_file_id = self._normalize_file_id(file_id)
+        normalized_channel_id = self._normalize_explicit_channel_id(channel_id)
+        channel_path = urllib.parse.quote(normalized_channel_id, safe="")
+        file_path = urllib.parse.quote(normalized_file_id, safe="")
+        return self._centaur_api_get_json(
+            f"/api/slack/channels/{channel_path}/files/{file_path}",
+            {},
+        )
+
     def get_channel_history(
         self,
         channel: str,
@@ -1475,20 +1600,28 @@ class SlackClient:
             for user in response.get("members", []):
                 if user.get("deleted"):
                     continue
-                profile = user.get("profile", {}) or {}
-                users.append(
-                    {
-                        "id": user.get("id", ""),
-                        "name": user.get("name", ""),
-                        "real_name": user.get("real_name", ""),
-                        "display_name": profile.get("display_name", ""),
-                        "email": profile.get("email", ""),
-                        "title": profile.get("title", ""),
-                        "is_bot": user.get("is_bot", False),
-                        "is_deleted": user.get("deleted", False),
-                        "team_id": user.get("team_id", "") or user.get("team", ""),
-                    }
-                )
+                users.append(self._serialize_user(user))
+
+            cursor = response.get("response_metadata", {}).get("next_cursor")
+            if not cursor:
+                break
+
+        return sorted(users[:limit], key=lambda x: x["name"])
+
+    def list_users_via_proxy(self, limit: int = 200) -> list[dict]:
+        """List workspace users through the Centaur API server proxy."""
+        users = []
+        cursor = None
+
+        while len(users) < limit:
+            response = self.list_users_proxy(
+                limit=min(limit - len(users), self._MAX_PAGE_SIZE),
+                cursor=cursor,
+            )
+            for user in response.get("members", []):
+                if user.get("deleted"):
+                    continue
+                users.append(self._serialize_user(user))
 
             cursor = response.get("response_metadata", {}).get("next_cursor")
             if not cursor:
@@ -1548,6 +1681,42 @@ class SlackClient:
 
         return members
 
+    def get_channel_members_via_proxy(self, channel_id: str) -> list[dict]:
+        """Get all members of an allowed Slack channel through the API server proxy."""
+        normalized_channel_id = self._normalize_explicit_channel_id(channel_id)
+        member_ids = []
+        cursor = None
+
+        while True:
+            response = self.get_channel_members_proxy(
+                normalized_channel_id,
+                limit=self._MAX_PAGE_SIZE,
+                cursor=cursor,
+            )
+            member_ids.extend(response.get("members", []))
+            cursor = response.get("response_metadata", {}).get("next_cursor")
+            if not cursor:
+                break
+
+        users_by_id = {
+            user["id"]: user for user in self.list_users_via_proxy(limit=1000) if user.get("id")
+        }
+        return [
+            users_by_id.get(member_id)
+            or {
+                "id": member_id,
+                "name": member_id,
+                "real_name": "",
+                "display_name": "",
+                "email": "",
+                "title": "",
+                "is_bot": False,
+                "is_deleted": False,
+                "team_id": "",
+            }
+            for member_id in member_ids
+        ]
+
     def get_channel_member_emails(self, channel: str) -> list[str]:
         """Get email addresses of all non-bot members in a Slack channel.
 
@@ -1558,6 +1727,11 @@ class SlackClient:
             List of email addresses (excludes members without email)
         """
         members = self.get_channel_members(channel)
+        return [m["email"] for m in members if m.get("email")]
+
+    def get_channel_member_emails_via_proxy(self, channel_id: str) -> list[str]:
+        """Get email addresses of all non-bot members through the API server proxy."""
+        members = self.get_channel_members_via_proxy(channel_id)
         return [m["email"] for m in members if m.get("email")]
 
     def get_user_email(self, user_id: str) -> str | None:
@@ -1613,6 +1787,41 @@ class SlackClient:
         profile = profile_response.get("profile", {}) or user.get("profile", {})
 
         # Extract custom profile fields (Telegram, Skype, pronouns, etc.)
+        custom_fields: dict[str, str] = {}
+        raw_custom_fields: dict[str, dict] = {}
+        for field_id, field_data in (profile.get("fields") or {}).items():
+            label = field_data.get("label") or field_id
+            value = field_data.get("value")
+            if value:
+                custom_fields[label] = value
+                raw_custom_fields[field_id] = dict(field_data)
+
+        return {
+            "id": user.get("id", ""),
+            "name": user.get("name", ""),
+            "real_name": user.get("real_name", ""),
+            "display_name": profile.get("display_name", ""),
+            "email": profile.get("email", ""),
+            "title": profile.get("title", ""),
+            "phone": profile.get("phone", ""),
+            "status_text": profile.get("status_text", ""),
+            "status_emoji": profile.get("status_emoji", ""),
+            "timezone": user.get("tz", ""),
+            "tz_label": user.get("tz_label", ""),
+            "image": profile.get("image_192", ""),
+            "skype": profile.get("skype", ""),
+            "is_bot": user.get("is_bot", False),
+            "deleted": user.get("deleted", False),
+            "custom_fields": custom_fields,
+            "raw_custom_fields": raw_custom_fields,
+        }
+
+    def get_user_profile_via_proxy(self, user_id: str) -> dict:
+        """Get a Slack user's profile through the API server users.info proxy."""
+        user_response = self.get_user_info_proxy(user_id)
+        user = user_response.get("user", {})
+        profile = user.get("profile", {}) or {}
+
         custom_fields: dict[str, str] = {}
         raw_custom_fields: dict[str, dict] = {}
         for field_id, field_data in (profile.get("fields") or {}).items():
@@ -2075,6 +2284,27 @@ class SlackClient:
         except SlackApiError as e:
             raise RuntimeError(f"Slack API error: {e.response['error']}") from e
 
+    def get_file_info(self, file_id: str) -> dict:
+        """Get Slack file metadata directly with the Slack SDK."""
+        normalized_file_id = self._normalize_file_id(file_id)
+        try:
+            response = self._retry_on_ratelimit(
+                self._client.files_info,
+                file=normalized_file_id,
+                method_key="files.info",
+            )
+        except SlackApiError as e:
+            self._raise_slack_api_error(
+                e,
+                slack_method="files.info",
+                access_path="bot_token",
+            )
+        return response.get("file", {})
+
+    def get_file_info_via_proxy(self, file_id: str, channel_id: str) -> dict:
+        """Get Slack file metadata through the API server files.info proxy."""
+        return self.get_file_info_proxy(file_id=file_id, channel_id=channel_id).get("file", {})
+
     def get_message_files(self, channel_id: str, message_ts: str) -> list[dict]:
         """Get files attached to a specific message."""
         try:
@@ -2204,6 +2434,60 @@ class SlackClient:
 
         return results
 
+    def search_files_via_proxy(
+        self,
+        query: str,
+        channel_id: str,
+        max_results: int = 20,
+        page: int | None = None,
+        ts_from: str | int | float | None = None,
+        ts_to: str | int | float | None = None,
+        types: str | None = None,
+        user: str | None = None,
+    ) -> list[dict]:
+        """Search files in one allowed Slack channel through files.list proxy."""
+        response = self.list_files_proxy(
+            channel_id=channel_id,
+            limit=max_results,
+            page=page,
+            ts_from=ts_from,
+            ts_to=ts_to,
+            types=types,
+            user=user,
+        )
+        files = response.get("files", [])
+        query_lower = query.lower()
+        users_by_id = {
+            user_info["id"]: user_info
+            for user_info in self.list_users_via_proxy(limit=1000)
+            if user_info.get("id")
+        }
+
+        results = []
+        for f in files:
+            name = f.get("name", "")
+            title = f.get("title", "")
+            if query_lower and query_lower not in name.lower() and query_lower not in title.lower():
+                continue
+            user_id = f.get("user", "")
+            user_info = users_by_id.get(user_id, {})
+            results.append(
+                {
+                    "id": f.get("id", ""),
+                    "name": name,
+                    "title": title,
+                    "filetype": f.get("filetype", ""),
+                    "size": f.get("size", 0),
+                    "user": user_info.get("name") or user_id,
+                    "channels": f.get("channels", []),
+                    "permalink": f.get("permalink", ""),
+                    "url_private": f.get("url_private", ""),
+                    "created": f.get("created", 0),
+                }
+            )
+
+        return results[:max_results]
+
     def search_users(
         self,
         query: str,
@@ -2222,6 +2506,23 @@ class SlackClient:
             List of user dicts with id, name, real_name, email, title, timezone
         """
         all_users = self.list_users(limit=1000)
+        query_lower = query.lower()
+
+        matches = []
+        for u in all_users:
+            searchable = f"{u['name']} {u['real_name']} {u['email']} {u['title']}".lower()
+            if query_lower in searchable:
+                matches.append(u)
+
+        return matches[:max_results]
+
+    def search_users_via_proxy(
+        self,
+        query: str,
+        max_results: int = 20,
+    ) -> list[dict]:
+        """Search workspace users through the API server users.list proxy."""
+        all_users = self.list_users_via_proxy(limit=1000)
         query_lower = query.lower()
 
         matches = []
@@ -2384,6 +2685,42 @@ def get_thread_replies_proxy(*args, **kwargs):
     return _client().get_thread_replies_proxy(*args, **kwargs)
 
 
+def get_channel_members_proxy(*args, **kwargs):
+    return _client().get_channel_members_proxy(*args, **kwargs)
+
+
+def get_channel_members_via_proxy(*args, **kwargs):
+    return _client().get_channel_members_via_proxy(*args, **kwargs)
+
+
+def list_users_proxy(*args, **kwargs):
+    return _client().list_users_proxy(*args, **kwargs)
+
+
+def list_users_via_proxy(*args, **kwargs):
+    return _client().list_users_via_proxy(*args, **kwargs)
+
+
+def get_user_info_proxy(*args, **kwargs):
+    return _client().get_user_info_proxy(*args, **kwargs)
+
+
+def get_user_profile_via_proxy(*args, **kwargs):
+    return _client().get_user_profile_via_proxy(*args, **kwargs)
+
+
+def list_files_proxy(*args, **kwargs):
+    return _client().list_files_proxy(*args, **kwargs)
+
+
+def get_file_info_proxy(*args, **kwargs):
+    return _client().get_file_info_proxy(*args, **kwargs)
+
+
+def get_file_info_via_proxy(*args, **kwargs):
+    return _client().get_file_info_via_proxy(*args, **kwargs)
+
+
 def get_channel_history(*args, **kwargs):
     return _client().get_channel_history(*args, **kwargs)
 
@@ -2414,6 +2751,10 @@ def get_channel_members(*args, **kwargs):
 
 def get_channel_member_emails(*args, **kwargs):
     return _client().get_channel_member_emails(*args, **kwargs)
+
+
+def get_channel_member_emails_via_proxy(*args, **kwargs):
+    return _client().get_channel_member_emails_via_proxy(*args, **kwargs)
 
 
 def get_user_email(*args, **kwargs):
@@ -2456,6 +2797,10 @@ def get_message_files(*args, **kwargs):
     return _client().get_message_files(*args, **kwargs)
 
 
+def get_file_info(*args, **kwargs):
+    return _client().get_file_info(*args, **kwargs)
+
+
 def _fetch_slack_file(*args, **kwargs):
     return _client()._fetch_slack_file(*args, **kwargs)
 
@@ -2468,8 +2813,16 @@ def search_files(*args, **kwargs):
     return _client().search_files(*args, **kwargs)
 
 
+def search_files_via_proxy(*args, **kwargs):
+    return _client().search_files_via_proxy(*args, **kwargs)
+
+
 def search_users(*args, **kwargs):
     return _client().search_users(*args, **kwargs)
+
+
+def search_users_via_proxy(*args, **kwargs):
+    return _client().search_users_via_proxy(*args, **kwargs)
 
 
 def get_user_profile(*args, **kwargs):

--- a/tools/productivity/slack/tests/test_client.py
+++ b/tools/productivity/slack/tests/test_client.py
@@ -537,6 +537,129 @@ def test_get_thread_replies_proxy_validates_inputs() -> None:
         client.get_thread_replies_proxy("C123456789", "1700000000.000001", limit=1000)
 
 
+def test_new_slack_proxy_endpoints_call_centaur_api(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import urllib.parse
+    import urllib.request
+
+    client, _ = _make_client()
+    request_urls: list[str] = []
+
+    def fake_urlopen(req, *args, **kwargs):
+        request_urls.append(req.full_url)
+        path = urllib.parse.urlparse(req.full_url).path
+        if path.endswith("/members"):
+            body = {"ok": True, "members": ["U123456789"], "response_metadata": {}}
+        elif path == "/api/slack/users":
+            body = {"ok": True, "members": [], "response_metadata": {}}
+        elif path.endswith("/info"):
+            body = {"ok": True, "user": {"id": "U123456789"}}
+        elif path.endswith("/files/F123456789"):
+            body = {"ok": True, "file": {"id": "F123456789"}}
+        else:
+            body = {"ok": True, "files": [], "response_metadata": {}}
+        return _FakeHTTPResponse(json.dumps(body).encode(), "application/json")
+
+    monkeypatch.setenv("CENTAUR_API_URL", "http://api.internal:8080")
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+
+    assert client.get_channel_members_proxy("C123456789", limit=50)["members"] == ["U123456789"]
+    assert client.list_users_proxy(limit=25, cursor="user-cursor")["ok"] is True
+    assert client.get_user_info_proxy("<@U123456789>")["user"]["id"] == "U123456789"
+    assert client.get_file_info_proxy("F123456789", "C123456789")["file"]["id"] == "F123456789"
+    assert (
+        client.list_files_proxy(
+            "C123456789",
+            limit=10,
+            page=2,
+            ts_from=0,
+            ts_to="1700000000.000001",
+            types="pdfs",
+            user="U123456789",
+            show_files_hidden_by_limit=True,
+        )["ok"]
+        is True
+    )
+
+    parsed = [urllib.parse.urlparse(url) for url in request_urls]
+    assert parsed[0].path == "/api/slack/channels/C123456789/members"
+    assert urllib.parse.parse_qs(parsed[0].query) == {"limit": ["50"]}
+    assert parsed[1].path == "/api/slack/users"
+    assert urllib.parse.parse_qs(parsed[1].query) == {
+        "limit": ["25"],
+        "cursor": ["user-cursor"],
+    }
+    assert parsed[2].path == "/api/slack/users/U123456789/info"
+    assert parsed[3].path == "/api/slack/channels/C123456789/files/F123456789"
+    assert parsed[4].path == "/api/slack/channels/C123456789/files"
+    assert urllib.parse.parse_qs(parsed[4].query) == {
+        "limit": ["10"],
+        "page": ["2"],
+        "ts_from": ["0.000000"],
+        "ts_to": ["1700000000.000001"],
+        "types": ["pdfs"],
+        "user": ["U123456789"],
+        "show_files_hidden_by_limit": ["true"],
+    }
+
+
+def test_proxy_normalizers_preserve_user_and_file_shapes() -> None:
+    client, _ = _make_client()
+
+    client.list_users_proxy = lambda **kwargs: {  # type: ignore[method-assign]
+        "members": [
+            {
+                "id": "U123456789",
+                "name": "alice",
+                "real_name": "Alice Example",
+                "profile": {"display_name": "Alice", "email": "alice@example.com", "title": "Eng"},
+            }
+        ],
+        "response_metadata": {},
+    }
+    assert client.list_users_via_proxy(limit=10) == [
+        {
+            "id": "U123456789",
+            "name": "alice",
+            "real_name": "Alice Example",
+            "display_name": "Alice",
+            "email": "alice@example.com",
+            "title": "Eng",
+            "is_bot": False,
+            "is_deleted": False,
+            "team_id": "",
+        }
+    ]
+
+    client.get_channel_members_proxy = lambda *args, **kwargs: {  # type: ignore[method-assign]
+        "members": ["U123456789"],
+        "response_metadata": {},
+    }
+    assert client.get_channel_members_via_proxy("C123456789")[0]["email"] == "alice@example.com"
+
+    client.list_files_proxy = lambda **kwargs: {  # type: ignore[method-assign]
+        "files": [
+            {
+                "id": "F123456789",
+                "name": "roadmap.pdf",
+                "title": "Roadmap",
+                "filetype": "pdf",
+                "size": 42,
+                "user": "U123456789",
+                "channels": ["C123456789"],
+            }
+        ]
+    }
+    results = client.search_files_via_proxy(
+        "roadmap",
+        channel_id="C123456789",
+        max_results=10,
+    )
+    assert results[0]["user"] == "alice"
+    assert results[0]["name"] == "roadmap.pdf"
+
+
 def test_upload_file_proxy_posts_file_bytes_to_centaur_api(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
Adds Slack proxy coverage for channel members, users, and file metadata/listing endpoints with the same JWT-based access model used by existing Slack proxy routes. Updates the Slack tool to prefer those proxy paths by default while keeping explicit direct Slack SDK fallbacks.