### PR TITLE
fix(sandbox): avoid AI co-author attribution

### DIFF
--- a/services/sandbox/Dockerfile
+++ b/services/sandbox/Dockerfile
@@ -197,13 +197,14 @@ RUN if [ "$(dpkg --print-architecture)" = "amd64" ]; then \
 # ── Agent skills + workspace setup (rarely changes) ─────────────────────────
 RUN --mount=type=cache,target=/home/agent/.npm,uid=1001,gid=1001,sharing=locked \
     npx -y skills add vercel-labs/agent-browser
+# git-branch configures each writable clone with the publishing GitHub account.
+# A baked agent identity would reappear as a co-author when GitHub squash-merges its commits.
 RUN mkdir -p ~/.amp/bin ~/.config/amp ~/.codex ~/.pi/agent ~/github ~/workspace \
     && git config --global init.defaultBranch main \
     && git config --global push.autoSetupRemote true \
     && git config --global core.hooksPath /opt/centaur/git-hooks \
     && git config --global --add safe.directory '*' \
-    && git config --global user.name "Centaur AI" \
-    && git config --global user.email "ai@centaur.local"
+    && git config --global user.useConfigOnly true
 
 # ==============================================================================
 # Final thin stage: only frequently-changing local files below.

--- a/services/sandbox/git-branch.sh
+++ b/services/sandbox/git-branch.sh
@@ -31,6 +31,38 @@ SLUG="$2"
 SRC="$HOME/github/$REPO"
 DEST="$HOME/branches/$REPO"
 
+# Match commit authorship to the account that will publish the PR so GitHub does
+# not preserve a separate sandbox identity as a squash-merge co-author.
+configure_git_identity() {
+    local name="${CENTAUR_GIT_USER_NAME:-}"
+    local email="${CENTAUR_GIT_USER_EMAIL:-}"
+    local github_identity_query='[.name // .login,
+        .email // ((.id | tostring) + "+" + .login + "@users.noreply.github.com")
+    ] | @tsv'
+
+    if [ -n "$name" ] || [ -n "$email" ]; then
+        if [ -z "$name" ] || [ -z "$email" ]; then
+            echo "Error: CENTAUR_GIT_USER_NAME and CENTAUR_GIT_USER_EMAIL" \
+                "must be set together" >&2
+            return 1
+        fi
+    elif command -v gh >/dev/null 2>&1 && [ -n "${GITHUB_TOKEN:-}" ]; then
+        local identity
+        identity="$({
+            GH_PROMPT_DISABLED=1 gh api user --jq "$github_identity_query"
+        } 2>/dev/null || true)"
+        IFS=$'\t' read -r name email <<< "$identity"
+    fi
+
+    if [ -n "$name" ] && [ -n "$email" ]; then
+        git -C "$DEST" config user.name "$name"
+        git -C "$DEST" config user.email "$email"
+    elif ! git -C "$DEST" var GIT_AUTHOR_IDENT >/dev/null 2>&1; then
+        echo "Warning: no Git author identity is configured; set" \
+            "CENTAUR_GIT_USER_NAME and CENTAUR_GIT_USER_EMAIL before committing" >&2
+    fi
+}
+
 if [[ ! "$SLUG" =~ ^[a-z0-9][a-z0-9-]*[a-z0-9]$|^[a-z0-9]$ ]]; then
     usage
     echo "Error: branch slug must be lowercase kebab-case using only a-z, 0-9, and hyphens." >&2
@@ -44,6 +76,7 @@ fi
 
 if [ -d "$DEST/.git" ]; then
     echo "$DEST already exists — reusing" >&2
+    configure_git_identity
     echo "$DEST"
     exit 0
 fi
@@ -65,5 +98,7 @@ fi
 
 BRANCH="centaur/$SLUG-$(date +%s)"
 git -C "$DEST" checkout -q -b "$BRANCH"
+
+configure_git_identity
 
 echo "$DEST"

--- a/services/sandbox/git-hooks/commit-msg
+++ b/services/sandbox/git-hooks/commit-msg
@@ -19,6 +19,7 @@ fi
 if rg -i -q \
   -e 'generated with (claude|codex|amp)' \
   -e 'co-authored-by:.*(claude|codex|anthropic|openai|amp)' \
+  -e 'co-authored-by:.*(centaur[[:space:]]+ai|ai@centaur\.local)' \
   "$message_file"; then
   cat >&2 <<'EOF'
 Commit message contains generated-by or AI co-author attribution.

--- a/services/sandbox/test_git_branch.py
+++ b/services/sandbox/test_git_branch.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+import os
+import stat
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SANDBOX_DIR = Path(__file__).parent
+GIT_BRANCH = SANDBOX_DIR / "git-branch.sh"
+COMMIT_MSG_HOOK = SANDBOX_DIR / "git-hooks" / "commit-msg"
+
+
+class GitBranchTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.root = Path(self.tempdir.name)
+        self.home = self.root / "home"
+        self.source = self.home / "github" / "acme" / "centaur"
+        self.source.mkdir(parents=True)
+        self._git("init", "--initial-branch=main", str(self.source))
+        self._git("-C", str(self.source), "config", "user.name", "Seed User")
+        self._git("-C", str(self.source), "config", "user.email", "seed@example.com")
+        (self.source / "README.md").write_text("seed\n")
+        self._git("-C", str(self.source), "add", "README.md")
+        self._git("-C", str(self.source), "commit", "-m", "chore: seed repository")
+
+    def tearDown(self) -> None:
+        self.tempdir.cleanup()
+
+    def _git(self, *args: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            ["git", *args],
+            check=True,
+            capture_output=True,
+            text=True,
+            env={**os.environ, "GIT_CONFIG_NOSYSTEM": "1"},
+        )
+
+    def _run_git_branch(self, extra_env: dict[str, str]) -> Path:
+        result = subprocess.run(
+            [str(GIT_BRANCH), "acme/centaur", "fix-attribution"],
+            check=True,
+            capture_output=True,
+            text=True,
+            env={
+                **os.environ,
+                "GIT_CONFIG_NOSYSTEM": "1",
+                "HOME": str(self.home),
+                **extra_env,
+            },
+        )
+        return Path(result.stdout.strip())
+
+    def test_uses_authenticated_github_identity(self) -> None:
+        bin_dir = self.root / "bin"
+        bin_dir.mkdir()
+        gh = bin_dir / "gh"
+        gh.write_text("#!/bin/sh\nprintf 'Perry Dime\\tsvc_ai@paradigm.xyz\\n'\n")
+        gh.chmod(gh.stat().st_mode | stat.S_IXUSR)
+
+        destination = self._run_git_branch(
+            {
+                "GITHUB_TOKEN": "placeholder",
+                "PATH": f"{bin_dir}:{os.environ['PATH']}",
+            }
+        )
+
+        self.assertEqual(
+            self._git("-C", str(destination), "config", "user.name").stdout.strip(),
+            "Perry Dime",
+        )
+        self.assertEqual(
+            self._git("-C", str(destination), "config", "user.email").stdout.strip(),
+            "svc_ai@paradigm.xyz",
+        )
+        (destination / "CHANGELOG.md").write_text("fixed\n")
+        self._git("-C", str(destination), "add", "CHANGELOG.md")
+        self._git("-C", str(destination), "commit", "-m", "fix: test attribution")
+        commit = self._git(
+            "-C",
+            str(destination),
+            "show",
+            "-s",
+            "--format=%an <%ae>%n%B",
+            "HEAD",
+        ).stdout
+        self.assertTrue(commit.startswith("Perry Dime <svc_ai@paradigm.xyz>\n"))
+        self.assertNotIn("Co-authored-by:", commit)
+
+    def test_explicit_identity_does_not_require_github(self) -> None:
+        destination = self._run_git_branch(
+            {
+                "CENTAUR_GIT_USER_NAME": "Release Bot",
+                "CENTAUR_GIT_USER_EMAIL": "release@example.com",
+                "GITHUB_TOKEN": "",
+            }
+        )
+
+        self.assertEqual(
+            self._git("-C", str(destination), "config", "user.name").stdout.strip(),
+            "Release Bot",
+        )
+        self.assertEqual(
+            self._git("-C", str(destination), "config", "user.email").stdout.strip(),
+            "release@example.com",
+        )
+
+    def test_refreshes_identity_when_reusing_clone(self) -> None:
+        destination = self._run_git_branch(
+            {
+                "CENTAUR_GIT_USER_NAME": "Old Bot",
+                "CENTAUR_GIT_USER_EMAIL": "old@example.com",
+                "GITHUB_TOKEN": "",
+            }
+        )
+        reused = self._run_git_branch(
+            {
+                "CENTAUR_GIT_USER_NAME": "New Bot",
+                "CENTAUR_GIT_USER_EMAIL": "new@example.com",
+                "GITHUB_TOKEN": "",
+            }
+        )
+
+        self.assertEqual(reused, destination)
+        self.assertEqual(
+            self._git("-C", str(destination), "config", "user.name").stdout.strip(),
+            "New Bot",
+        )
+        self.assertEqual(
+            self._git("-C", str(destination), "config", "user.email").stdout.strip(),
+            "new@example.com",
+        )
+
+    def test_rejects_partial_explicit_identity(self) -> None:
+        result = subprocess.run(
+            [str(GIT_BRANCH), "acme/centaur", "fix-attribution"],
+            check=False,
+            capture_output=True,
+            text=True,
+            env={
+                **os.environ,
+                "GIT_CONFIG_NOSYSTEM": "1",
+                "HOME": str(self.home),
+                "CENTAUR_GIT_USER_NAME": "Release Bot",
+                "CENTAUR_GIT_USER_EMAIL": "",
+                "GITHUB_TOKEN": "",
+            },
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("must be set together", result.stderr)
+
+
+class CommitMessageHookTest(unittest.TestCase):
+    def test_rejects_centaur_ai_coauthor(self) -> None:
+        with tempfile.NamedTemporaryFile(mode="w") as message:
+            message.write(
+                "fix: remove generated attribution\n\n"
+                "Co-authored-by: Centaur AI <ai@centaur.local>\n"
+            )
+            message.flush()
+
+            result = subprocess.run(
+                [str(COMMIT_MSG_HOOK), message.name],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("AI co-author attribution", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- stop baking the Centaur AI Git identity into sandbox images
- configure writable clones with the authenticated GitHub account
- reject explicit Centaur AI co-author trailers as a backstop
- add regression coverage for new and reused writable clones

## Test plan

- sandbox Python unit suite: 26 tests passed
- bash syntax checks for the changed sandbox scripts
- git diff whitespace validation

Per request, the agent image build and deployment verification are left to pull-request CI.