### PR TITLE
fix: detect bot mentions in Slack attachments

### DIFF
--- a/patches/@chat-adapter__slack@4.31.0.patch
+++ b/patches/@chat-adapter__slack@4.31.0.patch
@@ -1,5 +1,5 @@
 diff --git a/dist/index.js b/dist/index.js
-index a7048fd884020cfd96a51c48b7071fa7293f3dc4..e5bd30bb8f2d41f8f836e7dee742a67f32ccc951 100644
+index a7048fd884020cfd96a51c48b7071fa7293f3dc4..0c31d0499cb71be5653c7456bde468dbe9371f4b 100644
 --- a/dist/index.js
 +++ b/dist/index.js
 @@ -31,6 +31,216 @@ import {
@@ -253,19 +253,40 @@ index a7048fd884020cfd96a51c48b7071fa7293f3dc4..e5bd30bb8f2d41f8f836e7dee742a67f
    /**
     * Build the Slack API payload fields for a message.
     *
-@@ -2004,7 +2234,10 @@ var SlackAdapter = class _SlackAdapter {
+@@ -689,6 +919,10 @@ var TRAILING_SLASH_PATTERN = /\/$/;
+ var UNFURL_WAIT_MS = 2e3;
+ var UNFURL_POLL_MS = 150;
+ var SLACK_MESSAGE_URL_PATTERN = /^https?:\/\/[^/]+\.slack\.com\/archives\/([A-Z0-9]+)\/p(\d+)(?:\?.*)?$/;
++function extractEventText(event) {
++  const attachmentText = Array.isArray(event.attachments) ? event.attachments.map((attachment) => typeof attachment?.text === "string" ? attachment.text : "").filter(Boolean).join("\n\n") : "";
++  return [typeof event.text === "string" ? event.text : "", attachmentText].filter(Boolean).join("\n\n");
++}
+ function normalizeBotTokenProvider(value) {
+   if (value === void 0) {
+     return void 0;
+@@ -2004,7 +2238,11 @@ var SlackAdapter = class _SlackAdapter {
        channel: event.channel,
        threadTs
      });
 -    const isMention = event.type === "app_mention";
++    const eventText = extractEventText(event);
 +    const botMentioned = Boolean(
-+      this._botUserId && typeof event.text === "string" && (event.text.includes(`<@${this._botUserId}>`) || event.text.includes(`<@${this._botUserId}|`))
++      this._botUserId && (eventText.includes(`<@${this._botUserId}>`) || eventText.includes(`<@${this._botUserId}|`))
 +    );
 +    const isMention = event.type === "app_mention" || botMentioned && (event.bot_id || event.subtype === "bot_message");
      const factory = async () => {
        const msg = await this.parseSlackMessage(event, threadId);
        if (isMention) {
-@@ -2520,10 +2753,10 @@ var SlackAdapter = class _SlackAdapter {
+@@ -2486,7 +2724,7 @@ var SlackAdapter = class _SlackAdapter {
+   async parseSlackMessage(event, threadId, options) {
+     const isMe = this.isMessageFromSelf(event);
+     const skipSelfMention = options?.skipSelfMention ?? true;
+-    const rawText = event.text || "";
++    const rawText = extractEventText(event);
+     let userName = event.username || "unknown";
+     let fullName = event.username || "unknown";
+     if (event.user && !event.username) {
+@@ -2520,10 +2758,10 @@ var SlackAdapter = class _SlackAdapter {
        formatted: this.formatConverter.toAst(text),
        raw: event,
        author: {
@@ -278,7 +299,7 @@ index a7048fd884020cfd96a51c48b7071fa7293f3dc4..e5bd30bb8f2d41f8f836e7dee742a67f
          isMe
        },
        metadata: {
-@@ -3452,26 +3685,251 @@ var SlackAdapter = class _SlackAdapter {
+@@ -3452,26 +3690,251 @@ var SlackAdapter = class _SlackAdapter {
      }
      this.logger.debug("Slack: starting stream", { channel, threadTs });
      const token = await this.getToken();
@@ -539,7 +560,7 @@ index a7048fd884020cfd96a51c48b7071fa7293f3dc4..e5bd30bb8f2d41f8f836e7dee742a67f
      const sendStructuredChunk = async (chunk) => {
        if (!structuredChunksSupported) {
          return;
-@@ -3481,8 +3939,45 @@ var SlackAdapter = class _SlackAdapter {
+@@ -3481,8 +3944,45 @@ var SlackAdapter = class _SlackAdapter {
        await flushMarkdownDelta(delta);
        lastAppended = committable;
        try {
@@ -586,7 +607,7 @@ index a7048fd884020cfd96a51c48b7071fa7293f3dc4..e5bd30bb8f2d41f8f836e7dee742a67f
          structuredChunksSupported = false;
          this.logger.warn(
            "Structured streaming chunk failed, falling back to text-only streaming. Ensure your Slack app manifest includes assistant_view, assistant:write scope, and @slack/web-api >= 7.14.0",
-@@ -3497,31 +3992,91 @@ var SlackAdapter = class _SlackAdapter {
+@@ -3497,31 +3997,91 @@ var SlackAdapter = class _SlackAdapter {
        await flushMarkdownDelta(delta);
        lastAppended = committable;
      };
@@ -697,7 +718,7 @@ index a7048fd884020cfd96a51c48b7071fa7293f3dc4..e5bd30bb8f2d41f8f836e7dee742a67f
      };
    }
    /**
-@@ -3798,10 +4353,10 @@ var SlackAdapter = class _SlackAdapter {
+@@ -3798,10 +4358,10 @@ var SlackAdapter = class _SlackAdapter {
        formatted: this.formatConverter.toAst(text),
        raw: event,
        author: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,7 +12,7 @@ patchedDependencies:
     hash: fce7a692b030cfe3d325b020a4472b9424b8976aa2f7faded6ad4c83421e9132
     path: patches/@chat-adapter__linear@4.31.0.patch
   '@chat-adapter/slack@4.31.0':
-    hash: b005d7fc3498bc499bfd30ff79be29138a48b63944761da6f1b68bec59ef9d68
+    hash: 22c6d900d4d632a0119e1cf134afe8d5d9cfef49862226fa36874890ada82531
     path: patches/@chat-adapter__slack@4.31.0.patch
   '@chat-adapter/state-pg@4.31.0':
     hash: 69262b03c278ca9d4af0bed7b4e05f9d7a5a36d3d79fad31df2a85da4d349274
@@ -220,7 +220,7 @@ importers:
         version: link:../../packages/rendering
       '@chat-adapter/slack':
         specifier: ^4.31.0
-        version: 4.31.0(patch_hash=b005d7fc3498bc499bfd30ff79be29138a48b63944761da6f1b68bec59ef9d68)(zod@4.4.3)
+        version: 4.31.0(patch_hash=22c6d900d4d632a0119e1cf134afe8d5d9cfef49862226fa36874890ada82531)(zod@4.4.3)
       '@chat-adapter/state-pg':
         specifier: ^4.31.0
         version: 4.31.0(patch_hash=69262b03c278ca9d4af0bed7b4e05f9d7a5a36d3d79fad31df2a85da4d349274)(zod@4.4.3)
@@ -1998,7 +1998,7 @@ snapshots:
       - supports-color
       - zod
 
-  '@chat-adapter/slack@4.31.0(patch_hash=b005d7fc3498bc499bfd30ff79be29138a48b63944761da6f1b68bec59ef9d68)(zod@4.4.3)':
+  '@chat-adapter/slack@4.31.0(patch_hash=22c6d900d4d632a0119e1cf134afe8d5d9cfef49862226fa36874890ada82531)(zod@4.4.3)':
     dependencies:
       '@chat-adapter/shared': 4.31.0(zod@4.4.3)
       '@slack/socket-mode': 2.0.7

--- a/services/slackbotv2/test/chat-sdk-emulate.test.ts
+++ b/services/slackbotv2/test/chat-sdk-emulate.test.ts
@@ -4275,6 +4275,48 @@ describe('slackbotv2', () => {
         recipient_user_id: 'UOTHERBOT'
       })
     )
+
+    bot = createTestBot({ triggerBotAllowlist: ['bot:BOTHERBOT'] })
+    codexApi.reset()
+    slackApi.reset()
+    const attachmentBotMessage = await postUserMessage('VictoriaMetrics alert')
+    const attachmentBotWaits: Promise<unknown>[] = []
+    const attachmentBotResponse = await bot.app.request(
+      '/api/webhooks/slack',
+      signedSlackEvent({
+        event_id: 'Ev-slackbotv2-attachment-bot-message-allowed',
+        event: {
+          type: 'message',
+          app_id: 'AOTHERBOT',
+          attachments: [
+            {
+              text: `State root mismatch\n\n<@${BOT_USER_ID}> investigate this alert`
+            }
+          ],
+          bot_id: 'BOTHERBOT',
+          bot_profile: {
+            app_id: 'AOTHERBOT',
+            id: 'BOTHERBOT',
+            user_id: 'UOTHERBOT'
+          },
+          channel: CHANNEL_ID,
+          subtype: 'bot_message',
+          team: TEAM_ID,
+          text: '',
+          ts: attachmentBotMessage.ts,
+          username: 'VictoriaMetrics'
+        }
+      }),
+      {},
+      waitUntilContext(attachmentBotWaits)
+    )
+    expect(attachmentBotResponse.status).toBe(200)
+    await Promise.all(attachmentBotWaits)
+    expect(codexApi.appends).toHaveLength(1)
+    expect(codexApi.executes).toHaveLength(1)
+    expect(sessionMessageTexts(codexApi.appends[0]!.body.messages).join('\n')).toContain(
+      'State root mismatch'
+    )
   })
 })
 


### PR DESCRIPTION
## What changed

- Detect Centaur mentions in legacy Slack `attachments[].text`, not only top-level message text.
- Include attachment text in the message sent to the agent so alert context is preserved.
- Add regression coverage for attachment-only VictoriaMetrics bot alerts.

## Why

Alertmanager/VictoriaMetrics posts alerts as attachment-only bot messages. The alert template already included `<@U0ANX3AM5RR> investigate this alert`, but Slack delivered an empty top-level `event.text`, so Centaur did not recognize or execute the mention.

## Validation

- `pnpm --filter slackbotv2 exec bun test test/chat-sdk-emulate.test.ts`
- `pnpm --filter slackbotv2 check:types`
- `pnpm install --frozen-lockfile`

Prompted by: @Zygimantass
