### PR TITLE
fix: restore direct sandbox OTLP egress

### DIFF
--- a/services/api-rs/crates/centaur-api-server/src/args.rs
+++ b/services/api-rs/crates/centaur-api-server/src/args.rs
@@ -1374,8 +1374,8 @@ impl TryFrom<&SandboxArgs> for AgentSandboxConfig {
         }
         config.iron_control = args.iron_control.settings();
         config.tools = args.tools_source.to_config();
-        // The chart label policy handles sandbox OTLP egress; keep the
-        // per-sandbox proxy's own in-cluster OTLP egress explicit.
+        // Direct harness OTLP export and the per-sandbox proxy both need the
+        // exact in-cluster collector destination in their generated policies.
         config.otlp_egress = args.sandbox_otlp_egress_target()?;
         // iron-control is the only proxy mode: a per-sandbox proxy syncs its
         // secrets from the control plane, so configuring iron-proxy without

--- a/services/api-rs/crates/centaur-sandbox-agent-k8s/src/iron_proxy.rs
+++ b/services/api-rs/crates/centaur-sandbox-agent-k8s/src/iron_proxy.rs
@@ -1342,13 +1342,22 @@ fn build_iron_proxy_network_policies(
     observability_enabled: bool,
 ) -> Vec<NetworkPolicy> {
     let sandbox_to_proxy_ports = sandbox_to_proxy_ports(resolved);
-    let sandbox_egress = vec![
+    let mut sandbox_egress = vec![
         egress_to(
             vec![pod_peer(iron_proxy_labels(id, resolved.api_server_enabled))],
             sandbox_to_proxy_ports.clone(),
         ),
         dns_egress_rule(),
     ];
+    if observability_enabled && let Some(target) = otlp_egress {
+        // Harnesses export OTLP directly because the collector is in NO_PROXY;
+        // allow that exact in-cluster destination on the sandbox itself. The
+        // proxy keeps its matching rule for forwarded telemetry clients.
+        sandbox_egress.push(egress_to(
+            vec![namespace_peer(&target.namespace)],
+            vec![network_port(target.port)],
+        ));
+    }
     vec![
         NetworkPolicy {
             metadata: object_meta(
@@ -2105,7 +2114,7 @@ mod tests {
     }
 
     #[test]
-    fn sandbox_egress_policy_does_not_inline_otlp_collector_rule() {
+    fn observable_sandbox_and_proxy_policies_allow_otlp_collector() {
         let id = SandboxId::new("asbx-test");
         let iron_proxy = IronProxyConfig::new("proxy:test", "ca-cert", "ca-key");
         let control_target = control_target();
@@ -2131,7 +2140,7 @@ mod tests {
             .unwrap()
             .clone();
         assert!(
-            !sandbox_egress
+            sandbox_egress
                 .iter()
                 .any(|rule| rule_allows_namespace_port(rule, "laminar", 8000))
         );

--- a/services/api-rs/crates/centaur-sandbox-agent-k8s/src/lib.rs
+++ b/services/api-rs/crates/centaur-sandbox-agent-k8s/src/lib.rs
@@ -67,8 +67,8 @@ pub struct AgentSandboxConfig {
     /// is set so the agent's shim installer finds them.
     pub tools: Option<ToolsConfig>,
     /// In-cluster OTLP collector (e.g. Laminar) used for observability-capable
-    /// sandboxes. Sandbox pod egress is granted by chart-level label policy;
-    /// the per-sandbox proxy uses this target for its own explicit egress.
+    /// sandboxes. The per-sandbox policies grant this exact destination to both
+    /// the sandbox's direct harness exporter and its egress proxy.
     pub otlp_egress: Option<OtlpEgressTarget>,
     pub ready_timeout: Duration,
 }


### PR DESCRIPTION
## Summary

- restore endpoint-derived OTLP egress on observability-enabled sandbox NetworkPolicies
- keep the matching proxy rule while preserving the restricted-sandbox boundary
- update the config contract and regression test to require direct collector access

## Root cause

PR #864 removed the direct sandbox-to-collector rule under the assumption that a chart-level label policy would replace it. Harness OTLP exporters bypass the HTTP proxy via `NO_PROXY`, and production had no matching Laminar destination in the replacement policy, so model spans stopped at the rollout boundary while api-rs spans continued.

## Validation

- `cargo test -p centaur-sandbox-agent-k8s` (43 passed)
- `cargo fmt --all -- --check`
- `git diff --check`
- `just build-one api-rs`
- deployed the built image to the local OrbStack Kubernetes stack
- real Codex session completed with `OTLP_OK` and emitted token usage
- generated sandbox NetworkPolicy contained the configured collector namespace and port rule
