### PR TITLE
chore: agents.md cleanup

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -48,7 +48,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        service: [api-rs, slackbotv2, linearbot, discordbot, teamsbot, agent, iron-proxy, console]
+        service: [api-rs, slackbotv2, linearbot, discordbot, githubbot, teamsbot, agent, iron-proxy, console]
         platform: ${{ github.event_name == 'push' && fromJSON('["linux/amd64", "linux/arm64"]') || fromJSON('["linux/amd64"]') }}
         include:
           - service: api-rs
@@ -70,6 +70,11 @@ jobs:
             image: centaur-discordbot
             context: .
             dockerfile: services/discordbot/Dockerfile
+            target: ""
+          - service: githubbot
+            image: centaur-githubbot
+            context: .
+            dockerfile: services/githubbot/Dockerfile
             target: ""
           - service: teamsbot
             image: centaur-teamsbot
@@ -172,6 +177,7 @@ jobs:
           - image: centaur-iron-proxy
           - image: centaur-console
           - image: centaur-discordbot
+          - image: centaur-githubbot
           - image: centaur-teamsbot
 
     steps:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,826 +1,172 @@
-# Centaur — Developer Guide
+# Centaur Agent Guide
 
-## Quick Start
+## Scope and instruction hierarchy
 
-### 1. Clone and configure
+This file applies to the whole repository. Read the nearest `AGENTS.md` before
+changing files below it; service-local instructions extend this file and take
+precedence for that service.
+
+Keep new and rewritten service guidance deployment-neutral. Do not add new
+company names, private domains, cluster names, chat workspace identifiers,
+private repository names, absolute user paths, or private overlay procedures.
+Use neutral placeholders for new examples. Do not remove or rewrite existing
+product-specific defaults solely to make them neutral unless the user asks.
+
+## How to work here
+
+- Inspect `git status` before editing. Preserve unrelated work and never format,
+  stage, or revert files outside the task.
+- For a focused PR when the current checkout has unrelated changes, use an
+  isolated worktree based on the intended branch. Check the base branch and any
+  dependent PRs before implementing instead of rebuilding work that already
+  exists elsewhere.
+- Establish the requested boundary before acting: explanation, review,
+  diagnosis, implementation, local validation, and remote operation are
+  different scopes. Do not turn a read-only request into a change.
+- Read the current implementation, manifests, and tests before relying on prose
+  documentation. Prefer an existing name, setting, abstraction, or protocol to
+  a parallel one.
+- Keep clients thin and changes focused. If a contract changes, update every
+  producer, consumer, test fixture, and chart value affected by it.
+- Never expose credentials in output, logs, fixtures, commits, or command-line
+  arguments. Use placeholders and configured secret paths.
+- Do not mutate a remote environment unless the user explicitly asks. Local
+  testing does not authorize committing, pushing, deploying, or restarting.
+- Before any Kubernetes operation, verify the current context and namespace.
+  Pass an explicit `--context` for non-local or destructive work; never rely on
+  an ambient context when a mistake could affect another environment.
+- When the user explicitly requests an artifact such as a PR, CI repair, or
+  deployment, carry the authorized workflow through to that artifact and its
+  relevant verification instead of stopping after the code edit.
+- Concretely, a PR request means validate, commit, push the branch, open or
+  update the PR, and return its link. If the user also asks for CI, rollout, or
+  dependent-PR follow-through, monitor and repair that requested boundary too.
+- Use conventional commit prefixes when a commit is requested: `feat:`, `fix:`,
+  `docs:`, `refactor:`, `test:`, or `chore:`.
+
+## Architecture boundaries
+
+The durable request path is:
+
+1. A chat ingress verifies and normalizes a platform event.
+2. The ingress creates or reuses a session, appends the durable user message,
+   starts an execution, and consumes replayable events.
+3. `api-rs` owns session assignment, execution serialization, recovery,
+   workflow state, and persistence in Postgres.
+4. The sandbox runtime translates neutral content into the selected harness and
+   exposes tool CLIs. Harness and tool traffic reaches upstreams through
+   `iron-proxy` without materializing real credentials in the sandbox.
+5. The ingress renders durable output back to the originating platform.
+
+Ownership by tree:
+
+- `services/api-rs/`: Rust control plane, durable sessions, sandbox backends,
+  workflows, auth integration, and telemetry.
+- `services/slackbotv2/`, `discordbot/`, `githubbot/`, `linearbot/`,
+  `teamsbot/`: platform transport, policy gates, session forwarding, and
+  platform rendering.
+- `services/sandbox/`: agent image, startup composition, tool installation,
+  repo-cache helpers, and runtime prompt. Harness protocol normalization lives
+  in `crates/harness-server/`, which is built into the image.
+- `services/iron-proxy/`: credential-injecting proxy image and startup config.
+- `services/workflow-python/`: Python workflow compatibility host; durability
+  remains in `api-rs`.
+- `services/console/`: operator UI and credential-control API.
+- `tools/`: independently packaged agent-facing CLI plugins.
+- `workflows/`: discoverable workflow definitions.
+- `contrib/chart/`: Helm wiring, policies, probes, and service configuration.
+- `packages/`: shared TypeScript event and rendering contracts used by ingress
+  services.
+
+Do not reintroduce legacy control paths alongside the durable session API.
+Modern investigations should start with `sessions`, `session_messages`,
+`session_executions`, `session_events`, and workflow state, then follow the
+final platform-delivery boundary.
+
+## Local development and validation
+
+Centaur is validated on the local Kubernetes stack. Start with the narrowest
+relevant unit or integration test, then prove cross-service behavior when a
+boundary changed. Run `kubectl config current-context` before the local stack
+commands below; `just deploy` uses the ambient Helm/Kubernetes context.
 
 ```bash
-git clone <repo-url>
-cd centaur
-brew install just
+just up                         # build and start the local stack
+just deploy                     # update the local Helm release
+just status
+just logs <component>
 ```
 
-Centaur runs locally on Kubernetes through the Helm chart. Infra secrets are required as pre-created Kubernetes Secrets. For local development, `just bootstrap-secrets` creates them from your shell environment:
+For a runtime change requested for publication, local proof means:
+
+1. run the service's format, type, lint, and unit checks;
+2. build the affected runtime artifact with the repository's build recipes;
+3. deploy it to the local stack;
+4. make a real request through the changed path and inspect the durable result;
+5. only then commit or push, and only if requested.
+
+For a missing, duplicate, or stalled chat response, trace the full chain:
+platform receipt -> session creation -> durable message -> execution -> event
+stream -> render obligation -> final platform message. A healthy pod or one log
+line is not proof of successful delivery. If investigation and remediation are
+both requested, preserve a bounded evidence snapshot before destructive action
+when it is safe to do so.
+
+Useful repository-wide checks include:
 
 ```bash
-export OP_SERVICE_ACCOUNT_TOKEN=...
-export OP_VAULT=...
-export SLACK_BOT_TOKEN=...
-export SLACK_SIGNING_SECRET=...
-export SLACKBOT_API_KEY=...
+pnpm install --frozen-lockfile
+helm lint contrib/chart
+git diff --check
 ```
 
-Application-level LLM/tool secrets such as OpenAI and Anthropic tokens stay in 1Password and are loaded by the secrets service.
-
-### 2. Boot the stack
-
-```bash
-just up
-```
-
-### Database migrations
-
-api-rs embeds SQLx migrations from
-`services/api-rs/crates/centaur-session-sqlx/migrations`. To add schema, create
-the next numbered SQL file in that directory and keep it compatible with the
-embedded migrator. The api-rs binary applies those migrations on startup when
-the chart enables migration running, and the Rust tests use the same migration
-set for database-backed coverage.
-
-### 3. Test
-
-From inside the API deployment (localhost bypass — no key needed):
-
-```bash
-THREAD_KEY=cli:test-e2e-1
-THREAD_PATH=$(jq -rn --arg v "$THREAD_KEY" '$v|@uri')
-
-SESSION=$(kubectl exec -n centaur deploy/centaur-centaur-api-rs -- curl -s -X POST "http://localhost:8080/api/session/${THREAD_PATH}" \
-  -H "Content-Type: application/json" \
-  -d '{"harness_type":"codex","on_harness_conflict":"restart"}')
-
-kubectl exec -n centaur deploy/centaur-centaur-api-rs -- curl -s -X POST "http://localhost:8080/api/session/${THREAD_PATH}/messages" \
-  -H "Content-Type: application/json" \
-  -d '{"messages":[{"role":"user","parts":[{"type":"text","text":"Reply with exactly PONG and nothing else."}]}]}'
-
-EXECUTE=$(kubectl exec -n centaur deploy/centaur-centaur-api-rs -- curl -s -X POST "http://localhost:8080/api/session/${THREAD_PATH}/execute" \
-  -H "Content-Type: application/json" \
-  -d '{"input_lines":["{\"type\":\"user\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"Reply with exactly PONG and nothing else.\"}]}}"]}')
-EXECUTION_ID=$(printf '%s' "$EXECUTE" | jq -r '.execution_id')
-
-kubectl exec -n centaur deploy/centaur-centaur-api-rs -- curl -s -N \
-  "http://localhost:8080/api/session/${THREAD_PATH}/events?execution_id=${EXECUTION_ID}&after_event_id=0"
-```
-
-Or use the deployment's configured service bearer token path for external
-clients (see [API Key Management](#api-key-management)).
-
-## Architecture
-
-See the [architecture diagram in the README](README.md#architecture).
-
-### End-to-End Request Flow
-
-1. User mentions bot in Slack → webhook → slackbotv2 → api-rs
-2. api-rs spawns/reuses a Kubernetes sandbox pod (`centaur-agent:latest`) for that thread
-3. Executes harness (amp/claude-code/codex) through the sandbox backend
-4. Harness calls local tool CLI shims installed by `centaur-tools` (NOT MCP)
-5. LLM/API calls route through per-sandbox iron-proxy which injects real credentials
-6. Results stream as JSON events → posted to Slack
-
-### Service Interface Contracts
-
-Centaur is a modular service architecture. Each service communicates through well-defined interfaces. As long as you implement these interfaces, you can swap or extend any layer independently.
-
-**Client → API** (durable control-plane protocol):
-
-Clients (slackbotv2, CLI, external integrations) should stay thin. They create
-or reuse a session, append durable messages, execute the session, and stream or
-replay output from the durable event endpoint. api-rs owns runtime assignment,
-execution serialization, cancellation/recovery, and final delivery; Postgres is
-the source of truth.
-
-Thread keys are path parameters on the api-rs session routes, so callers must
-URL-encode values such as `slack:T123:C456:1773364194.179929`.
-
-**Step 1: Assign or reuse a session** (`POST /api/session/{thread_key}`)
-
-Creates a session for the thread, or returns the current one.
-
-```
-POST /api/session/slack%3AT123%3AC456%3A1773364194.179929
-{
-  "harness_type": "codex",
-  "persona_id": "incident-responder",
-  "metadata": {"platform": "slack"},
-  "on_harness_conflict": "reject"
-}
-
-← {
-    "thread_key": "slack:T123:C456:1773364194.179929",
-    "sandbox_id": "sbx_123",
-    "harness_type": "codex",
-    "status": "active",
-    "harness_switched": false
-  }
-```
-
-**Step 2: Persist the user turn** (`POST /api/session/{thread_key}/messages`)
-
-Writes one or more durable transcript messages. Parts use the same
-Anthropic-style content block shape the sandbox adapter understands.
-
-```
-POST /api/session/slack%3AT123%3AC456%3A1773364194.179929/messages
-{
-  "messages": [
-    {
-      "client_message_id": "slack-evt-123",
-      "role": "user",
-      "parts": [{"type": "text", "text": "analyze this"}],
-      "metadata": {"user_name": "alice", "platform": "slack"}
-    }
-  ]
-}
-
-← {"ok": true, "message_ids": ["msg_123"]}
-```
-
-**Step 3: Execute the session** (`POST /api/session/{thread_key}/execute`)
-
-Creates a durable execution row and drives the attached sandbox. `input_lines`
-are NDJSON strings sent to the harness adapter for this execution.
-
-```
-POST /api/session/slack%3AT123%3AC456%3A1773364194.179929/execute
-{
-  "idempotency_key": "slack-delivery-123",
-  "metadata": {"platform": "slack"},
-  "input_lines": [
-    "{\"type\":\"user\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"analyze this\"}]}}"
-  ]
-}
-
-← {
-    "ok": true,
-    "execution_id": "exe_123",
-    "thread_key": "slack:T123:C456:1773364194.179929",
-    "status": "queued"
-  }
-```
-
-**Step 4: Stream or replay output** (`GET /api/session/{thread_key}/events`)
-
-Consumers tail durable events for one execution. On disconnect, reconnect with
-the last seen event id.
-
-```
-GET /api/session/slack%3AT123%3AC456%3A1773364194.179929/events?execution_id=exe_123&after_event_id=0
-
-← SSE event: session.output.line
-← data: {"type":"assistant","message":{...}}
-← SSE event: session.execution_completed
-← data: {"status":"completed","result_text":"..."}
-```
-
-**Inspect the active session context** (`GET /api/session/{thread_key}`)
-
-Returns the normalized session context for a thread, including Slack channel
-and thread timestamp information when the thread key is Slack-shaped.
-
-**Durable state written for one turn:**
-
-| Table | What |
-|-------|------|
-| `sessions` | Thread-to-sandbox assignment, harness, persona, and status |
-| `session_messages` | Durable transcript messages |
-| `session_executions` | Queued/running/terminal execution rows |
-| `session_events` | Replayable execution, output, and status events |
-| `session_warm_sandboxes` | SQL-backed warm-pool inventory and claims |
-
-**API → Sandbox** (stdin/stdout, NDJSON):
-
-api-rs communicates with sandbox Pods through the active sandbox backend's
-attach stream. Execution `input_lines` are opaque newline-delimited strings at
-the session API layer; api-rs validates that each item is one line, adds
-session/trace context to JSON objects, writes them to sandbox stdin, and stores
-each stdout line as a durable `session.output.line` event. Current chat clients
-send Codex-compatible user lines shaped like:
-
-```
-→ stdin:  {"type":"user",
-           "thread_key":"slack:T123:C456:1773364194.179929",
-           "message":{
-             "role":"user",
-             "content":[
-               {"type":"text","text":"what is this?"},
-               {"type":"image","source":{"type":"base64","media_type":"image/png","data":"..."}}
-             ]
-           ]}
-
-← stdout: {"type":"system","subtype":"init","session_id":"T-..."}
-← stdout: {"type":"assistant","message":{"role":"assistant","content":[...]}}
-← stdout: {"type":"result","subtype":"success","result":"..."}
-← stdout: {"type":"turn.completed","turn_id":"turn-1","result":"..."}
-```
-
-**Harness adapter behavior**:
-
-The sandbox/runtime layer translates the user input content into whatever each
-harness CLI actually accepts:
-
-| Harness | Translation |
-|---------|-------------|
-| **claude-code** | Pass through directly (native Anthropic format) |
-| **amp** | Materialize image/document blocks to files on disk, replace with `@/path` text mentions (Amp stdin only accepts text blocks) |
-| **codex / pi-mono** | Extract text from content blocks, pass as CLI argument |
-
-This means clients and api-rs avoid most harness-specific quirks. Clients send
-durable messages plus the execution input lines they want delivered; the
-sandbox/runtime adapter handles the target harness.
-
-**Sandbox tools and API callbacks**:
-
-Agent sandboxes do not use legacy HTTP tool-method routes as a registry.
-Startup runs `services/sandbox/install_tool_shims.py`, which scans `TOOL_DIRS` for
-`pyproject.toml [project.scripts]`, installs each script with `uvx`, and emits
-the local `centaur-tools` catalog. Agents call tool CLIs directly; Python
-workflow hosts can use the generated `centaur-tools call` bridge for
-`ctx.call_tool(...)` compatibility.
-
-### Network Isolation
-
-The Helm chart installs deny-by-default NetworkPolicies, then explicitly allows
-the service paths the stack needs: chat ingress services to api-rs, api-rs to
-Postgres/iron-control/Kubernetes, sandbox Pods to api-rs/iron-proxy, DNS, and
-configured egress.
-
-## Directory Structure
-
-```
-centaur/
-├── services/
-│   ├── api-rs/           # Rust control plane, sessions, workflows, auth, metrics
-│   │   ├── crates/centaur-api-server/
-│   │   ├── crates/centaur-session-runtime/
-│   │   ├── crates/centaur-session-sqlx/
-│   │   ├── crates/centaur-workflows/
-│   │   └── crates/centaur-perms/
-│   ├── workflow-python/  # Python workflow host compatibility runtime
-│   ├── iron-proxy/       # Credential injection proxy
-│   ├── sandbox/          # Agent container image (Ubuntu 24.04 + uv + gh + node + bun + amp)
-│   ├── slackbotv2/       # Slack event handling and Slack delivery
-│   ├── teamsbot/         # Teams ingress
-│   ├── discordbot/       # Discord ingress
-│   ├── linearbot/        # Linear ingress
-│   └── console/          # Admin/operator console
-├── centaur_sdk/          # Standalone SDK (pip install centaur-sdk)
-├── tools/                # Open-source tool plugins (auto-discovered)
-│   ├── alchemy/          # One directory per tool — each has client.py + pyproject.toml
-│   ├── websearch/
-│   ├── telegram/
-│   └── …                 # 60+ tool plugins (crypto, research, productivity, infra, …)
-├── workflows/            # External workflow definitions (auto-discovered)
-│   ├── agent_loop.py     # Recurring agent polling/monitoring loop
-│   └── multi_step_demo.py       # Demo: branching, loops, conditionals
-├── scripts/              # Operational scripts
-└── Justfile              # Local Helm/Kubernetes workflow
-```
-
-## Terminology
-
-- **Chat SDK** always refers to the [Vercel Chat SDK](https://github.com/vercel/chat) (`~/github/vercel/chat`). When you need to understand how the Chat SDK or `@chat-adapter/*` packages work, **always read the source at `~/github/vercel/chat`** — never dig through `node_modules`.
-
-## Testing Before Pushing
-
-**NEVER push changes without testing them locally first.** Testing means actually running the affected service and proving the change works end-to-end — not just linting or reasoning about it.
-
-1. **Build the affected service:** `just build-one <service>`
-2. **Bring it up:** `just deploy`
-3. **Make a real request** that exercises the change and show the output
-4. **Only then** commit and push
-
-For tool changes: verify from a real sandbox with `centaur-tools list`,
-`<tool> --help`, and a command that exercises the changed behavior. If the
-change is only for workflow `ctx.call_tool(...)`, run a small workflow-host
-workflow that calls it. For Dockerfile/infra changes: rebuild, redeploy, and
-verify the binary/service is present and functional. For proxy changes: test
-from inside a sandbox pod through iron-proxy.
-
-## Local-First Testing — Never Touch the Deploy Box
-
-**All testing and E2E validation MUST happen on the local Kubernetes stack** (`just up` on this machine).
-The deploy box is **production**. Changes reach it via `git push` → GitHub Actions auto-deploy. The only reasons to SSH into it are:
-- Checking logs (`kubectl logs`, VictoriaLogs queries) for debugging production issues
-- Emergency manual intervention — **only when the user explicitly asks**
-
-For E2E testing, always:
-1. `just build-one <service>` locally
-2. `just deploy` locally
-3. Run curl commands against `localhost` through `kubectl exec -n centaur deploy/centaur-centaur-api-rs -- curl ...`
-4. Verify results locally
-5. Only then commit, push, and let CI/CD handle production
-
-## Code Conventions
-
-- Python 3.11+, `uv` for deps, `ruff` for lint/format (line-length=100)
-- `services/slackbotv2` uses `pnpm` only (single lockfile: `pnpm-lock.yaml`)
-- All imports at top of file, never inside functions
-- Absolute imports only: `from api.X`, `from centaur_sdk.X`
-- All secrets via env vars or secret manager, never hardcode
-- `asyncpg` for Postgres, `pgvector` for embeddings
-- Conventional commits: `feat:`, `fix:`, `docs:`, `refactor:`, `test:`, `chore:`
-
-## Lint & Test
-
-Each service has its own `pyproject.toml` and `ruff.toml`. From the repo root:
-
-```bash
-uv run ruff check .          # lint
-uv run ruff format .         # auto-fix
-uv run pytest                # tests
-```
-
-## Plugin System — Tools & Workflows
-
-Centaur has two plugin types that are auto-discovered at startup and hot-reloaded on file changes — no core code changes required to extend the system.
-
-### Tool Plugins
-
-Tools live in directories listed by `TOOL_DIRS` and ordered overlay sources.
-Each tool is a directory with `client.py` (class + `_client()` factory),
-`pyproject.toml`, and a CLI entry point exposed through `[project.scripts]`.
-api-rs discovers tool metadata for secret grants; sandboxes install the
-scripts as local CLI shims and list them with `centaur-tools list`.
-
-- `client.py`: NO `load_dotenv()`. Secrets via `secret()` from `centaur_sdk.tool_sdk`.
-- `cli.py`: YES `load_dotenv()` at top. Thin typer wrapper for standalone use.
-- Methods starting with `_` are excluded from registration.
-- Tool dependencies declared in `pyproject.toml` are installed by the shim
-  runner when the script is installed.
-- `[project.scripts]` is required for an agent-visible runtime tool.
-
-Example:
-
-```python
-# tools/my-tool/client.py
-import httpx
-
-class MyToolClient:
-    def search(self, query: str, limit: int = 10) -> dict:
-        """Search for something."""
-        resp = httpx.get(f"https://api.example.com/search?q={query}&limit={limit}")
-        return resp.json()
-
-def _client():
-    return MyToolClient()
-```
-
-### Workflow Plugins
-
-Workflows live in directories listed in the `WORKFLOW_DIRS` env var
-(colon-separated paths). api-rs discovers workflow metadata through the Python
-workflow host, and workflow-host sandboxes receive the same ordered list
-translated to sandbox mount paths. Each workflow is a Python file exporting
-`WORKFLOW_NAME`, an async `handler(params, ctx)`, and an optional `Input`
-dataclass. See [Durable Workflows](#durable-workflows) for the full programming
-model.
-
-Built-in workflows ship in the top-level `workflows/` tree. External workflows
-are loaded identically — add their directories to `WORKFLOW_DIRS` through the
-ordered overlay configuration.
-
-### Ordered Overlays
-
-Centaur supports a first-class ordered overlay model, so organizations can extend the base repo without forking or relying on filesystem overlayfs. A common deployment keeps the base repo and an external overlay checkout side by side:
-
-```
-your-deployment/
-├── centaur/              # This repo
-└── centaur-overlay/      # Org-specific tools, workflows, skills, personas, prompt overlay
-```
-
-The Helm chart supports ordered overlays by mounting an overlay image or prompt content at `/app/overlay/org`, including its `tools/`, `workflows/`, `.agents/skills/`, persona prompts, and `services/sandbox/SYSTEM_PROMPT.md` after the base repo content.
-
-Later overlay entries win cleanly when names collide, so the base repo stays generic while deployments can layer in org-specific behavior from outside the checkout.
-
-## Durable Workflows
-
-api-rs owns durable workflow state through Absurd queues, while
-`services/workflow-python` runs Python workflow handlers in a workflow-host
-sandbox. The Python compatibility layer exposes `WorkflowContext`, so the
-handler function is still the workflow: steps are runtime-discovered via
-`ctx.step(name, fn)`, checkpointed to Postgres, and skipped on replay after a
-restart. Dynamic branching, loops, and conditional logic work naturally because
-the handler remains Python.
-
-### WorkflowContext API
-
-Every handler receives `(params, ctx)` where `ctx: WorkflowContext` provides:
-
-| Primitive | Purpose |
-|-----------|---------|
-| `ctx.step(name, fn)` | Execute *fn* exactly once; return cached result on replay. Supports `retry` (RetryPolicy) and `timeout`. |
-| `ctx.sleep(name, duration)` | Suspend the run for *duration*; checkpoint + resume automatically. |
-| `ctx.sleep_until(name, when)` | Suspend until a specific datetime. |
-| `ctx.wait_for_event(name, event_type, correlation_id)` | Suspend until an external event arrives via `POST /api/workflows/events`. |
-| `ctx.start_workflow(name, workflow_name, run_input)` | Create a child workflow run (returns immediately). |
-| `ctx.wait_for_workflow(name, run_id)` | Suspend until a child workflow reaches terminal state. |
-| `ctx.run_workflow(name, workflow_name, run_input)` | Start + wait in one call. |
-| `ctx.start_agent(name, text=…)` | Shorthand: start a child `agent_turn` workflow. |
-| `ctx.run_agent(name, text=…)` | Shorthand: start + wait for a child `agent_turn` workflow. |
-| `ctx.log(msg, **kwargs)` | Structured log, suppressed during replay. |
-
-### Writing a workflow
-
-```python
-# workflows/my_workflow.py
-from dataclasses import dataclass
-from typing import Any
-from api.workflow_engine import WorkflowContext
-
-WORKFLOW_NAME = "my_workflow"
-
-@dataclass
-class Input:
-    message: str = "hello"
-
-async def handler(inp: Input, ctx: WorkflowContext) -> dict[str, Any]:
-    greeting = await ctx.step("gather", lambda: {"msg": inp.message})
-    await ctx.sleep("pause", timedelta(minutes=5))
-    result = await ctx.run_agent("agent", text=f"Summarize: {greeting['msg']}")
-    return {"greeting": greeting, "agent_result": result}
-```
-
-### Workflow lifecycle
-
-Runs go through: `queued → running → sleeping/waiting → running → … → completed/failed/cancelled`.
-
-- **Worker pool**: `WORKFLOW_WORKER_CONCURRENCY` workers (default 2) poll for claimable runs.
-- **Lease-based fencing**: Each worker holds a lease on its run, extended by a heartbeat. If the worker dies, the lease expires and another worker reclaims the run.
-- **Schedules**: Cron-based or interval-based schedules are discovered from workflow metadata by `api-rs`. The scheduler stores tick tasks in the Absurd `centaur_workflow_schedules` queue.
-- **External events**: `POST /api/workflows/events` delivers events that wake waiting runs.
-- **Child workflows**: Parent→child relationships are tracked; cancelling a parent cancels linked executions.
-
-### Workflow REST API
-
-| Endpoint | Purpose |
-|----------|---------|
-| `POST /api/workflows/runs` | Create a workflow run (`workflow_name`, `input`, optional idempotency fields, `eager_start`) |
-| `GET /api/workflows/runs` | List recent runs. |
-| `GET /api/workflows/runs/{run_id}` | Get run details. |
-| `POST /api/workflows/runs/{run_id}/cancel` | Cancel a run. |
-| `POST /api/workflows/events` | Deliver an external event (`event_name`, `payload`). |
-| `GET /api/workflows/schedules` | Inspect registered workflow schedules. |
-
-### Built-in workflows
-
-| Workflow | Description |
-|----------|-------------|
-| `echo` | Minimal smoke workflow. |
-| `slack_sync`, `slack_backfill` | Slack ETL sync and backfill jobs. |
-| `company_context_documents` | Projection from synced sources into retrieval documents. |
-| `google_drive_sync`, `google_calendar_sync`, `linear_sync` | Optional connector sync workflows. |
-| `github_issue_triage` | Example webhook-triggered triage flow. |
-
-### Durable state
-
-| Table | What |
-|-------|------|
-| `absurd.queues` | Registered workflow queues, including standard, ETL, backfill, Slack-live, and schedule queues |
-| `absurd.t_centaur_workflows*` | Workflow task metadata, state, input params, idempotency keys, and completed payloads |
-| `absurd.r_centaur_workflows*` | Per-attempt run state, leases, timing, result payloads, and failures |
-| `absurd.c_centaur_workflows*` | Per-step checkpoint state |
-| `absurd.e_centaur_workflows*` | Emitted workflow events for event-driven resumes |
-| `absurd.w_centaur_workflows*` | Wait registrations for sleeps and external events |
-| `absurd.t_centaur_workflow_schedules` | Scheduler tick tasks for registered cron and interval schedules |
-
-## Agent Sandbox
-
-### Overview
-
-1 conversation = 1 Kubernetes sandbox Pod. api-rs spawns Pods running harness
-CLIs (amp, claude-code, codex), streams messages over the sandbox attach
-channel, and records output in durable session events.
-
-### How the System Prompt Works
-
-The sandbox image bakes `services/sandbox/SYSTEM_PROMPT.md` into `~/AGENTS.md` at build time. On container startup, `entrypoint.sh` copies it into the workspace root as `workspace/AGENTS.md` — this is the file that AI harnesses (Amp, Claude Code, Codex) read as their system instructions.
-
-The system prompt tells the agent:
-- **Identity**: it's running inside a Kubernetes sandbox pod managed by api-rs
-- **Tools**: three kinds — harness built-ins (Read, Bash, etc.), tool plugins exposed as shell CLI shims, and a headless browser
-- **Tool CLIs**: each tool is installed as a shell command at container startup by `services/sandbox/install_tool_shims.py`, which scans `TOOL_DIRS` for `pyproject.toml [project.scripts]` and `uvx`-installs each. Agents invoke tool CLIs directly (`slack get_channel_history '{"channel":"general"}'`, `<tool> --help` to discover).
-- **Slack messaging**: the agent's stdout IS the Slack reply — never call `send_message` on the active thread
-- **Rules**: never display secrets, show your work, lead with the answer
-
-`centaur-tools` is the generated catalog CLI emitted by the same installer:
-- `centaur-tools list` → list available tool CLIs
-- `centaur-tools run <tool> [args]` → run a tool CLI
-- `centaur-tools call <tool> <method> [json]` → internal compatibility for the Python workflow host's `ctx.call_tool(...)`
-- `<tool> --help` → discover one tool's direct CLI
-
-### Persona System
-
-The entrypoint supports persona overlays via `AGENT_PERSONA`. Persona prompts are discovered from the loaded tool directories (including overlays such as `~/centaur-overlay`) and appended after the base + org overlay system prompts at container startup.
-
-### Sandbox Pod Config
-
-- Runs under Kubernetes NetworkPolicies with API reachable through the in-cluster service URL
-- Entrypoint injects the runtime URLs and tool catalog environment needed by the sandbox
-- Stub API keys so harnesses init in API-key mode (not browser login)
-- `HTTPS_PROXY` routes LLM and tool egress through iron-proxy
-- Resource limits: 4GB memory, 2 CPUs
-- Image tagged `centaur-agent:latest`
-- Labels identify Centaur-managed sandboxes and carry thread/harness metadata for discovery/recovery
-
-### Credential Injection (iron-proxy)
-
-Sandbox Pods never see real API keys. Per-sandbox `iron-proxy` pods inject
-credentials from the configured secret source and iron-control grants:
-
-| Target host | Header | Format |
-|-------------|--------|--------|
-| `api.anthropic.com` | `x-api-key` | raw |
-| `api.openai.com` | `authorization` | bearer |
-| `openrouter.ai` | `authorization` | bearer |
-| `ampcode.com` | `authorization` | bearer |
-| `api.github.com` | `authorization` | token |
-| `github.com` | `authorization` | basic auth |
-| `bedrock-mantle.<region>.api.aws` | `authorization` + `x-amz-*` | AWS SigV4 re-sign (opt-in, codex `amazon-bedrock`) |
-
-### Session Persistence
-
-- **`sessions`** table: tracks thread key, sandbox ID, harness, persona, and state
-- **`session_messages`** table: stores persisted user/assistant messages
-- **`session_executions`** and **`session_events`** tables: store durable run state and replayable output
-- On api-rs restart, sandbox ownership is re-read from Postgres; process-local attach pipes are rebuilt lazily per sandbox
-- Pods are still discoverable via Kubernetes labels even if DB state needs reconciliation
-
-## Security Model
-
-- **API auth**: Chat ingress services use deployment-scoped bearer tokens such as `SLACKBOT_API_KEY`, `TEAMSBOT_API_KEY`, `DISCORDBOT_API_KEY`, or `LINEARBOT_API_KEY` when configured. Local in-cluster service calls use the internal api-rs service URL.
-- **Sandbox auth**: Sandbox Pods use the runtime's tool and workflow surfaces; agents should not depend on a user-visible Centaur API key.
-- **Slack**: HMAC-SHA256 signature verification on all webhooks
-- **Public edge**: The Helm chart exposes public routes only when configured through Ingress, HTTPRoute, or service settings.
-- **Sandbox isolation**: Pods get stub keys only; real keys are injected by iron-proxy in-flight
-- **Filesystem**: Host repos mounted read-only by default; only working repo is read-write
-- **Kubernetes API**: The API service account is scoped to the Pod, Secret, exec, attach, and log operations needed to manage sandboxes.
-
-## API Key Management
-
-Chat ingress services send bearer tokens from the local infra Secret when the
-deployment configures them. The current api-rs control plane does not use the
-legacy DB-backed API-key table or legacy key prefix for the session routes.
-
-### Key types
-
-| Type | Prefix | Issued by | Used by | Scopes |
-|------|--------|-----------|---------|--------|
-| Service bearer | deployment-specific | Kubernetes Secret / bootstrap | Slackbotv2, Teamsbot, Discordbot, Linearbot | Service-to-api-rs calls |
-
-### How services get their keys
-
-- **Slackbotv2**: `SLACK_BOT_TOKEN`, `SLACK_SIGNING_SECRET`, and `SLACKBOT_API_KEY` are injected from the local infra Secret.
-- **Sandbox containers**: Use runtime-provided tool CLIs and workflow context rather than a direct Centaur API key
-- **Local testing**: Exec into the api-rs deployment and use `localhost:8080`, or use a bot/service token path configured for that deployment
-
-## Secrets
-
-Tool credentials (e.g., `ANTHROPIC_API_KEY`, `AMP_API_KEY`) are never materialized inside sandboxes or the API service. Tools declare which keys they need in their `pyproject.toml` and call `secret("KEY")` to receive a placeholder. Outbound HTTPS traffic is routed through iron-proxy, which substitutes the real credential based on the host/key injection map and iron-control grants. iron-proxy resolves `op://...` references directly against 1Password when that source is configured.
-
-For local development, infra secrets are stored in Kubernetes Secrets created by `just bootstrap-secrets`; application secrets continue to come from 1Password.
-
-### iron-control
-
-[iron-control](https://github.com/ironsh/iron-control) is an optional Rails control plane for permissioning and encrypted secret storage. It is off by default; enable it with `--set ironControl.enabled=true` (or set `ironControl.enabled: true` in a values file). When enabled, it runs against a dedicated `iron_control_production` database on the bundled Postgres (a separate logical DB so its Rails `schema_migrations` table never collides with api-rs SQLx migrations), created by an idempotent init container.
-
-`just bootstrap-secrets` seeds the required keys into `centaur-infra-env`: the three ActiveRecord encryption keys, `SECRET_KEY_BASE`, and the initial admin password/API key are auto-generated (only when absent, never rotated in place). `IRON_CONTROL_DATABASE_URL` defaults to the bundled Postgres server with no database path (so Rails resolves each connection's database name from the image's `database.yml`); export it before running `just bootstrap-secrets` to point at an external server. Override the admin email with `IRON_CONTROL_INITIAL_USER_EMAIL` (default `admin@centaur.local`).
-
-### centaur-perms
-
-`centaur-perms` is the operator CLI for iron-control permissions: it controls which chat principals (Slack users/channels, Discord channels, and Teams users/conversations) and which roles hold which tool roles and secrets. It lives at `services/api-rs/crates/centaur-perms` and reuses iron-control's canonical mappings (`derive_principal`, `RoleSpec::tool`), so every principal and role `foreign_id` it writes matches exactly what `api-rs` registers at session start. It is the supported way to inspect and edit grants by hand; the API writes the same resources at runtime.
-
-#### Concepts
-
-- **Principal** — the chat identity an agent session runs as. `foreign_id`s are derived canonically: `slack-channel-<team>-<conv>` for a Slack channel, `slack-user-<team>-<user>` for a Slack DM, `discord-channel-<guild>-<channel>` for Discord, `teams-conversation-<tenant-slug>-<conversation-slug>` for Teams conversations, and `teams-user-<tenant-slug>-<user-slug>` for Teams user-scoped runs. Each session binds to one derived principal; grant the channel/conversation principal for shared contexts and the user principal for DM or user-scoped contexts.
-- **Role** — a named bundle of secret grants assignable to principals. Canonical roles: `infra` (shared infra secrets), `tools` (shared harness/tool secrets), and one `tool-<slug>` per tool (e.g. `tool-github`).
-- **Secret** — a typed iron-control resource (static `ssr_`, OAuth token `ots_`, GCP auth `gas_`, Postgres DSN `pgs_`, HMAC signing `hms_`). iron-control never returns credential values, only the source each resolves from. Each `tool-<slug>` secret keeps a canonical `tool-<slug>-…` id so the same object is shared no matter which role grants it.
-- **Grant** — binds a secret to a grantee (a principal or a role). `centaur-perms` resources carry the label `managed-by=centaur`.
-
-A principal's *effective* access is the union of its directly granted secrets and the secrets carried by every role assigned to it.
-
-#### Setup
-
-The CLI talks to the iron-control admin API. Provide the connection via flags or env vars (iron-control must be enabled — see above):
-
-```bash
-export IRON_CONTROL_URL=http://localhost:3000        # admin API base URL
-export IRON_CONTROL_API_KEY=iak_…                    # admin API key
-export IRON_CONTROL_NAMESPACE=default                # optional, defaults to "default"
-```
-
-For `--tool` lookups, point the CLI at the same tool directories the API uses, via repeatable `--tools-dir` flags or the colon-separated `TOOL_DIRS` env var (explicit dirs first, then env; later dirs shadow earlier ones, matching the overlay order). Build and run from `services/api-rs`:
-
-```bash
-cd services/api-rs
-cargo run -p centaur-perms -- <args>     # or: cargo build -p centaur-perms; ./target/debug/centaur-perms <args>
-```
-
-The `--tool` flag parses a tool's `pyproject.toml` `[tool.centaur]` secrets and registers them in iron-control before granting. How each secret's `secret_ref` resolves to a source is set by `--source-policy` (`env` default, `onepassword`, or `onepassword-connect`); the 1Password policies also require `--op-vault` (and accept `--op-ttl`, default `10m`).
-
-#### Command surface
-
-Commands are resource-first — `centaur-perms <noun> <verb>`:
-
-| Command | What it does |
-|---------|--------------|
-| `principals list [--filter S] [--label k=v] [--managed]` | List principals. `--filter` is a case-insensitive substring on `foreign_id`/name; `--managed` is shorthand for `--label managed-by=centaur`. |
-| `principals show <principal> [--slack-user U]` | Show a principal's roles (with each role's grants), direct grants, and effective replace-secret placeholders. |
-| `principals grant <principal> [--slack-user U] [--tool N] [--role F] [--secret OID]` | Grant access. `--tool` registers its `tool-<slug>` role + secrets then assigns it; `--role` assigns an existing role; `--secret` grants a secret OID directly. All repeatable; creates the principal if absent. |
-| `principals revoke <principal> [--slack-user U] [--tool N] [--role F] [--secret OID] [--grant-id OID]` | Reverse of grant. `--tool`/`--role` unassign the role; `--secret` deletes the direct grant for that secret; `--grant-id` deletes a grant by its `grant_…` id. |
-| `roles list / show <role>` | List roles, or show the secrets granted to one role. |
-| `roles grant <role> [--secret OID] [--tool N [--secret-name NAME]]` | Grant secrets to a role by OID, or register+grant a tool's declared secrets. `--secret-name` (repeatable, requires `--tool`) selects specific declared secrets instead of all. |
-| `roles revoke <role> --secret OID` | Revoke one or more secrets from a role (`--secret` required, repeatable). |
-| `secrets list [--filter S] [--label k=v] [--managed]` | List secrets across every type, one row per secret. |
-| `secrets show <secret>` | Show one secret's full config by OID or `foreign_id` (values are never shown — only the source). |
-| `broker create --foreign-id F --token-endpoint URL --client-id ID [--client-secret S] [--refresh-token SEED] [--scope SC]…` | Create or update an iron-control broker credential. Values are passed literally; iron-control owns the OAuth refresh loop. Re-supplying `--refresh-token` re-bootstraps it. |
-| `broker list / show <credential> / delete <credential>` | List broker credentials, show one (status/expiry; secret material is never returned), or delete one (by `bcr_` OID or `foreign_id`). |
-
-A `<principal>` argument is treated as a chat thread key when it contains `:` (for example `slack:T123:C456:1700000000.0001`, `discord:111:222:333`, or `teams:<base64url-conversation-id>:<base64url-service-url>`) and run through `derive_principal`. Pass `--slack-user` so a Slack DM thread keys to the user. Any value without a `:` is used verbatim as a `foreign_id` (e.g. `slack-channel-t123-c456` or `teams-conversation-19-abc123-thread-tacv2`) or an OID. Grant/revoke operations are idempotent: re-granting an assigned role or revoking a missing grant is a no-op, reported as such.
-
-A tool's `brokered_token` secret registers the *consumer* side — a static secret that injects the access token from a `token_broker` source. The broker credential itself (the managed OAuth refresh loop) is provisioned out of band with `broker create`; the tool's `brokered_token` references it by `foreign_id` (its `credential`, defaulting to the secret `name`).
-
-#### Common workflows
-
-Give a channel access to a tool (registers the tool's role + secrets from its `pyproject.toml`, then assigns the role to the channel):
-
-```bash
-centaur-perms principals grant slack-channel-t123-c456 --tool github --tools-dir tools
-```
-
-Inspect what a principal can actually do (resolve a live thread key, then list roles, direct grants, and effective secrets):
-
-```bash
-centaur-perms principals show slack:T123:C456:1700000000.0001
-```
-
-Give an individual user a tool only in their DMs:
-
-```bash
-centaur-perms principals grant slack:D9999999:1700000000.0001 --slack-user U07ABC --tool github --tools-dir tools
-```
-
-Register a tool's secrets once on the shared `tools` role, then assign that role to many principals:
-
-```bash
-centaur-perms roles grant tools --tool github --tools-dir tools
-centaur-perms principals grant slack-channel-t123-c456 --role tools
-```
-
-Register only a single named secret from a tool onto a role:
-
-```bash
-centaur-perms roles grant infra --tool slackbot --secret-name SLACK_BOT_TOKEN --tools-dir tools
-```
-
-Revoke a tool from a channel (unassigns the `tool-<slug>` role; shared secrets on other roles are untouched):
-
-```bash
-centaur-perms principals revoke slack-channel-t123-c456 --tool github
-```
-
-Provision a managed broker credential a `brokered_token` secret (or a harness fragment) references — e.g. the Codex/Claude Code access-token harnesses reference `openai-codex` / `anthropic-claude`:
-
-```bash
-centaur-perms broker create --foreign-id openai-codex \
-  --token-endpoint https://auth.openai.com/oauth/token \
-  --client-id "$OPENAI_CODEX_CLIENT_ID" --refresh-token "$OPENAI_CODEX_REFRESH_TOKEN"
-```
-
-Audit Centaur-managed secrets and inspect one:
-
-```bash
-centaur-perms secrets list --managed
-centaur-perms secrets show tool-github-github_token
-```
-
-## Observability & Audit Logs
-
-### Architecture
-
-All services write structured JSON logs to **stdout**. Kubernetes captures pod logs, and optional observability deployments can forward them to VictoriaLogs. api-rs exposes Prometheus metrics at `/metrics` when scraping is enabled.
-
-```
-Service → stdout (JSON) → Kubernetes pod logs → optional log collector → VictoriaLogs/Grafana
-```
-
-This design keeps the local Helm stack minimal while preserving structured logs for collectors.
-
-### Components
-
-| Component | Role | Config |
-|-----------|------|--------|
-| **VictoriaLogs** | Optional log storage + query engine | External/overlay deployment |
-| **VictoriaMetrics** | Optional metrics storage + query engine | Push-based when enabled |
-| **Grafana** | Optional dashboards + log explorer | External/overlay deployment |
-
-### Querying logs
-
-Via Grafana: navigate to **Explore → VictoriaLogs** and use [LogsQL](https://docs.victoriametrics.com/victorialogs/logsql/).
-
-Via CLI (from inside the Kubernetes network):
-
-```bash
-# All logs for a specific thread
-kubectl exec -n centaur deploy/centaur-centaur-api-rs -- curl -s "http://victorialogs:9428/select/logsql/query" \
-  --data-urlencode "query=thread_key:C042WDDP89Y" --data-urlencode "limit=50"
-
-# API errors in the last hour
-kubectl exec -n centaur deploy/centaur-centaur-api-rs -- curl -s "http://victorialogs:9428/select/logsql/query" \
-  --data-urlencode "query=_stream:{service=\"api-rs\"} AND level:error" --data-urlencode "limit=20"
-
-# Firewall audit trail for a time range
-kubectl exec -n centaur deploy/centaur-centaur-api-rs -- curl -s "http://victorialogs:9428/select/logsql/query" \
-  --data-urlencode "query=_stream:{service=\"iron-proxy\"} AND event:proxy_audit" \
-  --data-urlencode "start=2026-03-10T00:00:00Z" --data-urlencode "end=2026-03-11T00:00:00Z"
-```
-
-### Audit logging
-
-**iron-proxy** emits structured audit events for outbound requests from sandbox
-containers: method, host, path, status code, request/response bytes, duration,
-and source container IP. These are searchable via `event:proxy_audit` in
-VictoriaLogs.
-
-**api-rs** logs session lifecycle, workflow, sandbox, proxy, and HTTP request
-events with thread context.
-
-### Logging contract
-
-Services must write single-line JSON to stdout with these fields:
-
-| Field | Required | Description |
-|-------|----------|-------------|
-| `timestamp` | Yes | ISO 8601 timestamp |
-| `level` | Yes | `debug`, `info`, `warning`, `error` |
-| `service` | Yes | Service name (`api-rs`, `iron-proxy`, `slackbotv2`, etc.) |
-| `event` | Yes | Machine-readable event name |
-| `msg` | No | Human-readable message |
-| `thread_key` | No | Thread identifier (when applicable) |
-
-> **Never log secret values, auth headers, or raw tokens.**
-
-## E2E Testing (without Slack)
-
-### 1. Bring up the stack
-
-```bash
-just up
-```
-
-All E2E curl commands below use `kubectl exec` for localhost bypass (no API key needed).
-To test from outside the container, create a DB-backed key via the [admin API](#api-key-management).
-
-### 2. Create or reuse a session
-
-```bash
-THREAD_KEY=cli:test-e2e-1
-THREAD_PATH=$(jq -rn --arg v "$THREAD_KEY" '$v|@uri')
-
-SESSION=$(kubectl exec -n centaur deploy/centaur-centaur-api-rs -- curl -s -X POST "http://localhost:8080/api/session/${THREAD_PATH}" \
-  -H "Content-Type: application/json" \
-  -d '{"harness_type":"codex","on_harness_conflict":"restart"}')
-```
-
-### 3. Persist a message
-
-```bash
-kubectl exec -n centaur deploy/centaur-centaur-api-rs -- curl -s -X POST "http://localhost:8080/api/session/${THREAD_PATH}/messages" \
-  -H "Content-Type: application/json" \
-  -d '{"messages":[{"role":"user","parts":[{"type":"text","text":"Reply with exactly PONG and nothing else."}]}]}'
-```
-
-### 4. Execute the session
-
-```bash
-EXECUTE=$(kubectl exec -n centaur deploy/centaur-centaur-api-rs -- curl -s -X POST "http://localhost:8080/api/session/${THREAD_PATH}/execute" \
-  -H "Content-Type: application/json" \
-  -d '{"input_lines":["{\"type\":\"user\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"Reply with exactly PONG and nothing else.\"}]}}"]}')
-EXECUTION_ID=$(printf '%s' "$EXECUTE" | jq -r '.execution_id')
-```
-
-### 5. Tail durable events (or reconnect later)
-
-```bash
-kubectl exec -n centaur deploy/centaur-centaur-api-rs -- curl -s -N \
-  "http://localhost:8080/api/session/${THREAD_PATH}/events?execution_id=${EXECUTION_ID}&after_event_id=0"
-```
-
-If this stream disconnects, reconnect with the last seen SSE `id` as
-`after_event_id`.
-
-### 6. Inspect the session
-
-```bash
-kubectl exec -n centaur deploy/centaur-centaur-api-rs -- curl -s \
-  "http://localhost:8080/api/session/${THREAD_PATH}" | jq
-```
-
-### Debugging
-
-```bash
-kubectl get pods -n centaur -l centaur.ai/managed=true
-kubectl exec -n centaur deploy/centaur-centaur-api-rs -- curl -s http://localhost:8080/healthz
-kubectl exec -n centaur <sandbox-pod> -- centaur-tools list
-```
+Python code targets Python 3.11+ and uses `uv` for environments and commands.
+Follow the local package's import style: service modules generally use
+top-level absolute imports, while independently packaged tool CLIs and optional
+dependencies may deliberately import lazily. Do not mechanically rewrite those
+boundaries. Rust, Ruby, TypeScript, shell, and image-only services have their
+own commands in local guides; there is no single repository-wide lint command
+that accurately validates every service.
+
+## Tools and workflows
+
+Tool plugins under `tools/` are independently packaged CLIs. Keep secret access
+in the client through the SDK placeholder mechanism; do not load dotenv files
+in reusable clients. A tool visible to agents needs a `[project.scripts]` entry,
+and its CLI wrapper should remain thin. Validate catalog discovery, `<tool>
+--help`, and one real command from a local sandbox.
+
+Workflow definitions under `workflows/` declare a unique `WORKFLOW_NAME` and an
+async handler. Use durable context primitives for side effects, sleeps, events,
+child workflows, agents, and tools; do not add process-local durability. Keep
+step names stable and test replay behavior after failures or restarts.
+
+For a credentialed tool change, trace the complete path: tool declaration ->
+principal/role grant -> proxy configuration -> controlled request from a real
+sandbox. Configuration presence alone does not prove usable or appropriately
+scoped access.
+
+## Reviews and incident reports
+
+- For reviews, report concrete findings in severity order with file and line
+  references. Passing tests do not prove protocol, authorization, or recovery
+  correctness. Do not edit unless asked to resolve findings.
+- For incidents, distinguish durable state, observed logs/metrics, live runtime
+  state, deployed version/configuration, and user-visible outcome. State what is
+  verified versus inferred.
+- Check authorization, credential exposure, idempotency, retry behavior,
+  cancellation, and crash recovery early when those boundaries are involved.
+- For a broad review, split independent protocol, authorization/lifecycle, and
+  deployment-wiring passes, then deduplicate and prioritize the findings.
+
+## Canonical references
+
+- `README.md` and `docs/pages/architecture.mdx`: system overview.
+- `docs/pages/quickstart.mdx`: local stack and end-to-end smoke path.
+- `contrib/chart/values.yaml`: supported deployment configuration.
+- Service `README.md` files, where present: behavior and environment variables.
+- `services/api-rs/rfcs/`: control-plane and sandbox design contracts.
+
+"Chat SDK" means the Vercel Chat SDK. When adapter behavior matters, inspect
+the source checkout at `~/github/vercel/chat` rather than generated files under
+`node_modules`.

--- a/Justfile
+++ b/Justfile
@@ -30,7 +30,7 @@ build:
       just _build-all-sequential
     else
       pids=()
-      for recipe in _build-api-rs _build-iron-proxy _build-slackbotv2 _build-discordbot _build-teamsbot _build-agent _build-console; do
+      for recipe in _build-api-rs _build-iron-proxy _build-slackbotv2 _build-linearbot _build-discordbot _build-githubbot _build-teamsbot _build-agent _build-console; do
         just "$recipe" &
         pids+=("$!")
       done
@@ -45,7 +45,9 @@ _build-all-sequential:
     just _build-api-rs
     just _build-iron-proxy
     just _build-slackbotv2
+    just _build-linearbot
     just _build-discordbot
+    just _build-githubbot
     just _build-teamsbot
     just _build-agent
     just _build-console
@@ -57,9 +59,12 @@ build-one service:
       api-rs) just _build-api-rs ;;
       iron-proxy) just _build-iron-proxy ;;
       slackbotv2) just _build-slackbotv2 ;;
+      linearbot) just _build-linearbot ;;
       discordbot) just _build-discordbot ;;
+      githubbot) just _build-githubbot ;;
       teamsbot) just _build-teamsbot ;;
       agent|sandbox) just _build-agent ;;
+      workflow-python) just _build-workflow-python ;;
       console) just _build-console ;;
       *) echo "unknown service: {{service}}" >&2; exit 2 ;;
     esac
@@ -73,14 +78,25 @@ _build-iron-proxy:
 _build-slackbotv2:
     docker build -t centaur-slackbotv2:latest -f services/slackbotv2/Dockerfile .
 
+_build-linearbot:
+    docker build -t centaur-linearbot:latest -f services/linearbot/Dockerfile .
+
 _build-discordbot:
     docker build -t centaur-discordbot:latest -f services/discordbot/Dockerfile .
+
+_build-githubbot:
+    docker build -t centaur-githubbot:latest -f services/githubbot/Dockerfile .
 
 _build-teamsbot:
     docker build -t centaur-teamsbot:latest -f services/teamsbot/Dockerfile .
 
 _build-agent:
     docker build --target "{{agent_build_target}}" -t "{{agent_image}}" -f "{{agent_dockerfile}}" .
+
+# The Python workflow host is embedded in both consumer images.
+_build-workflow-python:
+    just _build-api-rs
+    just _build-agent
 
 # The console builds from its own subdirectory context (services/console), unlike
 # the other services which build from the repo root.
@@ -93,7 +109,7 @@ _build-console:
 _push-registry:
     #!/usr/bin/env bash
     set -euo pipefail
-    for img in centaur-api-rs centaur-iron-proxy centaur-slackbotv2 centaur-discordbot centaur-teamsbot centaur-agent centaur-console; do
+    for img in centaur-api-rs centaur-iron-proxy centaur-slackbotv2 centaur-linearbot centaur-discordbot centaur-githubbot centaur-teamsbot centaur-agent centaur-console; do
       target="{{registry}}/library/${img}:latest"
       echo "pushing ${img}:latest -> ${target}..."
       docker tag "${img}:latest" "${target}"
@@ -106,7 +122,7 @@ _push-registry:
 _import-k3s:
     #!/usr/bin/env bash
     set -euo pipefail
-    for img in centaur-api-rs centaur-iron-proxy centaur-slackbotv2 centaur-discordbot centaur-teamsbot centaur-agent centaur-console; do
+    for img in centaur-api-rs centaur-iron-proxy centaur-slackbotv2 centaur-linearbot centaur-discordbot centaur-githubbot centaur-teamsbot centaur-agent centaur-console; do
       echo "importing ${img}:latest into k3s containerd..."
       docker save "${img}:latest" | {{k3s_ctr}} images import -
     done
@@ -126,7 +142,9 @@ deploy:
           --set apiRs.image.repository=ghcr.io/paradigmxyz/centaur/centaur-api-rs
           --set ironProxy.image.repository=ghcr.io/paradigmxyz/centaur/centaur-iron-proxy
           --set slackbotv2.image.repository=ghcr.io/paradigmxyz/centaur/centaur-slackbotv2
+          --set linearbot.image.repository=ghcr.io/paradigmxyz/centaur/centaur-linearbot
           --set discordbot.image.repository=ghcr.io/paradigmxyz/centaur/centaur-discordbot
+          --set githubbot.image.repository=ghcr.io/paradigmxyz/centaur/centaur-githubbot
           --set teamsbot.image.repository=ghcr.io/paradigmxyz/centaur/centaur-teamsbot
           --set sandbox.image.repository=ghcr.io/paradigmxyz/centaur/centaur-agent
           --set console.image.repository=ghcr.io/paradigmxyz/centaur/centaur-console

--- a/services/AGENTS.md
+++ b/services/AGENTS.md
@@ -1,0 +1,58 @@
+# Service Development Guide
+
+These instructions apply to all tracked services. Also follow the repository
+root guide and the nearest service-local `AGENTS.md`.
+
+## Shared rules
+
+- Keep service ownership explicit. Chat services own transport and rendering;
+  `api-rs` owns durable orchestration; the sandbox owns harness adaptation; the
+  workflow host executes Python handlers but does not own durable state.
+- Treat HTTP routes, NDJSON/SSE shapes, thread keys, database rows, environment
+  variables, health checks, metrics, and shutdown behavior as contracts.
+- When a runtime setting, port, route, probe, secret reference, or network path
+  changes, inspect the matching files under `contrib/chart/`.
+- Use structured logs with stable event names and correlation fields. Never log
+  authorization headers, cookies, tokens, secret values, raw credential
+  payloads, or unnecessarily large webhook bodies.
+- Preserve fail-closed policy gates. Authenticate or verify signatures before
+  accepting untrusted input, and keep allowlists and attachment restrictions
+  conservative.
+- Add focused regression coverage next to the behavior changed. For a
+  cross-service contract, test both sides or provide an integration test that
+  crosses the boundary.
+- For credentialed tools, prove the full path: declared tool metadata ->
+  principal/role authorization -> control-plane and proxy sync -> injected
+  outbound request. Confirm the sandbox contains placeholders, not real secret
+  values.
+
+## Chat ingress services
+
+Chat integrations should verify the platform event, derive a stable thread
+identity, persist the message, start or append to the durable session, and
+render replayable events. Do not move sandbox lifecycle, harness translation,
+workflow durability, or credential resolution into an ingress service.
+
+Keep these failure boundaries distinct:
+
+- webhook acknowledgement versus background execution completion;
+- message persistence versus execution start;
+- execution completion versus final platform delivery;
+- retryable transport failures versus permanent validation failures;
+- deduplication versus per-session serialization.
+
+Tests should cover signature/auth rejection, self-message loops, duplicate
+deliveries, session API failures, replay/reconnect behavior, and terminal render
+outcomes where applicable.
+
+All TypeScript services belong to the root pnpm workspace. Install dependencies
+once from the repository root with `pnpm install --frozen-lockfile`; their
+scripts invoke Bun for runtime, tests, and type checking. Do not create nested
+lockfiles. If Chat SDK behavior is unclear, inspect `~/github/vercel/chat` and
+the repository's registered patches, not `node_modules`.
+
+## Validation
+
+After unit checks, use the root local-stack flow when behavior crosses process,
+database, proxy, sandbox, or platform-emulation boundaries. Do not use a remote
+deployment as a development test environment.

--- a/services/api-rs/AGENTS.md
+++ b/services/api-rs/AGENTS.md
@@ -1,0 +1,95 @@
+# api-rs Guide
+
+## Role
+
+`api-rs` is the Rust control plane. It owns durable sessions and events,
+sandbox assignment and recovery, execution serialization, workflow state,
+service authentication, and control-plane telemetry. Postgres is the source of
+truth; process-local maps and attach streams are recoverable caches.
+
+Important crate boundaries:
+
+- `centaur-api-server`: HTTP routes, middleware, startup, health, and metrics.
+- `centaur-session-core`: shared session types and backend-neutral contracts.
+- `centaur-session-runtime`: orchestration, execution, recovery, and lifecycle.
+- `centaur-session-sqlx`: persistence and embedded SQLx migrations.
+- `centaur-sandbox-*`: backend-neutral sandbox contract and implementations.
+- `centaur-workflows` and `absurd-sdk`: durable workflow scheduling and state.
+- `centaur-iron-control`, `centaur-iron-proxy`, and `centaur-perms`: credential
+  control-plane integration and authorization resources.
+- `centaur-telemetry`: shared tracing and metrics support.
+
+Read the relevant RFC under `rfcs/` before changing a core protocol.
+
+## Invariants
+
+- The session flow remains create/reuse -> append messages -> execute -> replay
+  events. Persist state transitions before reporting them to clients.
+- `input_lines` are opaque, single-line NDJSON strings at the API boundary.
+  Add trace/session context without teaching the control plane every harness's
+  input format; harness-specific translation belongs in the runtime adapter.
+- Execution idempotency, per-session serialization, cancellation, leases, and
+  terminal events must remain correct across retries and process restarts.
+- New durable state belongs in Postgres, with repository methods and recovery
+  tests. Do not introduce a process-local source of truth.
+- Keep ingress/platform behavior out of the API. Keep Kubernetes-specific code
+  behind sandbox backend interfaces.
+- Authorization must be checked at the resource boundary. A valid token alone
+  is not proof that the caller may read another session, tool, or file.
+- Logs and durable events must not contain bearer tokens, secret values, or raw
+  credential material.
+
+## Database changes
+
+Migrations live in `crates/centaur-session-sqlx/migrations` and are embedded in
+the binary and tests. Add the next numbered SQL file; never edit or reorder an
+applied migration. Update SQLx repository code and add database-backed coverage
+for upgrade, read/write, and recovery behavior.
+
+Database-backed tests skip when their URL is absent. Point these variables at a
+disposable Postgres as required by the packages you run:
+
+- `SESSION_RUNTIME_TEST_DATABASE_URL`: session SQLx, runtime, and warm-pool
+  tests; the SQLx RLS integration tests also accept it as a fallback.
+- `SESSION_SQLX_TEST_DATABASE_URL`: SQLx RLS integration tests specifically.
+- `ABSURD_TEST_DATABASE_URL`: `absurd-sdk` database tests.
+
+Do not report full database coverage from `cargo test --workspace` unless the
+relevant variables were set and the database-backed tests actually ran.
+
+## Validation
+
+From `services/api-rs`:
+
+```bash
+cargo fmt --all --check
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test --workspace
+```
+
+During iteration, prefer a focused package/test first, for example:
+
+```bash
+cargo test -p centaur-session-runtime
+cargo test -p centaur-session-sqlx
+cargo test -p centaur-workflows
+```
+
+Sandbox backend invariants have a local Kind suite. Prepare the cluster and
+images with the `kind-e2e-*` recipes, then run all integration test binaries
+(the older `e2e-kind` wrapper names a removed test target):
+
+```bash
+just kind-e2e-up
+just kind-e2e-build-images
+KIND_E2E_FORCE_IMAGE_LOAD=1 just kind-e2e-load-images
+SANDBOX_E2E_IMPLS=all \
+SANDBOX_E2E_K8S_CONTEXT=kind-centaur-api-rs-e2e \
+SANDBOX_E2E_K8S_NAMESPACE=centaur-sandbox-e2e \
+cargo test -p centaur-sandbox-e2e --tests -- --ignored --nocapture
+```
+
+For an API contract or runtime change, also build the API image, deploy to the local
+stack, drive a real session through create/append/execute/events, and verify the
+durable rows and terminal event. Use explicit contexts for any Kind command so
+an ambient Kubernetes context cannot redirect a destructive operation.

--- a/services/console/AGENTS.md
+++ b/services/console/AGENTS.md
@@ -1,0 +1,50 @@
+# Console Guide
+
+## Role
+
+The console is a Rails application that provides the operator UI and the
+credential-control JSON API. It manages principals, roles, grants, encrypted
+secret records, proxy synchronization, broker credentials, console login, and
+MCP OAuth flows. Its Threads surface reads Centaur session data and is not a
+second session control plane.
+
+Use `README.md` and `docs/API.md` for the supported behavior and API shapes.
+
+## Invariants
+
+- Keep cookie-backed console sessions, bearer-authenticated operator APIs,
+  proxy sync authentication, and OAuth/MCP tokens as separate trust boundaries.
+- Secret plaintext may be accepted for creation or rotation but must never be
+  returned, logged, rendered, inspected in tests, or stored outside encrypted
+  model attributes and configured providers.
+- Apply authorization in controllers and service objects before loading or
+  mutating scoped resources. Test disabled users, non-admin users, namespace
+  isolation, token replay, and ownership checks where relevant.
+- OAuth/MCP changes must cover redirect validation, consent, PKCE, refresh-token
+  family rotation and replay, revocation, account disablement, and identity
+  reconciliation. A connected UI state alone is not proof of usable access.
+- The Threads UI is an observer of durable session data. Do not make it write
+  chat messages or bypass the session API.
+- Put business logic in models or `app/services`, keep controllers thin, and
+  preserve JSON error and pagination contracts.
+- Generate migrations with Rails and commit the resulting `db/schema.rb` change.
+  Do not hand-edit the schema dump.
+- Use local fixtures or synthetic snapshots for UI work; do not make tests
+  depend on a remote database.
+
+## Validation
+
+From `services/console`:
+
+```bash
+bundle install
+bin/rails db:prepare
+bin/rails test
+bin/rubocop
+bin/brakeman --quiet --no-pager --exit-on-warn --exit-on-error
+```
+
+`bin/ci` runs the full local CI sequence, including dependency audits, tests,
+and seed validation. Add focused controller/model/service tests with each
+behavior change. For visible UI changes, run `just dev`, exercise the affected
+flow in a browser, and check narrow and wide layouts plus keyboard/focus states.

--- a/services/discordbot/AGENTS.md
+++ b/services/discordbot/AGENTS.md
@@ -1,0 +1,44 @@
+# Discordbot Guide
+
+## Role
+
+Discordbot is an outbound Discord Gateway client with a small health server. It
+turns allowed mentions and subscribed thread messages into durable Centaur
+sessions and renders append-only progress and answers in Discord threads.
+
+Key modules are `src/gateway.ts`, `src/discord-allowlist.ts`,
+`src/discord-threading.ts`, `src/discord-narrator.ts`, and
+`src/session-api.ts`. See `README.md` for the platform setup and behavior.
+
+## Invariants
+
+- Run one Gateway consumer per bot token. Multiple replicas duplicate message
+  handling; preserve the single-replica/Recreate deployment contract.
+- Discord Gateway traffic is outbound. Do not add a public webhook route as a
+  substitute, and keep health tied to the Gateway controller's actual state.
+- Guild access is fail-closed. Empty guild policy means no work; DMs and bot or
+  webhook authors remain denied unless explicitly allowed by the existing
+  policy.
+- A channel mention creates or selects the correct thread; a mention or
+  follow-up inside a thread must retain one stable session key. Preserve loop
+  guards and per-thread concurrency control.
+- Respect Discord rate and content limits. Keep narration append-only and
+  throttle answer edits; a rendering refactor must not reorder the final answer
+  above later reasoning or user messages.
+- Gateway reconnect/resume and redelivered messages must not create duplicate
+  executions. Test deduplication separately from thread creation.
+
+## Validation
+
+From the repository root:
+
+```bash
+pnpm --filter discordbot run check:types
+pnpm --filter discordbot test
+```
+
+The unit suite uses fakes and needs no Discord credential. Add focused coverage
+for allowlist, threading, Gateway lifecycle, narration, and session API changes.
+When external validation is in scope and a controlled test application is
+explicitly authorized and configured, verify one input produces one thread,
+one execution, and one terminal answer.

--- a/services/githubbot/AGENTS.md
+++ b/services/githubbot/AGENTS.md
@@ -1,0 +1,44 @@
+# Githubbot Guide
+
+## Role
+
+Githubbot handles GitHub issue/PR conversations, review requests, issue work,
+and explicitly owned PR lifecycle events. Comment events use the Chat SDK
+adapter; lifecycle events are verified and handled directly.
+
+Key modules are `src/authorization.ts`, `src/turn.ts`, `src/review.ts`,
+`src/issue-manager.ts`, `src/pr-manager.ts`, and `src/session-api.ts`. The
+behavioral contract and supported webhook events are documented in `README.md`.
+
+## Invariants
+
+- Verify `X-Hub-Signature-256` before parsing or dispatching every directly
+  handled lifecycle event. Preserve delivery-id deduplication.
+- Comment-driven work is authorization-sensitive because the sandbox can
+  write. Keep the author-association gate fail-closed and retain self-message
+  and bot-loop guards.
+- Conversation, review, issue-work, and PR-management session keys are
+  intentionally isolated. Do not collapse them or let concurrent turns share
+  mutable git state accidentally.
+- Serialize turns for one management session and drain accepted work on
+  shutdown. A webhook acknowledgement is not evidence that the claimed turn
+  finished.
+- Automated merge behavior applies only to explicitly owned PRs and must honor
+  draft, hold, mergeability, settled-check, attempt-limit, and human-handoff
+  gates. Keep deterministic merge decisions outside the agent prompt.
+- Bundled prompts remain generic and fully overrideable. Do not embed private
+  review rules, repositories, user handles, or deployment behavior in defaults.
+- Unit tests must not write to real repositories, comments, branches, or PRs.
+
+## Validation
+
+From the repository root:
+
+```bash
+pnpm --filter githubbot run check:types
+pnpm --filter githubbot test
+```
+
+Add focused tests for authorization, signature rejection, deduplication,
+session serialization, review/issue triggers, and every PR-manager decision
+branch changed.

--- a/services/iron-proxy/AGENTS.md
+++ b/services/iron-proxy/AGENTS.md
@@ -1,0 +1,41 @@
+# iron-proxy Guide
+
+## Role
+
+This directory wraps a pinned upstream `iron-proxy` image with Centaur's
+startup contract and default unmanaged configuration. It is a security
+boundary: sandboxes send placeholder credentials and the proxy applies only
+the credential and request rules granted by the control plane.
+
+## Invariants
+
+- Keep the upstream image pinned by version and digest. Review upstream release
+  notes and config compatibility before changing it.
+- The CA key and certificate are required mounted inputs. Startup must fail
+  closed when they are missing, and the private key must retain restrictive
+  permissions.
+- Managed mode takes its configuration from the control plane and must not mix
+  in the baked local config. Unmanaged mode may seed the default config once
+  without overwriting a mounted or generated file.
+- Never bake credentials, provider tokens, private certificates, or deployment
+  endpoints into the image or YAML.
+- Header allowlisting and transforms are security policy. Add the narrowest
+  header/host/path support required; do not use a broad exception to make one
+  integration work.
+- JSON logs must not contain request headers, credential values, proxy tokens,
+  or upstream response bodies.
+
+## Validation
+
+Build from the repository root:
+
+```bash
+sh -n services/iron-proxy/entrypoint.sh
+(cd services/api-rs && cargo test -p centaur-iron-proxy)
+```
+
+For entrypoint changes, exercise both managed and unmanaged modes and the
+missing-CA failure path. For config or transform changes, deploy the local
+stack and make a request from inside a sandbox through the proxy to a controlled
+test upstream. Prove the intended header is injected, unrelated headers are
+removed, and the sandbox still contains only placeholder material.

--- a/services/linearbot/AGENTS.md
+++ b/services/linearbot/AGENTS.md
@@ -1,0 +1,43 @@
+# Linearbot Guide
+
+## Role
+
+Linearbot maps Linear comment threads and owned issue assignments to durable
+Centaur sessions. It intentionally uses ordinary Comment and Issue webhooks;
+Linear native agent sessions are not the primary interaction model.
+
+Key modules are `src/comment-bot.ts`, `src/issue-comments.ts`,
+`src/linear-context.ts`, `src/linear-status.ts`, and `src/session-api.ts`. Read
+`README.md` and the registered Linear adapter patch before changing event or
+thread behavior.
+
+## Invariants
+
+- Verify the Linear webhook HMAC before dispatch. Await the durable
+  create/append handoff for user input so transient failures receive a retryable
+  status; execute and render after acknowledgement.
+- Comment threads and issue-assignment sessions have different keys and
+  ownership. Keep the issue-level assignment session as the sole automated
+  status owner; comment turns must not race it or apply status markers.
+- Plain comments in active threads append context without starting a turn.
+  Preserve mention detection, active-thread checks, and self-message loops.
+- Issue webhooks should run only when the relevant assignee/delegate field
+  changed, not for unrelated issue updates or the bot's own status write.
+- Preserve the deliberate adapter patch and workspace patch registration. If
+  upstream behavior changes, add a regression test before modifying or removing
+  the patch.
+- Keep comment edits, reactions, issue fetches, and status updates best-effort
+  and bounded without hiding a failed durable execution.
+
+## Validation
+
+From the repository root:
+
+```bash
+pnpm --filter linearbot run check:types
+pnpm --filter linearbot test
+```
+
+The test suite includes a signed-webhook/fake-GraphQL path; extend it for
+changes to comment threading, assignment gating, status ownership, or session
+API retry behavior.

--- a/services/sandbox/AGENTS.md
+++ b/services/sandbox/AGENTS.md
@@ -1,0 +1,53 @@
+# Sandbox Guide
+
+## Role
+
+This directory builds the agent runtime image and composes its startup
+environment. It installs harness CLIs and tool shims, prepares persistent state,
+consumes repo-cache and overlay mounts supplied by the control plane, writes
+harness configuration, and launches `harness-server`.
+
+`SYSTEM_PROMPT.md` is runtime product behavior: the image bakes it into the
+agent home and startup copies/composes it into the workspace. It is distinct
+from repository `AGENTS.md` files, which guide contributors editing this repo.
+
+## Invariants
+
+- Sandboxes receive placeholder credentials only. Real secret values must not
+  appear in image layers, environment dumps, generated auth files, logs, or
+  tests; outbound substitution belongs to `iron-proxy`.
+- Preserve the non-root runtime user and the boundary between the reusable
+  toolchain stage and frequently changing final layers.
+- `entrypoint.sh` must be deterministic and safe to rerun against persistent
+  state. Preserve permissions, symlink targets, prompt composition order, and
+  configured overlay precedence.
+- Tool discovery comes from ordered `TOOL_DIRS` entries and each tool's
+  `[project.scripts]`. Keep `centaur-tools` catalog, direct CLI execution, and
+  workflow compatibility behavior aligned.
+- Repo-cache readiness must describe the exact repositories, refs, visibility,
+  and completed sync. Never report ready for stale or partial content.
+- `crates/harness-server/` owns app-server protocol normalization and is built
+  into this image. Keep harness-specific quirks there rather than in image
+  startup code or chat clients.
+- Pin runtime/tool versions deliberately. A Dockerfile version bump requires a
+  startup or functional smoke test, not just a successful image build.
+
+## Validation
+
+From the repository root:
+
+```bash
+uv run python -m unittest discover -s services/sandbox -p 'test_*.py'
+```
+
+Use focused tests for prompt, tool-shim, and repo-cache changes. After building,
+deploy to the local stack and verify from a real sandbox:
+
+```bash
+centaur-tools list
+<tool> --help
+```
+
+Also run one harness turn that exercises the changed startup or protocol path.
+For repo-cache changes, verify both the readiness sentinel and the checked-out
+commit inside the sandbox; the existence of a directory alone is insufficient.

--- a/services/sandbox/SYSTEM_PROMPT.md
+++ b/services/sandbox/SYSTEM_PROMPT.md
@@ -7,10 +7,10 @@
 |Run `centaur-tools list` to see available tool commands; run `<tool> --help` before using an unfamiliar tool
 
 [Self-introspection]
-|Your active persona, harness, and overlay are baked into the [Active deployment] block at the top of the effective AGENTS.md prompt. That block is authoritative.
-|For a live cross-check, run `echo "$AGENT_PERSONA"` or `echo "$CENTAUR_OVERLAY_DIR"`.
+|Your active persona and overlay state come from the live sandbox environment. Check `$AGENT_PERSONA` or `$CENTAUR_PERSONA_ID` and `$CENTAUR_OVERLAY_DIR`; those values are authoritative when set. For the harness, prefer current session context, then the PID 1 command; `$CENTAUR_HARNESS_TYPE` is only an optional hint.
+|For a live cross-check, print only those named variables or use the runtime discovery endpoint. Do not dump the full environment because it may contain sensitive values.
 |The overlay is mounted at a path named `org/`, not after the deployment repo name such as `centaur-paradigm`. Do not search for the literal repo name.
-|Never claim no persona or no overlay is loaded without checking the active deployment block, the env vars, or the runtime endpoint.
+|Never claim no persona or no overlay is loaded without checking the named variables or the runtime endpoint.
 
 [Writing Quality Gate]
 |Be brief in your response! Do not reply with multiple paragraphs, prefer 1-2 sentence answers.
@@ -50,7 +50,7 @@
 [Authoritative deployment-capability answers]
 |When a user asks what personas, tools, integrations, or other deployment-scoped capabilities Centaur has, prefer a live capability listing over workspace files or memory.
 |Use the deployment's runtime discovery path when available (for example `centaur-tools list` for tool CLIs, or the live persona registry when it is exposed). Repo files, local mounts, and prompt hints are supporting evidence, not proof that a capability is live in this deployment.
-|For your own active persona and overlay state specifically, prefer the [Active deployment] block, `$AGENT_PERSONA`, and `$CENTAUR_OVERLAY_DIR`.
+|For your own active persona and overlay state specifically, prefer `$AGENT_PERSONA` or `$CENTAUR_PERSONA_ID` and `$CENTAUR_OVERLAY_DIR`. For the harness, prefer current session context, then the PID 1 command; use `$CENTAUR_HARNESS_TYPE` only when it is set.
 |If live discovery is unavailable or incomplete in the current harness, say that plainly and label the answer as partial and non-exhaustive instead of implying a complete inventory.
 
 [Named skill resolution]
@@ -94,7 +94,7 @@
 |Do NOT assume files, git branches, or installed packages persist across turns.
 |
 |Rules:
-|  - Always push work-in-progress to a git branch before finishing a turn
+|  - Push work-in-progress only when the user authorized remote git work. For an already-authorized PR task, push before finishing if container recycling would otherwise lose the requested work.
 |  - Upload important user-visible artifacts with the relevant file tool, such as `slack upload`, rather than saving only locally
 |  - If you need files from a previous session, re-download or re-clone them
 |  - Your conversation context IS preserved — you remember what was discussed even after container recycling
@@ -120,21 +120,21 @@
 |
 |[Observability — logs + execution data]
 |You have full access to Centaur's internal observability via tool CLIs such as `vlogs`.
-|If a user says a workflow, alert, or channel post never populated, or asks you to check the code for issues, investigate runtime evidence before proposing redesigns or simplifications: read the relevant code paths, check workflow status, and inspect `vlogs thread_trace` or `vlogs thread_logs` plus any other relevant observability tools first.
+|If a user says a workflow, alert, or channel post never populated, or asks you to check the code for issues, investigate runtime evidence before proposing redesigns or simplifications: read the relevant code paths, check workflow status, and inspect the relevant `vlogs` queries plus any other observability tools first.
 |If a user reports an internal tool integration or auth failure, inspect runtime evidence before suggesting secret or permission rewiring: check live tool behavior and `vlogs` evidence to confirm whether secrets resolved and what request failed, then compare the tool's code path with a known-good integration before recommending secret or permission changes.
 |
 |Logs (VictoriaLogs via `vlogs`):
-|  vlogs errors                                           → errors across all services (last 1h)
-|  vlogs errors --service api --start 6h                  → API errors in last 6h
-|  vlogs thread_logs --thread-key C0AJ07U8Z1N:1234        → all logs for a specific thread
-|  vlogs thread_trace --thread-key C0AJ07U8Z1N:1234       → end-to-end timeline across API, sandbox, tools, subagents, and delivery
-|  vlogs slow_requests --threshold-ms 3000                → requests slower than 3s
-|  vlogs tool_calls --tool-name websearch --start 24h     → tool call history
-|  vlogs execution_timeline --execution-id exe_123        → full execution trace
-|  vlogs service_health                                   → error/request counts per service
-|  vlogs sandbox_activity                                 → sandbox container lifecycle
-|  vlogs tool_analytics --start 7d                        → tool usage stats
-|  vlogs query 'level:error AND event:tool_call_completed' --limit 20 → raw LogsQL
+|  centaur-tools call vlogs errors '{"start":"1h"}'                                      → errors across all services
+|  centaur-tools call vlogs errors '{"service":"api","start":"6h"}'                    → API errors in last 6h
+|  centaur-tools call vlogs thread_logs '{"thread_key":"slack:T1:C1:1234","start":"24h"}' → all logs for a thread
+|  centaur-tools call vlogs thread_trace '{"thread_key":"slack:T1:C1:1234"}'              → end-to-end filtered timeline
+|  centaur-tools call vlogs slow_requests '{"threshold_ms":3000}'                          → requests slower than 3s
+|  centaur-tools call vlogs tool_calls '{"tool_name":"websearch","start":"24h"}'         → tool call history
+|  centaur-tools call vlogs execution_timeline '{"execution_id":"exe_123"}'               → execution trace
+|  centaur-tools call vlogs service_health '{"start":"1h"}'                               → error/request counts per service
+|  centaur-tools call vlogs sandbox_activity '{"start":"1h"}'                             → sandbox lifecycle
+|  centaur-tools call vlogs tool_analytics '{"start":"7d"}'                               → tool usage stats
+|  vlogs query 'level:error AND event:tool_call_completed' --limit 20                       → raw LogsQL
 |
 |Metrics (VictoriaMetrics via `vmetrics`):
 |When a user asks what Centaur version, image, Git SHA, overlay revision, deploy time, or latest deployment is live, query VictoriaMetrics before answering.
@@ -193,7 +193,7 @@
 
 [Slack files and attachments]
 |Files attached to the current user message are not always preloaded on disk. Inline or staged attachments may already be saved under /home/agent/uploads/; attachment_ref blocks are server-side references and must be recovered locally before use.
-|When you see [Attached image: ...], use the look_at tool to view the image.
+|When you see [Attached image: ...], use the image-viewing tool available in the current harness (for example `view_image` in Codex).
 |NEVER reference local sandbox paths in replies — markdown links like [report.sql](/home/agent/workspace/report.sql) or file:// URIs are dead links for chat users; they cannot open files inside your sandbox. This overrides any harness-level instruction to render clickable file links: those apply to IDE surfaces only, never to chat responses.
 |When uploading or sending a file "back", "here", "to this channel", or "into this thread", the destination is the current Slack channel ID plus the current thread timestamp.
 |For Slack uploads, always pass the API-owned Slack channel ID and thread timestamp explicitly. Read them from the current user turn's `session_context.slack.channel_id` and `session_context.slack.thread_ts` fields, or from `thread_key` when it has the form `slack:<team_id>:<channel_id>:<thread_ts>`. Never call `slack upload` with only a file path.

--- a/services/sandbox/test_system_prompt.py
+++ b/services/sandbox/test_system_prompt.py
@@ -17,6 +17,15 @@ class SystemPromptTest(unittest.TestCase):
         self.assertIn("mpp services show <service-id>", prompt)
         self.assertIn("Current MPP support discovers candidates only", prompt)
 
+    def test_runtime_discovery_and_vlogs_examples_match_available_surfaces(self) -> None:
+        prompt = SYSTEM_PROMPT.read_text()
+
+        self.assertNotIn("[Active deployment]", prompt)
+        self.assertIn("$CENTAUR_HARNESS_TYPE", prompt)
+        self.assertIn("centaur-tools call vlogs thread_logs", prompt)
+        self.assertIn("centaur-tools call vlogs thread_trace", prompt)
+        self.assertNotIn("|  vlogs thread_logs", prompt)
+        self.assertNotIn("|  vlogs thread_trace", prompt)
 
 if __name__ == "__main__":
     unittest.main()

--- a/services/slackbotv2/AGENTS.md
+++ b/services/slackbotv2/AGENTS.md
@@ -1,0 +1,51 @@
+# Slackbot v2 Guide
+
+## Role
+
+Slackbot v2 is the Slack transport and renderer for the durable session API.
+`src/index.ts` wires Chat SDK callbacks and recovery, `src/session-api.ts` owns
+the control-plane client, `src/conflate.ts` and display helpers shape output,
+and `src/server.ts` owns runtime configuration and the HTTP server.
+
+Keep this service thin: it may collect Slack context, persist messages, start
+or interrupt executions, replay events, and deliver Slack output. Sandbox
+lifecycle, harness formatting, and durable execution state belong in `api-rs`.
+
+## Invariants
+
+- Verify Slack signatures and policy gates before processing an event. Ignore
+  bot/self events and unsupported event shapes without creating sessions.
+- For user-input webhooks, wait only for the create/append handoff needed to
+  make Slack retry a transient failure. Do not hold the webhook open for cold
+  sandbox execution or rendering.
+- Preserve the boundary between create/reuse, durable append, execute, SSE
+  replay, and final Slack delivery. Each phase needs its own timeout, retry,
+  metrics, and idempotency behavior.
+- Use stable client message and execution idempotency keys so Slack redelivery
+  cannot produce a second turn. Serialize work that targets the same session.
+- Postgres-backed Chat SDK state and render obligations are crash-recovery
+  state. A terminal execution without a delivered terminal render still needs
+  recovery.
+- Keep Slack API side effects bounded by the existing timeout helpers. Respect
+  message, block, attachment, and rate limits, including fallback text.
+- Avoid serializing raw webhook bodies on the hot path or in normal logs. Never
+  log bot tokens, signing secrets, private file URLs, or user file contents.
+- Preserve stop commands, harness/model overrides, late-file repair, initial
+  thread context, and subscribed-message append semantics when refactoring the
+  main callback flow.
+
+## Validation
+
+From the repository root:
+
+```bash
+pnpm --filter slackbotv2 run check:types
+pnpm --filter slackbotv2 test
+```
+
+Use targeted tests while iterating, especially `test/session-api.test.ts`,
+`test/chat-sdk-emulate.test.ts`, `test/conflate.test.ts`, and recovery/metrics
+tests. For changes to acknowledgement, retry, or rendering, deploy locally and
+exercise a signed emulated event through the HTTP route; prove the webhook
+status, durable execution count, replayed terminal event, and final rendered
+message.

--- a/services/teamsbot/AGENTS.md
+++ b/services/teamsbot/AGENTS.md
@@ -1,0 +1,42 @@
+# Teamsbot Guide
+
+## Role
+
+Teamsbot receives Bot Framework activities, applies tenant/team/channel policy,
+forwards normalized messages and attachments to durable Centaur sessions, and
+renders events back through stored conversation references.
+
+Key modules are `src/teamsbot.ts`, `src/session-api.ts`,
+`src/session-transport.ts`, `src/state.ts`, `src/reply-sink.ts`, and
+`src/teams-attachments.ts`. See `README.md` for runtime settings.
+
+## Invariants
+
+- Tenant, team, and channel access is fail-closed. Empty allowlists do not mean
+  public access, and mention requirements must be enforced before session work.
+- Preserve Bot Framework authentication and redact service URLs, access tokens,
+  credentials, and attachment authorization from logs and error messages.
+- Conversation references, active execution state, and render obligations are
+  durable recovery data. Leases and retries must prevent two replicas from
+  delivering the same terminal answer.
+- Persist the message before execute and keep retryable API failures distinct
+  from invalid activities. Do not acknowledge accepted work as complete.
+- Attachment download is opt-in, HTTPS-only, size-bounded, and host-allowlisted.
+  Validate redirects and authenticated Graph-backed downloads against the same
+  restrictions.
+- This package uses NodeNext module resolution; keep explicit `.js` suffixes in
+  TypeScript imports where the existing code requires them.
+
+## Validation
+
+From the repository root:
+
+```bash
+pnpm --filter teamsbot run check:types
+pnpm --filter teamsbot test
+pnpm --filter teamsbot simulate -- "Reply exactly PONG."
+```
+
+The simulator uses a mock Centaur API and needs no Teams credential. Add tests
+for allowlists, activity normalization, state recovery, render leases, retry
+classification, and attachment limits when those paths change.

--- a/services/workflow-python/AGENTS.md
+++ b/services/workflow-python/AGENTS.md
@@ -1,0 +1,41 @@
+# Python Workflow Host Guide
+
+## Role
+
+This service is the compatibility runtime for Python workflow handlers. It
+discovers workflow modules, invokes `handler(input, ctx)`, and speaks newline-
+delimited JSON with `api-rs`. `api-rs` and Postgres own scheduling, leases,
+checkpoints, waits, retries, child runs, and terminal state.
+
+## Invariants
+
+- Stdout is protocol-only: exactly one JSON object per line. Send diagnostics
+  to stderr and structured workflow messages through `ctx.log`.
+- Route durable actions through context RPC (`ctx.step`, sleeps, events, child
+  workflows, agent turns, and tool calls). Do not add local checkpoint files,
+  background schedulers, or a second workflow state machine.
+- A checkpointed step must be replay-safe. Put external side effects inside a
+  uniquely named step and keep names stable after deployment.
+- Discovery is deterministic. Ignore non-workflow modules, reject duplicate
+  workflow names, preserve allowlist behavior, and report load failures without
+  corrupting the NDJSON stream.
+- Keep the host usable both inside the sandbox image and in local tests. Avoid
+  dependencies on a contributor's shell state or remote services.
+- Python targets 3.11+. Keep imports at module scope, use absolute imports from
+  `api`, and keep serialized results JSON-compatible.
+
+## Validation
+
+From the repository root:
+
+```bash
+uv run --project services/workflow-python python -m unittest discover \
+  -s services/workflow-python/tests -p 'test_*.py'
+```
+
+For protocol changes, run the host as a subprocess and assert clean stdout,
+request/response correlation, stderr diagnostics, and shutdown behavior. For a
+context primitive change, add matching Rust-side coverage in `api-rs` and run a
+small workflow through the local stack. The host ships in both the `api-rs` and
+sandbox images rather than as an independent image, so validate both local and
+sandboxed host modes when its shared runtime behavior changes.


### PR DESCRIPTION
## Summary

- replace the monolithic root agent guide with concise repository and service-local guidance
- add AGENTS.md coverage for every tracked service while preserving existing runtime-specific prompt behavior
- make service image builds and publication cover Linearbot, Githubbot, and embedded workflow-python consumers

## Validation

- `uv run python -m unittest discover -s services/sandbox -p "test_*.py"`
- `uv run --project services/workflow-python python -m unittest discover -s services/workflow-python/tests -p "test_*.py"`
- `just build-one linearbot`
- `just build-one githubbot`
- bot typechecks and tests (523 passed, 1 skipped)
- `helm lint contrib/chart`
- `git diff --check`