### PR TITLE
feat: proxy slack channel listing

### DIFF
--- a/services/api-rs/crates/centaur-api-server/src/slack_proxy.rs
+++ b/services/api-rs/crates/centaur-api-server/src/slack_proxy.rs
@@ -43,6 +43,7 @@ pub(crate) fn slack_proxy_router() -> Router<AppState> {
             "/api/slack/files/{file_id}/download",
             get(download_slack_file),
         )
+        .route("/api/slack/channels", get(get_slack_channels))
         .route(
             "/api/slack/channels/{channel_id}/history",
             get(get_slack_channel_history),
@@ -114,6 +115,27 @@ struct SlackFileUploadResponse {
     channel_id: String,
     thread_ts: Option<String>,
     file: Value,
+}
+
+#[derive(Debug, Serialize)]
+struct SlackChannelsResponse {
+    ok: bool,
+    channels: Vec<SlackChannelItem>,
+    count: usize,
+}
+
+#[derive(Debug, Serialize)]
+struct SlackChannelItem {
+    id: String,
+    name: String,
+    purpose: String,
+    topic: String,
+    member_count: u64,
+    is_private: bool,
+    is_member: bool,
+    can_upload: bool,
+    can_download: bool,
+    can_read_history: bool,
 }
 
 async fn upload_slack_file(
@@ -244,6 +266,31 @@ async fn download_slack_file(
         headers.insert(header::CONTENT_DISPOSITION, value);
     }
     Ok(response)
+}
+
+async fn get_slack_channels(headers: HeaderMap) -> Result<Json<SlackChannelsResponse>, ApiError> {
+    let claims = authorize_slack_file_proxy(&headers)?;
+    let channel_ids = slack_channel_ids_from_claims(&claims)?;
+
+    let config = slack_proxy_config()?;
+    let client = http_client();
+    let mut channels = Vec::with_capacity(channel_ids.len());
+    for channel_id in channel_ids {
+        let channel = slack_channel_info(client, config, &channel_id).await?;
+        channels.push(slack_channel_item(&claims, &channel_id, &channel));
+    }
+    channels.sort_by(|left, right| {
+        left.name
+            .to_ascii_lowercase()
+            .cmp(&right.name.to_ascii_lowercase())
+            .then_with(|| left.id.cmp(&right.id))
+    });
+
+    Ok(Json(SlackChannelsResponse {
+        ok: true,
+        count: channels.len(),
+        channels,
+    }))
 }
 
 async fn get_slack_channel_history(
@@ -436,6 +483,23 @@ async fn slack_file_info(
     })
 }
 
+async fn slack_channel_info(
+    client: &reqwest::Client,
+    config: &SlackFileProxyConfig,
+    channel_id: &str,
+) -> Result<Value, ApiError> {
+    let value = slack_api_post_form(
+        client,
+        config,
+        "conversations.info",
+        &[("channel", channel_id.to_owned())],
+    )
+    .await?;
+    value.get("channel").cloned().ok_or_else(|| {
+        ApiError::BadRequest("Slack channel info response did not include channel".to_owned())
+    })
+}
+
 async fn slack_channel_history(
     client: &reqwest::Client,
     config: &SlackFileProxyConfig,
@@ -579,6 +643,75 @@ fn ensure_channel_allowed(
         return Ok(());
     }
     Err(ApiError::Forbidden(message.to_owned()))
+}
+
+fn slack_channel_ids_from_claims(claims: &SlackFileProxyClaims) -> Result<Vec<String>, ApiError> {
+    let mut channel_ids = BTreeSet::new();
+    for channel_id in claims
+        .slack
+        .upload_channels
+        .iter()
+        .chain(claims.slack.download_channels.iter())
+        .chain(claims.slack.history_channels.iter())
+    {
+        validate_slack_channel_id(channel_id)?;
+        channel_ids.insert(channel_id.to_owned());
+    }
+    Ok(channel_ids.into_iter().collect())
+}
+
+fn slack_channel_item(
+    claims: &SlackFileProxyClaims,
+    channel_id: &str,
+    channel: &Value,
+) -> SlackChannelItem {
+    SlackChannelItem {
+        id: channel_id.to_owned(),
+        name: channel
+            .get("name")
+            .and_then(Value::as_str)
+            .filter(|name| !name.is_empty())
+            .unwrap_or(channel_id)
+            .to_owned(),
+        purpose: slack_channel_text_field(channel, "purpose"),
+        topic: slack_channel_text_field(channel, "topic"),
+        member_count: channel
+            .get("num_members")
+            .and_then(Value::as_u64)
+            .unwrap_or_default(),
+        is_private: channel
+            .get("is_private")
+            .and_then(Value::as_bool)
+            .unwrap_or_else(|| channel_id.starts_with('G')),
+        is_member: channel
+            .get("is_member")
+            .and_then(Value::as_bool)
+            .unwrap_or_default(),
+        can_upload: claims
+            .slack
+            .upload_channels
+            .iter()
+            .any(|allowed| allowed == channel_id),
+        can_download: claims
+            .slack
+            .download_channels
+            .iter()
+            .any(|allowed| allowed == channel_id),
+        can_read_history: claims
+            .slack
+            .history_channels
+            .iter()
+            .any(|allowed| allowed == channel_id),
+    }
+}
+
+fn slack_channel_text_field(channel: &Value, field: &str) -> String {
+    channel
+        .get(field)
+        .and_then(|value| value.get("value"))
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_owned()
 }
 
 fn slack_file_in_channel(file: &Value, channel_id: &str) -> bool {
@@ -800,6 +933,59 @@ mod tests {
             ensure_history_channel_allowed(&claims, "C123456789").unwrap_err(),
             ApiError::Forbidden(_)
         ));
+    }
+
+    #[test]
+    fn extracts_deduped_channel_ids_from_all_slack_claims() {
+        let claims = SlackFileProxyClaims {
+            slack: SlackProxyClaims {
+                upload_channels: vec!["C123456789".to_owned()],
+                download_channels: vec!["G123456789".to_owned(), "C123456789".to_owned()],
+                history_channels: vec!["D123456789".to_owned(), "G123456789".to_owned()],
+            },
+        };
+
+        assert_eq!(
+            slack_channel_ids_from_claims(&claims).unwrap(),
+            vec![
+                "C123456789".to_owned(),
+                "D123456789".to_owned(),
+                "G123456789".to_owned(),
+            ]
+        );
+    }
+
+    #[test]
+    fn channel_item_enriches_slack_metadata_with_permissions() {
+        let claims = SlackFileProxyClaims {
+            slack: SlackProxyClaims {
+                upload_channels: vec!["C123456789".to_owned()],
+                download_channels: vec![],
+                history_channels: vec!["C123456789".to_owned()],
+            },
+        };
+        let channel = json!({
+            "id": "C123456789",
+            "name": "general",
+            "purpose": {"value": "Company updates"},
+            "topic": {"value": "Announcements"},
+            "num_members": 42,
+            "is_private": false,
+            "is_member": true
+        });
+
+        let item = slack_channel_item(&claims, "C123456789", &channel);
+
+        assert_eq!(item.id, "C123456789");
+        assert_eq!(item.name, "general");
+        assert_eq!(item.purpose, "Company updates");
+        assert_eq!(item.topic, "Announcements");
+        assert_eq!(item.member_count, 42);
+        assert!(!item.is_private);
+        assert!(item.is_member);
+        assert!(item.can_upload);
+        assert!(!item.can_download);
+        assert!(item.can_read_history);
     }
 
     #[test]

--- a/services/api-rs/crates/centaur-api-server/src/slack_proxy.rs
+++ b/services/api-rs/crates/centaur-api-server/src/slack_proxy.rs
@@ -276,8 +276,16 @@ async fn get_slack_channels(headers: HeaderMap) -> Result<Json<SlackChannelsResp
     let client = http_client();
     let mut channels = Vec::with_capacity(channel_ids.len());
     for channel_id in channel_ids {
-        let channel = slack_channel_info(client, config, &channel_id).await?;
-        channels.push(slack_channel_item(&claims, &channel_id, &channel));
+        match slack_channel_info(client, config, &channel_id).await {
+            Ok(channel) => channels.push(slack_channel_item(&claims, &channel_id, &channel)),
+            Err(error) => {
+                tracing::warn!(
+                    channel_id,
+                    error = %error,
+                    "skipping Slack channel whose metadata could not be fetched"
+                );
+            }
+        }
     }
     channels.sort_by(|left, right| {
         left.name
@@ -492,12 +500,19 @@ async fn slack_channel_info(
         client,
         config,
         "conversations.info",
-        &[("channel", channel_id.to_owned())],
+        &slack_channel_info_form(channel_id),
     )
     .await?;
     value.get("channel").cloned().ok_or_else(|| {
         ApiError::BadRequest("Slack channel info response did not include channel".to_owned())
     })
+}
+
+fn slack_channel_info_form(channel_id: &str) -> Vec<(&'static str, String)> {
+    vec![
+        ("channel", channel_id.to_owned()),
+        ("include_num_members", "true".to_owned()),
+    ]
 }
 
 async fn slack_channel_history(
@@ -986,6 +1001,17 @@ mod tests {
         assert!(item.can_upload);
         assert!(!item.can_download);
         assert!(item.can_read_history);
+    }
+
+    #[test]
+    fn channel_info_form_requests_member_counts() {
+        assert_eq!(
+            slack_channel_info_form("C123456789"),
+            vec![
+                ("channel", "C123456789".to_owned()),
+                ("include_num_members", "true".to_owned()),
+            ]
+        );
     }
 
     #[test]

--- a/tools/productivity/slack/cli.py
+++ b/tools/productivity/slack/cli.py
@@ -116,8 +116,9 @@ def search(
 ):
     """Search messages in bot-accessible channels.
 
-    Searches across all channels the bot is a member of. Results are ranked by
-    relevance (exact phrase matches score higher). Use --channels to limit scope.
+    Searches across Slack native search first, then scans channel history through
+    the Centaur API server proxy. Results are ranked by relevance (exact phrase
+    matches score higher). Use --channels to limit scope.
 
     Note: Only searches channels where the bot is a member. To search more channels,
     invite the bot to those channels first.
@@ -164,8 +165,8 @@ def search(
         console.print(table)
 
 
-@app.command()
-def channel(
+@app.command("channel-direct")
+def channel_direct(
     name: str = typer.Argument(..., help="Slack channel ID, e.g. C1234567890"),
     limit: int = typer.Option(50, "--limit", "-n", help="Max messages"),
     full: bool = typer.Option(False, "--full", "-f", help="Show full message text"),
@@ -192,14 +193,14 @@ def channel(
     ),
     json_output: bool = typer.Option(False, "--json", help="Output full page metadata as JSON"),
 ):
-    """Get recent messages from a channel or a bounded history window."""
+    """Get recent messages from a channel directly with the Slack SDK."""
     import sys
 
     from .client import get_channel_history_page
 
     if not allow_name_resolution and not _channel_arg_is_id(name):
         stderr_console.print(
-            "[red]Error: slack channel requires an explicit Slack channel ID like C1234567890. "
+            "[red]Error: slack channel-direct requires an explicit Slack channel ID like C1234567890. "
             "Pass --allow-name-resolution to resolve a channel name intentionally.[/]"
         )
         raise typer.Exit(1)
@@ -246,8 +247,8 @@ def channel(
         console.print(f"[green]{msg['user']}[/]{thread_info}: {text}")
 
 
-@app.command("channel-proxy")
-def channel_proxy(
+@app.command("channel")
+def channel(
     channel_id: str = typer.Argument(..., help="Slack channel ID, e.g. C1234567890"),
     limit: int = typer.Option(50, "--limit", "-n", help="Max messages"),
     cursor: str = typer.Option(None, "--cursor", help="Slack pagination cursor for the next page"),
@@ -545,8 +546,63 @@ def sync_history(
     console.print(f"[dim]sync_state={json.dumps(result['sync_state'], ensure_ascii=False)}[/]")
 
 
-@app.command()
+def _render_channels(results: list[dict], title: str, include_access: bool = False) -> None:
+    """Render a Slack channel list."""
+    if not results:
+        console.print("[yellow]No channels found.[/]")
+        raise typer.Exit()
+
+    table = Table(title=title)
+    table.add_column("Name", style="cyan", max_width=25)
+    table.add_column("Members", style="green", justify="right", max_width=8)
+    if include_access:
+        table.add_column("Access", style="magenta", max_width=12)
+    table.add_column("Purpose", style="white", max_width=50)
+
+    for ch in results:
+        priv = "[dim]🔒[/]" if ch["is_private"] else ""
+        purpose = (ch["purpose"] or ch["topic"] or "")[:50]
+        row = [f"#{ch['name']}{priv}", str(ch["member_count"])]
+        if include_access:
+            access = "".join(
+                label
+                for label, enabled in [
+                    ("h", ch.get("can_read_history")),
+                    ("u", ch.get("can_upload")),
+                    ("d", ch.get("can_download")),
+                ]
+                if enabled
+            )
+            row.append(access or "-")
+        row.append(purpose)
+        table.add_row(*row)
+
+    console.print(table)
+
+
+@app.command("channels")
 def channels(
+    limit: int = typer.Option(100, "--limit", "-n", help="Max channels"),
+    query: str = typer.Option(None, "--query", "-q", help="Filter by name"),
+    bot_member_only: bool = typer.Option(
+        False,
+        "--bot-member-only",
+        help="Only list JWT-authorized channels with history access",
+    ),
+):
+    """List Slack channels authorized by the Centaur API server proxy JWT."""
+    from .client import list_channels_proxy
+
+    results = list_channels_proxy(limit=limit, history_only=bot_member_only)
+
+    if query:
+        results = [c for c in results if query.lower() in c["name"].lower()]
+
+    _render_channels(results, f"Channels ({len(results)})", include_access=True)
+
+
+@app.command("channels-direct")
+def channels_direct(
     limit: int = typer.Option(100, "--limit", "-n", help="Max channels"),
     query: str = typer.Option(None, "--query", "-q", help="Filter by name"),
     bot_member_only: bool = typer.Option(
@@ -555,7 +611,7 @@ def channels(
         help="Only list channels the bot can actually read history from",
     ),
 ):
-    """List all Slack channels."""
+    """List Slack channels directly with the Slack SDK."""
     from .client import list_bot_channels, list_channels
 
     if bot_member_only:
@@ -566,21 +622,7 @@ def channels(
     if query:
         results = [c for c in results if query.lower() in c["name"].lower()]
 
-    if not results:
-        console.print("[yellow]No channels found.[/]")
-        raise typer.Exit()
-
-    table = Table(title=f"Channels ({len(results)})")
-    table.add_column("Name", style="cyan", max_width=25)
-    table.add_column("Members", style="green", justify="right", max_width=8)
-    table.add_column("Purpose", style="white", max_width=50)
-
-    for ch in results:
-        priv = "[dim]🔒[/]" if ch["is_private"] else ""
-        purpose = (ch["purpose"] or ch["topic"] or "")[:50]
-        table.add_row(f"#{ch['name']}{priv}", str(ch["member_count"]), purpose)
-
-    console.print(table)
+    _render_channels(results, f"Channels ({len(results)})")
 
 
 @app.command("channel-members")

--- a/tools/productivity/slack/client.py
+++ b/tools/productivity/slack/client.py
@@ -737,23 +737,17 @@ class SlackClient:
         self._save_channel_cache(result)
         return result
 
-    def _fetch_channel_history(
+    def _fetch_channel_history_for_search(
         self,
-        client: WebClient,
         channel_id: str,
         channel_name: str,
         limit: int,
         user_cache: dict[str, str],
     ) -> list[dict]:
-        """Fetch history for a single channel (used by search)."""
+        """Fetch history for a single search fallback channel through the proxy."""
         try:
-            response = self._retry_on_ratelimit(
-                client.conversations_history,
-                method_key="conversations.history",
-                channel=channel_id,
-                limit=limit,
-            )
-        except (SlackApiError, SlackRateLimitError):
+            response = self.get_channel_history_proxy(channel_id, limit=limit)
+        except (RuntimeError, ValueError):
             return []
 
         messages = []
@@ -826,7 +820,7 @@ class SlackClient:
         Uses Slack's native search.messages API for fast, workspace-wide
         search. When ``SLACK_SEARCH_TOKEN`` is configured, the native call runs
         with that dedicated user token and its ``search:read`` scope. Falls
-        back to local channel scanning if the native API fails.
+        back to proxy-backed channel history scanning if the native API fails.
 
         Supports Slack search modifiers in the query string:
             in:#channel, from:@user, before:YYYY-MM-DD, after:YYYY-MM-DD,
@@ -862,7 +856,7 @@ class SlackClient:
         try:
             return self._search_messages_native(search_query, max_results)
         except (SlackApiError, RuntimeError, SlackRateLimitError):
-            # Fall back to local scanning if native search fails
+            # Fall back to proxy-backed channel history scanning if native search fails.
             return self._search_messages_local(
                 local_query, max_results, local_channels, local_from_user, messages_per_channel
             )
@@ -980,7 +974,7 @@ class SlackClient:
                 unresolved_names.add(normalized.lower())
 
         if unresolved_names:
-            for channel in self.list_bot_channels():
+            for channel in self.list_channels_proxy(history_only=True):
                 if channel["name"].lower() in unresolved_names:
                     resolved[channel["id"]] = channel
 
@@ -994,13 +988,13 @@ class SlackClient:
         from_user: str | None = None,
         messages_per_channel: int = 200,
     ) -> list[dict]:
-        """Search messages by scanning channel histories locally (fallback)."""
+        """Search messages by scanning channel histories through the proxy."""
         query_terms = [t.strip().lower() for t in query.split() if t.strip()]
 
         if channels:
             bot_channels = self._channel_refs_for_search(channels)
         else:
-            bot_channels = self.list_bot_channels()
+            bot_channels = self.list_channels_proxy(history_only=True)
             bot_channels = self._rank_channels_for_query(bot_channels, query_terms)
             bot_channels = bot_channels[: self._MAX_SEARCH_CHANNELS]
 
@@ -1016,8 +1010,7 @@ class SlackClient:
         with ThreadPoolExecutor(max_workers=min(6, len(bot_channels))) as executor:
             futures = {
                 executor.submit(
-                    self._fetch_channel_history,
-                    self._client,
+                    self._fetch_channel_history_for_search,
                     ch["id"],
                     ch["name"],
                     effective_limit,
@@ -1447,6 +1440,36 @@ class SlackClient:
                 break
 
         return sorted(channels, key=lambda x: x["name"])
+
+    def list_channels_proxy(self, limit: int = 200, history_only: bool = False) -> list[dict]:
+        """List Slack channels exposed by the Centaur API server proxy JWT."""
+        if secret("CENTAUR_SANDBOX_API_SERVER_ENABLED", "true").strip().lower() == "false":
+            raise RuntimeError(
+                "Slack channel listing proxy requires the API server sandbox capability, "
+                "but it is disabled for this principal."
+            )
+
+        response = self._centaur_api_get_json("/api/slack/channels", {})
+        channels = response.get("channels", []) or []
+        if history_only:
+            channels = [channel for channel in channels if channel.get("can_read_history")]
+        normalized_channels = [
+            {
+                "id": channel.get("id", ""),
+                "name": channel.get("name", "") or channel.get("id", ""),
+                "purpose": channel.get("purpose", ""),
+                "topic": channel.get("topic", ""),
+                "member_count": channel.get("member_count", 0),
+                "is_private": channel.get("is_private", False),
+                "is_member": channel.get("is_member", False),
+                "can_upload": channel.get("can_upload", False),
+                "can_download": channel.get("can_download", False),
+                "can_read_history": channel.get("can_read_history", False),
+            }
+            for channel in channels
+        ]
+        normalized_channels.sort(key=lambda channel: (channel["name"].lower(), channel["id"]))
+        return normalized_channels[:limit]
 
     def list_users(self, limit: int = 200) -> list[dict]:
         """List workspace users."""
@@ -2402,6 +2425,10 @@ def sync_channel_history(*args, **kwargs):
 
 def list_channels(*args, **kwargs):
     return _client().list_channels(*args, **kwargs)
+
+
+def list_channels_proxy(*args, **kwargs):
+    return _client().list_channels_proxy(*args, **kwargs)
 
 
 def list_users(*args, **kwargs):

--- a/tools/productivity/slack/tests/test_cli.py
+++ b/tools/productivity/slack/tests/test_cli.py
@@ -18,6 +18,155 @@ def test_channel_arg_is_id_rejects_names() -> None:
     assert not _channel_arg_is_id("#eng-centaur")
 
 
+def test_channel_calls_proxy_client(monkeypatch) -> None:
+    calls = []
+
+    def fake_get_channel_history_proxy(*args, **kwargs):
+        calls.append((args, kwargs))
+        return {
+            "ok": True,
+            "messages": [{"user": "U123", "text": "root"}],
+            "has_more": False,
+            "response_metadata": {},
+        }
+
+    fake_client = types.SimpleNamespace(get_channel_history_proxy=fake_get_channel_history_proxy)
+    monkeypatch.setitem(sys.modules, "slack.client", fake_client)
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "channel",
+            "C1234567890",
+            "--limit",
+            "10",
+            "--cursor",
+            "next",
+            "--inclusive",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert calls == [
+        (
+            ("C1234567890",),
+            {
+                "cursor": "next",
+                "include_all_metadata": None,
+                "inclusive": True,
+                "latest": None,
+                "limit": 10,
+                "oldest": None,
+            },
+        )
+    ]
+
+
+def test_channel_direct_calls_direct_client(monkeypatch) -> None:
+    calls = []
+
+    def fake_get_channel_history_page(*args, **kwargs):
+        calls.append((args, kwargs))
+        return {
+            "channel": "C1234567890",
+            "messages": [{"user": "alice", "text": "root"}],
+            "has_more": False,
+            "window": {"oldest": None, "latest": None, "inclusive": False},
+        }
+
+    fake_client = types.SimpleNamespace(get_channel_history_page=fake_get_channel_history_page)
+    monkeypatch.setitem(sys.modules, "slack.client", fake_client)
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "channel-direct",
+            "C1234567890",
+            "--limit",
+            "10",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert calls == [
+        (
+            ("C1234567890",),
+            {
+                "limit": 10,
+                "cursor": None,
+                "oldest": None,
+                "latest": None,
+                "inclusive": False,
+            },
+        )
+    ]
+
+
+def test_channels_calls_proxy_client(monkeypatch) -> None:
+    calls = []
+
+    def fake_list_channels_proxy(*args, **kwargs):
+        calls.append((args, kwargs))
+        return [
+            {
+                "id": "C1234567890",
+                "name": "general",
+                "purpose": "Company",
+                "topic": "",
+                "member_count": 10,
+                "is_private": False,
+                "can_read_history": True,
+                "can_upload": False,
+                "can_download": True,
+            }
+        ]
+
+    fake_client = types.SimpleNamespace(list_channels_proxy=fake_list_channels_proxy)
+    monkeypatch.setitem(sys.modules, "slack.client", fake_client)
+
+    result = CliRunner().invoke(
+        app,
+        ["channels", "--limit", "10", "--bot-member-only"],
+    )
+
+    assert result.exit_code == 0
+    assert calls == [((), {"limit": 10, "history_only": True})]
+    assert "general" in result.output
+
+
+def test_channels_direct_calls_direct_client(monkeypatch) -> None:
+    calls = []
+
+    def fake_list_channels(*args, **kwargs):
+        calls.append(("list_channels", args, kwargs))
+        return [
+            {
+                "id": "C1234567890",
+                "name": "general",
+                "purpose": "Company",
+                "topic": "",
+                "member_count": 10,
+                "is_private": False,
+            }
+        ]
+
+    def fake_list_bot_channels(*args, **kwargs):
+        calls.append(("list_bot_channels", args, kwargs))
+        return []
+
+    fake_client = types.SimpleNamespace(
+        list_channels=fake_list_channels,
+        list_bot_channels=fake_list_bot_channels,
+    )
+    monkeypatch.setitem(sys.modules, "slack.client", fake_client)
+
+    result = CliRunner().invoke(app, ["channels-direct", "--limit", "10"])
+
+    assert result.exit_code == 0
+    assert calls == [("list_channels", (), {"limit": 10})]
+    assert "general" in result.output
+
+
 def test_upload_direct_requires_explicit_channel_and_thread(
     monkeypatch, tmp_path: Path
 ) -> None:

--- a/tools/productivity/slack/tests/test_client.py
+++ b/tools/productivity/slack/tests/test_client.py
@@ -473,6 +473,53 @@ def test_get_channel_history_proxy_validates_inputs() -> None:
         client.get_channel_history_proxy("C123456789", limit=1000)
 
 
+def test_list_channels_proxy_calls_centaur_api() -> None:
+    client, _ = _make_client()
+
+    def fake_get_json(path, params):
+        assert path == "/api/slack/channels"
+        assert params == {}
+        return {
+            "ok": True,
+            "channels": [
+                {
+                    "id": "C222222222",
+                    "name": "random",
+                    "purpose": "",
+                    "topic": "Chat",
+                    "member_count": 3,
+                    "is_private": False,
+                    "is_member": True,
+                    "can_upload": True,
+                    "can_download": False,
+                    "can_read_history": False,
+                },
+                {
+                    "id": "C111111111",
+                    "name": "general",
+                    "purpose": "Company",
+                    "topic": "",
+                    "member_count": 10,
+                    "is_private": False,
+                    "is_member": True,
+                    "can_upload": False,
+                    "can_download": True,
+                    "can_read_history": True,
+                },
+            ],
+        }
+
+    client._centaur_api_get_json = fake_get_json  # type: ignore[method-assign]
+
+    assert [channel["id"] for channel in client.list_channels_proxy()] == [
+        "C111111111",
+        "C222222222",
+    ]
+    assert [channel["id"] for channel in client.list_channels_proxy(history_only=True)] == [
+        "C111111111"
+    ]
+
+
 def test_get_thread_replies_proxy_calls_centaur_api(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -653,7 +700,7 @@ def test_file_proxy_methods_validate_inputs() -> None:
         client.download_file_proxy(file_id="bad", channel_id="C123456789")
 
 
-def test_search_messages_with_channel_ids_scans_history_without_listing() -> None:
+def test_search_messages_with_channel_ids_scans_proxy_history_without_listing() -> None:
     client, fake_web_client = _make_client()
     client._get_user_cache = lambda: {"UGZCSQTPE": "matt", "U1": "alice"}  # type: ignore[method-assign]
     history_by_channel = {
@@ -670,12 +717,13 @@ def test_search_messages_with_channel_ids_scans_history_without_listing() -> Non
             "messages": [{"user": "UGZCSQTPE", "text": "nothing relevant", "ts": "100.000000"}]
         },
     }
+    proxy_calls: list[dict] = []
 
-    def history(**kwargs):
-        fake_web_client.history_calls.append(kwargs)
-        return history_by_channel[kwargs["channel"]]
+    def history_proxy(channel_id: str, **kwargs):
+        proxy_calls.append({"channel_id": channel_id, **kwargs})
+        return history_by_channel[channel_id]
 
-    fake_web_client.conversations_history = history  # type: ignore[method-assign]
+    client.get_channel_history_proxy = history_proxy  # type: ignore[method-assign]
 
     results = client.search_messages(
         "Matt",
@@ -686,28 +734,33 @@ def test_search_messages_with_channel_ids_scans_history_without_listing() -> Non
 
     assert fake_web_client.api_calls == []
     assert fake_web_client.list_calls == []
-    assert sorted(call["channel"] for call in fake_web_client.history_calls) == sorted(
+    assert fake_web_client.history_calls == []
+    assert sorted(call["channel_id"] for call in proxy_calls) == sorted(
         [
             "C05HUE4KLF2",
             "C042WDDP89Y",
             "C0A174PPJDS",
         ]
     )
-    assert sorted(call["limit"] for call in fake_web_client.history_calls) == [25, 25, 25]
+    assert sorted(call["limit"] for call in proxy_calls) == [25, 25, 25]
     assert sorted(item["channel_id"] for item in results) == ["C042WDDP89Y", "C05HUE4KLF2"]
 
 
 def test_search_messages_parses_channel_and_user_modifiers_locally() -> None:
     client, fake_web_client = _make_client()
     client._get_user_cache = lambda: {"UGZCSQTPE": "matt", "U1": "alice"}  # type: ignore[method-assign]
-    fake_web_client.history_pages = [
-        {
+    proxy_calls: list[dict] = []
+
+    def history_proxy(channel_id: str, **kwargs):
+        proxy_calls.append({"channel_id": channel_id, **kwargs})
+        return {
             "messages": [
                 {"user": "UGZCSQTPE", "text": "Scott Wu on inference", "ts": "300.000000"},
                 {"user": "U1", "text": "also about inference", "ts": "301.000000"},
             ]
         }
-    ]
+
+    client.get_channel_history_proxy = history_proxy  # type: ignore[method-assign]
 
     results = client.search_messages(
         "from:<@UGZCSQTPE> in:<#C042WDDP89Y>",
@@ -717,7 +770,8 @@ def test_search_messages_parses_channel_and_user_modifiers_locally() -> None:
 
     assert fake_web_client.api_calls == []
     assert fake_web_client.list_calls == []
-    assert fake_web_client.history_calls == [{"channel": "C042WDDP89Y", "limit": 25}]
+    assert fake_web_client.history_calls == []
+    assert proxy_calls == [{"channel_id": "C042WDDP89Y", "limit": 25}]
     assert len(results) == 1
     assert results[0]["user_id"] == "UGZCSQTPE"
 


### PR DESCRIPTION
Adds a proxy-backed Slack channel listing endpoint that derives authorized channels from the sandbox JWT and enriches them with Slack metadata. Updates the Slack CLI so channel history, channel listing, and search fallback use the proxy path by default while keeping direct SDK escape hatches.