### PR TITLE
refactor: move the PWA install CTA into the account menu

### DIFF
--- a/services/console/app/views/layouts/console.html.erb
+++ b/services/console/app/views/layouts/console.html.erb
@@ -707,6 +707,13 @@
         color: #f4f4f5;
       }
 
+      /* The install item is hidden until beforeinstallprompt fires; the
+         explicit rule is needed because display: flex above would otherwise
+         override the hidden attribute. */
+      .console-account-menu-button[hidden] {
+        display: none;
+      }
+
       .console-main {
         display: flex;
         height: 100%;
@@ -1376,22 +1383,6 @@
           </div>
         </div>
 
-        <%# PWA install entry point. Hidden unless the browser reports the
-            console is installable (beforeinstallprompt); installing keeps the
-            standalone window plus the manifest's file_handlers registration. %>
-        <div data-controller="pwa-install"
-             data-pwa-install-target="banner"
-             hidden
-             style="padding: 0.25rem 0.75rem;">
-          <button type="button"
-                  class="console-nav-link w-full cursor-pointer"
-                  data-action="pwa-install#install"
-                  title="Install Centaur Console as a standalone app">
-            <span class="console-nav-icon"><%= console_icon("computer", classes: "size-4") %></span>
-            <span class="console-nav-label">Install app</span>
-          </button>
-        </div>
-
         <% if current_user %>
           <div class="console-sidebar-account" data-account-menu>
             <button type="button"
@@ -1411,6 +1402,22 @@
               <div class="console-account-menu-line" title="<%= current_user.email %>"><%= current_user.email %></div>
               <div class="console-account-menu-line console-account-menu-muted">Centaur Console</div>
               <div class="console-account-menu-separator"></div>
+              <%# PWA install entry point. Hidden unless the browser reports
+                  the console is installable (beforeinstallprompt); installing
+                  keeps the standalone window plus the manifest's file_handlers
+                  registration. %>
+              <button type="button"
+                      class="console-account-menu-button"
+                      data-controller="pwa-install"
+                      data-pwa-install-target="banner"
+                      data-action="pwa-install#install"
+                      hidden
+                      role="menuitem"
+                      title="Install Centaur Console as a standalone app"
+                      aria-label="Install app">
+                <%= console_icon("computer", classes: "size-4") %>
+                <span>Install app</span>
+              </button>
               <button type="button"
                       class="console-account-menu-button"
                       data-console-theme-toggle

--- a/services/console/test/integration/pwa_test.rb
+++ b/services/console/test/integration/pwa_test.rb
@@ -54,6 +54,7 @@ class PwaTest < ActionDispatch::IntegrationTest
 
     get console_integrations_url
     assert_response :ok
-    assert_select "[data-controller=pwa-install]"
+    # Lives in the account menu, above the theme toggle.
+    assert_select "#console-account-menu [data-controller=pwa-install][hidden]"
   end
 end


### PR DESCRIPTION
## What

Follow-up to #980: moves the "Install app" button from its own slot at the bottom of the sidebar into the **account menu**, as a `menuitem` directly above the theme toggle.

- Same behavior as before: hidden until the browser fires `beforeinstallprompt`, click triggers the native install prompt, disappears once installed.
- `.console-account-menu-button` forces `display: flex`, which would override the `hidden` attribute — added an explicit `[hidden] { display: none }` rule so the item stays invisible until installability is reported.
- Test updated to pin the new location (`#console-account-menu [data-controller=pwa-install][hidden]`).

## Testing

Full `test/controllers` + `test/integration` suites in the `codex-centaur-console-web` container against this branch tree: 596 runs, 0 failures.

Visual click-through of the menu (item appears in an installable browser, hidden in the installed app) still needs a manual check on the deployed console.

🤖 Generated with [Claude Code](https://claude.com/claude-code)