### PR TITLE
feat: expose Slack file and member proxies

### DIFF
--- a/services/api-rs/crates/centaur-api-server/src/slack_proxy.rs
+++ b/services/api-rs/crates/centaur-api-server/src/slack_proxy.rs
@@ -46,6 +46,7 @@ pub(crate) fn slack_proxy_router() -> Router<AppState> {
             "/api/slack/files/{file_id}/download",
             get(download_slack_file),
         )
+        .route("/api/slack/files/{file_id}/info", get(get_slack_file_info))
         .route("/api/slack/channels", get(get_slack_channels))
         .route(
             "/api/slack/channels/{channel_id}/history",
@@ -77,6 +78,11 @@ struct SlackFileUploadQuery {
 
 #[derive(Debug, Deserialize)]
 struct SlackFileDownloadQuery {
+    channel_id: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct SlackFileInfoQuery {
     channel_id: String,
 }
 
@@ -145,6 +151,14 @@ struct SlackFilesListResponse {
     page: u32,
     paging: Option<Value>,
     has_more: bool,
+}
+
+#[derive(Debug, Serialize)]
+struct SlackFileInfoResponse {
+    ok: bool,
+    file_id: String,
+    channel_id: String,
+    file: Value,
 }
 
 #[derive(Debug, Serialize)]
@@ -337,6 +351,32 @@ async fn get_slack_files(
         page: effective_page,
         paging,
         has_more,
+    }))
+}
+
+async fn get_slack_file_info(
+    headers: HeaderMap,
+    Path(file_id): Path<String>,
+    Query(query): Query<SlackFileInfoQuery>,
+) -> Result<Json<SlackFileInfoResponse>, ApiError> {
+    let claims = authorize_slack_file_proxy(&headers)?;
+    ensure_download_channel_allowed(&claims, &query.channel_id)?;
+    validate_slack_channel_id(&query.channel_id)?;
+    validate_slack_file_id(&file_id)?;
+
+    let config = slack_proxy_config()?;
+    let file = slack_file_info(http_client(), config, &file_id).await?;
+    if !slack_file_in_channel(&file, &query.channel_id) {
+        return Err(ApiError::Forbidden(
+            "file is not shared in an allowed Slack channel".to_owned(),
+        ));
+    }
+
+    Ok(Json(SlackFileInfoResponse {
+        ok: true,
+        file_id,
+        channel_id: query.channel_id,
+        file,
     }))
 }
 
@@ -551,13 +591,8 @@ async fn slack_file_info(
     config: &SlackFileProxyConfig,
     file_id: &str,
 ) -> Result<Value, ApiError> {
-    let value = slack_api_post_form(
-        client,
-        config,
-        "files.info",
-        &[("file", file_id.to_owned())],
-    )
-    .await?;
+    let value =
+        slack_api_post_form(client, config, "files.info", &slack_file_info_form(file_id)).await?;
     value.get("file").cloned().ok_or_else(|| {
         ApiError::BadRequest("Slack file info response did not include file".to_owned())
     })
@@ -627,6 +662,10 @@ fn slack_files_list_form(
         ("count", slack_files_list_limit(query).to_string()),
         ("page", slack_files_list_page(query).to_string()),
     ]
+}
+
+fn slack_file_info_form(file_id: &str) -> Vec<(&'static str, String)> {
+    vec![("file", file_id.to_owned())]
 }
 
 fn slack_channel_history_form(
@@ -1209,6 +1248,14 @@ mod tests {
                 ("count", DEFAULT_SLACK_FILES_LIST_LIMIT.to_string()),
                 ("page", "1".to_owned()),
             ]
+        );
+    }
+
+    #[test]
+    fn file_info_form_maps_proxy_query_to_slack_params() {
+        assert_eq!(
+            slack_file_info_form("F123456789"),
+            vec![("file", "F123456789".to_owned())]
         );
     }
 

--- a/services/api-rs/crates/centaur-api-server/src/slack_proxy.rs
+++ b/services/api-rs/crates/centaur-api-server/src/slack_proxy.rs
@@ -53,6 +53,10 @@ pub(crate) fn slack_proxy_router() -> Router<AppState> {
             get(get_slack_channel_history),
         )
         .route(
+            "/api/slack/channels/{channel_id}/members",
+            get(get_slack_channel_members),
+        )
+        .route(
             "/api/slack/channels/{channel_id}/threads/{thread_ts}/replies",
             get(get_slack_thread_replies),
         )
@@ -106,6 +110,14 @@ struct SlackChannelHistoryQuery {
     inclusive: Option<bool>,
     #[serde(default)]
     include_all_metadata: Option<bool>,
+    #[serde(default)]
+    limit: Option<u16>,
+    #[serde(default)]
+    cursor: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct SlackChannelMembersQuery {
     #[serde(default)]
     limit: Option<u16>,
     #[serde(default)]
@@ -429,6 +441,21 @@ async fn get_slack_channel_history(
     Ok(Json(value))
 }
 
+async fn get_slack_channel_members(
+    headers: HeaderMap,
+    Path(channel_id): Path<String>,
+    Query(query): Query<SlackChannelMembersQuery>,
+) -> Result<Json<Value>, ApiError> {
+    let claims = authorize_slack_file_proxy(&headers)?;
+    ensure_history_channel_allowed(&claims, &channel_id)?;
+    validate_slack_channel_id(&channel_id)?;
+    validate_slack_channel_members_query(&query)?;
+
+    let config = slack_proxy_config()?;
+    let value = slack_channel_members(http_client(), config, &channel_id, &query).await?;
+    Ok(Json(value))
+}
+
 async fn get_slack_thread_replies(
     headers: HeaderMap,
     Path((channel_id, thread_ts)): Path<(String, String)>,
@@ -654,6 +681,16 @@ async fn slack_files_list(
     slack_api_post_form(client, config, "files.list", &form).await
 }
 
+async fn slack_channel_members(
+    client: &reqwest::Client,
+    config: &SlackFileProxyConfig,
+    channel_id: &str,
+    query: &SlackChannelMembersQuery,
+) -> Result<Value, ApiError> {
+    let form = slack_channel_members_form(channel_id, query);
+    slack_api_post_form(client, config, "conversations.members", &form).await
+}
+
 fn slack_files_list_form(
     channel_id: &str,
     query: &SlackFilesListQuery,
@@ -663,6 +700,25 @@ fn slack_files_list_form(
         ("count", slack_files_list_limit(query).to_string()),
         ("page", slack_files_list_page(query).to_string()),
     ]
+}
+
+fn slack_channel_members_form(
+    channel_id: &str,
+    query: &SlackChannelMembersQuery,
+) -> Vec<(&'static str, String)> {
+    let mut form = vec![
+        ("channel", channel_id.to_owned()),
+        (
+            "limit",
+            query
+                .limit
+                .map(|value| value.to_string())
+                .unwrap_or_default(),
+        ),
+        ("cursor", query.cursor.clone().unwrap_or_default()),
+    ];
+    form.retain(|(_, value)| !value.is_empty());
+    form
 }
 
 fn slack_file_info_form(file_id: &str) -> Vec<(&'static str, String)> {
@@ -1006,6 +1062,20 @@ fn validate_slack_channel_history_query(query: &SlackChannelHistoryQuery) -> Res
     Ok(())
 }
 
+fn validate_slack_channel_members_query(query: &SlackChannelMembersQuery) -> Result<(), ApiError> {
+    if let Some(limit) = query.limit
+        && !(1..=1000).contains(&limit)
+    {
+        return Err(ApiError::BadRequest(
+            "Slack channel members limit must be between 1 and 1000".to_owned(),
+        ));
+    }
+    if let Some(cursor) = query.cursor.as_deref() {
+        validate_slack_cursor(cursor)?;
+    }
+    Ok(())
+}
+
 fn validate_slack_files_list_query(query: &SlackFilesListQuery) -> Result<(), ApiError> {
     if let Some(limit) = query.limit
         && !(1..=MAX_SLACK_FILES_LIST_LIMIT).contains(&limit)
@@ -1253,6 +1323,23 @@ mod tests {
     }
 
     #[test]
+    fn channel_members_form_maps_proxy_query_to_slack_params() {
+        let query = SlackChannelMembersQuery {
+            limit: Some(500),
+            cursor: Some("cursor-1".to_owned()),
+        };
+
+        assert_eq!(
+            slack_channel_members_form("C123456789", &query),
+            vec![
+                ("channel", "C123456789".to_owned()),
+                ("limit", "500".to_owned()),
+                ("cursor", "cursor-1".to_owned()),
+            ]
+        );
+    }
+
+    #[test]
     fn file_info_form_maps_proxy_query_to_slack_params() {
         assert_eq!(
             slack_file_info_form("F123456789"),
@@ -1302,6 +1389,32 @@ mod tests {
                 channel_id: Some("C123456789".to_owned()),
                 limit: Some(20),
                 page: Some(0),
+            })
+            .unwrap_err(),
+            ApiError::BadRequest(_)
+        ));
+    }
+
+    #[test]
+    fn validates_channel_members_query() {
+        validate_slack_channel_members_query(&SlackChannelMembersQuery {
+            limit: Some(1000),
+            cursor: Some("cursor-1".to_owned()),
+        })
+        .unwrap();
+
+        assert!(matches!(
+            validate_slack_channel_members_query(&SlackChannelMembersQuery {
+                limit: Some(1001),
+                cursor: None,
+            })
+            .unwrap_err(),
+            ApiError::BadRequest(_)
+        ));
+        assert!(matches!(
+            validate_slack_channel_members_query(&SlackChannelMembersQuery {
+                limit: Some(10),
+                cursor: Some("\n".to_owned()),
             })
             .unwrap_err(),
             ApiError::BadRequest(_)

--- a/services/api-rs/crates/centaur-api-server/src/slack_proxy.rs
+++ b/services/api-rs/crates/centaur-api-server/src/slack_proxy.rs
@@ -236,19 +236,10 @@ async fn download_slack_file(
     Path(file_id): Path<String>,
     Query(query): Query<SlackFileDownloadQuery>,
 ) -> Result<Response, ApiError> {
-    let claims = authorize_slack_file_proxy(&headers)?;
-    ensure_download_channel_allowed(&claims, &query.channel_id)?;
-    validate_slack_channel_id(&query.channel_id)?;
-    validate_slack_file_id(&file_id)?;
-
     let config = slack_proxy_config()?;
     let client = http_client();
-    let file = slack_file_info(client, config, &file_id).await?;
-    if !slack_file_in_channel(&file, &query.channel_id) {
-        return Err(ApiError::Forbidden(
-            "file is not shared in an allowed Slack channel".to_owned(),
-        ));
-    }
+    let file =
+        authorized_slack_file_info(&headers, client, config, &file_id, &query.channel_id).await?;
     let download_url = file
         .get("url_private_download")
         .or_else(|| file.get("url_private"))
@@ -359,18 +350,10 @@ async fn get_slack_file_info(
     Path(file_id): Path<String>,
     Query(query): Query<SlackFileInfoQuery>,
 ) -> Result<Json<SlackFileInfoResponse>, ApiError> {
-    let claims = authorize_slack_file_proxy(&headers)?;
-    ensure_download_channel_allowed(&claims, &query.channel_id)?;
-    validate_slack_channel_id(&query.channel_id)?;
-    validate_slack_file_id(&file_id)?;
-
     let config = slack_proxy_config()?;
-    let file = slack_file_info(http_client(), config, &file_id).await?;
-    if !slack_file_in_channel(&file, &query.channel_id) {
-        return Err(ApiError::Forbidden(
-            "file is not shared in an allowed Slack channel".to_owned(),
-        ));
-    }
+    let file =
+        authorized_slack_file_info(&headers, http_client(), config, &file_id, &query.channel_id)
+            .await?;
 
     Ok(Json(SlackFileInfoResponse {
         ok: true,
@@ -378,6 +361,27 @@ async fn get_slack_file_info(
         channel_id: query.channel_id,
         file,
     }))
+}
+
+async fn authorized_slack_file_info(
+    headers: &HeaderMap,
+    client: &reqwest::Client,
+    config: &SlackFileProxyConfig,
+    file_id: &str,
+    channel_id: &str,
+) -> Result<Value, ApiError> {
+    let claims = authorize_slack_file_proxy(headers)?;
+    ensure_download_channel_allowed(&claims, channel_id)?;
+    validate_slack_channel_id(channel_id)?;
+    validate_slack_file_id(file_id)?;
+
+    let file = slack_file_info(client, config, file_id).await?;
+    if !slack_file_in_channel(&file, channel_id) {
+        return Err(ApiError::Forbidden(
+            "file is not shared in an allowed Slack channel".to_owned(),
+        ));
+    }
+    Ok(file)
 }
 
 async fn get_slack_channels(headers: HeaderMap) -> Result<Json<SlackChannelsResponse>, ApiError> {

--- a/services/api-rs/crates/centaur-api-server/src/slack_proxy.rs
+++ b/services/api-rs/crates/centaur-api-server/src/slack_proxy.rs
@@ -236,10 +236,9 @@ async fn download_slack_file(
     Path(file_id): Path<String>,
     Query(query): Query<SlackFileDownloadQuery>,
 ) -> Result<Response, ApiError> {
-    let config = slack_proxy_config()?;
     let client = http_client();
-    let file =
-        authorized_slack_file_info(&headers, client, config, &file_id, &query.channel_id).await?;
+    let (config, file) =
+        authorized_slack_file_info(&headers, client, &file_id, &query.channel_id).await?;
     let download_url = file
         .get("url_private_download")
         .or_else(|| file.get("url_private"))
@@ -350,10 +349,8 @@ async fn get_slack_file_info(
     Path(file_id): Path<String>,
     Query(query): Query<SlackFileInfoQuery>,
 ) -> Result<Json<SlackFileInfoResponse>, ApiError> {
-    let config = slack_proxy_config()?;
-    let file =
-        authorized_slack_file_info(&headers, http_client(), config, &file_id, &query.channel_id)
-            .await?;
+    let (_, file) =
+        authorized_slack_file_info(&headers, http_client(), &file_id, &query.channel_id).await?;
 
     Ok(Json(SlackFileInfoResponse {
         ok: true,
@@ -366,22 +363,22 @@ async fn get_slack_file_info(
 async fn authorized_slack_file_info(
     headers: &HeaderMap,
     client: &reqwest::Client,
-    config: &SlackFileProxyConfig,
     file_id: &str,
     channel_id: &str,
-) -> Result<Value, ApiError> {
+) -> Result<(&'static SlackFileProxyConfig, Value), ApiError> {
     let claims = authorize_slack_file_proxy(headers)?;
     ensure_download_channel_allowed(&claims, channel_id)?;
     validate_slack_channel_id(channel_id)?;
     validate_slack_file_id(file_id)?;
 
+    let config = slack_proxy_config()?;
     let file = slack_file_info(client, config, file_id).await?;
     if !slack_file_in_channel(&file, channel_id) {
         return Err(ApiError::Forbidden(
             "file is not shared in an allowed Slack channel".to_owned(),
         ));
     }
-    Ok(file)
+    Ok((config, file))
 }
 
 async fn get_slack_channels(headers: HeaderMap) -> Result<Json<SlackChannelsResponse>, ApiError> {
@@ -1309,6 +1306,15 @@ mod tests {
             .unwrap_err(),
             ApiError::BadRequest(_)
         ));
+    }
+
+    #[tokio::test]
+    async fn file_info_authorizes_before_reading_slack_config() {
+        let headers = HeaderMap::new();
+        let result =
+            authorized_slack_file_info(&headers, http_client(), "F123456789", "C123456789").await;
+
+        assert!(matches!(result, Err(ApiError::Unauthorized(_))));
     }
 
     #[test]

--- a/tools/productivity/slack/cli.py
+++ b/tools/productivity/slack/cli.py
@@ -1013,6 +1013,52 @@ def _print_file_search_results(query: str, results: list[dict]) -> None:
     console.print(table)
 
 
+@app.command("file-info-proxy")
+@app.command("file-info")
+def file_info(
+    file_id: str = typer.Argument(..., help="Slack file ID, e.g. F1234567890"),
+    channel_id: str = typer.Argument(
+        ..., help="Slack channel/conversation ID that the file is shared in"
+    ),
+    json_output: bool = typer.Option(False, "--json", help="Output raw metadata as JSON"),
+):
+    """Fetch Slack file metadata through the Centaur API server Slack proxy."""
+    import sys
+
+    from .client import file_info_proxy
+
+    try:
+        result = file_info_proxy(file_id=file_id, channel_id=channel_id)
+    except (RuntimeError, ValueError) as e:
+        console.print(f"[red]Error fetching Slack file info: {e}[/]")
+        raise typer.Exit(1) from e
+
+    if json_output:
+        print(json.dumps(result, indent=2, ensure_ascii=False), file=sys.stdout)
+        raise typer.Exit()
+
+    file = result.get("file", {})
+    table = Table(title=f"Slack File {result.get('file_id') or file_id}")
+    table.add_column("Field", style="cyan", max_width=18)
+    table.add_column("Value", style="white", max_width=90)
+    for key in [
+        "id",
+        "name",
+        "title",
+        "mimetype",
+        "filetype",
+        "size",
+        "user",
+        "created",
+        "permalink",
+        "url_private",
+    ]:
+        value = file.get(key)
+        if value not in (None, "", []):
+            table.add_row(key, str(value))
+    console.print(table)
+
+
 @app.command("search-users")
 def search_users_cmd(
     query: str = typer.Argument(..., help="Search by name, email, or title"),

--- a/tools/productivity/slack/cli.py
+++ b/tools/productivity/slack/cli.py
@@ -989,6 +989,24 @@ def search_files_direct_cmd(
     _print_file_search_results(query, results)
 
 
+def _format_file_size(size: object) -> str:
+    try:
+        size_bytes = int(size or 0)
+    except (TypeError, ValueError):
+        return str(size)
+    if size_bytes >= 1_000_000:
+        return f"{size_bytes / 1_000_000:.1f}MB"
+    if size_bytes >= 1_000:
+        return f"{size_bytes / 1_000:.0f}KB"
+    return f"{size_bytes}B"
+
+
+def _format_file_info_value(key: str, value: object) -> str:
+    if key == "size":
+        return _format_file_size(value)
+    return str(value)
+
+
 def _print_file_search_results(query: str, results: list[dict]) -> None:
     if not results:
         console.print("[yellow]No files found.[/]")
@@ -1001,14 +1019,7 @@ def _print_file_search_results(query: str, results: list[dict]) -> None:
     table.add_column("Size", style="dim", justify="right", max_width=10)
 
     for f in results:
-        size = f["size"]
-        if size > 1_000_000:
-            size_str = f"{size / 1_000_000:.1f}MB"
-        elif size > 1000:
-            size_str = f"{size / 1000:.0f}KB"
-        else:
-            size_str = f"{size}B"
-        table.add_row(f["name"], f["filetype"], f["user"], size_str)
+        table.add_row(f["name"], f["filetype"], f["user"], _format_file_size(f["size"]))
 
     console.print(table)
 
@@ -1055,7 +1066,7 @@ def file_info(
     ]:
         value = file.get(key)
         if value not in (None, "", []):
-            table.add_row(key, str(value))
+            table.add_row(key, _format_file_info_value(key, value))
     console.print(table)
 
 
@@ -1202,8 +1213,9 @@ def files(
     else:
         console.print(f"[bold]Files ({len(files_list)})[/]\n")
         for f in files_list:
-            size_kb = f["size"] / 1024
-            console.print(f"[cyan]{f['name']}[/] ({f['filetype']}, {size_kb:.1f} KB)")
+            console.print(
+                f"[cyan]{f['name']}[/] ({f['filetype']}, {_format_file_size(f['size'])})"
+            )
             console.print(f"  [dim]{f['url_private']}[/]")
 
 

--- a/tools/productivity/slack/cli.py
+++ b/tools/productivity/slack/cli.py
@@ -625,18 +625,66 @@ def channels_direct(
     _render_channels(results, f"Channels ({len(results)})")
 
 
+def _render_channel_members(channel: str, members: list[dict], emails_only: bool) -> None:
+    if not members:
+        console.print("[yellow]No members found.[/]")
+        raise typer.Exit()
+
+    if emails_only:
+        for m in members:
+            if m.get("email"):
+                console.print(m["email"])
+        return
+
+    table = Table(title=f"#{channel} Members ({len(members)})")
+    table.add_column("Name", style="cyan", max_width=20)
+    table.add_column("Real Name", style="white", max_width=25)
+    table.add_column("Email", style="green", max_width=35)
+
+    for m in members:
+        table.add_row(f"@{m['name']}", m.get("real_name", ""), m.get("email", ""))
+
+    console.print(table)
+
+
+@app.command("channel-members-proxy")
 @app.command("channel-members")
 def channel_members_cmd(
+    channel_id: str = typer.Argument(..., help="Slack channel ID, e.g. C1234567890"),
+    limit: int = typer.Option(1000, "--limit", "-n", help="Max members"),
+    emails_only: bool = typer.Option(
+        False, "--emails", "-e", help="Output only email addresses (one per line)"
+    ),
+):
+    """List members of a Slack channel through the Centaur API server proxy.
+
+    Examples:
+        slack channel-members C1234567890
+        slack channel-members C1234567890 --emails
+    """
+    from .client import get_channel_members_proxy
+
+    try:
+        members = get_channel_members_proxy(channel_id, limit=limit)
+    except (RuntimeError, ValueError) as e:
+        console.print(f"[red]Error: {e}[/]")
+        raise typer.Exit(1)
+
+    _render_channel_members(channel_id, members, emails_only)
+
+
+@app.command("channel-members-direct")
+def channel_members_direct_cmd(
     channel: str = typer.Argument(..., help="Channel name (without #) or channel ID"),
     emails_only: bool = typer.Option(
         False, "--emails", "-e", help="Output only email addresses (one per line)"
     ),
 ):
-    """List all members of a Slack channel.
+    """List all members of a Slack channel directly with the Slack SDK.
 
     Examples:
-        slack channel-members eng-ai
-        slack channel-members eng-ai --emails
+        slack channel-members-direct eng-ai
+        slack channel-members-direct eng-ai --emails
     """
     from .client import get_channel_members
 
@@ -646,24 +694,7 @@ def channel_members_cmd(
         console.print(f"[red]Error: {e}[/]")
         raise typer.Exit(1)
 
-    if not members:
-        console.print("[yellow]No members found.[/]")
-        raise typer.Exit()
-
-    if emails_only:
-        for m in members:
-            if m.get("email"):
-                console.print(m["email"])
-    else:
-        table = Table(title=f"#{channel} Members ({len(members)})")
-        table.add_column("Name", style="cyan", max_width=20)
-        table.add_column("Real Name", style="white", max_width=25)
-        table.add_column("Email", style="green", max_width=35)
-
-        for m in members:
-            table.add_row(f"@{m['name']}", m.get("real_name", ""), m.get("email", ""))
-
-        console.print(table)
+    _render_channel_members(channel, members, emails_only)
 
 
 @app.command()

--- a/tools/productivity/slack/client.py
+++ b/tools/productivity/slack/client.py
@@ -2063,6 +2063,20 @@ class SlackClient:
             "content_base64": base64.b64encode(body).decode(),
         }
 
+    def file_info_proxy(self, file_id: str, channel_id: str) -> dict[str, Any]:
+        """Fetch Slack file metadata through the Centaur API server proxy."""
+        if not self._api_server_proxy_enabled():
+            raise RuntimeError(
+                "Slack file info proxy requires the API server sandbox capability, "
+                "but it is disabled for this principal."
+            )
+        normalized_file_id = self._normalize_file_id(file_id)
+        normalized_channel_id = self._normalize_explicit_channel_id(channel_id)
+        return self._centaur_api_get_json(
+            f"/api/slack/files/{urllib.parse.quote(normalized_file_id, safe='')}/info",
+            {"channel_id": normalized_channel_id},
+        )
+
     def list_usergroups(self) -> list[dict]:
         """List all user groups in the workspace."""
         try:
@@ -2565,6 +2579,10 @@ def upload_file_proxy(*args, **kwargs):
 
 def download_file_proxy(*args, **kwargs):
     return _client().download_file_proxy(*args, **kwargs)
+
+
+def file_info_proxy(*args, **kwargs):
+    return _client().file_info_proxy(*args, **kwargs)
 
 
 def list_usergroups(*args, **kwargs):

--- a/tools/productivity/slack/client.py
+++ b/tools/productivity/slack/client.py
@@ -1512,6 +1512,43 @@ class SlackClient:
         }
         return self._centaur_api_get_json("/api/slack/files", params)
 
+    def get_channel_members_proxy(self, channel_id: str, limit: int = 1000) -> list[dict]:
+        """List Slack channel members through the Centaur API server proxy."""
+        if not self._api_server_proxy_enabled():
+            raise RuntimeError(
+                "Slack channel members proxy requires the API server sandbox capability, "
+                "but it is disabled for this principal."
+            )
+
+        requested_limit = int(limit)
+        if not 1 <= requested_limit <= 10_000:
+            raise ValueError("limit must be between 1 and 10000")
+
+        normalized_channel_id = self._normalize_explicit_channel_id(channel_id)
+        channel_path = urllib.parse.quote(normalized_channel_id, safe="")
+        user_cache = self._get_user_cache()
+        member_ids: list[str] = []
+        cursor: str | None = None
+
+        while len(member_ids) < requested_limit:
+            page_limit = min(requested_limit - len(member_ids), 1000)
+            response = self._centaur_api_get_json(
+                f"/api/slack/channels/{channel_path}/members",
+                {"limit": page_limit, "cursor": cursor},
+            )
+            member_ids.extend(str(member_id) for member_id in response.get("members", []) or [])
+            cursor = response.get("response_metadata", {}).get("next_cursor") or None
+            if not cursor:
+                break
+
+        return [
+            {
+                "id": member_id,
+                "name": user_cache.get(member_id, member_id),
+            }
+            for member_id in member_ids[:requested_limit]
+        ]
+
     def list_users(self, limit: int = 200) -> list[dict]:
         """List workspace users."""
         users = []
@@ -2551,6 +2588,10 @@ def list_users(*args, **kwargs):
 
 def get_channel_members(*args, **kwargs):
     return _client().get_channel_members(*args, **kwargs)
+
+
+def get_channel_members_proxy(*args, **kwargs):
+    return _client().get_channel_members_proxy(*args, **kwargs)
 
 
 def get_channel_member_emails(*args, **kwargs):

--- a/tools/productivity/slack/tests/test_cli.py
+++ b/tools/productivity/slack/tests/test_cli.py
@@ -409,6 +409,7 @@ def test_file_info_calls_proxy_client(monkeypatch) -> None:
     assert result.exit_code == 0
     assert calls == [{"file_id": "F1234567890", "channel_id": "C1234567890"}]
     assert "report.pdf" in result.output
+    assert "1KB" in result.output
 
 
 def test_thread_calls_api_server_client(monkeypatch) -> None:

--- a/tools/productivity/slack/tests/test_cli.py
+++ b/tools/productivity/slack/tests/test_cli.py
@@ -167,6 +167,45 @@ def test_channels_direct_calls_direct_client(monkeypatch) -> None:
     assert "general" in result.output
 
 
+def test_channel_members_calls_proxy_client(monkeypatch) -> None:
+    calls = []
+
+    def fake_get_channel_members_proxy(*args, **kwargs):
+        calls.append((args, kwargs))
+        return [{"id": "U123456789", "name": "alice"}]
+
+    fake_client = types.SimpleNamespace(
+        get_channel_members_proxy=fake_get_channel_members_proxy
+    )
+    monkeypatch.setitem(sys.modules, "slack.client", fake_client)
+
+    result = CliRunner().invoke(
+        app,
+        ["channel-members", "C1234567890", "--limit", "25"],
+    )
+
+    assert result.exit_code == 0
+    assert calls == [(("C1234567890",), {"limit": 25})]
+    assert "alice" in result.output
+
+
+def test_channel_members_direct_calls_direct_client(monkeypatch) -> None:
+    calls = []
+
+    def fake_get_channel_members(*args, **kwargs):
+        calls.append((args, kwargs))
+        return [{"id": "U123456789", "name": "alice"}]
+
+    fake_client = types.SimpleNamespace(get_channel_members=fake_get_channel_members)
+    monkeypatch.setitem(sys.modules, "slack.client", fake_client)
+
+    result = CliRunner().invoke(app, ["channel-members-direct", "eng-ai"])
+
+    assert result.exit_code == 0
+    assert calls == [(("eng-ai",), {})]
+    assert "alice" in result.output
+
+
 def test_search_files_calls_proxy_client(monkeypatch) -> None:
     calls = []
 

--- a/tools/productivity/slack/tests/test_cli.py
+++ b/tools/productivity/slack/tests/test_cli.py
@@ -381,6 +381,36 @@ def test_download_writes_file_with_proxy(monkeypatch, tmp_path: Path) -> None:
     assert (tmp_path / "report.pdf").read_bytes() == b"%PDF"
 
 
+def test_file_info_calls_proxy_client(monkeypatch) -> None:
+    calls = []
+
+    def fake_file_info_proxy(**kwargs):
+        calls.append(kwargs)
+        return {
+            "ok": True,
+            "file_id": "F1234567890",
+            "channel_id": "C1234567890",
+            "file": {
+                "id": "F1234567890",
+                "name": "report.pdf",
+                "filetype": "pdf",
+                "size": 1234,
+            },
+        }
+
+    fake_client = types.SimpleNamespace(file_info_proxy=fake_file_info_proxy)
+    monkeypatch.setitem(sys.modules, "slack.client", fake_client)
+
+    result = CliRunner().invoke(
+        app,
+        ["file-info", "F1234567890", "C1234567890"],
+    )
+
+    assert result.exit_code == 0
+    assert calls == [{"file_id": "F1234567890", "channel_id": "C1234567890"}]
+    assert "report.pdf" in result.output
+
+
 def test_thread_calls_api_server_client(monkeypatch) -> None:
     calls = []
 

--- a/tools/productivity/slack/tests/test_client.py
+++ b/tools/productivity/slack/tests/test_client.py
@@ -725,6 +725,41 @@ def test_download_file_proxy_returns_base64_file(
     assert urllib.parse.parse_qs(parsed.query) == {"channel_id": ["C123456789"]}
 
 
+def test_file_info_proxy_calls_centaur_api(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import urllib.parse
+    import urllib.request
+
+    client, _ = _make_client()
+    request_info: dict[str, str | None] = {}
+
+    def fake_urlopen(req, *args, **kwargs):
+        request_info["url"] = req.full_url
+        request_info["authorization"] = req.get_header("Authorization")
+        body = json.dumps(
+            {
+                "ok": True,
+                "file_id": "F123456789",
+                "channel_id": "C123456789",
+                "file": {"id": "F123456789", "name": "report.pdf"},
+            }
+        ).encode()
+        return _FakeHTTPResponse(body, "application/json")
+
+    monkeypatch.setenv("CENTAUR_API_URL", "http://api.internal:8080")
+    monkeypatch.setenv("CENTAUR_API_BEARER_TOKEN", "test-jwt")
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+
+    result = client.file_info_proxy(file_id="F123456789", channel_id="<#C123456789|general>")
+
+    assert result["file"] == {"id": "F123456789", "name": "report.pdf"}
+    assert request_info["authorization"] == "Bearer test-jwt"
+    parsed = urllib.parse.urlparse(request_info["url"])
+    assert parsed.path == "/api/slack/files/F123456789/info"
+    assert urllib.parse.parse_qs(parsed.query) == {"channel_id": ["C123456789"]}
+
+
 def test_file_proxy_methods_validate_inputs() -> None:
     client, _ = _make_client()
 
@@ -742,6 +777,8 @@ def test_file_proxy_methods_validate_inputs() -> None:
         )
     with pytest.raises(ValueError, match="file_id"):
         client.download_file_proxy(file_id="bad", channel_id="C123456789")
+    with pytest.raises(ValueError, match="file_id"):
+        client.file_info_proxy(file_id="bad", channel_id="C123456789")
 
 
 def test_search_files_uses_proxy_with_user_cache(

--- a/tools/productivity/slack/tests/test_client.py
+++ b/tools/productivity/slack/tests/test_client.py
@@ -760,6 +760,39 @@ def test_file_info_proxy_calls_centaur_api(
     assert urllib.parse.parse_qs(parsed.query) == {"channel_id": ["C123456789"]}
 
 
+def test_get_channel_members_proxy_paginates_and_resolves_names() -> None:
+    client, _ = _make_client()
+    client._get_user_cache = lambda: {"U111111111": "alice", "U222222222": "bob"}  # type: ignore[method-assign]
+    calls: list[tuple[str, dict]] = []
+
+    def fake_get_json(path, params):
+        calls.append((path, params))
+        if params["cursor"] is None:
+            return {
+                "ok": True,
+                "members": ["U111111111"],
+                "response_metadata": {"next_cursor": "next"},
+            }
+        return {
+            "ok": True,
+            "members": ["U222222222"],
+            "response_metadata": {"next_cursor": ""},
+        }
+
+    client._centaur_api_get_json = fake_get_json  # type: ignore[method-assign]
+
+    result = client.get_channel_members_proxy("<#C123456789|general>", limit=10)
+
+    assert calls == [
+        ("/api/slack/channels/C123456789/members", {"limit": 10, "cursor": None}),
+        ("/api/slack/channels/C123456789/members", {"limit": 9, "cursor": "next"}),
+    ]
+    assert result == [
+        {"id": "U111111111", "name": "alice"},
+        {"id": "U222222222", "name": "bob"},
+    ]
+
+
 def test_file_proxy_methods_validate_inputs() -> None:
     client, _ = _make_client()
 
@@ -779,6 +812,8 @@ def test_file_proxy_methods_validate_inputs() -> None:
         client.download_file_proxy(file_id="bad", channel_id="C123456789")
     with pytest.raises(ValueError, match="file_id"):
         client.file_info_proxy(file_id="bad", channel_id="C123456789")
+    with pytest.raises(ValueError, match="channel_id"):
+        client.get_channel_members_proxy(channel_id="general")
 
 
 def test_search_files_uses_proxy_with_user_cache(


### PR DESCRIPTION
Adds Centaur API Slack proxy endpoints for files.info and conversations.members with principal-scoped channel authorization. Exposes the new metadata and member listing paths through the Slack client and CLI, while retaining direct SDK fallback commands. Also centralizes shared file authorization checks and normalizes Slack file size rendering.