### PR TITLE
feat(harness): add Hermes ACP adapter

### DIFF
--- a/contrib/chart/values.yaml
+++ b/contrib/chart/values.yaml
@@ -242,7 +242,7 @@ sandbox:
   #                  subscription token (proxy injects the brokered credential).
   codexAuthMode: api_key
   claudeCodeAuthMode: api_key
-  # The deployment's default harness: codex | amp | claudecode. Decides what
+  # The deployment's default harness: codex | amp | claudecode | hermes. Decides what
   # warm sandboxes boot (SESSION_SANDBOX_HARNESS) and which harness auth
   # fragment is required at startup (the other harnesses' fragments are
   # registered too when available, so per-session --claude/--amp/--codex

--- a/crates/harness-server/src/hermes.rs
+++ b/crates/harness-server/src/hermes.rs
@@ -1,0 +1,528 @@
+use std::env;
+use std::io::Write;
+use std::process::Command as ProcessCommand;
+use std::time::Duration;
+
+use codex_app_server_protocol::UserInput;
+use serde::Deserialize;
+use serde_json::{Value, json};
+use uuid::Uuid;
+
+use crate::traits::HarnessChild;
+use crate::{
+    HarnessKind, HarnessServer, NormalizedContent, NormalizedEvent, NormalizedToolResult, Result,
+    ThreadState, command_from_override, stable_id, user_input_to_anthropic_content,
+};
+
+const ACP_PROTOCOL_VERSION: u64 = 1;
+const STARTUP_TIMEOUT: Duration = Duration::from_secs(30);
+
+#[derive(Debug, Clone)]
+pub enum HermesEvent {
+    SessionUpdate(HermesSessionUpdate),
+    PromptResponse { result: Value },
+    Error { message: String },
+    PermissionRequest { id: Value },
+    Ignored,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HermesSessionUpdate {
+    pub session_id: String,
+    pub update: HermesUpdate,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HermesUpdate {
+    pub session_update: String,
+    #[serde(default)]
+    pub content: Option<Value>,
+    #[serde(default)]
+    pub tool_call_id: Option<String>,
+    #[serde(default)]
+    pub title: Option<String>,
+    #[serde(default)]
+    pub raw_input: Option<Value>,
+    #[serde(default)]
+    pub status: Option<String>,
+}
+
+impl HermesEvent {
+    pub fn parse_json_line(line: &str) -> Result<Self> {
+        let value: Value = serde_json::from_str(line)?;
+        let Some(object) = value.as_object() else {
+            return Ok(Self::Ignored);
+        };
+
+        if object.get("method").and_then(Value::as_str) == Some("session/update") {
+            let params = object.get("params").cloned().ok_or_else(|| {
+                crate::HarnessServerError::Protocol("session/update is missing params".to_string())
+            })?;
+            return Ok(Self::SessionUpdate(serde_json::from_value(params)?));
+        }
+
+        if object.get("method").and_then(Value::as_str) == Some("session/request_permission") {
+            let id = object.get("id").cloned().ok_or_else(|| {
+                crate::HarnessServerError::Protocol("permission request is missing id".to_string())
+            })?;
+            return Ok(Self::PermissionRequest { id });
+        }
+
+        if object.get("id").is_some() {
+            if let Some(error) = object.get("error") {
+                return Ok(Self::Error {
+                    message: error_message(error),
+                });
+            }
+            if let Some(result) = object.get("result") {
+                return Ok(Self::PromptResponse {
+                    result: result.clone(),
+                });
+            }
+        }
+
+        Ok(Self::Ignored)
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct HermesEventNormalizer {
+    session_started: bool,
+}
+
+impl HermesEventNormalizer {
+    pub fn normalize(&mut self, event: HermesEvent) -> Vec<NormalizedEvent> {
+        match event {
+            HermesEvent::SessionUpdate(params) => {
+                let mut events = Vec::new();
+                if !self.session_started {
+                    self.session_started = true;
+                    events.push(NormalizedEvent::SessionStarted {
+                        session_id: Some(params.session_id.clone()),
+                    });
+                }
+                events.extend(normalize_update(&params.session_id, params.update));
+                events
+            }
+            HermesEvent::PromptResponse { result } => {
+                let error = result
+                    .get("stopReason")
+                    .and_then(Value::as_str)
+                    .filter(|reason| matches!(*reason, "cancelled" | "refusal"))
+                    .map(str::to_owned);
+                vec![NormalizedEvent::Result { error }]
+            }
+            HermesEvent::Error { message } => vec![NormalizedEvent::Error { message }],
+            HermesEvent::PermissionRequest { .. } | HermesEvent::Ignored => {
+                vec![NormalizedEvent::Ignored]
+            }
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct HermesHarness;
+
+impl HarnessServer for HermesHarness {
+    type Event = HermesEvent;
+    type EventNormalizer = HermesEventNormalizer;
+
+    fn kind(&self) -> HarnessKind {
+        HarnessKind::Hermes
+    }
+
+    fn cli_version(&self) -> &'static str {
+        "hermes-agent"
+    }
+
+    fn default_model(&self) -> String {
+        env::var("HERMES_MODEL").unwrap_or_default()
+    }
+
+    fn default_model_provider(&self) -> &'static str {
+        "openrouter"
+    }
+
+    fn command_for_turn(&self, _state: &ThreadState) -> ProcessCommand {
+        if let Some(command) = command_from_override("CENTAUR_HERMES_COMMAND") {
+            return command;
+        }
+        ProcessCommand::new(env::var("HERMES_BIN").unwrap_or_else(|_| "hermes-acp".to_string()))
+    }
+
+    fn prepare_process(&self, process: &mut HarnessChild, state: &mut ThreadState) -> Result<()> {
+        let initialize_id = json!("centaur-initialize");
+        write_request(
+            process,
+            initialize_id.clone(),
+            "initialize",
+            json!({
+                "protocolVersion": ACP_PROTOCOL_VERSION,
+                "clientCapabilities": {},
+                "clientInfo": {
+                    "name": "centaur-harness-server",
+                    "version": env!("CARGO_PKG_VERSION"),
+                },
+            }),
+        )?;
+        wait_for_response(process, &initialize_id)?;
+
+        let session_id_request = json!("centaur-session");
+        write_request(
+            process,
+            session_id_request.clone(),
+            "session/new",
+            json!({
+                "cwd": state.cwd.to_string_lossy(),
+                "mcpServers": [],
+            }),
+        )?;
+        let result = wait_for_response(process, &session_id_request)?;
+        let session_id = result
+            .get("sessionId")
+            .and_then(Value::as_str)
+            .filter(|value| !value.trim().is_empty())
+            .ok_or_else(|| {
+                crate::HarnessServerError::Protocol(
+                    "Hermes session/new response did not include sessionId".to_string(),
+                )
+            })?;
+        state.harness_session_id = Some(session_id.to_string());
+        Ok(())
+    }
+
+    fn stdin_for_turn(&self, _input: &[UserInput]) -> Result<Vec<u8>> {
+        Err(crate::HarnessServerError::Protocol(
+            "Hermes prompts require a native session id".to_string(),
+        ))
+    }
+
+    fn stdin_for_thread_turn(&self, state: &ThreadState, input: &[UserInput]) -> Result<Vec<u8>> {
+        // The ACP server owns the native conversation state. Centaur therefore
+        // sends the same session id for every turn instead of replaying history.
+        let session_id = state.harness_session_id.as_deref().ok_or_else(|| {
+            crate::HarnessServerError::Protocol(
+                "Hermes session is not initialized before prompt".to_string(),
+            )
+        })?;
+        session_prompt_stdin(session_id, input)
+    }
+
+    fn stdin_for_steer_with_session(
+        &self,
+        session_id: Option<&str>,
+        input: &[UserInput],
+    ) -> Result<Vec<u8>> {
+        let session_id = session_id.ok_or_else(|| {
+            crate::HarnessServerError::Protocol(
+                "Hermes steer requires a native session id".to_string(),
+            )
+        })?;
+        session_prompt_stdin(session_id, input)
+    }
+
+    fn parse_stdout_line(&self, line: &str) -> Result<Self::Event> {
+        HermesEvent::parse_json_line(line)
+    }
+
+    fn handle_process_event(&self, process: &mut HarnessChild, event: &Self::Event) -> Result<()> {
+        if let HermesEvent::PermissionRequest { id } = event {
+            write_value(
+                process,
+                &json!({
+                    "jsonrpc": "2.0",
+                    "id": id,
+                    "result": {
+                        "outcome": {
+                            "outcome": "selected",
+                            "optionId": permission_option_id(),
+                        },
+                    },
+                }),
+            )?;
+        }
+        Ok(())
+    }
+
+    fn normalize_events(
+        &self,
+        normalizer: &mut Self::EventNormalizer,
+        event: Self::Event,
+    ) -> Result<Vec<NormalizedEvent>> {
+        Ok(normalizer.normalize(event))
+    }
+}
+
+fn normalize_update(session_id: &str, update: HermesUpdate) -> Vec<NormalizedEvent> {
+    match update.session_update.as_str() {
+        "agent_message_chunk" => text_from_content(update.content)
+            .filter(|text| !text.is_empty())
+            .map(|delta| {
+                vec![NormalizedEvent::AgentTextDelta {
+                    item_id: stable_id(session_id, "hermes-message"),
+                    delta,
+                }]
+            })
+            .unwrap_or_default(),
+        "agent_thought_chunk" => text_from_content(update.content)
+            .filter(|text| !text.is_empty())
+            .map(|delta| {
+                vec![NormalizedEvent::ReasoningTextDelta {
+                    item_id: stable_id(session_id, "hermes-thought"),
+                    delta,
+                }]
+            })
+            .unwrap_or_default(),
+        "tool_call" => {
+            let Some(tool_call_id) = update.tool_call_id else {
+                return Vec::new();
+            };
+            let tool = update.title.unwrap_or_else(|| "tool".to_string());
+            vec![NormalizedEvent::AssistantMessage {
+                partial: false,
+                stop_reason: None,
+                content: vec![NormalizedContent::ToolUse {
+                    raw_id: tool_call_id,
+                    tool,
+                    arguments: update.raw_input.unwrap_or_else(|| json!({})),
+                }],
+            }]
+        }
+        "tool_call_update" if update.status.as_deref() == Some("completed") => {
+            let Some(tool_call_id) = update.tool_call_id else {
+                return Vec::new();
+            };
+            vec![NormalizedEvent::ToolResults(vec![NormalizedToolResult {
+                tool_use_id: tool_call_id,
+                content: text_from_content(update.content).unwrap_or_default(),
+                is_error: false,
+                exit_code: None,
+            }])]
+        }
+        _ => Vec::new(),
+    }
+}
+
+fn session_prompt_stdin(session_id: &str, input: &[UserInput]) -> Result<Vec<u8>> {
+    let payload = json!({
+        "jsonrpc": "2.0",
+        "id": format!("centaur-turn-{}", Uuid::new_v4()),
+        "method": "session/prompt",
+        "params": {
+            "sessionId": session_id,
+            "prompt": user_input_to_anthropic_content(input),
+        },
+    });
+    let mut bytes = serde_json::to_vec(&payload)?;
+    bytes.push(b'\n');
+    Ok(bytes)
+}
+
+fn text_from_content(content: Option<Value>) -> Option<String> {
+    let value = content?;
+    if let Some(text) = value.get("text").and_then(Value::as_str) {
+        return Some(text.to_string());
+    }
+    value.as_array().map(|items| {
+        items
+            .iter()
+            .filter_map(|item| item.get("text").and_then(Value::as_str))
+            .collect::<Vec<_>>()
+            .join("")
+    })
+}
+
+fn error_message(error: &Value) -> String {
+    error
+        .get("message")
+        .and_then(Value::as_str)
+        .unwrap_or("Hermes ACP request failed")
+        .to_string()
+}
+
+fn permission_option_id() -> &'static str {
+    match env::var("HERMES_PERMISSION_OUTCOME")
+        .unwrap_or_else(|_| "allow_session".to_string())
+        .trim()
+    {
+        "deny" => "deny",
+        "allow_once" => "allow_once",
+        _ => "allow_session",
+    }
+}
+
+fn write_request(process: &mut HarnessChild, id: Value, method: &str, params: Value) -> Result<()> {
+    write_value(
+        process,
+        &json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "method": method,
+            "params": params,
+        }),
+    )
+}
+
+fn write_value(process: &mut HarnessChild, value: &Value) -> Result<()> {
+    serde_json::to_writer(&mut process.stdin, value)?;
+    process.stdin.write_all(b"\n")?;
+    process.stdin.flush()?;
+    Ok(())
+}
+
+fn wait_for_response(process: &mut HarnessChild, id: &Value) -> Result<Value> {
+    loop {
+        let line = process.stdout.recv_timeout(STARTUP_TIMEOUT).map_err(|_| {
+            crate::HarnessServerError::Protocol(
+                "timed out waiting for Hermes ACP startup response".to_string(),
+            )
+        })??;
+        let value: Value = serde_json::from_str(&line)?;
+        if value.get("method").and_then(Value::as_str) == Some("session/request_permission") {
+            if let Some(permission_id) = value.get("id") {
+                write_value(
+                    process,
+                    &json!({
+                        "jsonrpc": "2.0",
+                        "id": permission_id,
+                        "result": {
+                            "outcome": {
+                                "outcome": "selected",
+                                "optionId": permission_option_id(),
+                            },
+                        },
+                    }),
+                )?;
+            }
+            continue;
+        }
+        if value.get("id") != Some(id) {
+            continue;
+        }
+        if let Some(error) = value.get("error") {
+            return Err(crate::HarnessServerError::Protocol(error_message(error)));
+        }
+        return Ok(value.get("result").cloned().unwrap_or_else(|| json!({})));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn agent_message_chunk_becomes_canonical_text_delta() {
+        let mut normalizer = HermesEventNormalizer::default();
+        let event = HermesEvent::SessionUpdate(HermesSessionUpdate {
+            session_id: "hermes-session".to_string(),
+            update: HermesUpdate {
+                session_update: "agent_message_chunk".to_string(),
+                content: Some(json!({"type": "text", "text": "hello"})),
+                tool_call_id: None,
+                title: None,
+                raw_input: None,
+                status: None,
+            },
+        });
+
+        let normalized = normalizer.normalize(event);
+        assert!(matches!(
+            normalized.first(),
+            Some(NormalizedEvent::SessionStarted { .. })
+        ));
+        assert!(matches!(
+            normalized.get(1),
+            Some(NormalizedEvent::AgentTextDelta { delta, .. }) if delta == "hello"
+        ));
+    }
+
+    #[test]
+    fn prompt_response_is_terminal() {
+        let mut normalizer = HermesEventNormalizer::default();
+        let normalized = normalizer.normalize(HermesEvent::PromptResponse {
+            result: json!({"stopReason": "end_turn"}),
+        });
+        assert!(matches!(
+            normalized.as_slice(),
+            [NormalizedEvent::Result { error: None }]
+        ));
+    }
+
+    #[test]
+    fn parses_acp_session_update_wire_shape() {
+        let event = HermesEvent::parse_json_line(
+            r#"{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"s1","update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"ok"}}}}"#,
+        )
+        .unwrap();
+        assert!(matches!(event, HermesEvent::SessionUpdate(_)));
+    }
+
+    #[test]
+    fn tool_call_events_become_canonical_tool_use_and_result() {
+        let mut normalizer = HermesEventNormalizer::default();
+        let tool_start = HermesEvent::SessionUpdate(HermesSessionUpdate {
+            session_id: "hermes-session".to_string(),
+            update: HermesUpdate {
+                session_update: "tool_call".to_string(),
+                content: None,
+                tool_call_id: Some("call-1".to_string()),
+                title: Some("read_file".to_string()),
+                raw_input: Some(json!({"path": "README.md"})),
+                status: None,
+            },
+        });
+        let tool_done = HermesEvent::SessionUpdate(HermesSessionUpdate {
+            session_id: "hermes-session".to_string(),
+            update: HermesUpdate {
+                session_update: "tool_call_update".to_string(),
+                content: Some(json!({"type": "text", "text": "file body"})),
+                tool_call_id: Some("call-1".to_string()),
+                title: None,
+                raw_input: None,
+                status: Some("completed".to_string()),
+            },
+        });
+
+        let started = normalizer.normalize(tool_start);
+        assert!(matches!(
+            started.get(1),
+            Some(NormalizedEvent::AssistantMessage { content, .. })
+                if matches!(
+                    content.as_slice(),
+                    [NormalizedContent::ToolUse { raw_id, tool, arguments }]
+                        if raw_id == "call-1"
+                            && tool == "read_file"
+                            && arguments == &json!({"path": "README.md"})
+                )
+        ));
+
+        let finished = normalizer.normalize(tool_done);
+        assert!(matches!(
+            finished.as_slice(),
+            [NormalizedEvent::ToolResults(results)]
+                if results.len() == 1
+                    && results[0].tool_use_id == "call-1"
+                    && results[0].content == "file body"
+                    && !results[0].is_error
+        ));
+    }
+
+    #[test]
+    fn prompt_payload_reuses_native_session_id() {
+        let bytes = session_prompt_stdin(
+            "session-123",
+            &[UserInput::Text {
+                text: "hello".to_string(),
+                text_elements: Vec::new(),
+            }],
+        )
+        .unwrap();
+        let value: Value = serde_json::from_slice(&bytes).unwrap();
+
+        assert_eq!(value["method"], "session/prompt");
+        assert_eq!(value["params"]["sessionId"], "session-123");
+        assert_eq!(value["params"]["prompt"][0]["text"], "hello");
+    }
+}

--- a/crates/harness-server/src/lib.rs
+++ b/crates/harness-server/src/lib.rs
@@ -3,6 +3,7 @@ pub mod anthropic;
 pub mod claude;
 pub mod codex;
 mod error;
+pub mod hermes;
 mod otel;
 mod server;
 mod traits;

--- a/crates/harness-server/src/main.rs
+++ b/crates/harness-server/src/main.rs
@@ -21,6 +21,7 @@ enum CliCommand {
     #[command(alias = "claude")]
     ClaudeCode(HarnessCommand),
     Amp(HarnessCommand),
+    Hermes(HarnessCommand),
     ValidateJsonrpc,
     ValidateAgentDeltas,
 }
@@ -53,6 +54,7 @@ fn run() -> Result<()> {
         CliCommand::Codex(command) => run_mode(HarnessKind::Codex, command.mode),
         CliCommand::ClaudeCode(command) => run_mode(HarnessKind::ClaudeCode, command.mode),
         CliCommand::Amp(command) => run_mode(HarnessKind::Amp, command.mode),
+        CliCommand::Hermes(command) => run_mode(HarnessKind::Hermes, command.mode),
         CliCommand::ValidateJsonrpc => run_validate_jsonrpc(),
         CliCommand::ValidateAgentDeltas => run_validate_agent_deltas(),
     }

--- a/crates/harness-server/src/otel.rs
+++ b/crates/harness-server/src/otel.rs
@@ -827,6 +827,7 @@ fn harness_name(kind: HarnessKind) -> &'static str {
         HarnessKind::Codex => "codex",
         HarnessKind::ClaudeCode => "claude",
         HarnessKind::Amp => "amp",
+        HarnessKind::Hermes => "hermes",
     }
 }
 
@@ -838,6 +839,8 @@ fn gen_ai_system(kind: HarnessKind, model_provider: &str) -> &'static str {
         "openai"
     } else if provider.contains("amp") || matches!(kind, HarnessKind::Amp) {
         "amp"
+    } else if provider.contains("openrouter") || matches!(kind, HarnessKind::Hermes) {
+        "openrouter"
     } else {
         "unknown"
     }

--- a/crates/harness-server/src/server.rs
+++ b/crates/harness-server/src/server.rs
@@ -27,6 +27,7 @@ use uuid::Uuid;
 use crate::amp::AmpHarness;
 use crate::claude::ClaudeCodeHarness;
 use crate::codex::CodexHarnessServer;
+use crate::hermes::HermesHarness;
 use crate::otel::{self, HarnessUsageSpan, TraceContext};
 use crate::traits::{
     AppServerNormalizer, AppServerRuntime, HarnessChild, HarnessKind, HarnessServer,
@@ -42,6 +43,7 @@ pub fn server_for(kind: HarnessKind) -> Box<dyn AppServerRuntime> {
         HarnessKind::Codex => Box::new(CodexHarnessServer::codex()),
         HarnessKind::ClaudeCode => Box::new(AppServerNormalizer::new(ClaudeCodeHarness)),
         HarnessKind::Amp => Box::new(AppServerNormalizer::new(AmpHarness)),
+        HarnessKind::Hermes => Box::new(AppServerNormalizer::new(HermesHarness)),
     }
 }
 
@@ -54,6 +56,7 @@ pub fn run_blocks_server(kind: HarnessKind) -> Result<()> {
         HarnessKind::Codex => crate::codex::run_codex_blocks_server(CodexHarnessServer::codex()),
         HarnessKind::ClaudeCode => run_blocks_app_server(&ClaudeCodeHarness),
         HarnessKind::Amp => run_blocks_app_server(&AmpHarness),
+        HarnessKind::Hermes => run_blocks_app_server(&HermesHarness),
     }
 }
 
@@ -1013,6 +1016,7 @@ fn handle_active_turn_request<H: HarnessServer, W: Write>(
     process: &mut HarnessChild,
     normalizer: &mut CodexTurnNormalizer,
     request: ActiveTurnRequest,
+    session_id: Option<&str>,
     stdout: &mut W,
 ) -> Result<bool> {
     let ActiveTurnRequest::JsonRpc(request) = request else {
@@ -1047,7 +1051,7 @@ fn handle_active_turn_request<H: HarnessServer, W: Write>(
             }
             process
                 .stdin
-                .write_all(&harness.stdin_for_steer(&params.input)?)?;
+                .write_all(&harness.stdin_for_steer_with_session(session_id, &params.input)?)?;
             process.stdin.flush()?;
             write_client_response(
                 stdout,
@@ -1207,6 +1211,7 @@ fn run_harness_turn<H: HarnessServer, W: Write>(
     let mut usage_span_output = UsageSpanOutput::default();
     ensure_harness_process(harness, state)?;
     {
+        let stdin = harness.stdin_for_thread_turn(state, input)?;
         let process = state
             .process
             .as_mut()
@@ -1216,7 +1221,7 @@ fn run_harness_turn<H: HarnessServer, W: Write>(
         // late `result` (and trailing rate-limit noise) behind, which would
         // otherwise read as this turn's instant terminal.
         while process.stdout.try_recv().is_ok() {}
-        process.stdin.write_all(&harness.stdin_for_turn(input)?)?;
+        process.stdin.write_all(&stdin)?;
         process.stdin.flush()?;
     }
 
@@ -1232,11 +1237,19 @@ fn run_harness_turn<H: HarnessServer, W: Write>(
     let mut latest_usage = None;
     loop {
         while let Ok(request) = request_rx.try_recv() {
+            let session_id = state.harness_session_id.clone();
             let process = state
                 .process
                 .as_mut()
                 .ok_or(HarnessServerError::HarnessStdinUnavailable)?;
-            if handle_active_turn_request(harness, process, normalizer, request, stdout)? {
+            if handle_active_turn_request(
+                harness,
+                process,
+                normalizer,
+                request,
+                session_id.as_deref(),
+                stdout,
+            )? {
                 state.process = None;
                 return Err(HarnessServerError::TurnInterrupted {
                     kind: harness.kind(),
@@ -1264,6 +1277,13 @@ fn run_harness_turn<H: HarnessServer, W: Write>(
                     continue;
                 }
                 let event = harness.parse_stdout_line(trimmed)?;
+                harness.handle_process_event(
+                    state
+                        .process
+                        .as_mut()
+                        .ok_or(HarnessServerError::HarnessStdoutUnavailable)?,
+                    &event,
+                )?;
                 let normalized_events = harness.normalize_events(&mut event_normalizer, event)?;
                 let mut terminal_stop = false;
                 for normalized in normalized_events {
@@ -1523,11 +1543,13 @@ fn ensure_harness_process<H: HarnessServer>(harness: &H, state: &mut ThreadState
         }
     });
 
-    state.process = Some(HarnessChild {
+    let mut process = HarnessChild {
         child,
         stdin,
         stdout: stdout_rx,
-    });
+    };
+    harness.prepare_process(&mut process, state)?;
+    state.process = Some(process);
     Ok(())
 }
 

--- a/crates/harness-server/src/traits.rs
+++ b/crates/harness-server/src/traits.rs
@@ -15,6 +15,7 @@ pub enum HarnessKind {
     Codex,
     ClaudeCode,
     Amp,
+    Hermes,
 }
 
 pub struct ThreadState {
@@ -62,11 +63,35 @@ pub trait HarnessServer {
     fn default_model(&self) -> String;
     fn default_model_provider(&self) -> &'static str;
     fn command_for_turn(&self, state: &ThreadState) -> ProcessCommand;
+    /// Perform any protocol handshake required after the child process starts.
+    /// Most CLI harnesses are ready for a turn immediately; session-oriented
+    /// protocols can use this hook to establish their native session first.
+    fn prepare_process(&self, _process: &mut HarnessChild, _state: &mut ThreadState) -> Result<()> {
+        Ok(())
+    }
     fn stdin_for_turn(&self, input: &[UserInput]) -> Result<Vec<u8>>;
+    fn stdin_for_thread_turn(&self, _state: &ThreadState, input: &[UserInput]) -> Result<Vec<u8>> {
+        self.stdin_for_turn(input)
+    }
     fn stdin_for_steer(&self, input: &[UserInput]) -> Result<Vec<u8>> {
         self.stdin_for_turn(input)
     }
+    fn stdin_for_steer_with_session(
+        &self,
+        _session_id: Option<&str>,
+        input: &[UserInput],
+    ) -> Result<Vec<u8>> {
+        self.stdin_for_steer(input)
+    }
     fn parse_stdout_line(&self, line: &str) -> Result<Self::Event>;
+    /// Respond to child-initiated protocol requests before normalizing events.
+    fn handle_process_event(
+        &self,
+        _process: &mut HarnessChild,
+        _event: &Self::Event,
+    ) -> Result<()> {
+        Ok(())
+    }
     fn normalize_events(
         &self,
         normalizer: &mut Self::EventNormalizer,

--- a/docs/pages/deploying-in-production.mdx
+++ b/docs/pages/deploying-in-production.mdx
@@ -84,6 +84,7 @@ Store one secret per enabled harness credential:
 | Codex with Meta AI direct | `codex` | `--meta` | `META_AI_API_KEY` | `api.ai.meta.com` |
 | Amp | `amp` | `--amp` | `AMP_API_KEY` | `ampcode.com` |
 | Claude Code | `claude-code` | `--claude` | `ANTHROPIC_API_KEY` | `api.anthropic.com` |
+| Hermes Agent | `hermes` | default harness or API request | `OPENROUTER_API_KEY` | `openrouter.ai` |
 | pi-mono | `pi-mono` | `--pi` | `ANTHROPIC_API_KEY` | `api.anthropic.com` |
 
 In normal sandbox mode, containers receive placeholder values such as
@@ -99,6 +100,11 @@ model slug such as `openrouter/auto`, or set `CODEX_MODEL_PROVIDER=openrouter`
 alongside `CODEX_MODEL`. Per-turn Codex model overrides with provider-style
 slugs such as `--model anthropic/claude-fable-5` also select the OpenRouter
 provider even when `OPENROUTER_MODEL` is unset.
+
+Hermes runs through its ACP stdio server inside the sandbox. The baked sandbox
+installs `hermes-acp`; set `sandbox.harnessEngine=hermes` or request
+`harness_type=hermes` for a session, then provide `OPENROUTER_API_KEY` and
+optionally `HERMES_MODEL`.
 
 To run Codex through Meta AI direct, store `META_AI_API_KEY` and select the
 provider with `--meta`. Pair it with `--model <model-id>` when choosing a

--- a/docs/pages/reference/configuration.mdx
+++ b/docs/pages/reference/configuration.mdx
@@ -70,7 +70,7 @@ Optional required-by-mode variables:
 | `SLACKBOT_URL` | Chart-rendered Slackbot service URL. | API callback target for Slack delivery. |
 | `FINAL_DELIVERY_MAX_ATTEMPTS`, `FINAL_DELIVERY_READY_GRACE_S` | `api.extraEnv`. | Final-delivery retry and claim timing. |
 | `CENTAUR_ENABLE_GCLOUD_BOOTSTRAP`, `GCP_GCLOUD_CREDENTIAL`, `GCLOUD_PROJECT` | `api.extraEnv` or Secret. | Optional gcloud ADC bootstrap in the API container. |
-| `CLAUDE_MODEL`, `CODEX_MODEL` | `api.extraEnv` or request model override. | Harness model selection defaults. When set via `sandbox.extraEnv`, the chart also mirrors them into slackbotv2 and the Console so their model displays track the deployment. |
+| `CLAUDE_MODEL`, `CODEX_MODEL`, `HERMES_MODEL` | `api.extraEnv` or request model override. | Harness model selection defaults. When set via `sandbox.extraEnv`, the chart also mirrors Claude and Codex into slackbotv2 and the Console so their model displays track what sandboxes actually run. |
 
 ## API-RS
 
@@ -209,6 +209,7 @@ Sandbox entrypoint and wrappers:
 | `CODEX_MODEL_REASONING_EFFORT` | `sandbox.extraEnv`. | Overrides the codex `model_reasoning_effort` (baked into `harness/codex/config.toml`) by patching the per-sandbox `~/.codex/config.toml` at boot, without forking the image. One of `none`, `minimal`, `low`, `medium`, `high`, `xhigh`; an unknown value is ignored (the config default stands). |
 | `CLAUDE_MODEL`, `CLAUDE_CONTINUE_SESSION_ID` | `sandbox.extraEnv` or runtime resume. | Claude model and resume behavior. |
 | `CLAUDE_CODE_AUTH_MODE` | `sandbox.extraEnv`. | Claude Code auth flow: `api_key` (default, uses `ANTHROPIC_API_KEY`) or `access_token` (Claude.ai Pro or Max via the brokered OAuth login). See [Claude Auth Modes](/deploying-in-production#claude-auth-modes). |
+| `HERMES_MODEL`, `HERMES_BIN`, `HERMES_PERMISSION_OUTCOME` | `sandbox.extraEnv` or runtime harness process. | Hermes ACP model default, executable override, and permission response policy. `HERMES_PERMISSION_OUTCOME` accepts `allow_session`, `allow_once`, or `deny`. |
 | `DEPLOY_ENV`, `ENVIRONMENT`, `TRACEPARENT` | Deployment env or wrapper-generated. | Runtime environment and trace context. |
 | `CALL_TIMEOUT_SECONDS` | Sandbox env before running `call`. | Curl watchdog for API tool calls. |
 | `SLACK_CHANNEL`, `SLACK_THREAD_TS` | Sandbox env. | File-upload helper target. |

--- a/services/api-rs/crates/centaur-api-integration-test/src/main.rs
+++ b/services/api-rs/crates/centaur-api-integration-test/src/main.rs
@@ -222,6 +222,7 @@ async fn test_harness_wire_values(http: &HttpClient, base_url: &str) -> Result<(
         (HarnessType::Codex, "codex"),
         (HarnessType::Amp, "amp"),
         (HarnessType::ClaudeCode, "claudecode"),
+        (HarnessType::Hermes, "hermes"),
     ];
 
     for (harness_type, expected_wire_value) in cases {

--- a/services/api-rs/crates/centaur-api-server/src/args.rs
+++ b/services/api-rs/crates/centaur-api-server/src/args.rs
@@ -1924,6 +1924,9 @@ fn harness_fragment_engine_name(engine: &HarnessType) -> &'static str {
         HarnessType::Codex => "codex",
         HarnessType::Amp => "amp",
         HarnessType::ClaudeCode => "claude-code",
+        // Hermes ACP uses the same OpenRouter API-key transport that is
+        // already provisioned for the sandbox image.
+        HarnessType::Hermes => "openrouter",
     }
 }
 
@@ -1941,6 +1944,7 @@ fn harness_auth_mode_env(engine: &HarnessType) -> Option<String> {
         HarnessType::Codex => env::var("CODEX_AUTH_MODE").ok(),
         HarnessType::ClaudeCode => env::var("CLAUDE_CODE_AUTH_MODE").ok(),
         HarnessType::Amp => None,
+        HarnessType::Hermes => None,
     }
 }
 

--- a/services/api-rs/crates/centaur-session-cli/src/main.rs
+++ b/services/api-rs/crates/centaur-session-cli/src/main.rs
@@ -573,6 +573,7 @@ impl FromStr for ThreadKeyArg {
 enum HarnessTypeArg {
     Codex,
     Amp,
+    Hermes,
     #[value(name = "claudecode")]
     ClaudeCode,
 }
@@ -582,6 +583,7 @@ impl From<HarnessTypeArg> for HarnessType {
         match value {
             HarnessTypeArg::Codex => Self::Codex,
             HarnessTypeArg::Amp => Self::Amp,
+            HarnessTypeArg::Hermes => Self::Hermes,
             HarnessTypeArg::ClaudeCode => Self::ClaudeCode,
         }
     }

--- a/services/api-rs/crates/centaur-session-core/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-core/src/lib.rs
@@ -124,6 +124,7 @@ pub enum HarnessType {
     Codex,
     Amp,
     ClaudeCode,
+    Hermes,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, AsRefStr, Display, EnumString)]
@@ -338,6 +339,7 @@ mod tests {
             HarnessType::from_str("claudecode").unwrap(),
             HarnessType::ClaudeCode
         );
+        assert!(HarnessType::from_str("hermes").is_ok());
     }
 
     #[test]
@@ -350,6 +352,7 @@ mod tests {
             serde_json::from_value::<HarnessType>(serde_json::json!("codex")).unwrap(),
             HarnessType::Codex
         );
+        assert!(serde_json::from_value::<HarnessType>(serde_json::json!("hermes")).is_ok());
     }
 
     #[test]

--- a/services/api-rs/crates/centaur-session-runtime/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-runtime/src/lib.rs
@@ -3687,6 +3687,7 @@ fn harness_server_subcommand(harness: &HarnessType) -> &'static str {
         HarnessType::Codex => "codex",
         HarnessType::ClaudeCode => "claude-code",
         HarnessType::Amp => "amp",
+        HarnessType::Hermes => "hermes",
     }
 }
 
@@ -7580,10 +7581,12 @@ mod tests {
         let codex_spec = workload.spec(&thread_key, &HarnessType::Codex, None);
         let claude_spec = workload.spec(&thread_key, &HarnessType::ClaudeCode, None);
         let amp_spec = workload.spec(&thread_key, &HarnessType::Amp, None);
+        let hermes_spec = workload.spec(&thread_key, &HarnessType::Hermes, None);
 
         assert_eq!(codex_spec.args, vec!["harness-server", "codex"]);
         assert_eq!(claude_spec.args, vec!["harness-server", "claude-code"]);
         assert_eq!(amp_spec.args, vec!["harness-server", "amp"]);
+        assert_eq!(hermes_spec.args, vec!["harness-server", "hermes"]);
         // The image entrypoint must be preserved: only CMD is overridden.
         assert_eq!(codex_spec.command, None);
     }

--- a/services/githubbot/src/types.ts
+++ b/services/githubbot/src/types.ts
@@ -103,7 +103,7 @@ export type GithubbotOptions = {
   connectStateOnStart?: boolean;
   /**
    * Harness for new threads when no --claude/--amp/--codex flag is given
-   * (HarnessType wire value: codex | amp | claudecode). Defaults to codex.
+   * (HarnessType wire value: codex | amp | claudecode | hermes). Defaults to codex.
    */
   defaultHarnessType?: string;
   fetch?: GithubbotFetch;

--- a/services/linearbot/src/types.ts
+++ b/services/linearbot/src/types.ts
@@ -97,7 +97,7 @@ export type LinearbotOptions = {
   connectStateOnStart?: boolean;
   /**
    * Harness for new threads when no --claude/--amp/--codex flag is given
-   * (HarnessType wire value: codex | amp | claudecode). Defaults to codex.
+   * (HarnessType wire value: codex | amp | claudecode | hermes). Defaults to codex.
    */
   defaultHarnessType?: string;
   fetch?: LinearbotFetch;

--- a/services/sandbox/Dockerfile
+++ b/services/sandbox/Dockerfile
@@ -144,6 +144,7 @@ ENV PATH="/home/agent/.cargo/bin:/home/agent/.local/bin:/home/agent/.foundry/bin
 
 ARG FOUNDRY_VERSION=v1.7.0
 ARG AMP_CLI_VERSION=0.0.1774529752-g94f44d
+ARG HERMES_AGENT_VERSION=0.17.0
 ARG MANIM_VERSION=0.20.1
 ARG BUN_VERSION=bun-v1.3.13
 
@@ -168,6 +169,9 @@ RUN curl -fsSL https://bun.sh/install | bash -s "${BUN_VERSION}"
 RUN --mount=type=cache,target=/home/agent/.cache/uv,uid=1001,gid=1001,sharing=locked \
     uv tool install "manim==${MANIM_VERSION}" \
     && manim --version
+RUN --mount=type=cache,target=/home/agent/.cache/uv,uid=1001,gid=1001,sharing=locked \
+    uv tool install "hermes-agent[acp]==${HERMES_AGENT_VERSION}" \
+    && hermes-acp --check
 RUN curl -L https://foundry.paradigm.xyz | bash \
     && /home/agent/.foundry/bin/foundryup --install ${FOUNDRY_VERSION} \
     && for bin in forge cast anvil chisel; do \

--- a/services/sandbox/entrypoint.sh
+++ b/services/sandbox/entrypoint.sh
@@ -50,16 +50,17 @@ if [ -n "${TOOL_DIRS:-}" ]; then
 fi
 
 if [ -d "$STATE_DIR" ] && [ -w "$STATE_DIR" ]; then
-    mkdir -p "$STATE_DIR/workspace" "$STATE_DIR/uploads" "$STATE_DIR/branches" "$STATE_DIR/codex" "$STATE_DIR/claude"
-    rm -rf "$HOME_DIR/.codex" "$HOME_DIR/.claude" "$HOME_DIR/uploads" "$HOME_DIR/branches"
+    mkdir -p "$STATE_DIR/workspace" "$STATE_DIR/uploads" "$STATE_DIR/branches" "$STATE_DIR/codex" "$STATE_DIR/claude" "$STATE_DIR/hermes"
+    rm -rf "$HOME_DIR/.codex" "$HOME_DIR/.claude" "$HOME_DIR/.hermes" "$HOME_DIR/uploads" "$HOME_DIR/branches"
     ln -s "$STATE_DIR/codex" "$HOME_DIR/.codex"
     ln -s "$STATE_DIR/claude" "$HOME_DIR/.claude"
+    ln -s "$STATE_DIR/hermes" "$HOME_DIR/.hermes"
     ln -s "$STATE_DIR/uploads" "$HOME_DIR/uploads"
     ln -s "$STATE_DIR/branches" "$HOME_DIR/branches"
     export CENTAUR_PERSISTENT_STATE=1
 fi
 
-mkdir -p "$HOME_DIR/.config/amp"
+mkdir -p "$HOME_DIR/.config/amp" "$HOME_DIR/.hermes"
 
 # ── Write harness configs (no MCP — adds ~10s startup overhead) ───────────────
 cat > "$HOME_DIR/.config/amp/settings.json" <<EOF

--- a/services/slackbotv2/src/types.ts
+++ b/services/slackbotv2/src/types.ts
@@ -121,7 +121,7 @@ export type SlackbotV2Options = {
   consolePublicUrl?: string
   /**
    * Harness for new threads when no --claude/--amp/--codex flag is given
-   * (HarnessType wire value: codex | amp | claudecode). Defaults to codex.
+   * (HarnessType wire value: codex | amp | claudecode | hermes). Defaults to codex.
    */
   defaultHarnessType?: string
   fetch?: SlackbotV2Fetch


### PR DESCRIPTION
Refs #109

## Summary
- Adds a Hermes `harness-server` adapter that starts `hermes-acp`, performs the ACP initialize/session handshake, reuses the native Hermes session id across turns, and normalizes ACP `session/update` events into Centaur canonical events.
- Wires `hermes` through `HarnessKind`, `HarnessType`, API/runtime sandbox command selection, the session CLI, integration wire-value coverage, and OpenRouter proxy fragment selection.
- Installs `hermes-agent[acp]==0.17.0` in the sandbox image and preserves `~/.hermes` under persistent sandbox state.
- Documents `sandbox.harnessEngine=hermes`, `OPENROUTER_API_KEY`, and `HERMES_MODEL`.

## Context
This ports the earlier Hermes wrapper work from #142/#188 into the current Rust `harness-server` / `api-rs` path. #142 was closed with the suggestion to translate Hermes traces into Codex App Server format and port the work to the newer API/runtime layer.

## Tests
- `cargo test --offline --manifest-path crates/harness-server/Cargo.toml hermes -- --nocapture`
- `cargo test --offline --manifest-path services/api-rs/Cargo.toml -p centaur-session-core harness_type -- --nocapture`
- `cargo test --offline --manifest-path services/api-rs/Cargo.toml -p centaur-session-runtime codex_workload_pins_harness_via_container_args -- --nocapture`
- `cargo check --offline --manifest-path services/api-rs/Cargo.toml -p centaur-session-cli -p centaur-api-server -p centaur-api-integration-test`
- `git diff --check`

## Notes
I kept this as a draft because I could not run a full sandbox/Kubernetes Hermes E2E in this environment. The adapter follows Hermes 0.17 ACP distribution (`hermes-agent[acp]` / `hermes-acp`) and defaults provider routing to the existing OpenRouter fragment.