### PR TITLE
fix: make Attio sync resilient to detail failures

### DIFF
--- a/workflows/attio_sync.py
+++ b/workflows/attio_sync.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 import datetime as dt
 import hashlib
 import os
+import asyncio
 from dataclasses import dataclass, field
-from typing import Any, Protocol
+from typing import Any, Awaitable, Callable, Protocol
 
 from api.runtime_control import canonical_json
 from workflows.etl_metrics import (
@@ -21,6 +22,8 @@ WORKFLOW_NAME = "attio_sync"
 DEFAULT_SYNC_INTERVAL_SECONDS = 4 * 60 * 60
 DEFAULT_PAGE_SIZE = 50
 DEFAULT_WATERMARK_OVERLAP_SECONDS = 5 * 60
+DETAIL_REQUEST_MAX_ATTEMPTS = 3
+DETAIL_REQUEST_RETRY_SECONDS = 1
 MEETINGS_SCOPE = "meetings"
 
 
@@ -45,6 +48,16 @@ class Input:
     include_transcripts: bool = True
     watermark_overlap_seconds: int = DEFAULT_WATERMARK_OVERLAP_SECONDS
     metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class SyncResult:
+    meetings_seen: int = 0
+    meetings_upserted: int = 0
+    call_recordings_seen: int = 0
+    transcripts_upserted: int = 0
+    watermark: dt.datetime | None = None
+    detail_failures: list[str] = field(default_factory=list)
 
 
 class AttioSyncClient(Protocol):
@@ -224,6 +237,20 @@ def _failure_reason(error: str) -> str:
     if "database" in lowered or "postgres" in lowered:
         return "write_error"
     return "api_error"
+
+
+async def _retry_detail_request(
+    request: Callable[[], Awaitable[Any]],
+) -> Any:
+    """Retry transient Attio detail calls without replaying the whole scope."""
+    for attempt in range(DETAIL_REQUEST_MAX_ATTEMPTS):
+        try:
+            return await request()
+        except Exception:
+            if attempt == DETAIL_REQUEST_MAX_ATTEMPTS - 1:
+                raise
+            await asyncio.sleep(DETAIL_REQUEST_RETRY_SECONDS * (2**attempt))
+    raise RuntimeError("unreachable")
 
 
 def _attio_id(value: Any, *keys: str) -> str:
@@ -428,10 +455,12 @@ async def _load_call_recordings(
     recordings: list[dict[str, Any]] = []
     cursor: str | None = None
     while True:
-        page = await client.list_call_recordings(
-            meeting_id,
-            limit=page_size,
-            cursor=cursor,
+        page = await _retry_detail_request(
+            lambda: client.list_call_recordings(
+                meeting_id,
+                limit=page_size,
+                cursor=cursor,
+            )
         )
         items = _page_items(page)
         recordings.extend(items)
@@ -450,10 +479,12 @@ async def _load_transcript(
     transcript: list[dict[str, Any]] = []
     cursor: str | None = None
     while True:
-        page = await client.get_call_transcript(
-            meeting_id,
-            recording_id,
-            cursor=cursor,
+        page = await _retry_detail_request(
+            lambda: client.get_call_transcript(
+                meeting_id,
+                recording_id,
+                cursor=cursor,
+            )
         )
         transcript.extend(_page_items(page))
         cursor = _next_cursor(page)
@@ -565,12 +596,8 @@ async def _sync_meetings(
     max_meetings: int | None,
     include_transcripts: bool,
     run_id: str,
-) -> tuple[int, int, int, int, dt.datetime | None]:
-    seen = 0
-    upserted = 0
-    recordings_seen = 0
-    transcripts_upserted = 0
-    watermark: dt.datetime | None = None
+) -> SyncResult:
+    result = SyncResult()
     cursor: str | None = None
     ends_from = _rfc3339(updated_after) if updated_after else None
 
@@ -583,61 +610,78 @@ async def _sync_meetings(
         )
         meetings = [meeting for meeting in _page_items(page) if _meeting_id(meeting)]
         if max_meetings is not None:
-            meetings = meetings[: max(max_meetings - seen, 0)]
-        seen += len(meetings)
+            meetings = meetings[: max(max_meetings - result.meetings_seen, 0)]
+        result.meetings_seen += len(meetings)
         record_etl_items_seen("attio", MEETINGS_SCOPE, "meeting", len(meetings))
 
         for meeting_ref in meetings:
             meeting_id = _meeting_id(meeting_ref)
-            meeting = await client.get_meeting(meeting_id)
-            if not isinstance(meeting, dict) or not meeting:
-                meeting = meeting_ref
-            meeting.setdefault("id", {"meeting_id": meeting_id})
-            call_recordings: list[dict[str, Any]] = []
-            transcript_payload: list[dict[str, Any]] = []
-            if include_transcripts:
-                call_recordings = await _load_call_recordings(
-                    client,
-                    meeting_id=meeting_id,
-                    page_size=page_size,
+            try:
+                meeting = await _retry_detail_request(
+                    lambda: client.get_meeting(meeting_id)
                 )
-                recordings_seen += len(call_recordings)
-                for recording in call_recordings:
-                    recording_id = _recording_id(recording)
-                    if not recording_id:
-                        continue
-                    transcript_payload.extend(
-                        await _load_transcript(
-                            client,
-                            meeting_id=meeting_id,
-                            recording_id=recording_id,
-                        )
+                if not isinstance(meeting, dict) or not meeting:
+                    meeting = meeting_ref
+                meeting.setdefault("id", {"meeting_id": meeting_id})
+                call_recordings: list[dict[str, Any]] = []
+                transcript_payload: list[dict[str, Any]] = []
+                if include_transcripts:
+                    call_recordings = await _load_call_recordings(
+                        client,
+                        meeting_id=meeting_id,
+                        page_size=page_size,
                     )
-                if transcript_payload:
-                    transcripts_upserted += 1
-                    record_etl_items_upserted("attio", MEETINGS_SCOPE, "transcript", 1)
+                    result.call_recordings_seen += len(call_recordings)
+                    for recording in call_recordings:
+                        recording_id = _recording_id(recording)
+                        if not recording_id:
+                            continue
+                        transcript_payload.extend(
+                            await _load_transcript(
+                                client,
+                                meeting_id=meeting_id,
+                                recording_id=recording_id,
+                            )
+                        )
+                    if transcript_payload:
+                        result.transcripts_upserted += 1
+                        record_etl_items_upserted(
+                            "attio", MEETINGS_SCOPE, "transcript", 1
+                        )
 
-            source_updated_at = await _upsert_meeting(
-                pool,
-                meeting=meeting,
-                call_recordings=call_recordings,
-                transcript_payload=transcript_payload,
-                run_id=run_id,
-            )
-            upserted += 1
+                source_updated_at = await _upsert_meeting(
+                    pool,
+                    meeting=meeting,
+                    call_recordings=call_recordings,
+                    transcript_payload=transcript_payload,
+                    run_id=run_id,
+                )
+            except Exception as exc:
+                error = str(exc)
+                result.detail_failures.append(f"{meeting_id}: {error}")
+                record_etl_items_failed(
+                    "attio", MEETINGS_SCOPE, "meeting", _failure_reason(error)
+                )
+                continue
+
+            result.meetings_upserted += 1
             record_etl_items_upserted("attio", MEETINGS_SCOPE, "meeting", 1)
-            if source_updated_at and (
-                watermark is None or source_updated_at > watermark
+            # Keep the checkpoint before the first failed detail fetch so that
+            # subsequent runs retry the incomplete meeting and anything after it.
+            if (
+                not result.detail_failures
+                and source_updated_at
+                and (result.watermark is None or source_updated_at > result.watermark)
             ):
-                watermark = source_updated_at
+                result.watermark = source_updated_at
 
-        if max_meetings is not None and seen >= max_meetings:
+        if max_meetings is not None and result.meetings_seen >= max_meetings:
             break
         cursor = _next_cursor(page)
         if not cursor:
             break
 
-    return seen, upserted, recordings_seen, transcripts_upserted, watermark
+    return result
 
 
 async def handler(inp: Input, ctx: WorkflowContext) -> dict[str, Any]:
@@ -682,13 +726,7 @@ async def handler(inp: Input, ctx: WorkflowContext) -> dict[str, Any]:
         "transcripts_upserted": 0,
     }
     try:
-        (
-            counts["meetings_seen"],
-            counts["meetings_upserted"],
-            counts["call_recordings_seen"],
-            counts["transcripts_upserted"],
-            successful_watermark,
-        ) = await _sync_meetings(
+        sync_result = await _sync_meetings(
             client=client,
             pool=ctx._pool,
             page_size=page_size,
@@ -697,13 +735,33 @@ async def handler(inp: Input, ctx: WorkflowContext) -> dict[str, Any]:
             include_transcripts=inp.include_transcripts,
             run_id=run_id,
         )
-        await _update_checkpoint_success(
-            ctx._pool,
-            scope_id=MEETINGS_SCOPE,
-            watermark_time=successful_watermark,
-            run_id=run_id,
+        counts.update(
+            meetings_seen=sync_result.meetings_seen,
+            meetings_upserted=sync_result.meetings_upserted,
+            call_recordings_seen=sync_result.call_recordings_seen,
+            transcripts_upserted=sync_result.transcripts_upserted,
         )
-        synced.append(_scope_ref(MEETINGS_SCOPE))
+        if sync_result.detail_failures:
+            error = f"{len(sync_result.detail_failures)} meeting detail fetches failed"
+            failed.append(_scope_ref(MEETINGS_SCOPE, error))
+            await _update_checkpoint_failure(
+                ctx._pool,
+                scope_id=MEETINGS_SCOPE,
+                run_id=run_id,
+                error=error,
+            )
+            ctx.log(
+                "attio_sync_meeting_details_failed",
+                failures=len(sync_result.detail_failures),
+            )
+        else:
+            await _update_checkpoint_success(
+                ctx._pool,
+                scope_id=MEETINGS_SCOPE,
+                watermark_time=sync_result.watermark,
+                run_id=run_id,
+            )
+            synced.append(_scope_ref(MEETINGS_SCOPE))
     except Exception as exc:
         error = str(exc)
         failed.append(_scope_ref(MEETINGS_SCOPE, error))

--- a/workflows/tests/test_attio_sync.py
+++ b/workflows/tests/test_attio_sync.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import datetime as dt
 import importlib
 import json
 import sys
@@ -95,3 +96,158 @@ def test_attio_sync_uses_supported_meeting_sort():
     )
 
     assert client.sort == "start_asc"
+
+
+def test_attio_sync_retries_transient_meeting_detail_failure(monkeypatch):
+    attio = _load("workflows.attio_sync")
+
+    class FakeAttioClient:
+        def __init__(self) -> None:
+            self.detail_attempts = 0
+
+        async def list_meetings(self, **_kwargs):
+            return {"data": [{"id": {"meeting_id": "mtg_1"}}]}
+
+        async def get_meeting(self, _meeting_id):
+            self.detail_attempts += 1
+            if self.detail_attempts < 3:
+                raise RuntimeError("Name or service not known")
+            return {"id": {"meeting_id": "mtg_1"}, "updated_at": "2026-07-10T12:00:00Z"}
+
+    async def fake_upsert(*_args, **_kwargs):
+        return dt.datetime(2026, 7, 10, 12, tzinfo=dt.UTC)
+
+    sleeps: list[int] = []
+
+    async def fake_sleep(delay):
+        sleeps.append(delay)
+
+    monkeypatch.setattr(attio, "_upsert_meeting", fake_upsert)
+    monkeypatch.setattr(attio.asyncio, "sleep", fake_sleep)
+    client = FakeAttioClient()
+
+    result = asyncio.run(
+        attio._sync_meetings(
+            client=client,
+            pool=None,
+            page_size=50,
+            updated_after=None,
+            max_meetings=None,
+            include_transcripts=False,
+            run_id="run_1",
+        )
+    )
+
+    assert client.detail_attempts == 3
+    assert sleeps == [1, 2]
+    assert result.meetings_seen == 1
+    assert result.meetings_upserted == 1
+    assert result.detail_failures == []
+
+
+def test_attio_sync_continues_after_exhausted_detail_failure(monkeypatch):
+    attio = _load("workflows.attio_sync")
+
+    class FakeAttioClient:
+        def __init__(self) -> None:
+            self.detail_attempts: dict[str, int] = {}
+
+        async def list_meetings(self, **_kwargs):
+            return {
+                "data": [
+                    {"id": {"meeting_id": "mtg_failed"}},
+                    {"id": {"meeting_id": "mtg_ok"}},
+                ]
+            }
+
+        async def get_meeting(self, meeting_id):
+            self.detail_attempts[meeting_id] = (
+                self.detail_attempts.get(meeting_id, 0) + 1
+            )
+            if meeting_id == "mtg_failed":
+                raise RuntimeError("Name or service not known")
+            return {
+                "id": {"meeting_id": meeting_id},
+                "updated_at": "2026-07-10T12:00:00Z",
+            }
+
+    async def fake_upsert(*_args, **_kwargs):
+        return dt.datetime(2026, 7, 10, 12, tzinfo=dt.UTC)
+
+    async def no_sleep(_delay):
+        return None
+
+    monkeypatch.setattr(attio, "_upsert_meeting", fake_upsert)
+    monkeypatch.setattr(attio.asyncio, "sleep", no_sleep)
+    client = FakeAttioClient()
+
+    result = asyncio.run(
+        attio._sync_meetings(
+            client=client,
+            pool=None,
+            page_size=50,
+            updated_after=None,
+            max_meetings=None,
+            include_transcripts=False,
+            run_id="run_1",
+        )
+    )
+
+    assert client.detail_attempts == {"mtg_failed": 3, "mtg_ok": 1}
+    assert result.meetings_seen == 2
+    assert result.meetings_upserted == 1
+    assert len(result.detail_failures) == 1
+    assert result.watermark is None
+
+
+def test_attio_handler_records_partial_detail_progress(monkeypatch):
+    attio = _load("workflows.attio_sync")
+
+    class FakeContext:
+        run_id = "workflow-run-1"
+        _pool = object()
+
+        def __init__(self) -> None:
+            self.logs: list[tuple[str, dict]] = []
+
+        def log(self, message, **fields):
+            self.logs.append((message, fields))
+
+    async def no_op(*_args, **_kwargs):
+        return None
+
+    async def fake_sync(**_kwargs):
+        return attio.SyncResult(
+            meetings_seen=3,
+            meetings_upserted=2,
+            call_recordings_seen=1,
+            transcripts_upserted=1,
+            detail_failures=["mtg_failed: Name or service not known"],
+        )
+
+    recorded: dict[str, object] = {}
+
+    async def record_finish(*_args, **kwargs):
+        recorded.update(kwargs)
+
+    monkeypatch.setattr(attio, "env_flag_enabled", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(attio, "_record_run_start", no_op)
+    monkeypatch.setattr(attio, "_load_checkpoint", no_op)
+    monkeypatch.setattr(attio, "_sync_meetings", fake_sync)
+    monkeypatch.setattr(attio, "_update_checkpoint_failure", no_op)
+    monkeypatch.setattr(attio, "_record_run_finish", record_finish)
+    ctx = FakeContext()
+
+    result = asyncio.run(attio.handler(attio.Input(), ctx))
+
+    assert result["status"] == "failed"
+    assert result["meetings_seen"] == 3
+    assert result["meetings_upserted"] == 2
+    assert recorded["status"] == "failed"
+    assert recorded["counts"] == {
+        "meetings_seen": 3,
+        "meetings_upserted": 2,
+        "call_recordings_seen": 1,
+        "transcripts_upserted": 1,
+    }
+    assert ctx.logs == [("attio_sync_meeting_details_failed", {"failures": 1})]


### PR DESCRIPTION
## Summary
- retries transient Attio meeting, recording, and transcript detail requests with bounded exponential backoff
- continues processing later meetings after an exhausted detail failure
- preserves partial run counters and keeps the checkpoint behind the first incomplete detail fetch for safe retry

## Validation
- `PYTHONPATH=. uvx --from pytest pytest workflows/tests/test_attio_sync.py workflows/tests/test_granola_sync.py` — 11 passed
- `uvx ruff check workflows/attio_sync.py workflows/tests/test_attio_sync.py`
- `git diff --check`