### PR TITLE
fix(sandbox): log proxy owner adoption outcomes

### DIFF
--- a/services/api-rs/crates/centaur-sandbox-agent-k8s/src/iron_proxy.rs
+++ b/services/api-rs/crates/centaur-sandbox-agent-k8s/src/iron_proxy.rs
@@ -463,18 +463,45 @@ impl AgentSandboxBackend {
             };
             match self.pods().patch(&name, &params, &patch).await {
                 Ok(_) => {}
-                Err(err) if is_not_found(&err) => {}
-                Err(err) => return Err(map_kube_error("adopt iron-proxy pod", err)),
+                Err(err) if is_not_found(&err) => tracing::warn!(
+                    sandbox_id = id.as_str(),
+                    resource_kind = "Pod",
+                    resource_name = name,
+                    %err,
+                    "iron-proxy resource disappeared during owner adoption"
+                ),
+                Err(err) => {
+                    tracing::warn!(
+                        sandbox_id = id.as_str(),
+                        resource_kind = "Pod",
+                        resource_name = name,
+                        %err,
+                        "failed to patch ownerReference onto iron-proxy resource"
+                    );
+                    return Err(map_kube_error("adopt iron-proxy pod", err));
+                }
             }
         }
-        match self
-            .services()
-            .patch(&iron_proxy_service_name(id), &params, &patch)
-            .await
-        {
+        let service_name = iron_proxy_service_name(id);
+        match self.services().patch(&service_name, &params, &patch).await {
             Ok(_) => {}
-            Err(err) if is_not_found(&err) => {}
-            Err(err) => return Err(map_kube_error("adopt iron-proxy service", err)),
+            Err(err) if is_not_found(&err) => tracing::warn!(
+                sandbox_id = id.as_str(),
+                resource_kind = "Service",
+                resource_name = service_name,
+                %err,
+                "iron-proxy resource disappeared during owner adoption"
+            ),
+            Err(err) => {
+                tracing::warn!(
+                    sandbox_id = id.as_str(),
+                    resource_kind = "Service",
+                    resource_name = service_name,
+                    %err,
+                    "failed to patch ownerReference onto iron-proxy resource"
+                );
+                return Err(map_kube_error("adopt iron-proxy service", err));
+            }
         }
         for name in [
             iron_proxy_sandbox_egress_policy_name(id),
@@ -482,8 +509,23 @@ impl AgentSandboxBackend {
         ] {
             match self.network_policies().patch(&name, &params, &patch).await {
                 Ok(_) => {}
-                Err(err) if is_not_found(&err) => {}
-                Err(err) => return Err(map_kube_error("adopt iron-proxy network policy", err)),
+                Err(err) if is_not_found(&err) => tracing::warn!(
+                    sandbox_id = id.as_str(),
+                    resource_kind = "NetworkPolicy",
+                    resource_name = name,
+                    %err,
+                    "iron-proxy resource disappeared during owner adoption"
+                ),
+                Err(err) => {
+                    tracing::warn!(
+                        sandbox_id = id.as_str(),
+                        resource_kind = "NetworkPolicy",
+                        resource_name = name,
+                        %err,
+                        "failed to patch ownerReference onto iron-proxy resource"
+                    );
+                    return Err(map_kube_error("adopt iron-proxy network policy", err));
+                }
             }
         }
         tracing::info!(

--- a/services/api-rs/crates/centaur-sandbox-agent-k8s/src/iron_proxy.rs
+++ b/services/api-rs/crates/centaur-sandbox-agent-k8s/src/iron_proxy.rs
@@ -417,7 +417,22 @@ impl AgentSandboxBackend {
         id: &SandboxId,
         sandbox: &crate::crd::Sandbox,
     ) -> SandboxResult<()> {
+        let proxy_expected = sandbox
+            .metadata
+            .annotations
+            .as_ref()
+            .is_some_and(|annotations| {
+                annotations.contains_key(crate::IRON_CONTROL_PRINCIPAL_ANNOTATION)
+            });
         let Some(owner_reference) = sandbox_owner_reference(sandbox) else {
+            if proxy_expected {
+                tracing::warn!(
+                    sandbox_id = id.as_str(),
+                    sandbox_name_present = sandbox.metadata.name.is_some(),
+                    sandbox_uid_present = sandbox.metadata.uid.is_some(),
+                    "skipped iron-proxy owner adoption because sandbox owner metadata is incomplete"
+                );
+            }
             return Ok(());
         };
         let params = PatchParams::default();
@@ -432,6 +447,16 @@ impl AgentSandboxBackend {
             )))
             .await
             .map_err(|err| map_kube_error("list iron-proxy pods for adoption", err))?;
+        if pods.items.is_empty() {
+            if proxy_expected {
+                tracing::warn!(
+                    sandbox_id = id.as_str(),
+                    "no iron-proxy pods matched during owner adoption"
+                );
+            }
+            return Ok(());
+        }
+        let proxy_pod_count = pods.items.len();
         for pod in pods.items {
             let Some(name) = pod.metadata.name else {
                 continue;
@@ -461,6 +486,11 @@ impl AgentSandboxBackend {
                 Err(err) => return Err(map_kube_error("adopt iron-proxy network policy", err)),
             }
         }
+        tracing::info!(
+            sandbox_id = id.as_str(),
+            proxy_pod_count,
+            "adopted iron-proxy resources into sandbox ownership"
+        );
         Ok(())
     }
 


### PR DESCRIPTION
## Summary
- warn when proxy ownership adoption is skipped because Sandbox owner metadata is incomplete
- warn when an expected proxy has no pods matching the adoption selector
- log successful adoption with the number of proxy pods patched

## Testing
- `cargo test -p centaur-sandbox-agent-k8s`
- `cargo +nightly fmt --check`
- `cargo +nightly clippy -p centaur-sandbox-agent-k8s --all-targets -- -D warnings`

Prompted by: mslipper