### PR TITLE
fix(proxy): preserve Codex routing headers

### DIFF
--- a/services/api-rs/crates/centaur-iron-proxy/src/tests.rs
+++ b/services/api-rs/crates/centaur-iron-proxy/src/tests.rs
@@ -105,7 +105,7 @@ fn access_token_fragment_carries_no_broker_credentials_block() {
 }
 
 #[test]
-fn shipped_proxy_allowlist_preserves_railway_project_tokens() {
+fn shipped_proxy_allowlist_preserves_integration_headers() {
     let config: serde_yaml::Value =
         serde_yaml::from_str(include_str!("../../../../iron-proxy/iron-proxy.yaml")).unwrap();
     let transforms = config["transforms"].as_sequence().unwrap();
@@ -119,5 +119,15 @@ fn shipped_proxy_allowlist_preserves_railway_project_tokens() {
         headers
             .iter()
             .any(|header| header.as_str() == Some("project-access-token"))
+    );
+    assert!(
+        headers
+            .iter()
+            .any(|header| header.as_str() == Some("originator"))
+    );
+    assert!(
+        headers
+            .iter()
+            .any(|header| header.as_str() == Some("version"))
     );
 }

--- a/services/iron-proxy/iron-proxy.yaml
+++ b/services/iron-proxy/iron-proxy.yaml
@@ -40,6 +40,10 @@ transforms:
         - "openai-organization"
         - "openai-project"
         - "chatgpt-account-id"
+        # Codex uses this non-secret client marker when resolving model routes.
+        - "originator"
+        # Codex pairs the marker with its client version for model routing.
+        - "version"
         - "x-request-id"
         - "x-stainless-arch"
         - "x-stainless-os"


### PR DESCRIPTION
## Summary

- preserve the non-secret `originator` and `version` headers through the iron-proxy allowlist
- extend the shipped-policy regression test to cover both

Codex uses these client markers while resolving model routes. Stripping them makes `gpt-5.6-luna` resolve to a nonexistent fallback alias or return an empty execution behind the managed proxy, while the same CLI/account/model succeeds directly. No broad header exception is added.

## Validation

- `cargo test -p centaur-iron-proxy shipped_proxy_allowlist_preserves_integration_headers`
- live Codex 0.144.1 sandbox probe through managed iron-proxy with `gpt-5.6-luna`
- live Euler EVK workflow eval with a pinned governance evidence read