### PR TITLE
fix: restrict slack dm teams

### DIFF
--- a/contrib/chart/Chart.yaml
+++ b/contrib/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: centaur
 description: Helm chart for the trusted Centaur control plane
 type: application
-version: 0.1.96
+version: 0.1.97
 appVersion: "0.1.0"
 dependencies:
   - name: connect

--- a/contrib/chart/templates/slackbotv2.yaml
+++ b/contrib/chart/templates/slackbotv2.yaml
@@ -85,6 +85,10 @@ spec:
             - name: SLACKBOT_EXTERNAL_ORG_ALLOWLIST
               value: {{ .Values.slackbotv2.externalOrgAllowlist | quote }}
 {{- end }}
+{{- if .Values.slackbotv2.dmTeamAllowlist }}
+            - name: SLACKBOT_DM_TEAM_ALLOWLIST
+              value: {{ .Values.slackbotv2.dmTeamAllowlist | quote }}
+{{- end }}
 {{- if .Values.slackbotv2.triggerBotAllowlist }}
             - name: SLACKBOT_TRIGGER_BOT_ALLOWLIST
               value: {{ .Values.slackbotv2.triggerBotAllowlist | quote }}

--- a/contrib/chart/values.yaml
+++ b/contrib/chart/values.yaml
@@ -461,6 +461,10 @@ slackbotv2:
   # assumes users connect through `kubectl port-forward ... 3000:8080`.
   mcpPublicUrl: "http://localhost:3000"
   externalOrgAllowlist: ""
+  # Comma- or whitespace-separated Slack team IDs allowed to start sessions
+  # from DMs. Include the team that owns SLACK_BOT_TOKEN; Slackbot does not add
+  # it automatically.
+  dmTeamAllowlist: ""
   triggerBotAllowlist: ""
   metrics:
     # slackbotv2 serves Prometheus text metrics at /metrics. This flag only

--- a/services/slackbotv2/src/slack-events.ts
+++ b/services/slackbotv2/src/slack-events.ts
@@ -12,6 +12,10 @@ type RawSlackEvent = {
   app_id?: JsonValue
   bot_id?: JsonValue
   bot_profile?: RawSlackBotProfile
+  channel?: JsonValue
+  channel_type?: JsonValue
+  is_im?: JsonValue
+  is_mpim?: JsonValue
   source_team?: JsonValue
   subtype?: JsonValue
   team?: JsonValue
@@ -53,6 +57,17 @@ export function isAllowedSlackWebhookBody(
     })
     return false
   }
+  const allowedDmTeamIds = normalizedTeamIdSet(
+    options.allowedDmTeamIds ?? splitEnvList(process.env.SLACKBOT_DM_TEAM_ALLOWLIST)
+  )
+  const dmTeamId = slackDirectMessageTeamIdForHome(stringValue(payload.team_id), event)
+  if (dmTeamId && allowedDmTeamIds.size > 0 && !allowedDmTeamIds.has(normalizeTeamId(dmTeamId))) {
+    logger.warn('slackbotv2_dm_ignored_team_not_allowlisted', {
+      event_id: stringValue(payload.event_id),
+      slack_team_id: dmTeamId
+    })
+    return false
+  }
   return true
 }
 
@@ -69,6 +84,18 @@ export function isAllowedSlackMessage(
     logger.warn('slackbotv2_event_ignored_external_org_not_allowlisted', {
       external_team_id: externalTeamId,
       message_id: message.id,
+      thread_id: message.threadId
+    })
+    return false
+  }
+  const allowedDmTeamIds = normalizedTeamIdSet(
+    options.allowedDmTeamIds ?? splitEnvList(process.env.SLACKBOT_DM_TEAM_ALLOWLIST)
+  )
+  const dmTeamId = raw ? slackDirectMessageTeamId(raw) : undefined
+  if (dmTeamId && allowedDmTeamIds.size > 0 && !allowedDmTeamIds.has(normalizeTeamId(dmTeamId))) {
+    logger.warn('slackbotv2_dm_ignored_team_not_allowlisted', {
+      message_id: message.id,
+      slack_team_id: dmTeamId,
       thread_id: message.threadId
     })
     return false
@@ -90,6 +117,36 @@ export function isAllowedSlackMessage(
 
 function externalSlackTeamId(event: RawSlackEvent): string | undefined {
   return externalSlackTeamIdForHome(stringValue(event.team_id), event)
+}
+
+function slackDirectMessageTeamId(event: RawSlackEvent): string | undefined {
+  return slackDirectMessageTeamIdForHome(stringValue(event.team_id), event)
+}
+
+function slackDirectMessageTeamIdForHome(
+  homeTeamId: string | undefined,
+  event: RawSlackEvent
+): string | undefined {
+  if (!isSlackDirectMessageEvent(event)) return undefined
+  return (
+    externalSlackTeamIdForHome(homeTeamId, event)
+    ?? stringValue(event.user_team)
+    ?? stringValue(event.source_team)
+    ?? stringValue(event.team)
+    ?? stringValue(event.team_id)
+    ?? homeTeamId
+  )
+}
+
+function isSlackDirectMessageEvent(event: RawSlackEvent): boolean {
+  const channelType = stringValue(event.channel_type)
+  return (
+    channelType === 'im'
+    || channelType === 'mpim'
+    || event.is_im === true
+    || event.is_mpim === true
+    || stringValue(event.channel)?.startsWith('D') === true
+  )
 }
 
 function externalSlackTeamIdForHome(
@@ -134,6 +191,14 @@ function isAllowedTriggerBotMessage(
 
 function normalizedIdentifierSet(...values: Array<string | undefined>): Set<string> {
   return new Set(values.map(value => value?.trim()).filter((value): value is string => Boolean(value)))
+}
+
+function normalizedTeamIdSet(values: readonly string[] | undefined): Set<string> {
+  return new Set((values ?? []).map(normalizeTeamId).filter(Boolean))
+}
+
+function normalizeTeamId(value: string): string {
+  return value.trim().toUpperCase()
 }
 
 function parseTriggerBotAllowlistEntry(

--- a/services/slackbotv2/src/types.ts
+++ b/services/slackbotv2/src/types.ts
@@ -124,6 +124,8 @@ export type SlackbotV2Options = {
    * (HarnessType wire value: codex | amp | claudecode). Defaults to codex.
    */
   defaultHarnessType?: string
+  /** When non-empty, only these Slack team IDs may start sessions from DMs. */
+  allowedDmTeamIds?: readonly string[]
   fetch?: SlackbotV2Fetch
   /**
    * Deployment-configured default model per harness wire value (claudecode |

--- a/services/slackbotv2/test/slack-events.test.ts
+++ b/services/slackbotv2/test/slack-events.test.ts
@@ -1,0 +1,178 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+import type { Logger, Message } from 'chat'
+import { isAllowedSlackMessage, isAllowedSlackWebhookBody } from '../src/slack-events'
+import type { SlackbotV2Options } from '../src/types'
+
+const logger = (): Logger => {
+  const records: Array<{ event: string; data?: unknown }> = []
+  const item: Logger = {
+    debug: () => undefined,
+    info: () => undefined,
+    warn: (event: string, data?: unknown) => records.push({ data, event }),
+    error: () => undefined,
+    child: () => item
+  }
+  return Object.assign(item, { records })
+}
+
+describe('Slack event policy', () => {
+  afterEach(() => {
+    delete process.env.SLACKBOT_DM_TEAM_ALLOWLIST
+  })
+
+  test('allows DM events when no DM team allowlist is configured', () => {
+    const logs = logger()
+    expect(
+      isAllowedSlackWebhookBody(slackEvent({ channel: 'D1', team: 'THOST' }), options(), logs)
+    ).toBe(true)
+  })
+
+  test('rejects DM events from teams outside the configured allowlist', () => {
+    const logs = logger()
+    expect(
+      isAllowedSlackWebhookBody(
+        slackEvent({ channel: 'D1', team: 'THOST' }),
+        options({ allowedDmTeamIds: ['TOTHER'] }),
+        logs
+      )
+    ).toBe(false)
+    expect(logRecords(logs)).toContainEqual(
+      expect.objectContaining({ event: 'slackbotv2_dm_ignored_team_not_allowlisted' })
+    )
+  })
+
+  test('rejects group DM events from teams outside the configured allowlist', () => {
+    const logs = logger()
+    expect(
+      isAllowedSlackWebhookBody(
+        slackEvent({ channel: 'G1', channelType: 'mpim', team: 'THOST' }),
+        options({ allowedDmTeamIds: ['TOTHER'] }),
+        logs
+      )
+    ).toBe(false)
+    expect(logRecords(logs)).toContainEqual(
+      expect.objectContaining({ event: 'slackbotv2_dm_ignored_team_not_allowlisted' })
+    )
+  })
+
+  test('allows DM events from teams in the configured allowlist', () => {
+    const logs = logger()
+    expect(
+      isAllowedSlackWebhookBody(
+        slackEvent({ channel: 'D1', team: 'THOST' }),
+        options({ allowedDmTeamIds: ['thost'] }),
+        logs
+      )
+    ).toBe(true)
+  })
+
+  test('uses the requester team for Slack Connect DMs', () => {
+    const logs = logger()
+    expect(
+      isAllowedSlackWebhookBody(
+        slackEvent({ channel: 'D1', team: 'TEXTERNAL', teamId: 'THOST', userTeam: 'TEXTERNAL' }),
+        options({ allowedDmTeamIds: ['THOST'], allowedExternalTeamIds: ['TEXTERNAL'] }),
+        logs
+      )
+    ).toBe(false)
+    expect(
+      isAllowedSlackWebhookBody(
+        slackEvent({ channel: 'D1', team: 'TEXTERNAL', teamId: 'THOST', userTeam: 'TEXTERNAL' }),
+        options({ allowedDmTeamIds: ['TEXTERNAL'], allowedExternalTeamIds: ['TEXTERNAL'] }),
+        logs
+      )
+    ).toBe(true)
+  })
+
+  test('does not apply the DM team allowlist to channel events', () => {
+    const logs = logger()
+    expect(
+      isAllowedSlackWebhookBody(
+        slackEvent({ channel: 'C1', team: 'TOTHER' }),
+        options({ allowedDmTeamIds: ['THOST'] }),
+        logs
+      )
+    ).toBe(true)
+  })
+
+  test('reads the DM team allowlist from the environment', () => {
+    process.env.SLACKBOT_DM_TEAM_ALLOWLIST = 'THOST,TOTHER'
+    const logs = logger()
+    expect(
+      isAllowedSlackWebhookBody(slackEvent({ channel: 'D1', team: 'THOST' }), options(), logs)
+    ).toBe(true)
+  })
+
+  test('applies the DM team allowlist to adapter messages too', () => {
+    const logs = logger()
+    expect(
+      isAllowedSlackMessage(
+        slackMessage({ channel: 'D1', team: 'THOST' }),
+        options({ allowedDmTeamIds: ['TOTHER'] }),
+        logs
+      )
+    ).toBe(false)
+  })
+
+  test('applies the DM team allowlist to adapter group DM messages too', () => {
+    const logs = logger()
+    expect(
+      isAllowedSlackMessage(
+        slackMessage({ channel: 'G1', channelType: 'mpim', team: 'THOST' }),
+        options({ allowedDmTeamIds: ['TOTHER'] }),
+        logs
+      )
+    ).toBe(false)
+  })
+})
+
+function slackEvent(input: {
+  channel: string
+  channelType?: string
+  team: string
+  teamId?: string
+  userTeam?: string
+}): string {
+  return JSON.stringify({
+    type: 'event_callback',
+    team_id: input.teamId ?? input.team,
+    event_id: 'Ev-test',
+    event: {
+      type: 'message',
+      channel: input.channel,
+      channel_type: input.channelType ?? (input.channel.startsWith('D') ? 'im' : 'channel'),
+      team: input.team,
+      user: 'U1',
+      ...(input.userTeam ? { user_team: input.userTeam } : {})
+    }
+  })
+}
+
+function slackMessage(input: { channel: string; channelType?: string; team: string }): Message {
+  return {
+    author: { isBot: false },
+    id: '1710000000.000100',
+    raw: {
+      type: 'message',
+      channel: input.channel,
+      channel_type: input.channelType ?? (input.channel.startsWith('D') ? 'im' : 'channel'),
+      team: input.team,
+      team_id: input.team,
+      user: 'U1'
+    },
+    threadId: `slack:${input.channel}:1710000000.000100`
+  } as unknown as Message
+}
+
+function options(overrides: Partial<SlackbotV2Options> = {}): SlackbotV2Options {
+  return {
+    apiUrl: 'http://centaur.test',
+    botToken: 'xoxb-test',
+    signingSecret: 'secret',
+    ...overrides
+  }
+}
+
+function logRecords(logger: Logger): Array<{ event: string; data?: unknown }> {
+  return (logger as Logger & { records: Array<{ event: string; data?: unknown }> }).records
+}


### PR DESCRIPTION
Adds a Slackbot DM team allowlist that gates 1:1 and group DM events before session handoff. The Helm chart exposes it as a comma- or whitespace-separated slackbotv2.dmTeamAllowlist value, and the Slackbot policy tests cover host-team, Slack Connect, channel, and MPIM cases.