### PR TITLE
fix: gate otlp egress on observability

### DIFF
--- a/contrib/chart/Chart.yaml
+++ b/contrib/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: centaur
 description: Helm chart for the trusted Centaur control plane
 type: application
-version: 0.1.96
+version: 0.1.97
 appVersion: "0.1.0"
 dependencies:
   - name: connect

--- a/contrib/chart/templates/_helpers.tpl
+++ b/contrib/chart/templates/_helpers.tpl
@@ -177,16 +177,6 @@ namespace as this release, so a short DNS name is enough.
 {{- printf "http://%s:%v" (include "centaur.onepasswordConnectHost" .) (include "centaur.onepasswordConnectPort" .) -}}
 {{- end -}}
 
-{{- define "centaur.apiOtlpExportEnabled" -}}
-{{- $extraEnv := .Values.apiRs.extraEnv | default dict -}}
-{{- $exporter := lower (trim (toString (default "" (get $extraEnv "OTEL_TRACES_EXPORTER")))) -}}
-{{- $tracesEndpoint := trim (toString (default "" (get $extraEnv "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"))) -}}
-{{- $endpoint := trim (toString (default "" (get $extraEnv "OTEL_EXPORTER_OTLP_ENDPOINT"))) -}}
-{{- $explicitOff := has $exporter (list "none" "false" "0" "off") -}}
-{{- $hasEndpoint := or (ne $tracesEndpoint "") (ne $endpoint "") -}}
-{{- if and (not $explicitOff) (or (eq $exporter "otlp") $hasEndpoint) -}}true{{- else -}}false{{- end -}}
-{{- end -}}
-
 {{- /*
 console — Rails control plane (formerly "iron-control") for authenticated API
 access and encrypted secret storage. Flag-gated (console.enabled), in-cluster

--- a/contrib/chart/templates/_helpers.tpl
+++ b/contrib/chart/templates/_helpers.tpl
@@ -177,6 +177,16 @@ namespace as this release, so a short DNS name is enough.
 {{- printf "http://%s:%v" (include "centaur.onepasswordConnectHost" .) (include "centaur.onepasswordConnectPort" .) -}}
 {{- end -}}
 
+{{- define "centaur.apiOtlpExportEnabled" -}}
+{{- $extraEnv := .Values.apiRs.extraEnv | default dict -}}
+{{- $exporter := lower (trim (toString (default "" (get $extraEnv "OTEL_TRACES_EXPORTER")))) -}}
+{{- $tracesEndpoint := trim (toString (default "" (get $extraEnv "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"))) -}}
+{{- $endpoint := trim (toString (default "" (get $extraEnv "OTEL_EXPORTER_OTLP_ENDPOINT"))) -}}
+{{- $explicitOff := has $exporter (list "none" "false" "0" "off") -}}
+{{- $hasEndpoint := or (ne $tracesEndpoint "") (ne $endpoint "") -}}
+{{- if and (not $explicitOff) (or (eq $exporter "otlp") $hasEndpoint) -}}true{{- else -}}false{{- end -}}
+{{- end -}}
+
 {{- /*
 console — Rails control plane (formerly "iron-control") for authenticated API
 access and encrypted secret storage. Flag-gated (console.enabled), in-cluster

--- a/contrib/chart/templates/apirs.yaml
+++ b/contrib/chart/templates/apirs.yaml
@@ -190,6 +190,9 @@ spec:
 {{- end }}
       labels:
 {{ include "centaur.componentSelectorLabels" (dict "root" . "component" "api-rs") | nindent 8 }}
+{{- if eq (include "centaur.apiOtlpExportEnabled" .) "true" }}
+        centaur.ai/observability-enabled: "true"
+{{- end }}
     spec:
       terminationGracePeriodSeconds: {{ .Values.apiRs.terminationGracePeriodSeconds }}
       automountServiceAccountToken: true

--- a/contrib/chart/templates/apirs.yaml
+++ b/contrib/chart/templates/apirs.yaml
@@ -190,9 +190,7 @@ spec:
 {{- end }}
       labels:
 {{ include "centaur.componentSelectorLabels" (dict "root" . "component" "api-rs") | nindent 8 }}
-{{- if eq (include "centaur.apiOtlpExportEnabled" .) "true" }}
         centaur.ai/observability-enabled: "true"
-{{- end }}
     spec:
       terminationGracePeriodSeconds: {{ .Values.apiRs.terminationGracePeriodSeconds }}
       automountServiceAccountToken: true

--- a/contrib/chart/templates/networkpolicy.yaml
+++ b/contrib/chart/templates/networkpolicy.yaml
@@ -275,6 +275,32 @@ spec:
 {{- end }}
 ---
 {{- end }}
+{{- if .Values.networkPolicy.otlpEgress.enabled }}
+# Pods with observability enabled may call the configured in-cluster OTLP
+# collector. Without the centaur.ai/observability-enabled=true label, default
+# deny blocks access to Laminar or other OTLP endpoints.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "centaur.fullname" . }}-otlp-egress
+  labels:
+{{ include "centaur.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      centaur.ai/observability-enabled: "true"
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ required "networkPolicy.otlpEgress.namespace is required when networkPolicy.otlpEgress.enabled" .Values.networkPolicy.otlpEgress.namespace | quote }}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.networkPolicy.otlpEgress.port }}
+---
+{{- end }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -318,18 +344,6 @@ spec:
       ports:
         - protocol: TCP
           port: {{ $console.service.httpPort }}
-{{- end }}
-{{- if .Values.networkPolicy.otlpEgress.enabled }}
-    # OTLP trace export (e.g. Laminar). The collector lives in another
-    # namespace; without this rule api-rs's own spans die with
-    # BatchSpanProcessor "network error" export failures.
-    - to:
-        - namespaceSelector:
-            matchLabels:
-              kubernetes.io/metadata.name: {{ required "networkPolicy.otlpEgress.namespace is required when networkPolicy.otlpEgress.enabled" .Values.networkPolicy.otlpEgress.namespace | quote }}
-      ports:
-        - protocol: TCP
-          port: {{ .Values.networkPolicy.otlpEgress.port }}
 {{- end }}
     - ports:
         - protocol: TCP

--- a/contrib/chart/values.yaml
+++ b/contrib/chart/values.yaml
@@ -628,10 +628,9 @@ networkPolicy:
   # Egress to an in-cluster OTLP trace collector (e.g. Laminar) in another
   # namespace. The policy selects only pods labeled
   # centaur.ai/observability-enabled=true, matching observabilityEgress. api-rs
-  # receives that label only when API OTLP export is enabled by apiRs.extraEnv
-  # (OTEL_TRACES_EXPORTER=otlp or an OTLP endpoint without an explicit off
-  # value). The collector's own namespace must also admit ingress from this
-  # namespace's pods.
+  # always receives that label; sandboxes and proxy pods receive it only when
+  # their principal has observability enabled. The collector's own namespace
+  # must also admit ingress from this namespace's pods.
   otlpEgress:
     enabled: false
     # kubernetes.io/metadata.name of the collector's namespace, e.g. "laminar".

--- a/contrib/chart/values.yaml
+++ b/contrib/chart/values.yaml
@@ -626,10 +626,12 @@ networkPolicy:
   # on clusters whose API server endpoint already listens on 443.
   apiServerPort: 6443
   # Egress to an in-cluster OTLP trace collector (e.g. Laminar) in another
-  # namespace. api-rs needs this to export its own spans; sandboxes get their
-  # equivalent per-sandbox rule from api-rs, derived from the OTLP endpoint in
-  # sandbox.extraEnv. The collector's own namespace must also admit ingress
-  # from this namespace's pods.
+  # namespace. The policy selects only pods labeled
+  # centaur.ai/observability-enabled=true, matching observabilityEgress. api-rs
+  # receives that label only when API OTLP export is enabled by apiRs.extraEnv
+  # (OTEL_TRACES_EXPORTER=otlp or an OTLP endpoint without an explicit off
+  # value). The collector's own namespace must also admit ingress from this
+  # namespace's pods.
   otlpEgress:
     enabled: false
     # kubernetes.io/metadata.name of the collector's namespace, e.g. "laminar".


### PR DESCRIPTION
Moves OTLP collector egress into a standalone observability-labeled NetworkPolicy and labels api-rs only when API OTLP export is enabled. This keeps Laminar or other configured in-cluster OTLP collector access blocked for pods without observability while preserving export for observability-enabled api-rs.