### PR TITLE
docs: warn that schedule cron day-of-week is Quartz-style (1 = Sunday)

### DIFF
--- a/docs/pages/extend/workflows-v2.mdx
+++ b/docs/pages/extend/workflows-v2.mdx
@@ -151,11 +151,15 @@ Schedules can live beside the handler:
 ```python
 SCHEDULE = {
     "type": "cron",
-    "cron": "0 9 * * 1-5",
+    "cron": "0 9 * * MON-FRI",
     "timezone": "America/New_York",
     "input": {"profile": "default"},
 }
 ```
+
+Write day-of-week as names (`MON-FRI`), not numbers: the parser is Quartz-style
+(1 = Sunday), so a Unix-style `1-5` fires Sunday–Thursday. See
+[Schedule a workflow](/extend/workflows#schedule-a-workflow) for details.
 
 `api-rs` reconciles enabled schedule metadata into Absurd schedule tasks. ETL
 workflows can be routed to a separate queue so long-running sync jobs do not

--- a/docs/pages/extend/workflows.mdx
+++ b/docs/pages/extend/workflows.mdx
@@ -123,7 +123,7 @@ WORKFLOW_NAME = "daily_market_digest"
 
 SCHEDULE = {
     "type": "cron",
-    "cron": "0 9 * * 1-5",
+    "cron": "0 9 * * MON-FRI",
     "timezone": "America/New_York",
     "input": {
         "channel": "markets",
@@ -138,11 +138,20 @@ Cron schedules use five fields:
 minute hour day-of-month month day-of-week
 ```
 
+:::warning[Day-of-week numbering is Quartz-style, not Unix crontab]
+The schedule engine parses cron expressions with the Rust
+[`cron` crate](https://github.com/zslayton/cron), which numbers days of week
+1–7 with **1 = Sunday** (`0` is rejected). A Unix-style `1-5` therefore fires
+Sunday–Thursday, not Monday–Friday. Always write day-of-week as names
+(`MON`, `MON-FRI`, `SAT,SUN`) — they mean the same thing in every dialect.
+:::
+
 Examples:
 
 | Cron | Meaning |
 |------|---------|
-| `0 9 * * 1-5` | 9:00 AM every weekday. |
+| `0 9 * * MON-FRI` | 9:00 AM every weekday. |
+| `0 9 * * 1-5` | 9:00 AM Sunday–Thursday (Quartz numbering — probably not what you meant). |
 | `*/15 * * * *` | Every 15 minutes. |
 | `30 6 * * *` | 6:30 AM every day. |
 | `0 0 1 * *` | Midnight on the first day of every month. |

--- a/docs/public/md/extend/workflows-v2.md
+++ b/docs/public/md/extend/workflows-v2.md
@@ -151,11 +151,15 @@ Schedules can live beside the handler:
 ```python
 SCHEDULE = {
     "type": "cron",
-    "cron": "0 9 * * 1-5",
+    "cron": "0 9 * * MON-FRI",
     "timezone": "America/New_York",
     "input": {"profile": "default"},
 }
 ```
+
+Write day-of-week as names (`MON-FRI`), not numbers: the parser is Quartz-style
+(1 = Sunday), so a Unix-style `1-5` fires Sunday–Thursday. See
+[Schedule a workflow](/extend/workflows#schedule-a-workflow) for details.
 
 `api-rs` reconciles enabled schedule metadata into Absurd schedule tasks. ETL
 workflows can be routed to a separate queue so long-running sync jobs do not

--- a/docs/public/md/extend/workflows.md
+++ b/docs/public/md/extend/workflows.md
@@ -123,7 +123,7 @@ WORKFLOW_NAME = "daily_market_digest"
 
 SCHEDULE = {
     "type": "cron",
-    "cron": "0 9 * * 1-5",
+    "cron": "0 9 * * MON-FRI",
     "timezone": "America/New_York",
     "input": {
         "channel": "markets",
@@ -138,11 +138,20 @@ Cron schedules use five fields:
 minute hour day-of-month month day-of-week
 ```
 
+:::warning[Day-of-week numbering is Quartz-style, not Unix crontab]
+The schedule engine parses cron expressions with the Rust
+[`cron` crate](https://github.com/zslayton/cron), which numbers days of week
+1–7 with **1 = Sunday** (`0` is rejected). A Unix-style `1-5` therefore fires
+Sunday–Thursday, not Monday–Friday. Always write day-of-week as names
+(`MON`, `MON-FRI`, `SAT,SUN`) — they mean the same thing in every dialect.
+:::
+
 Examples:
 
 | Cron | Meaning |
 |------|---------|
-| `0 9 * * 1-5` | 9:00 AM every weekday. |
+| `0 9 * * MON-FRI` | 9:00 AM every weekday. |
+| `0 9 * * 1-5` | 9:00 AM Sunday–Thursday (Quartz numbering — probably not what you meant). |
 | `*/15 * * * *` | Every 15 minutes. |
 | `30 6 * * *` | 6:30 AM every day. |
 | `0 0 1 * *` | Midnight on the first day of every month. |

--- a/services/api-rs/crates/centaur-workflows/src/lib.rs
+++ b/services/api-rs/crates/centaur-workflows/src/lib.rs
@@ -2296,6 +2296,10 @@ fn next_schedule_time(
     }
 }
 
+/// Prepends a seconds field so five-field crontab-style expressions parse with the
+/// `cron` crate. Note the crate's day-of-week numbering is Quartz-style (1 = Sunday,
+/// 7 = Saturday; 0 rejected), NOT Unix crontab — schedules should use day names
+/// (`MON-FRI`) to avoid firing on the wrong days.
 fn normalize_cron_expression(expr: &str) -> String {
     let fields = expr.split_whitespace().collect::<Vec<_>>();
     if fields.len() == 5 {


### PR DESCRIPTION
## Problem

The workflow docs show `0 9 * * 1-5` and describe it as "9:00 AM every weekday", but the schedule engine parses `SCHEDULE` crons with the Rust [`cron` crate](https://github.com/zslayton/cron) (`Schedule::from_str` via `normalize_cron_expression` in `centaur-workflows`), which numbers days of week **1–7 with 1 = Sunday** (Quartz syntax; `0` is rejected — see [zslayton/cron#113](https://github.com/zslayton/cron/issues/113)). So the documented example actually fires **Sunday–Thursday**.

This bit us in production: a weekday-only workflow written against the docs example ran on Sunday and silently never ran on Fridays.

## Changes

- Doc examples now use day names (`MON-FRI`), which parse the same in every cron dialect
- Added a warning callout in `extend/workflows` explaining the Quartz numbering, plus an example-table row showing what numeric `1-5` really means
- One-line pointer in `extend/workflows-v2` linking back to the callout
- Regenerated the `public/md` mirrors for the two changed pages (left other stale mirrors untouched to keep the diff focused)
- Rustdoc note on `normalize_cron_expression` so the quirk is visible at the parse site

No behavior changes.