### PR TITLE
fix: preserve explicit repo cache visibility

### DIFF
--- a/contrib/chart/templates/repo-cache.yaml
+++ b/contrib/chart/templates/repo-cache.yaml
@@ -2,6 +2,7 @@
 {{- $overlaySources := include "centaur.overlaySources" . | fromJsonArray -}}
 {{- $repoCacheRepositories := list -}}
 {{- $repoCacheRepositoryVisibilities := dict -}}
+{{- $repoCacheExplicitRepositoryVisibilities := dict -}}
 {{- $repoCacheRepositoryRefs := list -}}
 {{- $repoCacheRepositoryRefRepos := list -}}
 {{- range $repo, $ref := .Values.repoCache.repositoryRefs }}
@@ -20,6 +21,9 @@
 {{- if $repo -}}
 {{- $repoCacheRepositories = append $repoCacheRepositories $repo -}}
 {{- $_ := set $repoCacheRepositoryVisibilities $repo (include "centaur.repositoryVisibility" (get . "visibility")) -}}
+{{- if hasKey . "visibility" -}}
+{{- $_ := set $repoCacheExplicitRepositoryVisibilities $repo true -}}
+{{- end -}}
 {{- $ref := get . "ref" | default "" -}}
 {{- if and $ref (not (has $repo $repoCacheRepositoryRefRepos)) -}}
 {{- $repoCacheRepositoryRefs = append $repoCacheRepositoryRefs (printf "%s=%s" $repo $ref) -}}
@@ -31,7 +35,9 @@
 {{- range $source := $overlaySources }}
 {{- with (get $source "repo") }}
 {{- $repoCacheRepositories = append $repoCacheRepositories . -}}
+{{- if not (hasKey $repoCacheExplicitRepositoryVisibilities .) -}}
 {{- $_ := set $repoCacheRepositoryVisibilities . (get $source "visibility" | default "private") -}}
+{{- end -}}
 {{- end }}
 {{- end }}
 {{- $repoCacheRepositories = uniq $repoCacheRepositories -}}


### PR DESCRIPTION
## Summary
- preserve explicit visibility settings from `repoCache.repositories`
- prevent overlay defaults for the same repository from overwriting that setting
- retain overlay-derived visibility when the repository has no explicit visibility

## Validation
- `uv run python -m unittest test_repo_cache_sync.py` (9 tests)
- `git diff --check`
- Helm is unavailable in the sandbox; chart linting is left to CI

Prompted by: mslipper