### PR TITLE
fix(console): preserve optimistic chat messages

### DIFF
--- a/services/console/app/views/console/threads/_composer.html.erb
+++ b/services/console/app/views/console/threads/_composer.html.erb
@@ -145,7 +145,9 @@
       if (container) {
         const column = document.createElement("div");
         column.className = "flex w-full flex-col gap-6";
+        column.setAttribute("data-console-optimistic-transcript", "");
         column.append(userBubble(text), thinkingRow());
+        container.classList.add("console-new-chat--optimistic");
         container.querySelector(".console-new-chat-title")?.setAttribute("hidden", "");
         container.insertBefore(column, form);
         form.hidden = true;
@@ -158,7 +160,10 @@
       if (!transcript) return;
       transcript.querySelector("[data-console-thinking-indicator]")?.remove();
       transcript.append(userBubble(text), thinkingRow());
-      input.value = "";
+      // Turbo builds FormData after the submit event has bubbled. Clearing the
+      // textarea here would therefore send an empty prompt; wait until the
+      // browser has captured the form payload before clearing the composer.
+      form.addEventListener("formdata", () => { input.value = ""; }, { once: true });
     });
 
     document.addEventListener("keydown", (event) => {

--- a/services/console/app/views/layouts/console.html.erb
+++ b/services/console/app/views/layouts/console.html.erb
@@ -990,9 +990,11 @@
         background: #3ace79;
       }
 
-      /* Full-page New-chat composer. Sits a bit above vertical center (the
-         claude.ai-style resting height) and matches the transcript column
-         width so it reads as an empty chat, not a separate page. */
+      /* Full-page New-chat composer. Its resting state sits a bit above
+         vertical center (the claude.ai-style resting height) and matches the
+         transcript column width so it reads as an empty chat, not a separate
+         page. Once submitted, it fills the available transcript height and
+         bottom-aligns the optimistic turn like an opened conversation. */
       .console-new-chat {
         width: 100%;
         max-width: 48rem;
@@ -1000,6 +1002,14 @@
         display: flex;
         flex-direction: column;
         gap: 1rem;
+      }
+
+      .console-new-chat--optimistic {
+        align-self: stretch;
+        max-width: 52rem;
+        margin-top: 0;
+        padding: 1.5rem 0;
+        justify-content: flex-end;
       }
 
       .console-new-chat-title {

--- a/services/console/test/controllers/console/threads_controller_test.rb
+++ b/services/console/test/controllers/console/threads_controller_test.rb
@@ -609,6 +609,10 @@ class Console::ThreadsControllerTest < ActionDispatch::IntegrationTest
       assert_select "[data-console-model-option][data-value=?]", "amp"
       assert_select "select", count: 0
     end
+    # Submitting replaces the centered empty state with a full-height,
+    # bottom-aligned optimistic transcript while the request is in flight.
+    assert_includes response.body, 'container.classList.add("console-new-chat--optimistic")'
+    assert_includes response.body, ".console-new-chat--optimistic"
   end
 
   test "shows the new chat screen when nothing is selected" do
@@ -702,6 +706,9 @@ class Console::ThreadsControllerTest < ActionDispatch::IntegrationTest
       # Follow-ups stay on the chat's existing harness/model: no picker.
       assert_select "[data-console-model-picker]", count: 0
     end
+    # Optimistic rendering must not clear the textarea until Turbo has copied
+    # its value into FormData, or the controller receives a blank prompt.
+    assert_includes response.body, 'form.addEventListener("formdata"'
   end
 
   test "starting a chat creates a session, appends the prompt, and executes it" do


### PR DESCRIPTION
## Summary
- defer clearing follow-up input until Turbo captures the form payload, preventing blank prompts
- stretch and bottom-align full-page optimistic conversation starts instead of retaining the centered empty-state layout
- add focused regression coverage for both composer paths

## Validation
- focused Rails tests: 2 runs, 22 assertions, 0 failures
- `bundle exec rubocop test/controllers/console/threads_controller_test.rb`
- inline composer JavaScript syntax check
- Console image build and asset precompilation
- headless Chrome geometry and visual check at 1280x800
- `git diff --check`