### PR TITLE
fix(slackbot): trigger on rich message mentions

### DIFF
--- a/services/slackbotv2/src/index.ts
+++ b/services/slackbotv2/src/index.ts
@@ -25,7 +25,11 @@ import {
 } from '@centaur/rendering'
 import { conflateChatSdkStream } from './conflate'
 import { observeSeconds, slackbotMetrics } from './metrics'
-import { renderSlackDisplayText, slackMessagePromptText } from './slack-display-text'
+import {
+  renderSlackDisplayText,
+  slackMessagePromptText,
+  slackRichTextMentionsUser
+} from './slack-display-text'
 import { slackUserIdForMessage } from './slack-user'
 import {
   collectInitialContext,
@@ -219,8 +223,26 @@ export function createSlackbotV2(options: SlackbotV2Options): SlackbotV2 {
     })
   })
 
+  // Slack does not classify mentions inside Block Kit or legacy attachments as
+  // app_mention events. Alertmanager uses attachment.pretext, so inspect rich
+  // payloads after Chat SDK has verified the webhook and before executing.
+  chat.onNewMessage(/^.*$/s, async (thread, message) => {
+    if (!slackRichTextMentionsUser(message.raw, options.botUserId)) return
+    if (!(await isAllowedSlackMessage(message, options, logger))) return
+    message.isMention = true
+    await handleSlackMessageHandoff(thread, message, {
+      assistantStatusRequested: true,
+      mode: 'execute',
+      options,
+      state,
+      subscribe: true,
+      trigger: 'new_mention'
+    })
+  })
+
   chat.onSubscribedMessage(async (thread, message) => {
     if (!(await isAllowedSlackMessage(message, options, logger))) return
+    if (slackRichTextMentionsUser(message.raw, options.botUserId)) message.isMention = true
     lateSlackFiles.rememberFilelessMention(thread, message)
     await handleSlackMessageHandoff(thread, message, {
       assistantStatusRequested: message.isMention === true,

--- a/services/slackbotv2/src/slack-display-text.ts
+++ b/services/slackbotv2/src/slack-display-text.ts
@@ -7,6 +7,18 @@ export type SlackDisplayText = {
   text: string
 }
 
+export function slackRichTextMentionsUser(raw: unknown, userId: string | undefined): boolean {
+  if (!userId) return false
+  const mention = new RegExp(`<@${escapeRegExp(userId)}(?:\\|[^>]*)?>`, 'i')
+  for (const record of slackMessageRecords(raw)) {
+    for (const key of ['blocks', 'attachments']) {
+      const value = record[key]
+      if (Array.isArray(value) && richValueMentionsUser(value, userId, mention)) return true
+    }
+  }
+  return false
+}
+
 const MAX_RAW_DISPLAY_TEXT_CHARS = 24_000
 
 type UnknownRecord = Record<string, unknown>
@@ -165,6 +177,22 @@ function collectRawAttachmentLines(records: UnknownRecord[]): string[] {
     for (const attachment of attachments) collectSlackAttachmentText(attachment, lines)
   }
   return lines
+}
+
+function richValueMentionsUser(value: unknown, userId: string, mention: RegExp): boolean {
+  if (typeof value === 'string') return mention.test(value)
+  if (Array.isArray(value)) {
+    return value.some(item => richValueMentionsUser(item, userId, mention))
+  }
+  if (!isRecord(value)) return false
+  if (value.type === 'user' && stringField(value.user_id).toUpperCase() === userId.toUpperCase()) {
+    return true
+  }
+  return Object.values(value).some(item => richValueMentionsUser(item, userId, mention))
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
 }
 
 function collectSlackAttachmentText(value: unknown, lines: string[]): void {

--- a/services/slackbotv2/test/chat-sdk-emulate.test.ts
+++ b/services/slackbotv2/test/chat-sdk-emulate.test.ts
@@ -4275,6 +4275,78 @@ describe('slackbotv2', () => {
         recipient_user_id: 'UOTHERBOT'
       })
     )
+
+    bot = createTestBot({ triggerBotAllowlist: ['UOTHERBOT'] })
+    codexApi.reset()
+    slackApi.reset()
+    const richBotMessage = await postUserMessage('')
+    const richBotWaits: Promise<unknown>[] = []
+    const richBotResponse = await bot.app.request(
+      '/api/webhooks/slack',
+      signedSlackEvent({
+        event_id: 'Ev-slackbotv2-bot-attachment-mention-allowed',
+        event: {
+          type: 'message',
+          app_id: 'AOTHERBOT',
+          attachments: [
+            {
+              pretext: `<@${BOT_USER_ID}> investigate`,
+              title: ':red_circle: Validator stalled',
+              text: '*Cluster:* stg-na\n*Tenant:* luganodes'
+            }
+          ],
+          bot_id: 'BOTHERBOT',
+          bot_profile: {
+            app_id: 'AOTHERBOT',
+            id: 'BOTHERBOT',
+            user_id: 'UOTHERBOT'
+          },
+          channel: CHANNEL_ID,
+          subtype: 'bot_message',
+          team: TEAM_ID,
+          text: '',
+          ts: richBotMessage.ts,
+          username: 'otherbot'
+        }
+      }),
+      {},
+      waitUntilContext(richBotWaits)
+    )
+    expect(richBotResponse.status).toBe(200)
+    await Promise.all(richBotWaits)
+    expect(codexApi.appends).toHaveLength(1)
+    expect(codexApi.executes).toHaveLength(1)
+    expect(sessionMessageTexts(codexApi.appends[0]!.body.messages).join('\n')).toContain(
+      'Validator stalled'
+    )
+
+    bot = createTestBot()
+    codexApi.reset()
+    const deniedRichBotMessage = await postUserMessage('')
+    const deniedRichBotWaits: Promise<unknown>[] = []
+    const deniedRichBotResponse = await bot.app.request(
+      '/api/webhooks/slack',
+      signedSlackEvent({
+        event_id: 'Ev-slackbotv2-bot-attachment-mention-denied',
+        event: {
+          type: 'message',
+          attachments: [{ pretext: `<@${BOT_USER_ID}> investigate` }],
+          bot_id: 'BOTHERBOT',
+          channel: CHANNEL_ID,
+          subtype: 'bot_message',
+          team: TEAM_ID,
+          text: '',
+          ts: deniedRichBotMessage.ts,
+          username: 'otherbot'
+        }
+      }),
+      {},
+      waitUntilContext(deniedRichBotWaits)
+    )
+    expect(deniedRichBotResponse.status).toBe(200)
+    await Promise.all(deniedRichBotWaits)
+    expect(codexApi.appends).toHaveLength(0)
+    expect(codexApi.executes).toHaveLength(0)
   })
 })
 

--- a/services/slackbotv2/test/slack-display-text.test.ts
+++ b/services/slackbotv2/test/slack-display-text.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'bun:test'
+import { slackRichTextMentionsUser } from '../src/slack-display-text'
+
+const BOT_USER_ID = 'U0ANX3AM5RR'
+const MENTION = `<@${BOT_USER_ID}> investigate`
+
+describe('Slack rich-text mentions', () => {
+  for (const [name, raw] of [
+    ['attachment pretext', { attachments: [{ pretext: MENTION }] }],
+    ['attachment fallback', { attachments: [{ fallback: MENTION }] }],
+    ['attachment title', { attachments: [{ title: MENTION }] }],
+    ['attachment text', { attachments: [{ text: MENTION }] }],
+    ['attachment field', { attachments: [{ fields: [{ value: MENTION }] }] }],
+    [
+      'attachment block',
+      { attachments: [{ blocks: [{ type: 'section', text: { type: 'mrkdwn', text: MENTION } }] }] }
+    ],
+    ['top-level block', { blocks: [{ type: 'section', text: { type: 'mrkdwn', text: MENTION } }] }],
+    [
+      'Block Kit user element',
+      {
+        blocks: [
+          {
+            type: 'rich_text',
+            elements: [
+              { type: 'rich_text_section', elements: [{ type: 'user', user_id: BOT_USER_ID }] }
+            ]
+          }
+        ]
+      }
+    ],
+    ['labeled mention', { attachments: [{ pretext: `<@${BOT_USER_ID}|centaur> investigate` }] }]
+  ] as const) {
+    it(`recognizes ${name}`, () => {
+      expect(slackRichTextMentionsUser(raw, BOT_USER_ID)).toBe(true)
+    })
+  }
+
+  it('does not infer a mention from top-level text or plain display text', () => {
+    expect(slackRichTextMentionsUser({ text: MENTION }, BOT_USER_ID)).toBe(false)
+    expect(slackRichTextMentionsUser({ attachments: [{ pretext: `@${BOT_USER_ID} investigate` }] }, BOT_USER_ID)).toBe(false)
+  })
+
+  it('requires the exact configured bot user', () => {
+    expect(slackRichTextMentionsUser({ attachments: [{ pretext: MENTION }] }, 'UOTHER')).toBe(false)
+    expect(slackRichTextMentionsUser({ attachments: [{ pretext: MENTION }] }, undefined)).toBe(false)
+  })
+})


### PR DESCRIPTION
Recognize exact Centaur mentions inside Slack Block Kit and legacy attachment payloads, including Alertmanager `pretext`. Rich-message triggers still pass through the existing bot identity allowlist before execution.

Adds unit coverage for attachment fields, nested/top-level blocks, Block Kit user elements, labeled mentions, negative matches, and allowlist enforcement.

Tests: `pnpm --filter slackbotv2 test` (173 passed, 1 skipped); `pnpm --filter slackbotv2 check:types`

Prompted by: @kuyziss