### PR TITLE
docs: fix company context latest-date guidance

### DIFF
--- a/.agents/skills/company-context/SKILL.md
+++ b/.agents/skills/company-context/SKILL.md
@@ -42,11 +42,13 @@ Use the source-specific tools that match the question. For broad cross-source qu
 4. For time-sensitive or "latest" asks, check index freshness:
 
 ```bash
-company_context latest-date --json
-company_context latest-date --source slack --json
-company_context latest-date --source docs --source-type google_doc --json
-company_context latest-date --source linear --json
+company_context latest-date
+company_context latest-date --source slack
+company_context latest-date --source docs --source-type google_doc
+company_context latest-date --source linear
 ```
+
+`latest-date` always outputs JSON, so it does not accept a `--json` flag.
 
 5. If results are weak, broaden or target source filters:
 

--- a/tools/productivity/company_context/cli.py
+++ b/tools/productivity/company_context/cli.py
@@ -295,7 +295,7 @@ def latest_date(
     ),
     source_type: str | None = typer.Option(None, "--source-type", help="Filter by source type."),
 ) -> None:
-    """Show the latest indexed timestamp."""
+    """Show the latest indexed timestamp as JSON."""
     result = CompanyContextClient().latest_date(source=source, source_type=source_type)
     _require_ok(result)
     _print_json(result)


### PR DESCRIPTION
## Summary

- Remove the unsupported `--json` option from `company_context latest-date` skill examples.
- Clarify in CLI help that `latest-date` always outputs JSON.

## Root cause

The skill instructed agents to pass `--json`, but the `latest-date` command emits JSON unconditionally and does not declare that flag.

## Impact

Agents can check indexed-context freshness without receiving a Typer option error.

## Validation

- `company_context latest-date --help` shows JSON output and no `--json` option.
- `git diff --check`
