### PR TITLE
feat(slack): read huddle transcripts — the one Slack record no bot token can reach

### DIFF
--- a/docs/pages/operate/slack-huddle-transcripts.mdx
+++ b/docs/pages/operate/slack-huddle-transcripts.mdx
@@ -1,0 +1,102 @@
+---
+title: Slack huddle transcripts
+description: Read the verbatim, speaker-attributed transcript of a recorded Slack huddle — the one Slack record no bot token can reach.
+---
+
+# Slack huddle transcripts
+
+Slack records every huddle and saves a full, speaker-attributed transcript. **A bot token cannot read
+it, and no public API exposes it.** `files.info` on the transcript's file id returns metadata and no
+words, whatever scopes the app holds; Slack support confirms this is deliberate.
+
+That leaves a hole in an agent's view of a workspace, and it is the wrong hole. The huddle is where
+the standup sets the day's priorities, where the incident call finds the cause, where the design
+argument is actually settled. Channels get the summary; the huddle had the reasoning. An agent that
+reads every channel and no huddle is missing the part that mattered.
+
+Centaur's Slack tool can read them, given a **user web session**.
+
+## How it works
+
+The Slack *web client* reads transcripts perfectly well. It calls `files.info` with
+`include_transcription=true` against the **workspace host** (`<workspace>.slack.com` — never
+`slack.com`), authenticated by a user web session: an `xoxc` token paired with the `d` cookie.
+The tool replays exactly that call.
+
+This is not a scope escalation and not a permission bypass. A user session sees precisely what that
+user could already read by opening the huddle in their own Slack client. If they cannot see the
+huddle, neither can this.
+
+```bash
+slack huddle-transcript F0123456789
+```
+
+```
+34 turns, 3 speakers
+<@U01ABC> [0:04]: the migration is blocked on the schema review
+<@U02DEF> [0:11]: I can review it this afternoon
+<@U01ABC> [0:19]: then we ship Friday
+```
+
+The agent-facing method is `get_huddle_transcript(file_id)`. It returns `{file_id, speakers, turns,
+text}`. Speakers stay as **Slack ids**, not names — an id round-trips to a real mention and cannot
+drift, while a name resolved at read time silently rots when someone changes their display name.
+
+Find a `file_id` from the huddle's message in `conversations.history` (the room object references its
+transcript file), or from the huddle's AI-notes canvas, which names it.
+
+## The credentials
+
+Two optional secrets. Without them every other Slack method works exactly as before, and only
+`get_huddle_transcript` reports what is missing.
+
+| Secret | What it is |
+| --- | --- |
+| `SLACK_WEB_TOKEN` | The `xoxc` token from a signed-in Slack web session |
+| `SLACK_WEB_COOKIE` | The paired `d` cookie (`d=xoxd-…`) |
+
+Both are declared as header-injected HTTP secrets scoped to `*.slack.com`, so **the sandbox holds
+placeholders and never the real session** — iron-proxy swaps in the true values at the network
+boundary, and only for Slack hosts.
+
+:::warning[Scope these to a service account, not to a person]
+A user web session carries **that user's full Slack visibility**, including their DMs. Mint it from an
+account whose visibility you are content for agents to inherit. This is the same trust decision as
+`SLACK_SEARCH_TOKEN`, but the blast radius is larger, so make it deliberately.
+:::
+
+### Obtaining them
+
+From a browser signed in to the workspace:
+
+1. Open the workspace in Slack (web or the desktop app), then open developer tools.
+2. `SLACK_WEB_COOKIE` — copy the `d` cookie for `.slack.com`. Its value begins `xoxd-`. Store it in
+   the `d=xoxd-…` form.
+3. `SLACK_WEB_TOKEN` — the paired `xoxc` token is embedded in the workspace boot page. Find it in any
+   authenticated XHR to `/api/…` (the `token` form field), or search the page source for `xoxc-`.
+
+The two are a **pair**: an `xoxc` token only authenticates alongside the `d` cookie it was issued
+with. Rotating one without the other yields `invalid_auth`.
+
+## Sessions expire — and the failure is loud on purpose
+
+A web session lapses. When it does, the tool raises `needs_reauth` rather than returning an empty
+transcript.
+
+That distinction is the whole design. **A silent empty read looks exactly like "nobody spoke."** An
+agent that quietly concludes a meeting was silent is far worse than one that says it cannot see —
+the first fabricates an absence of evidence, the second reports a broken credential. So a lapsed
+session fails loudly, and a caller can tell "sign in again" apart from "this is broken":
+
+```json
+{
+  "error": "huddle_transcript_failed",
+  "message": "the Slack web session expired — a human must sign in again …",
+  "slack_error": "invalid_auth",
+  "needs_reauth": true
+}
+```
+
+Treat `needs_reauth` as an operational alert, not an empty result. Discovery — which huddles exist —
+runs on the ordinary bot token and never needs the session, so nothing is lost while a session is
+stale: refresh it and the backlog reads fine.

--- a/docs/pages/reference/tool-directory.mdx
+++ b/docs/pages/reference/tool-directory.mdx
@@ -31,7 +31,7 @@ These are broadly useful across most deployments and are good candidates to conf
 |---|---|---|
 | `linear` | Search, create, update, and comment on Linear issues, projects, cycles, teams, and labels | `LINEAR_API_KEY` |
 | `notion` | Search and update Notion pages, databases, blocks, and comments | `NOTION_API_KEY` |
-| `slack` | Search Slack, read threads, inspect channels/users, and send or upload messages | `SLACK_BOT_TOKEN`; optional: `SLACK_SEARCH_TOKEN`, `SLACK_ETL_TOKEN` |
+| `slack` | Search Slack, read threads, inspect channels/users, read huddle transcripts, and send or upload messages | `SLACK_BOT_TOKEN`; optional: `SLACK_SEARCH_TOKEN`, `SLACK_ETL_TOKEN`, `SLACK_WEB_TOKEN` + `SLACK_WEB_COOKIE` (huddle transcripts) |
 | `gsuite` | Use Gmail, Calendar, Drive, Docs, Sheets, Slides, and Google Analytics | `GOOGLE_TOKEN_JSON` |
 | `websearch` | Free web search via Parallel and deep research | None; `PARALLEL_API_KEY` for `deep_research`; `ANTHROPIC_API_KEY` for search synthesis |
 | `company_context` | Search indexed company history, private Slack conversations, and Google Docs | None |
@@ -83,7 +83,7 @@ These are broadly useful across most deployments and are good candidates to conf
 | `linear` | Linear issues, projects, cycles, teams, workflow states, and labels | `LINEAR_API_KEY` |
 | `notion` | Notion pages, databases, blocks, comments, and users | `NOTION_API_KEY` |
 | `opentable` | Search OpenTable restaurant reservations | None |
-| `slack` | Slack messages, files, channels, threads, users, and usergroups | `SLACK_BOT_TOKEN`; optional: `SLACK_SEARCH_TOKEN`, `SLACK_ETL_TOKEN` |
+| `slack` | Slack messages, files, channels, threads, users, usergroups, and huddle transcripts | `SLACK_BOT_TOKEN`; optional: `SLACK_SEARCH_TOKEN`, `SLACK_ETL_TOKEN`, `SLACK_WEB_TOKEN` + `SLACK_WEB_COOKIE` (huddle transcripts) |
 
 ## Research
 

--- a/docs/public/md/operate/slack-huddle-transcripts.md
+++ b/docs/public/md/operate/slack-huddle-transcripts.md
@@ -1,0 +1,102 @@
+---
+title: Slack huddle transcripts
+description: Read the verbatim, speaker-attributed transcript of a recorded Slack huddle — the one Slack record no bot token can reach.
+---
+
+# Slack huddle transcripts
+
+Slack records every huddle and saves a full, speaker-attributed transcript. **A bot token cannot read
+it, and no public API exposes it.** `files.info` on the transcript's file id returns metadata and no
+words, whatever scopes the app holds; Slack support confirms this is deliberate.
+
+That leaves a hole in an agent's view of a workspace, and it is the wrong hole. The huddle is where
+the standup sets the day's priorities, where the incident call finds the cause, where the design
+argument is actually settled. Channels get the summary; the huddle had the reasoning. An agent that
+reads every channel and no huddle is missing the part that mattered.
+
+Centaur's Slack tool can read them, given a **user web session**.
+
+## How it works
+
+The Slack *web client* reads transcripts perfectly well. It calls `files.info` with
+`include_transcription=true` against the **workspace host** (`<workspace>.slack.com` — never
+`slack.com`), authenticated by a user web session: an `xoxc` token paired with the `d` cookie.
+The tool replays exactly that call.
+
+This is not a scope escalation and not a permission bypass. A user session sees precisely what that
+user could already read by opening the huddle in their own Slack client. If they cannot see the
+huddle, neither can this.
+
+```bash
+slack huddle-transcript F0123456789
+```
+
+```
+34 turns, 3 speakers
+<@U01ABC> [0:04]: the migration is blocked on the schema review
+<@U02DEF> [0:11]: I can review it this afternoon
+<@U01ABC> [0:19]: then we ship Friday
+```
+
+The agent-facing method is `get_huddle_transcript(file_id)`. It returns `{file_id, speakers, turns,
+text}`. Speakers stay as **Slack ids**, not names — an id round-trips to a real mention and cannot
+drift, while a name resolved at read time silently rots when someone changes their display name.
+
+Find a `file_id` from the huddle's message in `conversations.history` (the room object references its
+transcript file), or from the huddle's AI-notes canvas, which names it.
+
+## The credentials
+
+Two optional secrets. Without them every other Slack method works exactly as before, and only
+`get_huddle_transcript` reports what is missing.
+
+| Secret | What it is |
+| --- | --- |
+| `SLACK_WEB_TOKEN` | The `xoxc` token from a signed-in Slack web session |
+| `SLACK_WEB_COOKIE` | The paired `d` cookie (`d=xoxd-…`) |
+
+Both are declared as header-injected HTTP secrets scoped to `*.slack.com`, so **the sandbox holds
+placeholders and never the real session** — iron-proxy swaps in the true values at the network
+boundary, and only for Slack hosts.
+
+:::warning[Scope these to a service account, not to a person]
+A user web session carries **that user's full Slack visibility**, including their DMs. Mint it from an
+account whose visibility you are content for agents to inherit. This is the same trust decision as
+`SLACK_SEARCH_TOKEN`, but the blast radius is larger, so make it deliberately.
+:::
+
+### Obtaining them
+
+From a browser signed in to the workspace:
+
+1. Open the workspace in Slack (web or the desktop app), then open developer tools.
+2. `SLACK_WEB_COOKIE` — copy the `d` cookie for `.slack.com`. Its value begins `xoxd-`. Store it in
+   the `d=xoxd-…` form.
+3. `SLACK_WEB_TOKEN` — the paired `xoxc` token is embedded in the workspace boot page. Find it in any
+   authenticated XHR to `/api/…` (the `token` form field), or search the page source for `xoxc-`.
+
+The two are a **pair**: an `xoxc` token only authenticates alongside the `d` cookie it was issued
+with. Rotating one without the other yields `invalid_auth`.
+
+## Sessions expire — and the failure is loud on purpose
+
+A web session lapses. When it does, the tool raises `needs_reauth` rather than returning an empty
+transcript.
+
+That distinction is the whole design. **A silent empty read looks exactly like "nobody spoke."** An
+agent that quietly concludes a meeting was silent is far worse than one that says it cannot see —
+the first fabricates an absence of evidence, the second reports a broken credential. So a lapsed
+session fails loudly, and a caller can tell "sign in again" apart from "this is broken":
+
+```json
+{
+  "error": "huddle_transcript_failed",
+  "message": "the Slack web session expired — a human must sign in again …",
+  "slack_error": "invalid_auth",
+  "needs_reauth": true
+}
+```
+
+Treat `needs_reauth` as an operational alert, not an empty result. Discovery — which huddles exist —
+runs on the ordinary bot token and never needs the session, so nothing is lost while a session is
+stale: refresh it and the backlog reads fine.

--- a/docs/public/md/reference/tool-directory.md
+++ b/docs/public/md/reference/tool-directory.md
@@ -31,7 +31,7 @@ These are broadly useful across most deployments and are good candidates to conf
 |---|---|---|
 | `linear` | Search, create, update, and comment on Linear issues, projects, cycles, teams, and labels | `LINEAR_API_KEY` |
 | `notion` | Search and update Notion pages, databases, blocks, and comments | `NOTION_API_KEY` |
-| `slack` | Search Slack, read threads, inspect channels/users, and send or upload messages | `SLACK_BOT_TOKEN`; optional: `SLACK_SEARCH_TOKEN`, `SLACK_ETL_TOKEN` |
+| `slack` | Search Slack, read threads, inspect channels/users, read huddle transcripts, and send or upload messages | `SLACK_BOT_TOKEN`; optional: `SLACK_SEARCH_TOKEN`, `SLACK_ETL_TOKEN`, `SLACK_WEB_TOKEN` + `SLACK_WEB_COOKIE` (huddle transcripts) |
 | `gsuite` | Use Gmail, Calendar, Drive, Docs, Sheets, Slides, and Google Analytics | `GOOGLE_TOKEN_JSON` |
 | `websearch` | Free web search via Parallel and deep research | None; `PARALLEL_API_KEY` for `deep_research`; `ANTHROPIC_API_KEY` for search synthesis |
 | `company_context` | Search indexed company history, private Slack conversations, and Google Docs | None |
@@ -85,7 +85,7 @@ These are broadly useful across most deployments and are good candidates to conf
 | `linear` | Linear issues, projects, cycles, teams, workflow states, and labels | `LINEAR_API_KEY` |
 | `notion` | Notion pages, databases, blocks, comments, and users | `NOTION_API_KEY` |
 | `opentable` | Search OpenTable restaurant reservations | None |
-| `slack` | Slack messages, files, channels, threads, users, and usergroups | `SLACK_BOT_TOKEN`; optional: `SLACK_SEARCH_TOKEN`, `SLACK_ETL_TOKEN` |
+| `slack` | Slack messages, files, channels, threads, users, usergroups, and huddle transcripts | `SLACK_BOT_TOKEN`; optional: `SLACK_SEARCH_TOKEN`, `SLACK_ETL_TOKEN`, `SLACK_WEB_TOKEN` + `SLACK_WEB_COOKIE` (huddle transcripts) |
 
 ## Research
 

--- a/docs/sidebar.ts
+++ b/docs/sidebar.ts
@@ -15,6 +15,7 @@ export const sidebar = [
     text: 'Operate',
     items: [
       { text: 'Slack ETL', link: '/operate/slack-etl' },
+      { text: 'Slack huddle transcripts', link: '/operate/slack-huddle-transcripts' },
       { text: 'Expose Slackbot with Tailscale Funnel', link: '/operate/tailscale-funnel' },
     ],
   },

--- a/tools/productivity/slack/.env.example
+++ b/tools/productivity/slack/.env.example
@@ -1,0 +1,20 @@
+# Bot User OAuth Token. Required.
+# https://api.slack.com/apps -> OAuth & Permissions -> Bot User OAuth Token
+SLACK_BOT_TOKEN=xoxb-your-bot-token
+
+# User token used for search.messages, which Slack does not expose to bot tokens. Optional.
+SLACK_SEARCH_TOKEN=xoxp-your-user-token
+
+# User token used by Slack ETL for history and file reads. Optional.
+SLACK_ETL_TOKEN=xoxp-your-user-token
+
+# A signed-in Slack WEB session, used only to read huddle transcripts. Optional, and a pair:
+# an xoxc token authenticates only alongside the d cookie it was issued with.
+#
+# Slack exposes no bot-token API for huddle transcripts and this is deliberate, so the web client's
+# own files.info call is the only way to read them. See operate/slack-huddle-transcripts.
+#
+# A web session carries that user's FULL Slack visibility, DMs included. Mint it from an account
+# whose visibility you are content for agents to inherit.
+SLACK_WEB_TOKEN=xoxc-your-web-token
+SLACK_WEB_COOKIE=d=xoxd-your-d-cookie

--- a/tools/productivity/slack/cli.py
+++ b/tools/productivity/slack/cli.py
@@ -1701,5 +1701,35 @@ def user_info(
         raise typer.Exit(1)
 
 
+@app.command("huddle-transcript")
+def huddle_transcript(
+    file_id: str = typer.Argument(..., help="The huddle_transcript file id (F...)"),
+    as_json: bool = typer.Option(False, "--json", help="Emit the raw payload"),
+):
+    """Read the verbatim transcript of a recorded huddle.
+
+    Needs a Slack user web session (SLACK_WEB_TOKEN + SLACK_WEB_COOKIE): Slack exposes no bot-token
+    API for huddle transcripts, so this replays the web client's own files.info call.
+    """
+    from .client import _client
+
+    try:
+        result = _client().get_huddle_transcript(file_id)
+    except Exception as exc:
+        payload = getattr(exc, "payload", {"error": str(exc)})
+        console.print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+        # A lapsed session is not a bug in this command — say which it is, so a caller (or an agent)
+        # can tell "sign in again" apart from "this is broken".
+        if payload.get("needs_reauth"):
+            console.print("[yellow]The Slack web session needs refreshing.[/]")
+        raise typer.Exit(1) from exc
+
+    if as_json:
+        console.print(json.dumps(result, indent=2, ensure_ascii=False, default=str))
+        return
+    console.print(f"[bold]{result['turns']}[/] turns, {len(result['speakers'])} speakers")
+    console.print(result["text"])
+
+
 if __name__ == "__main__":
     app()

--- a/tools/productivity/slack/client.py
+++ b/tools/productivity/slack/client.py
@@ -23,6 +23,8 @@ from slack_sdk.errors import SlackApiError
 
 from centaur_sdk.tool_sdk import secret
 
+from . import huddle_transcript
+
 # structlog so these lines render as JSON through the tool-server's
 # configure_structlog() pipeline, like the rest of the service's logs.
 logger = structlog.get_logger()
@@ -115,6 +117,8 @@ class SlackClient:
         self,
         bot_token: str | None = None,
         search_token: str | None = None,
+        web_token: str | None = None,
+        web_cookie: str | None = None,
     ):
         token = (bot_token or secret("SLACK_BOT_TOKEN", default="")).strip()
         if not token:
@@ -124,6 +128,11 @@ class SlackClient:
             )
         self.token = token
         self.search_token = (search_token or secret("SLACK_SEARCH_TOKEN", default="")).strip()
+        # The user web session that unlocks huddle transcripts. Optional: without it every other
+        # method works exactly as before and only `get_huddle_transcript` reports that it is missing.
+        self.web_token = (web_token or secret("SLACK_WEB_TOKEN", default="")).strip()
+        self.web_cookie = (web_cookie or secret("SLACK_WEB_COOKIE", default="")).strip()
+        self._workspace_host_cache: str | None = None
         timeout = self._api_timeout_seconds()
         self._client = WebClient(token=token, timeout=timeout)
         self._search_client = (
@@ -137,6 +146,66 @@ class SlackClient:
     def __getattr__(self, name: str):
         """Proxy raw Slack SDK methods when the higher-level wrapper does not define them."""
         return getattr(self._client, name)
+
+    def _workspace_host(self) -> str:
+        """The workspace's own Slack host, e.g. ``acme.slack.com``.
+
+        Huddle transcripts are served only from the workspace host, never from ``slack.com``. Rather
+        than ask a deployment to configure that, derive it from the bot token we already hold:
+        ``auth.test`` returns the workspace URL. Cached, because it cannot change within a process.
+        """
+        if self._workspace_host_cache is None:
+            url = (self._client.auth_test().data or {}).get("url", "")
+            host = urlparse(url).hostname
+            if not host:
+                raise huddle_transcript.HuddleTranscriptError(
+                    "could not determine the workspace host from auth.test"
+                )
+            self._workspace_host_cache = host
+        return self._workspace_host_cache
+
+    def get_huddle_transcript(self, file_id: str) -> dict:
+        """The verbatim, speaker-attributed transcript of one recorded huddle.
+
+        Slack saves a recorded huddle's transcript as a ``huddle_transcript`` file that is never
+        shared into a channel, so **a bot token cannot read it and no public API exposes it** — this
+        is deliberate on Slack's side. The web client reads it through ``files.info`` with
+        ``include_transcription=true`` on the workspace host, authenticated by a user web session.
+        This replays that call, so it returns exactly what the signed-in user could already read by
+        scrolling the huddle themselves. It is not a scope escalation.
+
+        Needs ``SLACK_WEB_TOKEN`` (an ``xoxc`` token) and ``SLACK_WEB_COOKIE`` (the ``d`` cookie).
+        Both are optional secrets: without them the rest of this tool is unaffected and this method
+        says plainly what is missing.
+
+        When the session lapses the failure is **loud** — ``needs_reauth`` — never an empty
+        transcript. An agent that quietly believes a meeting was silent is worse than one that admits
+        it cannot see.
+
+        Find a ``file_id`` from the huddle's message in ``conversations.history`` (the huddle's room
+        object references its transcript file), or from the huddle's AI-notes canvas, which names it.
+        """
+        if not self.web_token or not self.web_cookie:
+            missing = [
+                name
+                for name, value in (
+                    ("SLACK_WEB_TOKEN", self.web_token),
+                    ("SLACK_WEB_COOKIE", self.web_cookie),
+                )
+                if not value
+            ]
+            raise huddle_transcript.HuddleTranscriptError(
+                "huddle transcripts need a Slack user web session; Slack exposes no bot-token API "
+                "for them",
+                missing=missing,
+                needs_reauth=True,
+            )
+        return huddle_transcript.fetch(
+            file_id,
+            host=self._workspace_host(),
+            token=self.web_token,
+            cookie=self.web_cookie,
+        )
 
     def _is_ratelimit_error(self, error: SlackApiError) -> bool:
         """Detect Slack rate limit responses from either payload or status code."""
@@ -2717,3 +2786,7 @@ def search_users(*args, **kwargs):
 
 def get_user_profile(*args, **kwargs):
     return _client().get_user_profile(*args, **kwargs)
+
+
+def get_huddle_transcript(*args, **kwargs):
+    return _client().get_huddle_transcript(*args, **kwargs)

--- a/tools/productivity/slack/huddle_transcript.py
+++ b/tools/productivity/slack/huddle_transcript.py
@@ -130,12 +130,18 @@ def speakers(segments: list[dict]) -> list[str]:
 def _call(host: str, token: str, cookie: str, **params: str) -> dict:
     """One ``files.info`` call against the workspace host.
 
-    The token rides in the ``Authorization`` header and the session in ``Cookie``. Both are places
-    iron-proxy is allowed to look (``match_headers``), so in a sandbox the tool holds only
-    placeholders and the real session never leaves the proxy. That is the reason this does not simply
-    post the token as a form field the way the browser does: a request body is the one place the
-    firewall cannot reach, and a user session token sitting in a sandbox is exactly the exposure the
-    injection model exists to prevent.
+    The token rides in the ``Authorization`` header and the session in ``Cookie``, and that choice is
+    the whole security story. Slack's web client posts the token as a **form field**, and it would be
+    the obvious thing to copy — but a request body is the one place iron-proxy cannot look
+    (``match_headers`` / ``match_query`` / ``match_path``, and there is no ``match_body``). Copying
+    the browser would therefore force a real user web session to sit inside the sandbox, which is
+    precisely the exposure the injection model exists to prevent.
+
+    Verified against the live API before choosing: Slack accepts this token in the form body, in the
+    query string, **and** in the ``Authorization`` header — all three authenticate. Since they are
+    equivalent to Slack, take the one the firewall can reach. Both credentials are then declared as
+    header-injected secrets, the sandbox holds only placeholders, and the real session never leaves
+    the proxy.
     """
     url = f"https://{host}/api/files.info?" + urllib.parse.urlencode(params)
     request = urllib.request.Request(

--- a/tools/productivity/slack/huddle_transcript.py
+++ b/tools/productivity/slack/huddle_transcript.py
@@ -1,0 +1,198 @@
+"""The verbatim transcript of a recorded Slack huddle.
+
+Slack records every huddle and saves the full, speaker-attributed transcript as a
+``huddle_transcript`` file. That file is never shared into a channel, so **a bot token cannot
+download it, and there is no public API for it** — Slack support confirms this is deliberate.
+``files.info`` on the id returns metadata and no words, whatever scopes the bot holds. So the richest
+record a company produces about its own decisions — the standup where the priority was set, the
+incident call where the cause was found — is the one thing an agent in that workspace cannot read.
+
+The Slack *web client* reads it perfectly well. It calls ``files.info`` on the **workspace host**
+(``<workspace>.slack.com``, never ``slack.com``) with ``include_transcription=true``, authenticated by
+a user web session: an ``xoxc`` token paired with the ``d`` cookie. This module replays exactly that
+call. Nothing here is a scope trick or a permission bypass — a user session sees precisely what that
+user could already read by scrolling the huddle in their own Slack client.
+
+Two halves, deliberately separate, because they fail in completely different ways:
+
+* **Discovery** — which huddles exist, and which transcript file belongs to each — runs on the
+  ordinary bot token and is stable. It never needs the session.
+* **Fetch** — the words themselves — is the session-bound half. When a session lapses it fails
+  **loudly** (``needs_reauth``), never by returning an empty transcript. That distinction is the whole
+  ballgame: a silent empty read looks exactly like "nobody said anything", and an agent that quietly
+  believes a meeting was silent is worse than one that admits it cannot see.
+
+The parsing below is pure and unit-tested against real Slack payloads; the network call is a thin
+shell around it.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import urllib.parse
+import urllib.request
+
+# Slack marks each spoken turn with a bold ` [mm:ss]: ` between the speaker and their words — how far
+# into the call the turn happened. Long huddles use `[h:mm:ss]`.
+_STAMP = re.compile(r"\[(\d{1,2}:\d{2}(?::\d{2})?)\]")
+
+_PAGE = 1000  # turns per page; long huddles paginate
+_MAX_PAGES = 60  # ~60k turns — a backstop against a pathological response, never hit by a real huddle
+
+# The failures that mean "the human must sign in again", as opposed to "this code is wrong". Only
+# these set ``needs_reauth``; everything else is a bug and should read like one.
+_REAUTH_ERRORS = frozenset(
+    {"not_authed", "invalid_auth", "token_revoked", "token_expired", "account_inactive"}
+)
+
+
+class HuddleTranscriptError(RuntimeError):
+    """A structured failure that survives stringification through the tool boundary.
+
+    ``needs_reauth=True`` marks the one failure that is not a defect: the user web session expired,
+    and only a human signing in again can restore it. Callers should surface that verbatim rather than
+    treating it as an empty result.
+    """
+
+    def __init__(self, message: str, **detail: object) -> None:
+        self.payload = {"error": "huddle_transcript_failed", "message": message, **detail}
+        super().__init__(str(self.payload))
+
+
+# ── parsing (pure) ──────────────────────────────────────────────────────────────────────────────
+
+
+def parse_segments(files_info: dict) -> list[dict]:
+    """The transcript as ordered turns: ``{"user_id", "at", "text"}``.
+
+    Slack returns it as one ``rich_text`` block whose elements are a ``rich_text_section`` per spoken
+    turn. Each section carries a ``user`` element (the speaker's id), a **bold** ``text`` element
+    holding the ` [mm:ss]: ` mark, and one or more plain ``text`` elements with the words.
+
+    Speakers stay as **Slack ids, never names**. An id round-trips to a real mention and cannot drift;
+    a name resolved at parse time silently rots when someone changes their display name.
+    """
+    block = ((files_info.get("file") or {}).get("huddle_transcription") or {}).get("blocks") or {}
+    out: list[dict] = []
+    for section in block.get("elements", []):
+        if section.get("type") != "rich_text_section":
+            continue
+        user_id: str | None = None
+        at: str | None = None
+        words: list[str] = []
+        for element in section.get("elements", []):
+            if element.get("type") == "user":
+                user_id = element.get("user_id")
+            elif element.get("type") == "text":
+                text = element.get("text", "")
+                stamp = _STAMP.search(text)
+                # The bold element that *is* a timestamp is the marker, not speech. A bold word inside
+                # the speech itself carries no [mm:ss] and must survive.
+                if stamp and (element.get("style") or {}).get("bold"):
+                    at = stamp.group(1)
+                else:
+                    words.append(text)
+        said = "".join(words).strip()
+        if said:
+            out.append({"user_id": user_id, "at": at, "text": said})
+    return out
+
+
+def render(segments: list[dict]) -> str:
+    """Turns → a readable transcript, one line each: ``<@U…> [mm:ss]: words``.
+
+    The ``<@U…>`` form is what Slack renders as a real mention, so a verbatim quote names the person
+    instead of printing id soup.
+    """
+    lines = []
+    for segment in segments:
+        who = f"<@{segment['user_id']}>" if segment.get("user_id") else "someone"
+        at = f" [{segment['at']}]" if segment.get("at") else ""
+        lines.append(f"{who}{at}: {segment['text']}")
+    return "\n".join(lines)
+
+
+def speakers(segments: list[dict]) -> list[str]:
+    """Distinct speaker ids in first-spoke order — an attendee list drawn from who actually *talked*,
+    which is not the same as who Slack listed as present."""
+    seen: list[str] = []
+    for segment in segments:
+        uid = segment.get("user_id")
+        if uid and uid not in seen:
+            seen.append(uid)
+    return seen
+
+
+# ── the session-bound fetch (thin shell) ────────────────────────────────────────────────────────
+
+
+def _call(host: str, token: str, cookie: str, **params: str) -> dict:
+    """One ``files.info`` call against the workspace host.
+
+    The token rides in the ``Authorization`` header and the session in ``Cookie``. Both are places
+    iron-proxy is allowed to look (``match_headers``), so in a sandbox the tool holds only
+    placeholders and the real session never leaves the proxy. That is the reason this does not simply
+    post the token as a form field the way the browser does: a request body is the one place the
+    firewall cannot reach, and a user session token sitting in a sandbox is exactly the exposure the
+    injection model exists to prevent.
+    """
+    url = f"https://{host}/api/files.info?" + urllib.parse.urlencode(params)
+    request = urllib.request.Request(
+        url,
+        data=b"",  # Slack wants a POST; the parameters ride in the query string
+        headers={"Authorization": f"Bearer {token}", "Cookie": cookie},
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=60) as response:
+            body = json.load(response)
+    except OSError as exc:  # network/TLS, not Slack saying no
+        raise HuddleTranscriptError(f"could not reach {host}", cause=str(exc)) from exc
+
+    if not body.get("ok"):
+        error = body.get("error")
+        if error in _REAUTH_ERRORS:
+            raise HuddleTranscriptError(
+                "the Slack web session expired — a human must sign in again and refresh the "
+                "SLACK_WEB_TOKEN / SLACK_WEB_COOKIE pair; huddle transcripts stay unreadable until "
+                "they do",
+                slack_error=error,
+                needs_reauth=True,
+            )
+        raise HuddleTranscriptError("Slack returned not-ok", slack_error=error)
+    return body
+
+
+def fetch(file_id: str, *, host: str, token: str, cookie: str) -> dict:
+    """The full verbatim transcript for one ``huddle_transcript`` file id.
+
+    Returns ``{"file_id", "speakers", "turns", "text"}``. Raises :class:`HuddleTranscriptError` with
+    ``needs_reauth=True`` when the session has lapsed — the loud signal that keeps a stale cookie from
+    ever reading as "this huddle had no transcript".
+
+    Only the rendered ``text`` comes back, not the parsed segments as well. They are the same words
+    twice, and this is the largest single payload the tool can produce: returning both writes the
+    whole huddle into the model's context a second time, and it is then re-read on every request of
+    the turn. Callers that need the structure can call :func:`parse_segments` themselves.
+    """
+    segments: list[dict] = []
+    for page in range(1, _MAX_PAGES + 1):
+        body = _call(
+            host,
+            token,
+            cookie,
+            file=file_id,
+            include_transcription="true",
+            page=str(page),
+            count=str(_PAGE),
+        )
+        chunk = parse_segments(body)
+        segments += chunk
+        if len(chunk) < _PAGE:  # a short page is the last page — also the no-pagination case
+            break
+    return {
+        "file_id": file_id,
+        "speakers": speakers(segments),
+        "turns": len(segments),
+        "text": render(segments),
+    }

--- a/tools/productivity/slack/pyproject.toml
+++ b/tools/productivity/slack/pyproject.toml
@@ -33,4 +33,10 @@ secrets = [
 optional_secrets = [
     {type = "http", name = "SLACK_SEARCH_TOKEN", match_headers = ["Authorization"], hosts = ["slack.com"]},
     {type = "http", name = "SLACK_ETL_TOKEN", match_headers = ["Authorization"], hosts = ["slack.com", "files.slack.com"]},
+    # The user web session that unlocks huddle transcripts. Slack serves them ONLY from the
+    # workspace host (`<workspace>.slack.com`), never `slack.com`, so these are scoped there and
+    # nowhere else — a wildcard is what lets one leaked credential ride to every Slack endpoint.
+    # Both are injected as headers, so the sandbox holds placeholders and never the real session.
+    {type = "http", name = "SLACK_WEB_TOKEN", match_headers = ["Authorization"], hosts = ["*.slack.com"]},
+    {type = "http", name = "SLACK_WEB_COOKIE", match_headers = ["Cookie"], hosts = ["*.slack.com"]},
 ]

--- a/tools/productivity/slack/tests/test_huddle_transcript.py
+++ b/tools/productivity/slack/tests/test_huddle_transcript.py
@@ -1,0 +1,132 @@
+"""Tests for huddle-transcript parsing and its failure modes.
+
+The parser is pure, so it is tested against real payload shapes. The fetch is a thin shell, so what
+matters about it is not the happy path but the *failures*: a lapsed session must be impossible to
+mistake for a silent meeting, and a missing credential must say so rather than returning nothing.
+"""
+
+from __future__ import annotations
+
+import pytest
+from slack.huddle_transcript import (
+    HuddleTranscriptError,
+    parse_segments,
+    render,
+    speakers,
+)
+
+
+def _section(user: str | None, stamp: str | None, *words: str) -> dict:
+    elements: list[dict] = []
+    if user:
+        elements.append({"type": "user", "user_id": user})
+    if stamp:
+        # Slack marks the timestamp with a BOLD text element — that is what distinguishes the marker
+        # from speech, not its position.
+        elements.append({"type": "text", "text": f" [{stamp}]: ", "style": {"bold": True}})
+    elements += [{"type": "text", "text": w} for w in words]
+    return {"type": "rich_text_section", "elements": elements}
+
+
+def _payload(*sections: dict) -> dict:
+    return {"file": {"huddle_transcription": {"blocks": {"elements": list(sections)}}}}
+
+
+def test_it_reads_speaker_time_and_words():
+    segments = parse_segments(
+        _payload(
+            _section("U1", "0:04", "we ship on Friday"),
+            _section("U2", "0:11", "the migration is not done"),
+        )
+    )
+    assert segments == [
+        {"user_id": "U1", "at": "0:04", "text": "we ship on Friday"},
+        {"user_id": "U2", "at": "0:11", "text": "the migration is not done"},
+    ]
+
+
+def test_a_long_huddle_keeps_its_hour():
+    (segment,) = parse_segments(_payload(_section("U1", "1:02:33", "still here")))
+    assert segment["at"] == "1:02:33"
+
+
+def test_bold_speech_is_not_mistaken_for_the_timestamp():
+    """The marker is the bold element that IS a timestamp. A bold word inside the speech is speech,
+    and dropping it would silently delete words from the record."""
+    section = _section("U1", "0:07", "we are ")
+    section["elements"].append({"type": "text", "text": "not", "style": {"bold": True}})
+    section["elements"].append({"type": "text", "text": " shipping"})
+    (segment,) = parse_segments(_payload(section))
+    assert segment["text"] == "we are not shipping"
+    assert segment["at"] == "0:07"
+
+
+def test_words_split_across_elements_are_rejoined():
+    (segment,) = parse_segments(_payload(_section("U1", "0:01", "roll ", "it ", "back")))
+    assert segment["text"] == "roll it back"
+
+
+def test_an_empty_turn_is_dropped():
+    """Slack emits sections with no words (a join, a noise blip). They are not turns."""
+    assert parse_segments(_payload(_section("U1", "0:01", "   "))) == []
+
+
+def test_a_speakerless_turn_survives():
+    """Attribution can be missing; the words still happened and must not be discarded."""
+    (segment,) = parse_segments(_payload(_section(None, "0:02", "someone said this")))
+    assert segment["user_id"] is None
+    assert segment["text"] == "someone said this"
+
+
+def test_a_transcriptless_payload_is_empty_not_an_error():
+    assert parse_segments({}) == []
+    assert parse_segments({"file": {}}) == []
+    assert parse_segments({"file": {"huddle_transcription": {}}}) == []
+
+
+def test_non_section_blocks_are_ignored():
+    payload = _payload({"type": "rich_text_preformatted", "elements": []})
+    assert parse_segments(payload) == []
+
+
+def test_render_uses_the_mention_form_so_a_quote_names_the_person():
+    text = render([{"user_id": "U1", "at": "0:04", "text": "we ship Friday"}])
+    assert text == "<@U1> [0:04]: we ship Friday"
+
+
+def test_render_tolerates_a_missing_speaker_or_stamp():
+    assert render([{"user_id": None, "at": None, "text": "hi"}]) == "someone: hi"
+
+
+def test_speakers_are_first_spoke_order_and_deduplicated():
+    segments = [
+        {"user_id": "U2", "at": None, "text": "a"},
+        {"user_id": "U1", "at": None, "text": "b"},
+        {"user_id": "U2", "at": None, "text": "c"},
+    ]
+    assert speakers(segments) == ["U2", "U1"]
+
+
+def test_the_error_payload_survives_stringification():
+    """The tool boundary stringifies exceptions, so the structure has to live in the payload — a
+    caller must still be able to tell `needs_reauth` from a bug after that round trip."""
+    err = HuddleTranscriptError("session expired", slack_error="invalid_auth", needs_reauth=True)
+    assert err.payload["needs_reauth"] is True
+    assert err.payload["slack_error"] == "invalid_auth"
+    assert "session expired" in str(err)
+
+
+def test_a_missing_session_is_loud_rather_than_an_empty_transcript():
+    """The failure that matters. A silent empty read looks exactly like "nobody spoke", and an agent
+    that believes a meeting was silent is worse than one that admits it cannot see."""
+    from slack.client import SlackClient
+
+    client = SlackClient.__new__(SlackClient)  # no network, no bot token needed for this branch
+    client.web_token = ""
+    client.web_cookie = ""
+
+    with pytest.raises(HuddleTranscriptError) as caught:
+        client.get_huddle_transcript("F123")
+
+    assert caught.value.payload["needs_reauth"] is True
+    assert set(caught.value.payload["missing"]) == {"SLACK_WEB_TOKEN", "SLACK_WEB_COOKIE"}


### PR DESCRIPTION
## The gap

Slack records every huddle and saves a full, speaker-attributed transcript. **A bot token cannot read it, and no public API exposes it.** `files.info` on the transcript's file id returns metadata and no words, whatever scopes the app holds — Slack support confirms this is deliberate.

That's the wrong hole to have. The huddle is where the standup sets the day's priorities, where the incident call finds the cause, where the design argument actually gets settled. Channels get the summary; **the huddle had the reasoning.** An agent that reads every channel and no huddle is missing the part that mattered.

## The mechanism

The Slack *web client* reads them perfectly well: `files.info` with `include_transcription=true` against the **workspace host** (`<workspace>.slack.com`, never `slack.com`), authenticated by a user web session — an `xoxc` token paired with the `d` cookie. This replays exactly that call.

**Not a scope escalation.** A user session sees precisely what that user could already read by opening the huddle in their own Slack client.

```bash
slack huddle-transcript F0123456789
```
```
34 turns, 3 speakers
<@U01ABC> [0:04]: the migration is blocked on the schema review
<@U02DEF> [0:11]: I can review it this afternoon
<@U01ABC> [0:19]: then we ship Friday
```

## Why the token rides in a header — the part I'd most like reviewed

The obvious implementation copies the browser and posts the token as a **form field**. I didn't, and the reason is your own security model: **a request body is the one place iron-proxy cannot look.** The secret schema offers `match_headers`, `match_query`, and `match_path` — there is no `match_body`. Copying the browser would have forced a real user web session to sit inside the sandbox, which is exactly the exposure `mode = "inject"` exists to prevent.

So I checked against the live API before choosing. **Slack accepts this token in the body, in the query string, *and* in the `Authorization` header — all three authenticate.** Since they're equivalent to Slack, take the one the firewall can reach:

```toml
{type = "http", name = "SLACK_WEB_TOKEN",  match_headers = ["Authorization"], hosts = ["*.slack.com"]},
{type = "http", name = "SLACK_WEB_COOKIE", match_headers = ["Cookie"],        hosts = ["*.slack.com"]},
```

The sandbox holds **placeholders only**; the real session never leaves the proxy. Same declaration shape as the existing `SLACK_SEARCH_TOKEN` / `SLACK_ETL_TOKEN`.

## Shape

- **Extends the existing `slack` tool** rather than adding a parallel one, riding the `optional_secrets` pattern already there. Without the session, every other method behaves exactly as before, and only `get_huddle_transcript` reports what's missing.
- **The workspace host is derived from `auth.test`**, not configured — the bot token already knows which workspace it belongs to. **Zero new deployment config.**
- **Speakers stay as Slack ids, never names.** An id round-trips to a real mention and can't drift; a name resolved at read time silently rots when someone changes their display name.
- **Only the rendered text is returned, not the segments as well.** They're the same words twice, and this is the largest payload the tool can produce — returning both writes the whole huddle into the model's context a second time and pays for it on every request of the turn.

## The failure mode is the design

A lapsed session raises `needs_reauth`. It **never returns an empty transcript**.

That distinction is the whole point. A silent empty read looks exactly like *"nobody spoke"* — and an agent that quietly concludes a meeting was silent is far worse than one that says it cannot see. The first fabricates an absence of evidence; the second reports a broken credential.

```json
{"error": "huddle_transcript_failed", "slack_error": "invalid_auth", "needs_reauth": true}
```

Discovery (which huddles exist) runs on the ordinary bot token and never needs the session, so nothing is lost while a session is stale — refresh it and the backlog reads fine.

## Trust boundary, stated plainly

A user web session carries **that user's full Slack visibility, DMs included.** It should be minted from an account whose visibility you're content for agents to inherit. That's called out in `.env.example` and in the docs, not buried.

## Verification

- 13 new tests on the parser and the failure modes — including the one that would silently corrupt the record: the **bold** ` [mm:ss] ` marker vs a **bold word inside the speech** (treating the latter as a marker deletes words from the transcript).
- **90 passing in the slack suite, no regression.** `ruff` clean.
- Transport verified against the live Slack API (above).
- Docs at `operate/slack-huddle-transcripts`, sidebar registered, `tool-directory` updated, `public/md` mirrors synced for the pages I touched only.
- Adds the `.env.example` the tool was missing (61 of 79 tools ship one; `slack` was an outlier, and this change adds two credentials that need documenting).