### PR TITLE
fix(slackbotv2): support scoped trigger bot IDs

### DIFF
--- a/services/slackbotv2/src/slack-events.ts
+++ b/services/slackbotv2/src/slack-events.ts
@@ -138,6 +138,15 @@ async function isAllowedTriggerBotMessage(
     stringValue(event.user),
     stringValue(event.bot_profile?.user_id)
   )
+  const allowedBotIds = new Set(
+    allowlist
+      .map(entry => entry.trim())
+      .filter(entry => entry.startsWith('bot:'))
+      .map(entry => entry.slice('bot:'.length))
+      .filter(isSlackBotId)
+  )
+  if ([...botIds].some(botId => allowedBotIds.has(botId))) return true
+
   const allowedUserIds = new Set(allowlist.map(entry => entry.trim()).filter(isSlackMemberId))
   if (!allowedUserIds.size) return false
   if ([...botUserIds].some(userId => allowedUserIds.has(userId))) return true
@@ -156,6 +165,10 @@ async function isAllowedTriggerBotMessage(
 
 function isSlackMemberId(value: string): boolean {
   return /^[UW][A-Z0-9]+$/i.test(value)
+}
+
+function isSlackBotId(value: string): boolean {
+  return /^B[A-Z0-9]+$/i.test(value)
 }
 
 async function resolveTriggerBotIdentity(

--- a/services/slackbotv2/test/slack-events.test.ts
+++ b/services/slackbotv2/test/slack-events.test.ts
@@ -87,6 +87,20 @@ describe('Slack trigger bot allowlist', () => {
     expect(await isAllowedSlackMessage(botMessage('BOTHER'), config, logger)).toBe(false)
   })
 
+  it('allows an explicitly scoped bot identifier without an identity lookup', async () => {
+    let requests = 0
+    const config = {
+      ...options(async () => {
+        requests += 1
+        return Response.json({ ok: true })
+      }),
+      triggerBotAllowlist: ['bot:BCHANNELBOT']
+    }
+
+    expect(await isAllowedSlackMessage(botMessage('BCHANNELBOT'), config, logger)).toBe(true)
+    expect(requests).toBe(0)
+  })
+
   it('does not treat bot or app identifiers as public allowlist entries', async () => {
     let requests = 0
     const config = {


### PR DESCRIPTION
## Summary
- accept explicit `bot:B…` entries in the Slack trigger-bot allowlist
- match scoped bot IDs directly without a Slack identity lookup
- continue rejecting unprefixed bot and app identifiers

This makes the deployed `slackbotv2.triggerBotAllowlist` entries effective, allowing deployment notifications to invoke the QA skill.

## Validation
- `pnpm --filter slackbotv2 exec bun test test/slack-events.test.ts`
- `pnpm --filter slackbotv2 run check:types`
- `git diff --check`

Prompted by: mslipper