### PR TITLE
fix(console): keep composer model picker menu inside the viewport

### DIFF
--- a/services/console/app/views/console/threads/_composer.html.erb
+++ b/services/console/app/views/console/threads/_composer.html.erb
@@ -181,10 +181,41 @@
       try { return JSON.parse(picker.dataset.agents || "{}"); } catch { return {}; }
     };
 
+    // Keep the popover inside the window: it normally hangs below the pill,
+    // but docked composers sit near the bottom of the viewport, so flip it
+    // above when the space below can't fit it — and cap its height (the
+    // menu scrolls) when neither side can. Runs on every level switch since
+    // the levels differ in height.
+    const positionMenu = (picker) => {
+      const menu = picker.querySelector("[role=menu]");
+      const trigger = picker.querySelector("[aria-haspopup=menu]");
+      if (!menu || !trigger || menu.hidden) return;
+      const margin = 8;
+      menu.classList.remove("console-composer-model-menu--above");
+      menu.style.maxHeight = "";
+      const pill = trigger.getBoundingClientRect();
+      const rect = menu.getBoundingClientRect();
+      const gap = rect.top - pill.bottom;
+      const below = window.innerHeight - rect.top - margin;
+      const above = pill.top - gap - margin;
+      if (rect.height <= below) return;
+      if (above > below) {
+        menu.classList.add("console-composer-model-menu--above");
+        if (rect.height > above) menu.style.maxHeight = `${Math.max(above, 0)}px`;
+      } else {
+        menu.style.maxHeight = `${Math.max(below, 0)}px`;
+      }
+    };
+
+    window.addEventListener("resize", () => {
+      document.querySelectorAll("[data-console-model-picker]").forEach(positionMenu);
+    });
+
     const showLevel = (picker, name) => {
       picker.querySelectorAll("[data-picker-level]").forEach((level) => {
         level.hidden = level.dataset.pickerLevel !== name;
       });
+      positionMenu(picker);
     };
 
     function closePicker(picker) {

--- a/services/console/app/views/layouts/console.html.erb
+++ b/services/console/app/views/layouts/console.html.erb
@@ -917,13 +917,22 @@
       }
 
       /* The picker sits just left of the send button, so the popover hangs
-         from its right edge. */
+         from its right edge. It scrolls when the composer script caps its
+         height to keep it inside the viewport. */
       .console-composer-model-menu {
         top: calc(100% + 0.4rem);
         right: 0;
         bottom: auto;
         left: auto;
         width: 15rem;
+        overflow-y: auto;
+      }
+
+      /* Flipped by the composer script when the space below the pill can't
+         fit the menu (docked composers sit at the bottom of the window). */
+      .console-composer-model-menu--above {
+        top: auto;
+        bottom: calc(100% + 0.4rem);
       }
 
       /* Root rows of the picker menu: setting name left, current value and a


### PR DESCRIPTION
The composer's model/effort picker popover always hung below the pill (`top: calc(100% + 0.4rem)`), so in docked composer panes near the bottom of the window the menu rendered partly or fully off-screen.

## Changes
- `_composer.html.erb`: new `positionMenu()` in the picker script — measures the pill and menu against the viewport, flips the menu above the trigger when the space below can't fit it, and caps its height (menu scrolls) when neither side can. Runs on open and on every level switch (root/model/effort levels differ in height), plus on window resize.
- `layouts/console.html.erb`: adds the `.console-composer-model-menu--above` modifier (`top: auto; bottom: calc(100% + 0.4rem)`) and `overflow-y: auto` on the menu so a capped height scrolls instead of clipping.

No behavior change when there is room below — the menu opens exactly as before.