### PR TITLE
fix(console): preserve requester attribution for PRs

### DIFF
--- a/services/console/app/controllers/console/threads_controller.rb
+++ b/services/console/app/controllers/console/threads_controller.rb
@@ -329,11 +329,46 @@ class Console::ThreadsController < ApplicationController
       thread_key: thread_key,
       client_user_message_id: client_message_id,
       trace_metadata: { action: "execute", source: "console" },
-      message: { role: "user", content: [ { type: "text", text: prompt } ] }
+      message: {
+        role: "user",
+        content: [
+          { type: "text", text: console_requester_context },
+          { type: "text", text: prompt }
+        ]
+      }
     }
     line[:model] = model if model.present?
     line[:reasoning] = effort if effort.present?
     line.to_json
+  end
+
+  # Resolve the signed-in human through the same Slack profile custom-field
+  # path as slackbotv2, falling back to their Console display name/email. Keep
+  # this separate from the persisted prompt: it is harness execution context.
+  def console_requester_context
+    github_identity = SlackRequesterIdentity.resolve(
+      user_ids: slack_thread_owners_for_current_user.map(&:user_id)
+    )
+    prompted_by = github_identity.handle.presence ||
+      (current_user&.name.to_s.strip.presence || current_user&.email.to_s)
+    github_status = github_identity.handle.present? ?
+      "GitHub handle source: #{github_identity.source}\nGitHub handle verified: yes" :
+      "GitHub handle verified: no\nGitHub handle unavailable reason: #{github_identity.reason}"
+    <<~CONTEXT.strip
+      # Requester Context
+
+      The Console user who prompted this turn is #{prompted_by}.
+
+      ## GitHub PR Attribution
+
+      If you create a GitHub PR for this request, the PR body MUST contain this standalone line:
+      Prompted by: #{prompted_by}
+
+      #{github_status}
+
+      The user message follows in the next content block.
+      ---
+    CONTEXT
   end
 
   # Follow-ups reuse the model the chat has been running on (mirrors the

--- a/services/console/app/services/slack_requester_identity.rb
+++ b/services/console/app/services/slack_requester_identity.rb
@@ -1,0 +1,68 @@
+require "json"
+require "net/http"
+require "uri"
+
+# Resolves a Console user's GitHub handle through the same authoritative source
+# as slackbotv2: the GitHub custom field on the human requester's Slack profile.
+class SlackRequesterIdentity
+  Result = Data.define(:handle, :source, :reason)
+  DEFAULT_API_URL = "https://slack.com/api".freeze
+  GITHUB_LABEL = /github/i
+  GITHUB_URL = %r{github\.com/([A-Za-z0-9-]{1,39})(?:[/?#]|$)}i
+  GITHUB_PREFIX = /github\s*[:=]\s*@?([A-Za-z0-9-]{1,39})/i
+  GITHUB_HANDLE = /\A[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?\z/
+
+  def self.resolve(user_ids:)
+    token = ENV["CENTAUR_CONSOLE_SLACK_BOT_TOKEN"].presence || ENV["SLACK_BOT_TOKEN"].presence
+    return Result.new(handle: nil, source: nil, reason: "Slack bot token is not configured") if token.blank?
+
+    resolver = new(token: token, api_url: ENV["SLACK_API_URL"].presence || DEFAULT_API_URL)
+    Array(user_ids).filter_map { |user_id| resolver.resolve(user_id) }.first ||
+      Result.new(handle: nil, source: nil, reason: "no GitHub custom field found on Slack profile")
+  end
+
+  def initialize(token:, api_url:)
+    @token = token
+    @api_url = api_url.to_s.delete_suffix("/")
+  end
+
+  def resolve(user_id)
+    payload = slack_get("users.profile.get", user: user_id, include_labels: "true")
+    return nil unless payload["ok"] == true && payload["profile"].is_a?(Hash)
+
+    github_field(payload["profile"])
+  rescue StandardError => e
+    Rails.logger.warn("console_slack_requester_identity_lookup_failed error=#{e.class}")
+    nil
+  end
+
+  private
+
+  def slack_get(method, params)
+    uri = URI("#{@api_url}/#{method}")
+    uri.query = URI.encode_www_form(params)
+    request = Net::HTTP::Get.new(uri)
+    request["Authorization"] = "Bearer #{@token}"
+    request["Accept"] = "application/json"
+    response = Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == "https",
+                               open_timeout: 2, read_timeout: 5) { |http| http.request(request) }
+    JSON.parse(response.body)
+  end
+
+  def github_field(profile)
+    fields = profile["fields"].is_a?(Hash) ? profile["fields"] : {}
+    fields.each_value do |field|
+      next unless field.is_a?(Hash)
+      label = field["label"].presence || field["alt"].to_s
+      value = field["value"].to_s.strip
+      next unless label.match?(GITHUB_LABEL) || value.match?(GITHUB_LABEL)
+
+      login = value[GITHUB_URL, 1] || value[GITHUB_PREFIX, 1] || (value if label.match?(GITHUB_LABEL))
+      login = login.to_s.delete_prefix("@")
+      next unless login.match?(GITHUB_HANDLE)
+
+      return Result.new(handle: "@#{login}", source: "Slack profile custom field \"#{label}\"", reason: nil)
+    end
+    nil
+  end
+end

--- a/services/console/test/controllers/console/threads_controller_test.rb
+++ b/services/console/test/controllers/console/threads_controller_test.rb
@@ -718,8 +718,9 @@ class Console::ThreadsControllerTest < ActionDispatch::IntegrationTest
     identity = SlackRequesterIdentity::Result.new(
       handle: "@ada", source: 'Slack profile custom field "GitHub"', reason: nil
     )
+    test_case = self
     with_singleton_method(SlackRequesterIdentity, :resolve, ->(user_ids:) {
-      assert_includes user_ids, "UADA"
+      test_case.assert_includes user_ids, "UADA"
       identity
     }) do
       with_composer(client: client) do

--- a/services/console/test/controllers/console/threads_controller_test.rb
+++ b/services/console/test/controllers/console/threads_controller_test.rb
@@ -720,7 +720,7 @@ class Console::ThreadsControllerTest < ActionDispatch::IntegrationTest
     )
     test_case = self
     with_singleton_method(SlackRequesterIdentity, :resolve, ->(user_ids:) {
-      test_case.assert_includes user_ids, "UADA"
+      test_case.assert_includes user_ids, "uada"
       identity
     }) do
       with_composer(client: client) do

--- a/services/console/test/controllers/console/threads_controller_test.rb
+++ b/services/console/test/controllers/console/threads_controller_test.rb
@@ -712,10 +712,20 @@ class Console::ThreadsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "starting a chat creates a session, appends the prompt, and executes it" do
+    @operator.update!(name: "Ada Admin")
+    UserIdentity.create!(user: @operator, provider: "slack", subject: "UADA")
     client = RecordingApiClient.new
-    with_composer(client: client) do
-      post console_threads_url,
-           params: { prompt: "Reply with PONG.", model: "claude-opus-4-8" }
+    identity = SlackRequesterIdentity::Result.new(
+      handle: "@ada", source: 'Slack profile custom field "GitHub"', reason: nil
+    )
+    SlackRequesterIdentity.stub(:resolve, ->(user_ids:) {
+      assert_includes user_ids, "UADA"
+      identity
+    }) do
+      with_composer(client: client) do
+        post console_threads_url,
+             params: { prompt: "Reply with PONG.", model: "claude-opus-4-8" }
+      end
     end
 
     assert_equal %i[create_session append_session_messages execute_session], client.calls.map(&:first)
@@ -744,7 +754,12 @@ class Console::ThreadsControllerTest < ActionDispatch::IntegrationTest
     assert_equal create[:thread_key], line["thread_key"]
     assert_equal "claude-opus-4-8", line["model"]
     assert_equal message[:client_message_id], line["client_user_message_id"]
-    assert_equal "Reply with PONG.", line.dig("message", "content", 0, "text")
+    requester_context = line.dig("message", "content", 0, "text")
+    assert_includes requester_context, "# Requester Context"
+    assert_includes requester_context, "Prompted by: @ada"
+    assert_includes requester_context, 'GitHub handle source: Slack profile custom field "GitHub"'
+    assert_includes requester_context, "GitHub handle verified: yes"
+    assert_equal "Reply with PONG.", line.dig("message", "content", 1, "text")
 
     assert_redirected_to console_threads_path(thread: create[:thread_key])
   end

--- a/services/console/test/controllers/console/threads_controller_test.rb
+++ b/services/console/test/controllers/console/threads_controller_test.rb
@@ -718,7 +718,7 @@ class Console::ThreadsControllerTest < ActionDispatch::IntegrationTest
     identity = SlackRequesterIdentity::Result.new(
       handle: "@ada", source: 'Slack profile custom field "GitHub"', reason: nil
     )
-    SlackRequesterIdentity.stub(:resolve, ->(user_ids:) {
+    with_singleton_method(SlackRequesterIdentity, :resolve, ->(user_ids:) {
       assert_includes user_ids, "UADA"
       identity
     }) do
@@ -1591,5 +1591,14 @@ class Console::ThreadsControllerTest < ActionDispatch::IntegrationTest
         now() + interval '1 day'
       )
     SQL
+  end
+
+  def with_singleton_method(object, method_name, replacement)
+    singleton = object.singleton_class
+    original = singleton.instance_method(method_name)
+    singleton.define_method(method_name, replacement)
+    yield
+  ensure
+    singleton.define_method(method_name, original)
   end
 end

--- a/services/console/test/services/slack_requester_identity_test.rb
+++ b/services/console/test/services/slack_requester_identity_test.rb
@@ -1,0 +1,19 @@
+require "test_helper"
+
+class SlackRequesterIdentityTest < ActiveSupport::TestCase
+  test "resolves a verified GitHub handle from the requester's labeled Slack profile field" do
+    response = Struct.new(:body).new({
+      ok: true,
+      profile: { fields: { "XfGithub" => { label: "GitHub", value: "https://github.com/ada" } } }
+    }.to_json)
+    http = Object.new
+    http.define_singleton_method(:request) { |_request| response }
+
+    Net::HTTP.stub(:start, ->(*_args, **_options, &block) { block.call(http) }) do
+      result = SlackRequesterIdentity.new(token: "xoxb-test", api_url: "https://slack.test/api").resolve("UADA")
+
+      assert_equal "@ada", result.handle
+      assert_equal 'Slack profile custom field "GitHub"', result.source
+    end
+  end
+end

--- a/services/console/test/services/slack_requester_identity_test.rb
+++ b/services/console/test/services/slack_requester_identity_test.rb
@@ -9,11 +9,22 @@ class SlackRequesterIdentityTest < ActiveSupport::TestCase
     http = Object.new
     http.define_singleton_method(:request) { |_request| response }
 
-    Net::HTTP.stub(:start, ->(*_args, **_options, &block) { block.call(http) }) do
+    with_singleton_method(Net::HTTP, :start, ->(*_args, **_options, &block) { block.call(http) }) do
       result = SlackRequesterIdentity.new(token: "xoxb-test", api_url: "https://slack.test/api").resolve("UADA")
 
       assert_equal "@ada", result.handle
       assert_equal 'Slack profile custom field "GitHub"', result.source
     end
+  end
+
+  private
+
+  def with_singleton_method(object, method_name, replacement)
+    singleton = object.singleton_class
+    original = singleton.instance_method(method_name)
+    singleton.define_method(method_name, replacement)
+    yield
+  ensure
+    singleton.define_method(method_name, original)
   end
 end

--- a/services/sandbox/SYSTEM_PROMPT.md
+++ b/services/sandbox/SYSTEM_PROMPT.md
@@ -85,8 +85,8 @@
 |For other cargo commands, prefer the repository's pinned/default toolchain unless the repo or user asks for nightly.
 
 [GitHub PR Attribution]
-|When opening a GitHub PR for a Slack request, attribute the requester in the PR body with one standalone `Prompted by: ...` line.
-|Use the [Requester Context] block when present: prefer the verified GitHub handle resolved from the requester's Slack profile; if none is configured, use the requester's Slack display name or username.
+|When opening a GitHub PR, attribute the requester in the PR body with one standalone `Prompted by: ...` line.
+|Use the [Requester Context] block when present. For Slack, prefer the verified GitHub handle resolved from the requester's Slack profile; otherwise use the exact `Prompted by:` value supplied by the requesting surface.
 |If [Requester Context] provides an exact `Prompted by:` line, copy that line exactly into the PR body.
 |Do not infer a GitHub username from a Slack name, email, or thread history. The credited prompter is the user who prompted the current turn, not necessarily the Slack thread root author.
 


### PR DESCRIPTION
## Summary
- map the signed-in Console user to their linked Slack user ID
- resolve the human requester through Slack `users.profile.get?include_labels=true`, matching Slackbot's trusted GitHub custom-field flow
- inject the verified handle into harness requester context for PR attribution
- cover Slack-profile parsing and Console context propagation

## Testing
- `git diff --check`
- Rails tests not run locally: Ruby is unavailable in the sandbox image

Attribution for this bootstrap PR is pending because the pre-fix Console turn did not include requester identity; the sandbox GitHub auth (`@decofe`) is intentionally not used.