### PR TITLE
feat: batch company context projections

### DIFF
--- a/contrib/chart/templates/apirs.yaml
+++ b/contrib/chart/templates/apirs.yaml
@@ -96,6 +96,7 @@
   (dict "name" "COMPANY_CONTEXT_DOCUMENTS_ENABLED" "value" (dig "companyContextDocuments" "enabled" true $apiRsEtl))
   (dict "name" "COMPANY_CONTEXT_DOCUMENTS_INTERVAL_SECONDS" "value" (dig "companyContextDocuments" "intervalSeconds" 14400 $apiRsEtl))
   (dict "name" "COMPANY_CONTEXT_DOCUMENTS_MAX_WINDOW_SECONDS" "value" (dig "companyContextDocuments" "maxWindowSeconds" 21600 $apiRsEtl))
+  (dict "name" "COMPANY_CONTEXT_DOCUMENTS_BATCH_SIZE" "value" (dig "companyContextDocuments" "batchSize" 50 $apiRsEtl))
 -}}
 {{- $apiRsEtlPassthroughNames := list -}}
 {{- range $env := $apiRsEtlEnv -}}

--- a/contrib/chart/values.schema.json
+++ b/contrib/chart/values.schema.json
@@ -332,7 +332,8 @@
               "properties": {
                 "enabled": { "type": "boolean" },
                 "intervalSeconds": { "type": "integer" },
-                "maxWindowSeconds": { "type": "integer" }
+                "maxWindowSeconds": { "type": "integer" },
+                "batchSize": { "type": "integer", "minimum": 1 }
               }
             }
           }

--- a/contrib/chart/values.yaml
+++ b/contrib/chart/values.yaml
@@ -399,6 +399,7 @@ apiRs:
       enabled: true
       intervalSeconds: 14400
       maxWindowSeconds: 21600
+      batchSize: 50
   # Reaper: stop sandboxes older than the max lifetime, regardless of whether
   # they are running or suspended. 0 disables the sweep. Interval must be >= 1.
   sandboxMaxLifetimeSecs: 259200 # 3 days

--- a/docs/public/md/extend/workflows.md
+++ b/docs/public/md/extend/workflows.md
@@ -70,9 +70,7 @@ async def handler(inp: Input, ctx: WorkflowContext) -> dict[str, Any]:
 | `ctx.sleep(name, duration)` | Suspend and resume later. |
 | `ctx.sleep_until(name, when)` | Resume at a specific time. |
 | `ctx.wait_for_event(name, event_type, correlation_id)` | Wait for an external event. |
-| `ctx.start_workflow(...)` | Start a child workflow and continue immediately. |
-| `ctx.wait_for_workflow(...)` | Wait for a child workflow to finish. |
-| `ctx.run_workflow(...)` | Start and wait in one call. |
+| `ctx.start_workflow(workflow_name, input, idempotency_key=...)` | Queue a child workflow and continue immediately; returns its durable task/run identifiers. |
 | `ctx.start_agent(...)` | Start an agent turn. |
 | `ctx.run_agent(...)` | Start an agent turn and wait for the result. |
 

--- a/docs/public/md/operate/slack-etl.md
+++ b/docs/public/md/operate/slack-etl.md
@@ -91,8 +91,9 @@ apiRs:
 | `SLACK_ETL_RETENTION_DAYS` | `0` | Deletes Slack ETL messages, derived Slack documents, and terminal ETL run/job rows older than this many days. `0` disables ETL retention. |
 | `SLACK_DM_RETENTION_DAYS` | `0` | Deletes Slack DM messages, stale empty DM conversations, and terminal DM run/job rows older than this many days. `0` disables DM retention. |
 | `COMPANY_CONTEXT_DOCUMENTS_ENABLED` | `true` | Enables projection from Slack sync rows into company context documents. |
-| `COMPANY_CONTEXT_DOCUMENTS_INTERVAL_SECONDS` | `14400` | How often to project changed Slack rows into documents. |
-| `COMPANY_CONTEXT_DOCUMENTS_MAX_WINDOW_SECONDS` | `21600` | Maximum source `updated_at` window projected by one company context documents run. |
+| `COMPANY_CONTEXT_DOCUMENTS_INTERVAL_SECONDS` | `14400` | How often the coordinator claims stale projection scopes. |
+| `COMPANY_CONTEXT_DOCUMENTS_MAX_WINDOW_SECONDS` | `21600` | Maximum source `updated_at` window claimed for one scope before it advances its watermark. |
+| `COMPANY_CONTEXT_DOCUMENTS_BATCH_SIZE` | `50` | Maximum changed source rows processed by one per-scope child workflow. |
 
 Example exclusion list:
 
@@ -262,7 +263,7 @@ setting alerts.
 | Channels are all skipped | Check `SLACK_ETL_EXCLUDED_CHANNEL_PATTERNS` for broad globs. |
 | Checkpoints show `missing_scope` or `not_allowed_token_type` | Add the missing Slack OAuth scope or use the expected user-token class. |
 | Backfill jobs keep failing | Inspect `slack_sync_backfill_jobs.last_error` and the corresponding `slack_sync_runs` row. |
-| Documents lag behind messages | Check the `company_context_documents` workflow status and `company_context_projection_lag_seconds`. |
+| Documents lag behind messages | Check `company_context_projection_checkpoints` for an expired lease or old watermark, then inspect the per-scope `company_context_documents` child workflow and `company_context_projection_lag_seconds`. |
 
 Keep the ETL token scoped to the channels and workspace data you actually want
 agents to retrieve. Synced rows and projected documents are deployment-wide

--- a/docs/public/md/reference/configuration.md
+++ b/docs/public/md/reference/configuration.md
@@ -239,6 +239,7 @@ Slack ETL workflows:
 | `SLACK_RETENTION_ENABLED`, `SLACK_RETENTION_INTERVAL_MINUTES`, `SLACK_ETL_RETENTION_DAYS`, `SLACK_DM_RETENTION_DAYS` | `apiRs.etl.slack.retention.*`. | Slack retention enablement, cadence, and separate public ETL/DM TTLs. |
 | `COMPANY_CONTEXT_DOCUMENTS_ENABLED` | `apiRs.etl.companyContextDocuments.enabled`. | Enables company-context projection when any ETL is on. |
 | `COMPANY_CONTEXT_DOCUMENTS_MAX_WINDOW_SECONDS` | `apiRs.etl.companyContextDocuments.maxWindowSeconds`. | Maximum source `updated_at` window projected by one company-context documents run. |
+| `COMPANY_CONTEXT_DOCUMENTS_BATCH_SIZE` | `apiRs.etl.companyContextDocuments.batchSize`. | Maximum changed source rows handled by one per-scope company-context child workflow. |
 
 Google Workspace ETL workflows:
 

--- a/services/api-rs/crates/centaur-session-sqlx/migrations/0043_company_context_projection_checkpoints.sql
+++ b/services/api-rs/crates/centaur-session-sqlx/migrations/0043_company_context_projection_checkpoints.sql
@@ -1,0 +1,48 @@
+create table if not exists company_context_projection_checkpoints (
+    scope text primary key,
+    watermark timestamptz,
+    window_start timestamptz,
+    window_end timestamptz,
+    cursor_updated_at timestamptz,
+    cursor_key text not null default '',
+    lease_token text,
+    lease_expires_at timestamptz,
+    created_at timestamptz not null default now(),
+    updated_at timestamptz not null default now(),
+    check (window_end is null or window_start is null or window_end >= window_start)
+);
+
+create index if not exists idx_company_context_projection_checkpoints_lease
+    on company_context_projection_checkpoints (lease_expires_at)
+    where lease_expires_at is not null;
+
+do $$
+declare
+    role_name text;
+begin
+    foreach role_name in array array['centaur_slack_admin', 'centaur_readonly'] loop
+        if exists (select 1 from pg_roles where rolname = role_name) then
+            execute format(
+                'grant select on company_context_projection_checkpoints to %I',
+                role_name
+            );
+        end if;
+    end loop;
+end $$;
+
+alter table company_context_projection_checkpoints enable row level security;
+
+drop policy if exists centaur_readonly_company_context_projection_checkpoints_select
+    on company_context_projection_checkpoints;
+create policy centaur_readonly_company_context_projection_checkpoints_select
+    on company_context_projection_checkpoints for select to centaur_readonly using (true);
+
+do $$
+begin
+    if exists (select 1 from pg_roles where rolname = 'centaur_slack_admin') then
+        drop policy if exists centaur_slack_admin_company_context_projection_checkpoints_select
+            on company_context_projection_checkpoints;
+        create policy centaur_slack_admin_company_context_projection_checkpoints_select
+            on company_context_projection_checkpoints for select to centaur_slack_admin using (true);
+    end if;
+end $$;

--- a/services/api-rs/crates/centaur-workflows/src/lib.rs
+++ b/services/api-rs/crates/centaur-workflows/src/lib.rs
@@ -464,6 +464,12 @@ impl WorkflowRuntime {
         schedule_client
             .create_queue(Some(WORKFLOW_SCHEDULE_QUEUE), CreateQueueOptions::default())
             .await?;
+        let workflow_clients = WorkflowQueueClients {
+            standard: client.clone(),
+            slack_live: slack_live_client.clone(),
+            etl: etl_client.clone(),
+            etl_backfill: etl_backfill_client.clone(),
+        };
 
         let discovery = discover_python_workflow_metadata()
             .await
@@ -483,44 +489,81 @@ impl WorkflowRuntime {
 
         let task_session_runtime = session_runtime.clone();
         let task_workflow_host_sandbox = workflow_host_sandbox.clone();
+        let task_workflow_clients = workflow_clients.clone();
         client.register_task(WORKFLOW_TASK, move |input: WorkflowTaskInput, ctx| {
             let session_runtime = task_session_runtime.clone();
             let workflow_host_sandbox = task_workflow_host_sandbox.clone();
-            async move { run_centaur_workflow(input, ctx, session_runtime, workflow_host_sandbox).await }
+            let workflow_clients = task_workflow_clients.clone();
+            async move {
+                run_centaur_workflow(
+                    input,
+                    ctx,
+                    session_runtime,
+                    workflow_host_sandbox,
+                    workflow_clients,
+                )
+                .await
+            }
         })?;
         let slack_live_session_runtime = session_runtime.clone();
         let slack_live_workflow_host_sandbox = workflow_host_sandbox.clone();
+        let slack_live_workflow_clients = workflow_clients.clone();
         slack_live_client.register_task(WORKFLOW_TASK, move |input: WorkflowTaskInput, ctx| {
             let session_runtime = slack_live_session_runtime.clone();
             let workflow_host_sandbox = slack_live_workflow_host_sandbox.clone();
-            async move { run_centaur_workflow(input, ctx, session_runtime, workflow_host_sandbox).await }
+            let workflow_clients = slack_live_workflow_clients.clone();
+            async move {
+                run_centaur_workflow(
+                    input,
+                    ctx,
+                    session_runtime,
+                    workflow_host_sandbox,
+                    workflow_clients,
+                )
+                .await
+            }
         })?;
         let etl_session_runtime = session_runtime.clone();
         let etl_workflow_host_sandbox = workflow_host_sandbox.clone();
+        let etl_workflow_clients = workflow_clients.clone();
         etl_client.register_task(WORKFLOW_TASK, move |input: WorkflowTaskInput, ctx| {
             let session_runtime = etl_session_runtime.clone();
             let workflow_host_sandbox = etl_workflow_host_sandbox.clone();
-            async move { run_centaur_workflow(input, ctx, session_runtime, workflow_host_sandbox).await }
+            let workflow_clients = etl_workflow_clients.clone();
+            async move {
+                run_centaur_workflow(
+                    input,
+                    ctx,
+                    session_runtime,
+                    workflow_host_sandbox,
+                    workflow_clients,
+                )
+                .await
+            }
         })?;
         let etl_backfill_session_runtime = session_runtime.clone();
         let etl_backfill_workflow_host_sandbox = workflow_host_sandbox.clone();
+        let etl_backfill_workflow_clients = workflow_clients.clone();
         etl_backfill_client.register_task(
             WORKFLOW_TASK,
             move |input: WorkflowTaskInput, ctx| {
                 let session_runtime = etl_backfill_session_runtime.clone();
                 let workflow_host_sandbox = etl_backfill_workflow_host_sandbox.clone();
+                let workflow_clients = etl_backfill_workflow_clients.clone();
                 async move {
-                    run_centaur_workflow(input, ctx, session_runtime, workflow_host_sandbox).await
+                    run_centaur_workflow(
+                        input,
+                        ctx,
+                        session_runtime,
+                        workflow_host_sandbox,
+                        workflow_clients,
+                    )
+                    .await
                 }
             },
         )?;
         let schedule_tick_client = schedule_client.clone();
-        let workflow_clients_for_schedule = WorkflowQueueClients {
-            standard: client.clone(),
-            slack_live: slack_live_client.clone(),
-            etl: etl_client.clone(),
-            etl_backfill: etl_backfill_client.clone(),
-        };
+        let workflow_clients_for_schedule = workflow_clients.clone();
         let schedule_registry_for_task = schedule_registry.clone();
         schedule_client.register_task_with(
             TaskRegistrationOptions::new(WORKFLOW_SCHEDULE_TASK),
@@ -621,12 +664,7 @@ impl WorkflowRuntime {
         if let Some(interval) = workflow_reconcile_interval() {
             spawn_workflow_metadata_reconciler(
                 schedule_client.clone(),
-                WorkflowQueueClients {
-                    standard: client.clone(),
-                    slack_live: slack_live_client.clone(),
-                    etl: etl_client.clone(),
-                    etl_backfill: etl_backfill_client.clone(),
-                },
+                workflow_clients,
                 webhook_registry.clone(),
                 schedule_registry.clone(),
                 interval,
@@ -2310,11 +2348,18 @@ async fn run_centaur_workflow(
     ctx: TaskContext,
     session_runtime: SessionRuntime,
     workflow_host_sandbox: Option<WorkflowHostSandboxRuntime>,
+    workflow_clients: WorkflowQueueClients,
 ) -> absurd::Result<WorkflowResult> {
     let mut cleanup_guard =
         WorkflowSandboxCleanupGuard::new(session_runtime.clone(), ctx.run_id().to_owned());
-    let result =
-        run_centaur_workflow_inner(input, ctx, session_runtime, workflow_host_sandbox).await;
+    let result = run_centaur_workflow_inner(
+        input,
+        ctx,
+        session_runtime,
+        workflow_host_sandbox,
+        workflow_clients,
+    )
+    .await;
     if let Some(reason) = workflow_cleanup_reason(&result) {
         cleanup_guard.cleanup(reason).await;
     } else {
@@ -2337,6 +2382,7 @@ async fn run_centaur_workflow_inner(
     ctx: TaskContext,
     session_runtime: SessionRuntime,
     workflow_host_sandbox: Option<WorkflowHostSandboxRuntime>,
+    workflow_clients: WorkflowQueueClients,
 ) -> absurd::Result<WorkflowResult> {
     let _heartbeat_guard = start_workflow_task_heartbeat(ctx.clone())
         .await
@@ -2494,6 +2540,7 @@ async fn run_centaur_workflow_inner(
                 ctx.clone(),
                 session_runtime,
                 workflow_host_sandbox,
+                workflow_clients,
             )
             .await
             .map_err(absurd_error)?;
@@ -2571,11 +2618,19 @@ async fn run_python_workflow_host(
     ctx: TaskContext,
     session_runtime: SessionRuntime,
     workflow_host_sandbox: Option<WorkflowHostSandboxRuntime>,
+    workflow_clients: WorkflowQueueClients,
 ) -> Result<Value, WorkflowRuntimeError> {
     if let Some(sandbox) = workflow_host_sandbox {
-        return run_python_workflow_host_in_sandbox(input, ctx, session_runtime, sandbox).await;
+        return run_python_workflow_host_in_sandbox(
+            input,
+            ctx,
+            session_runtime,
+            sandbox,
+            workflow_clients,
+        )
+        .await;
     }
-    run_python_workflow_host_local(input, ctx, session_runtime).await
+    run_python_workflow_host_local(input, ctx, session_runtime, workflow_clients).await
 }
 
 async fn start_workflow_task_heartbeat(
@@ -2597,6 +2652,7 @@ async fn run_python_workflow_host_local(
     input: WorkflowTaskInput,
     ctx: TaskContext,
     session_runtime: SessionRuntime,
+    workflow_clients: WorkflowQueueClients,
 ) -> Result<Value, WorkflowRuntimeError> {
     let host_path = python_workflow_host_path();
     let mut command = Command::new(
@@ -2691,18 +2747,23 @@ async fn run_python_workflow_host_local(
                 record_python_workflow_metric(&message);
             }
             Some(message_type) if message_type.starts_with("ctx.") => {
-                let response =
-                    match handle_python_context_request(&message, &ctx, &session_runtime, &input)
-                        .await
-                    {
-                        Ok(response) => response,
-                        Err(error) => {
-                            drop(stdin);
-                            let _ = child.start_kill();
-                            let _ = child.wait().await;
-                            return Err(error);
-                        }
-                    };
+                let response = match handle_python_context_request(
+                    &message,
+                    &ctx,
+                    &session_runtime,
+                    &input,
+                    &workflow_clients,
+                )
+                .await
+                {
+                    Ok(response) => response,
+                    Err(error) => {
+                        drop(stdin);
+                        let _ = child.start_kill();
+                        let _ = child.wait().await;
+                        return Err(error);
+                    }
+                };
                 write_host_message(&mut stdin, &response).await?;
             }
             other => {
@@ -2725,6 +2786,7 @@ async fn run_python_workflow_host_in_sandbox(
     ctx: TaskContext,
     session_runtime: SessionRuntime,
     sandbox: WorkflowHostSandboxRuntime,
+    workflow_clients: WorkflowQueueClients,
 ) -> Result<Value, WorkflowRuntimeError> {
     let mut spec = sandbox.spec.clone();
     spec = spec
@@ -2754,6 +2816,7 @@ async fn run_python_workflow_host_in_sandbox(
         input,
         ctx,
         session_runtime,
+        workflow_clients,
         &mut stdin,
         io.stdout,
         stderr_task,
@@ -2774,6 +2837,7 @@ async fn run_python_workflow_host_protocol<W, R>(
     input: WorkflowTaskInput,
     ctx: TaskContext,
     session_runtime: SessionRuntime,
+    workflow_clients: WorkflowQueueClients,
     stdin: &mut W,
     stdout: R,
     stderr_task: JoinHandle<String>,
@@ -2833,8 +2897,14 @@ where
                 record_python_workflow_metric(&message);
             }
             Some(message_type) if message_type.starts_with("ctx.") => {
-                let response =
-                    handle_python_context_request(&message, &ctx, &session_runtime, &input).await?;
+                let response = handle_python_context_request(
+                    &message,
+                    &ctx,
+                    &session_runtime,
+                    &input,
+                    &workflow_clients,
+                )
+                .await?;
                 write_host_message(stdin, &response).await?;
             }
             other => {
@@ -2964,6 +3034,7 @@ async fn handle_python_context_request(
     ctx: &TaskContext,
     session_runtime: &SessionRuntime,
     input: &WorkflowTaskInput,
+    workflow_clients: &WorkflowQueueClients,
 ) -> Result<Value, WorkflowRuntimeError> {
     let request_id = message
         .get("request_id")
@@ -3048,6 +3119,12 @@ async fn handle_python_context_request(
                 Err(error) => Err(error.to_string()),
             }
         }
+        Some("ctx.workflow.start") => {
+            match start_python_child_workflow(message, input, workflow_clients).await {
+                Ok(value) => Ok(value),
+                Err(error) => Err(error.to_string()),
+            }
+        }
         Some("ctx.call_tool") => match call_python_workflow_tool(message).await {
             Ok(value) => Ok(value),
             Err(error) => Err(error.to_string()),
@@ -3074,6 +3151,62 @@ async fn handle_python_context_request(
             "error": error,
         }),
     })
+}
+
+async fn start_python_child_workflow(
+    message: &Value,
+    parent: &WorkflowTaskInput,
+    workflow_clients: &WorkflowQueueClients,
+) -> Result<Value, WorkflowRuntimeError> {
+    let workflow_name = message
+        .get("workflow_name")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|name| !name.is_empty())
+        .ok_or_else(|| {
+            WorkflowRuntimeError::BadRequest(
+                "ctx.workflow.start requires a non-empty workflow_name".to_owned(),
+            )
+        })?;
+    WorkflowEnablement::from_env()?.ensure_enabled(workflow_name)?;
+    let child_input = message.get("input").cloned().unwrap_or_else(|| json!({}));
+    if !child_input.is_object() {
+        return Err(WorkflowRuntimeError::BadRequest(
+            "ctx.workflow.start input must be an object".to_owned(),
+        ));
+    }
+    let idempotency_key = message
+        .get("idempotency_key")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|key| !key.is_empty())
+        .map(ToOwned::to_owned);
+    let target_client = match workflow_queue_class(workflow_name) {
+        WorkflowQueueClass::Standard => &workflow_clients.standard,
+        WorkflowQueueClass::SlackLive => &workflow_clients.slack_live,
+        WorkflowQueueClass::Etl => &workflow_clients.etl,
+        WorkflowQueueClass::EtlBackfill => &workflow_clients.etl_backfill,
+    };
+    let spawn = target_client
+        .spawn(
+            WORKFLOW_TASK,
+            WorkflowTaskInput {
+                workflow_name: workflow_name.to_owned(),
+                input: child_input,
+                harness_type: parent.harness_type.clone(),
+            },
+            SpawnOptions {
+                idempotency_key,
+                ..SpawnOptions::default()
+            },
+        )
+        .await?;
+    Ok(json!({
+        "workflow_name": workflow_name,
+        "task_id": spawn.task_id,
+        "run_id": spawn.run_id,
+        "created": spawn.created,
+    }))
 }
 
 fn parse_python_duration_seconds(message: &Value) -> Result<Duration, String> {

--- a/services/workflow-python/api/workflow_engine.py
+++ b/services/workflow-python/api/workflow_engine.py
@@ -112,6 +112,23 @@ class WorkflowContext:
     async def start_agent(self, *args: Any, text: str | None = None, **kwargs: Any) -> Any:
         return await self.run_agent(*args, text=text, **kwargs)
 
+    async def start_workflow(
+        self,
+        workflow_name: str,
+        input: dict[str, Any] | None = None,
+        *,
+        idempotency_key: str | None = None,
+    ) -> dict[str, Any]:
+        """Queue another workflow and return its durable task identifiers."""
+        request: dict[str, Any] = {
+            "type": "ctx.workflow.start",
+            "workflow_name": workflow_name,
+            "input": input or {},
+        }
+        if idempotency_key:
+            request["idempotency_key"] = idempotency_key
+        return await self._rpc.request(request)
+
     async def call_tool(self, tool: str, method: str, args: dict[str, Any] | None = None) -> Any:
         return await WorkflowToolManager(self._rpc).call_tool_raw(tool, method, args or {})
 

--- a/services/workflow-python/tests/test_workflow_host.py
+++ b/services/workflow-python/tests/test_workflow_host.py
@@ -59,6 +59,13 @@ class RequestRpc(FakeRpc):
             }
         if message_type == "ctx.agent_turn":
             return payload["args"]
+        if message_type == "ctx.workflow.start":
+            return {
+                "workflow_name": payload["workflow_name"],
+                "task_id": "task-child",
+                "run_id": "run-child",
+                "created": True,
+            }
         if message_type == "ctx.sleep":
             return {"slept": True}
         raise AssertionError(f"unexpected request {payload}")
@@ -161,6 +168,37 @@ class WorkflowHostTests(unittest.TestCase):
         result = asyncio.run(ctx.run_agent("draft_summary", text="summarize this"))
 
         self.assertEqual(result, {"name": "draft_summary", "text": "summarize this"})
+
+    def test_start_workflow_enqueues_durable_child_with_idempotency_key(self) -> None:
+        host = load_workflow_host()
+        rpc = RequestRpc()
+        ctx = host.WorkflowContext(
+            rpc,
+            run_id="run-123",
+            task_id="task-456",
+            workflow_name="sample",
+        )
+
+        result = asyncio.run(
+            ctx.start_workflow(
+                "company_context_documents",
+                {"scope": "slack_thread"},
+                idempotency_key="company-context:slack-thread:42",
+            )
+        )
+
+        self.assertEqual(result["task_id"], "task-child")
+        self.assertEqual(
+            rpc.requests,
+            [
+                {
+                    "type": "ctx.workflow.start",
+                    "workflow_name": "company_context_documents",
+                    "input": {"scope": "slack_thread"},
+                    "idempotency_key": "company-context:slack-thread:42",
+                }
+            ],
+        )
 
     def test_create_pool_retries_transient_connection_failure(self) -> None:
         host = load_workflow_host()

--- a/workflows/company_context_documents.py
+++ b/workflows/company_context_documents.py
@@ -27,6 +27,8 @@ WORKFLOW_NAME = "company_context_documents"
 DEFAULT_SYNC_INTERVAL_SECONDS = 4 * 60 * 60
 DEFAULT_WATERMARK_OVERLAP_SECONDS = 60
 DEFAULT_MAX_WINDOW_SECONDS = 6 * 60 * 60
+DEFAULT_BATCH_SIZE = 50
+DEFAULT_SCOPE_LEASE_SECONDS = 20 * 60
 MIN_THREAD_MESSAGES = 5
 FALSE_ENV_VALUES = {"0", "false", "no", "off"}
 SLACK_MENTION_RE = re.compile(r"<@([A-Z0-9]+)>")
@@ -100,6 +102,9 @@ class Input:
     since: str | None = None
     watermark_overlap_seconds: int = DEFAULT_WATERMARK_OVERLAP_SECONDS
     max_window_seconds: int | None = None
+    scope: str | None = None
+    lease_token: str | None = None
+    batch_size: int | None = None
     metadata: dict[str, Any] = field(default_factory=dict)
 
 
@@ -341,6 +346,31 @@ def _emit_company_context_projection_lag(
         else:
             lag_seconds = 0.0
         set_company_context_projection_lag(source, lag_seconds)
+
+
+async def _emit_projection_lag_from_checkpoints(
+    pool,
+    enabled_scopes: dict[str, str],
+) -> None:
+    """Publish the oldest completed scope watermark as each source's lag."""
+    rows = await pool.fetch(
+        "SELECT scope, watermark FROM company_context_projection_checkpoints "
+        "WHERE scope = ANY($1::text[])",
+        list(enabled_scopes),
+    )
+    source_watermarks: dict[str, dt.datetime | None] = {}
+    for row in rows:
+        source = enabled_scopes.get(str(row["scope"]))
+        watermark = row["watermark"]
+        if source is None or not isinstance(watermark, dt.datetime):
+            continue
+        watermark = watermark.astimezone(dt.timezone.utc)
+        current = source_watermarks.get(source)
+        if current is None or watermark < current:
+            source_watermarks[source] = watermark
+    _emit_company_context_projection_lag(
+        sorted(set(enabled_scopes.values())), source_watermarks
+    )
 
 
 async def _load_slack_lookup_maps(pool) -> tuple[dict[str, str], dict[str, str]]:
@@ -1470,8 +1500,523 @@ async def _delete_document(pool, document_id: str) -> bool:
     return status.endswith(" 1")
 
 
+def _batch_size(value: int | str | None = None) -> int:
+    """Return a bounded source-row page size for one projection workflow."""
+    configured = (
+        value
+        if value is not None
+        else os.getenv("COMPANY_CONTEXT_DOCUMENTS_BATCH_SIZE")
+    )
+    return min(_positive_int(configured, DEFAULT_BATCH_SIZE), 250)
+
+
+def _enabled_scopes() -> dict[str, str]:
+    """Return the durable projection scopes enabled for this deployment."""
+    scopes: dict[str, str] = {}
+    if _env_flag_enabled("SLACK_ETL_ENABLED"):
+        scopes.update(
+            {
+                "slack_channel_day": "slack",
+                "slack_thread": "slack",
+                "slack_attachment": "slack",
+            }
+        )
+    if _env_flag_enabled("GOOGLE_DRIVE_ETL_ENABLED"):
+        scopes["google_doc"] = "google_drive"
+    if _env_flag_enabled("GOOGLE_CALENDAR_ETL_ENABLED"):
+        scopes["calendar_event"] = "google_calendar"
+    if _env_flag_enabled("LINEAR_ETL_ENABLED"):
+        # Comments have their own cursor because updating a comment does not update
+        # the parent issue row's synced timestamp.
+        scopes.update({"linear_issue": "linear", "linear_comment": "linear"})
+    if _env_flag_enabled("ATTIO_ETL_ENABLED"):
+        scopes["attio_meeting"] = "attio"
+    return scopes
+
+
+def _page_where(
+    column: str,
+    key_expression: str,
+    *,
+    window_start: dt.datetime | None,
+    window_end: dt.datetime,
+    cursor_updated_at: dt.datetime | None,
+    cursor_key: str,
+    base: tuple[str, ...] = (),
+) -> tuple[str, list[Any]]:
+    """Build a stable `(updated_at, key)` keyset page predicate."""
+    clauses = list(base)
+    args: list[Any] = []
+    if window_start is not None:
+        args.append(window_start)
+        clauses.append(f"{column} > ${len(args)}")
+    args.append(window_end)
+    clauses.append(f"{column} <= ${len(args)}")
+    if cursor_updated_at is not None:
+        args.extend((cursor_updated_at, cursor_key))
+        clauses.append(
+            f"({column} > ${len(args) - 1} OR "
+            f"({column} = ${len(args) - 1} AND {key_expression} > ${len(args)}))"
+        )
+    return " AND ".join(clauses), args
+
+
+async def _fetch_page(
+    pool,
+    *,
+    table: str,
+    column: str,
+    key_expression: str,
+    key_alias: str,
+    window_start: dt.datetime | None,
+    window_end: dt.datetime,
+    cursor_updated_at: dt.datetime | None,
+    cursor_key: str,
+    batch_size: int,
+    base: tuple[str, ...] = (),
+) -> list[Any]:
+    """Fetch one keyset page, always including its durable cursor columns."""
+    where_sql, args = _page_where(
+        column,
+        key_expression,
+        window_start=window_start,
+        window_end=window_end,
+        cursor_updated_at=cursor_updated_at,
+        cursor_key=cursor_key,
+        base=base,
+    )
+    args.append(batch_size)
+    return list(
+        await pool.fetch(
+            f"SELECT *, {column} AS projection_updated_at, {key_expression} AS {key_alias} "
+            f"FROM {table} WHERE {where_sql} "
+            f"ORDER BY {column}, {key_expression} LIMIT ${len(args)}",
+            *args,
+        )
+    )
+
+
+def _cursor_from_page(rows: list[Any]) -> tuple[dt.datetime | None, str]:
+    """Extract the next durable cursor from a source-row page."""
+    if not rows:
+        return None, ""
+    row = rows[-1]
+    updated_at = row["projection_updated_at"]
+    return (
+        updated_at.astimezone(dt.timezone.utc)
+        if isinstance(updated_at, dt.datetime)
+        else None,
+        str(row["projection_key"] or ""),
+    )
+
+
+async def _load_scope_page(
+    pool,
+    scope: str,
+    *,
+    window_start: dt.datetime | None,
+    window_end: dt.datetime,
+    cursor_updated_at: dt.datetime | None,
+    cursor_key: str,
+    batch_size: int,
+) -> list[Any]:
+    """Load one bounded source-row page for a projection scope."""
+    if scope == "slack_channel_day":
+        return await _fetch_page(
+            pool,
+            table="slack_sync_messages",
+            column="updated_at",
+            key_expression="channel_id || ':' || message_ts",
+            key_alias="projection_key",
+            window_start=window_start,
+            window_end=window_end,
+            cursor_updated_at=cursor_updated_at,
+            cursor_key=cursor_key,
+            batch_size=batch_size,
+            base=("occurred_at IS NOT NULL",),
+        )
+    if scope == "slack_thread":
+        return await _fetch_page(
+            pool,
+            table="slack_sync_messages",
+            column="updated_at",
+            key_expression="channel_id || ':' || message_ts",
+            key_alias="projection_key",
+            window_start=window_start,
+            window_end=window_end,
+            cursor_updated_at=cursor_updated_at,
+            cursor_key=cursor_key,
+            batch_size=batch_size,
+            base=("thread_ts IS NOT NULL", "thread_ts <> ''"),
+        )
+    if scope == "slack_attachment":
+        return await _fetch_page(
+            pool,
+            table="slack_sync_message_attachments",
+            column="updated_at",
+            key_expression="channel_id || ':' || message_ts || ':' || slack_file_id",
+            key_alias="projection_key",
+            window_start=window_start,
+            window_end=window_end,
+            cursor_updated_at=cursor_updated_at,
+            cursor_key=cursor_key,
+            batch_size=batch_size,
+        )
+    if scope == "google_doc":
+        return await _fetch_page(
+            pool,
+            table="google_drive_sync_files",
+            column="updated_at",
+            key_expression="file_id",
+            key_alias="projection_key",
+            window_start=window_start,
+            window_end=window_end,
+            cursor_updated_at=cursor_updated_at,
+            cursor_key=cursor_key,
+            batch_size=batch_size,
+            base=("last_error = ''", "trashed = FALSE"),
+        )
+    if scope == "calendar_event":
+        return await _fetch_page(
+            pool,
+            table="google_calendar_sync_events",
+            column="updated_at",
+            key_expression="calendar_id || ':' || event_id",
+            key_alias="projection_key",
+            window_start=window_start,
+            window_end=window_end,
+            cursor_updated_at=cursor_updated_at,
+            cursor_key=cursor_key,
+            batch_size=batch_size,
+            base=("last_error = ''",),
+        )
+    if scope == "linear_issue":
+        return await _fetch_page(
+            pool,
+            table="linear_sync_issues",
+            column="updated_at",
+            key_expression="issue_id",
+            key_alias="projection_key",
+            window_start=window_start,
+            window_end=window_end,
+            cursor_updated_at=cursor_updated_at,
+            cursor_key=cursor_key,
+            batch_size=batch_size,
+            base=("last_error = ''",),
+        )
+    if scope == "linear_comment":
+        return await _fetch_page(
+            pool,
+            table="linear_sync_comments",
+            column="updated_at",
+            key_expression="comment_id",
+            key_alias="projection_key",
+            window_start=window_start,
+            window_end=window_end,
+            cursor_updated_at=cursor_updated_at,
+            cursor_key=cursor_key,
+            batch_size=batch_size,
+            base=("last_error = ''",),
+        )
+    if scope == "attio_meeting":
+        return await _fetch_page(
+            pool,
+            table="attio_sync_meetings",
+            column="updated_at",
+            key_expression="meeting_id",
+            key_alias="projection_key",
+            window_start=window_start,
+            window_end=window_end,
+            cursor_updated_at=cursor_updated_at,
+            cursor_key=cursor_key,
+            batch_size=batch_size,
+            base=("last_error = ''",),
+        )
+    raise ValueError(f"unknown company context projection scope: {scope}")
+
+
+async def _project_scope_page(
+    pool,
+    scope: str,
+    rows: list[Any],
+) -> tuple[int, int]:
+    """Project one source-row page and return inserted/updated and deleted counts."""
+    upserted = 0
+    deleted = 0
+    users_by_id: dict[str, str] = {}
+    channels_by_id: dict[str, str] = {}
+    if scope.startswith("slack_"):
+        users_by_id, channels_by_id = await _load_slack_lookup_maps(pool)
+
+    async def save(
+        document: dict[str, Any] | None, source: str, source_type: str
+    ) -> None:
+        nonlocal upserted
+        if document is None:
+            return
+        observe_company_context_document_size(
+            source, source_type, len(str(document["body"] or ""))
+        )
+        action = await _upsert_document(pool, document)
+        record_company_context_documents_changed(source, source_type, action)
+        if action in {"inserted", "updated"}:
+            upserted += 1
+
+    if scope == "slack_channel_day":
+        keys = {(str(row["channel_id"]), row["occurred_at"].date()) for row in rows}
+        for channel_id, day in keys:
+            document = _channel_day_document(
+                channel_id=channel_id,
+                day=day,
+                messages=await _load_channel_day_messages(pool, channel_id, day),
+                users_by_id=users_by_id,
+                channels_by_id=channels_by_id,
+            )
+            if document is None:
+                if await _delete_document(
+                    pool, f"slack:channel_day:{channel_id}:{day.isoformat()}"
+                ):
+                    deleted += 1
+                    record_company_context_documents_changed(
+                        "slack", "slack_channel_day", "deleted"
+                    )
+            else:
+                await save(document, "slack", "slack_channel_day")
+    elif scope == "slack_thread":
+        keys = {(str(row["channel_id"]), str(row["thread_ts"])) for row in rows}
+        for channel_id, thread_ts in keys:
+            document = _thread_document(
+                channel_id=channel_id,
+                thread_ts=thread_ts,
+                messages=await _load_thread_messages(pool, channel_id, thread_ts),
+                users_by_id=users_by_id,
+                channels_by_id=channels_by_id,
+            )
+            if document is None:
+                if await _delete_document(
+                    pool, f"slack:thread:{channel_id}:{thread_ts}"
+                ):
+                    deleted += 1
+                    record_company_context_documents_changed(
+                        "slack", "slack_thread", "deleted"
+                    )
+            else:
+                await save(document, "slack", "slack_thread")
+    elif scope == "slack_attachment":
+        for row in rows:
+            attachment = await pool.fetchrow(
+                "SELECT a.*, c.channel_name, m.occurred_at, m.thread_ts, m.parent_message_ts, "
+                "m.user_id, u.user_name, u.real_name, u.display_name, m.text, "
+                "m.permalink AS message_permalink "
+                "FROM slack_sync_message_attachments a "
+                "JOIN slack_sync_messages m ON m.channel_id = a.channel_id AND m.message_ts = a.message_ts "
+                "LEFT JOIN slack_sync_channels c ON c.channel_id = a.channel_id "
+                "LEFT JOIN slack_sync_users u ON u.user_id = m.user_id "
+                "WHERE a.channel_id = $1 AND a.message_ts = $2 AND a.slack_file_id = $3",
+                row["channel_id"],
+                row["message_ts"],
+                row["slack_file_id"],
+            )
+            if attachment:
+                await save(
+                    _slack_attachment_document(
+                        attachment,
+                        users_by_id=users_by_id,
+                        channels_by_id=channels_by_id,
+                    ),
+                    "slack",
+                    "slack_attachment",
+                )
+    elif scope == "google_doc":
+        for row in rows:
+            await save(_drive_document(row), "google_drive", "google_doc")
+    elif scope == "calendar_event":
+        for row in rows:
+            event = await pool.fetchrow(
+                "SELECT e.*, c.summary AS calendar_summary, c.time_zone "
+                "FROM google_calendar_sync_events e "
+                "LEFT JOIN google_calendar_sync_calendars c ON c.calendar_id = e.calendar_id "
+                "WHERE e.calendar_id = $1 AND e.event_id = $2",
+                row["calendar_id"],
+                row["event_id"],
+            )
+            if event is None:
+                continue
+            if str(event["status"] or "") == "cancelled":
+                if await _delete_document(pool, _calendar_event_document_id(event)):
+                    deleted += 1
+                    record_company_context_documents_changed(
+                        "google_calendar", "calendar_event", "deleted"
+                    )
+            else:
+                await save(
+                    _calendar_event_document(event), "google_calendar", "calendar_event"
+                )
+    elif scope in {"linear_issue", "linear_comment"}:
+        issue_ids = {str(row["issue_id"]) for row in rows}
+        for issue_id in issue_ids:
+            issue = await pool.fetchrow(
+                "SELECT i.*, ("
+                "  SELECT MAX(COALESCE(c.source_updated_at, c.source_edited_at, c.updated_at)) "
+                "  FROM linear_sync_comments c WHERE c.issue_id = i.issue_id AND c.last_error = ''"
+                ") AS comments_source_updated_at "
+                "FROM linear_sync_issues i WHERE i.issue_id = $1 AND i.last_error = ''",
+                issue_id,
+            )
+            if issue:
+                await save(
+                    _linear_issue_document(
+                        issue, await _load_linear_issue_comments(pool, issue_id)
+                    ),
+                    "linear",
+                    "linear_issue",
+                )
+    elif scope == "attio_meeting":
+        for row in rows:
+            await save(_attio_meeting_document(row), "attio", "attio_meeting")
+    return upserted, deleted
+
+
+async def _claim_scope(
+    pool,
+    *,
+    scope: str,
+    seed_watermark: dt.datetime | None,
+    overlap_seconds: int,
+    max_window_seconds: int,
+) -> Any | None:
+    """Start or reclaim one scope window; only one child chain owns it at a time."""
+    now = dt.datetime.now(dt.timezone.utc)
+    initial_start = (
+        seed_watermark - dt.timedelta(seconds=overlap_seconds)
+        if seed_watermark is not None
+        else None
+    )
+    initial_end = _batch_until(initial_start, now, max_window_seconds) or now
+    token = hashlib.sha256(f"{scope}:{now.isoformat()}".encode()).hexdigest()
+    return await pool.fetchrow(
+        "INSERT INTO company_context_projection_checkpoints "
+        "(scope, watermark, window_start, window_end, cursor_updated_at, cursor_key, lease_token, lease_expires_at) "
+        "VALUES ($1, $2, $3, $4, NULL, '', $5, NOW() + ($6::text || ' seconds')::interval) "
+        "ON CONFLICT (scope) DO UPDATE SET "
+        "watermark = CASE WHEN company_context_projection_checkpoints.window_end IS NULL "
+        " THEN COALESCE(company_context_projection_checkpoints.watermark, EXCLUDED.watermark) "
+        " ELSE company_context_projection_checkpoints.watermark END, "
+        "window_start = CASE WHEN company_context_projection_checkpoints.window_end IS NULL "
+        " THEN COALESCE(company_context_projection_checkpoints.watermark - ($7::text || ' seconds')::interval, EXCLUDED.window_start) "
+        " ELSE company_context_projection_checkpoints.window_start END, "
+        "window_end = CASE WHEN company_context_projection_checkpoints.window_end IS NULL "
+        " THEN LEAST(NOW(), COALESCE(company_context_projection_checkpoints.watermark - ($7::text || ' seconds')::interval, EXCLUDED.window_start) + ($8::text || ' seconds')::interval) "
+        " ELSE company_context_projection_checkpoints.window_end END, "
+        "cursor_updated_at = CASE WHEN company_context_projection_checkpoints.window_end IS NULL THEN NULL ELSE company_context_projection_checkpoints.cursor_updated_at END, "
+        "cursor_key = CASE WHEN company_context_projection_checkpoints.window_end IS NULL THEN '' ELSE company_context_projection_checkpoints.cursor_key END, "
+        "lease_token = EXCLUDED.lease_token, lease_expires_at = EXCLUDED.lease_expires_at, updated_at = NOW() "
+        "WHERE company_context_projection_checkpoints.lease_expires_at IS NULL "
+        " OR company_context_projection_checkpoints.lease_expires_at < NOW() "
+        "RETURNING scope, lease_token, window_start, window_end",
+        scope,
+        seed_watermark,
+        initial_start,
+        initial_end,
+        token,
+        str(DEFAULT_SCOPE_LEASE_SECONDS),
+        str(overlap_seconds),
+        str(max_window_seconds),
+    )
+
+
+async def _read_owned_scope(pool, scope: str, lease_token: str) -> Any | None:
+    return await pool.fetchrow(
+        "SELECT scope, watermark, window_start, window_end, cursor_updated_at, cursor_key "
+        "FROM company_context_projection_checkpoints "
+        "WHERE scope = $1 AND lease_token = $2 AND lease_expires_at > NOW()",
+        scope,
+        lease_token,
+    )
+
+
+async def _finish_scope_window(pool, scope: str, lease_token: str) -> None:
+    await pool.execute(
+        "UPDATE company_context_projection_checkpoints SET watermark = window_end, "
+        "window_start = NULL, window_end = NULL, cursor_updated_at = NULL, cursor_key = '', "
+        "lease_token = NULL, lease_expires_at = NULL, updated_at = NOW() "
+        "WHERE scope = $1 AND lease_token = $2",
+        scope,
+        lease_token,
+    )
+
+
+async def _advance_scope_cursor(
+    pool,
+    scope: str,
+    lease_token: str,
+    cursor_updated_at: dt.datetime,
+    cursor_key: str,
+) -> None:
+    await pool.execute(
+        "UPDATE company_context_projection_checkpoints SET cursor_updated_at = $3, cursor_key = $4, "
+        "lease_expires_at = NOW() + ($5::text || ' seconds')::interval, updated_at = NOW() "
+        "WHERE scope = $1 AND lease_token = $2",
+        scope,
+        lease_token,
+        cursor_updated_at,
+        cursor_key,
+        str(DEFAULT_SCOPE_LEASE_SECONDS),
+    )
+
+
+async def _run_scope_batch(
+    inp: Input, ctx: WorkflowContext, scope: str
+) -> dict[str, Any]:
+    lease_token = str(inp.lease_token or "")
+    checkpoint = await _read_owned_scope(ctx._pool, scope, lease_token)
+    if checkpoint is None:
+        return {"status": "skipped", "scope": scope, "reason": "lease_not_owned"}
+    window_end = checkpoint["window_end"]
+    if not isinstance(window_end, dt.datetime):
+        return {"status": "skipped", "scope": scope, "reason": "no_active_window"}
+    rows = await _load_scope_page(
+        ctx._pool,
+        scope,
+        window_start=checkpoint["window_start"],
+        window_end=window_end,
+        cursor_updated_at=checkpoint["cursor_updated_at"],
+        cursor_key=str(checkpoint["cursor_key"] or ""),
+        batch_size=_batch_size(inp.batch_size),
+    )
+    upserted, deleted = await _project_scope_page(ctx._pool, scope, rows)
+    if len(rows) < _batch_size(inp.batch_size):
+        await _finish_scope_window(ctx._pool, scope, lease_token)
+        continuation = None
+    else:
+        cursor_updated_at, cursor_key = _cursor_from_page(rows)
+        if cursor_updated_at is None or not cursor_key:
+            raise RuntimeError(f"missing durable cursor for {scope} projection page")
+        await _advance_scope_cursor(
+            ctx._pool, scope, lease_token, cursor_updated_at, cursor_key
+        )
+        continuation = await ctx.start_workflow(
+            WORKFLOW_NAME,
+            {
+                "scope": scope,
+                "lease_token": lease_token,
+                "batch_size": _batch_size(inp.batch_size),
+            },
+            idempotency_key=f"company-context:{scope}:{window_end.isoformat()}:{cursor_updated_at.isoformat()}:{cursor_key}",
+        )
+    return {
+        "status": "completed",
+        "scope": scope,
+        "source_rows": len(rows),
+        "documents_upserted": upserted,
+        "documents_deleted": deleted,
+        "window_end": window_end.isoformat(),
+        "continuation": continuation,
+    }
+
+
 async def handler(inp: Input, ctx: WorkflowContext) -> dict[str, Any]:
-    """Project changed sync rows into embeddable company context documents."""
+    """Fan out bounded, durable projection pages for each enabled source scope."""
     if not (
         _source_enabled()
         and _env_flag_enabled("COMPANY_CONTEXT_DOCUMENTS_ENABLED", default=True)
@@ -1479,324 +2024,56 @@ async def handler(inp: Input, ctx: WorkflowContext) -> dict[str, Any]:
         ctx.log("company_context_documents_skipped_disabled")
         return {"status": "skipped", "reason": "company_context_documents_disabled"}
 
-    explicit_since = _parse_datetime(inp.since)
-    last_watermark = explicit_since or await _latest_successful_watermark(
-        ctx._pool, ctx.run_id
-    )
+    enabled_scopes = _enabled_scopes()
+    if inp.scope:
+        if inp.scope not in enabled_scopes:
+            return {"status": "skipped", "scope": inp.scope, "reason": "scope_disabled"}
+        result = await _run_scope_batch(inp, ctx, inp.scope)
+        ctx.log("company_context_documents_scope_completed", **result)
+        return result
+
     overlap_seconds = _nonnegative_int(
         inp.watermark_overlap_seconds,
         DEFAULT_WATERMARK_OVERLAP_SECONDS,
     )
-    since = (
-        last_watermark - dt.timedelta(seconds=overlap_seconds)
-        if last_watermark is not None
-        else None
+    seed_watermark = _parse_datetime(inp.since) or await _latest_successful_watermark(
+        ctx._pool, ctx.run_id
     )
-    now = dt.datetime.now(dt.timezone.utc)
-    max_window_seconds = _max_window_seconds(inp.max_window_seconds)
-    batch_until = _batch_until(since, now, max_window_seconds)
-
-    slack_enabled = _env_flag_enabled("SLACK_ETL_ENABLED")
-    google_drive_enabled = _env_flag_enabled("GOOGLE_DRIVE_ETL_ENABLED")
-    google_calendar_enabled = _env_flag_enabled("GOOGLE_CALENDAR_ETL_ENABLED")
-    linear_enabled = _env_flag_enabled("LINEAR_ETL_ENABLED")
-    attio_enabled = _env_flag_enabled("ATTIO_ETL_ENABLED")
-    enabled_sources = [
-        source
-        for source, enabled in (
-            ("slack", slack_enabled),
-            ("google_drive", google_drive_enabled),
-            ("google_calendar", google_calendar_enabled),
-            ("linear", linear_enabled),
-            ("attio", attio_enabled),
+    started: list[dict[str, Any]] = []
+    for scope in enabled_scopes:
+        checkpoint = await _claim_scope(
+            ctx._pool,
+            scope=scope,
+            seed_watermark=seed_watermark,
+            overlap_seconds=overlap_seconds,
+            max_window_seconds=_max_window_seconds(inp.max_window_seconds),
         )
-        if enabled
-    ]
+        if checkpoint is None:
+            continue
+        child = await ctx.start_workflow(
+            WORKFLOW_NAME,
+            {
+                "scope": str(checkpoint["scope"]),
+                "lease_token": str(checkpoint["lease_token"]),
+                "batch_size": _batch_size(inp.batch_size),
+            },
+            idempotency_key=(
+                f"company-context:{checkpoint['scope']}:{checkpoint['window_end'].isoformat()}:"
+                f"{checkpoint['lease_token']}"
+            ),
+        )
+        started.append({"scope": str(checkpoint["scope"]), "child": child})
+
+    enabled_sources = sorted(set(enabled_scopes.values()))
     _emit_company_context_counter_baselines(enabled_sources)
-    changed = {
-        "channel_days": [],
-        "threads": [],
-        "attachments": [],
-        "changed_messages": 0,
-        "changed_attachments": 0,
-        "max_updated_at": None,
-    }
-    users_by_id: dict[str, str] = {}
-    channels_by_id: dict[str, str] = {}
-    if slack_enabled:
-        users_by_id, channels_by_id = await _load_slack_lookup_maps(ctx._pool)
-        changed = await _load_changed_message_keys(ctx._pool, since, batch_until)
-    drive_changed = {
-        "files": [],
-        "changed_files": 0,
-        "max_updated_at": None,
-    }
-    if google_drive_enabled:
-        drive_changed = await _load_changed_drive_files(ctx._pool, since, batch_until)
-    calendar_changed = {
-        "events": [],
-        "changed_events": 0,
-        "max_updated_at": None,
-    }
-    if google_calendar_enabled:
-        calendar_changed = await _load_changed_calendar_events(
-            ctx._pool, since, batch_until
-        )
-    linear_changed = {
-        "issues": [],
-        "changed_issues": 0,
-        "max_updated_at": None,
-    }
-    if linear_enabled:
-        linear_changed = await _load_changed_linear_issues(
-            ctx._pool, since, batch_until
-        )
-    attio_changed = {
-        "meetings": [],
-        "changed_meetings": 0,
-        "max_updated_at": None,
-    }
-    if attio_enabled:
-        attio_changed = await _load_changed_attio_meetings(
-            ctx._pool, since, batch_until
-        )
-
-    documents_upserted = 0
-    documents_deleted = 0
-    for channel_id, day in changed["channel_days"]:
-        messages = await _load_channel_day_messages(ctx._pool, channel_id, day)
-        document = _channel_day_document(
-            channel_id=channel_id,
-            day=day,
-            messages=messages,
-            users_by_id=users_by_id,
-            channels_by_id=channels_by_id,
-        )
-        if document is None:
-            if await _delete_document(
-                ctx._pool,
-                f"slack:channel_day:{channel_id}:{day.isoformat()}",
-            ):
-                documents_deleted += 1
-                record_company_context_documents_changed(
-                    "slack",
-                    "slack_channel_day",
-                    "deleted",
-                )
-            continue
-        observe_company_context_document_size(
-            "slack",
-            str(document["source_type"]),
-            len(str(document["body"] or "")),
-        )
-        action = await _upsert_document(ctx._pool, document)
-        record_company_context_documents_changed(
-            "slack",
-            str(document["source_type"]),
-            action,
-        )
-        if action in {"inserted", "updated"}:
-            documents_upserted += 1
-
-    for channel_id, thread_ts in changed["threads"]:
-        messages = await _load_thread_messages(ctx._pool, channel_id, thread_ts)
-        document = _thread_document(
-            channel_id=channel_id,
-            thread_ts=thread_ts,
-            messages=messages,
-            users_by_id=users_by_id,
-            channels_by_id=channels_by_id,
-        )
-        if document is None:
-            if await _delete_document(
-                ctx._pool, f"slack:thread:{channel_id}:{thread_ts}"
-            ):
-                documents_deleted += 1
-                record_company_context_documents_changed(
-                    "slack",
-                    "slack_thread",
-                    "deleted",
-                )
-            continue
-        observe_company_context_document_size(
-            "slack",
-            str(document["source_type"]),
-            len(str(document["body"] or "")),
-        )
-        action = await _upsert_document(ctx._pool, document)
-        record_company_context_documents_changed(
-            "slack",
-            str(document["source_type"]),
-            action,
-        )
-        if action in {"inserted", "updated"}:
-            documents_upserted += 1
-
-    for row in changed["attachments"]:
-        document = _slack_attachment_document(
-            row,
-            users_by_id=users_by_id,
-            channels_by_id=channels_by_id,
-        )
-        if document is None:
-            continue
-        observe_company_context_document_size(
-            "slack",
-            str(document["source_type"]),
-            len(str(document["body"] or "")),
-        )
-        action = await _upsert_document(ctx._pool, document)
-        record_company_context_documents_changed(
-            "slack",
-            str(document["source_type"]),
-            action,
-        )
-        if action in {"inserted", "updated"}:
-            documents_upserted += 1
-
-    for row in drive_changed["files"]:
-        document = _drive_document(row)
-        if document is None:
-            continue
-        observe_company_context_document_size(
-            "google_drive",
-            str(document["source_type"]),
-            len(str(document["body"] or "")),
-        )
-        action = await _upsert_document(ctx._pool, document)
-        record_company_context_documents_changed(
-            "google_drive",
-            str(document["source_type"]),
-            action,
-        )
-        if action in {"inserted", "updated"}:
-            documents_upserted += 1
-
-    for row in calendar_changed["events"]:
-        if str(row["status"] or "") == "cancelled":
-            if await _delete_document(ctx._pool, _calendar_event_document_id(row)):
-                documents_deleted += 1
-                record_company_context_documents_changed(
-                    "google_calendar",
-                    "calendar_event",
-                    "deleted",
-                )
-            continue
-        document = _calendar_event_document(row)
-        if document is None:
-            continue
-        observe_company_context_document_size(
-            "google_calendar",
-            str(document["source_type"]),
-            len(str(document["body"] or "")),
-        )
-        action = await _upsert_document(ctx._pool, document)
-        record_company_context_documents_changed(
-            "google_calendar",
-            str(document["source_type"]),
-            action,
-        )
-        if action in {"inserted", "updated"}:
-            documents_upserted += 1
-
-    for row in linear_changed["issues"]:
-        comments = await _load_linear_issue_comments(ctx._pool, str(row["issue_id"]))
-        document = _linear_issue_document(row, comments)
-        if document is None:
-            continue
-        observe_company_context_document_size(
-            "linear",
-            str(document["source_type"]),
-            len(str(document["body"] or "")),
-        )
-        action = await _upsert_document(ctx._pool, document)
-        record_company_context_documents_changed(
-            "linear",
-            str(document["source_type"]),
-            action,
-        )
-        if action in {"inserted", "updated"}:
-            documents_upserted += 1
-
-    for row in attio_changed["meetings"]:
-        document = _attio_meeting_document(row)
-        if document is None:
-            continue
-        observe_company_context_document_size(
-            "attio",
-            str(document["source_type"]),
-            len(str(document["body"] or "")),
-        )
-        action = await _upsert_document(ctx._pool, document)
-        record_company_context_documents_changed(
-            "attio",
-            str(document["source_type"]),
-            action,
-        )
-        if action in {"inserted", "updated"}:
-            documents_upserted += 1
-
-    if batch_until is not None:
-        watermark = batch_until
-    else:
-        watermark_candidates = [
-            value
-            for value in (
-                changed["max_updated_at"],
-                drive_changed["max_updated_at"],
-                calendar_changed["max_updated_at"],
-                linear_changed["max_updated_at"],
-                attio_changed["max_updated_at"],
-                last_watermark,
-            )
-            if value is not None
-        ]
-        watermark = max(watermark_candidates) if watermark_candidates else None
-    source_watermarks = {
-        "slack": watermark
-        if batch_until is not None
-        else changed["max_updated_at"] or last_watermark,
-        "google_drive": watermark
-        if batch_until is not None
-        else drive_changed["max_updated_at"] or last_watermark,
-        "google_calendar": watermark
-        if batch_until is not None
-        else calendar_changed["max_updated_at"] or last_watermark,
-        "linear": watermark
-        if batch_until is not None
-        else linear_changed["max_updated_at"] or last_watermark,
-        "attio": watermark
-        if batch_until is not None
-        else attio_changed["max_updated_at"] or last_watermark,
-    }
-    remaining_lag_seconds = (
-        max((now - watermark).total_seconds(), 0.0) if watermark is not None else None
-    )
-    _emit_company_context_projection_lag(enabled_sources, source_watermarks)
+    await _emit_projection_lag_from_checkpoints(ctx._pool, enabled_scopes)
     await _emit_etl_scope_metrics(ctx._pool, enabled_sources)
     await _emit_company_context_document_size_snapshot(ctx._pool, enabled_sources)
     result = {
         "status": "completed",
-        "changed_messages": changed["changed_messages"],
-        "changed_slack_attachments": changed["changed_attachments"],
-        "changed_drive_files": drive_changed["changed_files"],
-        "changed_calendar_events": calendar_changed["changed_events"],
-        "changed_linear_issues": linear_changed["changed_issues"],
-        "changed_attio_meetings": attio_changed["changed_meetings"],
-        "channel_day_documents": len(changed["channel_days"]),
-        "thread_candidates": len(changed["threads"]),
-        "slack_attachment_documents": len(changed["attachments"]),
-        "drive_documents": len(drive_changed["files"]),
-        "calendar_event_documents": len(calendar_changed["events"]),
-        "linear_issue_documents": len(linear_changed["issues"]),
-        "attio_meeting_documents": len(attio_changed["meetings"]),
-        "documents_upserted": documents_upserted,
-        "documents_deleted": documents_deleted,
-        "since": since.isoformat() if since else None,
-        "batch_until": batch_until.isoformat() if batch_until else None,
-        "max_window_seconds": max_window_seconds,
-        "remaining_lag_seconds": remaining_lag_seconds,
-        "watermark": watermark.isoformat() if watermark else None,
+        "started_scopes": started,
+        "batch_size": _batch_size(inp.batch_size),
+        "max_window_seconds": _max_window_seconds(inp.max_window_seconds),
     }
-    ctx.log("company_context_documents_completed", **result)
+    ctx.log("company_context_documents_coordinator_completed", **result)
     return result

--- a/workflows/tests/test_company_context_documents_attachments.py
+++ b/workflows/tests/test_company_context_documents_attachments.py
@@ -112,9 +112,14 @@ class FakeWorkflowContext:
         self.run_id = "run_123"
         self._pool = object()
         self.logs: list[tuple[str, dict]] = []
+        self.children: list[tuple[str, dict, str | None]] = []
 
     def log(self, message, **fields):
         self.logs.append((message, fields))
+
+    async def start_workflow(self, workflow_name, input, *, idempotency_key=None):
+        self.children.append((workflow_name, input, idempotency_key))
+        return {"task_id": f"task_{len(self.children)}", "created": True}
 
 
 def test_latest_successful_watermark_reads_absurd_etl_queue():
@@ -159,26 +164,19 @@ def test_load_changed_message_keys_applies_upper_batch_bound():
         assert args == (since, until)
 
 
-def test_handler_advances_empty_bounded_window(monkeypatch):
+def test_coordinator_starts_one_child_per_enabled_scope(monkeypatch):
     last_watermark = dt.datetime(2026, 6, 18, 22, 59, 36, tzinfo=dt.UTC)
-    seen_bounds: dict[str, dt.datetime | None] = {}
+    claimed_scopes: list[str] = []
 
     async def latest_watermark(_pool, _run_id):
         return last_watermark
 
-    async def load_slack_lookup_maps(_pool):
-        return {}, {}
-
-    async def load_changed_message_keys(_pool, since, until=None):
-        seen_bounds["since"] = since
-        seen_bounds["until"] = until
+    async def claim_scope(_pool, *, scope, **_kwargs):
+        claimed_scopes.append(scope)
         return {
-            "channel_days": [],
-            "threads": [],
-            "attachments": [],
-            "changed_messages": 0,
-            "changed_attachments": 0,
-            "max_updated_at": None,
+            "scope": scope,
+            "lease_token": f"lease_{scope}",
+            "window_end": dt.datetime(2026, 6, 18, 23, 58, 36, tzinfo=dt.UTC),
         }
 
     async def noop_async(*_args, **_kwargs):
@@ -190,17 +188,13 @@ def test_handler_advances_empty_bounded_window(monkeypatch):
     monkeypatch.setenv("LINEAR_ETL_ENABLED", "false")
     monkeypatch.setenv("COMPANY_CONTEXT_DOCUMENTS_ENABLED", "true")
     monkeypatch.setattr(projection, "_latest_successful_watermark", latest_watermark)
-    monkeypatch.setattr(projection, "_load_slack_lookup_maps", load_slack_lookup_maps)
-    monkeypatch.setattr(
-        projection,
-        "_load_changed_message_keys",
-        load_changed_message_keys,
-    )
+    monkeypatch.setattr(projection, "_claim_scope", claim_scope)
     monkeypatch.setattr(
         projection,
         "_emit_company_context_document_size_snapshot",
         noop_async,
     )
+    monkeypatch.setattr(projection, "_emit_projection_lag_from_checkpoints", noop_async)
     monkeypatch.setattr(projection, "_emit_etl_scope_metrics", noop_async)
 
     ctx = FakeWorkflowContext()
@@ -211,14 +205,59 @@ def test_handler_advances_empty_bounded_window(monkeypatch):
         )
     )
 
-    expected_since = dt.datetime(2026, 6, 18, 22, 58, 36, tzinfo=dt.UTC)
-    expected_until = dt.datetime(2026, 6, 18, 23, 58, 36, tzinfo=dt.UTC)
-    assert seen_bounds == {"since": expected_since, "until": expected_until}
-    assert result["changed_messages"] == 0
-    assert result["batch_until"] == expected_until.isoformat()
-    assert result["watermark"] == expected_until.isoformat()
-    assert result["remaining_lag_seconds"] is not None
-    assert ctx.logs[-1][0] == "company_context_documents_completed"
+    assert claimed_scopes == ["slack_channel_day", "slack_thread", "slack_attachment"]
+    assert [child[1]["scope"] for child in ctx.children] == claimed_scopes
+    assert all(child[0] == "company_context_documents" for child in ctx.children)
+    assert all("company-context:slack_" in str(child[2]) for child in ctx.children)
+    assert result["started_scopes"]
+    assert result["batch_size"] == projection.DEFAULT_BATCH_SIZE
+    assert ctx.logs[-1][0] == "company_context_documents_coordinator_completed"
+
+
+def test_scope_batch_advances_cursor_before_starting_one_continuation(monkeypatch):
+    window_end = dt.datetime(2026, 6, 18, 23, 58, 36, tzinfo=dt.UTC)
+    cursor_at = dt.datetime(2026, 6, 18, 23, 0, tzinfo=dt.UTC)
+    advanced: list[tuple] = []
+
+    async def read_owned_scope(_pool, _scope, _lease_token):
+        return {
+            "window_start": dt.datetime(2026, 6, 18, 22, 58, 36, tzinfo=dt.UTC),
+            "window_end": window_end,
+            "cursor_updated_at": None,
+            "cursor_key": "",
+        }
+
+    async def load_scope_page(*_args, **_kwargs):
+        return [
+            {"projection_updated_at": cursor_at, "projection_key": "doc_a"},
+            {"projection_updated_at": cursor_at, "projection_key": "doc_b"},
+        ]
+
+    async def project_scope_page(*_args, **_kwargs):
+        return 2, 0
+
+    async def advance_scope_cursor(*args):
+        advanced.append(args)
+
+    monkeypatch.setattr(projection, "_read_owned_scope", read_owned_scope)
+    monkeypatch.setattr(projection, "_load_scope_page", load_scope_page)
+    monkeypatch.setattr(projection, "_project_scope_page", project_scope_page)
+    monkeypatch.setattr(projection, "_advance_scope_cursor", advance_scope_cursor)
+    monkeypatch.setattr(projection, "_batch_size", lambda _value=None: 2)
+
+    ctx = FakeWorkflowContext()
+    result = asyncio.run(
+        projection._run_scope_batch(
+            projection.Input(scope="google_doc", lease_token="lease_1", batch_size=2),
+            ctx,
+            "google_doc",
+        )
+    )
+
+    assert advanced == [(ctx._pool, "google_doc", "lease_1", cursor_at, "doc_b")]
+    assert ctx.children[0][1]["scope"] == "google_doc"
+    assert ctx.children[0][1]["lease_token"] == "lease_1"
+    assert result["continuation"]["created"] is True
 
 
 def test_etl_scope_metrics_no_longer_emit_slack_scope_gauges(monkeypatch):


### PR DESCRIPTION
## Summary
- add fire-and-forget child workflow spawning to the Python workflow host and runtime
- project Company Context in durable per-scope keyset batches with checkpointed windows and leases
- add Helm configuration, operator docs, and coverage for batching and child workflows

## Validation
- `pytest workflows/tests/test_company_context_documents_attachments.py`
- `pytest services/workflow-python/tests`
- `cargo test -p centaur-workflows`
- `helm lint contrib/chart`
- local Orbstack end-to-end coordinator + three Slack-scope child workflows