### PR TITLE
fix: include API controllers in console request logs

### DIFF
--- a/services/console/config/environments/production.rb
+++ b/services/console/config/environments/production.rb
@@ -48,6 +48,7 @@ Rails.application.configure do
   # request. The Raw formatter emits a hash that JsonLogFormatter merges into
   # the JSON log entry.
   config.lograge.enabled = true
+  config.lograge.base_controller_class = %w[ActionController::Base ActionController::API]
   config.lograge.formatter = Lograge::Formatters::Raw.new
   config.lograge.custom_payload do |controller|
     { request_id: controller.request.request_id }


### PR DESCRIPTION
Configures Lograge to apply its custom payload hook to both ActionController::Base and ActionController::API controllers. This keeps console UI, API, and error-controller request logs consistent with structured request IDs.