### PR TITLE
fix: remove company context size metric

### DIFF
--- a/services/api-rs/crates/centaur-telemetry/src/lib.rs
+++ b/services/api-rs/crates/centaur-telemetry/src/lib.rs
@@ -73,7 +73,6 @@ pub const ETL_ITEMS_FAILED_TOTAL: &str = "etl_items_failed_total";
 pub const ETL_BACKFILL_JOBS: &str = "etl_backfill_jobs";
 pub const ETL_BACKFILL_JOB_AGE_SECONDS: &str = "etl_backfill_job_age_seconds";
 pub const COMPANY_CONTEXT_DOCUMENTS_CHANGED_TOTAL: &str = "company_context_documents_changed_total";
-pub const COMPANY_CONTEXT_DOCUMENT_SIZE_CHARS: &str = "company_context_document_size_chars";
 pub const COMPANY_CONTEXT_PROJECTION_LAG_SECONDS: &str = "company_context_projection_lag_seconds";
 pub const WORKFLOW_QUEUE_TASKS: &str = "workflow_queue_tasks";
 pub const WORKFLOW_QUEUE_TASKS_BY_WORKFLOW: &str = "workflow_queue_tasks_by_workflow";
@@ -127,9 +126,6 @@ const SESSION_FIRST_TOKEN_LATENCY_BUCKETS: &[f64] = &[
 ];
 const SANDBOX_STARTUP_DURATION_BUCKETS: &[f64] =
     &[0.5, 1.0, 2.5, 5.0, 10.0, 30.0, 60.0, 120.0, 300.0];
-const COMPANY_CONTEXT_DOCUMENT_SIZE_BUCKETS: &[f64] = &[
-    100.0, 500.0, 1_000.0, 5_000.0, 10_000.0, 25_000.0, 50_000.0, 100_000.0, 250_000.0, 500_000.0,
-];
 const SLACK_ARCHIVE_IMPORT_DURATION_BUCKETS: &[f64] = &[
     1.0, 5.0, 10.0, 30.0, 60.0, 120.0, 300.0, 600.0, 1_200.0, 3_600.0,
 ];
@@ -265,10 +261,6 @@ pub fn prometheus_handle() -> Result<PrometheusHandle, TelemetryError> {
         .set_buckets_for_metric(
             Matcher::Full(SANDBOX_STARTUP_DURATION_SECONDS.to_owned()),
             SANDBOX_STARTUP_DURATION_BUCKETS,
-        )?
-        .set_buckets_for_metric(
-            Matcher::Full(COMPANY_CONTEXT_DOCUMENT_SIZE_CHARS.to_owned()),
-            COMPANY_CONTEXT_DOCUMENT_SIZE_BUCKETS,
         )?
         .set_buckets_for_metric(
             Matcher::Full(SLACK_ARCHIVE_IMPORT_DURATION_SECONDS.to_owned()),
@@ -994,10 +986,6 @@ fn describe_metrics() {
     metrics::describe_counter!(
         COMPANY_CONTEXT_DOCUMENTS_CHANGED_TOTAL,
         "Company context document changes observed by ETL workflows."
-    );
-    metrics::describe_histogram!(
-        COMPANY_CONTEXT_DOCUMENT_SIZE_CHARS,
-        "Company context document sizes in characters."
     );
     metrics::describe_gauge!(
         COMPANY_CONTEXT_PROJECTION_LAG_SECONDS,

--- a/workflows/company_context_documents.py
+++ b/workflows/company_context_documents.py
@@ -11,7 +11,6 @@ from typing import Any
 
 from api.runtime_control import canonical_json, decode_jsonb
 from workflows.company_context_metrics import (
-    observe_company_context_document_size,
     record_company_context_documents_changed,
     set_company_context_projection_lag,
 )
@@ -270,39 +269,6 @@ def _emit_company_context_counter_baselines(enabled_sources: list[str]) -> None:
                     action,
                     0,
                 )
-
-
-async def _emit_company_context_document_size_snapshot(
-    pool,
-    enabled_sources: list[str],
-) -> None:
-    """Observe current projected document sizes so the corpus p95 panel has data."""
-    if not enabled_sources:
-        return
-    rows = await pool.fetch(
-        "SELECT source, source_type, LENGTH(COALESCE(body, '')) AS body_chars "
-        "FROM company_context_documents "
-        "WHERE source = ANY($1::text[]) "
-        "ORDER BY source, source_type, document_id",
-        enabled_sources,
-    )
-    seen_source_types: set[tuple[str, str]] = set()
-    for row in rows:
-        source = str(row["source"] or "")
-        source_type = str(row["source_type"] or "")
-        if not source or not source_type:
-            continue
-        seen_source_types.add((source, source_type))
-        observe_company_context_document_size(
-            source,
-            source_type,
-            int(row["body_chars"] or 0),
-        )
-
-    for source in enabled_sources:
-        for source_type in COMPANY_CONTEXT_SOURCE_TYPES.get(source, ()):
-            if (source, source_type) not in seen_source_types:
-                observe_company_context_document_size(source, source_type, 0)
 
 
 async def _emit_etl_scope_metrics(pool, enabled_sources: list[str]) -> None:
@@ -1754,9 +1720,6 @@ async def _project_scope_page(
         nonlocal upserted
         if document is None:
             return
-        observe_company_context_document_size(
-            source, source_type, len(str(document["body"] or ""))
-        )
         action = await _upsert_document(pool, document)
         record_company_context_documents_changed(source, source_type, action)
         if action in {"inserted", "updated"}:
@@ -2068,7 +2031,6 @@ async def handler(inp: Input, ctx: WorkflowContext) -> dict[str, Any]:
     _emit_company_context_counter_baselines(enabled_sources)
     await _emit_projection_lag_from_checkpoints(ctx._pool, enabled_scopes)
     await _emit_etl_scope_metrics(ctx._pool, enabled_sources)
-    await _emit_company_context_document_size_snapshot(ctx._pool, enabled_sources)
     result = {
         "status": "completed",
         "started_scopes": started,

--- a/workflows/company_context_metrics.py
+++ b/workflows/company_context_metrics.py
@@ -1,20 +1,6 @@
 from __future__ import annotations
 
-from api.metrics import increment_metric, observe_histogram, set_gauge
-
-
-_COMPANY_CONTEXT_DOCUMENT_SIZE_BUCKETS = [
-    100,
-    500,
-    1_000,
-    5_000,
-    10_000,
-    25_000,
-    50_000,
-    100_000,
-    250_000,
-    500_000,
-]
+from api.metrics import increment_metric, set_gauge
 
 
 def record_company_context_documents_changed(
@@ -29,16 +15,6 @@ def record_company_context_documents_changed(
         source=source,
         source_type=source_type,
         action=action,
-    )
-
-
-def observe_company_context_document_size(source: str, source_type: str, chars: int) -> None:
-    observe_histogram(
-        "company_context_document_size_chars",
-        max(chars, 0),
-        _COMPANY_CONTEXT_DOCUMENT_SIZE_BUCKETS,
-        source=source,
-        source_type=source_type,
     )
 
 

--- a/workflows/tests/test_company_context_documents_attachments.py
+++ b/workflows/tests/test_company_context_documents_attachments.py
@@ -25,7 +25,6 @@ def _load_projection_module():
 
     company_context_metrics = types.ModuleType("workflows.company_context_metrics")
     for name in (
-        "observe_company_context_document_size",
         "record_company_context_documents_changed",
         "set_company_context_projection_lag",
     ):
@@ -189,11 +188,6 @@ def test_coordinator_starts_one_child_per_enabled_scope(monkeypatch):
     monkeypatch.setenv("COMPANY_CONTEXT_DOCUMENTS_ENABLED", "true")
     monkeypatch.setattr(projection, "_latest_successful_watermark", latest_watermark)
     monkeypatch.setattr(projection, "_claim_scope", claim_scope)
-    monkeypatch.setattr(
-        projection,
-        "_emit_company_context_document_size_snapshot",
-        noop_async,
-    )
     monkeypatch.setattr(projection, "_emit_projection_lag_from_checkpoints", noop_async)
     monkeypatch.setattr(projection, "_emit_etl_scope_metrics", noop_async)
 


### PR DESCRIPTION
## Summary

- remove the company-context document-size histogram and its full-corpus coordinator scan
- prevent each projection run from issuing one VictoriaMetrics request per indexed document

## Validation

- `uv run --with pytest pytest workflows/tests/test_company_context_documents_attachments.py`
- `cargo test -p centaur-telemetry`
- focused Ruff and diff checks
- local rebuilt/deployed API coordinator and child-workflow verification