### PR TITLE
feat: add Airtable record write operations

### DIFF
--- a/docs/pages/reference/tool-directory.mdx
+++ b/docs/pages/reference/tool-directory.mdx
@@ -73,7 +73,7 @@ These are broadly useful across most deployments and are good candidates to conf
 
 | Tool | Use | API key / credential |
 |---|---|---|
-| `airtable` | Bases, schemas, tables, records, views, and URL parsing | `AIRTABLE_API_KEY` |
+| `airtable` | Bases, schemas, tables, views, record reads, record writes, and URL parsing | `AIRTABLE_API_KEY` |
 | `company_context` | Search indexed company history, Slack DMs, and Google Docs | None |
 | `composio` | Execute tools from third-party services exposed through Composio | `COMPOSIO_API_KEY` |
 | `figma` | Extract Figma files, nodes, components, styles, and variables | `FIGMA_ACCESS_TOKEN` |

--- a/docs/public/md/reference/tool-directory.md
+++ b/docs/public/md/reference/tool-directory.md
@@ -75,7 +75,7 @@ These are broadly useful across most deployments and are good candidates to conf
 
 | Tool | Use | API key / credential |
 |---|---|---|
-| `airtable` | Bases, schemas, tables, records, views, and URL parsing | `AIRTABLE_API_KEY` |
+| `airtable` | Bases, schemas, tables, views, record reads, record writes, and URL parsing | `AIRTABLE_API_KEY` |
 | `company_context` | Search indexed company history, Slack DMs, and Google Docs | None |
 | `composio` | Execute tools from third-party services exposed through Composio | `COMPOSIO_API_KEY` |
 | `figma` | Extract Figma files, nodes, components, styles, and variables | `FIGMA_ACCESS_TOKEN` |

--- a/tools/productivity/airtable/cli.py
+++ b/tools/productivity/airtable/cli.py
@@ -40,6 +40,24 @@ def _print(data: object) -> None:
     console.print_json(json.dumps(data, default=str))
 
 
+def _json_object(value: str) -> dict:
+    parsed = json.loads(value)
+    if not isinstance(parsed, dict):
+        raise typer.BadParameter("Expected a JSON object.")
+    return parsed
+
+
+def _json_object_list(value: str) -> list[dict]:
+    parsed = json.loads(value)
+    if not isinstance(parsed, list) or not all(isinstance(item, dict) for item in parsed):
+        raise typer.BadParameter("Expected a JSON array of objects.")
+    return parsed
+
+
+def _comma_list(value: str) -> list[str]:
+    return [item.strip() for item in value.split(",") if item.strip()]
+
+
 @app.command()
 def bases(limit: int = typer.Option(100, "--limit", "-n")) -> None:
     """List visible Airtable bases."""
@@ -67,6 +85,128 @@ def records(
 def from_url(url: str, max_records: int = typer.Option(50, "--max-records", "-n")) -> None:
     """Read a compact snapshot from an Airtable table/view URL."""
     _print(AirtableClient().snapshot_from_url(url, max_records=max_records))
+
+
+@app.command()
+def create_record(
+    base_id: str,
+    table: str,
+    fields: str = typer.Option(..., "--fields", help="Record fields as a JSON object."),
+    typecast: bool = typer.Option(False, "--typecast", help="Let Airtable coerce field values."),
+) -> None:
+    """Create one record."""
+    _print(AirtableClient().create_record(base_id, table, _json_object(fields), typecast=typecast))
+
+
+@app.command()
+def create_records(
+    base_id: str,
+    table: str,
+    records: str = typer.Option(
+        ...,
+        "--records",
+        help="Records as a JSON array. Items may be field objects or objects with a fields property.",
+    ),
+    typecast: bool = typer.Option(False, "--typecast", help="Let Airtable coerce field values."),
+) -> None:
+    """Create records."""
+    _print(
+        AirtableClient().create_records(
+            base_id, table, _json_object_list(records), typecast=typecast
+        )
+    )
+
+
+@app.command()
+def update_record(
+    base_id: str,
+    table: str,
+    record_id: str,
+    fields: str = typer.Option(..., "--fields", help="Updated fields as a JSON object."),
+    typecast: bool = typer.Option(False, "--typecast", help="Let Airtable coerce field values."),
+    replace: bool = typer.Option(False, "--replace", help="Replace all writable fields with PUT."),
+) -> None:
+    """Update one record."""
+    _print(
+        AirtableClient().update_record(
+            base_id,
+            table,
+            record_id,
+            _json_object(fields),
+            typecast=typecast,
+            replace=replace,
+        )
+    )
+
+
+@app.command()
+def update_records(
+    base_id: str,
+    table: str,
+    records: str = typer.Option(
+        ...,
+        "--records",
+        help="Updates as a JSON array of objects with id and fields properties.",
+    ),
+    typecast: bool = typer.Option(False, "--typecast", help="Let Airtable coerce field values."),
+    replace: bool = typer.Option(False, "--replace", help="Replace all writable fields with PUT."),
+) -> None:
+    """Update records."""
+    _print(
+        AirtableClient().update_records(
+            base_id,
+            table,
+            _json_object_list(records),
+            typecast=typecast,
+            replace=replace,
+        )
+    )
+
+
+@app.command()
+def upsert_records(
+    base_id: str,
+    table: str,
+    records: str = typer.Option(
+        ...,
+        "--records",
+        help="Records as a JSON array. Items may be field objects or objects with a fields property.",
+    ),
+    merge_fields: str = typer.Option(
+        ...,
+        "--merge-fields",
+        help="Comma-separated field names for Airtable performUpsert matching.",
+    ),
+    typecast: bool = typer.Option(False, "--typecast", help="Let Airtable coerce field values."),
+) -> None:
+    """Create or update records by merge fields."""
+    _print(
+        AirtableClient().upsert_records(
+            base_id,
+            table,
+            _json_object_list(records),
+            fields_to_merge_on=_comma_list(merge_fields),
+            typecast=typecast,
+        )
+    )
+
+
+@app.command()
+def delete_record(base_id: str, table: str, record_id: str) -> None:
+    """Delete one record."""
+    _print(AirtableClient().delete_record(base_id, table, record_id))
+
+
+@app.command()
+def delete_records(
+    base_id: str,
+    table: str,
+    record_ids: str = typer.Option(
+        ..., "--record-ids", help="Comma-separated Airtable record IDs."
+    ),
+) -> None:
+    """Delete records."""
+    _print(AirtableClient().delete_records(base_id, table, _comma_list(record_ids)))
 
 
 if __name__ == "__main__":

--- a/tools/productivity/airtable/client.py
+++ b/tools/productivity/airtable/client.py
@@ -1,4 +1,4 @@
-"""Airtable API client for bases, schemas, views, and records."""
+"""Airtable API client for bases, schemas, views, and record writes."""
 
 from __future__ import annotations
 
@@ -57,6 +57,12 @@ def _compact_record(record: dict[str, Any], fields: list[str] | None = None) -> 
     }
 
 
+def _compact_records(
+    records: list[dict[str, Any]], fields: list[str] | None = None
+) -> list[dict[str, Any]]:
+    return [_compact_record(record, fields) for record in records]
+
+
 def _match_text(value: Any, query: str) -> bool:
     if value is None:
         return False
@@ -71,6 +77,47 @@ def _match_text(value: Any, query: str) -> bool:
 
 def _path_part(value: str) -> str:
     return quote(value, safe="")
+
+
+def _clamp_batch_size(value: int) -> int:
+    return max(1, min(value, 10))
+
+
+def _record_batch(
+    records: list[dict[str, Any]], batch_size: int = 10
+) -> list[list[dict[str, Any]]]:
+    size = _clamp_batch_size(batch_size)
+    return [records[index : index + size] for index in range(0, len(records), size)]
+
+
+def _record_id_batch(record_ids: list[str], batch_size: int = 10) -> list[list[str]]:
+    size = _clamp_batch_size(batch_size)
+    return [record_ids[index : index + size] for index in range(0, len(record_ids), size)]
+
+
+def _normalize_create_records(records: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    normalized: list[dict[str, Any]] = []
+    for record in records:
+        fields = record.get("fields") if "fields" in record else record
+        if not isinstance(fields, dict):
+            raise ValueError(
+                "Each record must be a field mapping or an object with a 'fields' mapping."
+            )
+        normalized.append({"fields": fields})
+    return normalized
+
+
+def _normalize_update_records(records: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    normalized: list[dict[str, Any]] = []
+    for record in records:
+        record_id = record.get("id")
+        fields = record.get("fields")
+        if not isinstance(record_id, str) or not record_id:
+            raise ValueError("Each record update must include a non-empty 'id'.")
+        if not isinstance(fields, dict):
+            raise ValueError("Each record update must include a 'fields' mapping.")
+        normalized.append({"id": record_id, "fields": fields})
+    return normalized
 
 
 def _airtable_host(host: str | None) -> str:
@@ -174,7 +221,9 @@ class AirtableClient:
             response.raise_for_status()
         except httpx.HTTPStatusError as exc:
             detail = error_message or exc.response.text
-            raise RuntimeError(f"Airtable API error: {exc.response.status_code} - {detail}") from exc
+            raise RuntimeError(
+                f"Airtable API error: {exc.response.status_code} - {detail}"
+            ) from exc
 
     def _request(
         self,
@@ -382,7 +431,8 @@ class AirtableClient:
             return {
                 "ok": False,
                 "status": "bad_url" if url else "bad_target",
-                "message": probe_error_message or "Airtable could not resolve the requested base, table, or view.",
+                "message": probe_error_message
+                or "Airtable could not resolve the requested base, table, or view.",
                 "target": target,
                 "auth": {
                     "attempted": True,
@@ -514,9 +564,10 @@ class AirtableClient:
         needle = query.lower()
         matches: list[dict[str, Any]] = []
         for table in self.list_tables(base_id):
-            table_hit = needle in str(table.get("name", "")).lower() or needle in str(
-                table.get("id", "")
-            ).lower()
+            table_hit = (
+                needle in str(table.get("name", "")).lower()
+                or needle in str(table.get("id", "")).lower()
+            )
             view_hits = [
                 view
                 for view in table.get("views", [])
@@ -627,6 +678,163 @@ class AirtableClient:
             "searched": data["count"],
             "count": len(matches),
             "records": matches,
+        }
+
+    def create_record(
+        self,
+        base_id: str,
+        table: str,
+        fields: dict[str, Any],
+        typecast: bool = False,
+    ) -> dict[str, Any]:
+        """Create one Airtable record.
+
+        `table` may be a table ID or table name. `fields` maps Airtable field names to values.
+        The API key needs Airtable's `data.records:write` scope for the target base.
+        """
+        data = self._request(
+            "POST",
+            f"{BASE_URL}/{_path_part(base_id)}/{_path_part(table)}",
+            json={"fields": fields, "typecast": typecast},
+        )
+        return _compact_record(data)
+
+    def create_records(
+        self,
+        base_id: str,
+        table: str,
+        records: list[dict[str, Any]],
+        typecast: bool = False,
+    ) -> dict[str, Any]:
+        """Create Airtable records in batches of up to 10 records per request."""
+        normalized = _normalize_create_records(records)
+        created: list[dict[str, Any]] = []
+        for batch in _record_batch(normalized):
+            data = self._request(
+                "POST",
+                f"{BASE_URL}/{_path_part(base_id)}/{_path_part(table)}",
+                json={"records": batch, "typecast": typecast},
+            )
+            created.extend(data.get("records", []))
+        return {
+            "base_id": base_id,
+            "table": table,
+            "count": len(created),
+            "records": _compact_records(created),
+        }
+
+    def update_record(
+        self,
+        base_id: str,
+        table: str,
+        record_id: str,
+        fields: dict[str, Any],
+        typecast: bool = False,
+        replace: bool = False,
+    ) -> dict[str, Any]:
+        """Update one Airtable record.
+
+        By default this partially updates fields with PATCH. Set `replace=True` to use PUT.
+        """
+        method = "PUT" if replace else "PATCH"
+        data = self._request(
+            method,
+            f"{BASE_URL}/{_path_part(base_id)}/{_path_part(table)}/{_path_part(record_id)}",
+            json={"fields": fields, "typecast": typecast},
+        )
+        return _compact_record(data)
+
+    def update_records(
+        self,
+        base_id: str,
+        table: str,
+        records: list[dict[str, Any]],
+        typecast: bool = False,
+        replace: bool = False,
+    ) -> dict[str, Any]:
+        """Update Airtable records in batches of up to 10 records per request."""
+        normalized = _normalize_update_records(records)
+        method = "PUT" if replace else "PATCH"
+        updated: list[dict[str, Any]] = []
+        for batch in _record_batch(normalized):
+            data = self._request(
+                method,
+                f"{BASE_URL}/{_path_part(base_id)}/{_path_part(table)}",
+                json={"records": batch, "typecast": typecast},
+            )
+            updated.extend(data.get("records", []))
+        return {
+            "base_id": base_id,
+            "table": table,
+            "count": len(updated),
+            "records": _compact_records(updated),
+        }
+
+    def upsert_records(
+        self,
+        base_id: str,
+        table: str,
+        records: list[dict[str, Any]],
+        fields_to_merge_on: list[str],
+        typecast: bool = False,
+    ) -> dict[str, Any]:
+        """Create or update records using Airtable's `performUpsert` merge fields."""
+        if not fields_to_merge_on:
+            raise ValueError("fields_to_merge_on must include at least one field name.")
+        normalized = _normalize_create_records(records)
+        upserted: list[dict[str, Any]] = []
+        created_record_ids: list[str] = []
+        updated_record_ids: list[str] = []
+        for batch in _record_batch(normalized):
+            data = self._request(
+                "PATCH",
+                f"{BASE_URL}/{_path_part(base_id)}/{_path_part(table)}",
+                json={
+                    "records": batch,
+                    "typecast": typecast,
+                    "performUpsert": {"fieldsToMergeOn": fields_to_merge_on},
+                },
+            )
+            upserted.extend(data.get("records", []))
+            created_record_ids.extend(data.get("createdRecords", []))
+            updated_record_ids.extend(data.get("updatedRecords", []))
+        return {
+            "base_id": base_id,
+            "table": table,
+            "count": len(upserted),
+            "records": _compact_records(upserted),
+            "createdRecords": created_record_ids,
+            "updatedRecords": updated_record_ids,
+        }
+
+    def delete_record(self, base_id: str, table: str, record_id: str) -> dict[str, Any]:
+        """Delete one Airtable record."""
+        return self._request(
+            "DELETE",
+            f"{BASE_URL}/{_path_part(base_id)}/{_path_part(table)}/{_path_part(record_id)}",
+        )
+
+    def delete_records(
+        self,
+        base_id: str,
+        table: str,
+        record_ids: list[str],
+    ) -> dict[str, Any]:
+        """Delete Airtable records in batches of up to 10 record IDs per request."""
+        deleted: list[dict[str, Any]] = []
+        for batch in _record_id_batch(record_ids):
+            params = [("records[]", record_id) for record_id in batch]
+            data = self._request(
+                "DELETE",
+                f"{BASE_URL}/{_path_part(base_id)}/{_path_part(table)}",
+                params=params,
+            )
+            deleted.extend(data.get("records", []))
+        return {
+            "base_id": base_id,
+            "table": table,
+            "count": len(deleted),
+            "records": deleted,
         }
 
     def snapshot_from_url(self, url: str, max_records: int = 50) -> dict[str, Any]:

--- a/tools/productivity/airtable/pyproject.toml
+++ b/tools/productivity/airtable/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "airtable"
-description = "Airtable API client for bases, schemas, views, and records"
+description = "Airtable API client for bases, schemas, views, records, and record writes"
 version = "0.1.0"
 requires-python = ">=3.11"
 dependencies = [

--- a/tools/productivity/airtable/test_client.py
+++ b/tools/productivity/airtable/test_client.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib.util
+import json
 import sys
 from pathlib import Path
 
@@ -9,7 +10,7 @@ import httpx
 REPO_ROOT = Path(__file__).resolve().parents[3]
 sys.path.insert(0, str(REPO_ROOT))
 
-from centaur_sdk import ToolContext, reset_tool_context, set_tool_context
+from centaur_sdk import ToolContext, reset_tool_context, set_tool_context  # noqa: E402
 
 CLIENT_PATH = REPO_ROOT / "tools" / "productivity" / "airtable" / "client.py"
 
@@ -36,7 +37,9 @@ def test_client_factory_loads_without_secret_and_preflight_reports_missing_secre
     token = set_tool_context(ToolContext(name="airtable", secrets={"AIRTABLE_API_KEY": ""}))
     try:
         client = module._client()
-        result = client.preflight_access(url="https://airtable.com/appBase123/tblTable456/viwView789")
+        result = client.preflight_access(
+            url="https://airtable.com/appBase123/tblTable456/viwView789"
+        )
         client.close()
     finally:
         reset_tool_context(token)
@@ -81,7 +84,9 @@ def test_preflight_access_reports_missing_base_scope_from_probe() -> None:
 
     def handler(request: httpx.Request) -> httpx.Response:
         if request.method == "GET" and request.url.path == "/v0/meta/whoami":
-            return httpx.Response(200, request=request, json={"id": "usr123", "scopes": ["data.records:read"]})
+            return httpx.Response(
+                200, request=request, json={"id": "usr123", "scopes": ["data.records:read"]}
+            )
         if request.method == "GET" and request.url.path == "/v0/appBase123/tblTable456":
             assert request.url.params.get("pageSize") == "1"
             return httpx.Response(
@@ -148,7 +153,9 @@ def test_preflight_access_returns_ok_when_auth_and_read_probe_succeed() -> None:
 
     _mock_client(client, handler)
     try:
-        result = client.preflight_access(url="https://airtable.com/appBase123/tblTable456/viwView789")
+        result = client.preflight_access(
+            url="https://airtable.com/appBase123/tblTable456/viwView789"
+        )
     finally:
         client.close()
 
@@ -156,3 +163,140 @@ def test_preflight_access_returns_ok_when_auth_and_read_probe_succeed() -> None:
     assert result["status"] == "ok"
     assert result["probe"]["type"] == "records"
     assert result["probe"]["details"] == {"record_count": 1, "has_more": True}
+
+
+def test_create_record_posts_fields_and_compacts_response() -> None:
+    module = _load_airtable_module()
+    client = module.AirtableClient(api_key="test-key")
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.method == "POST"
+        assert request.url.path == "/v0/appBase123/tblTable456"
+        assert json.loads(request.content) == {
+            "fields": {"Name": "Ada", "Done": True},
+            "typecast": True,
+        }
+        return httpx.Response(
+            200,
+            request=request,
+            json={
+                "id": "rec1",
+                "createdTime": "2026-07-13T00:00:00.000Z",
+                "fields": {"Name": "Ada", "Done": True},
+            },
+        )
+
+    _mock_client(client, handler)
+    try:
+        result = client.create_record(
+            "appBase123",
+            "tblTable456",
+            {"Name": "Ada", "Done": True},
+            typecast=True,
+        )
+    finally:
+        client.close()
+
+    assert result == {
+        "id": "rec1",
+        "createdTime": "2026-07-13T00:00:00.000Z",
+        "fields": {"Name": "Ada", "Done": True},
+    }
+
+
+def test_update_records_batches_and_uses_patch() -> None:
+    module = _load_airtable_module()
+    client = module.AirtableClient(api_key="test-key")
+    calls: list[list[dict]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.method == "PATCH"
+        assert request.url.path == "/v0/appBase123/tblTable456"
+        body = json.loads(request.content)
+        calls.append(body["records"])
+        assert body["typecast"] is False
+        return httpx.Response(200, request=request, json={"records": body["records"]})
+
+    records = [{"id": f"rec{index}", "fields": {"Index": index}} for index in range(11)]
+    _mock_client(client, handler)
+    try:
+        result = client.update_records("appBase123", "tblTable456", records)
+    finally:
+        client.close()
+
+    assert [len(call) for call in calls] == [10, 1]
+    assert result["count"] == 11
+    assert result["records"][0] == {
+        "id": "rec0",
+        "createdTime": None,
+        "fields": {"Index": 0},
+    }
+
+
+def test_upsert_records_sends_perform_upsert() -> None:
+    module = _load_airtable_module()
+    client = module.AirtableClient(api_key="test-key")
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.method == "PATCH"
+        assert request.url.path == "/v0/appBase123/Table Name"
+        assert json.loads(request.content) == {
+            "records": [{"fields": {"External ID": "ext-1", "Name": "Ada"}}],
+            "typecast": False,
+            "performUpsert": {"fieldsToMergeOn": ["External ID"]},
+        }
+        return httpx.Response(
+            200,
+            request=request,
+            json={
+                "records": [{"id": "rec1", "fields": {"External ID": "ext-1", "Name": "Ada"}}],
+                "createdRecords": ["rec1"],
+                "updatedRecords": [],
+            },
+        )
+
+    _mock_client(client, handler)
+    try:
+        result = client.upsert_records(
+            "appBase123",
+            "Table Name",
+            [{"External ID": "ext-1", "Name": "Ada"}],
+            fields_to_merge_on=["External ID"],
+        )
+    finally:
+        client.close()
+
+    assert result["createdRecords"] == ["rec1"]
+    assert result["updatedRecords"] == []
+    assert result["records"][0]["id"] == "rec1"
+
+
+def test_delete_records_batches_query_params() -> None:
+    module = _load_airtable_module()
+    client = module.AirtableClient(api_key="test-key")
+    calls: list[list[str]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.method == "DELETE"
+        assert request.url.path == "/v0/appBase123/tblTable456"
+        record_ids = request.url.params.get_list("records[]")
+        calls.append(record_ids)
+        return httpx.Response(
+            200,
+            request=request,
+            json={"records": [{"id": record_id, "deleted": True} for record_id in record_ids]},
+        )
+
+    _mock_client(client, handler)
+    try:
+        result = client.delete_records(
+            "appBase123",
+            "tblTable456",
+            [f"rec{index}" for index in range(12)],
+        )
+    finally:
+        client.close()
+
+    assert [len(call) for call in calls] == [10, 2]
+    assert result["count"] == 12
+    assert result["records"][-1] == {"id": "rec11", "deleted": True}


### PR DESCRIPTION
Adds Airtable record mutation support for create, update, upsert, and delete operations, including batch handling for Airtable's 10-record API limit. Also exposes matching CLI commands and updates the tool directory description.