### PR TITLE
fix: allow hosted MCP OAuth redirects

### DIFF
--- a/services/console/app/models/mcp_oauth_client.rb
+++ b/services/console/app/models/mcp_oauth_client.rb
@@ -66,7 +66,11 @@ class McpOauthClient < ApplicationRecord
 
   def self.allowed_redirect_uri?(value)
     uri = URI.parse(value.to_s)
-    uri.scheme == "http" && loopback_host?(uri.host)
+    return false unless uri.host.present?
+    return false if uri.fragment.present?
+    return false if value.to_s.include?("*")
+
+    uri.scheme == "https" || (uri.scheme == "http" && loopback_host?(uri.host))
   rescue URI::InvalidURIError
     false
   end

--- a/services/console/test/controllers/mcp/oauth_controller_test.rb
+++ b/services/console/test/controllers/mcp/oauth_controller_test.rb
@@ -57,12 +57,28 @@ module Mcp
       assert_equal "mcp:tools", body.fetch("scope")
     end
 
-    test "dynamic client registration rejects non-loopback redirect URIs" do
+    test "dynamic client registration creates a hosted HTTPS client" do
+      assert_difference -> { McpOauthClient.count }, 1 do
+        post "/mcp/oauth/register",
+             params: {
+               client_name: "Claude",
+               redirect_uris: [ "https://claude.ai/api/mcp/auth_callback" ],
+               scope: "mcp:tools"
+             },
+             as: :json
+      end
+
+      assert_response :created
+      body = JSON.parse(response.body)
+      assert_equal [ "https://claude.ai/api/mcp/auth_callback" ], body.fetch("redirect_uris")
+    end
+
+    test "dynamic client registration rejects non-loopback plain HTTP redirect URIs" do
       assert_no_difference -> { McpOauthClient.count } do
         post "/mcp/oauth/register",
              params: {
                client_name: "Attacker",
-               redirect_uris: [ "https://evil.example/callback" ],
+               redirect_uris: [ "http://evil.example/callback" ],
                scope: "mcp:tools"
              },
              as: :json

--- a/services/console/test/controllers/mcp/oauth_controller_test.rb
+++ b/services/console/test/controllers/mcp/oauth_controller_test.rb
@@ -88,14 +88,14 @@ module Mcp
       assert_equal "invalid_client_metadata", JSON.parse(response.body).fetch("error")
     end
 
-    test "authorize rejects non-loopback redirect URIs even when already stored" do
+    test "authorize rejects non-loopback plain HTTP redirect URIs even when already stored" do
       client = create_client
-      client.update_column(:redirect_uris, [ "https://evil.example/callback" ])
+      client.update_column(:redirect_uris, [ "http://evil.example/callback" ])
       post login_url, params: { email: @operator.email, password: "password123456" }
 
       assert_no_difference -> { McpOauthAuthorizationCode.count } do
         get "/mcp/oauth/authorize",
-            params: authorize_params(client).merge(redirect_uri: "https://evil.example/callback")
+            params: authorize_params(client).merge(redirect_uri: "http://evil.example/callback")
       end
 
       assert_response :bad_request

--- a/services/console/test/models/mcp_oauth_client_test.rb
+++ b/services/console/test/models/mcp_oauth_client_test.rb
@@ -1,16 +1,26 @@
 require "test_helper"
 
 class McpOauthClientTest < ActiveSupport::TestCase
-  test "allowed redirect URI accepts only localhost and loopback IP literals" do
+  test "allowed redirect URI accepts HTTPS and plain HTTP loopback redirects" do
+    assert McpOauthClient.allowed_redirect_uri?("https://claude.ai/api/mcp/auth_callback")
+    assert McpOauthClient.allowed_redirect_uri?("https://example.com/callback")
     assert McpOauthClient.allowed_redirect_uri?("http://localhost:49152/callback")
     assert McpOauthClient.allowed_redirect_uri?("http://127.0.0.1:49152/callback")
     assert McpOauthClient.allowed_redirect_uri?("http://127.1.2.3:49152/callback")
     assert McpOauthClient.allowed_redirect_uri?("http://[::1]:49152/callback")
 
-    refute McpOauthClient.allowed_redirect_uri?("https://127.0.0.1/callback")
     refute McpOauthClient.allowed_redirect_uri?("http://127.evil.com/callback")
     refute McpOauthClient.allowed_redirect_uri?("http://127.0.0.1.evil.com/callback")
     refute McpOauthClient.allowed_redirect_uri?("http://localhost.evil.com/callback")
+  end
+
+  test "allowed redirect URI rejects wildcard redirects" do
+    refute McpOauthClient.allowed_redirect_uri?("https://*.example.com/callback")
+    refute McpOauthClient.allowed_redirect_uri?("https://example.com/*")
+  end
+
+  test "allowed redirect URI rejects fragments" do
+    refute McpOauthClient.allowed_redirect_uri?("https://example.com/callback#token")
   end
 
   test "redirect matching rejects attacker controlled 127-looking hostnames" do


### PR DESCRIPTION
Allows MCP OAuth dynamic client registration to accept concrete HTTPS redirect URIs for hosted clients like Claude while keeping plain HTTP limited to loopback redirects. Also rejects wildcard and fragment-bearing redirect URIs and adds focused model/controller coverage.