### PR TITLE
fix: fall back to direct Slack threads

### DIFF
--- a/tools/productivity/slack/cli.py
+++ b/tools/productivity/slack/cli.py
@@ -362,7 +362,7 @@ def thread(
     """
     import sys
 
-    from .client import get_thread_replies_proxy
+    from .client import get_thread_replies_page, get_thread_replies_proxy
 
     channel_id, thread_ts = _parse_thread_ref(permalink)
 
@@ -376,9 +376,20 @@ def thread(
             latest=latest,
             inclusive=inclusive,
         )
-    except (RuntimeError, ValueError) as e:
-        stderr_console.print(f"[red]Error: {e}[/]")
-        raise typer.Exit(1) from e
+    except (RuntimeError, ValueError):
+        try:
+            page = get_thread_replies_page(
+                channel_id,
+                thread_ts,
+                limit=limit,
+                cursor=cursor,
+                oldest=oldest,
+                latest=latest,
+                inclusive=inclusive,
+            )
+        except (RuntimeError, ValueError) as direct_error:
+            stderr_console.print(f"[red]Error: {direct_error}[/]")
+            raise typer.Exit(1) from direct_error
 
     messages = page.get("messages", [])
 

--- a/tools/productivity/slack/client.py
+++ b/tools/productivity/slack/client.py
@@ -749,11 +749,16 @@ class SlackClient:
         limit: int,
         user_cache: dict[str, str],
     ) -> list[dict]:
-        """Fetch history for a single search fallback channel through the proxy."""
+        """Fetch history for a single search fallback channel."""
         try:
             response = self.get_channel_history_proxy(channel_id, limit=limit)
         except (RuntimeError, ValueError):
-            return []
+            return self._fetch_direct_channel_history_for_search(
+                channel_id,
+                channel_name,
+                limit,
+                user_cache,
+            )
 
         messages = []
         for msg in response.get("messages", []):
@@ -765,6 +770,54 @@ class SlackClient:
                     channel_name=channel_name,
                 )
             )
+
+        return messages
+
+    _MAX_SEARCH_DIRECT_THREADS = 10
+
+    def _fetch_direct_channel_history_for_search(
+        self,
+        channel_id: str,
+        channel_name: str,
+        limit: int,
+        user_cache: dict[str, str],
+    ) -> list[dict]:
+        """Fetch direct Slack history and expand a bounded number of threads."""
+        try:
+            page = self.get_channel_history_page(channel_id, limit=limit)
+        except (RuntimeError, ValueError):
+            return []
+
+        messages = [{**msg, "channel": channel_name} for msg in page.get("messages", [])]
+        seen_timestamps = {message.get("timestamp") for message in messages}
+        expanded_threads = 0
+
+        for message in list(messages):
+            if expanded_threads >= self._MAX_SEARCH_DIRECT_THREADS:
+                break
+            if int(message.get("reply_count") or 0) <= 0:
+                continue
+
+            thread_ts = message.get("thread_ts") or message.get("timestamp")
+            if not thread_ts:
+                continue
+
+            try:
+                thread_page = self.get_thread_replies_page(
+                    channel=channel_id,
+                    thread_ts=thread_ts,
+                    limit=min(limit, self._DEFAULT_THREAD_REPLY_LIMIT),
+                )
+            except (RuntimeError, ValueError):
+                continue
+
+            expanded_threads += 1
+            for reply in thread_page.get("messages", []):
+                timestamp = reply.get("timestamp")
+                if not timestamp or timestamp in seen_timestamps:
+                    continue
+                seen_timestamps.add(timestamp)
+                messages.append({**reply, "channel": channel_name})
 
         return messages
 

--- a/tools/productivity/slack/tests/test_cli.py
+++ b/tools/productivity/slack/tests/test_cli.py
@@ -462,7 +462,13 @@ def test_thread_calls_api_server_client(monkeypatch) -> None:
             "has_more": False,
         }
 
-    fake_client = types.SimpleNamespace(get_thread_replies_proxy=fake_get_thread_replies_proxy)
+    def fake_get_thread_replies_page(*args, **kwargs):
+        raise AssertionError("direct thread fallback should not be used")
+
+    fake_client = types.SimpleNamespace(
+        get_thread_replies_page=fake_get_thread_replies_page,
+        get_thread_replies_proxy=fake_get_thread_replies_proxy,
+    )
     monkeypatch.setitem(sys.modules, "slack.client", fake_client)
 
     result = CliRunner().invoke(
@@ -490,6 +496,53 @@ def test_thread_calls_api_server_client(monkeypatch) -> None:
             },
         )
     ]
+
+
+def test_thread_falls_back_to_direct_client_when_api_server_fails(monkeypatch) -> None:
+    proxy_calls = []
+    direct_calls = []
+
+    def fake_get_thread_replies_proxy(*args, **kwargs):
+        proxy_calls.append((args, kwargs))
+        raise RuntimeError("proxy unavailable")
+
+    def fake_get_thread_replies_page(*args, **kwargs):
+        direct_calls.append((args, kwargs))
+        return {
+            "messages": [{"user": "alice", "text": "root"}],
+            "has_more": False,
+            "window": {"oldest": None, "latest": None, "inclusive": True},
+        }
+
+    fake_client = types.SimpleNamespace(
+        get_thread_replies_page=fake_get_thread_replies_page,
+        get_thread_replies_proxy=fake_get_thread_replies_proxy,
+    )
+    monkeypatch.setitem(sys.modules, "slack.client", fake_client)
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "thread",
+            "C1234567890:1780000000.000000",
+            "--limit",
+            "10",
+        ],
+    )
+
+    expected_call = (
+        ("C1234567890", "1780000000.000000"),
+        {
+            "limit": 10,
+            "cursor": None,
+            "oldest": None,
+            "latest": None,
+            "inclusive": True,
+        },
+    )
+    assert result.exit_code == 0
+    assert proxy_calls == [expected_call]
+    assert direct_calls == [expected_call]
 
 
 def test_thread_direct_calls_direct_client(monkeypatch) -> None:

--- a/tools/productivity/slack/tests/test_client.py
+++ b/tools/productivity/slack/tests/test_client.py
@@ -1051,6 +1051,69 @@ def test_search_messages_parses_channel_and_user_modifiers_locally() -> None:
     assert results[0]["user_id"] == "UGZCSQTPE"
 
 
+def test_search_messages_falls_back_to_direct_history_and_threads_when_proxy_fails() -> None:
+    client, fake_web_client = _make_client()
+    client._get_user_cache = lambda: {"U1": "alice", "U2": "bob"}  # type: ignore[method-assign]
+    client._resolve_channel = lambda channel: channel  # type: ignore[method-assign]
+
+    def fail_proxy(*args, **kwargs):
+        raise RuntimeError("proxy unavailable")
+
+    client.get_channel_history_proxy = fail_proxy  # type: ignore[method-assign]
+    fake_web_client.history_pages = [
+        {
+            "messages": [
+                {
+                    "user": "U1",
+                    "text": "root without the query",
+                    "ts": "100.000000",
+                    "thread_ts": "100.000000",
+                    "reply_count": 1,
+                }
+            ],
+            "response_metadata": {"next_cursor": ""},
+        }
+    ]
+    fake_web_client.reply_pages = [
+        {
+            "messages": [
+                {
+                    "user": "U1",
+                    "text": "root without the query",
+                    "ts": "100.000000",
+                    "thread_ts": "100.000000",
+                },
+                {
+                    "user": "U2",
+                    "text": "needle is in the direct thread reply",
+                    "ts": "100.000001",
+                    "thread_ts": "100.000000",
+                },
+            ],
+            "response_metadata": {"next_cursor": ""},
+        }
+    ]
+
+    results = client.search_messages(
+        "needle",
+        channels=["C123456789"],
+        messages_per_channel=25,
+    )
+
+    assert fake_web_client.history_calls == [{"channel": "C123456789", "limit": 25}]
+    assert fake_web_client.reply_calls == [
+        {
+            "channel": "C123456789",
+            "ts": "100.000000",
+            "limit": 25,
+            "inclusive": True,
+        }
+    ]
+    assert len(results) == 1
+    assert results[0]["text"] == "needle is in the direct thread reply"
+    assert results[0]["channel"] == "C123456789"
+
+
 def test_list_channels_returns_cache_when_slack_rate_limited() -> None:
     client, fake_web_client = _make_client()
     cached_channels = [{"id": "C123", "name": "cached", "is_private": False}]


### PR DESCRIPTION
Adds direct Slack SDK fallback behavior when the API-server Slack history or thread proxy path fails. Search fallback now scans direct channel history and a bounded number of direct thread replies, and the thread CLI falls back to direct thread reads.