### PR TITLE
feat: project Granola notes into context

### DIFF
--- a/.agents/skills/company-context/SKILL.md
+++ b/.agents/skills/company-context/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: company-context
-description: "Use Centaur's indexed company context together with direct Slack, Linear, Google Docs, Drive, or Calendar searches when answering internal company-history, prior-decision, project-context, meeting-context, roadmap/status, or cross-source memory questions. Indexed context includes Slack channels, user-visible Slack DMs, Google Docs, Google Calendar, and Linear. Use for questions like what was discussed, decided, planned, mentioned, or documented internally, especially when the user did not name one exact source."
+description: "Use Centaur's indexed company context together with direct Slack, Linear, Google Docs, Drive, Calendar, or Granola searches when answering internal company-history, prior-decision, project-context, meeting-context, roadmap/status, or cross-source memory questions. Indexed context includes Slack channels, user-visible Slack DMs, Google Docs, Google Calendar, Linear, and user-visible Granola notes. Use for questions like what was discussed, decided, planned, mentioned, or documented internally, especially when the user did not name one exact source."
 ---
 
 # Company Context
 
-Use `company_context` as the first retrieval step for internal historical context. Its `search` command queries indexed company memory across enabled sources such as Slack channels, Google Docs (`--source docs`), Google Calendar, and Linear. It also has dedicated commands for user-visible Slack DMs and DM conversations. Always pair indexed results with the relevant direct source tools, then reconcile and collate both evidence sets before answering.
+Use `company_context` as the first retrieval step for internal historical context. Its `search` command queries indexed company memory across enabled sources such as Slack channels, Google Docs (`--source docs`), Google Calendar, Linear, and user-visible Granola notes (`--source granola`). It also has dedicated commands for user-visible Slack DMs and DM conversations. Always pair indexed results with the relevant direct source tools, then reconcile and collate both evidence sets before answering.
 
 ## Default Workflow
 
@@ -57,6 +57,7 @@ company_context search "QUERY" --source slack --limit 10 --json
 company_context search "QUERY" --source docs --source-type google_doc --limit 10 --json
 company_context search "QUERY" --source google_calendar --limit 10 --json
 company_context search "QUERY" --source linear --limit 10 --json
+company_context search "QUERY" --source granola --limit 10 --json
 company_context search-dms "QUERY" --limit 10 --json
 ```
 

--- a/services/api-rs/crates/centaur-session-sqlx/migrations/0044_granola_context_projection.sql
+++ b/services/api-rs/crates/centaur-session-sqlx/migrations/0044_granola_context_projection.sql
@@ -1,0 +1,157 @@
+-- Granola's OAuth sync writes normalized source rows. Project those rows into
+-- the dedicated search table in the same transaction, rather than routing
+-- them through the generic company_context_documents projection.
+
+create or replace function centaur_refresh_granola_context_document(
+    p_note_id text
+)
+returns void
+language sql
+as $$
+    with attendee_rows as (
+        select
+            coalesce(
+                nullif(btrim(attendee ->> 'name'), ''),
+                nullif(btrim(attendee ->> 'display_name'), ''),
+                nullif(btrim(attendee ->> 'email'), ''),
+                nullif(btrim(attendee ->> 'id'), '')
+            ) as attendee_label
+        from granola_sync_notes notes
+        cross join lateral jsonb_array_elements(notes.attendees) attendee
+        where notes.note_id = p_note_id
+    ),
+    projected as (
+        select
+            concat_ws(':', 'granola', notes.note_id) as document_id,
+            notes.note_id,
+            coalesce(nullif(notes.title, ''), 'Granola note') as title,
+            notes.content_text as body,
+            notes.url,
+            notes.owner_id,
+            notes.owner_email,
+            notes.owner_name,
+            notes.access_emails,
+            coalesce(
+                array_agg(distinct attendee_rows.attendee_label order by attendee_rows.attendee_label)
+                    filter (where attendee_rows.attendee_label is not null),
+                array[]::text[]
+            ) as attendee_labels,
+            coalesce(notes.source_created_at, notes.source_updated_at) as occurred_at,
+            notes.source_updated_at,
+            jsonb_build_object(
+                'source', 'granola',
+                'source_type', 'granola_note',
+                'note_id', notes.note_id,
+                'owner_id', notes.owner_id,
+                'owner_email', notes.owner_email,
+                'owner_name', notes.owner_name,
+                'attendee_count', jsonb_array_length(notes.attendees),
+                'calendar_event', notes.calendar_event
+            ) as metadata
+        from granola_sync_notes notes
+        left join attendee_rows on true
+        where notes.note_id = p_note_id
+        group by
+            notes.note_id,
+            notes.title,
+            notes.content_text,
+            notes.url,
+            notes.owner_id,
+            notes.owner_email,
+            notes.owner_name,
+            notes.access_emails,
+            notes.source_created_at,
+            notes.source_updated_at,
+            notes.attendees,
+            notes.calendar_event
+    ),
+    hashed as (
+        select
+            projected.*,
+            md5(concat_ws(
+                E'\\x1f',
+                title,
+                body,
+                url,
+                owner_id,
+                owner_email,
+                owner_name,
+                array_to_string(access_emails, E'\\x1e'),
+                array_to_string(attendee_labels, E'\\x1e'),
+                coalesce(occurred_at::text, ''),
+                coalesce(source_updated_at::text, ''),
+                metadata::text
+            )) as content_hash
+        from projected
+    )
+    insert into granola_context_documents (
+        document_id,
+        note_id,
+        title,
+        body,
+        url,
+        owner_id,
+        owner_email,
+        owner_name,
+        access_emails,
+        attendee_labels,
+        occurred_at,
+        source_updated_at,
+        content_hash,
+        metadata,
+        updated_at
+    )
+    select
+        document_id,
+        note_id,
+        title,
+        body,
+        url,
+        owner_id,
+        owner_email,
+        owner_name,
+        access_emails,
+        attendee_labels,
+        occurred_at,
+        source_updated_at,
+        content_hash,
+        metadata,
+        now()
+    from hashed
+    on conflict (document_id) do update set
+        note_id = excluded.note_id,
+        title = excluded.title,
+        body = excluded.body,
+        url = excluded.url,
+        owner_id = excluded.owner_id,
+        owner_email = excluded.owner_email,
+        owner_name = excluded.owner_name,
+        access_emails = excluded.access_emails,
+        attendee_labels = excluded.attendee_labels,
+        occurred_at = excluded.occurred_at,
+        source_updated_at = excluded.source_updated_at,
+        content_hash = excluded.content_hash,
+        metadata = excluded.metadata,
+        updated_at = now()
+    where granola_context_documents.content_hash is distinct from excluded.content_hash;
+$$;
+
+create or replace function centaur_refresh_granola_context_document_from_note()
+returns trigger
+language plpgsql
+as $$
+begin
+    perform centaur_refresh_granola_context_document(new.note_id);
+    return new;
+end;
+$$;
+
+drop trigger if exists trg_granola_sync_notes_refresh_context
+    on granola_sync_notes;
+create trigger trg_granola_sync_notes_refresh_context
+    after insert or update on granola_sync_notes
+    for each row
+    execute function centaur_refresh_granola_context_document_from_note();
+
+select centaur_refresh_granola_context_document(note_id)
+from granola_sync_notes;

--- a/services/api-rs/crates/centaur-session-sqlx/tests/granola_context_projection.rs
+++ b/services/api-rs/crates/centaur-session-sqlx/tests/granola_context_projection.rs
@@ -1,0 +1,298 @@
+use std::{
+    env,
+    error::Error,
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+use sqlx::{Connection, Executor, PgConnection, Row};
+
+const GRANOLA_SYNC_SQL: &str = include_str!("../migrations/0040_granola_sync_tables.sql");
+const GRANOLA_CONTEXT_PROJECTION_SQL: &str =
+    include_str!("../migrations/0044_granola_context_projection.sql");
+
+#[tokio::test]
+async fn granola_notes_project_into_their_dedicated_rls_protected_context_table()
+-> Result<(), Box<dyn Error>> {
+    let Some(database_url) = test_database_url() else {
+        return Ok(());
+    };
+    let mut conn = PgConnection::connect(&database_url).await?;
+    let schema = TestSchema::create(&mut conn).await?;
+
+    let result = run_assertions(&mut conn, &schema.name).await;
+    schema.drop(&mut conn).await?;
+    result
+}
+
+async fn run_assertions(conn: &mut PgConnection, schema: &str) -> Result<(), Box<dyn Error>> {
+    set_search_path(conn, schema).await?;
+    create_roles(conn).await?;
+    create_slack_identity_helpers(conn).await?;
+    execute_migration(conn, &granola_sync_without_bm25()).await?;
+    sqlx::raw_sql(
+        r#"
+        insert into granola_sync_notes (
+            note_id, title, owner_email, access_emails, content_text, source_created_at
+        ) values (
+            'note_backfilled', 'Existing note', 'alice@example.com',
+            array['alice@example.com'], 'Existing source data', '2026-07-13T09:00:00Z'
+        );
+        "#,
+    )
+    .execute(&mut *conn)
+    .await?;
+    execute_migration(conn, GRANOLA_CONTEXT_PROJECTION_SQL).await?;
+    grant_schema_usage(conn, schema).await?;
+
+    let backfilled_document_id: String = sqlx::query_scalar(
+        "select document_id from granola_context_documents where note_id = 'note_backfilled'",
+    )
+    .fetch_one(&mut *conn)
+    .await?;
+    assert_eq!(backfilled_document_id, "granola:note_backfilled");
+
+    sqlx::raw_sql(
+        r#"
+        insert into slack_sync_users (team_id, user_id, raw_payload) values
+            ('T_HOME', 'U_ALICE', '{"profile":{"email":"alice@example.com"}}'),
+            ('T_HOME', 'U_BOB', '{"profile":{"email":"bob@example.com"}}');
+
+        insert into granola_sync_notes (
+            note_id, title, owner_id, owner_email, owner_name, attendees,
+            access_emails, calendar_event, content_text, source_created_at,
+            source_updated_at
+        ) values
+            (
+                'note_alice', 'Launch review', 'owner_alice', 'alice@example.com', 'Alice',
+                '[{"name":"Bob", "email":"bob@example.com"}]',
+                array['alice@example.com', 'bob@example.com'],
+                '{"title":"Launch review"}', 'Launch status and risks',
+                '2026-07-13T10:00:00Z', '2026-07-13T11:00:00Z'
+            ),
+            (
+                'note_bob', 'Budget review', 'owner_bob', 'bob@example.com', 'Bob',
+                '[]', array['bob@example.com'], '{}', 'Budget details',
+                '2026-07-13T12:00:00Z', '2026-07-13T13:00:00Z'
+            );
+        "#,
+    )
+    .execute(&mut *conn)
+    .await?;
+
+    let projection = sqlx::query(
+        "select document_id, title, body, attendee_labels, access_emails, metadata \
+         from granola_context_documents where note_id = 'note_alice'",
+    )
+    .fetch_one(&mut *conn)
+    .await?;
+    assert_eq!(
+        projection.try_get::<String, _>("document_id")?,
+        "granola:note_alice"
+    );
+    assert_eq!(projection.try_get::<String, _>("title")?, "Launch review");
+    assert_eq!(
+        projection.try_get::<String, _>("body")?,
+        "Launch status and risks"
+    );
+    assert_eq!(
+        projection.try_get::<Vec<String>, _>("attendee_labels")?,
+        vec!["Bob"]
+    );
+    assert_eq!(
+        projection.try_get::<Vec<String>, _>("access_emails")?,
+        vec!["alice@example.com", "bob@example.com"]
+    );
+    assert_eq!(
+        projection
+            .try_get::<serde_json::Value, _>("metadata")?
+            .get("source_type")
+            .and_then(serde_json::Value::as_str),
+        Some("granola_note")
+    );
+
+    sqlx::query(
+        "update granola_sync_notes set title = 'Launch decision', \
+         content_text = 'Approved the launch', access_emails = array['alice@example.com'] \
+         where note_id = 'note_alice'",
+    )
+    .execute(&mut *conn)
+    .await?;
+    let updated = sqlx::query(
+        "select title, body, access_emails from granola_context_documents where note_id = 'note_alice'",
+    )
+    .fetch_one(&mut *conn)
+    .await?;
+    assert_eq!(updated.try_get::<String, _>("title")?, "Launch decision");
+    assert_eq!(updated.try_get::<String, _>("body")?, "Approved the launch");
+    assert_eq!(
+        updated.try_get::<Vec<String>, _>("access_emails")?,
+        vec!["alice@example.com"]
+    );
+
+    assert_visible_documents(
+        conn,
+        schema,
+        "U_ALICE",
+        &["granola:note_alice", "granola:note_backfilled"],
+    )
+    .await?;
+    assert_visible_documents(conn, schema, "U_BOB", &["granola:note_bob"]).await?;
+    Ok(())
+}
+
+async fn assert_visible_documents(
+    conn: &mut PgConnection,
+    schema: &str,
+    user_id: &str,
+    expected: &[&str],
+) -> Result<(), Box<dyn Error>> {
+    let user_email = match user_id {
+        "U_ALICE" => "alice@example.com",
+        "U_BOB" => "bob@example.com",
+        _ => unreachable!("test only defines Alice and Bob"),
+    };
+    sqlx::query("set role centaur_slack_reader")
+        .execute(&mut *conn)
+        .await?;
+    sqlx::query("select set_config('centaur.slack_team_id', 'T_HOME', false)")
+        .execute(&mut *conn)
+        .await?;
+    sqlx::query("select set_config('centaur.slack_user_id', $1, false)")
+        .bind(user_id)
+        .execute(&mut *conn)
+        .await?;
+    sqlx::query("select set_config('centaur.user_email', $1, false)")
+        .bind(user_email)
+        .execute(&mut *conn)
+        .await?;
+    let rows =
+        sqlx::query("select document_id from granola_context_documents order by document_id")
+            .fetch_all(&mut *conn)
+            .await?;
+    let actual = rows
+        .iter()
+        .map(|row| row.try_get::<String, _>("document_id"))
+        .collect::<Result<Vec<_>, _>>()?;
+    assert_eq!(
+        actual,
+        expected
+            .iter()
+            .map(|document_id| (*document_id).to_owned())
+            .collect::<Vec<_>>()
+    );
+    conn.execute("reset role").await?;
+    set_search_path(conn, schema).await?;
+    Ok(())
+}
+
+fn test_database_url() -> Option<String> {
+    env::var("SESSION_SQLX_TEST_DATABASE_URL")
+        .or_else(|_| env::var("SESSION_RUNTIME_TEST_DATABASE_URL"))
+        .map_err(|_| {
+            eprintln!(
+                "skipping Granola context projection tests: set SESSION_SQLX_TEST_DATABASE_URL to a Postgres URL"
+            );
+        })
+        .ok()
+}
+
+struct TestSchema {
+    name: String,
+}
+
+impl TestSchema {
+    async fn create(conn: &mut PgConnection) -> Result<Self, Box<dyn Error>> {
+        let nanos = SystemTime::now().duration_since(UNIX_EPOCH)?.as_nanos();
+        let name = format!("granola_context_{}_{}", std::process::id(), nanos);
+        conn.execute(format!(r#"create schema "{}""#, name).as_str())
+            .await?;
+        Ok(Self { name })
+    }
+
+    async fn drop(self, conn: &mut PgConnection) -> Result<(), Box<dyn Error>> {
+        conn.execute(format!(r#"drop schema if exists "{}" cascade"#, self.name).as_str())
+            .await?;
+        Ok(())
+    }
+}
+
+async fn set_search_path(conn: &mut PgConnection, schema: &str) -> Result<(), sqlx::Error> {
+    conn.execute(format!(r#"set search_path to "{}", public"#, schema).as_str())
+        .await?;
+    Ok(())
+}
+
+async fn create_roles(conn: &mut PgConnection) -> Result<(), sqlx::Error> {
+    sqlx::raw_sql(
+        r#"
+        do $$
+        begin
+            if not exists (select 1 from pg_roles where rolname = 'centaur_slack_reader') then
+                create role centaur_slack_reader nologin;
+            end if;
+        end
+        $$;
+        "#,
+    )
+    .execute(&mut *conn)
+    .await?;
+    Ok(())
+}
+
+async fn create_slack_identity_helpers(conn: &mut PgConnection) -> Result<(), sqlx::Error> {
+    sqlx::raw_sql(
+        r#"
+        create table slack_sync_users (
+            team_id text not null,
+            user_id text not null,
+            raw_payload jsonb not null default '{}'::jsonb,
+            primary key (team_id, user_id)
+        );
+
+        create function centaur_current_slack_team_id()
+        returns text language sql stable as $$
+            select nullif(current_setting('centaur.slack_team_id', true), '')
+        $$;
+
+        create function centaur_current_slack_user_id()
+        returns text language sql stable as $$
+            select nullif(current_setting('centaur.slack_user_id', true), '')
+        $$;
+        "#,
+    )
+    .execute(&mut *conn)
+    .await?;
+    Ok(())
+}
+
+async fn grant_schema_usage(conn: &mut PgConnection, schema: &str) -> Result<(), sqlx::Error> {
+    conn.execute(
+        format!(
+            r#"grant usage on schema "{}" to centaur_slack_reader"#,
+            schema
+        )
+        .as_str(),
+    )
+    .await?;
+    Ok(())
+}
+
+async fn execute_migration(conn: &mut PgConnection, sql: &str) -> Result<(), sqlx::Error> {
+    sqlx::raw_sql(sql).execute(&mut *conn).await?;
+    Ok(())
+}
+
+fn granola_sync_without_bm25() -> String {
+    let sql = GRANOLA_SYNC_SQL.replace(
+        "create extension if not exists pg_search;",
+        "-- search extension unavailable in this test database",
+    );
+    let (before_bm25, rest) = sql
+        .split_once("drop index if exists idx_granola_context_documents_bm25;")
+        .expect("Granola migration should contain BM25 index block");
+    let (_, after_bm25) = rest
+        .split_once("create table if not exists granola_sync_checkpoints")
+        .expect("Granola migration should create sync checkpoints after the BM25 index");
+
+    format!("{before_bm25}create table if not exists granola_sync_checkpoints{after_bm25}")
+}

--- a/services/api-rs/crates/centaur-session-sqlx/tests/granola_context_projection.rs
+++ b/services/api-rs/crates/centaur-session-sqlx/tests/granola_context_projection.rs
@@ -242,6 +242,18 @@ async fn create_roles(conn: &mut PgConnection) -> Result<(), sqlx::Error> {
 async fn create_slack_identity_helpers(conn: &mut PgConnection) -> Result<(), sqlx::Error> {
     sqlx::raw_sql(
         r#"
+        -- The Granola RLS helper intentionally pins its security-definer search
+        -- path to public, matching production. CI's disposable Postgres starts
+        -- without this source table, so provide the minimal public relation it
+        -- resolves. Local development already has the real table and is left
+        -- untouched by IF NOT EXISTS.
+        create table if not exists public.slack_sync_users (
+            team_id text not null,
+            user_id text not null,
+            raw_payload jsonb not null default '{}'::jsonb,
+            primary key (team_id, user_id)
+        );
+
         create table slack_sync_users (
             team_id text not null,
             user_id text not null,

--- a/services/api-rs/crates/centaur-session-sqlx/tests/granola_context_projection.rs
+++ b/services/api-rs/crates/centaur-session-sqlx/tests/granola_context_projection.rs
@@ -244,9 +244,9 @@ async fn create_slack_identity_helpers(conn: &mut PgConnection) -> Result<(), sq
         r#"
         -- The Granola RLS helper intentionally pins its security-definer search
         -- path to public, matching production. CI's disposable Postgres starts
-        -- without this source table, so provide the minimal public relation it
-        -- resolves. Local development already has the real table and is left
-        -- untouched by IF NOT EXISTS.
+        -- without its source table and identity functions, so provide their
+        -- minimal public definitions. Local development already has the real
+        -- objects and is left untouched by the conditional setup below.
         create table if not exists public.slack_sync_users (
             team_id text not null,
             user_id text not null,
@@ -260,6 +260,27 @@ async fn create_slack_identity_helpers(conn: &mut PgConnection) -> Result<(), sq
             raw_payload jsonb not null default '{}'::jsonb,
             primary key (team_id, user_id)
         );
+
+        do $$
+        begin
+            if to_regprocedure('public.centaur_current_slack_team_id()') is null then
+                execute $function$
+                    create function public.centaur_current_slack_team_id()
+                    returns text language sql stable as $body$
+                        select nullif(current_setting('centaur.slack_team_id', true), '')
+                    $body$
+                $function$;
+            end if;
+            if to_regprocedure('public.centaur_current_slack_user_id()') is null then
+                execute $function$
+                    create function public.centaur_current_slack_user_id()
+                    returns text language sql stable as $body$
+                        select nullif(current_setting('centaur.slack_user_id', true), '')
+                    $body$
+                $function$;
+            end if;
+        end
+        $$;
 
         create function centaur_current_slack_team_id()
         returns text language sql stable as $$

--- a/tools/productivity/company_context/cli.py
+++ b/tools/productivity/company_context/cli.py
@@ -17,7 +17,7 @@ load_dotenv()
 
 app = typer.Typer(
     name="company_context",
-    help="Search indexed company history, Slack DMs, and Google Docs.",
+    help="Search indexed company history, Slack DMs, Google Docs, and Granola notes.",
 )
 
 
@@ -75,7 +75,7 @@ def search(
     source: str | None = typer.Option(
         None,
         "--source",
-        help="Filter by source. Use 'docs' for Google Docs.",
+        help="Filter by source. Use 'docs' for Google Docs or 'granola' for Granola notes.",
     ),
     source_type: str | None = typer.Option(None, "--source-type", help="Filter by source type."),
     occurred_after: str | None = typer.Option(
@@ -86,7 +86,7 @@ def search(
     ),
     json_output: bool = typer.Option(False, "--json", help="Output raw JSON."),
 ) -> None:
-    """Search indexed company context documents, including Google Docs with --source docs."""
+    """Search indexed company context, including Google Docs and Granola notes."""
     result = CompanyContextClient().search(
         query=query,
         limit=limit,
@@ -211,7 +211,7 @@ def list_documents(
     source: str | None = typer.Option(
         None,
         "--source",
-        help="Filter by source. Use 'docs' for Google Docs.",
+        help="Filter by source. Use 'docs' for Google Docs or 'granola' for Granola notes.",
     ),
     source_type: str | None = typer.Option(None, "--source-type", help="Filter by source type."),
     occurred_after: str | None = typer.Option(
@@ -222,7 +222,7 @@ def list_documents(
     ),
     json_output: bool = typer.Option(False, "--json", help="Output raw JSON."),
 ) -> None:
-    """List indexed company context documents, including Google Docs with --source docs."""
+    """List indexed company context documents, including Google Docs and Granola notes."""
     result = CompanyContextClient().list_documents(
         limit=limit,
         source=source,
@@ -263,7 +263,7 @@ def read_document(
     ),
     json_output: bool = typer.Option(False, "--json", help="Output raw JSON."),
 ) -> None:
-    """Read a company context document returned by search, including Google Docs chunks."""
+    """Read a company context document returned by search, including Granola notes."""
     result = CompanyContextClient().read_document(
         document_id=document_id,
         max_chars=max_chars,
@@ -291,7 +291,7 @@ def latest_date(
     source: str | None = typer.Option(
         None,
         "--source",
-        help="Filter by source. Use 'docs' for Google Docs.",
+        help="Filter by source. Use 'docs' for Google Docs or 'granola' for Granola notes.",
     ),
     source_type: str | None = typer.Option(None, "--source-type", help="Filter by source type."),
 ) -> None:

--- a/tools/productivity/company_context/pyproject.toml
+++ b/tools/productivity/company_context/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "company_context"
-description = "Search indexed company history, user-visible Slack DMs, and Google Docs. Prefer this over direct Slack or Drive search for historical queries. Current sources: Slack, Slack DMs, Google Docs, Google Calendar, Linear."
+description = "Search indexed company history, user-visible Slack DMs, Google Docs, and Granola notes. Prefer this over direct Slack, Drive, or Granola search for historical queries. Current sources: Slack, Slack DMs, Google Docs, Google Calendar, Linear, Granola."
 version = "0.1.0"
 requires-python = ">=3.11"
 dependencies = [


### PR DESCRIPTION
## Summary

- Project `granola_sync_notes` into the dedicated `granola_context_documents` table transactionally via database trigger.
- Backfill existing Granola source rows without using the generic `company_context_documents` table.
- Retain Granola-specific `access_emails` RLS on the dedicated projection and document Granola as a Company Context source.

## Validation

- `cargo test -p centaur-session-sqlx` against local Postgres
- `uv run --no-project --with pytest --with asyncpg --with python-dotenv --with rich --with typer pytest tools/productivity/company_context/tests/test_client.py -q`