### PR TITLE
feat: add centaur console permissions tool

### DIFF
--- a/docs/pages/reference/tool-directory.mdx
+++ b/docs/pages/reference/tool-directory.mdx
@@ -59,6 +59,7 @@ These are broadly useful across most deployments and are good candidates to conf
 
 | Tool | Use | API key / credential |
 |---|---|---|
+| `centaur-console` | Inspect the current sandbox's redacted permissions and capabilities | None |
 | `chart` | Render charts as PNG images for Slack or reports | None |
 | `demo` | Test tool hot-reload and basic tool plumbing | None |
 | `grafana` | Grafana dashboards, alerts, VictoriaMetrics, VictoriaLogs, and annotations | `GRAFANA_URL`, `GRAFANA_API_KEY` |

--- a/docs/public/md/reference/tool-directory.md
+++ b/docs/public/md/reference/tool-directory.md
@@ -60,6 +60,7 @@ These are broadly useful across most deployments and are good candidates to conf
 
 | Tool | Use | API key / credential |
 |---|---|---|
+| `centaur-console` | Inspect the current sandbox's redacted permissions and capabilities | None |
 | `chart` | Render charts as PNG images for Slack or reports | None |
 | `demo` | Test tool hot-reload and basic tool plumbing | None |
 | `grafana` | Grafana dashboards, alerts, VictoriaMetrics, VictoriaLogs, and annotations | `GRAFANA_URL`, `GRAFANA_API_KEY` |

--- a/tools/infra/centaur-console/__init__.py
+++ b/tools/infra/centaur-console/__init__.py
@@ -1,0 +1,1 @@
+"""Centaur console sandbox-permissions tool."""

--- a/tools/infra/centaur-console/cli.py
+++ b/tools/infra/centaur-console/cli.py
@@ -1,0 +1,64 @@
+"""CLI for centaur-console sandbox permission introspection."""
+
+from __future__ import annotations
+
+import json
+
+import typer
+from dotenv import load_dotenv
+from rich.console import Console
+
+load_dotenv()
+
+app = typer.Typer(
+    name="centaur-console",
+    help="Inspect the current sandbox's centaur-console permissions",
+)
+console = Console()
+
+
+def get_client(
+    url: str | None = None,
+    bearer_token: str | None = None,
+):
+    from .client import ConsoleClient
+
+    return ConsoleClient(url=url, bearer_token=bearer_token)
+
+
+@app.command("permissions")
+def permissions(
+    url: str | None = typer.Option(None, "--url", help="centaur-console base URL"),
+    bearer_token: str | None = typer.Option(
+        None,
+        "--bearer-token",
+        help="Local/debug bearer token override",
+        envvar="CENTAUR_CONSOLE_BEARER_TOKEN",
+    ),
+):
+    """Print the current sandbox's redacted permissions as JSON."""
+    with get_client(url=url, bearer_token=bearer_token) as client:
+        result = client.sandbox_permissions()
+    console.print_json(json.dumps(result, default=str))
+
+
+@app.command()
+def health(
+    url: str | None = typer.Option(None, "--url", help="centaur-console base URL"),
+    bearer_token: str | None = typer.Option(
+        None,
+        "--bearer-token",
+        help="Local/debug bearer token override",
+        envvar="CENTAUR_CONSOLE_BEARER_TOKEN",
+    ),
+):
+    """Assert the sandbox permissions endpoint is reachable and authorized."""
+    with get_client(url=url, bearer_token=bearer_token) as client:
+        payload = client.health()
+    print(json.dumps(payload, indent=2, default=str))
+    if not payload.get("ok"):
+        raise typer.Exit(1)
+
+
+if __name__ == "__main__":
+    app()

--- a/tools/infra/centaur-console/client.py
+++ b/tools/infra/centaur-console/client.py
@@ -1,0 +1,119 @@
+"""Client for centaur-console sandbox-scoped permission introspection."""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import httpx
+
+SANDBOX_PERMISSIONS_PATH = "/api/v1/sandbox/permissions"
+
+
+class ConsoleClient:
+    """Read the current sandbox's redacted permissions from centaur-console."""
+
+    def __init__(
+        self,
+        url: str | None = None,
+        bearer_token: str | None = None,
+        timeout: float = 30.0,
+        transport: httpx.BaseTransport | None = None,
+    ):
+        self._url = url
+        self._bearer_token = bearer_token
+        self.timeout = timeout
+        self._transport = transport
+        self._client: httpx.Client | None = None
+
+    @property
+    def base_url(self) -> str:
+        # Non-secret endpoint config. Sandboxes receive this from api-rs.
+        url = (self._url or os.getenv("CENTAUR_CONSOLE_URL", "http://centaur-console:3000")).strip().rstrip("/")  # noqa: TID251
+        if url and not url.startswith(("http://", "https://")):
+            url = f"http://{url}"
+        return url
+
+    def _headers(self) -> dict[str, str]:
+        headers = {"Accept": "application/json"}
+        # Optional local/debug override. In sandboxes, iron-proxy injects the
+        # scoped Authorization header for this endpoint.
+        bearer = (self._bearer_token or os.getenv("CENTAUR_CONSOLE_BEARER_TOKEN", "")).strip()  # noqa: TID251
+        if bearer:
+            headers["Authorization"] = f"Bearer {bearer}"
+        return headers
+
+    @property
+    def client(self) -> httpx.Client:
+        if self._client is None:
+            self._client = httpx.Client(
+                base_url=self.base_url,
+                headers=self._headers(),
+                timeout=self.timeout,
+                transport=self._transport,
+            )
+        return self._client
+
+    def sandbox_permissions(self) -> dict[str, Any]:
+        """Return the current sandbox's redacted permissions payload."""
+        response = self.client.get(SANDBOX_PERMISSIONS_PATH)
+        try:
+            response.raise_for_status()
+        except httpx.HTTPStatusError as exc:
+            detail = _response_error_detail(exc.response)
+            raise RuntimeError(f"centaur-console permissions request failed: {detail}") from exc
+
+        payload = response.json()
+        data = payload.get("data")
+        if not isinstance(data, dict):
+            raise RuntimeError("centaur-console permissions response did not include a data object")
+        return data
+
+    def permissions(self) -> dict[str, Any]:
+        """Alias for tool bridge calls."""
+        return self.sandbox_permissions()
+
+    def health(self) -> dict[str, Any]:
+        """Assert the sandbox permissions endpoint is reachable and authorized."""
+        try:
+            data = self.sandbox_permissions()
+            return {
+                "ok": True,
+                "tool": "centaur-console",
+                "error": None,
+                "details": {
+                    "sandbox_id": data.get("sandbox_id"),
+                    "principal_id": data.get("principal_id"),
+                    "proxy_id": data.get("proxy_id"),
+                },
+            }
+        except Exception as exc:
+            return {
+                "ok": False,
+                "tool": "centaur-console",
+                "error": str(exc),
+                "details": {},
+            }
+
+    def close(self) -> None:
+        if self._client:
+            self._client.close()
+            self._client = None
+
+    def __enter__(self) -> ConsoleClient:
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        self.close()
+
+
+def _response_error_detail(response: httpx.Response) -> str:
+    try:
+        body = response.json()
+    except ValueError:
+        body = response.text
+    return f"HTTP {response.status_code}: {body}"
+
+
+def _client() -> ConsoleClient:
+    return ConsoleClient()

--- a/tools/infra/centaur-console/pyproject.toml
+++ b/tools/infra/centaur-console/pyproject.toml
@@ -1,0 +1,29 @@
+[project]
+name = "centaur-console"
+description = "Centaur console sandbox permission introspection"
+version = "0.1.0"
+requires-python = ">=3.11"
+dependencies = [
+    "httpx>=0.27.0",
+    "typer>=0.12.0",
+    "rich>=13.0.0",
+    "python-dotenv>=1.0.0",
+]
+
+[project.scripts]
+centaur-console = "centaur_tool_centaur_console.cli:app"
+
+[tool.hatch.build.targets.wheel]
+packages = ["."]
+
+[tool.hatch.build.targets.wheel.sources]
+"." = "centaur_tool_centaur_console"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.centaur]
+module = "client.py"
+hosts = []
+secrets = []

--- a/tools/infra/centaur-console/test_client.py
+++ b/tools/infra/centaur-console/test_client.py
@@ -1,0 +1,79 @@
+import httpx
+import pytest
+from client import SANDBOX_PERMISSIONS_PATH, ConsoleClient
+
+
+def json_response(payload, status_code=200):
+    return httpx.Response(status_code, json=payload)
+
+
+def make_client(handler, *, bearer_token=None):
+    return ConsoleClient(
+        url="http://centaur-console:3000",
+        bearer_token=bearer_token,
+        transport=httpx.MockTransport(handler),
+    )
+
+
+def test_sandbox_permissions_fetches_and_unwraps_data():
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.method == "GET"
+        assert request.url.path == SANDBOX_PERMISSIONS_PATH
+        assert request.headers["Accept"] == "application/json"
+        return json_response(
+            {
+                "data": {
+                    "sandbox_id": "sandbox-1",
+                    "principal_id": "prn_123",
+                    "permissions": {"secrets": []},
+                }
+            }
+        )
+
+    result = make_client(handler).sandbox_permissions()
+
+    assert result["sandbox_id"] == "sandbox-1"
+    assert result["principal_id"] == "prn_123"
+    assert result["permissions"] == {"secrets": []}
+
+
+def test_sandbox_permissions_sends_debug_bearer_token_when_provided():
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.headers["Authorization"] == "Bearer test-token"
+        return json_response({"data": {"sandbox_id": "sandbox-1"}})
+
+    assert make_client(handler, bearer_token="test-token").permissions()["sandbox_id"] == "sandbox-1"
+
+
+def test_sandbox_permissions_wraps_http_errors():
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return json_response({"error": {"message": "invalid sandbox token"}}, status_code=401)
+
+    with pytest.raises(RuntimeError, match="HTTP 401"):
+        make_client(handler).sandbox_permissions()
+
+
+def test_health_returns_identity_details():
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return json_response(
+            {
+                "data": {
+                    "sandbox_id": "sandbox-1",
+                    "proxy_id": "proxy-1",
+                    "principal_id": "principal-1",
+                }
+            }
+        )
+
+    result = make_client(handler).health()
+
+    assert result == {
+        "ok": True,
+        "tool": "centaur-console",
+        "error": None,
+        "details": {
+            "sandbox_id": "sandbox-1",
+            "proxy_id": "proxy-1",
+            "principal_id": "principal-1",
+        },
+    }


### PR DESCRIPTION
Adds a centaur-console tool that lets sandboxes inspect their redacted permissions through the existing console sandbox permissions endpoint. The CLI exposes permissions and health commands, and the tool directory docs list the new tool.