### PR TITLE
fix(workflows): Linear searchIssues takes `term`, not `query`

### DIFF
--- a/workflows/linear/readonly.py
+++ b/workflows/linear/readonly.py
@@ -374,8 +374,8 @@ class LinearReadonlyClient(LinearGraphQLClient):
     def search_issues(self, query_str: str, limit: int = 25) -> list[dict[str, Any]]:
         """Search issues by text."""
         query = """
-        query SearchIssues($query: String!, $first: Int!, $after: String) {
-            searchIssues(query: $query, first: $first, after: $after) {
+        query SearchIssues($term: String!, $first: Int!, $after: String) {
+            searchIssues(term: $term, first: $first, after: $after) {
                 nodes {
                     id
                     identifier
@@ -393,7 +393,7 @@ class LinearReadonlyClient(LinearGraphQLClient):
         return self._connection_nodes(
             query,
             connection_path=("searchIssues",),
-            variables={"query": query_str},
+            variables={"term": query_str},
             limit=limit,
         )
 

--- a/workflows/tests/test_linear_readonly.py
+++ b/workflows/tests/test_linear_readonly.py
@@ -1,0 +1,45 @@
+"""Tests for the workflows-side Linear read-only GraphQL helpers.
+
+This mirrors tools/productivity/linear/test_readonly.py. The two clients are
+independent copies of the same code, and the `term:` fix landed in only one of
+them -- so the invariant is pinned on both sides now, or they drift again.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from workflows.linear.readonly import LinearReadonlyClient
+
+
+class RecordingReadonlyClient(LinearReadonlyClient):
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    def _query(self, query: str, variables: dict[str, Any] | None = None) -> dict[str, Any]:
+        self.calls.append({"query": query, "variables": variables})
+        return {
+            "searchIssues": {
+                "nodes": [{"identifier": "ENG-1", "title": "Search result"}],
+                "pageInfo": {"hasNextPage": False, "endCursor": None},
+            }
+        }
+
+
+def test_search_issues_uses_linear_term_argument():
+    # `searchIssues` names its search string `term` and requires it. `query` was
+    # the argument of `issueSearch`, the endpoint Linear deprecated in favour of
+    # this one; passing it here fails GraphQL validation, which Linear returns as
+    # an HTTP 400.
+    client = RecordingReadonlyClient()
+
+    result = client.search_issues("auth", limit=1)
+
+    assert result == [{"identifier": "ENG-1", "title": "Search result"}]
+    assert "searchIssues(term: $term" in client.calls[0]["query"]
+    assert "query:" not in client.calls[0]["query"]
+    assert client.calls[0]["variables"] == {"term": "auth", "first": 1, "after": None}


### PR DESCRIPTION
#832 fixed the Linear `searchIssues` argument in `tools/productivity/linear/readonly.py`. There is a **second, independent copy** of the same client at `workflows/linear/readonly.py`, and it was never touched. It still builds:

```graphql
query SearchIssues($query: String!, ...) { searchIssues(query: $query, ...) }
```

`searchIssues` names its search string `term`, and requires it. `query` was the argument of `issueSearch` — the endpoint Linear deprecated in favour of this one. Passing it to `searchIssues` fails GraphQL validation, which Linear returns as an **HTTP 400**.

### Why it matters even though nothing calls it yet

This copy ships: `services/api-rs/Dockerfile` copies `workflows/` into the image and `WORKFLOW_DIRS` points at it, and `LinearReadonlyClient` is exported from `workflows/linear/__init__.py`. Nothing on the workflows path calls `search_issues` today — so this is a latent 400 on a public class rather than a live break. That is precisely why it went unnoticed.

The two copies now agree character-for-character in this method.

### The test is the actual fix

This also mirrors the regression test #832 added on the tools side (`assert "searchIssues(term: $term" in query` / `assert "query:" not in query`). **The absence of that test here is why the fix didn't propagate** — the `tools/` copy is pinned, this one wasn't, so they were free to drift.

Verified the new test fails against the unfixed client and passes against the fixed one.
