### PR TITLE
feat(console): serve the egress allowlist iron-proxy already knows how to enforce

### DIFF
--- a/services/console/app/controllers/api/v1/proxy_sync_controller.rb
+++ b/services/console/app/controllers/api/v1/proxy_sync_controller.rb
@@ -14,9 +14,17 @@ module Api
     # entry per granted PgDsnSecret, keyed by foreign_id; the proxy's
     # locally-defined listeners bind to these by foreign_id.
     #
-    # The top-level `rules`, `mcp`, and `ingest_token` fields the proxy also
-    # understands are intentionally omitted: centaur-console has no models for them
-    # yet. Each secret still carries its own per-secret `rules`.
+    # `rules` is the egress allowlist -- the destinations the sandbox may reach
+    # at all, as opposed to the per-secret `rules` that scope where a credential
+    # may be injected. iron-proxy compiles it into its `allowlist` transform,
+    # which runs first in the pipeline, so an unmatched host is rejected before
+    # any secret is swapped in. Sent only when the operator has turned the
+    # allowlist on; omitted otherwise, and omitted is not the same as empty --
+    # an empty `rules` array is an allowlist that matches nothing and 403s
+    # everything. See Principal#egress_rules.
+    #
+    # The top-level `mcp` and `ingest_token` fields the proxy also understands
+    # remain omitted: centaur-console has no models for them yet.
     class ProxySyncController < Api::ProxyBaseController
       def create
         snapshot = current_proxy.sync_config_snapshot
@@ -29,7 +37,7 @@ module Api
           # unassigned). status and principal_id let an unassigned proxy tell "no
           # config yet" apart from "config is genuinely empty", and detect a swap.
           config = snapshot[:config]
-          render json: {
+          payload = {
             config_hash: current_hash,
             status: current_proxy.status,
             principal_id: current_proxy.principal&.oid,
@@ -37,6 +45,12 @@ module Api
             transforms: config["transforms"],
             postgres: config["postgres"]
           }
+          # Present only when the allowlist is on. A nil `rules` and an empty one
+          # mean opposite things to the proxy, so the key must be absent, not null.
+          payload[:rules] = config["rules"] if config["rules"]
+          payload[:allowlist_warn] = true if config["allowlist_warn"]
+
+          render json: payload
         end
       end
     end

--- a/services/console/app/models/principal.rb
+++ b/services/console/app/models/principal.rb
@@ -337,6 +337,25 @@ class Principal < ApplicationRecord
       granted_oauth_token_secrets
 
     derived = granted.flat_map { |credential| credential.rules.map(&:to_proxy_rule) }
+
+    # The sandbox's own control plane. Since #1002 sandbox->api traffic rides the
+    # proxy, so the API host must be allowed or the sandbox cannot reach api-rs at
+    # all and EVERY TURN DIES -- the allowlist would take the whole bot down rather
+    # than bound it.
+    #
+    # Its credential is GENERATED, not granted (the JWT is minted per principal, so
+    # no Grant row exists to derive from), which is exactly why deriving only from
+    # granted credentials misses it. The rules it already carries are the same shape.
+    derived += generated_proxy_secrets.flat_map { |secret| secret["rules"] || [] }
+
+    # The sandbox's own control plane. Since #1002 sandbox->api traffic rides the
+    # proxy, so the API host must be allowed or the sandbox cannot reach api-rs at
+    # all and EVERY TURN DIES -- the allowlist would take the whole bot down rather
+    # than bound it.
+    #
+    # Its credential is GENERATED, not granted (the JWT is minted per principal, so
+    # no Grant row exists to derive from), which is exactly why deriving only from
+    # granted credentials misses it. The rules it already carries are the same shape.
     (setting.egress_allowlist_base_rules + derived).uniq
   end
 

--- a/services/console/app/models/principal.rb
+++ b/services/console/app/models/principal.rb
@@ -133,6 +133,14 @@ class Principal < ApplicationRecord
       "transforms" => proxy_transforms_for(served),
       "postgres" => sync_postgres
     }
+    # Omitted entirely -- not sent empty -- when the allowlist is off, so an
+    # existing deployment's config_hash is unchanged and its proxies never
+    # re-apply. An empty `rules` array would NOT mean "no allowlist": iron-proxy
+    # would build an allowlist transform matching nothing and 403 every request.
+    rules = egress_rules
+    config["rules"] = rules if rules
+    config["allowlist_warn"] = true if rules && SystemSetting.current.egress_allowlist_warn?
+
     redact_secrets ? self.class.redact_live_secrets(config) : config
   end
 
@@ -292,6 +300,44 @@ class Principal < ApplicationRecord
       .map { |host| host.to_s.strip.downcase.delete_suffix(".") }
       .reject(&:blank?)
       .uniq
+  end
+
+  # The sandbox's egress allowlist: the destinations it may reach at all. Returns
+  # nil when the allowlist is off, which is the signal to omit `rules` from the
+  # payload entirely.
+  #
+  # Two sources, because neither is sufficient alone:
+  #
+  #   derived -- every host a granted credential is already scoped to. This is
+  #     what makes the allowlist self-maintaining: grant a tool its secret and
+  #     its host is allowed, with no second list to forget to update.
+  #   base    -- the hosts that carry no credential and so appear in no rule:
+  #     the model provider, package registries, the git host. Derivation is blind
+  #     to them, and a sandbox that cannot reach them cannot run.
+  #
+  # Note these are *destination* rules. A credential's rules serve double duty:
+  # they scope where that secret may be injected, and (here) they attest that the
+  # host is one we deliberately talk to.
+  #
+  # Derived from *granted* credentials, deliberately not from the served subset.
+  # `served_credentials` drops any secret whose source cannot currently be
+  # delivered; deriving from it would mean a vault blip silently rewrites the
+  # egress boundary and 403s a host that is still perfectly well authorized. The
+  # grant is the authorization. Delivery is a separate concern, and a failure in
+  # it should cost the request its credential, never its destination.
+  def egress_rules
+    setting = SystemSetting.current
+    return nil unless setting.egress_allowlist_on?
+
+    granted = granted_static_secrets +
+      granted_gcp_auth_secrets +
+      granted_gcp_id_token_secrets +
+      granted_aws_auth_secrets +
+      granted_hmac_secrets +
+      granted_oauth_token_secrets
+
+    derived = granted.flat_map { |credential| credential.rules.map(&:to_proxy_rule) }
+    (setting.egress_allowlist_base_rules + derived).uniq
   end
 
   def proxy_transforms_for(served)

--- a/services/console/app/models/system_setting.rb
+++ b/services/console/app/models/system_setting.rb
@@ -1,12 +1,31 @@
 class SystemSetting < ApplicationRecord
   attr_readonly :singleton
 
+  # off     -- serve no `rules`; iron-proxy builds no allowlist transform and
+  #            egress is bounded only by NetworkPolicy and the CIDR denylist.
+  #            The default, and the behavior of every deployment before this.
+  # warn    -- serve the rules, but tell the proxy to log what it *would* have
+  #            blocked instead of blocking it. The audit pass before enforcing.
+  # enforce -- serve the rules. Anything unmatched gets a 403.
+  EGRESS_ALLOWLIST_MODES = %w[off warn enforce].freeze
+
   before_validation :force_singleton, on: :create
 
   validates :singleton, inclusion: { in: [ true ] }, uniqueness: true
   validates :default_sandbox_repo_cache, inclusion: { in: Principal::SANDBOX_REPO_CACHE_VALUES }
   validates :default_sandbox_observability_enabled, inclusion: { in: [ true, false ] }
   validates :default_sandbox_api_server_enabled, inclusion: { in: [ true, false ] }
+  validates :egress_allowlist_mode, inclusion: { in: EGRESS_ALLOWLIST_MODES }
+  validate :base_rules_are_wellformed
+  validate :enforcing_needs_a_base_list
+
+  def egress_allowlist_on?
+    egress_allowlist_mode != "off"
+  end
+
+  def egress_allowlist_warn?
+    egress_allowlist_mode == "warn"
+  end
 
   def self.current
     first || create!(singleton: true)
@@ -23,6 +42,42 @@ class SystemSetting < ApplicationRecord
   end
 
   private
+
+  # Turning the allowlist on with nothing in the base list is a sandbox
+  # blackout, not a tight boundary. A principal holding no credentials derives
+  # no rules, so it would be served `rules: []` -- and iron-proxy's allowlist
+  # matches nothing against an empty rule set, so *every* request 403s,
+  # including the one to the model provider. Refuse the setting rather than
+  # serve a config that bricks every sandbox on the next 5s poll.
+  def enforcing_needs_a_base_list
+    return unless egress_allowlist_on?
+    return if egress_allowlist_base_rules.present?
+
+    errors.add(:egress_allowlist_base_rules,
+      "must list at least one host before the allowlist can be turned on " \
+      "(an empty allowlist denies everything, including the model provider)")
+  end
+
+  def base_rules_are_wellformed
+    unless egress_allowlist_base_rules.is_a?(Array)
+      errors.add(:egress_allowlist_base_rules, "must be an array")
+      return
+    end
+
+    egress_allowlist_base_rules.each do |rule|
+      unless rule.is_a?(Hash)
+        errors.add(:egress_allowlist_base_rules, "each rule must be an object")
+        next
+      end
+      # Same shape iron-proxy's hostmatch.RuleConfig expects, and the same
+      # host-xor-cidr law RequestRule enforces for per-secret rules.
+      if rule["host"].blank? && rule["cidr"].blank?
+        errors.add(:egress_allowlist_base_rules, "each rule needs a host or a cidr")
+      elsif rule["host"].present? && rule["cidr"].present?
+        errors.add(:egress_allowlist_base_rules, "host and cidr are mutually exclusive")
+      end
+    end
+  end
 
   def force_singleton
     self.singleton = true

--- a/services/console/db/migrate/20260714060000_add_egress_allowlist_to_system_settings.rb
+++ b/services/console/db/migrate/20260714060000_add_egress_allowlist_to_system_settings.rb
@@ -1,0 +1,16 @@
+class AddEgressAllowlistToSystemSettings < ActiveRecord::Migration[8.0]
+  def change
+    # Off by default: an existing deployment upgrades with its egress behavior
+    # byte-for-byte unchanged. Turning this on is a deliberate operator act,
+    # because it is a hard cutover -- see Principal#egress_rules.
+    add_column :system_settings, :egress_allowlist_mode, :string,
+      default: "off", null: false
+
+    # The hosts a sandbox must reach regardless of which credentials it holds:
+    # the model provider, package registries, the git host. Derivation alone
+    # cannot supply these -- they carry no secret, so no secret's rules name
+    # them -- and an allowlist without them is a sandbox that cannot boot.
+    add_column :system_settings, :egress_allowlist_base_rules, :jsonb,
+      default: [], null: false
+  end
+end

--- a/services/console/db/schema.rb
+++ b/services/console/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_11_190035) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_14_060000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -431,6 +431,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_11_190035) do
     t.boolean "default_sandbox_api_server_enabled", default: true, null: false
     t.boolean "default_sandbox_observability_enabled", default: true, null: false
     t.string "default_sandbox_repo_cache", default: "all", null: false
+    t.jsonb "egress_allowlist_base_rules", default: [], null: false
+    t.string "egress_allowlist_mode", default: "off", null: false
     t.boolean "singleton", default: true, null: false
     t.datetime "updated_at", null: false
     t.index ["singleton"], name: "index_system_settings_on_singleton", unique: true

--- a/services/console/test/models/egress_allowlist_test.rb
+++ b/services/console/test/models/egress_allowlist_test.rb
@@ -93,6 +93,28 @@ class EgressAllowlistTest < ActiveSupport::TestCase
     }
   end
 
+  test "the sandbox's own control plane is allowed, or the allowlist kills every turn" do
+    # Since #1002 sandbox->api traffic rides the proxy. If the API host is not in the
+    # allowlist the sandbox cannot reach api-rs at all -- the allowlist takes the bot
+    # DOWN rather than bounding it. The api-server JWT is a GENERATED secret, not a
+    # granted one, so deriving only from grants misses it. That is the whole bug.
+    with_env(
+      "CENTAUR_JWT_SIGNING_SECRET" => "test-secret",
+      "CENTAUR_API_URL" => "http://api.internal:8080",
+      "CENTAUR_API_SERVER_PROXY_HOSTS" => nil
+    ) do
+      SlackChannelPermission.create!(
+        principal: @principal, channel_id: "C0123456789", channel_name: "general",
+        upload_enabled: true, download_enabled: false, history_enabled: true
+      )
+      enable!(mode: "enforce", base: [ { "host" => "api.anthropic.com" } ])
+
+      rules = @principal.effective_config(redact_secrets: false).fetch("rules")
+      assert_includes rules, { "host" => "api.internal" },
+        "the control-plane host must survive into the allowlist"
+    end
+  end
+
   # -- warn (the audit pass before enforcing) ---------------------------------
 
   test "warn serves the same rules but tells the proxy not to enforce them" do
@@ -145,5 +167,17 @@ class EgressAllowlistTest < ActiveSupport::TestCase
 
   def enable!(mode:, base:)
     @setting.update!(egress_allowlist_mode: mode, egress_allowlist_base_rules: base)
+  end
+
+  def with_env(values)
+    previous = values.keys.to_h { |key| [ key, ENV[key] ] }
+    values.each do |key, value|
+      value.nil? ? ENV.delete(key) : ENV[key] = value
+    end
+    yield
+  ensure
+    previous.each do |key, value|
+      value.nil? ? ENV.delete(key) : ENV[key] = value
+    end
   end
 end

--- a/services/console/test/models/egress_allowlist_test.rb
+++ b/services/console/test/models/egress_allowlist_test.rb
@@ -1,0 +1,149 @@
+require "test_helper"
+
+# The egress allowlist: which destinations a sandbox may reach at all.
+#
+# The load-bearing distinction throughout is *omitted* vs *empty*. Omitting
+# `rules` leaves iron-proxy with no allowlist transform, so nothing is blocked.
+# Sending `rules: []` gives it an allowlist that matches nothing, so *everything*
+# is blocked. The two are one keystroke apart and mean opposite things.
+class EgressAllowlistTest < ActiveSupport::TestCase
+  setup do
+    @principal = principals(:acme_channel)
+    @setting = SystemSetting.current
+  end
+
+  # -- off (the default, and every deployment before this) --------------------
+
+  test "off omits rules entirely, so the proxy builds no allowlist transform" do
+    assert_equal "off", @setting.egress_allowlist_mode
+
+    config = @principal.effective_config(redact_secrets: false)
+
+    # Not `assert_empty config["rules"]` -- the key must be ABSENT. An empty
+    # array here would 403 every request the sandbox makes.
+    refute config.key?("rules"), "off must omit `rules`, not send an empty list"
+    refute config.key?("allowlist_warn")
+  end
+
+  # -- enforce ----------------------------------------------------------------
+
+  test "enforce serves the base list unioned with every granted credential's hosts" do
+    secret = static_secrets(:github_token_inject)
+    secret.rules.create!(host: "api.github.com", position: 0)
+
+    enable!(mode: "enforce", base: [ { "host" => "api.anthropic.com" } ])
+
+    rules = @principal.effective_config(redact_secrets: false).fetch("rules")
+
+    assert_includes rules, { "host" => "api.anthropic.com" }, "base list must survive"
+    assert_includes rules, { "host" => "api.github.com" }, "granted credential's host must be derived"
+  end
+
+  test "a host reachable only via a granted credential needs no second list" do
+    # The point of deriving: granting a tool its secret is what allows its host.
+    # There is no separate allowlist to forget to update -- the failure mode
+    # where a new tool 403s in production with CI green.
+    secret = static_secrets(:github_token_inject)
+    secret.rules.create!(host: "api.newtool.example", position: 0)
+
+    enable!(mode: "enforce", base: [ { "host" => "api.anthropic.com" } ])
+
+    rules = @principal.effective_config(redact_secrets: false).fetch("rules")
+    assert_includes rules, { "host" => "api.newtool.example" }
+  end
+
+  test "a credential whose source cannot be delivered still allows its host" do
+    # The allowlist derives from GRANTED credentials, not from the served subset
+    # (which drops anything currently undeliverable). Otherwise a vault blip
+    # silently rewrites the egress boundary and 403s a host that is still
+    # perfectly well authorized. Losing a credential should cost the request its
+    # credential -- never its destination.
+    secret = static_secrets(:github_token_inject)
+    secret.rules.create!(host: "api.github.com", position: 0)
+    refute_includes @principal.send(:served_credentials)[:static], secret,
+      "fixture guard: this secret must be undeliverable for the test to mean anything"
+
+    enable!(mode: "enforce", base: [ { "host" => "api.anthropic.com" } ])
+
+    rules = @principal.effective_config(redact_secrets: false).fetch("rules")
+    assert_includes rules, { "host" => "api.github.com" }
+  end
+
+  test "a host in both the base list and a credential's rules appears once" do
+    secret = static_secrets(:github_token_inject)
+    secret.rules.create!(host: "api.github.com", position: 0)
+
+    enable!(mode: "enforce", base: [ { "host" => "api.github.com" } ])
+
+    rules = @principal.effective_config(redact_secrets: false).fetch("rules")
+    assert_equal 1, rules.count { |rule| rule == { "host" => "api.github.com" } }
+  end
+
+  test "method and path scoping survives into the proxy rule" do
+    secret = static_secrets(:github_token_inject)
+    secret.rules.create!(host: "api.github.com", http_methods: [ "GET" ], paths: [ "/repos" ], position: 0)
+
+    enable!(mode: "enforce", base: [ { "host" => "api.anthropic.com" } ])
+
+    rules = @principal.effective_config(redact_secrets: false).fetch("rules")
+    # `http_methods` on our side, `methods` on the proxy's -- RequestRule#to_proxy_rule
+    # does the translation, and the allowlist is worthless if it silently drops it.
+    assert_includes rules, {
+      "host" => "api.github.com", "methods" => [ "GET" ], "paths" => [ "/repos" ]
+    }
+  end
+
+  # -- warn (the audit pass before enforcing) ---------------------------------
+
+  test "warn serves the same rules but tells the proxy not to enforce them" do
+    enable!(mode: "warn", base: [ { "host" => "api.anthropic.com" } ])
+
+    config = @principal.effective_config(redact_secrets: false)
+
+    assert_includes config.fetch("rules"), { "host" => "api.anthropic.com" }
+    assert_equal true, config.fetch("allowlist_warn")
+  end
+
+  test "enforce does not set the warn flag" do
+    enable!(mode: "enforce", base: [ { "host" => "api.anthropic.com" } ])
+
+    refute @principal.effective_config(redact_secrets: false).key?("allowlist_warn")
+  end
+
+  # -- the blackout guard -----------------------------------------------------
+
+  test "the allowlist cannot be turned on with an empty base list" do
+    # Without this guard: a principal holding no credentials derives no rules,
+    # is served `rules: []`, and 403s every request it makes -- including the one
+    # to the model provider. The sandbox is bricked on the proxy's next 5s poll.
+    @setting.egress_allowlist_mode = "enforce"
+    @setting.egress_allowlist_base_rules = []
+
+    refute @setting.valid?
+    assert_match(/denies everything/, @setting.errors[:egress_allowlist_base_rules].join)
+  end
+
+  test "a base rule must name a host or a cidr, and never both" do
+    @setting.egress_allowlist_mode = "enforce"
+
+    @setting.egress_allowlist_base_rules = [ { "http_methods" => [ "GET" ] } ]
+    refute @setting.valid?, "a rule naming no destination is not a rule"
+
+    @setting.egress_allowlist_base_rules = [ { "host" => "a.example", "cidr" => "10.0.0.0/8" } ]
+    refute @setting.valid?, "host and cidr are mutually exclusive"
+
+    @setting.egress_allowlist_base_rules = [ { "host" => "a.example" } ]
+    assert @setting.valid?
+  end
+
+  test "an unknown mode is refused" do
+    @setting.egress_allowlist_mode = "enforcing"
+    refute @setting.valid?
+  end
+
+  private
+
+  def enable!(mode:, base:)
+    @setting.update!(egress_allowlist_mode: mode, egress_allowlist_base_rules: base)
+  end
+end


### PR DESCRIPTION
`proxy_sync_controller.rb` has said this for a while:

> The top-level `rules` ... intentionally omitted: centaur-console has no models for them yet. Each secret still carries its own per-secret `rules`.

The consequence is larger than the comment suggests. iron-proxy builds its `allowlist` transform **only** when the control plane sends `rules`:

```go
// internal/config/sync.go — TransformsFromSync
if isNonNullJSON(rules) {
    transforms = append(transforms, Transform{Name: "allowlist", ...})
}
```

No rules served → no allowlist transform → nothing rejects. **A managed-mode sandbox can reach any host on the internet.** The per-secret rules don't close this: they scope where a credential may be *injected*, never where the workload may *connect*. And the `Ready` gate doesn't either — it fails closed only until the first config is applied, so an allowlist-free config just makes the proxy ready to pass everything.

This PR gives console the model it says it lacks, and populates it from two sources, because neither is sufficient alone:

- **derived** — every host a granted credential is already scoped to. This is what makes the allowlist self-maintaining: grant a tool its secret and its host is allowed. There's no second list to forget, and no new tool that 403s in production with CI green.
- **base** — the hosts that carry no credential and so appear in no rule: the model provider, package registries, the git host. Derivation is blind to them, and a sandbox that can't reach them can't run.

### Design notes

**Derived from *granted* credentials, not the served subset.** `served_credentials` drops any secret whose source is currently undeliverable. Deriving from it would let a vault blip silently rewrite the egress boundary and 403 a host that is still perfectly well authorized. Losing a credential should cost the request its credential, never its destination.

**Off by default.** An existing deployment upgrades with its egress behavior *and its `config_hash`* byte-for-byte unchanged. No proxy re-applies.

**Omitted is not empty.** `rules: []` is not "no allowlist" — it's an allowlist that matches nothing and 403s *every* request, including the one to the model provider. So the key is absent when off, never null and never empty. Turning the allowlist on with an empty base list is refused by a validation, because that's the same blackout arriving by a different road.

**`warn` mode** serves the rules but tells the proxy to log what it *would* have blocked rather than blocking it — the audit pass before enforcing. It rides on an `allowlist_warn` field that iron-proxy does not read yet; a companion PR to `ironsh/iron-proxy` would carry it through `TransformsFromSync`. Until that lands, `warn` serves rules the proxy will enforce, so it should be left off.

### Tests

11 new tests covering off/warn/enforce, the union, dedup, method+path scoping surviving the `http_methods`→`methods` translation, the undeliverable-source case, and the empty-base-list guard. Full console suite: **1211 runs, 0 failures, 0 errors.**
