### PR TITLE
feat(slackbotv2): show Codex effort and speed

### DIFF
--- a/contrib/chart/templates/slackbotv2.yaml
+++ b/contrib/chart/templates/slackbotv2.yaml
@@ -89,12 +89,11 @@ spec:
             - name: SLACKBOT_TRIGGER_BOT_ALLOWLIST
               value: {{ .Values.slackbotv2.triggerBotAllowlist | quote }}
 {{- end }}
-{{- range $name := tuple "CLAUDE_MODEL" "CODEX_MODEL" }}
+{{- range $name := tuple "CLAUDE_MODEL" "CODEX_MODEL" "CODEX_MODEL_REASONING_EFFORT" }}
 {{- if and (hasKey $.Values.sandbox.extraEnv $name) (not (hasKey $.Values.slackbotv2.extraEnv $name)) }}
-            # Mirror the deployer's harness default-model override
-            # (sandbox.extraEnv) so the Slack Console-link line names the model
-            # sandboxes actually run. slackbotv2.extraEnv wins if it sets the
-            # same variable.
+            # Mirror deployer harness display settings (sandbox.extraEnv) so
+            # the Slack Console-link line names the model/effort sandboxes
+            # actually run. slackbotv2.extraEnv wins when explicitly set.
             - name: {{ $name }}
               value: {{ index $.Values.sandbox.extraEnv $name | toString | quote }}
 {{- end }}

--- a/services/slackbotv2/src/console-session-link.ts
+++ b/services/slackbotv2/src/console-session-link.ts
@@ -35,6 +35,16 @@ const BAKED_DEFAULT_MODELS: Record<string, string | undefined> = {
       : undefined
 }
 
+const BAKED_CODEX_EFFORT =
+  typeof (codexConfig as { model_reasoning_effort?: unknown }).model_reasoning_effort === 'string'
+    ? (codexConfig as { model_reasoning_effort: string }).model_reasoning_effort
+    : undefined
+
+const BAKED_CODEX_SPEED =
+  typeof (codexConfig as { service_tier?: unknown }).service_tier === 'string'
+    ? (codexConfig as { service_tier: string }).service_tier
+    : undefined
+
 /** Slack mrkdwn requires `&`, `<`, `>` to be escaped in free text. */
 function escapeSlackMrkdwn(text: string): string {
   return text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
@@ -76,6 +86,14 @@ export function defaultModelForHarness(
   return configured?.[key]?.trim() || BAKED_DEFAULT_MODELS[key]
 }
 
+export function defaultCodexEffort(configured?: string): string | undefined {
+  return configured?.trim() || BAKED_CODEX_EFFORT
+}
+
+export function defaultCodexSpeed(configured?: string): string | undefined {
+  return configured?.trim() || BAKED_CODEX_SPEED
+}
+
 /**
  * Builds the Console session URL for a Slack thread key, or undefined when no
  * Console base URL is configured (in which case no link/block should render).
@@ -98,7 +116,7 @@ export type SlackContextBlock = {
 }
 
 /**
- * Builds the "Open chat in Console · {MODEL} · {Harness}" context block, or
+ * Builds the Slack context block with model, harness, effort, and speed, or
  * undefined when no Console base URL is configured (a bare "Open chat in
  * Console" with no link is pointless, so the whole block is skipped). The
  * model id is uppercased for display.
@@ -108,6 +126,8 @@ export function buildConsoleSessionContextBlock(params: {
   threadKey: string
   harnessType?: string | null
   model?: string | null
+  effort?: string | null
+  speed?: string | null
 }): SlackContextBlock | undefined {
   const url = consoleSessionUrl(params.consoleBaseUrl, params.threadKey)
   if (!url) return undefined
@@ -116,6 +136,10 @@ export function buildConsoleSessionContextBlock(params: {
   if (model) segments.push(escapeSlackMrkdwn(model.toUpperCase()))
   const harness = harnessDisplayName(params.harnessType)
   if (harness) segments.push(escapeSlackMrkdwn(harness))
+  const effort = params.effort?.trim()
+  if (effort) segments.push(`Effort: ${escapeSlackMrkdwn(titleCase(effort))}`)
+  const speed = params.speed?.trim()
+  if (speed) segments.push(`Speed: ${escapeSlackMrkdwn(titleCase(speed))}`)
   // Middot (U+00B7) with a space on each side, matching the bot's other
   // context lines.
   return {

--- a/services/slackbotv2/src/index.ts
+++ b/services/slackbotv2/src/index.ts
@@ -42,6 +42,8 @@ import {
 } from './session-api'
 import {
   buildConsoleSessionContextBlock,
+  defaultCodexEffort,
+  defaultCodexSpeed,
   defaultModelForHarness,
   type SlackContextBlock
 } from './console-session-link'
@@ -744,12 +746,19 @@ async function syncThreadMessageToSession(
   const effectiveModel =
     effectiveOverrides.model ??
     defaultModelForHarness(effectiveHarnessType, input.options.harnessDefaultModels)
+  const effectiveEffort =
+    effectiveHarnessType === 'codex'
+      ? overrides.reasoning ?? defaultCodexEffort(input.options.codexDefaultReasoningEffort)
+      : undefined
+  const effectiveSpeed = effectiveHarnessType === 'codex' ? defaultCodexSpeed() : undefined
   const consoleSessionBlock = isFirstAssistantMessage
     ? buildConsoleSessionContextBlock({
         consoleBaseUrl: input.options.consolePublicUrl,
         threadKey: thread.id,
         harnessType: effectiveHarnessType,
-        model: effectiveModel
+        model: effectiveModel,
+        effort: effectiveEffort,
+        speed: effectiveSpeed
       })
     : undefined
   if (overrides.harnessType || overrides.model || overrides.provider || overrides.reasoning) {

--- a/services/slackbotv2/src/server.ts
+++ b/services/slackbotv2/src/server.ts
@@ -32,6 +32,7 @@ const options: SlackbotV2Options = {
   botToken,
   botUserId: optionalEnv('SLACK_BOT_USER_ID'),
   consolePublicUrl: optionalEnv('CENTAUR_CONSOLE_PUBLIC_URL'),
+  codexDefaultReasoningEffort: optionalEnv('CODEX_MODEL_REASONING_EFFORT'),
   defaultHarnessType: optionalEnv('SLACKBOTV2_DEFAULT_HARNESS'),
   // Same env vars deployers use to override the sandbox harness model
   // (sandbox.extraEnv); the chart mirrors them here so displayed defaults

--- a/services/slackbotv2/src/types.ts
+++ b/services/slackbotv2/src/types.ts
@@ -119,6 +119,8 @@ export type SlackbotV2Options = {
    * the block entirely.
    */
   consolePublicUrl?: string
+  /** Codex effort displayed in Slack when no per-turn `-rsn` override is set. */
+  codexDefaultReasoningEffort?: string
   /**
    * Harness for new threads when no --claude/--amp/--codex flag is given
    * (HarnessType wire value: codex | amp | claudecode). Defaults to codex.

--- a/services/slackbotv2/test/chat-sdk-emulate.test.ts
+++ b/services/slackbotv2/test/chat-sdk-emulate.test.ts
@@ -24,6 +24,7 @@ import {
 import { clearRequesterIdentityCacheForTests } from '../src/session-api'
 import { slackbotMetrics } from '../src/metrics'
 import claudeSettings from '../../../harness/claude/settings.json'
+import codexConfig from '../../../harness/codex/config.toml'
 
 const BOT_TOKEN = 'xoxb-slackbotv2-emulate'
 const USER_TOKEN = 'xoxp-slackbotv2-user'
@@ -531,10 +532,7 @@ describe('slackbotv2', () => {
         .filter(text => text.includes('Open chat in Console'))
 
     const parent = await postUserMessage('Default model thread context.')
-    const mention = await postUserMessage(
-      `<@${BOT_USER_ID}> --claude what is your current model?`,
-      parent.ts
-    )
+    const mention = await postUserMessage(`<@${BOT_USER_ID}> what is your current model?`, parent.ts)
     const waits: Promise<unknown>[] = []
     const response = await bot.app.request(
       '/api/webhooks/slack',
@@ -547,7 +545,7 @@ describe('slackbotv2', () => {
           team: TEAM_ID,
           ts: mention.ts,
           thread_ts: parent.ts,
-          text: `<@${BOT_USER_ID}> --claude what is your current model?`
+          text: `<@${BOT_USER_ID}> what is your current model?`
         }
       }),
       {},
@@ -558,15 +556,17 @@ describe('slackbotv2', () => {
 
     const blocks = consoleBlockTexts(slackApi.calls)
     expect(blocks).toHaveLength(1)
-    expect(blocks[0]).toContain('Claude Code')
-    expect(blocks[0]).toContain(claudeSettings.model.toUpperCase())
+    expect(blocks[0]).toContain('Codex')
+    expect(blocks[0]).toContain(codexConfig.model.toUpperCase())
+    expect(blocks[0]).toContain('Effort: Low')
+    expect(blocks[0]).toContain('Speed: Fast')
 
     // The effective (default) model is recorded in execution metadata for the
     // Console, but never forwarded to the harness — only explicit overrides
     // ride the input lines.
     expect(codexApi.executes).toHaveLength(1)
     const executeBody = codexApi.executes[0]!.body
-    expect(executeBody.metadata.model).toBe(claudeSettings.model)
+    expect(executeBody.metadata.model).toBe(codexConfig.model)
     expect(JSON.parse(executeBody.input_lines.at(-1)!).model).toBeUndefined()
   })
 

--- a/services/slackbotv2/test/console-session-link.test.ts
+++ b/services/slackbotv2/test/console-session-link.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, test } from 'bun:test'
 import {
   buildConsoleSessionContextBlock,
   consoleSessionUrl,
+  defaultCodexEffort,
+  defaultCodexSpeed,
   defaultModelForHarness,
   harnessDisplayName
 } from '../src/console-session-link'
@@ -85,12 +87,14 @@ describe('consoleSessionUrl', () => {
 })
 
 describe('buildConsoleSessionContextBlock', () => {
-  test('builds a context block with uppercased model then harness, middot separated', () => {
+  test('builds a context block with model, harness, effort, and speed', () => {
     const block = buildConsoleSessionContextBlock({
       consoleBaseUrl: 'https://console.centaur.dev',
       threadKey: 'slack:C123:1700000000.000100',
       harnessType: 'codex',
-      model: 'gpt-5.2'
+      model: 'gpt-5.2',
+      effort: 'xhigh',
+      speed: 'fast'
     })
     expect(block).toEqual({
       type: 'context',
@@ -98,7 +102,7 @@ describe('buildConsoleSessionContextBlock', () => {
         {
           type: 'mrkdwn',
           text:
-            '<https://console.centaur.dev/console/threads?thread=slack%3AC123%3A1700000000.000100|Open chat in Console> · GPT-5.2 · Codex'
+            '<https://console.centaur.dev/console/threads?thread=slack%3AC123%3A1700000000.000100|Open chat in Console> · GPT-5.2 · Codex · Effort: Xhigh · Speed: Fast'
         }
       ]
     })
@@ -124,5 +128,17 @@ describe('buildConsoleSessionContextBlock', () => {
         model: 'gpt-5.2'
       })
     ).toBeUndefined()
+  })
+})
+
+describe('Codex display defaults', () => {
+  test('reads effort and speed from the baked Codex config', () => {
+    expect(defaultCodexEffort()).toBe('low')
+    expect(defaultCodexSpeed()).toBe('fast')
+  })
+
+  test('allows deployment-configured defaults to override baked values', () => {
+    expect(defaultCodexEffort('high')).toBe('high')
+    expect(defaultCodexSpeed('flex')).toBe('flex')
   })
 })


### PR DESCRIPTION
## Summary
- show effective Codex reasoning effort and service-tier speed in the first Slack response context line
- honor per-turn `-rsn` and deployment-level effort overrides
- mirror the deployment effort setting into slackbotv2 and cover default rendering

## Testing
- `bun test test/console-session-link.test.ts`
- `bun test test/chat-sdk-emulate.test.ts -t "appends an Open-session|shows the harness default model"`
- `bun run check:types`
- `git diff --check`

Prompted by: @snario