### PR TITLE
fix(slackbot): upgrade deduped mention events

### DIFF
--- a/patches/chat@4.31.0.patch
+++ b/patches/chat@4.31.0.patch
@@ -1,0 +1,62 @@
+diff --git a/dist/index.js b/dist/index.js
+index 6af9d7fec34adeb8a7092a3ba0077d9f327a44d7..22062c519bde1d0aa5cf69fe4942b396bf2846f4 100644
+--- a/dist/index.js
++++ b/dist/index.js
+@@ -3425,6 +3425,12 @@ var Chat = class {
+    */
+   async handleIncomingMessage(adapter, threadId, message) {
+     setMessageAdapter(message, adapter);
++    // Some platforms deliver the same visible message more than once with
++    // progressively richer semantics. Slack, for example, can send a plain
++    // `message` callback before an `app_mention` callback with the same ts.
++    // Classify the message before deduplication so the later callback can
++    // upgrade the earlier non-mention instead of being discarded.
++    message.isMention = message.isMention || this.detectMention(adapter, message);
+     this.logger.debug("Incoming message", {
+       adapter: adapter.name,
+       threadId,
+@@ -3444,12 +3450,42 @@ var Chat = class {
+       return;
+     }
+     const dedupeKey = `dedupe:${adapter.name}:${message.id}`;
++    const priority = message.isMention ? 1 : 0;
+     const isFirstProcess = await this._stateAdapter.setIfNotExists(
+       dedupeKey,
+-      true,
++      priority,
+       this._dedupeTtlMs
+     );
+-    if (!isFirstProcess) {
++    let shouldProcess = isFirstProcess;
++    // A later mention is semantically richer than an earlier non-mention for
++    // the same platform message. Serialize only this uncommon upgrade path;
++    // ordinary first deliveries keep the single atomic set-if-absent call.
++    if (!shouldProcess && priority > 0) {
++      const dedupeLockKey = `dedupe-lock:${adapter.name}:${message.id}`;
++      let dedupeLock = null;
++      for (let attempt = 0; attempt < 40 && !dedupeLock; attempt++) {
++        dedupeLock = await this._stateAdapter.acquireLock(dedupeLockKey, 5e3);
++        if (!dedupeLock) await new Promise((resolve) => setTimeout(resolve, 25));
++      }
++      if (!dedupeLock) {
++        this.logger.warn("Unable to acquire message dedupe lock; skipping message", {
++          adapter: adapter.name,
++          messageId: message.id
++        });
++        return;
++      }
++      try {
++        const previous = await this._stateAdapter.get(dedupeKey);
++        const previousPriority = typeof previous === "number" ? previous : previous === null ? -1 : 0;
++        if (priority > previousPriority) {
++          await this._stateAdapter.set(dedupeKey, priority, this._dedupeTtlMs);
++          shouldProcess = true;
++        }
++      } finally {
++        await this._stateAdapter.releaseLock(dedupeLock);
++      }
++    }
++    if (!shouldProcess) {
+       this.logger.debug("Skipping duplicate message", {
+         adapter: adapter.name,
+         messageId: message.id

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ patchedDependencies:
   '@chat-adapter/state-pg@4.31.0':
     hash: 69262b03c278ca9d4af0bed7b4e05f9d7a5a36d3d79fad31df2a85da4d349274
     path: patches/@chat-adapter__state-pg@4.31.0.patch
+  chat@4.31.0:
+    hash: 69ddff60795975c673430c89c7688e6925f5128a1c4020996f953fdbde0ee658
+    path: patches/chat@4.31.0.patch
 
 importers:
 
@@ -85,7 +88,7 @@ importers:
         version: 4.31.0(patch_hash=69262b03c278ca9d4af0bed7b4e05f9d7a5a36d3d79fad31df2a85da4d349274)(zod@4.4.3)
       chat:
         specifier: ^4.31.0
-        version: 4.31.0(zod@4.4.3)
+        version: 4.31.0(patch_hash=69ddff60795975c673430c89c7688e6925f5128a1c4020996f953fdbde0ee658)(zod@4.4.3)
       discord.js:
         specifier: ^14.25.1
         version: 14.26.4
@@ -137,7 +140,7 @@ importers:
         version: 21.1.1
       chat:
         specifier: ^4.31.0
-        version: 4.31.0(zod@4.4.3)
+        version: 4.31.0(patch_hash=69ddff60795975c673430c89c7688e6925f5128a1c4020996f953fdbde0ee658)(zod@4.4.3)
       hono:
         specifier: ^4.12.18
         version: 4.12.25
@@ -183,7 +186,7 @@ importers:
         version: 76.0.0(graphql@17.0.0)
       chat:
         specifier: ^4.31.0
-        version: 4.31.0(zod@4.4.3)
+        version: 4.31.0(patch_hash=69ddff60795975c673430c89c7688e6925f5128a1c4020996f953fdbde0ee658)(zod@4.4.3)
       hono:
         specifier: ^4.12.18
         version: 4.12.25
@@ -226,7 +229,7 @@ importers:
         version: 4.31.0(patch_hash=69262b03c278ca9d4af0bed7b4e05f9d7a5a36d3d79fad31df2a85da4d349274)(zod@4.4.3)
       chat:
         specifier: ^4.31.0
-        version: 4.31.0(zod@4.4.3)
+        version: 4.31.0(patch_hash=69ddff60795975c673430c89c7688e6925f5128a1c4020996f953fdbde0ee658)(zod@4.4.3)
       hono:
         specifier: ^4.12.18
         version: 4.12.25
@@ -275,7 +278,7 @@ importers:
         version: 4.31.0(zod@4.4.3)
       chat:
         specifier: ^4.31.0
-        version: 4.31.0(zod@4.4.3)
+        version: 4.31.0(patch_hash=69ddff60795975c673430c89c7688e6925f5128a1c4020996f953fdbde0ee658)(zod@4.4.3)
       dotenv:
         specifier: ^17.3.1
         version: 17.4.2
@@ -1957,7 +1960,7 @@ snapshots:
   '@chat-adapter/discord@4.31.0(patch_hash=8f4fbb770159f924570fbad681297fcb9f8f7a6353a705cfcb78e39ef9e3a3ab)(zod@4.4.3)':
     dependencies:
       '@chat-adapter/shared': 4.31.0(zod@4.4.3)
-      chat: 4.31.0(zod@4.4.3)
+      chat: 4.31.0(patch_hash=69ddff60795975c673430c89c7688e6925f5128a1c4020996f953fdbde0ee658)(zod@4.4.3)
       discord-api-types: 0.37.120
       discord-interactions: 4.4.0
       discord.js: 14.26.4
@@ -1973,7 +1976,7 @@ snapshots:
       '@chat-adapter/shared': 4.31.0(zod@4.4.3)
       '@octokit/auth-app': 8.2.0
       '@octokit/rest': 22.0.1
-      chat: 4.31.0(zod@4.4.3)
+      chat: 4.31.0(patch_hash=69ddff60795975c673430c89c7688e6925f5128a1c4020996f953fdbde0ee658)(zod@4.4.3)
     transitivePeerDependencies:
       - ai
       - supports-color
@@ -1983,7 +1986,7 @@ snapshots:
     dependencies:
       '@chat-adapter/shared': 4.31.0(zod@4.4.3)
       '@linear/sdk': 76.0.0(graphql@17.0.0)
-      chat: 4.31.0(zod@4.4.3)
+      chat: 4.31.0(patch_hash=69ddff60795975c673430c89c7688e6925f5128a1c4020996f953fdbde0ee658)(zod@4.4.3)
     transitivePeerDependencies:
       - ai
       - graphql
@@ -1992,7 +1995,7 @@ snapshots:
 
   '@chat-adapter/shared@4.31.0(zod@4.4.3)':
     dependencies:
-      chat: 4.31.0(zod@4.4.3)
+      chat: 4.31.0(patch_hash=69ddff60795975c673430c89c7688e6925f5128a1c4020996f953fdbde0ee658)(zod@4.4.3)
     transitivePeerDependencies:
       - ai
       - supports-color
@@ -2003,7 +2006,7 @@ snapshots:
       '@chat-adapter/shared': 4.31.0(zod@4.4.3)
       '@slack/socket-mode': 2.0.7
       '@slack/web-api': 7.17.0
-      chat: 4.31.0(zod@4.4.3)
+      chat: 4.31.0(patch_hash=69ddff60795975c673430c89c7688e6925f5128a1c4020996f953fdbde0ee658)(zod@4.4.3)
     transitivePeerDependencies:
       - ai
       - bufferutil
@@ -2014,7 +2017,7 @@ snapshots:
 
   '@chat-adapter/state-memory@4.31.0(zod@4.4.3)':
     dependencies:
-      chat: 4.31.0(zod@4.4.3)
+      chat: 4.31.0(patch_hash=69ddff60795975c673430c89c7688e6925f5128a1c4020996f953fdbde0ee658)(zod@4.4.3)
     transitivePeerDependencies:
       - ai
       - supports-color
@@ -2022,7 +2025,7 @@ snapshots:
 
   '@chat-adapter/state-pg@4.31.0(patch_hash=69262b03c278ca9d4af0bed7b4e05f9d7a5a36d3d79fad31df2a85da4d349274)(zod@4.4.3)':
     dependencies:
-      chat: 4.31.0(zod@4.4.3)
+      chat: 4.31.0(patch_hash=69ddff60795975c673430c89c7688e6925f5128a1c4020996f953fdbde0ee658)(zod@4.4.3)
       pg: 8.21.0
     transitivePeerDependencies:
       - ai
@@ -2037,7 +2040,7 @@ snapshots:
       '@microsoft/teams.apps': 2.0.13
       '@microsoft/teams.cards': 2.0.13
       '@microsoft/teams.graph-endpoints': 2.0.13
-      chat: 4.31.0(zod@4.4.3)
+      chat: 4.31.0(patch_hash=69ddff60795975c673430c89c7688e6925f5128a1c4020996f953fdbde0ee658)(zod@4.4.3)
     transitivePeerDependencies:
       - ai
       - debug
@@ -2734,7 +2737,7 @@ snapshots:
 
   character-entities@2.0.2: {}
 
-  chat@4.31.0(zod@4.4.3):
+  chat@4.31.0(patch_hash=69ddff60795975c673430c89c7688e6925f5128a1c4020996f953fdbde0ee658)(zod@4.4.3):
     dependencies:
       '@workflow/serde': 4.1.0-beta.2
       mdast-util-to-string: 4.0.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,7 +7,8 @@ packages:
   - services/githubbot
 
 patchedDependencies:
-  '@chat-adapter/linear@4.31.0': patches/@chat-adapter__linear@4.31.0.patch
   '@chat-adapter/discord@4.31.0': patches/@chat-adapter__discord@4.31.0.patch
+  '@chat-adapter/linear@4.31.0': patches/@chat-adapter__linear@4.31.0.patch
   '@chat-adapter/slack@4.31.0': patches/@chat-adapter__slack@4.31.0.patch
   '@chat-adapter/state-pg@4.31.0': patches/@chat-adapter__state-pg@4.31.0.patch
+  chat@4.31.0: patches/chat@4.31.0.patch

--- a/services/slackbotv2/test/chat-sdk-emulate.test.ts
+++ b/services/slackbotv2/test/chat-sdk-emulate.test.ts
@@ -4348,6 +4348,79 @@ describe('slackbotv2', () => {
     expect(codexApi.appends).toHaveLength(0)
     expect(codexApi.executes).toHaveLength(0)
   })
+
+  it('executes an allowed bot mention once regardless of Slack callback order', async () => {
+    for (const order of ['message-first', 'mention-first'] as const) {
+      bot = createTestBot({ triggerBotAllowlist: ['UOTHERBOT'] })
+      codexApi.reset()
+      slackApi.reset()
+      const posted = await postUserMessage('')
+      const messageEvent = signedSlackEvent({
+        event_id: `Ev-slackbotv2-dedupe-${order}-message`,
+        event: {
+          type: 'message',
+          app_id: 'AOTHERBOT',
+          bot_id: 'BOTHERBOT',
+          bot_profile: {
+            app_id: 'AOTHERBOT',
+            id: 'BOTHERBOT',
+            user_id: 'UOTHERBOT'
+          },
+          channel: CHANNEL_ID,
+          subtype: 'bot_message',
+          team: TEAM_ID,
+          text: '',
+          ts: posted.ts,
+          username: 'otherbot'
+        }
+      })
+      const mentionEvent = signedSlackEvent({
+        event_id: `Ev-slackbotv2-dedupe-${order}-mention`,
+        event: {
+          type: 'app_mention',
+          app_id: 'AOTHERBOT',
+          attachments: [
+            {
+              pretext: `<@${BOT_USER_ID}> investigate`,
+              title: ':red_circle: Validator stalled',
+              text: '*Cluster:* stg-na'
+            }
+          ],
+          bot_id: 'BOTHERBOT',
+          bot_profile: {
+            app_id: 'AOTHERBOT',
+            id: 'BOTHERBOT',
+            user_id: 'UOTHERBOT'
+          },
+          channel: CHANNEL_ID,
+          subtype: 'bot_message',
+          team: TEAM_ID,
+          text: '',
+          ts: posted.ts,
+          user: 'UOTHERBOT',
+          username: 'otherbot'
+        }
+      })
+      const events = order === 'message-first' ? [messageEvent, mentionEvent] : [mentionEvent, messageEvent]
+      for (const event of events) {
+        const waits: Promise<unknown>[] = []
+        const response = await bot.app.request(
+          '/api/webhooks/slack',
+          event,
+          {},
+          waitUntilContext(waits)
+        )
+        expect(response.status).toBe(200)
+        await Promise.all(waits)
+      }
+
+      expect(codexApi.appends).toHaveLength(1)
+      expect(codexApi.executes).toHaveLength(1)
+      expect(sessionMessageTexts(codexApi.appends[0]!.body.messages).join('\n')).toContain(
+        'Validator stalled'
+      )
+    }
+  })
 })
 
 function createTestBot(


### PR DESCRIPTION
Slack may deliver the same visible message as both `message` and `app_mention`. When the empty `message` callback arrives first, Chat SDK currently claims the dedupe key and drops the later actionable mention.

Patch Chat SDK dedupe state to rank mentions above non-mentions, allowing one atomic upgrade while retaining duplicate suppression. The upgrade path is serialized; normal first deliveries retain the existing set-if-absent fast path.

Adds regression coverage for both observed callback orders and asserts exactly one append/execution with attachment content preserved.

Validation:
- `pnpm --filter slackbotv2 test -- chat-sdk-emulate.test.ts` (175 pass, 1 skipped)
- `pnpm --filter slackbotv2 check:types`

Prompted by: @kuyziss