### PR TITLE
feat: harden console public login

### DIFF
--- a/contrib/chart/Chart.yaml
+++ b/contrib/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: centaur
 description: Helm chart for the trusted Centaur control plane
 type: application
-version: 0.1.99
+version: 0.1.100
 appVersion: "0.1.0"
 dependencies:
   - name: connect

--- a/contrib/chart/templates/console.yaml
+++ b/contrib/chart/templates/console.yaml
@@ -191,6 +191,12 @@ spec:
             - name: CENTAUR_MCP_PUBLIC_URL
               value: {{ $mcpPublicUrl | quote }}
 {{- end }}
+            - name: CENTAUR_CONSOLE_PASSWORD_LOGIN_ENABLED
+              value: {{ $console.passwordLoginEnabled | quote }}
+{{- with $console.ssoEmailDomains }}
+            - name: CENTAUR_CONSOLE_SSO_EMAIL_DOMAINS
+              value: {{ join "," . | quote }}
+{{- end }}
 {{- if $console.googleOauth.enabled }}
             # Google OAuth app credentials (sign-in + brokered token refresh).
             # Gated on console.googleOauth.enabled; the keys must exist in the

--- a/contrib/chart/values.yaml
+++ b/contrib/chart/values.yaml
@@ -106,6 +106,12 @@ console:
   # When set, the slackbotv2 deployment also links the first assistant message
   # in a Slack thread to the Console session view; leave empty to omit the link.
   publicUrl: ""
+  # Break-glass email/password login. Disable when console is reachable from
+  # the public internet and SSO is configured.
+  passwordLoginEnabled: true
+  # Optional SSO admission policy. When non-empty, only identities whose email
+  # domain matches this list can sign in through Google or Slack.
+  ssoEmailDomains: []
   image:
     repository: centaur-console
     tag: latest

--- a/services/console/README.md
+++ b/services/console/README.md
@@ -96,7 +96,9 @@ The operator console always supports email and password sign-in. To add Google o
 | `CENTAUR_CONSOLE_GOOGLE_CLIENT_SECRET`   | for Google | Google OAuth client secret for console login.                                                |
 | `CENTAUR_CONSOLE_SLACK_CLIENT_ID`        | for Slack | Slack OpenID Connect client ID for console login.                                            |
 | `CENTAUR_CONSOLE_SLACK_CLIENT_SECRET`    | for Slack | Slack OpenID Connect client secret for console login.                                        |
-| `CENTAUR_CONSOLE_BOOTSTRAP_ADMINS`       | no       | Comma- or whitespace-separated email allowlist. Matching users become active admins on first SSO login. Other SSO users become active non-admin operators and land on the console directly -- the deployment's network boundary is the access control, there is no approval queue. |
+| `CENTAUR_CONSOLE_SSO_EMAIL_DOMAINS`      | recommended for public exposure | Comma- or whitespace-separated domain allowlist for SSO users, for example `acme.com example.org`. Empty allows any IdP-authenticated email. |
+| `CENTAUR_CONSOLE_PASSWORD_LOGIN_ENABLED` | no       | Set to `false` to disable email and password sign-in. Defaults to enabled.                    |
+| `CENTAUR_CONSOLE_BOOTSTRAP_ADMINS`       | no       | Comma- or whitespace-separated email allowlist. Matching users become active admins on first SSO login. Other accepted SSO users become active non-admin operators and land on the console directly. |
 
 Register these callback URLs with the provider:
 

--- a/services/console/app/controllers/application_controller.rb
+++ b/services/console/app/controllers/application_controller.rb
@@ -9,7 +9,7 @@ class ApplicationController < ActionController::Base
   # controllers don't each hand-roll a rescue. Mirrors Api::BaseController.
   rescue_from ActiveRecord::RecordNotFound, with: :render_not_found
 
-  helper_method :current_user, :acting_admin?, :descoped?
+  helper_method :current_user, :acting_admin?, :descoped?, :password_login_enabled?
   helper_method :public_base_url, :oauth_callback_redirect_uri
 
   # The public origin the console is reached at. Derived from the request by
@@ -74,6 +74,10 @@ class ApplicationController < ActionController::Base
 
     session.delete(:descoped)
     false
+  end
+
+  def password_login_enabled?
+    ConsoleAuth.password_login_enabled?
   end
 
   # The permission check console gates use instead of current_user.admin?: a

--- a/services/console/app/controllers/session_oauth_controller.rb
+++ b/services/console/app/controllers/session_oauth_controller.rb
@@ -71,6 +71,9 @@ class SessionOauthController < ApplicationController
   rescue Broker::ExchangeError => e
     Rails.logger.error { "console login exchange failed (#{@key}): #{e.reason}" }
     redirect_to login_path, alert: "Sign in failed. Please try again."
+  rescue User::SsoEmailDomainNotAllowed
+    Rails.logger.warn { "console login rejected by SSO email domain allowlist (#{@key})" }
+    redirect_to login_path, alert: "That email domain is not allowed to access the console."
   rescue ActiveRecord::RecordInvalid => e
     Rails.logger.error { "console login provisioning failed: #{e.record.errors.full_messages.to_sentence}" }
     redirect_to login_path, alert: "Sign in failed while setting up your account."

--- a/services/console/app/controllers/sessions_controller.rb
+++ b/services/console/app/controllers/sessions_controller.rb
@@ -1,7 +1,8 @@
 # Quick session-cookie login for the operator console. Authenticates an existing
 # User (has_secure_password) by email + password and stores their id in the
-# session. No registration, password reset, or rate limiting: this is an internal
-# gate, not a public auth system.
+# session. No registration, password reset, or rate limiting: deployments that
+# expose the console publicly should disable this break-glass path with
+# CENTAUR_CONSOLE_PASSWORD_LOGIN_ENABLED=false.
 class SessionsController < ApplicationController
   layout "auth"
 
@@ -24,6 +25,11 @@ class SessionsController < ApplicationController
   end
 
   def create
+    unless password_login_enabled?
+      flash.now[:alert] = "Email and password sign in is disabled."
+      return render :new, status: :not_found
+    end
+
     user = User.find_by(email: params[:email].to_s.strip.downcase)
     unless user&.authenticate(params[:password])
       flash.now[:alert] = "Invalid email or password."

--- a/services/console/app/models/user.rb
+++ b/services/console/app/models/user.rb
@@ -1,4 +1,6 @@
 class User < ApplicationRecord
+  class SsoEmailDomainNotAllowed < StandardError; end
+
   oid_prefix "usr"
 
   # validations: false because SSO-only users have no password. The password
@@ -46,6 +48,8 @@ class User < ApplicationRecord
   # verified email is on the bootstrap allowlist). +identity+ is the provider
   # strategy's { subject:, email:, email_verified:, name: } hash.
   def self.link_or_provision(provider:, identity:)
+    raise SsoEmailDomainNotAllowed unless ConsoleAuth.sso_email_allowed?(identity[:email])
+
     transaction do
       user =
         if (existing = UserIdentity.find_by(provider: provider, subject: identity[:subject]))
@@ -82,10 +86,9 @@ class User < ApplicationRecord
   end
   private_class_method :identity_attributes
 
-  # Attributes for a brand-new SSO user: everyone is provisioned active -- the
-  # console is only reachable on the internal network, so a completed SSO login
-  # is sufficient and there is no admin-approval queue. Admin additionally
-  # requires a bootstrap-allowlisted, IdP-verified email.
+  # Attributes for a brand-new SSO user: everyone is provisioned active once the
+  # IdP identity has passed the configured SSO admission policy. Admin
+  # additionally requires a bootstrap-allowlisted, IdP-verified email.
   def self.provisioned_attributes(identity)
     admin = identity[:email_verified] == true && ConsoleAuth.bootstrap_admin?(identity[:email])
     { email: identity[:email], name: identity[:name], status: :active, admin: admin }

--- a/services/console/app/views/sessions/new.html.erb
+++ b/services/console/app/views/sessions/new.html.erb
@@ -28,27 +28,31 @@
       <% end %>
     </div>
 
-    <div class="my-6 flex items-center gap-3 text-xs uppercase tracking-wider text-zinc-600">
-      <span class="h-px flex-1 bg-ink-600"></span>
-      or sign in with email
-      <span class="h-px flex-1 bg-ink-600"></span>
-    </div>
+    <% if password_login_enabled? %>
+      <div class="my-6 flex items-center gap-3 text-xs uppercase tracking-wider text-zinc-600">
+        <span class="h-px flex-1 bg-ink-600"></span>
+        or sign in with email
+        <span class="h-px flex-1 bg-ink-600"></span>
+      </div>
+    <% end %>
   <% end %>
 
-  <%= form_with url: login_path, method: :post do |f| %>
-    <div class="space-y-5">
-      <div>
-        <%= f.label :email, class: label %>
-        <%= f.email_field :email, class: input, placeholder: "you@example.com", autocomplete: "username", autofocus: true %>
+  <% if password_login_enabled? %>
+    <%= form_with url: login_path, method: :post do |f| %>
+      <div class="space-y-5">
+        <div>
+          <%= f.label :email, class: label %>
+          <%= f.email_field :email, class: input, placeholder: "you@example.com", autocomplete: "username", autofocus: true %>
+        </div>
+        <div>
+          <%= f.label :password, class: label %>
+          <%= f.password_field :password, class: input, autocomplete: "current-password" %>
+        </div>
       </div>
-      <div>
-        <%= f.label :password, class: label %>
-        <%= f.password_field :password, class: input, autocomplete: "current-password" %>
-      </div>
-    </div>
 
-    <div class="mt-6">
-      <%= f.submit "Sign in", class: "w-full cursor-pointer rounded border border-centaur-500/40 bg-centaur-500/10 px-4 py-2 text-sm text-centaur-300 transition-colors hover:bg-centaur-500/20 hover:text-centaur-200" %>
-    </div>
+      <div class="mt-6">
+        <%= f.submit "Sign in", class: "w-full cursor-pointer rounded border border-centaur-500/40 bg-centaur-500/10 px-4 py-2 text-sm text-centaur-300 transition-colors hover:bg-centaur-500/20 hover:text-centaur-200" %>
+      </div>
+    <% end %>
   <% end %>
 </div>

--- a/services/console/lib/console_auth.rb
+++ b/services/console/lib/console_auth.rb
@@ -54,8 +54,7 @@ module ConsoleAuth
 
   def sso_email_domains
     raw = ConsoleEnv["SSO_EMAIL_DOMAINS"].presence
-    list = raw.is_a?(Array) ? raw : raw.to_s.split(/[,\s]+/)
-    list.map { |domain| domain.to_s.strip.downcase }.reject(&:empty?).uniq
+    raw.to_s.split(/[,\s]+/).map { |domain| domain.strip.downcase }.reject(&:empty?).uniq
   end
 
   def bootstrap_admin?(email)

--- a/services/console/lib/console_auth.rb
+++ b/services/console/lib/console_auth.rb
@@ -8,6 +8,14 @@
 #   credentials.console_auth.<provider>.client_id/secret  (fallback)
 # A provider is offered on the login page only when both are present.
 #
+# SSO email domains are optional. When configured, every SSO login must use an
+# email address under one of these domains:
+#   CENTAUR_CONSOLE_SSO_EMAIL_DOMAINS="acme.com example.org"
+#
+# Password login is a break-glass fallback and can be disabled for public
+# deployments:
+#   CENTAUR_CONSOLE_PASSWORD_LOGIN_ENABLED=false
+#
 # Bootstrap admins are matched by email and become active + admin on first login
 # (the first admin needs no existing approver):
 #   CENTAUR_CONSOLE_BOOTSTRAP_ADMINS="me@acme.com, you@acme.com"   (ENV)
@@ -31,6 +39,25 @@ module ConsoleAuth
   def client_id(provider) = setting(provider, "client_id")
   def client_secret(provider) = setting(provider, "client_secret")
 
+  def password_login_enabled?
+    raw = ConsoleEnv["PASSWORD_LOGIN_ENABLED"]
+    raw.nil? ? true : boolean_setting(raw)
+  end
+
+  def sso_email_allowed?(email)
+    domains = sso_email_domains
+    return true if domains.empty?
+
+    domain = email.to_s.strip.downcase.split("@", 2).last
+    domains.include?(domain)
+  end
+
+  def sso_email_domains
+    raw = ConsoleEnv["SSO_EMAIL_DOMAINS"].presence
+    list = raw.is_a?(Array) ? raw : raw.to_s.split(/[,\s]+/)
+    list.map { |domain| domain.to_s.strip.downcase }.reject(&:empty?).uniq
+  end
+
   def bootstrap_admin?(email)
     normalized = email.to_s.strip.downcase
     return false if normalized.empty?
@@ -53,5 +80,9 @@ module ConsoleAuth
 
   def credentials_dig(*path)
     Rails.application.credentials.dig(:console_auth, *path)
+  end
+
+  def boolean_setting(value)
+    ActiveModel::Type::Boolean.new.cast(value)
   end
 end

--- a/services/console/test/controllers/session_oauth_controller_test.rb
+++ b/services/console/test/controllers/session_oauth_controller_test.rb
@@ -8,7 +8,8 @@ require "test_helper"
 class SessionOauthControllerTest < ActionDispatch::IntegrationTest
   GOOGLE_CLIENT_ID = "google-login-client-id".freeze
   ENV_KEYS = %w[
-    CENTAUR_CONSOLE_GOOGLE_CLIENT_ID CENTAUR_CONSOLE_GOOGLE_CLIENT_SECRET CENTAUR_CONSOLE_BOOTSTRAP_ADMINS
+    CENTAUR_CONSOLE_GOOGLE_CLIENT_ID CENTAUR_CONSOLE_GOOGLE_CLIENT_SECRET
+    CENTAUR_CONSOLE_BOOTSTRAP_ADMINS CENTAUR_CONSOLE_SSO_EMAIL_DOMAINS
   ].freeze
 
   setup do
@@ -112,6 +113,27 @@ class SessionOauthControllerTest < ActionDispatch::IntegrationTest
     assert_equal "Test User", user.name
     assert_equal user.id, session[:user_id]
     assert_equal [ [ "google", "new-sub" ] ], user.user_identities.pluck(:provider, :subject)
+  end
+
+  test "callback provisions a user inside the configured SSO domain allowlist" do
+    ENV["CENTAUR_CONSOLE_SSO_EMAIL_DOMAINS"] = "example.com acme.example"
+    assert_difference -> { User.count }, 1 do
+      run_callback(sub: "allowed-sub", email: "newcomer@example.com")
+    end
+    assert_redirected_to console_threads_path
+    assert_equal User.find_by!(email: "newcomer@example.com").id, session[:user_id]
+  end
+
+  test "callback rejects a user outside the configured SSO domain allowlist" do
+    ENV["CENTAUR_CONSOLE_SSO_EMAIL_DOMAINS"] = "acme.example"
+    assert_no_difference -> { User.count } do
+      assert_no_difference -> { UserIdentity.count } do
+        run_callback(sub: "outside-sub", email: "newcomer@example.com")
+      end
+    end
+    assert_redirected_to login_path
+    assert_equal "That email domain is not allowed to access the console.", flash[:alert]
+    assert_nil session[:user_id]
   end
 
   test "callback makes a bootstrap-allowlisted email active and admin" do

--- a/services/console/test/controllers/sessions_controller_test.rb
+++ b/services/console/test/controllers/sessions_controller_test.rb
@@ -9,10 +9,30 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
     assert_select "form[action=?]", login_path
   end
 
+  test "GET new hides the password form when password login is disabled" do
+    ENV["CENTAUR_CONSOLE_PASSWORD_LOGIN_ENABLED"] = "false"
+    get login_url
+    assert_response :ok
+    assert_select "form[action=?]", login_path, count: 0
+    assert_select "input[name=?]", "email", count: 0
+  ensure
+    ENV.delete("CENTAUR_CONSOLE_PASSWORD_LOGIN_ENABLED")
+  end
+
   test "valid credentials sign in and redirect to the console" do
     post login_url, params: { email: @operator.email, password: "password123456" }
     assert_redirected_to console_principals_path
     assert_equal @operator.id, session[:user_id]
+  end
+
+  test "password login rejects credentials when disabled" do
+    ENV["CENTAUR_CONSOLE_PASSWORD_LOGIN_ENABLED"] = "false"
+    post login_url, params: { email: @operator.email, password: "password123456" }
+    assert_response :not_found
+    assert_nil session[:user_id]
+    assert_select "div", /Email and password sign in is disabled/
+  ensure
+    ENV.delete("CENTAUR_CONSOLE_PASSWORD_LOGIN_ENABLED")
   end
 
   test "a non-admin lands on the threads view after login" do

--- a/services/console/test/models/user_test.rb
+++ b/services/console/test/models/user_test.rb
@@ -116,6 +116,30 @@ class UserTest < ActiveSupport::TestCase
     assert_equal [ [ "google", "sub-1" ] ], user.user_identities.pluck(:provider, :subject)
   end
 
+  test "link_or_provision rejects SSO emails outside the configured domain allowlist" do
+    ENV["CENTAUR_CONSOLE_SSO_EMAIL_DOMAINS"] = "acme.example example.org"
+    assert_no_difference [ "User.count", "UserIdentity.count" ] do
+      assert_raises(User::SsoEmailDomainNotAllowed) do
+        User.link_or_provision(provider: "google",
+                              identity: identity(subject: "outside-sub", email: "newcomer@example.com"))
+      end
+    end
+  ensure
+    ENV.delete("CENTAUR_CONSOLE_SSO_EMAIL_DOMAINS")
+  end
+
+  test "link_or_provision allows SSO emails inside the configured domain allowlist" do
+    ENV["CENTAUR_CONSOLE_SSO_EMAIL_DOMAINS"] = "acme.example example.org"
+    user = nil
+    assert_difference -> { User.count }, 1 do
+      user = User.link_or_provision(provider: "google",
+                                    identity: identity(subject: "inside-sub", email: "worker@acme.example"))
+    end
+    assert user.active?
+  ensure
+    ENV.delete("CENTAUR_CONSOLE_SSO_EMAIL_DOMAINS")
+  end
+
   test "link_or_provision returns the existing user for a returning identity" do
     existing = user_identities(:acme_admin_google)
     user = nil
@@ -124,6 +148,19 @@ class UserTest < ActiveSupport::TestCase
                                     identity: identity(subject: existing.subject, email: existing.email))
     end
     assert_equal existing.user, user
+  end
+
+  test "link_or_provision rejects a returning identity outside the configured domain allowlist" do
+    ENV["CENTAUR_CONSOLE_SSO_EMAIL_DOMAINS"] = "globex.example"
+    existing = user_identities(:acme_admin_google)
+    assert_no_difference [ "User.count", "UserIdentity.count" ] do
+      assert_raises(User::SsoEmailDomainNotAllowed) do
+        User.link_or_provision(provider: existing.provider,
+                              identity: identity(subject: existing.subject, email: existing.email))
+      end
+    end
+  ensure
+    ENV.delete("CENTAUR_CONSOLE_SSO_EMAIL_DOMAINS")
   end
 
   test "link_or_provision links a new identity to an existing user by verified email" do


### PR DESCRIPTION
Adds env-gated controls for public console exposure: an SSO email domain allowlist and a switch to disable email/password login. Wires the settings through the Helm chart, updates console auth docs, and covers the SSO and password-login paths with focused Rails tests.