### PR TITLE
feat(workflows): plumb model and reasoning effort through ctx.agent_turn

### DIFF
--- a/docs/pages/extend/workflows-v2.mdx
+++ b/docs/pages/extend/workflows-v2.mdx
@@ -110,6 +110,8 @@ result = await ctx.agent_turn(
     "Investigate this alert and return the next action.",
     thread_key=f"workflow:{ctx.run_id}:agent",
     harness="codex",
+    model="claude-opus-4-8",
+    reasoning="high",
     metadata={"workflow": WORKFLOW_NAME},
 )
 ```
@@ -117,6 +119,30 @@ result = await ctx.agent_turn(
 The workflow host sandbox is separate from the agent sandbox. The workflow
 handler coordinates the run; the agent turn runs through the normal Centaur
 session runtime.
+
+#### Pick the model and reasoning effort
+
+`ctx.agent_turn(...)` accepts optional `model`, `provider`, and `reasoning`
+kwargs. They ride the turn exactly like the Slack `--model` / `--bedrock` /
+`-rsn` flags: `model` selects the model within the harness, `reasoning` sets the
+codex reasoning effort (`none`/`minimal`/`low`/`medium`/`high`/`xhigh`/`max`),
+and `provider` selects the codex model provider. `provider` and `reasoning` only
+affect the codex harness; claude and amp ignore them. `reasoning` also accepts
+the `reasoning_effort` and `effort` aliases. When a kwarg is omitted the
+deployment/baked harness default stands — dispatched turns are no longer pinned
+to the deployment default.
+
+To set a default for **every** turn in a workflow, declare a module-level
+`AGENT_DEFAULTS` dict. Explicit per-call kwargs override it key by key:
+
+```python
+WORKFLOW_NAME = "nightly_report"
+AGENT_DEFAULTS = {"model": "claude-opus-4-8", "reasoning": "high"}
+
+async def handler(inp: Input, ctx: WorkflowContext) -> dict[str, Any]:
+    await ctx.agent_turn("Draft the report.")            # opus @ high
+    await ctx.agent_turn("Tidy formatting.", reasoning="low")  # opus @ low
+```
 
 ### Declare webhook metadata in the workflow
 

--- a/docs/pages/extend/workflows-v2.mdx
+++ b/docs/pages/extend/workflows-v2.mdx
@@ -110,7 +110,7 @@ result = await ctx.agent_turn(
     "Investigate this alert and return the next action.",
     thread_key=f"workflow:{ctx.run_id}:agent",
     harness="codex",
-    model="claude-opus-4-8",
+    model="gpt-5.2",
     reasoning="high",
     metadata={"workflow": WORKFLOW_NAME},
 )
@@ -137,12 +137,16 @@ To set a default for **every** turn in a workflow, declare a module-level
 
 ```python
 WORKFLOW_NAME = "nightly_report"
-AGENT_DEFAULTS = {"model": "claude-opus-4-8", "reasoning": "high"}
+AGENT_DEFAULTS = {"harness": "codex", "model": "gpt-5.2", "reasoning": "high"}
 
 async def handler(inp: Input, ctx: WorkflowContext) -> dict[str, Any]:
-    await ctx.agent_turn("Draft the report.")            # opus @ high
-    await ctx.agent_turn("Tidy formatting.", reasoning="low")  # opus @ low
+    await ctx.agent_turn("Draft the report.")            # gpt-5.2 @ high
+    await ctx.agent_turn("Tidy formatting.", reasoning="low")  # gpt-5.2 @ low
 ```
+
+Keep `harness` and `model` together — a model is only meaningful within its
+harness, and because kwargs override `AGENT_DEFAULTS` key by key, overriding one
+without the other can strand a model on the wrong harness.
 
 ### Declare webhook metadata in the workflow
 

--- a/docs/public/md/extend/workflows-v2.md
+++ b/docs/public/md/extend/workflows-v2.md
@@ -110,6 +110,8 @@ result = await ctx.agent_turn(
     "Investigate this alert and return the next action.",
     thread_key=f"workflow:{ctx.run_id}:agent",
     harness="codex",
+    model="claude-opus-4-8",
+    reasoning="high",
     metadata={"workflow": WORKFLOW_NAME},
 )
 ```
@@ -117,6 +119,30 @@ result = await ctx.agent_turn(
 The workflow host sandbox is separate from the agent sandbox. The workflow
 handler coordinates the run; the agent turn runs through the normal Centaur
 session runtime.
+
+#### Pick the model and reasoning effort
+
+`ctx.agent_turn(...)` accepts optional `model`, `provider`, and `reasoning`
+kwargs. They ride the turn exactly like the Slack `--model` / `--bedrock` /
+`-rsn` flags: `model` selects the model within the harness, `reasoning` sets the
+codex reasoning effort (`none`/`minimal`/`low`/`medium`/`high`/`xhigh`/`max`),
+and `provider` selects the codex model provider. `provider` and `reasoning` only
+affect the codex harness; claude and amp ignore them. `reasoning` also accepts
+the `reasoning_effort` and `effort` aliases. When a kwarg is omitted the
+deployment/baked harness default stands — dispatched turns are no longer pinned
+to the deployment default.
+
+To set a default for **every** turn in a workflow, declare a module-level
+`AGENT_DEFAULTS` dict. Explicit per-call kwargs override it key by key:
+
+```python
+WORKFLOW_NAME = "nightly_report"
+AGENT_DEFAULTS = {"model": "claude-opus-4-8", "reasoning": "high"}
+
+async def handler(inp: Input, ctx: WorkflowContext) -> dict[str, Any]:
+    await ctx.agent_turn("Draft the report.")            # opus @ high
+    await ctx.agent_turn("Tidy formatting.", reasoning="low")  # opus @ low
+```
 
 ### Declare webhook metadata in the workflow
 

--- a/docs/public/md/extend/workflows-v2.md
+++ b/docs/public/md/extend/workflows-v2.md
@@ -110,7 +110,7 @@ result = await ctx.agent_turn(
     "Investigate this alert and return the next action.",
     thread_key=f"workflow:{ctx.run_id}:agent",
     harness="codex",
-    model="claude-opus-4-8",
+    model="gpt-5.2",
     reasoning="high",
     metadata={"workflow": WORKFLOW_NAME},
 )
@@ -137,12 +137,16 @@ To set a default for **every** turn in a workflow, declare a module-level
 
 ```python
 WORKFLOW_NAME = "nightly_report"
-AGENT_DEFAULTS = {"model": "claude-opus-4-8", "reasoning": "high"}
+AGENT_DEFAULTS = {"harness": "codex", "model": "gpt-5.2", "reasoning": "high"}
 
 async def handler(inp: Input, ctx: WorkflowContext) -> dict[str, Any]:
-    await ctx.agent_turn("Draft the report.")            # opus @ high
-    await ctx.agent_turn("Tidy formatting.", reasoning="low")  # opus @ low
+    await ctx.agent_turn("Draft the report.")            # gpt-5.2 @ high
+    await ctx.agent_turn("Tidy formatting.", reasoning="low")  # gpt-5.2 @ low
 ```
+
+Keep `harness` and `model` together — a model is only meaningful within its
+harness, and because kwargs override `AGENT_DEFAULTS` key by key, overriding one
+without the other can strand a model on the wrong harness.
 
 ### Declare webhook metadata in the workflow
 

--- a/services/api-rs/crates/centaur-workflows/src/lib.rs
+++ b/services/api-rs/crates/centaur-workflows/src/lib.rs
@@ -2478,6 +2478,9 @@ async fn run_centaur_workflow_inner(
                                 workflow_owned_thread: true,
                                 idle_timeout_ms,
                                 max_duration_ms,
+                                model: None,
+                                provider: None,
+                                reasoning: None,
                             },
                         )
                         .await
@@ -3321,6 +3324,17 @@ async fn run_python_agent_turn(
         .and_then(Value::as_str)
         .map(ToOwned::to_owned)
         .unwrap_or_else(|| format!("absurd-workflow-agent-turn:{client_message_id}"));
+    // Optional per-turn harness knobs, mirroring the slackbot's `--model` /
+    // `--bedrock` / `-rsn` flags. `reasoning` accepts `reasoning_effort` and
+    // `effort` aliases so Python callers can use whichever reads best.
+    let model = first_str_arg(&args, &["model"]);
+    let provider = first_str_arg(&args, &["provider"]);
+    let reasoning = first_str_arg(&args, &["reasoning", "reasoning_effort", "effort"]);
+    // Record the model on the execution like the slackbot does, so Console
+    // readers can show what a workflow-dispatched turn ran on.
+    if let Some(model) = model.as_deref() {
+        object_insert(&mut execution_metadata, "model", json!(model));
+    }
     let result = run_agent_session_turn(
         session_runtime,
         AgentTurnRequest {
@@ -3336,10 +3350,22 @@ async fn run_python_agent_turn(
             workflow_owned_thread,
             idle_timeout_ms,
             max_duration_ms,
+            model,
+            provider,
+            reasoning,
         },
     )
     .await?;
     serde_json::to_value(result).map_err(WorkflowRuntimeError::from)
+}
+
+/// Returns the first arg key that holds a non-empty (trimmed) string, owned.
+fn first_str_arg(args: &Value, keys: &[&str]) -> Option<String> {
+    keys.iter()
+        .filter_map(|key| args.get(*key).and_then(Value::as_str))
+        .map(str::trim)
+        .find(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
 }
 
 fn parse_agent_harness(args: &Value) -> Result<Option<HarnessType>, WorkflowRuntimeError> {
@@ -3616,6 +3642,42 @@ struct AgentTurnRequest {
     workflow_owned_thread: bool,
     idle_timeout_ms: u64,
     max_duration_ms: u64,
+    // Optional per-turn model / provider / reasoning-effort overrides. When set
+    // they ride the execute input line exactly like the slackbot's per-turn
+    // `--model` / `--bedrock` / `-rsn` flags do (see slackbotv2's
+    // `toCodexInputLineWithStaged`), so the harness applies them to this turn;
+    // when `None` the deployment/baked harness default stands. `provider` and
+    // `reasoning` only affect the codex harness (claude/amp ignore them).
+    model: Option<String>,
+    provider: Option<String>,
+    reasoning: Option<String>,
+}
+
+/// Builds the single `type: "user"` execute input line for a workflow agent
+/// turn, mirroring the blocks-protocol shape the harness parses
+/// (`BlocksLine` in `harness-server`): optional top-level `model` / `provider`
+/// / `reasoning` keys, then the `message.content` parts. api-rs enriches the
+/// line with session/trace context before forwarding, so those keys are omitted
+/// here.
+fn agent_turn_input_line(
+    parts: &[Value],
+    model: Option<&str>,
+    provider: Option<&str>,
+    reasoning: Option<&str>,
+) -> Result<String, serde_json::Error> {
+    let mut line = serde_json::Map::new();
+    line.insert("type".to_owned(), json!("user"));
+    if let Some(model) = model {
+        line.insert("model".to_owned(), json!(model));
+    }
+    if let Some(provider) = provider {
+        line.insert("provider".to_owned(), json!(provider));
+    }
+    if let Some(reasoning) = reasoning {
+        line.insert("reasoning".to_owned(), json!(reasoning));
+    }
+    line.insert("message".to_owned(), json!({ "content": parts }));
+    serde_json::to_string(&Value::Object(line))
 }
 
 async fn run_agent_session_turn(
@@ -3635,6 +3697,9 @@ async fn run_agent_session_turn(
         workflow_owned_thread,
         idle_timeout_ms,
         max_duration_ms,
+        model,
+        provider,
+        reasoning,
     } = turn;
     let thread_key = ThreadKey::parse(thread_key)?;
     let mut session_metadata = session_metadata;
@@ -3667,12 +3732,12 @@ async fn run_agent_session_turn(
             ExecuteSessionInput {
                 idempotency_key: Some(execution_idempotency_key),
                 metadata: Some(execution_metadata),
-                input_lines: vec![serde_json::to_string(&json!({
-                    "type": "user",
-                    "message": {
-                        "content": parts,
-                    },
-                }))?],
+                input_lines: vec![agent_turn_input_line(
+                    &parts,
+                    model.as_deref(),
+                    provider.as_deref(),
+                    reasoning.as_deref(),
+                )?],
                 idle_timeout_ms: Some(idle_timeout_ms),
                 max_duration_ms: Some(max_duration_ms),
             },
@@ -3813,6 +3878,47 @@ pub enum WorkflowRuntimeError {
 mod tests {
     use super::*;
     use chrono::TimeZone;
+
+    #[test]
+    fn agent_turn_input_line_omits_unset_harness_knobs() {
+        let parts = vec![json!({"type": "text", "text": "hi"})];
+        let line = agent_turn_input_line(&parts, None, None, None).unwrap();
+        let value: Value = serde_json::from_str(&line).unwrap();
+        assert_eq!(value.get("type"), Some(&json!("user")));
+        assert_eq!(value.pointer("/message/content"), Some(&json!(parts)));
+        assert!(value.get("model").is_none());
+        assert!(value.get("provider").is_none());
+        assert!(value.get("reasoning").is_none());
+    }
+
+    #[test]
+    fn agent_turn_input_line_forwards_model_provider_reasoning() {
+        let parts = vec![json!({"type": "text", "text": "hi"})];
+        let line = agent_turn_input_line(
+            &parts,
+            Some("claude-opus-4-8"),
+            Some("amazon-bedrock"),
+            Some("high"),
+        )
+        .unwrap();
+        let value: Value = serde_json::from_str(&line).unwrap();
+        // Keys match the blocks-protocol shape the harness parses (BlocksLine).
+        assert_eq!(value.get("model"), Some(&json!("claude-opus-4-8")));
+        assert_eq!(value.get("provider"), Some(&json!("amazon-bedrock")));
+        assert_eq!(value.get("reasoning"), Some(&json!("high")));
+        assert_eq!(value.pointer("/message/content"), Some(&json!(parts)));
+    }
+
+    #[test]
+    fn first_str_arg_picks_first_non_empty_alias() {
+        let args = json!({"reasoning": "  ", "reasoning_effort": " high ", "effort": "low"});
+        assert_eq!(
+            first_str_arg(&args, &["reasoning", "reasoning_effort", "effort"]),
+            Some("high".to_owned())
+        );
+        assert_eq!(first_str_arg(&json!({}), &["model"]), None);
+        assert_eq!(first_str_arg(&json!({"model": "   "}), &["model"]), None);
+    }
 
     #[test]
     fn parse_worker_concurrency_uses_override_or_default() {

--- a/services/workflow-python/api/workflow_engine.py
+++ b/services/workflow-python/api/workflow_engine.py
@@ -25,12 +25,17 @@ class WorkflowContext:
         task_id: str,
         workflow_name: str,
         pool: Any = None,
+        agent_defaults: dict[str, Any] | None = None,
     ) -> None:
         self._rpc = rpc
         self.run_id = run_id
         self.task_id = task_id
         self.workflow_name = workflow_name
         self._pool = pool
+        # Module-level `AGENT_DEFAULTS` (e.g. {"model": ..., "reasoning": ...})
+        # applied to every ctx.agent_turn as a per-workflow default; explicit
+        # per-call kwargs always win. See agent_turn().
+        self._agent_defaults = dict(agent_defaults or {})
         self.tools = WorkflowTools(WorkflowToolManager(self._rpc))
 
     def log(self, event: str, **fields: Any) -> None:
@@ -97,7 +102,9 @@ class WorkflowContext:
         )
 
     async def agent_turn(self, text: str | None = None, **kwargs: Any) -> Any:
-        args = dict(kwargs)
+        # Per-workflow AGENT_DEFAULTS (model / provider / reasoning / harness,
+        # ...) form the base; explicit per-call kwargs override them key by key.
+        args = {**self._agent_defaults, **kwargs}
         if text is not None:
             args.setdefault("text", text)
         return await self._rpc.request({"type": "ctx.agent_turn", "args": args})

--- a/services/workflow-python/tests/test_workflow_host.py
+++ b/services/workflow-python/tests/test_workflow_host.py
@@ -4,6 +4,7 @@ import asyncio
 import importlib.util
 import os
 import sys
+import tempfile
 import types
 import unittest
 from pathlib import Path
@@ -169,6 +170,42 @@ class WorkflowHostTests(unittest.TestCase):
 
         self.assertEqual(result, {"name": "draft_summary", "text": "summarize this"})
 
+    def test_agent_turn_applies_workflow_agent_defaults(self) -> None:
+        host = load_workflow_host()
+        rpc = RequestRpc()
+        ctx = host.WorkflowContext(
+            rpc,
+            run_id="run-123",
+            task_id="task-456",
+            workflow_name="sample",
+            agent_defaults={"model": "claude-opus-4-8", "reasoning": "high"},
+        )
+
+        result = asyncio.run(ctx.agent_turn("do the thing"))
+
+        self.assertEqual(
+            result,
+            {"model": "claude-opus-4-8", "reasoning": "high", "text": "do the thing"},
+        )
+
+    def test_agent_turn_per_call_kwargs_override_agent_defaults(self) -> None:
+        host = load_workflow_host()
+        rpc = RequestRpc()
+        ctx = host.WorkflowContext(
+            rpc,
+            run_id="run-123",
+            task_id="task-456",
+            workflow_name="sample",
+            agent_defaults={"model": "claude-opus-4-8", "reasoning": "high"},
+        )
+
+        result = asyncio.run(ctx.agent_turn("cheap step", reasoning="low"))
+
+        self.assertEqual(
+            result,
+            {"model": "claude-opus-4-8", "reasoning": "low", "text": "cheap step"},
+        )
+
     def test_start_workflow_enqueues_durable_child_with_idempotency_key(self) -> None:
         host = load_workflow_host()
         rpc = RequestRpc()
@@ -284,6 +321,70 @@ class WorkflowHostTests(unittest.TestCase):
         )
         self.assertTrue(rpc.drained)
         self.assertTrue(pool.closed)
+
+    def test_run_workflow_threads_agent_defaults_into_context(self) -> None:
+        host = load_workflow_host()
+        rpc = RequestRpc()
+
+        async def handler(inp, ctx):
+            return await ctx.agent_turn("do the thing")
+
+        registered = host.RegisteredWorkflow(
+            workflow_name="sample_workflow",
+            source_path="workflows/sample.py",
+            handler=handler,
+            input_cls=None,
+            webhooks=None,
+            schedule=None,
+            agent_defaults={"model": "claude-opus-4-8", "reasoning": "high"},
+        )
+
+        async def create_pool():
+            return None
+
+        with (
+            patch.object(
+                host,
+                "discover_workflows",
+                return_value={"sample_workflow": registered},
+            ),
+            patch.object(host, "create_pool", create_pool),
+        ):
+            payload = asyncio.run(
+                host.run_workflow(
+                    {
+                        "type": "workflow.start",
+                        "workflow_name": "sample_workflow",
+                        "run_id": "run-123",
+                        "task_id": "task-456",
+                        "input": {},
+                    },
+                    rpc,
+                )
+            )
+
+        self.assertEqual(
+            payload["result"],
+            {"model": "claude-opus-4-8", "reasoning": "high", "text": "do the thing"},
+        )
+
+    def test_load_workflow_file_reads_agent_defaults(self) -> None:
+        host = load_workflow_host()
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "defaults_workflow.py"
+            path.write_text(
+                "WORKFLOW_NAME = 'defaults_workflow'\n"
+                "AGENT_DEFAULTS = {'model': 'claude-opus-4-8', 'reasoning': 'high'}\n"
+                "def handler(inp, ctx):\n"
+                "    return None\n"
+            )
+            registered = host.load_workflow_file(path)
+
+        assert registered is not None
+        self.assertEqual(
+            registered.agent_defaults,
+            {"model": "claude-opus-4-8", "reasoning": "high"},
+        )
 
 
 if __name__ == "__main__":

--- a/services/workflow-python/workflow_host.py
+++ b/services/workflow-python/workflow_host.py
@@ -84,6 +84,7 @@ class RegisteredWorkflow:
     input_cls: type | None
     webhooks: Any
     schedule: Any
+    agent_defaults: dict[str, Any] | None = None
 
 
 def workflow_dirs() -> list[Path]:
@@ -142,6 +143,9 @@ def load_workflow_file(path: Path) -> RegisteredWorkflow | None:
     handler = getattr(module, "handler", None)
     if not isinstance(workflow_name, str) or not callable(handler):
         return None
+    agent_defaults = getattr(module, "AGENT_DEFAULTS", None)
+    if not isinstance(agent_defaults, dict):
+        agent_defaults = None
     return RegisteredWorkflow(
         workflow_name=workflow_name,
         source_path=str(path),
@@ -149,6 +153,7 @@ def load_workflow_file(path: Path) -> RegisteredWorkflow | None:
         input_cls=getattr(module, "Input", None),
         webhooks=getattr(module, "WEBHOOKS", None),
         schedule=getattr(module, "SCHEDULE", None),
+        agent_defaults=agent_defaults,
     )
 
 
@@ -335,6 +340,7 @@ async def run_workflow(message: dict[str, Any], rpc: RpcClient) -> dict[str, Any
         task_id=str(message.get("task_id") or ""),
         workflow_name=workflow_name,
         pool=pool,
+        agent_defaults=registered.agent_defaults,
     )
     previous_metric_rpc = metrics.get_metric_rpc()
     metrics.set_metric_rpc(rpc)


### PR DESCRIPTION
## Summary

Workflow-dispatched agent turns could only run on the deployment/baked harness default. `run_python_agent_turn` never read a model or reasoning effort from the `ctx.agent_turn` args, and `run_agent_session_turn` built the execute input line as `{"type":"user","message":{...}}` with no `model`/`provider`/`reasoning` keys. A workflow that fans work out to agent turns therefore ran silently on the deployment default model and effort, with no way to choose otherwise — unlike a Slack turn, which can pass `--model` / `-rsn`.

This plumbs an optional per-turn model / provider / reasoning effort through the agent-turn path, and adds a per-workflow default.

## What changed

- **`ctx.agent_turn(...)` now honors `model`, `provider`, and `reasoning`.** The Rust `ctx.agent_turn` handler reads them from the RPC args (with `reasoning_effort` / `effort` accepted as aliases) and forwards them on the execute input line, using the same top-level `model`/`provider`/`reasoning` keys the harness already parses (`BlocksLine`) and that the slackbot emits for `--model` / `--bedrock` / `-rsn`. When omitted, the deployment/baked default stands. `provider` and `reasoning` are codex-only upstream; claude/amp ignore them.
- **Per-workflow default via `AGENT_DEFAULTS`.** A module-level `AGENT_DEFAULTS` dict (e.g. `{"model": "claude-opus-4-8", "reasoning": "high"}`) is captured at registration and folded into every `ctx.agent_turn` as a base; explicit per-call kwargs override it key by key. No Rust change beyond the plumbing above — the Python engine merges it before the RPC.
- **Records the model on the execution metadata**, mirroring the slackbot, so Console readers can see what a dispatched turn ran on.
- The input-line construction is factored into a small pure helper (`agent_turn_input_line`) so the wire shape is unit-tested.
- Docs: `docs/.../extend/workflows-v2` documents the new kwargs and `AGENT_DEFAULTS`.

```python
WORKFLOW_NAME = "nightly_report"
AGENT_DEFAULTS = {"model": "claude-opus-4-8", "reasoning": "high"}

async def handler(inp, ctx):
    await ctx.agent_turn("Draft the report.")              # opus @ high
    await ctx.agent_turn("Tidy formatting.", reasoning="low")  # opus @ low
```

## Testing

- `cargo test -p centaur-workflows` (adds `agent_turn_input_line_*` and `first_str_arg_*` cases) — 27 passed.
- `cargo clippy -p centaur-workflows` — clean.
- `cargo fmt -p centaur-workflows -- --check` — clean.
- `python -m unittest tests.test_workflow_host` (adds per-call/default merge, end-to-end `run_workflow`, and `load_workflow_file` cases) — 12 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)