### PR TITLE
fix: require console login for oauth credential minting

### DIFF
--- a/services/console/app/controllers/oauth/flows_controller.rb
+++ b/services/console/app/controllers/oauth/flows_controller.rb
@@ -9,21 +9,17 @@ module Oauth
   # BrokerCredential linked to the OauthApp, then sends the user back to the
   # console Integrations page (or renders a result page on failure).
   #
-  # Deliberately unauthenticated -- a team member connects an integration by
-  # clicking a well-known link; there is no external app to integrate with, so
-  # there is no return_to or user key. Safety comes from: a credential is only
-  # minted after a successful consent + code exchange, and re-consent for the
-  # same (app, provider account) upserts the existing credential. All
-  # provider-specific behavior comes from the strategy (Oauth::Providers), which
-  # is derived from the app.
+  # Authenticated console consent flow. A team member connects an integration by
+  # clicking a console link; a credential is only minted after an active console
+  # session, successful consent, and code exchange. Re-consent for the same (app,
+  # provider account) upserts the existing credential. All provider-specific
+  # behavior comes from the strategy (Oauth::Providers), which is derived from
+  # the app.
   #
   # SECURITY: never logs the code, tokens, client_secret, or response bodies --
   # only oids and error codes, like the rest of the Broker/Oauth subsystem.
   class FlowsController < ApplicationController
     layout "auth"
-
-    skip_before_action :require_login
-    skip_before_action :require_active_account
 
     # The message_verifier purpose binding the signed state to this flow, the
     # state/cookie lifetime, and the encrypted cookie that ties a callback back to
@@ -156,18 +152,17 @@ module Oauth
     end
 
     # Upserts one credential per (app, provider account). A new record gets its
-    # identity/endpoint fixed (and an auto-generated external_user_key, since the
-    # flow has no caller-supplied user); every consent (re)applies the rotating
-    # blob, including the freshly-exchanged access token so the credential is live
-    # immediately, and revives a dead credential.
+    # identity/endpoint fixed (and an auto-generated external_user_key); every
+    # consent (re)applies the rotating blob, including the freshly-exchanged
+    # access token so the credential is live immediately, and revives a dead
+    # credential.
     def upsert_credential(state, result, identity)
       BrokerCredential.transaction do
         credential = BrokerCredential.find_or_initialize_by(oauth_app: @app, provider_subject: identity[:subject])
-        # When the consenting browser carries a signed-in console session,
-        # remember which user connected this account. The Integrations page
-        # matches on it, so the card flips to "Connected" even when the
-        # provider account's email differs from the console login email.
-        # Never overwritten: the first linked user keeps the credential.
+        # Remember which user connected this account. The Integrations page
+        # matches on it, so the card flips to "Connected" even when the provider
+        # account's email differs from the console login email. Never
+        # overwritten: the first linked user keeps the credential.
         credential.created_by ||= current_user
         if credential.new_record?
           credential.namespace = @app.credential_namespace

--- a/services/console/config/routes.rb
+++ b/services/console/config/routes.rb
@@ -211,9 +211,8 @@ Rails.application.routes.draw do
     end
   end
 
-  # Public OAuth consent flow, keyed by the app's well-known slug
-  # (/oauth/google/start). Deliberately unauthenticated: a team member clicks the
-  # link to connect an integration; the provider is derived from the app.
+  # OAuth consent flow, keyed by the app's well-known slug (/oauth/google/start).
+  # Requires an active console session; the provider is derived from the app.
   get "oauth/:slug/start", to: "oauth/flows#start", as: :oauth_start
   get "oauth/:slug/callback", to: "oauth/flows#callback", as: :oauth_callback
 

--- a/services/console/test/controllers/oauth/flows_controller_test.rb
+++ b/services/console/test/controllers/oauth/flows_controller_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 module Oauth
   # Covers the consent flow end to end: /oauth/:slug/start builds the IdP redirect
   # and binds the browser; /oauth/:slug/callback exchanges the code, upserts a
-  # BrokerCredential, and renders an iron-control result page. The IdP is faked by
+  # BrokerCredential, and renders a console result page. The IdP is faked by
   # swapping the controller's exchange_client_factory for a client wrapped around
   # an HTTP double returning a canned token response.
   class FlowsControllerTest < ActionDispatch::IntegrationTest
@@ -22,6 +22,8 @@ module Oauth
       oauth_apps(:acme_github).update!(client_secret: "github-secret")
       oauth_apps(:acme_attio).update!(client_secret: "attio-secret")
       oauth_apps(:acme_linear).update!(client_secret: "linear-secret")
+      @user = users(:member_user)
+      sign_in @user
       clear_enqueued_jobs
     end
 
@@ -102,6 +104,10 @@ module Oauth
 
     def sign_in(user)
       post login_url, params: { email: user.email, password: "password123456" }
+    end
+
+    def sign_out
+      delete logout_url
     end
 
     # Runs /start and returns the state extracted from the IdP redirect (the flow
@@ -210,19 +216,23 @@ module Oauth
       assert_includes scopes, "write"
     end
 
-    test "start works without any session" do
+    test "start redirects signed-out users to login" do
+      sign_out
+
       get oauth_start_url(slug: "google")
+
       assert_response :redirect
+      assert_redirected_to login_path
       assert_nil session[:user_id]
     end
 
-    test "start works with a pending console session" do
+    test "start redirects pending console users to the pending page" do
       sign_in users(:pending_user)
 
       get oauth_start_url(slug: "google")
 
       assert_response :redirect
-      assert_equal "accounts.google.com", URI.parse(response.location).host
+      assert_redirected_to pending_path
     end
 
     test "start 404s an unknown slug" do
@@ -273,7 +283,7 @@ module Oauth
       assert_equal "AT", cred.access_token
       assert_equal "RT", cred.refresh_token
       assert cred.next_attempt_at.present?
-      assert_nil cred.created_by
+      assert_equal @user, cred.created_by
     end
 
     test "callback happy path supports Slack user tokens" do
@@ -400,7 +410,7 @@ module Oauth
       assert_equal cred, secret.broker_credential # first-class link to the credential
       assert_equal cred.namespace, secret.namespace
       assert_nil secret.foreign_id # found by association, so no collidable foreign_id
-      assert_nil secret.created_by # the unauthenticated flow has no operator
+      assert_nil secret.created_by # the wrapping secret is not owned by an operator
       assert_equal({ "header" => "Authorization", "formatter" => "Bearer {{ .Value }}" }, secret.inject_config)
       assert_equal "token_broker", secret.source.source_type
       assert_equal cred.oid, secret.source.config["credential_id"]
@@ -463,20 +473,31 @@ module Oauth
       assert_select "a.btn-secondary[href=?]", "http://www.example.com/oauth/slack/start", text: "Reconnect"
     end
 
-    test "callback works with a disabled console session" do
+    test "callback redirects signed-out users to login and mints nothing" do
+      state = start_flow
+      sign_out
+      stub_exchange(status: 200, body: token_body)
+
+      assert_no_difference -> { BrokerCredential.count } do
+        get oauth_callback_url(slug: "google"), params: { state: state, code: "auth-code" }
+      end
+
+      assert_redirected_to login_path
+      assert_nil session[:user_id]
+    end
+
+    test "callback rejects a disabled console session before minting" do
       user = users(:member_user)
-      sign_in user
       state = start_flow
       user.update!(status: :disabled)
       stub_exchange(status: 200, body: token_body)
 
-      assert_difference -> { BrokerCredential.count }, 1 do
+      assert_no_difference -> { BrokerCredential.count } do
         get oauth_callback_url(slug: "google"), params: { state: state, code: "auth-code" }
       end
 
-      assert_redirected_to console_integrations_path
-      assert_match(/connected/, flash[:notice])
-      assert_equal user.id, session[:user_id]
+      assert_redirected_to login_path
+      assert_nil session[:user_id]
     end
 
     test "re-consent for the same account updates the existing credential and revives a dead one" do


### PR DESCRIPTION
Requires an active console session for OAuth credential consent start and callback routes, so credentials cannot be minted anonymously. Updates the focused controller coverage for signed-out, pending, and disabled console users.