### PR TITLE
fix: harden console public access controls

### DIFF
--- a/services/console/app/controllers/api/base_controller.rb
+++ b/services/console/app/controllers/api/base_controller.rb
@@ -17,9 +17,12 @@ module Api
     def authenticate_api_key!
       token = bearer_token
       @current_api_key = ApiKey.find_by_token(token) if token.present?
-      return if @current_api_key
+      unless current_api_key&.user&.active?
+        return render_error(status: :unauthorized, message: "invalid or missing API key")
+      end
+      return if current_api_key.user.admin?
 
-      render_error(status: :unauthorized, message: "invalid or missing API key")
+      render_error(status: :forbidden, message: "API key owner is not an admin")
     end
 
     def render_not_found(e)

--- a/services/console/config/environments/production.rb
+++ b/services/console/config/environments/production.rb
@@ -1,4 +1,5 @@
 require "active_support/core_ext/integer/time"
+require "uri"
 
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
@@ -24,14 +25,10 @@ Rails.application.configure do
   # Store uploaded files on the local file system (see config/storage.yml for options).
   config.active_storage.service = :local
 
-  # Assume all access to the app is happening through a SSL-terminating reverse proxy.
+  # Do not assume or force SSL here: in-cluster callers reach the service over
+  # plain HTTP. Public TLS enforcement belongs at the ingress/proxy layer.
   # config.assume_ssl = true
-
-  # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   # config.force_ssl = true
-
-  # Skip http-to-https redirect for the default health check endpoint.
-  # config.ssl_options = { redirect: { exclude: ->(request) { request.path == "/up" } } }
 
   # Log to STDOUT as single-line JSON with the current request id as a default log tag.
   config.log_tags = [ :request_id ]
@@ -93,12 +90,18 @@ Rails.application.configure do
   # Only use :id for inspections in production.
   config.active_record.attributes_for_inspect = [ :id ]
 
-  # Enable DNS rebinding protection and other `Host` header attacks.
-  # config.hosts = [
-  #   "example.com",     # Allow requests from example.com
-  #   /.*\.example\.com/ # Allow requests from subdomains like `www.example.com`
-  # ]
-  #
+  # Enable DNS rebinding protection and other `Host` header attacks. Public
+  # deployments should set CENTAUR_CONSOLE_PUBLIC_URL; add any extra internal
+  # health-check or ingress hosts with CENTAUR_CONSOLE_ALLOWED_HOSTS.
+  public_url = ConsoleEnv["PUBLIC_URL"].presence
+  internal_url = ConsoleEnv["URL"].presence
+  allowed_hosts = ConsoleEnv["ALLOWED_HOSTS"].to_s.split(/[,\s]+/).map(&:strip).reject(&:blank?)
+  [ public_url, internal_url ].compact.each do |url|
+    host = URI.parse(url).host
+    allowed_hosts << host if host.present?
+  end
+  config.hosts.concat(allowed_hosts.uniq) if allowed_hosts.any?
+
   # Skip DNS rebinding protection for the default health check endpoint.
-  # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
+  config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
 end

--- a/services/console/test/controllers/api/v1/api_keys_controller_test.rb
+++ b/services/console/test/controllers/api/v1/api_keys_controller_test.rb
@@ -30,6 +30,17 @@ module Api
         assert_response :unauthorized
       end
 
+      test "rejects API keys for disabled users" do
+        get api_v1_api_keys_url, headers: auth_headers("iak_disabled-token")
+        assert_response :unauthorized
+      end
+
+      test "rejects API keys for non-admin users" do
+        get api_v1_api_keys_url, headers: auth_headers("iak_member-token")
+        assert_response :forbidden
+        assert_equal "API key owner is not an admin", json_body.dig("error", "message")
+      end
+
       test "GET index lists only the caller's keys and never returns plaintext token" do
         get api_v1_api_keys_url, headers: auth_headers
         assert_response :ok

--- a/services/console/test/fixtures/api_keys.yml
+++ b/services/console/test/fixtures/api_keys.yml
@@ -12,3 +12,13 @@ globex_ci_key:
   user: globex_admin
   name: ci
   token_hash: <%= Digest::SHA256.hexdigest("iak_globex-ci-token") %>
+
+member_key:
+  user: member_user
+  name: member
+  token_hash: <%= Digest::SHA256.hexdigest("iak_member-token") %>
+
+disabled_key:
+  user: disabled_user
+  name: disabled
+  token_hash: <%= Digest::SHA256.hexdigest("iak_disabled-token") %>


### PR DESCRIPTION
Tightens console API key authorization so bearer keys only work for active admin users, while preserving unauthorized responses for missing or inactive owners. Enables Rails host authorization in production from the configured public/internal console URLs and optional allowed hosts, without forcing SSL for in-cluster HTTP callers.