### PR TITLE
feat: ingest private Slack channels from OAuth

### DIFF
--- a/docs/pages/operate/slack-etl.mdx
+++ b/docs/pages/operate/slack-etl.mdx
@@ -72,8 +72,8 @@ reads channel history, and fetches the complete `conversations.members` list.
 Messages are deduplicated by Slack conversation and message timestamp when
 multiple credentials can see the same channel.
 
-User-scoped private channels are stored in the separate `slack_dm_sync_*` and
-`slack_dm_context_documents` private-conversation tables rather than
+User-scoped private channels are stored with DMs and MPIMs in the neutral
+`slack_private_sync_*` and `slack_private_*_context_documents` tables rather than
 `company_context_documents`. RLS checks `(team_id, channel_id, user_id)` against
 the reconciled membership list. A successful sync marks members omitted from
 Slack's complete member list inactive; a partial or truncated member list is

--- a/docs/pages/operate/slack-etl.mdx
+++ b/docs/pages/operate/slack-etl.mdx
@@ -58,6 +58,27 @@ visible to that token. It does not sync DMs or Slackbot-only live thread events.
 Private channel rows are protected by RLS: `centaur_readonly` sees public
 channel data and the channel in `centaur.slack_channel_id`.
 
+### User-scoped private-channel ingestion
+
+The console's Slack OAuth flow can ingest private channels through the same
+user-scoped pipeline used for DMs. Add `groups:read` and `groups:history` to the
+Slack OAuth app's allowed user scopes and have existing users consent again.
+DM-only credentials continue syncing DMs while credentials with the new scopes
+also request `private_channel` conversations.
+
+Every 10 minutes the console worker fans out across healthy Slack broker
+credentials. Each credential lists the private channels visible to that user,
+reads channel history, and fetches the complete `conversations.members` list.
+Messages are deduplicated by Slack conversation and message timestamp when
+multiple credentials can see the same channel.
+
+User-scoped private channels are stored in the separate `slack_dm_sync_*` and
+`slack_dm_context_documents` private-conversation tables rather than
+`company_context_documents`. RLS checks `(team_id, channel_id, user_id)` against
+the reconciled membership list. Private-channel membership expires closed when
+it has not been refreshed for 30 minutes; a partial or truncated Slack member
+list is never applied.
+
 ## Enable the schedules
 
 Set `apiRs.etl.slack.enabled=true` in Helm values. The chart renders the
@@ -89,7 +110,7 @@ apiRs:
 | `SLACK_RETENTION_ENABLED` | `true` | Allows the `slack_retention` schedule to run when at least one Slack retention TTL is positive. |
 | `SLACK_RETENTION_INTERVAL_MINUTES` | `60` | How often to prune Slack retention-managed rows. |
 | `SLACK_ETL_RETENTION_DAYS` | `0` | Deletes Slack ETL messages, derived Slack documents, and terminal ETL run/job rows older than this many days. `0` disables ETL retention. |
-| `SLACK_DM_RETENTION_DAYS` | `0` | Deletes Slack DM messages, stale empty DM conversations, and terminal DM run/job rows older than this many days. `0` disables DM retention. |
+| `SLACK_DM_RETENTION_DAYS` | `0` | Deletes user-scoped private Slack messages, stale empty conversations, and terminal run/job rows older than this many days. `0` disables retention. |
 | `COMPANY_CONTEXT_DOCUMENTS_ENABLED` | `true` | Enables projection from Slack sync rows into company context documents. |
 | `COMPANY_CONTEXT_DOCUMENTS_INTERVAL_SECONDS` | `14400` | How often to project changed Slack rows into documents. |
 | `COMPANY_CONTEXT_DOCUMENTS_MAX_WINDOW_SECONDS` | `21600` | Maximum source `updated_at` window projected by one company context documents run. |

--- a/docs/pages/operate/slack-etl.mdx
+++ b/docs/pages/operate/slack-etl.mdx
@@ -75,9 +75,9 @@ multiple credentials can see the same channel.
 User-scoped private channels are stored in the separate `slack_dm_sync_*` and
 `slack_dm_context_documents` private-conversation tables rather than
 `company_context_documents`. RLS checks `(team_id, channel_id, user_id)` against
-the reconciled membership list. Private-channel membership expires closed when
-it has not been refreshed for 30 minutes; a partial or truncated Slack member
-list is never applied.
+the reconciled membership list. A successful sync marks members omitted from
+Slack's complete member list inactive; a partial or truncated member list is
+never applied.
 
 ## Enable the schedules
 

--- a/docs/pages/reference/tool-directory.mdx
+++ b/docs/pages/reference/tool-directory.mdx
@@ -34,7 +34,7 @@ These are broadly useful across most deployments and are good candidates to conf
 | `slack` | Search Slack, read threads, inspect channels/users, and send or upload messages | `SLACK_BOT_TOKEN`; optional: `SLACK_SEARCH_TOKEN`, `SLACK_ETL_TOKEN` |
 | `gsuite` | Use Gmail, Calendar, Drive, Docs, Sheets, Slides, and Google Analytics | `GOOGLE_TOKEN_JSON` |
 | `websearch` | Free web search via Parallel and deep research | None; `PARALLEL_API_KEY` for `deep_research`; `ANTHROPIC_API_KEY` for search synthesis |
-| `company_context` | Search indexed company history, Slack DMs, and Google Docs | None |
+| `company_context` | Search indexed company history, private Slack conversations, and Google Docs | None |
 | `grafana` | Query dashboards, alerts, VictoriaMetrics, VictoriaLogs, and annotations | `GRAFANA_URL`, `GRAFANA_API_KEY` |
 | `posthog` | Query product analytics, events, pageviews, breakdowns, and user agents | `POSTHOG_API_KEY`, `POSTHOG_PROJECT_ID` |
 | `attio` | Work with CRM objects, records, lists, notes, tasks, calls, and meetings | `ATTIO_API_KEY` |
@@ -75,7 +75,7 @@ These are broadly useful across most deployments and are good candidates to conf
 | Tool | Use | API key / credential |
 |---|---|---|
 | `airtable` | Bases, schemas, tables, views, record reads, record writes, and URL parsing | `AIRTABLE_API_KEY` |
-| `company_context` | Search indexed company history, Slack DMs, and Google Docs | None |
+| `company_context` | Search indexed company history, private Slack conversations, and Google Docs | None |
 | `composio` | Execute tools from third-party services exposed through Composio | `COMPOSIO_API_KEY` |
 | `figma` | Extract Figma files, nodes, components, styles, and variables | `FIGMA_ACCESS_TOKEN` |
 | `granola` | Search and read Granola notes and transcripts | `GRANOLA_API_KEY` |

--- a/docs/public/md/operate/slack-etl.md
+++ b/docs/public/md/operate/slack-etl.md
@@ -72,8 +72,8 @@ reads channel history, and fetches the complete `conversations.members` list.
 Messages are deduplicated by Slack conversation and message timestamp when
 multiple credentials can see the same channel.
 
-User-scoped private channels are stored in the separate `slack_dm_sync_*` and
-`slack_dm_context_documents` private-conversation tables rather than
+User-scoped private channels are stored with DMs and MPIMs in the neutral
+`slack_private_sync_*` and `slack_private_*_context_documents` tables rather than
 `company_context_documents`. RLS checks `(team_id, channel_id, user_id)` against
 the reconciled membership list. A successful sync marks members omitted from
 Slack's complete member list inactive; a partial or truncated member list is

--- a/docs/public/md/operate/slack-etl.md
+++ b/docs/public/md/operate/slack-etl.md
@@ -75,9 +75,9 @@ multiple credentials can see the same channel.
 User-scoped private channels are stored in the separate `slack_dm_sync_*` and
 `slack_dm_context_documents` private-conversation tables rather than
 `company_context_documents`. RLS checks `(team_id, channel_id, user_id)` against
-the reconciled membership list. Private-channel membership expires closed when
-it has not been refreshed for 30 minutes; a partial or truncated Slack member
-list is never applied.
+the reconciled membership list. A successful sync marks members omitted from
+Slack's complete member list inactive; a partial or truncated member list is
+never applied.
 
 ## Enable the schedules
 

--- a/docs/public/md/operate/slack-etl.md
+++ b/docs/public/md/operate/slack-etl.md
@@ -58,6 +58,27 @@ visible to that token. It does not sync DMs or Slackbot-only live thread events.
 Private channel rows are protected by RLS: `centaur_readonly` sees public
 channel data and the channel in `centaur.slack_channel_id`.
 
+### User-scoped private-channel ingestion
+
+The console's Slack OAuth flow can ingest private channels through the same
+user-scoped pipeline used for DMs. Add `groups:read` and `groups:history` to the
+Slack OAuth app's allowed user scopes and have existing users consent again.
+DM-only credentials continue syncing DMs while credentials with the new scopes
+also request `private_channel` conversations.
+
+Every 10 minutes the console worker fans out across healthy Slack broker
+credentials. Each credential lists the private channels visible to that user,
+reads channel history, and fetches the complete `conversations.members` list.
+Messages are deduplicated by Slack conversation and message timestamp when
+multiple credentials can see the same channel.
+
+User-scoped private channels are stored in the separate `slack_dm_sync_*` and
+`slack_dm_context_documents` private-conversation tables rather than
+`company_context_documents`. RLS checks `(team_id, channel_id, user_id)` against
+the reconciled membership list. Private-channel membership expires closed when
+it has not been refreshed for 30 minutes; a partial or truncated Slack member
+list is never applied.
+
 ## Enable the schedules
 
 Set `apiRs.etl.slack.enabled=true` in Helm values. The chart renders the
@@ -89,7 +110,7 @@ apiRs:
 | `SLACK_RETENTION_ENABLED` | `true` | Allows the `slack_retention` schedule to run when at least one Slack retention TTL is positive. |
 | `SLACK_RETENTION_INTERVAL_MINUTES` | `60` | How often to prune Slack retention-managed rows. |
 | `SLACK_ETL_RETENTION_DAYS` | `0` | Deletes Slack ETL messages, derived Slack documents, and terminal ETL run/job rows older than this many days. `0` disables ETL retention. |
-| `SLACK_DM_RETENTION_DAYS` | `0` | Deletes Slack DM messages, stale empty DM conversations, and terminal DM run/job rows older than this many days. `0` disables DM retention. |
+| `SLACK_DM_RETENTION_DAYS` | `0` | Deletes user-scoped private Slack messages, stale empty conversations, and terminal run/job rows older than this many days. `0` disables retention. |
 | `COMPANY_CONTEXT_DOCUMENTS_ENABLED` | `true` | Enables projection from Slack sync rows into company context documents. |
 | `COMPANY_CONTEXT_DOCUMENTS_INTERVAL_SECONDS` | `14400` | How often the coordinator claims stale projection scopes. |
 | `COMPANY_CONTEXT_DOCUMENTS_MAX_WINDOW_SECONDS` | `21600` | Maximum source `updated_at` window claimed for one scope before it advances its watermark. |

--- a/docs/public/md/reference/tool-directory.md
+++ b/docs/public/md/reference/tool-directory.md
@@ -34,7 +34,7 @@ These are broadly useful across most deployments and are good candidates to conf
 | `slack` | Search Slack, read threads, inspect channels/users, and send or upload messages | `SLACK_BOT_TOKEN`; optional: `SLACK_SEARCH_TOKEN`, `SLACK_ETL_TOKEN` |
 | `gsuite` | Use Gmail, Calendar, Drive, Docs, Sheets, Slides, and Google Analytics | `GOOGLE_TOKEN_JSON` |
 | `websearch` | Free web search via Parallel and deep research | None; `PARALLEL_API_KEY` for `deep_research`; `ANTHROPIC_API_KEY` for search synthesis |
-| `company_context` | Search indexed company history, Slack DMs, and Google Docs | None |
+| `company_context` | Search indexed company history, private Slack conversations, and Google Docs | None |
 | `grafana` | Query dashboards, alerts, VictoriaMetrics, VictoriaLogs, and annotations | `GRAFANA_URL`, `GRAFANA_API_KEY` |
 | `posthog` | Query product analytics, events, pageviews, breakdowns, and user agents | `POSTHOG_API_KEY`, `POSTHOG_PROJECT_ID` |
 | `amplitude` | Query product analytics — event segmentation, funnels, retention, user activity, and taxonomy | `AMPLITUDE_API_KEY`, `AMPLITUDE_SECRET_KEY` |
@@ -77,7 +77,7 @@ These are broadly useful across most deployments and are good candidates to conf
 | Tool | Use | API key / credential |
 |---|---|---|
 | `airtable` | Bases, schemas, tables, views, record reads, record writes, and URL parsing | `AIRTABLE_API_KEY` |
-| `company_context` | Search indexed company history, Slack DMs, and Google Docs | None |
+| `company_context` | Search indexed company history, private Slack conversations, and Google Docs | None |
 | `composio` | Execute tools from third-party services exposed through Composio | `COMPOSIO_API_KEY` |
 | `figma` | Extract Figma files, nodes, components, styles, and variables | `FIGMA_ACCESS_TOKEN` |
 | `granola` | Search and read Granola notes and transcripts | `GRANOLA_API_KEY` |

--- a/services/api-rs/crates/centaur-api-server/src/routes.rs
+++ b/services/api-rs/crates/centaur-api-server/src/routes.rs
@@ -270,7 +270,7 @@ pub fn build_router_with_app_state(state: AppState) -> Router {
         )
         .route(
             "/api/admin/slack/dm-sync/checkpoints",
-            get(list_slack_dm_sync_checkpoints),
+            get(list_slack_private_sync_checkpoints),
         )
         .route(
             "/api/admin/slack/dm-sync/batch",
@@ -1768,7 +1768,7 @@ async fn retry_slack_archive_import(
     ))
 }
 
-async fn list_slack_dm_sync_checkpoints(
+async fn list_slack_private_sync_checkpoints(
     State(state): State<AppState>,
     Query(query): Query<ListSlackDmSyncCheckpointsQuery>,
 ) -> Result<Json<Value>, ApiError> {
@@ -1776,7 +1776,7 @@ async fn list_slack_dm_sync_checkpoints(
     require_non_empty("broker_credential_id", &query.broker_credential_id)?;
     let rows = sqlx::query_as::<_, SlackDmSyncCheckpointResponse>(
         "SELECT broker_credential_id, home_team_id, conversation_id, watermark_ts \
-         FROM slack_dm_sync_checkpoints \
+         FROM slack_private_sync_checkpoints \
          WHERE broker_credential_id = $1 \
          AND ($2::text IS NULL OR home_team_id = $2) \
          ORDER BY home_team_id, conversation_id",
@@ -1808,7 +1808,7 @@ async fn ingest_slack_dm_sync_batch(
 
     for conversation in &request.conversations {
         sqlx::query(
-            "INSERT INTO slack_dm_sync_conversations (\
+            "INSERT INTO slack_private_sync_conversations (\
              home_team_id, conversation_id, conversation_type, is_archived, is_ext_shared, \
              raw_payload, last_seen_at, updated_at\
              ) VALUES ($1, $2, $3, $4, $5, $6::jsonb, NOW(), NOW()) \
@@ -1840,7 +1840,7 @@ async fn ingest_slack_dm_sync_batch(
         }
         for ((home_team_id, conversation_id), _) in conversations {
             sqlx::query(
-                "UPDATE slack_dm_sync_conversation_members \
+                "UPDATE slack_private_sync_conversation_members \
                  SET is_current_member = false, updated_at = NOW() \
                  WHERE home_team_id = $1 AND conversation_id = $2",
             )
@@ -1853,7 +1853,7 @@ async fn ingest_slack_dm_sync_batch(
 
     for member in &request.members {
         sqlx::query(
-            "INSERT INTO slack_dm_sync_conversation_members (\
+            "INSERT INTO slack_private_sync_conversation_members (\
              home_team_id, conversation_id, user_id, user_team_id, is_external, \
              is_current_member, raw_payload, last_seen_at, updated_at\
              ) VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb, NOW(), NOW()) \
@@ -1884,7 +1884,7 @@ async fn ingest_slack_dm_sync_batch(
             None
         };
         sqlx::query(
-            "INSERT INTO slack_dm_sync_messages (\
+            "INSERT INTO slack_private_sync_messages (\
              home_team_id, conversation_id, message_ts, occurred_at, thread_ts, \
              parent_message_ts, is_thread_root, user_id, user_team_id, bot_id, \
              message_type, message_subtype, text, permalink, reply_count, reply_users, \
@@ -1909,9 +1909,9 @@ async fn ingest_slack_dm_sync_batch(
              reply_count = EXCLUDED.reply_count, \
              reply_users = EXCLUDED.reply_users, \
              latest_reply_ts = EXCLUDED.latest_reply_ts, \
-             thread_refreshed_at = COALESCE(EXCLUDED.thread_refreshed_at, slack_dm_sync_messages.thread_refreshed_at), \
+             thread_refreshed_at = COALESCE(EXCLUDED.thread_refreshed_at, slack_private_sync_messages.thread_refreshed_at), \
              raw_payload = EXCLUDED.raw_payload, \
-             source_run_id = COALESCE(EXCLUDED.source_run_id, slack_dm_sync_messages.source_run_id), \
+             source_run_id = COALESCE(EXCLUDED.source_run_id, slack_private_sync_messages.source_run_id), \
              last_seen_at = NOW(), \
              updated_at = NOW()",
         )
@@ -1941,7 +1941,7 @@ async fn ingest_slack_dm_sync_batch(
 
     for attachment in &request.attachments {
         sqlx::query(
-            "INSERT INTO slack_dm_sync_message_attachments (\
+            "INSERT INTO slack_private_sync_message_attachments (\
              home_team_id, conversation_id, message_ts, slack_file_id, name, title, \
              mimetype, filetype, size_bytes, url_private, permalink, download_status, \
              download_error, content_sha256, raw_payload, source_run_id, last_seen_at, updated_at\
@@ -1960,7 +1960,7 @@ async fn ingest_slack_dm_sync_batch(
              download_error = EXCLUDED.download_error, \
              content_sha256 = EXCLUDED.content_sha256, \
              raw_payload = EXCLUDED.raw_payload, \
-             source_run_id = COALESCE(EXCLUDED.source_run_id, slack_dm_sync_message_attachments.source_run_id), \
+             source_run_id = COALESCE(EXCLUDED.source_run_id, slack_private_sync_message_attachments.source_run_id), \
              last_seen_at = NOW(), \
              updated_at = NOW()",
         )
@@ -1991,14 +1991,14 @@ async fn ingest_slack_dm_sync_batch(
             None
         };
         sqlx::query(
-            "INSERT INTO slack_dm_sync_checkpoints (\
+            "INSERT INTO slack_private_sync_checkpoints (\
              broker_credential_id, home_team_id, conversation_id, watermark_ts, \
              last_run_id, last_success_at, last_error, updated_at\
              ) VALUES ($1, $2, $3, $4, $5, $6, $7, NOW()) \
              ON CONFLICT (broker_credential_id, home_team_id, conversation_id) DO UPDATE SET \
              watermark_ts = EXCLUDED.watermark_ts, \
              last_run_id = EXCLUDED.last_run_id, \
-             last_success_at = COALESCE(EXCLUDED.last_success_at, slack_dm_sync_checkpoints.last_success_at), \
+             last_success_at = COALESCE(EXCLUDED.last_success_at, slack_private_sync_checkpoints.last_success_at), \
              last_error = EXCLUDED.last_error, \
              updated_at = NOW()",
         )
@@ -2587,7 +2587,7 @@ async fn upsert_slack_dm_sync_run(
         None
     };
     sqlx::query(
-        "INSERT INTO slack_dm_sync_runs (\
+        "INSERT INTO slack_private_sync_runs (\
          run_id, workflow_run_id, mode, status, broker_credential_id, source_user_id, \
          home_team_id, conversations_requested, conversations_synced, conversations_failed, \
          messages_fetched, messages_upserted, replies_fetched, replies_upserted, \
@@ -2609,7 +2609,7 @@ async fn upsert_slack_dm_sync_run(
          messages_upserted = EXCLUDED.messages_upserted, \
          replies_fetched = EXCLUDED.replies_fetched, \
          replies_upserted = EXCLUDED.replies_upserted, \
-         finished_at = COALESCE(EXCLUDED.finished_at, slack_dm_sync_runs.finished_at), \
+         finished_at = COALESCE(EXCLUDED.finished_at, slack_private_sync_runs.finished_at), \
          error_text = EXCLUDED.error_text, \
          metadata = EXCLUDED.metadata",
     )

--- a/services/api-rs/crates/centaur-api-server/src/routes.rs
+++ b/services/api-rs/crates/centaur-api-server/src/routes.rs
@@ -2832,9 +2832,12 @@ fn validate_slack_dm_sync_batch(request: &SlackDmSyncBatchRequest) -> Result<(),
             "conversation.conversation_id",
             &conversation.conversation_id,
         )?;
-        if !matches!(conversation.conversation_type.as_str(), "im" | "mpim") {
+        if !matches!(
+            conversation.conversation_type.as_str(),
+            "im" | "mpim" | "private_channel"
+        ) {
             return Err(ApiError::BadRequest(
-                "conversation.conversation_type must be im or mpim".to_owned(),
+                "conversation.conversation_type must be im, mpim, or private_channel".to_owned(),
             ));
         }
         validate_json_shape("conversation.raw_payload", &conversation.raw_payload, true)?;
@@ -2869,6 +2872,42 @@ fn validate_slack_dm_sync_batch(request: &SlackDmSyncBatchRequest) -> Result<(),
         require_non_empty("checkpoint.conversation_id", &checkpoint.conversation_id)?;
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod slack_user_sync_tests {
+    use super::*;
+
+    fn request_with_conversation_type(conversation_type: &str) -> SlackDmSyncBatchRequest {
+        SlackDmSyncBatchRequest {
+            run: None,
+            replace_memberships: false,
+            conversations: vec![SlackDmSyncConversationPayload {
+                home_team_id: "T123".to_owned(),
+                conversation_id: "G123".to_owned(),
+                conversation_type: conversation_type.to_owned(),
+                is_archived: false,
+                is_ext_shared: false,
+                raw_payload: json!({"name": "leadership"}),
+            }],
+            members: vec![],
+            messages: vec![],
+            attachments: vec![],
+            checkpoints: vec![],
+        }
+    }
+
+    #[test]
+    fn accepts_private_channel_conversations() {
+        validate_slack_dm_sync_batch(&request_with_conversation_type("private_channel")).unwrap();
+    }
+
+    #[test]
+    fn rejects_public_channel_conversations() {
+        let error = validate_slack_dm_sync_batch(&request_with_conversation_type("public_channel"))
+            .unwrap_err();
+        assert!(matches!(error, ApiError::BadRequest(_)));
+    }
 }
 
 fn validate_google_docs_sync_batch(request: &GoogleDocsSyncBatchRequest) -> Result<(), ApiError> {

--- a/services/api-rs/crates/centaur-session-sqlx/migrations/0045_slack_private_channel_oauth_sync.sql
+++ b/services/api-rs/crates/centaur-session-sqlx/migrations/0045_slack_private_channel_oauth_sync.sql
@@ -1,12 +1,156 @@
--- Extend the user-scoped Slack conversation store to private channels. The
--- existing slack_dm_* names are retained for compatibility, but all rows in
--- these tables are private Slack conversations protected by membership RLS.
-
+-- Generalize the existing user-scoped DM store before adding private channels.
+-- Table renames preserve all DM/MPIM rows, foreign keys, indexes, grants, RLS,
+-- and triggers in place.
 alter table slack_dm_sync_conversations
+    rename to slack_private_sync_conversations;
+alter table slack_dm_sync_conversation_members
+    rename to slack_private_sync_conversation_members;
+alter table slack_dm_sync_runs
+    rename to slack_private_sync_runs;
+alter table slack_dm_sync_messages
+    rename to slack_private_sync_messages;
+alter table slack_dm_sync_message_attachments
+    rename to slack_private_sync_message_attachments;
+alter table slack_dm_sync_checkpoints
+    rename to slack_private_sync_checkpoints;
+alter table slack_dm_sync_backfill_jobs
+    rename to slack_private_sync_backfill_jobs;
+alter table slack_dm_context_documents
+    rename to slack_private_context_documents;
+alter table slack_dm_conversation_context_documents
+    rename to slack_private_conversation_context_documents;
+
+-- ParadeDB ties BM25 metadata to the indexed relation name, so rebuild these
+-- two indexes after the table rename instead of relying on the index OID alone.
+drop index if exists idx_slack_dm_context_documents_bm25;
+drop index if exists idx_slack_private_context_documents_bm25;
+create index idx_slack_private_context_documents_bm25
+    on slack_private_context_documents
+    using bm25 (
+        document_id,
+        title,
+        body,
+        home_team_id,
+        conversation_id,
+        conversation_type,
+        user_id,
+        bot_id,
+        message_type,
+        message_subtype,
+        occurred_at,
+        source_updated_at,
+        metadata
+    )
+    with (
+        key_field = 'document_id',
+        text_fields = '{
+            "document_id": {
+                "tokenizer": {"type": "keyword"}
+            },
+            "home_team_id": {
+                "tokenizer": {"type": "keyword"}
+            },
+            "conversation_id": {
+                "tokenizer": {"type": "keyword"}
+            },
+            "user_id": {
+                "tokenizer": {"type": "keyword"}
+            },
+            "bot_id": {
+                "tokenizer": {"type": "keyword"}
+            }
+        }'
+    );
+
+drop index if exists idx_slack_dm_conversation_context_documents_bm25;
+drop index if exists idx_slack_private_conversation_context_documents_bm25;
+create index idx_slack_private_conversation_context_documents_bm25
+    on slack_private_conversation_context_documents
+    using bm25 (
+        document_id,
+        title,
+        body,
+        home_team_id,
+        conversation_id,
+        conversation_type,
+        last_seen_at,
+        source_updated_at,
+        metadata
+    )
+    with (
+        key_field = 'document_id',
+        text_fields = '{
+            "document_id": {
+                "tokenizer": {"type": "keyword"}
+            },
+            "home_team_id": {
+                "tokenizer": {"type": "keyword"}
+            },
+            "conversation_id": {
+                "tokenizer": {"type": "keyword"}
+            }
+        }'
+    );
+
+-- PL/pgSQL function bodies retain relation names as source text. Recreate any
+-- existing projection function with the new table names so the triggers that
+-- moved with the tables continue to work after the rename.
+do $$
+declare
+    fn record;
+    old_definition text;
+    new_definition text;
+begin
+    for fn in
+        select p.oid
+        from pg_proc p
+        join pg_namespace n on n.oid = p.pronamespace
+        where n.nspname = 'public'
+          and p.prokind = 'f'
+          and pg_get_functiondef(p.oid) like '%slack_dm_%'
+    loop
+        old_definition := pg_get_functiondef(fn.oid);
+        new_definition := old_definition;
+        new_definition := replace(new_definition,
+            'slack_dm_conversation_context_documents',
+            'slack_private_conversation_context_documents');
+        new_definition := replace(new_definition,
+            'slack_dm_sync_conversation_members',
+            'slack_private_sync_conversation_members');
+        new_definition := replace(new_definition,
+            'slack_dm_sync_message_attachments',
+            'slack_private_sync_message_attachments');
+        new_definition := replace(new_definition,
+            'slack_dm_sync_backfill_jobs',
+            'slack_private_sync_backfill_jobs');
+        new_definition := replace(new_definition,
+            'slack_dm_sync_conversations',
+            'slack_private_sync_conversations');
+        new_definition := replace(new_definition,
+            'slack_dm_sync_checkpoints',
+            'slack_private_sync_checkpoints');
+        new_definition := replace(new_definition,
+            'slack_dm_sync_messages',
+            'slack_private_sync_messages');
+        new_definition := replace(new_definition,
+            'slack_dm_sync_runs',
+            'slack_private_sync_runs');
+        new_definition := replace(new_definition,
+            'slack_dm_context_documents',
+            'slack_private_context_documents');
+
+        if new_definition is distinct from old_definition then
+            execute new_definition;
+        end if;
+    end loop;
+end
+$$;
+
+alter table slack_private_sync_conversations
     drop constraint if exists slack_dm_sync_conversations_conversation_type_check;
 
-alter table slack_dm_sync_conversations
-    add constraint slack_dm_sync_conversations_conversation_type_check
+alter table slack_private_sync_conversations
+    add constraint slack_private_sync_conversations_conversation_type_check
     check (conversation_type in ('im', 'mpim', 'private_channel'));
 
 -- Centralize access checks for every user-scoped Slack conversation. A user
@@ -24,7 +168,7 @@ set search_path = pg_catalog, public
 as $$
     select exists (
         select 1
-        from public.slack_dm_sync_conversation_members members
+        from public.slack_private_sync_conversation_members members
         where members.home_team_id = p_home_team_id
           and members.conversation_id = p_conversation_id
           and members.home_team_id = public.centaur_current_slack_team_id()
@@ -38,93 +182,93 @@ grant execute on function centaur_can_read_slack_user_conversation(text, text)
     to centaur_slack_reader, centaur_readonly;
 
 drop policy if exists centaur_slack_dm_conversations_reader_select
-    on slack_dm_sync_conversations;
+    on slack_private_sync_conversations;
 create policy centaur_slack_dm_conversations_reader_select
-    on slack_dm_sync_conversations for select to centaur_slack_reader
+    on slack_private_sync_conversations for select to centaur_slack_reader
     using (centaur_can_read_slack_user_conversation(home_team_id, conversation_id));
 
 drop policy if exists centaur_readonly_slack_dm_sync_conversations_select
-    on slack_dm_sync_conversations;
+    on slack_private_sync_conversations;
 create policy centaur_readonly_slack_dm_sync_conversations_select
-    on slack_dm_sync_conversations for select to centaur_readonly
+    on slack_private_sync_conversations for select to centaur_readonly
     using (centaur_can_read_slack_user_conversation(home_team_id, conversation_id));
 
 drop policy if exists centaur_slack_dm_members_reader_select
-    on slack_dm_sync_conversation_members;
+    on slack_private_sync_conversation_members;
 create policy centaur_slack_dm_members_reader_select
-    on slack_dm_sync_conversation_members for select to centaur_slack_reader
+    on slack_private_sync_conversation_members for select to centaur_slack_reader
     using (
         user_id = centaur_current_slack_user_id()
         and centaur_can_read_slack_user_conversation(home_team_id, conversation_id)
     );
 
 drop policy if exists centaur_readonly_slack_dm_sync_conversation_members_select
-    on slack_dm_sync_conversation_members;
+    on slack_private_sync_conversation_members;
 create policy centaur_readonly_slack_dm_sync_conversation_members_select
-    on slack_dm_sync_conversation_members for select to centaur_readonly
+    on slack_private_sync_conversation_members for select to centaur_readonly
     using (
         user_id = centaur_current_slack_user_id()
         and centaur_can_read_slack_user_conversation(home_team_id, conversation_id)
     );
 
 drop policy if exists centaur_slack_dm_messages_reader_select
-    on slack_dm_sync_messages;
+    on slack_private_sync_messages;
 create policy centaur_slack_dm_messages_reader_select
-    on slack_dm_sync_messages for select to centaur_slack_reader
+    on slack_private_sync_messages for select to centaur_slack_reader
     using (centaur_can_read_slack_user_conversation(home_team_id, conversation_id));
 
 drop policy if exists centaur_readonly_slack_dm_sync_messages_select
-    on slack_dm_sync_messages;
+    on slack_private_sync_messages;
 create policy centaur_readonly_slack_dm_sync_messages_select
-    on slack_dm_sync_messages for select to centaur_readonly
+    on slack_private_sync_messages for select to centaur_readonly
     using (centaur_can_read_slack_user_conversation(home_team_id, conversation_id));
 
 drop policy if exists centaur_slack_dm_attachments_reader_select
-    on slack_dm_sync_message_attachments;
+    on slack_private_sync_message_attachments;
 create policy centaur_slack_dm_attachments_reader_select
-    on slack_dm_sync_message_attachments for select to centaur_slack_reader
+    on slack_private_sync_message_attachments for select to centaur_slack_reader
     using (centaur_can_read_slack_user_conversation(home_team_id, conversation_id));
 
 drop policy if exists centaur_readonly_slack_dm_sync_message_attachments_select
-    on slack_dm_sync_message_attachments;
+    on slack_private_sync_message_attachments;
 create policy centaur_readonly_slack_dm_sync_message_attachments_select
-    on slack_dm_sync_message_attachments for select to centaur_readonly
+    on slack_private_sync_message_attachments for select to centaur_readonly
     using (centaur_can_read_slack_user_conversation(home_team_id, conversation_id));
 
 drop policy if exists centaur_slack_dm_checkpoints_reader_select
-    on slack_dm_sync_checkpoints;
+    on slack_private_sync_checkpoints;
 create policy centaur_slack_dm_checkpoints_reader_select
-    on slack_dm_sync_checkpoints for select to centaur_slack_reader
+    on slack_private_sync_checkpoints for select to centaur_slack_reader
     using (centaur_can_read_slack_user_conversation(home_team_id, conversation_id));
 
 drop policy if exists centaur_readonly_slack_dm_sync_checkpoints_select
-    on slack_dm_sync_checkpoints;
+    on slack_private_sync_checkpoints;
 create policy centaur_readonly_slack_dm_sync_checkpoints_select
-    on slack_dm_sync_checkpoints for select to centaur_readonly
+    on slack_private_sync_checkpoints for select to centaur_readonly
     using (centaur_can_read_slack_user_conversation(home_team_id, conversation_id));
 
 drop policy if exists centaur_slack_dm_context_documents_reader_select
-    on slack_dm_context_documents;
+    on slack_private_context_documents;
 create policy centaur_slack_dm_context_documents_reader_select
-    on slack_dm_context_documents for select to centaur_slack_reader
+    on slack_private_context_documents for select to centaur_slack_reader
     using (centaur_can_read_slack_user_conversation(home_team_id, conversation_id));
 
 drop policy if exists centaur_readonly_slack_dm_context_documents_select
-    on slack_dm_context_documents;
+    on slack_private_context_documents;
 create policy centaur_readonly_slack_dm_context_documents_select
-    on slack_dm_context_documents for select to centaur_readonly
+    on slack_private_context_documents for select to centaur_readonly
     using (centaur_can_read_slack_user_conversation(home_team_id, conversation_id));
 
 drop policy if exists centaur_slack_dm_conversation_context_documents_reader_select
-    on slack_dm_conversation_context_documents;
+    on slack_private_conversation_context_documents;
 create policy centaur_slack_dm_conversation_context_documents_reader_select
-    on slack_dm_conversation_context_documents for select to centaur_slack_reader
+    on slack_private_conversation_context_documents for select to centaur_slack_reader
     using (centaur_can_read_slack_user_conversation(home_team_id, conversation_id));
 
 drop policy if exists centaur_readonly_slack_dm_conversation_context_documents_select
-    on slack_dm_conversation_context_documents;
+    on slack_private_conversation_context_documents;
 create policy centaur_readonly_slack_dm_conversation_context_documents_select
-    on slack_dm_conversation_context_documents for select to centaur_readonly
+    on slack_private_conversation_context_documents for select to centaur_readonly
     using (centaur_can_read_slack_user_conversation(home_team_id, conversation_id));
 
 -- The existing projection triggers still populate the private conversation
@@ -143,7 +287,7 @@ begin
 
     select nullif(conversations.raw_payload ->> 'name', '')
       into channel_name
-      from slack_dm_sync_conversations conversations
+      from slack_private_sync_conversations conversations
      where conversations.home_team_id = new.home_team_id
        and conversations.conversation_id = new.conversation_id;
 
@@ -162,9 +306,9 @@ end;
 $$;
 
 drop trigger if exists trg_label_slack_private_channel_message_document
-    on slack_dm_context_documents;
+    on slack_private_context_documents;
 create trigger trg_label_slack_private_channel_message_document
-    before insert or update on slack_dm_context_documents
+    before insert or update on slack_private_context_documents
     for each row
     execute function centaur_label_slack_private_channel_message_document();
 
@@ -181,7 +325,7 @@ begin
 
     select nullif(conversations.raw_payload ->> 'name', '')
       into channel_name
-      from slack_dm_sync_conversations conversations
+      from slack_private_sync_conversations conversations
      where conversations.home_team_id = new.home_team_id
        and conversations.conversation_id = new.conversation_id;
 
@@ -203,8 +347,8 @@ end;
 $$;
 
 drop trigger if exists trg_label_slack_private_channel_conversation_document
-    on slack_dm_conversation_context_documents;
+    on slack_private_conversation_context_documents;
 create trigger trg_label_slack_private_channel_conversation_document
-    before insert or update on slack_dm_conversation_context_documents
+    before insert or update on slack_private_conversation_context_documents
     for each row
     execute function centaur_label_slack_private_channel_conversation_document();

--- a/services/api-rs/crates/centaur-session-sqlx/migrations/0045_slack_private_channel_oauth_sync.sql
+++ b/services/api-rs/crates/centaur-session-sqlx/migrations/0045_slack_private_channel_oauth_sync.sql
@@ -1,0 +1,217 @@
+-- Extend the user-scoped Slack conversation store to private channels. The
+-- existing slack_dm_* names are retained for compatibility, but all rows in
+-- these tables are private Slack conversations protected by membership RLS.
+
+alter table slack_dm_sync_conversations
+    drop constraint if exists slack_dm_sync_conversations_conversation_type_check;
+
+alter table slack_dm_sync_conversations
+    add constraint slack_dm_sync_conversations_conversation_type_check
+    check (conversation_type in ('im', 'mpim', 'private_channel'));
+
+-- Private-channel access fails closed when no successful membership
+-- reconciliation has refreshed the user's row recently. DMs and MPIMs retain
+-- their existing behavior because Slack exposes their participants directly.
+create or replace function centaur_can_read_slack_user_conversation(
+    p_home_team_id text,
+    p_conversation_id text
+)
+returns boolean
+language sql
+stable
+security definer
+set search_path = pg_catalog, public
+as $$
+    select exists (
+        select 1
+        from public.slack_dm_sync_conversation_members members
+        join public.slack_dm_sync_conversations conversations
+          on conversations.home_team_id = members.home_team_id
+         and conversations.conversation_id = members.conversation_id
+        where members.home_team_id = p_home_team_id
+          and members.conversation_id = p_conversation_id
+          and members.home_team_id = public.centaur_current_slack_team_id()
+          and members.user_id = public.centaur_current_slack_user_id()
+          and members.is_current_member
+          and (
+              conversations.conversation_type <> 'private_channel'
+              or members.last_seen_at >= now() - interval '30 minutes'
+          )
+    )
+$$;
+
+revoke all on function centaur_can_read_slack_user_conversation(text, text) from public;
+grant execute on function centaur_can_read_slack_user_conversation(text, text)
+    to centaur_slack_reader, centaur_readonly;
+
+drop policy if exists centaur_slack_dm_conversations_reader_select
+    on slack_dm_sync_conversations;
+create policy centaur_slack_dm_conversations_reader_select
+    on slack_dm_sync_conversations for select to centaur_slack_reader
+    using (centaur_can_read_slack_user_conversation(home_team_id, conversation_id));
+
+drop policy if exists centaur_readonly_slack_dm_sync_conversations_select
+    on slack_dm_sync_conversations;
+create policy centaur_readonly_slack_dm_sync_conversations_select
+    on slack_dm_sync_conversations for select to centaur_readonly
+    using (centaur_can_read_slack_user_conversation(home_team_id, conversation_id));
+
+drop policy if exists centaur_slack_dm_members_reader_select
+    on slack_dm_sync_conversation_members;
+create policy centaur_slack_dm_members_reader_select
+    on slack_dm_sync_conversation_members for select to centaur_slack_reader
+    using (
+        user_id = centaur_current_slack_user_id()
+        and centaur_can_read_slack_user_conversation(home_team_id, conversation_id)
+    );
+
+drop policy if exists centaur_readonly_slack_dm_sync_conversation_members_select
+    on slack_dm_sync_conversation_members;
+create policy centaur_readonly_slack_dm_sync_conversation_members_select
+    on slack_dm_sync_conversation_members for select to centaur_readonly
+    using (
+        user_id = centaur_current_slack_user_id()
+        and centaur_can_read_slack_user_conversation(home_team_id, conversation_id)
+    );
+
+drop policy if exists centaur_slack_dm_messages_reader_select
+    on slack_dm_sync_messages;
+create policy centaur_slack_dm_messages_reader_select
+    on slack_dm_sync_messages for select to centaur_slack_reader
+    using (centaur_can_read_slack_user_conversation(home_team_id, conversation_id));
+
+drop policy if exists centaur_readonly_slack_dm_sync_messages_select
+    on slack_dm_sync_messages;
+create policy centaur_readonly_slack_dm_sync_messages_select
+    on slack_dm_sync_messages for select to centaur_readonly
+    using (centaur_can_read_slack_user_conversation(home_team_id, conversation_id));
+
+drop policy if exists centaur_slack_dm_attachments_reader_select
+    on slack_dm_sync_message_attachments;
+create policy centaur_slack_dm_attachments_reader_select
+    on slack_dm_sync_message_attachments for select to centaur_slack_reader
+    using (centaur_can_read_slack_user_conversation(home_team_id, conversation_id));
+
+drop policy if exists centaur_readonly_slack_dm_sync_message_attachments_select
+    on slack_dm_sync_message_attachments;
+create policy centaur_readonly_slack_dm_sync_message_attachments_select
+    on slack_dm_sync_message_attachments for select to centaur_readonly
+    using (centaur_can_read_slack_user_conversation(home_team_id, conversation_id));
+
+drop policy if exists centaur_slack_dm_checkpoints_reader_select
+    on slack_dm_sync_checkpoints;
+create policy centaur_slack_dm_checkpoints_reader_select
+    on slack_dm_sync_checkpoints for select to centaur_slack_reader
+    using (centaur_can_read_slack_user_conversation(home_team_id, conversation_id));
+
+drop policy if exists centaur_readonly_slack_dm_sync_checkpoints_select
+    on slack_dm_sync_checkpoints;
+create policy centaur_readonly_slack_dm_sync_checkpoints_select
+    on slack_dm_sync_checkpoints for select to centaur_readonly
+    using (centaur_can_read_slack_user_conversation(home_team_id, conversation_id));
+
+drop policy if exists centaur_slack_dm_context_documents_reader_select
+    on slack_dm_context_documents;
+create policy centaur_slack_dm_context_documents_reader_select
+    on slack_dm_context_documents for select to centaur_slack_reader
+    using (centaur_can_read_slack_user_conversation(home_team_id, conversation_id));
+
+drop policy if exists centaur_readonly_slack_dm_context_documents_select
+    on slack_dm_context_documents;
+create policy centaur_readonly_slack_dm_context_documents_select
+    on slack_dm_context_documents for select to centaur_readonly
+    using (centaur_can_read_slack_user_conversation(home_team_id, conversation_id));
+
+drop policy if exists centaur_slack_dm_conversation_context_documents_reader_select
+    on slack_dm_conversation_context_documents;
+create policy centaur_slack_dm_conversation_context_documents_reader_select
+    on slack_dm_conversation_context_documents for select to centaur_slack_reader
+    using (centaur_can_read_slack_user_conversation(home_team_id, conversation_id));
+
+drop policy if exists centaur_readonly_slack_dm_conversation_context_documents_select
+    on slack_dm_conversation_context_documents;
+create policy centaur_readonly_slack_dm_conversation_context_documents_select
+    on slack_dm_conversation_context_documents for select to centaur_readonly
+    using (centaur_can_read_slack_user_conversation(home_team_id, conversation_id));
+
+-- The existing projection triggers still populate the private conversation
+-- tables. These BEFORE triggers give private-channel rows accurate titles and
+-- metadata without duplicating the projection pipeline.
+create or replace function centaur_label_slack_private_channel_message_document()
+returns trigger
+language plpgsql
+as $$
+declare
+    channel_name text;
+begin
+    if new.conversation_type <> 'private_channel' then
+        return new;
+    end if;
+
+    select nullif(conversations.raw_payload ->> 'name', '')
+      into channel_name
+      from slack_dm_sync_conversations conversations
+     where conversations.home_team_id = new.home_team_id
+       and conversations.conversation_id = new.conversation_id;
+
+    new.title := 'Slack private channel: #' || coalesce(channel_name, new.conversation_id);
+    new.metadata := new.metadata || jsonb_build_object(
+        'source', 'slack_private_channel',
+        'channel_id', new.conversation_id,
+        'channel_name', coalesce(channel_name, '')
+    );
+    new.content_hash := md5(concat_ws(
+        E'\x1f', new.title, new.body, new.permalink,
+        coalesce(new.occurred_at::text, ''), new.metadata::text
+    ));
+    return new;
+end;
+$$;
+
+drop trigger if exists trg_label_slack_private_channel_message_document
+    on slack_dm_context_documents;
+create trigger trg_label_slack_private_channel_message_document
+    before insert or update on slack_dm_context_documents
+    for each row
+    execute function centaur_label_slack_private_channel_message_document();
+
+create or replace function centaur_label_slack_private_channel_conversation_document()
+returns trigger
+language plpgsql
+as $$
+declare
+    channel_name text;
+begin
+    if new.conversation_type <> 'private_channel' then
+        return new;
+    end if;
+
+    select nullif(conversations.raw_payload ->> 'name', '')
+      into channel_name
+      from slack_dm_sync_conversations conversations
+     where conversations.home_team_id = new.home_team_id
+       and conversations.conversation_id = new.conversation_id;
+
+    new.title := 'Slack private channel: #' || coalesce(channel_name, new.conversation_id);
+    new.body := concat_ws(E'\n', channel_name, new.body);
+    new.metadata := new.metadata || jsonb_build_object(
+        'source', 'slack_private_channel',
+        'channel_id', new.conversation_id,
+        'channel_name', coalesce(channel_name, '')
+    );
+    new.content_hash := md5(concat_ws(
+        E'\x1f', new.title, new.body,
+        array_to_string(new.participant_user_ids, E'\x1e'),
+        array_to_string(new.participant_labels, E'\x1e'),
+        coalesce(new.last_seen_at::text, ''), new.metadata::text
+    ));
+    return new;
+end;
+$$;
+
+drop trigger if exists trg_label_slack_private_channel_conversation_document
+    on slack_dm_conversation_context_documents;
+create trigger trg_label_slack_private_channel_conversation_document
+    before insert or update on slack_dm_conversation_context_documents
+    for each row
+    execute function centaur_label_slack_private_channel_conversation_document();

--- a/services/api-rs/crates/centaur-session-sqlx/migrations/0045_slack_private_channel_oauth_sync.sql
+++ b/services/api-rs/crates/centaur-session-sqlx/migrations/0045_slack_private_channel_oauth_sync.sql
@@ -9,9 +9,9 @@ alter table slack_dm_sync_conversations
     add constraint slack_dm_sync_conversations_conversation_type_check
     check (conversation_type in ('im', 'mpim', 'private_channel'));
 
--- Private-channel access fails closed when no successful membership
--- reconciliation has refreshed the user's row recently. DMs and MPIMs retain
--- their existing behavior because Slack exposes their participants directly.
+-- Centralize access checks for every user-scoped Slack conversation. A user
+-- retains access until a successful membership reconciliation marks the row
+-- inactive; incomplete membership responses are rejected by the console sync.
 create or replace function centaur_can_read_slack_user_conversation(
     p_home_team_id text,
     p_conversation_id text
@@ -25,18 +25,11 @@ as $$
     select exists (
         select 1
         from public.slack_dm_sync_conversation_members members
-        join public.slack_dm_sync_conversations conversations
-          on conversations.home_team_id = members.home_team_id
-         and conversations.conversation_id = members.conversation_id
         where members.home_team_id = p_home_team_id
           and members.conversation_id = p_conversation_id
           and members.home_team_id = public.centaur_current_slack_team_id()
           and members.user_id = public.centaur_current_slack_user_id()
           and members.is_current_member
-          and (
-              conversations.conversation_type <> 'private_channel'
-              or members.last_seen_at >= now() - interval '30 minutes'
-          )
     )
 $$;
 

--- a/services/api-rs/crates/centaur-session-sqlx/tests/slack_dm_context_rls.rs
+++ b/services/api-rs/crates/centaur-session-sqlx/tests/slack_dm_context_rls.rs
@@ -14,6 +14,8 @@ const SLACK_DM_CONVERSATION_CONTEXT_DOCUMENTS_SQL: &str =
     include_str!("../migrations/0029_slack_dm_conversation_context_documents.sql");
 const READONLY_DM_RLS_SQL: &str =
     include_str!("../migrations/0042_centaur_readonly_slack_dm_rls.sql");
+const SLACK_PRIVATE_CONVERSATIONS_SQL: &str =
+    include_str!("../migrations/0045_slack_private_channel_oauth_sync.sql");
 
 const RLS_TABLES: &[&str] = &[
     "slack_dm_sync_conversations",
@@ -358,6 +360,48 @@ fn slack_dm_context_documents_test_migration_omits_bm25_when_extension_is_unavai
             "create policy centaur_slack_dm_conversation_context_documents_reader_select"
         )
     );
+}
+
+#[test]
+fn slack_private_conversation_migration_renames_every_user_scoped_table() {
+    for (old_name, new_name) in [
+        (
+            "slack_dm_sync_conversations",
+            "slack_private_sync_conversations",
+        ),
+        (
+            "slack_dm_sync_conversation_members",
+            "slack_private_sync_conversation_members",
+        ),
+        ("slack_dm_sync_runs", "slack_private_sync_runs"),
+        ("slack_dm_sync_messages", "slack_private_sync_messages"),
+        (
+            "slack_dm_sync_message_attachments",
+            "slack_private_sync_message_attachments",
+        ),
+        (
+            "slack_dm_sync_checkpoints",
+            "slack_private_sync_checkpoints",
+        ),
+        (
+            "slack_dm_sync_backfill_jobs",
+            "slack_private_sync_backfill_jobs",
+        ),
+        (
+            "slack_dm_context_documents",
+            "slack_private_context_documents",
+        ),
+        (
+            "slack_dm_conversation_context_documents",
+            "slack_private_conversation_context_documents",
+        ),
+    ] {
+        assert!(
+            SLACK_PRIVATE_CONVERSATIONS_SQL
+                .contains(format!("alter table {old_name}\n    rename to {new_name};").as_str()),
+            "missing table rename from {old_name} to {new_name}"
+        );
+    }
 }
 
 async fn assert_rls_enabled(conn: &mut PgConnection) -> Result<(), sqlx::Error> {

--- a/services/console/app/services/slack_dm/sync_credential.rb
+++ b/services/console/app/services/slack_dm/sync_credential.rb
@@ -4,7 +4,12 @@ require "uri"
 
 module SlackDm
   class SyncCredential
-    REQUIRED_SCOPES = %w[im:read im:history mpim:read mpim:history].freeze
+    DM_REQUIRED_SCOPES = %w[im:read im:history].freeze
+    MPIM_REQUIRED_SCOPES = %w[mpim:read mpim:history].freeze
+    PRIVATE_CHANNEL_REQUIRED_SCOPES = %w[groups:read groups:history].freeze
+    REQUIRED_SCOPES = (
+      DM_REQUIRED_SCOPES + MPIM_REQUIRED_SCOPES + PRIVATE_CHANNEL_REQUIRED_SCOPES
+    ).freeze
 
     AUTH_TEST_ENDPOINT = "https://slack.com/api/auth.test"
     CONVERSATIONS_LIST_ENDPOINT = "https://slack.com/api/conversations.list"
@@ -22,7 +27,16 @@ module SlackDm
       end
 
       def required_scopes_granted?(scopes)
-        (REQUIRED_SCOPES - Array(scopes)).empty?
+        supported_conversation_types(scopes).any?
+      end
+
+      def supported_conversation_types(scopes)
+        granted = Array(scopes)
+        types = []
+        types << "im" if (DM_REQUIRED_SCOPES - granted).empty?
+        types << "mpim" if (MPIM_REQUIRED_SCOPES - granted).empty?
+        types << "private_channel" if (PRIVATE_CHANNEL_REQUIRED_SCOPES - granted).empty?
+        types
       end
     end
 
@@ -111,9 +125,12 @@ module SlackDm
     end
 
     def list_conversations
+      types = self.class.supported_conversation_types(@credential.scopes)
+      raise SlackApiError, "Slack credential has no supported conversation scopes" if types.empty?
+
       each_page(
         CONVERSATIONS_LIST_ENDPOINT,
-        { "types" => "im,mpim", "exclude_archived" => "false", "limit" => list_page_size },
+        { "types" => types.join(","), "exclude_archived" => "false", "limit" => list_page_size },
         max_pages: list_max_pages
       ).flat_map { |page| Array(page["channels"]) }
     end
@@ -122,7 +139,7 @@ module SlackDm
       batch[:conversations] << {
         home_team_id: home_team_id,
         conversation_id: conversation.fetch("id"),
-        conversation_type: conversation["is_mpim"] ? "mpim" : "im",
+        conversation_type: conversation_type(conversation),
         is_archived: conversation["is_archived"] == true,
         is_ext_shared: conversation["is_ext_shared"] == true,
         raw_payload: conversation
@@ -151,14 +168,30 @@ module SlackDm
         return members.uniq
       end
 
+      complete = true
       pages = each_page(
         CONVERSATIONS_MEMBERS_ENDPOINT,
         { "channel" => conversation.fetch("id"), "limit" => members_page_size },
         max_pages: members_max_pages
-      )
+      ) do |_page, truncated|
+        complete = false if truncated
+      end
+      unless complete
+        raise SlackApiError,
+              "Slack membership pagination truncated for #{conversation.fetch('id')}"
+      end
+
       members = pages.flat_map { |page| Array(page["members"]) }.compact
       members << @credential.provider_subject if @credential.provider_subject.present?
       members.uniq
+    end
+
+    def conversation_type(conversation)
+      return "mpim" if conversation["is_mpim"]
+      return "im" if conversation["is_im"]
+      return "private_channel" if conversation["is_private"]
+
+      raise SlackApiError, "Unsupported Slack conversation #{conversation['id']}"
     end
 
     def sync_history(conversation, home_team_id, checkpoint, batch)

--- a/services/console/test/jobs/slack_dm/jobs_test.rb
+++ b/services/console/test/jobs/slack_dm/jobs_test.rb
@@ -34,10 +34,11 @@ module SlackDm
       )
     end
 
-    test "PollSyncJob enqueues credentials for the configured Slack OAuth app with required scopes" do
+    test "PollSyncJob enqueues credentials with any supported private conversation scopes" do
       app = slack_app
       good = slack_credential(app: app)
-      missing_scope = slack_credential(app: app, scopes: %w[im:read im:history])
+      dm_only = slack_credential(app: app, scopes: SlackDm::SyncCredential::DM_REQUIRED_SCOPES)
+      missing_scope = slack_credential(app: app, scopes: %w[chat:write])
       no_token = slack_credential(app: app, access_token: nil)
       other_app = slack_app(slug: "other-slack")
       other = slack_credential(app: other_app)
@@ -48,6 +49,7 @@ module SlackDm
         .select { |job| job[:job] == SlackDm::SyncCredentialJob }
         .map { |job| job[:args].first }
       assert_includes enqueued_ids, good.id
+      assert_includes enqueued_ids, dm_only.id
       refute_includes enqueued_ids, missing_scope.id
       refute_includes enqueued_ids, no_token.id
       refute_includes enqueued_ids, other.id

--- a/services/console/test/services/slack_dm/sync_credential_test.rb
+++ b/services/console/test/services/slack_dm/sync_credential_test.rb
@@ -83,6 +83,7 @@ module SlackDm
         when SlackDm::SyncCredential::AUTH_TEST_ENDPOINT
           { "ok" => true, "team_id" => "T123", "user_id" => "U_ME" }
         when SlackDm::SyncCredential::CONVERSATIONS_LIST_ENDPOINT
+          assert_equal "im,mpim,private_channel", params["types"]
           {
             "ok" => true,
             "channels" => [
@@ -175,6 +176,105 @@ module SlackDm
       assert_equal "1700000000.000002", batch[:messages].last[:parent_message_ts]
       assert_equal "F123", batch[:attachments].first[:slack_file_id]
       assert_equal "1700000000.000002", batch[:checkpoints].first[:watermark_ts]
+    end
+
+    test "sync ingests private channels and their complete member list" do
+      api_client = FakeApiClient.new
+      slack_http = lambda do |endpoint:, params:, access_token:|
+        assert_equal "xoxp-live", access_token
+        case endpoint
+        when SlackDm::SyncCredential::AUTH_TEST_ENDPOINT
+          { "ok" => true, "team_id" => "T123", "user_id" => "U_ME" }
+        when SlackDm::SyncCredential::CONVERSATIONS_LIST_ENDPOINT
+          assert_equal "im,mpim,private_channel", params["types"]
+          {
+            "ok" => true,
+            "channels" => [
+              {
+                "id" => "G123",
+                "name" => "leadership",
+                "is_private" => true,
+                "is_archived" => false
+              }
+            ],
+            "response_metadata" => { "next_cursor" => "" }
+          }
+        when SlackDm::SyncCredential::CONVERSATIONS_MEMBERS_ENDPOINT
+          assert_equal "G123", params["channel"]
+          {
+            "ok" => true,
+            "members" => %w[U_ME U_OTHER],
+            "response_metadata" => { "next_cursor" => "" }
+          }
+        when SlackDm::SyncCredential::CONVERSATIONS_HISTORY_ENDPOINT
+          {
+            "ok" => true,
+            "messages" => [
+              {
+                "type" => "message",
+                "ts" => "1700000001.000001",
+                "user" => "U_OTHER",
+                "text" => "private roadmap"
+              }
+            ],
+            "response_metadata" => { "next_cursor" => "" }
+          }
+        else
+          flunk "unexpected Slack endpoint #{endpoint}"
+        end
+      end
+
+      SlackDm::SyncCredential.new(
+        credential,
+        api_client: api_client,
+        slack_api_http: slack_http
+      ).call
+
+      batch = api_client.batch
+      assert_equal "private_channel", batch[:conversations].first[:conversation_type]
+      assert_equal "leadership", batch[:conversations].first[:raw_payload]["name"]
+      assert_equal %w[U_ME U_OTHER], batch[:members].map { |member| member[:user_id] }
+      assert_equal "private roadmap", batch[:messages].first[:text]
+    end
+
+    test "sync never replaces membership from truncated pagination" do
+      env_key = "CENTAUR_CONSOLE_SLACK_DM_SYNC_MEMBERS_MAX_PAGES"
+      previous = ENV[env_key]
+      ENV[env_key] = "1"
+      api_client = FakeApiClient.new
+      slack_http = lambda do |endpoint:, params:, access_token:|
+        assert_equal "xoxp-live", access_token
+        case endpoint
+        when SlackDm::SyncCredential::AUTH_TEST_ENDPOINT
+          { "ok" => true, "team_id" => "T123", "user_id" => "U_ME" }
+        when SlackDm::SyncCredential::CONVERSATIONS_LIST_ENDPOINT
+          {
+            "ok" => true,
+            "channels" => [ { "id" => "G123", "is_private" => true } ],
+            "response_metadata" => { "next_cursor" => "" }
+          }
+        when SlackDm::SyncCredential::CONVERSATIONS_MEMBERS_ENDPOINT
+          {
+            "ok" => true,
+            "members" => [ "U_ME" ],
+            "response_metadata" => { "next_cursor" => "more" }
+          }
+        else
+          flunk "unexpected Slack endpoint #{endpoint} with #{params}"
+        end
+      end
+
+      error = assert_raises(SlackDm::SyncCredential::SlackApiError) do
+        SlackDm::SyncCredential.new(
+          credential,
+          api_client: api_client,
+          slack_api_http: slack_http
+        ).call
+      end
+      assert_match "membership pagination truncated", error.message
+      assert_nil api_client.batch
+    ensure
+      previous.nil? ? ENV.delete(env_key) : ENV[env_key] = previous
     end
   end
 end

--- a/tools/productivity/company_context/client.py
+++ b/tools/productivity/company_context/client.py
@@ -456,7 +456,7 @@ def _granola_doc_summary(row: Any) -> dict[str, Any]:
 
 
 def _dm_document_summary(row: Any) -> dict[str, Any]:
-    """Return the common metadata we expose for Slack DM context records."""
+    """Return metadata for user-scoped Slack conversation context records."""
     metadata = _as_dict(_row_value(row, "metadata", {}))
     conversation_type = str(_row_value(row, "conversation_type", ""))
     conversation_id = str(_row_value(row, "conversation_id", ""))
@@ -473,7 +473,11 @@ def _dm_document_summary(row: Any) -> dict[str, Any]:
         "title": str(_row_value(row, "title", "")),
         "url": str(_row_value(row, "permalink", "")),
         "author_name": user_id or bot_id,
-        "access_scope": "slack_dm",
+        "access_scope": (
+            "slack_private_channel"
+            if conversation_type == "private_channel"
+            else "slack_dm"
+        ),
         "occurred_at": _isoformat(_row_value(row, "occurred_at")),
         "source_updated_at": _isoformat(_row_value(row, "source_updated_at")),
         "conversation_id": conversation_id,
@@ -521,6 +525,7 @@ def _include_slack_dms_source(source: str | None, source_type: str | None) -> bo
         SLACK_DM_SOURCE,
         "slack_im",
         "slack_mpim",
+        "slack_private_channel",
         "slack_dm_conversation",
     )
 
@@ -925,8 +930,14 @@ class CompanyContextClient:
             return self._empty_latest_date_result(source=source, source_type=source_type)
 
         message_conversation_type = None
-        include_messages = source_type in (None, SLACK_DM_SOURCE, "slack_im", "slack_mpim")
-        if source_type in ("slack_im", "slack_mpim"):
+        include_messages = source_type in (
+            None,
+            SLACK_DM_SOURCE,
+            "slack_im",
+            "slack_mpim",
+            "slack_private_channel",
+        )
+        if source_type in ("slack_im", "slack_mpim", "slack_private_channel"):
             message_conversation_type = source_type.removeprefix("slack_")
         include_conversations = source_type in (None, SLACK_DM_SOURCE, "slack_dm_conversation")
 
@@ -1271,7 +1282,7 @@ class CompanyContextClient:
         occurred_after: str | datetime | None = None,
         occurred_before: str | datetime | None = None,
     ) -> dict:
-        """Search Slack DM and group DM context visible to the current Slack user."""
+        """Search private Slack context visible to the current Slack user."""
         normalized_query = query.strip()
         if not normalized_query:
             return {"status": "error", "error": "query cannot be empty"}

--- a/tools/productivity/company_context/client.py
+++ b/tools/productivity/company_context/client.py
@@ -953,7 +953,7 @@ class CompanyContextClient:
                         MAX(source_updated_at) AS latest_source_updated_at,
                         MAX(occurred_at) AS latest_occurred_at,
                         COUNT(*)::bigint AS document_count
-                    FROM slack_dm_context_documents
+                    FROM slack_private_context_documents
                     WHERE ($1::text IS NULL OR conversation_type = $1)
                     """,
                     message_conversation_type,
@@ -973,7 +973,7 @@ class CompanyContextClient:
                         MAX(source_updated_at) AS latest_source_updated_at,
                         MAX(last_seen_at) AS latest_occurred_at,
                         COUNT(*)::bigint AS document_count
-                    FROM slack_dm_conversation_context_documents
+                    FROM slack_private_conversation_context_documents
                     """,
                 )
                 conversations = self._latest_date_result_from_row(
@@ -1135,7 +1135,7 @@ class CompanyContextClient:
                     participant_count,
                     metadata,
                     paradedb.score(document_id) AS score
-                FROM slack_dm_conversation_context_documents
+                FROM slack_private_conversation_context_documents
                 WHERE {_search_where_clause(len(terms))}
                 ORDER BY paradedb.score(document_id) DESC,
                          last_seen_at DESC NULLS LAST,
@@ -1230,7 +1230,7 @@ class CompanyContextClient:
                     source_updated_at,
                     metadata,
                     paradedb.score(document_id) AS score
-                FROM slack_dm_context_documents
+                FROM slack_private_context_documents
                 WHERE {_search_where_clause(len(terms))}
                   AND (${conversation_id_param}::text IS NULL
                        OR conversation_id = ${conversation_id_param})

--- a/tools/productivity/company_context/tests/test_client.py
+++ b/tools/productivity/company_context/tests/test_client.py
@@ -845,6 +845,22 @@ def test_search_dms_queries_bm25_and_returns_compact_results(monkeypatch):
     assert fake.closed is True
 
 
+def test_private_channel_documents_use_private_access_scope():
+    summary = company_context_client._dm_document_summary(
+        {
+            "document_id": "slack_dm:T_HOME:G123:1770000000.000000",
+            "conversation_id": "G123",
+            "conversation_type": "private_channel",
+            "message_ts": "1770000000.000000",
+            "title": "Slack private channel: #leadership",
+            "metadata": {"channel_name": "leadership"},
+        }
+    )
+
+    assert summary["source_type"] == "slack_private_channel"
+    assert summary["access_scope"] == "slack_private_channel"
+
+
 def test_search_dms_applies_occurred_at_filters(monkeypatch):
     fake = _FakeConnection(rows=[])
 
@@ -1104,6 +1120,35 @@ def test_latest_date_can_filter_slack_dm_messages_by_conversation_type(monkeypat
     query, args = fake.fetchrow_calls[0]
     assert "FROM slack_dm_context_documents" in query
     assert args == ("im",)
+    assert fake.closed is True
+
+
+def test_latest_date_can_filter_private_channel_messages(monkeypatch):
+    fake = _FakeConnection(
+        fetchrow_rows=[
+            {
+                "latest_date": dt.datetime(2026, 5, 9, 15, 30, tzinfo=dt.UTC),
+                "latest_source_updated_at": dt.datetime(2026, 5, 9, 15, 30, tzinfo=dt.UTC),
+                "latest_occurred_at": dt.datetime(2026, 5, 8, 14, 0, tzinfo=dt.UTC),
+                "document_count": 12,
+            },
+        ]
+    )
+
+    async def fake_connect(*args, **kwargs):
+        return fake
+
+    monkeypatch.setattr(company_context_client.asyncpg, "connect", fake_connect)
+
+    result = CompanyContextClient("postgresql://example").latest_date(
+        source="slack_dm",
+        source_type="slack_private_channel",
+    )
+
+    assert result["document_count"] == 12
+    query, args = fake.fetchrow_calls[0]
+    assert "FROM slack_dm_context_documents" in query
+    assert args == ("private_channel",)
     assert fake.closed is True
 
 

--- a/tools/productivity/company_context/tests/test_client.py
+++ b/tools/productivity/company_context/tests/test_client.py
@@ -748,7 +748,7 @@ def test_search_dm_conversations_queries_projection(monkeypatch):
         ],
     }
     query, args = fake.fetch_calls[0]
-    assert "FROM slack_dm_conversation_context_documents" in query
+    assert "FROM slack_private_conversation_context_documents" in query
     assert "title ||| $1::text::pdb.boost(8) OR body ||| $1::text::pdb.boost(2)" in query
     assert "OR (title ||| $2::text::pdb.boost(4) OR body ||| $2::text)" in query
     assert "LIMIT $3" in query
@@ -831,7 +831,7 @@ def test_search_dms_queries_bm25_and_returns_compact_results(monkeypatch):
         ],
     }
     query, args = fake.fetch_calls[0]
-    assert "FROM slack_dm_context_documents" in query
+    assert "FROM slack_private_context_documents" in query
     assert "title ||| $1::text::pdb.boost(8) OR body ||| $1::text::pdb.boost(2)" in query
     assert "OR (title ||| $2::text::pdb.boost(4) OR body ||| $2::text)" in query
     assert "OR (title ||| $3::text::pdb.boost(4) OR body ||| $3::text)" in query
@@ -1087,8 +1087,8 @@ def test_latest_date_counts_slack_dm_projection_tables(monkeypatch):
         "latest_occurred_at": "2026-05-10T10:00:00+00:00",
     }
     assert len(fake.fetchrow_calls) == 2
-    assert "FROM slack_dm_context_documents" in fake.fetchrow_calls[0][0]
-    assert "FROM slack_dm_conversation_context_documents" in fake.fetchrow_calls[1][0]
+    assert "FROM slack_private_context_documents" in fake.fetchrow_calls[0][0]
+    assert "FROM slack_private_conversation_context_documents" in fake.fetchrow_calls[1][0]
     assert fake.closed is True
 
 
@@ -1118,7 +1118,7 @@ def test_latest_date_can_filter_slack_dm_messages_by_conversation_type(monkeypat
     assert result["latest_date"] == "2026-05-09T15:30:00+00:00"
     assert len(fake.fetchrow_calls) == 1
     query, args = fake.fetchrow_calls[0]
-    assert "FROM slack_dm_context_documents" in query
+    assert "FROM slack_private_context_documents" in query
     assert args == ("im",)
     assert fake.closed is True
 
@@ -1147,7 +1147,7 @@ def test_latest_date_can_filter_private_channel_messages(monkeypatch):
 
     assert result["document_count"] == 12
     query, args = fake.fetchrow_calls[0]
-    assert "FROM slack_dm_context_documents" in query
+    assert "FROM slack_private_context_documents" in query
     assert args == ("private_channel",)
     assert fake.closed is True
 

--- a/workflows/slack/retention.py
+++ b/workflows/slack/retention.py
@@ -180,12 +180,12 @@ async def prune_slack_dm(pool, *, retention_days: int, dry_run: bool = False) ->
         "messages": await _count_or_delete(
             pool,
             count_sql=(
-                "SELECT COUNT(*) FROM slack_dm_sync_messages "
+                "SELECT COUNT(*) FROM slack_private_sync_messages "
                 "WHERE occurred_at < NOW() - make_interval(days => $1)"
             ),
             delete_sql=(
                 "WITH deleted AS ("
-                "    DELETE FROM slack_dm_sync_messages "
+                "    DELETE FROM slack_private_sync_messages "
                 "    WHERE occurred_at < NOW() - make_interval(days => $1) "
                 "    RETURNING 1"
                 ") SELECT COUNT(*) FROM deleted"
@@ -196,20 +196,20 @@ async def prune_slack_dm(pool, *, retention_days: int, dry_run: bool = False) ->
         "conversations": await _count_or_delete(
             pool,
             count_sql=(
-                "SELECT COUNT(*) FROM slack_dm_sync_conversations c "
+                "SELECT COUNT(*) FROM slack_private_sync_conversations c "
                 "WHERE c.last_seen_at < NOW() - make_interval(days => $1) "
                 "  AND NOT EXISTS ("
-                "      SELECT 1 FROM slack_dm_sync_messages m "
+                "      SELECT 1 FROM slack_private_sync_messages m "
                 "      WHERE m.home_team_id = c.home_team_id "
                 "        AND m.conversation_id = c.conversation_id"
                 "  )"
             ),
             delete_sql=(
                 "WITH deleted AS ("
-                "    DELETE FROM slack_dm_sync_conversations c "
+                "    DELETE FROM slack_private_sync_conversations c "
                 "    WHERE c.last_seen_at < NOW() - make_interval(days => $1) "
                 "      AND NOT EXISTS ("
-                "          SELECT 1 FROM slack_dm_sync_messages m "
+                "          SELECT 1 FROM slack_private_sync_messages m "
                 "          WHERE m.home_team_id = c.home_team_id "
                 "            AND m.conversation_id = c.conversation_id"
                 "      ) "
@@ -222,13 +222,13 @@ async def prune_slack_dm(pool, *, retention_days: int, dry_run: bool = False) ->
         "backfill_jobs": await _count_or_delete(
             pool,
             count_sql=(
-                "SELECT COUNT(*) FROM slack_dm_sync_backfill_jobs "
+                "SELECT COUNT(*) FROM slack_private_sync_backfill_jobs "
                 "WHERE status IN ('completed', 'failed') "
                 "  AND updated_at < NOW() - make_interval(days => $1)"
             ),
             delete_sql=(
                 "WITH deleted AS ("
-                "    DELETE FROM slack_dm_sync_backfill_jobs "
+                "    DELETE FROM slack_private_sync_backfill_jobs "
                 "    WHERE status IN ('completed', 'failed') "
                 "      AND updated_at < NOW() - make_interval(days => $1) "
                 "    RETURNING 1"
@@ -240,13 +240,13 @@ async def prune_slack_dm(pool, *, retention_days: int, dry_run: bool = False) ->
         "runs": await _count_or_delete(
             pool,
             count_sql=(
-                "SELECT COUNT(*) FROM slack_dm_sync_runs "
+                "SELECT COUNT(*) FROM slack_private_sync_runs "
                 "WHERE status <> 'running' "
                 "  AND COALESCE(finished_at, started_at) < NOW() - make_interval(days => $1)"
             ),
             delete_sql=(
                 "WITH deleted AS ("
-                "    DELETE FROM slack_dm_sync_runs "
+                "    DELETE FROM slack_private_sync_runs "
                 "    WHERE status <> 'running' "
                 "      AND COALESCE(finished_at, started_at) "
                 "          < NOW() - make_interval(days => $1) "

--- a/workflows/slack/tests/test_retention.py
+++ b/workflows/slack/tests/test_retention.py
@@ -126,11 +126,11 @@ def test_prune_slack_dm_dry_run_counts_expected_tables():
         "runs": 8,
     }
     sql = "\n".join(call[0] for call in pool.calls)
-    assert "SELECT COUNT(*) FROM slack_dm_sync_messages" in sql
-    assert "SELECT COUNT(*) FROM slack_dm_sync_conversations" in sql
+    assert "SELECT COUNT(*) FROM slack_private_sync_messages" in sql
+    assert "SELECT COUNT(*) FROM slack_private_sync_conversations" in sql
     assert "NOT EXISTS" in sql
-    assert "SELECT COUNT(*) FROM slack_dm_sync_backfill_jobs" in sql
-    assert "SELECT COUNT(*) FROM slack_dm_sync_runs" in sql
+    assert "SELECT COUNT(*) FROM slack_private_sync_backfill_jobs" in sql
+    assert "SELECT COUNT(*) FROM slack_private_sync_runs" in sql
     assert "DELETE FROM" not in sql
 
 


### PR DESCRIPTION
## Summary

- fan out the existing console Slack sync across OAuth credentials that grant DM, MPIM, or private-channel scope pairs
- ingest private-channel conversations, history, and complete membership snapshots
- rename the shared user-scoped storage from `slack_dm_*` to neutral `slack_private_*` tables while preserving existing DM/MPIM data
- enforce team/user/conversation membership through RLS and reject truncated member pagination
- expose private-channel documents to the company-context tool as `slack_private_channel`

## Slack scopes

- `im:read`, `im:history`
- `mpim:read`, `mpim:history`
- `groups:read`, `groups:history`

Existing DM-only credentials continue to sync the conversation types their granted scope pairs support. Users must consent again after the OAuth app allows the private-channel scopes.

## Storage migration

Migration 0045 renames all nine `slack_dm_*` tables in place to `slack_private_*`, preserving rows, foreign keys, grants, RLS, and triggers. It rewrites stored projection functions that reference the old relation names and rebuilds the ParadeDB BM25 indexes against the renamed document tables.

Document IDs and the existing `/api/admin/slack/dm-sync/*` endpoints remain stable for compatibility.

## Membership behavior

Each successful sync replaces the channel's complete membership snapshot. Users omitted from that snapshot are marked inactive and immediately lose access through RLS. Membership does not expire based on time; if syncing is unavailable, the last successfully reconciled state remains authoritative. Partial or truncated member lists are rejected and never applied.

## Validation

- API and console images built successfully
- console sync tests: 6 runs, 48 assertions
- targeted RuboCop and Ruff checks passed
- Rust API validation tests passed
- company-context and Slack retention tests: 46 passed
- migration rename coverage test passed for all nine tables
- upgrade test preserved a pre-existing DM, message, and projected document
- post-migration projection functions contained zero old table references
- real API request ingested a private channel through the renamed tables
- company-context BM25 message and conversation searches returned the private channel
- RLS BM25 search returned one result for a member and zero for a non-member
- truncated member pagination preserved the prior membership snapshot

## Notes

The shared local API database contains an unrelated migration-0038 checksum conflict from another development branch. The PR API image was therefore exercised in the local Kubernetes stack against an isolated clone of the local schema with migration 0045 applied; the normal local API, console, and worker deployments remained healthy.
