### PR TITLE
feat(console): allow linking an SSO provider only after signing in

### DIFF
--- a/services/console/README.md
+++ b/services/console/README.md
@@ -97,6 +97,7 @@ The operator console always supports email and password sign-in. To add Google o
 | `CENTAUR_CONSOLE_SLACK_CLIENT_ID`        | for Slack | Slack OpenID Connect client ID for console login.                                            |
 | `CENTAUR_CONSOLE_SLACK_CLIENT_SECRET`    | for Slack | Slack OpenID Connect client secret for console login.                                        |
 | `CENTAUR_CONSOLE_BOOTSTRAP_ADMINS`       | no       | Comma- or whitespace-separated email allowlist. Matching users become active admins on first SSO login. Other SSO users become active non-admin operators and land on the console directly -- the deployment's network boundary is the access control, there is no approval queue. |
+| `CENTAUR_CONSOLE_LINK_ONLY_PROVIDERS`    | no       | Comma- or whitespace-separated provider list (`google`, `slack`) that may only be **linked to an already-signed-in account**, never used to log in. A link-only provider is hidden from the login page and rejected by the login flow; instead it appears as a "Connect" button on the Integrations page. Empty by default (every configured provider can log in). |
 
 Register these callback URLs with the provider:
 
@@ -104,6 +105,10 @@ Register these callback URLs with the provider:
 - Slack: `<CENTAUR_CONSOLE_PUBLIC_URL>/auth/slack/callback`
 
 Both providers request the `openid`, `email`, and `profile` scopes. Client credentials may also be stored in Rails credentials under `console_auth.<provider>.client_id` and `console_auth.<provider>.client_secret`, but environment variables take precedence.
+
+### Link-only providers
+
+By default any configured provider can both log in and be linked. Listing a provider in `CENTAUR_CONSOLE_LINK_ONLY_PROVIDERS` restricts it to **account linking only**: it never provisions or authenticates a user, so it cannot widen who can reach the console. A signed-in operator links it from **Integrations → Linked accounts** (which runs the same OIDC flow but attaches the returned identity to the current account); an operator can only claim an IdP account they can actually sign into, and an account already linked to another user is rejected. This is the recommended setup when you want, say, Google to remain the sole login/access gate while still linking Slack identities so the console can scope the threads each operator opened from Slack.
 
 Google OAuth consent apps for broker credentials are configured separately in the console under **OAuth Apps**. Those app callbacks use `/oauth/<slug>/callback` and currently support Google only; Slack support here applies to operator console sign-in.
 

--- a/services/console/app/controllers/console/identities_controller.rb
+++ b/services/console/app/controllers/console/identities_controller.rb
@@ -1,0 +1,20 @@
+# Lets a signed-in operator remove a linked SSO identity from their own account
+# (the "Disconnect" action on the Integrations page). Only link-only identities
+# (e.g. Slack) can be removed here -- the login identity that authenticates the
+# account is protected so a user can't lock themselves out. Not admin-gated: a
+# user manages only their own identities (scoped through current_user).
+class Console::IdentitiesController < ApplicationController
+  layout "console"
+
+  def destroy
+    identity = current_user.user_identities.find_by_oid!(params[:id])
+    if ConsoleAuth.link_only?(identity.provider)
+      identity.destroy!
+      redirect_to console_integrations_path,
+                  notice: "Disconnected your #{identity.provider.capitalize} account."
+    else
+      redirect_to console_integrations_path,
+                  alert: "You can't disconnect the account you sign in with."
+    end
+  end
+end

--- a/services/console/app/controllers/console/integrations_controller.rb
+++ b/services/console/app/controllers/console/integrations_controller.rb
@@ -21,5 +21,14 @@ class Console::IntegrationsController < ApplicationController
       .where(oauth_app_id: @oauth_apps.select(:id))
       .order(:updated_at)
       .index_by(&:oauth_app_id)
+
+    # Link-only SSO providers (e.g. Slack) the operator can attach to their
+    # account for thread/credential scoping, plus the identities they've already
+    # linked. Empty unless the deployment configures a link-only provider, so
+    # the "Linked accounts" section is hidden by default.
+    @linkable_login_providers = ConsoleAuth.linkable_providers
+    @linked_identities_by_provider = current_user.user_identities
+      .where(provider: @linkable_login_providers)
+      .index_by(&:provider)
   end
 end

--- a/services/console/app/controllers/session_oauth_controller.rb
+++ b/services/console/app/controllers/session_oauth_controller.rb
@@ -33,13 +33,32 @@ class SessionOauthController < ApplicationController
 
   before_action :set_provider
 
-  # GET /auth/:provider/start
+  # GET /auth/:provider/start -- begin a login (authenticate + provision).
   def start
+    if ConsoleAuth.link_only?(@key)
+      return redirect_to login_path, alert: "That sign-in method is not available."
+    end
+    begin_flow(mode: "login")
+  end
+
+  # GET /auth/:provider/connect -- begin linking a provider to the signed-in
+  # account. Only link-only providers use this; it never logs in or provisions.
+  def connect
+    return redirect_to login_path unless current_user
+    unless ConsoleAuth.link_only?(@key)
+      return redirect_to console_integrations_path, alert: "That account can't be linked."
+    end
+    begin_flow(mode: "link")
+  end
+
+  # Builds the signed state (carrying the flow +mode+) + PKCE cookie and sends
+  # the browser to the IdP. Shared by #start (login) and #connect (link).
+  def begin_flow(mode:)
     nonce = SecureRandom.urlsafe_base64(32)
     code_verifier = SecureRandom.urlsafe_base64(64)
 
     state = Rails.application.message_verifier(STATE_PURPOSE).generate(
-      { "provider" => @key, "nonce" => nonce },
+      { "provider" => @key, "nonce" => nonce, "mode" => mode },
       purpose: STATE_PURPOSE, expires_in: FLOW_TTL
     )
 
@@ -52,6 +71,7 @@ class SessionOauthController < ApplicationController
 
     redirect_to authorization_url(state, code_verifier), allow_other_host: true
   end
+  private :begin_flow
 
   # GET /auth/:provider/callback?code=&state=  (or ?error=)
   def callback
@@ -67,7 +87,17 @@ class SessionOauthController < ApplicationController
 
     result = exchange_code(params[:code], flow["code_verifier"])
     identity = @provider.identity_from(result, client_id: ConsoleAuth.client_id(@key))
-    sign_in_console_user(User.link_or_provision(provider: @key, identity: identity))
+
+    if state["mode"] == "link"
+      complete_link(identity)
+    else
+      # Login must never accept a link-only provider, even if a stale/forged
+      # login state names one.
+      if ConsoleAuth.link_only?(@key)
+        return redirect_to login_path, alert: "That sign-in method is not available."
+      end
+      sign_in_console_user(User.link_or_provision(provider: @key, identity: identity))
+    end
   rescue Broker::ExchangeError => e
     Rails.logger.error { "console login exchange failed (#{@key}): #{e.reason}" }
     redirect_to login_path, alert: "Sign in failed. Please try again."
@@ -132,5 +162,23 @@ class SessionOauthController < ApplicationController
 
   def invalid_flow
     redirect_to login_path, alert: "This sign-in link is invalid or expired. Start again."
+  end
+
+  # Attaches the linked identity to the operator who started the connect flow.
+  # The session (established via the login provider) is the trust anchor, so we
+  # require a live current_user and never provision or switch accounts. A
+  # link-only guard is defensive: only link-only providers should reach here.
+  def complete_link(identity)
+    user = current_user
+    return invalid_flow if user.nil?
+    unless ConsoleAuth.link_only?(@key)
+      return redirect_to console_integrations_path, alert: "That account can't be linked."
+    end
+
+    user.link_identity!(provider: @key, identity: identity)
+    redirect_to console_integrations_path, notice: "Linked your #{@key.capitalize} account."
+  rescue User::IdentityConflict
+    redirect_to console_integrations_path,
+                alert: "That #{@key.capitalize} account is already linked to another user."
   end
 end

--- a/services/console/app/models/user.rb
+++ b/services/console/app/models/user.rb
@@ -38,6 +38,31 @@ class User < ApplicationRecord
     mcp_oauth_refresh_tokens.usable.update_all(revoked_at: now, updated_at: now)
   end
 
+  # Raised when an SSO identity a user is trying to link is already bound to a
+  # different console account.
+  IdentityConflict = Class.new(StandardError)
+
+  # Attaches an SSO +identity+ to THIS already-authenticated user, without any
+  # provisioning or session change -- the account-linking counterpart to
+  # link_or_provision. Used by the authenticated "Connect" flow for link-only
+  # providers (e.g. Slack), where the existing session is the trust anchor, so
+  # no email match is required. The (provider, subject) DB uniqueness prevents
+  # one IdP account from being claimed by two users; we surface that as an
+  # IdentityConflict rather than a bare RecordInvalid. A subject already bound to
+  # this same user is refreshed idempotently.
+  def link_identity!(provider:, identity:)
+    existing = UserIdentity.find_by(provider: provider, subject: identity[:subject])
+    raise IdentityConflict if existing && existing.user_id != id
+
+    attributes = { email: identity[:email], email_verified: identity[:email_verified] }
+    if provider == UserIdentity::SLACK_PROVIDER && identity[:team_id].present?
+      attributes[:team_id] = identity[:team_id]
+    end
+    record = user_identities.find_or_initialize_by(provider: provider, subject: identity[:subject])
+    record.update!(attributes)
+    record
+  end
+
   # Resolves the console user behind a verified SSO identity, creating or linking
   # as needed, and (re)caches the identity's email/name. A returning login matches
   # by the stable (provider, subject). A new identity links to an existing user

--- a/services/console/app/views/console/integrations/index.html.erb
+++ b/services/console/app/views/console/integrations/index.html.erb
@@ -4,6 +4,42 @@
            title: "Integrations",
            subtitle: "Connect your accounts so Centaur can act on your behalf." %>
 
+<% if @linkable_login_providers.present? %>
+  <section class="mb-8">
+    <h2 class="mb-1 text-sm font-semibold text-zinc-200">Linked accounts</h2>
+    <p class="mb-4 text-xs text-zinc-500">
+      Link a sign-in identity to this account so the console can show the
+      conversations you started there. This only links to your signed-in
+      account -- it never signs anyone in.
+    </p>
+    <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+      <% @linkable_login_providers.each do |provider| %>
+        <% identity = @linked_identities_by_provider[provider] %>
+        <div class="console-panel flex flex-col gap-3 p-5">
+          <div class="flex items-center gap-3">
+            <span class="flex size-10 shrink-0 items-center justify-center rounded-lg bg-ink-700 text-xs font-semibold uppercase tracking-wide text-zinc-300"><%= provider.first(2) %></span>
+            <div class="min-w-0">
+              <div class="truncate text-sm font-semibold text-zinc-100"><%= provider.capitalize %></div>
+              <div class="text-[11px] uppercase tracking-wide text-zinc-500">Sign-in identity</div>
+            </div>
+          </div>
+          <div class="mt-auto flex items-center justify-between gap-3 pt-1">
+            <% if identity %>
+              <%= button_to "Disconnect", console_identity_path(identity), method: :delete, class: "btn-secondary" %>
+              <span class="flex items-center gap-1.5 text-xs text-emerald-300" title="<%= identity.email %>">
+                <span class="size-1.5 rounded-full bg-emerald-400"></span>
+                Linked
+              </span>
+            <% else %>
+              <a href="<%= auth_connect_path(provider: provider) %>" class="btn-primary inline-block">Connect</a>
+            <% end %>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  </section>
+<% end %>
+
 <% if @oauth_apps.empty? %>
   <p class="empty-state">No integrations available yet.</p>
 <% else %>

--- a/services/console/app/views/sessions/new.html.erb
+++ b/services/console/app/views/sessions/new.html.erb
@@ -17,7 +17,7 @@
     <div class="alert-error"><%= flash[:alert] %></div>
   <% end %>
 
-  <% providers = ConsoleAuth.providers %>
+  <% providers = ConsoleAuth.login_providers %>
   <% if providers.any? %>
     <div class="space-y-3">
       <% providers.each do |provider| %>

--- a/services/console/config/routes.rb
+++ b/services/console/config/routes.rb
@@ -27,6 +27,12 @@ Rails.application.routes.draw do
   # /oauth/:slug/* consent flow below.
   get "auth/:provider/start", to: "session_oauth#start", as: :auth_start
   get "auth/:provider/callback", to: "session_oauth#callback", as: :auth_callback
+  # Link a provider to the signed-in account (link-only providers, e.g. Slack).
+  # Authenticated -- distinct from /start, which logs in/provisions.
+  get "auth/:provider/connect", to: "session_oauth#connect", as: :auth_connect
+  # Remove a linked SSO identity from the signed-in account.
+  delete "console/integrations/identities/:id", to: "console/identities#destroy",
+         as: :console_identity
 
   # MCP OAuth authorization server. MCP clients discover this from api-rs'
   # OAuth protected-resource metadata and register public PKCE clients here.

--- a/services/console/lib/console_auth.rb
+++ b/services/console/lib/console_auth.rb
@@ -19,9 +19,38 @@ module ConsoleAuth
 
   module_function
 
-  # Configured + supported provider keys, for the login page buttons.
+  # Configured + supported provider keys.
   def providers
     SUPPORTED.select { |p| configured?(p) }
+  end
+
+  # Providers offered on the login page: every configured provider that is not
+  # marked link-only. Login-capable providers can authenticate AND provision a
+  # user; link-only providers cannot log anyone in (see #link_only_providers).
+  def login_providers
+    providers.reject { |p| link_only?(p) }
+  end
+
+  # Configured providers that may only be linked to an already-authenticated
+  # account (never used to log in or provision). These are what the console
+  # offers as "Connect" buttons on the Integrations page.
+  def linkable_providers
+    providers.select { |p| link_only?(p) }
+  end
+
+  # Whether a configured provider is link-only. Controlled by
+  #   CENTAUR_CONSOLE_LINK_ONLY_PROVIDERS="slack"   (comma/space list, ENV)
+  #   credentials.console_auth.link_only_providers   (fallback: string or array)
+  # Empty by default, so a deployment that configures a provider keeps today's
+  # behavior (it logs in) unless it opts that provider into link-only.
+  def link_only?(provider)
+    link_only_providers.include?(provider.to_s.strip.downcase)
+  end
+
+  def link_only_providers
+    raw = ConsoleEnv["LINK_ONLY_PROVIDERS"].presence || credentials_dig(:link_only_providers)
+    list = raw.is_a?(Array) ? raw : raw.to_s.split(/[,\s]+/)
+    list.map { |p| p.to_s.strip.downcase }.reject(&:empty?).select { |p| SUPPORTED.include?(p) }.uniq
   end
 
   def configured?(provider)

--- a/services/console/test/controllers/console/identities_controller_test.rb
+++ b/services/console/test/controllers/console/identities_controller_test.rb
@@ -1,0 +1,51 @@
+require "test_helper"
+
+class Console::IdentitiesControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @prev = ENV["CENTAUR_CONSOLE_LINK_ONLY_PROVIDERS"]
+    ENV["CENTAUR_CONSOLE_LINK_ONLY_PROVIDERS"] = "slack"
+    @member = users(:member_user)
+    post login_url, params: { email: @member.email, password: "password123456" }
+    assert_equal @member.id, session[:user_id]
+  end
+
+  teardown do
+    if @prev.nil?
+      ENV.delete("CENTAUR_CONSOLE_LINK_ONLY_PROVIDERS")
+    else
+      ENV["CENTAUR_CONSOLE_LINK_ONLY_PROVIDERS"] = @prev
+    end
+  end
+
+  test "destroy removes a link-only identity from the current user" do
+    identity = @member.user_identities.create!(
+      provider: "slack", subject: "U-mine", email: "member@acme.example", email_verified: true
+    )
+    assert_difference -> { @member.user_identities.count }, -1 do
+      delete console_identity_url(identity)
+    end
+    assert_redirected_to console_integrations_path
+    assert_match(/disconnected/i, flash[:notice])
+  end
+
+  test "destroy refuses to remove the login identity" do
+    identity = @member.user_identities.create!(
+      provider: "google", subject: "g-mine", email: "member@acme.example", email_verified: true
+    )
+    assert_no_difference -> { @member.user_identities.count } do
+      delete console_identity_url(identity)
+    end
+    assert_redirected_to console_integrations_path
+    assert_match(/can't disconnect/i, flash[:alert])
+  end
+
+  test "destroy cannot touch another user's identity" do
+    other = users(:acme_admin)
+    identity = other.user_identities.create!(
+      provider: "slack", subject: "U-other", email: "admin@acme.example", email_verified: true
+    )
+    delete console_identity_url(identity)
+    assert_response :not_found
+    assert UserIdentity.exists?(identity.id)
+  end
+end

--- a/services/console/test/controllers/console/integrations_controller_test.rb
+++ b/services/console/test/controllers/console/integrations_controller_test.rb
@@ -101,4 +101,41 @@ class Console::IntegrationsControllerTest < ActionDispatch::IntegrationTest
     assert_response :ok
     assert_select "a[href=?]", "http://www.example.com/oauth/google/start"
   end
+
+  test "the Linked accounts section is hidden when no provider is link-only" do
+    post login_url, params: { email: users(:member_user).email, password: "password123456" }
+    get console_integrations_url
+    assert_response :ok
+    assert_no_match "Linked accounts", response.body
+  end
+
+  LINK_ONLY_ENV = %w[
+    CENTAUR_CONSOLE_SLACK_CLIENT_ID CENTAUR_CONSOLE_SLACK_CLIENT_SECRET CENTAUR_CONSOLE_LINK_ONLY_PROVIDERS
+  ].freeze
+
+  test "a link-only provider renders Connect, then Disconnect once linked" do
+    prev = ENV.to_hash.slice(*LINK_ONLY_ENV)
+    # A provider must be BOTH configured (client creds) and link-only to appear
+    # as a linkable account.
+    ENV["CENTAUR_CONSOLE_SLACK_CLIENT_ID"] = "slack-login-client-id"
+    ENV["CENTAUR_CONSOLE_SLACK_CLIENT_SECRET"] = "slack-login-secret"
+    ENV["CENTAUR_CONSOLE_LINK_ONLY_PROVIDERS"] = "slack"
+    member = users(:member_user)
+    post login_url, params: { email: member.email, password: "password123456" }
+
+    get console_integrations_url
+    assert_response :ok
+    assert_match "Linked accounts", response.body
+    assert_select "a.btn-primary[href=?]", auth_connect_path(provider: "slack"), text: "Connect"
+
+    member.user_identities.create!(
+      provider: "slack", subject: "U-linked", email: member.email, email_verified: true
+    )
+    get console_integrations_url
+    assert_response :ok
+    assert_select "form[action=?]", console_identity_path(member.user_identities.find_by(provider: "slack"))
+  ensure
+    LINK_ONLY_ENV.each { |k| ENV.delete(k) }
+    prev&.each { |k, v| ENV[k] = v }
+  end
 end

--- a/services/console/test/controllers/session_oauth_controller_test.rb
+++ b/services/console/test/controllers/session_oauth_controller_test.rb
@@ -7,8 +7,10 @@ require "test_helper"
 # HTTP double returning a canned token response (mirrors the broker flow test).
 class SessionOauthControllerTest < ActionDispatch::IntegrationTest
   GOOGLE_CLIENT_ID = "google-login-client-id".freeze
+  SLACK_CLIENT_ID = "slack-login-client-id".freeze
   ENV_KEYS = %w[
     CENTAUR_CONSOLE_GOOGLE_CLIENT_ID CENTAUR_CONSOLE_GOOGLE_CLIENT_SECRET CENTAUR_CONSOLE_BOOTSTRAP_ADMINS
+    CENTAUR_CONSOLE_SLACK_CLIENT_ID CENTAUR_CONSOLE_SLACK_CLIENT_SECRET CENTAUR_CONSOLE_LINK_ONLY_PROVIDERS
   ].freeze
 
   setup do
@@ -186,5 +188,98 @@ class SessionOauthControllerTest < ActionDispatch::IntegrationTest
     get auth_callback_url(provider: "google"), params: { code: "bad", state: state }
     assert_redirected_to login_path
     assert_nil session[:user_id]
+  end
+
+  # --- link-only providers (e.g. Slack) --------------------------------------
+
+  def configure_slack_link_only
+    ENV["CENTAUR_CONSOLE_SLACK_CLIENT_ID"] = SLACK_CLIENT_ID
+    ENV["CENTAUR_CONSOLE_SLACK_CLIENT_SECRET"] = "slack-login-secret"
+    ENV["CENTAUR_CONSOLE_LINK_ONLY_PROVIDERS"] = "slack"
+  end
+
+  def sign_in(user)
+    post login_url, params: { email: user.email, password: "password123456" }
+    assert_equal user.id, session[:user_id]
+  end
+
+  def slack_token_body(sub:, email:, team_id: "T123", email_verified: true)
+    {
+      access_token: "AT",
+      id_token: id_token({
+        "aud" => SLACK_CLIENT_ID, "iss" => "https://slack.com", "sub" => sub,
+        "email" => email, "email_verified" => email_verified, "name" => "Slack User",
+        Login::Providers::Slack::TEAM_ID_CLAIM => team_id
+      })
+    }.to_json
+  end
+
+  def connect_flow
+    get auth_connect_url(provider: "slack")
+    assert_response :redirect
+    URI.decode_www_form(URI.parse(response.location).query).to_h.fetch("state")
+  end
+
+  test "a link-only provider cannot be used to log in" do
+    configure_slack_link_only
+    get auth_start_url(provider: "slack")
+    assert_redirected_to login_path
+    assert_equal "That sign-in method is not available.", flash[:alert]
+  end
+
+  test "the login page hides link-only providers" do
+    configure_slack_link_only
+    get login_url
+    assert_response :ok
+    assert_select "a[href=?]", auth_start_path(provider: "slack"), count: 0
+    assert_select "a[href=?]", auth_start_path(provider: "google"), text: /Continue with Google/
+  end
+
+  test "connect requires an authenticated session" do
+    configure_slack_link_only
+    get auth_connect_url(provider: "slack")
+    assert_redirected_to login_path
+    assert_nil session[:user_id]
+  end
+
+  test "connect links the provider to the signed-in account without switching users" do
+    configure_slack_link_only
+    member = users(:member_user)
+    sign_in(member)
+    stub_exchange(status: 200, body: slack_token_body(sub: "U-member", email: "member.slack@acme.example"))
+    state = connect_flow
+    assert_difference -> { member.user_identities.where(provider: "slack").count }, 1 do
+      get auth_callback_url(provider: "slack"), params: { code: "the-code", state: state }
+    end
+    assert_redirected_to console_integrations_path
+    assert_equal "Linked your Slack account.", flash[:notice]
+    # Same session, same user -- linking never re-authenticates.
+    assert_equal member.id, session[:user_id]
+    identity = member.user_identities.find_by(provider: "slack")
+    assert_equal "U-member", identity.subject
+    assert_equal "T123", identity.team_id
+  end
+
+  test "connect refuses to link a Slack account already linked to another user" do
+    configure_slack_link_only
+    member = users(:member_user)
+    sign_in(member)
+    # slack-pending-sub is bound to pending_user via fixtures.
+    stub_exchange(status: 200, body: slack_token_body(sub: "slack-pending-sub", email: "member@acme.example"))
+    state = connect_flow
+    assert_no_difference -> { member.user_identities.where(provider: "slack").count } do
+      get auth_callback_url(provider: "slack"), params: { code: "the-code", state: state }
+    end
+    assert_redirected_to console_integrations_path
+    assert_match(/already linked/i, flash[:alert])
+  end
+
+  test "connect rejects a non-link-only provider" do
+    # Google is a login provider, not linkable; connect must refuse it even when
+    # signed in.
+    sign_in(users(:member_user))
+    get auth_connect_url(provider: "google")
+    assert_redirected_to console_integrations_path
+    assert_equal "That account can't be linked.", flash[:alert]
   end
 end

--- a/services/console/test/lib/console_auth_test.rb
+++ b/services/console/test/lib/console_auth_test.rb
@@ -1,0 +1,47 @@
+require "test_helper"
+
+class ConsoleAuthTest < ActiveSupport::TestCase
+  ENV_KEYS = %w[
+    CENTAUR_CONSOLE_GOOGLE_CLIENT_ID CENTAUR_CONSOLE_GOOGLE_CLIENT_SECRET
+    CENTAUR_CONSOLE_SLACK_CLIENT_ID CENTAUR_CONSOLE_SLACK_CLIENT_SECRET
+    CENTAUR_CONSOLE_LINK_ONLY_PROVIDERS
+  ].freeze
+
+  setup do
+    @prev_env = ENV.to_hash.slice(*ENV_KEYS)
+    ENV_KEYS.each { |k| ENV.delete(k) }
+    ENV["CENTAUR_CONSOLE_GOOGLE_CLIENT_ID"] = "g-id"
+    ENV["CENTAUR_CONSOLE_GOOGLE_CLIENT_SECRET"] = "g-secret"
+    ENV["CENTAUR_CONSOLE_SLACK_CLIENT_ID"] = "s-id"
+    ENV["CENTAUR_CONSOLE_SLACK_CLIENT_SECRET"] = "s-secret"
+  end
+
+  teardown do
+    ENV_KEYS.each { |k| ENV.delete(k) }
+    @prev_env.each { |k, v| ENV[k] = v }
+  end
+
+  test "with no link-only providers both configured providers can log in" do
+    assert_equal %w[google slack], ConsoleAuth.providers
+    assert_equal %w[google slack], ConsoleAuth.login_providers
+    assert_empty ConsoleAuth.linkable_providers
+    assert_not ConsoleAuth.link_only?("slack")
+  end
+
+  test "a link-only provider is excluded from login and offered as linkable" do
+    ENV["CENTAUR_CONSOLE_LINK_ONLY_PROVIDERS"] = "slack"
+    assert ConsoleAuth.link_only?("slack")
+    assert_equal %w[google], ConsoleAuth.login_providers
+    assert_equal %w[slack], ConsoleAuth.linkable_providers
+    # Still "configured" -- it just can't log in.
+    assert_includes ConsoleAuth.providers, "slack"
+  end
+
+  test "link-only list ignores unknown and unconfigured providers and is normalized" do
+    ENV["CENTAUR_CONSOLE_LINK_ONLY_PROVIDERS"] = " Slack, github "
+    assert_equal %w[slack], ConsoleAuth.link_only_providers
+    # A link-only provider with no client credentials is not linkable.
+    ENV.delete("CENTAUR_CONSOLE_SLACK_CLIENT_ID")
+    assert_empty ConsoleAuth.linkable_providers
+  end
+end


### PR DESCRIPTION
## Summary

Adds the notion of a **link-only SSO provider**: one a signed-in operator can attach to their existing account, but that can **never be used to log in or provision a user**.

This lets a deployment keep a single provider as the sole login/access gate (e.g. Google restricted to an internal org) while still linking a *second* identity (e.g. Slack) purely so the console can scope the threads and credentials each operator opened there. Today, offering Slack for that linkage means enabling it as a full login provider — and since console SSO has no email-domain allowlist and no approval queue ("a completed SSO login is sufficient"), that turns *any* member of the Slack workspace into an active operator. A link-only provider gives you the identity linkage without widening who can reach the console.

## What changed

- **`ConsoleAuth`**: `CENTAUR_CONSOLE_LINK_ONLY_PROVIDERS` (comma/space list) marks configured providers as link-only. `login_providers` excludes them; `linkable_providers` surfaces them. **Empty by default → no behavior change** for existing deployments.
- **`SessionOauthController`**: the login page and `/auth/:provider/start` now offer login providers only, and the login callback refuses a link-only provider (defence in depth against a stale/forged login state). A new authenticated `GET /auth/:provider/connect` runs the same OIDC dance with `mode=link` in the signed state; the shared callback attaches the identity to `current_user` via `User#link_identity!` — never provisioning, never switching the session.
- **Anti-hijack**: an IdP account already linked to a *different* user is rejected (`User::IdentityConflict`, backed by the existing `(provider, subject)` uniqueness). The signed-in session is the trust anchor, and an operator can only complete OIDC as themselves, so they can't claim someone else's identity.
- **Integrations page**: a "Linked accounts" section with Connect / Disconnect. `Console::IdentitiesController#destroy` removes a link-only identity (scoped to `current_user`) and refuses to remove the login identity, so a user can't lock themselves out.
- **README**: documents the variable and the recommended "Google login + Slack link" setup.

## Testing

`bin/rails test` for the touched areas — **68 runs, 289 assertions, 0 failures** (also rubocop-clean):
- `console_auth_test`: `login_providers` / `linkable_providers` / `link_only?` resolution, normalization, unconfigured handling.
- `session_oauth_controller_test`: link-only provider rejected at login `start` + hidden on the login page; `connect` requires a session; the authenticated link happy path (identity attached, session unchanged); cross-user conflict; `connect` rejects a non-link-only provider.
- `identities_controller_test` + `integrations_controller_test`: Disconnect removes a link-only identity, refuses the login identity, can't touch another user's identity; the "Linked accounts" section renders Connect → Disconnect and stays hidden when nothing is link-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)