### PR TITLE
feat: add Telegram chat ingress (telegrambot)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
       discordbot_checks: ${{ steps.filter.outputs.discordbot_checks }}
       githubbot_checks: ${{ steps.filter.outputs.githubbot_checks }}
       teamsbot_checks: ${{ steps.filter.outputs.teamsbot_checks }}
+      telegrambot_checks: ${{ steps.filter.outputs.telegrambot_checks }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
@@ -90,6 +91,12 @@ jobs:
             '^\.github/workflows/ci\.yml$'
           set_output teamsbot_checks \
             '^services/teamsbot/' \
+            '^package\.json$' \
+            '^pnpm-lock\.yaml$' \
+            '^pnpm-workspace\.yaml$' \
+            '^\.github/workflows/ci\.yml$'
+          set_output telegrambot_checks \
+            '^services/telegrambot/' \
             '^package\.json$' \
             '^pnpm-lock\.yaml$' \
             '^pnpm-workspace\.yaml$' \
@@ -373,6 +380,40 @@ jobs:
         working-directory: services/teamsbot
         run: bun run test
 
+  telegrambot-checks:
+    name: Telegrambot typecheck and tests
+    runs-on: depot-ubuntu-24.04-16
+    needs: ci_changes
+    if: needs.ci_changes.outputs.telegrambot_checks == 'true'
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: "24"
+
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+        with:
+          version: 10.28.1
+          run_install: false
+
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+
+      # Workspace-root install: telegrambot links @centaur/* workspace packages
+      # and relies on the root pnpm patches.
+      - name: Install Node dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Typecheck Telegrambot
+        working-directory: services/telegrambot
+        run: bun run check:types
+
+      - name: Telegrambot tests
+        working-directory: services/telegrambot
+        run: bun run test
+
   ci-success:
     name: CI success
     runs-on: ubuntu-latest
@@ -385,10 +426,11 @@ jobs:
       - discordbot-checks
       - githubbot-checks
       - teamsbot-checks
+      - telegrambot-checks
     timeout-minutes: 30
     steps:
       - name: Decide whether the needed jobs succeeded or failed
         uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # release/v1
         with:
-          allowed-skips: migration-order, rust-api, slackbotv2-tests, discordbot-checks, githubbot-checks, teamsbot-checks
+          allowed-skips: migration-order, rust-api, slackbotv2-tests, discordbot-checks, githubbot-checks, teamsbot-checks, telegrambot-checks
           jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,7 @@ jobs:
             '^\.github/workflows/ci\.yml$'
           set_output telegrambot_checks \
             '^services/telegrambot/' \
+            '^packages/' \
             '^package\.json$' \
             '^pnpm-lock\.yaml$' \
             '^pnpm-workspace\.yaml$' \
@@ -385,6 +386,23 @@ jobs:
     runs-on: depot-ubuntu-24.04-16
     needs: ci_changes
     if: needs.ci_changes.outputs.telegrambot_checks == 'true'
+    # The durability core (inbox receipt/claims, fenced ownership, migrations,
+    # poller recovery, and the end-to-end emulate suite) is DB-gated on
+    # TELEGRAMBOT_TEST_DATABASE_URL and would silently skip without Postgres,
+    # so provision one (mirrors the rust-api job's service container).
+    services:
+      postgres:
+        image: postgres:17
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd="pg_isready -U postgres"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
@@ -412,6 +430,8 @@ jobs:
 
       - name: Telegrambot tests
         working-directory: services/telegrambot
+        env:
+          TELEGRAMBOT_TEST_DATABASE_URL: postgres://postgres:postgres@localhost:5432/postgres
         run: bun run test
 
   ci-success:

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -48,7 +48,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        service: [api-rs, slackbotv2, linearbot, discordbot, githubbot, teamsbot, agent, iron-proxy, console]
+        service: [api-rs, slackbotv2, linearbot, discordbot, githubbot, teamsbot, telegrambot, agent, iron-proxy, console]
         platform: ${{ github.event_name == 'push' && fromJSON('["linux/amd64", "linux/arm64"]') || fromJSON('["linux/amd64"]') }}
         include:
           - service: api-rs
@@ -80,6 +80,11 @@ jobs:
             image: centaur-teamsbot
             context: .
             dockerfile: services/teamsbot/Dockerfile
+            target: ""
+          - service: telegrambot
+            image: centaur-telegrambot
+            context: .
+            dockerfile: services/telegrambot/Dockerfile
             target: ""
           - service: agent
             image: centaur-agent
@@ -179,6 +184,7 @@ jobs:
           - image: centaur-discordbot
           - image: centaur-githubbot
           - image: centaur-teamsbot
+          - image: centaur-telegrambot
 
     steps:
       - name: Download digests

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,8 +63,8 @@ Ownership by tree:
 - `services/api-rs/`: Rust control plane, durable sessions, sandbox backends,
   workflows, auth integration, and telemetry.
 - `services/slackbotv2/`, `discordbot/`, `githubbot/`, `linearbot/`,
-  `teamsbot/`: platform transport, policy gates, session forwarding, and
-  platform rendering.
+  `teamsbot/`, `telegrambot/`: platform transport, policy gates, session
+  forwarding, and platform rendering.
 - `services/sandbox/`: agent image, startup composition, tool installation,
   repo-cache helpers, and runtime prompt. Harness protocol normalization lives
   in `crates/harness-server/`, which is built into the image.

--- a/Justfile
+++ b/Justfile
@@ -30,7 +30,7 @@ build:
       just _build-all-sequential
     else
       pids=()
-      for recipe in _build-api-rs _build-iron-proxy _build-slackbotv2 _build-linearbot _build-discordbot _build-githubbot _build-teamsbot _build-agent _build-console; do
+      for recipe in _build-api-rs _build-iron-proxy _build-slackbotv2 _build-linearbot _build-discordbot _build-githubbot _build-teamsbot _build-telegrambot _build-agent _build-console; do
         just "$recipe" &
         pids+=("$!")
       done
@@ -49,6 +49,7 @@ _build-all-sequential:
     just _build-discordbot
     just _build-githubbot
     just _build-teamsbot
+    just _build-telegrambot
     just _build-agent
     just _build-console
 
@@ -63,6 +64,7 @@ build-one service:
       discordbot) just _build-discordbot ;;
       githubbot) just _build-githubbot ;;
       teamsbot) just _build-teamsbot ;;
+      telegrambot) just _build-telegrambot ;;
       agent|sandbox) just _build-agent ;;
       workflow-python) just _build-workflow-python ;;
       console) just _build-console ;;
@@ -90,6 +92,9 @@ _build-githubbot:
 _build-teamsbot:
     docker build -t centaur-teamsbot:latest -f services/teamsbot/Dockerfile .
 
+_build-telegrambot:
+    docker build -t centaur-telegrambot:latest -f services/telegrambot/Dockerfile .
+
 _build-agent:
     docker build --target "{{agent_build_target}}" -t "{{agent_image}}" -f "{{agent_dockerfile}}" .
 
@@ -109,7 +114,7 @@ _build-console:
 _push-registry:
     #!/usr/bin/env bash
     set -euo pipefail
-    for img in centaur-api-rs centaur-iron-proxy centaur-slackbotv2 centaur-linearbot centaur-discordbot centaur-githubbot centaur-teamsbot centaur-agent centaur-console; do
+    for img in centaur-api-rs centaur-iron-proxy centaur-slackbotv2 centaur-linearbot centaur-discordbot centaur-githubbot centaur-teamsbot centaur-telegrambot centaur-agent centaur-console; do
       target="{{registry}}/library/${img}:latest"
       echo "pushing ${img}:latest -> ${target}..."
       docker tag "${img}:latest" "${target}"
@@ -122,7 +127,7 @@ _push-registry:
 _import-k3s:
     #!/usr/bin/env bash
     set -euo pipefail
-    for img in centaur-api-rs centaur-iron-proxy centaur-slackbotv2 centaur-linearbot centaur-discordbot centaur-githubbot centaur-teamsbot centaur-agent centaur-console; do
+    for img in centaur-api-rs centaur-iron-proxy centaur-slackbotv2 centaur-linearbot centaur-discordbot centaur-githubbot centaur-teamsbot centaur-telegrambot centaur-agent centaur-console; do
       echo "importing ${img}:latest into k3s containerd..."
       docker save "${img}:latest" | {{k3s_ctr}} images import -
     done
@@ -146,6 +151,7 @@ deploy:
           --set discordbot.image.repository=ghcr.io/paradigmxyz/centaur/centaur-discordbot
           --set githubbot.image.repository=ghcr.io/paradigmxyz/centaur/centaur-githubbot
           --set teamsbot.image.repository=ghcr.io/paradigmxyz/centaur/centaur-teamsbot
+          --set telegrambot.image.repository=ghcr.io/paradigmxyz/centaur/centaur-telegrambot
           --set sandbox.image.repository=ghcr.io/paradigmxyz/centaur/centaur-agent
           --set console.image.repository=ghcr.io/paradigmxyz/centaur/centaur-console
         )

--- a/contrib/chart/templates/networkpolicy.yaml
+++ b/contrib/chart/templates/networkpolicy.yaml
@@ -86,6 +86,11 @@ spec:
             matchLabels:
 {{ include "centaur.componentSelectorLabels" (dict "root" . "component" "teamsbot") | nindent 14 }}
 {{- end }}
+{{- if .Values.telegrambot.enabled }}
+        - podSelector:
+            matchLabels:
+{{ include "centaur.componentSelectorLabels" (dict "root" . "component" "telegrambot") | nindent 14 }}
+{{- end }}
 {{- if $console.enabled }}
         - podSelector:
             matchLabels:
@@ -181,6 +186,11 @@ spec:
         - podSelector:
             matchLabels:
 {{ include "centaur.componentSelectorLabels" (dict "root" . "component" "teamsbot") | nindent 14 }}
+{{- end }}
+{{- if .Values.telegrambot.enabled }}
+        - podSelector:
+            matchLabels:
+{{ include "centaur.componentSelectorLabels" (dict "root" . "component" "telegrambot") | nindent 14 }}
 {{- end }}
 {{- if $console.enabled }}
         # Console pages call api-rs for admin-backed views such as ETLs.
@@ -598,6 +608,59 @@ spec:
           port: 5432
 {{- end }}
     # Teams Bot Framework, Graph, SharePoint, and proactive activity delivery use direct HTTPS.
+    - ports:
+        - protocol: TCP
+          port: 443
+---
+{{- end }}
+{{- if .Values.telegrambot.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "centaur.componentName" (dict "root" . "component" "telegrambot") }}
+  labels:
+{{ include "centaur.componentLabels" (dict "root" . "component" "telegrambot") | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+{{ include "centaur.componentSelectorLabels" (dict "root" . "component" "telegrambot") | nindent 6 }}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    # Only health probes reach telegrambot; nothing routes traffic to it (long-polling is outbound).
+    - from:
+{{- range $ingressSourceNamespaces }}
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ . | quote }}
+{{- end }}
+      ports:
+        - protocol: TCP
+          port: 3001
+  egress:
+{{- if .Values.apiRs.enabled }}
+    - to:
+        - podSelector:
+            matchLabels:
+{{ include "centaur.componentSelectorLabels" (dict "root" . "component" "api-rs") | nindent 14 }}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.apiRs.port }}
+{{- end }}
+{{- if .Values.postgres.enabled }}
+    - to:
+        - podSelector:
+            matchLabels:
+{{ include "centaur.componentSelectorLabels" (dict "root" . "component" "postgres") | nindent 14 }}
+      ports:
+        - protocol: TCP
+          port: 5432
+{{- end }}
+    # Telegram Bot API (api.telegram.org) long-polling and sends use direct HTTPS. Portable
+    # NetworkPolicy cannot select destinations by FQDN, so this allows any TCP/443 egress;
+    # deployments needing strict destination control must add an egress proxy / service mesh
+    # or a CNI-specific FQDN policy (e.g. Cilium CiliumNetworkPolicy toFQDNs).
     - ports:
         - protocol: TCP
           port: 443

--- a/contrib/chart/templates/telegrambot.yaml
+++ b/contrib/chart/templates/telegrambot.yaml
@@ -1,0 +1,118 @@
+{{- if .Values.telegrambot.enabled }}
+{{- $apiRsName := include "centaur.componentName" (dict "root" . "component" "api-rs") -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "centaur.componentName" (dict "root" . "component" "telegrambot") }}
+  labels:
+{{ include "centaur.componentLabels" (dict "root" . "component" "telegrambot") | nindent 4 }}
+spec:
+  # Exactly one replica: getUpdates allows a single consumer per bot token, so a second pod polling
+  # concurrently gets 409s and messages bounce between pods. Recreate tears the old pod down before
+  # the new one starts polling. Correctness is still guarded by the fenced Postgres lease inside the
+  # service; this is rollout hygiene. Do NOT add an HPA.
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+{{ include "centaur.componentSelectorLabels" (dict "root" . "component" "telegrambot") | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/infra-secrets: {{ include "centaur.infraSecretsChecksum" . }}
+      labels:
+{{ include "centaur.componentSelectorLabels" (dict "root" . "component" "telegrambot") | nindent 8 }}
+    spec:
+      automountServiceAccountToken: false
+      # Let the in-flight long poll and lease release finish on SIGTERM so the replacement pod can
+      # acquire ownership without waiting out the lease TTL.
+      terminationGracePeriodSeconds: 35
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: telegrambot
+          image: {{ printf "%s:%s" .Values.telegrambot.image.repository .Values.telegrambot.image.tag | quote }}
+          imagePullPolicy: {{ .Values.telegrambot.image.pullPolicy }}
+          env:
+            - name: PORT
+              value: "3001"
+            - name: CENTAUR_API_URL
+              value: {{ printf "http://%s:%v" $apiRsName .Values.apiRs.port | quote }}
+            # Shared with the tools/comms/telegram tool: one bot token secret key for the deployment.
+            - name: TELEGRAM_BOT_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "centaur.secretEnvName" . }}
+                  key: {{ printf "%sTELEGRAM_BOT_TOKEN" .Values.secretManager.envPrefix }}
+            - name: TELEGRAMBOT_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "centaur.secretEnvName" . }}
+                  key: {{ printf "%sTELEGRAMBOT_API_KEY" .Values.secretManager.envPrefix }}
+            - name: TELEGRAMBOT_DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "centaur.secretEnvName" . }}
+                  key: {{ printf "%sDATABASE_URL" .Values.secretManager.envPrefix }}
+            - name: TELEGRAMBOT_USER_NAME
+              value: {{ .Values.telegrambot.userName | quote }}
+            - name: TELEGRAMBOT_CHAT_ALLOWLIST
+              value: {{ .Values.telegrambot.chatAllowlist | quote }}
+            - name: TELEGRAMBOT_USER_ALLOWLIST
+              value: {{ .Values.telegrambot.userAllowlist | quote }}
+{{- range $name, $value := .Values.telegrambot.extraEnv }}
+            - name: {{ $name }}
+              value: {{ $value | quote }}
+{{- end }}
+          ports:
+            - containerPort: 3001
+              name: http
+          # /live reports only local process liveness; /ready additionally requires database
+          # initialization, fenced ownership, webhook reconciliation, and fresh poll progress.
+          # A Telegram outage or stale polling must only fail readiness — never liveness — so the
+          # pod is never restarted into a probe-induced crash loop it cannot poll its way out of.
+          # Startup gets a generous window (24 * 5s = 120s) because first boot runs migrations,
+          # acquires the ownership lease, and reconciles webhook state before serving.
+          startupProbe:
+            httpGet:
+              path: /live
+              port: 3001
+            periodSeconds: 5
+            failureThreshold: 24
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 3001
+            timeoutSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /live
+              port: 3001
+            periodSeconds: 15
+          securityContext:
+{{ toYaml .Values.containerSecurityContext | nindent 12 }}
+            # The oven/bun runtime image ships the `bun` user (uid/gid 1000); the Dockerfile drops
+            # to it, so enforce non-root here too.
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+          resources:
+{{ toYaml .Values.telegrambot.resources | nindent 12 }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "centaur.componentName" (dict "root" . "component" "telegrambot") }}
+  labels:
+{{ include "centaur.componentLabels" (dict "root" . "component" "telegrambot") | nindent 4 }}
+spec:
+  selector:
+{{ include "centaur.componentSelectorLabels" (dict "root" . "component" "telegrambot") | nindent 4 }}
+  ports:
+    - name: http
+      port: 3001
+      targetPort: 3001
+{{- end }}

--- a/contrib/chart/values.dev.yaml
+++ b/contrib/chart/values.dev.yaml
@@ -28,6 +28,12 @@ teamsbot:
   image:
     pullPolicy: IfNotPresent
 
+telegrambot:
+  # Enable once TELEGRAM_BOT_TOKEN and the chat/user allowlists are configured.
+  enabled: false
+  image:
+    pullPolicy: IfNotPresent
+
 apiRs:
   image:
     pullPolicy: IfNotPresent

--- a/contrib/chart/values.yaml
+++ b/contrib/chart/values.yaml
@@ -572,6 +572,24 @@ teamsbot:
   extraEnv: {}
   resources: {}
 
+# Telegram chat ingress — mirrors discordbot's pull model, long-polling getUpdates and forwarding
+# to the api-rs control plane (:8080). Off by default; needs a @BotFather bot token plus explicit
+# chat/user allowlists (fail-closed: both empty leaves the bot inert). Always exactly one replica
+# (getUpdates allows a single consumer per token).
+telegrambot:
+  enabled: false
+  image:
+    repository: centaur-telegrambot
+    tag: latest
+    pullPolicy: Always
+  userName: centaur
+  # Comma/space-separated Telegram chat ids allowed for group/supergroup chats.
+  chatAllowlist: ""
+  # Comma/space-separated Telegram user ids allowed for private (DM) chats.
+  userAllowlist: ""
+  extraEnv: {}
+  resources: {}
+
 postgres:
   enabled: true
   image:

--- a/contrib/scripts/bootstrap-k8s-secrets.sh
+++ b/contrib/scripts/bootstrap-k8s-secrets.sh
@@ -63,6 +63,14 @@ Optional Discord ingress bootstrap (consumed when discordbot.enabled=true):
   DISCORDBOT_API_KEY           bearer the bot sends to api-rs; auto-generated
                                once when absent (never rotated in place)
 
+Optional Telegram bootstrap (consumed when telegrambot.enabled=true, and by
+the tools/comms/telegram tool):
+  TELEGRAM_BOT_TOKEN           bot token from @BotFather. Overwritten on every
+                               run so it rotates. Shared by the telegrambot
+                               ingress and the outbound telegram tool.
+  TELEGRAMBOT_API_KEY          bearer the bot sends to api-rs; auto-generated
+                               once when absent (never rotated in place)
+
 Optional Teams ingress bootstrap (consumed when teamsbot.enabled=true):
   TEAMS_BOT_APP_ID             when set, seeds the teamsbot keys; requires
                                TEAMS_BOT_APP_PASSWORD and
@@ -223,6 +231,15 @@ if secret_exists centaur-infra-env; then
       patch_data+=("\"DISCORDBOT_API_KEY\":\"$(printf '%s' "${DISCORDBOT_API_KEY:-$(rand_hex)}" | base64 | tr -d '\n')\"")
     fi
   fi
+  # Telegram keys: added when TELEGRAM_BOT_TOKEN is in the env. The token is shared by the
+  # telegrambot ingress and the outbound telegram tool, and is overwritten on each run (so
+  # rotation works); TELEGRAMBOT_API_KEY is generated once if absent.
+  if [[ -n "${TELEGRAM_BOT_TOKEN:-}" ]]; then
+    patch_data+=("\"TELEGRAM_BOT_TOKEN\":\"$(printf '%s' "$TELEGRAM_BOT_TOKEN" | base64 | tr -d '\n')\"")
+    if ! secret_key_present TELEGRAMBOT_API_KEY; then
+      patch_data+=("\"TELEGRAMBOT_API_KEY\":\"$(printf '%s' "${TELEGRAMBOT_API_KEY:-$(rand_hex)}" | base64 | tr -d '\n')\"")
+    fi
+  fi
   # Teams ingress (teamsbot) keys: added when TEAMS_BOT_APP_ID is in the env.
   # TEAMS_BOT_* are overwritten on each run; TEAMSBOT_API_KEY is generated once
   # if absent.
@@ -340,6 +357,12 @@ else
       --from-literal=DISCORD_PUBLIC_KEY="$DISCORD_PUBLIC_KEY"
       --from-literal=DISCORD_APPLICATION_ID="$DISCORD_APPLICATION_ID"
       --from-literal=DISCORDBOT_API_KEY="${DISCORDBOT_API_KEY:-$(rand_hex)}"
+    )
+  fi
+  if [[ -n "${TELEGRAM_BOT_TOKEN:-}" ]]; then
+    secret_args+=(
+      --from-literal=TELEGRAM_BOT_TOKEN="$TELEGRAM_BOT_TOKEN"
+      --from-literal=TELEGRAMBOT_API_KEY="${TELEGRAMBOT_API_KEY:-$(rand_hex)}"
     )
   fi
   if [[ -n "${TEAMS_BOT_APP_ID:-}" ]]; then

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -308,6 +308,37 @@ importers:
         specifier: ^6.0.3
         version: 6.0.3
 
+  services/telegrambot:
+    dependencies:
+      '@centaur/harness-events':
+        specifier: workspace:*
+        version: link:../../packages/harness-events
+      '@centaur/rendering':
+        specifier: workspace:*
+        version: link:../../packages/rendering
+      hono:
+        specifier: ^4.12.18
+        version: 4.12.25
+      pg:
+        specifier: ^8.21.0
+        version: 8.21.0
+    devDependencies:
+      '@types/bun':
+        specifier: ^1.3.13
+        version: 1.3.14
+      '@types/node':
+        specifier: ^25.7.0
+        version: 25.9.3
+      '@types/pg':
+        specifier: ^8.15.5
+        version: 8.20.0
+      '@typescript/native-preview':
+        specifier: ^7.0.0-dev.20260512.1
+        version: 7.0.0-dev.20260616.1
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+
 packages:
 
   '@azure/msal-common@16.10.0':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,6 +5,7 @@ packages:
   - services/discordbot
   - services/teamsbot
   - services/githubbot
+  - services/telegrambot
 
 patchedDependencies:
   '@chat-adapter/linear@4.31.0': patches/@chat-adapter__linear@4.31.0.patch

--- a/services/api-rs/crates/centaur-iron-control/src/principal.rs
+++ b/services/api-rs/crates/centaur-iron-control/src/principal.rs
@@ -4,7 +4,9 @@
 //! the principal is the conversation: a Discord **channel** (every thread in it
 //! shares one principal), a Linear **issue** (every agent session on it shares
 //! one principal), a Microsoft Teams **channel/conversation** (or **user** for
-//! a personal/user-scoped run when the acting user is known), or — for Slack —
+//! a personal/user-scoped run when the acting user is known), a Telegram
+//! **chat** for a group/supergroup (or **user** for a private chat — the key's
+//! discriminator decides, never metadata), or — for Slack —
 //! a **user** for a 1:1 DM and a **channel** for a multi-party channel/group
 //! thread. The Slack thread key is
 //! ``<source>:[<team_id>:]<conversation_id>[:<thread_ts>]`` — segments are
@@ -155,6 +157,42 @@ pub fn derive_principal_with_slack_team(
         };
     }
 
+    // Telegram sessions key on the chat id with the kind encoded in the key:
+    // ``telegram:chat:<chat_id>[:<message_thread_id>]`` for groups/supergroups
+    // and ``telegram:private:<chat_id>[:<message_thread_id>]`` for DMs. The
+    // discriminator — never metadata — decides whether the principal is a chat
+    // or a user, and forum-topic sessions collapse onto the same chat/user
+    // principal (the topic id is a label, not part of the key, mirroring the
+    // Slack ``thread_ts`` model). A Telegram ``chat.id`` is globally unique, so
+    // no workspace/team scoping is needed (see #1032: scope principals only
+    // where the conversation id could collide). The validated id is used
+    // verbatim rather than slugged: group ids are negative and ``slugify``
+    // would drop the sign, colliding ``-N`` with ``N``.
+    if let Some((is_private, chat_id, message_thread_id)) = parse_telegram_segments(thread_key) {
+        let mut labels = BTreeMap::new();
+        if let Some(thread) = message_thread_id {
+            labels.insert("telegram_thread_id".to_owned(), thread.to_owned());
+        }
+        if is_private {
+            labels.insert("telegram_user_id".to_owned(), chat_id.to_owned());
+            return PrincipalRef {
+                foreign_id: format!("telegram-user-{chat_id}"),
+                name: display_name
+                    .map(|name| format!("Telegram DM @{name}"))
+                    .unwrap_or_else(|| format!("Telegram User {chat_id}")),
+                labels,
+            };
+        }
+        labels.insert("telegram_chat_id".to_owned(), chat_id.to_owned());
+        return PrincipalRef {
+            foreign_id: format!("telegram-chat-{chat_id}"),
+            name: display_name
+                .map(|name| format!("Telegram Chat {name}"))
+                .unwrap_or_else(|| format!("Telegram Chat {chat_id}")),
+            labels,
+        };
+    }
+
     let (thread_team_id, conversation_id) = parse_slack_segments(thread_key);
     let metadata_team_id = slack_team_id.map(str::trim).filter(|team| !team.is_empty());
     // Channel principals must never be scoped by the message-derived metadata
@@ -286,6 +324,40 @@ fn parse_teams_adapter_segments(thread_key: &str) -> Option<(String, String, Opt
         })
         .unwrap_or((conversation_id, None));
     Some((conversation_id, service_url, thread_id))
+}
+
+/// The kind (``true`` for a private chat), chat id, and optional forum-topic
+/// id from a ``telegram:chat:<chat_id>[:<message_thread_id>]`` or
+/// ``telegram:private:<chat_id>[:<message_thread_id>]`` thread key, or
+/// ``None`` when the key is not a well-formed Telegram thread. Group and
+/// supergroup chat ids are negative numbers, so every id segment is validated
+/// as an optionally minus-prefixed integer; a malformed key falls through to
+/// the generic fallback like every other platform.
+fn parse_telegram_segments(thread_key: &str) -> Option<(bool, &str, Option<&str>)> {
+    let rest = thread_key.strip_prefix("telegram:")?;
+    let mut segments = rest.split(':').map(str::trim);
+    let is_private = match segments.next()? {
+        "chat" => false,
+        "private" => true,
+        _ => return None,
+    };
+    let chat_id = segments.next().filter(|id| is_telegram_id(id))?;
+    let message_thread_id = match segments.next() {
+        Some(thread) if is_telegram_id(thread) => Some(thread),
+        Some(_) => return None,
+        None => None,
+    };
+    if segments.next().is_some() {
+        return None;
+    }
+    Some((is_private, chat_id, message_thread_id))
+}
+
+/// A Telegram id segment: a non-empty run of ASCII digits with an optional
+/// leading minus (group/supergroup chat ids are negative).
+fn is_telegram_id(segment: &str) -> bool {
+    let digits = segment.strip_prefix('-').unwrap_or(segment);
+    !digits.is_empty() && digits.bytes().all(|byte| byte.is_ascii_digit())
 }
 
 /// Slack direct-message conversation ids start with ``D``.
@@ -565,6 +637,105 @@ mod tests {
             principal.labels.get("teams_user_id").map(String::as_str),
             Some("aad-user-1")
         );
+    }
+
+    #[test]
+    fn telegram_group_sessions_key_on_the_chat() {
+        let principal = derive_principal("telegram:chat:-1001234567890", None, None);
+        assert_eq!(principal.foreign_id, "telegram-chat--1001234567890");
+        assert_eq!(principal.name, "Telegram Chat -1001234567890");
+        assert_eq!(
+            principal.labels.get("telegram_chat_id").map(String::as_str),
+            Some("-1001234567890")
+        );
+        assert_eq!(principal.labels.get("telegram_thread_id"), None);
+    }
+
+    #[test]
+    fn telegram_private_sessions_key_on_the_user() {
+        let principal = derive_principal("telegram:private:5551234", None, None);
+        assert_eq!(principal.foreign_id, "telegram-user-5551234");
+        assert_eq!(principal.name, "Telegram User 5551234");
+        assert_eq!(
+            principal.labels.get("telegram_user_id").map(String::as_str),
+            Some("5551234")
+        );
+    }
+
+    #[test]
+    fn telegram_topic_sessions_collapse_onto_the_chat_principal() {
+        // A forum-topic session resolves to the same principal as the plain
+        // chat; the topic id survives only as a label.
+        let topic = derive_principal("telegram:chat:-1001234567890:42", None, None);
+        let plain = derive_principal("telegram:chat:-1001234567890", None, None);
+        assert_eq!(topic.foreign_id, "telegram-chat--1001234567890");
+        assert_eq!(topic.foreign_id, plain.foreign_id);
+        assert_eq!(
+            topic.labels.get("telegram_thread_id").map(String::as_str),
+            Some("42")
+        );
+    }
+
+    #[test]
+    fn telegram_private_topic_sessions_collapse_onto_the_user_principal() {
+        let topic = derive_principal("telegram:private:5551234:7", None, None);
+        let plain = derive_principal("telegram:private:5551234", None, None);
+        assert_eq!(topic.foreign_id, "telegram-user-5551234");
+        assert_eq!(topic.foreign_id, plain.foreign_id);
+        assert_eq!(
+            topic.labels.get("telegram_thread_id").map(String::as_str),
+            Some("7")
+        );
+    }
+
+    #[test]
+    fn telegram_conversation_name_overrides_the_chat_display_name_but_not_the_key() {
+        let principal = derive_principal("telegram:chat:-100987", None, Some("eng-oncall"));
+        // Key stays derived from the chat id so a title change never splits it.
+        assert_eq!(principal.foreign_id, "telegram-chat--100987");
+        assert_eq!(principal.name, "Telegram Chat eng-oncall");
+    }
+
+    #[test]
+    fn telegram_conversation_name_overrides_the_dm_display_name() {
+        let principal = derive_principal("telegram:private:5551234", None, Some("Ada Lovelace"));
+        assert_eq!(principal.foreign_id, "telegram-user-5551234");
+        assert_eq!(principal.name, "Telegram DM @Ada Lovelace");
+    }
+
+    #[test]
+    fn telegram_metadata_never_selects_the_principal_foreign_id() {
+        // The private principal derives from the validated key segment; a
+        // metadata-supplied actor user id must never pick a different one.
+        let principal = derive_principal("telegram:private:5551234", Some("999"), None);
+        assert_eq!(principal.foreign_id, "telegram-user-5551234");
+        assert_eq!(
+            principal.labels.get("telegram_user_id").map(String::as_str),
+            Some("5551234")
+        );
+    }
+
+    #[test]
+    fn malformed_telegram_keys_fall_through_to_the_generic_fallback() {
+        for thread_key in [
+            "telegram:chat:abc",
+            "telegram:chat:",
+            "telegram:chat:-",
+            "telegram:chat:12x",
+            "telegram:private:",
+            "telegram:private:1.5",
+            "telegram:group:123",
+            "telegram:123",
+            "telegram:chat:123:topic",
+            "telegram:chat:123:42:extra",
+        ] {
+            let principal = derive_principal(thread_key, None, None);
+            assert!(
+                principal.foreign_id.starts_with("thread-"),
+                "{thread_key} must fall through, got {}",
+                principal.foreign_id
+            );
+        }
     }
 
     #[test]

--- a/services/api-rs/crates/centaur-iron-control/src/principal.rs
+++ b/services/api-rs/crates/centaur-iron-control/src/principal.rs
@@ -193,6 +193,24 @@ pub fn derive_principal_with_slack_team(
         };
     }
 
+    // Telegram delta: a ``telegram:``-prefixed key that failed validation must
+    // never reach the Slack segment parser below — a Slack-shaped segment like
+    // ``C123`` or ``D0420`` in a malformed key would otherwise be mistaken for
+    // a Slack conversation id and mint (and later grant Slack channel
+    // permissions to) the real Slack principal for that id. Short-circuit to
+    // the same generic thread- fallback an unrecognized key gets, keeping the
+    // fail-closed contract: an invalid key of one platform can never resolve
+    // onto another platform's principal.
+    if thread_key.starts_with("telegram:") {
+        return PrincipalRef {
+            foreign_id: format!("thread-{}", slugify(thread_key)),
+            name: display_name
+                .map(ToOwned::to_owned)
+                .unwrap_or_else(|| thread_key.to_owned()),
+            labels: BTreeMap::new(),
+        };
+    }
+
     let (thread_team_id, conversation_id) = parse_slack_segments(thread_key);
     let metadata_team_id = slack_team_id.map(str::trim).filter(|team| !team.is_empty());
     // Channel principals must never be scoped by the message-derived metadata
@@ -331,8 +349,10 @@ fn parse_teams_adapter_segments(thread_key: &str) -> Option<(String, String, Opt
 /// ``telegram:private:<chat_id>[:<message_thread_id>]`` thread key, or
 /// ``None`` when the key is not a well-formed Telegram thread. Group and
 /// supergroup chat ids are negative numbers, so every id segment is validated
-/// as an optionally minus-prefixed integer; a malformed key falls through to
-/// the generic fallback like every other platform.
+/// as an optionally minus-prefixed integer. A malformed ``telegram:`` key is
+/// short-circuited by the caller to the generic thread- fallback — it must
+/// never reach the Slack segment parser, where a Slack-shaped segment could
+/// mint another platform's principal.
 fn parse_telegram_segments(thread_key: &str) -> Option<(bool, &str, Option<&str>)> {
     let rest = thread_key.strip_prefix("telegram:")?;
     let mut segments = rest.split(':').map(str::trim);
@@ -728,6 +748,14 @@ mod tests {
             "telegram:123",
             "telegram:chat:123:topic",
             "telegram:chat:123:42:extra",
+            // Slack-shaped segments must not escape into the Slack parser and
+            // mint (or grant permissions to) a real Slack principal.
+            "telegram:chat:C123ABC",
+            "telegram:chat:C123",
+            "telegram:chat:D0420",
+            "telegram:private:U999:extra",
+            "telegram:T123:C456",
+            "telegram:garbage",
         ] {
             let principal = derive_principal(thread_key, None, None);
             assert!(
@@ -735,7 +763,26 @@ mod tests {
                 "{thread_key} must fall through, got {}",
                 principal.foreign_id
             );
+            for label in ["slack_team_id", "slack_channel_id", "slack_user_id"] {
+                assert_eq!(
+                    principal.labels.get(label),
+                    None,
+                    "{thread_key} must not carry {label}"
+                );
+            }
         }
+    }
+
+    #[test]
+    fn malformed_telegram_key_never_collides_with_a_real_slack_principal() {
+        // "telegram:chat:D0420" once parsed as the Slack DM conversation D0420
+        // (compare dm_without_user_falls_back_to_the_conversation) — the two
+        // keys must resolve to different principals.
+        let telegram = derive_principal("telegram:chat:D0420", None, None);
+        let slack = derive_principal("slack:D0420:1780000000.0001", None, None);
+        assert_eq!(telegram.foreign_id, "thread-telegram-chat-d0420");
+        assert_eq!(slack.foreign_id, "slack-channel-d0420");
+        assert_ne!(telegram.foreign_id, slack.foreign_id);
     }
 
     #[test]

--- a/services/api-rs/crates/centaur-iron-control/src/session.rs
+++ b/services/api-rs/crates/centaur-iron-control/src/session.rs
@@ -41,6 +41,7 @@ impl<'a> SessionPrincipalMetadata<'a> {
                 .or_else(|| metadata.get("discord_conversation_name"))
                 .or_else(|| metadata.get("linear_conversation_name"))
                 .or_else(|| metadata.get("teams_conversation_name"))
+                .or_else(|| metadata.get("telegram_conversation_name"))
                 .and_then(Value::as_str),
         }
     }
@@ -220,6 +221,32 @@ mod tests {
             .conversation_name,
             Some("Casey Harper")
         );
+    }
+
+    #[test]
+    fn session_principal_metadata_accepts_telegram_name() {
+        assert_eq!(
+            SessionPrincipalMetadata::from_session_metadata(Some(&json!({
+                "telegram_conversation_name": "Engineering"
+            })))
+            .conversation_name,
+            Some("Engineering")
+        );
+    }
+
+    #[test]
+    fn session_principal_metadata_reads_generic_user_id_for_telegram_sessions() {
+        // The telegrambot sends the acting user under the generic ``user_id``
+        // key; it stays descriptive actor metadata (no parallel Telegram
+        // parser) and must keep mapping to ``actor_user_id``.
+        let metadata = json!({
+            "platform": "telegram",
+            "user_id": "5551234",
+            "telegram_conversation_name": "Ada Lovelace"
+        });
+        let parsed = SessionPrincipalMetadata::from_session_metadata(Some(&metadata));
+        assert_eq!(parsed.actor_user_id, Some("5551234"));
+        assert_eq!(parsed.conversation_name, Some("Ada Lovelace"));
     }
 
     #[test]

--- a/services/telegrambot/AGENTS.md
+++ b/services/telegrambot/AGENTS.md
@@ -1,0 +1,66 @@
+# Telegrambot Guide
+
+## Role
+
+Telegrambot is a long-polling Telegram Bot API client with a small health server. It turns
+allowed replies, addressed commands, and DMs into durable Centaur sessions and renders
+progress and answers back into the originating chat/topic.
+
+Key modules are `src/poller.ts` (long-poll controller), `src/inbox.ts` +
+`src/ownership.ts` + `src/migrations.ts` (durable receipt ledger and fenced
+ownership), `src/telegram-allowlist.ts`, `src/telegram-threading.ts`,
+`src/telegram-render.ts` (entity-aware HTML chunking), `src/telegram-narrator.ts`,
+`src/rate-limit.ts`, and `src/session-api.ts`. See `README.md` for platform setup
+and behavior.
+
+## Invariants
+
+- Run one `getUpdates` consumer per bot token (single replica, `Recreate`). Fenced
+  ownership in Postgres — not the replica count — is the correctness mechanism: every
+  cursor update, inbox claim, and render transition must match the current
+  `holder_id` + `generation` on an unexpired lease. A pod that cannot prove its lease
+  stops polling and fails readiness.
+- Receipt is separate from processing. A `getUpdates` batch is upserted and
+  `receive_offset` advanced in one transaction; only a committed cursor may feed the
+  next poll. Processing/rendering completion never gates the cursor. Update ids are
+  not assumed contiguous.
+- Accepted updates progress idempotently through
+  `received → message_appended → execution_accepted → render_obligation_persisted → terminal`,
+  keyed by stable `telegram:{chatId}:{messageId}` idempotency keys. Append success is
+  not terminal; crashes at any handoff resume without duplicating executions.
+  Ignored/rejected updates are terminal only with a durable reason.
+- Access is fail-closed. Empty chat/user allowlists mean the bot is inert; DMs
+  require per-user allowlisting (Telegram has no workspace boundary). Self-messages
+  and other bots are rejected. Privacy mode is delivery minimization, not
+  authorization — unrelated group traffic must still fail the trigger gate.
+- One chat/topic maps to one stable typed thread key (`telegram:chat:…` /
+  `telegram:private:…`, preserving `message_thread_id`). Same-thread updates stay
+  FIFO; a follow-up during an active execution is steered via api-rs, never dropped
+  and never a competing execution.
+- Respect Telegram limits: ≤4096 chars per message with balanced entities across
+  chunks, ~1 msg/s per chat, honor `429 retry_after`, throttle in-progress edits,
+  and keep reactions/typing best-effort — cosmetic failures must not fail delivery.
+- Terminal delivery is at-least-once via persisted render obligations; recovery may
+  duplicate the final answer but must never re-execute the agent to redeliver it.
+- `/live` reflects only local process health; `/ready` gates on database, schema
+  version, ownership, webhook reconciliation, and poll freshness. Telegram outages
+  fail readiness, not liveness.
+- Never log the bot token or unredacted Bot API URLs (the token is in the URL path).
+
+## Validation
+
+From the repository root:
+
+```bash
+pnpm --filter telegrambot run check:types
+pnpm --filter telegrambot test
+```
+
+The unit suite uses fakes (including a fake Bot API HTTP server) and needs no Telegram
+credential; inbox/ownership suites run against Postgres when `TELEGRAMBOT_TEST_DATABASE_URL`
+is set and are skipped otherwise. Add focused coverage for allowlist, threading, poller
+receipt/recovery, narration, rendering, and session API changes.
+
+Plain textual `@botname` mention delivery under privacy mode is **not** covered by CI: it
+requires a live acceptance test with an ordinary, non-admin, privacy-enabled bot. Until that
+test passes, replies + addressed commands + DMs are the supported trigger contract.

--- a/services/telegrambot/AGENTS.md
+++ b/services/telegrambot/AGENTS.md
@@ -58,9 +58,28 @@ pnpm --filter telegrambot test
 
 The unit suite uses fakes (including a fake Bot API HTTP server) and needs no Telegram
 credential; inbox/ownership suites run against Postgres when `TELEGRAMBOT_TEST_DATABASE_URL`
-is set and are skipped otherwise. Add focused coverage for allowlist, threading, poller
+is set and are skipped otherwise (CI provisions a Postgres service container and sets it). Add focused coverage for allowlist, threading, poller
 receipt/recovery, narration, rendering, and session API changes.
 
 Plain textual `@botname` mention delivery under privacy mode is **not** covered by CI: it
 requires a live acceptance test with an ordinary, non-admin, privacy-enabled bot. Until that
 test passes, replies + addressed commands + DMs are the supported trigger contract.
+
+### Manual acceptance: plain-mention delivery
+
+Run this live check before any release that would rely on plain `@botname` mentions as a
+group trigger (spec task 8). It needs a throwaway test bot and group — no Centaur deployment.
+
+1. Create a fresh test bot via @BotFather; confirm privacy mode is **enabled**
+   (`/mybots` → Bot Settings → Group Privacy shows "disabled" only when turned off — leave
+   it on) and add the bot to a test group as an **ordinary member, not admin**.
+2. Call `deleteWebhook`, then have a non-bot user send a plain textual mention with no
+   command and no reply, e.g. `hey @<botname> ping`.
+3. Poll `getUpdates` (no offset) and check whether that message update was delivered.
+4. Record the outcome (date, Bot API version, delivered yes/no) here and set the trigger
+   contract accordingly: **delivered** → plain mentions may be promoted to a supported
+   trigger (still behind the local trigger + allowlist gates); **not delivered** → the
+   privacy-on contract stays replies + addressed commands + DMs, and plain mentions require
+   privacy-off/admin delivery plus the same local gating.
+
+Outcome log: none recorded yet — plain mentions remain unsupported until a pass is logged.

--- a/services/telegrambot/Dockerfile
+++ b/services/telegrambot/Dockerfile
@@ -1,0 +1,28 @@
+# syntax=docker/dockerfile:1.7
+
+FROM oven/bun:1.3.13-slim
+
+WORKDIR /repo
+ENV NODE_ENV=production
+
+RUN --mount=type=cache,target=/root/.bun/install/cache,sharing=locked \
+    bun install -g pnpm@10.28.1
+
+# Workspace manifests first so dependency install is a cached layer. telegrambot depends on the
+# @centaur/* workspace packages, so they must be present for pnpm to link the `workspace:*` ranges.
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY patches/ patches/
+COPY packages/ packages/
+COPY services/telegrambot/package.json services/telegrambot/package.json
+RUN --mount=type=cache,target=/root/.local/share/pnpm/store,sharing=locked \
+    pnpm install --filter telegrambot --prod --frozen-lockfile
+
+COPY services/telegrambot/ services/telegrambot/
+WORKDIR /repo/services/telegrambot
+
+EXPOSE 3001
+ENV PORT=3001
+# Run as the non-root `bun` user (uid/gid 1000) shipped by the base image; the bot only needs
+# read access to /repo and listens on 3001 (>1024), so no ownership changes are required.
+USER bun
+CMD ["bun", "src/server.ts"]

--- a/services/telegrambot/README.md
+++ b/services/telegrambot/README.md
@@ -1,0 +1,71 @@
+# telegrambot
+
+Telegram chat ingress for the Centaur agent. Mirrors `discordbot`'s pull model (single-replica
+service that fetches its own events instead of receiving webhooks) with a **long-polling
+`getUpdates`** transport. There is no Chat SDK Telegram adapter, so the transport, durable inbox,
+and rendering are bespoke; the session logic is a deliberate clone of `services/discordbot` kept in
+sync manually. The Rust `api-rs` control plane derives Telegram principals from the typed
+`telegram:…` thread keys.
+
+## Behavior
+
+- **Reply to the bot or send `/ask@botname <text>` in an allowlisted group** → the bot reacts 👀,
+  posts throttled progress blurbs, and streams the answer into the chat (edited in place, split
+  into ≤4096-char messages when long). On settle 👀 flips to ✅ (or ❌).
+- **Message the bot in an allowlisted DM** → every message triggers or appends, no addressing
+  needed.
+- **Follow-ups in the same chat/topic** append to the same durable session
+  (`telegram:chat:{chatId}[:{topicId}]` / `telegram:private:{chatId}[:{topicId}]`); a follow-up
+  during an active execution is steered into it via api-rs instead of starting a second run.
+- Plain textual `@botname` mentions are **not** a guaranteed trigger with privacy mode enabled;
+  see the acceptance-test note in `AGENTS.md`.
+
+## Ingress model
+
+The bot long-polls `getUpdates` (one consumer per token; Telegram rejects concurrent pollers) and
+durably persists every returned update batch plus the receipt cursor in one Postgres transaction
+before dispatching work. Processing progresses through an idempotent stage machine
+(`received → message_appended → execution_accepted → render_obligation_persisted → terminal`), so a
+crash at any handoff resumes without duplicating executions. Terminal answer delivery is
+**at-least-once**: a send whose response was never recorded is retried after restart and may
+duplicate the final message, but never re-executes the agent.
+
+> ⚠️ **Run exactly one replica** (`replicas: 1` + `strategy: Recreate`). Correctness does not rely
+> on that: a fenced Postgres lease (holder + generation) guards the cursor, inbox claims, and
+> render recovery, so a stale pod cannot advance state after losing ownership.
+
+There is no public ingress — only health endpoints: `GET /live` (process liveness only) and
+`GET /ready` (database + schema + ownership + webhook reconciliation + fresh poll progress).
+
+## Environment
+
+| Var | Required | Notes |
+|-----|----------|-------|
+| `TELEGRAM_BOT_TOKEN` | ✅ | Bot token from @BotFather. Embedded in every Bot API URL path — never log request URLs unredacted. |
+| `TELEGRAMBOT_CHAT_ALLOWLIST` | ✅ for groups | Comma/space-separated chat ids allowed for group/supergroup chats. **Fail-closed: empty ⇒ no group work.** |
+| `TELEGRAMBOT_USER_ALLOWLIST` | ✅ for DMs | Comma/space-separated Telegram user ids allowed for private chats. **Fail-closed: empty ⇒ no DMs.** There is no workspace boundary on Telegram; the allowlists carry the entire access-control load. |
+| `TELEGRAMBOT_API_KEY` | – | Bearer to api-rs. Use a dedicated key. |
+| `CENTAUR_API_URL` | – | api-rs base URL (default `http://127.0.0.1:8080`). |
+| `TELEGRAMBOT_DATABASE_URL` / `DATABASE_URL` / `POSTGRES_URL` | ✅ | Durable inbox + render state. The bot refuses to boot without one (no silent localhost fallback). |
+| `TELEGRAMBOT_USER_NAME` | – | Bot display name for docs/messages (default `centaur`). |
+| `TELEGRAMBOT_POLL_TIMEOUT_S` | – | getUpdates long-poll timeout (default 50). |
+| `TELEGRAMBOT_LEASE_TTL_MS` | – | Fenced-ownership lease TTL (default 30000). |
+| `TELEGRAMBOT_MAX_CONCURRENT_THREADS` | – | Cross-thread worker concurrency (default 4); updates within one thread stay FIFO. |
+| `TELEGRAMBOT_ANSWER_EDIT_INTERVAL_MS` | – | Edit cadence for the streamed answer message (default 1500 ms). |
+| `TELEGRAMBOT_RETENTION_HOURS` | – | Terminal inbox rows below the receipt cursor are pruned after this age (default 72). |
+| `TELEGRAM_API_URL` | – | Override the Bot API base (default `https://api.telegram.org`), used by tests/emulation. |
+| `PORT` | – | Health server port (default 3001). |
+| `SESSION_IDLE_TIMEOUT_MS` / `SESSION_MAX_DURATION_MS` | – | Forwarded to api-rs execute. |
+
+## Platform setup
+
+1. Create a bot with [@BotFather](https://t.me/BotFather) (`/newbot`) and note the token.
+2. Leave **privacy mode enabled** (the default). The bot then receives replies to its messages,
+   `/commands`, and DMs — exactly the v1 trigger surface. Disabling privacy mode or making the bot
+   a group admin delivers *all* group traffic; the local trigger + allowlist gates still discard
+   what should not run, but prefer minimal delivery.
+3. Add the bot to the target group, then put that chat id in `TELEGRAMBOT_CHAT_ALLOWLIST` (send a
+   message in the group and read `chat.id` from the bot logs, or use @userinfobot).
+4. For DMs, put each user's Telegram id in `TELEGRAMBOT_USER_ALLOWLIST`.
+5. Do **not** configure a webhook for this token: `getUpdates` and webhooks are mutually exclusive.
+   The service calls `deleteWebhook` (preserving pending updates) at startup.

--- a/services/telegrambot/README.md
+++ b/services/telegrambot/README.md
@@ -52,6 +52,7 @@ There is no public ingress — only health endpoints: `GET /live` (process liven
 | `TELEGRAMBOT_LEASE_TTL_MS` | – | Fenced-ownership lease TTL (default 30000). |
 | `TELEGRAMBOT_MAX_CONCURRENT_THREADS` | – | Cross-thread worker concurrency (default 4); updates within one thread stay FIFO. |
 | `TELEGRAMBOT_ANSWER_EDIT_INTERVAL_MS` | – | Edit cadence for the streamed answer message (default 1500 ms). |
+| `TELEGRAMBOT_ANSWER_MAX_MESSAGES` | – | Max Telegram messages per answer; longer answers end with an honest truncation notice (default 8). |
 | `TELEGRAMBOT_RETENTION_HOURS` | – | Terminal inbox rows below the receipt cursor are pruned after this age (default 72). |
 | `TELEGRAM_API_URL` | – | Override the Bot API base (default `https://api.telegram.org`), used by tests/emulation. |
 | `PORT` | – | Health server port (default 3001). |

--- a/services/telegrambot/package.json
+++ b/services/telegrambot/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "telegrambot",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "bun --hot --watch src/server.ts",
+    "start": "bun src/server.ts",
+    "test": "bun test test",
+    "check:types": "bun tsgo --project tsconfig.json --noEmit"
+  },
+  "dependencies": {
+    "@centaur/harness-events": "workspace:*",
+    "@centaur/rendering": "workspace:*",
+    "hono": "^4.12.18",
+    "pg": "^8.21.0"
+  },
+  "devDependencies": {
+    "@types/pg": "^8.15.5",
+    "@types/bun": "^1.3.13",
+    "@types/node": "^25.7.0",
+    "@typescript/native-preview": "^7.0.0-dev.20260512.1",
+    "typescript": "^6.0.3"
+  }
+}

--- a/services/telegrambot/src/db.ts
+++ b/services/telegrambot/src/db.ts
@@ -1,0 +1,69 @@
+import pg from "pg";
+import type { Pool, PoolClient } from "pg";
+import type { Logger } from "./types";
+import { errorMessage, noopLogger } from "./utils";
+
+/**
+ * Telegram delta: discordbot hands its pool to the Chat SDK Postgres state
+ * adapter; telegrambot owns its tables directly (see src/migrations.ts), so
+ * the pool and the explicit-transaction helper live here instead.
+ *
+ * The 'error' listener exists for the same reason as discordbot's: pg.Pool
+ * emits 'error' for idle clients whose connection drops (Postgres restart, a
+ * network blip during pod startup). Without a listener node-postgres rethrows
+ * it as an uncaught exception; logging and swallowing lets the pool reconnect
+ * on the next query.
+ */
+export function createPool(postgresUrl: string, logger?: Logger): Pool {
+  const log = logger ?? noopLogger;
+  const pool = new pg.Pool({
+    connectionString: postgresUrl,
+    max: 10,
+    idleTimeoutMillis: 30_000,
+    connectionTimeoutMillis: 10_000,
+  });
+  pool.on("error", (error) => {
+    log.warn("telegrambot_postgres_pool_error", {
+      error: errorMessage(error),
+    });
+  });
+  return pool;
+}
+
+/**
+ * Runs `fn` on a checked-out client between BEGIN/COMMIT, rolling back on
+ * throw. The receipt contract (spec §2a) requires inbox upsert and cursor
+ * advancement to commit or fail together on ONE connection — independent
+ * pool.query calls each grab their own client and cannot provide that.
+ *
+ * If ROLLBACK itself fails the connection state is unknown, so the client is
+ * destroyed (released with an error) rather than returned to the pool where a
+ * dangling open transaction could poison later queries.
+ */
+export async function withTransaction<T>(
+  pool: Pool,
+  fn: (client: PoolClient) => Promise<T>,
+): Promise<T> {
+  const client = await pool.connect();
+  let destroy: Error | undefined;
+  try {
+    await client.query("BEGIN");
+    try {
+      const result = await fn(client);
+      await client.query("COMMIT");
+      return result;
+    } catch (error) {
+      try {
+        await client.query("ROLLBACK");
+      } catch (rollbackError) {
+        destroy =
+          rollbackError instanceof Error
+            ? rollbackError
+            : new Error(errorMessage(rollbackError));
+      }
+      throw error;
+    }
+  } finally {
+    client.release(destroy);
+  }
+}

--- a/services/telegrambot/src/inbox.ts
+++ b/services/telegrambot/src/inbox.ts
@@ -365,6 +365,41 @@ export async function pruneTerminal(
 }
 
 /**
+ * Per-thread worker feed: the oldest nonterminal rows for ONE stamped
+ * thread_key, oldest first, skipping update ids already owned by in-process
+ * work (a detached render or steering wait). claimNextPerThread only exposes
+ * one row per thread, which is right for cross-thread scheduling but starves
+ * live steering — a follow-up must be appendable while the thread's oldest row
+ * is still rendering in the background — so the thread worker drains its own
+ * backlog through this query instead.
+ *
+ * Plain SELECT for the same reason as claimNextPerThread: the fence protects
+ * transitions, not reads.
+ */
+export async function claimThreadBacklog(
+  pool: Pool,
+  botUserId: string,
+  threadKey: string,
+  excludeUpdateIds: readonly number[],
+  limit: number,
+): Promise<TelegramInboxRecord[]> {
+  if (limit <= 0) return [];
+  const result = await pool.query<InboxDbRow>(
+    `
+    SELECT * FROM telegram_update_inbox
+    WHERE bot_user_id = $1
+      AND thread_key = $2
+      AND NOT (status = ANY($3::text[]))
+      AND NOT (update_id = ANY($4::bigint[]))
+    ORDER BY update_id ASC
+    LIMIT $5
+    `,
+    [botUserId, threadKey, TERMINAL_STATUS_ARRAY, [...excludeUpdateIds], limit],
+  );
+  return result.rows.map(mapRow);
+}
+
+/**
  * Startup render recovery: rows whose execution was accepted and whose render
  * obligation is durable but whose terminal delivery was never confirmed.
  * Long-polling has no platform redelivery, so these are the only record that

--- a/services/telegrambot/src/inbox.ts
+++ b/services/telegrambot/src/inbox.ts
@@ -1,0 +1,416 @@
+import type { Pool, PoolClient } from "pg";
+import { withTransaction } from "./db";
+import { OwnershipLostError, fenceSql } from "./ownership";
+import type {
+  Logger,
+  OwnershipLease,
+  TelegramInboxRow,
+  TelegramInboxStatus,
+  TelegramRenderObligation,
+  TelegramUpdate,
+} from "./types";
+import { TERMINAL_INBOX_STATUSES } from "./types";
+import { noopLogger } from "./utils";
+
+/**
+ * Durable Telegram inbox (spec §2 / §2a). Receipt is separate from
+ * processing: ingestBatch persists a whole getUpdates batch and advances
+ * receive_offset in one explicit transaction, and only that committed cursor
+ * feeds the next poll. Processing stages then move idempotently through
+ * fenced compare-and-set transitions; a redelivered update never regresses
+ * its stage and a fenced-out old owner can neither move the cursor nor touch
+ * a row.
+ */
+
+/**
+ * Telegram delta: types.ts's TelegramInboxRow omits render_obligation (the
+ * shared row shape predates the renderer wiring), so the inbox exposes rows
+ * with the parsed obligation attached.
+ */
+export type TelegramInboxRecord = TelegramInboxRow & {
+  renderObligation: TelegramRenderObligation | null;
+};
+
+export type TransitionPatch = {
+  executionId?: string;
+  renderObligation?: TelegramRenderObligation;
+  statusReason?: string;
+};
+
+/** Fault-injection seam for tests proving receipt atomicity (crash between
+ * inbox insert and cursor advance must roll back both). Never set in
+ * production paths. */
+export type IngestHooks = {
+  beforeCursorAdvance?: (client: PoolClient) => void | Promise<void>;
+};
+
+const TERMINAL_STATUS_ARRAY = [...TERMINAL_INBOX_STATUSES];
+
+/** Terminal statuses that must carry a durable reason (spec: ignored /
+ * rejected / failed are terminal only after a reason is recorded). */
+const REASON_REQUIRED_STATUSES: readonly TelegramInboxStatus[] = [
+  "ignored",
+  "rejected",
+  "failed",
+];
+
+/**
+ * Upsert the ENTIRE returned getUpdates batch and advance receive_offset to
+ * max(update_id) + 1 in ONE transaction. ON CONFLICT DO NOTHING keeps the
+ * existing stage of redelivered updates; the cursor advance is fenced and
+ * uses GREATEST so a redelivered older batch can never regress the committed
+ * cursor. Any failure (including ownership loss) rolls back both the inserts
+ * and the cursor. Update ids are never assumed contiguous.
+ *
+ * Returns the committed cursor: max(update_id)+1 for a non-empty batch, the
+ * current committed cursor (possibly null on first start) for an empty one.
+ */
+export async function ingestBatch(
+  pool: Pool,
+  lease: OwnershipLease,
+  updates: readonly TelegramUpdate[],
+  logger?: Logger,
+  hooks?: IngestHooks,
+): Promise<number | null> {
+  const log = logger ?? noopLogger;
+
+  if (updates.length === 0) {
+    // Nothing to persist, but an empty poll must still prove the lease: a
+    // fenced-out owner has no business learning "its" cursor and polling on.
+    const result = await pool.query<{ receive_offset: string | null }>(
+      `
+      SELECT receive_offset FROM telegram_poll_state
+      WHERE bot_user_id = $1 AND holder_id = $2 AND generation = $3
+        AND lease_expires_at > now()
+      `,
+      [lease.botUserId, lease.holderId, lease.generation],
+    );
+    const row = result.rows[0];
+    if (!row) throw new OwnershipLostError(lease, "ingest_batch");
+    return row.receive_offset === null ? null : Number(row.receive_offset);
+  }
+
+  const maxUpdateId = Math.max(...updates.map((update) => update.update_id));
+  const newOffset = maxUpdateId + 1;
+
+  const committedOffset = await withTransaction(pool, async (client) => {
+    await client.query(
+      `
+      INSERT INTO telegram_update_inbox (bot_user_id, update_id, payload)
+      SELECT $1, (elem->>'update_id')::bigint, elem
+      FROM jsonb_array_elements($2::jsonb) AS elem
+      ON CONFLICT (bot_user_id, update_id) DO NOTHING
+      `,
+      [lease.botUserId, JSON.stringify(updates)],
+    );
+
+    await hooks?.beforeCursorAdvance?.(client);
+
+    const cursor = await client.query<{ receive_offset: string }>(
+      `
+      UPDATE telegram_poll_state
+      SET receive_offset = GREATEST(coalesce(receive_offset, $4::bigint), $4::bigint)
+      WHERE bot_user_id = $1 AND holder_id = $2 AND generation = $3
+        AND lease_expires_at > now()
+      RETURNING receive_offset
+      `,
+      [lease.botUserId, lease.holderId, lease.generation, newOffset],
+    );
+    const row = cursor.rows[0];
+    if (!row) throw new OwnershipLostError(lease, "ingest_batch");
+    return Number(row.receive_offset);
+  });
+
+  log.info("telegrambot_inbox_ingested", {
+    bot_user_id: lease.botUserId,
+    count: updates.length,
+    new_offset: committedOffset,
+  });
+  return committedOffset;
+}
+
+/**
+ * Committed cursor for the next poll. Null on first start, in which case
+ * getUpdates is called WITHOUT an offset so the earliest pending updates are
+ * ingested (never jump to the queue head). Read-only, so unfenced — the fence
+ * protects the writes; a stale read only produces a poll whose ingest will be
+ * fenced out.
+ */
+export async function readReceiveOffset(
+  pool: Pool,
+  botUserId: string,
+): Promise<number | null> {
+  const result = await pool.query<{ receive_offset: string | null }>(
+    "SELECT receive_offset FROM telegram_poll_state WHERE bot_user_id = $1",
+    [botUserId],
+  );
+  const offset = result.rows[0]?.receive_offset;
+  return offset === null || offset === undefined ? null : Number(offset);
+}
+
+export async function markIgnored(
+  pool: Pool,
+  lease: OwnershipLease,
+  updateId: number,
+  reason: string,
+  logger?: Logger,
+): Promise<boolean> {
+  return transition(pool, lease, updateId, NONTERMINAL_STATUSES, "ignored", {
+    statusReason: reason,
+  }, logger);
+}
+
+export async function markRejected(
+  pool: Pool,
+  lease: OwnershipLease,
+  updateId: number,
+  reason: string,
+  logger?: Logger,
+): Promise<boolean> {
+  return transition(pool, lease, updateId, NONTERMINAL_STATUSES, "rejected", {
+    statusReason: reason,
+  }, logger);
+}
+
+const NONTERMINAL_STATUSES: readonly TelegramInboxStatus[] = [
+  "received",
+  "message_appended",
+  "steering_pending",
+  "execution_accepted",
+  "render_obligation_persisted",
+];
+
+/**
+ * Stamp acceptance metadata (typed thread key + stable client_message_id) on
+ * a received row. Status deliberately stays `received`: acceptance is
+ * metadata for FIFO grouping and idempotent append keys, not a processing
+ * stage — the append transition is what moves the row forward.
+ */
+export async function acceptForProcessing(
+  pool: Pool,
+  lease: OwnershipLease,
+  updateId: number,
+  threadKey: string,
+  clientMessageId: string,
+): Promise<boolean> {
+  return withTransaction(pool, async (client) => {
+    const result = await client.query(
+      `
+      UPDATE telegram_update_inbox
+      SET thread_key = $5, client_message_id = $6, updated_at = now()
+      WHERE bot_user_id = $1 AND update_id = $4 AND status = 'received'
+        AND ${fenceSql(1, 2, 3)}
+      `,
+      [
+        lease.botUserId,
+        lease.holderId,
+        lease.generation,
+        updateId,
+        threadKey,
+        clientMessageId,
+      ],
+    );
+    return (result.rowCount ?? 0) === 1;
+  });
+}
+
+/**
+ * Fenced compare-and-set stage transition. Returns false when the row is not
+ * in one of `fromStatuses` (a concurrent/older transition already happened —
+ * idempotent recovery treats that as "someone got there first") or when the
+ * fence no longer holds; either way the caller must not assume the write
+ * landed. Patch fields coalesce onto existing values so a retried transition
+ * never erases earlier durable metadata.
+ */
+export async function transition(
+  pool: Pool,
+  lease: OwnershipLease,
+  updateId: number,
+  fromStatuses: readonly TelegramInboxStatus[],
+  toStatus: TelegramInboxStatus,
+  patch: TransitionPatch = {},
+  logger?: Logger,
+): Promise<boolean> {
+  const log = logger ?? noopLogger;
+  if (
+    REASON_REQUIRED_STATUSES.includes(toStatus) &&
+    !patch.statusReason?.trim()
+  ) {
+    throw new Error(
+      `inbox status '${toStatus}' is terminal and requires a durable reason`,
+    );
+  }
+  if (fromStatuses.length === 0) return false;
+
+  const moved = await withTransaction(pool, async (client) => {
+    const result = await client.query(
+      `
+      UPDATE telegram_update_inbox
+      SET status = $5,
+          execution_id = coalesce($6, execution_id),
+          render_obligation = coalesce($7::jsonb, render_obligation),
+          status_reason = coalesce($8, status_reason),
+          updated_at = now()
+      WHERE bot_user_id = $1 AND update_id = $4 AND status = ANY($9::text[])
+        AND ${fenceSql(1, 2, 3)}
+      `,
+      [
+        lease.botUserId,
+        lease.holderId,
+        lease.generation,
+        updateId,
+        toStatus,
+        patch.executionId ?? null,
+        patch.renderObligation ? JSON.stringify(patch.renderObligation) : null,
+        patch.statusReason ?? null,
+        [...fromStatuses],
+      ],
+    );
+    return (result.rowCount ?? 0) === 1;
+  });
+
+  if (moved) {
+    log.info("telegrambot_inbox_transition", {
+      bot_user_id: lease.botUserId,
+      update_id: updateId,
+      to_status: toStatus,
+      ...(patch.statusReason ? { status_reason: patch.statusReason } : {}),
+    });
+  }
+  return moved;
+}
+
+/**
+ * Recovery/dispatch scan: the OLDEST nonterminal row per thread_key (FIFO
+ * within a thread), at most one per thread, up to `limit` threads, skipping
+ * threads already claimed in-process. Rows not yet stamped with a thread_key
+ * (status `received`, pre-acceptance) form a single NULL group so at most one
+ * unstamped row — the oldest — is handed out per scan; its true thread is
+ * unknown until acceptance, so dispatching several concurrently could break
+ * same-thread FIFO.
+ *
+ * Plain SELECT by design: workers are in-process and the fence protects the
+ * transitions, not the read — a stale claim simply loses its CAS.
+ */
+export async function claimNextPerThread(
+  pool: Pool,
+  botUserId: string,
+  excludeThreadKeys: readonly string[],
+  limit: number,
+): Promise<TelegramInboxRecord[]> {
+  if (limit <= 0) return [];
+  const result = await pool.query<InboxDbRow>(
+    `
+    SELECT * FROM (
+      SELECT DISTINCT ON (thread_key) *
+      FROM telegram_update_inbox
+      WHERE bot_user_id = $1
+        AND NOT (status = ANY($2::text[]))
+        AND (thread_key IS NULL OR NOT (thread_key = ANY($3::text[])))
+      ORDER BY thread_key, update_id ASC
+    ) AS oldest_per_thread
+    ORDER BY update_id ASC
+    LIMIT $4
+    `,
+    [botUserId, TERMINAL_STATUS_ARRAY, [...excludeThreadKeys], limit],
+  );
+  return result.rows.map(mapRow);
+}
+
+/**
+ * Retention: delete terminal rows that are BOTH below the committed
+ * receive_offset (Telegram has confirmed them; they can never be redelivered
+ * into a fresh stage) and older than the retention window. The join against
+ * the lease row is the fence — a fenced-out owner deletes nothing. Never
+ * touches telegram_poll_state, so the receipt cursor survives pruning.
+ */
+export async function pruneTerminal(
+  pool: Pool,
+  lease: OwnershipLease,
+  retentionHours: number,
+  logger?: Logger,
+): Promise<number> {
+  const log = logger ?? noopLogger;
+  const result = await pool.query(
+    `
+    DELETE FROM telegram_update_inbox AS inbox
+    USING telegram_poll_state AS fence
+    WHERE inbox.bot_user_id = $1
+      AND fence.bot_user_id = $1
+      AND fence.holder_id = $2
+      AND fence.generation = $3
+      AND fence.lease_expires_at > now()
+      AND inbox.status = ANY($4::text[])
+      AND inbox.updated_at < now() - ($5::double precision * interval '1 hour')
+      AND fence.receive_offset IS NOT NULL
+      AND inbox.update_id < fence.receive_offset
+    `,
+    [
+      lease.botUserId,
+      lease.holderId,
+      lease.generation,
+      TERMINAL_STATUS_ARRAY,
+      retentionHours,
+    ],
+  );
+  const deleted = result.rowCount ?? 0;
+  if (deleted > 0) {
+    log.info("telegrambot_inbox_pruned", {
+      bot_user_id: lease.botUserId,
+      deleted,
+      retention_hours: retentionHours,
+    });
+  }
+  return deleted;
+}
+
+/**
+ * Startup render recovery: rows whose execution was accepted and whose render
+ * obligation is durable but whose terminal delivery was never confirmed.
+ * Long-polling has no platform redelivery, so these are the only record that
+ * an answer still owes the chat a message.
+ */
+export async function listRecoverableObligations(
+  pool: Pool,
+  botUserId: string,
+): Promise<TelegramInboxRecord[]> {
+  const result = await pool.query<InboxDbRow>(
+    `
+    SELECT * FROM telegram_update_inbox
+    WHERE bot_user_id = $1 AND status = 'render_obligation_persisted'
+    ORDER BY update_id ASC
+    `,
+    [botUserId],
+  );
+  return result.rows.map(mapRow);
+}
+
+type InboxDbRow = {
+  bot_user_id: string;
+  update_id: string;
+  payload: TelegramUpdate;
+  status: TelegramInboxStatus;
+  thread_key: string | null;
+  client_message_id: string | null;
+  execution_id: string | null;
+  status_reason: string | null;
+  render_obligation: TelegramRenderObligation | null;
+  received_at: Date;
+  updated_at: Date;
+};
+
+function mapRow(row: InboxDbRow): TelegramInboxRecord {
+  return {
+    botUserId: row.bot_user_id,
+    updateId: Number(row.update_id),
+    payload: row.payload,
+    status: row.status,
+    threadKey: row.thread_key,
+    clientMessageId: row.client_message_id,
+    executionId: row.execution_id,
+    statusReason: row.status_reason,
+    renderObligation: row.render_obligation,
+    receivedAt: row.received_at,
+    updatedAt: row.updated_at,
+  };
+}

--- a/services/telegrambot/src/index.ts
+++ b/services/telegrambot/src/index.ts
@@ -51,8 +51,10 @@ import {
 } from "./telegram-api";
 import { TelegramNarrator } from "./telegram-narrator";
 import {
+  TELEGRAM_MAX_MESSAGE_CHARS,
   chunkTelegramHtml,
   escapeTelegramHtml,
+  parsedTextLength,
   renderMarkdownToTelegramHtml,
 } from "./telegram-render";
 import {
@@ -85,6 +87,11 @@ export type { Telegrambot, TelegrambotOptions } from "./types";
 
 const DEFAULT_MAX_CONCURRENT_THREADS = 4;
 const DEFAULT_ANSWER_EDIT_INTERVAL_MS = 1_500;
+// Spec §6: collapse honestly past a max-messages cap — a runaway answer stops
+// opening new messages and says so instead of flooding the chat.
+const DEFAULT_ANSWER_MAX_MESSAGES = 8;
+const ANSWER_TRUNCATION_NOTICE =
+  "<i>… answer truncated: it exceeded the Telegram message cap.</i>";
 const DEFAULT_RETENTION_HOURS = 72;
 // Periodic recovery sweep: restarts resume mid-flight work, missed nudges and
 // steering fallbacks self-heal. Failed renders additionally schedule their own
@@ -94,9 +101,13 @@ const PRUNE_INTERVAL_MS = 15 * 60 * 1000;
 // A steering_pending row with no in-process active execution (recovery, or an
 // execute-conflict against an execution another/previous process started)
 // re-tries the idempotent execute on this cadence until api-rs accepts it.
-const STEERING_RETRY_DELAY_MS = 1_000;
+const STEERING_RETRY_BASE_DELAY_MS = 1_000;
+const STEERING_RETRY_MAX_DELAY_MS = 30_000;
 const RENDER_RETRY_BASE_DELAY_MS = 1_000;
 const RENDER_RETRY_MAX_DELAY_MS = 30_000;
+// Consecutive no-progress re-claims of the same oldest row before the thread
+// worker yields to the sweep (hot-loop guard that never reorders the thread).
+const MAX_BLOCKED_ROW_RECLAIMS = 3;
 // Typing keepalive starts only when execution is noticeably slow: no answer
 // text within this window after the render stream opens.
 const SLOW_TYPING_AFTER_MS = 5_000;
@@ -233,8 +244,17 @@ type ActiveExecution = {
   wait(updateId: number, serverMessageIds: readonly string[]): Promise<SteeringOutcome>;
 };
 
-function createActiveExecution(executionId: string): ActiveExecution {
+/** Exported for the settled-wait regression test only. */
+export function createActiveExecution(executionId: string): ActiveExecution {
   const waiters = new Set<SteeringWaiter>();
+  // Once settled, late waiters resolve immediately as execution-terminal: a
+  // follow-up worker can capture this instance, await a fenced transition,
+  // and only then register its wait — racing the render's finally(), which
+  // settles existing waiters and removes the instance from activeExecutions.
+  // Without this flag that late wait() would never resolve, permanently
+  // wedging the follow-up row (its update id stays owned) and hanging
+  // shutdown on the tracked promise.
+  let settled = false;
   const resolve = (waiter: SteeringWaiter, outcome: SteeringOutcome) => {
     waiters.delete(waiter);
     waiter.resolve(outcome);
@@ -242,6 +262,7 @@ function createActiveExecution(executionId: string): ActiveExecution {
   return {
     executionId,
     wait(updateId, serverMessageIds) {
+      if (settled) return Promise.resolve("terminal");
       return new Promise<SteeringOutcome>((res) => {
         waiters.add({ resolve: res, serverMessageIds, updateId });
       });
@@ -262,6 +283,7 @@ function createActiveExecution(executionId: string): ActiveExecution {
       for (const waiter of [...waiters]) resolve(waiter, "failed");
     },
     settle() {
+      settled = true;
       for (const waiter of [...waiters]) resolve(waiter, "terminal");
     },
   };
@@ -281,6 +303,8 @@ export function createTelegramDispatcher(
     options.maxConcurrentThreads ?? DEFAULT_MAX_CONCURRENT_THREADS;
   const answerEditIntervalMs =
     options.answerEditIntervalMs ?? DEFAULT_ANSWER_EDIT_INTERVAL_MS;
+  const answerMaxMessages =
+    options.answerMaxMessages ?? DEFAULT_ANSWER_MAX_MESSAGES;
   const retentionHours = options.retentionHours ?? DEFAULT_RETENTION_HOURS;
 
   let stopped = false;
@@ -308,6 +332,7 @@ export function createTelegramDispatcher(
   const pendingThreads = new Set<string>();
   const detached = new Set<Promise<unknown>>();
   const renderAttempts = new Map<number, number>();
+  const steeringAttempts = new Map<number, number>();
   let runningWorkers = 0;
   let sweepTimer: ReturnType<typeof setInterval> | undefined;
   let pruneTimer: ReturnType<typeof setInterval> | undefined;
@@ -322,22 +347,13 @@ export function createTelegramDispatcher(
     return wrapped;
   }
 
-  function abortableSleep(ms: number): Promise<void> {
-    return new Promise((resolve) => {
-      if (stopController.signal.aborted || ms <= 0) {
-        resolve();
-        return;
-      }
-      const timer = setTimeout(() => {
-        stopController.signal.removeEventListener("abort", onAbort);
-        resolve();
-      }, ms);
-      const onAbort = () => {
-        clearTimeout(timer);
-        resolve();
-      };
-      stopController.signal.addEventListener("abort", onAbort, { once: true });
-    });
+  /** Per-row in-memory bookkeeping is dropped on every terminal disposition —
+   * failed/ignored/rejected rows would otherwise leak their entries for the
+   * process's lifetime. */
+  function dropRowState(updateId: number): void {
+    appendedServerIds.delete(updateId);
+    renderAttempts.delete(updateId);
+    steeringAttempts.delete(updateId);
   }
 
   // -------------------------------------------------------------------------
@@ -511,24 +527,40 @@ export function createTelegramDispatcher(
   }
 
   async function runThreadWorker(threadKey: string): Promise<void> {
-    // Rows that failed to make progress this run (fenced-out CAS, transient
-    // session API failure): skipped so the loop cannot spin hot on them; a
-    // later sweep starts a fresh worker that retries them.
-    const skip = new Set<number>();
+    // FIFO invariant: a blocked/deferred OLDER row must end this worker run —
+    // never let a newer sibling in the same thread append or execute first
+    // (the sweep retries the whole thread from its oldest row later). Only
+    // update ids owned by detached work (post-append renders/steering waits)
+    // are excluded from the claim: bypassing those is safe because their turn
+    // already reached the durable session in order. A bounded number of
+    // no-progress re-claims of the same oldest row guards against a CAS-race
+    // hot loop without ever reordering.
+    let blockedUpdateId: number | null = null;
+    let blockedReclaims = 0;
     while (!stopped) {
       const own = deps.ownership();
       if (!own) return;
-      const exclude = [...ownedUpdateIds, ...skip];
       const rows = await store.claimThreadBacklog(
         own.botUserId,
         threadKey,
-        exclude,
+        [...ownedUpdateIds],
         1,
       );
       const row = rows[0];
       if (!row) return;
-      const progressed = await processRow(row, threadKey);
-      if (!progressed) skip.add(row.updateId);
+      const outcome = await processRow(row, threadKey);
+      if (outcome === "defer_thread") return;
+      if (outcome === "advanced") {
+        blockedUpdateId = null;
+        blockedReclaims = 0;
+        continue;
+      }
+      blockedReclaims = row.updateId === blockedUpdateId ? blockedReclaims + 1 : 1;
+      blockedUpdateId = row.updateId;
+      if (blockedReclaims >= MAX_BLOCKED_ROW_RECLAIMS) {
+        scheduleRetrySweep(RENDER_RETRY_BASE_DELAY_MS);
+        return;
+      }
     }
   }
 
@@ -536,11 +568,17 @@ export function createTelegramDispatcher(
    * Advance one row through the stage machine until it is terminal, detached
    * (background render / steering wait), or blocked. Every transition is
    * fenced with the poller's CURRENT lease, re-read at each step.
+   *
+   * Outcomes: "advanced" — the row moved (or this process cannot act on it);
+   * "blocked" — a fenced CAS lost a race and the same row should be re-read;
+   * "defer_thread" — a transient failure or backoff means the WHOLE thread
+   * must wait for the retry sweep (processing a newer sibling first would
+   * break same-thread FIFO).
    */
   async function processRow(
     record: TelegramInboxRecord,
     threadKey: string,
-  ): Promise<boolean> {
+  ): Promise<"advanced" | "blocked" | "defer_thread"> {
     let status = record.status;
     let executionId = record.executionId;
     let obligation = record.renderObligation;
@@ -554,34 +592,42 @@ export function createTelegramDispatcher(
 
     if (status === "received") {
       const own = deps.ownership();
-      if (!own) return true;
+      if (!own) return "advanced";
       if (!message) {
-        return store.markIgnored(
+        return (await store.markIgnored(
           own.lease,
           record.updateId,
           `unsupported_update_type:${updateKind(record.payload)}`,
-        );
+        ))
+          ? "advanced"
+          : "blocked";
       }
       // Re-run the gate even though acceptance stamped the row: allowlists
       // may have changed across a restart, and the append inputs (trigger
       // classification, command stripping) are derived from it.
       const gate = await evaluateGate(message);
       if (gate.kind === "rejected") {
-        return store.markRejected(own.lease, record.updateId, gate.reason);
+        return (await store.markRejected(own.lease, record.updateId, gate.reason))
+          ? "advanced"
+          : "blocked";
       }
       if (gate.kind === "ignored") {
-        if (gate.reason === "ownership_lost") return true;
-        return store.markIgnored(own.lease, record.updateId, gate.reason);
+        if (gate.reason === "ownership_lost") return "advanced";
+        return (await store.markIgnored(own.lease, record.updateId, gate.reason))
+          ? "advanced"
+          : "blocked";
       }
       const built = await getApiMessage();
       if (isContentlessApiMessage(built)) {
         // Sticker/location/poll-style messages serialize to nothing;
         // executing them would fabricate a synthetic "continue" turn.
-        return store.markIgnored(
+        return (await store.markIgnored(
           own.lease,
           record.updateId,
           "contentless_message",
-        );
+        ))
+          ? "advanced"
+          : "blocked";
       }
       // Create-if-missing (metadata re-upserted on every create by design)
       // plus the idempotent append keyed by the stable client_message_id. The
@@ -610,7 +656,7 @@ export function createTelegramDispatcher(
       }
       appendedServerIds.set(record.updateId, serverIds);
       const current = deps.ownership();
-      if (!current) return true;
+      if (!current) return "advanced";
       if (
         !(await store.transition(
           current.lease,
@@ -619,15 +665,15 @@ export function createTelegramDispatcher(
           "message_appended",
         ))
       ) {
-        return false;
+        return "blocked";
       }
       status = "message_appended";
     }
 
     while (status === "message_appended" || status === "steering_pending") {
-      if (stopped) return true;
+      if (stopped) return "advanced";
       const own = deps.ownership();
-      if (!own) return true;
+      if (!own) return "advanced";
 
       if (status === "message_appended") {
         const active = activeExecutions.get(threadKey);
@@ -640,10 +686,15 @@ export function createTelegramDispatcher(
               "steering_pending",
             ))
           ) {
-            return false;
+            return "blocked";
           }
-          detachSteeringWait(record, threadKey, active);
-          return true;
+          // The render's finally() may have settled `active` and removed it
+          // during the fenced transition above. The settled flag makes a late
+          // wait() resolve as execution-terminal, but when a FRESH instance
+          // already replaced it the wait belongs on that one instead.
+          const freshest = activeExecutions.get(threadKey) ?? active;
+          detachSteeringWait(record, threadKey, freshest);
+          return "advanced";
         }
         try {
           const execution = await executeSessionTurn(sessionOptions, {
@@ -655,13 +706,20 @@ export function createTelegramDispatcher(
             openStream: false,
             threadKey,
           });
-          if (!execution) return true;
+          if (!execution) return "advanced";
           executionId = execution.execution_id;
         } catch (error) {
           if (isExecuteConflict(error)) {
             // An execution this process does not know about (recovery, or a
             // race) is running: keep the row nonterminal as steering_pending
-            // and let the loop below re-resolve it. Never a second execution.
+            // and let the steering branch below decide between a live wait
+            // and a backed-off execute retry. Never a second execution. The
+            // attempt bump makes the branch defer rather than immediately
+            // re-issuing the execute that just conflicted.
+            steeringAttempts.set(
+              record.updateId,
+              (steeringAttempts.get(record.updateId) ?? 0) + 1,
+            );
             if (
               !(await store.transition(
                 own.lease,
@@ -670,13 +728,14 @@ export function createTelegramDispatcher(
                 "steering_pending",
               ))
             ) {
-              return false;
+              return "blocked";
             }
             status = "steering_pending";
             continue;
           }
           return failOrDefer(record.updateId, "execute", error);
         }
+        steeringAttempts.delete(record.updateId);
         if (
           !(await store.transition(
             own.lease,
@@ -686,7 +745,7 @@ export function createTelegramDispatcher(
             { executionId },
           ))
         ) {
-          return false;
+          return "blocked";
         }
         status = "execution_accepted";
         break;
@@ -696,32 +755,39 @@ export function createTelegramDispatcher(
       const active = activeExecutions.get(threadKey);
       if (active) {
         detachSteeringWait(record, threadKey, active);
-        return true;
+        return "advanced";
       }
       // No live execution in this process: after a restart the appended
       // message ids are gone, so steering resolution falls back to
-      // execution-terminal detection — retry the idempotent execute until it
-      // is accepted (prior execution terminal) or conflicts again.
-      await abortableSleep(STEERING_RETRY_DELAY_MS);
-      if (stopped) return true;
-      const current = deps.ownership();
-      if (!current) return true;
+      // execution-terminal detection — the idempotent execute either lands
+      // (prior execution terminal) or conflicts again. Retries back off
+      // exponentially and yield this worker's slot to the retry sweep instead
+      // of spinning fenced writes + execute conflicts inside it for the life
+      // of a foreign execution.
+      const attempt = steeringAttempts.get(record.updateId) ?? 0;
       if (
         !(await store.transition(
-          current.lease,
+          own.lease,
           record.updateId,
           ["steering_pending"],
           "message_appended",
         ))
       ) {
-        return false;
+        return "blocked";
       }
-      status = "message_appended";
+      if (attempt === 0) {
+        // Restart recovery: no conflict has been observed this process-life,
+        // so the prior execution is most likely gone — execute immediately.
+        status = "message_appended";
+        continue;
+      }
+      scheduleRetrySweep(steeringRetryDelayMs(attempt));
+      return "defer_thread";
     }
 
     if (status === "execution_accepted") {
       const own = deps.ownership();
-      if (!own) return true;
+      if (!own) return "advanced";
       obligation ??= buildObligation(
         assertMessage(message),
         threadKey,
@@ -736,26 +802,27 @@ export function createTelegramDispatcher(
           { renderObligation: obligation },
         ))
       ) {
-        return false;
+        return "blocked";
       }
       status = "render_obligation_persisted";
     }
 
     if (status === "render_obligation_persisted") {
       detachRender(record, obligation ?? record.renderObligation, threadKey);
-      return true;
+      return "advanced";
     }
 
-    return true;
+    return "advanced";
   }
 
-  /** Retryable session API failures leave the row at its stage for the sweep;
+  /** Retryable session API failures defer the WHOLE thread to the retry
+   * sweep (skipping to a newer sibling would break same-thread FIFO);
    * permanent validation failures record a durable terminal reason. */
   async function failOrDefer(
     updateId: number,
     action: string,
     error: unknown,
-  ): Promise<boolean> {
+  ): Promise<"advanced" | "defer_thread"> {
     if (isRetryableSessionApiError(error)) {
       logger.warn("telegrambot_dispatch_deferred", {
         action,
@@ -763,7 +830,7 @@ export function createTelegramDispatcher(
         update_id: updateId,
       });
       scheduleRetrySweep(RENDER_RETRY_BASE_DELAY_MS);
-      return false;
+      return "defer_thread";
     }
     logger.warn("telegrambot_dispatch_failed", {
       action,
@@ -771,7 +838,7 @@ export function createTelegramDispatcher(
       update_id: updateId,
     });
     const own = deps.ownership();
-    if (!own) return true;
+    if (!own) return "advanced";
     await store.transition(
       own.lease,
       updateId,
@@ -779,7 +846,8 @@ export function createTelegramDispatcher(
       "failed",
       { statusReason: `${action}: ${errorMessage(error)}` },
     );
-    return true;
+    dropRowState(updateId);
+    return "advanced";
   }
 
   // -------------------------------------------------------------------------
@@ -806,7 +874,7 @@ export function createTelegramDispatcher(
             ["steering_pending"],
             "steered",
           );
-          appendedServerIds.delete(record.updateId);
+          dropRowState(record.updateId);
           return;
         }
         // steering_failed or execution terminal without delivery: back to
@@ -874,8 +942,7 @@ export function createTelegramDispatcher(
     const promise = runRender(record, obligation, active)
       .then((result) => {
         if (result === "completed") {
-          renderAttempts.delete(record.updateId);
-          appendedServerIds.delete(record.updateId);
+          dropRowState(record.updateId);
           release();
           return;
         }
@@ -932,6 +999,7 @@ export function createTelegramDispatcher(
       let sawAnswerText = false;
       const delivery = new AnswerDelivery({
         answerEditIntervalMs,
+        answerMaxMessages,
         api,
         logger,
         obligation,
@@ -1164,6 +1232,7 @@ export function createTelegramDispatcher(
 
 type AnswerDeliveryDeps = {
   answerEditIntervalMs: number;
+  answerMaxMessages: number;
   api: RateLimitedTelegramApi;
   logger: Logger;
   obligation: TelegramRenderObligation;
@@ -1189,6 +1258,7 @@ class AnswerDelivery {
   private eventIdForAccumulated: number;
   private readonly posted: number[];
   private plainMode = false;
+  private truncated = false;
   private currentContent: string | null = null;
   private lastEditAtMs = 0;
 
@@ -1205,7 +1275,12 @@ class AnswerDelivery {
   }
 
   /** Rendered chunks of the full answer so far, each ≤4096 parsed chars with
-   * balanced tags (fences close at a boundary and re-open in the next chunk). */
+   * balanced tags (fences close at a boundary and re-open in the next chunk).
+   * Past the max-messages cap the chunk list is collapsed honestly: the final
+   * message ends with an explicit truncation notice instead of the overflow
+   * silently continuing into further sends (spec §6). Chunk boundaries are
+   * prefix-stable as the markdown grows, so capped earlier messages never
+   * churn. */
   private renderChunks(): string[] {
     // Plain mode: Telegram rejected the rendered HTML with a parse/entity
     // error, so the fallback is the escaped tag-free markdown — the same body
@@ -1213,7 +1288,26 @@ class AnswerDelivery {
     const html = this.plainMode
       ? escapeTelegramHtml(this.markdown)
       : renderMarkdownToTelegramHtml(this.markdown);
-    return chunkTelegramHtml(html);
+    const chunks = chunkTelegramHtml(html);
+    const max = Math.max(1, this.deps.answerMaxMessages);
+    if (chunks.length <= max) return chunks;
+    if (!this.truncated) {
+      this.truncated = true;
+      this.deps.logger.warn("telegrambot_answer_truncated", {
+        chat_id: this.deps.obligation.chatId,
+        chunks: chunks.length,
+        max_messages: max,
+      });
+    }
+    // Re-chunk the capped tail to leave parsed-length budget for the notice;
+    // the sub-chunker closes any open tags, so appending the notice is valid.
+    const kept = chunks.slice(0, max);
+    const tail = kept[max - 1] ?? "";
+    const budget =
+      TELEGRAM_MAX_MESSAGE_CHARS - parsedTextLength(ANSWER_TRUNCATION_NOTICE) - 1;
+    const trimmedTail = chunkTelegramHtml(tail, budget)[0] ?? "";
+    kept[max - 1] = `${trimmedTail}\n${ANSWER_TRUNCATION_NOTICE}`;
+    return kept;
   }
 
   async flush(final: boolean): Promise<void> {
@@ -1256,9 +1350,17 @@ class AnswerDelivery {
           ? {}
           : { message_thread_id: obligation.messageThreadId }),
         // Only the first answer message replies to the trigger; overflow
-        // chunks follow it in the timeline.
+        // chunks follow it in the timeline. allow_sending_without_reply:
+        // Telegram otherwise rejects the send outright when the trigger
+        // message was deleted, which would wedge the render obligation in an
+        // infinite retry loop — a reply-less answer beats no answer.
         ...(this.posted.length === 0
-          ? { reply_parameters: { message_id: obligation.triggerMessageId } }
+          ? {
+              reply_parameters: {
+                allow_sending_without_reply: true,
+                message_id: obligation.triggerMessageId,
+              },
+            }
           : {}),
       });
       this.posted.push(message.message_id);
@@ -1477,6 +1579,13 @@ function renderRetryDelayMs(attempt: number): number {
   return Math.min(
     RENDER_RETRY_MAX_DELAY_MS,
     RENDER_RETRY_BASE_DELAY_MS * 2 ** Math.min(attempt, 10),
+  );
+}
+
+function steeringRetryDelayMs(attempt: number): number {
+  return Math.min(
+    STEERING_RETRY_MAX_DELAY_MS,
+    STEERING_RETRY_BASE_DELAY_MS * 2 ** Math.min(attempt, 10),
   );
 }
 

--- a/services/telegrambot/src/index.ts
+++ b/services/telegrambot/src/index.ts
@@ -1,0 +1,1537 @@
+import {
+  codexAppServerToChatSdkStream,
+  type CodexAppServerToChatStreamOptions,
+  type RendererEvent,
+} from "@centaur/rendering";
+import { Hono } from "hono";
+import type { Pool } from "pg";
+import { createPool } from "./db";
+import type { TelegramInboxRecord, TransitionPatch } from "./inbox";
+import {
+  acceptForProcessing,
+  claimNextPerThread,
+  claimThreadBacklog,
+  markIgnored,
+  markRejected,
+  pruneTerminal,
+  transition,
+} from "./inbox";
+import type { IngestedUpdates, PollerController } from "./poller";
+import { createPollerController } from "./poller";
+import type { RateLimitedTelegramApi } from "./rate-limit";
+import { createRateLimitedTelegramApi } from "./rate-limit";
+import type { TelegramApiMessage } from "./session-api";
+import {
+  SessionApiError,
+  executeSessionTurn,
+  forwardToSessionApi,
+  isContentlessApiMessage,
+  isRetryableSessionApiError,
+  isSteeringDeliveredEvent,
+  isSteeringFailedEvent,
+  openSessionEventStream,
+  serializeTelegramAttachments,
+  serializeTelegramMessage,
+  startingStreamNotification,
+  steeringDeliveredMessageIds,
+  telegramAttachmentCandidates,
+  type TelegramSessionCreateContext,
+} from "./session-api";
+import {
+  extractCommandText,
+  isAllowedTelegramMessage,
+  isChatAllowlistEmpty,
+  isTriggerMessage,
+  isUserAllowlistEmpty,
+} from "./telegram-allowlist";
+import {
+  TelegramApiError,
+  createTelegramApi,
+  isTelegramParseError,
+} from "./telegram-api";
+import { TelegramNarrator } from "./telegram-narrator";
+import {
+  chunkTelegramHtml,
+  escapeTelegramHtml,
+  renderMarkdownToTelegramHtml,
+} from "./telegram-render";
+import {
+  deriveClientMessageId,
+  deriveConversationName,
+  deriveThreadKey,
+  parseTelegramThreadKey,
+} from "./telegram-threading";
+import type {
+  Logger,
+  OwnershipLease,
+  TelegramInboxStatus,
+  TelegramMessage,
+  TelegramNarratorOutcome,
+  TelegramRenderObligation,
+  TelegramUpdate,
+  Telegrambot,
+  TelegrambotOptions,
+  TelegrambotRendererSource,
+} from "./types";
+import { errorMessage, noopLogger, nowMs } from "./utils";
+
+export type { Telegrambot, TelegrambotOptions } from "./types";
+
+// Composition root. Telegram delta vs discordbot/index.ts: there is no Chat
+// SDK adapter for Telegram, so instead of Chat handlers + thread state this
+// file owns a durable-inbox dispatcher — per-thread FIFO workers over the
+// fenced Postgres ledger (src/inbox.ts), with rendering resumed from persisted
+// TelegramRenderObligation rows rather than Chat SDK state keys.
+
+const DEFAULT_MAX_CONCURRENT_THREADS = 4;
+const DEFAULT_ANSWER_EDIT_INTERVAL_MS = 1_500;
+const DEFAULT_RETENTION_HOURS = 72;
+// Periodic recovery sweep: restarts resume mid-flight work, missed nudges and
+// steering fallbacks self-heal. Failed renders additionally schedule their own
+// sooner retry sweep (see renderRetryDelayMs).
+const SWEEP_INTERVAL_MS = 15_000;
+const PRUNE_INTERVAL_MS = 15 * 60 * 1000;
+// A steering_pending row with no in-process active execution (recovery, or an
+// execute-conflict against an execution another/previous process started)
+// re-tries the idempotent execute on this cadence until api-rs accepts it.
+const STEERING_RETRY_DELAY_MS = 1_000;
+const RENDER_RETRY_BASE_DELAY_MS = 1_000;
+const RENDER_RETRY_MAX_DELAY_MS = 30_000;
+// Typing keepalive starts only when execution is noticeably slow: no answer
+// text within this window after the render stream opens.
+const SLOW_TYPING_AFTER_MS = 5_000;
+// Sweep passes per nudge: each pass stamps at most one unrouted (NULL
+// thread_key) row, so draining a backlog of them needs a bounded loop.
+const MAX_SWEEP_PASSES = 50;
+
+const NONTERMINAL_STATUSES: readonly TelegramInboxStatus[] = [
+  "received",
+  "message_appended",
+  "steering_pending",
+  "execution_accepted",
+  "render_obligation_persisted",
+];
+
+// ---------------------------------------------------------------------------
+// Inbox store seam
+// ---------------------------------------------------------------------------
+
+/**
+ * The dispatcher's view of the durable inbox. A thin interface over
+ * src/inbox.ts so orchestration unit tests can drive the full stage machine
+ * against an in-memory fake without Postgres; every mutation is fenced with
+ * the lease the caller passes (the poller's CURRENT lease, never a cached
+ * one).
+ */
+export type TelegramInboxStore = {
+  acceptForProcessing(
+    lease: OwnershipLease,
+    updateId: number,
+    threadKey: string,
+    clientMessageId: string,
+  ): Promise<boolean>;
+  claimNextPerThread(
+    botUserId: string,
+    excludeThreadKeys: readonly string[],
+    limit: number,
+  ): Promise<TelegramInboxRecord[]>;
+  claimThreadBacklog(
+    botUserId: string,
+    threadKey: string,
+    excludeUpdateIds: readonly number[],
+    limit: number,
+  ): Promise<TelegramInboxRecord[]>;
+  markIgnored(
+    lease: OwnershipLease,
+    updateId: number,
+    reason: string,
+  ): Promise<boolean>;
+  markRejected(
+    lease: OwnershipLease,
+    updateId: number,
+    reason: string,
+  ): Promise<boolean>;
+  pruneTerminal(lease: OwnershipLease, retentionHours: number): Promise<number>;
+  transition(
+    lease: OwnershipLease,
+    updateId: number,
+    fromStatuses: readonly TelegramInboxStatus[],
+    toStatus: TelegramInboxStatus,
+    patch?: TransitionPatch,
+  ): Promise<boolean>;
+};
+
+export function createPgInboxStore(
+  pool: Pool,
+  logger?: Logger,
+): TelegramInboxStore {
+  return {
+    acceptForProcessing: (lease, updateId, threadKey, clientMessageId) =>
+      acceptForProcessing(pool, lease, updateId, threadKey, clientMessageId),
+    claimNextPerThread: (botUserId, excludeThreadKeys, limit) =>
+      claimNextPerThread(pool, botUserId, excludeThreadKeys, limit),
+    claimThreadBacklog: (botUserId, threadKey, excludeUpdateIds, limit) =>
+      claimThreadBacklog(pool, botUserId, threadKey, excludeUpdateIds, limit),
+    markIgnored: (lease, updateId, reason) =>
+      markIgnored(pool, lease, updateId, reason, logger),
+    markRejected: (lease, updateId, reason) =>
+      markRejected(pool, lease, updateId, reason, logger),
+    pruneTerminal: (lease, retentionHours) =>
+      pruneTerminal(pool, lease, retentionHours, logger),
+    transition: (lease, updateId, fromStatuses, toStatus, patch) =>
+      transition(pool, lease, updateId, fromStatuses, toStatus, patch, logger),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Dispatcher
+// ---------------------------------------------------------------------------
+
+export type TelegramOwnership = {
+  botUserId: string;
+  lease: OwnershipLease;
+};
+
+export type TelegramDispatcherDeps = {
+  api: RateLimitedTelegramApi;
+  /** Bot @username (from getMe) for trigger matching / command stripping. */
+  botUsername(): Promise<string>;
+  logger?: Logger;
+  options: TelegrambotOptions;
+  /** The poller's CURRENT fenced identity; null whenever it cannot be proven. */
+  ownership(): TelegramOwnership | null;
+  store: TelegramInboxStore;
+};
+
+export type TelegramDispatcher = {
+  /** Schedule a sweep pass; the returned promise settles when it has run. */
+  nudge(): Promise<void>;
+  /** Starts the periodic recovery sweep and retention pruning. */
+  start(): void;
+  shutdown(): Promise<void>;
+};
+
+type SteeringOutcome = "delivered" | "failed" | "terminal";
+
+type SteeringWaiter = {
+  resolve(outcome: SteeringOutcome): void;
+  serverMessageIds: readonly string[];
+  updateId: number;
+};
+
+/**
+ * In-process record of a live execution for one thread: follow-up rows go
+ * steering_pending against it and wait here for `session.steering_delivered`
+ * (matched by the SERVER-assigned message ids the append response returned —
+ * NOT client_message_ids), `session.steering_failed`, or execution end.
+ */
+type ActiveExecution = {
+  deliver(serverMessageIds: readonly string[]): void;
+  executionId: string;
+  fail(): void;
+  settle(): void;
+  wait(updateId: number, serverMessageIds: readonly string[]): Promise<SteeringOutcome>;
+};
+
+function createActiveExecution(executionId: string): ActiveExecution {
+  const waiters = new Set<SteeringWaiter>();
+  const resolve = (waiter: SteeringWaiter, outcome: SteeringOutcome) => {
+    waiters.delete(waiter);
+    waiter.resolve(outcome);
+  };
+  return {
+    executionId,
+    wait(updateId, serverMessageIds) {
+      return new Promise<SteeringOutcome>((res) => {
+        waiters.add({ resolve: res, serverMessageIds, updateId });
+      });
+    },
+    deliver(serverMessageIds) {
+      const delivered = new Set(serverMessageIds);
+      for (const waiter of [...waiters]) {
+        if (waiter.serverMessageIds.some((id) => delivered.has(id))) {
+          resolve(waiter, "delivered");
+        }
+      }
+    },
+    // steering_failed carries no message ids, so every pending waiter is
+    // bounced back to message_appended; the idempotent execute either lands
+    // (prior execution gone) or conflicts back into steering_pending. Never a
+    // dropped message, never a competing execution.
+    fail() {
+      for (const waiter of [...waiters]) resolve(waiter, "failed");
+    },
+    settle() {
+      for (const waiter of [...waiters]) resolve(waiter, "terminal");
+    },
+  };
+}
+
+type GateResult =
+  | { kind: "accepted"; clientMessageId: string; threadKey: string }
+  | { kind: "ignored"; reason: string }
+  | { kind: "rejected"; reason: string };
+
+export function createTelegramDispatcher(
+  deps: TelegramDispatcherDeps,
+): TelegramDispatcher {
+  const { api, options, store } = deps;
+  const logger = deps.logger ?? options.logger ?? noopLogger;
+  const maxConcurrentThreads =
+    options.maxConcurrentThreads ?? DEFAULT_MAX_CONCURRENT_THREADS;
+  const answerEditIntervalMs =
+    options.answerEditIntervalMs ?? DEFAULT_ANSWER_EDIT_INTERVAL_MS;
+  const retentionHours = options.retentionHours ?? DEFAULT_RETENTION_HOURS;
+
+  let stopped = false;
+  const stopController = new AbortController();
+  // Session API calls ride a stop-abortable fetch so shutdown can sever an
+  // open SSE render stream instead of waiting out the execution.
+  const baseFetch = options.fetch ?? fetch;
+  const sessionOptions: TelegrambotOptions = {
+    ...options,
+    logger,
+    fetch: (input, init) =>
+      baseFetch(input, { ...init, signal: stopController.signal }),
+  };
+
+  // Update ids owned by detached in-process work (a background render or a
+  // steering wait): the claim scans must not re-serve them while they are
+  // live, and shutdown abandons them (rows stay durable for the next owner).
+  const ownedUpdateIds = new Set<number>();
+  // Server-assigned `msg_…` ids returned by the append response, keyed by
+  // update id — in-memory only; after a restart steering correlation degrades
+  // to execution-terminal detection by design.
+  const appendedServerIds = new Map<number, string[]>();
+  const activeExecutions = new Map<string, ActiveExecution>();
+  const workerThreads = new Map<string, Promise<void>>();
+  const pendingThreads = new Set<string>();
+  const detached = new Set<Promise<unknown>>();
+  const renderAttempts = new Map<number, number>();
+  let runningWorkers = 0;
+  let sweepTimer: ReturnType<typeof setInterval> | undefined;
+  let pruneTimer: ReturnType<typeof setInterval> | undefined;
+  const retryTimers = new Set<ReturnType<typeof setTimeout>>();
+
+  let sweepChain: Promise<void> = Promise.resolve();
+  let sweepQueued = false;
+
+  function track<T>(promise: Promise<T>): Promise<T> {
+    const wrapped = promise.finally(() => detached.delete(wrapped));
+    detached.add(wrapped);
+    return wrapped;
+  }
+
+  function abortableSleep(ms: number): Promise<void> {
+    return new Promise((resolve) => {
+      if (stopController.signal.aborted || ms <= 0) {
+        resolve();
+        return;
+      }
+      const timer = setTimeout(() => {
+        stopController.signal.removeEventListener("abort", onAbort);
+        resolve();
+      }, ms);
+      const onAbort = () => {
+        clearTimeout(timer);
+        resolve();
+      };
+      stopController.signal.addEventListener("abort", onAbort, { once: true });
+    });
+  }
+
+  // -------------------------------------------------------------------------
+  // Gate (stage `received`, pre-append)
+  // -------------------------------------------------------------------------
+
+  async function evaluateGate(message: TelegramMessage): Promise<GateResult> {
+    const own = deps.ownership();
+    if (!own) return { kind: "ignored", reason: "ownership_lost" };
+    const derived = deriveThreadKey(message, own.botUserId);
+    if ("rejected" in derived) {
+      return { kind: "rejected", reason: derived.rejected };
+    }
+    const allowed = isAllowedTelegramMessage(
+      message,
+      {
+        botUserId: own.botUserId,
+        chatAllowlist: options.chatAllowlist,
+        userAllowlist: options.userAllowlist,
+      },
+      logger,
+    );
+    if (!allowed) return { kind: "rejected", reason: "not_allowlisted" };
+    const trigger = isTriggerMessage(
+      message,
+      own.botUserId,
+      await deps.botUsername(),
+    );
+    if (!trigger) return { kind: "ignored", reason: "not_a_trigger" };
+    return {
+      kind: "accepted",
+      clientMessageId: deriveClientMessageId(message),
+      threadKey: derived.threadKey,
+    };
+  }
+
+  /**
+   * Gate + stamp an unrouted `received` row. Runs in the sweep (not a thread
+   * worker) because the row's thread is unknown until acceptance; the claim
+   * scan hands out at most one such row per pass, oldest first, which is what
+   * preserves same-thread FIFO for rows that have not been stamped yet.
+   * Returns the stamped thread key, or null when the row went terminal.
+   */
+  async function gateAndStamp(
+    record: TelegramInboxRecord,
+    own: TelegramOwnership,
+  ): Promise<string | null> {
+    const message = record.payload.message;
+    if (!message) {
+      // Poller-side markIgnored can fail and leave a non-message row in
+      // `received`; the claim scan tolerates it and stamps the disposition
+      // durably here instead of letting it stall the thread scan.
+      await store.markIgnored(
+        own.lease,
+        record.updateId,
+        `unsupported_update_type:${updateKind(record.payload)}`,
+      );
+      return null;
+    }
+    const gate = await evaluateGate(message);
+    if (gate.kind === "rejected") {
+      await store.markRejected(own.lease, record.updateId, gate.reason);
+      return null;
+    }
+    if (gate.kind === "ignored") {
+      if (gate.reason === "ownership_lost") return null;
+      await store.markIgnored(own.lease, record.updateId, gate.reason);
+      return null;
+    }
+    const stamped = await store.acceptForProcessing(
+      own.lease,
+      record.updateId,
+      gate.threadKey,
+      gate.clientMessageId,
+    );
+    return stamped ? gate.threadKey : null;
+  }
+
+  // -------------------------------------------------------------------------
+  // Session helpers
+  // -------------------------------------------------------------------------
+
+  async function buildApiMessage(
+    message: TelegramMessage,
+    threadKey: string,
+  ): Promise<TelegramApiMessage> {
+    const attachments =
+      telegramAttachmentCandidates(message).length > 0
+        ? await serializeTelegramAttachments(api, message, logger)
+        : [];
+    const apiMessage = serializeTelegramMessage(message, threadKey, {
+      attachments,
+    });
+    // Strip the /ask[@bot] prefix from the session input; caption-only media
+    // messages have no `text`, so their caption must not be clobbered by the
+    // empty command extraction.
+    if (message.text !== undefined) {
+      apiMessage.text = extractCommandText(message, await deps.botUsername());
+    }
+    return apiMessage;
+  }
+
+  function createContext(
+    message: TelegramMessage,
+    threadKey: string,
+  ): TelegramSessionCreateContext {
+    const parsed = parseTelegramThreadKey(threadKey);
+    return {
+      chatType: message.chat.type,
+      conversationName: deriveConversationName(message.chat),
+      userId: message.from ? String(message.from.id) : "unknown",
+      ...(parsed.messageThreadId === undefined
+        ? {}
+        : { messageThreadId: parsed.messageThreadId }),
+    };
+  }
+
+  function buildObligation(
+    message: TelegramMessage,
+    threadKey: string,
+    executionId: string,
+  ): TelegramRenderObligation {
+    return {
+      afterEventId: 0,
+      chatId: String(message.chat.id),
+      deliveredText: "",
+      executionId,
+      messageThreadId: parseTelegramThreadKey(threadKey).messageThreadId ?? null,
+      postedMessageIds: [],
+      threadKey,
+      triggerMessageId: message.message_id,
+    };
+  }
+
+  /** api-rs refuses to start a competing execution with a 409 conflict; the
+   * message then waits as steering_pending instead of executing twice. */
+  function isExecuteConflict(error: unknown): boolean {
+    return error instanceof SessionApiError && error.status === 409;
+  }
+
+  // -------------------------------------------------------------------------
+  // Thread workers (per-thread FIFO, bounded cross-thread concurrency)
+  // -------------------------------------------------------------------------
+
+  function ensureThreadWorker(threadKey: string): void {
+    if (stopped || workerThreads.has(threadKey)) return;
+    if (runningWorkers >= maxConcurrentThreads) {
+      pendingThreads.add(threadKey);
+      return;
+    }
+    pendingThreads.delete(threadKey);
+    runningWorkers += 1;
+    const promise = runThreadWorker(threadKey)
+      .catch((error) => {
+        logger.error("telegrambot_thread_worker_failed", {
+          error: errorMessage(error),
+          thread_key: threadKey,
+        });
+      })
+      .finally(() => {
+        workerThreads.delete(threadKey);
+        runningWorkers -= 1;
+        if (stopped) return;
+        const next = pendingThreads.values().next();
+        if (!next.done) {
+          pendingThreads.delete(next.value);
+          ensureThreadWorker(next.value);
+        }
+      });
+    workerThreads.set(threadKey, track(promise));
+  }
+
+  async function runThreadWorker(threadKey: string): Promise<void> {
+    // Rows that failed to make progress this run (fenced-out CAS, transient
+    // session API failure): skipped so the loop cannot spin hot on them; a
+    // later sweep starts a fresh worker that retries them.
+    const skip = new Set<number>();
+    while (!stopped) {
+      const own = deps.ownership();
+      if (!own) return;
+      const exclude = [...ownedUpdateIds, ...skip];
+      const rows = await store.claimThreadBacklog(
+        own.botUserId,
+        threadKey,
+        exclude,
+        1,
+      );
+      const row = rows[0];
+      if (!row) return;
+      const progressed = await processRow(row, threadKey);
+      if (!progressed) skip.add(row.updateId);
+    }
+  }
+
+  /**
+   * Advance one row through the stage machine until it is terminal, detached
+   * (background render / steering wait), or blocked. Every transition is
+   * fenced with the poller's CURRENT lease, re-read at each step.
+   */
+  async function processRow(
+    record: TelegramInboxRecord,
+    threadKey: string,
+  ): Promise<boolean> {
+    let status = record.status;
+    let executionId = record.executionId;
+    let obligation = record.renderObligation;
+    const message = record.payload.message;
+    let apiMessage: TelegramApiMessage | null = null;
+    const getApiMessage = async (): Promise<TelegramApiMessage> => {
+      if (!message) throw new Error("inbox row has no message payload");
+      apiMessage ??= await buildApiMessage(message, threadKey);
+      return apiMessage;
+    };
+
+    if (status === "received") {
+      const own = deps.ownership();
+      if (!own) return true;
+      if (!message) {
+        return store.markIgnored(
+          own.lease,
+          record.updateId,
+          `unsupported_update_type:${updateKind(record.payload)}`,
+        );
+      }
+      // Re-run the gate even though acceptance stamped the row: allowlists
+      // may have changed across a restart, and the append inputs (trigger
+      // classification, command stripping) are derived from it.
+      const gate = await evaluateGate(message);
+      if (gate.kind === "rejected") {
+        return store.markRejected(own.lease, record.updateId, gate.reason);
+      }
+      if (gate.kind === "ignored") {
+        if (gate.reason === "ownership_lost") return true;
+        return store.markIgnored(own.lease, record.updateId, gate.reason);
+      }
+      const built = await getApiMessage();
+      if (isContentlessApiMessage(built)) {
+        // Sticker/location/poll-style messages serialize to nothing;
+        // executing them would fabricate a synthetic "continue" turn.
+        return store.markIgnored(
+          own.lease,
+          record.updateId,
+          "contentless_message",
+        );
+      }
+      // Create-if-missing (metadata re-upserted on every create by design)
+      // plus the idempotent append keyed by the stable client_message_id. The
+      // returned SERVER-assigned message ids are what steering_delivered
+      // events reference, so they are kept for live correlation.
+      let serverIds: string[] = [];
+      try {
+        await forwardToSessionApi(
+          sessionOptions,
+          {
+            afterEventId: 0,
+            create: createContext(message, threadKey),
+            messages: [built],
+            onEventId: () => undefined,
+            openStream: false,
+            threadKey,
+          },
+          {
+            onMessagesAppended: async (ids) => {
+              serverIds = ids;
+            },
+          },
+        );
+      } catch (error) {
+        return failOrDefer(record.updateId, "append", error);
+      }
+      appendedServerIds.set(record.updateId, serverIds);
+      const current = deps.ownership();
+      if (!current) return true;
+      if (
+        !(await store.transition(
+          current.lease,
+          record.updateId,
+          ["received"],
+          "message_appended",
+        ))
+      ) {
+        return false;
+      }
+      status = "message_appended";
+    }
+
+    while (status === "message_appended" || status === "steering_pending") {
+      if (stopped) return true;
+      const own = deps.ownership();
+      if (!own) return true;
+
+      if (status === "message_appended") {
+        const active = activeExecutions.get(threadKey);
+        if (active) {
+          if (
+            !(await store.transition(
+              own.lease,
+              record.updateId,
+              ["message_appended"],
+              "steering_pending",
+            ))
+          ) {
+            return false;
+          }
+          detachSteeringWait(record, threadKey, active);
+          return true;
+        }
+        try {
+          const execution = await executeSessionTurn(sessionOptions, {
+            afterEventId: 0,
+            create: createContext(assertMessage(message), threadKey),
+            executeMessage: await getApiMessage(),
+            messages: [],
+            onEventId: () => undefined,
+            openStream: false,
+            threadKey,
+          });
+          if (!execution) return true;
+          executionId = execution.execution_id;
+        } catch (error) {
+          if (isExecuteConflict(error)) {
+            // An execution this process does not know about (recovery, or a
+            // race) is running: keep the row nonterminal as steering_pending
+            // and let the loop below re-resolve it. Never a second execution.
+            if (
+              !(await store.transition(
+                own.lease,
+                record.updateId,
+                ["message_appended"],
+                "steering_pending",
+              ))
+            ) {
+              return false;
+            }
+            status = "steering_pending";
+            continue;
+          }
+          return failOrDefer(record.updateId, "execute", error);
+        }
+        if (
+          !(await store.transition(
+            own.lease,
+            record.updateId,
+            ["message_appended"],
+            "execution_accepted",
+            { executionId },
+          ))
+        ) {
+          return false;
+        }
+        status = "execution_accepted";
+        break;
+      }
+
+      // steering_pending
+      const active = activeExecutions.get(threadKey);
+      if (active) {
+        detachSteeringWait(record, threadKey, active);
+        return true;
+      }
+      // No live execution in this process: after a restart the appended
+      // message ids are gone, so steering resolution falls back to
+      // execution-terminal detection — retry the idempotent execute until it
+      // is accepted (prior execution terminal) or conflicts again.
+      await abortableSleep(STEERING_RETRY_DELAY_MS);
+      if (stopped) return true;
+      const current = deps.ownership();
+      if (!current) return true;
+      if (
+        !(await store.transition(
+          current.lease,
+          record.updateId,
+          ["steering_pending"],
+          "message_appended",
+        ))
+      ) {
+        return false;
+      }
+      status = "message_appended";
+    }
+
+    if (status === "execution_accepted") {
+      const own = deps.ownership();
+      if (!own) return true;
+      obligation ??= buildObligation(
+        assertMessage(message),
+        threadKey,
+        assertExecutionId(executionId),
+      );
+      if (
+        !(await store.transition(
+          own.lease,
+          record.updateId,
+          ["execution_accepted"],
+          "render_obligation_persisted",
+          { renderObligation: obligation },
+        ))
+      ) {
+        return false;
+      }
+      status = "render_obligation_persisted";
+    }
+
+    if (status === "render_obligation_persisted") {
+      detachRender(record, obligation ?? record.renderObligation, threadKey);
+      return true;
+    }
+
+    return true;
+  }
+
+  /** Retryable session API failures leave the row at its stage for the sweep;
+   * permanent validation failures record a durable terminal reason. */
+  async function failOrDefer(
+    updateId: number,
+    action: string,
+    error: unknown,
+  ): Promise<boolean> {
+    if (isRetryableSessionApiError(error)) {
+      logger.warn("telegrambot_dispatch_deferred", {
+        action,
+        error: errorMessage(error),
+        update_id: updateId,
+      });
+      scheduleRetrySweep(RENDER_RETRY_BASE_DELAY_MS);
+      return false;
+    }
+    logger.warn("telegrambot_dispatch_failed", {
+      action,
+      error: errorMessage(error),
+      update_id: updateId,
+    });
+    const own = deps.ownership();
+    if (!own) return true;
+    await store.transition(
+      own.lease,
+      updateId,
+      NONTERMINAL_STATUSES,
+      "failed",
+      { statusReason: `${action}: ${errorMessage(error)}` },
+    );
+    return true;
+  }
+
+  // -------------------------------------------------------------------------
+  // Steering waits (detached)
+  // -------------------------------------------------------------------------
+
+  function detachSteeringWait(
+    record: TelegramInboxRecord,
+    threadKey: string,
+    active: ActiveExecution,
+  ): void {
+    ownedUpdateIds.add(record.updateId);
+    const serverIds = appendedServerIds.get(record.updateId) ?? [];
+    const promise = active
+      .wait(record.updateId, serverIds)
+      .then(async (outcome) => {
+        if (stopped) return;
+        const own = deps.ownership();
+        if (!own) return;
+        if (outcome === "delivered") {
+          await store.transition(
+            own.lease,
+            record.updateId,
+            ["steering_pending"],
+            "steered",
+          );
+          appendedServerIds.delete(record.updateId);
+          return;
+        }
+        // steering_failed or execution terminal without delivery: back to
+        // message_appended for the idempotent execute. The row is never
+        // dropped and no competing execution starts (conflicts loop back).
+        await store.transition(
+          own.lease,
+          record.updateId,
+          ["steering_pending"],
+          "message_appended",
+        );
+      })
+      .catch((error) => {
+        logger.warn("telegrambot_steering_resolution_failed", {
+          error: errorMessage(error),
+          update_id: record.updateId,
+        });
+      })
+      .finally(() => {
+        ownedUpdateIds.delete(record.updateId);
+        if (!stopped) ensureThreadWorker(threadKey);
+      });
+    track(promise);
+  }
+
+  // -------------------------------------------------------------------------
+  // Rendering (detached, at-least-once)
+  // -------------------------------------------------------------------------
+
+  function detachRender(
+    record: TelegramInboxRecord,
+    obligation: TelegramRenderObligation | null,
+    threadKey: string,
+  ): void {
+    if (!obligation) {
+      logger.error("telegrambot_render_obligation_missing", {
+        update_id: record.updateId,
+      });
+      return;
+    }
+    ownedUpdateIds.add(record.updateId);
+    const active = createActiveExecution(obligation.executionId);
+    activeExecutions.set(threadKey, active);
+    // Releasing ownership immediately after a FAILED attempt would let the
+    // thread worker reclaim the row in a zero-delay hot loop; the row stays
+    // owned until the backoff timer fires and hands it back to the sweep.
+    const release = (): void => {
+      ownedUpdateIds.delete(record.updateId);
+      if (!stopped) {
+        ensureThreadWorker(threadKey);
+        void nudge();
+      }
+    };
+    const releaseAfterBackoff = (): void => {
+      const attempt = renderAttempts.get(record.updateId) ?? 0;
+      renderAttempts.set(record.updateId, attempt + 1);
+      if (stopped) return;
+      const timer = setTimeout(() => {
+        retryTimers.delete(timer);
+        release();
+      }, renderRetryDelayMs(attempt));
+      timer.unref?.();
+      retryTimers.add(timer);
+    };
+    const promise = runRender(record, obligation, active)
+      .then((result) => {
+        if (result === "completed") {
+          renderAttempts.delete(record.updateId);
+          appendedServerIds.delete(record.updateId);
+          release();
+          return;
+        }
+        releaseAfterBackoff();
+      })
+      .catch((error) => {
+        logger.error("telegrambot_render_crashed", {
+          error: errorMessage(error),
+          update_id: record.updateId,
+        });
+        releaseAfterBackoff();
+      })
+      .finally(() => {
+        if (activeExecutions.get(threadKey) === active) {
+          activeExecutions.delete(threadKey);
+        }
+        // Waiters resolve as execution-terminal either way: if the execution
+        // is actually still live (render failure, not terminal), their
+        // idempotent execute conflicts straight back into steering_pending.
+        active.settle();
+      });
+    track(promise);
+  }
+
+  async function runRender(
+    record: TelegramInboxRecord,
+    obligation: TelegramRenderObligation,
+    active: ActiveExecution,
+  ): Promise<"completed" | "retry"> {
+    // Narrator posts ride the plain (normal-priority) TelegramApi surface —
+    // narration must never delay terminal answer delivery, which uses the
+    // urgent path inside AnswerDelivery.
+    const narrator = TelegramNarrator.start(
+      api,
+      {
+        chatId: obligation.chatId,
+        messageThreadId: obligation.messageThreadId,
+        triggerMessageId: obligation.triggerMessageId,
+      },
+      { logger },
+    );
+    const slowTimer = setTimeout(() => {
+      narrator.startTypingKeepalive();
+    }, SLOW_TYPING_AFTER_MS);
+    slowTimer.unref?.();
+    let outcome: TelegramNarratorOutcome = "retrying";
+    let result: "completed" | "retry" = "retry";
+    try {
+      let lastEventId = obligation.afterEventId;
+      // Ref object rather than a plain `let`: the value is assigned from the
+      // observeSource generator, and TS control-flow narrowing on a captured
+      // let would pin it to the initializer's null.
+      const terminal: { kind: "done" | "failed" | null } = { kind: null };
+      let sawAnswerText = false;
+      const delivery = new AnswerDelivery({
+        answerEditIntervalMs,
+        api,
+        logger,
+        obligation,
+        ownership: deps.ownership,
+        store,
+        updateId: record.updateId,
+      });
+      const stream = await openSessionEventStream(sessionOptions, {
+        afterEventId: obligation.afterEventId,
+        executionId: obligation.executionId,
+        onEventId: (eventId) => {
+          lastEventId = Math.max(lastEventId, eventId);
+        },
+        threadKey: obligation.threadKey,
+      });
+      const source = observeSource(stream, obligation.threadKey, active, (t) => {
+        terminal.kind = t;
+      });
+      for await (const chunk of codexAppServerToChatSdkStream(
+        source,
+        rendererOptions(narrator),
+      )) {
+        if (stopped) throw new Error("dispatcher stopped mid-render");
+        if (chunk.type === "markdown_text") {
+          if (!sawAnswerText) {
+            sawAnswerText = true;
+            clearTimeout(slowTimer);
+            narrator.stopTypingKeepalive();
+          }
+          delivery.append(chunk.text, lastEventId);
+          await delivery.flush(false);
+          continue;
+        }
+        if (chunk.type === "task_update") narrator.update(chunk);
+      }
+      const terminalKindSeen = terminal.kind;
+      if (terminalKindSeen === null) {
+        // Connection drop, not a terminal event: the execution may still be
+        // running. Leave the row for the sweep; never fake a completion.
+        throw new Error("session event stream ended without a terminal event");
+      }
+      await delivery.flush(true);
+      const own = deps.ownership();
+      if (
+        own &&
+        (await store.transition(
+          own.lease,
+          record.updateId,
+          ["render_obligation_persisted"],
+          "completed",
+        ))
+      ) {
+        outcome = terminalKindSeen;
+        result = "completed";
+      }
+      return result;
+    } catch (error) {
+      logger.warn("telegrambot_render_attempt_failed", {
+        error: errorMessage(error),
+        execution_id: obligation.executionId,
+        thread_key: obligation.threadKey,
+        update_id: record.updateId,
+      });
+      return "retry";
+    } finally {
+      clearTimeout(slowTimer);
+      // Exactly one finish per render attempt: done/failed settle the
+      // reaction; "retrying" leaves 👀 in place for the sweep's next attempt.
+      await narrator.finish(outcome);
+    }
+  }
+
+  /**
+   * Prime the mapper (immediate answer streaming, no pre-stream grace), keep
+   * steering events out of the renderer (they resolve steering_pending rows
+   * instead), and record the terminal disposition.
+   */
+  async function* observeSource(
+    stream: AsyncIterable<TelegrambotRendererSource>,
+    threadKey: string,
+    active: ActiveExecution,
+    onTerminal: (kind: "done" | "failed") => void,
+  ): AsyncIterable<TelegrambotRendererSource> {
+    yield startingStreamNotification(threadKey);
+    for await (const event of stream) {
+      if (isSteeringDeliveredEvent(event)) {
+        active.deliver(steeringDeliveredMessageIds(event));
+        continue;
+      }
+      if (isSteeringFailedEvent(event)) {
+        active.fail();
+        continue;
+      }
+      const terminal = terminalKind(event);
+      if (terminal) onTerminal(terminal);
+      yield event;
+    }
+  }
+
+  function rendererOptions(
+    narrator: TelegramNarrator,
+  ): CodexAppServerToChatStreamOptions {
+    const mapper = options.mapper;
+    return {
+      ...mapper,
+      // Answer text streams into its own Telegram messages, so there is no
+      // card to wait for (same reasoning as discordbot).
+      preStreamGraceMs: 0,
+      async onRendererEvent(event: RendererEvent) {
+        await mapper?.onRendererEvent?.(event);
+        if (event.type === "renderer.status") narrator.status(event.status);
+      },
+    };
+  }
+
+  // -------------------------------------------------------------------------
+  // Sweep
+  // -------------------------------------------------------------------------
+
+  function nudge(): Promise<void> {
+    if (stopped) return Promise.resolve();
+    if (!sweepQueued) {
+      sweepQueued = true;
+      sweepChain = sweepChain
+        .then(() => {
+          sweepQueued = false;
+          return runSweep();
+        })
+        .catch((error) => {
+          logger.warn("telegrambot_sweep_failed", {
+            error: errorMessage(error),
+          });
+        });
+    }
+    return sweepChain;
+  }
+
+  function scheduleRetrySweep(delayMs: number): void {
+    if (stopped) return;
+    const timer = setTimeout(() => {
+      retryTimers.delete(timer);
+      void nudge();
+    }, delayMs);
+    timer.unref?.();
+    retryTimers.add(timer);
+  }
+
+  /**
+   * Dispatch + recovery share one path: claim the oldest nonterminal row per
+   * thread (skipping threads that already have an in-process worker) and hand
+   * each stamped thread to its FIFO worker. Unrouted rows (NULL thread_key,
+   * including payloads without .message) are gated and stamped here, one per
+   * pass, oldest first. Running everything through the durable claim scan is
+   * what makes restarts resume mid-flight work before any new dispatch.
+   */
+  async function runSweep(): Promise<void> {
+    for (let pass = 0; pass < MAX_SWEEP_PASSES; pass += 1) {
+      if (stopped) return;
+      const own = deps.ownership();
+      if (!own) return;
+      const exclude = [...workerThreads.keys(), ...pendingThreads];
+      const records = await store.claimNextPerThread(
+        own.botUserId,
+        exclude,
+        Math.max(maxConcurrentThreads * 2, 8),
+      );
+      let stampedUnrouted = false;
+      for (const record of records) {
+        if (stopped) return;
+        if (ownedUpdateIds.has(record.updateId)) {
+          // Oldest row is a live detached render/steering wait; its thread
+          // worker (if any newer rows exist) drains the rest of the backlog.
+          if (record.threadKey) ensureThreadWorker(record.threadKey);
+          continue;
+        }
+        if (record.threadKey) {
+          ensureThreadWorker(record.threadKey);
+          continue;
+        }
+        stampedUnrouted = true;
+        const threadKey = await gateAndStamp(record, own);
+        if (threadKey) ensureThreadWorker(threadKey);
+      }
+      // Another pass only while unrouted rows are being drained (the scan
+      // exposes one per pass); otherwise the workers own the rest.
+      if (!stampedUnrouted) return;
+    }
+  }
+
+  async function prune(): Promise<void> {
+    const own = deps.ownership();
+    if (!own) return;
+    try {
+      await store.pruneTerminal(own.lease, retentionHours);
+    } catch (error) {
+      logger.warn("telegrambot_prune_failed", { error: errorMessage(error) });
+    }
+  }
+
+  return {
+    nudge,
+
+    start(): void {
+      sweepTimer = setInterval(() => void nudge(), SWEEP_INTERVAL_MS);
+      sweepTimer.unref?.();
+      pruneTimer = setInterval(() => void prune(), PRUNE_INTERVAL_MS);
+      pruneTimer.unref?.();
+      void nudge();
+      void track(prune());
+    },
+
+    async shutdown(): Promise<void> {
+      stopped = true;
+      if (sweepTimer !== undefined) clearInterval(sweepTimer);
+      if (pruneTimer !== undefined) clearInterval(pruneTimer);
+      for (const timer of retryTimers) clearTimeout(timer);
+      retryTimers.clear();
+      // Sever open SSE streams / in-flight session calls; the durable rows
+      // stay at their stage for the next owner's recovery.
+      stopController.abort();
+      for (const active of activeExecutions.values()) active.settle();
+      await Promise.allSettled([...detached, sweepChain]);
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Answer delivery (streamed, durable, at-least-once)
+// ---------------------------------------------------------------------------
+
+type AnswerDeliveryDeps = {
+  answerEditIntervalMs: number;
+  api: RateLimitedTelegramApi;
+  logger: Logger;
+  obligation: TelegramRenderObligation;
+  ownership(): TelegramOwnership | null;
+  store: TelegramInboxStore;
+  updateId: number;
+};
+
+/**
+ * Streams the accumulated answer markdown into Telegram messages: the first
+ * chunk is an urgent send replying to the trigger message, in-place growth is
+ * a throttled urgent edit, and overflow past the 4096 parsed-char boundary
+ * becomes further urgent sends. Every returned message_id and the delivered
+ * markdown snapshot are persisted into the render obligation (fenced patch)
+ * BEFORE any subsequent edit/chunk, so recovery resumes with an edit or the
+ * next chunk and never reposts a recorded one. A send whose response was
+ * never recorded is ambiguous and may be duplicated on recovery — that is the
+ * documented at-least-once contract; execution is never repeated to redeliver.
+ */
+class AnswerDelivery {
+  private readonly deps: AnswerDeliveryDeps;
+  private markdown: string;
+  private eventIdForAccumulated: number;
+  private readonly posted: number[];
+  private plainMode = false;
+  private currentContent: string | null = null;
+  private lastEditAtMs = 0;
+
+  constructor(deps: AnswerDeliveryDeps) {
+    this.deps = deps;
+    this.markdown = deps.obligation.deliveredText;
+    this.eventIdForAccumulated = deps.obligation.afterEventId;
+    this.posted = [...deps.obligation.postedMessageIds];
+  }
+
+  append(text: string, eventId: number): void {
+    this.markdown += text;
+    this.eventIdForAccumulated = eventId;
+  }
+
+  /** Rendered chunks of the full answer so far, each ≤4096 parsed chars with
+   * balanced tags (fences close at a boundary and re-open in the next chunk). */
+  private renderChunks(): string[] {
+    // Plain mode: Telegram rejected the rendered HTML with a parse/entity
+    // error, so the fallback is the escaped tag-free markdown — the same body
+    // renderPlainTextFallback produces — still sent with parse_mode HTML.
+    const html = this.plainMode
+      ? escapeTelegramHtml(this.markdown)
+      : renderMarkdownToTelegramHtml(this.markdown);
+    return chunkTelegramHtml(html);
+  }
+
+  async flush(final: boolean): Promise<void> {
+    let chunks = this.renderChunks();
+    if (chunks.length === 0) return;
+
+    while (this.posted.length < chunks.length) {
+      const index = this.posted.length;
+      if (index > 0) {
+        // Freeze the previous message at its final chunk before overflowing
+        // into a new one.
+        chunks = await this.editChunk(index - 1, chunks);
+        if (this.posted.length >= chunks.length) break;
+      }
+      chunks = await this.sendChunk(this.posted.length, chunks);
+    }
+
+    const tailIndex = Math.min(this.posted.length, chunks.length) - 1;
+    const tailContent = tailIndex >= 0 ? chunks[tailIndex] : undefined;
+    if (
+      tailContent !== undefined &&
+      tailContent !== this.currentContent &&
+      (final || nowMs() - this.lastEditAtMs >= this.deps.answerEditIntervalMs)
+    ) {
+      this.lastEditAtMs = nowMs();
+      await this.editChunk(tailIndex, chunks);
+    }
+  }
+
+  private async sendChunk(index: number, chunks: string[]): Promise<string[]> {
+    const content = chunks[index];
+    if (content === undefined) return chunks;
+    const { api, obligation } = this.deps;
+    try {
+      const message = await api.sendMessageUrgent({
+        chat_id: obligation.chatId,
+        parse_mode: "HTML",
+        text: content,
+        ...(obligation.messageThreadId === null
+          ? {}
+          : { message_thread_id: obligation.messageThreadId }),
+        // Only the first answer message replies to the trigger; overflow
+        // chunks follow it in the timeline.
+        ...(this.posted.length === 0
+          ? { reply_parameters: { message_id: obligation.triggerMessageId } }
+          : {}),
+      });
+      this.posted.push(message.message_id);
+      this.currentContent = content;
+      await this.persist();
+      return chunks;
+    } catch (error) {
+      const fallback = this.enterPlainMode(error);
+      if (!fallback) throw error;
+      return index < fallback.length
+        ? await this.sendChunk(index, fallback)
+        : fallback;
+    }
+  }
+
+  private async editChunk(index: number, chunks: string[]): Promise<string[]> {
+    const content = chunks[index];
+    const messageId = this.posted[index];
+    if (content === undefined || messageId === undefined) return chunks;
+    if (index === this.posted.length - 1 && content === this.currentContent) {
+      return chunks;
+    }
+    const { api, obligation } = this.deps;
+    try {
+      await api.editMessageTextUrgent({
+        chat_id: obligation.chatId,
+        message_id: messageId,
+        parse_mode: "HTML",
+        text: content,
+      });
+    } catch (error) {
+      if (isMessageNotModifiedError(error)) {
+        // Recovery re-edit with identical content; the message already shows
+        // exactly this chunk.
+      } else {
+        const fallback = this.enterPlainMode(error);
+        if (!fallback) throw error;
+        return index < fallback.length
+          ? await this.editChunk(index, fallback)
+          : fallback;
+      }
+    }
+    if (index === this.posted.length - 1) {
+      this.currentContent = content;
+      await this.persist();
+    }
+    return chunks;
+  }
+
+  /** One-way switch to the escaped plain-text fallback on a Telegram parse
+   * rejection; a second parse error in plain mode is a real fault. */
+  private enterPlainMode(error: unknown): string[] | null {
+    if (!isTelegramParseError(error) || this.plainMode) return null;
+    this.deps.logger.warn("telegrambot_answer_parse_fallback", {
+      chat_id: this.deps.obligation.chatId,
+      error: errorMessage(error),
+    });
+    this.plainMode = true;
+    this.currentContent = null;
+    return this.renderChunks();
+  }
+
+  /**
+   * Fenced obligation patch. afterEventId only ever advances together with
+   * the deliveredText snapshot that contains those events' answer deltas —
+   * advancing it past undelivered text would lose that text on SSE replay.
+   */
+  private async persist(): Promise<void> {
+    const own = this.deps.ownership();
+    if (!own) throw new Error("ownership lost during answer delivery");
+    const moved = await this.deps.store.transition(
+      own.lease,
+      this.deps.updateId,
+      ["render_obligation_persisted"],
+      "render_obligation_persisted",
+      {
+        renderObligation: {
+          ...this.deps.obligation,
+          afterEventId: this.eventIdForAccumulated,
+          deliveredText: this.markdown,
+          postedMessageIds: [...this.posted],
+        },
+      },
+    );
+    if (!moved) throw new Error("render obligation persist was fenced out");
+  }
+}
+
+// ---------------------------------------------------------------------------
+// createTelegrambot
+// ---------------------------------------------------------------------------
+
+export function createTelegrambot(options: TelegrambotOptions): Telegrambot {
+  const logger = options.logger ?? noopLogger;
+  if (!options.pool && !options.postgresUrl) {
+    throw new Error("telegrambot requires postgresUrl or an injected pool");
+  }
+  const createdPool = !options.pool;
+  const pool = options.pool ?? createPool(options.postgresUrl ?? "", logger);
+
+  // Fail-closed allowlists: warn loudly at boot when a surface is inert.
+  if (isChatAllowlistEmpty(options)) {
+    logger.warn("telegrambot_chat_allowlist_empty_inert", {
+      hint: "Set TELEGRAMBOT_CHAT_ALLOWLIST; all group messages are ignored until configured.",
+    });
+  }
+  if (isUserAllowlistEmpty(options)) {
+    logger.warn("telegrambot_user_allowlist_empty_inert", {
+      hint: "Set TELEGRAMBOT_USER_ALLOWLIST; all DMs are ignored until configured.",
+    });
+  }
+
+  const rawApi = createTelegramApi(options);
+  const api = createRateLimitedTelegramApi(rawApi, logger);
+
+  // The trigger gate needs the bot @username, known only after getMe; cached
+  // per process, re-fetched on failure.
+  let botUsernamePromise: Promise<string> | null = null;
+  const botUsername = (): Promise<string> => {
+    botUsernamePromise ??= rawApi
+      .getMe()
+      .then((me) => me.username ?? options.userName ?? "centaur")
+      .catch((error: unknown) => {
+        botUsernamePromise = null;
+        throw error;
+      });
+    return botUsernamePromise;
+  };
+
+  const store = createPgInboxStore(pool, logger);
+  let poller: PollerController | null = null;
+  const dispatcher = createTelegramDispatcher({
+    api,
+    botUsername,
+    logger,
+    options,
+    ownership: () => poller?.ownership() ?? null,
+    store,
+  });
+  poller = createPollerController({
+    api,
+    pool,
+    logger,
+    ...(options.leaseTtlMs === undefined
+      ? {}
+      : { leaseTtlMs: options.leaseTtlMs }),
+    ...(options.pollTimeoutSeconds === undefined
+      ? {}
+      : { pollTimeoutSeconds: options.pollTimeoutSeconds }),
+    // Ingested batches are already durable `received` rows; the dispatcher's
+    // claim scan is the single dispatch path, so the callback is just a nudge.
+    onUpdatesIngested: (_batch: IngestedUpdates) => void dispatcher.nudge(),
+  });
+  const controller = poller;
+
+  const app = new Hono();
+  app.get("/live", (c) => {
+    const status = controller.status();
+    return c.json(
+      { ok: status.live, service: "telegrambot" },
+      status.live ? 200 : 503,
+    );
+  });
+  app.get("/ready", (c) => {
+    const status = controller.status();
+    return c.json(
+      { ok: status.ready, reasons: status.reasons, service: "telegrambot" },
+      status.ready ? 200 : 503,
+    );
+  });
+
+  return {
+    app,
+
+    // The poller's background run loop gates every dispatch on fenced
+    // ownership, and the dispatcher's first sweeps resume nonterminal rows
+    // (oldest-first per thread) before any newly polled update is dispatched
+    // — recovery and new work share the same ordered claim scan.
+    async start(): Promise<void> {
+      controller.start();
+      if (options.recoverRenderObligationsOnStart !== false) {
+        dispatcher.start();
+      }
+    },
+
+    async shutdown(): Promise<void> {
+      await dispatcher.shutdown();
+      await controller.shutdown();
+      if (createdPool) await pool.end();
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function updateKind(update: TelegramUpdate): string {
+  for (const key of Object.keys(update)) {
+    if (key !== "update_id") return key;
+  }
+  return "unknown";
+}
+
+function assertMessage(message: TelegramMessage | undefined): TelegramMessage {
+  if (!message) throw new Error("inbox row has no message payload");
+  return message;
+}
+
+function assertExecutionId(executionId: string | null): string {
+  if (!executionId) throw new Error("inbox row has no execution id");
+  return executionId;
+}
+
+function renderRetryDelayMs(attempt: number): number {
+  return Math.min(
+    RENDER_RETRY_MAX_DELAY_MS,
+    RENDER_RETRY_BASE_DELAY_MS * 2 ** Math.min(attempt, 10),
+  );
+}
+
+/** Telegram answers an edit whose body already matches with a 400; recovery
+ * legitimately re-edits the tail with identical content, so this is success. */
+function isMessageNotModifiedError(error: unknown): boolean {
+  return (
+    error instanceof TelegramApiError &&
+    error.status === 400 &&
+    /not modified/i.test(error.description ?? "")
+  );
+}
+
+/**
+ * Terminal disposition of a session stream event. session-api ends the
+ * iterable after these, but the iterable ALSO ends on a plain connection
+ * drop — only an observed terminal event may complete the render.
+ */
+function terminalKind(
+  source: TelegrambotRendererSource,
+): "done" | "failed" | null {
+  if (!source || typeof source !== "object") return null;
+  const record = source as { data?: unknown; event?: unknown; eventKind?: unknown };
+  const kind =
+    typeof record.eventKind === "string"
+      ? record.eventKind
+      : typeof record.event === "string"
+        ? record.event
+        : "";
+  if (kind === "session.execution_completed") return "done";
+  if (
+    kind === "session.execution_failed" ||
+    kind === "session.stream_error" ||
+    kind === "session.execution_cancelled"
+  ) {
+    return "failed";
+  }
+  if (kind !== "session.output.line" || typeof record.data !== "string") {
+    return null;
+  }
+  let payload: unknown;
+  try {
+    payload = JSON.parse(record.data);
+  } catch {
+    return null;
+  }
+  if (!payload || typeof payload !== "object") return null;
+  const line = payload as { method?: unknown; type?: unknown };
+  if (line.type === "turn.failed" || line.method === "error") return "failed";
+  if (
+    line.type === "turn.completed" ||
+    line.type === "turn.done" ||
+    line.method === "turn/completed"
+  ) {
+    return "done";
+  }
+  return null;
+}

--- a/services/telegrambot/src/migrations.ts
+++ b/services/telegrambot/src/migrations.ts
@@ -1,0 +1,202 @@
+import type { Pool, PoolClient } from "pg";
+import type { Logger } from "./types";
+import { noopLogger } from "./utils";
+
+/**
+ * Application-startup migration runner for the Telegram-owned tables
+ * (spec §2a). The runtime role is also the migration runner: this service has
+ * no chart migration job, and the tables are purpose-built for this service
+ * alone, so startup DDL keeps the deployment story identical to discordbot
+ * (readiness simply stays false until migrations have applied).
+ *
+ * Migrations are embedded ordered SQL strings — no filesystem reads, so the
+ * container image and the code can never disagree about schema content.
+ *
+ * Rollback behavior: migrations are additive and forward-compatible; there
+ * are no down migrations. Rolling a deployment back one release leaves the
+ * newer schema in place, which older additive-compatible code can normally
+ * still use — but readiness fails closed on a schema version the running
+ * build does not know (`unsupported_future`), so rolling back across a
+ * schema-version boundary is an explicit operator decision (deploy a build
+ * that supports the version, or intervene manually), never a silent one.
+ */
+
+/**
+ * Advisory-lock key serializing concurrent migration runs (two pods racing a
+ * rollout, or startup racing a manual run). Constant, service-scoped:
+ * 0x74656c65 is ASCII "tele" — stable across releases so every telegrambot
+ * build contends on the same lock.
+ */
+const MIGRATION_LOCK_KEY = 0x74656c65;
+
+const MIGRATIONS: readonly string[] = [
+  // 1: durable receipt ledger + fenced poll state.
+  //   - telegram_poll_state: one row per bot user id (never token-derived, so
+  //     token rotation preserves state); carries the committed receive_offset
+  //     and the fencing lease (holder_id, generation, lease_expires_at).
+  //   - telegram_update_inbox: every update returned by getUpdates and its
+  //     processing stage, keyed (bot_user_id, update_id). render_obligation
+  //     holds the durable TelegramRenderObligation — renderer state rides on
+  //     the inbox row of the triggering update so obligation persistence is a
+  //     fenced stage transition like any other.
+  //   - status index for claim/recovery scans; a partial nonterminal index
+  //     because recovery scans only care about in-flight rows while the table
+  //     is dominated by terminal rows awaiting retention pruning.
+  `
+  CREATE TABLE IF NOT EXISTS telegram_poll_state (
+    bot_user_id text PRIMARY KEY,
+    receive_offset bigint,
+    holder_id text,
+    generation bigint NOT NULL DEFAULT 0,
+    lease_expires_at timestamptz
+  );
+
+  CREATE TABLE IF NOT EXISTS telegram_update_inbox (
+    bot_user_id text NOT NULL,
+    update_id bigint NOT NULL,
+    payload jsonb NOT NULL,
+    status text NOT NULL DEFAULT 'received',
+    thread_key text,
+    client_message_id text,
+    execution_id text,
+    status_reason text,
+    render_obligation jsonb,
+    received_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz NOT NULL DEFAULT now(),
+    PRIMARY KEY (bot_user_id, update_id)
+  );
+
+  CREATE INDEX IF NOT EXISTS telegram_update_inbox_status_idx
+    ON telegram_update_inbox (bot_user_id, status, update_id);
+
+  CREATE INDEX IF NOT EXISTS telegram_update_inbox_nonterminal_idx
+    ON telegram_update_inbox (bot_user_id, update_id)
+    WHERE status NOT IN ('completed', 'steered', 'ignored', 'rejected', 'failed');
+  `,
+];
+
+/** Highest schema version this build can run against. */
+export const SUPPORTED_SCHEMA_VERSION = MIGRATIONS.length;
+
+export type SchemaVersionState = "ok" | "pending" | "unsupported_future";
+
+export type SchemaVersionCheck = {
+  ok: boolean;
+  state: SchemaVersionState;
+  dbVersion: number;
+  supportedVersion: number;
+};
+
+export async function runMigrations(
+  pool: Pool,
+  logger?: Logger,
+): Promise<void> {
+  const log = logger ?? noopLogger;
+  // Dedicated connection: pg_advisory_lock is session-scoped, so lock and
+  // unlock must run on the same physical connection, never through the pool's
+  // per-query client rotation.
+  const client = await pool.connect();
+  let destroy: Error | undefined;
+  try {
+    await client.query("SELECT pg_advisory_lock($1)", [MIGRATION_LOCK_KEY]);
+    try {
+      await applyPending(client, log);
+    } finally {
+      try {
+        await client.query("SELECT pg_advisory_unlock($1)", [
+          MIGRATION_LOCK_KEY,
+        ]);
+      } catch (unlockError) {
+        // Unlock failed => connection state unknown; destroy it so the
+        // advisory lock is released by connection close, not leaked into a
+        // recycled pool client.
+        destroy =
+          unlockError instanceof Error ? unlockError : new Error("unlock");
+      }
+    }
+  } finally {
+    client.release(destroy);
+  }
+}
+
+async function applyPending(client: PoolClient, log: Logger): Promise<void> {
+  await client.query(`
+    CREATE TABLE IF NOT EXISTS telegram_schema_migrations (
+      version int PRIMARY KEY,
+      applied_at timestamptz NOT NULL DEFAULT now()
+    )
+  `);
+  const { rows } = await client.query<{ version: number }>(
+    "SELECT version FROM telegram_schema_migrations",
+  );
+  const applied = new Set(rows.map((row) => Number(row.version)));
+
+  let appliedCount = 0;
+  for (const [index, sql] of MIGRATIONS.entries()) {
+    const version = index + 1;
+    if (applied.has(version)) continue;
+    // Each migration commits atomically with its version row so a crash
+    // mid-run can never record a version whose DDL did not land (or vice
+    // versa).
+    await client.query("BEGIN");
+    try {
+      await client.query(sql);
+      await client.query(
+        "INSERT INTO telegram_schema_migrations (version) VALUES ($1)",
+        [version],
+      );
+      await client.query("COMMIT");
+    } catch (error) {
+      await client.query("ROLLBACK");
+      throw error;
+    }
+    appliedCount += 1;
+    log.info("telegrambot_migration_applied", { version });
+  }
+
+  log.info("telegrambot_migrations_complete", {
+    applied_count: appliedCount,
+    schema_version: SUPPORTED_SCHEMA_VERSION,
+  });
+}
+
+/**
+ * Readiness gate: fails on pending (db < supported — migrations have not run
+ * or did not finish) and on unsupported-future (db > supported — a newer
+ * release migrated this database and this build cannot prove compatibility).
+ */
+export async function checkSchemaVersion(
+  pool: Pool,
+): Promise<SchemaVersionCheck> {
+  let dbVersion = 0;
+  try {
+    const { rows } = await pool.query<{ version: number | null }>(
+      "SELECT max(version) AS version FROM telegram_schema_migrations",
+    );
+    dbVersion = Number(rows[0]?.version ?? 0);
+  } catch (error) {
+    // undefined_table: clean database, migrations never ran => pending.
+    if (!isUndefinedTable(error)) throw error;
+  }
+
+  const state: SchemaVersionState =
+    dbVersion === SUPPORTED_SCHEMA_VERSION
+      ? "ok"
+      : dbVersion < SUPPORTED_SCHEMA_VERSION
+        ? "pending"
+        : "unsupported_future";
+  return {
+    ok: state === "ok",
+    state,
+    dbVersion,
+    supportedVersion: SUPPORTED_SCHEMA_VERSION,
+  };
+}
+
+function isUndefinedTable(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    (error as { code?: unknown }).code === "42P01"
+  );
+}

--- a/services/telegrambot/src/ownership.ts
+++ b/services/telegrambot/src/ownership.ts
@@ -1,0 +1,193 @@
+import type { Pool } from "pg";
+import type { Logger, OwnershipLease } from "./types";
+import { errorMessage, noopLogger } from "./utils";
+
+/**
+ * Fenced ownership per spec §2 option (b): a lease row in telegram_poll_state
+ * keyed by bot_user_id with holder_id, a monotonically increasing generation,
+ * and a database-time expiry. Every cursor update, inbox claim, and stage
+ * transition must match (holder_id, generation, lease_expires_at > now()) in
+ * the same statement (see fenceSql), so a paused/partitioned old owner cannot
+ * mutate durable state after a takeover — `replicas: 1` is rollout hygiene,
+ * not the correctness mechanism.
+ *
+ * Telegram delta: discordbot leans on the Discord Gateway's own
+ * one-session-per-token semantics; getUpdates has no such server-side session,
+ * so the fence lives entirely in Postgres. All expiry math uses database
+ * now() exclusively — client clocks never participate, so clock skew between
+ * pods cannot open a split-brain window.
+ */
+
+/** Thrown when a fenced statement proves the lease is no longer ours. */
+export class OwnershipLostError extends Error {
+  readonly botUserId: string;
+  readonly holderId: string;
+  readonly generation: number;
+
+  constructor(lease: OwnershipLease, operation: string) {
+    super(
+      `ownership lost during ${operation} (holder ${lease.holderId}, generation ${lease.generation})`,
+    );
+    this.name = "OwnershipLostError";
+    this.botUserId = lease.botUserId;
+    this.holderId = lease.holderId;
+    this.generation = lease.generation;
+  }
+}
+
+/**
+ * Fence fragment for statements on OTHER tables (inbox transitions/claims):
+ * an EXISTS guard against the lease row using the caller's placeholder
+ * positions for (bot_user_id, holder_id, generation). Statements on
+ * telegram_poll_state itself put the same predicates directly in their WHERE
+ * clause instead.
+ */
+export function fenceSql(
+  botUserIdParam: number,
+  holderIdParam: number,
+  generationParam: number,
+): string {
+  return `EXISTS (
+    SELECT 1 FROM telegram_poll_state AS fence
+    WHERE fence.bot_user_id = $${botUserIdParam}
+      AND fence.holder_id = $${holderIdParam}
+      AND fence.generation = $${generationParam}
+      AND fence.lease_expires_at > now()
+  )`;
+}
+
+/**
+ * Take the lease iff it is expired or already ours, in one statement so two
+ * candidates cannot both win. Generation increments ONLY on takeover (holder
+ * change); a same-holder re-acquire extends the lease without bumping, because
+ * holder ids are unique per process instance and the process's own in-flight
+ * fenced work stays valid. Returns null when someone else holds an unexpired
+ * lease.
+ */
+export async function acquireOwnership(
+  pool: Pool,
+  botUserId: string,
+  holderId: string,
+  ttlMs: number,
+  logger?: Logger,
+): Promise<OwnershipLease | null> {
+  const log = logger ?? noopLogger;
+  const result = await pool.query<{ generation: string }>(
+    `
+    INSERT INTO telegram_poll_state (bot_user_id, holder_id, generation, lease_expires_at)
+    VALUES ($1, $2, 1, now() + ($3::bigint * interval '1 millisecond'))
+    ON CONFLICT (bot_user_id) DO UPDATE SET
+      holder_id = EXCLUDED.holder_id,
+      generation = CASE
+        WHEN telegram_poll_state.holder_id IS NOT DISTINCT FROM EXCLUDED.holder_id
+          THEN telegram_poll_state.generation
+        ELSE telegram_poll_state.generation + 1
+      END,
+      lease_expires_at = now() + ($3::bigint * interval '1 millisecond')
+    WHERE telegram_poll_state.holder_id IS NOT DISTINCT FROM EXCLUDED.holder_id
+       OR telegram_poll_state.lease_expires_at IS NULL
+       OR telegram_poll_state.lease_expires_at <= now()
+    RETURNING generation
+    `,
+    [botUserId, holderId, ttlMs],
+  );
+
+  const row = result.rows[0];
+  if (!row) return null;
+
+  const lease: OwnershipLease = {
+    botUserId,
+    holderId,
+    generation: Number(row.generation),
+  };
+  log.info("telegrambot_ownership_acquired", {
+    bot_user_id: botUserId,
+    holder_id: holderId,
+    generation: lease.generation,
+  });
+  return lease;
+}
+
+/**
+ * Extends the lease only when it is provably still ours AND unexpired.
+ * Requiring unexpired is deliberately stricter than holder+generation alone:
+ * once the lease has lapsed, fenced statements are already failing, so
+ * resurrecting the same generation would make ownership loss non-monotonic.
+ * Errors are folded into `false` — an uncertain renewal is a lost renewal;
+ * the caller must stop initiating work.
+ */
+export async function renewLease(
+  pool: Pool,
+  lease: OwnershipLease,
+  ttlMs: number,
+  logger?: Logger,
+): Promise<boolean> {
+  const log = logger ?? noopLogger;
+  try {
+    const result = await pool.query(
+      `
+      UPDATE telegram_poll_state
+      SET lease_expires_at = now() + ($4::bigint * interval '1 millisecond')
+      WHERE bot_user_id = $1
+        AND holder_id = $2
+        AND generation = $3
+        AND lease_expires_at > now()
+      `,
+      [lease.botUserId, lease.holderId, lease.generation, ttlMs],
+    );
+    const renewed = (result.rowCount ?? 0) === 1;
+    if (!renewed) {
+      log.warn("telegrambot_ownership_lost", {
+        bot_user_id: lease.botUserId,
+        holder_id: lease.holderId,
+        generation: lease.generation,
+        reason: "renewal_fenced_out",
+      });
+    }
+    return renewed;
+  } catch (error) {
+    log.warn("telegrambot_ownership_renew_uncertain", {
+      bot_user_id: lease.botUserId,
+      holder_id: lease.holderId,
+      generation: lease.generation,
+      error: errorMessage(error),
+    });
+    return false;
+  }
+}
+
+/**
+ * Best-effort shutdown: expire our own lease immediately so a successor can
+ * acquire without waiting out the TTL. Holder/generation stay in place —
+ * generation must only ever move forward, and the successor's takeover is
+ * what increments it. Failures are logged and swallowed; the TTL is the
+ * backstop.
+ */
+export async function releaseOwnership(
+  pool: Pool,
+  lease: OwnershipLease,
+  logger?: Logger,
+): Promise<void> {
+  const log = logger ?? noopLogger;
+  try {
+    const result = await pool.query(
+      `
+      UPDATE telegram_poll_state
+      SET lease_expires_at = now()
+      WHERE bot_user_id = $1 AND holder_id = $2 AND generation = $3
+      `,
+      [lease.botUserId, lease.holderId, lease.generation],
+    );
+    log.info("telegrambot_ownership_released", {
+      bot_user_id: lease.botUserId,
+      holder_id: lease.holderId,
+      generation: lease.generation,
+      released: (result.rowCount ?? 0) === 1,
+    });
+  } catch (error) {
+    log.warn("telegrambot_ownership_release_failed", {
+      bot_user_id: lease.botUserId,
+      error: errorMessage(error),
+    });
+  }
+}

--- a/services/telegrambot/src/poller.ts
+++ b/services/telegrambot/src/poller.ts
@@ -1,0 +1,608 @@
+import type { Pool } from "pg";
+import type { IngestHooks } from "./inbox";
+import { ingestBatch, markIgnored, readReceiveOffset } from "./inbox";
+import type { SchemaVersionState } from "./migrations";
+import { checkSchemaVersion, runMigrations } from "./migrations";
+import {
+  OwnershipLostError,
+  acquireOwnership,
+  releaseOwnership,
+  renewLease,
+} from "./ownership";
+import type { TelegramApi } from "./telegram-api";
+import {
+  isFatalTelegramAuthError,
+  isTelegramRateLimitError,
+} from "./telegram-api";
+import type { Logger, OwnershipLease, TelegramUpdate } from "./types";
+import { errorMessage, noopLogger, nowMs } from "./utils";
+
+/**
+ * Long-poll ingress controller, modeled on discordbot's gateway controller:
+ * transport only, crash-to-restart on configuration faults, injectable
+ * `onFatalEnd` for tests. Telegram delta: discord.js owns reconnection and the
+ * Gateway enforces one session per token server-side, so gateway.ts only
+ * monitors a connection; `getUpdates` has neither, so this controller also
+ * owns the startup sequence (migrations -> schema check -> getMe -> fenced
+ * ownership -> deleteWebhook) and the fenced receipt loop. Message processing
+ * lives elsewhere — ingested batches are handed to `onUpdatesIngested` and
+ * must never gate the next poll.
+ */
+
+const DEFAULT_LEASE_TTL_MS = 30_000;
+const DEFAULT_POLL_TIMEOUT_SECONDS = 50;
+const DEFAULT_BACKOFF_BASE_MS = 500;
+const DEFAULT_BACKOFF_MAX_MS = 30_000;
+const DEFAULT_HEARTBEAT_INTERVAL_MS = 1_000;
+const DEFAULT_HEARTBEAT_STALE_MS = 10_000;
+
+/** Only `message` is requested; everything else is filtered server-side. Any
+ * other update kind Telegram still queues is durably marked ignored during
+ * ingest (see settleIngested). */
+const ALLOWED_UPDATES = ["message"];
+
+export type PollerStatus = {
+  /** Event-loop heartbeat via a monotonic timer — a wedged loop goes false. */
+  live: boolean;
+  /** Migrations + schema + identity + ownership + webhook + poll freshness. */
+  ready: boolean;
+  reasons: string[];
+  lastSuccessfulPollAtMs: number | null;
+};
+
+export type IngestedUpdates = {
+  botUserId: string;
+  lease: OwnershipLease;
+  /** Message-bearing updates only; non-message updates in the batch were
+   * already durably marked ignored before this callback fires. */
+  updates: TelegramUpdate[];
+};
+
+export type PollerControllerDeps = {
+  api: TelegramApi;
+  pool: Pool;
+  logger?: Logger;
+  /** Stable per-process holder id for the fenced lease (default random UUID —
+   * a restart is deliberately a new holder so takeover bumps the generation). */
+  holderId?: string;
+  leaseTtlMs?: number;
+  pollTimeoutSeconds?: number;
+  /** Readiness freshness window; must exceed the long-poll timeout so one
+   * quiet-but-healthy poll cannot read as staleness (default max(90s, poll
+   * timeout + 30s)). */
+  freshnessWindowMs?: number;
+  heartbeatIntervalMs?: number;
+  heartbeatStaleMs?: number;
+  backoff?: { baseMs?: number; maxMs?: number };
+  /** Dispatch nudge for the worker layer. Fire-and-forget: rendering and
+   * processing must never gate the next poll, and a failed callback is safe
+   * because the rows are already durable and recovery scans re-serve them. */
+  onUpdatesIngested?: (batch: IngestedUpdates) => void | Promise<void>;
+  /** Test override, mirrors discordbot gateway.ts. Defaults to process.exit(1)
+   * so k8s restarts and surfaces the configuration fault. */
+  onFatalEnd?: () => void;
+  /** Fault-injection seam for receipt-atomicity tests. Never set in production. */
+  ingestHooks?: IngestHooks;
+};
+
+export type PollerController = {
+  /** Launches the startup/poll loop in the background and returns; readiness
+   * (with reasons) is observable via status() while startup retries. */
+  start(): void;
+  status(): PollerStatus;
+  /** Current fenced identity while ownership is held, for worker claims and
+   * render recovery; null whenever the lease cannot be proven. */
+  ownership(): { botUserId: string; lease: OwnershipLease } | null;
+  /** Aborts an in-flight getUpdates, stops timers, releases the lease
+   * best-effort. */
+  shutdown(): Promise<void>;
+};
+
+type PollExit = "stopped" | "fatal" | "ownership_lost" | "transient";
+
+export function createPollerController(
+  deps: PollerControllerDeps,
+): PollerController {
+  const { api, pool } = deps;
+  const log = deps.logger ?? noopLogger;
+  const holderId = deps.holderId ?? crypto.randomUUID();
+  const leaseTtlMs = deps.leaseTtlMs ?? DEFAULT_LEASE_TTL_MS;
+  const pollTimeoutSeconds =
+    deps.pollTimeoutSeconds ?? DEFAULT_POLL_TIMEOUT_SECONDS;
+  const freshnessWindowMs =
+    deps.freshnessWindowMs ??
+    Math.max(90_000, (pollTimeoutSeconds + 30) * 1000);
+  const heartbeatIntervalMs =
+    deps.heartbeatIntervalMs ?? DEFAULT_HEARTBEAT_INTERVAL_MS;
+  const heartbeatStaleMs = deps.heartbeatStaleMs ?? DEFAULT_HEARTBEAT_STALE_MS;
+  const backoffBaseMs = deps.backoff?.baseMs ?? DEFAULT_BACKOFF_BASE_MS;
+  const backoffMaxMs = deps.backoff?.maxMs ?? DEFAULT_BACKOFF_MAX_MS;
+  const onFatalEnd = deps.onFatalEnd ?? (() => process.exit(1));
+  // Client-side watchdog for a poll whose response never arrives (network
+  // black hole): telegram-api only applies its own timeout when no signal is
+  // passed, and the controller always passes one for shutdown/loss aborts.
+  const pollWatchdogMs = (pollTimeoutSeconds + 20) * 1000;
+
+  const stop = new AbortController();
+  let started = false;
+  let fatal = false;
+  let runPromise: Promise<void> | undefined;
+
+  let heartbeatTimer: ReturnType<typeof setInterval> | undefined;
+  let renewTimer: ReturnType<typeof setInterval> | undefined;
+  let currentPollAbort: AbortController | null = null;
+
+  let lastHeartbeatMono = nowMs();
+  let lastPollOkMono: number | null = null;
+  let lastSuccessfulPollAtMs: number | null = null;
+  let pollLoopStartedMono: number | null = null;
+
+  // Ownership terms: each pollLoop entry is a new term so an in-flight lease
+  // renewal from a previous term (still awaiting Postgres when the loop moved
+  // on) can never mark the CURRENT term lost or abort its poll.
+  let term = 0;
+  let ownershipLostThisTerm = false;
+
+  const readiness = {
+    database: false,
+    schema: false,
+    identity: false,
+    ownership: false,
+    webhook: false,
+  };
+  let schemaState: SchemaVersionState | null = null;
+  let botUserId: string | null = null;
+  let lease: OwnershipLease | null = null;
+
+  function stopRenewTimer(): void {
+    if (renewTimer !== undefined) {
+      clearInterval(renewTimer);
+      renewTimer = undefined;
+    }
+  }
+
+  function fatalExit(stage: string, error: unknown): void {
+    fatal = true;
+    // TelegramApiError messages are rebuilt from method + description and can
+    // never carry the token-bearing request URL (see telegram-api.ts).
+    log.error("telegrambot_fatal_configuration_error", {
+      stage,
+      error: errorMessage(error),
+    });
+    stopRenewTimer();
+    currentPollAbort?.abort();
+    onFatalEnd();
+  }
+
+  function handleOwnershipLoss(myTerm: number, reason: string): void {
+    if (myTerm !== term || ownershipLostThisTerm) return;
+    ownershipLostThisTerm = true;
+    readiness.ownership = false;
+    // deleteWebhook is an owner-only action: the next owner (possibly this
+    // process, next term) must re-reconcile before polling again.
+    readiness.webhook = false;
+    stopRenewTimer();
+    currentPollAbort?.abort();
+    log.warn("telegrambot_ownership_lost_polling_stopped", {
+      reason,
+      holder_id: holderId,
+    });
+  }
+
+  function markPollSuccess(): void {
+    lastPollOkMono = nowMs();
+    lastSuccessfulPollAtMs = Date.now();
+  }
+
+  /**
+   * Renewal cadence at ~TTL/3 on its own timer: renewal must not depend on
+   * poll latency, since a healthy long poll legitimately blocks longer than
+   * the lease TTL. renewLease folds errors into `false` — an uncertain
+   * renewal is a lost renewal.
+   */
+  function startRenewTimer(activeLease: OwnershipLease, myTerm: number): void {
+    stopRenewTimer();
+    const cadenceMs = Math.max(50, Math.floor(leaseTtlMs / 3));
+    let renewing = false;
+    renewTimer = setInterval(() => {
+      if (renewing || stop.signal.aborted || ownershipLostThisTerm) return;
+      renewing = true;
+      void renewLease(pool, activeLease, leaseTtlMs, log)
+        .then((renewed) => {
+          if (!renewed) handleOwnershipLoss(myTerm, "renewal_failed");
+        })
+        .finally(() => {
+          renewing = false;
+        });
+    }, cadenceMs);
+    renewTimer.unref?.();
+  }
+
+  /**
+   * Spec-mandated startup order: database (migrations + schema gate) ->
+   * getMe (the bot user id scopes all durable state; never the token) ->
+   * fenced ownership -> deleteWebhook(drop_pending_updates: false) as an
+   * idempotent owner-only action. Any failure leaves readiness flags exactly
+   * where they failed (reasons surface via status()) and the run loop retries
+   * with backoff — receive_offset is never touched here.
+   */
+  async function startupOnce(): Promise<{
+    lease: OwnershipLease;
+    botUserId: string;
+  } | null> {
+    try {
+      await runMigrations(pool, log);
+      readiness.database = true;
+    } catch (error) {
+      readiness.database = false;
+      log.warn("telegrambot_database_init_failed", {
+        error: errorMessage(error),
+      });
+      return null;
+    }
+
+    try {
+      const check = await checkSchemaVersion(pool);
+      schemaState = check.state;
+      readiness.schema = check.ok;
+      if (!check.ok) {
+        log.warn("telegrambot_schema_version_incompatible", {
+          state: check.state,
+          db_version: check.dbVersion,
+          supported_version: check.supportedVersion,
+        });
+        return null;
+      }
+    } catch (error) {
+      readiness.schema = false;
+      log.warn("telegrambot_schema_check_failed", {
+        error: errorMessage(error),
+      });
+      return null;
+    }
+
+    try {
+      const me = await api.getMe();
+      botUserId = String(me.id);
+      readiness.identity = true;
+    } catch (error) {
+      readiness.identity = false;
+      if (isFatalTelegramAuthError(error)) {
+        fatalExit("get_me", error);
+        return null;
+      }
+      log.warn("telegrambot_get_me_failed", { error: errorMessage(error) });
+      return null;
+    }
+
+    try {
+      const acquired = await acquireOwnership(
+        pool,
+        botUserId,
+        holderId,
+        leaseTtlMs,
+        log,
+      );
+      if (!acquired) {
+        readiness.ownership = false;
+        log.info("telegrambot_ownership_unavailable", {
+          bot_user_id: botUserId,
+          holder_id: holderId,
+        });
+        return null;
+      }
+      lease = acquired;
+      readiness.ownership = true;
+    } catch (error) {
+      readiness.ownership = false;
+      log.warn("telegrambot_ownership_acquire_failed", {
+        error: errorMessage(error),
+      });
+      return null;
+    }
+
+    try {
+      // Never drop pending updates: the durable inbox decides what to do with
+      // the backlog, deployment transitions must not.
+      await api.deleteWebhook({ drop_pending_updates: false });
+      readiness.webhook = true;
+      log.info("telegrambot_webhook_reconciled", { bot_user_id: botUserId });
+    } catch (error) {
+      readiness.webhook = false;
+      if (isFatalTelegramAuthError(error)) {
+        fatalExit("delete_webhook", error);
+        return null;
+      }
+      log.warn("telegrambot_delete_webhook_failed", {
+        error: errorMessage(error),
+      });
+      return null;
+    }
+
+    return { lease, botUserId };
+  }
+
+  /**
+   * Durable dispositions for non-message updates happen inside the same
+   * ingest flow so an unexpected update kind (channel_post etc.) can never
+   * stall processing, then message-bearing updates are handed to the dispatch
+   * callback fire-and-forget. A markIgnored failure after the batch committed
+   * is recoverable: the row is already durable in `received` and the worker
+   * claim scan re-serves it, so only ownership loss is escalated.
+   */
+  async function settleIngested(
+    activeLease: OwnershipLease,
+    activeBotUserId: string,
+    updates: readonly TelegramUpdate[],
+  ): Promise<void> {
+    const dispatchable: TelegramUpdate[] = [];
+    for (const update of updates) {
+      if (update.message) {
+        dispatchable.push(update);
+        continue;
+      }
+      await markIgnored(
+        pool,
+        activeLease,
+        update.update_id,
+        `unsupported_update_type:${updateKind(update)}`,
+        log,
+      );
+    }
+    if (dispatchable.length === 0 || !deps.onUpdatesIngested) return;
+    const callback = deps.onUpdatesIngested;
+    void Promise.resolve()
+      .then(() =>
+        callback({
+          botUserId: activeBotUserId,
+          lease: activeLease,
+          updates: dispatchable,
+        }),
+      )
+      .catch((error) => {
+        log.warn("telegrambot_dispatch_callback_failed", {
+          error: errorMessage(error),
+        });
+      });
+  }
+
+  async function pollLoop(
+    activeLease: OwnershipLease,
+    activeBotUserId: string,
+  ): Promise<PollExit> {
+    term += 1;
+    const myTerm = term;
+    ownershipLostThisTerm = false;
+    pollLoopStartedMono = nowMs();
+    startRenewTimer(activeLease, myTerm);
+
+    // Only the committed cursor may feed a poll. Null on first start: call
+    // getUpdates WITHOUT an offset so the earliest pending updates are
+    // ingested — never jump to the queue head, never drop the backlog.
+    let committedOffset: number | null;
+    try {
+      committedOffset = await readReceiveOffset(pool, activeBotUserId);
+    } catch (error) {
+      log.warn("telegrambot_receive_offset_read_failed", {
+        error: errorMessage(error),
+      });
+      return "transient";
+    }
+
+    const backoff = createBackoff(backoffBaseMs, backoffMaxMs);
+    while (true) {
+      if (stop.signal.aborted) return "stopped";
+      if (ownershipLostThisTerm) return "ownership_lost";
+      const pollAbort = new AbortController();
+      currentPollAbort = pollAbort;
+      try {
+        const updates = await api.getUpdates(
+          {
+            ...(committedOffset !== null ? { offset: committedOffset } : {}),
+            timeout: pollTimeoutSeconds,
+            allowed_updates: [...ALLOWED_UPDATES],
+          },
+          AbortSignal.any([
+            pollAbort.signal,
+            AbortSignal.timeout(pollWatchdogMs),
+          ]),
+        );
+        currentPollAbort = null;
+        if (stop.signal.aborted) return "stopped";
+        if (ownershipLostThisTerm) return "ownership_lost";
+        // Atomic receipt: the whole batch and the cursor commit together, and
+        // the empty-batch path still proves the lease + refreshes freshness.
+        // A batch that fails to ingest durably is NOT confirmed — the catch
+        // below leaves committedOffset unchanged and Telegram redelivers.
+        committedOffset = await ingestBatch(
+          pool,
+          activeLease,
+          updates,
+          log,
+          deps.ingestHooks,
+        );
+        markPollSuccess();
+        backoff.reset();
+        if (updates.length > 0) {
+          await settleIngested(activeLease, activeBotUserId, updates);
+        }
+      } catch (error) {
+        currentPollAbort = null;
+        if (stop.signal.aborted) return "stopped";
+        if (error instanceof OwnershipLostError) {
+          handleOwnershipLoss(myTerm, "fenced_statement");
+          return "ownership_lost";
+        }
+        if (ownershipLostThisTerm) return "ownership_lost";
+        if (isFatalTelegramAuthError(error)) {
+          fatalExit("get_updates", error);
+          return "fatal";
+        }
+        const delayMs = retryDelay(error, backoff);
+        log.warn("telegrambot_poll_retry", {
+          error: errorMessage(error),
+          retry_in_ms: delayMs,
+        });
+        await sleep(delayMs, stop.signal);
+      }
+    }
+  }
+
+  async function run(): Promise<void> {
+    const startupBackoff = createBackoff(backoffBaseMs, backoffMaxMs);
+    while (!stop.signal.aborted && !fatal) {
+      const owned = await startupOnce();
+      if (stop.signal.aborted || fatal) return;
+      if (!owned) {
+        await sleep(startupBackoff.next(), stop.signal);
+        continue;
+      }
+      startupBackoff.reset();
+      log.info("telegrambot_poller_started", {
+        bot_user_id: owned.botUserId,
+        holder_id: holderId,
+      });
+      const exit = await pollLoop(owned.lease, owned.botUserId);
+      stopRenewTimer();
+      if (exit === "stopped" || exit === "fatal") return;
+      if (exit === "ownership_lost") {
+        // Reacquire only after the old lease term has fully lapsed: loss was
+        // detected at most one TTL before expiry, so a full-TTL wait
+        // guarantees no fenced write from this holder's old term can race the
+        // successor's takeover.
+        await sleep(leaseTtlMs, stop.signal);
+      } else {
+        await sleep(startupBackoff.next(), stop.signal);
+      }
+    }
+  }
+
+  function status(): PollerStatus {
+    const now = nowMs();
+    const live = !started || now - lastHeartbeatMono <= heartbeatStaleMs;
+    const reasons: string[] = [];
+    if (!started) reasons.push("not_started");
+    if (stop.signal.aborted) reasons.push("shutting_down");
+    if (fatal) reasons.push("fatal_configuration_error");
+    if (!readiness.database) reasons.push("database_not_ready");
+    if (readiness.database && !readiness.schema) {
+      reasons.push(
+        schemaState === "unsupported_future"
+          ? "schema_version_unsupported"
+          : "schema_version_pending",
+      );
+    }
+    if (!readiness.identity) reasons.push("bot_identity_unresolved");
+    if (!readiness.ownership) reasons.push("ownership_not_held");
+    if (!readiness.webhook) reasons.push("webhook_not_reconciled");
+    // Freshness anchors on poll-loop start until the first success so a quiet
+    // first long poll is not misread as staleness; the window exceeds the
+    // long-poll timeout, so a healthy poll always lands inside it.
+    const anchor = lastPollOkMono ?? pollLoopStartedMono;
+    if (anchor === null) reasons.push("poll_never_started");
+    else if (now - anchor > freshnessWindowMs) reasons.push("poll_stale");
+    return {
+      live,
+      ready: reasons.length === 0,
+      reasons,
+      lastSuccessfulPollAtMs,
+    };
+  }
+
+  return {
+    start(): void {
+      if (started) return;
+      started = true;
+      lastHeartbeatMono = nowMs();
+      heartbeatTimer = setInterval(() => {
+        lastHeartbeatMono = nowMs();
+      }, heartbeatIntervalMs);
+      heartbeatTimer.unref?.();
+      runPromise = run().catch((error) => {
+        // Mirrors gateway.ts: the loop ending on its own is always a bug or a
+        // configuration fault — exit so k8s restarts with backoff.
+        log.error("telegrambot_poller_ended_unexpectedly", {
+          error: errorMessage(error),
+        });
+        fatal = true;
+        onFatalEnd();
+      });
+    },
+
+    status,
+
+    ownership() {
+      return lease && botUserId && readiness.ownership && !fatal
+        ? { botUserId, lease }
+        : null;
+    },
+
+    async shutdown(): Promise<void> {
+      stop.abort();
+      stopRenewTimer();
+      if (heartbeatTimer !== undefined) clearInterval(heartbeatTimer);
+      currentPollAbort?.abort();
+      if (runPromise) await runPromise;
+      const heldLease = lease;
+      // Best-effort: expire our own lease so a successor starts immediately.
+      // releaseOwnership is holder+generation guarded, so releasing a lease
+      // we already lost is a harmless no-op.
+      if (heldLease && readiness.ownership) {
+        await releaseOwnership(pool, heldLease, log);
+      }
+    },
+  };
+}
+
+function updateKind(update: TelegramUpdate): string {
+  for (const key of Object.keys(update)) {
+    if (key !== "update_id") return key;
+  }
+  return "unknown";
+}
+
+type Backoff = { next(): number; reset(): void };
+
+/** Exponential backoff with jitter (half fixed, half random) so a fleet of
+ * retries against a recovering dependency does not synchronize. */
+function createBackoff(baseMs: number, maxMs: number): Backoff {
+  let attempt = 0;
+  return {
+    next(): number {
+      const capped = Math.min(maxMs, baseMs * 2 ** attempt);
+      attempt = Math.min(attempt + 1, 20);
+      return Math.round(capped / 2 + Math.random() * (capped / 2));
+    },
+    reset(): void {
+      attempt = 0;
+    },
+  };
+}
+
+function retryDelay(error: unknown, backoff: Backoff): number {
+  const backoffMs = backoff.next();
+  // 429 retry_after is authoritative: waiting less just burns the budget.
+  if (isTelegramRateLimitError(error) && error.retryAfterSeconds !== undefined) {
+    return Math.max(error.retryAfterSeconds * 1000, backoffMs);
+  }
+  return backoffMs;
+}
+
+/** Abort-aware sleep so shutdown never waits out a backoff or lease term. */
+function sleep(ms: number, signal: AbortSignal): Promise<void> {
+  return new Promise((resolve) => {
+    if (signal.aborted || ms <= 0) {
+      resolve();
+      return;
+    }
+    const timer = setTimeout(() => {
+      signal.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    const onAbort = () => {
+      clearTimeout(timer);
+      resolve();
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+  });
+}

--- a/services/telegrambot/src/rate-limit.ts
+++ b/services/telegrambot/src/rate-limit.ts
@@ -1,0 +1,425 @@
+import { isTelegramRateLimitError } from "./telegram-api";
+import type {
+  EditMessageTextParams,
+  SendMessageParams,
+  TelegramApi,
+} from "./telegram-api";
+import type { Logger, TelegramMessage } from "./types";
+
+/**
+ * Coordinated outbound rate control for the Bot API.
+ *
+ * Telegram delta: Discord returns proactive bucket headers the SDK can obey,
+ * but the Bot API publishes only soft guidance (~1 message/s per chat,
+ * 20 messages/min per group) and punishes overruns with 429 + retry_after.
+ * So mutations are scheduled locally — per-chat FIFO queues with sendMessage
+ * pacing and a group message budget — and every method reactively honors its
+ * own 429s. The 20/min quota applies to *messages*; edits, reactions, and
+ * chat actions ride the same FIFO (ordering) but are never charged against it.
+ *
+ * Reads (getMe/getUpdates/deleteWebhook/getFile/downloadFile) pass through
+ * untouched: they have no per-chat quota and must not sit behind a paced send.
+ */
+
+const MESSAGE_INTERVAL_MS = 1_000;
+const GROUP_MESSAGES_PER_MINUTE = 20;
+const GROUP_BUDGET_WINDOW_MS = 60_000;
+const MAX_RATE_LIMIT_RETRIES = 5;
+// Fallback when a 429 arrives without parameters.retry_after.
+const DEFAULT_RETRY_AFTER_SECONDS = 1;
+
+export type RateLimitClock = {
+  now(): number;
+  sleep(ms: number): Promise<void>;
+};
+
+export type RateLimitOptions = {
+  /** Injectable clock/sleep so tests drive pacing deterministically. */
+  clock?: RateLimitClock;
+  /** sendMessage budget per group chat per minute (default 20). */
+  groupMessagesPerMinute?: number;
+  /** Additive backoff jitter in ms so concurrent chats don't retry in lockstep. */
+  jitterMs?: () => number;
+  /** 429 retries per call before the error is rethrown (default 5). */
+  maxRetries?: number;
+  /** Minimum gap between sendMessage calls in one chat (default 1000ms). */
+  messageIntervalMs?: number;
+};
+
+export type TelegramMutationMethod =
+  | "sendMessage"
+  | "editMessageText"
+  | "setMessageReaction"
+  | "sendChatAction";
+
+export type TelegramSendPriority = "normal" | "high";
+
+export type TelegramSendQueueTask<T> = {
+  chatId: number | string;
+  method: TelegramMutationMethod;
+  /**
+   * Tasks sharing a coalesce key supersede each other: enqueueing marks every
+   * not-yet-in-flight pending task with the same key as superseded (its
+   * promise resolves with `undefined` immediately). Only use for calls whose
+   * result type is `void` — in practice, editMessageText keyed by
+   * chat+message_id, where the newest body is the only one worth sending.
+   */
+  coalesceKey?: string;
+  /** "high" schedules ahead of queued normal work (terminal answer sends). */
+  priority?: TelegramSendPriority;
+  run: () => Promise<T>;
+};
+
+type QueueTask = {
+  coalesceKey: string | undefined;
+  inFlight: boolean;
+  method: TelegramMutationMethod;
+  priority: TelegramSendPriority;
+  reject: (error: unknown) => void;
+  resolve: (value: unknown) => void;
+  run: () => Promise<unknown>;
+  superseded: boolean;
+};
+
+type ChatState = {
+  current: QueueTask | null;
+  draining: boolean;
+  isGroup: boolean;
+  lastMessageAtMs: number;
+  /** clock timestamps of sendMessage successes inside the sliding window. */
+  messageWindow: number[];
+  tasks: QueueTask[];
+};
+
+/**
+ * Per-chat FIFO scheduler for outbound Bot API mutations. One worker per chat
+ * drains its queue serially — a rate-limited chat blocks only itself — while
+ * priority insertion lets terminal sends jump queued progress edits and
+ * coalesce keys drop stale edit bodies before they ever hit the network.
+ *
+ * Exported separately from the wrapper so the answer streamer can enqueue its
+ * own work (custom priorities/coalescing) on the same budget.
+ */
+export class TelegramSendQueue {
+  private readonly logger: Logger;
+  private readonly clock: RateLimitClock;
+  private readonly jitterMs: () => number;
+  private readonly maxRetries: number;
+  private readonly messageIntervalMs: number;
+  private readonly groupMessagesPerMinute: number;
+  private readonly chats = new Map<string, ChatState>();
+
+  constructor(logger: Logger, options: RateLimitOptions = {}) {
+    this.logger = logger;
+    this.clock = options.clock ?? {
+      now: () => Date.now(),
+      sleep: (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+    };
+    this.jitterMs =
+      options.jitterMs ?? (() => Math.floor(Math.random() * 250));
+    this.maxRetries = options.maxRetries ?? MAX_RATE_LIMIT_RETRIES;
+    this.messageIntervalMs = options.messageIntervalMs ?? MESSAGE_INTERVAL_MS;
+    this.groupMessagesPerMinute =
+      options.groupMessagesPerMinute ?? GROUP_MESSAGES_PER_MINUTE;
+  }
+
+  enqueue<T>(input: TelegramSendQueueTask<T>): Promise<T> {
+    const chat = this.chatState(input.chatId);
+    return new Promise<T>((resolve, reject) => {
+      const task: QueueTask = {
+        coalesceKey: input.coalesceKey,
+        inFlight: false,
+        method: input.method,
+        priority: input.priority ?? "normal",
+        reject,
+        resolve: resolve as (value: unknown) => void,
+        run: input.run,
+        superseded: false,
+      };
+      if (task.coalesceKey) {
+        this.supersede(chat, input.chatId, task.coalesceKey, "replaced");
+      }
+      this.insert(chat, task);
+      if (!chat.draining) void this.drain(chat, input.chatId);
+    });
+  }
+
+  /**
+   * Supersede pending tasks for a coalesce key without enqueueing a
+   * replacement — e.g. progress edits made moot by a delivered terminal
+   * answer. Returns how many pending tasks were dropped.
+   */
+  cancel(chatId: number | string, coalesceKey: string): number {
+    const chat = this.chats.get(chatKey(chatId));
+    if (!chat) return 0;
+    return this.supersede(chat, chatId, coalesceKey, "cancelled");
+  }
+
+  private chatState(chatId: number | string): ChatState {
+    const key = chatKey(chatId);
+    let chat = this.chats.get(key);
+    if (!chat) {
+      chat = {
+        current: null,
+        draining: false,
+        isGroup: isGroupChatId(chatId),
+        lastMessageAtMs: Number.NEGATIVE_INFINITY,
+        messageWindow: [],
+        tasks: [],
+      };
+      this.chats.set(key, chat);
+    }
+    return chat;
+  }
+
+  private insert(chat: ChatState, task: QueueTask): void {
+    if (task.priority === "high") {
+      // Ahead of queued normal work, behind earlier high-priority work
+      // (FIFO within a priority level); never preempts the in-flight task.
+      const index = chat.tasks.findIndex((t) => t.priority !== "high");
+      if (index === -1) chat.tasks.push(task);
+      else chat.tasks.splice(index, 0, task);
+      return;
+    }
+    chat.tasks.push(task);
+  }
+
+  private supersede(
+    chat: ChatState,
+    chatId: number | string,
+    coalesceKey: string,
+    reason: "replaced" | "cancelled",
+  ): number {
+    // The current task is cancellable while it is between attempts (waiting
+    // out pacing or a 429 backoff); once a request is actually in flight the
+    // send may already have happened, so it must settle on its own.
+    const candidates =
+      chat.current && !chat.current.inFlight
+        ? [chat.current, ...chat.tasks]
+        : chat.tasks;
+    let dropped = 0;
+    for (const task of candidates) {
+      if (task.superseded || task.coalesceKey !== coalesceKey) continue;
+      task.superseded = true;
+      task.resolve(undefined);
+      dropped += 1;
+    }
+    if (dropped) {
+      this.logger.debug("telegrambot_edit_superseded", {
+        chat_id: chatKey(chatId),
+        coalesce_key: coalesceKey,
+        dropped,
+        reason,
+      });
+    }
+    return dropped;
+  }
+
+  private async drain(
+    chat: ChatState,
+    chatId: number | string,
+  ): Promise<void> {
+    chat.draining = true;
+    try {
+      let task: QueueTask | undefined;
+      while ((task = chat.tasks.shift())) {
+        if (task.superseded) continue;
+        chat.current = task;
+        await this.runTask(chat, chatId, task);
+        chat.current = null;
+      }
+    } finally {
+      chat.draining = false;
+      chat.current = null;
+    }
+  }
+
+  /** Never throws — the task settles via its own resolve/reject. */
+  private async runTask(
+    chat: ChatState,
+    chatId: number | string,
+    task: QueueTask,
+  ): Promise<void> {
+    let retries = 0;
+    for (;;) {
+      // A task superseded while it waited (its promise already resolved)
+      // must never reach the network with its stale body.
+      if (task.superseded) return;
+      if (task.method === "sendMessage") await this.awaitSendBudget(chat, chatId);
+      if (task.superseded) return;
+      task.inFlight = true;
+      try {
+        const result = await task.run();
+        if (task.method === "sendMessage") this.recordSend(chat);
+        task.resolve(result);
+        return;
+      } catch (error) {
+        if (!isTelegramRateLimitError(error)) {
+          task.reject(error);
+          return;
+        }
+        const retryAfterSeconds =
+          error.retryAfterSeconds ?? DEFAULT_RETRY_AFTER_SECONDS;
+        // Method-specific telemetry; never the URL (it embeds the token).
+        this.logger.warn("telegrambot_rate_limited", {
+          attempt: retries + 1,
+          chat_id: chatKey(chatId),
+          method: task.method,
+          retry_after: retryAfterSeconds,
+        });
+        if (retries >= this.maxRetries) {
+          task.reject(error);
+          return;
+        }
+        retries += 1;
+        task.inFlight = false;
+        await this.clock.sleep(
+          retryAfterSeconds * 1_000 + Math.max(0, this.jitterMs()),
+        );
+      }
+    }
+  }
+
+  /** Blocks until this chat may send a new message (pacing + group budget). */
+  private async awaitSendBudget(
+    chat: ChatState,
+    chatId: number | string,
+  ): Promise<void> {
+    for (;;) {
+      const now = this.clock.now();
+      const paceWaitMs =
+        chat.lastMessageAtMs + this.messageIntervalMs - now;
+      let budgetWaitMs = 0;
+      if (chat.isGroup) {
+        this.pruneWindow(chat, now);
+        if (chat.messageWindow.length >= this.groupMessagesPerMinute) {
+          const oldest = chat.messageWindow[0];
+          if (oldest !== undefined) {
+            budgetWaitMs = oldest + GROUP_BUDGET_WINDOW_MS - now;
+          }
+        }
+      }
+      const waitMs = Math.max(paceWaitMs, budgetWaitMs);
+      if (waitMs <= 0) return;
+      this.logger.debug("telegrambot_send_paced", {
+        chat_id: chatKey(chatId),
+        reason:
+          budgetWaitMs > paceWaitMs ? "group_budget" : "message_interval",
+        wait_ms: waitMs,
+      });
+      await this.clock.sleep(waitMs);
+    }
+  }
+
+  private recordSend(chat: ChatState): void {
+    const now = this.clock.now();
+    chat.lastMessageAtMs = now;
+    if (!chat.isGroup) return;
+    chat.messageWindow.push(now);
+    this.pruneWindow(chat, now);
+  }
+
+  private pruneWindow(chat: ChatState, now: number): void {
+    const cutoff = now - GROUP_BUDGET_WINDOW_MS;
+    while (chat.messageWindow.length) {
+      const oldest = chat.messageWindow[0];
+      if (oldest === undefined || oldest > cutoff) break;
+      chat.messageWindow.shift();
+    }
+  }
+}
+
+export type RateLimitedTelegramApi = TelegramApi & {
+  /** Drop queued progress edits for a message the streamer no longer needs. */
+  cancelPendingEdits(chatId: number | string, messageId: number): number;
+  /** Terminal in-place answer edit: jumps queued progress edits and coalesces them away. */
+  editMessageTextUrgent(params: EditMessageTextParams): Promise<void>;
+  /** Shared scheduler, exposed so the streamer can enqueue custom work on the same budget. */
+  queue: TelegramSendQueue;
+  /** Terminal answer send: schedules ahead of queued progress edits. */
+  sendMessageUrgent(params: SendMessageParams): Promise<TelegramMessage>;
+};
+
+export function createRateLimitedTelegramApi(
+  api: TelegramApi,
+  logger: Logger,
+  options: RateLimitOptions = {},
+): RateLimitedTelegramApi {
+  const queue = new TelegramSendQueue(logger, options);
+
+  const sendMessage = (
+    params: SendMessageParams,
+    priority: TelegramSendPriority,
+  ): Promise<TelegramMessage> =>
+    queue.enqueue({
+      chatId: params.chat_id,
+      method: "sendMessage",
+      priority,
+      run: () => api.sendMessage(params),
+    });
+
+  const editMessageText = (
+    params: EditMessageTextParams,
+    priority: TelegramSendPriority,
+  ): Promise<void> =>
+    queue.enqueue({
+      chatId: params.chat_id,
+      coalesceKey: editCoalesceKey(params.chat_id, params.message_id),
+      method: "editMessageText",
+      priority,
+      run: () => api.editMessageText(params),
+    });
+
+  return {
+    // Reads pass through: no per-chat quota, must not queue behind sends.
+    getMe: () => api.getMe(),
+    getUpdates: (params, signal) => api.getUpdates(params, signal),
+    deleteWebhook: (params) => api.deleteWebhook(params),
+    getFile: (fileId) => api.getFile(fileId),
+    downloadFile: (filePath, signal) => api.downloadFile(filePath, signal),
+
+    sendMessage: (params) => sendMessage(params, "normal"),
+    sendMessageUrgent: (params) => sendMessage(params, "high"),
+    editMessageText: (params) => editMessageText(params, "normal"),
+    editMessageTextUrgent: (params) => editMessageText(params, "high"),
+    setMessageReaction: (params) =>
+      queue.enqueue({
+        chatId: params.chat_id,
+        method: "setMessageReaction",
+        run: () => api.setMessageReaction(params),
+      }),
+    sendChatAction: (params) =>
+      queue.enqueue({
+        chatId: params.chat_id,
+        method: "sendChatAction",
+        run: () => api.sendChatAction(params),
+      }),
+
+    cancelPendingEdits: (chatId, messageId) =>
+      queue.cancel(chatId, editCoalesceKey(chatId, messageId)),
+    queue,
+  };
+}
+
+function editCoalesceKey(
+  chatId: number | string,
+  messageId: number,
+): string {
+  return `edit:${chatKey(chatId)}:${messageId}`;
+}
+
+function chatKey(chatId: number | string): string {
+  return String(chatId);
+}
+
+/**
+ * Telegram encodes chat kind in the id's sign: groups/supergroups/channels are
+ * negative, private chats positive. `@channelusername` strings are treated as
+ * group-like conservatively (the 20/min budget applies to them too).
+ */
+function isGroupChatId(chatId: number | string): boolean {
+  if (typeof chatId === "number") return chatId < 0;
+  if (chatId.startsWith("@")) return true;
+  const numeric = Number(chatId);
+  return Number.isFinite(numeric) && numeric < 0;
+}

--- a/services/telegrambot/src/rate-limit.ts
+++ b/services/telegrambot/src/rate-limit.ts
@@ -17,8 +17,13 @@ import type { Logger, TelegramMessage } from "./types";
  * own 429s. The 20/min quota applies to *messages*; edits, reactions, and
  * chat actions ride the same FIFO (ordering) but are never charged against it.
  *
- * Reads (getMe/getUpdates/deleteWebhook/getFile/downloadFile) pass through
- * untouched: they have no per-chat quota and must not sit behind a paced send.
+ * Reads (getMe/getUpdates/deleteWebhook/getFile/downloadFile) are never
+ * queued: they have no per-chat quota and must not sit behind a paced send.
+ * getFile/downloadFile still honor their own 429 retry_after (same retry cap
+ * as mutations) — a transient rate limit on an attachment fetch would
+ * otherwise degrade silently into a permanent per-attachment fetch error
+ * downstream (getUpdates has its own poller-side retry_after handling, and
+ * getMe/deleteWebhook run inside the startup retry loop).
  */
 
 const MESSAGE_INTERVAL_MS = 1_000;
@@ -53,6 +58,9 @@ export type TelegramMutationMethod =
   | "sendChatAction";
 
 export type TelegramSendPriority = "normal" | "high";
+
+/** Pass-through reads that skip the queue but still honor 429 retry_after. */
+export type TelegramPassThroughMethod = "getFile" | "downloadFile";
 
 export type TelegramSendQueueTask<T> = {
   chatId: number | string;
@@ -280,6 +288,40 @@ export class TelegramSendQueue {
     }
   }
 
+  /**
+   * 429 retry_after policy for pass-through reads. Telegram delta: reads have
+   * no per-chat quota, so they bypass the FIFO/pacing entirely — but a 429
+   * still names exactly how long to wait, and ignoring it turns a transient
+   * rate limit into a hard failure (e.g. an attachment the agent never sees).
+   * Non-429 errors rethrow untouched; retries share the mutation retry cap.
+   */
+  async retryPassThrough<T>(
+    method: TelegramPassThroughMethod,
+    run: () => Promise<T>,
+  ): Promise<T> {
+    let retries = 0;
+    for (;;) {
+      try {
+        return await run();
+      } catch (error) {
+        if (!isTelegramRateLimitError(error)) throw error;
+        const retryAfterSeconds =
+          error.retryAfterSeconds ?? DEFAULT_RETRY_AFTER_SECONDS;
+        // Method-specific telemetry; never the URL (it embeds the token).
+        this.logger.warn("telegrambot_rate_limited", {
+          attempt: retries + 1,
+          method,
+          retry_after: retryAfterSeconds,
+        });
+        if (retries >= this.maxRetries) throw error;
+        retries += 1;
+        await this.clock.sleep(
+          retryAfterSeconds * 1_000 + Math.max(0, this.jitterMs()),
+        );
+      }
+    }
+  }
+
   /** Blocks until this chat may send a new message (pacing + group budget). */
   private async awaitSendBudget(
     chat: ChatState,
@@ -375,8 +417,14 @@ export function createRateLimitedTelegramApi(
     getMe: () => api.getMe(),
     getUpdates: (params, signal) => api.getUpdates(params, signal),
     deleteWebhook: (params) => api.deleteWebhook(params),
-    getFile: (fileId) => api.getFile(fileId),
-    downloadFile: (filePath, signal) => api.downloadFile(filePath, signal),
+    // Attachment reads stay un-queued but must not shrug off a 429 — the
+    // downstream downloader converts any error into a permanent fetch_error.
+    getFile: (fileId) =>
+      queue.retryPassThrough("getFile", () => api.getFile(fileId)),
+    downloadFile: (filePath, signal) =>
+      queue.retryPassThrough("downloadFile", () =>
+        api.downloadFile(filePath, signal),
+      ),
 
     sendMessage: (params) => sendMessage(params, "normal"),
     sendMessageUrgent: (params) => sendMessage(params, "high"),

--- a/services/telegrambot/src/server.ts
+++ b/services/telegrambot/src/server.ts
@@ -30,6 +30,7 @@ if (!postgresUrl) {
 
 const options: TelegrambotOptions = {
   answerEditIntervalMs: optionalNumberEnv("TELEGRAMBOT_ANSWER_EDIT_INTERVAL_MS"),
+  answerMaxMessages: optionalNumberEnv("TELEGRAMBOT_ANSWER_MAX_MESSAGES"),
   apiKey: optionalEnv("TELEGRAMBOT_API_KEY"),
   apiUrl,
   botToken,

--- a/services/telegrambot/src/server.ts
+++ b/services/telegrambot/src/server.ts
@@ -1,0 +1,122 @@
+import { createTelegrambot } from "./index";
+import type { TelegrambotOptions } from "./types";
+
+const port = numberEnv("PORT", 3001);
+const apiUrl = stringEnv("CENTAUR_API_URL", "http://127.0.0.1:8080");
+// The bot token IS the platform credential (embedded in every Bot API URL
+// path); it must never be logged, and telegram-api.ts redacts it defensively.
+const botToken = requiredEnv("TELEGRAM_BOT_TOKEN");
+
+const consoleLogger = {
+  debug: (message: string, data?: unknown) => log("debug", message, data),
+  info: (message: string, data?: unknown) => log("info", message, data),
+  warn: (message: string, data?: unknown) => log("warn", message, data),
+  error: (message: string, data?: unknown) => log("error", message, data),
+  child: () => consoleLogger,
+};
+
+// Telegram delta mirrors the Discord one: pg.Pool silently falls back to
+// localhost when no URL is provided and every handler fails at runtime. Fail
+// fast at boot instead — the chart always provides TELEGRAMBOT_DATABASE_URL.
+const postgresUrl =
+  optionalEnv("TELEGRAMBOT_DATABASE_URL") ??
+  optionalEnv("DATABASE_URL") ??
+  optionalEnv("POSTGRES_URL");
+if (!postgresUrl) {
+  throw new Error(
+    "TELEGRAMBOT_DATABASE_URL (or DATABASE_URL / POSTGRES_URL) is required",
+  );
+}
+
+const options: TelegrambotOptions = {
+  answerEditIntervalMs: optionalNumberEnv("TELEGRAMBOT_ANSWER_EDIT_INTERVAL_MS"),
+  apiKey: optionalEnv("TELEGRAMBOT_API_KEY"),
+  apiUrl,
+  botToken,
+  chatAllowlist: optionalList("TELEGRAMBOT_CHAT_ALLOWLIST"),
+  idleTimeoutMs: optionalNumberEnv("SESSION_IDLE_TIMEOUT_MS"),
+  leaseTtlMs: optionalNumberEnv("TELEGRAMBOT_LEASE_TTL_MS"),
+  logger: consoleLogger,
+  maxConcurrentThreads: optionalNumberEnv("TELEGRAMBOT_MAX_CONCURRENT_THREADS"),
+  maxDurationMs: optionalNumberEnv("SESSION_MAX_DURATION_MS"),
+  pollTimeoutSeconds: optionalNumberEnv("TELEGRAMBOT_POLL_TIMEOUT_S"),
+  postgresUrl,
+  retentionHours: optionalNumberEnv("TELEGRAMBOT_RETENTION_HOURS"),
+  telegramApiUrl: optionalEnv("TELEGRAM_API_URL"),
+  userAllowlist: optionalList("TELEGRAMBOT_USER_ALLOWLIST"),
+  userName: stringEnv("TELEGRAMBOT_USER_NAME", "centaur"),
+};
+
+const bot = createTelegrambot(options);
+const server = Bun.serve({ port, fetch: bot.app.fetch });
+
+log("info", "telegrambot_started", {
+  port: server.port,
+  api_url: apiUrl,
+});
+
+const shutdown = async (signal: string): Promise<void> => {
+  log("info", "telegrambot_shutdown_started", { signal });
+  await bot.shutdown().catch(() => undefined);
+  server.stop();
+  log("info", "telegrambot_shutdown_complete", { signal });
+  process.exit(0);
+};
+process.on("SIGTERM", () => void shutdown("SIGTERM"));
+process.on("SIGINT", () => void shutdown("SIGINT"));
+
+await bot.start();
+
+function optionalEnv(name: string): string | undefined {
+  const value = process.env[name]?.trim();
+  return value ? value : undefined;
+}
+
+function optionalList(name: string): string[] | undefined {
+  const value = optionalEnv(name);
+  if (!value) return undefined;
+  return value
+    .split(/[\s,]+/)
+    .map((part) => part.trim())
+    .filter(Boolean);
+}
+
+function requiredEnv(name: string): string {
+  const value = optionalEnv(name);
+  if (!value) {
+    throw new Error(`${name} is required`);
+  }
+  return value;
+}
+
+function stringEnv(name: string, fallback: string): string {
+  return optionalEnv(name) ?? fallback;
+}
+
+function numberEnv(name: string, fallback: number): number {
+  return optionalNumberEnv(name) ?? fallback;
+}
+
+function optionalNumberEnv(name: string): number | undefined {
+  const value = optionalEnv(name);
+  if (!value) return undefined;
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new Error(`${name} must be a positive integer`);
+  }
+  return parsed;
+}
+
+function log(level: string, message: string, data?: unknown): void {
+  console.log(
+    JSON.stringify({
+      level,
+      service: "telegrambot",
+      timestamp: new Date().toISOString(),
+      event: message,
+      ...(data && typeof data === "object"
+        ? (data as Record<string, unknown>)
+        : {}),
+    }),
+  );
+}

--- a/services/telegrambot/src/session-api.ts
+++ b/services/telegrambot/src/session-api.ts
@@ -1,5 +1,6 @@
 import type { RustSessionStreamEvent } from "@centaur/harness-events";
 import type { TelegramApi } from "./telegram-api";
+import { deriveClientMessageId } from "./telegram-threading";
 import type {
   JsonObject,
   JsonValue,
@@ -142,12 +143,14 @@ type ForwardSessionApiCallbacks = {
 };
 
 /**
- * Stable append/execute idempotency key for a Telegram message. Must stay in
- * lockstep with the inbox `client_message_id` contract in types.ts
- * (`telegram:{chatId}:{messageId}`).
+ * Stable append/execute idempotency key for a Telegram message. Delegates to
+ * telegram-threading's deriveClientMessageId so there is exactly ONE canonical
+ * derivation of the `telegram:{chatId}:{messageId}` key — the inbox
+ * `client_message_id`, the session append `client_message_id`, and the execute
+ * `idempotency_key` must never be able to drift apart.
  */
 export function telegramClientMessageId(message: TelegramMessage): string {
-  return `telegram:${message.chat.id}:${message.message_id}`;
+  return deriveClientMessageId(message);
 }
 
 // Telegram analog of discordbot's isContentlessApiMessage: sticker-only,

--- a/services/telegrambot/src/session-api.ts
+++ b/services/telegrambot/src/session-api.ts
@@ -1,0 +1,1209 @@
+import type { RustSessionStreamEvent } from "@centaur/harness-events";
+import type { TelegramApi } from "./telegram-api";
+import type {
+  JsonObject,
+  JsonValue,
+  Logger,
+  TelegramChat,
+  TelegramMessage,
+  TelegramPhotoSize,
+  TelegrambotAppendMessagesRequest,
+  TelegrambotCreateSessionRequest,
+  TelegrambotExecuteSessionRequest,
+  TelegrambotExecuteSessionResponse,
+  TelegrambotOptions,
+  TelegrambotRendererSource,
+  TelegrambotSessionMessage,
+  TelegrambotTrace,
+} from "./types";
+import {
+  elapsedMs,
+  errorMessage,
+  isJsonObject,
+  noopLogger,
+  nowMs,
+  stringValue,
+  toAsyncIterable,
+  traceLog,
+} from "./utils";
+
+export class SessionApiError extends Error {
+  readonly action: string;
+  readonly body: string;
+  readonly retryable: boolean;
+  readonly status: number;
+  readonly statusText: string;
+
+  constructor(input: {
+    action: string;
+    body: string;
+    retryable: boolean;
+    status: number;
+    statusText: string;
+  }) {
+    // api-rs error bodies can carry internals; keep them out of the message,
+    // which is surfaced verbatim into the user-facing Telegram chat.
+    super(
+      `Centaur session ${input.action} failed: ${input.status} ${input.statusText}`,
+    );
+    this.name = "SessionApiError";
+    this.action = input.action;
+    this.body = input.body;
+    this.retryable = input.retryable;
+    this.status = input.status;
+    this.statusText = input.statusText;
+  }
+}
+
+export function isRetryableSessionApiError(error: unknown): boolean {
+  if (error instanceof SessionApiError) return error.retryable;
+  if (!(error instanceof Error)) return false;
+  return error.name === "AbortError" || error.name === "TypeError";
+}
+
+// ---------------------------------------------------------------------------
+// Serialized message shapes (Telegram delta: no Chat SDK adapter exists for
+// Telegram, so the intermediate ApiMessage/ApiAttachment shapes the discordbot
+// keeps in types.ts live here, next to the only code that produces them).
+// ---------------------------------------------------------------------------
+
+export type TelegramApiAuthor = {
+  fullName: string;
+  isBot: boolean | "unknown";
+  isMe: boolean;
+  userId: string;
+  userName: string;
+};
+
+export type TelegramApiAttachment = {
+  dataBase64?: string;
+  dataBase64Omitted?: string;
+  fetchError?: string;
+  height?: number;
+  mimeType?: string;
+  name?: string;
+  size?: number;
+  type: "image" | "file";
+  url?: string;
+  width?: number;
+};
+
+export type TelegramApiMessage = {
+  attachments: TelegramApiAttachment[];
+  author: TelegramApiAuthor;
+  /** Stable idempotency key `telegram:{chatId}:{messageId}` (see below). */
+  id: string;
+  isMention: boolean;
+  raw: unknown;
+  text: string;
+  threadId: string;
+  timestamp: string;
+};
+
+/**
+ * Descriptive/routing context sent with EVERY create-session call: api-rs
+ * re-upserts the principal on each create, so omitting a field on a later
+ * create would erase it. Principal *selection* comes from the typed thread
+ * key, never from this metadata.
+ */
+export type TelegramSessionCreateContext = {
+  /** Display name for the principal (chat title, or the DM peer's name). */
+  conversationName: string;
+  chatType: TelegramChat["type"];
+  /** Telegram numeric user id of the triggering user, as a string. */
+  userId: string;
+  /** Forum/private topic id; omitted from metadata when absent. */
+  messageThreadId?: number;
+};
+
+export type ForwardSessionInput = {
+  afterEventId: number;
+  create: TelegramSessionCreateContext;
+  executionId?: string;
+  executeMessage?: TelegramApiMessage;
+  messages: TelegramApiMessage[];
+  onEventId(eventId: number): void;
+  openStream: boolean;
+  threadKey: string;
+  trace?: TelegrambotTrace;
+};
+
+type ForwardSessionApiCallbacks = {
+  onExecutionStarted?(
+    execution: TelegrambotExecuteSessionResponse,
+  ): Promise<void>;
+  /**
+   * Telegram delta: discordbot ignores the append response body, but the
+   * telegram poller must correlate `session.steering_delivered.message_ids`
+   * (server-assigned `msg_…` ids) with the messages it appended, so the ids
+   * returned by POST /messages are handed back here.
+   */
+  onMessagesAppended?(messageIds: string[]): Promise<void>;
+};
+
+/**
+ * Stable append/execute idempotency key for a Telegram message. Must stay in
+ * lockstep with the inbox `client_message_id` contract in types.ts
+ * (`telegram:{chatId}:{messageId}`).
+ */
+export function telegramClientMessageId(message: TelegramMessage): string {
+  return `telegram:${message.chat.id}:${message.message_id}`;
+}
+
+// Telegram analog of discordbot's isContentlessApiMessage: sticker-only,
+// location, poll, and service messages serialize to empty text with no
+// supported attachments; executing them would fabricate a synthetic
+// "continue" turn. Callers skip execution instead.
+export function isContentlessApiMessage(message: TelegramApiMessage): boolean {
+  return message.text.trim() === "" && message.attachments.length === 0;
+}
+
+/**
+ * Build the session ApiMessage from a raw Telegram message. Text falls back
+ * to the media caption; author metadata comes from `from` (the threading
+ * gate has already rejected `from`-less and `sender_chat` messages, so the
+ * fallbacks here are defensive, not a policy path). `isMe` is always false:
+ * self-messages are rejected upstream and Telegram bots never receive their
+ * own sends via getUpdates.
+ */
+export function serializeTelegramMessage(
+  message: TelegramMessage,
+  threadKey: string,
+  options: {
+    attachments?: TelegramApiAttachment[];
+    isMention?: boolean;
+  } = {},
+): TelegramApiMessage {
+  const from = message.from;
+  const fullName = [from?.first_name, from?.last_name]
+    .filter(Boolean)
+    .join(" ");
+  const userId = from ? String(from.id) : "unknown";
+  return {
+    attachments: options.attachments ?? [],
+    author: {
+      fullName: fullName || from?.username || userId,
+      isBot: from ? from.is_bot : "unknown",
+      isMe: false,
+      userId,
+      userName: from?.username ?? userId,
+    },
+    id: telegramClientMessageId(message),
+    isMention: options.isMention ?? true,
+    raw: message,
+    text: message.text ?? message.caption ?? "",
+    threadId: threadKey,
+    timestamp: new Date(message.date * 1000).toISOString(),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Attachment ingest
+// ---------------------------------------------------------------------------
+
+/**
+ * Telegram delta: discordbot inlines up to 100MB because Discord CDN objects
+ * are already vetted by Discord's own upload limits; Telegram `getFile` only
+ * serves files ≤20MB anyway, and the ingest cap is deliberately tighter.
+ */
+export const MAX_TELEGRAM_ATTACHMENT_BYTES = 10 * 1024 * 1024;
+
+/**
+ * A single Telegram message carries at most one photo (the `photo` array is
+ * one image at several sizes) and one document today, so this cap is
+ * future-proofing against richer update kinds, not a live constraint.
+ */
+export const MAX_TELEGRAM_ATTACHMENTS = 5;
+
+export type TelegramAttachmentCandidate = {
+  fileId: string;
+  fileUniqueId: string;
+  height?: number;
+  mimeType?: string;
+  name: string;
+  size?: number;
+  type: "image" | "file";
+  width?: number;
+};
+
+/**
+ * Downloadable attachments on a message: the largest rendition of `photo`
+ * (smaller ones are the same image) plus `document`. Exported so callers can
+ * check for media before paying for downloads.
+ */
+export function telegramAttachmentCandidates(
+  message: TelegramMessage,
+): TelegramAttachmentCandidate[] {
+  const candidates: TelegramAttachmentCandidate[] = [];
+  const photo = largestPhotoSize(message.photo);
+  if (photo) {
+    candidates.push({
+      fileId: photo.file_id,
+      fileUniqueId: photo.file_unique_id,
+      height: photo.height,
+      // Telegram re-encodes all photos as JPEG.
+      mimeType: "image/jpeg",
+      name: `photo-${photo.file_unique_id}.jpg`,
+      size: photo.file_size,
+      type: "image",
+      width: photo.width,
+    });
+  }
+  const document = message.document;
+  if (document) {
+    candidates.push({
+      fileId: document.file_id,
+      fileUniqueId: document.file_unique_id,
+      mimeType: document.mime_type,
+      name: document.file_name ?? `document-${document.file_unique_id}`,
+      size: document.file_size,
+      type: "file",
+    });
+  }
+  return candidates;
+}
+
+function largestPhotoSize(
+  photo: TelegramPhotoSize[] | undefined,
+): TelegramPhotoSize | undefined {
+  if (!photo || photo.length === 0) return undefined;
+  // Documented as ascending, but sort defensively rather than trust ordering.
+  return [...photo].sort((a, b) => a.width * a.height - b.width * b.height)[
+    photo.length - 1
+  ];
+}
+
+/**
+ * Download photo/document attachments via getFile + downloadFile and inline
+ * them as base64 for the staged-attachment scheme in toCodexInputLines.
+ * Per-attachment failures and oversize skips are recorded as `fetchError` on
+ * the serialized attachment (mirroring discordbot) and never thrown, so one
+ * broken file cannot drop the message. TelegramApiError messages are already
+ * token-redacted by the api module.
+ */
+export async function serializeTelegramAttachments(
+  api: TelegramApi,
+  message: TelegramMessage,
+  logger: Logger = noopLogger,
+): Promise<TelegramApiAttachment[]> {
+  return serializeTelegramAttachmentList(
+    api,
+    telegramAttachmentCandidates(message),
+    logger,
+  );
+}
+
+/** Split from serializeTelegramAttachments so the count cap is testable (a real message today yields ≤2 candidates). */
+export async function serializeTelegramAttachmentList(
+  api: TelegramApi,
+  candidates: TelegramAttachmentCandidate[],
+  logger: Logger = noopLogger,
+): Promise<TelegramApiAttachment[]> {
+  const attachments: TelegramApiAttachment[] = [];
+  for (const [index, candidate] of candidates.entries()) {
+    if (index >= MAX_TELEGRAM_ATTACHMENTS) {
+      logger.warn("telegrambot_attachment_skipped_cap", {
+        file_unique_id: candidate.fileUniqueId,
+        attachment_count: candidates.length,
+        cap: MAX_TELEGRAM_ATTACHMENTS,
+      });
+      attachments.push({
+        ...baseAttachment(candidate),
+        fetchError: `attachment skipped: message exceeds the ${MAX_TELEGRAM_ATTACHMENTS}-attachment cap`,
+      });
+      continue;
+    }
+    attachments.push(await downloadAttachment(api, candidate, logger));
+  }
+  return attachments;
+}
+
+async function downloadAttachment(
+  api: TelegramApi,
+  candidate: TelegramAttachmentCandidate,
+  logger: Logger,
+): Promise<TelegramApiAttachment> {
+  const serialized = baseAttachment(candidate);
+  if (
+    typeof candidate.size === "number" &&
+    candidate.size > MAX_TELEGRAM_ATTACHMENT_BYTES
+  ) {
+    logger.warn("telegrambot_attachment_skipped_oversized", {
+      file_unique_id: candidate.fileUniqueId,
+      declared_bytes: candidate.size,
+    });
+    serialized.fetchError = attachmentTooLargeError(candidate.size);
+    return serialized;
+  }
+
+  try {
+    const file = await api.getFile(candidate.fileId);
+    if (!file.file_path) {
+      serialized.fetchError = "telegram getFile returned no file_path";
+      return serialized;
+    }
+    const bytes = await api.downloadFile(file.file_path);
+    // Re-check the actual byte count: Telegram size metadata can be absent.
+    if (bytes.byteLength > MAX_TELEGRAM_ATTACHMENT_BYTES) {
+      logger.warn("telegrambot_attachment_skipped_oversized", {
+        file_unique_id: candidate.fileUniqueId,
+        actual_bytes: bytes.byteLength,
+      });
+      serialized.fetchError = attachmentTooLargeError(bytes.byteLength);
+      return serialized;
+    }
+    serialized.size = bytes.byteLength;
+    serialized.dataBase64 = Buffer.from(bytes).toString("base64");
+  } catch (error) {
+    serialized.fetchError = errorMessage(error);
+    logger.warn("telegrambot_attachment_fetch_failed", {
+      file_unique_id: candidate.fileUniqueId,
+      error: serialized.fetchError,
+    });
+  }
+  return serialized;
+}
+
+function baseAttachment(
+  candidate: TelegramAttachmentCandidate,
+): TelegramApiAttachment {
+  return {
+    height: candidate.height,
+    mimeType: candidate.mimeType,
+    name: candidate.name,
+    size: candidate.size,
+    type: candidate.type,
+    width: candidate.width,
+  };
+}
+
+function attachmentTooLargeError(bytes: number): string {
+  return `attachment too large to inline (${bytes} bytes > ${MAX_TELEGRAM_ATTACHMENT_BYTES} byte limit)`;
+}
+
+// ---------------------------------------------------------------------------
+// Session API client
+// ---------------------------------------------------------------------------
+
+// Note: on Telegram (as on Discord) the execute/openStream tail below is dead
+// code — the live path always calls with `executeMessage: undefined` and runs
+// the execute via `executeSessionTurn` inside the render stream (after the 👀
+// reaction lands). The tail is kept verbatim so 3-way syncs against
+// discordbot/slackbotv2 diff cleanly.
+export async function forwardToSessionApi(
+  options: TelegrambotOptions,
+  input: ForwardSessionInput,
+  callbacks: ForwardSessionApiCallbacks = {},
+): Promise<AsyncIterable<TelegrambotRendererSource> | null> {
+  const createStartedAtMs = nowMs();
+  await createSession(options, input.threadKey, input.create);
+  traceLog(options.logger, "telegrambot_session_create_complete", input.trace, {
+    phase_ms: elapsedMs(createStartedAtMs),
+  });
+  if (input.messages.length > 0) {
+    const appendStartedAtMs = nowMs();
+    const messageIds = await appendSessionMessages(
+      options,
+      input.threadKey,
+      input.messages,
+    );
+    traceLog(
+      options.logger,
+      "telegrambot_session_append_complete",
+      input.trace,
+      {
+        message_count: input.messages.length,
+        phase_ms: elapsedMs(appendStartedAtMs),
+      },
+    );
+    await callbacks.onMessagesAppended?.(messageIds);
+  } else {
+    traceLog(
+      options.logger,
+      "telegrambot_session_append_skipped",
+      input.trace,
+      { message_count: 0 },
+    );
+  }
+  if (!input.executeMessage) return null;
+
+  const executeStartedAtMs = nowMs();
+  const execution = await executeSession(
+    options,
+    input.threadKey,
+    input.executeMessage,
+  );
+  traceLog(
+    options.logger,
+    "telegrambot_session_execute_complete",
+    input.trace,
+    {
+      execution_id: execution.execution_id,
+      phase_ms: elapsedMs(executeStartedAtMs),
+    },
+  );
+  await callbacks.onExecutionStarted?.(execution);
+  if (!input.openStream) return null;
+
+  return openSessionEventStream(options, input);
+}
+
+/**
+ * Execute the session turn on its own (start the agent run), returning the
+ * execution. Split out of forwardToSessionApi so the render stream can run it
+ * AFTER the 👀 working reaction lands — the execute call blocks on cold
+ * sandbox spin-up. Idempotent via the request's idempotency_key (the stable
+ * `telegram:{chatId}:{messageId}` message id), so a render retry or inbox
+ * recovery won't re-spawn the sandbox.
+ */
+export async function executeSessionTurn(
+  options: TelegrambotOptions,
+  input: ForwardSessionInput,
+): Promise<TelegrambotExecuteSessionResponse | null> {
+  if (!input.executeMessage) return null;
+  const executeStartedAtMs = nowMs();
+  const execution = await executeSession(
+    options,
+    input.threadKey,
+    input.executeMessage,
+  );
+  traceLog(
+    options.logger,
+    "telegrambot_session_execute_complete",
+    input.trace,
+    {
+      execution_id: execution.execution_id,
+      phase_ms: elapsedMs(executeStartedAtMs),
+    },
+  );
+  return execution;
+}
+
+export async function openSessionEventStream(
+  options: TelegrambotOptions,
+  input: Pick<
+    ForwardSessionInput,
+    "afterEventId" | "executionId" | "onEventId" | "threadKey" | "trace"
+  >,
+): Promise<AsyncIterable<TelegrambotRendererSource>> {
+  const streamStartedAtMs = nowMs();
+  const stream = await streamSessionNotifications(
+    options,
+    input.threadKey,
+    input.afterEventId,
+    input.executionId,
+    input.onEventId,
+  );
+  traceLog(options.logger, "telegrambot_session_events_opened", input.trace, {
+    after_event_id: input.afterEventId,
+    execution_id: input.executionId,
+    phase_ms: elapsedMs(streamStartedAtMs),
+  });
+  return stream;
+}
+
+// Deliberate delta from slackbotv2 (kept from the Discord port): the synthetic
+// starting item primes the mapper's task state so answer deltas stream
+// immediately instead of waiting out the pre-stream grace period.
+export function startingStreamNotification(threadKey: string): JsonObject {
+  return {
+    method: "item/started",
+    params: {
+      threadId: threadKey,
+      turnId: "telegrambot-starting-turn",
+      startedAtMs: Date.now(),
+      item: {
+        id: "telegrambot-starting",
+        memoryCitation: null,
+        phase: "commentary",
+        text: "",
+        type: "agentMessage",
+      },
+    },
+  };
+}
+
+export function sessionStreamError(error: unknown): RustSessionStreamEvent {
+  return {
+    data: { error: error instanceof Error ? error.message : String(error) },
+    event: "session.stream_error",
+    eventKind: "session.stream_error",
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Steering events
+// ---------------------------------------------------------------------------
+
+/**
+ * Event names verified against api-rs
+ * `centaur-session-runtime/src/lib.rs` (`forward_messages_to_active_execution`
+ * / `record_steering_failure`):
+ *
+ * - `session.steering_delivered` data:
+ *   `{ execution_id, thread_key, message_ids, input_line_count }`
+ * - `session.steering_failed` data:
+ *   `{ execution_id, thread_key, error }`
+ *
+ * `message_ids` are the server-assigned `msg_…` ids the append route returns
+ * as `message_ids` — NOT the client_message_ids — which is why
+ * appendSessionMessages surfaces the append response ids to its caller.
+ */
+export const SESSION_STEERING_DELIVERED_EVENT = "session.steering_delivered";
+export const SESSION_STEERING_FAILED_EVENT = "session.steering_failed";
+
+export function isSteeringDeliveredEvent(
+  source: TelegrambotRendererSource,
+): boolean {
+  return sourceEventKind(source) === SESSION_STEERING_DELIVERED_EVENT;
+}
+
+export function isSteeringFailedEvent(
+  source: TelegrambotRendererSource,
+): boolean {
+  return sourceEventKind(source) === SESSION_STEERING_FAILED_EVENT;
+}
+
+/** Server-assigned session message ids a steering_delivered event covers ([] otherwise). */
+export function steeringDeliveredMessageIds(
+  source: TelegrambotRendererSource,
+): string[] {
+  if (!isSteeringDeliveredEvent(source)) return [];
+  const data = sourceEventData(source);
+  if (!isJsonObject(data) || !Array.isArray(data.message_ids)) return [];
+  return data.message_ids.filter(
+    (value): value is string => typeof value === "string",
+  );
+}
+
+export function steeringFailedError(
+  source: TelegrambotRendererSource,
+): string | undefined {
+  if (!isSteeringFailedEvent(source)) return undefined;
+  const data = sourceEventData(source);
+  if (!isJsonObject(data)) return undefined;
+  return stringValue(data.error);
+}
+
+function sourceEventKind(
+  source: TelegrambotRendererSource,
+): string | undefined {
+  if (!source || typeof source !== "object") return undefined;
+  const record = source as { event?: unknown; eventKind?: unknown };
+  if (typeof record.eventKind === "string") return record.eventKind;
+  if (typeof record.event === "string") return record.event;
+  return undefined;
+}
+
+function sourceEventData(source: TelegrambotRendererSource): unknown {
+  if (!source || typeof source !== "object") return undefined;
+  return (source as { data?: unknown }).data;
+}
+
+// ---------------------------------------------------------------------------
+// HTTP calls
+// ---------------------------------------------------------------------------
+
+async function createSession(
+  options: TelegrambotOptions,
+  threadKey: string,
+  create: TelegramSessionCreateContext,
+): Promise<void> {
+  const fetchFn = options.fetch ?? fetch;
+  const name = create.conversationName.trim();
+  const body: TelegrambotCreateSessionRequest = {
+    harness_type: options.harnessType ?? "codex",
+    metadata: {
+      source: "telegrambot",
+      platform: "telegram",
+      thread_id: threadKey,
+      // api-rs reads this as the session principal's display name; a blank
+      // name is omitted rather than upserted over a previous good one.
+      ...(name ? { telegram_conversation_name: name } : {}),
+      telegram_chat_type: create.chatType,
+      user_id: create.userId,
+      ...(create.messageThreadId === undefined
+        ? {}
+        : { message_thread_id: create.messageThreadId }),
+    },
+  };
+  const response = await fetchFn(apiSessionUrl(options.apiUrl, threadKey), {
+    method: "POST",
+    headers: apiHeaders(options),
+    body: JSON.stringify(body),
+  });
+  await ensureApiOk(response, "create session", options);
+}
+
+/** Returns the server-assigned `msg_…` ids (see steering doc above); [] when the response body is unreadable. */
+async function appendSessionMessages(
+  options: TelegrambotOptions,
+  threadKey: string,
+  messages: TelegramApiMessage[],
+): Promise<string[]> {
+  const fetchFn = options.fetch ?? fetch;
+  const body: TelegrambotAppendMessagesRequest = {
+    messages: messages.map(toSessionMessage),
+  };
+  const response = await fetchFn(
+    apiSessionUrl(options.apiUrl, threadKey, "messages"),
+    {
+      method: "POST",
+      headers: apiHeaders(options),
+      body: JSON.stringify(body),
+    },
+  );
+  await ensureApiOk(response, "append session messages", options);
+  try {
+    const payload: unknown = await response.json();
+    if (isJsonObject(payload) && Array.isArray(payload.message_ids)) {
+      return payload.message_ids.filter(
+        (value): value is string => typeof value === "string",
+      );
+    }
+  } catch {
+    // Correlation degrades gracefully: without ids the poller falls back to
+    // resolving steering_pending rows on execution termination.
+  }
+  return [];
+}
+
+async function executeSession(
+  options: TelegrambotOptions,
+  threadKey: string,
+  message: TelegramApiMessage,
+): Promise<TelegrambotExecuteSessionResponse> {
+  const fetchFn = options.fetch ?? fetch;
+  const body: TelegrambotExecuteSessionRequest = {
+    idempotency_key: message.id,
+    metadata: sessionMetadata(message, { action: "execute" }),
+    input_lines: toCodexInputLines(message, threadKey),
+    ...(options.idleTimeoutMs === undefined
+      ? {}
+      : { idle_timeout_ms: options.idleTimeoutMs }),
+    ...(options.maxDurationMs === undefined
+      ? {}
+      : { max_duration_ms: options.maxDurationMs }),
+  };
+  const response = await fetchFn(
+    apiSessionUrl(options.apiUrl, threadKey, "execute"),
+    {
+      method: "POST",
+      headers: apiHeaders(options),
+      body: JSON.stringify(body),
+    },
+  );
+  await ensureApiOk(response, "execute session", options);
+  return (await response.json()) as TelegrambotExecuteSessionResponse;
+}
+
+async function ensureApiOk(
+  response: Response,
+  action: string,
+  options: TelegrambotOptions,
+): Promise<void> {
+  if (response.ok) return;
+  let body = "";
+  try {
+    body = await response.text();
+  } catch {
+    body = "";
+  }
+  // api-rs is internal and unauthenticated; its error bodies can carry stack
+  // traces, internal hostnames, or echoed payloads. Log the full body
+  // server-side, but the thrown message stays generic — it is surfaced
+  // verbatim into the user-facing chat via sessionStreamError.
+  if (body) {
+    (options.logger ?? noopLogger).warn("telegrambot_session_api_error", {
+      action,
+      status: response.status,
+      status_text: response.statusText,
+      body,
+    });
+  }
+  throw new SessionApiError({
+    action,
+    body,
+    retryable: isRetryableApiStatus(response.status),
+    status: response.status,
+    statusText: response.statusText,
+  });
+}
+
+function isRetryableApiStatus(status: number): boolean {
+  return status === 408 || status === 425 || status === 429 || status >= 500;
+}
+
+async function streamSessionNotifications(
+  options: TelegrambotOptions,
+  threadKey: string,
+  afterEventId: number,
+  executionId: string | undefined,
+  onEventId: (eventId: number) => void,
+): Promise<AsyncIterable<TelegrambotRendererSource>> {
+  const fetchFn = options.fetch ?? fetch;
+  const url = new URL(apiSessionUrl(options.apiUrl, threadKey, "events"));
+  url.searchParams.set("after_event_id", String(afterEventId));
+  if (executionId) url.searchParams.set("execution_id", executionId);
+  const response = await fetchFn(url.toString(), {
+    method: "GET",
+    headers: apiHeaders(options, false),
+  });
+  await ensureApiOk(response, "stream events", options);
+  if (!response.body) return toAsyncIterable([]);
+  return parseSessionEventStream(response.body, onEventId);
+}
+
+function apiSessionUrl(
+  apiUrl: string,
+  threadKey: string,
+  suffix?: "messages" | "execute" | "events",
+): string {
+  const path = `/api/session/${encodeURIComponent(threadKey)}${suffix ? `/${suffix}` : ""}`;
+  return new URL(path, ensureTrailingSlash(apiUrl)).toString();
+}
+
+function ensureTrailingSlash(value: string): string {
+  return value.endsWith("/") ? value : `${value}/`;
+}
+
+function apiHeaders(
+  options: TelegrambotOptions,
+  jsonBody = true,
+): HeadersInit {
+  const apiKey = options.apiKey ?? process.env.TELEGRAMBOT_API_KEY;
+  return {
+    ...(jsonBody ? { "content-type": "application/json" } : {}),
+    ...(apiKey ? { authorization: `Bearer ${apiKey}` } : {}),
+  };
+}
+
+function toSessionMessage(
+  message: TelegramApiMessage,
+): TelegrambotSessionMessage {
+  return {
+    client_message_id: message.id,
+    role: message.author.isMe ? "assistant" : "user",
+    parts: sessionMessageParts(message),
+    metadata: sessionMetadata(message),
+  };
+}
+
+function sessionMessageParts(message: TelegramApiMessage): JsonValue[] {
+  const parts: JsonValue[] = [];
+  if (message.text.trim()) {
+    parts.push({ type: "text", text: message.text });
+  }
+  for (const attachment of message.attachments) {
+    parts.push(sessionAttachmentPart(attachment));
+  }
+  return parts.length > 0 ? parts : [{ type: "text", text: "" }];
+}
+
+function sessionAttachmentPart(attachment: TelegramApiAttachment): JsonObject {
+  const part: JsonObject = {
+    ...attachment,
+    attachment_type: attachment.type,
+    type: "attachment",
+  };
+  // Don't persist megabytes of base64 in the stored session message; the
+  // executing turn delivers the bytes separately (inline or staged chunks).
+  if (
+    typeof attachment.dataBase64 === "string" &&
+    attachment.dataBase64.length > MAX_CODEX_INPUT_LINE_CHARS
+  ) {
+    delete part.dataBase64;
+    part.dataBase64Omitted = `${attachment.dataBase64.length} base64 chars omitted from stored session message`;
+  }
+  return part;
+}
+
+function sessionMetadata(
+  message: TelegramApiMessage,
+  extra: JsonObject = {},
+): JsonObject {
+  return {
+    source: "telegrambot",
+    platform: "telegram",
+    message_id: message.id,
+    thread_id: message.threadId,
+    is_mention: message.isMention,
+    timestamp: message.timestamp,
+    user_id: message.author.userId,
+    user_name: message.author.userName,
+    ...extra,
+  };
+}
+
+/**
+ * Largest JSON codex input line we will emit. A `data:` URL inlined directly
+ * in the user message blows past this for larger images, so anything bigger
+ * is delivered out-of-band as `attachment.chunk` lines and referenced by a
+ * staged attachment id (mirrors discordbot/slackbotv2).
+ */
+const MAX_CODEX_INPUT_LINE_CHARS = 900 * 1024;
+const STAGED_ATTACHMENT_CHUNK_CHARS = 700 * 1024;
+
+/**
+ * Build the codex input lines for an execute turn. Attachments whose inlined
+ * `data:` URL would push the user-message line past `MAX_CODEX_INPUT_LINE_CHARS`
+ * are streamed ahead of it as `attachment.chunk` lines and referenced by a
+ * staged attachment id; everything else stays inline.
+ */
+export function toCodexInputLines(
+  message: TelegramApiMessage,
+  threadKey: string,
+): string[] {
+  const staged = new Map<TelegramApiAttachment, string>();
+  const lines: string[] = [];
+  for (const attachment of message.attachments) {
+    if (!attachment.dataBase64) continue;
+    const inlineLine = toCodexInputLineWithStaged(message, threadKey, staged);
+    if (
+      inlineLine.length <= MAX_CODEX_INPUT_LINE_CHARS &&
+      attachment.dataBase64.length <= MAX_CODEX_INPUT_LINE_CHARS
+    ) {
+      continue;
+    }
+    const stagedAttachmentId = `att-${message.id}-${staged.size + 1}`;
+    staged.set(attachment, stagedAttachmentId);
+    lines.push(...stagedAttachmentInputLines(attachment, stagedAttachmentId));
+  }
+  lines.push(toCodexInputLineWithStaged(message, threadKey, staged));
+  return lines;
+}
+
+function toCodexInputLineWithStaged(
+  message: TelegramApiMessage,
+  threadKey: string,
+  staged: Map<TelegramApiAttachment, string>,
+): string {
+  return JSON.stringify({
+    type: "user",
+    thread_key: threadKey,
+    trace_metadata: sessionMetadata(message, { action: "execute" }),
+    message: {
+      role: "user",
+      content: codexInputContent(message, staged),
+    },
+  });
+}
+
+function stagedAttachmentInputLines(
+  attachment: TelegramApiAttachment,
+  stagedAttachmentId: string,
+): string[] {
+  const dataBase64 = attachment.dataBase64;
+  if (!dataBase64) return [];
+  const lines: string[] = [];
+  // Keep chunks on a base64 boundary (multiple of 4) so each decodes cleanly.
+  const chunkSize =
+    STAGED_ATTACHMENT_CHUNK_CHARS - (STAGED_ATTACHMENT_CHUNK_CHARS % 4);
+  for (
+    let offset = 0, index = 0;
+    offset < dataBase64.length;
+    offset += chunkSize, index += 1
+  ) {
+    const chunk = dataBase64.slice(offset, offset + chunkSize);
+    lines.push(
+      JSON.stringify({
+        type: "attachment.chunk",
+        attachmentId: stagedAttachmentId,
+        name: attachment.name,
+        mimeType: attachment.mimeType,
+        attachmentType: attachment.type,
+        chunkIndex: index,
+        final: offset + chunkSize >= dataBase64.length,
+        dataBase64: chunk,
+      }),
+    );
+  }
+  return lines;
+}
+
+function codexInputContent(
+  message: TelegramApiMessage,
+  staged: Map<TelegramApiAttachment, string> = new Map(),
+): JsonValue[] {
+  const content: JsonValue[] = [];
+  if (message.text.trim()) {
+    content.push({ type: "text", text: message.text });
+  }
+  for (const attachment of message.attachments) {
+    content.push(codexAttachmentInput(attachment, staged.get(attachment)));
+  }
+  return content.length > 0 ? content : [{ type: "text", text: "continue" }];
+}
+
+export function codexAttachmentInput(
+  attachment: TelegramApiAttachment,
+  stagedAttachmentId?: string,
+): JsonValue {
+  if (stagedAttachmentId) {
+    return {
+      type: "attachment",
+      attachment_type: attachment.type,
+      stagedAttachmentId,
+      name: attachment.name,
+      mimeType: attachment.mimeType,
+      size: attachment.size,
+    };
+  }
+  const dataUrl =
+    attachment.dataBase64 && attachment.mimeType
+      ? `data:${attachment.mimeType};base64,${attachment.dataBase64}`
+      : undefined;
+  if (attachment.type === "image" && (dataUrl || attachment.url)) {
+    return {
+      type: "image",
+      url: dataUrl ?? attachment.url,
+      detail: "auto",
+      name: attachment.name,
+    };
+  }
+  if (attachment.dataBase64) {
+    return {
+      type: "attachment",
+      attachment_type: attachment.type,
+      dataBase64: attachment.dataBase64,
+      mimeType: attachment.mimeType,
+      name: attachment.name,
+      size: attachment.size,
+    };
+  }
+  return {
+    type: "text",
+    text: attachmentDescription(attachment),
+  };
+}
+
+function attachmentDescription(attachment: TelegramApiAttachment): string {
+  const fields = [
+    `name=${attachment.name ?? "attachment"}`,
+    `type=${attachment.type}`,
+    attachment.mimeType ? `mime=${attachment.mimeType}` : undefined,
+    attachment.dataBase64Omitted
+      ? `content=${attachment.dataBase64Omitted}`
+      : undefined,
+    attachment.fetchError ? `fetch_error=${attachment.fetchError}` : undefined,
+  ].filter(Boolean);
+  return `[Telegram attachment: ${fields.join(" ")}]`;
+}
+
+// ---------------------------------------------------------------------------
+// SSE parsing
+// ---------------------------------------------------------------------------
+
+type ParsedSessionEvent = {
+  data: string;
+  event?: string;
+  id?: number;
+};
+
+async function* parseSessionEventStream(
+  stream: ReadableStream<Uint8Array>,
+  onEventId: (eventId: number) => void,
+): AsyncIterable<TelegrambotRendererSource> {
+  for await (const event of parseSseEvents(stream)) {
+    if (typeof event.id === "number") onEventId(event.id);
+    if (event.event === "session.output.line") {
+      yield {
+        data: event.data,
+        event: event.event,
+        eventId: event.id,
+        eventKind: event.event,
+      } satisfies RustSessionStreamEvent;
+      if (isTerminalCodexOutputLine(event.data)) return;
+      continue;
+    }
+    if (event.event === "session.activity_summary") {
+      yield {
+        data: sessionEventData(event),
+        event: event.event,
+        eventId: event.id,
+        eventKind: event.event,
+      } satisfies RustSessionStreamEvent;
+      continue;
+    }
+    // Telegram delta: discordbot drops steering events on the floor; here
+    // they must reach the consumer so the inbox can resolve steering_pending
+    // rows (delivered) or reschedule the message (failed). Non-terminal.
+    if (
+      event.event === SESSION_STEERING_DELIVERED_EVENT ||
+      event.event === SESSION_STEERING_FAILED_EVENT
+    ) {
+      yield {
+        data: sessionEventData(event),
+        event: event.event,
+        eventId: event.id,
+        eventKind: event.event,
+      } satisfies RustSessionStreamEvent;
+      continue;
+    }
+    if (
+      event.event === "session.execution_failed" ||
+      event.event === "session.stream_error"
+    ) {
+      yield {
+        data: { error: sessionErrorMessage(event) },
+        event: event.event,
+        eventId: event.id,
+        eventKind: event.event,
+      } satisfies RustSessionStreamEvent;
+      return;
+    }
+    if (event.event === "session.execution_cancelled") {
+      yield {
+        data: { error: sessionErrorMessage(event, "Execution cancelled") },
+        event: event.event,
+        eventId: event.id,
+        eventKind: event.event,
+      } satisfies RustSessionStreamEvent;
+      return;
+    }
+    if (event.event === "session.execution_completed") {
+      yield {
+        data: sessionEventData(event),
+        event: event.event,
+        eventId: event.id,
+        eventKind: event.event,
+      } satisfies RustSessionStreamEvent;
+      return;
+    }
+  }
+}
+
+async function* parseSseEvents(
+  stream: ReadableStream<Uint8Array>,
+): AsyncIterable<ParsedSessionEvent> {
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+  let eventName: string | undefined;
+  let eventId: number | undefined;
+  let data: string[] = [];
+
+  // The consumer returns early on terminal events, abandoning this generator
+  // at a yield point. Without the finally, the reader lock is never released
+  // and the HTTP response body is never cancelled, leaking the SSE connection
+  // on every completed run (kept from the Discord port).
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      const lines = buffer.split(/\r?\n/);
+      buffer = lines.pop() ?? "";
+
+      for (const line of lines) {
+        const emitted = parseSseLine(line, { data, eventId, eventName });
+        data = emitted.state.data;
+        eventId = emitted.state.eventId;
+        eventName = emitted.state.eventName;
+        if (emitted.event) yield emitted.event;
+      }
+    }
+
+    buffer += decoder.decode();
+    if (buffer) {
+      const emitted = parseSseLine(buffer, { data, eventId, eventName });
+      data = emitted.state.data;
+      eventId = emitted.state.eventId;
+      eventName = emitted.state.eventName;
+      if (emitted.event) yield emitted.event;
+    }
+    if (data.length > 0) {
+      yield { data: data.join("\n"), event: eventName, id: eventId };
+    }
+  } finally {
+    await reader.cancel().catch(() => undefined);
+    reader.releaseLock();
+  }
+}
+
+function parseSseLine(
+  line: string,
+  state: {
+    data: string[];
+    eventId?: number;
+    eventName?: string;
+  },
+): {
+  event?: ParsedSessionEvent;
+  state: { data: string[]; eventId?: number; eventName?: string };
+} {
+  if (!line.trim()) {
+    const event =
+      state.data.length > 0
+        ? {
+            data: state.data.join("\n"),
+            event: state.eventName,
+            id: state.eventId,
+          }
+        : undefined;
+    return { event, state: { data: [] } };
+  }
+  if (line.startsWith(":")) return { state };
+
+  const separator = line.indexOf(":");
+  const field = separator >= 0 ? line.slice(0, separator) : line;
+  const value =
+    separator >= 0 ? line.slice(separator + 1).replace(/^ /, "") : "";
+  if (field === "event") return { state: { ...state, eventName: value } };
+  if (field === "id") {
+    const id = Number.parseInt(value, 10);
+    return {
+      state: { ...state, eventId: Number.isFinite(id) ? id : undefined },
+    };
+  }
+  if (field === "data" && value !== "[DONE]") {
+    return { state: { ...state, data: [...state.data, value] } };
+  }
+
+  return { state };
+}
+
+function isTerminalCodexOutputLine(line: string): boolean {
+  let payload: unknown;
+  try {
+    payload = JSON.parse(line);
+  } catch {
+    // Non-JSON stdout lines (e.g. sandbox bootstrap notices) are noise, not a
+    // signal that the turn finished; treating them as terminal drops the answer.
+    return false;
+  }
+  if (!isJsonObject(payload)) return false;
+
+  return (
+    payload.type === "turn.completed" ||
+    payload.type === "turn.failed" ||
+    payload.type === "turn.done" ||
+    payload.method === "error" ||
+    payload.method === "turn/completed"
+  );
+}
+
+function sessionEventData(event: ParsedSessionEvent): unknown {
+  try {
+    return JSON.parse(event.data);
+  } catch {
+    return event.data;
+  }
+}
+
+function sessionErrorMessage(
+  event: ParsedSessionEvent,
+  fallback?: string,
+): string {
+  let message = fallback ?? `${event.event ?? "session error"}`;
+  try {
+    const payload = JSON.parse(event.data);
+    if (isJsonObject(payload)) {
+      message =
+        stringValue(payload.error) ?? stringValue(payload.message) ?? message;
+    }
+  } catch {
+    if (event.data.trim()) message = event.data.trim();
+  }
+  return message;
+}

--- a/services/telegrambot/src/telegram-allowlist.ts
+++ b/services/telegrambot/src/telegram-allowlist.ts
@@ -88,6 +88,27 @@ export function isAllowedTelegramMessage(
   }
 
   if (chat.type === "group" || chat.type === "supergroup") {
+    // Telegram delta: allowlisting a discussion group does not vouch for its
+    // linked channel. Channel posts surface in the group as auto-forwards
+    // (is_automatic_forward) and anonymous-admin/channel-identity messages
+    // carry sender_chat — both bypass per-user identity, so a reply chain off
+    // them could otherwise reach execution without any allowlisted human
+    // sender. Reject both shapes fail-closed.
+    if (message.sender_chat) {
+      logger.warn("telegrambot_message_ignored_sender_chat", {
+        chat_id: String(chat.id),
+        message_id: message.message_id,
+        sender_chat_id: String(message.sender_chat.id),
+      });
+      return false;
+    }
+    if (message.is_automatic_forward) {
+      logger.warn("telegrambot_message_ignored_automatic_forward", {
+        chat_id: String(chat.id),
+        message_id: message.message_id,
+      });
+      return false;
+    }
     const allowlist = resolveChatAllowlist(options);
     if (allowlist.length === 0) {
       logger.warn("telegrambot_message_ignored_allowlist_empty", {

--- a/services/telegrambot/src/telegram-allowlist.ts
+++ b/services/telegrambot/src/telegram-allowlist.ts
@@ -1,0 +1,251 @@
+import type { Logger, TelegramMessage, TelegrambotOptions } from "./types";
+
+/** The only addressed command the bot answers in v1. */
+const TRIGGER_COMMAND = "/ask";
+
+export type TelegramTrigger = "dm" | "reply" | "command";
+
+/**
+ * Allowlist inputs plus the bot's own identity (from getMe), needed to reject
+ * self-echoes before any allowlist logic runs.
+ */
+export type TelegramAllowlistOptions = Pick<
+  TelegrambotOptions,
+  "chatAllowlist" | "userAllowlist"
+> & {
+  botUserId: string;
+};
+
+/**
+ * Authorization gate for inbound Telegram messages.
+ *
+ * Intentionally **fail-closed**, mirroring discord-allowlist: the api-rs
+ * control plane has no ingress auth, so this guard is the primary
+ * authorization boundary and empty allowlists render the bot inert.
+ *
+ * Telegram delta: a bot is world-reachable with no workspace/guild boundary,
+ * so DMs are not open by default — a private chat is allowed only when the
+ * sender's user id is explicitly allowlisted, and groups/supergroups only when
+ * the chat id is. Channel posts are out of scope for v1 and always denied.
+ * Bot-authored and bot-relayed (`via_bot`) messages are rejected even though
+ * Telegram normally withholds other bots' messages — privacy mode is delivery
+ * minimization, not authorization.
+ */
+export function isAllowedTelegramMessage(
+  message: TelegramMessage,
+  options: TelegramAllowlistOptions,
+  logger: Logger,
+): boolean {
+  const { chat, from } = message;
+
+  if (!from) {
+    logger.warn("telegrambot_message_ignored_missing_sender", {
+      chat_id: String(chat.id),
+      message_id: message.message_id,
+    });
+    return false;
+  }
+  if (String(from.id) === String(options.botUserId)) {
+    // Self-echo; routine, so no warn (matches discordbot's silent isMe gate).
+    return false;
+  }
+  if (from.is_bot) {
+    logger.warn("telegrambot_message_ignored_bot_author", {
+      chat_id: String(chat.id),
+      message_id: message.message_id,
+      user_id: String(from.id),
+    });
+    return false;
+  }
+  if (message.via_bot) {
+    logger.warn("telegrambot_message_ignored_via_bot", {
+      chat_id: String(chat.id),
+      message_id: message.message_id,
+      user_id: String(from.id),
+      via_bot_id: String(message.via_bot.id),
+    });
+    return false;
+  }
+
+  if (chat.type === "private") {
+    const allowlist = resolveUserAllowlist(options);
+    if (allowlist.length === 0) {
+      logger.warn("telegrambot_message_ignored_allowlist_empty", {
+        chat_type: chat.type,
+        message_id: message.message_id,
+        user_id: String(from.id),
+      });
+      return false;
+    }
+    if (!new Set(allowlist).has(String(from.id))) {
+      logger.warn("telegrambot_message_ignored_user_not_allowlisted", {
+        message_id: message.message_id,
+        user_id: String(from.id),
+      });
+      return false;
+    }
+    return true;
+  }
+
+  if (chat.type === "group" || chat.type === "supergroup") {
+    const allowlist = resolveChatAllowlist(options);
+    if (allowlist.length === 0) {
+      logger.warn("telegrambot_message_ignored_allowlist_empty", {
+        chat_id: String(chat.id),
+        chat_type: chat.type,
+        message_id: message.message_id,
+      });
+      return false;
+    }
+    if (!new Set(allowlist).has(String(chat.id))) {
+      logger.warn("telegrambot_message_ignored_chat_not_allowlisted", {
+        chat_id: String(chat.id),
+        message_id: message.message_id,
+      });
+      return false;
+    }
+    return true;
+  }
+
+  logger.warn("telegrambot_message_ignored_unsupported_chat_type", {
+    chat_id: String(chat.id),
+    chat_type: chat.type,
+    message_id: message.message_id,
+  });
+  return false;
+}
+
+/**
+ * Whether an *already allowed* message triggers the agent, and how.
+ *
+ * DMs: every allowed message triggers (`"command"` when it is an /ask form so
+ * the caller strips the prefix, `"dm"` otherwise). Groups: only (a) replies
+ * to one of the bot's own messages and (b) the addressed command
+ * `/ask@{botUsername}` carried as a `bot_command` entity at offset 0 — a bare
+ * `/ask` in a group is not addressed to us and may target another bot.
+ *
+ * Telegram delta: plain textual `@botname` mentions deliberately do NOT
+ * trigger. Under privacy mode Telegram does not reliably deliver arbitrary
+ * mention messages to an ordinary non-admin bot, and with privacy off (or an
+ * admin bot) unrelated group traffic IS delivered and must still fail this
+ * gate — so the v1 contract is replies + addressed commands + DMs until the
+ * live privacy-mode acceptance test proves mention delivery (spec §3).
+ * Non-triggering group messages are ignored locally, never executed.
+ */
+export function isTriggerMessage(
+  message: TelegramMessage,
+  botUserId: string,
+  botUsername: string,
+): TelegramTrigger | null {
+  const chatType = message.chat.type;
+
+  if (chatType === "private") {
+    return matchesTriggerCommand(message, botUsername, { allowBare: true })
+      ? "command"
+      : "dm";
+  }
+  if (chatType !== "group" && chatType !== "supergroup") return null;
+
+  const repliedTo = message.reply_to_message?.from;
+  if (repliedTo && String(repliedTo.id) === String(botUserId)) return "reply";
+  if (matchesTriggerCommand(message, botUsername, { allowBare: false })) {
+    return "command";
+  }
+  return null;
+}
+
+/**
+ * Message text with the leading `/ask[@botUsername]` stripped, ready for use
+ * as the session input. Text without a recognized trigger command passes
+ * through trimmed (DM free-text).
+ */
+export function extractCommandText(
+  message: TelegramMessage,
+  botUsername: string,
+): string {
+  const text = message.text ?? "";
+  const command = commandEntityText(message);
+  if (command === undefined) return text.trim();
+  const normalized = command.toLowerCase();
+  const addressed = `${TRIGGER_COMMAND}@${normalizeBotUsername(botUsername)}`;
+  if (normalized !== TRIGGER_COMMAND && normalized !== addressed) {
+    return text.trim();
+  }
+  return text.slice(command.length).trim();
+}
+
+/** Resolved group/supergroup chat allowlist (options first, env fallback). */
+export function resolveChatAllowlist(
+  options: Pick<TelegrambotOptions, "chatAllowlist">,
+): string[] {
+  return [
+    ...(options.chatAllowlist ??
+      splitEnvList(process.env.TELEGRAMBOT_CHAT_ALLOWLIST)),
+  ];
+}
+
+/** Resolved DM user allowlist (options first, env fallback). */
+export function resolveUserAllowlist(
+  options: Pick<TelegrambotOptions, "userAllowlist">,
+): string[] {
+  return [
+    ...(options.userAllowlist ??
+      splitEnvList(process.env.TELEGRAMBOT_USER_ALLOWLIST)),
+  ];
+}
+
+/** True when no group chats are allowlisted and every group message is ignored. */
+export function isChatAllowlistEmpty(
+  options: Pick<TelegrambotOptions, "chatAllowlist">,
+): boolean {
+  return resolveChatAllowlist(options).length === 0;
+}
+
+/** True when no DM users are allowlisted and every private message is ignored. */
+export function isUserAllowlistEmpty(
+  options: Pick<TelegrambotOptions, "userAllowlist">,
+): boolean {
+  return resolveUserAllowlist(options).length === 0;
+}
+
+/**
+ * The command token at the start of the message, taken from an explicit
+ * `bot_command` entity at offset 0. Requiring the entity (rather than
+ * regexing the text) means Telegram itself vouched the token is a command;
+ * entity offsets/lengths are UTF-16 code units, matching String#slice.
+ */
+function commandEntityText(message: TelegramMessage): string | undefined {
+  const text = message.text;
+  if (!text) return undefined;
+  const entity = (message.entities ?? []).find(
+    (candidate) => candidate.type === "bot_command" && candidate.offset === 0,
+  );
+  if (!entity) return undefined;
+  return text.slice(0, entity.length);
+}
+
+function matchesTriggerCommand(
+  message: TelegramMessage,
+  botUsername: string,
+  { allowBare }: { allowBare: boolean },
+): boolean {
+  const command = commandEntityText(message);
+  if (command === undefined) return false;
+  const normalized = command.toLowerCase();
+  if (normalized === `${TRIGGER_COMMAND}@${normalizeBotUsername(botUsername)}`) {
+    return true;
+  }
+  return allowBare && normalized === TRIGGER_COMMAND;
+}
+
+/** Bot usernames compare case-insensitively; tolerate a configured leading @. */
+function normalizeBotUsername(botUsername: string): string {
+  return botUsername.replace(/^@/, "").toLowerCase();
+}
+
+function splitEnvList(value: string | undefined): string[] {
+  return (value ?? "")
+    .split(/[\s,]+/)
+    .map((part) => part.trim())
+    .filter(Boolean);
+}

--- a/services/telegrambot/src/telegram-api.ts
+++ b/services/telegrambot/src/telegram-api.ts
@@ -82,7 +82,12 @@ export type SendMessageParams = {
   text: string;
   parse_mode?: "HTML";
   message_thread_id?: number;
-  reply_parameters?: { message_id: number };
+  reply_parameters?: {
+    message_id: number;
+    /** Send anyway when the replied-to message no longer exists — Telegram
+     * otherwise rejects the whole send, wedging retried deliveries. */
+    allow_sending_without_reply?: boolean;
+  };
   link_preview_options?: { is_disabled?: boolean };
 };
 

--- a/services/telegrambot/src/telegram-api.ts
+++ b/services/telegrambot/src/telegram-api.ts
@@ -1,0 +1,275 @@
+import type {
+  JsonObject,
+  JsonValue,
+  TelegramFile,
+  TelegramMessage,
+  TelegramUpdate,
+  TelegramUser,
+  TelegrambotFetch,
+  TelegrambotOptions,
+} from "./types";
+import { errorMessage } from "./utils";
+
+export const DEFAULT_TELEGRAM_API_URL = "https://api.telegram.org";
+
+/**
+ * Telegram delta: the Bot API embeds the token in the URL path
+ * (`/bot<token>/<method>`), so no error message, log line, or wrapped cause in
+ * this module may ever carry a request URL. Errors are rebuilt from the method
+ * name plus the API's own `description`, and any accidental token occurrence
+ * in an underlying cause is redacted defensively.
+ */
+export class TelegramApiError extends Error {
+  readonly method: string;
+  /** HTTP status (0 for transport-level failures). */
+  readonly status: number;
+  /** Telegram `error_code` when the API returned a structured error. */
+  readonly errorCode: number | undefined;
+  readonly description: string | undefined;
+  /** `parameters.retry_after` from a 429, in seconds. */
+  readonly retryAfterSeconds: number | undefined;
+
+  constructor(input: {
+    method: string;
+    status: number;
+    errorCode?: number;
+    description?: string;
+    retryAfterSeconds?: number;
+  }) {
+    super(
+      `telegram ${input.method} failed: ${input.status}${
+        input.description ? ` ${input.description}` : ""
+      }`,
+    );
+    this.name = "TelegramApiError";
+    this.method = input.method;
+    this.status = input.status;
+    this.errorCode = input.errorCode;
+    this.description = input.description;
+    this.retryAfterSeconds = input.retryAfterSeconds;
+  }
+}
+
+/** 401/404 mean a bad token; 409 means a competing poller/webhook. Both are
+ * configuration faults the process should surface by exiting, not retrying. */
+export function isFatalTelegramAuthError(error: unknown): boolean {
+  return (
+    error instanceof TelegramApiError &&
+    (error.status === 401 || error.status === 404 || error.status === 409)
+  );
+}
+
+export function isTelegramRateLimitError(
+  error: unknown,
+): error is TelegramApiError {
+  return error instanceof TelegramApiError && error.status === 429;
+}
+
+/**
+ * Parse/entity rejections (400 "can't parse entities…") — the render fallback
+ * regenerates plain text instead of resending the same malformed body.
+ */
+export function isTelegramParseError(error: unknown): boolean {
+  return (
+    error instanceof TelegramApiError &&
+    error.status === 400 &&
+    /parse|entit/i.test(error.description ?? "")
+  );
+}
+
+export type SendMessageParams = {
+  chat_id: number | string;
+  text: string;
+  parse_mode?: "HTML";
+  message_thread_id?: number;
+  reply_parameters?: { message_id: number };
+  link_preview_options?: { is_disabled?: boolean };
+};
+
+export type EditMessageTextParams = {
+  chat_id: number | string;
+  message_id: number;
+  text: string;
+  parse_mode?: "HTML";
+  link_preview_options?: { is_disabled?: boolean };
+};
+
+export type SetMessageReactionParams = {
+  chat_id: number | string;
+  message_id: number;
+  reaction: Array<{ type: "emoji"; emoji: string }>;
+};
+
+export type SendChatActionParams = {
+  chat_id: number | string;
+  action: "typing";
+  message_thread_id?: number;
+};
+
+export type GetUpdatesParams = {
+  offset?: number;
+  timeout?: number;
+  allowed_updates?: string[];
+};
+
+export type TelegramApi = {
+  getMe(): Promise<TelegramUser>;
+  getUpdates(
+    params: GetUpdatesParams,
+    signal?: AbortSignal,
+  ): Promise<TelegramUpdate[]>;
+  deleteWebhook(params: { drop_pending_updates: boolean }): Promise<void>;
+  sendMessage(params: SendMessageParams): Promise<TelegramMessage>;
+  editMessageText(params: EditMessageTextParams): Promise<void>;
+  setMessageReaction(params: SetMessageReactionParams): Promise<void>;
+  sendChatAction(params: SendChatActionParams): Promise<void>;
+  getFile(fileId: string): Promise<TelegramFile>;
+  /** Download a file previously located via getFile. */
+  downloadFile(filePath: string, signal?: AbortSignal): Promise<Uint8Array>;
+};
+
+export function createTelegramApi(
+  options: Pick<
+    TelegrambotOptions,
+    "botToken" | "telegramApiUrl" | "fetch" | "pollTimeoutSeconds"
+  >,
+): TelegramApi {
+  const fetchFn: TelegrambotFetch = options.fetch ?? fetch;
+  const apiBase = (options.telegramApiUrl ?? DEFAULT_TELEGRAM_API_URL).replace(
+    /\/$/,
+    "",
+  );
+  const token = options.botToken;
+
+  const call = async <T>(
+    method: string,
+    params?: JsonObject,
+    init?: { signal?: AbortSignal; timeoutMs?: number },
+  ): Promise<T> => {
+    let response: Response;
+    try {
+      response = await fetchFn(`${apiBase}/bot${token}/${method}`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: params ? JSON.stringify(params) : undefined,
+        signal: init?.signal ?? timeoutSignal(init?.timeoutMs),
+      });
+    } catch (error) {
+      // Transport failure: rebuild the message so a URL-bearing cause (which
+      // would include the token) never propagates.
+      throw new TelegramApiError({
+        method,
+        status: 0,
+        description: redactToken(errorMessage(error), token),
+      });
+    }
+
+    let body: {
+      ok?: boolean;
+      result?: JsonValue;
+      description?: string;
+      error_code?: number;
+      parameters?: { retry_after?: number };
+    };
+    try {
+      body = (await response.json()) as typeof body;
+    } catch {
+      throw new TelegramApiError({ method, status: response.status });
+    }
+
+    if (!response.ok || body.ok !== true) {
+      throw new TelegramApiError({
+        method,
+        status: response.status,
+        errorCode: body.error_code,
+        description: body.description,
+        retryAfterSeconds: body.parameters?.retry_after,
+      });
+    }
+    return body.result as T;
+  };
+
+  const pollTimeoutSeconds = options.pollTimeoutSeconds ?? 50;
+
+  return {
+    getMe: () => call<TelegramUser>("getMe", undefined, { timeoutMs: 15_000 }),
+
+    getUpdates: (params, signal) =>
+      call<TelegramUpdate[]>(
+        "getUpdates",
+        { timeout: pollTimeoutSeconds, ...params } as JsonObject,
+        {
+          signal,
+          // Grace beyond the server-side long-poll window so a healthy but
+          // slow response is not aborted at exactly the poll timeout.
+          timeoutMs: ((params.timeout ?? pollTimeoutSeconds) + 15) * 1000,
+        },
+      ),
+
+    deleteWebhook: async (params) => {
+      await call<boolean>("deleteWebhook", params as JsonObject, {
+        timeoutMs: 15_000,
+      });
+    },
+
+    sendMessage: (params) =>
+      call<TelegramMessage>("sendMessage", params as JsonObject, {
+        timeoutMs: 30_000,
+      }),
+
+    editMessageText: async (params) => {
+      await call<JsonValue>("editMessageText", params as JsonObject, {
+        timeoutMs: 30_000,
+      });
+    },
+
+    setMessageReaction: async (params) => {
+      await call<boolean>("setMessageReaction", params as JsonObject, {
+        timeoutMs: 15_000,
+      });
+    },
+
+    sendChatAction: async (params) => {
+      await call<boolean>("sendChatAction", params as JsonObject, {
+        timeoutMs: 15_000,
+      });
+    },
+
+    getFile: (fileId) =>
+      call<TelegramFile>(
+        "getFile",
+        { file_id: fileId },
+        { timeoutMs: 30_000 },
+      ),
+
+    downloadFile: async (filePath, signal) => {
+      let response: Response;
+      try {
+        response = await fetchFn(`${apiBase}/file/bot${token}/${filePath}`, {
+          signal: signal ?? timeoutSignal(60_000),
+        });
+      } catch (error) {
+        throw new TelegramApiError({
+          method: "downloadFile",
+          status: 0,
+          description: redactToken(errorMessage(error), token),
+        });
+      }
+      if (!response.ok) {
+        throw new TelegramApiError({
+          method: "downloadFile",
+          status: response.status,
+        });
+      }
+      return new Uint8Array(await response.arrayBuffer());
+    },
+  };
+}
+
+function timeoutSignal(timeoutMs?: number): AbortSignal | undefined {
+  return timeoutMs ? AbortSignal.timeout(timeoutMs) : undefined;
+}
+
+function redactToken(text: string, token: string): string {
+  return token ? text.split(token).join("<redacted>") : text;
+}

--- a/services/telegrambot/src/telegram-narrator.ts
+++ b/services/telegrambot/src/telegram-narrator.ts
@@ -1,0 +1,411 @@
+import type { ChatSDKStreamChunk } from "@centaur/rendering";
+import { TelegramApiError } from "./telegram-api";
+import type { SendMessageParams, TelegramApi } from "./telegram-api";
+import type { Logger, TelegramNarratorOutcome } from "./types";
+import { errorMessage, nowMs, sliceSurrogateSafe } from "./utils";
+
+export type TelegramNarratorChunk = Exclude<
+  ChatSDKStreamChunk,
+  { type: "markdown_text" }
+>;
+
+const REACTION_WORKING = "👀";
+const REACTION_DONE = "✅";
+const REACTION_FAILED = "❌";
+
+// Telegram delta: sendMessage allows 4096 chars *after entity parsing*, so the
+// budget below is measured on the visible (unescaped) text and the HTML
+// tags/escapes ride free; 3900 keeps every post conservatively under the cap.
+const NARRATOR_MESSAGE_MAX_CHARS = 3_900;
+// A single blurb is truncated to this, and a thought still pending at this size
+// is flushed early so long reasoning doesn't sit invisible for the whole run.
+const NARRATOR_BLURB_MAX_CHARS = 600;
+// Thoughts that complete within this window merge into one message; also keeps
+// posts well inside Telegram's ~1 msg/s + 20/min-per-group send guidance.
+const NARRATOR_MIN_POST_GAP_MS = 1_500;
+// Runaway runs stop narrating past this many posted messages.
+const NARRATOR_MAX_POSTS = 12;
+// Fragments shorter than this aren't worth a message of their own.
+const NARRATOR_MIN_BLURB_CHARS = 12;
+// sendChatAction("typing") shows for ~5s, so the keepalive re-sends on that
+// cadence while execution is noticeably slow.
+const TYPING_KEEPALIVE_INTERVAL_MS = 5_000;
+
+/** Injectable time source so tests drive the typing cadence deterministically
+ * (same seam as rate-limit's RateLimitClock, declared locally because the
+ * narrator must not depend on rate-limit.ts). */
+export type TelegramNarratorClock = {
+  now(): number;
+  sleep(ms: number): Promise<void>;
+};
+
+/**
+ * Where narration lands. Telegram delta (vs the Discord Chat SDK Thread): the
+ * narrator addresses the chat directly — blurbs go to `chatId` (staying in
+ * `messageThreadId` when the conversation is a forum/private topic), and
+ * reactions target the triggering message, which needs no topic id because it
+ * already lives in one.
+ */
+export type TelegramNarratorTarget = {
+  chatId: number | string;
+  messageThreadId?: number | null;
+  triggerMessageId: number;
+};
+
+export type TelegramNarratorOptions = {
+  logger: Logger;
+  clock?: TelegramNarratorClock;
+  maxPosts?: number;
+  minPostGapMs?: number;
+  typingIntervalMs?: number;
+};
+
+/**
+ * The Telegram-side chain-of-thought surface, fully append-only: the
+ * triggering message gets an instant 👀 reaction while the agent works, the
+ * agent's reasoning blurbs post as their own italic messages as each thought
+ * completes, and on settle the reaction becomes ✅ (or ❌). No bot message is
+ * ever edited or deleted. Commands, tools, and plan updates are not rendered;
+ * they just mark where a thought ends.
+ *
+ * Telegram deltas vs discord-narrator:
+ * - setMessageReaction REPLACES the message's reaction set, so start and
+ *   settle are each a single call — no separate DELETE of the 👀.
+ * - Discord subtext (-#) becomes italic HTML (<i>), with blurb content
+ *   escaped so reasoning text can never inject entities.
+ * - A typing keepalive (sendChatAction) is available for noticeably slow
+ *   executions; Discord has no equivalent surface.
+ *
+ * Callers hand in the rate-limited TelegramApi wrapper so narration shares
+ * the per-chat send budget; the narrator itself is transport-agnostic.
+ */
+export class TelegramNarrator {
+  private readonly api: TelegramApi;
+  private readonly logger: Logger;
+  private readonly clock: TelegramNarratorClock;
+  private readonly chatId: number | string;
+  private readonly messageThreadId: number | null;
+  private readonly triggerMessageId: number;
+  private readonly minPostGapMs: number;
+  private readonly maxPosts: number;
+  private readonly typingIntervalMs: number;
+  // Current thought, keyed by chunk id: reasoning deltas have unique ids and
+  // concatenate; a commentary item re-uses its id and replaces its body.
+  private pendingParts = new Map<string, string>();
+  private queuedBlurbs: string[] = [];
+  private lastStatus = "";
+  private postedCount = 0;
+  private droppedBlurbs = 0;
+  private lastPostAtMs = 0;
+  private sawError = false;
+  private timer: ReturnType<typeof setTimeout> | null = null;
+  private chain: Promise<void> = Promise.resolve();
+  private finished = false;
+  private typingStop: (() => void) | null = null;
+  private typingLoop: Promise<void> | null = null;
+
+  private constructor(
+    api: TelegramApi,
+    target: TelegramNarratorTarget,
+    options: TelegramNarratorOptions,
+  ) {
+    this.api = api;
+    this.logger = options.logger;
+    this.clock = options.clock ?? {
+      now: () => nowMs(),
+      sleep: (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+    };
+    this.chatId = target.chatId;
+    this.messageThreadId = target.messageThreadId ?? null;
+    this.triggerMessageId = target.triggerMessageId;
+    this.minPostGapMs = options.minPostGapMs ?? NARRATOR_MIN_POST_GAP_MS;
+    this.maxPosts = options.maxPosts ?? NARRATOR_MAX_POSTS;
+    this.typingIntervalMs =
+      options.typingIntervalMs ?? TYPING_KEEPALIVE_INTERVAL_MS;
+  }
+
+  /** Adds the 👀 working reaction (best-effort) and returns the narrator. */
+  static start(
+    api: TelegramApi,
+    target: TelegramNarratorTarget,
+    options: TelegramNarratorOptions,
+  ): TelegramNarrator {
+    const narrator = new TelegramNarrator(api, target, options);
+    narrator.enqueueReaction(REACTION_WORKING);
+    return narrator;
+  }
+
+  /**
+   * Server-side activity summaries (renderer.status events) — the Telegram
+   * analog of Slack's assistant status. Telegram has no ephemeral status
+   * surface, so summaries post as append-only italic blurbs. Empty statuses
+   * (the end-of-run clear) and consecutive repeats are dropped.
+   */
+  status(text: string): void {
+    if (this.finished) return;
+    const trimmed = text.trim();
+    if (!trimmed || trimmed === this.lastStatus) return;
+    this.lastStatus = trimmed;
+    if (trimmed.length < NARRATOR_MIN_BLURB_CHARS) return;
+    this.queuedBlurbs.push(truncateBlurb(trimmed));
+    this.schedulePost();
+  }
+
+  update(chunk: TelegramNarratorChunk): void {
+    if (this.finished) return;
+    if (chunk.type !== "task_update") return;
+    if (chunk.status === "error") this.sawError = true;
+    if (chunk.title === "Thinking") {
+      if (chunk.details) this.pendingParts.set(chunk.id, chunk.details);
+      if (
+        chunk.status === "complete" ||
+        this.pendingText().length >= NARRATOR_BLURB_MAX_CHARS
+      ) {
+        this.flushPending();
+      }
+      return;
+    }
+    // Any other task means the model moved on — the current thought is over.
+    this.flushPending();
+  }
+
+  /**
+   * Keeps the chat's "typing…" indicator alive on a ~5s cadence. Callers
+   * start it only once execution is noticeably slow (an instant answer should
+   * not flash a typing bubble) and it stops automatically on finish. Purely
+   * cosmetic: sendChatAction failures are logged and the loop keeps going.
+   */
+  startTypingKeepalive(): void {
+    if (this.finished || this.typingStop) return;
+    let stop!: () => void;
+    const stopped = new Promise<void>((resolve) => {
+      stop = resolve;
+    });
+    this.typingStop = stop;
+    this.typingLoop = this.runTypingLoop(stopped);
+  }
+
+  stopTypingKeepalive(): void {
+    this.typingStop?.();
+    this.typingStop = null;
+  }
+
+  /**
+   * Posts any remaining thought, stops the typing keepalive, then settles the
+   * reaction: ✅ on success, ❌ on failure, and 👀 stays put for "retrying"
+   * (the retry attempt re-adds it; the set-reaction call is idempotent).
+   * Never throws — narration is cosmetic. A "done" outcome downgrades to
+   * "failed" when an error task was seen (the renderer surfaces in-stream
+   * failures as error tasks, not throws).
+   */
+  async finish(outcome: TelegramNarratorOutcome): Promise<void> {
+    if (this.finished) return;
+    this.finished = true;
+    this.stopTypingKeepalive();
+    if (this.timer) {
+      clearTimeout(this.timer);
+      this.timer = null;
+    }
+    this.flushPendingText();
+    this.enqueueBlurbPost();
+    const failed =
+      outcome === "failed" || (outcome === "done" && this.sawError);
+    if (outcome !== "retrying") {
+      // Telegram delta: one call replaces 👀 with the settled emoji — the
+      // message always carries exactly one indicator, with no removal step.
+      this.enqueueReaction(failed ? REACTION_FAILED : REACTION_DONE);
+    }
+    await this.chain;
+    await this.typingLoop;
+    if (this.droppedBlurbs) {
+      this.logger.debug("telegrambot_narrator_blurbs_dropped", {
+        dropped: this.droppedBlurbs,
+      });
+    }
+  }
+
+  private async runTypingLoop(stopped: Promise<void>): Promise<void> {
+    let stopRequested = false;
+    void stopped.then(() => {
+      stopRequested = true;
+    });
+    while (!stopRequested && !this.finished) {
+      try {
+        await this.api.sendChatAction({
+          chat_id: this.chatId,
+          action: "typing",
+          ...(this.messageThreadId === null
+            ? {}
+            : { message_thread_id: this.messageThreadId }),
+        });
+      } catch (error) {
+        this.logger.warn("telegrambot_narrator_typing_failed", {
+          chat_id: String(this.chatId),
+          error: errorMessage(error),
+        });
+      }
+      if (stopRequested || this.finished) return;
+      await Promise.race([this.clock.sleep(this.typingIntervalMs), stopped]);
+    }
+  }
+
+  private pendingText(): string {
+    return Array.from(this.pendingParts.values()).join("").trim();
+  }
+
+  private flushPending(): void {
+    this.flushPendingText();
+    this.schedulePost();
+  }
+
+  private flushPendingText(): void {
+    const text = this.pendingText();
+    this.pendingParts = new Map();
+    if (text.length < NARRATOR_MIN_BLURB_CHARS) return;
+    this.queuedBlurbs.push(truncateBlurb(text));
+  }
+
+  private schedulePost(): void {
+    if (this.timer || !this.queuedBlurbs.length) return;
+    const delayMs = Math.max(
+      0,
+      this.minPostGapMs - (nowMs() - this.lastPostAtMs),
+    );
+    this.timer = setTimeout(() => {
+      this.timer = null;
+      this.enqueueBlurbPost();
+    }, delayMs);
+  }
+
+  private enqueueBlurbPost(): void {
+    if (!this.queuedBlurbs.length) return;
+    if (this.postedCount >= this.maxPosts) {
+      this.droppedBlurbs += this.queuedBlurbs.length;
+      this.queuedBlurbs = [];
+      return;
+    }
+    const blurbs = this.queuedBlurbs;
+    this.queuedBlurbs = [];
+    this.postedCount += 1;
+    this.lastPostAtMs = nowMs();
+    const params: SendMessageParams = {
+      chat_id: this.chatId,
+      text: this.renderBlurbs(blurbs),
+      parse_mode: "HTML",
+      // Reasoning text may quote URLs; progress noise must not unfurl them.
+      link_preview_options: { is_disabled: true },
+      ...(this.messageThreadId === null
+        ? {}
+        : { message_thread_id: this.messageThreadId }),
+    };
+    this.chain = this.chain.then(async () => {
+      try {
+        await this.api.sendMessage(params);
+      } catch (error) {
+        this.logger.warn("telegrambot_narrator_post_failed", {
+          chat_id: String(this.chatId),
+          error: errorMessage(error),
+        });
+      }
+    });
+  }
+
+  /**
+   * Telegram delta: Discord's per-line -# subtext becomes one italic segment
+   * per blurb (<i> spans newlines), with the content HTML-escaped so agent
+   * reasoning can never inject entities. The message budget counts visible
+   * characters (Telegram's limit applies after entity parsing); blurbs beyond
+   * it are dropped, and the one crossing it is truncated.
+   */
+  private renderBlurbs(blurbs: string[]): string {
+    const pieces: string[] = [];
+    let used = 0;
+    for (const [index, blurb] of blurbs.entries()) {
+      const separator = pieces.length ? 2 : 0;
+      const budget = NARRATOR_MESSAGE_MAX_CHARS - used - separator;
+      if (budget < NARRATOR_MIN_BLURB_CHARS) {
+        this.droppedBlurbs += blurbs.length - index;
+        break;
+      }
+      const text =
+        blurb.length <= budget
+          ? blurb
+          : `${sliceSurrogateSafe(blurb, budget - 1).trimEnd()}…`;
+      pieces.push(`<i>${escapeHtml(text)}</i>`);
+      used += separator + text.length;
+    }
+    return pieces.join("\n\n");
+  }
+
+  private enqueueReaction(emoji: string): void {
+    this.chain = this.chain.then(() =>
+      setTelegramReaction(
+        this.api,
+        {
+          chatId: this.chatId,
+          emoji,
+          messageId: this.triggerMessageId,
+        },
+        this.logger,
+      ),
+    );
+  }
+}
+
+/**
+ * Best-effort reaction set-and-replace; never throws (reactions are cosmetic).
+ * Shared by the narrator and the ingress guards, mirroring
+ * reactToDiscordMessage. Reactions target an existing message id and take no
+ * topic id — the message already lives in its topic.
+ */
+export async function setTelegramReaction(
+  api: TelegramApi,
+  input: { chatId: number | string; emoji: string; messageId: number },
+  logger: Logger,
+): Promise<void> {
+  try {
+    await api.setMessageReaction({
+      chat_id: input.chatId,
+      message_id: input.messageId,
+      reaction: [{ type: "emoji", emoji: input.emoji }],
+    });
+  } catch (error) {
+    // Telegram delta: reactions can be structurally unavailable — chats may
+    // restrict the allowed reaction set and some messages cannot be reacted
+    // to at all. Both surface as 400s naming the reaction; classify them so
+    // an expected restriction is distinguishable from a real fault, but
+    // suppress either way — cosmetic failures must never fail the run.
+    const event = isReactionUnavailable(error)
+      ? "telegrambot_narrator_reaction_unavailable"
+      : "telegrambot_narrator_reaction_failed";
+    logger.warn(event, {
+      chat_id: String(input.chatId),
+      emoji: input.emoji,
+      message_id: input.messageId,
+      error: errorMessage(error),
+    });
+  }
+}
+
+function isReactionUnavailable(error: unknown): boolean {
+  return (
+    error instanceof TelegramApiError &&
+    error.status === 400 &&
+    /reaction|react/i.test(error.description ?? "")
+  );
+}
+
+/** Escape for Telegram HTML parse mode (only &, <, > are significant). */
+function escapeHtml(text: string): string {
+  return text
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;");
+}
+
+// Same motivation as the Discord port: truncation cuts are surrogate-safe
+// because halving an emoji's surrogate pair yields an invalid payload.
+function truncateBlurb(text: string): string {
+  if (text.length <= NARRATOR_BLURB_MAX_CHARS) return text;
+  return `${sliceSurrogateSafe(text, NARRATOR_BLURB_MAX_CHARS - 1).trimEnd()}…`;
+}

--- a/services/telegrambot/src/telegram-narrator.ts
+++ b/services/telegrambot/src/telegram-narrator.ts
@@ -9,9 +9,13 @@ export type TelegramNarratorChunk = Exclude<
   { type: "markdown_text" }
 >;
 
+// Telegram delta: setMessageReaction accepts only the Bot API's fixed
+// ReactionTypeEmoji whitelist — the Discord-inherited ✅/❌ are NOT in it and
+// the real API rejects them with 400 REACTION_INVALID on every settle, so
+// done/failed map to the whitelisted 👍/👎 (👀 is whitelisted and stays).
 const REACTION_WORKING = "👀";
-const REACTION_DONE = "✅";
-const REACTION_FAILED = "❌";
+const REACTION_DONE = "👍";
+const REACTION_FAILED = "👎";
 
 // Telegram delta: sendMessage allows 4096 chars *after entity parsing*, so the
 // budget below is measured on the visible (unescaped) text and the HTML
@@ -27,9 +31,11 @@ const NARRATOR_MIN_POST_GAP_MS = 1_500;
 const NARRATOR_MAX_POSTS = 12;
 // Fragments shorter than this aren't worth a message of their own.
 const NARRATOR_MIN_BLURB_CHARS = 12;
-// sendChatAction("typing") shows for ~5s, so the keepalive re-sends on that
-// cadence while execution is noticeably slow.
-const TYPING_KEEPALIVE_INTERVAL_MS = 5_000;
+// sendChatAction("typing") lights the indicator for ~5s, so the keepalive
+// re-sends every 4s measured from the START of each send: the send itself can
+// ride the per-chat FIFO behind paced messages for a second or more, and a
+// full 5s sleep after it completes would let the indicator lapse and flicker.
+const TYPING_KEEPALIVE_INTERVAL_MS = 4_000;
 
 /** Injectable time source so tests drive the typing cadence deterministically
  * (same seam as rate-limit's RateLimitClock, declared locally because the
@@ -64,7 +70,7 @@ export type TelegramNarratorOptions = {
  * The Telegram-side chain-of-thought surface, fully append-only: the
  * triggering message gets an instant 👀 reaction while the agent works, the
  * agent's reasoning blurbs post as their own italic messages as each thought
- * completes, and on settle the reaction becomes ✅ (or ❌). No bot message is
+ * completes, and on settle the reaction becomes 👍 (or 👎). No bot message is
  * ever edited or deleted. Commands, tools, and plan updates are not rendered;
  * they just mark where a thought ends.
  *
@@ -170,7 +176,8 @@ export class TelegramNarrator {
   }
 
   /**
-   * Keeps the chat's "typing…" indicator alive on a ~5s cadence. Callers
+   * Keeps the chat's "typing…" indicator alive on a ~4s cadence (below the
+   * indicator's ~5s lifetime so it never lapses between refreshes). Callers
    * start it only once execution is noticeably slow (an instant answer should
    * not flash a typing bubble) and it stops automatically on finish. Purely
    * cosmetic: sendChatAction failures are logged and the loop keeps going.
@@ -192,7 +199,7 @@ export class TelegramNarrator {
 
   /**
    * Posts any remaining thought, stops the typing keepalive, then settles the
-   * reaction: ✅ on success, ❌ on failure, and 👀 stays put for "retrying"
+   * reaction: 👍 on success, 👎 on failure, and 👀 stays put for "retrying"
    * (the retry attempt re-adds it; the set-reaction call is idempotent).
    * Never throws — narration is cosmetic. A "done" outcome downgrades to
    * "failed" when an error task was seen (the renderer surfaces in-stream
@@ -230,6 +237,11 @@ export class TelegramNarrator {
       stopRequested = true;
     });
     while (!stopRequested && !this.finished) {
+      // Cadence is measured from the start of each send: the send may sit
+      // behind paced queue work, and sleeping the full interval after it
+      // completes would stretch the effective period past the indicator's
+      // ~5s lifetime.
+      const sendStartedAtMs = this.clock.now();
       try {
         await this.api.sendChatAction({
           chat_id: this.chatId,
@@ -245,7 +257,11 @@ export class TelegramNarrator {
         });
       }
       if (stopRequested || this.finished) return;
-      await Promise.race([this.clock.sleep(this.typingIntervalMs), stopped]);
+      const elapsedMs = this.clock.now() - sendStartedAtMs;
+      await Promise.race([
+        this.clock.sleep(Math.max(0, this.typingIntervalMs - elapsedMs)),
+        stopped,
+      ]);
     }
   }
 

--- a/services/telegrambot/src/telegram-render.ts
+++ b/services/telegrambot/src/telegram-render.ts
@@ -1,0 +1,504 @@
+import { sliceSurrogateSafe } from "./utils";
+
+/**
+ * Markdown -> Telegram HTML rendering and parsed-length-aware chunking.
+ *
+ * Telegram delta: discordbot posts raw Markdown and only keeps ``` fences
+ * balanced across 2000-char chunks (`takeDiscordMessageChunk`). Telegram
+ * instead parses formatting server-side, enforces its 4096-char limit on the
+ * PARSED text (tag characters are free, entity text is not), and rejects the
+ * entire sendMessage call on any unbalanced tag. So the renderer emits only
+ * the tag vocabulary Telegram documents — <b> <i> <s> <u> <code> <pre>
+ * <pre><code class="language-x"> <a href> <blockquote> <tg-spoiler> — with all
+ * text content escaped, and the chunker splits on parsed length, closing every
+ * open tag at a boundary and re-opening it (language class included) at the
+ * top of the next chunk so each chunk parses independently.
+ */
+
+/** Telegram counts sendMessage text in parsed UTF-16 code units, max 4096. */
+export const TELEGRAM_MAX_MESSAGE_CHARS = 4096;
+
+export function escapeTelegramHtml(text: string): string {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+function escapeTelegramAttribute(text: string): string {
+  return escapeTelegramHtml(text).replace(/"/g, "&quot;");
+}
+
+// ---------------------------------------------------------------------------
+// Markdown -> Telegram HTML
+// ---------------------------------------------------------------------------
+
+const FENCE_OPEN = /^\s*```(.*)$/;
+const FENCE_CLOSE = /^\s*```\s*$/;
+const HEADING = /^#{1,6}\s+(.*)$/;
+const BLOCKQUOTE_LINE = /^\s*>\s?/;
+const LIST_ITEM = /^(\s*)(?:[-*+]|\d{1,9}[.)])\s+(.*)$/;
+const TABLE_ROW = /^\s*\|/;
+const TABLE_SEPARATOR = /^\s*\|?[\s:\-|]+\|[\s:\-|]*$/;
+const CODE_LANGUAGE = /^[A-Za-z0-9_+#.-]+$/;
+const LINK = /^\[([^\]\n]*)\]\(([^()\s]+)\)/;
+const SAFE_LINK_SCHEME = /^(https?|tg|mailto):/i;
+const MAX_INLINE_DEPTH = 6;
+
+/**
+ * Translates the harness's GitHub-flavored Markdown subset into Telegram
+ * HTML. Telegram has no block semantics beyond <pre>/<blockquote>, so
+ * headings become bold lines and list items become "- " prefixed plain lines;
+ * tables have no Telegram representation at all and pass through as <pre> so
+ * their alignment survives. Anything unsupported or unterminated degrades to
+ * escaped plain text — the output must never be invalid HTML, because
+ * Telegram rejects the whole message rather than the offending span.
+ */
+export function renderMarkdownToTelegramHtml(markdown: string): string {
+  const lines = markdown.replace(/\r\n/g, "\n").split("\n");
+  const blocks: string[] = [];
+  let i = 0;
+  while (i < lines.length) {
+    const line = lines[i] ?? "";
+
+    const fence = FENCE_OPEN.exec(line);
+    if (fence) {
+      const info = (fence[1] ?? "").trim().split(/\s+/)[0] ?? "";
+      const language = CODE_LANGUAGE.test(info) ? info : "";
+      const code: string[] = [];
+      i += 1;
+      while (i < lines.length && !FENCE_CLOSE.test(lines[i] ?? "")) {
+        code.push(lines[i] ?? "");
+        i += 1;
+      }
+      i += 1; // consume the closing fence (an unterminated fence eats the rest)
+      const body = escapeTelegramHtml(code.join("\n"));
+      blocks.push(
+        language
+          ? `<pre><code class="language-${language}">${body}</code></pre>`
+          : `<pre>${body}</pre>`,
+      );
+      continue;
+    }
+
+    const separator = lines[i + 1] ?? "";
+    if (
+      TABLE_ROW.test(line) &&
+      TABLE_SEPARATOR.test(separator) &&
+      separator.includes("-")
+    ) {
+      const rows: string[] = [];
+      while (i < lines.length && TABLE_ROW.test(lines[i] ?? "")) {
+        rows.push(lines[i] ?? "");
+        i += 1;
+      }
+      blocks.push(`<pre>${escapeTelegramHtml(rows.join("\n"))}</pre>`);
+      continue;
+    }
+
+    const heading = HEADING.exec(line);
+    if (heading) {
+      blocks.push(`<b>${renderInline(heading[1] ?? "")}</b>`);
+      i += 1;
+      continue;
+    }
+
+    if (BLOCKQUOTE_LINE.test(line)) {
+      const quoted: string[] = [];
+      while (i < lines.length && BLOCKQUOTE_LINE.test(lines[i] ?? "")) {
+        quoted.push(renderInline((lines[i] ?? "").replace(BLOCKQUOTE_LINE, "")));
+        i += 1;
+      }
+      blocks.push(`<blockquote>${quoted.join("\n")}</blockquote>`);
+      continue;
+    }
+
+    const listItem = LIST_ITEM.exec(line);
+    if (listItem) {
+      blocks.push(`${listItem[1] ?? ""}- ${renderInline(listItem[2] ?? "")}`);
+      i += 1;
+      continue;
+    }
+
+    blocks.push(renderInline(line));
+    i += 1;
+  }
+  return blocks.join("\n");
+}
+
+function renderInline(text: string, depth = 0): string {
+  // Depth cap: pathological nesting degrades to plain text instead of
+  // recursing without bound.
+  if (depth > MAX_INLINE_DEPTH) return escapeTelegramHtml(text);
+  let out = "";
+  let i = 0;
+
+  const wrap = (marker: string, tag: string): boolean => {
+    const close = text.indexOf(marker, i + marker.length);
+    if (close === -1) return false;
+    const inner = text.slice(i + marker.length, close);
+    if (!inner.trim()) return false;
+    out += `<${tag}>${renderInline(inner, depth + 1)}</${tag}>`;
+    i = close + marker.length;
+    return true;
+  };
+
+  while (i < text.length) {
+    const ch = text[i] ?? "";
+    if (ch === "`") {
+      let run = 1;
+      while (text[i + run] === "`") run += 1;
+      const marker = "`".repeat(run);
+      const close = text.indexOf(marker, i + run);
+      if (close !== -1) {
+        out += `<code>${escapeTelegramHtml(text.slice(i + run, close))}</code>`;
+        i = close + run;
+        continue;
+      }
+      out += escapeTelegramHtml(marker);
+      i += run;
+      continue;
+    }
+    if (ch === "[") {
+      const link = LINK.exec(text.slice(i));
+      const url = link?.[2] ?? "";
+      // Scheme allowlist: a javascript:/data: label must not become a live
+      // link, so anything else degrades to the literal markdown text.
+      if (link && SAFE_LINK_SCHEME.test(url)) {
+        const label = renderInline(link[1] ?? "", depth + 1);
+        out += `<a href="${escapeTelegramAttribute(url)}">${label}</a>`;
+        i += (link[0] ?? "").length;
+        continue;
+      }
+      out += "[";
+      i += 1;
+      continue;
+    }
+    if (text.startsWith("**", i) && wrap("**", "b")) continue;
+    if (text.startsWith("__", i) && wrap("__", "b")) continue;
+    if (text.startsWith("~~", i) && wrap("~~", "s")) continue;
+    if (ch === "*" && wrap("*", "i")) continue;
+    if (ch === "_") {
+      const prev = i > 0 ? (text[i - 1] ?? "") : "";
+      // Intra-word underscores (snake_case identifiers) are not emphasis.
+      if (!/[A-Za-z0-9_]/.test(prev) && wrap("_", "i")) continue;
+    }
+    out += escapeTelegramHtml(ch);
+    i += 1;
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Telegram HTML tokenizer (shared by parsedTextLength and the chunker)
+// ---------------------------------------------------------------------------
+
+type HtmlToken =
+  | { kind: "open"; name: string; raw: string }
+  | { kind: "close"; name: string }
+  | { kind: "text"; text: string };
+
+const TAG_TOKEN = /^<(\/?)([a-zA-Z][a-zA-Z0-9-]*)((?:\s[^<>]*)?)(\/?)>/;
+const ENTITY_TOKEN =
+  /^&(?:#(\d{1,7})|#[xX]([0-9a-fA-F]{1,6})|([a-zA-Z][a-zA-Z0-9]{0,30}));/;
+const NAMED_ENTITIES: Record<string, string> = {
+  amp: "&",
+  lt: "<",
+  gt: ">",
+  quot: '"',
+  apos: "'",
+  nbsp: " ",
+};
+
+function decodeEntityAt(
+  html: string,
+  index: number,
+): { value: string; length: number } | null {
+  const match = ENTITY_TOKEN.exec(html.slice(index));
+  if (!match) return null;
+  const raw = match[0] ?? "";
+  const name = match[3];
+  if (name !== undefined) {
+    const value = NAMED_ENTITIES[name.toLowerCase()];
+    return value === undefined ? null : { value, length: raw.length };
+  }
+  const codePoint =
+    match[1] !== undefined
+      ? Number(match[1])
+      : Number.parseInt(match[2] ?? "", 16);
+  if (!Number.isFinite(codePoint) || codePoint > 0x10ffff) return null;
+  // A numeric reference to a lone surrogate would poison every downstream
+  // UTF-16 cut; leave the ampersand as literal text instead.
+  if (codePoint >= 0xd800 && codePoint <= 0xdfff) return null;
+  return { value: String.fromCodePoint(codePoint), length: raw.length };
+}
+
+/** Text tokens carry DECODED text so all length math is in parsed units. */
+function tokenizeTelegramHtml(html: string): HtmlToken[] {
+  const tokens: HtmlToken[] = [];
+  let text = "";
+  const flushText = () => {
+    if (text) {
+      tokens.push({ kind: "text", text });
+      text = "";
+    }
+  };
+  let i = 0;
+  while (i < html.length) {
+    const ch = html[i] ?? "";
+    if (ch === "<") {
+      const match = TAG_TOKEN.exec(html.slice(i));
+      if (match) {
+        const raw = match[0] ?? "";
+        const name = (match[2] ?? "").toLowerCase();
+        flushText();
+        if (match[1]) tokens.push({ kind: "close", name });
+        else if (!match[4]) tokens.push({ kind: "open", name, raw });
+        // Self-closing tags carry no formatting state and no text; dropped.
+        i += raw.length;
+        continue;
+      }
+      text += "<";
+      i += 1;
+      continue;
+    }
+    if (ch === "&") {
+      const entity = decodeEntityAt(html, i);
+      if (entity) {
+        text += entity.value;
+        i += entity.length;
+        continue;
+      }
+      text += "&";
+      i += 1;
+      continue;
+    }
+    text += ch;
+    i += 1;
+  }
+  flushText();
+  return tokens;
+}
+
+/**
+ * Length of the message as Telegram counts it: UTF-16 code units of the
+ * parsed entity text, excluding all tag characters.
+ */
+export function parsedTextLength(html: string): number {
+  let length = 0;
+  for (const token of tokenizeTelegramHtml(html)) {
+    if (token.kind === "text") length += token.text.length;
+  }
+  return length;
+}
+
+// ---------------------------------------------------------------------------
+// Chunker
+// ---------------------------------------------------------------------------
+
+type OpenTag = { name: string; raw: string };
+type ChunkPosition = { token: number; offset: number };
+type ChunkCut = {
+  html: string;
+  plain: string;
+  parsed: number;
+  next: ChunkPosition;
+  stack: OpenTag[];
+};
+type ChunkPiece = {
+  html: string;
+  plain: string;
+  next: ChunkPosition;
+  stack: OpenTag[];
+  done: boolean;
+};
+
+function closingTags(stack: readonly OpenTag[]): string {
+  return stack
+    .map((tag) => `</${tag.name}>`)
+    .reverse()
+    .join("");
+}
+
+const EMPTY_ELEMENT = /<([a-zA-Z][a-zA-Z0-9-]*)(?:\s[^<>]*)?><\/\1>/g;
+
+/**
+ * A cut that lands directly after an open tag (or emptied a fence opener)
+ * leaves `<pre><code ...></code></pre>` husks behind; they are valid but
+ * render as stray blocks, so strip them. The open stack still carries the
+ * tags, so the next chunk re-opens them correctly.
+ */
+function stripEmptyElements(html: string): string {
+  let current = html;
+  for (;;) {
+    const stripped = current.replace(EMPTY_ELEMENT, "");
+    if (stripped === current) return current;
+    current = stripped;
+  }
+}
+
+function takeChunk(
+  tokens: readonly HtmlToken[],
+  start: ChunkPosition,
+  startStack: readonly OpenTag[],
+  limit: number,
+): ChunkPiece {
+  // Formatting that spans the previous boundary re-opens verbatim (raw open
+  // tag), which is what keeps a language-classed code block continuing
+  // seamlessly across chunks.
+  let out = startStack.map((tag) => tag.raw).join("");
+  let plain = "";
+  let parsed = 0;
+  const stack: OpenTag[] = startStack.slice();
+  let tokenIndex = start.token;
+  let offset = start.offset;
+  // Mirror of the Discord chunker's boundary preference: only boundaries in
+  // the latter half of the window qualify, the latest boundary outside a code
+  // block wins over any (even later) newline inside one, and a hard cut is
+  // the last resort.
+  const minCut = Math.max(1, Math.floor(limit / 2));
+  let lastOutsideCode: ChunkCut | null = null;
+  let lastInsideCodeNewline: ChunkCut | null = null;
+
+  const cutHere = (next: ChunkPosition): ChunkCut => ({
+    html: out,
+    plain,
+    parsed,
+    next,
+    stack: stack.slice(),
+  });
+
+  while (tokenIndex < tokens.length) {
+    const token = tokens[tokenIndex];
+    if (!token) break;
+    if (token.kind === "open") {
+      out += token.raw;
+      stack.push({ name: token.name, raw: token.raw });
+      tokenIndex += 1;
+      offset = 0;
+      continue;
+    }
+    if (token.kind === "close") {
+      // Drop a close that does not match the innermost open (malformed
+      // input); emitting it would unbalance every downstream chunk.
+      if (stack.length > 0 && stack[stack.length - 1]?.name === token.name) {
+        stack.pop();
+        out += `</${token.name}>`;
+      }
+      tokenIndex += 1;
+      offset = 0;
+      continue;
+    }
+
+    const text = token.text;
+    const insideCode = stack.some(
+      (tag) => tag.name === "pre" || tag.name === "code",
+    );
+    while (offset < text.length) {
+      const ch = text[offset] ?? "";
+      // Inside <pre>/<code> only newlines are safe boundaries — dropping a
+      // space would corrupt code alignment. Outside, any whitespace works.
+      const isBoundary =
+        ch === "\n" || ((ch === " " || ch === "\t") && !insideCode);
+      if (isBoundary && parsed >= minCut) {
+        const cut = cutHere({ token: tokenIndex, offset: offset + 1 });
+        if (!insideCode) lastOutsideCode = cut;
+        else if (ch === "\n") lastInsideCodeNewline = cut;
+      }
+      // Consume a surrogate pair atomically so no cut can land between the
+      // halves; sliceSurrogateSafe backing off to "" identifies a pair start.
+      const pair = text.slice(offset, offset + 2);
+      const width =
+        pair.length === 2 && sliceSurrogateSafe(pair, 1) === "" ? 2 : 1;
+      if (parsed + width > limit) {
+        let cut =
+          lastOutsideCode ??
+          lastInsideCodeNewline ??
+          cutHere({ token: tokenIndex, offset });
+        if (cut.parsed <= 0) {
+          // Window smaller than one character (e.g. a surrogate pair with
+          // limit 1): force progress over strict limit adherence so the
+          // caller's guard loop always terminates.
+          const forced = text.slice(offset, offset + width);
+          out += escapeTelegramHtml(forced);
+          plain += forced;
+          parsed += width;
+          offset += width;
+          cut = cutHere({ token: tokenIndex, offset });
+        }
+        return {
+          html: stripEmptyElements(cut.html + closingTags(cut.stack)),
+          plain: cut.plain,
+          next: cut.next,
+          stack: cut.stack,
+          done: false,
+        };
+      }
+      const piece = text.slice(offset, offset + width);
+      out += escapeTelegramHtml(piece);
+      plain += piece;
+      parsed += width;
+      offset += width;
+    }
+    tokenIndex += 1;
+    offset = 0;
+  }
+
+  return {
+    html: stripEmptyElements(out + closingTags(stack)),
+    plain,
+    next: { token: tokens.length, offset: 0 },
+    stack: [],
+    done: true,
+  };
+}
+
+/**
+ * Splits Telegram HTML into independently valid chunks whose PARSED text
+ * length is at most `maxChars` (Telegram's limit ignores tag characters).
+ * Never splits inside a tag or an entity; formatting open at a boundary is
+ * closed there and re-opened at the top of the next chunk.
+ */
+export function chunkTelegramHtml(
+  html: string,
+  maxChars: number = TELEGRAM_MAX_MESSAGE_CHARS,
+): string[] {
+  const limit = Math.max(1, Math.floor(maxChars));
+  const tokens = tokenizeTelegramHtml(html);
+  const chunks: string[] = [];
+  let position: ChunkPosition = { token: 0, offset: 0 };
+  let stack: OpenTag[] = [];
+  // The guard bounds runaway splits if a degenerate input ever stops
+  // shrinking (same defense as splitDiscordMessageChunks).
+  for (let guard = 0; guard < 10_000; guard += 1) {
+    if (position.token >= tokens.length) break;
+    const piece = takeChunk(tokens, position, stack, limit);
+    if (piece.plain.trim()) chunks.push(piece.html);
+    if (piece.done) break;
+    if (
+      piece.next.token === position.token &&
+      piece.next.offset === position.offset
+    ) {
+      break;
+    }
+    position = piece.next;
+    stack = piece.stack;
+  }
+  return chunks;
+}
+
+/**
+ * Fallback for when Telegram rejects rendered HTML with a parse/entity error
+ * (`isTelegramParseError`): the raw markdown, HTML-escaped with no tags, so
+ * the body stays valid under parse_mode=HTML (the chunks are still meant to
+ * be sent with parse_mode=HTML — the entities are escaped for it). Escaping
+ * guarantees the resend can never be byte-identical to a malformed HTML body:
+ * a body that failed to parse contained a `<` or `&`, and here both are
+ * always re-escaped.
+ */
+export function renderPlainTextFallback(
+  markdown: string,
+  maxChars: number = TELEGRAM_MAX_MESSAGE_CHARS,
+): string[] {
+  return chunkTelegramHtml(escapeTelegramHtml(markdown), maxChars);
+}

--- a/services/telegrambot/src/telegram-threading.ts
+++ b/services/telegrambot/src/telegram-threading.ts
@@ -1,0 +1,137 @@
+import type { TelegramChat, TelegramMessage } from "./types";
+
+export type TelegramThreadKind = "private" | "chat";
+
+export type ParsedTelegramThreadKey = {
+  kind?: TelegramThreadKind;
+  chatId?: string;
+  messageThreadId?: number;
+};
+
+/**
+ * Derive the durable typed thread key for an inbound message, or a rejection
+ * reason recorded as the update's durable disposition.
+ *
+ * Telegram delta (vs discord-threading, where the Chat SDK adapter hands us a
+ * ready-made key): the key encodes the chat kind so api-rs can derive a user
+ * principal for DMs and a chat principal for groups without trusting mutable
+ * metadata — `telegram:private:{chatId}[:{messageThreadId}]` and
+ * `telegram:chat:{chatId}[:{messageThreadId}]`. Private `chat.id` is the
+ * canonical user identity, so a private message is accepted only when the
+ * sender provably *is* that chat: `from` is a real user, `sender_chat` is
+ * absent, and `String(from.id) === String(chat.id)`. Telegram Business and
+ * channel direct-message-topic conversations break that equality (the peer's
+ * messages arrive with a `from` that differs from the owning chat), so the
+ * identity check rejects them without needing their extra fields; channel
+ * chats are rejected outright (channel posts are out of scope for v1).
+ */
+export function deriveThreadKey(
+  message: TelegramMessage,
+  botUserId: string,
+): { threadKey: string } | { rejected: string } {
+  const { chat, from } = message;
+
+  if (from && String(from.id) === String(botUserId)) {
+    return { rejected: "self_message" };
+  }
+  if (chat.type === "channel") {
+    return { rejected: "channel_chat" };
+  }
+
+  if (chat.type === "private") {
+    if (!from) return { rejected: "private_missing_from" };
+    if (from.is_bot) return { rejected: "private_bot_sender" };
+    if (message.sender_chat) return { rejected: "private_sender_chat_present" };
+    if (String(from.id) !== String(chat.id)) {
+      return { rejected: "private_identity_mismatch" };
+    }
+    // Private forum-mode threads carry message_thread_id without
+    // is_topic_message; preserve it whenever present.
+    return {
+      threadKey: buildThreadKey("private", chat.id, message.message_thread_id),
+    };
+  }
+
+  if (chat.type === "group" || chat.type === "supergroup") {
+    return {
+      threadKey: buildThreadKey("chat", chat.id, groupTopicId(message)),
+    };
+  }
+
+  return { rejected: "unsupported_chat_type" };
+}
+
+/**
+ * Topic segment for group/supergroup keys. Non-forum supergroup replies also
+ * carry `message_thread_id` (the reply-chain root), and keying on it would
+ * split one chat's session per reply chain — reply-to-bot follow-ups must land
+ * in the same session — so only genuine forum topics extend the key.
+ */
+function groupTopicId(message: TelegramMessage): number | undefined {
+  return message.is_topic_message === true
+    ? message.message_thread_id
+    : undefined;
+}
+
+function buildThreadKey(
+  kind: TelegramThreadKind,
+  chatId: number,
+  messageThreadId: number | undefined,
+): string {
+  return messageThreadId === undefined
+    ? `telegram:${kind}:${chatId}`
+    : `telegram:${kind}:${chatId}:${messageThreadId}`;
+}
+
+/**
+ * Decode `telegram:{kind}:{chatId}[:{messageThreadId}]` into parts. Returns an
+ * empty object for anything that is not a well-formed Telegram thread key
+ * (mirrors parseDiscordThreadKey, but fail-closed on the typed discriminator
+ * and a malformed topic segment since principals hang off these parts).
+ */
+export function parseTelegramThreadKey(
+  threadKey: string,
+): ParsedTelegramThreadKey {
+  const parts = threadKey.split(":");
+  if (parts[0] !== "telegram") return {};
+  const kind = parts[1];
+  if (kind !== "private" && kind !== "chat") return {};
+  const chatId = parts[2];
+  if (!chatId || parts.length > 4) return {};
+  const rawThreadId = parts[3];
+  if (rawThreadId === undefined) return { kind, chatId };
+  const messageThreadId = Number(rawThreadId);
+  if (!/^\d+$/.test(rawThreadId) || !Number.isSafeInteger(messageThreadId)) {
+    return {};
+  }
+  return { kind, chatId, messageThreadId };
+}
+
+/**
+ * Human-readable conversation name for the session principal: `chat.title`
+ * for groups, the person's name/username for DMs, falling back to the id so
+ * the principal is never nameless.
+ */
+export function deriveConversationName(chat: TelegramChat): string {
+  if (chat.type === "private") {
+    const fullName = [chat.first_name, chat.last_name]
+      .map((part) => part?.trim())
+      .filter(Boolean)
+      .join(" ");
+    if (fullName && chat.username) return `${fullName} (@${chat.username})`;
+    if (fullName) return fullName;
+    if (chat.username) return `@${chat.username}`;
+    return String(chat.id);
+  }
+  return chat.title?.trim() || String(chat.id);
+}
+
+/**
+ * Stable append/execute idempotency key. `chat.id` is globally unique and
+ * `message_id` is unique within a chat, so re-delivered updates (crash between
+ * receipt and append, duplicate getUpdates batches) dedupe to one session
+ * message and one execution.
+ */
+export function deriveClientMessageId(message: TelegramMessage): string {
+  return `telegram:${message.chat.id}:${message.message_id}`;
+}

--- a/services/telegrambot/src/types.ts
+++ b/services/telegrambot/src/types.ts
@@ -84,6 +84,8 @@ export type TelegramMessage = {
   document?: TelegramDocument;
   reply_to_message?: TelegramMessage;
   is_topic_message?: boolean;
+  /** True for linked-channel posts auto-forwarded into a discussion group. */
+  is_automatic_forward?: boolean;
   via_bot?: TelegramUser;
 };
 
@@ -114,6 +116,8 @@ export type TelegrambotFetch = (
 export type TelegrambotOptions = {
   /** Edit cadence for the in-progress answer message (default ~1.5s). */
   answerEditIntervalMs?: number;
+  /** Max Telegram messages per answer before honest truncation (default 8). */
+  answerMaxMessages?: number;
   apiKey?: string;
   apiUrl: string;
   botToken: string;

--- a/services/telegrambot/src/types.ts
+++ b/services/telegrambot/src/types.ts
@@ -1,0 +1,303 @@
+import type { RustSessionStreamEvent } from "@centaur/harness-events";
+import type { CodexAppServerToChatStreamOptions } from "@centaur/rendering";
+import type { Hono } from "hono";
+import type { Pool } from "pg";
+
+export type JsonPrimitive = string | number | boolean | null;
+export type JsonValue = JsonPrimitive | JsonObject | JsonValue[];
+export type JsonObject = { [key: string]: JsonValue | undefined };
+
+/**
+ * Telegram delta: the other bots take their Logger from the Chat SDK, but
+ * telegrambot has no Chat SDK adapter (none exists for Telegram), so the same
+ * shape is declared locally instead of importing the `chat` package for one
+ * type.
+ */
+export type Logger = {
+  debug(message: string, data?: unknown): void;
+  info(message: string, data?: unknown): void;
+  warn(message: string, data?: unknown): void;
+  error(message: string, data?: unknown): void;
+  child(bindings?: Record<string, unknown>): Logger;
+};
+
+// ---------------------------------------------------------------------------
+// Telegram Bot API payloads (subset the service consumes; unknown fields pass
+// through as raw JSON in the inbox).
+// ---------------------------------------------------------------------------
+
+export type TelegramUser = {
+  id: number;
+  is_bot: boolean;
+  first_name: string;
+  last_name?: string;
+  username?: string;
+};
+
+export type TelegramChat = {
+  id: number;
+  type: "private" | "group" | "supergroup" | "channel";
+  title?: string;
+  username?: string;
+  first_name?: string;
+  last_name?: string;
+  is_forum?: boolean;
+};
+
+export type TelegramMessageEntity = {
+  type: string;
+  offset: number;
+  length: number;
+  url?: string;
+  user?: TelegramUser;
+  language?: string;
+};
+
+export type TelegramPhotoSize = {
+  file_id: string;
+  file_unique_id: string;
+  width: number;
+  height: number;
+  file_size?: number;
+};
+
+export type TelegramDocument = {
+  file_id: string;
+  file_unique_id: string;
+  file_name?: string;
+  mime_type?: string;
+  file_size?: number;
+};
+
+export type TelegramMessage = {
+  message_id: number;
+  message_thread_id?: number;
+  from?: TelegramUser;
+  sender_chat?: TelegramChat;
+  chat: TelegramChat;
+  date: number;
+  text?: string;
+  caption?: string;
+  entities?: TelegramMessageEntity[];
+  caption_entities?: TelegramMessageEntity[];
+  photo?: TelegramPhotoSize[];
+  document?: TelegramDocument;
+  reply_to_message?: TelegramMessage;
+  is_topic_message?: boolean;
+  via_bot?: TelegramUser;
+};
+
+export type TelegramUpdate = {
+  update_id: number;
+  message?: TelegramMessage;
+  // Other update kinds are filtered server-side via allowed_updates; anything
+  // that still arrives is durably recorded as ignored, never processed.
+  [key: string]: unknown;
+};
+
+export type TelegramFile = {
+  file_id: string;
+  file_unique_id: string;
+  file_size?: number;
+  file_path?: string;
+};
+
+// ---------------------------------------------------------------------------
+// Service options / composition
+// ---------------------------------------------------------------------------
+
+export type TelegrambotFetch = (
+  input: RequestInfo | URL,
+  init?: RequestInit,
+) => Promise<Response>;
+
+export type TelegrambotOptions = {
+  /** Edit cadence for the in-progress answer message (default ~1.5s). */
+  answerEditIntervalMs?: number;
+  apiKey?: string;
+  apiUrl: string;
+  botToken: string;
+  /** Group/supergroup chat ids allowed to trigger sessions. Empty = inert. */
+  chatAllowlist?: readonly string[];
+  fetch?: TelegrambotFetch;
+  harnessType?: string;
+  idleTimeoutMs?: number;
+  /** Lease TTL for fenced ownership (default 30s; renewed at TTL/3). */
+  leaseTtlMs?: number;
+  logger?: Logger;
+  mapper?: CodexAppServerToChatStreamOptions;
+  /** Bounded cross-thread worker concurrency (default 4). */
+  maxConcurrentThreads?: number;
+  maxDurationMs?: number;
+  /** Long-poll timeout passed to getUpdates (default 50s). */
+  pollTimeoutSeconds?: number;
+  postgresUrl?: string;
+  /** Injected pool for tests; otherwise built from postgresUrl. */
+  pool?: Pool;
+  recoverRenderObligationsOnStart?: boolean;
+  /** Terminal inbox rows older than this are eligible for pruning (default 72h). */
+  retentionHours?: number;
+  /** Base URL override for the Bot API (default https://api.telegram.org). */
+  telegramApiUrl?: string;
+  /** Telegram user ids allowed to use private (DM) chats. Empty = no DMs. */
+  userAllowlist?: readonly string[];
+  userName?: string;
+};
+
+export type Telegrambot = {
+  app: Hono;
+  /** Starts ownership, migrations, webhook reconciliation, poller, workers. */
+  start(): Promise<void>;
+  shutdown(): Promise<void>;
+};
+
+// ---------------------------------------------------------------------------
+// Session API contracts (mirrors the discordbot session client shapes)
+// ---------------------------------------------------------------------------
+
+export type TelegrambotSessionMessageRole =
+  | "user"
+  | "assistant"
+  | "system"
+  | "tool";
+
+export type TelegrambotSessionMessage = {
+  client_message_id?: string;
+  metadata: JsonObject;
+  parts: JsonValue[];
+  role: TelegrambotSessionMessageRole;
+};
+
+export type TelegrambotAppendMessagesRequest = {
+  messages: TelegrambotSessionMessage[];
+};
+
+export type TelegrambotCreateSessionRequest = {
+  harness_type: string;
+  metadata: JsonObject;
+};
+
+export type TelegrambotExecuteSessionRequest = {
+  idempotency_key?: string;
+  idle_timeout_ms?: number;
+  input_lines: string[];
+  max_duration_ms?: number;
+  metadata: JsonObject;
+};
+
+export type TelegrambotExecuteSessionResponse = {
+  execution_id: string;
+  ok: boolean;
+  status: string;
+  thread_key: string;
+};
+
+export type TelegrambotRendererSource = RustSessionStreamEvent | JsonObject;
+
+// ---------------------------------------------------------------------------
+// Durable inbox / poll state (owned tables, see src/migrations.ts)
+// ---------------------------------------------------------------------------
+
+/**
+ * Processing stages an accepted update moves through. Receipt
+ * (`receive_offset`) is tracked separately in telegram_poll_state and is never
+ * gated on these stages.
+ *
+ * - received: durably stored, not yet dispatched
+ * - message_appended: durable session message appended (stable client_message_id)
+ * - steering_pending: appended while an execution was active; awaiting
+ *   steering_delivered / execution-terminal resolution
+ * - execution_accepted: api-rs accepted an idempotent execution
+ * - render_obligation_persisted: replayable render state is discoverable
+ * - completed | steered | ignored | rejected | failed: terminal (ignored /
+ *   rejected / failed always carry a durable reason)
+ */
+export type TelegramInboxStatus =
+  | "received"
+  | "message_appended"
+  | "steering_pending"
+  | "execution_accepted"
+  | "render_obligation_persisted"
+  | "completed"
+  | "steered"
+  | "ignored"
+  | "rejected"
+  | "failed";
+
+export const TERMINAL_INBOX_STATUSES: readonly TelegramInboxStatus[] = [
+  "completed",
+  "steered",
+  "ignored",
+  "rejected",
+  "failed",
+];
+
+export type TelegramInboxRow = {
+  botUserId: string;
+  updateId: number;
+  payload: TelegramUpdate;
+  status: TelegramInboxStatus;
+  /** Typed durable key; null until the update is accepted for processing. */
+  threadKey: string | null;
+  /** Stable append/execute idempotency key: telegram:{chatId}:{messageId}. */
+  clientMessageId: string | null;
+  executionId: string | null;
+  statusReason: string | null;
+  receivedAt: Date;
+  updatedAt: Date;
+};
+
+/**
+ * Fenced ownership + receipt cursor, one row per bot user id. Every cursor
+ * update and inbox transition must match holder_id + generation on an
+ * unexpired lease in the same statement/transaction (see src/ownership.ts).
+ */
+export type TelegramPollState = {
+  botUserId: string;
+  receiveOffset: number | null;
+  holderId: string | null;
+  generation: number;
+  leaseExpiresAt: Date | null;
+};
+
+export type OwnershipLease = {
+  botUserId: string;
+  holderId: string;
+  generation: number;
+};
+
+// ---------------------------------------------------------------------------
+// Rendering
+// ---------------------------------------------------------------------------
+
+/**
+ * Durable render obligation: persisted before any Telegram send so a crashed
+ * or restarted worker can resume terminal delivery (at-least-once; a send
+ * whose response was never recorded may be duplicated on recovery).
+ */
+export type TelegramRenderObligation = {
+  threadKey: string;
+  executionId: string;
+  chatId: string;
+  /** Forum/private topic the output must stay in, when present. */
+  messageThreadId: number | null;
+  /** message_id of the triggering Telegram message (reactions target it). */
+  triggerMessageId: number;
+  afterEventId: number;
+  /** message_ids already posted for this answer, oldest first. */
+  postedMessageIds: number[];
+  /** Rendered text already durably delivered into postedMessageIds. */
+  deliveredText: string;
+};
+
+export type TelegramNarratorOutcome = "done" | "failed" | "retrying";
+
+export type TelegrambotMessageMode = "append" | "execute" | "steer";
+
+export type TelegrambotTrace = {
+  messageId: string;
+  mode: TelegrambotMessageMode;
+  openStream: boolean;
+  startedAtMs: number;
+  threadKey: string;
+};

--- a/services/telegrambot/src/utils.ts
+++ b/services/telegrambot/src/utils.ts
@@ -1,0 +1,109 @@
+import type { JsonObject, Logger, TelegrambotTrace } from "./types";
+
+export const noopLogger: Logger = {
+  debug: () => undefined,
+  info: () => undefined,
+  warn: () => undefined,
+  error: () => undefined,
+  child: () => noopLogger,
+};
+
+export function nowMs(): number {
+  return globalThis.performance?.now?.() ?? Date.now();
+}
+
+export function elapsedMs(startedAtMs: number): number {
+  return Math.max(0, Math.round(nowMs() - startedAtMs));
+}
+
+export function traceLog(
+  logger: Logger | undefined,
+  event: string,
+  trace?: TelegrambotTrace,
+  fields: JsonObject = {},
+): void {
+  (logger ?? noopLogger).info(event, {
+    ...(trace
+      ? {
+          elapsed_ms: elapsedMs(trace.startedAtMs),
+          message_id: trace.messageId,
+          mode: trace.mode,
+          open_stream: trace.openStream,
+          thread_key: trace.threadKey,
+        }
+      : {}),
+    ...fields,
+  });
+}
+
+export function errorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  return String(error);
+}
+
+export function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+export function isJsonObject(value: unknown): value is JsonObject {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}
+
+export async function* toAsyncIterable<T>(
+  source: Iterable<T>,
+): AsyncIterable<T> {
+  for await (const item of source) {
+    yield item;
+  }
+}
+
+// Telegram delta (same motivation as the Discord port): Telegram counts
+// message length in UTF-16 code units and rejects payloads that cut a
+// surrogate pair in half, so every truncation of user-visible text must back
+// off the cut when it lands mid-pair.
+/** Surrogate-safe prefix: never cuts between a UTF-16 surrogate pair. */
+export function sliceSurrogateSafe(value: string, maxUnits: number): string {
+  if (maxUnits <= 0) return "";
+  if (value.length <= maxUnits) return value;
+  const tail = value.charCodeAt(maxUnits - 1);
+  const end = tail >= 0xd800 && tail <= 0xdbff ? maxUnits - 1 : maxUnits;
+  return value.slice(0, end);
+}
+
+/**
+ * Single-consumer async queue bridging a producer loop to an AsyncIterable
+ * consumer (e.g. the answer streamer). push() never blocks; end() lets the
+ * consumer drain the remaining items and finish.
+ */
+export class AsyncTextQueue implements AsyncIterable<string> {
+  private readonly values: string[] = [];
+  private done = false;
+  private wake: (() => void) | null = null;
+
+  push(value: string): void {
+    this.values.push(value);
+    this.wake?.();
+  }
+
+  end(): void {
+    this.done = true;
+    this.wake?.();
+  }
+
+  async *[Symbol.asyncIterator](): AsyncIterator<string> {
+    while (true) {
+      const value = this.values.shift();
+      if (value !== undefined) {
+        yield value;
+        continue;
+      }
+      if (this.done) return;
+      await new Promise<void>((resolve) => {
+        this.wake = () => {
+          this.wake = null;
+          resolve();
+        };
+      });
+    }
+  }
+}

--- a/services/telegrambot/test/inbox.test.ts
+++ b/services/telegrambot/test/inbox.test.ts
@@ -1,0 +1,467 @@
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import pg from "pg";
+import type { Pool } from "pg";
+import {
+  acceptForProcessing,
+  claimNextPerThread,
+  ingestBatch,
+  listRecoverableObligations,
+  markIgnored,
+  markRejected,
+  pruneTerminal,
+  readReceiveOffset,
+  transition,
+} from "../src/inbox";
+import { runMigrations } from "../src/migrations";
+import { OwnershipLostError, acquireOwnership } from "../src/ownership";
+import type {
+  OwnershipLease,
+  TelegramInboxStatus,
+  TelegramRenderObligation,
+  TelegramUpdate,
+} from "../src/types";
+
+/**
+ * Durable inbox tests (spec §2 receipt contract + §2a atomicity) against real
+ * Postgres. Skipped cleanly when TELEGRAMBOT_TEST_DATABASE_URL is unset.
+ * Every test uses its own bot_user_id, so state is hermetic per test and the
+ * shared tables are cleaned up in afterAll (same pattern as poller.test.ts).
+ */
+
+const databaseUrl = process.env.TELEGRAMBOT_TEST_DATABASE_URL;
+
+let nextBotId = 830_000_000 + Math.floor(Math.random() * 100_000_000);
+
+const NONTERMINAL_STATUSES: readonly TelegramInboxStatus[] = [
+  "received",
+  "message_appended",
+  "steering_pending",
+  "execution_accepted",
+  "render_obligation_persisted",
+];
+
+function messageUpdate(updateId: number, text?: string): TelegramUpdate {
+  return {
+    update_id: updateId,
+    message: {
+      message_id: updateId,
+      from: { id: 42, is_bot: false, first_name: "Alice" },
+      chat: { id: -1001, type: "supergroup" as const, title: "ops" },
+      date: Math.floor(Date.now() / 1000),
+      text: text ?? `hello ${updateId}`,
+    },
+  };
+}
+
+describe.skipIf(!databaseUrl)("durable inbox (requires Postgres)", () => {
+  const pool: Pool = new pg.Pool({
+    connectionString: databaseUrl,
+    max: 10,
+    connectionTimeoutMillis: 10_000,
+  });
+  const usedBotIds: string[] = [];
+
+  async function setup(): Promise<{
+    botUserId: string;
+    lease: OwnershipLease;
+  }> {
+    const botUserId = String(nextBotId++);
+    usedBotIds.push(botUserId);
+    const lease = await acquireOwnership(pool, botUserId, "worker-1", 60_000);
+    if (!lease) throw new Error("failed to acquire test lease");
+    return { botUserId, lease };
+  }
+
+  async function inboxRow(
+    botUserId: string,
+    updateId: number,
+  ): Promise<{
+    status: string;
+    executionId: string | null;
+    statusReason: string | null;
+    text: string | undefined;
+  } | null> {
+    const result = await pool.query<{
+      status: string;
+      execution_id: string | null;
+      status_reason: string | null;
+      payload: TelegramUpdate;
+    }>(
+      `SELECT status, execution_id, status_reason, payload
+       FROM telegram_update_inbox WHERE bot_user_id = $1 AND update_id = $2`,
+      [botUserId, updateId],
+    );
+    const row = result.rows[0];
+    if (!row) return null;
+    return {
+      status: row.status,
+      executionId: row.execution_id,
+      statusReason: row.status_reason,
+      text: row.payload.message?.text,
+    };
+  }
+
+  async function inboxUpdateIds(botUserId: string): Promise<number[]> {
+    const result = await pool.query<{ update_id: string }>(
+      "SELECT update_id FROM telegram_update_inbox WHERE bot_user_id = $1 ORDER BY update_id",
+      [botUserId],
+    );
+    return result.rows.map((row) => Number(row.update_id));
+  }
+
+  beforeAll(async () => {
+    await runMigrations(pool);
+  });
+
+  afterAll(async () => {
+    if (usedBotIds.length > 0) {
+      await pool.query(
+        "DELETE FROM telegram_update_inbox WHERE bot_user_id = ANY($1::text[])",
+        [usedBotIds],
+      );
+      await pool.query(
+        "DELETE FROM telegram_poll_state WHERE bot_user_id = ANY($1::text[])",
+        [usedBotIds],
+      );
+    }
+    await pool.end();
+  });
+
+  it("readReceiveOffset is null on first start, before and after the lease row exists", async () => {
+    const botUserId = String(nextBotId++);
+    usedBotIds.push(botUserId);
+
+    // No poll_state row at all.
+    expect(await readReceiveOffset(pool, botUserId)).toBe(null);
+
+    // Lease row exists but no batch was ever committed: still null, so the
+    // first getUpdates is issued WITHOUT an offset.
+    const lease = await acquireOwnership(pool, botUserId, "worker-1", 60_000);
+    expect(lease).not.toBeNull();
+    expect(await readReceiveOffset(pool, botUserId)).toBe(null);
+  });
+
+  it("ingestBatch persists the whole batch and advances the cursor to max(update_id)+1 in one commit", async () => {
+    const { botUserId, lease } = await setup();
+
+    const committed = await ingestBatch(pool, lease, [
+      messageUpdate(10),
+      messageUpdate(12),
+    ]);
+    expect(committed).toBe(13);
+    expect(await readReceiveOffset(pool, botUserId)).toBe(13);
+    expect(await inboxUpdateIds(botUserId)).toEqual([10, 12]);
+
+    const row = await inboxRow(botUserId, 12);
+    expect(row?.status).toBe("received");
+    expect(row?.text).toBe("hello 12");
+  });
+
+  it("an empty batch returns the committed cursor and still proves the lease", async () => {
+    const { botUserId, lease } = await setup();
+
+    // Empty poll before any batch: cursor is still null.
+    expect(await ingestBatch(pool, lease, [])).toBe(null);
+    await ingestBatch(pool, lease, [messageUpdate(7)]);
+    expect(await ingestBatch(pool, lease, [])).toBe(8);
+
+    // A fenced-out identity may not even read "its" cursor via an empty poll.
+    const ghost: OwnershipLease = {
+      botUserId,
+      holderId: "ghost",
+      generation: 99,
+    };
+    await expect(ingestBatch(pool, ghost, [])).rejects.toThrow(
+      OwnershipLostError,
+    );
+  });
+
+  it("a failure between batch upsert and cursor advance rolls back BOTH", async () => {
+    const { botUserId, lease } = await setup();
+    await ingestBatch(pool, lease, [messageUpdate(20)]);
+
+    await expect(
+      ingestBatch(pool, lease, [messageUpdate(21), messageUpdate(22)], undefined, {
+        beforeCursorAdvance: () => {
+          throw new Error("injected crash before cursor advance");
+        },
+      }),
+    ).rejects.toThrow("injected crash before cursor advance");
+
+    // Neither the rows nor the cursor moved: the next poll re-fetches the
+    // same batch instead of silently losing it.
+    expect(await inboxUpdateIds(botUserId)).toEqual([20]);
+    expect(await readReceiveOffset(pool, botUserId)).toBe(21);
+
+    // The same batch then ingests cleanly (redelivery path).
+    expect(await ingestBatch(pool, lease, [messageUpdate(21), messageUpdate(22)])).toBe(
+      23,
+    );
+    expect(await inboxUpdateIds(botUserId)).toEqual([20, 21, 22]);
+  });
+
+  it("re-ingesting a duplicate update keeps the existing row's stage and payload while still advancing the cursor", async () => {
+    const { botUserId, lease } = await setup();
+    await ingestBatch(pool, lease, [messageUpdate(30, "original text")]);
+    expect(
+      await transition(pool, lease, 30, ["received"], "message_appended"),
+    ).toBe(true);
+
+    // Telegram redelivers 30 (with a mutated payload, to prove DO NOTHING)
+    // alongside new update 31.
+    const committed = await ingestBatch(pool, lease, [
+      messageUpdate(30, "redelivered text"),
+      messageUpdate(31),
+    ]);
+    expect(committed).toBe(32);
+    expect(await readReceiveOffset(pool, botUserId)).toBe(32);
+
+    const row = await inboxRow(botUserId, 30);
+    expect(row?.status).toBe("message_appended");
+    expect(row?.text).toBe("original text");
+    expect((await inboxRow(botUserId, 31))?.status).toBe("received");
+  });
+
+  it("non-sequential update ids set the offset to max+1 without assuming contiguity", async () => {
+    const { botUserId, lease } = await setup();
+    const committed = await ingestBatch(pool, lease, [
+      messageUpdate(100),
+      messageUpdate(150),
+      messageUpdate(120),
+    ]);
+    expect(committed).toBe(151);
+    expect(await readReceiveOffset(pool, botUserId)).toBe(151);
+    expect(await inboxUpdateIds(botUserId)).toEqual([100, 120, 150]);
+  });
+
+  it("the cursor never regresses when an older batch is replayed", async () => {
+    const { botUserId, lease } = await setup();
+    await ingestBatch(pool, lease, [messageUpdate(40), messageUpdate(41)]);
+    expect(await readReceiveOffset(pool, botUserId)).toBe(42);
+
+    // Replay of an older, already-confirmed batch: rows dedupe, cursor holds.
+    const committed = await ingestBatch(pool, lease, [messageUpdate(40)]);
+    expect(committed).toBe(42);
+    expect(await readReceiveOffset(pool, botUserId)).toBe(42);
+  });
+
+  it("receipt is independent of processing: 100 updates with the first held nonterminal still let update 101 ingest and advance", async () => {
+    const { botUserId, lease } = await setup();
+    const batch = Array.from({ length: 100 }, (_, index) =>
+      messageUpdate(index + 1),
+    );
+    expect(await ingestBatch(pool, lease, batch)).toBe(101);
+
+    // First update starts processing and stays at a nonterminal stage.
+    expect(
+      await acceptForProcessing(
+        pool,
+        lease,
+        1,
+        "telegram:chat:-1001",
+        "telegram:-1001:1",
+      ),
+    ).toBe(true);
+    expect(
+      await transition(pool, lease, 1, ["received"], "message_appended"),
+    ).toBe(true);
+
+    // Telegram would only return update 101 to a poll at offset 101; that
+    // batch must ingest and advance regardless of update 1's stage.
+    expect(await ingestBatch(pool, lease, [messageUpdate(101)])).toBe(102);
+    expect(await readReceiveOffset(pool, botUserId)).toBe(102);
+    expect((await inboxRow(botUserId, 1))?.status).toBe("message_appended");
+    expect((await inboxRow(botUserId, 101))?.status).toBe("received");
+  });
+
+  it("markIgnored and markRejected record durable reasons and are terminal", async () => {
+    const { botUserId, lease } = await setup();
+    await ingestBatch(pool, lease, [messageUpdate(50), messageUpdate(51)]);
+
+    expect(
+      await markIgnored(pool, lease, 50, "unsupported_update_type:channel_post"),
+    ).toBe(true);
+    expect(await markRejected(pool, lease, 51, "not_allowlisted")).toBe(true);
+
+    const ignored = await inboxRow(botUserId, 50);
+    expect(ignored?.status).toBe("ignored");
+    expect(ignored?.statusReason).toBe("unsupported_update_type:channel_post");
+    const rejected = await inboxRow(botUserId, 51);
+    expect(rejected?.status).toBe("rejected");
+    expect(rejected?.statusReason).toBe("not_allowlisted");
+
+    // Terminal: neither a repeat marking nor a normal stage transition moves
+    // the row again, and the original reason is preserved.
+    expect(await markIgnored(pool, lease, 50, "second reason")).toBe(false);
+    expect(
+      await transition(pool, lease, 50, NONTERMINAL_STATUSES, "message_appended"),
+    ).toBe(false);
+    expect((await inboxRow(botUserId, 50))?.statusReason).toBe(
+      "unsupported_update_type:channel_post",
+    );
+
+    // A terminal reason is mandatory, checked before any write.
+    await expect(markIgnored(pool, lease, 50, "   ")).rejects.toThrow(
+      /durable reason/,
+    );
+    await expect(
+      transition(pool, lease, 51, ["received"], "rejected"),
+    ).rejects.toThrow(/durable reason/);
+  });
+
+  it("transition is a fenced compare-and-set: wrong fromStatus changes nothing, the right one persists patch fields with JSON round-trip", async () => {
+    const { botUserId, lease } = await setup();
+    await ingestBatch(pool, lease, [messageUpdate(60)]);
+
+    // Wrong fromStatus: no write at all.
+    expect(
+      await transition(pool, lease, 60, ["message_appended"], "execution_accepted", {
+        executionId: "exec-should-not-land",
+      }),
+    ).toBe(false);
+    const untouched = await inboxRow(botUserId, 60);
+    expect(untouched?.status).toBe("received");
+    expect(untouched?.executionId).toBe(null);
+
+    // Correct CAS chain persists each patch.
+    expect(
+      await transition(pool, lease, 60, ["received"], "message_appended"),
+    ).toBe(true);
+    expect(
+      await transition(pool, lease, 60, ["message_appended"], "execution_accepted", {
+        executionId: "exec-1",
+      }),
+    ).toBe(true);
+
+    const obligation: TelegramRenderObligation = {
+      threadKey: "telegram:chat:-1001:17",
+      executionId: "exec-1",
+      chatId: "-1001",
+      messageThreadId: 17,
+      triggerMessageId: 60,
+      afterEventId: 41,
+      postedMessageIds: [900, 901],
+      deliveredText: "partial answer\nwith unicode \u{1F680}",
+    };
+    expect(
+      await transition(
+        pool,
+        lease,
+        60,
+        ["execution_accepted"],
+        "render_obligation_persisted",
+        { renderObligation: obligation },
+      ),
+    ).toBe(true);
+
+    // The obligation round-trips through jsonb byte-for-value identical, and
+    // earlier patch fields (execution id) were not erased.
+    const recoverable = await listRecoverableObligations(pool, botUserId);
+    expect(recoverable).toHaveLength(1);
+    expect(recoverable[0]?.updateId).toBe(60);
+    expect(recoverable[0]?.executionId).toBe("exec-1");
+    expect(recoverable[0]?.renderObligation).toEqual(obligation);
+    expect(recoverable[0]?.status).toBe("render_obligation_persisted");
+  });
+
+  it("claimNextPerThread returns the oldest nonterminal row per thread, at most one per thread, honoring exclusions and unstamped rows", async () => {
+    const { botUserId, lease } = await setup();
+    await ingestBatch(pool, lease, [
+      messageUpdate(70),
+      messageUpdate(71),
+      messageUpdate(72),
+      messageUpdate(73),
+      messageUpdate(74),
+    ]);
+
+    // Thread A holds 70 (in-flight) and 72; thread B holds 71 (nonterminal)
+    // and 73 (terminal); 74 stays unstamped `received`.
+    await acceptForProcessing(pool, lease, 70, "thread-a", "telegram:-1001:70");
+    await acceptForProcessing(pool, lease, 72, "thread-a", "telegram:-1001:72");
+    await acceptForProcessing(pool, lease, 71, "thread-b", "telegram:-1001:71");
+    await acceptForProcessing(pool, lease, 73, "thread-b", "telegram:-1001:73");
+    await transition(pool, lease, 70, ["received"], "message_appended");
+    await transition(pool, lease, 73, ["received"], "completed");
+
+    const claimed = await claimNextPerThread(pool, botUserId, [], 10);
+    expect(claimed.map((row) => row.updateId)).toEqual([70, 71, 74]);
+    expect(claimed.map((row) => row.threadKey)).toEqual([
+      "thread-a",
+      "thread-b",
+      null,
+    ]);
+
+    // Exclusion list skips a claimed thread but never hides unstamped rows.
+    const excluded = await claimNextPerThread(pool, botUserId, ["thread-a"], 10);
+    expect(excluded.map((row) => row.updateId)).toEqual([71, 74]);
+
+    // Limit takes the oldest threads first.
+    const limited = await claimNextPerThread(pool, botUserId, [], 2);
+    expect(limited.map((row) => row.updateId)).toEqual([70, 71]);
+
+    expect(await claimNextPerThread(pool, botUserId, [], 0)).toEqual([]);
+  });
+
+  it("pruneTerminal deletes only old terminal rows below the committed cursor and never touches poll_state", async () => {
+    const { botUserId, lease } = await setup();
+    await ingestBatch(pool, lease, [
+      messageUpdate(80),
+      messageUpdate(81),
+      messageUpdate(82),
+    ]);
+    // Cursor is 83.
+    await markIgnored(pool, lease, 80, "old terminal below cursor");
+    await markIgnored(pool, lease, 81, "fresh terminal below cursor");
+
+    // Synthetic terminal row ABOVE the committed cursor (Telegram has not
+    // confirmed it; it could still be redelivered) — must survive pruning.
+    await pool.query(
+      `INSERT INTO telegram_update_inbox (bot_user_id, update_id, payload, status, status_reason)
+       VALUES ($1, 90, '{"update_id": 90}'::jsonb, 'completed', null)`,
+      [botUserId],
+    );
+
+    // Age rows 80 (terminal), 82 (nonterminal), and 90 (above cursor) past
+    // the retention window; 81 stays fresh.
+    await pool.query(
+      `UPDATE telegram_update_inbox SET updated_at = now() - interval '48 hours'
+       WHERE bot_user_id = $1 AND update_id = ANY($2::bigint[])`,
+      [botUserId, [80, 82, 90]],
+    );
+
+    const pollStateBefore = await pool.query(
+      "SELECT receive_offset, holder_id, generation FROM telegram_poll_state WHERE bot_user_id = $1",
+      [botUserId],
+    );
+
+    const deleted = await pruneTerminal(pool, lease, 24);
+    expect(deleted).toBe(1);
+
+    // Only 80 (terminal AND old AND below the cursor) is gone. The fresh
+    // terminal row, the old nonterminal row, and the terminal row above the
+    // cursor all survive.
+    expect(await inboxUpdateIds(botUserId)).toEqual([81, 82, 90]);
+
+    // The receipt cursor and lease are untouched.
+    const pollStateAfter = await pool.query(
+      "SELECT receive_offset, holder_id, generation FROM telegram_poll_state WHERE bot_user_id = $1",
+      [botUserId],
+    );
+    expect(pollStateAfter.rows).toEqual(pollStateBefore.rows);
+    expect(await readReceiveOffset(pool, botUserId)).toBe(83);
+
+    // A fenced-out identity prunes nothing.
+    const ghost: OwnershipLease = {
+      botUserId,
+      holderId: "ghost",
+      generation: 99,
+    };
+    await pool.query(
+      `UPDATE telegram_update_inbox SET updated_at = now() - interval '48 hours'
+       WHERE bot_user_id = $1 AND update_id = 81`,
+      [botUserId],
+    );
+    expect(await pruneTerminal(pool, ghost, 24)).toBe(0);
+    expect(await inboxUpdateIds(botUserId)).toEqual([81, 82, 90]);
+  });
+});

--- a/services/telegrambot/test/index.test.ts
+++ b/services/telegrambot/test/index.test.ts
@@ -1,0 +1,565 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import type { TelegramInboxRecord, TransitionPatch } from "../src/inbox";
+import type {
+  TelegramDispatcher,
+  TelegramInboxStore,
+  TelegramOwnership,
+} from "../src/index";
+import { createTelegramDispatcher } from "../src/index";
+import { createRateLimitedTelegramApi } from "../src/rate-limit";
+import type { TelegramApi } from "../src/telegram-api";
+import { TelegramApiError } from "../src/telegram-api";
+import type {
+  OwnershipLease,
+  TelegramInboxStatus,
+  TelegramMessage,
+  TelegramUpdate,
+  TelegrambotOptions,
+} from "../src/types";
+import { TERMINAL_INBOX_STATUSES } from "../src/types";
+import { noopLogger } from "../src/utils";
+
+/**
+ * Orchestration unit tests: the dispatcher's stage machine driven end to end
+ * with in-memory fakes — an in-memory inbox store (the TelegramInboxStore
+ * seam), a recording fake Telegram Bot API, and a fake api-rs fetch — no
+ * Postgres and no network. The Postgres-backed inbox behavior itself is
+ * covered by inbox.test.ts / telegram-emulate.test.ts.
+ */
+
+const BOT_USER_ID = "999001";
+const BOT_USERNAME = "fake_bot";
+
+const NONTERMINAL: readonly TelegramInboxStatus[] = [
+  "received",
+  "message_appended",
+  "steering_pending",
+  "execution_accepted",
+  "render_obligation_persisted",
+];
+
+const lease: OwnershipLease = {
+  botUserId: BOT_USER_ID,
+  holderId: "holder-1",
+  generation: 1,
+};
+const ownership = (): TelegramOwnership => ({ botUserId: BOT_USER_ID, lease });
+
+// ---------------------------------------------------------------------------
+// In-memory inbox store
+// ---------------------------------------------------------------------------
+
+type FakeStore = TelegramInboxStore & {
+  row(updateId: number): TelegramInboxRecord;
+  rows: Map<number, TelegramInboxRecord>;
+  seed(update: TelegramUpdate): void;
+};
+
+function createFakeStore(): FakeStore {
+  const rows = new Map<number, TelegramInboxRecord>();
+  const terminal = new Set<TelegramInboxStatus>(TERMINAL_INBOX_STATUSES);
+  const nonterminal = (record: TelegramInboxRecord): boolean =>
+    !terminal.has(record.status);
+
+  const doTransition = (
+    updateId: number,
+    fromStatuses: readonly TelegramInboxStatus[],
+    toStatus: TelegramInboxStatus,
+    patch: TransitionPatch = {},
+  ): boolean => {
+    const row = rows.get(updateId);
+    if (!row || !fromStatuses.includes(row.status)) return false;
+    row.status = toStatus;
+    if (patch.executionId !== undefined) row.executionId = patch.executionId;
+    if (patch.renderObligation !== undefined) {
+      row.renderObligation = patch.renderObligation;
+    }
+    if (patch.statusReason !== undefined) row.statusReason = patch.statusReason;
+    row.updatedAt = new Date();
+    return true;
+  };
+
+  return {
+    rows,
+    seed(update) {
+      rows.set(update.update_id, {
+        botUserId: BOT_USER_ID,
+        updateId: update.update_id,
+        payload: update,
+        status: "received",
+        threadKey: null,
+        clientMessageId: null,
+        executionId: null,
+        statusReason: null,
+        renderObligation: null,
+        receivedAt: new Date(),
+        updatedAt: new Date(),
+      });
+    },
+    row(updateId) {
+      const row = rows.get(updateId);
+      if (!row) throw new Error(`no inbox row for update ${updateId}`);
+      return row;
+    },
+    async acceptForProcessing(_lease, updateId, threadKey, clientMessageId) {
+      const row = rows.get(updateId);
+      if (!row || row.status !== "received") return false;
+      row.threadKey = threadKey;
+      row.clientMessageId = clientMessageId;
+      return true;
+    },
+    async claimNextPerThread(_botUserId, excludeThreadKeys, limit) {
+      const excluded = new Set(excludeThreadKeys);
+      const oldestPerThread = new Map<string | null, TelegramInboxRecord>();
+      const ordered = [...rows.values()].sort(
+        (a, b) => a.updateId - b.updateId,
+      );
+      for (const row of ordered) {
+        if (!nonterminal(row)) continue;
+        if (row.threadKey !== null && excluded.has(row.threadKey)) continue;
+        if (!oldestPerThread.has(row.threadKey)) {
+          oldestPerThread.set(row.threadKey, row);
+        }
+      }
+      return [...oldestPerThread.values()]
+        .sort((a, b) => a.updateId - b.updateId)
+        .slice(0, limit)
+        .map((row) => ({ ...row }));
+    },
+    async claimThreadBacklog(_botUserId, threadKey, excludeUpdateIds, limit) {
+      const excluded = new Set(excludeUpdateIds);
+      return [...rows.values()]
+        .filter(
+          (row) =>
+            nonterminal(row) &&
+            row.threadKey === threadKey &&
+            !excluded.has(row.updateId),
+        )
+        .sort((a, b) => a.updateId - b.updateId)
+        .slice(0, limit)
+        .map((row) => ({ ...row }));
+    },
+    async markIgnored(_lease, updateId, reason) {
+      return doTransition(updateId, NONTERMINAL, "ignored", {
+        statusReason: reason,
+      });
+    },
+    async markRejected(_lease, updateId, reason) {
+      return doTransition(updateId, NONTERMINAL, "rejected", {
+        statusReason: reason,
+      });
+    },
+    async pruneTerminal() {
+      return 0;
+    },
+    async transition(_lease, updateId, fromStatuses, toStatus, patch) {
+      return doTransition(updateId, fromStatuses, toStatus, patch);
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Recording fake Telegram Bot API (plain surface, wrapped by the real
+// rate-limit scheduler with zero pacing so tests stay fast)
+// ---------------------------------------------------------------------------
+
+type ApiCall = { method: string; params: Record<string, unknown> };
+
+type FakeTelegramApi = TelegramApi & {
+  calls: ApiCall[];
+  callsFor(method: string): ApiCall[];
+  failNextSendMessage(error: Error): void;
+};
+
+function createFakeTelegramApi(): FakeTelegramApi {
+  const calls: ApiCall[] = [];
+  let nextMessageId = 5_000;
+  let sendFailure: Error | null = null;
+  const record = (method: string, params: unknown): void => {
+    calls.push({ method, params: params as Record<string, unknown> });
+  };
+  return {
+    calls,
+    callsFor: (method) => calls.filter((call) => call.method === method),
+    failNextSendMessage(error) {
+      sendFailure = error;
+    },
+    async getMe() {
+      return {
+        id: Number(BOT_USER_ID),
+        is_bot: true,
+        first_name: "Fake",
+        username: BOT_USERNAME,
+      };
+    },
+    async getUpdates() {
+      return [];
+    },
+    async deleteWebhook() {},
+    async sendMessage(params) {
+      record("sendMessage", params);
+      if (sendFailure) {
+        const failure = sendFailure;
+        sendFailure = null;
+        throw failure;
+      }
+      return {
+        message_id: nextMessageId++,
+        date: Math.floor(Date.now() / 1000),
+        chat: { id: Number(params.chat_id), type: "private" as const },
+        text: params.text,
+      };
+    },
+    async editMessageText(params) {
+      record("editMessageText", params);
+    },
+    async setMessageReaction(params) {
+      record("setMessageReaction", params);
+    },
+    async sendChatAction(params) {
+      record("sendChatAction", params);
+    },
+    async getFile() {
+      throw new Error("getFile not stubbed");
+    },
+    async downloadFile() {
+      throw new Error("downloadFile not stubbed");
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Fake api-rs fetch
+// ---------------------------------------------------------------------------
+
+type FakeSessionApi = {
+  appends: number;
+  creates: number;
+  executes: number;
+  failEvents: boolean;
+  fetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response>;
+};
+
+function answerOutputLines(answer: string): string[] {
+  return [
+    JSON.stringify({
+      method: "item/started",
+      params: {
+        threadId: "t",
+        turnId: "turn-1",
+        startedAtMs: 1,
+        item: {
+          type: "agentMessage",
+          id: "answer-1",
+          text: "",
+          phase: "final_answer",
+          memoryCitation: null,
+        },
+      },
+    }),
+    JSON.stringify({
+      method: "item/agentMessage/delta",
+      params: {
+        threadId: "t",
+        turnId: "turn-1",
+        itemId: "answer-1",
+        delta: answer,
+      },
+    }),
+    JSON.stringify({ type: "turn.completed", turn: { id: "turn-1", items: [] } }),
+  ];
+}
+
+function sseBody(lines: string[]): string {
+  return lines
+    .map(
+      (line, index) =>
+        `id: ${index + 1}\nevent: session.output.line\ndata: ${line}\n\n`,
+    )
+    .join("");
+}
+
+function createFakeSessionApi(answer: string): FakeSessionApi {
+  const api: FakeSessionApi = {
+    appends: 0,
+    creates: 0,
+    executes: 0,
+    failEvents: false,
+    async fetch(input) {
+      const url = new URL(
+        typeof input === "string"
+          ? input
+          : input instanceof URL
+            ? input.toString()
+            : input.url,
+      );
+      const match =
+        /^\/api\/session\/([^/]+)(?:\/(messages|execute|events))?$/.exec(
+          url.pathname,
+        );
+      if (!match) return new Response("not found", { status: 404 });
+      const endpoint = match[2];
+      if (endpoint === "events") {
+        if (api.failEvents) {
+          return new Response("unavailable", {
+            status: 503,
+            statusText: "Service Unavailable",
+          });
+        }
+        return new Response(sseBody(answerOutputLines(answer)), {
+          status: 200,
+          headers: { "content-type": "text/event-stream" },
+        });
+      }
+      if (endpoint === "messages") {
+        api.appends += 1;
+        return Response.json({ ok: true, message_ids: [`msg-${api.appends}`] });
+      }
+      if (endpoint === "execute") {
+        api.executes += 1;
+        return Response.json({
+          ok: true,
+          execution_id: "exe-1",
+          thread_key: decodeURIComponent(match[1] ?? ""),
+          status: "accepted",
+        });
+      }
+      api.creates += 1;
+      return Response.json({ ok: true });
+    },
+  };
+  return api;
+}
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function dmUpdate(updateId: number, userId: number, text: string): TelegramUpdate {
+  const message: TelegramMessage = {
+    message_id: updateId,
+    from: { id: userId, is_bot: false, first_name: "Alice" },
+    chat: { id: userId, type: "private", first_name: "Alice" },
+    date: Math.floor(Date.now() / 1000),
+    text,
+  };
+  return { update_id: updateId, message };
+}
+
+function groupUpdate(
+  updateId: number,
+  chatId: number,
+  text: string,
+): TelegramUpdate {
+  const message: TelegramMessage = {
+    message_id: updateId,
+    from: { id: 42, is_bot: false, first_name: "Alice" },
+    chat: { id: chatId, type: "supergroup", title: "ops" },
+    date: Math.floor(Date.now() / 1000),
+    text,
+  };
+  return { update_id: updateId, message };
+}
+
+type Harness = {
+  api: FakeTelegramApi;
+  dispatcher: TelegramDispatcher;
+  session: FakeSessionApi;
+  store: FakeStore;
+};
+
+const dispatchers: TelegramDispatcher[] = [];
+
+function createHarness(input: {
+  answer?: string;
+  chatAllowlist?: string[];
+  userAllowlist?: string[];
+}): Harness {
+  const store = createFakeStore();
+  const api = createFakeTelegramApi();
+  const session = createFakeSessionApi(input.answer ?? "answer text");
+  const options: TelegrambotOptions = {
+    answerEditIntervalMs: 10,
+    apiUrl: "http://fake-api-rs.invalid",
+    botToken: "fake-token",
+    chatAllowlist: input.chatAllowlist ?? [],
+    fetch: (request, init) => session.fetch(request, init),
+    userAllowlist: input.userAllowlist ?? [],
+  };
+  const dispatcher = createTelegramDispatcher({
+    api: createRateLimitedTelegramApi(api, noopLogger, {
+      jitterMs: () => 0,
+      messageIntervalMs: 0,
+    }),
+    botUsername: async () => BOT_USERNAME,
+    logger: noopLogger,
+    options,
+    ownership,
+    store,
+  });
+  dispatchers.push(dispatcher);
+  return { api, dispatcher, session, store };
+}
+
+afterEach(async () => {
+  for (const dispatcher of dispatchers.splice(0)) {
+    await dispatcher.shutdown();
+  }
+});
+
+async function waitFor(
+  condition: () => boolean,
+  label: string,
+  timeoutMs = 5_000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (condition()) return;
+    await Bun.sleep(10);
+  }
+  throw new Error(`timed out waiting for ${label}`);
+}
+
+function reactionEmojis(api: FakeTelegramApi): string[] {
+  return api.callsFor("setMessageReaction").map((call) => {
+    const reaction = call.params.reaction as Array<{ emoji: string }>;
+    return reaction[0]?.emoji ?? "";
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("telegram dispatcher stage machine", () => {
+  it("walks an allowed DM from received to completed", async () => {
+    const { api, dispatcher, session, store } = createHarness({
+      answer: "**hi** there",
+      userAllowlist: ["42"],
+    });
+    store.seed(dmUpdate(1, 42, "hello centaur"));
+    await dispatcher.nudge();
+    await waitFor(() => store.row(1).status === "completed", "row completed");
+
+    expect(session.creates).toBe(1);
+    expect(session.appends).toBe(1);
+    expect(session.executes).toBe(1);
+    expect(store.row(1).threadKey).toBe("telegram:private:42");
+    expect(store.row(1).clientMessageId).toBe("telegram:42:1");
+    expect(store.row(1).renderObligation?.postedMessageIds.length).toBe(1);
+
+    const sends = api.callsFor("sendMessage");
+    expect(sends.length).toBe(1);
+    expect(sends[0]?.params.text).toBe("<b>hi</b> there");
+    expect(sends[0]?.params.parse_mode).toBe("HTML");
+    expect(sends[0]?.params.reply_parameters).toEqual({ message_id: 1 });
+    // 👀 while working, replaced by ✅ on settle.
+    expect(reactionEmojis(api)).toEqual(["👀", "✅"]);
+  });
+
+  it("rejects an unauthorized DM with a durable reason", async () => {
+    const { api, dispatcher, session, store } = createHarness({
+      userAllowlist: ["7"],
+    });
+    store.seed(dmUpdate(2, 42, "let me in"));
+    await dispatcher.nudge();
+    await waitFor(() => store.row(2).status === "rejected", "row rejected");
+
+    expect(store.row(2).statusReason).toBe("not_allowlisted");
+    expect(session.creates + session.appends + session.executes).toBe(0);
+    expect(api.calls.length).toBe(0);
+  });
+
+  it("ignores a non-triggering group message", async () => {
+    const { api, dispatcher, session, store } = createHarness({
+      chatAllowlist: ["-1001"],
+    });
+    store.seed(groupUpdate(3, -1001, "just chatting"));
+    await dispatcher.nudge();
+    await waitFor(() => store.row(3).status === "ignored", "row ignored");
+
+    expect(store.row(3).statusReason).toBe("not_a_trigger");
+    expect(session.creates + session.appends + session.executes).toBe(0);
+    expect(api.calls.length).toBe(0);
+  });
+
+  it("durably ignores a payload without .message", async () => {
+    const { dispatcher, session, store } = createHarness({});
+    store.seed({ update_id: 4, channel_post: { message_id: 9 } });
+    await dispatcher.nudge();
+    await waitFor(() => store.row(4).status === "ignored", "row ignored");
+
+    expect(store.row(4).statusReason).toBe(
+      "unsupported_update_type:channel_post",
+    );
+    expect(session.creates + session.appends + session.executes).toBe(0);
+  });
+
+  it("executes exactly once on double dispatch", async () => {
+    const { dispatcher, session, store } = createHarness({
+      userAllowlist: ["42"],
+    });
+    store.seed(dmUpdate(5, 42, "run it"));
+    const first = dispatcher.nudge();
+    const second = dispatcher.nudge();
+    await Promise.all([first, second]);
+    await dispatcher.nudge();
+    await waitFor(() => store.row(5).status === "completed", "row completed");
+
+    expect(session.executes).toBe(1);
+    expect(session.appends).toBe(1);
+  });
+
+  it("leaves the obligation in place and settles the narrator as retrying on render failure", async () => {
+    const { api, dispatcher, session, store } = createHarness({
+      userAllowlist: ["42"],
+    });
+    session.failEvents = true;
+    store.seed(dmUpdate(6, 42, "will fail to render"));
+    await dispatcher.nudge();
+    await waitFor(
+      () =>
+        store.row(6).status === "render_obligation_persisted" &&
+        store.row(6).renderObligation !== null &&
+        api.callsFor("setMessageReaction").length > 0,
+      "render attempted",
+    );
+    // Let the failed attempt settle its narrator before asserting.
+    await Bun.sleep(50);
+
+    expect(session.executes).toBe(1);
+    expect(store.row(6).status).toBe("render_obligation_persisted");
+    expect(store.row(6).renderObligation?.executionId).toBe("exe-1");
+    // "retrying" leaves 👀 in place: no ✅/❌ may be posted, and no answer.
+    const emojis = reactionEmojis(api);
+    expect(emojis.length).toBeGreaterThan(0);
+    expect(emojis.every((emoji) => emoji === "👀")).toBe(true);
+    expect(api.callsFor("sendMessage").length).toBe(0);
+  });
+
+  it("falls back to escaped plain text exactly once on a Telegram parse error", async () => {
+    const { api, dispatcher, store } = createHarness({
+      answer: "**bold** answer",
+      userAllowlist: ["42"],
+    });
+    api.failNextSendMessage(
+      new TelegramApiError({
+        method: "sendMessage",
+        status: 400,
+        description: "Bad Request: can't parse entities",
+      }),
+    );
+    store.seed(dmUpdate(7, 42, "render me"));
+    await dispatcher.nudge();
+    await waitFor(() => store.row(7).status === "completed", "row completed");
+
+    const sends = api.callsFor("sendMessage");
+    expect(sends.length).toBe(2);
+    // First attempt was the rendered HTML Telegram rejected...
+    expect(sends[0]?.params.text).toBe("<b>bold</b> answer");
+    // ...the fallback is the escaped tag-free markdown, still parse_mode HTML.
+    expect(sends[1]?.params.text).toBe("**bold** answer");
+    expect(sends[1]?.params.parse_mode).toBe("HTML");
+    expect(reactionEmojis(api)).toEqual(["👀", "✅"]);
+  });
+});

--- a/services/telegrambot/test/index.test.ts
+++ b/services/telegrambot/test/index.test.ts
@@ -5,7 +5,10 @@ import type {
   TelegramInboxStore,
   TelegramOwnership,
 } from "../src/index";
-import { createTelegramDispatcher } from "../src/index";
+import {
+  createActiveExecution,
+  createTelegramDispatcher,
+} from "../src/index";
 import { createRateLimitedTelegramApi } from "../src/rate-limit";
 import type { TelegramApi } from "../src/telegram-api";
 import { TelegramApiError } from "../src/telegram-api";
@@ -372,6 +375,7 @@ const dispatchers: TelegramDispatcher[] = [];
 
 function createHarness(input: {
   answer?: string;
+  answerMaxMessages?: number;
   chatAllowlist?: string[];
   userAllowlist?: string[];
 }): Harness {
@@ -380,6 +384,9 @@ function createHarness(input: {
   const session = createFakeSessionApi(input.answer ?? "answer text");
   const options: TelegrambotOptions = {
     answerEditIntervalMs: 10,
+    ...(input.answerMaxMessages === undefined
+      ? {}
+      : { answerMaxMessages: input.answerMaxMessages }),
     apiUrl: "http://fake-api-rs.invalid",
     botToken: "fake-token",
     chatAllowlist: input.chatAllowlist ?? [],
@@ -452,9 +459,14 @@ describe("telegram dispatcher stage machine", () => {
     expect(sends.length).toBe(1);
     expect(sends[0]?.params.text).toBe("<b>hi</b> there");
     expect(sends[0]?.params.parse_mode).toBe("HTML");
-    expect(sends[0]?.params.reply_parameters).toEqual({ message_id: 1 });
-    // 👀 while working, replaced by ✅ on settle.
-    expect(reactionEmojis(api)).toEqual(["👀", "✅"]);
+    // allow_sending_without_reply: a deleted trigger message must degrade to
+    // a reply-less answer, never a wedged infinite render retry.
+    expect(sends[0]?.params.reply_parameters).toEqual({
+      allow_sending_without_reply: true,
+      message_id: 1,
+    });
+    // 👀 while working, replaced by 👍 on settle.
+    expect(reactionEmojis(api)).toEqual(["👀", "👍"]);
   });
 
   it("rejects an unauthorized DM with a durable reason", async () => {
@@ -530,7 +542,7 @@ describe("telegram dispatcher stage machine", () => {
     expect(session.executes).toBe(1);
     expect(store.row(6).status).toBe("render_obligation_persisted");
     expect(store.row(6).renderObligation?.executionId).toBe("exe-1");
-    // "retrying" leaves 👀 in place: no ✅/❌ may be posted, and no answer.
+    // "retrying" leaves 👀 in place: no 👍/👎 may be posted, and no answer.
     const emojis = reactionEmojis(api);
     expect(emojis.length).toBeGreaterThan(0);
     expect(emojis.every((emoji) => emoji === "👀")).toBe(true);
@@ -560,6 +572,341 @@ describe("telegram dispatcher stage machine", () => {
     // ...the fallback is the escaped tag-free markdown, still parse_mode HTML.
     expect(sends[1]?.params.text).toBe("**bold** answer");
     expect(sends[1]?.params.parse_mode).toBe("HTML");
-    expect(reactionEmojis(api)).toEqual(["👀", "✅"]);
+    expect(reactionEmojis(api)).toEqual(["👀", "👍"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Steering follow-ups (spec §2 recovery cases) and FIFO regressions. These use
+// a push-style fake api-rs whose SSE stream stays open until the test emits
+// events, so a follow-up can arrive while a render is genuinely live.
+// ---------------------------------------------------------------------------
+
+type LiveSessionApi = {
+  appendedClientIds: string[];
+  appends: number;
+  conflictsRemaining: number;
+  creates: number;
+  emit(event: string, data: unknown): void;
+  emitAnswer(answer: string): void;
+  executes: number;
+  failNextAppend: boolean;
+  fetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response>;
+  streams: number;
+};
+
+function createLiveSessionApi(): LiveSessionApi {
+  const encoder = new TextEncoder();
+  let controller: ReadableStreamDefaultController<Uint8Array> | null = null;
+  let eventId = 0;
+  const frame = (event: string, data: string): Uint8Array =>
+    encoder.encode(`id: ${++eventId}\nevent: ${event}\ndata: ${data}\n\n`);
+  const api: LiveSessionApi = {
+    appendedClientIds: [],
+    appends: 0,
+    conflictsRemaining: 0,
+    creates: 0,
+    executes: 0,
+    failNextAppend: false,
+    streams: 0,
+    emit(event, data) {
+      controller?.enqueue(frame(event, JSON.stringify(data)));
+    },
+    emitAnswer(answer) {
+      for (const line of answerOutputLines(answer)) {
+        controller?.enqueue(frame("session.output.line", line));
+      }
+    },
+    async fetch(input, init) {
+      const url = new URL(
+        typeof input === "string"
+          ? input
+          : input instanceof URL
+            ? input.toString()
+            : input.url,
+      );
+      const match =
+        /^\/api\/session\/([^/]+)(?:\/(messages|execute|events))?$/.exec(
+          url.pathname,
+        );
+      if (!match) return new Response("not found", { status: 404 });
+      const endpoint = match[2];
+      if (endpoint === "events") {
+        api.streams += 1;
+        const body = new ReadableStream<Uint8Array>({
+          start(streamController) {
+            controller = streamController;
+          },
+        });
+        return new Response(body, {
+          status: 200,
+          headers: { "content-type": "text/event-stream" },
+        });
+      }
+      if (endpoint === "messages") {
+        if (api.failNextAppend) {
+          api.failNextAppend = false;
+          return new Response("unavailable", {
+            status: 503,
+            statusText: "Service Unavailable",
+          });
+        }
+        api.appends += 1;
+        const parsed = JSON.parse(String(init?.body ?? "{}")) as {
+          messages?: Array<{ client_message_id?: string }>;
+        };
+        api.appendedClientIds.push(
+          parsed.messages?.[0]?.client_message_id ?? "",
+        );
+        return Response.json({ ok: true, message_ids: [`msg-${api.appends}`] });
+      }
+      if (endpoint === "execute") {
+        if (api.conflictsRemaining > 0) {
+          api.conflictsRemaining -= 1;
+          return new Response("execution already active", {
+            status: 409,
+            statusText: "Conflict",
+          });
+        }
+        api.executes += 1;
+        return Response.json({
+          ok: true,
+          execution_id: `exe-${api.executes}`,
+          thread_key: decodeURIComponent(match[1] ?? ""),
+          status: "accepted",
+        });
+      }
+      api.creates += 1;
+      return Response.json({ ok: true });
+    },
+  };
+  return api;
+}
+
+type LiveHarness = {
+  api: FakeTelegramApi;
+  dispatcher: TelegramDispatcher;
+  session: LiveSessionApi;
+  store: FakeStore;
+};
+
+function createLiveHarness(): LiveHarness {
+  const store = createFakeStore();
+  const api = createFakeTelegramApi();
+  const session = createLiveSessionApi();
+  const options: TelegrambotOptions = {
+    answerEditIntervalMs: 10,
+    apiUrl: "http://fake-api-rs.invalid",
+    botToken: "fake-token",
+    chatAllowlist: [],
+    fetch: (request, init) => session.fetch(request, init),
+    userAllowlist: ["42"],
+  };
+  const dispatcher = createTelegramDispatcher({
+    api: createRateLimitedTelegramApi(api, noopLogger, {
+      jitterMs: () => 0,
+      messageIntervalMs: 0,
+    }),
+    botUsername: async () => BOT_USERNAME,
+    logger: noopLogger,
+    options,
+    ownership,
+    store,
+  });
+  dispatchers.push(dispatcher);
+  return { api, dispatcher, session, store };
+}
+
+describe("steering follow-ups", () => {
+  it("steers a follow-up into the live execution on steering_delivered", async () => {
+    const { dispatcher, session, store } = createLiveHarness();
+    store.seed(dmUpdate(1, 42, "first question"));
+    await dispatcher.nudge();
+    await waitFor(() => session.streams === 1, "render stream open");
+
+    store.seed(dmUpdate(2, 42, "follow-up"));
+    await dispatcher.nudge();
+    await waitFor(
+      () => store.row(2).status === "steering_pending",
+      "follow-up steering_pending",
+    );
+    // The follow-up's turn already reached the durable session, in order.
+    expect(session.appendedClientIds).toEqual([
+      "telegram:42:1",
+      "telegram:42:2",
+    ]);
+
+    // api-rs confirms delivery by the SERVER-assigned append id.
+    session.emit("session.steering_delivered", {
+      execution_id: "exe-1",
+      message_ids: ["msg-2"],
+      thread_key: "telegram:private:42",
+    });
+    await waitFor(() => store.row(2).status === "steered", "row steered");
+
+    session.emitAnswer("done");
+    await waitFor(() => store.row(1).status === "completed", "row completed");
+    expect(session.executes).toBe(1);
+  });
+
+  it("re-executes idempotently when steering fails", async () => {
+    const { dispatcher, session, store } = createLiveHarness();
+    store.seed(dmUpdate(1, 42, "first question"));
+    await dispatcher.nudge();
+    await waitFor(() => session.streams === 1, "render stream open");
+
+    store.seed(dmUpdate(2, 42, "follow-up"));
+    await dispatcher.nudge();
+    await waitFor(
+      () => store.row(2).status === "steering_pending",
+      "follow-up steering_pending",
+    );
+
+    session.emit("session.steering_failed", {
+      execution_id: "exe-1",
+      error: "execution not accepting input",
+      thread_key: "telegram:private:42",
+    });
+    // The failed steer bounces back and waits on the still-live execution;
+    // its terminal settle releases the idempotent execute, whose own render
+    // opens a second stream this test must feed.
+    session.emitAnswer("first answer");
+    await waitFor(() => store.row(1).status === "completed", "row 1 completed");
+    await waitFor(() => session.streams === 2, "second render stream open");
+    session.emitAnswer("second answer");
+    await waitFor(() => store.row(2).status === "completed", "row 2 completed");
+    // The message was never dropped and never ran concurrently.
+    expect(session.executes).toBe(2);
+    expect(session.appends).toBe(2);
+  });
+
+  it("falls back to exactly one idempotent execute when the execution ends without delivering", async () => {
+    const { dispatcher, session, store } = createLiveHarness();
+    store.seed(dmUpdate(1, 42, "first question"));
+    await dispatcher.nudge();
+    await waitFor(() => session.streams === 1, "render stream open");
+
+    store.seed(dmUpdate(2, 42, "follow-up"));
+    await dispatcher.nudge();
+    await waitFor(
+      () => store.row(2).status === "steering_pending",
+      "follow-up steering_pending",
+    );
+
+    // Execution terminates without ever acknowledging the steer; the
+    // fallback execute runs its own render on a second stream.
+    session.emitAnswer("first answer");
+    await waitFor(() => store.row(1).status === "completed", "row 1 completed");
+    await waitFor(() => session.streams === 2, "second render stream open");
+    session.emitAnswer("second answer");
+    await waitFor(() => store.row(2).status === "completed", "row 2 completed");
+    expect(session.executes).toBe(2);
+  });
+
+  it("recovers a crash after append: resumes at message_appended without re-appending", async () => {
+    const { dispatcher, session, store } = createLiveHarness();
+    // Durable state left by a process that crashed after the append landed
+    // but before any execute/steering disposition.
+    store.seed(dmUpdate(1, 42, "recovered question"));
+    const row = store.row(1);
+    row.status = "message_appended";
+    row.threadKey = "telegram:private:42";
+    row.clientMessageId = "telegram:42:1";
+
+    await dispatcher.nudge();
+    await waitFor(() => session.streams === 1, "render stream open");
+    session.emitAnswer("recovered answer");
+    await waitFor(() => store.row(1).status === "completed", "row completed");
+    expect(session.appends).toBe(0);
+    expect(session.executes).toBe(1);
+  });
+
+  it("retries a foreign-execution conflict with backoff and executes exactly once after it ends", async () => {
+    const { dispatcher, session, store } = createLiveHarness();
+    // api-rs knows an execution this process does not (e.g. pre-crash);
+    // the first execute conflicts, the retry after backoff is accepted.
+    session.conflictsRemaining = 1;
+    store.seed(dmUpdate(1, 42, "conflicted question"));
+    await dispatcher.nudge();
+    // The conflicted row parks as steering_pending, reverts, and retries the
+    // execute after backoff — observable only by the eventual stream open
+    // (the intermediate states last microseconds in-process).
+    await waitFor(() => session.streams === 1, "render stream open", 10_000);
+    session.emitAnswer("late answer");
+    await waitFor(() => store.row(1).status === "completed", "row completed");
+    expect(session.executes).toBe(1);
+    expect(session.appends).toBe(1);
+  });
+});
+
+describe("same-thread FIFO under transient failures", () => {
+  it("defers the whole thread when the oldest row's append fails, preserving order", async () => {
+    const { dispatcher, session, store } = createLiveHarness();
+    session.failNextAppend = true;
+    store.seed(dmUpdate(1, 42, "first"));
+    store.seed(dmUpdate(2, 42, "second"));
+    await dispatcher.nudge();
+
+    // Regression: the old skip-set would append "second" past the transiently
+    // failed "first", inverting the session transcript order.
+    await waitFor(() => session.appends >= 1, "first append retried", 10_000);
+    expect(session.appendedClientIds[0]).toBe("telegram:42:1");
+
+    await waitFor(() => session.streams === 1, "render stream open");
+    await waitFor(
+      () => store.row(2).status === "steering_pending",
+      "second row steered into live execution",
+    );
+    expect(session.appendedClientIds).toEqual([
+      "telegram:42:1",
+      "telegram:42:2",
+    ]);
+
+    session.emit("session.steering_delivered", {
+      execution_id: "exe-1",
+      message_ids: ["msg-2"],
+      thread_key: "telegram:private:42",
+    });
+    await waitFor(() => store.row(2).status === "steered", "row 2 steered");
+    session.emitAnswer("answer");
+    await waitFor(() => store.row(1).status === "completed", "row 1 completed");
+  });
+});
+
+describe("active execution settling", () => {
+  it("resolves a wait registered after settle as terminal instead of wedging", async () => {
+    // Regression: a follow-up worker can capture the ActiveExecution, await a
+    // fenced transition, and register its wait after the render's finally()
+    // settled existing waiters — that wait must resolve, not hang forever.
+    const active = createActiveExecution("exe-1");
+    active.settle();
+    expect(await active.wait(7, ["msg-9"])).toBe("terminal");
+  });
+});
+
+describe("answer max-messages cap", () => {
+  it("collapses honestly past the cap with a truncation notice", async () => {
+    const paragraph = "lorem ipsum dolor sit amet ".repeat(40).trim();
+    const longAnswer = Array.from({ length: 12 }, () => paragraph).join("\n\n");
+    const { api, dispatcher, store } = createHarness({
+      answer: longAnswer,
+      answerMaxMessages: 2,
+      userAllowlist: ["42"],
+    });
+    store.seed(dmUpdate(1, 42, "long question"));
+    await dispatcher.nudge();
+    await waitFor(() => store.row(1).status === "completed", "row completed");
+
+    const texts = [
+      ...api.callsFor("sendMessage").map((call) => String(call.params.text)),
+    ];
+    const edits = api.callsFor("editMessageText");
+    const finalTail = edits.length
+      ? String(edits[edits.length - 1]?.params.text)
+      : texts[texts.length - 1];
+    // Never more messages than the cap, and the final one says so honestly.
+    expect(texts.length).toBe(2);
+    expect(finalTail).toContain("answer truncated");
+    expect(store.row(1).renderObligation?.postedMessageIds.length).toBe(2);
   });
 });

--- a/services/telegrambot/test/migrations.test.ts
+++ b/services/telegrambot/test/migrations.test.ts
@@ -1,0 +1,173 @@
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import pg from "pg";
+import type { Pool } from "pg";
+import {
+  SUPPORTED_SCHEMA_VERSION,
+  checkSchemaVersion,
+  runMigrations,
+} from "../src/migrations";
+
+/**
+ * Migration runner + schema version gate tests against real Postgres.
+ * Skipped cleanly when TELEGRAMBOT_TEST_DATABASE_URL is unset (CI has no
+ * Postgres). The tests in this file are ordered: they walk a database from
+ * clean, through migrated, through simulated version-skew states, and leave
+ * the schema fully migrated for the other DB-backed test files.
+ */
+
+const databaseUrl = process.env.TELEGRAMBOT_TEST_DATABASE_URL;
+
+const TELEGRAM_TABLES = [
+  "telegram_update_inbox",
+  "telegram_poll_state",
+  "telegram_schema_migrations",
+] as const;
+
+describe.skipIf(!databaseUrl)("migrations (requires Postgres)", () => {
+  const pool: Pool = new pg.Pool({
+    connectionString: databaseUrl,
+    max: 10,
+    connectionTimeoutMillis: 10_000,
+  });
+
+  async function dropTelegramTables(): Promise<void> {
+    await pool.query(`DROP TABLE IF EXISTS ${TELEGRAM_TABLES.join(", ")}`);
+  }
+
+  async function tableExists(name: string): Promise<boolean> {
+    const result = await pool.query<{ oid: string | null }>(
+      "SELECT to_regclass($1) AS oid",
+      [name],
+    );
+    return result.rows[0]?.oid != null;
+  }
+
+  async function appliedVersions(): Promise<number[]> {
+    const result = await pool.query<{ version: number }>(
+      "SELECT version FROM telegram_schema_migrations ORDER BY version",
+    );
+    return result.rows.map((row) => Number(row.version));
+  }
+
+  const allVersions = Array.from(
+    { length: SUPPORTED_SCHEMA_VERSION },
+    (_, index) => index + 1,
+  );
+
+  beforeAll(async () => {
+    // Hermetic per-run state: this file exercises clean-database migration,
+    // so it starts from no telegram_* tables at all.
+    await dropTelegramTables();
+  });
+
+  afterAll(async () => {
+    await pool.end();
+  });
+
+  it("checkSchemaVersion reports pending on a clean database", async () => {
+    const check = await checkSchemaVersion(pool);
+    expect(check).toEqual({
+      ok: false,
+      state: "pending",
+      dbVersion: 0,
+      supportedVersion: SUPPORTED_SCHEMA_VERSION,
+    });
+  });
+
+  it("migrates a clean database and passes checkSchemaVersion at SUPPORTED_SCHEMA_VERSION", async () => {
+    await runMigrations(pool);
+
+    expect(await tableExists("telegram_poll_state")).toBe(true);
+    expect(await tableExists("telegram_update_inbox")).toBe(true);
+    expect(await tableExists("telegram_schema_migrations")).toBe(true);
+    expect(await appliedVersions()).toEqual(allVersions);
+
+    const check = await checkSchemaVersion(pool);
+    expect(check).toEqual({
+      ok: true,
+      state: "ok",
+      dbVersion: SUPPORTED_SCHEMA_VERSION,
+      supportedVersion: SUPPORTED_SCHEMA_VERSION,
+    });
+  });
+
+  it("re-running migrations is idempotent and preserves existing data", async () => {
+    await pool.query(
+      `INSERT INTO telegram_poll_state (bot_user_id, receive_offset)
+       VALUES ('migration-idempotency-bot', 42)
+       ON CONFLICT (bot_user_id) DO UPDATE SET receive_offset = 42`,
+    );
+
+    await runMigrations(pool);
+    await runMigrations(pool);
+
+    expect(await appliedVersions()).toEqual(allVersions);
+    const row = await pool.query<{ receive_offset: string }>(
+      "SELECT receive_offset FROM telegram_poll_state WHERE bot_user_id = 'migration-idempotency-bot'",
+    );
+    expect(Number(row.rows[0]?.receive_offset)).toBe(42);
+    expect((await checkSchemaVersion(pool)).ok).toBe(true);
+  });
+
+  it("checkSchemaVersion fails pending when the version ledger is emptied, and a re-run repairs it additively", async () => {
+    await pool.query("TRUNCATE telegram_schema_migrations");
+
+    const pending = await checkSchemaVersion(pool);
+    expect(pending.ok).toBe(false);
+    expect(pending.state).toBe("pending");
+    expect(pending.dbVersion).toBe(0);
+
+    // Re-run repairs the ledger without recreating (and thus wiping) the
+    // tables: the data planted by the previous test must survive.
+    await runMigrations(pool);
+    expect((await checkSchemaVersion(pool)).ok).toBe(true);
+    const row = await pool.query<{ receive_offset: string }>(
+      "SELECT receive_offset FROM telegram_poll_state WHERE bot_user_id = 'migration-idempotency-bot'",
+    );
+    expect(Number(row.rows[0]?.receive_offset)).toBe(42);
+  });
+
+  it("checkSchemaVersion fails closed on an unsupported future schema version", async () => {
+    const futureVersion = SUPPORTED_SCHEMA_VERSION + 1;
+    await pool.query(
+      "INSERT INTO telegram_schema_migrations (version) VALUES ($1)",
+      [futureVersion],
+    );
+
+    const check = await checkSchemaVersion(pool);
+    expect(check.ok).toBe(false);
+    expect(check.state).toBe("unsupported_future");
+    expect(check.dbVersion).toBe(futureVersion);
+
+    // Restore a supported schema so later files see a clean migrated state.
+    await pool.query(
+      "DELETE FROM telegram_schema_migrations WHERE version = $1",
+      [futureVersion],
+    );
+    expect((await checkSchemaVersion(pool)).ok).toBe(true);
+  });
+
+  it("concurrent runMigrations calls on a clean database serialize safely", async () => {
+    await dropTelegramTables();
+
+    await Promise.all([
+      runMigrations(pool),
+      runMigrations(pool),
+      runMigrations(pool),
+    ]);
+
+    // Exactly one ledger row per version — the advisory lock kept the three
+    // runners from double-applying or racing the ledger CREATE.
+    expect(await appliedVersions()).toEqual(allVersions);
+    expect((await checkSchemaVersion(pool)).ok).toBe(true);
+
+    // The migrated schema is actually usable afterwards.
+    await pool.query(
+      "INSERT INTO telegram_poll_state (bot_user_id) VALUES ('migration-concurrency-bot')",
+    );
+    const count = await pool.query<{ count: number }>(
+      "SELECT count(*)::int AS count FROM telegram_poll_state WHERE bot_user_id = 'migration-concurrency-bot'",
+    );
+    expect(count.rows[0]?.count).toBe(1);
+  });
+});

--- a/services/telegrambot/test/migrations.test.ts
+++ b/services/telegrambot/test/migrations.test.ts
@@ -9,10 +9,11 @@ import {
 
 /**
  * Migration runner + schema version gate tests against real Postgres.
- * Skipped cleanly when TELEGRAMBOT_TEST_DATABASE_URL is unset (CI has no
- * Postgres). The tests in this file are ordered: they walk a database from
- * clean, through migrated, through simulated version-skew states, and leave
- * the schema fully migrated for the other DB-backed test files.
+ * Skipped cleanly when TELEGRAMBOT_TEST_DATABASE_URL is unset (CI provisions
+ * a Postgres service container and sets it; local runs without one skip).
+ * The tests in this file are ordered: they walk a database from clean,
+ * through migrated, through simulated version-skew states, and leave the
+ * schema fully migrated for the other DB-backed test files.
  */
 
 const databaseUrl = process.env.TELEGRAMBOT_TEST_DATABASE_URL;
@@ -169,5 +170,68 @@ describe.skipIf(!databaseUrl)("migrations (requires Postgres)", () => {
       "SELECT count(*)::int AS count FROM telegram_poll_state WHERE bot_user_id = 'migration-concurrency-bot'",
     );
     expect(count.rows[0]?.count).toBe(1);
+  });
+
+  it("fails closed when the runtime role lacks DDL privileges: runMigrations rejects and the schema stays pending", async () => {
+    // The runtime role is deliberately the migration runner (see
+    // src/migrations.ts): a locked-down deployment role without CREATE on the
+    // schema must surface as a hard migration failure with the version gate
+    // still pending, so startup stays unready and retries instead of
+    // half-migrating (spec §2a "insufficient DDL privileges").
+    if (!databaseUrl) {
+      throw new Error("unreachable: suite skipped without databaseUrl");
+    }
+    await dropTelegramTables();
+
+    const role = "telegrambot_test_lowpriv";
+    // Test-only fixture credential for the throwaway role below.
+    const password = "telegrambot-test-lowpriv";
+    await pool.query(`DROP ROLE IF EXISTS ${role}`);
+    await pool.query(`CREATE ROLE ${role} LOGIN PASSWORD '${password}'`);
+    // Postgres 15+ already denies CREATE on the public schema to non-owners;
+    // revoke the legacy PUBLIC grant too so the test is deterministic on
+    // older servers.
+    await pool.query("REVOKE CREATE ON SCHEMA public FROM PUBLIC");
+    await pool.query(`REVOKE CREATE ON SCHEMA public FROM ${role}`);
+
+    const lowPrivUrl = new URL(databaseUrl);
+    lowPrivUrl.username = role;
+    lowPrivUrl.password = password;
+    const lowPrivPool: Pool = new pg.Pool({
+      connectionString: lowPrivUrl.toString(),
+      max: 2,
+      connectionTimeoutMillis: 10_000,
+    });
+
+    try {
+      // insufficient_privilege (42501) on the ledger CREATE — before any
+      // version row could possibly be recorded.
+      await expect(runMigrations(lowPrivPool)).rejects.toMatchObject({
+        code: "42501",
+      });
+
+      // The readiness gate, as seen by the low-privilege runtime role
+      // itself, still reports pending: /ready would stay false and the
+      // startup loop would retry.
+      const check = await checkSchemaVersion(lowPrivPool);
+      expect(check).toEqual({
+        ok: false,
+        state: "pending",
+        dbVersion: 0,
+        supportedVersion: SUPPORTED_SCHEMA_VERSION,
+      });
+
+      // Nothing partial landed: no ledger, no telegram tables.
+      for (const table of TELEGRAM_TABLES) {
+        expect(await tableExists(table)).toBe(false);
+      }
+    } finally {
+      await lowPrivPool.end();
+      await pool.query(`DROP ROLE IF EXISTS ${role}`);
+      // Leave the schema fully migrated for the other DB-backed test files.
+      await runMigrations(pool);
+    }
+
+    expect((await checkSchemaVersion(pool)).ok).toBe(true);
   });
 });

--- a/services/telegrambot/test/ownership.test.ts
+++ b/services/telegrambot/test/ownership.test.ts
@@ -1,0 +1,240 @@
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import pg from "pg";
+import type { Pool } from "pg";
+import { ingestBatch, readReceiveOffset, transition } from "../src/inbox";
+import { runMigrations } from "../src/migrations";
+import {
+  OwnershipLostError,
+  acquireOwnership,
+  releaseOwnership,
+  renewLease,
+} from "../src/ownership";
+import type { OwnershipLease, TelegramUpdate } from "../src/types";
+
+/**
+ * Fenced ownership lease tests (spec §2 option b) against real Postgres.
+ * Skipped cleanly when TELEGRAMBOT_TEST_DATABASE_URL is unset. All expiry
+ * timing is database now(); the short TTLs + generous sleeps below only need
+ * "clearly before expiry" / "clearly after expiry", never exact clocks.
+ */
+
+const databaseUrl = process.env.TELEGRAMBOT_TEST_DATABASE_URL;
+
+let nextBotId = 820_000_000 + Math.floor(Math.random() * 100_000_000);
+
+function messageUpdate(updateId: number): TelegramUpdate {
+  return {
+    update_id: updateId,
+    message: {
+      message_id: updateId,
+      from: { id: 42, is_bot: false, first_name: "Alice" },
+      chat: { id: -1001, type: "supergroup" as const, title: "ops" },
+      date: Math.floor(Date.now() / 1000),
+      text: `hello ${updateId}`,
+    },
+  };
+}
+
+describe.skipIf(!databaseUrl)("ownership lease (requires Postgres)", () => {
+  const pool: Pool = new pg.Pool({
+    connectionString: databaseUrl,
+    max: 10,
+    connectionTimeoutMillis: 10_000,
+  });
+  const usedBotIds: string[] = [];
+
+  function newBotUserId(): string {
+    const botUserId = String(nextBotId++);
+    usedBotIds.push(botUserId);
+    return botUserId;
+  }
+
+  async function acquired(
+    botUserId: string,
+    holderId: string,
+    ttlMs: number,
+  ): Promise<OwnershipLease> {
+    const lease = await acquireOwnership(pool, botUserId, holderId, ttlMs);
+    if (!lease) throw new Error(`expected ${holderId} to acquire the lease`);
+    return lease;
+  }
+
+  async function leaseRow(botUserId: string): Promise<{
+    holderId: string | null;
+    generation: number;
+    expired: boolean;
+    expiresAt: Date | null;
+  }> {
+    const result = await pool.query<{
+      holder_id: string | null;
+      generation: string;
+      expired: boolean | null;
+      lease_expires_at: Date | null;
+    }>(
+      `SELECT holder_id, generation, lease_expires_at,
+              lease_expires_at <= now() AS expired
+       FROM telegram_poll_state WHERE bot_user_id = $1`,
+      [botUserId],
+    );
+    const row = result.rows[0];
+    if (!row) throw new Error(`no poll_state row for ${botUserId}`);
+    return {
+      holderId: row.holder_id,
+      generation: Number(row.generation),
+      expired: row.expired ?? true,
+      expiresAt: row.lease_expires_at,
+    };
+  }
+
+  beforeAll(async () => {
+    await runMigrations(pool);
+  });
+
+  afterAll(async () => {
+    if (usedBotIds.length > 0) {
+      await pool.query(
+        "DELETE FROM telegram_update_inbox WHERE bot_user_id = ANY($1::text[])",
+        [usedBotIds],
+      );
+      await pool.query(
+        "DELETE FROM telegram_poll_state WHERE bot_user_id = ANY($1::text[])",
+        [usedBotIds],
+      );
+    }
+    await pool.end();
+  });
+
+  it("acquires on empty state at generation 1 with an unexpired lease", async () => {
+    const botUserId = newBotUserId();
+    const lease = await acquireOwnership(pool, botUserId, "holder-a", 60_000);
+
+    expect(lease).toEqual({ botUserId, holderId: "holder-a", generation: 1 });
+    const row = await leaseRow(botUserId);
+    expect(row.holderId).toBe("holder-a");
+    expect(row.generation).toBe(1);
+    expect(row.expired).toBe(false);
+  });
+
+  it("renewLease extends the lease for the current holder and generation", async () => {
+    const botUserId = newBotUserId();
+    const lease = await acquired(botUserId, "holder-a", 60_000);
+    const before = (await leaseRow(botUserId)).expiresAt;
+    if (!before) throw new Error("expected an expiry");
+
+    // Renewing with a longer TTL must strictly extend database expiry.
+    expect(await renewLease(pool, lease, 120_000)).toBe(true);
+    const after = (await leaseRow(botUserId)).expiresAt;
+    if (!after) throw new Error("expected an expiry");
+    expect(after.getTime()).toBeGreaterThan(before.getTime());
+    expect((await leaseRow(botUserId)).generation).toBe(1);
+  });
+
+  it("a rival cannot take an unexpired lease", async () => {
+    const botUserId = newBotUserId();
+    await acquired(botUserId, "holder-a", 60_000);
+
+    expect(await acquireOwnership(pool, botUserId, "holder-b", 60_000)).toBe(
+      null,
+    );
+    const row = await leaseRow(botUserId);
+    expect(row.holderId).toBe("holder-a");
+    expect(row.generation).toBe(1);
+  });
+
+  it("takeover succeeds only after expiry, increments the generation, and fences out the old holder's renew", async () => {
+    const botUserId = newBotUserId();
+    const oldLease = await acquired(botUserId, "holder-a", 250);
+
+    // Before expiry: no takeover.
+    expect(await acquireOwnership(pool, botUserId, "holder-b", 60_000)).toBe(
+      null,
+    );
+
+    await Bun.sleep(600);
+    const newLease = await acquired(botUserId, "holder-b", 60_000);
+    expect(newLease.generation).toBe(2);
+
+    // The old holder can no longer prove its lease.
+    expect(await renewLease(pool, oldLease, 60_000)).toBe(false);
+    const row = await leaseRow(botUserId);
+    expect(row.holderId).toBe("holder-b");
+    expect(row.generation).toBe(2);
+  });
+
+  it("release expires the lease immediately; reacquire keeps the generation for the same holder and bumps it for a successor", async () => {
+    const botUserId = newBotUserId();
+    const first = await acquired(botUserId, "holder-a", 60_000);
+    expect(first.generation).toBe(1);
+
+    await releaseOwnership(pool, first);
+    expect((await leaseRow(botUserId)).expired).toBe(true);
+
+    // Same holder reacquiring its own released lease: no generation bump —
+    // its in-flight fenced work stays valid.
+    const again = await acquired(botUserId, "holder-a", 60_000);
+    expect(again.generation).toBe(1);
+    expect((await leaseRow(botUserId)).expired).toBe(false);
+
+    // A successor after release does not wait out the TTL and takes a new
+    // generation.
+    await releaseOwnership(pool, again);
+    const successor = await acquired(botUserId, "holder-b", 60_000);
+    expect(successor.generation).toBe(2);
+  });
+
+  it("split-brain: after takeover the expired holder's renew, cursor writes, and transitions all fail while the new holder's succeed", async () => {
+    const botUserId = newBotUserId();
+    const leaseA = await acquired(botUserId, "holder-a", 300);
+
+    // A works normally while its lease is live.
+    expect(await ingestBatch(pool, leaseA, [messageUpdate(1)])).toBe(2);
+    expect(await readReceiveOffset(pool, botUserId)).toBe(2);
+
+    // A pauses (GC/partition) past expiry; B takes over.
+    await Bun.sleep(700);
+    const leaseB = await acquired(botUserId, "holder-b", 60_000);
+    expect(leaseB.generation).toBe(2);
+
+    // A resumes: renewal fails...
+    expect(await renewLease(pool, leaseA, 60_000)).toBe(false);
+
+    // ...its fenced cursor write throws AND rolls back the batch it tried to
+    // persist...
+    await expect(
+      ingestBatch(pool, leaseA, [messageUpdate(5)]),
+    ).rejects.toThrow(OwnershipLostError);
+    const ghostRow = await pool.query(
+      "SELECT 1 FROM telegram_update_inbox WHERE bot_user_id = $1 AND update_id = 5",
+      [botUserId],
+    );
+    expect(ghostRow.rowCount).toBe(0);
+    expect(await readReceiveOffset(pool, botUserId)).toBe(2);
+
+    // ...even an empty poll cannot use A's identity to learn the cursor...
+    await expect(ingestBatch(pool, leaseA, [])).rejects.toThrow(
+      OwnershipLostError,
+    );
+
+    // ...and its fenced stage transition is a no-op.
+    expect(
+      await transition(pool, leaseA, 1, ["received"], "message_appended"),
+    ).toBe(false);
+    const untouched = await pool.query<{ status: string }>(
+      "SELECT status FROM telegram_update_inbox WHERE bot_user_id = $1 AND update_id = 1",
+      [botUserId],
+    );
+    expect(untouched.rows[0]?.status).toBe("received");
+
+    // B, holding the current generation, does all of the above successfully.
+    expect(await ingestBatch(pool, leaseB, [messageUpdate(5)])).toBe(6);
+    expect(await readReceiveOffset(pool, botUserId)).toBe(6);
+    expect(
+      await transition(pool, leaseB, 1, ["received"], "message_appended"),
+    ).toBe(true);
+    const moved = await pool.query<{ status: string }>(
+      "SELECT status FROM telegram_update_inbox WHERE bot_user_id = $1 AND update_id = 1",
+      [botUserId],
+    );
+    expect(moved.rows[0]?.status).toBe("message_appended");
+  });
+});

--- a/services/telegrambot/test/poller.test.ts
+++ b/services/telegrambot/test/poller.test.ts
@@ -1,0 +1,526 @@
+import { afterAll, afterEach, describe, expect, it } from "bun:test";
+import pg from "pg";
+import type { Pool } from "pg";
+import { createPollerController } from "../src/poller";
+import type {
+  IngestedUpdates,
+  PollerController,
+  PollerControllerDeps,
+} from "../src/poller";
+import { acquireOwnership, releaseOwnership } from "../src/ownership";
+import { runMigrations } from "../src/migrations";
+import {
+  createTelegramApi,
+  isTelegramRateLimitError,
+  TelegramApiError,
+} from "../src/telegram-api";
+import type { TelegramUpdate } from "../src/types";
+import { startFakeTelegramServer } from "./support/fake-telegram-server";
+import type { FakeTelegramServer } from "./support/fake-telegram-server";
+
+/**
+ * Poller controller tests: fake Bot API HTTP server + real Postgres.
+ * DB-dependent cases are skipped cleanly when TELEGRAMBOT_TEST_DATABASE_URL
+ * is unset; the fake-server semantics themselves are covered unconditionally.
+ */
+
+const databaseUrl = process.env.TELEGRAMBOT_TEST_DATABASE_URL;
+
+const servers: FakeTelegramServer[] = [];
+const controllers: PollerController[] = [];
+
+function fakeServer(botId: number): FakeTelegramServer {
+  const server = startFakeTelegramServer({ botUser: { id: botId } });
+  servers.push(server);
+  return server;
+}
+
+afterEach(async () => {
+  for (const controller of controllers.splice(0)) {
+    await controller.shutdown();
+  }
+  for (const server of servers.splice(0)) {
+    server.stop();
+  }
+});
+
+async function waitFor(
+  condition: () => boolean | Promise<boolean>,
+  label: string,
+  timeoutMs = 8_000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await condition()) return;
+    await Bun.sleep(20);
+  }
+  throw new Error(`timed out waiting for ${label}`);
+}
+
+let nextBotId = 700_000_000 + Math.floor(Math.random() * 100_000_000);
+
+function messageUpdate(
+  updateId: number,
+  overrides: Partial<TelegramUpdate> = {},
+): TelegramUpdate {
+  return {
+    update_id: updateId,
+    message: {
+      message_id: updateId,
+      from: { id: 42, is_bot: false, first_name: "Alice" },
+      chat: { id: -1001, type: "supergroup" as const, title: "ops" },
+      date: Math.floor(Date.now() / 1000),
+      text: `hello ${updateId}`,
+    },
+    ...overrides,
+  };
+}
+
+describe("fake telegram server", () => {
+  it("honors getUpdates offset semantics: confirms below, redelivers at/above", async () => {
+    const server = fakeServer(nextBotId++);
+    const api = createTelegramApi({
+      botToken: server.token,
+      telegramApiUrl: server.baseUrl,
+      pollTimeoutSeconds: 0,
+    });
+    server.queueUpdates(messageUpdate(1), messageUpdate(2), messageUpdate(3));
+
+    const first = await api.getUpdates({ timeout: 0 });
+    expect(first.map((update) => update.update_id)).toEqual([1, 2, 3]);
+
+    // Same updates again without an offset: nothing confirmed yet.
+    const again = await api.getUpdates({ timeout: 0 });
+    expect(again.map((update) => update.update_id)).toEqual([1, 2, 3]);
+
+    const confirmed = await api.getUpdates({ offset: 3, timeout: 0 });
+    expect(confirmed.map((update) => update.update_id)).toEqual([3]);
+    expect(server.confirmedUpdateIds).toEqual([1, 2]);
+    expect(server.pendingUpdateIds()).toEqual([3]);
+  });
+
+  it("injects scripted failures with Telegram error shape", async () => {
+    const server = fakeServer(nextBotId++);
+    const api = createTelegramApi({
+      botToken: server.token,
+      telegramApiUrl: server.baseUrl,
+      pollTimeoutSeconds: 0,
+    });
+    server.failNext("getUpdates", {
+      status: 429,
+      description: "Too Many Requests",
+      retryAfterSeconds: 7,
+    });
+
+    expect.assertions(4);
+    try {
+      await api.getUpdates({ timeout: 0 });
+    } catch (error) {
+      expect(error).toBeInstanceOf(TelegramApiError);
+      expect(isTelegramRateLimitError(error)).toBe(true);
+      expect((error as TelegramApiError).retryAfterSeconds).toBe(7);
+    }
+    // Script consumed: the next call succeeds.
+    expect(await api.getUpdates({ timeout: 0 })).toEqual([]);
+  });
+});
+
+describe.skipIf(!databaseUrl)("poller controller (requires Postgres)", () => {
+  const pool: Pool = new pg.Pool({
+    connectionString: databaseUrl,
+    max: 10,
+    connectionTimeoutMillis: 10_000,
+  });
+  const usedBotIds: string[] = [];
+  let migrated = false;
+
+  afterAll(async () => {
+    if (usedBotIds.length > 0 && migrated) {
+      await pool.query(
+        "DELETE FROM telegram_update_inbox WHERE bot_user_id = ANY($1::text[])",
+        [usedBotIds],
+      );
+      await pool.query(
+        "DELETE FROM telegram_poll_state WHERE bot_user_id = ANY($1::text[])",
+        [usedBotIds],
+      );
+    }
+    await pool.end();
+  });
+
+  async function setup(
+    overrides: Partial<PollerControllerDeps> = {},
+  ): Promise<{
+    server: FakeTelegramServer;
+    controller: PollerController;
+    botUserId: string;
+    batches: IngestedUpdates[];
+    fatal: { called: boolean };
+  }> {
+    if (!migrated) {
+      await runMigrations(pool);
+      migrated = true;
+    }
+    const botId = nextBotId++;
+    const botUserId = String(botId);
+    usedBotIds.push(botUserId);
+    const server = fakeServer(botId);
+    const api = createTelegramApi({
+      botToken: server.token,
+      telegramApiUrl: server.baseUrl,
+    });
+    const batches: IngestedUpdates[] = [];
+    const fatal = { called: false };
+    const controller = createPollerController({
+      api,
+      pool,
+      leaseTtlMs: 1_500,
+      pollTimeoutSeconds: 1,
+      freshnessWindowMs: 5_000,
+      backoff: { baseMs: 25, maxMs: 100 },
+      onUpdatesIngested: (batch) => {
+        batches.push(batch);
+      },
+      onFatalEnd: () => {
+        fatal.called = true;
+      },
+      ...overrides,
+    });
+    controllers.push(controller);
+    return { server, controller, botUserId, batches, fatal };
+  }
+
+  async function receiveOffset(botUserId: string): Promise<number | null> {
+    const result = await pool.query<{ receive_offset: string | null }>(
+      "SELECT receive_offset FROM telegram_poll_state WHERE bot_user_id = $1",
+      [botUserId],
+    );
+    const raw = result.rows[0]?.receive_offset;
+    return raw === null || raw === undefined ? null : Number(raw);
+  }
+
+  it("startup order: webhook deleted only after ownership, before polling", async () => {
+    const { server, controller, botUserId } = await setup();
+    // A rival holds an unexpired lease: the controller must resolve its
+    // identity but go no further than the ownership gate.
+    const rival = await acquireOwnership(pool, botUserId, "rival", 60_000);
+    expect(rival).not.toBeNull();
+    if (!rival) throw new Error("rival lease not acquired");
+
+    controller.start();
+    await waitFor(
+      () => server.callsFor("getMe").length > 0,
+      "getMe while ownership blocked",
+    );
+    await Bun.sleep(300);
+    expect(server.callsFor("deleteWebhook")).toHaveLength(0);
+    expect(server.callsFor("getUpdates")).toHaveLength(0);
+    const blocked = controller.status();
+    expect(blocked.ready).toBe(false);
+    expect(blocked.reasons).toContain("ownership_not_held");
+
+    // Rival releases: startup proceeds ownership -> deleteWebhook -> poll.
+    await releaseOwnership(pool, rival);
+    await waitFor(
+      () => server.callsFor("getUpdates").length > 0,
+      "polling after ownership acquired",
+    );
+    const webhookIndex = server.calls.findIndex(
+      (call) => call.method === "deleteWebhook",
+    );
+    const pollIndex = server.calls.findIndex(
+      (call) => call.method === "getUpdates",
+    );
+    expect(webhookIndex).toBeGreaterThan(-1);
+    expect(webhookIndex).toBeLessThan(pollIndex);
+    await waitFor(() => controller.status().ready, "ready after startup");
+    expect(controller.ownership()?.botUserId).toBe(botUserId);
+  });
+
+  it("first start polls without an offset, then advances to max(update_id)+1", async () => {
+    const { server, controller, botUserId, batches } = await setup();
+    // Non-contiguous ids: the cursor is max+1, never a contiguity assumption.
+    server.queueUpdates(messageUpdate(10), messageUpdate(12));
+
+    controller.start();
+    await waitFor(
+      () => server.callsFor("getUpdates").length > 0,
+      "first poll",
+    );
+    const firstPoll = server.callsFor("getUpdates")[0];
+    expect(firstPoll?.params["offset"]).toBeUndefined();
+    expect(firstPoll?.params["allowed_updates"]).toEqual(["message"]);
+
+    await waitFor(
+      () =>
+        server
+          .callsFor("getUpdates")
+          .some((call) => call.params["offset"] === 13),
+      "next poll uses committed offset 13",
+    );
+    expect(await receiveOffset(botUserId)).toBe(13);
+    await waitFor(() => batches.length > 0, "dispatch callback");
+    expect(
+      batches[0]?.updates.map((update) => update.update_id),
+    ).toEqual([10, 12]);
+    expect(batches[0]?.botUserId).toBe(botUserId);
+  });
+
+  it("polls only from the committed cursor across restarts", async () => {
+    const { server, controller, botUserId } = await setup();
+    server.queueUpdates(messageUpdate(5), messageUpdate(7));
+    controller.start();
+    await waitFor(
+      async () => (await receiveOffset(botUserId)) === 8,
+      "cursor committed at 8",
+    );
+    await controller.shutdown();
+
+    const callsBeforeRestart = server.callsFor("getUpdates").length;
+    const restarted = createPollerController({
+      api: createTelegramApi({
+        botToken: server.token,
+        telegramApiUrl: server.baseUrl,
+      }),
+      pool,
+      leaseTtlMs: 1_500,
+      pollTimeoutSeconds: 1,
+      freshnessWindowMs: 5_000,
+      backoff: { baseMs: 25, maxMs: 100 },
+      onFatalEnd: () => undefined,
+    });
+    controllers.push(restarted);
+    restarted.start();
+    await waitFor(
+      () => server.callsFor("getUpdates").length > callsBeforeRestart,
+      "restarted controller polls",
+    );
+    const firstAfterRestart = server.callsFor("getUpdates")[callsBeforeRestart];
+    expect(firstAfterRestart?.params["offset"]).toBe(8);
+  });
+
+  it("re-polls the same offset when ingest fails before the cursor commits", async () => {
+    let failures = 1;
+    const { server, controller, botUserId, batches } = await setup({
+      ingestHooks: {
+        beforeCursorAdvance: () => {
+          if (failures > 0) {
+            failures -= 1;
+            throw new Error("injected crash before cursor advance");
+          }
+        },
+      },
+    });
+    server.queueUpdates(messageUpdate(21));
+
+    controller.start();
+    await waitFor(
+      async () => (await receiveOffset(botUserId)) === 22,
+      "batch eventually confirmed",
+    );
+    // The failed ingest never confirmed the batch: the next poll carried the
+    // same (absent) offset and Telegram redelivered update 21.
+    const polls = server.callsFor("getUpdates");
+    expect(polls.length).toBeGreaterThanOrEqual(2);
+    expect(polls[0]?.params["offset"]).toBeUndefined();
+    expect(polls[1]?.params["offset"]).toBeUndefined();
+    const rows = await pool.query(
+      "SELECT update_id FROM telegram_update_inbox WHERE bot_user_id = $1",
+      [botUserId],
+    );
+    expect(rows.rowCount).toBe(1);
+    await waitFor(() => batches.length > 0, "dispatch after successful ingest");
+    expect(batches).toHaveLength(1);
+  });
+
+  it("fatal 401 on getMe fires onFatalEnd and never polls", async () => {
+    const { server, controller, fatal } = await setup();
+    server.failNext("getMe", { status: 401, description: "Unauthorized" });
+
+    controller.start();
+    await waitFor(() => fatal.called, "onFatalEnd");
+    expect(server.callsFor("getUpdates")).toHaveLength(0);
+    expect(server.callsFor("deleteWebhook")).toHaveLength(0);
+    const status = controller.status();
+    expect(status.ready).toBe(false);
+    expect(status.reasons).toContain("fatal_configuration_error");
+    expect(status.live).toBe(true);
+  });
+
+  it("fatal 409 on getUpdates fires onFatalEnd and stops polling", async () => {
+    const { server, controller, fatal } = await setup();
+    server.failNext("getUpdates", {
+      status: 409,
+      description: "Conflict: terminated by other getUpdates request",
+    });
+
+    controller.start();
+    await waitFor(() => fatal.called, "onFatalEnd");
+    const pollsAtFatal = server.callsFor("getUpdates").length;
+    await Bun.sleep(300);
+    expect(server.callsFor("getUpdates")).toHaveLength(pollsAtFatal);
+  });
+
+  it("transient 5xx: backoff keeps retrying, ready fails past the freshness window, live stays true", async () => {
+    const { server, controller } = await setup({ freshnessWindowMs: 300 });
+    server.failNext(
+      "getUpdates",
+      { status: 500, description: "Internal Server Error" },
+      Number.POSITIVE_INFINITY,
+    );
+
+    controller.start();
+    await waitFor(() => {
+      const status = controller.status();
+      return !status.ready && status.reasons.includes("poll_stale");
+    }, "readiness degrades to poll_stale");
+    expect(controller.status().live).toBe(true);
+    const failedPolls = server.callsFor("getUpdates").length;
+    expect(failedPolls).toBeGreaterThanOrEqual(2);
+
+    // Outage clears: polling resumes on the same loop and readiness recovers.
+    server.clearScripts("getUpdates");
+    await waitFor(() => controller.status().ready, "ready after recovery");
+    expect(controller.status().lastSuccessfulPollAtMs).not.toBeNull();
+  });
+
+  it("429 delays the next poll by at least retry_after", async () => {
+    const { server, controller } = await setup();
+    server.failNext("getUpdates", {
+      status: 429,
+      description: "Too Many Requests",
+      retryAfterSeconds: 1,
+    });
+
+    controller.start();
+    await waitFor(
+      () => server.callsFor("getUpdates").length >= 2,
+      "poll after 429",
+    );
+    const polls = server.callsFor("getUpdates");
+    const first = polls[0];
+    const second = polls[1];
+    if (!first || !second) throw new Error("expected two polls");
+    expect(second.atMs - first.atMs).toBeGreaterThanOrEqual(700);
+  });
+
+  it("ownership loss stops polling immediately and blocks reacquisition", async () => {
+    const { server, controller, botUserId } = await setup();
+    controller.start();
+    await waitFor(() => controller.status().ready, "ready");
+
+    // Usurp the lease the way a successor takeover would: new holder, bumped
+    // generation, unexpired term. The next renewal cannot prove the lease.
+    await pool.query(
+      `UPDATE telegram_poll_state
+       SET holder_id = 'usurper', generation = generation + 1,
+           lease_expires_at = now() + interval '60 seconds'
+       WHERE bot_user_id = $1`,
+      [botUserId],
+    );
+
+    await waitFor(() => {
+      const status = controller.status();
+      return !status.ready && status.reasons.includes("ownership_not_held");
+    }, "readiness fails on ownership loss");
+    expect(controller.ownership()).toBeNull();
+
+    const pollsAtLoss = server.callsFor("getUpdates").length;
+    // Usurper's lease is 60s: reacquisition must fail, so no new polls even
+    // after the old lease term lapses and startup retries begin.
+    await Bun.sleep(1_500);
+    expect(server.callsFor("getUpdates")).toHaveLength(pollsAtLoss);
+    expect(controller.status().reasons).toContain("ownership_not_held");
+  });
+
+  it("empty batches still refresh poll freshness", async () => {
+    const { server, controller, botUserId } = await setup({
+      pollTimeoutSeconds: 0,
+    });
+    controller.start();
+    await waitFor(() => controller.status().ready, "ready");
+    await waitFor(
+      () => controller.status().lastSuccessfulPollAtMs !== null,
+      "first successful poll",
+    );
+    const first = controller.status().lastSuccessfulPollAtMs;
+    await Bun.sleep(250);
+    const second = controller.status().lastSuccessfulPollAtMs;
+    if (first === null || second === null) throw new Error("expected polls");
+    expect(second).toBeGreaterThan(first);
+    expect(controller.status().ready).toBe(true);
+    // No updates were ever queued, so nothing was written to the inbox.
+    const rows = await pool.query(
+      "SELECT count(*)::int AS count FROM telegram_update_inbox WHERE bot_user_id = $1",
+      [botUserId],
+    );
+    expect(rows.rows[0]?.count).toBe(0);
+    expect(server.callsFor("getUpdates").length).toBeGreaterThan(1);
+  });
+
+  it("non-message updates get a durable ignored disposition and never stall the cursor", async () => {
+    const { server, controller, botUserId, batches } = await setup();
+    server.queueUpdates(
+      {
+        update_id: 30,
+        channel_post: { message_id: 1, chat: { id: 5, type: "channel" } },
+      },
+      messageUpdate(31),
+    );
+
+    controller.start();
+    await waitFor(
+      async () => (await receiveOffset(botUserId)) === 32,
+      "cursor advanced past both updates",
+    );
+    await waitFor(async () => {
+      const result = await pool.query<{ status: string }>(
+        "SELECT status FROM telegram_update_inbox WHERE bot_user_id = $1 AND update_id = 30",
+        [botUserId],
+      );
+      return result.rows[0]?.status === "ignored";
+    }, "channel_post durably ignored");
+    const ignored = await pool.query<{ status_reason: string | null }>(
+      "SELECT status_reason FROM telegram_update_inbox WHERE bot_user_id = $1 AND update_id = 30",
+      [botUserId],
+    );
+    expect(ignored.rows[0]?.status_reason).toBe(
+      "unsupported_update_type:channel_post",
+    );
+
+    await waitFor(() => batches.length > 0, "dispatch");
+    // Only the message-bearing update reaches dispatch.
+    expect(
+      batches.flatMap((batch) =>
+        batch.updates.map((update) => update.update_id),
+      ),
+    ).toEqual([31]);
+    const messageRow = await pool.query<{ status: string }>(
+      "SELECT status FROM telegram_update_inbox WHERE bot_user_id = $1 AND update_id = 31",
+      [botUserId],
+    );
+    expect(messageRow.rows[0]?.status).toBe("received");
+  });
+
+  it("shutdown aborts a hanging long poll promptly and releases the lease", async () => {
+    const { server, controller, botUserId } = await setup({
+      pollTimeoutSeconds: 40,
+      leaseTtlMs: 5_000,
+    });
+    controller.start();
+    await waitFor(
+      () => server.callsFor("getUpdates").length > 0,
+      "long poll in flight",
+    );
+
+    const startedAt = Date.now();
+    await controller.shutdown();
+    expect(Date.now() - startedAt).toBeLessThan(1_500);
+
+    const released = await pool.query<{ released: boolean }>(
+      "SELECT lease_expires_at <= now() AS released FROM telegram_poll_state WHERE bot_user_id = $1",
+      [botUserId],
+    );
+    expect(released.rows[0]?.released).toBe(true);
+  });
+});

--- a/services/telegrambot/test/rate-limit.test.ts
+++ b/services/telegrambot/test/rate-limit.test.ts
@@ -1,0 +1,697 @@
+import { describe, expect, it } from "bun:test";
+import {
+  createRateLimitedTelegramApi,
+  TelegramSendQueue,
+} from "../src/rate-limit";
+import type { RateLimitClock, RateLimitOptions } from "../src/rate-limit";
+import { TelegramApiError } from "../src/telegram-api";
+import type { TelegramApi } from "../src/telegram-api";
+import type { Logger, TelegramMessage } from "../src/types";
+
+const tick = (): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, 0));
+
+/**
+ * Virtual clock: sleep() parks until advance() moves time past the wake
+ * point, then flushes continuations so woken workers can sleep again within
+ * the same advance window.
+ */
+class FakeClock implements RateLimitClock {
+  private nowMs = 0;
+  private sleepers: Array<{ at: number; resolve: () => void }> = [];
+
+  now = (): number => this.nowMs;
+
+  sleep = (ms: number): Promise<void> =>
+    new Promise((resolve) => {
+      this.sleepers.push({ at: this.nowMs + ms, resolve });
+    });
+
+  async advance(ms: number): Promise<void> {
+    this.nowMs += ms;
+    for (;;) {
+      const due = this.sleepers.filter((sleeper) => sleeper.at <= this.nowMs);
+      if (!due.length) break;
+      this.sleepers = this.sleepers.filter(
+        (sleeper) => sleeper.at > this.nowMs,
+      );
+      for (const sleeper of due) sleeper.resolve();
+      await tick();
+    }
+    await tick();
+  }
+}
+
+type LoggedEvent = { event: string; data: Record<string, unknown> };
+
+function captureLogger(): { logger: Logger; events: LoggedEvent[] } {
+  const events: LoggedEvent[] = [];
+  const push = (event: string, data?: unknown): void => {
+    events.push({ event, data: (data ?? {}) as Record<string, unknown> });
+  };
+  const logger: Logger = {
+    debug: push,
+    info: push,
+    warn: push,
+    error: push,
+    child: () => logger,
+  };
+  return { logger, events };
+}
+
+type RecordedCall = {
+  method: string;
+  params: Record<string, unknown>;
+};
+
+type FakeApiHooks = {
+  onEditMessageText?: (
+    params: Record<string, unknown>,
+  ) => Promise<void> | void;
+  onSendMessage?: (
+    params: Record<string, unknown>,
+  ) => Promise<TelegramMessage> | TelegramMessage;
+};
+
+function message(id = 1): TelegramMessage {
+  return { message_id: id, chat: { id: 1, type: "private" }, date: 0 };
+}
+
+function rateLimitError(
+  method: string,
+  retryAfterSeconds?: number,
+): TelegramApiError {
+  return new TelegramApiError({
+    method,
+    status: 429,
+    errorCode: 429,
+    description: "Too Many Requests",
+    ...(retryAfterSeconds === undefined ? {} : { retryAfterSeconds }),
+  });
+}
+
+function createFakeApi(hooks: FakeApiHooks = {}): {
+  api: TelegramApi;
+  calls: RecordedCall[];
+} {
+  const calls: RecordedCall[] = [];
+  const record = (method: string, params: unknown): RecordedCall => {
+    const call = { method, params: params as Record<string, unknown> };
+    calls.push(call);
+    return call;
+  };
+  const api: TelegramApi = {
+    getMe: async () => {
+      record("getMe", {});
+      return { id: 42, is_bot: true, first_name: "bot" };
+    },
+    getUpdates: async (params) => {
+      record("getUpdates", params);
+      return [];
+    },
+    deleteWebhook: async (params) => {
+      record("deleteWebhook", params);
+    },
+    sendMessage: async (params) => {
+      record("sendMessage", params);
+      return hooks.onSendMessage ? hooks.onSendMessage(params) : message();
+    },
+    editMessageText: async (params) => {
+      record("editMessageText", params);
+      await hooks.onEditMessageText?.(params);
+    },
+    setMessageReaction: async (params) => {
+      record("setMessageReaction", params);
+    },
+    sendChatAction: async (params) => {
+      record("sendChatAction", params);
+    },
+    getFile: async (fileId) => {
+      record("getFile", { file_id: fileId });
+      return { file_id: fileId, file_unique_id: "u" };
+    },
+    downloadFile: async (filePath) => {
+      record("downloadFile", { file_path: filePath });
+      return new Uint8Array();
+    },
+  };
+  return { api, calls };
+}
+
+function harness(input: { hooks?: FakeApiHooks } & RateLimitOptions = {}) {
+  const clock = new FakeClock();
+  const { hooks, ...options } = input;
+  const { api, calls } = createFakeApi(hooks);
+  const { logger, events } = captureLogger();
+  const limited = createRateLimitedTelegramApi(api, logger, {
+    clock,
+    jitterMs: () => 0,
+    ...options,
+  });
+  return { limited, calls, clock, events };
+}
+
+/** Gate an underlying call so the chat queue stays busy until released. */
+function gate(): { open: Promise<void>; release: () => void } {
+  let release!: () => void;
+  const open = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  return { open, release };
+}
+
+describe("createRateLimitedTelegramApi", () => {
+  it("routes mutations FIFO per chat behind an in-flight call", async () => {
+    const sendGate = gate();
+    const { limited, calls } = harness({
+      hooks: {
+        onSendMessage: async () => {
+          await sendGate.open;
+          return message();
+        },
+      },
+    });
+
+    const send = limited.sendMessage({ chat_id: 5, text: "one" });
+    await tick();
+    const edit = limited.editMessageText({
+      chat_id: 5,
+      message_id: 1,
+      text: "edit",
+    });
+    const reaction = limited.setMessageReaction({
+      chat_id: 5,
+      message_id: 1,
+      reaction: [{ type: "emoji", emoji: "👀" }],
+    });
+    const action = limited.sendChatAction({ chat_id: 5, action: "typing" });
+    await tick();
+
+    // Everything after the gated send waits its turn.
+    expect(calls.map((call) => call.method)).toEqual(["sendMessage"]);
+
+    sendGate.release();
+    await Promise.all([send, edit, reaction, action]);
+    expect(calls.map((call) => call.method)).toEqual([
+      "sendMessage",
+      "editMessageText",
+      "setMessageReaction",
+      "sendChatAction",
+    ]);
+  });
+
+  it("keeps chats independent: one rate-limited chat never blocks another", async () => {
+    const { limited, calls, clock } = harness({
+      hooks: {
+        onSendMessage: (params) => {
+          if (params.chat_id === -100) throw rateLimitError("sendMessage", 60);
+          return message();
+        },
+      },
+    });
+
+    const blocked = limited
+      .sendMessage({ chat_id: -100, text: "group" })
+      .catch(() => undefined);
+    await tick();
+    await limited.sendMessage({ chat_id: 7, text: "dm" });
+
+    const sends = calls.filter((call) => call.method === "sendMessage");
+    expect(sends.map((call) => call.params.chat_id)).toEqual([-100, 7]);
+
+    for (let i = 0; i < 6; i += 1) await clock.advance(61_000);
+    await blocked;
+  });
+
+  it("passes reads through even while a chat is backing off a 429", async () => {
+    const { limited, calls, clock } = harness({
+      hooks: {
+        onSendMessage: () => {
+          throw rateLimitError("sendMessage", 120);
+        },
+      },
+    });
+
+    const blocked = limited
+      .sendMessage({ chat_id: 5, text: "hi" })
+      .catch(() => undefined);
+    await tick();
+
+    await limited.getMe();
+    await limited.getFile("f1");
+    await limited.deleteWebhook({ drop_pending_updates: false });
+    expect(calls.map((call) => call.method)).toEqual([
+      "sendMessage",
+      "getMe",
+      "getFile",
+      "deleteWebhook",
+    ]);
+
+    for (let i = 0; i < 6; i += 1) await clock.advance(121_000);
+    await blocked;
+  });
+
+  it("paces sendMessage to one per interval per chat", async () => {
+    const { limited, calls, clock } = harness();
+
+    const first = limited.sendMessage({ chat_id: 5, text: "one" });
+    const second = limited.sendMessage({ chat_id: 5, text: "two" });
+    await tick();
+    await first;
+    expect(calls.length).toBe(1);
+
+    await clock.advance(500);
+    expect(calls.length).toBe(1);
+
+    await clock.advance(500);
+    await second;
+    expect(calls.length).toBe(2);
+    expect(calls[1]?.params.text).toBe("two");
+  });
+
+  it("does not pace sends across different chats", async () => {
+    const { limited, calls } = harness();
+
+    await Promise.all([
+      limited.sendMessage({ chat_id: 1, text: "a" }),
+      limited.sendMessage({ chat_id: 2, text: "b" }),
+      limited.sendMessage({ chat_id: 3, text: "c" }),
+    ]);
+    expect(calls.length).toBe(3);
+  });
+
+  it("enforces the 20/min budget for group chats only", async () => {
+    const { limited, calls, clock } = harness({ messageIntervalMs: 0 });
+
+    for (let i = 0; i < 20; i += 1) {
+      await limited.sendMessage({ chat_id: -100, text: `g${i}` });
+    }
+    expect(calls.length).toBe(20);
+
+    const overBudget = limited.sendMessage({ chat_id: -100, text: "g20" });
+    await tick();
+    expect(calls.length).toBe(20);
+
+    // A private chat is unaffected by the group budget.
+    await limited.sendMessage({ chat_id: 9, text: "dm" });
+    expect(calls.length).toBe(21);
+
+    await clock.advance(59_999);
+    expect(
+      calls.filter((call) => call.params.chat_id === -100).length,
+    ).toBe(20);
+
+    await clock.advance(1);
+    await overBudget;
+    expect(
+      calls.filter((call) => call.params.chat_id === -100).length,
+    ).toBe(21);
+  });
+
+  it("charges only sendMessage against the group message quota", async () => {
+    const { limited, calls, clock } = harness({ messageIntervalMs: 0 });
+
+    // Non-message mutations before and after budget exhaustion never count.
+    for (let i = 0; i < 5; i += 1) {
+      await limited.editMessageText({
+        chat_id: -100,
+        message_id: 100 + i,
+        text: `e${i}`,
+      });
+    }
+    for (let i = 0; i < 20; i += 1) {
+      await limited.sendMessage({ chat_id: -100, text: `g${i}` });
+    }
+    expect(calls.filter((call) => call.method === "sendMessage").length).toBe(
+      20,
+    );
+
+    await limited.editMessageText({ chat_id: -100, message_id: 1, text: "e" });
+    await limited.setMessageReaction({
+      chat_id: -100,
+      message_id: 1,
+      reaction: [{ type: "emoji", emoji: "✅" }],
+    });
+    await limited.sendChatAction({ chat_id: -100, action: "typing" });
+    expect(calls.length).toBe(28);
+
+    // The 21st message is still budget-blocked despite the interleaved work.
+    const overBudget = limited.sendMessage({ chat_id: -100, text: "g20" });
+    await tick();
+    expect(calls.filter((call) => call.method === "sendMessage").length).toBe(
+      20,
+    );
+    await clock.advance(60_000);
+    await overBudget;
+  });
+
+  it("waits retry_after on 429 then retries the same call", async () => {
+    let attempts = 0;
+    const { limited, calls, clock, events } = harness({
+      hooks: {
+        onSendMessage: () => {
+          attempts += 1;
+          if (attempts === 1) throw rateLimitError("sendMessage", 3);
+          return message(99);
+        },
+      },
+    });
+
+    const send = limited.sendMessage({ chat_id: 5, text: "hi" });
+    await tick();
+    expect(calls.length).toBe(1);
+
+    await clock.advance(2_999);
+    expect(calls.length).toBe(1);
+
+    await clock.advance(1);
+    const result = await send;
+    expect(result.message_id).toBe(99);
+    expect(calls.length).toBe(2);
+
+    const limitedEvents = events.filter(
+      (entry) => entry.event === "telegrambot_rate_limited",
+    );
+    expect(limitedEvents.length).toBe(1);
+    expect(limitedEvents[0]?.data.method).toBe("sendMessage");
+    expect(limitedEvents[0]?.data.retry_after).toBe(3);
+  });
+
+  it("honors 429s for non-message methods without touching the quota", async () => {
+    let attempts = 0;
+    const { limited, calls, clock, events } = harness({
+      hooks: {
+        onEditMessageText: () => {
+          attempts += 1;
+          if (attempts === 1) throw rateLimitError("editMessageText", 2);
+        },
+      },
+    });
+
+    const edit = limited.editMessageText({
+      chat_id: -100,
+      message_id: 1,
+      text: "e",
+    });
+    await tick();
+    await clock.advance(2_000);
+    await edit;
+    expect(
+      calls.filter((call) => call.method === "editMessageText").length,
+    ).toBe(2);
+    expect(
+      events.find((entry) => entry.event === "telegrambot_rate_limited")?.data
+        .method,
+    ).toBe("editMessageText");
+
+    // The failed+retried edit consumed none of the group message budget.
+    const { limited: fresh } = harness({ messageIntervalMs: 0 });
+    void fresh;
+    await limited.sendMessage({ chat_id: -100, text: "still fine" });
+    expect(calls.filter((call) => call.method === "sendMessage").length).toBe(
+      1,
+    );
+  });
+
+  it("rethrows after the retry cap", async () => {
+    const { limited, calls, clock } = harness({
+      maxRetries: 2,
+      hooks: {
+        onSendMessage: () => {
+          throw rateLimitError("sendMessage", 1);
+        },
+      },
+    });
+
+    let caught: unknown;
+    const send = limited
+      .sendMessage({ chat_id: 5, text: "hi" })
+      .catch((error: unknown) => {
+        caught = error;
+      });
+    await tick();
+    await clock.advance(1_000);
+    await clock.advance(1_000);
+    await send;
+
+    // maxRetries=2 means one initial attempt plus two retries.
+    expect(calls.length).toBe(3);
+    expect(caught).toBeInstanceOf(TelegramApiError);
+    expect((caught as TelegramApiError).status).toBe(429);
+  });
+
+  it("falls back to a default backoff when 429 lacks retry_after", async () => {
+    let attempts = 0;
+    const { limited, calls, clock } = harness({
+      hooks: {
+        onSendMessage: () => {
+          attempts += 1;
+          if (attempts === 1) throw rateLimitError("sendMessage");
+          return message();
+        },
+      },
+    });
+
+    const send = limited.sendMessage({ chat_id: 5, text: "hi" });
+    await tick();
+    expect(calls.length).toBe(1);
+    await clock.advance(1_000);
+    await send;
+    expect(calls.length).toBe(2);
+  });
+
+  it("supersedes a queued edit with a newer edit for the same message", async () => {
+    const sendGate = gate();
+    const { limited, calls } = harness({
+      hooks: {
+        onSendMessage: async () => {
+          await sendGate.open;
+          return message();
+        },
+      },
+    });
+
+    const send = limited.sendMessage({ chat_id: 5, text: "block" });
+    await tick();
+    const stale = limited.editMessageText({
+      chat_id: 5,
+      message_id: 7,
+      text: "old",
+    });
+    const otherMessage = limited.editMessageText({
+      chat_id: 5,
+      message_id: 8,
+      text: "unrelated",
+    });
+    const fresh = limited.editMessageText({
+      chat_id: 5,
+      message_id: 7,
+      text: "new",
+    });
+
+    // The superseded edit settles immediately; it will never be sent.
+    await stale;
+
+    sendGate.release();
+    await Promise.all([send, otherMessage, fresh]);
+
+    const edits = calls.filter((call) => call.method === "editMessageText");
+    expect(edits.map((call) => call.params.text)).toEqual([
+      "unrelated",
+      "new",
+    ]);
+  });
+
+  it("supersedes an edit parked in 429 backoff before it resends", async () => {
+    let attempts = 0;
+    const { limited, calls, clock } = harness({
+      hooks: {
+        onEditMessageText: () => {
+          attempts += 1;
+          if (attempts === 1) throw rateLimitError("editMessageText", 5);
+        },
+      },
+    });
+
+    const stale = limited.editMessageText({
+      chat_id: 5,
+      message_id: 7,
+      text: "old",
+    });
+    await tick();
+    expect(calls.length).toBe(1);
+
+    const fresh = limited.editMessageText({
+      chat_id: 5,
+      message_id: 7,
+      text: "new",
+    });
+    await stale;
+
+    await clock.advance(5_000);
+    await fresh;
+
+    const edits = calls.filter((call) => call.method === "editMessageText");
+    expect(edits.map((call) => call.params.text)).toEqual(["old", "new"]);
+  });
+
+  it("cancelPendingEdits drops queued edits for a message", async () => {
+    const sendGate = gate();
+    const { limited, calls } = harness({
+      hooks: {
+        onSendMessage: async () => {
+          await sendGate.open;
+          return message();
+        },
+      },
+    });
+
+    const send = limited.sendMessage({ chat_id: 5, text: "block" });
+    await tick();
+    const pending = limited.editMessageText({
+      chat_id: 5,
+      message_id: 7,
+      text: "progress",
+    });
+
+    expect(limited.cancelPendingEdits(5, 7)).toBe(1);
+    expect(limited.cancelPendingEdits(5, 7)).toBe(0);
+    await pending;
+
+    sendGate.release();
+    await send;
+    expect(
+      calls.filter((call) => call.method === "editMessageText").length,
+    ).toBe(0);
+  });
+
+  it("schedules urgent terminal work ahead of queued progress edits", async () => {
+    const sendGate = gate();
+    const { limited, calls } = harness({
+      messageIntervalMs: 0,
+      hooks: {
+        onSendMessage: async (params) => {
+          if (params.text === "block") await sendGate.open;
+          return message();
+        },
+      },
+    });
+
+    const blocker = limited.sendMessage({ chat_id: 5, text: "block" });
+    await tick();
+    const progressA = limited.editMessageText({
+      chat_id: 5,
+      message_id: 7,
+      text: "progress a",
+    });
+    const progressB = limited.editMessageText({
+      chat_id: 5,
+      message_id: 8,
+      text: "progress b",
+    });
+    const terminal = limited.sendMessageUrgent({
+      chat_id: 5,
+      text: "final answer",
+    });
+    const terminalEdit = limited.editMessageTextUrgent({
+      chat_id: 5,
+      message_id: 9,
+      text: "final edit",
+    });
+
+    sendGate.release();
+    await Promise.all([blocker, progressA, progressB, terminal, terminalEdit]);
+
+    // FIFO within the high-priority band, all of it ahead of normal edits.
+    expect(
+      calls.map((call) => [call.method, call.params.text]),
+    ).toEqual([
+      ["sendMessage", "block"],
+      ["sendMessage", "final answer"],
+      ["editMessageText", "final edit"],
+      ["editMessageText", "progress a"],
+      ["editMessageText", "progress b"],
+    ]);
+  });
+
+  it("never puts a URL or token in rate-limit logs", async () => {
+    const { limited, clock, events } = harness({
+      hooks: {
+        onSendMessage: () => {
+          throw rateLimitError("sendMessage", 1);
+        },
+      },
+    });
+
+    const send = limited
+      .sendMessage({ chat_id: 5, text: "hi" })
+      .catch(() => undefined);
+    await tick();
+    for (let i = 0; i < 6; i += 1) await clock.advance(1_100);
+    await send;
+
+    for (const entry of events) {
+      expect(JSON.stringify(entry)).not.toContain("http");
+      expect(JSON.stringify(entry)).not.toContain("api.telegram.org");
+    }
+  });
+});
+
+describe("TelegramSendQueue", () => {
+  it("lets a caller enqueue custom work with priority and coalescing", async () => {
+    const clock = new FakeClock();
+    const { logger } = captureLogger();
+    const queue = new TelegramSendQueue(logger, {
+      clock,
+      jitterMs: () => 0,
+      messageIntervalMs: 0,
+    });
+
+    const order: string[] = [];
+    const blockGate = gate();
+    const blocker = queue.enqueue({
+      chatId: 5,
+      method: "sendMessage",
+      run: async () => {
+        order.push("block");
+        await blockGate.open;
+      },
+    });
+    await tick();
+    const normal = queue.enqueue({
+      chatId: 5,
+      method: "editMessageText",
+      coalesceKey: "edit:5:1",
+      run: async () => {
+        order.push("normal");
+      },
+    });
+    const urgent = queue.enqueue({
+      chatId: 5,
+      method: "sendMessage",
+      priority: "high",
+      run: async () => {
+        order.push("urgent");
+      },
+    });
+    const replacement = queue.enqueue({
+      chatId: 5,
+      method: "editMessageText",
+      coalesceKey: "edit:5:1",
+      run: async () => {
+        order.push("replacement");
+      },
+    });
+    await normal; // superseded by `replacement`, resolves without running
+
+    blockGate.release();
+    await Promise.all([blocker, urgent, replacement]);
+    expect(order).toEqual(["block", "urgent", "replacement"]);
+  });
+
+  it("cancel is a no-op for unknown chats and keys", () => {
+    const { logger } = captureLogger();
+    const queue = new TelegramSendQueue(logger);
+    expect(queue.cancel(123, "edit:123:1")).toBe(0);
+  });
+});

--- a/services/telegrambot/test/rate-limit.test.ts
+++ b/services/telegrambot/test/rate-limit.test.ts
@@ -68,6 +68,7 @@ type FakeApiHooks = {
   onEditMessageText?: (
     params: Record<string, unknown>,
   ) => Promise<void> | void;
+  onGetFile?: (fileId: string) => void;
   onSendMessage?: (
     params: Record<string, unknown>,
   ) => Promise<TelegramMessage> | TelegramMessage;
@@ -128,6 +129,7 @@ function createFakeApi(hooks: FakeApiHooks = {}): {
     },
     getFile: async (fileId) => {
       record("getFile", { file_id: fileId });
+      hooks.onGetFile?.(fileId);
       return { file_id: fileId, file_unique_id: "u" };
     },
     downloadFile: async (filePath) => {
@@ -249,6 +251,46 @@ describe("createRateLimitedTelegramApi", () => {
 
     for (let i = 0; i < 6; i += 1) await clock.advance(121_000);
     await blocked;
+  });
+
+  it("honors 429 retry_after on getFile even though it bypasses the queue", async () => {
+    let attempts = 0;
+    const { limited, calls, clock, events } = harness({
+      hooks: {
+        onGetFile: () => {
+          attempts += 1;
+          if (attempts === 1) throw rateLimitError("getFile", 2);
+        },
+      },
+    });
+
+    const fetching = limited.getFile("f1");
+    await tick();
+    expect(calls.filter((call) => call.method === "getFile")).toHaveLength(1);
+
+    await clock.advance(2_000);
+    const file = await fetching;
+    expect(file.file_id).toBe("f1");
+    expect(calls.filter((call) => call.method === "getFile")).toHaveLength(2);
+    expect(
+      events.filter((entry) => entry.event === "telegrambot_rate_limited"),
+    ).toHaveLength(1);
+  });
+
+  it("rethrows non-429 getFile errors without retrying", async () => {
+    let attempts = 0;
+    const { limited, calls } = harness({
+      hooks: {
+        onGetFile: () => {
+          attempts += 1;
+          throw new TelegramApiError({ method: "getFile", status: 400 });
+        },
+      },
+    });
+
+    await expect(limited.getFile("f1")).rejects.toMatchObject({ status: 400 });
+    expect(attempts).toBe(1);
+    expect(calls.filter((call) => call.method === "getFile")).toHaveLength(1);
   });
 
   it("paces sendMessage to one per interval per chat", async () => {

--- a/services/telegrambot/test/session-api.test.ts
+++ b/services/telegrambot/test/session-api.test.ts
@@ -1,0 +1,924 @@
+import { describe, expect, it } from "bun:test";
+import type { TelegramApi } from "../src/telegram-api";
+import {
+  codexAttachmentInput,
+  executeSessionTurn,
+  forwardToSessionApi,
+  isContentlessApiMessage,
+  isRetryableSessionApiError,
+  isSteeringDeliveredEvent,
+  isSteeringFailedEvent,
+  MAX_TELEGRAM_ATTACHMENT_BYTES,
+  MAX_TELEGRAM_ATTACHMENTS,
+  openSessionEventStream,
+  serializeTelegramAttachmentList,
+  serializeTelegramAttachments,
+  serializeTelegramMessage,
+  SESSION_STEERING_DELIVERED_EVENT,
+  SESSION_STEERING_FAILED_EVENT,
+  SessionApiError,
+  steeringDeliveredMessageIds,
+  steeringFailedError,
+  telegramClientMessageId,
+  toCodexInputLines,
+} from "../src/session-api";
+import type {
+  ForwardSessionInput,
+  TelegramApiMessage,
+  TelegramAttachmentCandidate,
+} from "../src/session-api";
+import type {
+  TelegramMessage,
+  TelegrambotFetch,
+  TelegrambotOptions,
+  TelegrambotRendererSource,
+} from "../src/types";
+
+type JsonRecord = Record<string, unknown>;
+
+const THREAD_KEY = "telegram:chat:-1001";
+
+function telegramMessage(
+  overrides: Partial<TelegramMessage> = {},
+): TelegramMessage {
+  return {
+    message_id: 42,
+    from: {
+      id: 777,
+      is_bot: false,
+      first_name: "Alice",
+      last_name: "Liddell",
+      username: "alice",
+    },
+    chat: { id: -1001, type: "supergroup", title: "ops" },
+    date: 1_767_225_600,
+    text: "hello",
+    ...overrides,
+  };
+}
+
+function apiMessage(
+  overrides: Partial<TelegramApiMessage> = {},
+): TelegramApiMessage {
+  return {
+    attachments: [],
+    author: {
+      fullName: "Alice Liddell",
+      isBot: false,
+      isMe: false,
+      userId: "777",
+      userName: "alice",
+    },
+    id: "telegram:-1001:42",
+    isMention: true,
+    raw: {},
+    text: "hello",
+    threadId: THREAD_KEY,
+    timestamp: "2026-01-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function options(fetchFn: TelegrambotFetch): TelegrambotOptions {
+  return {
+    apiUrl: "http://api.test",
+    botToken: "token",
+    fetch: fetchFn,
+  };
+}
+
+function forwardInput(
+  overrides: Partial<ForwardSessionInput> = {},
+): ForwardSessionInput {
+  return {
+    afterEventId: 0,
+    create: {
+      conversationName: "ops",
+      chatType: "supergroup",
+      userId: "777",
+      messageThreadId: 9,
+    },
+    executeMessage: apiMessage(),
+    messages: [apiMessage()],
+    onEventId: () => undefined,
+    openStream: false,
+    threadKey: THREAD_KEY,
+    ...overrides,
+  };
+}
+
+type RecordedRequest = { url: string; body?: JsonRecord };
+
+function recorderApi(): {
+  fetchFn: TelegrambotFetch;
+  creates: JsonRecord[];
+  appends: JsonRecord[];
+  executes: JsonRecord[];
+  requests: RecordedRequest[];
+} {
+  const creates: JsonRecord[] = [];
+  const appends: JsonRecord[] = [];
+  const executes: JsonRecord[] = [];
+  const requests: RecordedRequest[] = [];
+  const fetchFn: TelegrambotFetch = async (input, init) => {
+    const url = String(input);
+    const body = init?.body
+      ? (JSON.parse(String(init.body)) as JsonRecord)
+      : undefined;
+    requests.push({ url, body });
+    if (url.endsWith("/execute")) {
+      executes.push(body ?? {});
+      return Response.json({
+        execution_id: "exec-1",
+        ok: true,
+        status: "running",
+        thread_key: THREAD_KEY,
+      });
+    }
+    if (url.endsWith("/messages")) {
+      appends.push(body ?? {});
+      return Response.json({ ok: true, message_ids: ["msg_1", "msg_2"] });
+    }
+    creates.push(body ?? {});
+    return Response.json({ ok: true });
+  };
+  return { fetchFn, creates, appends, executes, requests };
+}
+
+describe("isRetryableSessionApiError", () => {
+  it("respects the SessionApiError retryable flag", () => {
+    const retryable = new SessionApiError({
+      action: "create session",
+      body: "",
+      retryable: true,
+      status: 503,
+      statusText: "Service Unavailable",
+    });
+    const fatal = new SessionApiError({
+      action: "create session",
+      body: "",
+      retryable: false,
+      status: 400,
+      statusText: "Bad Request",
+    });
+    expect(isRetryableSessionApiError(retryable)).toBe(true);
+    expect(isRetryableSessionApiError(fatal)).toBe(false);
+  });
+
+  it("treats AbortError as retryable", () => {
+    const error = new Error("aborted");
+    error.name = "AbortError";
+    expect(isRetryableSessionApiError(error)).toBe(true);
+  });
+
+  it("treats TypeError as retryable (fetch network failures)", () => {
+    expect(isRetryableSessionApiError(new TypeError("fetch failed"))).toBe(
+      true,
+    );
+  });
+
+  it("does not retry generic errors or non-errors", () => {
+    expect(isRetryableSessionApiError(new Error("boom"))).toBe(false);
+    expect(isRetryableSessionApiError("boom")).toBe(false);
+    expect(isRetryableSessionApiError(undefined)).toBe(false);
+  });
+
+  it("classifies retryable statuses from real API failures", async () => {
+    const codes: Array<[number, boolean]> = [
+      [400, false],
+      [404, false],
+      [408, true],
+      [409, false],
+      [425, true],
+      [429, true],
+      [500, true],
+      [503, true],
+    ];
+    for (const [status, retryable] of codes) {
+      const fetchFn: TelegrambotFetch = async () =>
+        new Response("nope", { status });
+      let caught: unknown;
+      try {
+        await forwardToSessionApi(options(fetchFn), forwardInput());
+      } catch (error) {
+        caught = error;
+      }
+      expect(caught).toBeInstanceOf(SessionApiError);
+      expect((caught as SessionApiError).retryable).toBe(retryable);
+    }
+  });
+});
+
+describe("serializeTelegramMessage", () => {
+  it("derives the stable client message id from chat and message ids", () => {
+    expect(telegramClientMessageId(telegramMessage())).toBe(
+      "telegram:-1001:42",
+    );
+    const message = serializeTelegramMessage(telegramMessage(), THREAD_KEY);
+    expect(message.id).toBe("telegram:-1001:42");
+  });
+
+  it("maps author metadata from the from field", () => {
+    const message = serializeTelegramMessage(telegramMessage(), THREAD_KEY);
+    expect(message.author).toEqual({
+      fullName: "Alice Liddell",
+      isBot: false,
+      isMe: false,
+      userId: "777",
+      userName: "alice",
+    });
+    expect(message.threadId).toBe(THREAD_KEY);
+    expect(message.timestamp).toBe(new Date(1_767_225_600_000).toISOString());
+  });
+
+  it("falls back to the caption when text is absent", () => {
+    const message = serializeTelegramMessage(
+      telegramMessage({ text: undefined, caption: "look at this" }),
+      THREAD_KEY,
+    );
+    expect(message.text).toBe("look at this");
+  });
+
+  it("falls back to the user id when the user has no username", () => {
+    const message = serializeTelegramMessage(
+      telegramMessage({
+        from: { id: 777, is_bot: false, first_name: "Alice" },
+      }),
+      THREAD_KEY,
+    );
+    expect(message.author.userName).toBe("777");
+    expect(message.author.fullName).toBe("Alice");
+  });
+});
+
+describe("isContentlessApiMessage", () => {
+  it("is true for empty text with no attachments (sticker/poll/service)", () => {
+    expect(isContentlessApiMessage(apiMessage({ text: "" }))).toBe(true);
+    expect(isContentlessApiMessage(apiMessage({ text: "  \n " }))).toBe(true);
+  });
+
+  it("is false when there is text or an attachment", () => {
+    expect(isContentlessApiMessage(apiMessage({ text: "do the thing" }))).toBe(
+      false,
+    );
+    expect(
+      isContentlessApiMessage(
+        apiMessage({ text: "", attachments: [{ type: "image" }] }),
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("forwardToSessionApi", () => {
+  it("sends the full principal metadata on every create", async () => {
+    const { fetchFn, creates } = recorderApi();
+    await forwardToSessionApi(options(fetchFn), forwardInput());
+    expect(creates[0]?.metadata).toEqual({
+      source: "telegrambot",
+      platform: "telegram",
+      thread_id: THREAD_KEY,
+      telegram_conversation_name: "ops",
+      telegram_chat_type: "supergroup",
+      user_id: "777",
+      message_thread_id: 9,
+    });
+    expect(creates[0]?.harness_type).toBe("codex");
+  });
+
+  it("omits message_thread_id when absent and blank conversation names", async () => {
+    const { fetchFn, creates } = recorderApi();
+    await forwardToSessionApi(
+      options(fetchFn),
+      forwardInput({
+        create: { conversationName: "  ", chatType: "private", userId: "777" },
+      }),
+    );
+    const metadata = creates[0]?.metadata as JsonRecord;
+    expect("message_thread_id" in metadata).toBe(false);
+    expect("telegram_conversation_name" in metadata).toBe(false);
+    expect(metadata.telegram_chat_type).toBe("private");
+  });
+
+  it("appends with the stable client_message_id and user role", async () => {
+    const { fetchFn, appends } = recorderApi();
+    await forwardToSessionApi(options(fetchFn), forwardInput());
+    const appended = (appends[0]?.messages as JsonRecord[])[0]!;
+    expect(appended.client_message_id).toBe("telegram:-1001:42");
+    expect(appended.role).toBe("user");
+    expect(appended.parts).toEqual([{ type: "text", text: "hello" }]);
+    expect((appended.metadata as JsonRecord).user_id).toBe("777");
+  });
+
+  it("hands the server-assigned message ids to onMessagesAppended for steering correlation", async () => {
+    const { fetchFn } = recorderApi();
+    let appendedIds: string[] | undefined;
+    await forwardToSessionApi(options(fetchFn), forwardInput(), {
+      onMessagesAppended: async (messageIds) => {
+        appendedIds = messageIds;
+      },
+    });
+    expect(appendedIds).toEqual(["msg_1", "msg_2"]);
+  });
+
+  it("skips the append call when there are no messages", async () => {
+    const { fetchFn, appends } = recorderApi();
+    await forwardToSessionApi(
+      options(fetchFn),
+      forwardInput({ messages: [], executeMessage: undefined }),
+    );
+    expect(appends).toHaveLength(0);
+  });
+
+  it("executes with the message id as idempotency key", async () => {
+    const { fetchFn, executes } = recorderApi();
+    const execution = await forwardToSessionApi(
+      options(fetchFn),
+      forwardInput(),
+    );
+    // openStream is false: no stream is returned even though execute ran.
+    expect(execution).toBeNull();
+    expect(executes[0]?.idempotency_key).toBe("telegram:-1001:42");
+    expect(
+      (executes[0]?.input_lines as string[]).length,
+    ).toBeGreaterThanOrEqual(1);
+  });
+});
+
+describe("executeSessionTurn", () => {
+  it("returns the accepted execution", async () => {
+    const { fetchFn, executes } = recorderApi();
+    const execution = await executeSessionTurn(
+      options(fetchFn),
+      forwardInput(),
+    );
+    expect(execution?.execution_id).toBe("exec-1");
+    expect(executes[0]?.idempotency_key).toBe("telegram:-1001:42");
+  });
+
+  it("is a no-op without an execute message", async () => {
+    const { fetchFn, executes } = recorderApi();
+    const execution = await executeSessionTurn(
+      options(fetchFn),
+      forwardInput({ executeMessage: undefined }),
+    );
+    expect(execution).toBeNull();
+    expect(executes).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SSE replay
+// ---------------------------------------------------------------------------
+
+function sseResponseFor(events: string): TelegrambotFetch & {
+  urls: string[];
+} {
+  const urls: string[] = [];
+  const fetchFn = (async (input: RequestInfo | URL) => {
+    urls.push(String(input));
+    return new Response(events, { status: 200 });
+  }) as TelegrambotFetch & { urls: string[] };
+  fetchFn.urls = urls;
+  return fetchFn;
+}
+
+async function collect(
+  stream: AsyncIterable<TelegrambotRendererSource>,
+): Promise<TelegrambotRendererSource[]> {
+  const items: TelegrambotRendererSource[] = [];
+  for await (const item of stream) items.push(item);
+  return items;
+}
+
+describe("openSessionEventStream", () => {
+  const sseBody = [
+    "id: 5",
+    "event: session.output.line",
+    'data: {"type":"item.completed"}',
+    "",
+    "id: 6",
+    "event: session.steering_delivered",
+    'data: {"execution_id":"exec-1","thread_key":"telegram:chat:-1001","message_ids":["msg_9"],"input_line_count":1}',
+    "",
+    "id: 7",
+    "event: session.execution_completed",
+    'data: {"execution_id":"exec-1"}',
+    "",
+  ].join("\n");
+
+  it("requests after_event_id and execution_id and reports observed event ids", async () => {
+    const fetchFn = sseResponseFor(sseBody);
+    const seen: number[] = [];
+    const stream = await openSessionEventStream(options(fetchFn), {
+      afterEventId: 4,
+      executionId: "exec-1",
+      onEventId: (eventId) => seen.push(eventId),
+      threadKey: THREAD_KEY,
+    });
+    const events = await collect(stream);
+
+    const url = new URL(fetchFn.urls[0]!);
+    expect(url.searchParams.get("after_event_id")).toBe("4");
+    expect(url.searchParams.get("execution_id")).toBe("exec-1");
+    expect(seen).toEqual([5, 6, 7]);
+    expect(events.map((event) => (event as JsonRecord).eventKind)).toEqual([
+      "session.output.line",
+      "session.steering_delivered",
+      "session.execution_completed",
+    ]);
+  });
+
+  it("passes steering events through non-terminally with parsed data", async () => {
+    const fetchFn = sseResponseFor(sseBody);
+    const stream = await openSessionEventStream(options(fetchFn), {
+      afterEventId: 0,
+      onEventId: () => undefined,
+      threadKey: THREAD_KEY,
+    });
+    const events = await collect(stream);
+    const steering = events.find(isSteeringDeliveredEvent);
+    expect(steering).toBeDefined();
+    expect(steeringDeliveredMessageIds(steering!)).toEqual(["msg_9"]);
+    // The stream continued past steering to the terminal completion event.
+    expect(
+      (events.at(-1) as JsonRecord).eventKind,
+    ).toBe("session.execution_completed");
+  });
+
+  it("stops at terminal events and replays only later events on reconnect", async () => {
+    const fetchFn = sseResponseFor(
+      [
+        "id: 3",
+        "event: session.output.line",
+        'data: {"type":"item.completed"}',
+        "",
+        "id: 4",
+        "event: session.execution_failed",
+        'data: {"error":"sandbox died"}',
+        "",
+        "id: 5",
+        "event: session.output.line",
+        'data: {"type":"item.completed"}',
+        "",
+      ].join("\n"),
+    );
+    let lastEventId = 0;
+    const stream = await openSessionEventStream(options(fetchFn), {
+      afterEventId: 0,
+      onEventId: (eventId) => {
+        lastEventId = eventId;
+      },
+      threadKey: THREAD_KEY,
+    });
+    const events = await collect(stream);
+    expect((events.at(-1) as JsonRecord).eventKind).toBe(
+      "session.execution_failed",
+    );
+    expect((events.at(-1) as JsonRecord).data).toEqual({
+      error: "sandbox died",
+    });
+    // Terminal error ends iteration; event 5 is never surfaced.
+    expect(events).toHaveLength(2);
+    expect(lastEventId).toBe(4);
+
+    // Reconnect resumes strictly after the last durably observed event id.
+    const reconnect = await openSessionEventStream(options(fetchFn), {
+      afterEventId: lastEventId,
+      onEventId: () => undefined,
+      threadKey: THREAD_KEY,
+    });
+    await collect(reconnect);
+    const url = new URL(fetchFn.urls[1]!);
+    expect(url.searchParams.get("after_event_id")).toBe("4");
+  });
+
+  it("treats a terminal codex output line as end of stream", async () => {
+    const fetchFn = sseResponseFor(
+      [
+        "id: 1",
+        "event: session.output.line",
+        'data: {"type":"turn.completed"}',
+        "",
+        "id: 2",
+        "event: session.output.line",
+        'data: {"type":"item.completed"}',
+        "",
+      ].join("\n"),
+    );
+    const stream = await openSessionEventStream(options(fetchFn), {
+      afterEventId: 0,
+      onEventId: () => undefined,
+      threadKey: THREAD_KEY,
+    });
+    const events = await collect(stream);
+    expect(events).toHaveLength(1);
+  });
+});
+
+describe("steering event guards", () => {
+  const delivered: TelegrambotRendererSource = {
+    event: SESSION_STEERING_DELIVERED_EVENT,
+    eventKind: SESSION_STEERING_DELIVERED_EVENT,
+    eventId: 12,
+    data: {
+      execution_id: "exec-1",
+      thread_key: THREAD_KEY,
+      message_ids: ["msg_1", "msg_2"],
+      input_line_count: 2,
+    },
+  };
+  const failed: TelegrambotRendererSource = {
+    event: SESSION_STEERING_FAILED_EVENT,
+    eventKind: SESSION_STEERING_FAILED_EVENT,
+    eventId: 13,
+    data: {
+      execution_id: "exec-1",
+      thread_key: THREAD_KEY,
+      error: "stdin pipe closed",
+    },
+  };
+
+  it("detects delivered and failed steering events", () => {
+    expect(isSteeringDeliveredEvent(delivered)).toBe(true);
+    expect(isSteeringFailedEvent(delivered)).toBe(false);
+    expect(isSteeringFailedEvent(failed)).toBe(true);
+    expect(isSteeringDeliveredEvent(failed)).toBe(false);
+  });
+
+  it("ignores mapper notifications and other session events", () => {
+    const notification: TelegrambotRendererSource = {
+      method: "item/started",
+      params: {},
+    };
+    expect(isSteeringDeliveredEvent(notification)).toBe(false);
+    expect(isSteeringFailedEvent(notification)).toBe(false);
+    expect(
+      isSteeringDeliveredEvent({
+        event: "session.execution_completed",
+        eventKind: "session.execution_completed",
+      }),
+    ).toBe(false);
+  });
+
+  it("extracts the delivered message ids and failure error", () => {
+    expect(steeringDeliveredMessageIds(delivered)).toEqual(["msg_1", "msg_2"]);
+    expect(steeringDeliveredMessageIds(failed)).toEqual([]);
+    expect(steeringFailedError(failed)).toBe("stdin pipe closed");
+    expect(steeringFailedError(delivered)).toBeUndefined();
+  });
+
+  it("tolerates malformed steering payloads", () => {
+    expect(
+      steeringDeliveredMessageIds({
+        event: SESSION_STEERING_DELIVERED_EVENT,
+        eventKind: SESSION_STEERING_DELIVERED_EVENT,
+        data: { message_ids: [1, "msg_1", null] },
+      }),
+    ).toEqual(["msg_1"]);
+    expect(
+      steeringFailedError({
+        event: SESSION_STEERING_FAILED_EVENT,
+        eventKind: SESSION_STEERING_FAILED_EVENT,
+        data: "not json",
+      }),
+    ).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Attachments
+// ---------------------------------------------------------------------------
+
+function fakeTelegramApi(overrides: Partial<TelegramApi> = {}): TelegramApi {
+  const unexpected = (method: string) => async () => {
+    throw new Error(`unexpected call: ${method}`);
+  };
+  return {
+    getMe: unexpected("getMe") as TelegramApi["getMe"],
+    getUpdates: unexpected("getUpdates") as TelegramApi["getUpdates"],
+    deleteWebhook: unexpected("deleteWebhook") as TelegramApi["deleteWebhook"],
+    sendMessage: unexpected("sendMessage") as TelegramApi["sendMessage"],
+    editMessageText: unexpected(
+      "editMessageText",
+    ) as TelegramApi["editMessageText"],
+    setMessageReaction: unexpected(
+      "setMessageReaction",
+    ) as TelegramApi["setMessageReaction"],
+    sendChatAction: unexpected(
+      "sendChatAction",
+    ) as TelegramApi["sendChatAction"],
+    getFile: unexpected("getFile") as TelegramApi["getFile"],
+    downloadFile: unexpected("downloadFile") as TelegramApi["downloadFile"],
+    ...overrides,
+  };
+}
+
+function candidate(
+  overrides: Partial<TelegramAttachmentCandidate> = {},
+): TelegramAttachmentCandidate {
+  return {
+    fileId: "file-1",
+    fileUniqueId: "uniq-1",
+    mimeType: "image/jpeg",
+    name: "photo.jpg",
+    size: 4,
+    type: "image",
+    ...overrides,
+  };
+}
+
+describe("serializeTelegramAttachments", () => {
+  it("downloads only the largest photo size and inlines it as base64", async () => {
+    const bytes = new Uint8Array([1, 2, 3, 4]);
+    const requestedFileIds: string[] = [];
+    const api = fakeTelegramApi({
+      getFile: async (fileId) => {
+        requestedFileIds.push(fileId);
+        return {
+          file_id: fileId,
+          file_unique_id: "uniq-big",
+          file_path: "photos/big.jpg",
+        };
+      },
+      downloadFile: async () => bytes,
+    });
+    const message = telegramMessage({
+      text: undefined,
+      caption: "pic",
+      photo: [
+        // Deliberately unsorted: selection must not trust ordering.
+        {
+          file_id: "big",
+          file_unique_id: "uniq-big",
+          width: 800,
+          height: 600,
+        },
+        {
+          file_id: "small",
+          file_unique_id: "uniq-small",
+          width: 90,
+          height: 67,
+        },
+      ],
+    });
+
+    const attachments = await serializeTelegramAttachments(api, message);
+
+    expect(requestedFileIds).toEqual(["big"]);
+    expect(attachments).toHaveLength(1);
+    expect(attachments[0]?.type).toBe("image");
+    expect(attachments[0]?.mimeType).toBe("image/jpeg");
+    expect(attachments[0]?.dataBase64).toBe(
+      Buffer.from(bytes).toString("base64"),
+    );
+    expect(attachments[0]?.fetchError).toBeUndefined();
+  });
+
+  it("serializes documents with their declared name and mime type", async () => {
+    const api = fakeTelegramApi({
+      getFile: async (fileId) => ({
+        file_id: fileId,
+        file_unique_id: "uniq-doc",
+        file_path: "documents/report.pdf",
+      }),
+      downloadFile: async (filePath) => {
+        expect(filePath).toBe("documents/report.pdf");
+        return new Uint8Array([9, 9]);
+      },
+    });
+    const message = telegramMessage({
+      text: undefined,
+      caption: "report",
+      document: {
+        file_id: "doc-1",
+        file_unique_id: "uniq-doc",
+        file_name: "report.pdf",
+        mime_type: "application/pdf",
+        file_size: 2,
+      },
+    });
+
+    const attachments = await serializeTelegramAttachments(api, message);
+
+    expect(attachments).toHaveLength(1);
+    expect(attachments[0]).toMatchObject({
+      type: "file",
+      name: "report.pdf",
+      mimeType: "application/pdf",
+    });
+    expect(attachments[0]?.dataBase64).toBe(
+      Buffer.from([9, 9]).toString("base64"),
+    );
+  });
+
+  it("skips the download entirely when the declared size exceeds the cap", async () => {
+    const api = fakeTelegramApi(); // any API call throws "unexpected call"
+    const message = telegramMessage({
+      document: {
+        file_id: "doc-1",
+        file_unique_id: "uniq-doc",
+        file_name: "huge.bin",
+        file_size: MAX_TELEGRAM_ATTACHMENT_BYTES + 1,
+      },
+    });
+
+    const attachments = await serializeTelegramAttachments(api, message);
+
+    expect(attachments[0]?.dataBase64).toBeUndefined();
+    expect(attachments[0]?.fetchError).toContain("too large");
+  });
+
+  it("re-checks the actual byte count when size metadata is absent", async () => {
+    const api = fakeTelegramApi({
+      getFile: async () => ({
+        file_id: "doc-1",
+        file_unique_id: "uniq-doc",
+        file_path: "documents/huge.bin",
+      }),
+      downloadFile: async () =>
+        new Uint8Array(MAX_TELEGRAM_ATTACHMENT_BYTES + 1),
+    });
+    const message = telegramMessage({
+      document: {
+        file_id: "doc-1",
+        file_unique_id: "uniq-doc",
+        file_name: "huge.bin",
+      },
+    });
+
+    const attachments = await serializeTelegramAttachments(api, message);
+
+    expect(attachments[0]?.dataBase64).toBeUndefined();
+    expect(attachments[0]?.fetchError).toContain("too large");
+  });
+
+  it("records a fetchError instead of throwing when the download fails", async () => {
+    const api = fakeTelegramApi({
+      getFile: async () => {
+        throw new Error("telegram getFile failed: 400 file is too big");
+      },
+    });
+    const message = telegramMessage({
+      photo: [
+        { file_id: "p", file_unique_id: "uniq-p", width: 10, height: 10 },
+      ],
+    });
+
+    const attachments = await serializeTelegramAttachments(api, message);
+
+    expect(attachments[0]?.dataBase64).toBeUndefined();
+    expect(attachments[0]?.fetchError).toContain("file is too big");
+  });
+
+  it("records a fetchError when getFile returns no file_path", async () => {
+    const api = fakeTelegramApi({
+      getFile: async () => ({ file_id: "p", file_unique_id: "uniq-p" }),
+    });
+    const message = telegramMessage({
+      photo: [
+        { file_id: "p", file_unique_id: "uniq-p", width: 10, height: 10 },
+      ],
+    });
+
+    const attachments = await serializeTelegramAttachments(api, message);
+
+    expect(attachments[0]?.fetchError).toContain("no file_path");
+  });
+
+  it("returns no attachments for a plain text message", async () => {
+    const attachments = await serializeTelegramAttachments(
+      fakeTelegramApi(),
+      telegramMessage(),
+    );
+    expect(attachments).toEqual([]);
+  });
+
+  it("caps downloads at MAX_TELEGRAM_ATTACHMENTS and notes the skipped rest", async () => {
+    let downloads = 0;
+    const api = fakeTelegramApi({
+      getFile: async (fileId) => ({
+        file_id: fileId,
+        file_unique_id: `uniq-${fileId}`,
+        file_path: `files/${fileId}`,
+      }),
+      downloadFile: async () => {
+        downloads += 1;
+        return new Uint8Array([1]);
+      },
+    });
+    const candidates = Array.from({ length: MAX_TELEGRAM_ATTACHMENTS + 2 }).map(
+      (_, index) =>
+        candidate({ fileId: `file-${index}`, fileUniqueId: `uniq-${index}` }),
+    );
+
+    const attachments = await serializeTelegramAttachmentList(api, candidates);
+
+    expect(attachments).toHaveLength(MAX_TELEGRAM_ATTACHMENTS + 2);
+    expect(downloads).toBe(MAX_TELEGRAM_ATTACHMENTS);
+    const skipped = attachments.slice(MAX_TELEGRAM_ATTACHMENTS);
+    expect(skipped.every((a) => a.dataBase64 === undefined)).toBe(true);
+    expect(skipped.every((a) => a.fetchError?.includes("cap"))).toBe(true);
+  });
+});
+
+describe("codexAttachmentInput", () => {
+  it("inlines an image with bytes as a data: URL", () => {
+    const out = codexAttachmentInput({
+      type: "image",
+      mimeType: "image/jpeg",
+      dataBase64: "QUJD",
+      name: "photo.jpg",
+    }) as JsonRecord;
+    expect(out.type).toBe("image");
+    expect(out.url).toBe("data:image/jpeg;base64,QUJD");
+  });
+
+  it("references a staged attachment id instead of inlining", () => {
+    const out = codexAttachmentInput(
+      { type: "image", mimeType: "image/jpeg", dataBase64: "QUJD" },
+      "att-m1-1",
+    ) as JsonRecord;
+    expect(out).toMatchObject({
+      type: "attachment",
+      stagedAttachmentId: "att-m1-1",
+    });
+    expect(out.dataBase64).toBeUndefined();
+    expect(out.url).toBeUndefined();
+  });
+
+  it("describes byte-less attachments (fetch failures) as text", () => {
+    const out = codexAttachmentInput({
+      type: "file",
+      name: "huge.bin",
+      fetchError: "attachment too large to inline",
+    }) as JsonRecord;
+    expect(out.type).toBe("text");
+    expect(out.text).toContain("huge.bin");
+    expect(out.text).toContain("too large");
+  });
+});
+
+describe("toCodexInputLines", () => {
+  it("inlines a small image in a single user line as a data: URL", () => {
+    const message = apiMessage({
+      attachments: [
+        {
+          type: "image",
+          mimeType: "image/jpeg",
+          dataBase64: "QUJD",
+          name: "photo.jpg",
+        },
+      ],
+    });
+
+    const lines = toCodexInputLines(message, message.threadId);
+
+    expect(lines).toHaveLength(1);
+    const parsed = JSON.parse(lines[0]!) as {
+      thread_key: string;
+      trace_metadata: JsonRecord;
+      message: { content: JsonRecord[] };
+    };
+    expect(parsed.thread_key).toBe(THREAD_KEY);
+    expect(parsed.trace_metadata.source).toBe("telegrambot");
+    expect(parsed.trace_metadata.platform).toBe("telegram");
+    const image = parsed.message.content.find((part) => part.type === "image");
+    expect(image?.url).toBe("data:image/jpeg;base64,QUJD");
+  });
+
+  it("stages a large image as chunk lines plus a referencing user line", () => {
+    const dataBase64 = Buffer.alloc(700 * 1024, 1).toString("base64");
+    const message = apiMessage({
+      attachments: [
+        {
+          type: "image",
+          mimeType: "image/jpeg",
+          dataBase64,
+          name: "photo.jpg",
+        },
+      ],
+    });
+
+    const lines = toCodexInputLines(message, message.threadId);
+
+    expect(lines.length).toBeGreaterThan(1);
+    const chunks = lines.slice(0, -1).map((line) => JSON.parse(line));
+    expect(chunks.every((c) => c.type === "attachment.chunk")).toBe(true);
+    expect(chunks.at(-1).final).toBe(true);
+    // The chunks must reassemble to the original base64 payload.
+    expect(chunks.map((c) => c.dataBase64).join("")).toBe(dataBase64);
+
+    const lastLine = lines[lines.length - 1]!;
+    const content = JSON.parse(lastLine).message.content as JsonRecord[];
+    const ref = content.find((part) => part.type === "attachment");
+    expect(ref?.stagedAttachmentId).toBe(chunks[0].attachmentId);
+    // The huge payload must NOT also be inlined in the user line.
+    expect(lastLine.length).toBeLessThan(dataBase64.length);
+  });
+
+  it("emits a synthetic continue turn for empty content", () => {
+    const lines = toCodexInputLines(apiMessage({ text: "  " }), THREAD_KEY);
+    const content = JSON.parse(lines[0]!).message.content as JsonRecord[];
+    expect(content).toEqual([{ type: "text", text: "continue" }]);
+  });
+});

--- a/services/telegrambot/test/support/fake-telegram-server.ts
+++ b/services/telegrambot/test/support/fake-telegram-server.ts
@@ -1,0 +1,265 @@
+import type { TelegramUpdate, TelegramUser } from "../../src/types";
+
+/**
+ * Bun.serve-based fake Telegram Bot API for unit and e2e tests. Routes
+ * `POST /bot<token>/<method>`, records every call, and honors getUpdates
+ * offset semantics the way the real API does: updates with `update_id` below
+ * the supplied offset are confirmed (dropped forever), updates at or above it
+ * are redelivered until a later poll confirms them. Failures (401/409/429/
+ * 5xx) and hangs are scriptable per method so tests can drive the poller's
+ * error taxonomy without a network.
+ */
+
+export type RecordedTelegramCall = {
+  method: string;
+  params: Record<string, unknown>;
+  atMs: number;
+};
+
+export type ScriptedTelegramFailure = {
+  /** HTTP status, echoed as Telegram's error_code. */
+  status: number;
+  description?: string;
+  /** Included as parameters.retry_after (seconds), Telegram 429 style. */
+  retryAfterSeconds?: number;
+};
+
+type Script = { kind: "http"; failure: ScriptedTelegramFailure } | { kind: "hang" };
+
+type ScriptEntry = { script: Script; remaining: number };
+
+export type FakeTelegramServer = {
+  baseUrl: string;
+  token: string;
+  botUser: TelegramUser;
+  /** All calls in arrival order, including scripted failures and hangs. */
+  calls: RecordedTelegramCall[];
+  callsFor(method: string): RecordedTelegramCall[];
+  /** Queue updates for getUpdates delivery; wakes any waiting long poll. */
+  queueUpdates(...updates: TelegramUpdate[]): void;
+  /** update_ids confirmed (dropped) by a later-offset getUpdates call. */
+  confirmedUpdateIds: number[];
+  /** update_ids still queued (unconfirmed). */
+  pendingUpdateIds(): number[];
+  /** Script the next `times` calls to `method` to fail with a Telegram-shaped
+   * error body. Use Number.POSITIVE_INFINITY + clearScripts for outages. */
+  failNext(
+    method: string,
+    failure: ScriptedTelegramFailure,
+    times?: number,
+  ): void;
+  /** Script the next `times` calls to `method` to hang until client abort or
+   * server stop. */
+  hangNext(method: string, times?: number): void;
+  clearScripts(method?: string): void;
+  stop(): void;
+};
+
+export function startFakeTelegramServer(
+  options: { token?: string; botUser?: Partial<TelegramUser> } = {},
+): FakeTelegramServer {
+  const token = options.token ?? "fake-telegram-token";
+  const botUser: TelegramUser = {
+    id: 999_001,
+    is_bot: true,
+    first_name: "Fake Bot",
+    username: "fake_bot",
+    ...options.botUser,
+  };
+
+  const calls: RecordedTelegramCall[] = [];
+  const scripts = new Map<string, ScriptEntry[]>();
+  const confirmedUpdateIds: number[] = [];
+  let pending: TelegramUpdate[] = [];
+  let stopped = false;
+  let nextMessageId = 1_000;
+
+  // Long polls wake on queueUpdates or stop; hangs release only on stop (or
+  // client abort) so queuing updates cannot un-hang a scripted hang.
+  const pollWakers = new Set<() => void>();
+  const hangReleases = new Set<() => void>();
+
+  const wakePolls = () => {
+    for (const wake of [...pollWakers]) wake();
+  };
+
+  const waitForWake = (ms: number, signal: AbortSignal | undefined) =>
+    new Promise<void>((resolve) => {
+      const finish = () => {
+        pollWakers.delete(finish);
+        clearTimeout(timer);
+        signal?.removeEventListener("abort", finish);
+        resolve();
+      };
+      const timer = setTimeout(finish, ms);
+      pollWakers.add(finish);
+      signal?.addEventListener("abort", finish, { once: true });
+    });
+
+  const ok = (result: unknown) => Response.json({ ok: true, result });
+  const err = (failure: ScriptedTelegramFailure) =>
+    Response.json(
+      {
+        ok: false,
+        error_code: failure.status,
+        description:
+          failure.description ?? `fake telegram error ${failure.status}`,
+        ...(failure.retryAfterSeconds !== undefined
+          ? { parameters: { retry_after: failure.retryAfterSeconds } }
+          : {}),
+      },
+      { status: failure.status },
+    );
+
+  const takeScript = (method: string): Script | undefined => {
+    const queue = scripts.get(method);
+    const entry = queue?.[0];
+    if (!queue || !entry) return undefined;
+    entry.remaining -= 1;
+    if (entry.remaining <= 0) queue.shift();
+    if (queue.length === 0) scripts.delete(method);
+    return entry.script;
+  };
+
+  async function handleGetUpdates(
+    params: Record<string, unknown>,
+    signal: AbortSignal | undefined,
+  ): Promise<TelegramUpdate[]> {
+    const offsetRaw = params["offset"];
+    const offset = typeof offsetRaw === "number" ? offsetRaw : undefined;
+    if (offset !== undefined) {
+      const dropped = pending.filter((update) => update.update_id < offset);
+      if (dropped.length > 0) {
+        confirmedUpdateIds.push(...dropped.map((update) => update.update_id));
+        pending = pending.filter((update) => update.update_id >= offset);
+      }
+    }
+    const timeoutRaw = params["timeout"];
+    const timeoutMs = (typeof timeoutRaw === "number" ? timeoutRaw : 0) * 1000;
+    const deadline = Date.now() + timeoutMs;
+    while (!stopped && !signal?.aborted) {
+      const available = pending.filter(
+        (update) => offset === undefined || update.update_id >= offset,
+      );
+      if (available.length > 0) return available.slice(0, 100);
+      const remainingMs = deadline - Date.now();
+      if (remainingMs <= 0) return [];
+      await waitForWake(Math.min(remainingMs, 5_000), signal);
+    }
+    return [];
+  }
+
+  const server = Bun.serve({
+    hostname: "127.0.0.1",
+    port: 0,
+    // Above the longest realistic long-poll (Telegram caps timeout at 50s);
+    // Bun's 10s default would sever a healthy hanging poll mid-test.
+    idleTimeout: 255,
+    async fetch(req) {
+      const url = new URL(req.url);
+      const match = /^\/bot([^/]+)\/([^/]+)$/.exec(url.pathname);
+      if (!match || req.method !== "POST") {
+        return new Response("not found", { status: 404 });
+      }
+      const requestToken = match[1] ?? "";
+      const method = match[2] ?? "";
+
+      let params: Record<string, unknown> = {};
+      const bodyText = await req.text();
+      if (bodyText) {
+        try {
+          params = JSON.parse(bodyText) as Record<string, unknown>;
+        } catch {
+          // keep {}: a malformed body is still a recorded call
+        }
+      }
+      calls.push({ method, params, atMs: Date.now() });
+
+      if (requestToken !== token) {
+        return err({ status: 401, description: "Unauthorized" });
+      }
+
+      const script = takeScript(method);
+      if (script) {
+        if (script.kind === "hang") {
+          await new Promise<void>((resolve) => {
+            const finish = () => {
+              hangReleases.delete(finish);
+              req.signal?.removeEventListener("abort", finish);
+              resolve();
+            };
+            hangReleases.add(finish);
+            req.signal?.addEventListener("abort", finish, { once: true });
+          });
+          return err({ status: 503, description: "hang released" });
+        }
+        return err(script.failure);
+      }
+
+      switch (method) {
+        case "getMe":
+          return ok(botUser);
+        case "getUpdates":
+          return ok(await handleGetUpdates(params, req.signal));
+        case "deleteWebhook":
+          return ok(true);
+        case "sendMessage": {
+          const chatIdRaw = params["chat_id"];
+          const chatId =
+            typeof chatIdRaw === "number" ? chatIdRaw : Number(chatIdRaw ?? 0);
+          return ok({
+            message_id: nextMessageId++,
+            date: Math.floor(Date.now() / 1000),
+            chat: { id: chatId, type: "private" },
+            text: typeof params["text"] === "string" ? params["text"] : "",
+          });
+        }
+        case "editMessageText":
+        case "setMessageReaction":
+        case "sendChatAction":
+          return ok(true);
+        default:
+          return err({
+            status: 404,
+            description: `Not Found: method ${method}`,
+          });
+      }
+    },
+  });
+
+  return {
+    baseUrl: `http://127.0.0.1:${server.port}`,
+    token,
+    botUser,
+    calls,
+    callsFor: (method) => calls.filter((call) => call.method === method),
+    queueUpdates(...updates) {
+      pending.push(...updates);
+      pending.sort((a, b) => a.update_id - b.update_id);
+      wakePolls();
+    },
+    confirmedUpdateIds,
+    pendingUpdateIds: () => pending.map((update) => update.update_id),
+    failNext(method, failure, times = 1) {
+      const queue = scripts.get(method) ?? [];
+      queue.push({ script: { kind: "http", failure }, remaining: times });
+      scripts.set(method, queue);
+    },
+    hangNext(method, times = 1) {
+      const queue = scripts.get(method) ?? [];
+      queue.push({ script: { kind: "hang" }, remaining: times });
+      scripts.set(method, queue);
+    },
+    clearScripts(method) {
+      if (method === undefined) scripts.clear();
+      else scripts.delete(method);
+    },
+    stop() {
+      if (stopped) return;
+      stopped = true;
+      wakePolls();
+      for (const release of [...hangReleases]) release();
+      server.stop(true);
+    },
+  };
+}

--- a/services/telegrambot/test/telegram-allowlist.test.ts
+++ b/services/telegrambot/test/telegram-allowlist.test.ts
@@ -1,0 +1,349 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  extractCommandText,
+  isAllowedTelegramMessage,
+  isChatAllowlistEmpty,
+  isTriggerMessage,
+  isUserAllowlistEmpty,
+  resolveChatAllowlist,
+  resolveUserAllowlist,
+  type TelegramAllowlistOptions,
+} from "../src/telegram-allowlist";
+import type {
+  TelegramChat,
+  TelegramMessage,
+  TelegramUser,
+} from "../src/types";
+import { noopLogger } from "../src/utils";
+
+const BOT_USER_ID = "999";
+const BOT_USERNAME = "centaur_bot";
+const GROUP_CHAT_ID = -1005000;
+const DM_USER_ID = 42;
+
+function user(overrides: Partial<TelegramUser> = {}): TelegramUser {
+  return { id: DM_USER_ID, is_bot: false, first_name: "Alice", ...overrides };
+}
+
+function privateChat(overrides: Partial<TelegramChat> = {}): TelegramChat {
+  return { id: DM_USER_ID, type: "private", first_name: "Alice", ...overrides };
+}
+
+function groupChat(overrides: Partial<TelegramChat> = {}): TelegramChat {
+  return { id: GROUP_CHAT_ID, type: "supergroup", title: "Team", ...overrides };
+}
+
+function dmMessage(overrides: Partial<TelegramMessage> = {}): TelegramMessage {
+  return {
+    message_id: 1,
+    date: 0,
+    chat: privateChat(),
+    from: user(),
+    text: "hello",
+    ...overrides,
+  };
+}
+
+function groupMessage(
+  overrides: Partial<TelegramMessage> = {},
+): TelegramMessage {
+  return {
+    message_id: 2,
+    date: 0,
+    chat: groupChat(),
+    from: user(),
+    text: "hello",
+    ...overrides,
+  };
+}
+
+/** Text starting with a Telegram-vouched bot_command entity at offset 0. */
+function commandMessage(
+  base: TelegramMessage,
+  text: string,
+  commandLength: number,
+): TelegramMessage {
+  return {
+    ...base,
+    text,
+    entities: [{ type: "bot_command", offset: 0, length: commandLength }],
+  };
+}
+
+function options(
+  overrides: Partial<TelegramAllowlistOptions> = {},
+): TelegramAllowlistOptions {
+  return {
+    botUserId: BOT_USER_ID,
+    chatAllowlist: [String(GROUP_CHAT_ID)],
+    userAllowlist: [String(DM_USER_ID)],
+    ...overrides,
+  };
+}
+
+describe("isAllowedTelegramMessage", () => {
+  test("allows an allowlisted DM user", () => {
+    expect(isAllowedTelegramMessage(dmMessage(), options(), noopLogger)).toBe(
+      true,
+    );
+  });
+
+  test("allows an allowlisted group chat", () => {
+    expect(
+      isAllowedTelegramMessage(groupMessage(), options(), noopLogger),
+    ).toBe(true);
+  });
+
+  test("allows an allowlisted plain group (not only supergroups)", () => {
+    const message = groupMessage({ chat: groupChat({ type: "group" }) });
+    expect(isAllowedTelegramMessage(message, options(), noopLogger)).toBe(true);
+  });
+
+  test("is fail-closed: empty user allowlist denies every DM", () => {
+    expect(
+      isAllowedTelegramMessage(
+        dmMessage(),
+        options({ userAllowlist: [] }),
+        noopLogger,
+      ),
+    ).toBe(false);
+  });
+
+  test("is fail-closed: empty chat allowlist denies every group", () => {
+    expect(
+      isAllowedTelegramMessage(
+        groupMessage(),
+        options({ chatAllowlist: [] }),
+        noopLogger,
+      ),
+    ).toBe(false);
+  });
+
+  test("denies a DM user not on the allowlist", () => {
+    const message = dmMessage({
+      chat: privateChat({ id: 43 }),
+      from: user({ id: 43 }),
+    });
+    expect(isAllowedTelegramMessage(message, options(), noopLogger)).toBe(
+      false,
+    );
+  });
+
+  test("denies a group chat not on the allowlist", () => {
+    const message = groupMessage({ chat: groupChat({ id: -777 }) });
+    expect(isAllowedTelegramMessage(message, options(), noopLogger)).toBe(
+      false,
+    );
+  });
+
+  test("denies the bot's own messages even in allowlisted chats", () => {
+    const message = groupMessage({
+      from: user({ id: Number(BOT_USER_ID), is_bot: true }),
+    });
+    expect(isAllowedTelegramMessage(message, options(), noopLogger)).toBe(
+      false,
+    );
+  });
+
+  test("denies other bots even in allowlisted chats", () => {
+    const message = groupMessage({ from: user({ id: 55, is_bot: true }) });
+    expect(isAllowedTelegramMessage(message, options(), noopLogger)).toBe(
+      false,
+    );
+  });
+
+  test("denies bot-relayed (via_bot) messages", () => {
+    const message = dmMessage({
+      via_bot: user({ id: 55, is_bot: true, username: "inline_bot" }),
+    });
+    expect(isAllowedTelegramMessage(message, options(), noopLogger)).toBe(
+      false,
+    );
+  });
+
+  test("denies messages without a sender", () => {
+    const message = groupMessage({ from: undefined });
+    expect(isAllowedTelegramMessage(message, options(), noopLogger)).toBe(
+      false,
+    );
+  });
+
+  test("denies channel chats regardless of allowlists", () => {
+    const message = groupMessage({
+      chat: { id: GROUP_CHAT_ID, type: "channel", title: "News" },
+    });
+    expect(
+      isAllowedTelegramMessage(
+        message,
+        options({ chatAllowlist: [String(GROUP_CHAT_ID)] }),
+        noopLogger,
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("isTriggerMessage", () => {
+  test("any allowed DM message triggers as dm", () => {
+    expect(isTriggerMessage(dmMessage(), BOT_USER_ID, BOT_USERNAME)).toBe("dm");
+  });
+
+  test("a bare /ask in a DM triggers as command", () => {
+    const message = commandMessage(dmMessage(), "/ask what is up", 4);
+    expect(isTriggerMessage(message, BOT_USER_ID, BOT_USERNAME)).toBe(
+      "command",
+    );
+  });
+
+  test("an addressed /ask@bot in a DM triggers as command", () => {
+    const message = commandMessage(
+      dmMessage(),
+      `/ask@${BOT_USERNAME} what is up`,
+      4 + 1 + BOT_USERNAME.length,
+    );
+    expect(isTriggerMessage(message, BOT_USER_ID, BOT_USERNAME)).toBe(
+      "command",
+    );
+  });
+
+  test("a reply to the bot's own message triggers in a group", () => {
+    const message = groupMessage({
+      reply_to_message: groupMessage({
+        from: user({ id: Number(BOT_USER_ID), is_bot: true }),
+      }),
+    });
+    expect(isTriggerMessage(message, BOT_USER_ID, BOT_USERNAME)).toBe("reply");
+  });
+
+  test("a reply to another user does not trigger in a group", () => {
+    const message = groupMessage({
+      reply_to_message: groupMessage({ from: user({ id: 77 }) }),
+    });
+    expect(isTriggerMessage(message, BOT_USER_ID, BOT_USERNAME)).toBeNull();
+  });
+
+  test("/ask@bot triggers in a group", () => {
+    const message = commandMessage(
+      groupMessage(),
+      `/ask@${BOT_USERNAME} deploy the thing`,
+      4 + 1 + BOT_USERNAME.length,
+    );
+    expect(isTriggerMessage(message, BOT_USER_ID, BOT_USERNAME)).toBe(
+      "command",
+    );
+  });
+
+  test("the @suffix comparison is case-insensitive", () => {
+    const message = commandMessage(
+      groupMessage(),
+      "/ask@Centaur_Bot deploy",
+      16,
+    );
+    expect(isTriggerMessage(message, BOT_USER_ID, BOT_USERNAME)).toBe(
+      "command",
+    );
+  });
+
+  test("a wrong-bot @suffix does not trigger in a group", () => {
+    const message = commandMessage(groupMessage(), "/ask@other_bot hi", 14);
+    expect(isTriggerMessage(message, BOT_USER_ID, BOT_USERNAME)).toBeNull();
+  });
+
+  test("a bare /ask does not trigger in a group", () => {
+    const message = commandMessage(groupMessage(), "/ask hi", 4);
+    expect(isTriggerMessage(message, BOT_USER_ID, BOT_USERNAME)).toBeNull();
+  });
+
+  test("/ask@bot text without a bot_command entity does not trigger", () => {
+    const message = groupMessage({ text: `/ask@${BOT_USERNAME} hi` });
+    expect(isTriggerMessage(message, BOT_USER_ID, BOT_USERNAME)).toBeNull();
+  });
+
+  test("a plain textual @mention does not trigger (privacy-mode contract)", () => {
+    const message = groupMessage({
+      text: `@${BOT_USERNAME} are you there?`,
+      entities: [
+        { type: "mention", offset: 0, length: BOT_USERNAME.length + 1 },
+      ],
+    });
+    expect(isTriggerMessage(message, BOT_USER_ID, BOT_USERNAME)).toBeNull();
+  });
+
+  test("plain group chatter does not trigger", () => {
+    expect(isTriggerMessage(groupMessage(), BOT_USER_ID, BOT_USERNAME)).toBe(
+      null,
+    );
+  });
+
+  test("channel messages never trigger", () => {
+    const message = groupMessage({
+      chat: { id: GROUP_CHAT_ID, type: "channel", title: "News" },
+    });
+    expect(isTriggerMessage(message, BOT_USER_ID, BOT_USERNAME)).toBeNull();
+  });
+});
+
+describe("extractCommandText", () => {
+  test("strips a bare /ask", () => {
+    const message = commandMessage(dmMessage(), "/ask what is up", 4);
+    expect(extractCommandText(message, BOT_USERNAME)).toBe("what is up");
+  });
+
+  test("strips an addressed /ask@bot", () => {
+    const message = commandMessage(
+      groupMessage(),
+      `/ask@${BOT_USERNAME} deploy the thing`,
+      4 + 1 + BOT_USERNAME.length,
+    );
+    expect(extractCommandText(message, BOT_USERNAME)).toBe("deploy the thing");
+  });
+
+  test("leaves a wrong-bot command intact", () => {
+    const message = commandMessage(groupMessage(), "/ask@other_bot hi", 14);
+    expect(extractCommandText(message, BOT_USERNAME)).toBe(
+      "/ask@other_bot hi",
+    );
+  });
+
+  test("passes free text through trimmed", () => {
+    const message = dmMessage({ text: "  hello there  " });
+    expect(extractCommandText(message, BOT_USERNAME)).toBe("hello there");
+  });
+
+  test("returns empty for a command with no arguments", () => {
+    const message = commandMessage(dmMessage(), "/ask", 4);
+    expect(extractCommandText(message, BOT_USERNAME)).toBe("");
+  });
+});
+
+describe("allowlist resolution", () => {
+  afterEach(() => {
+    delete process.env.TELEGRAMBOT_CHAT_ALLOWLIST;
+    delete process.env.TELEGRAMBOT_USER_ALLOWLIST;
+  });
+
+  test("isChatAllowlistEmpty / isUserAllowlistEmpty reflect the options", () => {
+    expect(isChatAllowlistEmpty({ chatAllowlist: [] })).toBe(true);
+    expect(isChatAllowlistEmpty({ chatAllowlist: ["-1"] })).toBe(false);
+    expect(isUserAllowlistEmpty({ userAllowlist: [] })).toBe(true);
+    expect(isUserAllowlistEmpty({ userAllowlist: ["42"] })).toBe(false);
+  });
+
+  test("falls back to env lists when options are unset", () => {
+    process.env.TELEGRAMBOT_CHAT_ALLOWLIST = "-1001, -1002 -1003";
+    process.env.TELEGRAMBOT_USER_ALLOWLIST = "42";
+    expect(resolveChatAllowlist({})).toEqual(["-1001", "-1002", "-1003"]);
+    expect(resolveUserAllowlist({})).toEqual(["42"]);
+    expect(isChatAllowlistEmpty({})).toBe(false);
+  });
+
+  test("explicit options take precedence over env", () => {
+    process.env.TELEGRAMBOT_USER_ALLOWLIST = "42";
+    expect(resolveUserAllowlist({ userAllowlist: [] })).toEqual([]);
+    expect(isUserAllowlistEmpty({ userAllowlist: [] })).toBe(true);
+  });
+
+  test("unset options and env mean inert", () => {
+    expect(resolveChatAllowlist({})).toEqual([]);
+    expect(resolveUserAllowlist({})).toEqual([]);
+  });
+});

--- a/services/telegrambot/test/telegram-allowlist.test.ts
+++ b/services/telegrambot/test/telegram-allowlist.test.ts
@@ -99,6 +99,22 @@ describe("isAllowedTelegramMessage", () => {
     expect(isAllowedTelegramMessage(message, options(), noopLogger)).toBe(true);
   });
 
+  test("rejects group messages sent under a channel/anonymous-admin identity (sender_chat)", () => {
+    const message = groupMessage({
+      sender_chat: { id: -100999, type: "channel", title: "Linked" },
+    });
+    expect(isAllowedTelegramMessage(message, options(), noopLogger)).toBe(
+      false,
+    );
+  });
+
+  test("rejects linked-channel auto-forwards in an allowlisted group", () => {
+    const message = groupMessage({ is_automatic_forward: true });
+    expect(isAllowedTelegramMessage(message, options(), noopLogger)).toBe(
+      false,
+    );
+  });
+
   test("is fail-closed: empty user allowlist denies every DM", () => {
     expect(
       isAllowedTelegramMessage(

--- a/services/telegrambot/test/telegram-emulate.test.ts
+++ b/services/telegrambot/test/telegram-emulate.test.ts
@@ -442,10 +442,11 @@ describe.skipIf(!databaseUrl)("telegram end-to-end emulation", () => {
       expect(sends[0]?.params["text"]).toBe("<b>hi</b> <i>there</i>");
       expect(sends[0]?.params["parse_mode"]).toBe("HTML");
       expect(sends[0]?.params["reply_parameters"]).toEqual({
+        allow_sending_without_reply: true,
         message_id: update.message?.message_id,
       });
-      // 👀 while working, ✅ on settle (setMessageReaction replaces the set).
-      expect(reactionEmojis(server, userId)).toEqual(["👀", "✅"]);
+      // 👀 while working, 👍 on settle (setMessageReaction replaces the set).
+      expect(reactionEmojis(server, userId)).toEqual(["👀", "👍"]);
     },
     20_000,
   );

--- a/services/telegrambot/test/telegram-emulate.test.ts
+++ b/services/telegrambot/test/telegram-emulate.test.ts
@@ -1,0 +1,725 @@
+import { afterAll, afterEach, describe, expect, it } from "bun:test";
+import pg from "pg";
+import type { Pool } from "pg";
+import { createTelegrambot } from "../src/index";
+import { parsedTextLength } from "../src/telegram-render";
+import type {
+  JsonObject,
+  TelegramInboxStatus,
+  TelegramMessage,
+  TelegramUpdate,
+  Telegrambot,
+  TelegrambotOptions,
+} from "../src/types";
+import { noopLogger } from "../src/utils";
+import { startFakeTelegramServer } from "./support/fake-telegram-server";
+import type {
+  FakeTelegramServer,
+  RecordedTelegramCall,
+} from "./support/fake-telegram-server";
+
+/**
+ * End-to-end emulation (pattern: discordbot/test/chat-sdk-emulate.test.ts):
+ * real Postgres + the fake Telegram Bot API HTTP server + a fake api-rs
+ * session server with a scripted SSE event stream. Skipped cleanly when
+ * TELEGRAMBOT_TEST_DATABASE_URL is unset, matching poller.test.ts.
+ */
+
+const databaseUrl = process.env.TELEGRAMBOT_TEST_DATABASE_URL;
+
+const TELEGRAM_MUTATION_METHODS = [
+  "sendMessage",
+  "editMessageText",
+  "setMessageReaction",
+  "sendChatAction",
+];
+
+// ---------------------------------------------------------------------------
+// Fake api-rs session server (Bun.serve + SSE ReadableStream)
+// ---------------------------------------------------------------------------
+
+type SessionRequest = { body: JsonObject; threadKey: string };
+
+type SessionEvent = {
+  data: string;
+  event: string;
+  executionId: string | undefined;
+  id: number;
+  threadKey: string;
+};
+
+type StreamEntry = {
+  afterEventId: number;
+  controller: ReadableStreamDefaultController<Uint8Array>;
+  executionId: string | undefined;
+  threadKey: string;
+};
+
+type FakeSessionApi = {
+  appends: SessionRequest[];
+  creates: SessionRequest[];
+  emit(
+    threadKey: string,
+    event: string,
+    data: unknown,
+    executionId?: string,
+  ): void;
+  emitAnswerLines(threadKey: string, lines: string[]): void;
+  executes: SessionRequest[];
+  stop(): void;
+  streamCount(): number;
+  url: string;
+};
+
+function startFakeSessionApi(): FakeSessionApi {
+  const appends: SessionRequest[] = [];
+  const creates: SessionRequest[] = [];
+  const executes: SessionRequest[] = [];
+  const events: SessionEvent[] = [];
+  const streams = new Set<StreamEntry>();
+  const idempotent = new Map<string, string>();
+  const encoder = new TextEncoder();
+  let eventId = 0;
+
+  const matches = (entry: StreamEntry, event: SessionEvent): boolean =>
+    event.threadKey === entry.threadKey &&
+    event.id > entry.afterEventId &&
+    (!entry.executionId ||
+      !event.executionId ||
+      event.executionId === entry.executionId);
+
+  const write = (entry: StreamEntry, event: SessionEvent): void => {
+    try {
+      entry.controller.enqueue(
+        encoder.encode(
+          `id: ${event.id}\nevent: ${event.event}\ndata: ${event.data}\n\n`,
+        ),
+      );
+    } catch {
+      streams.delete(entry);
+    }
+  };
+
+  const server = Bun.serve({
+    hostname: "127.0.0.1",
+    port: 0,
+    // SSE streams stay open for the whole scripted execution; Bun's default
+    // 10s idle timeout would sever them mid-test.
+    idleTimeout: 255,
+    async fetch(req) {
+      const url = new URL(req.url);
+      const match =
+        /^\/api\/session\/([^/]+)(?:\/(messages|execute|events))?$/.exec(
+          url.pathname,
+        );
+      if (!match) return new Response("not found", { status: 404 });
+      const threadKey = decodeURIComponent(match[1] ?? "");
+      const endpoint = match[2];
+
+      if (endpoint === "events") {
+        const afterEventId =
+          Number.parseInt(url.searchParams.get("after_event_id") ?? "0", 10) ||
+          0;
+        const executionId = url.searchParams.get("execution_id") ?? undefined;
+        let entry: StreamEntry | null = null;
+        const stream = new ReadableStream<Uint8Array>({
+          start(controller) {
+            entry = { afterEventId, controller, executionId, threadKey };
+            streams.add(entry);
+            for (const event of events) {
+              if (matches(entry, event)) write(entry, event);
+            }
+          },
+          cancel() {
+            if (entry) streams.delete(entry);
+          },
+        });
+        return new Response(stream, {
+          headers: {
+            "cache-control": "no-cache",
+            "content-type": "text/event-stream",
+          },
+        });
+      }
+
+      const body = (await req.json()) as JsonObject;
+      if (endpoint === "messages") {
+        appends.push({ body, threadKey });
+        const messages = Array.isArray(body.messages) ? body.messages : [];
+        return Response.json({
+          ok: true,
+          message_ids: messages.map(
+            (_, index) => `msg-${appends.length}-${index}`,
+          ),
+        });
+      }
+      if (endpoint === "execute") {
+        executes.push({ body, threadKey });
+        const key = `${threadKey}:${String(body.idempotency_key ?? "")}`;
+        const existing = idempotent.get(key);
+        const executionId = existing ?? `exe-${idempotent.size + 1}`;
+        if (!existing) idempotent.set(key, executionId);
+        return Response.json({
+          ok: true,
+          execution_id: executionId,
+          status: "accepted",
+          thread_key: threadKey,
+        });
+      }
+      creates.push({ body, threadKey });
+      return Response.json({
+        harness_type: body.harness_type,
+        status: "active",
+        thread_key: threadKey,
+      });
+    },
+  });
+
+  return {
+    appends,
+    creates,
+    executes,
+    url: `http://127.0.0.1:${server.port}`,
+    streamCount: () => streams.size,
+    emit(threadKey, event, data, executionId) {
+      const entry: SessionEvent = {
+        data: typeof data === "string" ? data : JSON.stringify(data),
+        event,
+        executionId,
+        id: ++eventId,
+        threadKey,
+      };
+      events.push(entry);
+      for (const stream of [...streams]) {
+        if (matches(stream, entry)) write(stream, entry);
+      }
+    },
+    emitAnswerLines(threadKey, lines) {
+      for (const line of lines) {
+        this.emit(threadKey, "session.output.line", line);
+      }
+    },
+    stop() {
+      for (const stream of [...streams]) {
+        try {
+          stream.controller.close();
+        } catch {
+          // already closed
+        }
+      }
+      server.stop(true);
+    },
+  };
+}
+
+function answerStartLine(): string {
+  return JSON.stringify({
+    method: "item/started",
+    params: {
+      threadId: "thread-1",
+      turnId: "turn-1",
+      startedAtMs: 1,
+      item: {
+        type: "agentMessage",
+        id: "answer-1",
+        text: "",
+        phase: "final_answer",
+        memoryCitation: null,
+      },
+    },
+  });
+}
+
+function answerDeltaLine(delta: string): string {
+  return JSON.stringify({
+    method: "item/agentMessage/delta",
+    params: {
+      threadId: "thread-1",
+      turnId: "turn-1",
+      itemId: "answer-1",
+      delta,
+    },
+  });
+}
+
+function turnCompletedLine(): string {
+  return JSON.stringify({
+    type: "turn.completed",
+    turn: { id: "turn-1", items: [] },
+  });
+}
+
+function answerLines(answer: string): string[] {
+  return [answerStartLine(), answerDeltaLine(answer), turnCompletedLine()];
+}
+
+// ---------------------------------------------------------------------------
+// Fixtures / helpers
+// ---------------------------------------------------------------------------
+
+let nextBotId = 800_000_000 + Math.floor(Math.random() * 100_000_000);
+let nextUpdateId = 1;
+
+function dmUpdate(userId: number, text: string): TelegramUpdate {
+  const updateId = nextUpdateId++;
+  const message: TelegramMessage = {
+    message_id: updateId,
+    from: { id: userId, is_bot: false, first_name: "Alice" },
+    chat: { id: userId, type: "private", first_name: "Alice" },
+    date: Math.floor(Date.now() / 1000),
+    text,
+  };
+  return { update_id: updateId, message };
+}
+
+function groupCommandUpdate(chatId: number, prompt: string): TelegramUpdate {
+  const updateId = nextUpdateId++;
+  const command = "/ask@fake_bot";
+  const message: TelegramMessage = {
+    message_id: updateId,
+    from: { id: 42, is_bot: false, first_name: "Alice" },
+    chat: { id: chatId, type: "supergroup", title: "ops" },
+    date: Math.floor(Date.now() / 1000),
+    text: `${command} ${prompt}`,
+    entities: [{ type: "bot_command", offset: 0, length: command.length }],
+  };
+  return { update_id: updateId, message };
+}
+
+async function waitFor(
+  condition: () => boolean | Promise<boolean>,
+  label: string,
+  timeoutMs = 10_000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await condition()) return;
+    await Bun.sleep(25);
+  }
+  throw new Error(`timed out waiting for ${label}`);
+}
+
+function chatCalls(
+  server: FakeTelegramServer,
+  method: string,
+  chatId: number,
+): RecordedTelegramCall[] {
+  return server
+    .callsFor(method)
+    .filter((call) => Number(call.params["chat_id"]) === chatId);
+}
+
+function answerSends(
+  server: FakeTelegramServer,
+  chatId: number,
+): RecordedTelegramCall[] {
+  // Narrator blurbs are italic (<i>…), answer sends are not; the scripted
+  // streams below never emit reasoning, so every send in the chat is answer.
+  return chatCalls(server, "sendMessage", chatId);
+}
+
+function reactionEmojis(
+  server: FakeTelegramServer,
+  chatId: number,
+): string[] {
+  return chatCalls(server, "setMessageReaction", chatId).map((call) => {
+    const reaction = call.params["reaction"] as Array<{ emoji: string }>;
+    return reaction[0]?.emoji ?? "";
+  });
+}
+
+describe.skipIf(!databaseUrl)("telegram end-to-end emulation", () => {
+  const pool: Pool = new pg.Pool({ connectionString: databaseUrl });
+  const servers: FakeTelegramServer[] = [];
+  const sessionApis: FakeSessionApi[] = [];
+  const bots: Telegrambot[] = [];
+
+  afterEach(async () => {
+    for (const bot of bots.splice(0)) {
+      await bot.shutdown().catch(() => undefined);
+    }
+    for (const session of sessionApis.splice(0)) session.stop();
+    for (const server of servers.splice(0)) server.stop();
+  });
+
+  afterAll(async () => {
+    await pool.end();
+  });
+
+  function fakeTelegram(): FakeTelegramServer {
+    const server = startFakeTelegramServer({
+      botUser: { id: nextBotId++, username: "fake_bot" },
+    });
+    servers.push(server);
+    return server;
+  }
+
+  function fakeSession(): FakeSessionApi {
+    const session = startFakeSessionApi();
+    sessionApis.push(session);
+    return session;
+  }
+
+  function startBot(
+    server: FakeTelegramServer,
+    session: FakeSessionApi,
+    overrides: Partial<TelegrambotOptions> = {},
+  ): Telegrambot {
+    const bot = createTelegrambot({
+      answerEditIntervalMs: 50,
+      apiUrl: session.url,
+      botToken: server.token,
+      chatAllowlist: [],
+      logger: noopLogger,
+      pollTimeoutSeconds: 1,
+      postgresUrl: databaseUrl ?? "",
+      telegramApiUrl: server.baseUrl,
+      userAllowlist: [],
+      ...overrides,
+    });
+    bots.push(bot);
+    void bot.start();
+    return bot;
+  }
+
+  async function inboxRow(
+    botUserId: number,
+    updateId: number,
+  ): Promise<{
+    render_obligation: { postedMessageIds: number[] } | null;
+    status: TelegramInboxStatus;
+    status_reason: string | null;
+  } | null> {
+    const result = await pool.query(
+      `SELECT status, status_reason, render_obligation
+       FROM telegram_update_inbox WHERE bot_user_id = $1 AND update_id = $2`,
+      [String(botUserId), updateId],
+    );
+    return result.rows[0] ?? null;
+  }
+
+  async function rowStatus(
+    botUserId: number,
+    updateId: number,
+  ): Promise<TelegramInboxStatus | null> {
+    return (await inboxRow(botUserId, updateId))?.status ?? null;
+  }
+
+  it(
+    "streams an allowlisted DM end to end: thread key, metadata, reactions, HTML reply",
+    async () => {
+      const server = fakeTelegram();
+      const session = fakeSession();
+      const userId = 4242;
+      startBot(server, session, { userAllowlist: [String(userId)] });
+
+      const update = dmUpdate(userId, "hello centaur");
+      server.queueUpdates(update);
+
+      await waitFor(() => session.executes.length === 1, "execute accepted");
+      const threadKey = `telegram:private:${userId}`;
+      expect(session.executes[0]?.threadKey).toBe(threadKey);
+      expect(session.creates[0]?.threadKey).toBe(threadKey);
+      const metadata = session.creates[0]?.body.metadata as JsonObject;
+      expect(metadata.source).toBe("telegrambot");
+      expect(metadata.platform).toBe("telegram");
+      expect(metadata.thread_id).toBe(threadKey);
+      expect(metadata.telegram_chat_type).toBe("private");
+      expect(metadata.user_id).toBe(String(userId));
+      expect(metadata.telegram_conversation_name).toBe("Alice");
+
+      session.emitAnswerLines(threadKey, answerLines("**hi** _there_"));
+
+      await waitFor(
+        async () =>
+          (await rowStatus(server.botUser.id, update.update_id)) ===
+          "completed",
+        "inbox row completed",
+      );
+
+      const sends = answerSends(server, userId);
+      expect(sends.length).toBe(1);
+      expect(sends[0]?.params["text"]).toBe("<b>hi</b> <i>there</i>");
+      expect(sends[0]?.params["parse_mode"]).toBe("HTML");
+      expect(sends[0]?.params["reply_parameters"]).toEqual({
+        message_id: update.message?.message_id,
+      });
+      // 👀 while working, ✅ on settle (setMessageReaction replaces the set).
+      expect(reactionEmojis(server, userId)).toEqual(["👀", "✅"]);
+    },
+    20_000,
+  );
+
+  it(
+    "routes a group /ask@bot command from an allowlisted chat to a telegram:chat key",
+    async () => {
+      const server = fakeTelegram();
+      const session = fakeSession();
+      const chatId = -100_123;
+      startBot(server, session, { chatAllowlist: [String(chatId)] });
+
+      const update = groupCommandUpdate(chatId, "deploy the thing");
+      server.queueUpdates(update);
+
+      await waitFor(() => session.executes.length === 1, "execute accepted");
+      const threadKey = `telegram:chat:${chatId}`;
+      expect(session.executes[0]?.threadKey).toBe(threadKey);
+      // The /ask@bot prefix is stripped from the session input.
+      const inputLines = JSON.stringify(session.executes[0]?.body.input_lines);
+      expect(inputLines).toContain("deploy the thing");
+      expect(inputLines).not.toContain("/ask");
+
+      session.emitAnswerLines(threadKey, answerLines("done"));
+      await waitFor(
+        async () =>
+          (await rowStatus(server.botUser.id, update.update_id)) ===
+          "completed",
+        "inbox row completed",
+      );
+      expect(answerSends(server, chatId).length).toBe(1);
+    },
+    20_000,
+  );
+
+  it(
+    "appends a same-chat follow-up to the same session",
+    async () => {
+      const server = fakeTelegram();
+      const session = fakeSession();
+      const userId = 5151;
+      startBot(server, session, { userAllowlist: [String(userId)] });
+      const threadKey = `telegram:private:${userId}`;
+
+      const first = dmUpdate(userId, "first question");
+      server.queueUpdates(first);
+      await waitFor(() => session.executes.length === 1, "first execute");
+      session.emitAnswerLines(threadKey, answerLines("first answer"));
+      await waitFor(
+        async () =>
+          (await rowStatus(server.botUser.id, first.update_id)) === "completed",
+        "first row completed",
+      );
+
+      const second = dmUpdate(userId, "follow-up question");
+      server.queueUpdates(second);
+      await waitFor(() => session.executes.length === 2, "second execute");
+      session.emitAnswerLines(threadKey, answerLines("second answer"));
+      await waitFor(
+        async () =>
+          (await rowStatus(server.botUser.id, second.update_id)) ===
+          "completed",
+        "second row completed",
+      );
+
+      // One durable session: every create/append/execute targets the same
+      // typed thread key (create metadata is re-upserted per message by
+      // design, so the session identity — not the call count — is the check).
+      expect(new Set(session.creates.map((c) => c.threadKey)).size).toBe(1);
+      expect(session.creates[0]?.threadKey).toBe(threadKey);
+      expect(session.appends.length).toBe(2);
+      expect(
+        session.executes.map((call) => call.body.idempotency_key),
+      ).toEqual([
+        `telegram:${userId}:${first.message?.message_id}`,
+        `telegram:${userId}:${second.message?.message_id}`,
+      ]);
+    },
+    25_000,
+  );
+
+  it(
+    "rejects a non-allowlisted chat with zero Telegram mutations and zero api-rs calls",
+    async () => {
+      const server = fakeTelegram();
+      const session = fakeSession();
+      startBot(server, session, { chatAllowlist: ["-999"] });
+
+      const update = groupCommandUpdate(-100_777, "let me in");
+      server.queueUpdates(update);
+
+      await waitFor(
+        async () =>
+          (await rowStatus(server.botUser.id, update.update_id)) === "rejected",
+        "row rejected",
+      );
+      const row = await inboxRow(server.botUser.id, update.update_id);
+      expect(row?.status_reason).toBe("not_allowlisted");
+      expect(
+        session.creates.length + session.appends.length + session.executes.length,
+      ).toBe(0);
+      for (const method of TELEGRAM_MUTATION_METHODS) {
+        expect(server.callsFor(method).length).toBe(0);
+      }
+    },
+    20_000,
+  );
+
+  it(
+    "recovers a crash after execution_accepted and delivers without a second execute",
+    async () => {
+      const server = fakeTelegram();
+      const session = fakeSession();
+      const userId = 6161;
+      const threadKey = `telegram:private:${userId}`;
+      const botA = startBot(server, session, {
+        userAllowlist: [String(userId)],
+      });
+
+      const update = dmUpdate(userId, "crash mid-flight");
+      server.queueUpdates(update);
+      await waitFor(() => session.executes.length === 1, "execute accepted");
+      await waitFor(
+        async () =>
+          (await rowStatus(server.botUser.id, update.update_id)) ===
+          "render_obligation_persisted",
+        "obligation persisted",
+      );
+      // Nothing was sent yet — the scripted stream is silent.
+      expect(answerSends(server, userId).length).toBe(0);
+
+      // "Crash": stop the first instance entirely (releases the lease), then
+      // bring up a fresh one against the same durable state.
+      await botA.shutdown();
+      startBot(server, session, { userAllowlist: [String(userId)] });
+
+      session.emitAnswerLines(threadKey, answerLines("recovered answer"));
+      await waitFor(
+        async () =>
+          (await rowStatus(server.botUser.id, update.update_id)) ===
+          "completed",
+        "row completed after recovery",
+        20_000,
+      );
+
+      // Recovery resumed the persisted obligation — it never re-executed.
+      expect(session.executes.length).toBe(1);
+      const sends = answerSends(server, userId);
+      expect(sends.length).toBe(1);
+      expect(sends[0]?.params["text"]).toBe("recovered answer");
+    },
+    40_000,
+  );
+
+  it(
+    "retries delivery after a dropped send without re-executing, and resumes with an edit once a message_id is persisted",
+    async () => {
+      const server = fakeTelegram();
+      const session = fakeSession();
+      const userId = 7171;
+      const threadKey = `telegram:private:${userId}`;
+      const botA = startBot(server, session, {
+        userAllowlist: [String(userId)],
+      });
+
+      // Part 1: the first answer send fails (response lost); the persisted
+      // obligation retries terminal delivery — duplicates allowed, but no
+      // re-execution.
+      server.failNext("sendMessage", { status: 500, description: "dropped" });
+      const update = dmUpdate(userId, "fault injection");
+      server.queueUpdates(update);
+      await waitFor(() => session.executes.length === 1, "execute accepted");
+      session.emitAnswerLines(threadKey, [
+        answerStartLine(),
+        answerDeltaLine("part one"),
+      ]);
+      // First attempt hits the scripted 500; the retry sweep re-renders and
+      // the second send succeeds.
+      await waitFor(
+        async () => {
+          const row = await inboxRow(server.botUser.id, update.update_id);
+          return (row?.render_obligation?.postedMessageIds.length ?? 0) > 0;
+        },
+        "message_id persisted after retry",
+        20_000,
+      );
+      expect(session.executes.length).toBe(1);
+      // Two send attempts (the dropped one + the successful retry) at most;
+      // exactly one message_id was recorded.
+      expect(answerSends(server, userId).length).toBeGreaterThanOrEqual(2);
+
+      // Part 2: crash after the message_id is durably recorded; the new
+      // instance must resume with an edit / next chunk, never repost chunk 1.
+      const sendsBeforeRestart = answerSends(server, userId).length;
+      await botA.shutdown();
+      startBot(server, session, { userAllowlist: [String(userId)] });
+
+      session.emitAnswerLines(threadKey, [
+        answerDeltaLine(" and part two"),
+        turnCompletedLine(),
+      ]);
+      await waitFor(
+        async () =>
+          (await rowStatus(server.botUser.id, update.update_id)) ===
+          "completed",
+        "row completed after restart",
+        20_000,
+      );
+
+      expect(session.executes.length).toBe(1);
+      // No repost: the recorded chunk is grown in place via edits.
+      expect(answerSends(server, userId).length).toBe(sendsBeforeRestart);
+      const edits = chatCalls(server, "editMessageText", userId);
+      expect(edits.length).toBeGreaterThanOrEqual(1);
+      const lastEdit = edits[edits.length - 1];
+      expect(String(lastEdit?.params["text"])).toContain("part two");
+      const row = await inboxRow(server.botUser.id, update.update_id);
+      expect(row?.render_obligation?.postedMessageIds.length).toBe(1);
+    },
+    40_000,
+  );
+
+  it(
+    "splits a long answer with a code fence across the 4096 parsed-char boundary into balanced chunks",
+    async () => {
+      const server = fakeTelegram();
+      const session = fakeSession();
+      const userId = 8181;
+      const threadKey = `telegram:private:${userId}`;
+      startBot(server, session, { userAllowlist: [String(userId)] });
+
+      const codeLines = Array.from(
+        { length: 260 },
+        (_, index) => `print("row ${index} of the generated report")`,
+      ).join("\n");
+      const answer = `Intro paragraph.\n\n\`\`\`python\n${codeLines}\n\`\`\`\n\nClosing remarks.`;
+
+      const update = dmUpdate(userId, "long answer please");
+      server.queueUpdates(update);
+      await waitFor(() => session.executes.length === 1, "execute accepted");
+      session.emitAnswerLines(threadKey, answerLines(answer));
+      await waitFor(
+        async () =>
+          (await rowStatus(server.botUser.id, update.update_id)) ===
+          "completed",
+        "row completed",
+        20_000,
+      );
+
+      const sends = answerSends(server, userId);
+      expect(sends.length).toBeGreaterThanOrEqual(2);
+      for (const send of sends) {
+        const text = String(send.params["text"]);
+        // Telegram's limit applies to the PARSED text; tags ride free.
+        expect(parsedTextLength(text)).toBeLessThanOrEqual(4096);
+        // Balanced entities in every independently valid chunk.
+        expect(count(text, "<pre>")).toBe(count(text, "</pre>"));
+        expect(count(text, "<code")).toBe(count(text, "</code>"));
+      }
+      // The fence crosses the boundary: a later chunk re-opens the
+      // language-classed code block.
+      const reopened = sends
+        .slice(1)
+        .some((send) =>
+          String(send.params["text"]).startsWith(
+            '<pre><code class="language-python">',
+          ),
+        );
+      expect(reopened).toBe(true);
+    },
+    30_000,
+  );
+});
+
+function count(haystack: string, needle: string): number {
+  return haystack.split(needle).length - 1;
+}

--- a/services/telegrambot/test/telegram-narrator.test.ts
+++ b/services/telegrambot/test/telegram-narrator.test.ts
@@ -6,8 +6,8 @@ import type { TelegramApi } from "../src/telegram-api";
 import type { Logger, TelegramMessage } from "../src/types";
 
 const EYES = "👀";
-const CHECK = "✅";
-const CROSS = "❌";
+const CHECK = "👍";
+const CROSS = "👎";
 
 const CHAT_ID = -1001234;
 const TRIGGER_MESSAGE_ID = 41;
@@ -197,7 +197,7 @@ describe("TelegramNarrator reactions", () => {
     });
   });
 
-  it("settles done with a single replacing ✅ call (no delete step)", async () => {
+  it("settles done with a single replacing 👍 call (no delete step)", async () => {
     const h = harness();
     const narrator = startNarrator(h);
     await narrator.finish("done");
@@ -209,7 +209,7 @@ describe("TelegramNarrator reactions", () => {
     }
   });
 
-  it("settles as ❌ when an error task was seen", async () => {
+  it("settles as 👎 when an error task was seen", async () => {
     const h = harness();
     const narrator = startNarrator(h);
     narrator.update(
@@ -220,7 +220,7 @@ describe("TelegramNarrator reactions", () => {
     expect(h.reactions().map(emojiOf)).toEqual([EYES, CROSS]);
   });
 
-  it("settles as ❌ for a failed outcome", async () => {
+  it("settles as 👎 for a failed outcome", async () => {
     const h = harness();
     const narrator = startNarrator(h);
     await narrator.finish("failed");
@@ -587,7 +587,7 @@ describe("TelegramNarrator status", () => {
 });
 
 describe("TelegramNarrator typing keepalive", () => {
-  it("sends typing immediately and then on the interval", async () => {
+  it("sends typing immediately and then on a sub-5s interval so the indicator never lapses", async () => {
     const clock = new FakeClock();
     const h = harness();
     const narrator = startNarrator(h, { clock });
@@ -596,9 +596,13 @@ describe("TelegramNarrator typing keepalive", () => {
     expect(h.typing()).toHaveLength(1);
     expect(h.typing()[0]?.params).toEqual({ chat_id: CHAT_ID, action: "typing" });
 
-    await clock.advance(5_000);
+    // The indicator lives ~5s; the keepalive must refresh strictly before
+    // that, measured from the start of the previous send.
+    await clock.advance(3_999);
+    expect(h.typing()).toHaveLength(1);
+    await clock.advance(1);
     expect(h.typing()).toHaveLength(2);
-    await clock.advance(5_000);
+    await clock.advance(4_000);
     expect(h.typing()).toHaveLength(3);
 
     narrator.stopTypingKeepalive();

--- a/services/telegrambot/test/telegram-narrator.test.ts
+++ b/services/telegrambot/test/telegram-narrator.test.ts
@@ -1,0 +1,698 @@
+import { describe, expect, it } from "bun:test";
+import { TelegramNarrator, setTelegramReaction } from "../src/telegram-narrator";
+import type { TelegramNarratorClock } from "../src/telegram-narrator";
+import { TelegramApiError } from "../src/telegram-api";
+import type { TelegramApi } from "../src/telegram-api";
+import type { Logger, TelegramMessage } from "../src/types";
+
+const EYES = "👀";
+const CHECK = "✅";
+const CROSS = "❌";
+
+const CHAT_ID = -1001234;
+const TRIGGER_MESSAGE_ID = 41;
+
+const tick = (): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, 0));
+
+/**
+ * Virtual clock (same seam as the rate-limit suite): sleep() parks until
+ * advance() moves time past the wake point, then flushes continuations so the
+ * woken typing loop can send and sleep again within the same advance window.
+ */
+class FakeClock implements TelegramNarratorClock {
+  private nowMs = 0;
+  private sleepers: Array<{ at: number; resolve: () => void }> = [];
+
+  now = (): number => this.nowMs;
+
+  sleep = (ms: number): Promise<void> =>
+    new Promise((resolve) => {
+      this.sleepers.push({ at: this.nowMs + ms, resolve });
+    });
+
+  async advance(ms: number): Promise<void> {
+    this.nowMs += ms;
+    for (;;) {
+      const due = this.sleepers.filter((sleeper) => sleeper.at <= this.nowMs);
+      if (!due.length) break;
+      this.sleepers = this.sleepers.filter(
+        (sleeper) => sleeper.at > this.nowMs,
+      );
+      for (const sleeper of due) sleeper.resolve();
+      await tick();
+    }
+    await tick();
+  }
+}
+
+type LoggedEvent = { event: string; data: Record<string, unknown> };
+
+function captureLogger(): { logger: Logger; events: LoggedEvent[] } {
+  const events: LoggedEvent[] = [];
+  const push = (event: string, data?: unknown): void => {
+    events.push({ event, data: (data ?? {}) as Record<string, unknown> });
+  };
+  const logger: Logger = {
+    debug: push,
+    info: push,
+    warn: push,
+    error: push,
+    child: () => logger,
+  };
+  return { logger, events };
+}
+
+type RecordedCall = { method: string; params: Record<string, unknown> };
+
+type Hooks = {
+  onSendMessage?: () => void;
+  onSetMessageReaction?: () => void;
+  onSendChatAction?: () => void;
+};
+
+type Harness = {
+  api: TelegramApi;
+  calls: RecordedCall[];
+  events: LoggedEvent[];
+  logger: Logger;
+  posts: () => RecordedCall[];
+  reactions: () => RecordedCall[];
+  typing: () => RecordedCall[];
+};
+
+function harness(hooks: Hooks = {}): Harness {
+  const calls: RecordedCall[] = [];
+  const record = (method: string, params: unknown): void => {
+    calls.push({ method, params: params as Record<string, unknown> });
+  };
+  const message: TelegramMessage = {
+    message_id: 900,
+    chat: { id: CHAT_ID, type: "supergroup" },
+    date: 0,
+  };
+  const api: TelegramApi = {
+    getMe: async () => ({ id: 42, is_bot: true, first_name: "bot" }),
+    getUpdates: async () => [],
+    deleteWebhook: async () => undefined,
+    sendMessage: async (params) => {
+      record("sendMessage", params);
+      hooks.onSendMessage?.();
+      return message;
+    },
+    editMessageText: async (params) => {
+      record("editMessageText", params);
+    },
+    setMessageReaction: async (params) => {
+      record("setMessageReaction", params);
+      hooks.onSetMessageReaction?.();
+    },
+    sendChatAction: async (params) => {
+      record("sendChatAction", params);
+      hooks.onSendChatAction?.();
+    },
+    getFile: async (fileId) => ({ file_id: fileId, file_unique_id: "u" }),
+    downloadFile: async () => new Uint8Array(),
+  };
+  const { logger, events } = captureLogger();
+  return {
+    api,
+    calls,
+    events,
+    logger,
+    posts: () => calls.filter((call) => call.method === "sendMessage"),
+    reactions: () =>
+      calls.filter((call) => call.method === "setMessageReaction"),
+    typing: () => calls.filter((call) => call.method === "sendChatAction"),
+  };
+}
+
+function startNarrator(
+  h: Harness,
+  options?: {
+    clock?: TelegramNarratorClock;
+    maxPosts?: number;
+    messageThreadId?: number;
+    minPostGapMs?: number;
+    typingIntervalMs?: number;
+  },
+): TelegramNarrator {
+  return TelegramNarrator.start(
+    h.api,
+    {
+      chatId: CHAT_ID,
+      messageThreadId: options?.messageThreadId,
+      triggerMessageId: TRIGGER_MESSAGE_ID,
+    },
+    {
+      logger: h.logger,
+      clock: options?.clock,
+      maxPosts: options?.maxPosts,
+      minPostGapMs: options?.minPostGapMs ?? 1,
+      typingIntervalMs: options?.typingIntervalMs,
+    },
+  );
+}
+
+function task(input: {
+  id: string;
+  title: string;
+  status?: "pending" | "in_progress" | "complete" | "error";
+  details?: string;
+}): {
+  type: "task_update";
+  id: string;
+  title: string;
+  status: "pending" | "in_progress" | "complete" | "error";
+  details?: string;
+} {
+  return {
+    type: "task_update",
+    id: input.id,
+    title: input.title,
+    status: input.status ?? "in_progress",
+    ...(input.details ? { details: input.details } : {}),
+  };
+}
+
+function emojiOf(call: RecordedCall): string {
+  const reaction = call.params.reaction as Array<{ emoji: string }>;
+  return reaction[0]?.emoji ?? "";
+}
+
+function postText(call: RecordedCall): string {
+  return String(call.params.text ?? "");
+}
+
+describe("TelegramNarrator reactions", () => {
+  it("sets 👀 on the triggering message at start", async () => {
+    const h = harness();
+    const narrator = startNarrator(h);
+    await narrator.finish("done");
+
+    expect(h.reactions()[0]?.params).toEqual({
+      chat_id: CHAT_ID,
+      message_id: TRIGGER_MESSAGE_ID,
+      reaction: [{ type: "emoji", emoji: EYES }],
+    });
+  });
+
+  it("settles done with a single replacing ✅ call (no delete step)", async () => {
+    const h = harness();
+    const narrator = startNarrator(h);
+    await narrator.finish("done");
+
+    expect(h.reactions().map(emojiOf)).toEqual([EYES, CHECK]);
+    // Every call carries exactly one emoji: replacement, never accumulation.
+    for (const call of h.reactions()) {
+      expect(call.params.reaction).toHaveLength(1);
+    }
+  });
+
+  it("settles as ❌ when an error task was seen", async () => {
+    const h = harness();
+    const narrator = startNarrator(h);
+    narrator.update(
+      task({ id: "err-1", title: "Execution failed", status: "error" }),
+    );
+    await narrator.finish("done");
+
+    expect(h.reactions().map(emojiOf)).toEqual([EYES, CROSS]);
+  });
+
+  it("settles as ❌ for a failed outcome", async () => {
+    const h = harness();
+    const narrator = startNarrator(h);
+    await narrator.finish("failed");
+
+    expect(h.reactions().map(emojiOf)).toEqual([EYES, CROSS]);
+  });
+
+  it("leaves 👀 in place for a retrying outcome", async () => {
+    const h = harness();
+    const narrator = startNarrator(h);
+    await narrator.finish("retrying");
+
+    expect(h.reactions().map(emojiOf)).toEqual([EYES]);
+  });
+
+  it("classifies reaction-unavailable 400s and suppresses them", async () => {
+    const h = harness({
+      onSetMessageReaction: () => {
+        throw new TelegramApiError({
+          method: "setMessageReaction",
+          status: 400,
+          errorCode: 400,
+          description: "Bad Request: message can't be reacted",
+        });
+      },
+    });
+    const narrator = startNarrator(h);
+    await expect(narrator.finish("done")).resolves.toBeUndefined();
+
+    const classified = h.events.filter(
+      (event) => event.event === "telegrambot_narrator_reaction_unavailable",
+    );
+    expect(classified.length).toBeGreaterThan(0);
+    expect(
+      h.events.some(
+        (event) => event.event === "telegrambot_narrator_reaction_failed",
+      ),
+    ).toBe(false);
+  });
+
+  it("warns on unexpected reaction failures without throwing", async () => {
+    const h = harness({
+      onSetMessageReaction: () => {
+        throw new Error("network down");
+      },
+    });
+    const narrator = startNarrator(h);
+    await expect(narrator.finish("done")).resolves.toBeUndefined();
+
+    expect(
+      h.events.some(
+        (event) => event.event === "telegrambot_narrator_reaction_failed",
+      ),
+    ).toBe(true);
+  });
+
+  it("finishes settle exactly once across repeated finish calls", async () => {
+    const h = harness();
+    const narrator = startNarrator(h);
+    await Promise.all([narrator.finish("done"), narrator.finish("failed")]);
+    await narrator.finish("failed");
+
+    expect(h.reactions().map(emojiOf)).toEqual([EYES, CHECK]);
+  });
+});
+
+describe("setTelegramReaction", () => {
+  it("never throws on failure", async () => {
+    const h = harness({
+      onSetMessageReaction: () => {
+        throw new Error("boom");
+      },
+    });
+    await expect(
+      setTelegramReaction(
+        h.api,
+        { chatId: CHAT_ID, emoji: EYES, messageId: 7 },
+        h.logger,
+      ),
+    ).resolves.toBeUndefined();
+  });
+});
+
+describe("TelegramNarrator blurbs", () => {
+  it("coalesces reasoning deltas into one italic HTML message when the thought completes", async () => {
+    const h = harness();
+    const narrator = startNarrator(h);
+    narrator.update(
+      task({ id: "reasoning-1", title: "Thinking", details: "Comparing the " }),
+    );
+    narrator.update(
+      task({
+        id: "reasoning-2",
+        title: "Thinking",
+        status: "complete",
+        details: "deploy manifests against the defaults",
+      }),
+    );
+    await narrator.finish("done");
+
+    expect(h.posts().map(postText)).toEqual([
+      "<i>Comparing the deploy manifests against the defaults</i>",
+    ]);
+    expect(h.posts()[0]?.params.parse_mode).toBe("HTML");
+    expect(h.posts()[0]?.params.chat_id).toBe(CHAT_ID);
+  });
+
+  it("escapes HTML in blurb content", async () => {
+    const h = harness();
+    const narrator = startNarrator(h);
+    narrator.update(
+      task({
+        id: "reasoning-1",
+        title: "Thinking",
+        status: "complete",
+        details: "Compare <a> & <b> tags before rendering",
+      }),
+    );
+    await narrator.finish("done");
+
+    expect(h.posts().map(postText)).toEqual([
+      "<i>Compare &lt;a&gt; &amp; &lt;b&gt; tags before rendering</i>",
+    ]);
+  });
+
+  it("flushes the pending thought when the model moves on to a command", async () => {
+    const h = harness();
+    const narrator = startNarrator(h);
+    narrator.update(
+      task({
+        id: "reasoning-1",
+        title: "Thinking",
+        details: "Need to check the recent deploy history first",
+      }),
+    );
+    narrator.update(task({ id: "cmd-1", title: "Command execution (1)" }));
+    await narrator.finish("done");
+
+    expect(h.posts().map(postText)).toEqual([
+      "<i>Need to check the recent deploy history first</i>",
+    ]);
+  });
+
+  it("never renders commands, tools, or plan updates", async () => {
+    const h = harness();
+    const narrator = startNarrator(h);
+    narrator.update({ type: "plan_update", title: "Investigate" });
+    narrator.update(
+      task({ id: "cmd-1", title: "Command execution (1)", details: "ls" }),
+    );
+    narrator.update(task({ id: "tool-1", title: "Web search" }));
+    await narrator.finish("done");
+
+    expect(h.posts()).toEqual([]);
+  });
+
+  it("skips fragments too short to be worth a message", async () => {
+    const h = harness();
+    const narrator = startNarrator(h);
+    narrator.update(
+      task({
+        id: "thinking-1",
+        title: "Thinking",
+        status: "complete",
+        details: "Hmm.",
+      }),
+    );
+    await narrator.finish("done");
+
+    expect(h.posts()).toEqual([]);
+  });
+
+  it("merges thoughts that complete within the min post gap into one message", async () => {
+    const h = harness();
+    const narrator = startNarrator(h, { minPostGapMs: 50 });
+    narrator.update(
+      task({
+        id: "thinking-1",
+        title: "Thinking",
+        status: "complete",
+        details: "First completed thought here",
+      }),
+    );
+    narrator.update(
+      task({
+        id: "thinking-2",
+        title: "Thinking",
+        status: "complete",
+        details: "Second completed thought here",
+      }),
+    );
+    await new Promise((resolve) => setTimeout(resolve, 80));
+    await narrator.finish("done");
+
+    expect(h.posts().map(postText)).toEqual([
+      "<i>First completed thought here</i>\n\n<i>Second completed thought here</i>",
+    ]);
+  });
+
+  it("flushes an oversized pending thought early and truncates the visible text", async () => {
+    const h = harness();
+    const narrator = startNarrator(h);
+    narrator.update(
+      task({ id: "reasoning-1", title: "Thinking", details: "x".repeat(700) }),
+    );
+    await narrator.finish("done");
+
+    expect(h.posts()).toHaveLength(1);
+    const text = postText(h.posts()[0] ?? { method: "", params: {} });
+    expect(text).toStartWith("<i>");
+    expect(text).toEndWith("…</i>");
+    const visible = text.replaceAll("<i>", "").replaceAll("</i>", "");
+    expect(visible.length).toBeLessThanOrEqual(600);
+  });
+
+  it("stops posting past the max post cap", async () => {
+    const h = harness();
+    const narrator = startNarrator(h, { maxPosts: 2 });
+    for (let index = 0; index < 5; index++) {
+      narrator.update(
+        task({
+          id: `thinking-${index}`,
+          title: "Thinking",
+          status: "complete",
+          details: `Completed thought number ${index}`,
+        }),
+      );
+      await new Promise((resolve) => setTimeout(resolve, 5));
+    }
+    await narrator.finish("done");
+
+    expect(h.posts().length).toBeLessThanOrEqual(2);
+  });
+
+  it("posts the pending thought during finish, before settling the reaction", async () => {
+    const h = harness();
+    const narrator = startNarrator(h, { minPostGapMs: 10_000 });
+    narrator.update(
+      task({
+        id: "reasoning-1",
+        title: "Thinking",
+        details: "A final trailing thought",
+      }),
+    );
+    await narrator.finish("done");
+
+    expect(h.posts().map(postText)).toEqual([
+      "<i>A final trailing thought</i>",
+    ]);
+    const postIndex = h.calls.findIndex(
+      (call) => call.method === "sendMessage",
+    );
+    const checkIndex = h.calls.findIndex(
+      (call) => call.method === "setMessageReaction" && emojiOf(call) === CHECK,
+    );
+    expect(postIndex).toBeGreaterThan(-1);
+    expect(checkIndex).toBeGreaterThan(postIndex);
+  });
+
+  it("ignores updates after finish", async () => {
+    const h = harness();
+    const narrator = startNarrator(h);
+    await narrator.finish("done");
+    narrator.update(
+      task({
+        id: "thinking-1",
+        title: "Thinking",
+        status: "complete",
+        details: "Posthumous thought that should not post",
+      }),
+    );
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(h.posts()).toEqual([]);
+  });
+
+  it("swallows blurb post failures", async () => {
+    const h = harness({
+      onSendMessage: () => {
+        throw new Error("post failed");
+      },
+    });
+    const narrator = startNarrator(h);
+    narrator.update(
+      task({
+        id: "thinking-1",
+        title: "Thinking",
+        status: "complete",
+        details: "A thought that will fail to post",
+      }),
+    );
+    await expect(narrator.finish("done")).resolves.toBeUndefined();
+    expect(
+      h.events.some(
+        (event) => event.event === "telegrambot_narrator_post_failed",
+      ),
+    ).toBe(true);
+  });
+
+  it("keeps blurbs in the originating forum topic; reactions carry no topic id", async () => {
+    const h = harness();
+    const narrator = startNarrator(h, { messageThreadId: 7 });
+    narrator.update(
+      task({
+        id: "thinking-1",
+        title: "Thinking",
+        status: "complete",
+        details: "Topic-scoped completed thought",
+      }),
+    );
+    await narrator.finish("done");
+
+    expect(h.posts()[0]?.params.message_thread_id).toBe(7);
+    for (const call of h.reactions()) {
+      expect("message_thread_id" in call.params).toBe(false);
+    }
+  });
+
+  it("omits message_thread_id for plain (non-topic) chats", async () => {
+    const h = harness();
+    const narrator = startNarrator(h);
+    narrator.update(
+      task({
+        id: "thinking-1",
+        title: "Thinking",
+        status: "complete",
+        details: "Plain-chat completed thought",
+      }),
+    );
+    await narrator.finish("done");
+
+    const params = h.posts()[0]?.params ?? {};
+    expect("message_thread_id" in params).toBe(false);
+  });
+});
+
+describe("TelegramNarrator status", () => {
+  it("posts a status once and drops repeats, empties, and short fragments", async () => {
+    const h = harness();
+    const narrator = startNarrator(h);
+    narrator.status("Reviewing deployment manifests");
+    narrator.status("Reviewing deployment manifests");
+    narrator.status("   ");
+    narrator.status("Short");
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    await narrator.finish("done");
+
+    expect(h.posts().map(postText)).toEqual([
+      "<i>Reviewing deployment manifests</i>",
+    ]);
+  });
+
+  it("posts distinct consecutive statuses", async () => {
+    const h = harness();
+    const narrator = startNarrator(h);
+    narrator.status("Reviewing deployment manifests");
+    narrator.status("Cross-checking helm values");
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    await narrator.finish("done");
+
+    expect(h.posts().map(postText)).toEqual([
+      "<i>Reviewing deployment manifests</i>\n\n<i>Cross-checking helm values</i>",
+    ]);
+  });
+});
+
+describe("TelegramNarrator typing keepalive", () => {
+  it("sends typing immediately and then on the interval", async () => {
+    const clock = new FakeClock();
+    const h = harness();
+    const narrator = startNarrator(h, { clock });
+    narrator.startTypingKeepalive();
+    await tick();
+    expect(h.typing()).toHaveLength(1);
+    expect(h.typing()[0]?.params).toEqual({ chat_id: CHAT_ID, action: "typing" });
+
+    await clock.advance(5_000);
+    expect(h.typing()).toHaveLength(2);
+    await clock.advance(5_000);
+    expect(h.typing()).toHaveLength(3);
+
+    narrator.stopTypingKeepalive();
+    await narrator.finish("done");
+  });
+
+  it("propagates the forum topic id on every chat action", async () => {
+    const clock = new FakeClock();
+    const h = harness();
+    const narrator = startNarrator(h, { clock, messageThreadId: 7 });
+    narrator.startTypingKeepalive();
+    await tick();
+    await clock.advance(5_000);
+
+    expect(h.typing().length).toBeGreaterThanOrEqual(2);
+    for (const call of h.typing()) {
+      expect(call.params.action).toBe("typing");
+      expect(call.params.message_thread_id).toBe(7);
+    }
+    await narrator.finish("done");
+  });
+
+  it("stop halts the cadence", async () => {
+    const clock = new FakeClock();
+    const h = harness();
+    const narrator = startNarrator(h, { clock });
+    narrator.startTypingKeepalive();
+    await tick();
+    await clock.advance(5_000);
+    const before = h.typing().length;
+
+    narrator.stopTypingKeepalive();
+    await clock.advance(20_000);
+    expect(h.typing()).toHaveLength(before);
+    await narrator.finish("done");
+  });
+
+  it("finish stops the keepalive and does not hang on a parked sleep", async () => {
+    const clock = new FakeClock();
+    const h = harness();
+    const narrator = startNarrator(h, { clock });
+    narrator.startTypingKeepalive();
+    await tick();
+
+    await narrator.finish("done");
+    const before = h.typing().length;
+    await clock.advance(20_000);
+    expect(h.typing()).toHaveLength(before);
+  });
+
+  it("survives sendChatAction failures and keeps the cadence", async () => {
+    const clock = new FakeClock();
+    let attempts = 0;
+    const h = harness({
+      onSendChatAction: () => {
+        attempts += 1;
+        if (attempts === 1) throw new Error("typing failed");
+      },
+    });
+    const narrator = startNarrator(h, { clock });
+    narrator.startTypingKeepalive();
+    await tick();
+    await clock.advance(5_000);
+
+    expect(h.typing()).toHaveLength(2);
+    expect(
+      h.events.some(
+        (event) => event.event === "telegrambot_narrator_typing_failed",
+      ),
+    ).toBe(true);
+    await narrator.finish("done");
+  });
+
+  it("double start does not double the cadence", async () => {
+    const clock = new FakeClock();
+    const h = harness();
+    const narrator = startNarrator(h, { clock });
+    narrator.startTypingKeepalive();
+    narrator.startTypingKeepalive();
+    await tick();
+    expect(h.typing()).toHaveLength(1);
+    await clock.advance(5_000);
+    expect(h.typing()).toHaveLength(2);
+    await narrator.finish("done");
+  });
+
+  it("does not start after finish", async () => {
+    const clock = new FakeClock();
+    const h = harness();
+    const narrator = startNarrator(h, { clock });
+    await narrator.finish("done");
+    narrator.startTypingKeepalive();
+    await tick();
+    await clock.advance(20_000);
+    expect(h.typing()).toEqual([]);
+  });
+});

--- a/services/telegrambot/test/telegram-render.test.ts
+++ b/services/telegrambot/test/telegram-render.test.ts
@@ -1,0 +1,457 @@
+import { describe, expect, it } from "bun:test";
+import {
+  TELEGRAM_MAX_MESSAGE_CHARS,
+  chunkTelegramHtml,
+  escapeTelegramHtml,
+  parsedTextLength,
+  renderMarkdownToTelegramHtml,
+  renderPlainTextFallback,
+} from "../src/telegram-render";
+
+// ---------------------------------------------------------------------------
+// Test-side strict validator: simulates Telegram's HTML parser. Every chunk
+// the service sends must pass this independently — allowed tags only, strictly
+// balanced nesting, no raw < > & outside tags/entities, no lone UTF-16
+// surrogates. Returns the parsed (entity-decoded, tag-stripped) text.
+// ---------------------------------------------------------------------------
+
+const ALLOWED_TAGS = new Set([
+  "b",
+  "i",
+  "s",
+  "u",
+  "code",
+  "pre",
+  "a",
+  "blockquote",
+  "tg-spoiler",
+]);
+
+const TAG = /^<(\/?)([a-zA-Z][a-zA-Z0-9-]*)((?:\s[^<>]*)?)>/;
+const ENTITY = /^&(amp|lt|gt|quot|#(\d{1,7})|#[xX]([0-9a-fA-F]{1,6}));/;
+const ENTITY_VALUES: Record<string, string> = {
+  amp: "&",
+  lt: "<",
+  gt: ">",
+  quot: '"',
+};
+
+function parseTelegramChunk(chunk: string): string {
+  for (let u = 0; u < chunk.length; u++) {
+    const code = chunk.charCodeAt(u);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      const next = chunk.charCodeAt(u + 1);
+      if (!(next >= 0xdc00 && next <= 0xdfff)) {
+        throw new Error(`lone high surrogate at ${u}`);
+      }
+      u += 1;
+    } else if (code >= 0xdc00 && code <= 0xdfff) {
+      throw new Error(`lone low surrogate at ${u}`);
+    }
+  }
+
+  const stack: string[] = [];
+  let text = "";
+  let i = 0;
+  while (i < chunk.length) {
+    const ch = chunk[i] ?? "";
+    if (ch === "<") {
+      const match = TAG.exec(chunk.slice(i));
+      if (!match) throw new Error(`raw '<' at ${i} in ${JSON.stringify(chunk)}`);
+      const name = (match[2] ?? "").toLowerCase();
+      if (!ALLOWED_TAGS.has(name)) throw new Error(`unsupported tag <${name}>`);
+      if (match[1]) {
+        const open = stack.pop();
+        if (open !== name) throw new Error(`</${name}> closes <${open ?? "nothing"}>`);
+      } else {
+        stack.push(name);
+      }
+      i += (match[0] ?? "").length;
+      continue;
+    }
+    if (ch === ">") throw new Error(`raw '>' at ${i} in ${JSON.stringify(chunk)}`);
+    if (ch === "&") {
+      const entity = ENTITY.exec(chunk.slice(i));
+      if (!entity) throw new Error(`raw '&' at ${i} in ${JSON.stringify(chunk)}`);
+      const named = ENTITY_VALUES[entity[1] ?? ""];
+      if (named !== undefined) text += named;
+      else if (entity[2] !== undefined) text += String.fromCodePoint(Number(entity[2]));
+      else text += String.fromCodePoint(Number.parseInt(entity[3] ?? "", 16));
+      i += (entity[0] ?? "").length;
+      continue;
+    }
+    text += ch;
+    i += 1;
+  }
+  if (stack.length > 0) throw new Error(`unclosed tags: ${stack.join(", ")}`);
+  return text;
+}
+
+function assertChunksValid(chunks: string[], limit: number): string[] {
+  return chunks.map((chunk) => {
+    const text = parseTelegramChunk(chunk);
+    expect(text.length).toBe(parsedTextLength(chunk));
+    expect(text.length).toBeLessThanOrEqual(limit);
+    return text;
+  });
+}
+
+const stripWs = (value: string) => value.replace(/\s+/g, "");
+
+// ---------------------------------------------------------------------------
+// renderMarkdownToTelegramHtml
+// ---------------------------------------------------------------------------
+
+describe("renderMarkdownToTelegramHtml", () => {
+  it("maps bold, italic, and strikethrough", () => {
+    expect(renderMarkdownToTelegramHtml("**bold**")).toBe("<b>bold</b>");
+    expect(renderMarkdownToTelegramHtml("__bold__")).toBe("<b>bold</b>");
+    expect(renderMarkdownToTelegramHtml("*italic*")).toBe("<i>italic</i>");
+    expect(renderMarkdownToTelegramHtml("_italic_")).toBe("<i>italic</i>");
+    expect(renderMarkdownToTelegramHtml("~~gone~~")).toBe("<s>gone</s>");
+  });
+
+  it("nests inline formatting", () => {
+    expect(renderMarkdownToTelegramHtml("**bold _and italic_**")).toBe(
+      "<b>bold <i>and italic</i></b>",
+    );
+    // The ambiguous ***-overlap form degrades to valid HTML with literal
+    // markers instead of guessing at nesting.
+    parseTelegramChunk(renderMarkdownToTelegramHtml("**bold *and italic***"));
+  });
+
+  it("does not treat intra-word underscores as emphasis", () => {
+    expect(renderMarkdownToTelegramHtml("snake_case_name")).toBe(
+      "snake_case_name",
+    );
+  });
+
+  it("escapes &, <, > in plain text", () => {
+    expect(renderMarkdownToTelegramHtml("a & b < c > d")).toBe(
+      "a &amp; b &lt; c &gt; d",
+    );
+  });
+
+  it("maps inline code and escapes its content literally", () => {
+    expect(renderMarkdownToTelegramHtml("run `a<b> && c`")).toBe(
+      "run <code>a&lt;b&gt; &amp;&amp; c</code>",
+    );
+    // Markdown markers inside inline code stay literal.
+    expect(renderMarkdownToTelegramHtml("`**not bold**`")).toBe(
+      "<code>**not bold**</code>",
+    );
+  });
+
+  it("maps fenced code with a language class", () => {
+    const html = renderMarkdownToTelegramHtml(
+      '```ts\nconst ok = 1 < 2 && "a" > "b";\n```',
+    );
+    expect(html).toBe(
+      '<pre><code class="language-ts">const ok = 1 &lt; 2 &amp;&amp; "a" &gt; "b";</code></pre>',
+    );
+  });
+
+  it("maps fenced code without a language to bare <pre>", () => {
+    expect(renderMarkdownToTelegramHtml("```\nplain\n```")).toBe(
+      "<pre>plain</pre>",
+    );
+  });
+
+  it("keeps an unterminated fence valid by consuming the rest", () => {
+    const html = renderMarkdownToTelegramHtml("```js\nlet x = 1;\nlet y = 2;");
+    expect(html).toBe(
+      '<pre><code class="language-js">let x = 1;\nlet y = 2;</code></pre>',
+    );
+    parseTelegramChunk(html);
+  });
+
+  it("maps links and escapes the href", () => {
+    expect(
+      renderMarkdownToTelegramHtml("[docs](https://example.com/?a=1&b=2)"),
+    ).toBe('<a href="https://example.com/?a=1&amp;b=2">docs</a>');
+  });
+
+  it("degrades unsafe link schemes to literal text", () => {
+    const html = renderMarkdownToTelegramHtml("[x](javascript:alert(1))");
+    expect(html).not.toContain("<a");
+    expect(parseTelegramChunk(html)).toBe("[x](javascript:alert(1))");
+  });
+
+  it("renders headings as bold lines", () => {
+    expect(renderMarkdownToTelegramHtml("## Heading **two**")).toBe(
+      "<b>Heading <b>two</b></b>",
+    );
+  });
+
+  it("renders list items as '- ' prefixed plain lines", () => {
+    const html = renderMarkdownToTelegramHtml(
+      ["- one", "* two", "3. three", "4) four"].join("\n"),
+    );
+    expect(html).toBe(["- one", "- two", "- three", "- four"].join("\n"));
+  });
+
+  it("groups consecutive quoted lines into one blockquote", () => {
+    expect(renderMarkdownToTelegramHtml("> first & second\n> **third**")).toBe(
+      "<blockquote>first &amp; second\n<b>third</b></blockquote>",
+    );
+  });
+
+  it("passes tables through as <pre> blocks", () => {
+    const html = renderMarkdownToTelegramHtml(
+      ["| a | b |", "|---|---|", "| 1 | 2 |"].join("\n"),
+    );
+    expect(html).toBe("<pre>| a | b |\n|---|---|\n| 1 | 2 |</pre>");
+  });
+
+  it("degrades unmatched markers to plain text, never invalid HTML", () => {
+    for (const input of ["**open", "~~open", "`open", "*", "[label](", "____"]) {
+      parseTelegramChunk(renderMarkdownToTelegramHtml(input));
+    }
+    expect(renderMarkdownToTelegramHtml("**open")).toBe("**open");
+  });
+
+  it("returns empty output for empty input", () => {
+    expect(renderMarkdownToTelegramHtml("")).toBe("");
+  });
+
+  it("produces one independently parseable document for mixed content", () => {
+    const md = [
+      "# Report",
+      "Text with **bold**, `code<>`, and [a link](https://example.com).",
+      "> a quote",
+      "- a list item",
+      "```py",
+      "print('x < y')",
+      "```",
+    ].join("\n");
+    const html = renderMarkdownToTelegramHtml(md);
+    const text = parseTelegramChunk(html);
+    expect(text).toContain("code<>");
+    expect(text).toContain("print('x < y')");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parsedTextLength
+// ---------------------------------------------------------------------------
+
+describe("parsedTextLength", () => {
+  it("excludes tag characters and counts entities as one char", () => {
+    expect(parsedTextLength("<b>ab</b>")).toBe(2);
+    expect(parsedTextLength("<b>&amp;</b>")).toBe(1);
+    expect(parsedTextLength('<a href="https://example.com/very/long">x</a>')).toBe(1);
+    expect(parsedTextLength("")).toBe(0);
+    expect(parsedTextLength("plain")).toBe(5);
+  });
+
+  it("counts UTF-16 code units like Telegram does", () => {
+    expect(parsedTextLength("💥")).toBe(2);
+    expect(parsedTextLength("<i>💥</i>")).toBe(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// chunkTelegramHtml
+// ---------------------------------------------------------------------------
+
+describe("chunkTelegramHtml", () => {
+  it("returns a single chunk when the parsed text fits", () => {
+    const html = "<b>short</b> message";
+    expect(chunkTelegramHtml(html, 100)).toEqual([html]);
+  });
+
+  it("returns no chunks for empty or whitespace-only input", () => {
+    expect(chunkTelegramHtml("", 100)).toEqual([]);
+    expect(chunkTelegramHtml("   \n \t ", 100)).toEqual([]);
+  });
+
+  it("uses the 4096-char Telegram limit by default", () => {
+    const html = "word ".repeat(1200).trim(); // 5999 parsed chars
+    const chunks = chunkTelegramHtml(html);
+    expect(chunks.length).toBe(2);
+    assertChunksValid(chunks, TELEGRAM_MAX_MESSAGE_CHARS);
+  });
+
+  it("splits prose at newline boundaries into independently valid chunks", () => {
+    const md = Array.from(
+      { length: 30 },
+      (_, i) => `paragraph ${i} with **bold** & \`code<>\` ${"word ".repeat(10)}`,
+    ).join("\n");
+    const html = renderMarkdownToTelegramHtml(md);
+    const chunks = chunkTelegramHtml(html, 200);
+    expect(chunks.length).toBeGreaterThan(1);
+    const texts = assertChunksValid(chunks, 200);
+    // Only boundary whitespace may be dropped between chunks.
+    expect(stripWs(texts.join(""))).toBe(stripWs(parseTelegramChunk(html)));
+  });
+
+  it("enforces the limit on parsed text, not raw HTML length", () => {
+    const html = renderMarkdownToTelegramHtml("**ab** ".repeat(80).trim());
+    const parsed = parsedTextLength(html); // 239 parsed chars
+    expect(html.length).toBeGreaterThan(400);
+    const chunks = chunkTelegramHtml(html, 400);
+    expect(chunks.length).toBe(1);
+    expect(parsedTextLength(chunks[0] ?? "")).toBe(parsed);
+  });
+
+  it("never splits inside a tag even when tags straddle the window", () => {
+    const html = Array.from(
+      { length: 40 },
+      (_, i) => `<a href="https://example.com/${i}">${"y".repeat(23)}</a> `,
+    ).join("");
+    const chunks = chunkTelegramHtml(html, 50);
+    expect(chunks.length).toBeGreaterThan(1);
+    assertChunksValid(chunks, 50);
+  });
+
+  it("closes open formatting at a boundary and re-opens it in the next chunk", () => {
+    const html = `<b><i>${"word ".repeat(60).trim()}</i></b>`;
+    const chunks = chunkTelegramHtml(html, 100);
+    expect(chunks.length).toBeGreaterThan(1);
+    assertChunksValid(chunks, 100);
+    for (const chunk of chunks) {
+      expect(chunk.startsWith("<b><i>")).toBe(true);
+      expect(chunk.endsWith("</i></b>")).toBe(true);
+    }
+  });
+
+  it("continues code fences across chunks with the language class preserved", () => {
+    const lines = Array.from({ length: 60 }, (_, i) => `line_${i} = ${i}`);
+    const html = renderMarkdownToTelegramHtml(
+      `\`\`\`py\n${lines.join("\n")}\n\`\`\``,
+    );
+    const chunks = chunkTelegramHtml(html, 120);
+    expect(chunks.length).toBeGreaterThan(1);
+    const texts = assertChunksValid(chunks, 120);
+    for (const chunk of chunks) {
+      expect(chunk.startsWith('<pre><code class="language-py">')).toBe(true);
+      expect(chunk.endsWith("</code></pre>")).toBe(true);
+      // No empty husk elements left behind by a cut at a tag edge.
+      expect(chunk).not.toMatch(/<([a-zA-Z][a-zA-Z0-9-]*)(?:\s[^<>]*)?><\/\1>/);
+    }
+    // Splits land on newlines inside the fence: no code line is cut in half.
+    const allLines = texts.flatMap((text) => text.split("\n"));
+    for (const line of allLines) expect(lines).toContain(line);
+    expect(stripWs(texts.join(""))).toBe(stripWs(lines.join("")));
+  });
+
+  it("prefers a boundary outside a code block over a later one inside", () => {
+    const prose = "p".repeat(50);
+    const html = renderMarkdownToTelegramHtml(
+      `${prose}\n\`\`\`ts\n${"code line\n".repeat(20)}\`\`\``,
+    );
+    const chunks = chunkTelegramHtml(html, 80);
+    expect(chunks[0]).toBe(prose);
+    expect(chunks[1]?.startsWith('<pre><code class="language-ts">')).toBe(true);
+    assertChunksValid(chunks, 80);
+  });
+
+  it("hard-cuts a single giant line and terminates", () => {
+    const html = "x".repeat(1000);
+    const chunks = chunkTelegramHtml(html, 100);
+    expect(chunks.length).toBe(10);
+    const texts = assertChunksValid(chunks, 100);
+    expect(texts.join("")).toBe(html);
+  });
+
+  it("hard-cuts a giant line inside a code block, keeping <pre> balanced", () => {
+    const html = renderMarkdownToTelegramHtml(`\`\`\`\n${"z".repeat(500)}\n\`\`\``);
+    const chunks = chunkTelegramHtml(html, 100);
+    expect(chunks.length).toBeGreaterThan(1);
+    const texts = assertChunksValid(chunks, 100);
+    for (const chunk of chunks) {
+      expect(chunk.startsWith("<pre>")).toBe(true);
+      expect(chunk.endsWith("</pre>")).toBe(true);
+    }
+    expect(texts.join("")).toBe("z".repeat(500));
+  });
+
+  it("never cuts between surrogate pair halves", () => {
+    const html = renderMarkdownToTelegramHtml("💥".repeat(300));
+    const chunks = chunkTelegramHtml(html, 99);
+    expect(chunks.length).toBeGreaterThan(1);
+    const texts = assertChunksValid(chunks, 99);
+    expect(texts.join("")).toBe("💥".repeat(300));
+    for (const text of texts) expect(text.length % 2).toBe(0);
+  });
+
+  it("keeps surrogate pairs intact inside a chunked code block", () => {
+    const html = renderMarkdownToTelegramHtml(
+      `\`\`\`\n${"💥".repeat(200)}\n\`\`\``,
+    );
+    const texts = assertChunksValid(chunkTelegramHtml(html, 77), 77);
+    expect(texts.join("")).toBe("💥".repeat(200));
+  });
+
+  it("makes forced progress when the window is smaller than one character", () => {
+    // A surrogate pair cannot fit in a 1-unit window; the chunker must still
+    // terminate and preserve the content rather than loop.
+    const texts = chunkTelegramHtml("💥💥", 1).map(parseTelegramChunk);
+    expect(texts.join("")).toBe("💥💥");
+  });
+
+  it("drops mismatched close tags instead of emitting invalid chunks", () => {
+    const chunks = chunkTelegramHtml("<b>bold</i></b> tail", 100);
+    assertChunksValid(chunks, 100);
+    expect(chunks[0]).toBe("<b>bold</b> tail");
+  });
+
+  it("closes tags left open by malformed input", () => {
+    const chunks = chunkTelegramHtml("<b>never closed", 100);
+    expect(chunks[0]).toBe("<b>never closed</b>");
+    assertChunksValid(chunks, 100);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// renderPlainTextFallback
+// ---------------------------------------------------------------------------
+
+describe("renderPlainTextFallback", () => {
+  it("emits escaped tag-free chunks that can never repeat a malformed body", () => {
+    const malformed = "<div>unsupported & <b>unbalanced</div>";
+    const chunks = renderPlainTextFallback(malformed, 100);
+    expect(chunks.length).toBe(1);
+    const text = parseTelegramChunk(chunks[0] ?? "");
+    expect(text).toBe(malformed);
+    // No tags survive, and the body differs from the rejected input.
+    expect(chunks[0]).not.toContain("<");
+    expect(chunks[0]).not.toBe(malformed);
+  });
+
+  it("chunks long plain text within the parsed-length limit", () => {
+    const markdown = Array.from(
+      { length: 40 },
+      (_, i) => `row ${i}: value < ${i} & value > ${i - 1}`,
+    ).join("\n");
+    const chunks = renderPlainTextFallback(markdown, 120);
+    expect(chunks.length).toBeGreaterThan(1);
+    const texts = assertChunksValid(chunks, 120);
+    for (const chunk of chunks) expect(chunk).not.toContain("<");
+    expect(stripWs(texts.join(""))).toBe(stripWs(markdown));
+  });
+
+  it("applies the 4096 default limit", () => {
+    const chunks = renderPlainTextFallback("word ".repeat(1200));
+    expect(chunks.length).toBe(2);
+    assertChunksValid(chunks, TELEGRAM_MAX_MESSAGE_CHARS);
+  });
+
+  it("returns no chunks for empty or whitespace-only input", () => {
+    expect(renderPlainTextFallback("", 100)).toEqual([]);
+    expect(renderPlainTextFallback("  \n \t ", 100)).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// escapeTelegramHtml
+// ---------------------------------------------------------------------------
+
+describe("escapeTelegramHtml", () => {
+  it("escapes every &, <, and >", () => {
+    expect(escapeTelegramHtml("&&<<>>")).toBe(
+      "&amp;&amp;&lt;&lt;&gt;&gt;",
+    );
+    expect(escapeTelegramHtml("plain")).toBe("plain");
+  });
+});

--- a/services/telegrambot/test/telegram-threading.test.ts
+++ b/services/telegrambot/test/telegram-threading.test.ts
@@ -1,0 +1,262 @@
+import { describe, expect, test } from "bun:test";
+import {
+  deriveClientMessageId,
+  deriveConversationName,
+  deriveThreadKey,
+  parseTelegramThreadKey,
+} from "../src/telegram-threading";
+import type {
+  TelegramChat,
+  TelegramMessage,
+  TelegramUser,
+} from "../src/types";
+
+const BOT_USER_ID = "999";
+
+function user(overrides: Partial<TelegramUser> = {}): TelegramUser {
+  return { id: 42, is_bot: false, first_name: "Alice", ...overrides };
+}
+
+function privateMessage(
+  overrides: Partial<TelegramMessage> = {},
+): TelegramMessage {
+  return {
+    message_id: 10,
+    date: 0,
+    chat: { id: 42, type: "private", first_name: "Alice" },
+    from: user(),
+    text: "hello",
+    ...overrides,
+  };
+}
+
+function groupMessage(
+  overrides: Partial<TelegramMessage> = {},
+): TelegramMessage {
+  return {
+    message_id: 11,
+    date: 0,
+    chat: { id: -1005000, type: "supergroup", title: "Team" },
+    from: user(),
+    text: "hello",
+    ...overrides,
+  };
+}
+
+function expectThreadKey(
+  result: ReturnType<typeof deriveThreadKey>,
+  threadKey: string,
+): void {
+  expect(result).toEqual({ threadKey });
+}
+
+function expectRejected(
+  result: ReturnType<typeof deriveThreadKey>,
+  rejected: string,
+): void {
+  expect(result).toEqual({ rejected });
+}
+
+describe("deriveThreadKey", () => {
+  test("private chat without a topic", () => {
+    expectThreadKey(
+      deriveThreadKey(privateMessage(), BOT_USER_ID),
+      "telegram:private:42",
+    );
+  });
+
+  test("private chat preserves a forum-mode message_thread_id", () => {
+    expectThreadKey(
+      deriveThreadKey(privateMessage({ message_thread_id: 7 }), BOT_USER_ID),
+      "telegram:private:42:7",
+    );
+  });
+
+  test("supergroup without a topic", () => {
+    expectThreadKey(
+      deriveThreadKey(groupMessage(), BOT_USER_ID),
+      "telegram:chat:-1005000",
+    );
+  });
+
+  test("plain group uses the same telegram:chat: kind as supergroups", () => {
+    const message = groupMessage({
+      chat: { id: -333, type: "group", title: "Small" },
+    });
+    expectThreadKey(
+      deriveThreadKey(message, BOT_USER_ID),
+      "telegram:chat:-333",
+    );
+  });
+
+  test("forum topic message extends the group key", () => {
+    const message = groupMessage({
+      chat: { id: -1005000, type: "supergroup", title: "Team", is_forum: true },
+      is_topic_message: true,
+      message_thread_id: 55,
+    });
+    expectThreadKey(
+      deriveThreadKey(message, BOT_USER_ID),
+      "telegram:chat:-1005000:55",
+    );
+  });
+
+  test("non-topic reply-chain message_thread_id does not fragment the group key", () => {
+    // Non-forum supergroup replies carry message_thread_id (the reply root);
+    // reply-to-bot follow-ups must land in the same chat session.
+    const message = groupMessage({ message_thread_id: 88 });
+    expectThreadKey(
+      deriveThreadKey(message, BOT_USER_ID),
+      "telegram:chat:-1005000",
+    );
+  });
+
+  test("rejects channel chats", () => {
+    const message = groupMessage({
+      chat: { id: -1007000, type: "channel", title: "News" },
+      from: undefined,
+      sender_chat: { id: -1007000, type: "channel", title: "News" },
+    });
+    expectRejected(deriveThreadKey(message, BOT_USER_ID), "channel_chat");
+  });
+
+  test("rejects the bot's own messages", () => {
+    const message = groupMessage({
+      from: user({ id: Number(BOT_USER_ID), is_bot: true }),
+    });
+    expectRejected(deriveThreadKey(message, BOT_USER_ID), "self_message");
+  });
+
+  describe("private identity validation", () => {
+    test("rejects a missing sender", () => {
+      expectRejected(
+        deriveThreadKey(privateMessage({ from: undefined }), BOT_USER_ID),
+        "private_missing_from",
+      );
+    });
+
+    test("rejects a bot sender", () => {
+      expectRejected(
+        deriveThreadKey(
+          privateMessage({ from: user({ is_bot: true }) }),
+          BOT_USER_ID,
+        ),
+        "private_bot_sender",
+      );
+    });
+
+    test("rejects when sender_chat is present", () => {
+      const message = privateMessage({
+        sender_chat: { id: -1007000, type: "channel", title: "News" },
+      });
+      expectRejected(
+        deriveThreadKey(message, BOT_USER_ID),
+        "private_sender_chat_present",
+      );
+    });
+
+    test("rejects when from.id differs from chat.id (Business/DM-topic shapes)", () => {
+      expectRejected(
+        deriveThreadKey(privateMessage({ from: user({ id: 43 }) }), BOT_USER_ID),
+        "private_identity_mismatch",
+      );
+    });
+  });
+});
+
+describe("parseTelegramThreadKey", () => {
+  test("round-trips a private key with a topic", () => {
+    const derived = deriveThreadKey(
+      privateMessage({ message_thread_id: 7 }),
+      BOT_USER_ID,
+    );
+    if (!("threadKey" in derived)) throw new Error("expected a thread key");
+    expect(parseTelegramThreadKey(derived.threadKey)).toEqual({
+      kind: "private",
+      chatId: "42",
+      messageThreadId: 7,
+    });
+  });
+
+  test("round-trips a group key without a topic", () => {
+    const derived = deriveThreadKey(groupMessage(), BOT_USER_ID);
+    if (!("threadKey" in derived)) throw new Error("expected a thread key");
+    expect(parseTelegramThreadKey(derived.threadKey)).toEqual({
+      kind: "chat",
+      chatId: "-1005000",
+    });
+  });
+
+  test("parses negative chat ids with topic segments", () => {
+    expect(parseTelegramThreadKey("telegram:chat:-1005000:55")).toEqual({
+      kind: "chat",
+      chatId: "-1005000",
+      messageThreadId: 55,
+    });
+  });
+
+  test("returns empty for non-telegram keys", () => {
+    expect(parseTelegramThreadKey("discord:G1:C1")).toEqual({});
+  });
+
+  test("returns empty for an unknown kind discriminator", () => {
+    expect(parseTelegramThreadKey("telegram:channel:-1")).toEqual({});
+  });
+
+  test("returns empty for malformed topic or extra segments", () => {
+    expect(parseTelegramThreadKey("telegram:chat:-1:abc")).toEqual({});
+    expect(parseTelegramThreadKey("telegram:chat:-1:2:3")).toEqual({});
+    expect(parseTelegramThreadKey("telegram:chat:")).toEqual({});
+  });
+});
+
+describe("deriveConversationName", () => {
+  const chat = (overrides: Partial<TelegramChat>): TelegramChat => ({
+    id: 42,
+    type: "private",
+    ...overrides,
+  });
+
+  test("uses the title for groups", () => {
+    expect(
+      deriveConversationName(
+        chat({ id: -1, type: "supergroup", title: "Team" }),
+      ),
+    ).toBe("Team");
+  });
+
+  test("falls back to the id for an untitled group", () => {
+    expect(deriveConversationName(chat({ id: -1, type: "group" }))).toBe("-1");
+  });
+
+  test("composes first/last/username for private chats", () => {
+    expect(
+      deriveConversationName(
+        chat({ first_name: "Alice", last_name: "Smith", username: "alice" }),
+      ),
+    ).toBe("Alice Smith (@alice)");
+  });
+
+  test("uses the bare name when there is no username", () => {
+    expect(deriveConversationName(chat({ first_name: "Alice" }))).toBe(
+      "Alice",
+    );
+  });
+
+  test("uses the username when there is no name", () => {
+    expect(deriveConversationName(chat({ username: "alice" }))).toBe("@alice");
+  });
+
+  test("falls back to the id for private chats", () => {
+    expect(deriveConversationName(chat({}))).toBe("42");
+  });
+});
+
+describe("deriveClientMessageId", () => {
+  test("is stable per chat and message", () => {
+    expect(deriveClientMessageId(groupMessage())).toBe(
+      "telegram:-1005000:11",
+    );
+    expect(deriveClientMessageId(privateMessage())).toBe("telegram:42:10");
+  });
+});

--- a/services/telegrambot/test/utils.test.ts
+++ b/services/telegrambot/test/utils.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "bun:test";
+import { AsyncTextQueue, sliceSurrogateSafe } from "../src/utils";
+
+describe("sliceSurrogateSafe", () => {
+  test("returns short strings unchanged", () => {
+    expect(sliceSurrogateSafe("abc", 10)).toBe("abc");
+  });
+
+  test("cuts at the limit outside surrogate pairs", () => {
+    expect(sliceSurrogateSafe("abcdef", 3)).toBe("abc");
+  });
+
+  test("backs off a cut that would split a surrogate pair", () => {
+    const text = "ab\u{1f600}cd"; // 😀 is a surrogate pair at units 2-3
+    expect(sliceSurrogateSafe(text, 3)).toBe("ab");
+    expect(sliceSurrogateSafe(text, 4)).toBe("ab\u{1f600}");
+  });
+
+  test("returns empty for non-positive limits", () => {
+    expect(sliceSurrogateSafe("abc", 0)).toBe("");
+  });
+});
+
+describe("AsyncTextQueue", () => {
+  test("drains pushed values then finishes on end()", async () => {
+    const queue = new AsyncTextQueue();
+    queue.push("a");
+    queue.push("b");
+    queue.end();
+    const seen: string[] = [];
+    for await (const value of queue) seen.push(value);
+    expect(seen).toEqual(["a", "b"]);
+  });
+
+  test("wakes a waiting consumer", async () => {
+    const queue = new AsyncTextQueue();
+    const seen: string[] = [];
+    const consumer = (async () => {
+      for await (const value of queue) seen.push(value);
+    })();
+    queue.push("late");
+    queue.end();
+    await consumer;
+    expect(seen).toEqual(["late"]);
+  });
+});

--- a/services/telegrambot/tsconfig.json
+++ b/services/telegrambot/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "schema": "https://json.schemastore.org/tsconfig.json",
+  "compilerOptions": {
+    "strict": true,
+    "noEmit": true,
+    "lib": ["DOM", "ESNext", "DOM.Iterable"],
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "types": ["bun", "node"],
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    "allowImportingTsExtensions": true,
+    "resolvePackageJsonExports": true,
+    "resolvePackageJsonImports": true,
+    "forceConsistentCasingInFileNames": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedIndexedAccess": true,
+    "useUnknownInCatchVariables": true
+  },
+  "include": ["src/**/*", "test/**/*"]
+}


### PR DESCRIPTION
> **Draft:** under internal review on my fork; I'll mark this ready for review when that completes. Direction/architecture feedback welcome in the meantime.

### Summary
Adds `services/telegrambot`, a Telegram chat frontend with the same experience as the Slack/Discord/Teams bots: mention-driven durable agent sessions with streamed progress and answers. The service follows the chat-ingress contract in `services/AGENTS.md` and mirrors discordbot's pull model — long-polling `getUpdates` (single replica, `Recreate`, no public ingress) instead of webhooks.

Key design points:
- **Durable receipt ledger**: purpose-built `telegram_poll_state` / `telegram_update_inbox` tables (startup migrations, advisory-lock serialized). Each `getUpdates` batch upserts and advances `receive_offset` in one fenced transaction; processing never gates receipt. Accepted updates progress idempotently through `received → message_appended → execution_accepted → render_obligation_persisted → terminal`.
- **Fenced ownership**: a lease row (holder, monotonic generation, database-time expiry) guards every cursor update, stage transition, and render claim — a paused old owner can't mutate state after takeover; `replicas: 1` is rollout hygiene, not the correctness mechanism.
- **Fail-closed access**: empty chat/user allowlists render the bot inert; DMs are per-user allowlisted (Telegram has no workspace boundary); linked-channel identities (`sender_chat`, auto-forwards) are rejected. Group triggers are replies-to-bot and `/ask@botname`; plain `@botname` mentions are deliberately unsupported until the manual acceptance test below records a pass.
- **Rendering**: entity-aware Markdown→Telegram-HTML chunking (≤4096 parsed chars, balanced `<pre>/<code>` across chunks), per-chat rate control honoring `429 retry_after`, throttled in-place edits, honest truncation at a max-messages cap, at-least-once terminal delivery via persisted render obligations (recovery may duplicate a final answer, never re-executes the agent).
- **api-rs**: `telegram:chat:{id}` / `telegram:private:{id}` thread keys derive `telegram-chat-*` / `telegram-user-*` principals (topic ids collapse to labels; malformed keys fall to the generic fallback, never another platform's parser).
- **Deploy**: Helm Deployment/Service gated on `telegrambot.enabled`, `/live` vs `/ready` probe split (Telegram outages fail readiness only), network policy entries, secrets bootstrap, CI job with a Postgres service container, publish-images matrix entry.

### How to review
Suggested order: `services/telegrambot/AGENTS.md` (invariants) → `src/inbox.ts` + `src/ownership.ts` (correctness core) → `src/poller.ts` → `src/index.ts` (stage machine, steering, answer delivery) → `src/telegram-render.ts` / `rate-limit.ts` / `telegram-narrator.ts` → api-rs `principal.rs` diff → chart. `src/session-api.ts` is a deliberate port of discordbot's client — reviewing the delta against that file is faster than reading it cold. Tests mirror module names under `test/`.

### Test plan
- [x] Automated: `pnpm install --frozen-lockfile`, then from `services/telegrambot`: `bun run check:types` and `TELEGRAMBOT_TEST_DATABASE_URL=postgres://… bun test test` (260 tests incl. receipt-cursor atomicity, split-brain fencing, steering recovery, FIFO regressions, render fault injection, 7-scenario e2e against a fake Bot API + fake api-rs + real Postgres; without the env var the DB suites skip cleanly — 216 pass/52 skip). `cargo test -p centaur-iron-control` (68), `cargo fmt --check`, `clippy -D warnings`, `helm lint contrib/chart`.
- [ ] Manual smoke (needs a throwaway bot + running api-rs):
  1. Create a bot via @BotFather; **leave privacy mode on**; do not set a webhook.
  2. Start Postgres and api-rs (local stack), then from `services/telegrambot`: set `TELEGRAM_BOT_TOKEN`, `TELEGRAMBOT_USER_ALLOWLIST=<your telegram user id>`, `DATABASE_URL`, `CENTAUR_API_URL`, and run `bun src/server.ts`.
  3. `GET :3001/ready` → 200 after startup (`/live` is immediate).
  4. DM the bot → expect 👀 reaction, streamed HTML answer replying to your message, 👍 on settle; a follow-up during a run steers into the same session (no second execution in api-rs logs).
  5. Add the bot to a test group, allowlist the chat id via `TELEGRAMBOT_CHAT_ALLOWLIST`, and verify `/ask@<botname> ping` answers while plain chatter is ignored; a non-allowlisted chat gets zero responses.
  6. Kill the process mid-answer and restart → the answer is delivered without re-running the agent (a duplicated final message is acceptable per the at-least-once contract).
- [ ] Manual acceptance (release gate for plain mentions): follow "Manual acceptance: plain-mention delivery" in `services/telegrambot/AGENTS.md` and record the outcome there.

### Risk / impact
Disabled by default (`telegrambot.enabled: false`); no existing service's behavior changes. The api-rs change adds a principal branch plus a fallback guard (covered by regression tests, incl. that malformed telegram keys can't mint Slack principals). The bot token rides in every Bot API URL path — client code redacts it from all errors/logs; reviewers should keep an eye on that in any follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
