### PR TITLE
Show Codex effort and speed in Slack run footer

### DIFF
--- a/contrib/chart/templates/slackbotv2.yaml
+++ b/contrib/chart/templates/slackbotv2.yaml
@@ -89,12 +89,12 @@ spec:
             - name: SLACKBOT_TRIGGER_BOT_ALLOWLIST
               value: {{ .Values.slackbotv2.triggerBotAllowlist | quote }}
 {{- end }}
-{{- range $name := tuple "CLAUDE_MODEL" "CODEX_MODEL" }}
+{{- range $name := tuple "CLAUDE_MODEL" "CODEX_MODEL" "CODEX_MODEL_REASONING_EFFORT" }}
 {{- if and (hasKey $.Values.sandbox.extraEnv $name) (not (hasKey $.Values.slackbotv2.extraEnv $name)) }}
-            # Mirror the deployer's harness default-model override
+            # Mirror the deployer's harness default-model/effort override
             # (sandbox.extraEnv) so the Slack Console-link line names the model
-            # sandboxes actually run. slackbotv2.extraEnv wins if it sets the
-            # same variable.
+            # and effort sandboxes actually run. slackbotv2.extraEnv wins if it
+            # sets the same variable.
             - name: {{ $name }}
               value: {{ index $.Values.sandbox.extraEnv $name | toString | quote }}
 {{- end }}

--- a/contrib/chart/values.yaml
+++ b/contrib/chart/values.yaml
@@ -264,7 +264,8 @@ sandbox:
   harnessEngine: codex
   # Copied into every sandbox pod. CLAUDE_MODEL / CODEX_MODEL set here (the
   # harness default-model overrides) are also mirrored into slackbotv2 and the
-  # Console so their model displays match what sandboxes actually run.
+  # Console so their model displays match what sandboxes actually run. The
+  # Codex reasoning-effort override is mirrored into slackbotv2 as well.
   extraEnv: {}
   stateVolume:
     enabled: false

--- a/services/slackbotv2/src/console-session-link.ts
+++ b/services/slackbotv2/src/console-session-link.ts
@@ -35,6 +35,25 @@ const BAKED_DEFAULT_MODELS: Record<string, string | undefined> = {
       : undefined
 }
 
+const BAKED_CODEX_EFFORT =
+  typeof (codexConfig as { model_reasoning_effort?: unknown }).model_reasoning_effort === 'string'
+    ? (codexConfig as { model_reasoning_effort: string }).model_reasoning_effort
+    : undefined
+const BAKED_CODEX_SPEED =
+  typeof (codexConfig as { service_tier?: unknown }).service_tier === 'string'
+    ? (codexConfig as { service_tier: string }).service_tier
+    : undefined
+
+const CODEX_EFFORT_DISPLAY_NAMES: Record<string, string> = {
+  none: 'None',
+  minimal: 'Minimal',
+  low: 'Low',
+  medium: 'Medium',
+  high: 'High',
+  xhigh: 'XHigh',
+  max: 'Max'
+}
+
 /** Slack mrkdwn requires `&`, `<`, `>` to be escaped in free text. */
 function escapeSlackMrkdwn(text: string): string {
   return text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
@@ -98,24 +117,34 @@ export type SlackContextBlock = {
 }
 
 /**
- * Builds the "Open chat in Console · {MODEL} · {Harness}" context block, or
+ * Builds the "Open chat in Console · {Harness} · {MODEL}" context block, or
  * undefined when no Console base URL is configured (a bare "Open chat in
  * Console" with no link is pointless, so the whole block is skipped). The
- * model id is uppercased for display.
+ * model id is uppercased for display. Codex also includes the effective
+ * reasoning effort and service tier (speed).
  */
 export function buildConsoleSessionContextBlock(params: {
   consoleBaseUrl: string | null | undefined
   threadKey: string
   harnessType?: string | null
   model?: string | null
+  effort?: string | null
 }): SlackContextBlock | undefined {
   const url = consoleSessionUrl(params.consoleBaseUrl, params.threadKey)
   if (!url) return undefined
   const segments = [`<${url}|Open chat in Console>`]
-  const model = params.model?.trim()
-  if (model) segments.push(escapeSlackMrkdwn(model.toUpperCase()))
+  const harnessKey = params.harnessType?.trim().toLowerCase()
   const harness = harnessDisplayName(params.harnessType)
   if (harness) segments.push(escapeSlackMrkdwn(harness))
+  const model = params.model?.trim()
+  if (model) segments.push(escapeSlackMrkdwn(model.toUpperCase()))
+  if (harnessKey === 'codex') {
+    const effort = params.effort?.trim() || BAKED_CODEX_EFFORT
+    if (effort) {
+      segments.push(escapeSlackMrkdwn(CODEX_EFFORT_DISPLAY_NAMES[effort.toLowerCase()] ?? titleCase(effort)))
+    }
+    if (BAKED_CODEX_SPEED) segments.push(escapeSlackMrkdwn(titleCase(BAKED_CODEX_SPEED)))
+  }
   // Middot (U+00B7) with a space on each side, matching the bot's other
   // context lines.
   return {

--- a/services/slackbotv2/src/index.ts
+++ b/services/slackbotv2/src/index.ts
@@ -771,7 +771,8 @@ async function syncThreadMessageToSession(
         consoleBaseUrl: input.options.consolePublicUrl,
         threadKey: thread.id,
         harnessType: effectiveHarnessType,
-        model: effectiveModel
+        model: effectiveModel,
+        effort: overrides.reasoning ?? input.options.codexDefaultEffort
       })
     : undefined
   if (overrides.harnessType || overrides.model || overrides.provider || overrides.reasoning) {

--- a/services/slackbotv2/src/server.ts
+++ b/services/slackbotv2/src/server.ts
@@ -40,6 +40,7 @@ const options: SlackbotV2Options = {
     ...(optionalEnv('CLAUDE_MODEL') ? { claudecode: optionalEnv('CLAUDE_MODEL')! } : {}),
     ...(optionalEnv('CODEX_MODEL') ? { codex: optionalEnv('CODEX_MODEL')! } : {})
   },
+  codexDefaultEffort: optionalEnv('CODEX_MODEL_REASONING_EFFORT'),
   idleTimeoutMs: optionalNumberEnv('SESSION_IDLE_TIMEOUT_MS'),
   maxDurationMs: optionalNumberEnv('SESSION_MAX_DURATION_MS'),
   postgresUrl:

--- a/services/slackbotv2/src/types.ts
+++ b/services/slackbotv2/src/types.ts
@@ -133,6 +133,8 @@ export type SlackbotV2Options = {
    * harness config files (see console-session-link.ts).
    */
   harnessDefaultModels?: Record<string, string>
+  /** Deployment-configured default Codex reasoning effort. */
+  codexDefaultEffort?: string
   /**
    * Backoff delays between in-process retries of a Slack handoff after a
    * retryable session API failure. Slack's own webhook redelivery cannot

--- a/services/slackbotv2/test/console-session-link.test.ts
+++ b/services/slackbotv2/test/console-session-link.test.ts
@@ -85,12 +85,13 @@ describe('consoleSessionUrl', () => {
 })
 
 describe('buildConsoleSessionContextBlock', () => {
-  test('builds a context block with uppercased model then harness, middot separated', () => {
+  test('builds codex context as harness, model, effort, and speed', () => {
     const block = buildConsoleSessionContextBlock({
       consoleBaseUrl: 'https://console.centaur.dev',
       threadKey: 'slack:C123:1700000000.000100',
       harnessType: 'codex',
-      model: 'gpt-5.2'
+      model: 'gpt-5.2',
+      effort: 'xhigh'
     })
     expect(block).toEqual({
       type: 'context',
@@ -98,10 +99,22 @@ describe('buildConsoleSessionContextBlock', () => {
         {
           type: 'mrkdwn',
           text:
-            '<https://console.centaur.dev/console/threads?thread=slack%3AC123%3A1700000000.000100|Open chat in Console> · GPT-5.2 · Codex'
+            '<https://console.centaur.dev/console/threads?thread=slack%3AC123%3A1700000000.000100|Open chat in Console> · Codex · GPT-5.2 · XHigh · Fast'
         }
       ]
     })
+  })
+
+  test('uses the baked codex effort when no per-turn or deployment override is provided', () => {
+    const block = buildConsoleSessionContextBlock({
+      consoleBaseUrl: 'https://console.centaur.dev',
+      threadKey: 'slack:C1:1',
+      harnessType: 'codex',
+      model: 'gpt-5.6-sol'
+    })
+    expect(block?.elements[0]?.text).toContain(
+      `· Codex · GPT-5.6-SOL · ${(codexConfig as { model_reasoning_effort: string }).model_reasoning_effort.replace(/^./, character => character.toUpperCase())} · Fast`
+    )
   })
 
   test('omits the model segment when no model is provided', () => {


### PR DESCRIPTION
## Summary
- reorder the Slack Console run footer to harness, model, effort, and speed
- show effective per-turn or deployment-default Codex effort plus the configured service tier
- mirror the sandbox Codex effort override into Slackbot

## Validation
- `pnpm --filter slackbotv2 test`
- `pnpm --filter slackbotv2 run check:types`
- `git diff --check`
- Helm lint not run: Helm CLI is unavailable in this sandbox

Prompted by: Goksu Toprak