### PR TITLE
fix(console): scope while-running transcript refresh to the active panel

### DIFF
--- a/services/console/app/controllers/console/threads_controller.rb
+++ b/services/console/app/controllers/console/threads_controller.rb
@@ -190,6 +190,33 @@ class Console::ThreadsController < ApplicationController
     render partial: "console/threads/sidebar_threads", layout: false
   end
 
+  # Single-panel transcript refresh, polled by thread_poller_controller.js
+  # while a turn is running in that panel. Renders only the panel's transcript
+  # stream (no layout) so an active thread never drags the rest of the console
+  # — other panes, composers, drafts — through a full Turbo visit. Resolves the
+  # key through the same readable scope as the page render.
+  def panel
+    thread_key = params[:thread_key].to_s.strip
+    session = readable_thread(thread_key)
+    if session.nil?
+      head :not_found
+      return
+    end
+
+    @latest_executions = latest_executions_for([ session.thread_key ])
+    panel = thread_panel_for(session)
+    active = thread_execution_active?(session.thread_key)
+    # The poller stops rescheduling once this header reports the turn is done,
+    # after swapping in the final transcript below.
+    response.set_header("X-Console-Execution-Active", active.to_s)
+    render partial: "console/threads/panel_transcript",
+           locals: { items: panel[:transcript_items], active: active },
+           layout: false
+  rescue ActiveRecord::ActiveRecordError, PG::Error => e
+    Rails.logger.warn("console_threads_panel_refresh_failed error=#{e.class}: #{e.message}")
+    head :service_unavailable
+  end
+
   # Publishes a chat inside the authenticated Console boundary. Publication is
   # stored in Console's own database rather than mutating api-rs session data;
   # the Threads surface remains an observer of the durable transcript.

--- a/services/console/app/javascript/controllers/thread_poller_controller.js
+++ b/services/console/app/javascript/controllers/thread_poller_controller.js
@@ -1,0 +1,78 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Polls one thread panel's transcript while its turn is running and swaps only
+// that panel's transcript stream in place (ThreadsController#panel). Replaces
+// the old whole-page Turbo refresh, so a running thread never re-renders the
+// other panes, their composers, or in-progress drafts.
+export default class extends Controller {
+  static targets = ["transcript"]
+  static values = {
+    url: String,
+    active: Boolean,
+    interval: { type: Number, default: 4000 }
+  }
+
+  connect() {
+    // A composer submit hands control to the server-side redirect; polling in
+    // that window could paint a pre-submit transcript over the optimistic
+    // user bubble (see _composer.html.erb).
+    this.section = this.element.closest("section")
+    this.onSubmit = () => this.cancel()
+    this.section?.addEventListener("submit", this.onSubmit)
+    if (this.activeValue) this.schedule()
+  }
+
+  disconnect() {
+    this.section?.removeEventListener("submit", this.onSubmit)
+    this.cancel()
+  }
+
+  schedule() {
+    this.cancel()
+    this.timer = window.setTimeout(() => this.refresh(), this.intervalValue)
+  }
+
+  cancel() {
+    if (this.timer) window.clearTimeout(this.timer)
+    this.timer = null
+  }
+
+  async refresh() {
+    try {
+      const response = await fetch(this.urlValue, {
+        credentials: "same-origin",
+        headers: { "Accept": "text/html" }
+      })
+      if (response.ok) {
+        const active = response.headers.get("X-Console-Execution-Active") === "true"
+        this.swap(await response.text())
+        // The final transcript (turn result included) just rendered; a
+        // composer submit re-renders the page and restarts the poller.
+        if (!active) return
+      }
+    } catch {
+      // Transient network error; retry on the next tick.
+    }
+    this.schedule()
+  }
+
+  swap(html) {
+    if (html === this.lastHtml) return
+    this.lastHtml = html
+
+    // Keep the reader's place: reopen the disclosures they had expanded and
+    // stay pinned to the bottom when they were already there. The transcript
+    // is append-mostly, so positional indexes are stable across swaps.
+    const openIndexes = new Set()
+    this.transcriptTarget.querySelectorAll("details").forEach((details, index) => {
+      if (details.open) openIndexes.add(index)
+    })
+    const pinned = this.element.scrollHeight - this.element.scrollTop - this.element.clientHeight < 48
+
+    this.transcriptTarget.innerHTML = html
+    this.transcriptTarget.querySelectorAll("details").forEach((details, index) => {
+      if (openIndexes.has(index)) details.open = true
+    })
+    if (pinned) this.element.scrollTop = this.element.scrollHeight
+  }
+}

--- a/services/console/app/views/console/threads/_panel_transcript.html.erb
+++ b/services/console/app/views/console/threads/_panel_transcript.html.erb
@@ -1,0 +1,5 @@
+<%# Poll payload for one thread panel: the transcript stream plus the thinking
+    indicator while the turn is still running. Swapped into the panel's scroll
+    container by thread_poller_controller.js — see ThreadsController#panel. %>
+<%= render "console/threads/transcript", items: items %>
+<%= render "console/threads/thinking_indicator" if active %>

--- a/services/console/app/views/console/threads/_thread_panel.html.erb
+++ b/services/console/app/views/console/threads/_thread_panel.html.erb
@@ -61,10 +61,14 @@
       <%= console_icon("x-mark", classes: "size-4") %>
     </a>
   </header>
-  <div class="console-transcript-scroll min-h-0 flex-1 overflow-y-auto px-4 py-4">
-    <div class="flex flex-col gap-5">
-      <%= render "console/threads/transcript", items: panel[:transcript_items] %>
-      <%= render "console/threads/thinking_indicator" if thread_execution_active?(session.thread_key) %>
+  <div class="console-transcript-scroll min-h-0 flex-1 overflow-y-auto px-4 py-4"
+       data-controller="thread-poller"
+       data-thread-poller-url-value="<%= console_thread_panel_path(thread_key: session.thread_key) %>"
+       data-thread-poller-active-value="<%= thread_execution_active?(session.thread_key) %>">
+    <div class="flex flex-col gap-5" data-thread-poller-target="transcript">
+      <%= render "console/threads/panel_transcript",
+                 items: panel[:transcript_items],
+                 active: thread_execution_active?(session.thread_key) %>
     </div>
   </div>
   <% if panel[:writable] %>

--- a/services/console/app/views/console/threads/index.html.erb
+++ b/services/console/app/views/console/threads/index.html.erb
@@ -68,11 +68,17 @@
           </div>
         </div>
       <% else %>
-      <div id="thread-transcript-scroll" class="console-transcript-scroll min-h-0 flex-1 overflow-y-auto py-6">
+      <div id="thread-transcript-scroll" class="console-transcript-scroll min-h-0 flex-1 overflow-y-auto py-6"
+           <% if @selected_session %>
+           data-controller="thread-poller"
+           data-thread-poller-url-value="<%= console_thread_panel_path(thread_key: @selected_session.thread_key) %>"
+           data-thread-poller-active-value="<%= thread_execution_active?(@selected_session.thread_key) %>"
+           <% end %>>
         <% if @selected_session %>
-          <div class="console-thread-content flex flex-col gap-6">
-            <%= render "console/threads/transcript", items: @selected_transcript_items %>
-            <%= render "console/threads/thinking_indicator" if thread_execution_active?(@selected_session.thread_key) %>
+          <div class="console-thread-content flex flex-col gap-6" data-thread-poller-target="transcript">
+            <%= render "console/threads/panel_transcript",
+                       items: @selected_transcript_items,
+                       active: thread_execution_active?(@selected_session.thread_key) %>
           </div>
         <% else %>
           <div class="flex h-full items-center justify-center px-6">
@@ -97,27 +103,8 @@
     </section>
   <% end %>
 
-  <% if @thread_panels.any? { |panel| thread_execution_active?(panel[:thread_key]) } %>
-    <%# The console has no event stream; while a turn is running in any open
-        pane, refresh the transcript every few seconds. Skipped whenever a
-        composer holds a draft so a reload never eats typed text. %>
-    <script>
-      (() => {
-        const refresh = () => {
-          const drafting = Array.from(document.querySelectorAll("[data-console-composer-input]"))
-            .some((input) => input.value.trim() !== "" || document.activeElement === input);
-          if (drafting) {
-            setTimeout(refresh, 4000);
-            return;
-          }
-          if (window.Turbo) {
-            window.Turbo.visit(window.location.href, { action: "replace" });
-          } else {
-            window.location.reload();
-          }
-        };
-        setTimeout(refresh, 4000);
-      })();
-    </script>
-  <% end %>
+  <%# Live updates while a turn runs are per-panel: each transcript scroll
+      container carries a thread-poller Stimulus controller that polls
+      ThreadsController#panel and swaps only its own transcript, so activity
+      in one pane never re-renders the others (or eats composer drafts). %>
 </div>

--- a/services/console/config/routes.rb
+++ b/services/console/config/routes.rb
@@ -48,6 +48,10 @@ Rails.application.routes.draw do
   namespace :console do
     resources :threads, only: %i[index create]
     post "threads/share", to: "threads#share", as: :thread_share
+    # Single-panel transcript refresh polled by thread_poller_controller.js
+    # while a turn is running. thread_key rides as a query param: keys carry
+    # colons and dots a path segment would mangle.
+    get "threads/panel", to: "threads#panel", as: :thread_panel
     resources :workflows, only: %i[index show] do
       member do
         post :run, action: :force_start

--- a/services/console/test/controllers/console/threads_controller_test.rb
+++ b/services/console/test/controllers/console/threads_controller_test.rb
@@ -804,6 +804,65 @@ class Console::ThreadsControllerTest < ActionDispatch::IntegrationTest
     assert_select "[data-console-thinking-indicator]", count: 0
   end
 
+  test "an active thread wires a per-panel poller instead of a full-page refresh" do
+    skip_unless_session_table
+    thread_key = "console:poller-active-#{SecureRandom.hex(6)}"
+    insert_console_session(thread_key)
+    insert_session_execution(thread_key, status: "running")
+
+    get console_threads_url(thread: thread_key)
+
+    assert_response :ok
+    assert_select "[data-controller=thread-poller][data-thread-poller-active-value=true]", count: 1
+    assert_select "[data-thread-poller-url-value=?]",
+                  console_thread_panel_path(thread_key: thread_key),
+                  count: 1
+    # The old behavior re-rendered the whole console with a Turbo visit while
+    # any pane was executing; that script must stay gone.
+    assert_no_match "Turbo.visit(window.location.href", response.body
+  end
+
+  test "panel poll renders one thread's transcript with the active header" do
+    skip_unless_session_table
+    thread_key = "console:poller-panel-#{SecureRandom.hex(6)}"
+    insert_console_session(thread_key)
+    insert_session_message(thread_key, index: 1)
+    insert_session_execution(thread_key, status: "running")
+
+    get console_thread_panel_url(thread_key: thread_key)
+
+    assert_response :ok
+    assert_equal "true", response.headers["X-Console-Execution-Active"]
+    assert_select "[data-console-thinking-indicator]", count: 1
+    assert_match "message 1", response.body
+    # Transcript stream only: no layout, no composer, no panel chrome.
+    assert_select "textarea[name=prompt]", count: 0
+    assert_select "[data-thread-panel]", count: 0
+  end
+
+  test "panel poll reports inactive once the execution completes" do
+    skip_unless_session_table
+    thread_key = "console:poller-done-#{SecureRandom.hex(6)}"
+    insert_console_session(thread_key)
+    insert_session_execution(thread_key, status: "completed")
+
+    get console_thread_panel_url(thread_key: thread_key)
+
+    assert_response :ok
+    assert_equal "false", response.headers["X-Console-Execution-Active"]
+    assert_select "[data-console-thinking-indicator]", count: 0
+  end
+
+  test "panel poll is scoped to threads the current user can read" do
+    skip_unless_session_table
+    thread_key = "slack:C0POLL:#{SecureRandom.hex(6)}"
+    insert_slack_session(thread_key, slack_user_id: "U_OTHER", slack_user_name: "someone-else")
+
+    get console_thread_panel_url(thread_key: thread_key)
+
+    assert_response :not_found
+  end
+
   test "a new sentinel pane opens a composer panel alongside a thread" do
     skip_unless_session_table
     insert_console_session("console:with-new-pane")


### PR DESCRIPTION
## Problem

With multiple threads open in the Console's split view, a running turn in *any* pane re-rendered the whole console every 4 seconds: the while-running refresh was an inline script doing `Turbo.visit(window.location.href, {action: "replace"})` gated on `@thread_panels.any? { thread_execution_active? }`. One busy thread dragged every other panel, composer, and scroll position through a full page reload.

## Fix

Scope the while-running refresh to the panel that is actually executing:

- **`ThreadsController#panel`** (new, `GET /console/threads/panel?thread_key=`): renders only one thread's transcript stream (`_panel_transcript.html.erb`, no layout), resolved through the same readable scope as the page render, and reports execution liveness in an `X-Console-Execution-Active` header.
- **`thread_poller_controller.js`** (new Stimulus controller): wraps each transcript scroll container — both split-view panels and the single-thread view. While its own panel's turn is running it polls the endpoint every 4s and swaps only its own transcript, then stops once the turn completes (after the final transcript, result included, has landed).
- The swap preserves open `<details>` disclosures and bottom-pinned scroll, skips no-op swaps, and pauses on composer submit so the optimistic user bubble is never painted over.
- The global inline refresh script in `index.html.erb` is gone; drafts are inherently safe now because the composer is never re-rendered mid-turn.

## Testing

- 4 new controller tests: poller wiring replaces the full-page refresh, panel poll payload + active header, inactive-on-completion, and readable-scope 404.
- `bin/rails test`: 1236 runs, 0 failures, 0 errors, 0 skips (with api-rs-shaped session tables provisioned locally so the thread tests exercise the real paths).
- `bin/rubocop`: no offenses. `bin/brakeman`: no warnings.

Not verified in a live browser session (sandbox has no browser); the polling/swap behavior is covered by the controller tests plus code review of the Stimulus controller.

Prompted by: Goksu Toprak
