### PR TITLE
feat(console): make the operator console responsive on mobile

### DIFF
--- a/services/console/app/assets/tailwind/application.css
+++ b/services/console/app/assets/tailwind/application.css
@@ -44,8 +44,11 @@
     @apply mt-1 text-sm text-zinc-500;
   }
 
+  /* Stacks the title over its action buttons on narrow screens so long action
+     labels (e.g. "Add Principal" + "Cancel") stay fully on-screen; reverts to
+     the title/actions row from the sm breakpoint up. */
   .console-page-header {
-    @apply mb-6 flex min-h-11 items-start justify-between gap-4;
+    @apply mb-6 flex min-h-11 flex-col gap-3 sm:flex-row sm:items-start sm:justify-between sm:gap-4;
   }
 
   .console-page-heading {

--- a/services/console/app/helpers/application_helper.rb
+++ b/services/console/app/helpers/application_helper.rb
@@ -225,6 +225,8 @@ module ApplicationHelper
         classes,
         "M9.75 10.5a3.75 3.75 0 1 1 7.5 0 3.75 3.75 0 0 1-7.5 0ZM4.5 18.75a6.75 6.75 0 0 1 13.5 0M18 8.25a3 3 0 0 1 0 6M19.5 18.75a5.25 5.25 0 0 0-2.25-4.307"
       )
+    when "menu"
+      outline_icon(classes, "M3.75 6.75h16.5M3.75 12h16.5M3.75 17.25h16.5")
     end
   end
 

--- a/services/console/app/views/console/threads/_thread_panel.html.erb
+++ b/services/console/app/views/console/threads/_thread_panel.html.erb
@@ -7,7 +7,7 @@
 <% remaining_keys = panels.map { |other| other[:thread_key] } - [ panel[:thread_key] ] %>
 <% close_path = console_threads_path(thread: remaining_keys.join(",")) %>
 <% if panel[:new_chat] %>
-  <section class="flex min-h-0 min-w-0 flex-col overflow-hidden rounded-xl border border-ink-700 bg-ink-900/35"
+  <section class="flex min-h-[75vh] min-w-0 flex-col overflow-hidden rounded-xl border border-ink-700 bg-ink-900/35 md:min-h-0"
            data-thread-panel="<%= panel[:thread_key] %>">
     <header class="flex shrink-0 items-center gap-2 border-b border-ink-700 px-4 py-2.5">
       <div class="min-w-0 flex-1">
@@ -31,7 +31,7 @@
     </div>
   </section>
 <% else %>
-<section class="flex min-h-0 min-w-0 flex-col overflow-hidden rounded-xl border border-ink-700 bg-ink-900/35"
+<section class="flex min-h-[75vh] min-w-0 flex-col overflow-hidden rounded-xl border border-ink-700 bg-ink-900/35 md:min-h-0"
          data-thread-panel="<%= session.thread_key %>">
   <header class="flex shrink-0 items-center gap-2 border-b border-ink-700 px-4 py-2.5">
     <div class="min-w-0 flex-1">

--- a/services/console/app/views/console/threads/index.html.erb
+++ b/services/console/app/views/console/threads/index.html.erb
@@ -9,13 +9,15 @@
 
 <div class="flex min-h-0 flex-1 overflow-hidden bg-ink-950/15">
   <% if @thread_panels.size > 1 %>
+    <%# On phones the multi-pane grid can't fit side by side, so it stacks into
+        a single scrolling column; the md+ tracks below restore the split grid. %>
     <% grid_classes =
          case @thread_panels.size
-         when 2 then "grid-cols-2"
-         when 3 then "grid-cols-3"
-         else "grid-cols-2 grid-rows-2"
+         when 2 then "grid-cols-1 md:grid-cols-2"
+         when 3 then "grid-cols-1 md:grid-cols-3"
+         else "grid-cols-1 md:grid-cols-2 md:grid-rows-2"
          end %>
-    <section class="grid min-h-0 min-w-0 flex-1 gap-3 overflow-hidden pb-3 <%= grid_classes %>">
+    <section class="grid min-h-0 min-w-0 flex-1 gap-3 overflow-y-auto overflow-x-hidden pb-3 md:overflow-hidden <%= grid_classes %>">
       <% @thread_panels.each do |panel| %>
         <%= render "console/threads/thread_panel", panel: panel, panels: @thread_panels %>
       <% end %>

--- a/services/console/app/views/layouts/console.html.erb
+++ b/services/console/app/views/layouts/console.html.erb
@@ -1994,14 +1994,28 @@
         const shell = document.getElementById("console-shell");
         const toggle = document.querySelector("[data-console-nav-toggle]");
         const scrim = document.querySelector("[data-console-nav-scrim]");
-        if (!shell || !toggle) return;
+        const sidebar = shell && shell.querySelector(".console-sidebar");
+        if (!shell || !toggle || !sidebar) return;
 
         const OPEN_CLASS = "console-nav-open";
+        // Mirrors the CSS breakpoint: only in the off-canvas range does a
+        // closed drawer need to be pulled out of the tab / assistive-tech order.
+        const mobileQuery = window.matchMedia("(max-width: 768px)");
 
         const isOpen = () => shell.classList.contains(OPEN_CLASS);
+
+        // Off-canvas and closed => hide the sidebar from keyboard and assistive
+        // tech: it sits before the page in DOM order, so leaving it merely
+        // translated off-screen makes users tab through invisible controls
+        // first. Desktop and the open drawer stay fully interactive.
+        const syncInert = () => {
+          sidebar.inert = mobileQuery.matches && !isOpen();
+        };
+
         const setOpen = (open) => {
           shell.classList.toggle(OPEN_CLASS, open);
           toggle.setAttribute("aria-expanded", String(open));
+          syncInert();
         };
 
         toggle.addEventListener("click", () => setOpen(!isOpen()));
@@ -2011,17 +2025,24 @@
           if (event.key === "Escape" && isOpen()) setOpen(false);
         });
 
-        // Any navigation within the drawer (section links, thread rows, the
-        // brand/account controls) should dismiss it once the visit starts.
+        // Only real navigations should dismiss the drawer. Links (section nav,
+        // thread rows, the brand) qualify; in-drawer buttons that open a menu
+        // or reveal more rows (account menu, theme toggle, "show more") must
+        // not, or they'd slam the drawer shut before doing anything. Form
+        // buttons that submit (sign out, view as operator) trigger a full
+        // navigation, which the turbo listeners below already close on.
         shell.addEventListener("click", (event) => {
           if (!isOpen()) return;
-          if (event.target.closest(".console-sidebar a, .console-sidebar button")) {
+          if (event.target.closest(".console-sidebar a[href]")) {
             setOpen(false);
           }
         });
 
+        mobileQuery.addEventListener("change", syncInert);
         document.addEventListener("turbo:visit", () => setOpen(false));
         document.addEventListener("turbo:load", () => setOpen(false));
+
+        syncInert();
       })();
 
       (() => {

--- a/services/console/app/views/layouts/console.html.erb
+++ b/services/console/app/views/layouts/console.html.erb
@@ -1115,15 +1115,25 @@
         gap: 0.25rem;
         margin-bottom: 1.5rem;
         border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+        /* Too many tabs to fit a phone width: scroll them horizontally rather
+           than clipping the trailing ones off the edge. */
+        overflow-x: auto;
+        scrollbar-width: none;
+      }
+
+      .console-control-tabs::-webkit-scrollbar {
+        display: none;
       }
 
       .console-control-tab {
         margin-bottom: -1px;
+        flex: 0 0 auto;
         padding: 0.625rem 0.75rem;
         border-bottom: 1px solid transparent;
         color: #a1a1aa;
         font-size: 0.875rem;
         font-weight: 500;
+        white-space: nowrap;
         text-decoration: none;
         transition: border-color 120ms ease, color 120ms ease;
       }
@@ -1635,23 +1645,120 @@
         color: #1c1f23;
       }
 
-      @media (max-width: 760px) {
+      /* The mobile top bar (hamburger + brand) and the drawer scrim are hidden
+         on desktop; the media query below turns them on for narrow viewports. */
+      .console-mobile-bar {
+        display: none;
+        flex: 0 0 auto;
+        position: sticky;
+        top: 0;
+        z-index: 30;
+        height: 3.25rem;
+        align-items: center;
+        gap: 0.75rem;
+        padding: 0 0.75rem;
+        border-bottom: 1px solid rgba(255, 255, 255, 0.07);
+        background: rgba(7, 7, 8, 0.92);
+        backdrop-filter: blur(8px);
+      }
+
+      .console-mobile-nav-toggle {
+        display: grid;
+        height: 2.25rem;
+        width: 2.25rem;
+        flex: 0 0 auto;
+        cursor: pointer;
+        place-items: center;
+        border-radius: 0.625rem;
+        color: #d4d4d8;
+        transition: background 120ms ease, color 120ms ease;
+      }
+
+      .console-mobile-nav-toggle:hover {
+        background: rgba(255, 255, 255, 0.06);
+        color: #f4f4f5;
+      }
+
+      .console-mobile-brand {
+        display: flex;
+        min-width: 0;
+        align-items: center;
+        color: #f4f4f5;
+        text-decoration: none;
+      }
+
+      .console-mobile-brand img {
+        height: 1.4rem;
+        width: auto;
+      }
+
+      .console-scrim {
+        display: none;
+        position: fixed;
+        inset: 0;
+        z-index: 40;
+        background: rgba(0, 0, 0, 0.55);
+        opacity: 0;
+        pointer-events: none;
+        transition: opacity 200ms ease;
+      }
+
+      html[data-console-theme="light"] .console-mobile-bar {
+        border-bottom-color: #deded7;
+        background: rgba(251, 251, 248, 0.92);
+      }
+
+      html[data-console-theme="light"] .console-mobile-nav-toggle {
+        color: #5f656c;
+      }
+
+      html[data-console-theme="light"] .console-mobile-nav-toggle:hover {
+        background: #edede8;
+        color: #24272b;
+      }
+
+      html[data-console-theme="light"] .console-mobile-brand {
+        color: #24272b;
+      }
+
+      html[data-console-theme="light"] .console-mobile-brand img {
+        filter: invert(1) drop-shadow(0 0 14px rgba(40, 194, 106, 0.14));
+      }
+
+      /* Mobile: the 18rem rail squeezes the content to a sliver, so below this
+         breakpoint the sidebar becomes an off-canvas drawer toggled from the
+         top bar. The main content then gets the full viewport width, and the
+         drawer keeps its full labels/brand/account row (no cryptic icon-only
+         rail). */
+      @media (max-width: 768px) {
+        .console-mobile-bar {
+          display: flex;
+        }
+
         .console-sidebar {
-          width: 11rem;
+          position: fixed;
+          top: 0;
+          bottom: 0;
+          left: 0;
+          z-index: 50;
+          width: 17rem;
+          max-width: 82vw;
+          transform: translateX(-100%);
+          transition: transform 200ms ease;
         }
 
-        .console-brand-lockup,
-        .console-account-details {
-          display: none;
+        .console-nav-open .console-sidebar {
+          transform: translateX(0);
+          box-shadow: 0 24px 60px rgba(0, 0, 0, 0.5);
         }
 
-        .console-brand-glyph {
-          display: grid;
+        .console-scrim {
+          display: block;
         }
 
-        .console-sidebar-top {
-          justify-content: center;
-          padding: 0;
+        .console-nav-open .console-scrim {
+          opacity: 1;
+          pointer-events: auto;
         }
 
         .console-main-page {
@@ -1659,9 +1766,8 @@
         }
 
         .console-main-thread-frame {
-          padding: 1rem 1rem 0;
+          padding: 0.85rem 0.85rem 0;
         }
-
       }
     </style>
   </head>
@@ -1850,6 +1956,20 @@
       </aside>
 
       <main class="console-main <%= "console-main-threads" if threads_view %>">
+        <div class="console-mobile-bar">
+          <button type="button"
+                  id="console-mobile-nav-toggle"
+                  class="console-mobile-nav-toggle"
+                  aria-label="Open navigation"
+                  aria-controls="console-shell"
+                  aria-expanded="false"
+                  data-console-nav-toggle>
+            <%= console_icon("menu", classes: "size-5") %>
+          </button>
+          <a href="<%= root_path %>" class="console-mobile-brand" aria-label="Centaur Console">
+            <%= image_tag "centaur-lockup-white.svg", alt: "Centaur", class: "glow", width: 497, height: 127 %>
+          </a>
+        </div>
         <div class="<%= threads_view ? "console-main-thread-frame" : "console-main-page" %>">
           <% if flash[:notice] %>
             <div class="mb-6 rounded border border-ink-600 bg-ink-850/60 px-4 py-3 text-sm text-zinc-400"><%= flash[:notice] %></div>
@@ -1860,9 +1980,50 @@
           <%= yield %>
         </div>
       </main>
+
+      <div class="console-scrim" data-console-nav-scrim aria-hidden="true"></div>
     </div>
 
     <script>
+      (() => {
+        // Mobile navigation drawer. Below the CSS breakpoint the sidebar is
+        // off-canvas; the hamburger in the top bar toggles a `console-nav-open`
+        // class on the shell that slides it in over a scrim. The drawer closes
+        // on scrim click, Escape, following any nav link, and after every Turbo
+        // navigation so it never lingers over the freshly loaded page.
+        const shell = document.getElementById("console-shell");
+        const toggle = document.querySelector("[data-console-nav-toggle]");
+        const scrim = document.querySelector("[data-console-nav-scrim]");
+        if (!shell || !toggle) return;
+
+        const OPEN_CLASS = "console-nav-open";
+
+        const isOpen = () => shell.classList.contains(OPEN_CLASS);
+        const setOpen = (open) => {
+          shell.classList.toggle(OPEN_CLASS, open);
+          toggle.setAttribute("aria-expanded", String(open));
+        };
+
+        toggle.addEventListener("click", () => setOpen(!isOpen()));
+        if (scrim) scrim.addEventListener("click", () => setOpen(false));
+
+        document.addEventListener("keydown", (event) => {
+          if (event.key === "Escape" && isOpen()) setOpen(false);
+        });
+
+        // Any navigation within the drawer (section links, thread rows, the
+        // brand/account controls) should dismiss it once the visit starts.
+        shell.addEventListener("click", (event) => {
+          if (!isOpen()) return;
+          if (event.target.closest(".console-sidebar a, .console-sidebar button")) {
+            setOpen(false);
+          }
+        });
+
+        document.addEventListener("turbo:visit", () => setOpen(false));
+        document.addEventListener("turbo:load", () => setOpen(false));
+      })();
+
       (() => {
         const accountButton = document.getElementById("console-account-menu-button");
         const accountMenu = document.getElementById("console-account-menu");


### PR DESCRIPTION
## Summary

On viewports narrower than ~768px the operator console was effectively unusable: the fixed 18rem sidebar squeezed page content into a ~200px sliver, the control tabs and table columns were clipped off the right edge, and form action buttons were cut in half. This makes the console shell responsive without touching any desktop styling.

**Changes**
- **Off-canvas sidebar drawer.** Below 768px the sidebar slides off-canvas and is toggled from a new mobile top bar (hamburger + brand). The drawer keeps its full nav labels, brand lockup, and account row — no cryptic icon-only rail — and closes on scrim click, `Escape`, following a nav link, or any Turbo navigation. Main content now gets the full viewport width.
- **Control tabs** scroll horizontally instead of clipping the trailing tabs.
- **Page header** stacks its title over its action buttons on narrow screens (so `Add Principal`/`Cancel` stay fully on-screen) and reverts to a title/actions row from the `sm` breakpoint up.
- **Threads split-view** collapses to a single scrolling column on phones; the `md+` split grid is unchanged.
- Adds a `menu` (hamburger) icon to `console_icon`.

All mobile rules are gated behind the `max-width: 768px` media query or `sm`/`md` Tailwind variants, so the desktop layout is byte-for-byte unchanged.

## Screenshots (390px viewport)

### Principals list — before / after
| Before | After |
|---|---|
| ![principals before](https://github.com/user-attachments/assets/976564bc-5a6a-4a1b-b76f-3d0ed2bb43ec) | ![principals after](https://github.com/user-attachments/assets/3af8cf0a-7b92-47bf-9e7d-c4f61884329b) |

The sidebar ate ~45% of the screen, the `Credentials` tab and `LABELS` column were clipped. After: full-width content, scrollable tabs, hamburger top bar.

### Navigation drawer (open)
![drawer open](https://github.com/user-attachments/assets/1d774d26-c88a-46d8-ba5d-41ec527ed07e)

### New Principal form — before / after
| Before | After |
|---|---|
| ![principal form before](https://github.com/user-attachments/assets/0692223c-5156-44c0-8267-34ff4d464215) | ![principal form after](https://github.com/user-attachments/assets/79953af0-173b-4dc8-becd-f48a814c560a) |

Before, the `Cancel` button was clipped to `Canc`. After: the title stacks over both fully-visible action buttons.

### New Secret form — before / after
| Before | After |
|---|---|
| ![secret form before](https://github.com/user-attachments/assets/5f182ed6-7172-4e36-a24b-7c23fa9cb0e2) | ![secret form after](https://github.com/user-attachments/assets/cdacbb9b-8f55-4dd7-af46-cc5b4d5ace17) |

Before, the injection radio labels wrapped one word per line and `Replace placeholder value` + the header/query inputs ran off the edge. After: full-width fields, both options readable.

### Threads — before / after
| Before | After |
|---|---|
| ![threads before](https://github.com/user-attachments/assets/6d6d8386-bbd9-46a3-a32e-ee4ef4c04d94) | ![threads after](https://github.com/user-attachments/assets/92a21fc4-872e-452a-a7da-c4717b894c53) |

### Desktop unchanged (1440px)
![desktop principals](https://github.com/user-attachments/assets/d63b2ecb-4a0c-4900-b16a-0a42123a27f4)

## Test plan
- `bundle exec rubocop` clean on the changed helper
- Manually exercised at 390px and 1440px: drawer open/close (hamburger, scrim, Escape, nav-link, Turbo visit), control-tab scroll, form action buttons, threads composer
- Confirmed desktop layout unchanged at 1440px