### PR TITLE
feat: expose sandbox oauth connection discovery

### DIFF
--- a/services/console/app/controllers/api/v1/sandbox_oauth_apps_controller.rb
+++ b/services/console/app/controllers/api/v1/sandbox_oauth_apps_controller.rb
@@ -1,0 +1,51 @@
+module Api
+  module V1
+    class SandboxOauthAppsController < ActionController::API
+      include ApiRequestSupport
+
+      before_action :authenticate_sandbox_jwt!
+
+      def index
+        apps = OauthApp.where(enabled: true).order(:slug, :id)
+        render json: { data: apps.map { |app| app_payload(app) } }
+      end
+
+      private
+
+      def authenticate_sandbox_jwt!
+        token = bearer_token
+        if token.blank?
+          return render_error(status: :unauthorized, message: "invalid or missing sandbox token")
+        end
+
+        # This endpoint only needs to prove the caller has the same signed
+        # sandbox entitlement used by /sandbox/permissions. The listed start URLs
+        # are public OAuth entrypoints, so no proxy/principal claim check is
+        # needed here.
+        SandboxEntitlements::Jwt.decode(token)
+      rescue CentaurJwt::Hs256::VerificationError
+        render_error(status: :unauthorized, message: "invalid or missing sandbox token")
+      end
+
+      def app_payload(app)
+        {
+          id: app.oid,
+          slug: app.slug,
+          description: app.description,
+          labels: app.labels,
+          provider: app.provider,
+          allowed_scopes: app.allowed_scopes,
+          start_url: oauth_start_url_for(app)
+        }
+      end
+
+      def oauth_start_url_for(app)
+        URI.join(public_base_url, "/oauth/#{app.slug}/start").to_s
+      end
+
+      def public_base_url
+        ConsoleEnv["PUBLIC_URL"].presence || request.base_url
+      end
+    end
+  end
+end

--- a/services/console/app/controllers/api/v1/sandbox_permissions_controller.rb
+++ b/services/console/app/controllers/api/v1/sandbox_permissions_controller.rb
@@ -26,6 +26,7 @@ module Api
             principal: principal_payload(principal),
             capabilities: capabilities_payload(principal),
             slack_channel_permissions: principal.slack_channel_permissions_payload,
+            oauth_credentials: oauth_credentials_payload(principal),
             permissions: permissions
           }
         }.to_json
@@ -75,6 +76,26 @@ module Api
           sandbox_observability_enabled: principal.sandbox_observability_enabled,
           sandbox_api_server_enabled: principal.sandbox_api_server_enabled
         }
+      end
+
+      def oauth_credentials_payload(principal)
+        principal.granted_static_secrets
+          .includes(broker_credential: :oauth_app)
+          .filter_map(&:broker_credential)
+          .select(&:oauth_app)
+          .sort_by { |credential| [ credential.oauth_app.slug, credential.provider_email.to_s, credential.id ] }
+          .map do |credential|
+            {
+              id: credential.oid,
+              oauth_app_id: credential.oauth_app.oid,
+              slug: credential.oauth_app.slug,
+              provider: credential.oauth_app.provider,
+              provider_email: credential.provider_email,
+              provider_subject: credential.provider_subject,
+              status: credential.status,
+              scopes: credential.scopes
+            }
+          end
       end
     end
   end

--- a/services/console/app/models/proxy.rb
+++ b/services/console/app/models/proxy.rb
@@ -3,7 +3,7 @@ class Proxy < ApplicationRecord
 
   TOKEN_PREFIX = "iprx_".freeze
   TOKEN_FORMAT = /\Aiprx_[0-9a-f]{64}\z/
-  SANDBOX_ENTITLEMENTS_PATH = "/api/v1/sandbox/permissions".freeze
+  SANDBOX_ENTITLEMENTS_PATH_PATTERN = "/api/v1/sandbox/*".freeze
 
   attr_readonly :bearer_token_hash
   attr_accessor :token
@@ -95,7 +95,7 @@ class Proxy < ApplicationRecord
         {
           "host" => host,
           "methods" => [ "GET" ],
-          "paths" => [ SANDBOX_ENTITLEMENTS_PATH ]
+          "paths" => [ SANDBOX_ENTITLEMENTS_PATH_PATTERN ]
         }
       end
     return nil if rules.empty?

--- a/services/console/config/routes.rb
+++ b/services/console/config/routes.rb
@@ -211,8 +211,9 @@ Rails.application.routes.draw do
       post "proxy/sync", to: "proxy_sync#create"
 
       # Called from inside sandboxes through their assigned iron-proxy. The
-      # proxy injects a short-lived sandbox entitlement JWT scoped to this path.
+      # proxy injects a short-lived sandbox entitlement JWT scoped to these paths.
       get "sandbox/permissions", to: "sandbox_permissions#show"
+      get "sandbox/oauth_apps", to: "sandbox_oauth_apps#index"
     end
   end
 

--- a/services/console/docs/API.md
+++ b/services/console/docs/API.md
@@ -1,6 +1,6 @@
 # iron-control API
 
-`iron-control` exposes a JSON API under `/api/v1`. Every resource endpoint requires API key authentication. The single exception is `POST /api/v1/proxy/sync`, which `iron-proxy` instances call with a proxy bearer token.
+`iron-control` exposes a JSON API under `/api/v1`. Resource endpoints require API key authentication. `POST /api/v1/proxy/sync` uses proxy bearer authentication, and sandbox read endpoints use the sandbox entitlement JWT injected by `iron-proxy`.
 
 - [Authentication](#authentication)
 - [Conventions](#conventions)
@@ -1061,6 +1061,53 @@ Returns `201`. The `client_secret` is never echoed back:
 | `GET`  | `/api/v1/oauth_apps/lookup/:slug` | Fetch by slug. `404` if missing. |
 | `PUT`/`PATCH` | `/api/v1/oauth_apps/:id` | [Upsert](#upsert-put--patch) by OID or slug. Omitted fields are preserved; `client_secret` is only changed when supplied. |
 | `DELETE` | `/api/v1/oauth_apps/:id` | Delete. Returns `204`; `404` if missing. Returns `409` while the app still has minted credentials (delete or unlink them first). |
+
+### Sandbox Start URLs
+
+`GET /api/v1/sandbox/oauth_apps`
+
+Returns enabled OAuth apps and the console URLs a sandbox user can open to start consent. Authenticate with the same sandbox entitlement JWT as `GET /api/v1/sandbox/permissions`. The token signature, issuer, audience, and expiry are verified. Proxy and principal claims are not checked because these URLs are not sensitive.
+
+```json
+{
+  "data": [
+    {
+      "id": "oap_...",
+      "slug": "google",
+      "description": "Gmail",
+      "labels": {},
+      "provider": "google",
+      "allowed_scopes": ["https://www.googleapis.com/auth/gmail.readonly"],
+      "start_url": "https://<iron-control>/oauth/google/start"
+    }
+  ]
+}
+```
+
+### Sandbox OAuth Credential Metadata
+
+`GET /api/v1/sandbox/permissions`
+
+The sandbox permissions response includes an `oauth_credentials` array with non-secret metadata for OAuth-flow credentials currently granted to the sandbox principal. Use it to confirm that a user completed consent for the expected app and personal email.
+
+```json
+{
+  "data": {
+    "oauth_credentials": [
+      {
+        "id": "bcr_...",
+        "oauth_app_id": "oap_...",
+        "slug": "google",
+        "provider": "google",
+        "provider_email": "person@example.com",
+        "provider_subject": "google-subject",
+        "status": "live",
+        "scopes": ["https://www.googleapis.com/auth/gmail.readonly"]
+      }
+    ]
+  }
+}
+```
 
 ## OAuth consent flow
 

--- a/services/console/lib/sandbox_entitlements/jwt.rb
+++ b/services/console/lib/sandbox_entitlements/jwt.rb
@@ -2,10 +2,10 @@ module SandboxEntitlements
   module Jwt
     DEFAULT_AUDIENCE = "centaur-console-sandbox-entitlements".freeze
     DEFAULT_ISSUER = "centaur-console".freeze
-    # The token is low-sensitivity (scoped to one read-only endpoint that
-    # serves redacted config, and the endpoint re-validates the
-    # proxy -> principal binding against the database on every request, so
-    # reassignment revokes it immediately regardless of exp). Rotation is
+    # The token is low-sensitivity (scoped to read-only sandbox endpoints). The
+    # permissions endpoint re-validates the proxy -> principal binding against
+    # the database on every request, so reassignment revokes permissions access
+    # immediately regardless of exp. Rotation is
     # therefore infrequent: it exists to bound the lifetime of a leaked token,
     # not to enforce freshness. Keep the window long — every rotation changes
     # the synced config hash and forces a full config re-push to the proxy.

--- a/services/console/test/controllers/api/v1/proxy_sync_controller_test.rb
+++ b/services/console/test/controllers/api/v1/proxy_sync_controller_test.rb
@@ -63,13 +63,13 @@ class ProxySyncControllerTest < ActionDispatch::IntegrationTest
 
     entry = json_body.fetch("secrets").find do |secret|
       secret.dig("inject", "header") == "Authorization" &&
-        secret.fetch("rules").any? { |rule| rule["paths"] == [ Proxy::SANDBOX_ENTITLEMENTS_PATH ] }
+        secret.fetch("rules").any? { |rule| rule["paths"] == [ Proxy::SANDBOX_ENTITLEMENTS_PATH_PATTERN ] }
     end
 
     refute_nil entry
     assert_equal "Bearer {{ .Value }}", entry.dig("inject", "formatter")
     assert_equal(
-      { "host" => "centaur-console", "methods" => [ "GET" ], "paths" => [ Proxy::SANDBOX_ENTITLEMENTS_PATH ] },
+      { "host" => "centaur-console", "methods" => [ "GET" ], "paths" => [ Proxy::SANDBOX_ENTITLEMENTS_PATH_PATTERN ] },
       entry.fetch("rules").first
     )
 
@@ -88,7 +88,7 @@ class ProxySyncControllerTest < ActionDispatch::IntegrationTest
     assert_response :ok
 
     entry = json_body.fetch("secrets").find do |secret|
-      secret.fetch("rules", []).any? { |rule| rule["paths"] == [ Proxy::SANDBOX_ENTITLEMENTS_PATH ] }
+      secret.fetch("rules", []).any? { |rule| rule["paths"] == [ Proxy::SANDBOX_ENTITLEMENTS_PATH_PATTERN ] }
     end
 
     assert_nil entry

--- a/services/console/test/controllers/api/v1/sandbox_oauth_apps_controller_test.rb
+++ b/services/console/test/controllers/api/v1/sandbox_oauth_apps_controller_test.rb
@@ -1,0 +1,87 @@
+require "test_helper"
+
+module Api
+  module V1
+    class SandboxOauthAppsControllerTest < ActionDispatch::IntegrationTest
+      setup do
+        @proxy = proxies(:acme_proxy)
+      end
+
+      test "returns enabled OAuth app start URLs for a valid sandbox token" do
+        with_env(
+          "CENTAUR_JWT_SIGNING_SECRET" => "test-secret",
+          "CENTAUR_CONSOLE_PUBLIC_URL" => "https://console.example.test"
+        ) do
+          get "/api/v1/sandbox/oauth_apps", headers: auth_headers(token_for(@proxy))
+        end
+        assert_response :ok
+
+        data = json_body.fetch("data")
+        slugs = data.map { |app| app.fetch("slug") }
+        assert_equal slugs.sort, slugs
+        assert_includes slugs, "google"
+        refute_includes slugs, "google-disabled"
+
+        google = data.find { |app| app.fetch("slug") == "google" }
+        assert_equal oauth_apps(:acme_google).oid, google.fetch("id")
+        assert_equal "google", google.fetch("provider")
+        assert_equal({ "team" => "comms" }, google.fetch("labels"))
+        assert_equal oauth_apps(:acme_google).allowed_scopes, google.fetch("allowed_scopes")
+        assert_equal "https://console.example.test/oauth/google/start", google.fetch("start_url")
+        refute google.key?("client_id")
+      end
+
+      test "does not reject a valid token when proxy claims are stale" do
+        with_env("CENTAUR_JWT_SIGNING_SECRET" => "test-secret") do
+          token = token_for(@proxy)
+          @proxy.update!(principal: principals(:globex_user))
+
+          get "/api/v1/sandbox/oauth_apps", headers: auth_headers(token)
+        end
+
+        assert_response :ok
+      end
+
+      test "rejects requests without a sandbox token" do
+        get "/api/v1/sandbox/oauth_apps"
+        assert_response :unauthorized
+      end
+
+      test "rejects expired sandbox tokens" do
+        with_env("CENTAUR_JWT_SIGNING_SECRET" => "test-secret") do
+          token = token_for(@proxy, now: (SandboxEntitlements::Jwt::DEFAULT_TTL_SECONDS + 1.hour).seconds.ago)
+
+          get "/api/v1/sandbox/oauth_apps", headers: auth_headers(token)
+        end
+
+        assert_response :unauthorized
+      end
+
+      private
+
+      def auth_headers(token)
+        { "Authorization" => "Bearer #{token}" }
+      end
+
+      def token_for(proxy, now: Time.current)
+        SandboxEntitlements::Jwt.encode_for_proxy(proxy, now: now)
+      end
+
+      def json_body
+        JSON.parse(response.body)
+      end
+
+      def with_env(values)
+        previous = values.keys.to_h { |key| [ key, ENV[key] ] }
+        values.each do |key, value|
+          value.nil? ? ENV.delete(key) : ENV[key] = value
+        end
+        yield
+      ensure
+        previous.each do |key, value|
+          value.nil? ? ENV.delete(key) : ENV[key] = value
+        end
+      end
+    end
+  end
+end

--- a/services/console/test/controllers/api/v1/sandbox_permissions_controller_test.rb
+++ b/services/console/test/controllers/api/v1/sandbox_permissions_controller_test.rb
@@ -20,6 +20,31 @@ module Api
       end
 
       test "returns redacted sandbox permissions for a valid sandbox token" do
+        credential = BrokerCredential.create!(
+          namespace: @proxy.principal.namespace,
+          foreign_id: "google-personal",
+          name: "Google - Personal User",
+          token_endpoint: "https://oauth2.googleapis.com/token",
+          oauth_app: oauth_apps(:acme_google),
+          provider_email: "person@example.com",
+          provider_subject: "google-sub-1",
+          scopes: [ "https://www.googleapis.com/auth/gmail.readonly" ],
+          refresh_token: "refresh-token",
+          access_token: "access-token",
+          expires_at: 1.hour.from_now,
+          last_refresh: Time.current
+        )
+        secret = StaticSecret.new(
+          namespace: @proxy.principal.namespace,
+          name: "Google - Personal User token",
+          broker_credential: credential,
+          inject_config: { "header" => "Authorization", "formatter" => "Bearer {{ .Value }}" }
+        )
+        secret.build_source(source_type: "token_broker", config: { "credential_id" => credential.oid })
+        secret.rules.build(host: "www.googleapis.com", position: 0)
+        secret.save!
+        Grant.create!(principal: @proxy.principal, static_secret: secret, created_by: users(:acme_admin))
+
         with_env("CENTAUR_JWT_SIGNING_SECRET" => "test-secret") do
           get "/api/v1/sandbox/permissions", headers: auth_headers(token_for(@proxy))
         end
@@ -32,6 +57,18 @@ module Api
         assert_equal @proxy.principal.namespace, data.dig("principal", "namespace")
         assert_equal @proxy.principal.sandbox_repo_cache, data.dig("capabilities", "sandbox_repo_cache")
         assert_equal 1, data.fetch("slack_channel_permissions").length
+        assert_equal [
+          {
+            "id" => credential.oid,
+            "oauth_app_id" => oauth_apps(:acme_google).oid,
+            "slug" => "google",
+            "provider" => "google",
+            "provider_email" => "person@example.com",
+            "provider_subject" => "google-sub-1",
+            "status" => "live",
+            "scopes" => [ "https://www.googleapis.com/auth/gmail.readonly" ]
+          }
+        ], data.fetch("oauth_credentials")
 
         entry = data.dig("permissions", "secrets").find { |secret| secret.dig("source", "type") == "control_plane" }
         refute_nil entry

--- a/services/sandbox/SYSTEM_PROMPT.md
+++ b/services/sandbox/SYSTEM_PROMPT.md
@@ -178,6 +178,15 @@
 |  notion search "meeting notes"
 |  vlogs query 'level:error AND _stream:{service="api"}' --limit 20
 
+[Personal OAuth app connections]
+|When a user asks how to connect, authorize, sign in, link, or use their personal account for OAuth-backed apps in a Centaur DM, first fetch the live configured start URLs with `centaur-console oauth-apps`.
+|This applies to apps such as Google, Granola, Attio, Linear, Slack, and GitHub. The endpoint returns only apps configured and enabled for this deployment.
+|Use the returned `start_url` for the matching app. Do not invent OAuth links, hard-code `/oauth/<slug>/start`, or assume an app is configured because the tool exists.
+|Tell the user to open the returned start URL, complete the provider consent flow in their browser, then come back to the DM. After they return, validate the connection with `centaur-console permissions`: look in `oauth_credentials` for the requested app/provider and the user's personal `provider_email`.
+|If `oauth_credentials` contains that app/provider and personal email, tell the user the account is connected and that Centaur can use their personal connected account where the relevant tool or workflow supports user-scoped credentials.
+|If the credential is not present yet, ask the user to confirm which email they used in the provider consent flow or to retry the returned start URL. Do not claim the account is connected until `centaur-console permissions` shows the matching email.
+|If the requested app is missing from the endpoint response, say that it is not currently configured for self-service connection in this deployment. If the endpoint call fails, say you cannot retrieve connection links right now and include the tool error briefly.
+
 [Tool discovery — discover before you call]
 |IMPORTANT: Before using any unfamiliar tool CLI, run `<tool> --help` to see commands, parameters, and descriptions.
 |This tells you exactly which command to use and avoids redundant calls.

--- a/services/sandbox/test_system_prompt.py
+++ b/services/sandbox/test_system_prompt.py
@@ -41,5 +41,18 @@ class SystemPromptTest(unittest.TestCase):
         self.assertIn("`--bedrock` selects Codex with the Bedrock provider", prompt)
         self.assertIn("`-rsn <effort>` sets Codex reasoning effort", prompt)
 
+    def test_personal_oauth_app_connection_guidance_is_present(self) -> None:
+        prompt = SYSTEM_PROMPT.read_text()
+
+        self.assertIn("[Personal OAuth app connections]", prompt)
+        self.assertIn("centaur-console oauth-apps", prompt)
+        self.assertIn("Google, Granola, Attio, Linear, Slack, and GitHub", prompt)
+        self.assertIn("Use the returned `start_url`", prompt)
+        self.assertIn("Do not invent OAuth links", prompt)
+        self.assertIn("validate the connection with `centaur-console permissions`", prompt)
+        self.assertIn("look in `oauth_credentials`", prompt)
+        self.assertIn("personal `provider_email`", prompt)
+        self.assertIn("Centaur can use their personal connected account", prompt)
+
 if __name__ == "__main__":
     unittest.main()

--- a/tools/infra/centaur-console/cli.py
+++ b/tools/infra/centaur-console/cli.py
@@ -42,6 +42,22 @@ def permissions(
     console.print_json(json.dumps(result, default=str))
 
 
+@app.command("oauth-apps")
+def oauth_apps(
+    url: str | None = typer.Option(None, "--url", help="centaur-console base URL"),
+    bearer_token: str | None = typer.Option(
+        None,
+        "--bearer-token",
+        help="Local/debug bearer token override",
+        envvar="CENTAUR_CONSOLE_BEARER_TOKEN",
+    ),
+):
+    """Print enabled OAuth apps and their consent start URLs as JSON."""
+    with get_client(url=url, bearer_token=bearer_token) as client:
+        result = client.sandbox_oauth_apps()
+    console.print_json(json.dumps({"data": result}, default=str))
+
+
 @app.command()
 def health(
     url: str | None = typer.Option(None, "--url", help="centaur-console base URL"),

--- a/tools/infra/centaur-console/client.py
+++ b/tools/infra/centaur-console/client.py
@@ -8,6 +8,7 @@ from typing import Any
 import httpx
 
 SANDBOX_PERMISSIONS_PATH = "/api/v1/sandbox/permissions"
+SANDBOX_OAUTH_APPS_PATH = "/api/v1/sandbox/oauth_apps"
 
 
 class ConsoleClient:
@@ -72,6 +73,25 @@ class ConsoleClient:
     def permissions(self) -> dict[str, Any]:
         """Alias for tool bridge calls."""
         return self.sandbox_permissions()
+
+    def sandbox_oauth_apps(self) -> list[dict[str, Any]]:
+        """Return enabled OAuth apps with user-facing consent start URLs."""
+        response = self.client.get(SANDBOX_OAUTH_APPS_PATH)
+        try:
+            response.raise_for_status()
+        except httpx.HTTPStatusError as exc:
+            detail = _response_error_detail(exc.response)
+            raise RuntimeError(f"centaur-console OAuth apps request failed: {detail}") from exc
+
+        payload = response.json()
+        data = payload.get("data")
+        if not isinstance(data, list):
+            raise RuntimeError("centaur-console OAuth apps response did not include a data array")
+        return data
+
+    def oauth_apps(self) -> list[dict[str, Any]]:
+        """Alias for tool bridge calls."""
+        return self.sandbox_oauth_apps()
 
     def health(self) -> dict[str, Any]:
         """Assert the sandbox permissions endpoint is reachable and authorized."""

--- a/tools/infra/centaur-console/test_client.py
+++ b/tools/infra/centaur-console/test_client.py
@@ -1,6 +1,6 @@
 import httpx
 import pytest
-from client import SANDBOX_PERMISSIONS_PATH, ConsoleClient
+from client import SANDBOX_OAUTH_APPS_PATH, SANDBOX_PERMISSIONS_PATH, ConsoleClient
 
 
 def json_response(payload, status_code=200):
@@ -51,6 +51,42 @@ def test_sandbox_permissions_wraps_http_errors():
 
     with pytest.raises(RuntimeError, match="HTTP 401"):
         make_client(handler).sandbox_permissions()
+
+
+def test_sandbox_oauth_apps_fetches_and_unwraps_data():
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.method == "GET"
+        assert request.url.path == SANDBOX_OAUTH_APPS_PATH
+        assert request.headers["Accept"] == "application/json"
+        return json_response(
+            {
+                "data": [
+                    {
+                        "slug": "google",
+                        "provider": "google",
+                        "start_url": "https://console.example/oauth/google/start",
+                    }
+                ]
+            }
+        )
+
+    result = make_client(handler).sandbox_oauth_apps()
+
+    assert result == [
+        {
+            "slug": "google",
+            "provider": "google",
+            "start_url": "https://console.example/oauth/google/start",
+        }
+    ]
+
+
+def test_sandbox_oauth_apps_wraps_http_errors():
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return json_response({"error": {"message": "invalid sandbox token"}}, status_code=401)
+
+    with pytest.raises(RuntimeError, match="HTTP 401"):
+        make_client(handler).sandbox_oauth_apps()
 
 
 def test_health_returns_identity_details():


### PR DESCRIPTION
Adds a sandbox-authenticated OAuth app discovery endpoint that returns enabled app start URLs, and exposes connected OAuth credential metadata in sandbox permissions so agents can validate a user's personal email after consent. Updates the centaur-console tool and sandbox system prompt so Centaur can guide users through connecting Google, Granola, Attio, Linear, Slack, and GitHub accounts in DMs.