### PR TITLE
fix: support non-rotating Slack OAuth tokens

### DIFF
--- a/services/console/app/controllers/oauth/flows_controller.rb
+++ b/services/console/app/controllers/oauth/flows_controller.rb
@@ -147,7 +147,7 @@ module Oauth
         code: code.to_s,
         redirect_uri: oauth_callback_redirect_uri(@app.slug),
         code_verifier: code_verifier.to_s,
-        require_refresh_token: @provider.refreshable?
+        require_refresh_token: provider_requires_refresh_token?
       )
     end
 
@@ -185,11 +185,23 @@ module Oauth
           last_refresh: now,
           failure_count: 0, dead: false, dead_reason: nil
         )
-        credential.next_attempt_at = @provider.refreshable? ? credential.compute_next_attempt_at(now: now) : nil
+        credential.next_attempt_at = provider_refreshable_result?(result) ? credential.compute_next_attempt_at(now: now) : nil
         credential.save!
         ensure_wrapping_secret(credential)
         credential
       end
+    end
+
+    def provider_requires_refresh_token?
+      return @provider.require_refresh_token? if @provider.respond_to?(:require_refresh_token?)
+
+      @provider.refreshable?
+    end
+
+    def provider_refreshable_result?(result)
+      return @provider.refreshable_result?(result) if @provider.respond_to?(:refreshable_result?)
+
+      @provider.refreshable?
     end
 
     def granted_scopes(result, state)

--- a/services/console/app/controllers/oauth/flows_controller.rb
+++ b/services/console/app/controllers/oauth/flows_controller.rb
@@ -83,6 +83,7 @@ module Oauth
       end
 
       result = exchange_code(params[:code], flow["code_verifier"])
+      validate_provider_result!(result)
       identity = @provider.identity_from(result, client_id: @app.client_id)
       @credential = upsert_credential(state, result, identity)
       enqueue_identity_enrichment(@credential)
@@ -173,7 +174,7 @@ module Oauth
         end
 
         now = Time.current
-        expires_in = result.expires_in&.positive? ? result.expires_in : BrokerCredential::DEFAULT_EXPIRES_IN_SECONDS
+        refreshable_result = provider_refreshable_result?(result)
         credential.assign_attributes(
           provider_email: identity[:email],
           # Store exactly what the IdP granted, so the refresh POST re-requests it.
@@ -181,15 +182,19 @@ module Oauth
           labels: credential_labels(credential, identity),
           refresh_token: result.refresh_token,
           access_token: result.access_token,
-          expires_at: now + expires_in,
+          expires_at: credential_expires_at(result, now: now, refreshable_result: refreshable_result),
           last_refresh: now,
           failure_count: 0, dead: false, dead_reason: nil
         )
-        credential.next_attempt_at = provider_refreshable_result?(result) ? credential.compute_next_attempt_at(now: now) : nil
+        credential.next_attempt_at = refreshable_result ? credential.compute_next_attempt_at(now: now) : nil
         credential.save!
         ensure_wrapping_secret(credential)
         credential
       end
+    end
+
+    def validate_provider_result!(result)
+      @provider.validate_result!(result) if @provider.respond_to?(:validate_result!)
     end
 
     def provider_requires_refresh_token?
@@ -202,6 +207,13 @@ module Oauth
       return @provider.refreshable_result?(result) if @provider.respond_to?(:refreshable_result?)
 
       @provider.refreshable?
+    end
+
+    def credential_expires_at(result, now:, refreshable_result:)
+      return now + result.expires_in if result.expires_in&.positive?
+      return nil unless refreshable_result
+
+      now + BrokerCredential::DEFAULT_EXPIRES_IN_SECONDS
     end
 
     def granted_scopes(result, state)

--- a/services/console/docs/API.md
+++ b/services/console/docs/API.md
@@ -1154,7 +1154,7 @@ A tampered, expired, or missing flow state or cookie renders an error page with 
 | Google   | `google`         |
 | Slack    | `slack`          |
 
-Slack OAuth apps should have token rotation enabled so the callback receives a refresh token for the broker refresh loop.
+Slack OAuth apps may use token rotation or long-lived tokens. When token rotation is enabled, the callback stores the returned refresh token and the broker refresh loop keeps the access token fresh. When Slack returns a long-lived token without a refresh token, the credential is stored without scheduling broker refresh.
 Slack OAuth apps should use normal Slack API scopes such as `channels:history`, not Sign in with Slack scopes such as `openid`, `email`, or `profile`.
 
 ## Principals

--- a/services/console/docs/API.md
+++ b/services/console/docs/API.md
@@ -1154,7 +1154,7 @@ A tampered, expired, or missing flow state or cookie renders an error page with 
 | Google   | `google`         |
 | Slack    | `slack`          |
 
-Slack OAuth apps may use token rotation or long-lived tokens. When token rotation is enabled, the callback stores the returned refresh token and the broker refresh loop keeps the access token fresh. When Slack returns a long-lived token without a refresh token, the credential is stored without scheduling broker refresh.
+Slack OAuth apps may use token rotation or long-lived tokens. When token rotation is enabled, the callback stores the returned refresh token and the broker refresh loop keeps the access token fresh. When Slack returns a long-lived token without a refresh token or expiry, the credential is stored without scheduling broker refresh.
 Slack OAuth apps should use normal Slack API scopes such as `channels:history`, not Sign in with Slack scopes such as `openid`, `email`, or `profile`.
 
 ## Principals

--- a/services/console/lib/oauth/providers/slack.rb
+++ b/services/console/lib/oauth/providers/slack.rb
@@ -30,6 +30,16 @@ module Oauth
       def require_refresh_token? = false
       def refreshable_result?(result) = result.refresh_token.present?
 
+      def validate_result!(result)
+        return unless result.refresh_token.blank? && result.expires_in.present?
+
+        raise Broker::ExchangeError.new(
+          "token endpoint returned expiring Slack token without refresh_token",
+          stage: "oauth",
+          code: "missing_refresh_token"
+        )
+      end
+
       def parse_granted_scopes(scope)
         scope.to_s.split(/[,\s]+/).reject(&:blank?)
       end

--- a/services/console/lib/oauth/providers/slack.rb
+++ b/services/console/lib/oauth/providers/slack.rb
@@ -23,6 +23,12 @@ module Oauth
       def scope_separator = ","
       def extra_authorization_params = {}
       def refreshable? = true
+      # Slack app token rotation is deployment-specific. When token rotation is
+      # enabled Slack returns a refresh_token and the broker loop keeps it fresh;
+      # when it is disabled Slack returns long-lived xoxp/xoxb tokens without a
+      # refresh_token, which should be stored without scheduling refresh.
+      def require_refresh_token? = false
+      def refreshable_result?(result) = result.refresh_token.present?
 
       def parse_granted_scopes(scope)
         scope.to_s.split(/[,\s]+/).reject(&:blank?)
@@ -37,6 +43,16 @@ module Oauth
             subject: user_id,
             email: result.response.dig("authed_user", "email"),
             name: slack_user_name(result.response),
+            team_id: slack_team_id(result.response)
+          }
+        end
+
+        bot_user_id = result.response&.dig("bot_user_id")
+        if bot_user_id.present?
+          return {
+            subject: bot_user_id,
+            email: nil,
+            name: slack_bot_name(result.response),
             team_id: slack_team_id(result.response)
           }
         end
@@ -56,6 +72,10 @@ module Oauth
       def slack_team_id(response)
         response.dig("team", "id").presence ||
           response.dig("authed_user", "team_id").presence
+      end
+
+      def slack_bot_name(response)
+        response.dig("team", "name").presence || response["bot_user_id"].presence
       end
     end
   end

--- a/services/console/test/controllers/oauth/flows_controller_test.rb
+++ b/services/console/test/controllers/oauth/flows_controller_test.rb
@@ -77,6 +77,33 @@ module Oauth
       }.merge(overrides).to_json
     end
 
+    def slack_bot_token_body(**overrides)
+      {
+        ok: true,
+        access_token: "xoxb-non-rotating-bot",
+        token_type: "bot",
+        scope: "commands,chat:write",
+        bot_user_id: "U0BOTUSER",
+        app_id: "A0APP",
+        team: { id: "TACME", name: "Acme" }
+      }.merge(overrides).to_json
+    end
+
+    def slack_static_user_token_body
+      slack_token_body(
+        access_token: "xoxb-non-rotating-bot",
+        refresh_token: nil,
+        expires_in: nil,
+        authed_user: {
+          id: "USTATIC",
+          user: "static-grace",
+          access_token: "xoxp-non-rotating-user",
+          scope: "chat:write",
+          token_type: "user"
+        }
+      )
+    end
+
     def github_token_body(scope: "repo,read:user", **overrides)
       {
         access_token: "gho-user-token",
@@ -306,9 +333,54 @@ module Oauth
       assert_equal %w[chat:write], cred.scopes
       assert_equal "xoxe.xoxp-1-user", cred.access_token
       assert_equal "xoxe-1-refresh", cred.refresh_token
+      assert cred.next_attempt_at.present?
       assert_equal "TACME", cred.labels["slack_team_id"]
       assert_equal [ "slack.com" ], cred.static_secret.rules.map(&:host)
       assert_equal "Slack – grace token", cred.static_secret.name
+    end
+
+    test "callback happy path supports non-rotating Slack user tokens" do
+      state = start_flow(slug: "slack", scopes: "chat:write")
+      stub_exchange(status: 200, body: slack_static_user_token_body)
+
+      assert_difference -> { BrokerCredential.count } => 1 do
+        get oauth_callback_url(slug: "slack"), params: { state: state, code: "auth-code" }
+      end
+      assert_redirected_to console_integrations_path
+
+      app = oauth_apps(:acme_slack)
+      cred = BrokerCredential.find_by(oauth_app: app, provider_subject: "USTATIC")
+      assert_equal "Slack – static-grace", cred.name
+      assert_equal %w[chat:write], cred.scopes
+      assert_equal "xoxp-non-rotating-user", cred.access_token
+      assert_nil cred.refresh_token
+      assert_nil cred.next_attempt_at
+      refute_includes BrokerCredential.refreshable, cred
+    end
+
+    test "callback happy path supports non-rotating Slack bot tokens" do
+      state = start_flow(slug: "slack", scopes: "chat:write")
+      stub_exchange(status: 200, body: slack_bot_token_body)
+
+      assert_difference -> { BrokerCredential.count } => 1 do
+        get oauth_callback_url(slug: "slack"), params: { state: state, code: "auth-code" }
+      end
+      assert_redirected_to console_integrations_path
+
+      app = oauth_apps(:acme_slack)
+      cred = BrokerCredential.find_by(oauth_app: app, provider_subject: "U0BOTUSER")
+      assert_equal "acme", cred.namespace
+      assert_equal "slack-slack-u0botuser", cred.foreign_id
+      assert_equal "Slack – Acme", cred.name
+      assert_equal "https://slack.com/api/oauth.v2.access", cred.token_endpoint
+      assert_nil cred.provider_email
+      assert_equal %w[commands chat:write], cred.scopes
+      assert_equal "xoxb-non-rotating-bot", cred.access_token
+      assert_nil cred.refresh_token
+      assert_nil cred.next_attempt_at
+      assert_equal "TACME", cred.labels["slack_team_id"]
+      assert_equal [ "slack.com" ], cred.static_secret.rules.map(&:host)
+      refute_includes BrokerCredential.refreshable, cred
     end
 
     test "callback happy path supports Attio workspace tokens" do

--- a/services/console/test/controllers/oauth/flows_controller_test.rb
+++ b/services/console/test/controllers/oauth/flows_controller_test.rb
@@ -354,6 +354,7 @@ module Oauth
       assert_equal %w[chat:write], cred.scopes
       assert_equal "xoxp-non-rotating-user", cred.access_token
       assert_nil cred.refresh_token
+      assert_nil cred.expires_at
       assert_nil cred.next_attempt_at
       refute_includes BrokerCredential.refreshable, cred
     end
@@ -377,6 +378,7 @@ module Oauth
       assert_equal %w[commands chat:write], cred.scopes
       assert_equal "xoxb-non-rotating-bot", cred.access_token
       assert_nil cred.refresh_token
+      assert_nil cred.expires_at
       assert_nil cred.next_attempt_at
       assert_equal "TACME", cred.labels["slack_team_id"]
       assert_equal [ "slack.com" ], cred.static_secret.rules.map(&:host)

--- a/services/console/test/lib/oauth/providers/slack_test.rb
+++ b/services/console/test/lib/oauth/providers/slack_test.rb
@@ -80,6 +80,13 @@ module Oauth
         refute strategy.refreshable_result?(static)
       end
 
+      test "rejects expiring Slack responses without a refresh token" do
+        result = result_with(claims: valid_claims, refresh_token: nil, expires_in: 43_200)
+
+        err = assert_raises(Broker::ExchangeError) { strategy.validate_result!(result) }
+        assert_equal "missing_refresh_token", err.code
+      end
+
       test "aud mismatch raises an oauth exchange error" do
         result = result_with(claims: valid_claims("aud" => "someone-else"))
         err = assert_raises(Broker::ExchangeError) { strategy.identity_from(result, client_id: CLIENT_ID) }

--- a/services/console/test/lib/oauth/providers/slack_test.rb
+++ b/services/console/test/lib/oauth/providers/slack_test.rb
@@ -55,6 +55,31 @@ module Oauth
         assert_equal "ada", identity[:name]
       end
 
+      test "uses Slack bot user id when no authed user token or id token is returned" do
+        result = result_with(
+          claims: valid_claims,
+          id_token: nil,
+          response: {
+            "team" => { "id" => "T12345", "name" => "Acme" },
+            "bot_user_id" => "U0BOTUSER"
+          }
+        )
+
+        identity = strategy.identity_from(result, client_id: CLIENT_ID)
+        assert_equal "U0BOTUSER", identity[:subject]
+        assert_equal "Acme", identity[:name]
+        assert_equal "T12345", identity[:team_id]
+      end
+
+      test "only schedules refresh when Slack returned a refresh token" do
+        rotating = result_with(claims: valid_claims, refresh_token: "RT")
+        static = result_with(claims: valid_claims, refresh_token: nil)
+
+        refute strategy.require_refresh_token?
+        assert strategy.refreshable_result?(rotating)
+        refute strategy.refreshable_result?(static)
+      end
+
       test "aud mismatch raises an oauth exchange error" do
         result = result_with(claims: valid_claims("aud" => "someone-else"))
         err = assert_raises(Broker::ExchangeError) { strategy.identity_from(result, client_id: CLIENT_ID) }


### PR DESCRIPTION
Allows Slack OAuth consent to accept long-lived Slack tokens that do not include a refresh token, while still scheduling broker refresh when Slack returns a rotating refresh token. Also handles Slack bot-token OAuth responses that identify the installation by bot_user_id and updates the OAuth docs to describe both modes.