### PR TITLE
docs: clarify cron weekday numbering

### DIFF
--- a/docs/pages/extend/workflows-v2.mdx
+++ b/docs/pages/extend/workflows-v2.mdx
@@ -181,11 +181,15 @@ Schedules can live beside the handler:
 ```python
 SCHEDULE = {
     "type": "cron",
-    "cron": "0 9 * * 1-5",
+    "cron": "0 9 * * MON-FRI",
     "timezone": "America/New_York",
     "input": {"profile": "default"},
 }
 ```
+
+Write day-of-week as names (`MON-FRI`), not numbers: the parser is Quartz-style
+(1 = Sunday), so a Unix-style `1-5` fires Sunday–Thursday. See
+[Schedule a workflow](/extend/workflows#schedule-a-workflow) for details.
 
 `api-rs` reconciles enabled schedule metadata into Absurd schedule tasks. ETL
 workflows can be routed to a separate queue so long-running sync jobs do not

--- a/docs/pages/extend/workflows.mdx
+++ b/docs/pages/extend/workflows.mdx
@@ -123,7 +123,7 @@ WORKFLOW_NAME = "daily_market_digest"
 
 SCHEDULE = {
     "type": "cron",
-    "cron": "0 9 * * 1-5",
+    "cron": "0 9 * * MON-FRI",
     "timezone": "America/New_York",
     "input": {
         "channel": "markets",
@@ -138,11 +138,20 @@ Cron schedules use five fields:
 minute hour day-of-month month day-of-week
 ```
 
+:::warning[Day-of-week numbering is Quartz-style, not Unix crontab]
+The schedule engine parses cron expressions with the Rust
+[`cron` crate](https://github.com/zslayton/cron), which numbers days of week
+1–7 with **1 = Sunday** (`0` is rejected). A Unix-style `1-5` therefore fires
+Sunday–Thursday, not Monday–Friday. Always write day-of-week as names
+(`MON`, `MON-FRI`, `SAT,SUN`) — they mean the same thing in every dialect.
+:::
+
 Examples:
 
 | Cron | Meaning |
 |------|---------|
-| `0 9 * * 1-5` | 9:00 AM every weekday. |
+| `0 9 * * MON-FRI` | 9:00 AM every weekday. |
+| `0 9 * * 1-5` | 9:00 AM Sunday–Thursday (Quartz numbering — probably not what you meant). |
 | `*/15 * * * *` | Every 15 minutes. |
 | `30 6 * * *` | 6:30 AM every day. |
 | `0 0 1 * *` | Midnight on the first day of every month. |

--- a/docs/public/md/extend/workflows-v2.md
+++ b/docs/public/md/extend/workflows-v2.md
@@ -181,11 +181,15 @@ Schedules can live beside the handler:
 ```python
 SCHEDULE = {
     "type": "cron",
-    "cron": "0 9 * * 1-5",
+    "cron": "0 9 * * MON-FRI",
     "timezone": "America/New_York",
     "input": {"profile": "default"},
 }
 ```
+
+Write day-of-week as names (`MON-FRI`), not numbers: the parser is Quartz-style
+(1 = Sunday), so a Unix-style `1-5` fires Sunday–Thursday. See
+[Schedule a workflow](/extend/workflows#schedule-a-workflow) for details.
 
 `api-rs` reconciles enabled schedule metadata into Absurd schedule tasks. ETL
 workflows can be routed to a separate queue so long-running sync jobs do not

--- a/docs/public/md/extend/workflows.md
+++ b/docs/public/md/extend/workflows.md
@@ -121,7 +121,7 @@ WORKFLOW_NAME = "daily_market_digest"
 
 SCHEDULE = {
     "type": "cron",
-    "cron": "0 9 * * 1-5",
+    "cron": "0 9 * * MON-FRI",
     "timezone": "America/New_York",
     "input": {
         "channel": "markets",
@@ -136,11 +136,20 @@ Cron schedules use five fields:
 minute hour day-of-month month day-of-week
 ```
 
+:::warning[Day-of-week numbering is Quartz-style, not Unix crontab]
+The schedule engine parses cron expressions with the Rust
+[`cron` crate](https://github.com/zslayton/cron), which numbers days of week
+1–7 with **1 = Sunday** (`0` is rejected). A Unix-style `1-5` therefore fires
+Sunday–Thursday, not Monday–Friday. Always write day-of-week as names
+(`MON`, `MON-FRI`, `SAT,SUN`) — they mean the same thing in every dialect.
+:::
+
 Examples:
 
 | Cron | Meaning |
 |------|---------|
-| `0 9 * * 1-5` | 9:00 AM every weekday. |
+| `0 9 * * MON-FRI` | 9:00 AM every weekday. |
+| `0 9 * * 1-5` | 9:00 AM Sunday–Thursday (Quartz numbering — probably not what you meant). |
 | `*/15 * * * *` | Every 15 minutes. |
 | `30 6 * * *` | 6:30 AM every day. |
 | `0 0 1 * *` | Midnight on the first day of every month. |

--- a/services/api-rs/crates/centaur-workflows/src/lib.rs
+++ b/services/api-rs/crates/centaur-workflows/src/lib.rs
@@ -2334,6 +2334,10 @@ fn next_schedule_time(
     }
 }
 
+/// Prepends a seconds field so five-field crontab-style expressions parse with the
+/// `cron` crate. Note the crate's day-of-week numbering is Quartz-style (1 = Sunday,
+/// 7 = Saturday; 0 rejected), NOT Unix crontab — schedules should use day names
+/// (`MON-FRI`) to avoid firing on the wrong days.
 fn normalize_cron_expression(expr: &str) -> String {
     let fields = expr.split_whitespace().collect::<Vec<_>>();
     if fields.len() == 5 {
@@ -3976,6 +3980,36 @@ mod tests {
                 .with_ymd_and_hms(2026, 6, 8, 7, 45, 0)
                 .unwrap()
                 .with_timezone(&Utc)
+        );
+    }
+
+    #[test]
+    fn cron_schedule_day_names_avoid_quartz_numbering() {
+        let named_days = normalize_schedule(json!({
+            "workflow_name": "weekday_report",
+            "schedule_id": "named_weekdays",
+            "cron": "0 9 * * MON-FRI",
+            "timezone": "UTC",
+            "enabled": true,
+        }))
+        .unwrap();
+        let numeric_days = normalize_schedule(json!({
+            "workflow_name": "weekday_report",
+            "schedule_id": "numeric_days",
+            "cron": "0 9 * * 1-5",
+            "timezone": "UTC",
+            "enabled": true,
+        }))
+        .unwrap();
+        let after_thursday = Utc.with_ymd_and_hms(2026, 7, 16, 10, 0, 0).unwrap();
+
+        assert_eq!(
+            next_schedule_time(&named_days, after_thursday).unwrap(),
+            Utc.with_ymd_and_hms(2026, 7, 17, 9, 0, 0).unwrap()
+        );
+        assert_eq!(
+            next_schedule_time(&numeric_days, after_thursday).unwrap(),
+            Utc.with_ymd_and_hms(2026, 7, 19, 9, 0, 0).unwrap()
         );
     }
 


### PR DESCRIPTION
## Summary

- replace ambiguous numeric weekday examples with `MON-FRI`
- document the Rust `cron` crate's Quartz-style day-of-week numbering in the
  workflow guides and at the parser boundary
- add regression coverage for named weekdays versus numeric `1-5`

This supersedes #1040 and preserves the original author's contribution through
the commit's co-author trailer.

## Testing

- `cargo fmt --all --check`
- `cargo test -p centaur-workflows`
- `./node_modules/.bin/vocs build`
- `git diff --check`
