### PR TITLE
fix: preserve Granola projection document IDs

### DIFF
--- a/services/api-rs/crates/centaur-session-sqlx/migrations/0044_granola_context_projection.sql
+++ b/services/api-rs/crates/centaur-session-sqlx/migrations/0044_granola_context_projection.sql
@@ -22,7 +22,7 @@ as $$
     ),
     projected as (
         select
-            concat_ws(':', 'granola', notes.note_id) as document_id,
+            concat_ws(':', 'granola', 'note', notes.note_id) as document_id,
             notes.note_id,
             coalesce(nullif(notes.title, ''), 'Granola note') as title,
             notes.content_text as body,

--- a/services/api-rs/crates/centaur-session-sqlx/tests/granola_context_projection.rs
+++ b/services/api-rs/crates/centaur-session-sqlx/tests/granola_context_projection.rs
@@ -37,6 +37,13 @@ async fn run_assertions(conn: &mut PgConnection, schema: &str) -> Result<(), Box
             'note_backfilled', 'Existing note', 'alice@example.com',
             array['alice@example.com'], 'Existing source data', '2026-07-13T09:00:00Z'
         );
+
+        insert into granola_context_documents (
+            document_id, note_id, title, body, content_hash
+        ) values (
+            'granola:note:note_backfilled', 'note_backfilled',
+            'Stale title', 'Stale body', 'stale-hash'
+        );
         "#,
     )
     .execute(&mut *conn)
@@ -44,12 +51,21 @@ async fn run_assertions(conn: &mut PgConnection, schema: &str) -> Result<(), Box
     execute_migration(conn, GRANOLA_CONTEXT_PROJECTION_SQL).await?;
     grant_schema_usage(conn, schema).await?;
 
-    let backfilled_document_id: String = sqlx::query_scalar(
-        "select document_id from granola_context_documents where note_id = 'note_backfilled'",
+    let backfilled = sqlx::query(
+        "select document_id, title, body from granola_context_documents \
+         where note_id = 'note_backfilled'",
     )
     .fetch_one(&mut *conn)
     .await?;
-    assert_eq!(backfilled_document_id, "granola:note_backfilled");
+    assert_eq!(
+        backfilled.try_get::<String, _>("document_id")?,
+        "granola:note:note_backfilled"
+    );
+    assert_eq!(backfilled.try_get::<String, _>("title")?, "Existing note");
+    assert_eq!(
+        backfilled.try_get::<String, _>("body")?,
+        "Existing source data"
+    );
 
     sqlx::raw_sql(
         r#"
@@ -87,7 +103,7 @@ async fn run_assertions(conn: &mut PgConnection, schema: &str) -> Result<(), Box
     .await?;
     assert_eq!(
         projection.try_get::<String, _>("document_id")?,
-        "granola:note_alice"
+        "granola:note:note_alice"
     );
     assert_eq!(projection.try_get::<String, _>("title")?, "Launch review");
     assert_eq!(
@@ -133,10 +149,10 @@ async fn run_assertions(conn: &mut PgConnection, schema: &str) -> Result<(), Box
         conn,
         schema,
         "U_ALICE",
-        &["granola:note_alice", "granola:note_backfilled"],
+        &["granola:note:note_alice", "granola:note:note_backfilled"],
     )
     .await?;
-    assert_visible_documents(conn, schema, "U_BOB", &["granola:note_bob"]).await?;
+    assert_visible_documents(conn, schema, "U_BOB", &["granola:note:note_bob"]).await?;
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

- preserve the existing `granola:note:<note_id>` document ID format in migration 44
- add a regression fixture with a preexisting Granola projection
- verify the migration refreshes the existing row instead of violating the unique `note_id` constraint

## Root cause

Migration 44 generated `granola:<note_id>` while production rows already used `granola:note:<note_id>`. Its `ON CONFLICT` targeted `document_id`, so the changed primary key collided with the separate unique constraint on `note_id` and caused API-RS to crash during startup.

## Impact

This allows migration 44 to apply over existing production Granola projections, unblocking the API-RS rollout without rewriting stable document IDs.

## Validation

- `cargo fmt --manifest-path services/api-rs/Cargo.toml --all --check`
- `SESSION_SQLX_TEST_DATABASE_URL=... cargo test --manifest-path services/api-rs/Cargo.toml -p centaur-session-sqlx`
- 13 tests passed against the local Kubernetes Postgres instance
