### PR TITLE
fix: label Slack DM principals with email

### DIFF
--- a/services/api-rs/crates/centaur-iron-control/src/session.rs
+++ b/services/api-rs/crates/centaur-iron-control/src/session.rs
@@ -21,6 +21,7 @@ use crate::principal::{
 struct SessionPrincipalMetadata<'a> {
     actor_user_id: Option<&'a str>,
     slack_team_id: Option<&'a str>,
+    slack_user_email: Option<&'a str>,
     conversation_name: Option<&'a str>,
 }
 
@@ -36,6 +37,7 @@ impl<'a> SessionPrincipalMetadata<'a> {
                 .or_else(|| metadata.get("user_id"))
                 .and_then(Value::as_str),
             slack_team_id: metadata.get("slack_team_id").and_then(Value::as_str),
+            slack_user_email: metadata.get("slack_user_email").and_then(Value::as_str),
             conversation_name: metadata
                 .get("slack_conversation_name")
                 .or_else(|| metadata.get("discord_conversation_name"))
@@ -94,6 +96,7 @@ impl SessionRegistrar {
             metadata.conversation_name,
         );
         let mut input = principal.to_identity_input(&self.namespace);
+        apply_slack_dm_email_label(thread_key, metadata.slack_user_email, &mut input.labels);
         let existing = match self
             .client
             .get_principal(&self.namespace, &input.foreign_id)
@@ -155,6 +158,25 @@ fn slack_permission_for_thread(
             Some(user_id.trim().to_owned()).filter(|value| !value.is_empty()),
         )
     })
+}
+
+fn apply_slack_dm_email_label(
+    thread_key: &str,
+    slack_user_email: Option<&str>,
+    labels: &mut BTreeMap<String, String>,
+) {
+    let Some(email) = slack_user_email
+        .map(str::trim)
+        .filter(|email| !email.is_empty())
+    else {
+        return;
+    };
+    let Some(conversation_id) = slack_conversation_id(thread_key) else {
+        return;
+    };
+    if is_direct_message(Some(conversation_id)) && labels.contains_key("slack_user_id") {
+        labels.insert("slack_email".to_owned(), email.to_owned());
+    }
 }
 
 fn slack_permission(
@@ -231,6 +253,41 @@ mod tests {
             .slack_team_id,
             Some("T123")
         );
+    }
+
+    #[test]
+    fn session_principal_metadata_carries_slack_user_email() {
+        assert_eq!(
+            SessionPrincipalMetadata::from_session_metadata(Some(&json!({
+                "slack_user_email": "ada@example.com"
+            })))
+            .slack_user_email,
+            Some("ada@example.com")
+        );
+    }
+
+    #[test]
+    fn slack_dm_email_label_applies_only_to_dm_user_principals() {
+        let mut dm_labels = BTreeMap::new();
+        dm_labels.insert("slack_user_id".to_owned(), "U123".to_owned());
+        apply_slack_dm_email_label(
+            "slack:T123:D123:1773364194.179929",
+            Some(" ada@example.com "),
+            &mut dm_labels,
+        );
+        assert_eq!(
+            dm_labels.get("slack_email").map(String::as_str),
+            Some("ada@example.com")
+        );
+
+        let mut channel_labels = BTreeMap::new();
+        channel_labels.insert("slack_channel_id".to_owned(), "C123".to_owned());
+        apply_slack_dm_email_label(
+            "slack:T123:C123:1773364194.179929",
+            Some("ada@example.com"),
+            &mut channel_labels,
+        );
+        assert_eq!(channel_labels.get("slack_email"), None);
     }
 
     #[tokio::test]

--- a/services/slackbotv2/src/session-api.ts
+++ b/services/slackbotv2/src/session-api.ts
@@ -684,6 +684,7 @@ type RequesterIdentity = {
   githubHandleSource?: string
   githubUnavailableReason?: string
   slackDisplayName?: string
+  slackEmail?: string
   slackMention?: string
   slackTeamId?: string
   slackUserId?: string
@@ -778,13 +779,17 @@ async function postCreateSession(
   // iron-control; resolve it here so it rides the create-session metadata that
   // api-rs reads when it registers the principal.
   const conversationName = message ? await resolveConversationName(options, message) : undefined
+  const requesterIdentity =
+    message && slackConversationKind(slackConversationId(message)) === 'dm'
+      ? await resolveRequesterIdentity(options, message)
+      : undefined
   const body: SlackbotV2CreateSessionRequest = {
     harness_type: harnessType,
     metadata: {
       source: 'slackbotv2',
       platform: 'slack',
       thread_id: threadId,
-      ...sessionRequesterMetadata(message),
+      ...sessionRequesterMetadata(message, requesterIdentity),
       ...(conversationName ? { slack_conversation_name: conversationName } : {})
     },
     ...(onHarnessConflict ? { on_harness_conflict: onHarnessConflict } : {})
@@ -836,11 +841,13 @@ function sessionRequesterMetadata(
   const slackTeamId = identity?.slackTeamId ?? messageSlackTeamId(message)
   const slackUserName = identity?.slackUserName ?? message?.author.userName
   const slackDisplayName = identity?.slackDisplayName ?? message?.author.fullName
+  const slackEmail = identity?.slackEmail
   return {
     ...(slackUserId ? { slack_user_id: slackUserId } : {}),
     ...(slackTeamId ? { slack_team_id: slackTeamId } : {}),
     ...(slackUserName ? { slack_user_name: slackUserName } : {}),
     ...(slackDisplayName ? { slack_display_name: slackDisplayName } : {}),
+    ...(slackEmail ? { slack_user_email: slackEmail } : {}),
     ...(identity?.githubHandle ? { github_handle: identity.githubHandle } : {})
   }
 }
@@ -887,6 +894,7 @@ async function resolveRequesterIdentity(
     ?? stringValue(profile.real_name)
     ?? stringValue(profile.name)
     ?? identity.slackDisplayName
+  identity.slackEmail = stringValue(profile.email) ?? identity.slackEmail
   identity.slackUserName = stringValue(profile.name) ?? identity.slackUserName
 
   const github = extractGithubHandleFromSlackProfile(profile)
@@ -937,6 +945,7 @@ function mergeRequesterIdentity(
     ...fallback,
     ...cached,
     slackDisplayName: cached.slackDisplayName ?? fallback.slackDisplayName,
+    slackEmail: cached.slackEmail ?? fallback.slackEmail,
     slackMention: fallback.slackMention ?? cached.slackMention,
     slackTeamId: fallback.slackTeamId ?? cached.slackTeamId,
     slackUserId: fallback.slackUserId ?? cached.slackUserId,
@@ -962,6 +971,7 @@ async function fetchSlackUserProfile(
     if (!user && !profile) return null
     return {
       ...(user ?? {}),
+      ...(userProfile ?? {}),
       ...(profile ?? {}),
       ...(profile?.fields ? { fields: profile.fields } : {}),
       ...(profile?.custom_fields ? { custom_fields: profile.custom_fields } : {})

--- a/services/slackbotv2/test/session-api.test.ts
+++ b/services/slackbotv2/test/session-api.test.ts
@@ -815,6 +815,7 @@ describe('session principal display name', () => {
     metadata?: {
       slack_conversation_name?: string
       slack_team_id?: string
+      slack_user_email?: string
       slack_user_id?: string
     }
   } {
@@ -822,6 +823,7 @@ describe('session principal display name', () => {
       metadata?: {
         slack_conversation_name?: string
         slack_team_id?: string
+        slack_user_email?: string
         slack_user_id?: string
       }
     }
@@ -964,16 +966,25 @@ describe('session principal display name', () => {
     dm.threadId = 'slack:D9:1700000000.000100'
     dm.raw = { channel: 'D9' }
     await withSlackStub(
-      url =>
-        url.includes('users.info')
-          ? Response.json({ ok: true, user: { profile: { display_name: 'Ada Lovelace' } } })
-          : Response.json({ ok: true }),
+      url => {
+        if (url.includes('users.info')) {
+          return Response.json({
+            ok: true,
+            user: { profile: { display_name: 'Ada Lovelace', email: 'ada@example.com' } }
+          })
+        }
+        return Response.json({
+          ok: true,
+          profile: { display_name: 'Ada Lovelace' }
+        })
+      },
       async () => {
         await forwardToSessionApi(slackOptions(fetchFn), forwardInput(dm))
       }
     )
     expect(createBody(requests).metadata?.slack_conversation_name).toBe('Ada Lovelace')
     expect(createBody(requests).metadata?.slack_team_id).toBe('T1')
+    expect(createBody(requests).metadata?.slack_user_email).toBe('ada@example.com')
     expect(createBody(requests).metadata?.slack_user_id).toBe('U1')
   })
 


### PR DESCRIPTION
Adds Slack requester e-mail to DM create-session metadata when Slack exposes it, then applies it as a slack_email label on Slack DM user principals during iron-control registration. This keeps channel principals scoped to channel metadata while giving user-scoped DM principals an e-mail label for reconciliation and diagnostics.