### PR TITLE
fix: preserve console return path on login

### DIFF
--- a/services/console/app/controllers/application_controller.rb
+++ b/services/console/app/controllers/application_controller.rb
@@ -177,7 +177,7 @@ class ApplicationController < ActionController::Base
   end
 
   def store_return_to_for_login
-    return unless request.get?
+    return unless request.request_method == "GET"
 
     session[:return_to] = request.fullpath
   end

--- a/services/console/app/controllers/application_controller.rb
+++ b/services/console/app/controllers/application_controller.rb
@@ -90,7 +90,10 @@ class ApplicationController < ActionController::Base
   # before_action gate for console pages: bounce anonymous requests to the login
   # form rather than rendering the page.
   def require_login
-    redirect_to login_path unless current_user
+    return if current_user
+
+    store_return_to_for_login
+    redirect_to login_path
   end
 
   # Second gate, after require_login: a disabled user is signed out; a pending
@@ -171,6 +174,12 @@ class ApplicationController < ActionController::Base
     path = session.delete(:return_to).to_s
     return default_console_landing_path unless path.start_with?("/") && !path.start_with?("//")
     path
+  end
+
+  def store_return_to_for_login
+    return unless request.get?
+
+    session[:return_to] = request.fullpath
   end
 
   def safe_console_return_path(default: default_console_landing_path)

--- a/services/console/test/controllers/session_oauth_controller_test.rb
+++ b/services/console/test/controllers/session_oauth_controller_test.rb
@@ -115,6 +115,17 @@ class SessionOauthControllerTest < ActionDispatch::IntegrationTest
     assert_equal [ [ "google", "new-sub" ] ], user.user_identities.pluck(:provider, :subject)
   end
 
+  test "callback redirects to the protected console URL the user first requested" do
+    get console_credentials_url(kind: "oauth")
+    assert_redirected_to login_path
+    assert_equal "/console/credentials?kind=oauth", session[:return_to]
+
+    run_callback(sub: "returning-sub", email: "returning@example.com")
+    assert_redirected_to "/console/credentials?kind=oauth"
+    assert_equal User.find_by!(email: "returning@example.com").id, session[:user_id]
+    assert_nil session[:return_to]
+  end
+
   test "callback provisions a user inside the configured SSO domain allowlist" do
     ENV["CENTAUR_CONSOLE_SSO_EMAIL_DOMAINS"] = "example.com acme.example"
     assert_difference -> { User.count }, 1 do

--- a/services/console/test/controllers/sessions_controller_test.rb
+++ b/services/console/test/controllers/sessions_controller_test.rb
@@ -25,6 +25,26 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
     assert_equal @operator.id, session[:user_id]
   end
 
+  test "login redirects to the protected console URL the user first requested" do
+    get console_credentials_url(kind: "oauth")
+    assert_redirected_to login_path
+    assert_equal "/console/credentials?kind=oauth", session[:return_to]
+
+    post login_url, params: { email: @operator.email, password: "password123456" }
+    assert_redirected_to "/console/credentials?kind=oauth"
+    assert_equal @operator.id, session[:user_id]
+    assert_nil session[:return_to]
+  end
+
+  test "unsafe methods do not replace the remembered login destination" do
+    get console_credentials_url(kind: "oauth")
+    assert_equal "/console/credentials?kind=oauth", session[:return_to]
+
+    post console_roles_url, params: { role: { foreign_id: "new-role", namespace: "default" } }
+    assert_redirected_to login_path
+    assert_equal "/console/credentials?kind=oauth", session[:return_to]
+  end
+
   test "password login rejects credentials when disabled" do
     ENV["CENTAUR_CONSOLE_PASSWORD_LOGIN_ENABLED"] = "false"
     post login_url, params: { email: @operator.email, password: "password123456" }


### PR DESCRIPTION
Preserves the originally requested console URL when an unauthenticated user is redirected to login. The saved return path is consumed by both password and SSO login, with coverage for query strings and non-GET requests.