### PR TITLE
feat: add LLM message override strategy

### DIFF
--- a/contrib/chart/Chart.yaml
+++ b/contrib/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: centaur
 description: Helm chart for the trusted Centaur control plane
 type: application
-version: 0.1.103
+version: 0.1.104
 appVersion: "0.1.0"
 dependencies:
   - name: connect

--- a/contrib/chart/templates/slackbotv2.yaml
+++ b/contrib/chart/templates/slackbotv2.yaml
@@ -66,6 +66,11 @@ spec:
                 secretKeyRef:
                   name: {{ include "centaur.secretEnvName" . }}
                   key: {{ printf "%sDATABASE_URL" .Values.secretManager.envPrefix }}
+            - name: OPENAI_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "centaur.secretEnvName" . }}
+                  key: {{ printf "%sOPENAI_API_KEY" .Values.secretManager.envPrefix }}
             - name: SLACKBOTV2_USER_NAME
               value: {{ .Values.slackbotv2.userName | quote }}
             - name: SLACKBOTV2_ACTIVITY_SUMMARY_STATUS_ENABLED

--- a/contrib/chart/templates/slackbotv2.yaml
+++ b/contrib/chart/templates/slackbotv2.yaml
@@ -71,6 +71,7 @@ spec:
                 secretKeyRef:
                   name: {{ include "centaur.secretEnvName" . }}
                   key: {{ printf "%sOPENAI_API_KEY" .Values.secretManager.envPrefix }}
+                  optional: true
             - name: SLACKBOTV2_USER_NAME
               value: {{ .Values.slackbotv2.userName | quote }}
             - name: SLACKBOTV2_ACTIVITY_SUMMARY_STATUS_ENABLED

--- a/contrib/chart/templates/slackbotv2.yaml
+++ b/contrib/chart/templates/slackbotv2.yaml
@@ -70,6 +70,16 @@ spec:
               value: {{ .Values.slackbotv2.userName | quote }}
             - name: SLACKBOTV2_ACTIVITY_SUMMARY_STATUS_ENABLED
               value: {{ .Values.apiRs.activitySummary.enabled | quote }}
+            - name: SLACKBOTV2_MESSAGE_OVERRIDES_STRATEGY
+              value: {{ .Values.slackbotv2.messageOverridesStrategy.mode | quote }}
+            - name: SLACKBOTV2_MESSAGE_OVERRIDES_MODEL
+              value: {{ .Values.slackbotv2.messageOverridesStrategy.model | quote }}
+            - name: SLACKBOTV2_MESSAGE_OVERRIDES_OPENAI_BASE_URL
+              value: {{ .Values.slackbotv2.messageOverridesStrategy.openaiBaseUrl | quote }}
+            - name: SLACKBOTV2_MESSAGE_OVERRIDES_TIMEOUT_MS
+              value: {{ .Values.slackbotv2.messageOverridesStrategy.timeoutMs | quote }}
+            - name: SLACKBOTV2_MESSAGE_OVERRIDES_MAX_OUTPUT_TOKENS
+              value: {{ .Values.slackbotv2.messageOverridesStrategy.maxOutputTokens | quote }}
 {{- if $console.publicUrl }}
             # Public origin of the Console UI (matches the Console's own
             # CENTAUR_CONSOLE_PUBLIC_URL). When set, the first assistant message

--- a/contrib/chart/values.yaml
+++ b/contrib/chart/values.yaml
@@ -489,6 +489,18 @@ slackbotv2:
   #     C0ENG: { harness: claude, model: opus, reasoning: high }
   #     C0TRIAGE: { reasoning: low }
   channelDefaults: {}
+  # Message overrides strategy for Slack message text. "flags" keeps the legacy
+  # deterministic --model/--claude/-rsn strategy. "llm" asks a small model for
+  # normalized overrides, allowing natural language requests such as
+  # "use max effort and the sol model". In llm mode,
+  # set OPENAI_API_KEY in the shared secret or provide
+  # SLACKBOTV2_MESSAGE_OVERRIDES_OPENAI_API_KEY via extraEnv.
+  messageOverridesStrategy:
+    mode: flags
+    model: gpt-5.4-nano
+    openaiBaseUrl: https://api.openai.com/v1
+    timeoutMs: 1500
+    maxOutputTokens: 300
   metrics:
     # slackbotv2 serves Prometheus text metrics at /metrics. This flag only
     # controls scrape annotations for Prometheus/VictoriaMetrics-style discovery.

--- a/services/slackbotv2/src/index.ts
+++ b/services/slackbotv2/src/index.ts
@@ -778,7 +778,11 @@ async function syncThreadMessageToSession(
 
   const serializeStartedAtMs = nowMs()
   const serializedMessage = await serializeMessage(message, input.options)
-  const messageOverrides = await messageOverridesForText(input.options, serializedMessage.text, trace)
+  const messageOverrides = await messageOverridesForText(
+    input.options,
+    slackMessagePromptText(serializedMessage),
+    trace
+  )
   if (messageOverrides.cleanedText !== undefined) {
     setMessageText(serializedMessage, messageOverrides.cleanedText)
   }

--- a/services/slackbotv2/src/index.ts
+++ b/services/slackbotv2/src/index.ts
@@ -778,11 +778,7 @@ async function syncThreadMessageToSession(
 
   const serializeStartedAtMs = nowMs()
   const serializedMessage = await serializeMessage(message, input.options)
-  const messageOverrides = await messageOverridesForText(
-    input.options,
-    slackMessagePromptText(serializedMessage),
-    trace
-  )
+  const messageOverrides = await messageOverridesForText(input.options, serializedMessage.text, trace)
   if (messageOverrides.cleanedText !== undefined) {
     setMessageText(serializedMessage, messageOverrides.cleanedText)
   }

--- a/services/slackbotv2/src/index.ts
+++ b/services/slackbotv2/src/index.ts
@@ -50,7 +50,8 @@ import {
   type SlackContextBlock
 } from './console-session-link'
 import { resolveChannelDefault } from './channel-defaults'
-import { extractMessageOverrides } from './overrides'
+import { type HarnessOverrides } from './overrides'
+import { createFlagMessageOverridesStrategy } from './message-overrides-strategy'
 import { isAllowedSlackMessage, isAllowedSlackWebhookBody } from './slack-events'
 import { isSlackStopCommand } from './stop-command'
 import type {
@@ -148,6 +149,23 @@ type PendingLateSlackFileMention = {
 }
 
 type StickyThreadOverrides = Pick<SlackbotV2ThreadState, 'harnessType' | 'model' | 'provider'>
+const DEFAULT_MESSAGE_OVERRIDES_STRATEGY = createFlagMessageOverridesStrategy()
+
+export async function messageOverridesForText(
+  options: SlackbotV2Options,
+  text: string,
+  trace: SlackbotV2Trace
+): Promise<{ cleanedText?: string; overrides: HarnessOverrides }> {
+  const strategy = options.messageOverridesStrategy ?? DEFAULT_MESSAGE_OVERRIDES_STRATEGY
+  try {
+    return await strategy({ text })
+  } catch (error) {
+    traceWarn(options, 'slackbotv2_message_overrides_strategy_failed', trace, {
+      error: errorMessage(error)
+    })
+    return { overrides: {} }
+  }
+}
 
 function stickyThreadOverrideUpdate(
   overrides: StickyThreadOverrides
@@ -760,8 +778,11 @@ async function syncThreadMessageToSession(
 
   const serializeStartedAtMs = nowMs()
   const serializedMessage = await serializeMessage(message, input.options)
-  const overrides = extractMessageOverrides(serializedMessage.text)
-  setMessageText(serializedMessage, overrides.cleanedText)
+  const messageOverrides = await messageOverridesForText(input.options, serializedMessage.text, trace)
+  if (messageOverrides.cleanedText !== undefined) {
+    setMessageText(serializedMessage, messageOverrides.cleanedText)
+  }
+  const overrides = messageOverrides.overrides
   const stickyOverridesUpdate = stickyThreadOverrideUpdate(overrides)
   const effectiveOverrides = resolveStickyThreadOverrides(state, stickyOverridesUpdate)
   // Slack-only "Open chat in Console" link on the FIRST assistant message in

--- a/services/slackbotv2/src/index.ts
+++ b/services/slackbotv2/src/index.ts
@@ -665,6 +665,8 @@ type SyncThreadMessageInput = {
   options: SlackbotV2Options
   /** Number of in-process retries already spent on this message's handoff. */
   retryAttempt?: number
+  /** Resolved once per local handoff chain so retryable failures stay idempotent. */
+  resolvedMessageOverrides?: Awaited<ReturnType<typeof messageOverridesForText>>
   state: StateAdapter
 }
 
@@ -778,7 +780,13 @@ async function syncThreadMessageToSession(
 
   const serializeStartedAtMs = nowMs()
   const serializedMessage = await serializeMessage(message, input.options)
-  const messageOverrides = await messageOverridesForText(input.options, serializedMessage.text, trace)
+  const messageOverrides =
+    input.resolvedMessageOverrides ??
+    (input.resolvedMessageOverrides = await messageOverridesForText(
+      input.options,
+      serializedMessage.text,
+      trace
+    ))
   if (messageOverrides.cleanedText !== undefined) {
     setMessageText(serializedMessage, messageOverrides.cleanedText)
   }

--- a/services/slackbotv2/src/message-overrides-strategy.ts
+++ b/services/slackbotv2/src/message-overrides-strategy.ts
@@ -1,10 +1,9 @@
 import {
   extractMessageOverrides,
-  validateStrategyOverrides,
-  type HarnessOverrides
+  validateStrategyOverrides
 } from './overrides'
-import type { MessageOverridesStrategy } from './types'
-import { isJsonObject } from './utils'
+import type { JsonObject, MessageOverridesStrategy } from './types'
+import { errorMessage, isJsonObject } from './utils'
 
 const DEFAULT_TIMEOUT_MS = 1_500
 const DEFAULT_MAX_OUTPUT_TOKENS = 300
@@ -72,6 +71,7 @@ export type OpenAiMessageOverridesStrategyOptions = {
   apiKey: string
   baseUrl?: string
   fetch?: typeof fetch
+  logger?: (event: string, fields: JsonObject) => void
   maxOutputTokens?: number
   model: string
   timeoutMs?: number
@@ -128,26 +128,33 @@ export function createOpenAiMessageOverridesStrategy(
         method: 'POST',
         signal: controller.signal
       })
-      if (!response.ok) return emptyMessageOverrides()
+      if (!response.ok) {
+        throw new Error(
+          `message overrides strategy request failed with HTTP ${response.status} ${response.statusText}: ${await responseErrorText(response)}`
+        )
+      }
       const value = await response.json()
       const outputText = responseOutputText(value)
-      if (!outputText) return emptyMessageOverrides()
+      if (!outputText) {
+        throw new Error('message overrides strategy response did not include output text')
+      }
       const parsed = JSON.parse(outputText)
       return {
         overrides: validateStrategyOverrides(
           isJsonObject(parsed) ? (parsed as OpenAiMessageOverridesStrategyOutput) : null
         )
       }
-    } catch {
-      return emptyMessageOverrides()
+    } catch (error) {
+      options.logger?.('slackbotv2_message_overrides_strategy_request_failed', {
+        error: errorMessage(error),
+        model: options.model,
+        timeout_ms: timeoutMs
+      })
+      return { overrides: {} }
     } finally {
       clearTimeout(timeout)
     }
   }
-}
-
-function emptyMessageOverrides(): { overrides: HarnessOverrides } {
-  return { overrides: {} }
 }
 
 function responseOutputText(value: unknown): string | undefined {
@@ -161,4 +168,13 @@ function responseOutputText(value: unknown): string | undefined {
 
 function arrayValue(value: unknown): unknown[] {
   return Array.isArray(value) ? value : []
+}
+
+async function responseErrorText(response: Response): Promise<string> {
+  try {
+    const body = await response.text()
+    return body.trim().slice(0, 500) || '<empty body>'
+  } catch {
+    return '<unavailable body>'
+  }
 }

--- a/services/slackbotv2/src/message-overrides-strategy.ts
+++ b/services/slackbotv2/src/message-overrides-strategy.ts
@@ -1,0 +1,164 @@
+import {
+  extractMessageOverrides,
+  validateStrategyOverrides,
+  type HarnessOverrides
+} from './overrides'
+import type { MessageOverridesStrategy } from './types'
+import { isJsonObject } from './utils'
+
+const DEFAULT_TIMEOUT_MS = 1_500
+const DEFAULT_MAX_OUTPUT_TOKENS = 300
+
+const SYSTEM_PROMPT = [
+  'Decide whether the Slack message asks to use a specific AI harness, model, provider, or reasoning effort.',
+  'Return only canonical override values from the schema.',
+  'Use null for every field when the message does not ask to change model selection.',
+  'Allowed harness values: codex, claudecode, amp.',
+  'Allowed provider values: responses, amazon-bedrock, openrouter.',
+  'Allowed reasoning values: none, minimal, low, medium, high, xhigh, max.',
+  'Map fuzzy effort words to the nearest reasoning value by magnitude. Examples: tiny/cheap/fast -> low or minimal; normal/default -> medium; deep/strong/intense -> high or xhigh; maximum/superduper/biggest -> max.',
+  'Return reasoning even when the requested model is not Codex; validation will ignore reasoning that cannot apply.',
+  'Map OpenAI model aliases to canonical IDs: sol -> gpt-5.6-sol, terra -> gpt-5.6-terra, luna -> gpt-5.6-luna, 5.5 -> gpt-5.5, 5.5 pro -> gpt-5.5-pro, 5.4 -> gpt-5.4, 5.4 pro -> gpt-5.4-pro, 5.4 mini -> gpt-5.4-mini, 5.4 nano -> gpt-5.4-nano.',
+  'Map Claude model aliases to canonical IDs: fable -> claude-fable-5, opus -> claude-opus-4-8, sonnet -> claude-sonnet-5, haiku -> claude-haiku-4-5.',
+  'Map Amp model aliases to canonical IDs: deep -> deep, fast -> fast.',
+  'For example, "use max effort and the sol model" should return model "gpt-5.6-sol" and reasoning "max".',
+  'Do not treat ordinary discussion of model names as a selection request.'
+].join('\n')
+
+const MODEL_VALUES = [
+  'claude-fable-5',
+  'claude-haiku-4-5',
+  'claude-opus-4-8',
+  'claude-sonnet-5',
+  'deep',
+  'fast',
+  'gpt-5.4',
+  'gpt-5.4-mini',
+  'gpt-5.4-nano',
+  'gpt-5.4-pro',
+  'gpt-5.5',
+  'gpt-5.5-pro',
+  'gpt-5.6-luna',
+  'gpt-5.6-sol',
+  'gpt-5.6-terra',
+  null
+] as const
+
+const MESSAGE_OVERRIDES_SCHEMA = {
+  additionalProperties: false,
+  properties: {
+    harness: {
+      enum: ['codex', 'claudecode', 'amp', null],
+      type: ['string', 'null']
+    },
+    model: {
+      enum: MODEL_VALUES,
+      type: ['string', 'null']
+    },
+    provider: {
+      enum: ['responses', 'amazon-bedrock', 'openrouter', null],
+      type: ['string', 'null']
+    },
+    reasoning: {
+      enum: ['none', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max', null],
+      type: ['string', 'null']
+    }
+  },
+  required: ['harness', 'model', 'provider', 'reasoning'],
+  type: 'object'
+}
+
+export type OpenAiMessageOverridesStrategyOptions = {
+  apiKey: string
+  baseUrl?: string
+  fetch?: typeof fetch
+  maxOutputTokens?: number
+  model: string
+  timeoutMs?: number
+}
+
+type OpenAiMessageOverridesStrategyOutput = {
+  harness?: unknown
+  model?: unknown
+  provider?: unknown
+  reasoning?: unknown
+}
+
+export function createFlagMessageOverridesStrategy(): MessageOverridesStrategy {
+  return async ({ text }) => {
+    const parsed = extractMessageOverrides(text)
+    const { cleanedText, ...overrides } = parsed
+    return { cleanedText, overrides }
+  }
+}
+
+export function createOpenAiMessageOverridesStrategy(
+  options: OpenAiMessageOverridesStrategyOptions
+): MessageOverridesStrategy {
+  const responsesUrl = `${(options.baseUrl ?? 'https://api.openai.com/v1').replace(/\/+$/, '')}/responses`
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS
+  const maxOutputTokens = options.maxOutputTokens ?? DEFAULT_MAX_OUTPUT_TOKENS
+  const fetchFn = options.fetch ?? fetch
+
+  return async ({ text }) => {
+    const controller = new AbortController()
+    const timeout = setTimeout(() => controller.abort(), timeoutMs)
+    try {
+      const response = await fetchFn(responsesUrl, {
+        body: JSON.stringify({
+          input: text,
+          instructions: SYSTEM_PROMPT,
+          max_output_tokens: maxOutputTokens,
+          model: options.model,
+          reasoning: { effort: 'none' },
+          store: false,
+          text: {
+            format: {
+              name: 'slack_message_overrides',
+              schema: MESSAGE_OVERRIDES_SCHEMA,
+              strict: true,
+              type: 'json_schema'
+            }
+          }
+        }),
+        headers: {
+          authorization: `Bearer ${options.apiKey}`,
+          'content-type': 'application/json'
+        },
+        method: 'POST',
+        signal: controller.signal
+      })
+      if (!response.ok) return emptyMessageOverrides()
+      const value = await response.json()
+      const outputText = responseOutputText(value)
+      if (!outputText) return emptyMessageOverrides()
+      const parsed = JSON.parse(outputText)
+      return {
+        overrides: validateStrategyOverrides(
+          isJsonObject(parsed) ? (parsed as OpenAiMessageOverridesStrategyOutput) : null
+        )
+      }
+    } catch {
+      return emptyMessageOverrides()
+    } finally {
+      clearTimeout(timeout)
+    }
+  }
+}
+
+function emptyMessageOverrides(): { overrides: HarnessOverrides } {
+  return { overrides: {} }
+}
+
+function responseOutputText(value: unknown): string | undefined {
+  const parts = arrayValue(isJsonObject(value) ? value.output : undefined).flatMap(item =>
+    arrayValue(isJsonObject(item) ? item.content : undefined).flatMap(content =>
+      isJsonObject(content) && typeof content.text === 'string' ? [content.text] : []
+    )
+  )
+  return parts.length > 0 ? parts.join('\n') : undefined
+}
+
+function arrayValue(value: unknown): unknown[] {
+  return Array.isArray(value) ? value : []
+}

--- a/services/slackbotv2/src/message-overrides-strategy.ts
+++ b/services/slackbotv2/src/message-overrides-strategy.ts
@@ -18,7 +18,7 @@ const SYSTEM_PROMPT = [
   'Map fuzzy effort words to the nearest reasoning value by magnitude. Examples: tiny/cheap/fast -> low or minimal; normal/default -> medium; deep/strong/intense -> high or xhigh; maximum/superduper/biggest -> max.',
   'Return reasoning even when the requested model is not Codex; validation will ignore reasoning that cannot apply.',
   'Map OpenAI model aliases to canonical IDs: sol -> gpt-5.6-sol, terra -> gpt-5.6-terra, luna -> gpt-5.6-luna, 5.5 -> gpt-5.5, 5.5 pro -> gpt-5.5-pro, 5.4 -> gpt-5.4, 5.4 pro -> gpt-5.4-pro, 5.4 mini -> gpt-5.4-mini, 5.4 nano -> gpt-5.4-nano.',
-  'Map Claude model aliases to canonical IDs: fable -> claude-fable-5, opus -> claude-opus-4-8, sonnet -> claude-sonnet-4-6, haiku -> claude-haiku-4-5.',
+  'Map Claude model aliases to canonical IDs: fable -> claude-fable-5, opus -> claude-opus-4-8, sonnet -> claude-sonnet-4-6, sonnet 5 -> claude-sonnet-5, haiku -> claude-haiku-4-5.',
   'Map Amp model aliases to canonical IDs: deep -> deep, fast -> fast.',
   'For example, "use max effort and the sol model" should return model "gpt-5.6-sol" and reasoning "max".',
   'Do not treat ordinary discussion of model names as a selection request.'
@@ -29,6 +29,7 @@ const MODEL_VALUES = [
   'claude-haiku-4-5',
   'claude-opus-4-8',
   'claude-sonnet-4-6',
+  'claude-sonnet-5',
   'deep',
   'fast',
   'gpt-5.4',

--- a/services/slackbotv2/src/message-overrides-strategy.ts
+++ b/services/slackbotv2/src/message-overrides-strategy.ts
@@ -130,7 +130,7 @@ export function createOpenAiMessageOverridesStrategy(
       })
       if (!response.ok) {
         throw new Error(
-          `message overrides strategy request failed with HTTP ${response.status} ${response.statusText}: ${await responseErrorText(response)}`
+          `message overrides strategy request failed with HTTP ${response.status} ${response.statusText}`
         )
       }
       const value = await response.json()
@@ -168,13 +168,4 @@ function responseOutputText(value: unknown): string | undefined {
 
 function arrayValue(value: unknown): unknown[] {
   return Array.isArray(value) ? value : []
-}
-
-async function responseErrorText(response: Response): Promise<string> {
-  try {
-    const body = await response.text()
-    return body.trim().slice(0, 500) || '<empty body>'
-  } catch {
-    return '<unavailable body>'
-  }
 }

--- a/services/slackbotv2/src/message-overrides-strategy.ts
+++ b/services/slackbotv2/src/message-overrides-strategy.ts
@@ -2,7 +2,7 @@ import {
   extractMessageOverrides,
   validateStrategyOverrides
 } from './overrides'
-import type { JsonObject, MessageOverridesStrategy } from './types'
+import type { JsonObject, JsonValue, MessageOverridesStrategy } from './types'
 import { errorMessage, isJsonObject } from './utils'
 
 const DEFAULT_TIMEOUT_MS = 1_500
@@ -135,6 +135,10 @@ export function createOpenAiMessageOverridesStrategy(
         )
       }
       const value = await response.json()
+      options.logger?.('slackbotv2_message_overrides_strategy_response_received', {
+        model: options.model,
+        response_body: value as JsonValue
+      })
       const outputText = responseOutputText(value)
       if (!outputText) {
         throw new Error('message overrides strategy response did not include output text')

--- a/services/slackbotv2/src/message-overrides-strategy.ts
+++ b/services/slackbotv2/src/message-overrides-strategy.ts
@@ -18,7 +18,7 @@ const SYSTEM_PROMPT = [
   'Map fuzzy effort words to the nearest reasoning value by magnitude. Examples: tiny/cheap/fast -> low or minimal; normal/default -> medium; deep/strong/intense -> high or xhigh; maximum/superduper/biggest -> max.',
   'Return reasoning even when the requested model is not Codex; validation will ignore reasoning that cannot apply.',
   'Map OpenAI model aliases to canonical IDs: sol -> gpt-5.6-sol, terra -> gpt-5.6-terra, luna -> gpt-5.6-luna, 5.5 -> gpt-5.5, 5.5 pro -> gpt-5.5-pro, 5.4 -> gpt-5.4, 5.4 pro -> gpt-5.4-pro, 5.4 mini -> gpt-5.4-mini, 5.4 nano -> gpt-5.4-nano.',
-  'Map Claude model aliases to canonical IDs: fable -> claude-fable-5, opus -> claude-opus-4-8, sonnet -> claude-sonnet-5, haiku -> claude-haiku-4-5.',
+  'Map Claude model aliases to canonical IDs: fable -> claude-fable-5, opus -> claude-opus-4-8, sonnet -> claude-sonnet-4-6, haiku -> claude-haiku-4-5.',
   'Map Amp model aliases to canonical IDs: deep -> deep, fast -> fast.',
   'For example, "use max effort and the sol model" should return model "gpt-5.6-sol" and reasoning "max".',
   'Do not treat ordinary discussion of model names as a selection request.'
@@ -28,7 +28,7 @@ const MODEL_VALUES = [
   'claude-fable-5',
   'claude-haiku-4-5',
   'claude-opus-4-8',
-  'claude-sonnet-5',
+  'claude-sonnet-4-6',
   'deep',
   'fast',
   'gpt-5.4',

--- a/services/slackbotv2/src/overrides.ts
+++ b/services/slackbotv2/src/overrides.ts
@@ -70,6 +70,36 @@ const MODEL_SHORTCUTS: Record<string, { harnessType: string; model: string }> =
     ])
   )
 
+const STRATEGY_HARNESSES = new Set(['amp', 'claudecode', 'codex'])
+const STRATEGY_PROVIDERS = new Set(['amazon-bedrock', 'openrouter', 'responses'])
+const STRATEGY_REASONING_EFFORTS = new Set([
+  'none',
+  'minimal',
+  'low',
+  'medium',
+  'high',
+  'xhigh',
+  'max'
+])
+
+const STRATEGY_MODEL_HARNESSES: Record<string, string> = {
+  'claude-fable-5': 'claudecode',
+  'claude-haiku-4-5': 'claudecode',
+  'claude-opus-4-8': 'claudecode',
+  'claude-sonnet-5': 'claudecode',
+  deep: 'amp',
+  fast: 'amp',
+  'gpt-5.4': 'codex',
+  'gpt-5.4-mini': 'codex',
+  'gpt-5.4-nano': 'codex',
+  'gpt-5.4-pro': 'codex',
+  'gpt-5.5': 'codex',
+  'gpt-5.5-pro': 'codex',
+  'gpt-5.6-luna': 'codex',
+  'gpt-5.6-sol': 'codex',
+  'gpt-5.6-terra': 'codex'
+}
+
 // Values are one horizontal-whitespace-delimited token; a newline after the
 // value starts the user's prompt, not part of the model/reasoning value.
 const MODEL_VALUE_SEPARATOR = String.raw`(?:[^\S\r\n]*=[^\S\r\n]*|[^\S\r\n]+)`
@@ -156,6 +186,55 @@ export function extractMessageOverrides(text: string): MessageOverrides {
     provider,
     reasoning
   }
+}
+
+export function validateStrategyOverrides(
+  raw: {
+    harness?: unknown
+    model?: unknown
+    provider?: unknown
+    reasoning?: unknown
+  } | null | undefined
+): HarnessOverrides {
+  if (!raw || typeof raw !== 'object') return {}
+  let harnessType: string | undefined
+  let model: string | undefined
+  let provider: string | undefined
+  let reasoning: string | undefined
+
+  const harnessRaw = cleanString(raw.harness)
+  if (harnessRaw) {
+    const normalized = harnessRaw.toLowerCase()
+    if (!STRATEGY_HARNESSES.has(normalized)) return {}
+    harnessType = normalized
+  }
+
+  const providerRaw = cleanString(raw.provider)
+  if (providerRaw) {
+    const normalized = providerRaw.toLowerCase()
+    if (!STRATEGY_PROVIDERS.has(normalized)) return {}
+    provider = normalized
+    if (harnessType && harnessType !== 'codex') return {}
+    harnessType = 'codex'
+  }
+
+  const modelRaw = cleanString(raw.model)
+  if (modelRaw) {
+    const modelHarness = STRATEGY_MODEL_HARNESSES[modelRaw.toLowerCase()]
+    if (!modelHarness) return {}
+    if (harnessType && harnessType !== modelHarness) return {}
+    model = modelRaw.toLowerCase()
+    harnessType = modelHarness
+  }
+
+  const reasoningRaw = cleanString(raw.reasoning)
+  if (reasoningRaw) {
+    const normalized = reasoningRaw.toLowerCase()
+    if (!STRATEGY_REASONING_EFFORTS.has(normalized)) return {}
+    reasoning = harnessType === undefined || harnessType === 'codex' ? normalized : undefined
+  }
+
+  return { harnessType, model, provider, reasoning }
 }
 
 /**

--- a/services/slackbotv2/src/overrides.ts
+++ b/services/slackbotv2/src/overrides.ts
@@ -87,6 +87,7 @@ const STRATEGY_MODEL_HARNESSES: Record<string, string> = {
   'claude-haiku-4-5': 'claudecode',
   'claude-opus-4-8': 'claudecode',
   'claude-sonnet-4-6': 'claudecode',
+  'claude-sonnet-5': 'claudecode',
   deep: 'amp',
   fast: 'amp',
   'gpt-5.4': 'codex',

--- a/services/slackbotv2/src/overrides.ts
+++ b/services/slackbotv2/src/overrides.ts
@@ -86,7 +86,7 @@ const STRATEGY_MODEL_HARNESSES: Record<string, string> = {
   'claude-fable-5': 'claudecode',
   'claude-haiku-4-5': 'claudecode',
   'claude-opus-4-8': 'claudecode',
-  'claude-sonnet-5': 'claudecode',
+  'claude-sonnet-4-6': 'claudecode',
   deep: 'amp',
   fast: 'amp',
   'gpt-5.4': 'codex',

--- a/services/slackbotv2/src/server.ts
+++ b/services/slackbotv2/src/server.ts
@@ -1,10 +1,19 @@
 import { createSlackbotV2, type SlackbotV2Options } from './index'
 import { parseChannelDefaults } from './channel-defaults'
+import {
+  createFlagMessageOverridesStrategy,
+  createOpenAiMessageOverridesStrategy
+} from './message-overrides-strategy'
 
 const port = numberEnv('PORT', 3002)
 const apiUrl = stringEnv('CENTAUR_API_URL', 'http://127.0.0.1:8080')
 const botToken = requiredEnv('SLACK_BOT_TOKEN')
 const signingSecret = requiredEnv('SLACK_SIGNING_SECRET')
+const messageOverridesStrategyMode = messageOverridesStrategyModeEnv(
+  'SLACKBOTV2_MESSAGE_OVERRIDES_STRATEGY'
+)
+const messageOverridesStrategyApiKey =
+  optionalEnv('SLACKBOTV2_MESSAGE_OVERRIDES_OPENAI_API_KEY') ?? optionalEnv('OPENAI_API_KEY')
 
 // Default to info: the chat adapter logs entire raw Slack webhook bodies at
 // debug, and JSON-serializing those multi-hundred-KB payloads on the hot path
@@ -46,6 +55,7 @@ const options: SlackbotV2Options = {
   },
   idleTimeoutMs: optionalNumberEnv('SESSION_IDLE_TIMEOUT_MS'),
   maxDurationMs: optionalNumberEnv('SESSION_MAX_DURATION_MS'),
+  messageOverridesStrategy: createMessageOverridesStrategy(),
   postgresUrl:
     optionalEnv('SLACKBOTV2_DATABASE_URL') ??
     optionalEnv('DATABASE_URL') ??
@@ -75,6 +85,9 @@ console.log(
     event: 'slackbotv2_started',
     service: 'slackbotv2',
     activity_summary_status_enabled: options.activitySummaryStatusEnabled,
+    message_overrides_strategy: messageOverridesStrategyMode,
+    message_overrides_strategy_enabled:
+      messageOverridesStrategyMode !== 'llm' || Boolean(messageOverridesStrategyApiKey),
     port: server.port,
     api_url: apiUrl
   })
@@ -107,6 +120,27 @@ function booleanEnv(name: string, fallback: boolean): boolean {
   if (['1', 'true', 'yes', 'on'].includes(value.toLowerCase())) return true
   if (['0', 'false', 'no', 'off'].includes(value.toLowerCase())) return false
   throw new Error(`${name} must be a boolean`)
+}
+
+function messageOverridesStrategyModeEnv(name: string): 'flags' | 'llm' {
+  const value = optionalEnv(name)?.toLowerCase()
+  if (!value) return 'flags'
+  if (value === 'flags' || value === 'llm') return value
+  throw new Error(`${name} must be "flags" or "llm"`)
+}
+
+function createMessageOverridesStrategy(): SlackbotV2Options['messageOverridesStrategy'] {
+  if (messageOverridesStrategyMode !== 'llm') return createFlagMessageOverridesStrategy()
+  if (!messageOverridesStrategyApiKey) {
+    return async () => ({ overrides: {} })
+  }
+  return createOpenAiMessageOverridesStrategy({
+    apiKey: messageOverridesStrategyApiKey,
+    baseUrl: optionalEnv('SLACKBOTV2_MESSAGE_OVERRIDES_OPENAI_BASE_URL'),
+    maxOutputTokens: optionalNumberEnv('SLACKBOTV2_MESSAGE_OVERRIDES_MAX_OUTPUT_TOKENS'),
+    model: stringEnv('SLACKBOTV2_MESSAGE_OVERRIDES_MODEL', 'gpt-5.4-nano'),
+    timeoutMs: optionalNumberEnv('SLACKBOTV2_MESSAGE_OVERRIDES_TIMEOUT_MS')
+  })
 }
 
 function optionalNumberEnv(name: string): number | undefined {

--- a/services/slackbotv2/src/server.ts
+++ b/services/slackbotv2/src/server.ts
@@ -137,6 +137,7 @@ function createMessageOverridesStrategy(): SlackbotV2Options['messageOverridesSt
   return createOpenAiMessageOverridesStrategy({
     apiKey: messageOverridesStrategyApiKey,
     baseUrl: optionalEnv('SLACKBOTV2_MESSAGE_OVERRIDES_OPENAI_BASE_URL'),
+    logger: (event, fields) => consoleLogger.warn(event, fields),
     maxOutputTokens: optionalNumberEnv('SLACKBOTV2_MESSAGE_OVERRIDES_MAX_OUTPUT_TOKENS'),
     model: stringEnv('SLACKBOTV2_MESSAGE_OVERRIDES_MODEL', 'gpt-5.4-nano'),
     timeoutMs: optionalNumberEnv('SLACKBOTV2_MESSAGE_OVERRIDES_TIMEOUT_MS')

--- a/services/slackbotv2/src/types.ts
+++ b/services/slackbotv2/src/types.ts
@@ -3,6 +3,7 @@ import type { CodexAppServerToChatStreamOptions } from '@centaur/rendering'
 import type { Attachment, Chat, Logger, StateAdapter } from 'chat'
 import type { Hono } from 'hono'
 import type { ChannelDefaults } from './channel-defaults'
+import type { HarnessOverrides } from './overrides'
 import type { SlackDisplayTextSource } from './slack-display-text'
 
 export type JsonPrimitive = string | number | boolean | null
@@ -139,6 +140,8 @@ export type SlackbotV2Options = {
    * harness config files (see console-session-link.ts).
    */
   harnessDefaultModels?: Record<string, string>
+  /** Strategy for resolving message-level harness/model/provider/reasoning overrides. */
+  messageOverridesStrategy?: MessageOverridesStrategy
   /**
    * Backoff delays between in-process retries of a Slack handoff after a
    * retryable session API failure. Slack's own webhook redelivery cannot
@@ -171,6 +174,19 @@ export type SlackbotV2Options = {
   userName?: string
   mapper?: CodexAppServerToChatStreamOptions
 }
+
+export type MessageOverridesStrategyInput = {
+  text: string
+}
+
+export type MessageOverridesStrategyResult = {
+  cleanedText?: string
+  overrides: HarnessOverrides
+}
+
+export type MessageOverridesStrategy = (
+  input: MessageOverridesStrategyInput
+) => Promise<MessageOverridesStrategyResult>
 
 export type SlackbotV2 = {
   app: Hono

--- a/services/slackbotv2/test/channel-defaults.test.ts
+++ b/services/slackbotv2/test/channel-defaults.test.ts
@@ -40,7 +40,12 @@ describe('parseChannelDefaults', () => {
     // with no `harness` inherits the thread/deployment harness rather than one
     // guessed from the model name.
     expect(
-      parseChannelDefaults(JSON.stringify({ C0A: { model: 'opus' }, C0B: { model: 'gpt-5.2' } }))
+      parseChannelDefaults(
+        JSON.stringify({
+          C0A: { model: 'opus' },
+          C0B: { model: 'gpt-5.2' }
+        })
+      )
     ).toEqual({
       C0A: { model: 'claude-opus-4-8' },
       C0B: { model: 'gpt-5.2' }

--- a/services/slackbotv2/test/chat-sdk-emulate.test.ts
+++ b/services/slackbotv2/test/chat-sdk-emulate.test.ts
@@ -4125,7 +4125,19 @@ describe('slackbotv2', () => {
   })
 
   it('reuses an accepted execution when the local retry follows a lost execute response', async () => {
-    bot = createTestBot({ handoffRetryDelaysMs: [50] })
+    let overrideStrategyCalls = 0
+    bot = createTestBot({
+      handoffRetryDelaysMs: [50],
+      messageOverridesStrategy: async () => {
+        overrideStrategyCalls += 1
+        return {
+          overrides: {
+            harnessType: overrideStrategyCalls === 1 ? 'claudecode' : 'codex',
+            model: overrideStrategyCalls === 1 ? 'claude-opus-4-8' : 'gpt-5.6-sol'
+          }
+        }
+      }
+    })
     codexApi.failNextExecuteAfterAccept = true
 
     const parent = await postUserMessage('History before response loss.')
@@ -4160,6 +4172,15 @@ describe('slackbotv2', () => {
     expect(codexApi.executes.map(execute => execute.body.idempotency_key)).toEqual([
       mention.ts,
       mention.ts
+    ])
+    expect(overrideStrategyCalls).toBe(1)
+    expect(
+      codexApi.executes.map(execute =>
+        JSON.parse(execute.body.input_lines.at(-1) ?? '{}') as Record<string, unknown>
+      )
+    ).toEqual([
+      expect.objectContaining({ model: 'claude-opus-4-8' }),
+      expect.objectContaining({ model: 'claude-opus-4-8' })
     ])
     expect(codexApi.appends).toHaveLength(1)
     expect(codexApi.eventRequests).toHaveLength(1)

--- a/services/slackbotv2/test/chat-sdk-emulate.test.ts
+++ b/services/slackbotv2/test/chat-sdk-emulate.test.ts
@@ -436,64 +436,6 @@ describe('slackbotv2', () => {
     )
   })
 
-  it('classifies message overrides using raw Slack block prompt text', async () => {
-    const strategyInputs: string[] = []
-    bot = createTestBot({
-      messageOverridesStrategy: async ({ text }) => {
-        strategyInputs.push(text)
-        return text.includes('use max effort and sol')
-          ? {
-              overrides: {
-                harnessType: 'codex',
-                model: 'gpt-5.6-sol',
-                reasoning: 'max'
-              }
-            }
-          : { overrides: {} }
-      }
-    })
-
-    const waits: Promise<unknown>[] = []
-    const response = await bot.app.request(
-      '/api/webhooks/slack',
-      signedSlackEvent({
-        event_id: 'Ev-slackbotv2-block-message-overrides',
-        event: {
-          type: 'app_mention',
-          user: USER_ID,
-          channel: CHANNEL_ID,
-          team: TEAM_ID,
-          ts: '1700000000.000200',
-          text: '',
-          blocks: [
-            {
-              type: 'section',
-              text: {
-                type: 'mrkdwn',
-                text: `<@${BOT_USER_ID}> use max effort and sol`
-              }
-            }
-          ]
-        }
-      }),
-      {},
-      waitUntilContext(waits)
-    )
-    expect(response.status).toBe(200)
-    await Promise.all(waits)
-
-    expect(strategyInputs).toEqual([`@${BOT_USER_ID} use max effort and sol`])
-    expect(codexApi.creates.map(create => create.body.harness_type)).toEqual(['codex'])
-    expect(codexApi.executes).toHaveLength(1)
-    const inputLine = JSON.parse(codexApi.executes[0]!.body.input_lines.at(-1)!) as Record<
-      string,
-      unknown
-    >
-    expect(inputLine.model).toBe('gpt-5.6-sol')
-    expect(inputLine.reasoning).toBe('max')
-    expect(JSON.stringify(inputLine)).toContain('use max effort and sol')
-  })
-
   it('appends an Open-session-in-Console context block to the first assistant message only', async () => {
     const sharedState = createMemoryState()
     await sharedState.connect()

--- a/services/slackbotv2/test/chat-sdk-emulate.test.ts
+++ b/services/slackbotv2/test/chat-sdk-emulate.test.ts
@@ -436,6 +436,64 @@ describe('slackbotv2', () => {
     )
   })
 
+  it('classifies message overrides using raw Slack block prompt text', async () => {
+    const strategyInputs: string[] = []
+    bot = createTestBot({
+      messageOverridesStrategy: async ({ text }) => {
+        strategyInputs.push(text)
+        return text.includes('use max effort and sol')
+          ? {
+              overrides: {
+                harnessType: 'codex',
+                model: 'gpt-5.6-sol',
+                reasoning: 'max'
+              }
+            }
+          : { overrides: {} }
+      }
+    })
+
+    const waits: Promise<unknown>[] = []
+    const response = await bot.app.request(
+      '/api/webhooks/slack',
+      signedSlackEvent({
+        event_id: 'Ev-slackbotv2-block-message-overrides',
+        event: {
+          type: 'app_mention',
+          user: USER_ID,
+          channel: CHANNEL_ID,
+          team: TEAM_ID,
+          ts: '1700000000.000200',
+          text: '',
+          blocks: [
+            {
+              type: 'section',
+              text: {
+                type: 'mrkdwn',
+                text: `<@${BOT_USER_ID}> use max effort and sol`
+              }
+            }
+          ]
+        }
+      }),
+      {},
+      waitUntilContext(waits)
+    )
+    expect(response.status).toBe(200)
+    await Promise.all(waits)
+
+    expect(strategyInputs).toEqual([`@${BOT_USER_ID} use max effort and sol`])
+    expect(codexApi.creates.map(create => create.body.harness_type)).toEqual(['codex'])
+    expect(codexApi.executes).toHaveLength(1)
+    const inputLine = JSON.parse(codexApi.executes[0]!.body.input_lines.at(-1)!) as Record<
+      string,
+      unknown
+    >
+    expect(inputLine.model).toBe('gpt-5.6-sol')
+    expect(inputLine.reasoning).toBe('max')
+    expect(JSON.stringify(inputLine)).toContain('use max effort and sol')
+  })
+
   it('appends an Open-session-in-Console context block to the first assistant message only', async () => {
     const sharedState = createMemoryState()
     await sharedState.connect()

--- a/services/slackbotv2/test/overrides.test.ts
+++ b/services/slackbotv2/test/overrides.test.ts
@@ -363,11 +363,16 @@ describe('validateStrategyOverrides', () => {
       provider: undefined,
       reasoning: undefined
     })
+    expect(validateStrategyOverrides({ model: 'claude-sonnet-5' })).toEqual({
+      harnessType: 'claudecode',
+      model: 'claude-sonnet-5',
+      provider: undefined,
+      reasoning: undefined
+    })
   })
 
   test('rejects aliases and arbitrary model ids from the strategy path', () => {
     expect(validateStrategyOverrides({ model: 'terra' })).toEqual({})
-    expect(validateStrategyOverrides({ model: 'claude-sonnet-5' })).toEqual({})
     expect(validateStrategyOverrides({ model: 'anthropic/claude-fable-5' })).toEqual({})
     expect(validateStrategyOverrides({ model: 'not real model id' })).toEqual({})
   })

--- a/services/slackbotv2/test/overrides.test.ts
+++ b/services/slackbotv2/test/overrides.test.ts
@@ -357,10 +357,17 @@ describe('validateStrategyOverrides', () => {
       provider: undefined,
       reasoning: undefined
     })
+    expect(validateStrategyOverrides({ model: 'claude-sonnet-4-6' })).toEqual({
+      harnessType: 'claudecode',
+      model: 'claude-sonnet-4-6',
+      provider: undefined,
+      reasoning: undefined
+    })
   })
 
   test('rejects aliases and arbitrary model ids from the strategy path', () => {
     expect(validateStrategyOverrides({ model: 'terra' })).toEqual({})
+    expect(validateStrategyOverrides({ model: 'claude-sonnet-5' })).toEqual({})
     expect(validateStrategyOverrides({ model: 'anthropic/claude-fable-5' })).toEqual({})
     expect(validateStrategyOverrides({ model: 'not real model id' })).toEqual({})
   })

--- a/services/slackbotv2/test/overrides.test.ts
+++ b/services/slackbotv2/test/overrides.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, test } from 'bun:test'
 import { SlackFormatConverter } from '@chat-adapter/slack'
-import { extractMessageOverrides, normalizeHarnessOverrides } from '../src/overrides'
+import {
+  extractMessageOverrides,
+  normalizeHarnessOverrides,
+  validateStrategyOverrides
+} from '../src/overrides'
+import { messageOverridesForText } from '../src/index'
+import type { SlackbotV2Options, SlackbotV2Trace } from '../src/types'
 
 describe('extractMessageOverrides', () => {
   test('returns text untouched without flags', () => {
@@ -302,6 +308,167 @@ describe('normalizeHarnessOverrides', () => {
     expect(errors.some(e => e.includes('unknown reasoning effort'))).toBe(true)
   })
 })
+
+describe('validateStrategyOverrides', () => {
+  test('accepts canonical strategy model ids', () => {
+    expect(
+      validateStrategyOverrides({
+        model: 'gpt-5.6-sol',
+        reasoning: 'max'
+      })
+    ).toEqual({
+      harnessType: 'codex',
+      model: 'gpt-5.6-sol',
+      provider: undefined,
+      reasoning: 'max'
+    })
+  })
+
+  test('accepts canonical OpenAI model ids from the model catalog', () => {
+    expect(validateStrategyOverrides({ model: 'gpt-5.6-terra' })).toEqual({
+      harnessType: 'codex',
+      model: 'gpt-5.6-terra',
+      provider: undefined,
+      reasoning: undefined
+    })
+    expect(validateStrategyOverrides({ model: 'gpt-5.6-luna' })).toEqual({
+      harnessType: 'codex',
+      model: 'gpt-5.6-luna',
+      provider: undefined,
+      reasoning: undefined
+    })
+    expect(validateStrategyOverrides({ model: 'gpt-5.5-pro' })).toEqual({
+      harnessType: 'codex',
+      model: 'gpt-5.5-pro',
+      provider: undefined,
+      reasoning: undefined
+    })
+  })
+
+  test('canonical strategy model ids imply their compatible harness', () => {
+    expect(
+      validateStrategyOverrides({
+        model: 'claude-opus-4-8'
+      })
+    ).toEqual({
+      harnessType: 'claudecode',
+      model: 'claude-opus-4-8',
+      provider: undefined,
+      reasoning: undefined
+    })
+  })
+
+  test('rejects aliases and arbitrary model ids from the strategy path', () => {
+    expect(validateStrategyOverrides({ model: 'terra' })).toEqual({})
+    expect(validateStrategyOverrides({ model: 'anthropic/claude-fable-5' })).toEqual({})
+    expect(validateStrategyOverrides({ model: 'not real model id' })).toEqual({})
+  })
+
+  test('rejects incompatible canonical strategy fields', () => {
+    expect(validateStrategyOverrides({ harness: 'codex', model: 'claude-opus-4-8' })).toEqual({})
+    expect(validateStrategyOverrides({ harness: 'amp', provider: 'responses' })).toEqual({})
+    expect(validateStrategyOverrides({ reasoning: 'turbo' })).toEqual({})
+  })
+
+  test('drops reasoning when the resolved strategy harness cannot use it', () => {
+    expect(validateStrategyOverrides({ reasoning: 'max' })).toEqual({
+      harnessType: undefined,
+      model: undefined,
+      provider: undefined,
+      reasoning: 'max'
+    })
+    expect(validateStrategyOverrides({ model: 'claude-opus-4-8', reasoning: 'max' })).toEqual({
+      harnessType: 'claudecode',
+      model: 'claude-opus-4-8',
+      provider: undefined,
+      reasoning: undefined
+    })
+    expect(validateStrategyOverrides({ harness: 'amp', reasoning: 'max' })).toEqual({
+      harnessType: 'amp',
+      model: undefined,
+      provider: undefined,
+      reasoning: undefined
+    })
+    expect(validateStrategyOverrides({ model: 'gpt-5.6-sol', reasoning: 'max' })).toEqual({
+      harnessType: 'codex',
+      model: 'gpt-5.6-sol',
+      provider: undefined,
+      reasoning: 'max'
+    })
+  })
+})
+
+describe('messageOverridesForText strategy invocation', () => {
+  const trace: SlackbotV2Trace = {
+    includeContext: false,
+    messageId: 'm1',
+    mode: 'execute',
+    openStream: false,
+    startedAtMs: 0,
+    threadId: 'slack:C1:1'
+  }
+
+  test('uses the flags strategy by default', async () => {
+    await expect(
+      messageOverridesForText(slackOptions({}), '--opus fix it', trace)
+    ).resolves.toEqual({
+      cleanedText: 'fix it',
+      overrides: {
+        harnessType: 'claudecode',
+        model: 'claude-opus-4-8',
+        provider: undefined,
+        reasoning: undefined
+      }
+    })
+  })
+
+  test('uses the configured strategy instead of the legacy flag parser', async () => {
+    await expect(
+      messageOverridesForText(
+        slackOptions({
+          messageOverridesStrategy: async () => ({ overrides: {} })
+        }),
+        '--opus fix it',
+        trace
+      )
+    ).resolves.toEqual({ overrides: {} })
+  })
+
+  test('returns configured strategy overrides without cleaning prompt text', async () => {
+    await expect(
+      messageOverridesForText(
+        slackOptions({
+          messageOverridesStrategy: async () => ({
+            overrides: {
+              harnessType: 'codex',
+              model: 'gpt-5.6-sol',
+              provider: undefined,
+              reasoning: 'max'
+            }
+          })
+        }),
+        'do the work. use max effort and the sol model.',
+        trace
+      )
+    ).resolves.toEqual({
+      overrides: {
+        harnessType: 'codex',
+        model: 'gpt-5.6-sol',
+        provider: undefined,
+        reasoning: 'max'
+      }
+    })
+  })
+})
+
+function slackOptions(overrides: Partial<SlackbotV2Options>): SlackbotV2Options {
+  return {
+    apiUrl: 'http://api.example.test',
+    botToken: 'xoxb-test',
+    signingSecret: 'secret',
+    ...overrides
+  }
+}
 
 // The adapter's plain-text extraction feeds extractMessageOverrides. The
 // unpatched @chat-adapter/slack flattened the parsed AST with

--- a/services/slackbotv2/test/overrides.test.ts
+++ b/services/slackbotv2/test/overrides.test.ts
@@ -6,6 +6,7 @@ import {
   validateStrategyOverrides
 } from '../src/overrides'
 import { messageOverridesForText } from '../src/index'
+import { createOpenAiMessageOverridesStrategy } from '../src/message-overrides-strategy'
 import type { SlackbotV2Options, SlackbotV2Trace } from '../src/types'
 
 describe('extractMessageOverrides', () => {
@@ -458,6 +459,34 @@ describe('messageOverridesForText strategy invocation', () => {
         reasoning: 'max'
       }
     })
+  })
+
+  test('logs OpenAI strategy request failures before falling back', async () => {
+    const logs: Array<{ event: string; fields: Record<string, unknown> }> = []
+    await expect(
+      messageOverridesForText(
+        slackOptions({
+          messageOverridesStrategy: createOpenAiMessageOverridesStrategy({
+            apiKey: 'test-key',
+            fetch: (async () =>
+              new Response('upstream unavailable', {
+                status: 503,
+                statusText: 'Service Unavailable'
+              })) as unknown as typeof fetch,
+            logger: (event, fields) => logs.push({ event, fields }),
+            model: 'gpt-5.4-nano'
+          })
+        }),
+        'use sol',
+        trace
+      )
+    ).resolves.toEqual({ overrides: {} })
+
+    expect(logs).toHaveLength(1)
+    expect(logs[0]?.event).toBe('slackbotv2_message_overrides_strategy_request_failed')
+    expect(logs[0]?.fields.error).toContain('HTTP 503 Service Unavailable')
+    expect(logs[0]?.fields.error).toContain('upstream unavailable')
+    expect(logs[0]?.fields.model).toBe('gpt-5.4-nano')
   })
 })
 

--- a/services/slackbotv2/test/overrides.test.ts
+++ b/services/slackbotv2/test/overrides.test.ts
@@ -469,7 +469,7 @@ describe('messageOverridesForText strategy invocation', () => {
           messageOverridesStrategy: createOpenAiMessageOverridesStrategy({
             apiKey: 'test-key',
             fetch: (async () =>
-              new Response('upstream unavailable', {
+              new Response('secret-token=do-not-log', {
                 status: 503,
                 statusText: 'Service Unavailable'
               })) as unknown as typeof fetch,
@@ -485,7 +485,7 @@ describe('messageOverridesForText strategy invocation', () => {
     expect(logs).toHaveLength(1)
     expect(logs[0]?.event).toBe('slackbotv2_message_overrides_strategy_request_failed')
     expect(logs[0]?.fields.error).toContain('HTTP 503 Service Unavailable')
-    expect(logs[0]?.fields.error).toContain('upstream unavailable')
+    expect(logs[0]?.fields.error).not.toContain('secret-token')
     expect(logs[0]?.fields.model).toBe('gpt-5.4-nano')
   })
 })


### PR DESCRIPTION
Adds an opt-in Slackbot message overrides strategy that uses a small OpenAI Responses call to map natural language model, harness, provider, and reasoning requests into validated canonical overrides. The legacy flag strategy remains the default and continues to preserve existing prompt-cleaning behavior, while LLM mode leaves prompt text untouched and falls back to no override on invalid output.