### PR TITLE
fix: improve console dropdown labels

### DIFF
--- a/services/console/app/controllers/console_controller.rb
+++ b/services/console/app/controllers/console_controller.rb
@@ -28,7 +28,7 @@ class ConsoleController < ApplicationController
     @slack_channel_catalog = SlackChannelCatalog.fetch
     @slack_channel_permissions = @principal.slack_channel_permissions.ordered
     @slack_channel_options = @slack_channel_catalog.channels.map do |channel|
-      label = "#{channel.private ? "Private" : "Public"} ##{channel.name} (#{channel.id})"
+      label = "##{channel.name} (#{channel.id}) #{channel.private ? "Private" : "Public"}"
       [ label, channel.id ]
     end
     @roles = @principal.roles.order(:id)

--- a/services/console/app/helpers/application_helper.rb
+++ b/services/console/app/helpers/application_helper.rb
@@ -102,6 +102,14 @@ module ApplicationHelper
     distance_of_time_in_words(started_at, finished_at)
   end
 
+  def secret_option_label(secret)
+    primary = secret.try(:name).presence || secret.foreign_id.presence || secret.oid
+    identifier = secret.foreign_id.presence || secret.oid
+    details = [ (identifier unless identifier == primary), secret.namespace ].compact_blank
+
+    details.any? ? "#{primary} (#{details.join(", ")})" : primary
+  end
+
   def console_icon(name, classes: "size-4")
     case name
     when "arrow-up"

--- a/services/console/app/views/console/principal.html.erb
+++ b/services/console/app/views/console/principal.html.erb
@@ -313,7 +313,7 @@
           <% next if secrets.empty? %>
           <optgroup label="<%= secret_kind_label(kind) %>">
             <% secrets.each do |s| %>
-              <option value="<%= kind %>:<%= s.oid %>"><%= s.try(:name).presence || s.foreign_id.presence || s.oid %> (<%= s.namespace %>)</option>
+              <option value="<%= kind %>:<%= s.oid %>"><%= secret_option_label(s) %></option>
             <% end %>
           </optgroup>
         <% end %>

--- a/services/console/app/views/console/roles/show.html.erb
+++ b/services/console/app/views/console/roles/show.html.erb
@@ -40,7 +40,7 @@
             <% next if secrets.empty? %>
             <optgroup label="<%= secret_kind_label(kind) %>">
               <% secrets.each do |secret| %>
-                <option value="<%= kind %>:<%= secret.oid %>"><%= secret.try(:name).presence || secret.foreign_id.presence || secret.oid %></option>
+                <option value="<%= kind %>:<%= secret.oid %>"><%= secret_option_label(secret) %></option>
               <% end %>
             </optgroup>
           <% end %>


### PR DESCRIPTION
Updates the console principal Slack channel chooser so channel names come before IDs and visibility labels. Also makes principal and role secret grant dropdowns show secret names first with identifying context.