### PR TITLE
fix: omit Slack client secret for PKCE login

### DIFF
--- a/services/console/app/controllers/session_oauth_controller.rb
+++ b/services/console/app/controllers/session_oauth_controller.rb
@@ -110,7 +110,7 @@ class SessionOauthController < ApplicationController
     exchange_client_factory.call.exchange(
       token_endpoint: @provider.token_endpoint,
       client_id: ConsoleAuth.client_id(@key),
-      client_secret: ConsoleAuth.client_secret(@key),
+      client_secret: @provider.token_exchange_client_secret(ConsoleAuth.client_secret(@key)),
       code: code.to_s,
       redirect_uri: callback_redirect_uri,
       code_verifier: code_verifier.to_s,

--- a/services/console/lib/login/providers/google.rb
+++ b/services/console/lib/login/providers/google.rb
@@ -16,6 +16,7 @@ module Login
       def token_endpoint = TOKEN_ENDPOINT
       def scopes = SCOPES
       def extra_authorization_params = {}
+      def token_exchange_client_secret(secret) = secret
 
       def identity_from(result, client_id:)
         Login::IdToken.identity(result.id_token, client_id: client_id, valid_issuers: VALID_ISSUERS)

--- a/services/console/lib/login/providers/slack.rb
+++ b/services/console/lib/login/providers/slack.rb
@@ -17,6 +17,11 @@ module Login
       def scopes = SCOPES
       def extra_authorization_params = {}
 
+      # PKCE-enabled Slack apps are public clients. Slack binds the authorization
+      # code to code_verifier, so the token exchange must not authenticate with
+      # client_secret as well.
+      def token_exchange_client_secret(_secret) = nil
+
       def identity_from(result, client_id:)
         identity = Login::IdToken.identity(result.id_token, client_id: client_id, valid_issuers: VALID_ISSUERS)
         claims = Login::IdToken.decode_claims(result.id_token)

--- a/services/console/test/controllers/session_oauth_controller_test.rb
+++ b/services/console/test/controllers/session_oauth_controller_test.rb
@@ -7,8 +7,10 @@ require "test_helper"
 # HTTP double returning a canned token response (mirrors the broker flow test).
 class SessionOauthControllerTest < ActionDispatch::IntegrationTest
   GOOGLE_CLIENT_ID = "google-login-client-id".freeze
+  SLACK_CLIENT_ID = "slack-login-client-id".freeze
   ENV_KEYS = %w[
     CENTAUR_CONSOLE_GOOGLE_CLIENT_ID CENTAUR_CONSOLE_GOOGLE_CLIENT_SECRET
+    CENTAUR_CONSOLE_SLACK_CLIENT_ID CENTAUR_CONSOLE_SLACK_CLIENT_SECRET
     CENTAUR_CONSOLE_BOOTSTRAP_ADMINS CENTAUR_CONSOLE_SSO_EMAIL_DOMAINS
   ].freeze
 
@@ -26,18 +28,23 @@ class SessionOauthControllerTest < ActionDispatch::IntegrationTest
   end
 
   class StubHTTP
+    attr_reader :captured
+
     def initialize(status:, body:)
       @status = status
       @body = body
     end
 
     def call(url:, form:, headers:, timeout:)
+      @captured = { url: url, form: form, headers: headers, timeout: timeout }
       Broker::AuthorizationCodeClient::Response.new(status: @status, body: @body)
     end
   end
 
   def stub_exchange(status:, body:)
-    SessionOauthController.exchange_client_factory = -> { Broker::AuthorizationCodeClient.new(http: StubHTTP.new(status: status, body: body)) }
+    http = StubHTTP.new(status: status, body: body)
+    SessionOauthController.exchange_client_factory = -> { Broker::AuthorizationCodeClient.new(http: http) }
+    http
   end
 
   def id_token(claims)
@@ -98,6 +105,44 @@ class SessionOauthControllerTest < ActionDispatch::IntegrationTest
     get auth_start_url(provider: "slack") # no slack creds set
     assert_redirected_to login_path
     assert_equal "That sign-in method is not available.", flash[:alert]
+  end
+
+  test "Slack PKCE exchange omits client secret and accepts a rotating token response" do
+    ENV["CENTAUR_CONSOLE_SLACK_CLIENT_ID"] = SLACK_CLIENT_ID
+    ENV["CENTAUR_CONSOLE_SLACK_CLIENT_SECRET"] = "slack-login-secret"
+
+    state = start_flow(provider: "slack")
+    query = URI.decode_www_form(URI.parse(response.location).query).to_h
+    assert_equal "slack.com", URI.parse(response.location).host
+    assert_equal "openid email profile", query["scope"]
+
+    claims = {
+      "aud" => SLACK_CLIENT_ID,
+      "iss" => "https://slack.com",
+      "sub" => "U123ROTATING",
+      "email" => "rotating@example.com",
+      "email_verified" => true,
+      "name" => "Rotating User"
+    }
+    exchange = stub_exchange(
+      status: 200,
+      body: {
+        ok: true,
+        access_token: "xoxe.xoxp-1-access",
+        refresh_token: "xoxe-1-refresh",
+        expires_in: 43_200,
+        id_token: id_token(claims)
+      }.to_json
+    )
+
+    get auth_callback_url(provider: "slack"), params: { code: "the-code", state: state }
+
+    assert_redirected_to console_threads_path
+    assert_nil exchange.captured.dig(:form, "client_secret")
+    assert exchange.captured.dig(:form, "code_verifier").present?
+    user = User.find_by!(email: "rotating@example.com")
+    assert_equal "Rotating User", user.name
+    assert_equal [ [ "slack", "U123ROTATING" ] ], user.user_identities.pluck(:provider, :subject)
   end
 
   # --- callback: provisioning ------------------------------------------------


### PR DESCRIPTION
## Summary

- keep PKCE enabled for console Sign in with Slack
- omit `client_secret` from Slack's authorization-code exchange
- preserve Google's existing confidential-client exchange behavior
- cover rotating Slack token responses and verify the PKCE verifier remains present

## Root cause

The console always opts into PKCE, but its shared token exchange also sent the Slack app's `client_secret`. PKCE-enabled Slack apps are public clients, and Slack's PKCE exchange expects the authorization code and `code_verifier` without client-secret authentication. Slack rejected the mixed request with `internal_error`.

## Impact

Slack console sign-in can use the existing PKCE- and token-rotation-enabled app. Other console login providers retain their previous token-exchange behavior.

## Validation

- `just build-one console`
- `RAILS_ENV=test bin/rails test test/controllers/session_oauth_controller_test.rb` — 16 tests, 118 assertions
- RuboCop on the four changed files — no offenses
- local console `/up` — HTTP 200
