### PR TITLE
fix: use confidential Slack OIDC login

### DIFF
--- a/services/console/app/controllers/session_oauth_controller.rb
+++ b/services/console/app/controllers/session_oauth_controller.rb
@@ -4,7 +4,7 @@ require "uri"
 
 # Console SSO login, keyed by provider: /auth/:provider/start sends an operator to
 # the IdP, and /auth/:provider/callback turns the returned code into a signed-in
-# User. Structurally mirrors Oauth::FlowsController (signed state, PKCE, an
+# User. Structurally mirrors Oauth::FlowsController (signed state, optional PKCE, an
 # encrypted flow cookie binding the callback to the browser that started it), but
 # it produces a console session instead of a BrokerCredential.
 #
@@ -36,7 +36,7 @@ class SessionOauthController < ApplicationController
   # GET /auth/:provider/start
   def start
     nonce = SecureRandom.urlsafe_base64(32)
-    code_verifier = SecureRandom.urlsafe_base64(64)
+    code_verifier = SecureRandom.urlsafe_base64(64) if @provider.pkce?
 
     state = Rails.application.message_verifier(STATE_PURPOSE).generate(
       { "provider" => @key, "nonce" => nonce },
@@ -90,16 +90,20 @@ class SessionOauthController < ApplicationController
   end
 
   def authorization_url(state, code_verifier)
-    challenge = Base64.urlsafe_encode64(Digest::SHA256.digest(code_verifier), padding: false)
     query = {
       "client_id" => ConsoleAuth.client_id(@key),
       "redirect_uri" => callback_redirect_uri,
       "response_type" => "code",
       "scope" => @provider.scopes.join(" "),
-      "state" => state,
-      "code_challenge" => challenge,
-      "code_challenge_method" => "S256"
+      "state" => state
     }.merge(@provider.extra_authorization_params)
+
+    if code_verifier.present?
+      query["code_challenge"] = Base64.urlsafe_encode64(
+        Digest::SHA256.digest(code_verifier), padding: false
+      )
+      query["code_challenge_method"] = "S256"
+    end
 
     uri = URI.parse(@provider.authorization_endpoint)
     uri.query = URI.encode_www_form(query)

--- a/services/console/lib/broker/authorization_code_client.rb
+++ b/services/console/lib/broker/authorization_code_client.rb
@@ -3,7 +3,7 @@ require "json"
 require "uri"
 
 module Broker
-  # Performs the RFC 6749 4.1.3 authorization_code grant POST (with PKCE) and
+  # Performs the RFC 6749 4.1.3 authorization_code grant POST (optionally with PKCE) and
   # returns the parsed response. Used once per consent flow; it owns no
   # retry/backoff state -- a consent flow is synchronous and any failure surfaces
   # to the end user as a redirect. Provider-agnostic: the caller supplies the
@@ -47,16 +47,14 @@ module Broker
       raise ArgumentError, "client_id is required" if client_id.blank?
       raise ArgumentError, "code is required" if code.blank?
       raise ArgumentError, "redirect_uri is required" if redirect_uri.blank?
-      raise ArgumentError, "code_verifier is required" if code_verifier.blank?
-
       form = {
         "grant_type" => "authorization_code",
         "code" => code,
         "client_id" => client_id,
-        "redirect_uri" => redirect_uri,
-        "code_verifier" => code_verifier
+        "redirect_uri" => redirect_uri
       }
       form["client_secret"] = client_secret if client_secret.present?
+      form["code_verifier"] = code_verifier if code_verifier.present?
 
       response = perform(token_endpoint, form, timeout)
 

--- a/services/console/lib/login/providers.rb
+++ b/services/console/lib/login/providers.rb
@@ -1,8 +1,8 @@
 module Login
   # Registry of console-login provider strategies. A strategy owns the
   # IdP-specific parts of the login flow (endpoints, scopes, id_token identity
-  # extraction); state signing, PKCE, the code exchange, and user provisioning
-  # are provider-agnostic and live in SessionOauthController.
+  # extraction and whether the authorization request uses PKCE); state signing,
+  # the code exchange, and user provisioning live in SessionOauthController.
   module Providers
     def self.registry
       @registry ||= { Google::KEY => Google.new, Slack::KEY => Slack.new }.freeze

--- a/services/console/lib/login/providers/google.rb
+++ b/services/console/lib/login/providers/google.rb
@@ -16,6 +16,7 @@ module Login
       def token_endpoint = TOKEN_ENDPOINT
       def scopes = SCOPES
       def extra_authorization_params = {}
+      def pkce? = true
       def token_exchange_client_secret(secret) = secret
 
       def identity_from(result, client_id:)

--- a/services/console/lib/login/providers/slack.rb
+++ b/services/console/lib/login/providers/slack.rb
@@ -16,11 +16,11 @@ module Login
       def token_endpoint = TOKEN_ENDPOINT
       def scopes = SCOPES
       def extra_authorization_params = {}
+      def pkce? = false
 
-      # PKCE-enabled Slack apps are public clients. Slack binds the authorization
-      # code to code_verifier, so the token exchange must not authenticate with
-      # client_secret as well.
-      def token_exchange_client_secret(_secret) = nil
+      # Sign in with Slack uses a confidential OIDC exchange for standard HTTPS
+      # callbacks, even when the Slack app has opted into optional PKCE support.
+      def token_exchange_client_secret(secret) = secret
 
       def identity_from(result, client_id:)
         identity = Login::IdToken.identity(result.id_token, client_id: client_id, valid_issuers: VALID_ISSUERS)

--- a/services/console/test/controllers/session_oauth_controller_test.rb
+++ b/services/console/test/controllers/session_oauth_controller_test.rb
@@ -107,7 +107,7 @@ class SessionOauthControllerTest < ActionDispatch::IntegrationTest
     assert_equal "That sign-in method is not available.", flash[:alert]
   end
 
-  test "Slack PKCE exchange omits client secret and accepts a rotating token response" do
+  test "Slack HTTPS login uses client secret without PKCE and accepts a rotating token response" do
     ENV["CENTAUR_CONSOLE_SLACK_CLIENT_ID"] = SLACK_CLIENT_ID
     ENV["CENTAUR_CONSOLE_SLACK_CLIENT_SECRET"] = "slack-login-secret"
 
@@ -115,6 +115,8 @@ class SessionOauthControllerTest < ActionDispatch::IntegrationTest
     query = URI.decode_www_form(URI.parse(response.location).query).to_h
     assert_equal "slack.com", URI.parse(response.location).host
     assert_equal "openid email profile", query["scope"]
+    assert_nil query["code_challenge"]
+    assert_nil query["code_challenge_method"]
 
     claims = {
       "aud" => SLACK_CLIENT_ID,
@@ -138,8 +140,8 @@ class SessionOauthControllerTest < ActionDispatch::IntegrationTest
     get auth_callback_url(provider: "slack"), params: { code: "the-code", state: state }
 
     assert_redirected_to console_threads_path
-    assert_nil exchange.captured.dig(:form, "client_secret")
-    assert exchange.captured.dig(:form, "code_verifier").present?
+    assert_equal "slack-login-secret", exchange.captured.dig(:form, "client_secret")
+    assert_nil exchange.captured.dig(:form, "code_verifier")
     user = User.find_by!(email: "rotating@example.com")
     assert_equal "Rotating User", user.name
     assert_equal [ [ "slack", "U123ROTATING" ] ], user.user_identities.pluck(:provider, :subject)

--- a/services/console/test/lib/broker/authorization_code_client_test.rb
+++ b/services/console/test/lib/broker/authorization_code_client_test.rb
@@ -98,6 +98,12 @@ module Broker
       assert_nil result.refresh_token
     end
 
+    test "omits code_verifier when the caller does not use PKCE" do
+      client, http = client_with(status: 200, body: success_body)
+      client.exchange(**base_args(code_verifier: nil))
+      assert_nil http.captured[:form]["code_verifier"]
+    end
+
     test "parses Slack nested authed_user token payload" do
       body = {
         ok: true,
@@ -137,7 +143,6 @@ module Broker
     test "validates required inputs" do
       client, _ = client_with(status: 200, body: success_body)
       assert_raises(ArgumentError) { client.exchange(**base_args(code: "")) }
-      assert_raises(ArgumentError) { client.exchange(**base_args(code_verifier: "")) }
       assert_raises(ArgumentError) { client.exchange(**base_args(redirect_uri: "")) }
     end
   end


### PR DESCRIPTION
## What changed

- make PKCE a console-login provider capability
- keep PKCE enabled for Google login
- use Slack's confidential OpenID Connect exchange for HTTPS callbacks by sending `client_secret` and omitting PKCE parameters
- allow the shared authorization-code client to omit `code_verifier`

## Why

Console sign-in uses Slack's `openid.connect.token` endpoint, but the previous fix applied the public-client behavior documented for `oauth.v2.access`. Staging returned `bad_client_secret` when the secret was omitted, while production continued returning `internal_error` for the OIDC/PKCE combination.

Slack permits a PKCE-enabled app to use the confidential non-PKCE flow for standard HTTPS redirects, so the same implementation works with staging's PKCE-disabled app and production's PKCE-enabled app. Token rotation remains enabled and independent.

## Validation

- full Console suite: 1,254 runs, 4,738 assertions, 0 failures, 0 errors
- local Kubernetes redirect check: Slack omits PKCE; Google includes `code_challenge_method=S256`
- production Console image builds successfully
