### PR TITLE
fix(console): separate chat discovery from access

### DIFF
--- a/services/console/README.md
+++ b/services/console/README.md
@@ -53,8 +53,8 @@ The script exports recent `sessions`, `session_messages`,
 `session.output.line` events (capped by `THINKING_EVENT_LIMIT_PER_THREAD`,
 default 200 per thread), and referenced `slack_sync_users` rows with the source
 connection forced read-only, then imports them into the local `ai_v2` database
-used by the Console dev container. The Threads surface is read-only: it does
-not render a composer and rejects POSTs server-side.
+used by the Console dev container. The Console never writes directly to those
+session tables; starting and continuing accessible chats goes through api-rs.
 
 Threads extras beyond the Slack surface:
 

--- a/services/console/app/controllers/application_controller.rb
+++ b/services/console/app/controllers/application_controller.rb
@@ -207,10 +207,6 @@ class ApplicationController < ActionController::Base
       console_sidebar_console_thread_owner_sql,
       (console_sidebar_slack_thread_owner_sql(slack_owners) if slack_owners.any?)
     ].compact
-    if CentaurSession.public_slack_threads_enabled?
-      public_slack_sql = CentaurSession.public_slack_channel_sql
-      conditions << public_slack_sql if public_slack_sql
-    end
 
     return CentaurSession.where("1=0") if conditions.empty?
 
@@ -226,12 +222,11 @@ class ApplicationController < ActionController::Base
     thread_keys = console_sidebar_selected_thread_keys - threads.map(&:thread_key)
     return [] if thread_keys.empty?
 
+    # Global and explicitly shared chats remain readable from their direct
+    # links, but the sidebar is a personal navigation surface. Only recover a
+    # selected thread here when it belongs to the signed-in user.
     visible = console_sidebar_visible_thread_scope.where(thread_key: thread_keys).to_a
-    missing_keys = thread_keys - visible.map(&:thread_key)
-    shared_keys = ThreadShare.where(thread_key: missing_keys).pluck(:thread_key)
-    shared = CentaurSession.where(thread_key: shared_keys).to_a
-    sessions_by_key = (visible + shared).index_by(&:thread_key)
-
+    sessions_by_key = visible.index_by(&:thread_key)
     thread_keys.filter_map { |thread_key| sessions_by_key[thread_key] }
   end
 

--- a/services/console/app/controllers/console/threads_controller.rb
+++ b/services/console/app/controllers/console/threads_controller.rb
@@ -134,7 +134,8 @@ class Console::ThreadsController < ApplicationController
                 :composer_default_agent_value,
                 :composer_agents_json,
                 :thread_execution_active?,
-                :thread_owned?
+                :thread_owned?,
+                :thread_writable?
 
   def index
     @query = params[:q].to_s.strip
@@ -262,12 +263,20 @@ class Console::ThreadsController < ApplicationController
     execution.present? && %w[queued running executing].include?(execution.status.to_s)
   end
 
-  # Public and explicitly shared chats are read-only for non-owners. Keep the
-  # composer and write endpoint tied to the original owner scope.
+  # Ownership still controls publication. Access controls whether a user can
+  # continue a chat, and includes deployment-public and explicitly shared
+  # threads in addition to chats they started themselves.
   def thread_owned?(session)
     @thread_owned ||= {}
     @thread_owned.fetch(session.thread_key) do |thread_key|
       @thread_owned[thread_key] = owned_thread_scope.where(thread_key: thread_key).exists?
+    end
+  end
+
+  def thread_writable?(session)
+    @thread_writable ||= {}
+    @thread_writable.fetch(session.thread_key) do |thread_key|
+      @thread_writable[thread_key] = readable_thread(thread_key).present?
     end
   end
 
@@ -335,9 +344,10 @@ class Console::ThreadsController < ApplicationController
   end
 
   def reply_to_thread(thread_key, prompt)
-    # Resolve through the owner scope so a crafted thread_key cannot post into
-    # another user's chat, even when public or shared read access is allowed.
-    session = owned_thread_scope.where(thread_key: thread_key).first
+    # Resolve through the same access policy as the transcript. This lets users
+    # continue deployment-public and explicitly shared chats while still
+    # rejecting a crafted key for a private, inaccessible thread.
+    session = readable_thread(thread_key)
     if session.nil?
       redirect_to console_threads_path, alert: "Chat not found."
       return
@@ -481,8 +491,11 @@ class Console::ThreadsController < ApplicationController
   end
 
   def load_threads
-    session_scope = visible_thread_scope
-    base_sessions = session_scope.recent_first.limit(THREAD_LIMIT).to_a
+    # Keep discovery personal even when deployment-wide read access is enabled.
+    # Public and explicitly shared chats are resolved only when directly linked.
+    owned_scope = owned_thread_scope
+    readable_scope = visible_thread_scope
+    base_sessions = owned_scope.recent_first.limit(THREAD_LIMIT).to_a
     keys = base_sessions.map(&:thread_key).uniq
 
     @latest_messages = latest_messages_for(keys)
@@ -491,7 +504,7 @@ class Console::ThreadsController < ApplicationController
     @execution_counts = count_records(CentaurSessionExecution, keys)
 
     @sessions = base_sessions.select { |session| matches_query?(session) }
-    @selected_session = selected_session(session_scope, base_sessions)
+    @selected_session = selected_session(readable_scope, base_sessions)
     if @thread_not_found
       @pane_sessions = []
       @thread_panels = []
@@ -501,7 +514,7 @@ class Console::ThreadsController < ApplicationController
       @selected_transcript_items = []
       return
     end
-    @pane_sessions = resolve_pane_sessions(session_scope, base_sessions)
+    @pane_sessions = resolve_pane_sessions(readable_scope, base_sessions)
     load_selected_session_summaries(keys)
     @selected_thread_key = @selected_session&.thread_key.to_s
     @thread_panels = build_thread_panels
@@ -611,7 +624,8 @@ class Console::ThreadsController < ApplicationController
     {
       session: session,
       thread_key: session.thread_key,
-      writable: thread_owned?(session),
+      owned: thread_owned?(session),
+      writable: thread_writable?(session),
       transcript_items: selected_transcript_items
     }
   end

--- a/services/console/app/views/console/threads/_thread_menu.html.erb
+++ b/services/console/app/views/console/threads/_thread_menu.html.erb
@@ -23,7 +23,7 @@
       <div class="console-share-dialog-copy">
         <h2>Share chat</h2>
         <p>
-          Anyone with access to Centaur Console will be able to view this chat.
+          Anyone with access to Centaur Console will be able to view and continue this chat.
         </p>
         <p class="console-share-dialog-error"
            role="alert"

--- a/services/console/app/views/console/threads/_thread_panel.html.erb
+++ b/services/console/app/views/console/threads/_thread_panel.html.erb
@@ -53,7 +53,7 @@
         <%= local_time(session.updated_at || session.created_at, relative: true, format: :compact) %>
       </div>
     </div>
-    <%= render "console/threads/thread_menu", session: session if panel[:writable] %>
+    <%= render "console/threads/thread_menu", session: session if panel[:owned] %>
     <a href="<%= close_path %>"
        class="console-panel-close"
        aria-label="Close panel"

--- a/services/console/app/views/console/threads/index.html.erb
+++ b/services/console/app/views/console/threads/index.html.erb
@@ -94,7 +94,7 @@
         <% end %>
       </div>
 
-      <% if @selected_session && thread_owned?(@selected_session) %>
+      <% if @selected_session && thread_writable?(@selected_session) %>
         <div class="console-composer-dock">
           <div class="console-thread-content">
             <%= render "console/threads/composer", mode: :thread, session: @selected_session %>

--- a/services/console/test/controllers/console/threads_controller_test.rb
+++ b/services/console/test/controllers/console/threads_controller_test.rb
@@ -130,7 +130,7 @@ class Console::ThreadsControllerTest < ActionDispatch::IntegrationTest
       get console_threads_url(thread: public_thread_key)
       assert_response :ok
       assert_select ".console-thread-detail-header", count: 1
-      assert_select "textarea[name=prompt]", count: 0
+      assert_select "textarea[name=prompt]", count: 1
 
       get console_threads_url(thread: private_thread_key)
       assert_response :not_found
@@ -140,7 +140,43 @@ class Console::ThreadsControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
-  test "sharing publishes a direct read-only link from an in-page copy dialog" do
+  test "public Slack channel threads stay out of the personal chat list" do
+    skip_unless_session_table
+    skip_unless_slack_channel_table
+
+    owned_thread_key = "console:owned-list-#{SecureRandom.hex(6)}"
+    public_channel_id = "C#{SecureRandom.hex(6).upcase}"
+    public_thread_key = "slack:#{public_channel_id}:#{SecureRandom.hex(6)}"
+    insert_console_session(owned_thread_key)
+    insert_slack_sync_channel(public_channel_id, is_private: false)
+    insert_slack_session(public_thread_key, slack_user_id: "U_OTHER", slack_user_name: "someone-else")
+
+    with_env("CENTAUR_CONSOLE_PUBLIC_SLACK_THREADS_ENABLED" => "true") do
+      get console_sidebar_threads_url
+      assert_response :ok
+      assert_select "a[href=?]", console_threads_path(thread: owned_thread_key), count: 1
+      assert_select "a[href=?]", console_threads_path(thread: public_thread_key), count: 0
+
+      # Even an active globally readable chat must not be injected into the
+      # user's personal sidebar.
+      get console_sidebar_threads_url(thread: public_thread_key)
+      assert_response :ok
+      assert_select "a[href=?]", console_threads_path(thread: public_thread_key), count: 0
+
+      # The default Chats landing also discovers only owned chats.
+      get console_threads_url
+      assert_redirected_to console_threads_path(thread: owned_thread_key)
+
+      # Global access itself is unchanged: a direct link remains readable and
+      # can be continued by a non-owner.
+      get console_threads_url(thread: public_thread_key)
+      assert_response :ok
+      assert_select ".console-thread-detail-header", count: 1
+      assert_select "textarea[name=prompt]", count: 1
+    end
+  end
+
+  test "sharing publishes a direct writable link from an in-page copy dialog" do
     skip_unless_session_table
 
     thread_key = "console:shared-#{SecureRandom.hex(6)}"
@@ -157,7 +193,7 @@ class Console::ThreadsControllerTest < ActionDispatch::IntegrationTest
     assert_select "button[data-turbo-confirm]", count: 0
     assert_select "dialog.console-share-dialog[data-thread-share-target=dialog]" do
       assert_select "h2", text: "Share chat"
-      assert_select "p", text: "Anyone with access to Centaur Console will be able to view this chat."
+      assert_select "p", text: "Anyone with access to Centaur Console will be able to view and continue this chat."
       assert_select "form[action=?][data-action*=?]", console_thread_share_path, "thread-share#copyLink" do
         assert_select "input[name=thread_key][value=?]", thread_key
         assert_select "button.btn-secondary[type=button]", text: "Cancel"
@@ -183,7 +219,7 @@ class Console::ThreadsControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :ok
     assert_select ".console-thread-detail-header", count: 1
-    assert_select "textarea[name=prompt]", count: 0
+    assert_select "textarea[name=prompt]", count: 1
   end
 
   test "a user cannot share a chat they cannot read" do
@@ -716,15 +752,13 @@ class Console::ThreadsControllerTest < ActionDispatch::IntegrationTest
     assert_includes sql, "ussoonly"
   end
 
-  test "sidebar includes public Slack threads only when the deploy setting is enabled" do
+  test "sidebar scope never expands to public Slack threads" do
     controller = threads_controller_for(@operator)
 
     with_env("CENTAUR_CONSOLE_PUBLIC_SLACK_THREADS_ENABLED" => "true") do
       sql = controller.send(:console_sidebar_visible_thread_scope).to_sql
 
-      if slack_channel_privacy_catalog_available?
-        assert_includes sql, "slack_sync_channels"
-      end
+      refute_includes sql, "slack_sync_channels"
     end
   end
 
@@ -1108,7 +1142,49 @@ class Console::ThreadsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to console_threads_path(thread: "console:composer-reply,console:other")
   end
 
-  test "replying into a chat outside the owner scope is rejected" do
+  test "replying appends and executes on a deployment-public chat" do
+    skip_unless_session_table
+    skip_unless_slack_channel_table
+
+    channel_id = "C#{SecureRandom.hex(6).upcase}"
+    thread_key = "slack:#{channel_id}:#{SecureRandom.hex(6)}"
+    insert_slack_sync_channel(channel_id, is_private: false)
+    insert_slack_session(thread_key, slack_user_id: "U_OTHER", slack_user_name: "someone-else")
+
+    client = RecordingApiClient.new
+    with_env("CENTAUR_CONSOLE_PUBLIC_SLACK_THREADS_ENABLED" => "true") do
+      with_composer(client: client) do
+        post console_threads_url,
+             params: { prompt: "Continue from here.", thread_key: thread_key }
+      end
+    end
+
+    assert_equal %i[append_session_messages execute_session], client.calls.map(&:first)
+    assert_equal thread_key, client.calls[0].last[:thread_key]
+    assert_redirected_to console_threads_path(thread: thread_key)
+  end
+
+  test "replying appends and executes on an explicitly shared chat" do
+    skip_unless_session_table
+
+    thread_key = "console:shared-reply-#{SecureRandom.hex(6)}"
+    insert_console_session(thread_key)
+    ThreadShare.create!(thread_key: thread_key, created_by: @operator)
+    delete logout_url
+    post login_url, params: { email: users(:member_user).email, password: "password123456" }
+
+    client = RecordingApiClient.new
+    with_composer(client: client) do
+      post console_threads_url,
+           params: { prompt: "Continue from here.", thread_key: thread_key }
+    end
+
+    assert_equal %i[append_session_messages execute_session], client.calls.map(&:first)
+    assert_equal thread_key, client.calls[0].last[:thread_key]
+    assert_redirected_to console_threads_path(thread: thread_key)
+  end
+
+  test "replying into a chat outside the readable scope is rejected" do
     skip_unless_session_table
 
     client = RecordingApiClient.new


### PR DESCRIPTION
## Summary

- keep the sidebar and default Chats landing scoped to the signed-in user's chats
- preserve direct access to deployment-public and explicitly shared chats
- allow users with access to continue those chats while keeping share controls owner-only
- add regression coverage for discovery, direct access, and reply authorization

## Validation

- Ruby syntax checks for the changed controller and test files
- RuboCop on the changed Ruby files
- git diff --check
- Database-backed controller tests could not run locally because PostgreSQL is not running; CI should exercise them