### PR TITLE
feat: render attached images in console chat

### DIFF
--- a/services/console/app/controllers/console/threads_controller.rb
+++ b/services/console/app/controllers/console/threads_controller.rb
@@ -9,6 +9,14 @@ class Console::ThreadsController < ApplicationController
   EXECUTION_LIMIT = 8
   TRANSCRIPT_EVENT_LIMIT = 80
   PANEL_LIMIT = 4
+  MAX_INLINE_IMAGE_BASE64_CHARS = 1_000_000
+  INLINE_IMAGE_MIME_TYPES = %w[
+    image/avif
+    image/gif
+    image/jpeg
+    image/png
+    image/webp
+  ].freeze
   THINKING_EVENT_LIMIT = 200
   ACTIVITY_SUMMARY_EVENT_LIMIT = 200
   RAW_TRACE_OUTPUT_LINE_PATTERNS = %w[
@@ -1325,9 +1333,41 @@ class Console::ThreadsController < ApplicationController
       label: transcript_message_label(message.role, metadata),
       align: transcript_message_align(message.role, metadata),
       text: resolve_slack_mentions(thread_message_text(message)),
+      images: transcript_message_images(message),
       created_at: message.created_at,
       source: :message
     }
+  end
+
+  def transcript_message_images(message)
+    message.parts_array.filter_map do |part|
+      next unless inline_image_part?(part)
+
+      mime_type = part["mimeType"].to_s.downcase
+      data = part["dataBase64"].to_s
+      next unless INLINE_IMAGE_MIME_TYPES.include?(mime_type)
+      next if data.blank? || data.bytesize > MAX_INLINE_IMAGE_BASE64_CHARS
+      next unless data.bytesize.modulo(4).zero? && data.match?(/\A[A-Za-z0-9+\/]*={0,2}\z/)
+
+      {
+        src: "data:#{mime_type};base64,#{data}",
+        alt: part["name"].presence || "Attached image",
+        width: positive_image_dimension(part["width"]),
+        height: positive_image_dimension(part["height"])
+      }
+    end
+  end
+
+  def inline_image_part?(part)
+    return false unless part.is_a?(Hash)
+
+    part["type"] == "image" ||
+      (part["type"] == "attachment" && part["attachment_type"] == "image")
+  end
+
+  def positive_image_dimension(value)
+    dimension = Integer(value, exception: false)
+    dimension if dimension&.positive? && dimension <= 100_000
   end
 
   def count_records(model, keys)

--- a/services/console/app/views/console/threads/_transcript.html.erb
+++ b/services/console/app/views/console/threads/_transcript.html.erb
@@ -63,7 +63,24 @@
           <% unless user_message %>
             <div class="mb-1 text-xs font-medium text-zinc-500"><%= item[:label] || item[:role] %></div>
           <% end %>
-          <div class="console-markdown text-sm leading-6"><%= console_markdown(item[:text].presence || "No text content.") %></div>
+          <% if item[:text].present? %>
+            <div class="console-markdown text-sm leading-6"><%= console_markdown(item[:text]) %></div>
+          <% elsif item[:images].blank? %>
+            <div class="console-markdown text-sm leading-6"><%= console_markdown("No text content.") %></div>
+          <% end %>
+          <% if item[:images].present? %>
+            <div class="console-message-images <%= "mt-3" if item[:text].present? %>">
+              <% item[:images].each do |image| %>
+                <% dimensions = { width: image[:width], height: image[:height] }.compact %>
+                <%= image_tag image[:src],
+                              alt: image[:alt],
+                              class: "console-message-image",
+                              loading: "lazy",
+                              decoding: "async",
+                              **dimensions %>
+              <% end %>
+            </div>
+          <% end %>
         </div>
         <div class="console-message-timestamp <%= "text-right" if user_message %>">
           <%= local_time(item[:created_at]) if item[:created_at] %>

--- a/services/console/app/views/layouts/console.html.erb
+++ b/services/console/app/views/layouts/console.html.erb
@@ -890,6 +890,25 @@
         min-width: 0;
       }
 
+      .console-message-images {
+        display: flex;
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 0.75rem;
+        max-width: 100%;
+      }
+
+      .console-message-image {
+        display: block;
+        width: auto;
+        height: auto;
+        max-width: 100%;
+        max-height: min(28rem, 60vh);
+        border: 1px solid rgba(255, 255, 255, 0.1);
+        border-radius: 0.75rem;
+        object-fit: contain;
+      }
+
       .console-message-timestamp {
         min-height: 1.25rem;
         padding-top: 0.375rem;

--- a/services/console/test/controllers/console/threads_controller_test.rb
+++ b/services/console/test/controllers/console/threads_controller_test.rb
@@ -286,6 +286,63 @@ class Console::ThreadsControllerTest < ActionDispatch::IntegrationTest
     assert_equal "Root Slack bot post", item[:text]
   end
 
+  test "transcript messages expose stored image attachments as bounded inline data" do
+    controller = Console::ThreadsController.new
+    controller.define_singleton_method(:current_slack_user_ids) { [] }
+    controller.instance_variable_set(:@selected_session, TranscriptSession.new(metadata_hash: {}))
+    image_data = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII="
+    message = TranscriptMessage.new(
+      role: "user",
+      parts_array: [
+        { "type" => "text", "text" => "See attached." },
+        {
+          "type" => "attachment",
+          "attachment_type" => "image",
+          "dataBase64" => image_data,
+          "mimeType" => "image/png",
+          "name" => "screenshot.png",
+          "width" => 1440,
+          "height" => 900
+        }
+      ],
+      metadata_hash: {},
+      created_at: Time.zone.parse("2026-06-26 17:15:58 UTC")
+    )
+
+    item = controller.send(:transcript_item_for_message, message)
+
+    assert_equal "See attached.", item[:text]
+    assert_equal [
+      {
+        src: "data:image/png;base64,#{image_data}",
+        alt: "screenshot.png",
+        width: 1440,
+        height: 900
+      }
+    ], item[:images]
+  end
+
+  test "transcript images reject remote, unsafe, malformed, and oversized image data" do
+    controller = Console::ThreadsController.new
+    message = TranscriptMessage.new(
+      role: "user",
+      parts_array: [
+        { "type" => "attachment", "attachment_type" => "image", "mimeType" => "image/png",
+          "url" => "https://files.example.test/private.png" },
+        { "type" => "attachment", "attachment_type" => "image", "mimeType" => "image/svg+xml",
+          "dataBase64" => "PHN2Zz4=" },
+        { "type" => "attachment", "attachment_type" => "image", "mimeType" => "image/png",
+          "dataBase64" => "not base64" },
+        { "type" => "attachment", "attachment_type" => "image", "mimeType" => "image/png",
+          "dataBase64" => "A" * (Console::ThreadsController::MAX_INLINE_IMAGE_BASE64_CHARS + 1) }
+      ],
+      metadata_hash: {},
+      created_at: Time.zone.now
+    )
+
+    assert_empty controller.send(:transcript_message_images, message)
+  end
+
   test "slack message text resolves mentions from bot identity and selected actor metadata" do
     controller = Console::ThreadsController.new
     controller.define_singleton_method(:current_slack_user_ids) { [ "u123" ] }

--- a/services/console/test/views/console/threads/transcript_test.rb
+++ b/services/console/test/views/console/threads/transcript_test.rb
@@ -1,0 +1,37 @@
+require "test_helper"
+
+class ConsoleThreadsTranscriptTest < ActionView::TestCase
+  include ApplicationHelper
+
+  test "renders attached images with intrinsic dimensions and lazy loading" do
+    image_data = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII="
+    render partial: "console/threads/transcript", locals: {
+      items: [
+        {
+          source: :message,
+          role: "user",
+          label: "User",
+          align: :end,
+          text: "",
+          images: [
+            {
+              src: "data:image/png;base64,#{image_data}",
+              alt: "screenshot.png",
+              width: 1440,
+              height: 900
+            }
+          ],
+          created_at: nil
+        }
+      ]
+    }
+
+    assert_select "img.console-message-image[src=?]", "data:image/png;base64,#{image_data}", count: 1
+    assert_select "img.console-message-image[alt=?]", "screenshot.png", count: 1
+    assert_select "img.console-message-image[width=?]", "1440", count: 1
+    assert_select "img.console-message-image[height=?]", "900", count: 1
+    assert_select "img.console-message-image[loading=?]", "lazy", count: 1
+    assert_select "img.console-message-image[decoding=?]", "async", count: 1
+    assert_select ".console-markdown", text: /No text content/, count: 0
+  end
+end


### PR DESCRIPTION
## Summary
- render stored image attachment parts directly in Console transcripts
- preserve intrinsic aspect ratio while capping images to message width and `min(28rem, 60vh)`
- allow validated inline PNG, JPEG, GIF, WebP, and AVIF data while rejecting SVG, private remote URLs, malformed base64, and oversized payloads
- add controller and view regression coverage

## Verification
- confirmed the example thread contains a persisted `attachment` part via the read-only source database
- verified stored-image extraction and transcript HTML rendering through Rails
- `bundle exec rubocop`
- `bundle exec brakeman --quiet --no-pager --exit-on-warn --exit-on-error`
- `RAILS_ENV=development bin/rails zeitwerk:check`
- `bin/rails tailwindcss:build`
- full database-backed tests deferred to CI because this sandbox has no Postgres server

Prompted by: Goksu Toprak