### PR TITLE
feat: add workflow-scoped principals

### DIFF
--- a/contrib/chart/Chart.yaml
+++ b/contrib/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: centaur
 description: Helm chart for the trusted Centaur control plane
 type: application
-version: 0.1.104
+version: 0.1.105
 appVersion: "0.1.0"
 dependencies:
   - name: connect

--- a/contrib/chart/templates/apirs.yaml
+++ b/contrib/chart/templates/apirs.yaml
@@ -249,6 +249,10 @@ spec:
             - name: KUBERNETES_WORKFLOW_DIRS
               value: {{ $sandboxWorkflowDirs | quote }}
 {{- end }}
+{{- if not (hasKey .Values.apiRs.extraEnv "WORKFLOW_HOST_SANDBOX") }}
+            - name: WORKFLOW_HOST_SANDBOX
+              value: {{ .Values.apiRs.workflowHostSandbox | quote }}
+{{- end }}
 {{- if not (hasKey .Values.apiRs.extraEnv "WORKFLOW_ENABLE_MODE") }}
             - name: WORKFLOW_ENABLE_MODE
               value: {{ .Values.apiRs.workflowEnableMode | quote }}

--- a/contrib/chart/values.schema.json
+++ b/contrib/chart/values.schema.json
@@ -267,6 +267,7 @@
         "mcpPublicUrl": { "type": "string" },
         "sandboxRunningLimit": { "type": "integer", "minimum": 0 },
         "sandboxHotIdleGraceSecs": { "type": "integer", "minimum": 0 },
+        "workflowHostSandbox": { "type": "boolean" },
         "etl": {
           "type": "object",
           "properties": {

--- a/contrib/chart/values.yaml
+++ b/contrib/chart/values.yaml
@@ -372,6 +372,7 @@ apiRs:
   # Workflow enablement policy. Production defaults to all workflows enabled.
   # Set workflowEnableMode: allowlist in staging and list allowed workflow names
   # in workflowAllowedNames as a comma/whitespace-separated string.
+  workflowHostSandbox: true
   workflowEnableMode: all
   workflowAllowedNames: ""
   # Scheduled ETL workflow configuration. The chart renders these into api-rs

--- a/contrib/chart/values.yaml
+++ b/contrib/chart/values.yaml
@@ -372,7 +372,7 @@ apiRs:
   # Workflow enablement policy. Production defaults to all workflows enabled.
   # Set workflowEnableMode: allowlist in staging and list allowed workflow names
   # in workflowAllowedNames as a comma/whitespace-separated string.
-  workflowHostSandbox: false
+  workflowHostSandbox: true
   workflowEnableMode: all
   workflowAllowedNames: ""
   # Scheduled ETL workflow configuration. The chart renders these into api-rs

--- a/contrib/chart/values.yaml
+++ b/contrib/chart/values.yaml
@@ -372,7 +372,7 @@ apiRs:
   # Workflow enablement policy. Production defaults to all workflows enabled.
   # Set workflowEnableMode: allowlist in staging and list allowed workflow names
   # in workflowAllowedNames as a comma/whitespace-separated string.
-  workflowHostSandbox: true
+  workflowHostSandbox: false
   workflowEnableMode: all
   workflowAllowedNames: ""
   # Scheduled ETL workflow configuration. The chart renders these into api-rs

--- a/docs/pages/extend/workflows-v2.mdx
+++ b/docs/pages/extend/workflows-v2.mdx
@@ -64,6 +64,7 @@ Supported v2 primitives:
 | `ctx._pool` | Supported when the workflow-host sandbox receives `DATABASE_URL` |
 | `WEBHOOKS` | Supported |
 | `SCHEDULE` | Supported |
+| `WORKFLOW_PRINCIPAL` | Supported for workflow-host sandbox tool permissions |
 
 ## Required migrations
 
@@ -119,6 +120,31 @@ result = await ctx.agent_turn(
 The workflow host sandbox is separate from the agent sandbox. The workflow
 handler coordinates the run; the agent turn runs through the normal Centaur
 session runtime.
+
+#### Declare Workflow-Host Permissions
+
+When a workflow calls tools directly from the workflow host with
+`ctx.call_tool(...)`, declare the principal that should own those permissions:
+
+```python
+WORKFLOW_NAME = "nightly_report"
+WORKFLOW_PRINCIPAL = True
+```
+
+The API derives and registers the `workflow-nightly-report` principal in the
+Centaur Console and runs that workflow's host sandbox under it. Grant only the
+roles or secrets that workflow needs:
+
+```bash
+cargo run -p centaur-perms -- \
+  principals grant workflow-nightly-report \
+  --tool slack
+```
+
+The principal id is always `workflow-` plus the slugged `WORKFLOW_NAME`.
+Workflow code cannot choose another principal id, display name, or labels.
+`WORKFLOW_PRINCIPAL = True` requires `WORKFLOW_HOST_SANDBOX=true`; startup fails
+if a workflow declares a principal while workflow-host sandboxing is disabled.
 
 #### Pick the model and reasoning effort
 

--- a/docs/pages/extend/workflows-v2.mdx
+++ b/docs/pages/extend/workflows-v2.mdx
@@ -143,8 +143,9 @@ cargo run -p centaur-perms -- \
 
 The principal id is always `workflow-` plus the slugged `WORKFLOW_NAME`.
 Workflow code cannot choose another principal id, display name, or labels.
-`WORKFLOW_PRINCIPAL = True` requires `WORKFLOW_HOST_SANDBOX=true`; startup fails
-if a workflow declares a principal while workflow-host sandboxing is disabled.
+`WORKFLOW_PRINCIPAL = True` requires `apiRs.workflowHostSandbox=true`, which
+renders `WORKFLOW_HOST_SANDBOX=true`; startup fails if a workflow declares a
+principal while workflow-host sandboxing is disabled.
 
 #### Pick the model and reasoning effort
 

--- a/docs/pages/extend/workflows.mdx
+++ b/docs/pages/extend/workflows.mdx
@@ -70,8 +70,9 @@ The API derives and registers the `workflow-nightly-report` principal from
 `WORKFLOW_NAME` and runs that workflow-host sandbox under it. Workflow code
 cannot choose another principal id, display name, or labels. Grant the required
 tool roles or secrets to the derived principal. `WORKFLOW_PRINCIPAL = True`
-requires `WORKFLOW_HOST_SANDBOX=true`; startup fails if workflow-host sandboxing
-is disabled.
+requires `apiRs.workflowHostSandbox=true`, which renders
+`WORKFLOW_HOST_SANDBOX=true`; startup fails if workflow-host sandboxing is
+disabled.
 
 ## Durable primitives
 

--- a/docs/pages/extend/workflows.mdx
+++ b/docs/pages/extend/workflows.mdx
@@ -45,6 +45,8 @@ from api.workflow_engine import WorkflowContext
 
 WORKFLOW_NAME = "nightly_report"
 
+WORKFLOW_PRINCIPAL = True
+
 
 @dataclass
 class Input:
@@ -61,6 +63,15 @@ async def handler(inp: Input, ctx: WorkflowContext) -> dict[str, Any]:
     )
     return {"channel": inp.channel, "report": result}
 ```
+
+`WORKFLOW_PRINCIPAL` is optional. Use it when the workflow host calls tools
+directly with `ctx.call_tool(...)` and should have its own credential boundary.
+The API derives and registers the `workflow-nightly-report` principal from
+`WORKFLOW_NAME` and runs that workflow-host sandbox under it. Workflow code
+cannot choose another principal id, display name, or labels. Grant the required
+tool roles or secrets to the derived principal. `WORKFLOW_PRINCIPAL = True`
+requires `WORKFLOW_HOST_SANDBOX=true`; startup fails if workflow-host sandboxing
+is disabled.
 
 ## Durable primitives
 

--- a/docs/pages/reference/configuration.mdx
+++ b/docs/pages/reference/configuration.mdx
@@ -81,6 +81,7 @@ Optional required-by-mode variables:
 | `CENTAUR_ENVIRONMENT`, `DEPLOY_ENV`, `ENVIRONMENT` | `apiRs.extraEnv` or deployment env. | Deployment environment resource attribute for telemetry. |
 | `OTEL_TRACES_EXPORTER` | `apiRs.extraEnv`. | Set to `otlp` to force OTLP trace export, or `none`/`off` to disable it. |
 | `OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` | `apiRs.extraEnv`. | Enables OTLP trace export to Tempo, Jaeger, or another OTLP collector. |
+| `apiRs.workflowHostSandbox`, `WORKFLOW_HOST_SANDBOX` | Helm value, default `true`; override with `apiRs.extraEnv`. | Runs workflow hosts in Kubernetes sandboxes instead of the api-rs process. Required for workflow-scoped principals. |
 | `apiRs.metrics.scrapeAnnotations` | Helm value, default `true`. | Adds Prometheus scrape annotations to the API-RS Pod template and Service. |
 | `apiRs.metrics.path` | Helm value, default `/metrics`. | Metrics scrape path for annotation-based discovery. |
 | `apiRs.metrics.annotations` | Helm value. | Additional scrape annotations for Prometheus-compatible collectors. |

--- a/docs/pages/reference/configuration.mdx
+++ b/docs/pages/reference/configuration.mdx
@@ -81,7 +81,7 @@ Optional required-by-mode variables:
 | `CENTAUR_ENVIRONMENT`, `DEPLOY_ENV`, `ENVIRONMENT` | `apiRs.extraEnv` or deployment env. | Deployment environment resource attribute for telemetry. |
 | `OTEL_TRACES_EXPORTER` | `apiRs.extraEnv`. | Set to `otlp` to force OTLP trace export, or `none`/`off` to disable it. |
 | `OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` | `apiRs.extraEnv`. | Enables OTLP trace export to Tempo, Jaeger, or another OTLP collector. |
-| `apiRs.workflowHostSandbox`, `WORKFLOW_HOST_SANDBOX` | Helm value, default `true`; override with `apiRs.extraEnv`. | Runs workflow hosts in Kubernetes sandboxes instead of the api-rs process. Required for workflow-scoped principals. |
+| `apiRs.workflowHostSandbox`, `WORKFLOW_HOST_SANDBOX` | Helm value, default `false`; override with `apiRs.extraEnv`. | Runs workflow hosts in Kubernetes sandboxes instead of the api-rs process. Required for workflow-scoped principals. |
 | `apiRs.metrics.scrapeAnnotations` | Helm value, default `true`. | Adds Prometheus scrape annotations to the API-RS Pod template and Service. |
 | `apiRs.metrics.path` | Helm value, default `/metrics`. | Metrics scrape path for annotation-based discovery. |
 | `apiRs.metrics.annotations` | Helm value. | Additional scrape annotations for Prometheus-compatible collectors. |

--- a/docs/pages/reference/configuration.mdx
+++ b/docs/pages/reference/configuration.mdx
@@ -81,7 +81,7 @@ Optional required-by-mode variables:
 | `CENTAUR_ENVIRONMENT`, `DEPLOY_ENV`, `ENVIRONMENT` | `apiRs.extraEnv` or deployment env. | Deployment environment resource attribute for telemetry. |
 | `OTEL_TRACES_EXPORTER` | `apiRs.extraEnv`. | Set to `otlp` to force OTLP trace export, or `none`/`off` to disable it. |
 | `OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` | `apiRs.extraEnv`. | Enables OTLP trace export to Tempo, Jaeger, or another OTLP collector. |
-| `apiRs.workflowHostSandbox`, `WORKFLOW_HOST_SANDBOX` | Helm value, default `false`; override with `apiRs.extraEnv`. | Runs workflow hosts in Kubernetes sandboxes instead of the api-rs process. Required for workflow-scoped principals. |
+| `apiRs.workflowHostSandbox`, `WORKFLOW_HOST_SANDBOX` | Helm value, default `true`; override with `apiRs.extraEnv`. | Runs workflow hosts in Kubernetes sandboxes instead of the api-rs process. Required for workflow-scoped principals. |
 | `apiRs.metrics.scrapeAnnotations` | Helm value, default `true`. | Adds Prometheus scrape annotations to the API-RS Pod template and Service. |
 | `apiRs.metrics.path` | Helm value, default `/metrics`. | Metrics scrape path for annotation-based discovery. |
 | `apiRs.metrics.annotations` | Helm value. | Additional scrape annotations for Prometheus-compatible collectors. |

--- a/services/api-rs/Cargo.lock
+++ b/services/api-rs/Cargo.lock
@@ -1035,6 +1035,7 @@ name = "centaur-workflows"
 version = "0.1.0"
 dependencies = [
  "absurd-sdk",
+ "centaur-iron-control",
  "centaur-sandbox-core",
  "centaur-session-core",
  "centaur-session-runtime",

--- a/services/api-rs/crates/centaur-api-server/src/args.rs
+++ b/services/api-rs/crates/centaur-api-server/src/args.rs
@@ -33,7 +33,7 @@ use centaur_session_core::HarnessType;
 use centaur_session_runtime::{
     PersonaRegistry, SandboxCapacityConfig, SandboxWorkloadMode, SessionSandboxCleanupConfig,
 };
-use centaur_workflows::WorkflowHostSandboxRuntime;
+use centaur_workflows::{WorkflowHostSandboxRuntime, WorkflowPrincipalRegistrar};
 use clap::{Args as ClapArgs, Parser, ValueEnum};
 use tracing::{info, warn};
 
@@ -123,6 +123,7 @@ pub(crate) struct IronControlRuntime {
     pub(crate) registrar: SessionRegistrar,
     pub(crate) warm_pool_bootstrap_principal: String,
     pub(crate) workflow_host_principal: String,
+    pub(crate) workflow_principal_registrar: WorkflowPrincipalRegistrar,
 }
 
 #[derive(Debug, ClapArgs)]
@@ -723,9 +724,10 @@ impl SandboxArgs {
             client.assign_role(&workflow_host.id, role_id).await?;
         }
         Ok(Some(IronControlRuntime {
-            registrar: SessionRegistrar::new(client, namespace, role_ids),
+            registrar: SessionRegistrar::new(client.clone(), namespace.clone(), role_ids),
             warm_pool_bootstrap_principal: bootstrap.id,
             workflow_host_principal: workflow_host.id,
+            workflow_principal_registrar: WorkflowPrincipalRegistrar::new(client, namespace),
         }))
     }
 

--- a/services/api-rs/crates/centaur-api-server/src/main.rs
+++ b/services/api-rs/crates/centaur-api-server/src/main.rs
@@ -79,10 +79,12 @@ async fn initialize_runtime(args: Args, app_state: AppState) -> Result<(), Serve
         .with_openai_session_title_generator_from_env();
     let mut warm_pool_bootstrap_principal = None;
     let mut workflow_host_principal = None;
+    let mut workflow_principal_registrar = None;
     if let Some(iron_control) = args.iron_control_runtime().await? {
         info!("iron-control session registration enabled");
         warm_pool_bootstrap_principal = Some(iron_control.warm_pool_bootstrap_principal);
         workflow_host_principal = Some(iron_control.workflow_host_principal);
+        workflow_principal_registrar = Some(iron_control.workflow_principal_registrar);
         runtime = runtime.with_iron_control(iron_control.registrar);
     }
     runtime = runtime.with_personas(args.persona_registry()?);
@@ -100,10 +102,11 @@ async fn initialize_runtime(args: Args, app_state: AppState) -> Result<(), Serve
         .workflow_host_sandbox_runtime(workflow_host_principal.as_deref())
         .await?;
     let workflows = Some(
-        WorkflowRuntime::new_with_workflow_host_sandbox(
+        WorkflowRuntime::new_with_workflow_host_sandbox_and_principal_registrar(
             store,
             runtime.clone(),
             workflow_host_sandbox,
+            workflow_principal_registrar,
         )
         .await?,
     );

--- a/services/api-rs/crates/centaur-workflows/Cargo.toml
+++ b/services/api-rs/crates/centaur-workflows/Cargo.toml
@@ -7,6 +7,7 @@ repository.workspace = true
 
 [dependencies]
 absurd-sdk.workspace = true
+centaur-iron-control.workspace = true
 centaur-session-core.workspace = true
 centaur-session-runtime.workspace = true
 centaur-session-sqlx.workspace = true

--- a/services/api-rs/crates/centaur-workflows/src/lib.rs
+++ b/services/api-rs/crates/centaur-workflows/src/lib.rs
@@ -324,7 +324,6 @@ fn workflow_principal_labels(workflow_name: &str) -> BTreeMap<String, String> {
     BTreeMap::from([
         ("kind".to_owned(), "workflow".to_owned()),
         ("managed-by".to_owned(), "centaur".to_owned()),
-        ("purpose".to_owned(), "workflow".to_owned()),
         ("workflow_name".to_owned(), workflow_name.to_owned()),
     ])
 }
@@ -4450,7 +4449,7 @@ mod tests {
         let labels = workflow_principal_labels("nightly_report");
 
         assert_eq!(labels.get("kind").map(String::as_str), Some("workflow"));
-        assert_eq!(labels.get("purpose").map(String::as_str), Some("workflow"));
+        assert!(!labels.contains_key("purpose"));
         assert_eq!(
             labels.get("workflow_name").map(String::as_str),
             Some("nightly_report")

--- a/services/api-rs/crates/centaur-workflows/src/lib.rs
+++ b/services/api-rs/crates/centaur-workflows/src/lib.rs
@@ -11,6 +11,7 @@ use absurd::{
     Client, ClientOptions, CreateQueueOptions, RetryKind, RetryStrategy, SpawnOptions, StepHandle,
     TaskContext, TaskRegistrationOptions, Worker, WorkerOptions,
 };
+use centaur_iron_control::{IdentityInput, IronControlClient, IronControlError, slugify};
 use centaur_sandbox_core::SandboxSpec;
 use centaur_session_core::{HarnessType, MessageRole, SessionMessageInput, ThreadKey};
 use centaur_session_runtime::{
@@ -177,6 +178,9 @@ impl WorkflowEnablement {
                 .and_then(Value::as_str)
                 .is_some_and(|workflow_name| self.is_enabled(workflow_name))
         });
+        metadata
+            .principals
+            .retain(|workflow_name| self.is_enabled(workflow_name));
     }
 }
 
@@ -201,12 +205,83 @@ struct WorkflowQueueClients {
 pub struct WorkflowHostSandboxRuntime {
     runtime: SandboxRuntime,
     spec: SandboxSpec,
+    workflow_principals: Arc<RwLock<BTreeMap<String, String>>>,
 }
 
 impl WorkflowHostSandboxRuntime {
     pub fn new(runtime: SandboxRuntime, spec: SandboxSpec) -> Self {
-        Self { runtime, spec }
+        Self {
+            runtime,
+            spec,
+            workflow_principals: Arc::new(RwLock::new(BTreeMap::new())),
+        }
     }
+
+    fn update_workflow_principals(&self, principals: BTreeMap<String, String>) {
+        let mut current = self
+            .workflow_principals
+            .write()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        *current = principals;
+    }
+
+    fn spec_for_workflow(&self, workflow_name: &str) -> SandboxSpec {
+        let mut spec = self.spec.clone();
+        let principal = self
+            .workflow_principals
+            .read()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .get(workflow_name)
+            .cloned();
+        if let Some(principal) = principal {
+            spec.iron_control_principal = Some(principal);
+        }
+        spec
+    }
+}
+
+#[derive(Clone)]
+pub struct WorkflowPrincipalRegistrar {
+    client: IronControlClient,
+    namespace: String,
+}
+
+impl WorkflowPrincipalRegistrar {
+    pub fn new(client: IronControlClient, namespace: impl Into<String>) -> Self {
+        Self {
+            client,
+            namespace: namespace.into(),
+        }
+    }
+
+    async fn register_workflow_principals(
+        &self,
+        principals: &BTreeSet<String>,
+    ) -> Result<BTreeMap<String, String>, WorkflowRuntimeError> {
+        let mut registered = BTreeMap::new();
+        for workflow_name in principals {
+            let foreign_id = canonical_workflow_principal_foreign_id(workflow_name);
+            let record = self
+                .client
+                .upsert_principal(&IdentityInput {
+                    namespace: self.namespace.clone(),
+                    foreign_id,
+                    name: format!("Workflow {workflow_name}"),
+                    labels: BTreeMap::from([
+                        ("managed-by".to_owned(), "centaur".to_owned()),
+                        ("purpose".to_owned(), "workflow".to_owned()),
+                        ("workflow_name".to_owned(), workflow_name.clone()),
+                    ]),
+                })
+                .await?;
+            registered.insert(workflow_name.clone(), record.id);
+        }
+        Ok(registered)
+    }
+}
+
+fn canonical_workflow_principal_foreign_id(workflow_name: &str) -> String {
+    format!("workflow-{}", slugify(workflow_name))
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -408,6 +483,21 @@ impl WorkflowRuntime {
         session_runtime: SessionRuntime,
         workflow_host_sandbox: Option<WorkflowHostSandboxRuntime>,
     ) -> Result<Self, WorkflowRuntimeError> {
+        Self::new_with_workflow_host_sandbox_and_principal_registrar(
+            store,
+            session_runtime,
+            workflow_host_sandbox,
+            None,
+        )
+        .await
+    }
+
+    pub async fn new_with_workflow_host_sandbox_and_principal_registrar(
+        store: PgSessionStore,
+        session_runtime: SessionRuntime,
+        workflow_host_sandbox: Option<WorkflowHostSandboxRuntime>,
+        workflow_principal_registrar: Option<WorkflowPrincipalRegistrar>,
+    ) -> Result<Self, WorkflowRuntimeError> {
         let client = Client::from_pool_with_options(
             store.pool().clone(),
             ClientOptions {
@@ -478,6 +568,13 @@ impl WorkflowRuntime {
                 PythonWorkflowMetadata::default()
             });
         let enablement = WorkflowEnablement::from_env()?;
+        let workflow_host_sandbox = prepare_workflow_host_sandbox(
+            workflow_host_sandbox,
+            workflow_principal_registrar.clone(),
+            &discovery,
+            &enablement,
+        )
+        .await?;
         let schedule_registry = Arc::new(RwLock::new(build_schedule_registry(
             &discovery,
             &enablement,
@@ -667,6 +764,8 @@ impl WorkflowRuntime {
                 workflow_clients,
                 webhook_registry.clone(),
                 schedule_registry.clone(),
+                workflow_host_sandbox.clone(),
+                workflow_principal_registrar,
                 interval,
             );
         }
@@ -1514,6 +1613,8 @@ struct PythonWorkflowDiscovery {
     webhooks: Vec<RegisteredWorkflowWebhook>,
     #[serde(default)]
     schedule: Option<Value>,
+    #[serde(default)]
+    principal: Option<bool>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -1526,6 +1627,7 @@ struct PythonWorkflowMetadata {
     webhooks: Vec<RegisteredWorkflowWebhook>,
     schedules: Vec<Value>,
     workflow_names: BTreeSet<String>,
+    principals: BTreeSet<String>,
 }
 
 fn metadata_from_discovery_payload(
@@ -1548,8 +1650,64 @@ fn metadata_from_discovery_payload(
             }
             metadata.schedules.push(schedule);
         }
+        if workflow.principal.unwrap_or(false) {
+            metadata.principals.insert(workflow.workflow_name);
+        }
     }
     metadata
+}
+
+async fn prepare_workflow_host_sandbox(
+    workflow_host_sandbox: Option<WorkflowHostSandboxRuntime>,
+    workflow_principal_registrar: Option<WorkflowPrincipalRegistrar>,
+    discovery: &PythonWorkflowMetadata,
+    enablement: &WorkflowEnablement,
+) -> Result<Option<WorkflowHostSandboxRuntime>, WorkflowRuntimeError> {
+    let Some(sandbox) = workflow_host_sandbox else {
+        if !discovery.principals.is_empty() {
+            let workflow_names = discovery
+                .principals
+                .iter()
+                .cloned()
+                .collect::<Vec<_>>()
+                .join(", ");
+            return Err(WorkflowRuntimeError::BadRequest(format!(
+                "WORKFLOW_PRINCIPAL requires workflow-host sandboxing, but WORKFLOW_HOST_SANDBOX is disabled for workflows: {workflow_names}"
+            )));
+        }
+        return Ok(None);
+    };
+    reconcile_workflow_principals(
+        &sandbox,
+        workflow_principal_registrar.as_ref(),
+        discovery,
+        enablement,
+    )
+    .await?;
+    Ok(Some(sandbox))
+}
+
+async fn reconcile_workflow_principals(
+    sandbox: &WorkflowHostSandboxRuntime,
+    registrar: Option<&WorkflowPrincipalRegistrar>,
+    discovery: &PythonWorkflowMetadata,
+    enablement: &WorkflowEnablement,
+) -> Result<(), WorkflowRuntimeError> {
+    let Some(registrar) = registrar else {
+        if !discovery.principals.is_empty() {
+            warn!(
+                principal_count = discovery.principals.len(),
+                "workflow principals declared but iron-control is disabled"
+            );
+        }
+        sandbox.update_workflow_principals(BTreeMap::new());
+        return Ok(());
+    };
+    let mut principals = discovery.principals.clone();
+    principals.retain(|workflow_name| enablement.is_enabled(workflow_name));
+    let registered = registrar.register_workflow_principals(&principals).await?;
+    sandbox.update_workflow_principals(registered);
+    Ok(())
 }
 
 async fn discover_python_workflow_metadata() -> Result<PythonWorkflowMetadata, WorkflowRuntimeError>
@@ -1683,6 +1841,8 @@ fn spawn_workflow_metadata_reconciler(
     workflow_clients: WorkflowQueueClients,
     webhook_registry: Arc<RwLock<BTreeMap<String, RegisteredWorkflowWebhook>>>,
     schedule_registry: Arc<RwLock<BTreeMap<String, RegisteredWorkflowSchedule>>>,
+    workflow_host_sandbox: Option<WorkflowHostSandboxRuntime>,
+    workflow_principal_registrar: Option<WorkflowPrincipalRegistrar>,
     interval: Duration,
 ) {
     tokio::spawn(async move {
@@ -1697,6 +1857,8 @@ fn spawn_workflow_metadata_reconciler(
                 &schedule_client,
                 &webhook_registry,
                 &schedule_registry,
+                workflow_host_sandbox.as_ref(),
+                workflow_principal_registrar.as_ref(),
             )
             .await
             {
@@ -1732,6 +1894,8 @@ async fn reconcile_workflow_metadata_once(
     schedule_client: &Client,
     webhook_registry: &Arc<RwLock<BTreeMap<String, RegisteredWorkflowWebhook>>>,
     schedule_registry: &Arc<RwLock<BTreeMap<String, RegisteredWorkflowSchedule>>>,
+    workflow_host_sandbox: Option<&WorkflowHostSandboxRuntime>,
+    workflow_principal_registrar: Option<&WorkflowPrincipalRegistrar>,
 ) -> Result<
     (
         PythonWorkflowMetadata,
@@ -1743,6 +1907,15 @@ async fn reconcile_workflow_metadata_once(
     let discovery = discover_python_workflow_metadata().await?;
     let next_webhooks = build_webhook_registry(&discovery, &enablement)?;
     let next_schedules = build_schedule_registry(&discovery, &enablement)?;
+    if let Some(sandbox) = workflow_host_sandbox {
+        reconcile_workflow_principals(
+            sandbox,
+            workflow_principal_registrar,
+            &discovery,
+            &enablement,
+        )
+        .await?;
+    }
     {
         let mut webhooks = webhook_registry
             .write()
@@ -2795,7 +2968,7 @@ async fn run_python_workflow_host_in_sandbox(
     sandbox: WorkflowHostSandboxRuntime,
     workflow_clients: WorkflowQueueClients,
 ) -> Result<Value, WorkflowRuntimeError> {
-    let mut spec = sandbox.spec.clone();
+    let mut spec = sandbox.spec_for_workflow(&input.workflow_name);
     spec = spec
         .env("WORKFLOW_RUN_ID", ctx.run_id())
         .env("WORKFLOW_TASK_ID", ctx.task_id())
@@ -3875,6 +4048,8 @@ pub enum WorkflowRuntimeError {
     #[error(transparent)]
     Http(#[from] reqwest::Error),
     #[error(transparent)]
+    IronControl(#[from] IronControlError),
+    #[error(transparent)]
     Io(#[from] std::io::Error),
 }
 
@@ -4189,6 +4364,7 @@ mod tests {
                     "workflow_name": "scheduled_workflow",
                     "source_path": "workflows/scheduled_workflow.py",
                     "schedule": {"schedule_id": "scheduled_workflow", "cron": "*/5 * * * *"},
+                    "principal": true,
                 },
                 {
                     "workflow_name": "manual_workflow",
@@ -4210,6 +4386,40 @@ mod tests {
             metadata.schedules[0].get("workflow_name"),
             Some(&json!("scheduled_workflow"))
         );
+        assert!(metadata.principals.contains("scheduled_workflow"));
+    }
+
+    #[test]
+    fn workflow_principal_foreign_id_is_derived_from_workflow_name() {
+        assert_eq!(
+            canonical_workflow_principal_foreign_id("nightly_report"),
+            "workflow-nightly-report"
+        );
+        assert_eq!(
+            canonical_workflow_principal_foreign_id("Managing Partner Daily Briefing"),
+            "workflow-managing-partner-daily-briefing"
+        );
+    }
+
+    #[tokio::test]
+    async fn workflow_principal_requires_workflow_host_sandbox() {
+        let discovery = PythonWorkflowMetadata {
+            principals: BTreeSet::from(["nightly_report".to_owned()]),
+            workflow_names: BTreeSet::from(["nightly_report".to_owned()]),
+            ..PythonWorkflowMetadata::default()
+        };
+
+        let error =
+            match prepare_workflow_host_sandbox(None, None, &discovery, &WorkflowEnablement::all())
+                .await
+            {
+                Ok(_) => panic!("workflow principal should require workflow-host sandboxing"),
+                Err(error) => error,
+            };
+
+        assert!(matches!(error, WorkflowRuntimeError::BadRequest(_)));
+        assert!(error.to_string().contains("WORKFLOW_HOST_SANDBOX"));
+        assert!(error.to_string().contains("nightly_report"));
     }
 
     #[test]
@@ -4356,6 +4566,7 @@ mod tests {
                     "workflow_name": "allowed_workflow",
                     "source_path": "workflows/allowed_workflow.py",
                     "schedule": {"schedule_id": "allowed", "cron": "*/5 * * * *"},
+                    "principal": true,
                     "webhooks": [{
                         "workflow_name": "allowed_workflow",
                         "source_path": "workflows/allowed_workflow.py",
@@ -4369,6 +4580,7 @@ mod tests {
                     "workflow_name": "blocked_workflow",
                     "source_path": "workflows/blocked_workflow.py",
                     "schedule": {"schedule_id": "blocked", "cron": "*/10 * * * *"},
+                    "principal": true,
                     "webhooks": [{
                         "workflow_name": "blocked_workflow",
                         "source_path": "workflows/blocked_workflow.py",
@@ -4395,6 +4607,10 @@ mod tests {
         );
         assert_eq!(metadata.webhooks.len(), 1);
         assert_eq!(metadata.webhooks[0].workflow_name, "allowed_workflow");
+        assert_eq!(
+            metadata.principals.iter().cloned().collect::<Vec<_>>(),
+            vec!["allowed_workflow".to_owned()]
+        );
     }
 
     #[test]

--- a/services/api-rs/crates/centaur-workflows/src/lib.rs
+++ b/services/api-rs/crates/centaur-workflows/src/lib.rs
@@ -307,11 +307,7 @@ impl WorkflowPrincipalRegistrar {
                     namespace: self.namespace.clone(),
                     foreign_id,
                     name: format!("Workflow {workflow_name}"),
-                    labels: BTreeMap::from([
-                        ("managed-by".to_owned(), "centaur".to_owned()),
-                        ("purpose".to_owned(), "workflow".to_owned()),
-                        ("workflow_name".to_owned(), workflow_name.clone()),
-                    ]),
+                    labels: workflow_principal_labels(workflow_name),
                 })
                 .await?;
             registered.insert(workflow_name.clone(), record.id);
@@ -322,6 +318,15 @@ impl WorkflowPrincipalRegistrar {
 
 fn canonical_workflow_principal_foreign_id(workflow_name: &str) -> String {
     format!("workflow-{}", slugify(workflow_name))
+}
+
+fn workflow_principal_labels(workflow_name: &str) -> BTreeMap<String, String> {
+    BTreeMap::from([
+        ("kind".to_owned(), "workflow".to_owned()),
+        ("managed-by".to_owned(), "centaur".to_owned()),
+        ("purpose".to_owned(), "workflow".to_owned()),
+        ("workflow_name".to_owned(), workflow_name.to_owned()),
+    ])
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -4437,6 +4442,18 @@ mod tests {
         assert_eq!(
             canonical_workflow_principal_foreign_id("Managing Partner Daily Briefing"),
             "workflow-managing-partner-daily-briefing"
+        );
+    }
+
+    #[test]
+    fn workflow_principal_labels_identify_workflow_kind() {
+        let labels = workflow_principal_labels("nightly_report");
+
+        assert_eq!(labels.get("kind").map(String::as_str), Some("workflow"));
+        assert_eq!(labels.get("purpose").map(String::as_str), Some("workflow"));
+        assert_eq!(
+            labels.get("workflow_name").map(String::as_str),
+            Some("nightly_report")
         );
     }
 

--- a/services/api-rs/crates/centaur-workflows/src/lib.rs
+++ b/services/api-rs/crates/centaur-workflows/src/lib.rs
@@ -205,7 +205,39 @@ struct WorkflowQueueClients {
 pub struct WorkflowHostSandboxRuntime {
     runtime: SandboxRuntime,
     spec: SandboxSpec,
-    workflow_principals: Arc<RwLock<BTreeMap<String, String>>>,
+    workflow_principals: Arc<RwLock<WorkflowPrincipalAssignments>>,
+}
+
+#[derive(Clone, Default)]
+struct WorkflowPrincipalAssignments {
+    required: BTreeSet<String>,
+    registered: BTreeMap<String, String>,
+}
+
+impl WorkflowPrincipalAssignments {
+    fn principal_for_workflow(
+        &self,
+        workflow_name: &str,
+    ) -> Result<Option<String>, WorkflowRuntimeError> {
+        if let Some(principal) = self.registered.get(workflow_name) {
+            return Ok(Some(principal.clone()));
+        }
+        if self.required.contains(workflow_name) {
+            return Err(WorkflowRuntimeError::Internal(format!(
+                "workflow {workflow_name} declares WORKFLOW_PRINCIPAL but no scoped principal is registered"
+            )));
+        }
+        Ok(None)
+    }
+}
+
+fn workflow_principals_require_iron_control_error(
+    principals: &BTreeSet<String>,
+) -> WorkflowRuntimeError {
+    let workflow_names = principals.iter().cloned().collect::<Vec<_>>().join(", ");
+    WorkflowRuntimeError::BadRequest(format!(
+        "WORKFLOW_PRINCIPAL requires Iron Control, but Iron Control is disabled for workflows: {workflow_names}"
+    ))
 }
 
 impl WorkflowHostSandboxRuntime {
@@ -213,30 +245,38 @@ impl WorkflowHostSandboxRuntime {
         Self {
             runtime,
             spec,
-            workflow_principals: Arc::new(RwLock::new(BTreeMap::new())),
+            workflow_principals: Arc::new(RwLock::new(WorkflowPrincipalAssignments::default())),
         }
     }
 
-    fn update_workflow_principals(&self, principals: BTreeMap<String, String>) {
+    fn update_workflow_principals(
+        &self,
+        registered: BTreeMap<String, String>,
+        required: BTreeSet<String>,
+    ) {
         let mut current = self
             .workflow_principals
             .write()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
-        *current = principals;
+        *current = WorkflowPrincipalAssignments {
+            required,
+            registered,
+        };
     }
 
-    fn spec_for_workflow(&self, workflow_name: &str) -> SandboxSpec {
+    fn spec_for_workflow(&self, workflow_name: &str) -> Result<SandboxSpec, WorkflowRuntimeError> {
         let mut spec = self.spec.clone();
-        let principal = self
-            .workflow_principals
-            .read()
-            .unwrap_or_else(|poisoned| poisoned.into_inner())
-            .get(workflow_name)
-            .cloned();
+        let principal = {
+            let assignments = self
+                .workflow_principals
+                .read()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            assignments.principal_for_workflow(workflow_name)?
+        };
         if let Some(principal) = principal {
             spec.iron_control_principal = Some(principal);
         }
-        spec
+        Ok(spec)
     }
 }
 
@@ -561,12 +601,7 @@ impl WorkflowRuntime {
             etl_backfill: etl_backfill_client.clone(),
         };
 
-        let discovery = discover_python_workflow_metadata()
-            .await
-            .unwrap_or_else(|error| {
-                warn!(%error, "python workflow discovery failed");
-                PythonWorkflowMetadata::default()
-            });
+        let discovery = discover_python_workflow_metadata().await?;
         let enablement = WorkflowEnablement::from_env()?;
         let workflow_host_sandbox = prepare_workflow_host_sandbox(
             workflow_host_sandbox,
@@ -1693,20 +1728,24 @@ async fn reconcile_workflow_principals(
     discovery: &PythonWorkflowMetadata,
     enablement: &WorkflowEnablement,
 ) -> Result<(), WorkflowRuntimeError> {
-    let Some(registrar) = registrar else {
-        if !discovery.principals.is_empty() {
-            warn!(
-                principal_count = discovery.principals.len(),
-                "workflow principals declared but iron-control is disabled"
-            );
-        }
-        sandbox.update_workflow_principals(BTreeMap::new());
-        return Ok(());
-    };
     let mut principals = discovery.principals.clone();
     principals.retain(|workflow_name| enablement.is_enabled(workflow_name));
-    let registered = registrar.register_workflow_principals(&principals).await?;
-    sandbox.update_workflow_principals(registered);
+    let Some(registrar) = registrar else {
+        if !principals.is_empty() {
+            sandbox.update_workflow_principals(BTreeMap::new(), principals.clone());
+            return Err(workflow_principals_require_iron_control_error(&principals));
+        }
+        sandbox.update_workflow_principals(BTreeMap::new(), BTreeSet::new());
+        return Ok(());
+    };
+    let registered = match registrar.register_workflow_principals(&principals).await {
+        Ok(registered) => registered,
+        Err(error) => {
+            sandbox.update_workflow_principals(BTreeMap::new(), principals);
+            return Err(error);
+        }
+    };
+    sandbox.update_workflow_principals(registered, principals);
     Ok(())
 }
 
@@ -2968,7 +3007,7 @@ async fn run_python_workflow_host_in_sandbox(
     sandbox: WorkflowHostSandboxRuntime,
     workflow_clients: WorkflowQueueClients,
 ) -> Result<Value, WorkflowRuntimeError> {
-    let mut spec = sandbox.spec_for_workflow(&input.workflow_name);
+    let mut spec = sandbox.spec_for_workflow(&input.workflow_name)?;
     spec = spec
         .env("WORKFLOW_RUN_ID", ctx.run_id())
         .env("WORKFLOW_TASK_ID", ctx.task_id())
@@ -4399,6 +4438,45 @@ mod tests {
             canonical_workflow_principal_foreign_id("Managing Partner Daily Briefing"),
             "workflow-managing-partner-daily-briefing"
         );
+    }
+
+    #[test]
+    fn required_workflow_principal_fails_closed_when_unregistered() {
+        let assignments = WorkflowPrincipalAssignments {
+            required: BTreeSet::from(["nightly_report".to_owned()]),
+            registered: BTreeMap::new(),
+        };
+
+        let error = assignments
+            .principal_for_workflow("nightly_report")
+            .expect_err("required workflow principal should not fall back");
+
+        assert!(matches!(error, WorkflowRuntimeError::Internal(_)));
+        assert!(error.to_string().contains("nightly_report"));
+        assert!(error.to_string().contains("WORKFLOW_PRINCIPAL"));
+    }
+
+    #[test]
+    fn optional_workflow_principal_uses_shared_principal() {
+        let assignments = WorkflowPrincipalAssignments::default();
+
+        assert_eq!(
+            assignments
+                .principal_for_workflow("nightly_report")
+                .expect("optional workflow should be allowed"),
+            None
+        );
+    }
+
+    #[test]
+    fn workflow_principal_requires_iron_control() {
+        let error = workflow_principals_require_iron_control_error(&BTreeSet::from([
+            "nightly_report".to_owned(),
+        ]));
+
+        assert!(matches!(error, WorkflowRuntimeError::BadRequest(_)));
+        assert!(error.to_string().contains("Iron Control"));
+        assert!(error.to_string().contains("nightly_report"));
     }
 
     #[tokio::test]

--- a/services/workflow-python/tests/test_workflow_host.py
+++ b/services/workflow-python/tests/test_workflow_host.py
@@ -386,6 +386,21 @@ class WorkflowHostTests(unittest.TestCase):
             {"model": "claude-opus-4-8", "reasoning": "high"},
         )
 
+    def test_load_workflow_file_reads_workflow_principal(self) -> None:
+        host = load_workflow_host()
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "principal_workflow.py"
+            path.write_text(
+                "WORKFLOW_NAME = 'principal_workflow'\n"
+                "WORKFLOW_PRINCIPAL = True\n"
+                "def handler(inp, ctx):\n"
+                "    return None\n"
+            )
+            registered = host.load_workflow_file(path)
+
+        assert registered is not None
+        self.assertEqual(host.normalize_principal(registered), True)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/services/workflow-python/workflow_host.py
+++ b/services/workflow-python/workflow_host.py
@@ -84,6 +84,7 @@ class RegisteredWorkflow:
     input_cls: type | None
     webhooks: Any
     schedule: Any
+    principal: Any = None
     agent_defaults: dict[str, Any] | None = None
 
 
@@ -153,6 +154,7 @@ def load_workflow_file(path: Path) -> RegisteredWorkflow | None:
         input_cls=getattr(module, "Input", None),
         webhooks=getattr(module, "WEBHOOKS", None),
         schedule=getattr(module, "SCHEDULE", None),
+        principal=getattr(module, "WORKFLOW_PRINCIPAL", None),
         agent_defaults=agent_defaults,
     )
 
@@ -326,6 +328,11 @@ def normalize_schedule(workflow: RegisteredWorkflow) -> dict[str, Any] | None:
     return schedule
 
 
+def normalize_principal(workflow: RegisteredWorkflow) -> bool | None:
+    raw = workflow.principal
+    return raw if isinstance(raw, bool) and raw else None
+
+
 async def run_workflow(message: dict[str, Any], rpc: RpcClient) -> dict[str, Any]:
     workflows = discover_workflows()
     workflow_name = str(message.get("workflow_name") or "")
@@ -375,6 +382,7 @@ def discovery_payload() -> dict[str, Any]:
                 "source_path": workflow.source_path,
                 "webhooks": normalize_webhooks(workflow),
                 "schedule": normalize_schedule(workflow),
+                "principal": normalize_principal(workflow),
             }
             for workflow in workflows.values()
         ],


### PR DESCRIPTION
Adds an optional boolean WORKFLOW_PRINCIPAL declaration for Python workflows. When enabled, api-rs deterministically derives a workflow-scoped principal from WORKFLOW_NAME, registers it in Iron Control, and runs that workflow-host sandbox under the derived principal so ctx.call_tool permissions can be granted narrowly.

Updates workflow docs and focused Rust/Python tests for discovery, allowlist filtering, and deterministic principal derivation.