### PR TITLE
fix(console): clean up chat detail rows

### DIFF
--- a/services/console/app/controllers/console/threads_controller.rb
+++ b/services/console/app/controllers/console/threads_controller.rb
@@ -34,8 +34,6 @@ class Console::ThreadsController < ApplicationController
     tool_use
     functioncall
     function_call
-    filechange
-    file_change
   ].freeze
   TOOL_TRACE_ITEM_TYPES = %w[
     commandExecution
@@ -48,8 +46,6 @@ class Console::ThreadsController < ApplicationController
     tool_use
     functionCall
     function_call
-    fileChange
-    file_change
   ].freeze
   # Messages and thinking precede the terminal event for a same-timestamp tie.
   TRANSCRIPT_SOURCE_ORDER = { message: 0, thinking: 1, event: 2 }.freeze
@@ -1161,7 +1157,6 @@ class Console::ThreadsController < ApplicationController
   end
 
   def generic_tool_item_trace(item)
-    label = trace_label_for_item(item)
     name = first_present(item["name"], item["tool"], item["toolName"], item["tool_name"])
     input = item["input"] || item["arguments"] || item["args"]
     output = item["output"] || item["result"]
@@ -1175,7 +1170,7 @@ class Console::ThreadsController < ApplicationController
     text = sections.compact.join("\n\n").strip
     return nil if text.blank?
 
-    { label: label, text: text }
+    { label: "Tool call", text: text }
   end
 
   def claude_tool_use_trace(value)
@@ -1229,14 +1224,6 @@ class Console::ThreadsController < ApplicationController
   def message_content(value)
     message = value["message"]
     message.is_a?(Hash) ? message["content"] : value["content"]
-  end
-
-  def trace_label_for_item(item)
-    case item["type"].to_s
-    when "fileChange", "file_change" then "File change"
-    when "mcpToolCall", "mcp_tool_call" then "Tool call"
-    else "Tool call"
-    end
   end
 
   def markdown_code_block(value, language: nil)

--- a/services/console/app/views/layouts/console.html.erb
+++ b/services/console/app/views/layouts/console.html.erb
@@ -506,6 +506,7 @@
       }
 
       .console-thinking-preview {
+        flex: 1 1 auto;
         min-width: 0;
         overflow: hidden;
         text-overflow: ellipsis;
@@ -517,6 +518,7 @@
         flex: 0 0 auto;
         color: #d4d4d8;
         font-weight: 500;
+        white-space: nowrap;
       }
 
       .console-thinking-failed,
@@ -527,7 +529,9 @@
       /* The comma hugs the group title: pull the label back across the flex
          gap so it reads "Ran 2 commands, 1 failed". */
       .console-thinking-failed {
+        flex: 0 0 auto;
         margin-left: -0.4rem;
+        white-space: nowrap;
       }
 
       .console-thinking-failed::before {

--- a/services/console/test/controllers/console/threads_controller_test.rb
+++ b/services/console/test/controllers/console/threads_controller_test.rb
@@ -1285,6 +1285,23 @@ class Console::ThreadsControllerTest < ActionDispatch::IntegrationTest
     assert_includes item[:text], "```text\nok\n```"
   end
 
+  test "thinking extraction omits file change status events" do
+    controller = Console::ThreadsController.new
+    line = {
+      method: "item/completed",
+      params: {
+        item: {
+          type: "fileChange",
+          status: "completed",
+          changes: [ { path: "app/models/thread.rb", kind: "update" } ]
+        }
+      }
+    }.to_json
+    event = OutputLineEvent.new(payload: line, created_at: Time.zone.now)
+
+    assert_nil controller.send(:thinking_transcript_item, event)
+  end
+
   test "compact trace grouping combines adjacent command executions for one run" do
     controller = Console::ThreadsController.new
     now = Time.zone.now


### PR DESCRIPTION
## Summary

- keep command failure summaries intact in narrow chat panels
- let activity previews truncate into the remaining row space
- remove redundant completed file-change status rows
- add regression coverage for file-change event filtering

## Testing

- bin/rails test test/controllers/console/threads_controller_test.rb
- bin/rubocop app/controllers/console/threads_controller.rb test/controllers/console/threads_controller_test.rb
- git diff --check