### PR TITLE
[Remote Agent] feat(api): add durable agent execution endpoints

### DIFF
--- a/services/api-rs/crates/centaur-api-server/src/lib.rs
+++ b/services/api-rs/crates/centaur-api-server/src/lib.rs
@@ -319,9 +319,63 @@ mod tests {
             .and_then(|value| value.to_str().ok())
             .unwrap();
         assert!(challenge.contains("Bearer"));
-        assert!(challenge.contains(
-            "resource_metadata=\"http://centaur.local/.well-known/oauth-protected-resource/mcp\""
-        ));
+        assert!(challenge.contains("/.well-known/oauth-protected-resource/mcp"));
+    }
+
+    #[tokio::test]
+    async fn agent_api_requires_bearer_before_runtime_is_ready() {
+        let app = build_router_with_app_state(AppState::unready());
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri("/api/agents/executions")
+                    .header(header::HOST, "centaur.local")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(
+                        r#"{"prompt":"hello","idempotency_key":"request-1"}"#,
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+        let challenge = response
+            .headers()
+            .get(header::WWW_AUTHENTICATE)
+            .and_then(|value| value.to_str().ok())
+            .unwrap();
+        assert!(challenge.contains("Bearer"));
+        assert!(challenge.contains("scope=\"agents:execute\""));
+        assert!(challenge.contains("/.well-known/oauth-protected-resource/api/agents"));
+    }
+
+    #[tokio::test]
+    async fn agent_api_exposes_protected_resource_metadata_at_rfc_path() {
+        let app = build_router_with_app_state(AppState::unready());
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method(Method::GET)
+                    .uri("/.well-known/oauth-protected-resource/api/agents")
+                    .header(header::HOST, "centaur.local")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let body: Value = serde_json::from_slice(&body).unwrap();
+        assert!(
+            body["resource"]
+                .as_str()
+                .is_some_and(|resource| resource.ends_with("/api/agents"))
+        );
+        assert_eq!(body["scopes_supported"], json!(["agents:execute"]));
     }
 
     #[tokio::test]

--- a/services/api-rs/crates/centaur-api-server/src/mcp.rs
+++ b/services/api-rs/crates/centaur-api-server/src/mcp.rs
@@ -34,7 +34,7 @@ use crate::{
     tool_discovery::{DiscoveredTool, ToolDiscoveryConfig, discover_tool_catalog},
 };
 
-const MCP_AGENT_MAX_DURATION_MS: u64 = 24 * 60 * 60 * 1_000;
+const MCP_AGENT_MAX_DURATION_MS: u64 = 60 * 60 * 1_000;
 const MCP_AGENT_IDEMPOTENCY_KEY_MAX_BYTES: usize = 256;
 
 pub(crate) async fn mcp_get() -> Response {
@@ -259,7 +259,7 @@ fn mcp_agent_tool_entries() -> Vec<Value> {
                         "type": "integer",
                         "minimum": 1,
                         "maximum": MCP_AGENT_MAX_DURATION_MS,
-                        "description": "Maximum execution duration. Defaults to 24 hours and cannot exceed 24 hours."
+                        "description": "Maximum execution duration. Defaults to 1 hour and cannot exceed 1 hour."
                     }
                 },
                 "additionalProperties": false

--- a/services/api-rs/crates/centaur-api-server/src/mcp.rs
+++ b/services/api-rs/crates/centaur-api-server/src/mcp.rs
@@ -114,6 +114,7 @@ struct McpAgentEventsArguments {
 #[derive(Debug, Deserialize)]
 struct McpAgentCancelArguments {
     thread_key: String,
+    execution_id: String,
     #[serde(default)]
     reason: Option<String>,
 }
@@ -296,14 +297,18 @@ fn mcp_agent_tool_entries() -> Vec<Value> {
         }),
         json!({
             "name": "centaur_agent_cancel",
-            "description": "Ask the active Centaur sub-agent execution for a thread to stop.",
+            "description": "Ask one exact active Centaur sub-agent execution for a thread to stop.",
             "inputSchema": {
                 "type": "object",
-                "required": ["thread_key"],
+                "required": ["thread_key", "execution_id"],
                 "properties": {
                     "thread_key": {
                         "type": "string",
                         "description": "mcp-agent thread key returned by centaur_agent_start."
+                    },
+                    "execution_id": {
+                        "type": "string",
+                        "description": "Execution id returned by centaur_agent_start. Cancellation is ignored if this execution is no longer active."
                     },
                     "reason": {
                         "type": "string",
@@ -537,11 +542,7 @@ async fn mcp_agent_start_result(
         _ if params.thread_key.is_some() => runtime.session(&thread_key).await?.harness_type,
         _ => runtime.default_harness(),
     };
-    let metadata = json!({
-        "mcp_agent": true,
-        "mcp_principal_id": principal.principal_id,
-        "mcp_token_id": principal.token_id,
-    });
+    let metadata = mcp_agent_session_metadata(principal);
     let request_fingerprint = mcp_agent_request_fingerprint(
         &prompt,
         &harness,
@@ -549,12 +550,7 @@ async fn mcp_agent_start_result(
         params.idle_timeout_ms,
         max_duration_ms,
     )?;
-    let execution_metadata = json!({
-        "mcp_agent": true,
-        "mcp_principal_id": principal.principal_id,
-        "mcp_token_id": principal.token_id,
-        "mcp_request_fingerprint": request_fingerprint,
-    });
+    let execution_metadata = mcp_agent_execution_metadata(principal, &request_fingerprint);
     let session = runtime
         .create_or_get_external_session(
             &thread_key,
@@ -565,12 +561,9 @@ async fn mcp_agent_start_result(
             &principal.principal_id,
         )
         .await?;
-    let input_line = serde_json::to_string(&json!({
-        "type": "user",
-        "text": prompt,
-    }))?;
+    let input_line = mcp_agent_input_line(&thread_key, &prompt, &execution_metadata)?;
     let execution = runtime
-        .execute_session_with_messages(
+        .execute_external_session_with_messages(
             &thread_key,
             ExecuteSessionInput {
                 idempotency_key: Some(idempotency_key.clone()),
@@ -588,6 +581,7 @@ async fn mcp_agent_start_result(
                 })],
                 metadata: metadata.clone(),
             }],
+            &principal.principal_id,
         )
         .await?;
     mcp_json_result(json!({
@@ -613,30 +607,50 @@ async fn mcp_agent_events_result(
             "limit must be between 1 and 500".to_owned(),
         ));
     }
-    let mut events = state
-        .runtime()?
-        .list_events(
+    let runtime = state.runtime()?;
+    let mut events = runtime
+        .list_external_events(
             &thread_key,
             params.after_event_id.unwrap_or(0),
             params.execution_id.as_deref(),
             limit + 1,
+            &principal.principal_id,
         )
         .await?;
     let has_more = events.len() > limit as usize;
     events.truncate(limit as usize);
     let last_event_id = events.last().map(|event| event.event_id);
-    let terminal_status = mcp_terminal_status(
-        state
-            .runtime()?
-            .execution_status(&thread_key, params.execution_id.as_deref())
-            .await?,
-    );
+    let execution_status = match params.execution_id.as_deref() {
+        Some(execution_id) => {
+            runtime
+                .external_execution_status(&thread_key, execution_id, &principal.principal_id)
+                .await?
+        }
+        None => None,
+    };
+    let terminal_status = mcp_terminal_status_from_execution_status(execution_status.as_ref());
+    let terminal_event_observed = match (params.execution_id.as_deref(), execution_status.as_ref())
+    {
+        (Some(execution_id), Some(status)) => {
+            mcp_terminal_event_visible_in_events(&events, execution_id, status)
+                || runtime
+                    .external_terminal_event_observed(
+                        &thread_key,
+                        execution_id,
+                        status,
+                        &principal.principal_id,
+                    )
+                    .await?
+        }
+        _ => false,
+    };
     mcp_json_result(json!({
         "thread_key": thread_key,
         "execution_id": params.execution_id,
         "events": events,
         "last_event_id": last_event_id,
         "terminal_status": terminal_status,
+        "terminal_event_observed": terminal_event_observed,
         "has_more": has_more,
     }))
 }
@@ -655,15 +669,38 @@ async fn mcp_agent_cancel_result(
         .map(str::trim)
         .filter(|value| !value.is_empty())
         .unwrap_or("Interrupted from MCP");
+    let execution_id = params.execution_id.trim();
+    if execution_id.is_empty() {
+        return Err(ApiError::BadRequest("execution_id is required".to_owned()));
+    }
     let outcome = state
         .runtime()?
-        .interrupt_active_execution(&thread_key, reason)
+        .interrupt_external_execution(&thread_key, execution_id, reason, &principal.principal_id)
         .await?;
     mcp_json_result(json!({
         "thread_key": thread_key,
         "interrupted": outcome.interrupted,
         "execution_id": outcome.execution_id,
     }))
+}
+
+fn mcp_agent_input_line(
+    thread_key: &ThreadKey,
+    prompt: &str,
+    trace_metadata: &Value,
+) -> Result<String, ApiError> {
+    Ok(serde_json::to_string(&json!({
+        "type": "user",
+        "thread_key": thread_key,
+        "trace_metadata": trace_metadata,
+        "message": {
+            "role": "user",
+            "content": [{
+                "type": "text",
+                "text": prompt,
+            }],
+        },
+    }))?)
 }
 
 fn mcp_parse_agent_harness(value: &str) -> Result<HarnessType, ApiError> {
@@ -704,12 +741,51 @@ fn mcp_agent_thread_prefix(principal: &McpPrincipal) -> String {
     format!("mcp-agent:{}:", hex::encode(&digest[..12]))
 }
 
-fn mcp_terminal_status(status: Option<ExecutionStatus>) -> Option<&'static str> {
+fn mcp_agent_session_metadata(principal: &McpPrincipal) -> Value {
+    json!({
+        "mcp_agent": true,
+        "mcp_principal_id": principal.principal_id,
+    })
+}
+
+fn mcp_agent_execution_metadata(principal: &McpPrincipal, request_fingerprint: &str) -> Value {
+    json!({
+        "mcp_agent": true,
+        "mcp_principal_id": principal.principal_id,
+        "mcp_request_fingerprint": request_fingerprint,
+    })
+}
+
+fn mcp_terminal_status_from_execution_status(
+    status: Option<&ExecutionStatus>,
+) -> Option<&'static str> {
     match status {
         Some(ExecutionStatus::Completed) => Some("completed"),
         Some(ExecutionStatus::Failed) => Some("failed"),
         Some(ExecutionStatus::Cancelled) => Some("cancelled"),
         Some(ExecutionStatus::Queued | ExecutionStatus::Running) | None => None,
+    }
+}
+
+fn mcp_terminal_event_visible_in_events(
+    events: &[centaur_session_core::SessionEvent],
+    execution_id: &str,
+    status: &ExecutionStatus,
+) -> bool {
+    let Some(event_type) = mcp_terminal_event_type_for_status(status) else {
+        return false;
+    };
+    events.iter().any(|event| {
+        event.execution_id.as_deref() == Some(execution_id) && event.event_type == event_type
+    })
+}
+
+fn mcp_terminal_event_type_for_status(status: &ExecutionStatus) -> Option<&'static str> {
+    match status {
+        ExecutionStatus::Completed => Some("session.execution_completed"),
+        ExecutionStatus::Failed => Some("session.execution_failed"),
+        ExecutionStatus::Cancelled => Some("session.execution_cancelled"),
+        ExecutionStatus::Queued | ExecutionStatus::Running => None,
     }
 }
 
@@ -1358,6 +1434,32 @@ mod mcp_tests {
             tools[0]["inputSchema"]["required"],
             json!(["prompt", "idempotency_key"])
         );
+        assert_eq!(
+            tools[2]["inputSchema"]["required"],
+            json!(["thread_key", "execution_id"])
+        );
+    }
+
+    #[test]
+    fn mcp_agent_input_uses_harness_user_message_shape() {
+        let thread_key = ThreadKey::parse("mcp-agent:principal:request").unwrap();
+        let line = mcp_agent_input_line(
+            &thread_key,
+            "inspect the failure",
+            &json!({"source": "mcp"}),
+        )
+        .unwrap();
+        let input: Value = serde_json::from_str(&line).unwrap();
+
+        assert_eq!(input["type"], "user");
+        assert_eq!(input["thread_key"], thread_key.as_str());
+        assert_eq!(input["trace_metadata"], json!({"source": "mcp"}));
+        assert_eq!(input["message"]["role"], "user");
+        assert_eq!(
+            input["message"]["content"],
+            json!([{"type": "text", "text": "inspect the failure"}])
+        );
+        assert!(input.get("text").is_none());
     }
 
     #[test]
@@ -1395,21 +1497,55 @@ mod mcp_tests {
     }
 
     #[test]
-    fn mcp_terminal_status_uses_durable_execution_status() {
+    fn mcp_agent_execution_metadata_survives_token_rotation() {
+        let mut first = test_principal("principal-ada");
+        first.token_id = "token-before-refresh".to_owned();
+        let mut refreshed = test_principal("principal-ada");
+        refreshed.token_id = "token-after-refresh".to_owned();
+
+        let first_metadata = mcp_agent_execution_metadata(&first, "fingerprint-1");
+        let refreshed_metadata = mcp_agent_execution_metadata(&refreshed, "fingerprint-1");
+
+        assert_eq!(first_metadata, refreshed_metadata);
+        assert_eq!(first_metadata["mcp_principal_id"], "principal-ada");
+        assert_eq!(first_metadata["mcp_request_fingerprint"], "fingerprint-1");
+        assert!(first_metadata.get("mcp_token_id").is_none());
+    }
+
+    #[test]
+    fn mcp_terminal_status_uses_execution_status_and_tracks_visible_event() {
+        let thread_key = ThreadKey::parse("mcp-agent:principal:request").unwrap();
+        let completed = centaur_session_core::SessionEvent {
+            event_id: 10,
+            thread_key: thread_key.clone(),
+            execution_id: Some("exec-1".to_owned()),
+            event_type: "session.execution_completed".to_owned(),
+            payload: json!({"execution_id": "exec-1"}),
+            created_at: OffsetDateTime::now_utc(),
+        };
+        let output = centaur_session_core::SessionEvent {
+            event_id: 9,
+            thread_key,
+            execution_id: Some("exec-1".to_owned()),
+            event_type: "session.output.line".to_owned(),
+            payload: json!("done"),
+            created_at: OffsetDateTime::now_utc(),
+        };
+
         assert_eq!(
-            mcp_terminal_status(Some(ExecutionStatus::Completed)),
+            mcp_terminal_status_from_execution_status(Some(&ExecutionStatus::Completed)),
             Some("completed")
         );
-        assert_eq!(
-            mcp_terminal_status(Some(ExecutionStatus::Failed)),
-            Some("failed")
-        );
-        assert_eq!(
-            mcp_terminal_status(Some(ExecutionStatus::Cancelled)),
-            Some("cancelled")
-        );
-        assert_eq!(mcp_terminal_status(Some(ExecutionStatus::Running)), None);
-        assert_eq!(mcp_terminal_status(None), None);
+        assert!(!mcp_terminal_event_visible_in_events(
+            &[output],
+            "exec-1",
+            &ExecutionStatus::Completed,
+        ));
+        assert!(mcp_terminal_event_visible_in_events(
+            &[completed],
+            "exec-1",
+            &ExecutionStatus::Completed,
+        ));
     }
 
     #[test]

--- a/services/api-rs/crates/centaur-api-server/src/mcp.rs
+++ b/services/api-rs/crates/centaur-api-server/src/mcp.rs
@@ -2,6 +2,7 @@ use std::{
     collections::BTreeMap,
     env, fs,
     path::PathBuf,
+    str::FromStr,
     sync::{Mutex, OnceLock},
     time::{Duration, Instant},
 };
@@ -13,12 +14,19 @@ use axum::{
     response::{IntoResponse, Response},
 };
 use base64::{Engine as _, engine::general_purpose};
-use centaur_session_runtime::{SessionRuntime, ToolHostCallInput};
+use centaur_session_core::{
+    HarnessType, MessageRole, SessionEvent, SessionMessageInput, ThreadKey,
+};
+use centaur_session_runtime::{
+    ExecuteSessionInput, HarnessConflictPolicy, SessionRuntime, SessionRuntimeError,
+    ToolHostCallInput,
+};
 use hmac::{Hmac, Mac};
 use serde::Deserialize;
 use serde_json::{Value, json};
 use sha2::{Digest, Sha256};
 use time::OffsetDateTime;
+use uuid::Uuid;
 
 use crate::{
     ApiError,
@@ -26,6 +34,8 @@ use crate::{
     routes::{AppState, header_value},
     tool_discovery::{DiscoveredTool, ToolDiscoveryConfig, discover_tool_catalog},
 };
+
+const MCP_AGENT_MAX_DURATION_MS: u64 = 10 * 60 * 1_000;
 
 pub(crate) async fn mcp_get() -> Response {
     (
@@ -74,6 +84,39 @@ struct CentaurToolMcpArguments {
     arguments: Value,
 }
 
+#[derive(Debug, Deserialize)]
+struct McpAgentStartArguments {
+    prompt: String,
+    #[serde(default)]
+    harness: Option<String>,
+    #[serde(default)]
+    persona_id: Option<String>,
+    #[serde(default)]
+    thread_key: Option<String>,
+    #[serde(default)]
+    idle_timeout_ms: Option<u64>,
+    #[serde(default)]
+    max_duration_ms: Option<u64>,
+}
+
+#[derive(Debug, Deserialize)]
+struct McpAgentEventsArguments {
+    thread_key: String,
+    #[serde(default)]
+    execution_id: Option<String>,
+    #[serde(default)]
+    after_event_id: Option<i64>,
+    #[serde(default)]
+    limit: Option<i64>,
+}
+
+#[derive(Debug, Deserialize)]
+struct McpAgentCancelArguments {
+    thread_key: String,
+    #[serde(default)]
+    reason: Option<String>,
+}
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 struct McpPrincipal {
     token_id: String,
@@ -119,6 +162,7 @@ pub(crate) async fn mcp_post(
         "tools/list" => {
             ensure_mcp_scope(&principal.scopes, "mcp:tools")?;
             let mut tools = vec![mcp_whoami_tool()];
+            tools.extend(mcp_agent_tool_entries());
             tools.extend(mcp_centaur_tool_entries()?);
             json!({
                 "tools": tools,
@@ -130,6 +174,21 @@ pub(crate) async fn mcp_post(
                 .map_err(|error| ApiError::BadRequest(error.to_string()))?;
             if params.name == "centaur_whoami" {
                 mcp_whoami_result(&principal, params.arguments)?
+            } else if params.name == "centaur_agent_start" {
+                match mcp_agent_start_result(&state, &principal, params.arguments).await {
+                    Ok(result) => result,
+                    Err(error) => mcp_agent_domain_error_result(error)?,
+                }
+            } else if params.name == "centaur_agent_events" {
+                match mcp_agent_events_result(&state, &principal, params.arguments).await {
+                    Ok(result) => result,
+                    Err(error) => mcp_agent_domain_error_result(error)?,
+                }
+            } else if params.name == "centaur_agent_cancel" {
+                match mcp_agent_cancel_result(&state, &principal, params.arguments).await {
+                    Ok(result) => result,
+                    Err(error) => mcp_agent_domain_error_result(error)?,
+                }
             } else {
                 let Some(tool) = mcp_find_centaur_tool(&params.name)? else {
                     return Ok(mcp_json_error(id, -32602, "unknown tool"));
@@ -158,6 +217,96 @@ fn mcp_whoami_tool() -> Value {
             "additionalProperties": false,
         },
     })
+}
+
+fn mcp_agent_tool_entries() -> Vec<Value> {
+    vec![
+        json!({
+            "name": "centaur_agent_start",
+            "description": "Start a durable Centaur sub-agent execution in a sandbox and return its thread_key and execution_id. Use centaur_agent_events to read progress.",
+            "inputSchema": {
+                "type": "object",
+                "required": ["prompt"],
+                "properties": {
+                    "prompt": {
+                        "type": "string",
+                        "description": "Instruction to run in the sub-agent sandbox."
+                    },
+                    "harness": {
+                        "type": "string",
+                        "description": "Harness to run: codex, amp, or claudecode. New threads default to the deployment harness; existing threads keep their current harness."
+                    },
+                    "persona_id": {
+                        "type": "string",
+                        "description": "Optional Centaur persona id."
+                    },
+                    "thread_key": {
+                        "type": "string",
+                        "description": "Optional existing mcp-agent thread key returned by centaur_agent_start."
+                    },
+                    "idle_timeout_ms": {
+                        "type": "integer",
+                        "minimum": 1
+                    },
+                    "max_duration_ms": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": MCP_AGENT_MAX_DURATION_MS,
+                        "description": "Maximum execution duration. Defaults to 10 minutes and cannot exceed 10 minutes."
+                    }
+                },
+                "additionalProperties": false
+            }
+        }),
+        json!({
+            "name": "centaur_agent_events",
+            "description": "Read durable events for a Centaur sub-agent execution.",
+            "inputSchema": {
+                "type": "object",
+                "required": ["thread_key"],
+                "properties": {
+                    "thread_key": {
+                        "type": "string",
+                        "description": "mcp-agent thread key returned by centaur_agent_start."
+                    },
+                    "execution_id": {
+                        "type": "string",
+                        "description": "Optional execution id returned by centaur_agent_start."
+                    },
+                    "after_event_id": {
+                        "type": "integer",
+                        "description": "Only return events with event_id greater than this value."
+                    },
+                    "limit": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": 500,
+                        "description": "Maximum events to return. Defaults to 100."
+                    }
+                },
+                "additionalProperties": false
+            }
+        }),
+        json!({
+            "name": "centaur_agent_cancel",
+            "description": "Ask the active Centaur sub-agent execution for a thread to stop.",
+            "inputSchema": {
+                "type": "object",
+                "required": ["thread_key"],
+                "properties": {
+                    "thread_key": {
+                        "type": "string",
+                        "description": "mcp-agent thread key returned by centaur_agent_start."
+                    },
+                    "reason": {
+                        "type": "string",
+                        "description": "Optional cancellation reason."
+                    }
+                },
+                "additionalProperties": false
+            }
+        }),
+    ]
 }
 
 fn mcp_centaur_tool_entries() -> Result<Vec<Value>, ApiError> {
@@ -347,6 +496,209 @@ fn mcp_whoami_result(principal: &McpPrincipal, arguments: Value) -> Result<Value
     ))
 }
 
+async fn mcp_agent_start_result(
+    state: &AppState,
+    principal: &McpPrincipal,
+    arguments: Value,
+) -> Result<Value, ApiError> {
+    let params = serde_json::from_value::<McpAgentStartArguments>(arguments)
+        .map_err(|error| ApiError::BadRequest(error.to_string()))?;
+    let prompt = params.prompt.trim().to_owned();
+    if prompt.is_empty() {
+        return Err(ApiError::BadRequest("prompt is required".to_owned()));
+    }
+    let runtime = state.runtime()?;
+    let thread_key = match params.thread_key.as_deref() {
+        Some(thread_key) => mcp_validate_agent_thread_key(principal, thread_key)?,
+        None => mcp_generate_agent_thread_key(principal)?,
+    };
+    let harness = match params.harness.as_deref() {
+        Some(harness) if !harness.trim().is_empty() => mcp_parse_agent_harness(harness)?,
+        _ if params.thread_key.is_some() => runtime.session(&thread_key).await?.harness_type,
+        _ => runtime.default_harness(),
+    };
+    let idempotency_key = format!("mcp-agent-{}", Uuid::new_v4().simple());
+    let max_duration_ms = params.max_duration_ms.unwrap_or(MCP_AGENT_MAX_DURATION_MS);
+    if max_duration_ms > MCP_AGENT_MAX_DURATION_MS {
+        return Err(ApiError::BadRequest(format!(
+            "max_duration_ms cannot exceed {MCP_AGENT_MAX_DURATION_MS}"
+        )));
+    }
+    let metadata = json!({
+        "mcp_agent": true,
+        "mcp_principal_id": principal.principal_id,
+        "mcp_token_id": principal.token_id,
+    });
+    let session = runtime
+        .create_or_get_external_session(
+            &thread_key,
+            &harness,
+            params.persona_id.as_deref(),
+            Some(metadata.clone()),
+            HarnessConflictPolicy::Reject,
+            &principal.principal_id,
+        )
+        .await?;
+    let message_ids = runtime
+        .append_messages(
+            &thread_key,
+            &[SessionMessageInput {
+                client_message_id: Some(idempotency_key.clone()),
+                role: MessageRole::User,
+                parts: vec![json!({
+                    "type": "text",
+                    "text": prompt,
+                })],
+                metadata: metadata.clone(),
+            }],
+        )
+        .await?;
+    let input_line = serde_json::to_string(&json!({
+        "type": "user",
+        "text": prompt,
+    }))?;
+    let execution = runtime
+        .execute_session(
+            &thread_key,
+            ExecuteSessionInput {
+                idempotency_key: Some(idempotency_key),
+                metadata: Some(metadata),
+                input_lines: vec![input_line],
+                idle_timeout_ms: params.idle_timeout_ms,
+                max_duration_ms: Some(max_duration_ms),
+            },
+        )
+        .await?;
+    mcp_json_result(json!({
+        "thread_key": thread_key,
+        "execution_id": execution.execution_id,
+        "status": execution.status,
+        "harness": session.session.harness_type,
+        "harness_switched": session.harness_switched,
+        "message_ids": message_ids,
+    }))
+}
+
+async fn mcp_agent_events_result(
+    state: &AppState,
+    principal: &McpPrincipal,
+    arguments: Value,
+) -> Result<Value, ApiError> {
+    let params = serde_json::from_value::<McpAgentEventsArguments>(arguments)
+        .map_err(|error| ApiError::BadRequest(error.to_string()))?;
+    let thread_key = mcp_validate_agent_thread_key(principal, &params.thread_key)?;
+    let limit = params.limit.unwrap_or(100);
+    if !(1..=500).contains(&limit) {
+        return Err(ApiError::BadRequest(
+            "limit must be between 1 and 500".to_owned(),
+        ));
+    }
+    let mut events = state
+        .runtime()?
+        .list_events(
+            &thread_key,
+            params.after_event_id.unwrap_or(0),
+            params.execution_id.as_deref(),
+            limit + 1,
+        )
+        .await?;
+    let has_more = events.len() > limit as usize;
+    events.truncate(limit as usize);
+    let last_event_id = events.last().map(|event| event.event_id);
+    let terminal_status = (!has_more)
+        .then(|| mcp_terminal_status(&events, params.execution_id.as_deref()))
+        .flatten();
+    mcp_json_result(json!({
+        "thread_key": thread_key,
+        "execution_id": params.execution_id,
+        "events": events,
+        "last_event_id": last_event_id,
+        "terminal_status": terminal_status,
+        "has_more": has_more,
+    }))
+}
+
+async fn mcp_agent_cancel_result(
+    state: &AppState,
+    principal: &McpPrincipal,
+    arguments: Value,
+) -> Result<Value, ApiError> {
+    let params = serde_json::from_value::<McpAgentCancelArguments>(arguments)
+        .map_err(|error| ApiError::BadRequest(error.to_string()))?;
+    let thread_key = mcp_validate_agent_thread_key(principal, &params.thread_key)?;
+    let reason = params
+        .reason
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or("Interrupted from MCP");
+    let outcome = state
+        .runtime()?
+        .interrupt_active_execution(&thread_key, reason)
+        .await?;
+    mcp_json_result(json!({
+        "thread_key": thread_key,
+        "interrupted": outcome.interrupted,
+        "execution_id": outcome.execution_id,
+    }))
+}
+
+fn mcp_parse_agent_harness(value: &str) -> Result<HarnessType, ApiError> {
+    let value = value.trim();
+    HarnessType::from_str(value)
+        .map_err(|_| ApiError::BadRequest(format!("unsupported harness {value:?}")))
+}
+
+fn mcp_generate_agent_thread_key(principal: &McpPrincipal) -> Result<ThreadKey, ApiError> {
+    ThreadKey::parse(format!(
+        "{}{}",
+        mcp_agent_thread_prefix(principal),
+        Uuid::new_v4().simple()
+    ))
+    .map_err(Into::into)
+}
+
+fn mcp_validate_agent_thread_key(
+    principal: &McpPrincipal,
+    value: &str,
+) -> Result<ThreadKey, ApiError> {
+    let thread_key = ThreadKey::parse(value.trim().to_owned())?;
+    let prefix = mcp_agent_thread_prefix(principal);
+    if !thread_key.as_str().starts_with(&prefix) {
+        return Err(ApiError::Forbidden(
+            "mcp agent thread_key does not belong to this principal".to_owned(),
+        ));
+    }
+    Ok(thread_key)
+}
+
+fn mcp_agent_thread_prefix(principal: &McpPrincipal) -> String {
+    let digest = Sha256::digest(principal.principal_id.as_bytes());
+    format!("mcp-agent:{}:", hex::encode(&digest[..12]))
+}
+
+fn mcp_terminal_status(
+    events: &[SessionEvent],
+    requested_execution_id: Option<&str>,
+) -> Option<&'static str> {
+    let execution_id = requested_execution_id.or_else(|| {
+        events
+            .iter()
+            .rev()
+            .find_map(|event| event.execution_id.as_deref())
+    })?;
+    events
+        .iter()
+        .rev()
+        .filter(|event| event.execution_id.as_deref() == Some(execution_id))
+        .find_map(|event| match event.event_type.as_str() {
+            "session.execution_completed" => Some("completed"),
+            "session.execution_failed" => Some("failed"),
+            "session.execution_cancelled" => Some("cancelled"),
+            _ => None,
+        })
+}
+
 async fn mcp_centaur_tool_result(
     state: &AppState,
     principal: &McpPrincipal,
@@ -476,6 +828,33 @@ fn mcp_text_result(text: String, is_error: bool) -> Value {
         ],
         "isError": is_error,
     })
+}
+
+fn mcp_json_result(value: Value) -> Result<Value, ApiError> {
+    Ok(mcp_text_result(
+        serde_json::to_string_pretty(&value)?,
+        false,
+    ))
+}
+
+fn mcp_agent_domain_error_result(error: ApiError) -> Result<Value, ApiError> {
+    let is_domain_error = matches!(
+        &error,
+        ApiError::BadRequest(_) | ApiError::Forbidden(_) | ApiError::NotFound(_)
+    ) || matches!(
+        &error,
+        ApiError::Runtime(SessionRuntimeError::BadRequest(_))
+            | ApiError::Runtime(SessionRuntimeError::CapacityExceeded { .. })
+            | ApiError::Runtime(SessionRuntimeError::Store(
+                centaur_session_sqlx::SessionStoreError::NotFound { .. }
+                    | centaur_session_sqlx::SessionStoreError::HarnessConflict { .. }
+                    | centaur_session_sqlx::SessionStoreError::PersonaConflict { .. }
+            ))
+    );
+    if is_domain_error {
+        return Ok(mcp_text_result(error.to_string(), true));
+    }
+    Err(error)
 }
 
 fn authenticate_mcp_bearer(headers: &HeaderMap) -> Result<Option<McpPrincipal>, ApiError> {
@@ -885,6 +1264,81 @@ mod mcp_tests {
             HeaderValue::from_str(&format!("Bearer {token}")).unwrap(),
         );
         headers
+    }
+
+    fn test_principal(id: &str) -> McpPrincipal {
+        McpPrincipal {
+            token_id: "mcp_tok_test".to_owned(),
+            principal_id: id.to_owned(),
+            name: "Test User".to_owned(),
+            scopes: vec!["mcp:tools".to_owned()],
+            expires_at: None,
+        }
+    }
+
+    #[test]
+    fn mcp_agent_tools_are_listed_as_builtin_tools() {
+        let names = mcp_agent_tool_entries()
+            .into_iter()
+            .map(|tool| tool["name"].as_str().unwrap().to_owned())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            names,
+            vec![
+                "centaur_agent_start",
+                "centaur_agent_events",
+                "centaur_agent_cancel"
+            ]
+        );
+    }
+
+    #[test]
+    fn mcp_agent_thread_keys_are_scoped_to_principal() {
+        let ada = test_principal("principal-ada");
+        let grace = test_principal("principal-grace");
+        let thread_key = mcp_generate_agent_thread_key(&ada).unwrap();
+
+        assert!(
+            thread_key
+                .as_str()
+                .starts_with(&mcp_agent_thread_prefix(&ada))
+        );
+        assert!(mcp_validate_agent_thread_key(&ada, thread_key.as_str()).is_ok());
+        assert!(mcp_validate_agent_thread_key(&grace, thread_key.as_str()).is_err());
+    }
+
+    #[test]
+    fn mcp_agent_harness_uses_canonical_values() {
+        assert_eq!(
+            mcp_parse_agent_harness("claudecode").unwrap(),
+            HarnessType::ClaudeCode
+        );
+        assert!(mcp_parse_agent_harness("claude-code").is_err());
+        assert!(mcp_parse_agent_harness("claude_code").is_err());
+        assert!(mcp_parse_agent_harness("unknown").is_err());
+    }
+
+    #[test]
+    fn mcp_terminal_status_uses_latest_execution_when_unscoped() {
+        let thread_key = ThreadKey::parse("mcp-agent:test:thread").unwrap();
+        let event = |event_id, execution_id: &str, event_type: &str| SessionEvent {
+            event_id,
+            thread_key: thread_key.clone(),
+            execution_id: Some(execution_id.to_owned()),
+            event_type: event_type.to_owned(),
+            payload: json!({}),
+            created_at: OffsetDateTime::UNIX_EPOCH,
+        };
+        let events = vec![
+            event(1, "exe-old", "session.execution_completed"),
+            event(2, "exe-new", "session.execution_started"),
+        ];
+
+        assert_eq!(mcp_terminal_status(&events, None), None);
+        assert_eq!(
+            mcp_terminal_status(&events, Some("exe-old")),
+            Some("completed")
+        );
     }
 
     #[test]

--- a/services/api-rs/crates/centaur-api-server/src/mcp.rs
+++ b/services/api-rs/crates/centaur-api-server/src/mcp.rs
@@ -34,7 +34,7 @@ use crate::{
     tool_discovery::{DiscoveredTool, ToolDiscoveryConfig, discover_tool_catalog},
 };
 
-const MCP_AGENT_MAX_DURATION_MS: u64 = 60 * 60 * 1_000;
+const MCP_AGENT_MAX_DURATION_MS: u64 = 30 * 60 * 1_000;
 const MCP_AGENT_IDEMPOTENCY_KEY_MAX_BYTES: usize = 256;
 
 pub(crate) async fn mcp_get() -> Response {
@@ -259,7 +259,7 @@ fn mcp_agent_tool_entries() -> Vec<Value> {
                         "type": "integer",
                         "minimum": 1,
                         "maximum": MCP_AGENT_MAX_DURATION_MS,
-                        "description": "Maximum execution duration. Defaults to 1 hour and cannot exceed 1 hour."
+                        "description": "Maximum execution duration. Defaults to 30 minutes and cannot exceed 30 minutes."
                     }
                 },
                 "additionalProperties": false

--- a/services/api-rs/crates/centaur-api-server/src/mcp.rs
+++ b/services/api-rs/crates/centaur-api-server/src/mcp.rs
@@ -176,12 +176,9 @@ pub(crate) async fn mcp_post(
             if params.name == "centaur_whoami" {
                 mcp_whoami_result(&principal, params.arguments)?
             } else if params.name == "centaur_agent_start" {
-                let error_thread_key = mcp_agent_error_thread_key(&principal, &params.arguments);
                 match mcp_agent_start_result(&state, &principal, params.arguments).await {
                     Ok(result) => result,
-                    Err(error) => {
-                        mcp_agent_domain_error_result_with_thread(error, error_thread_key.as_ref())?
-                    }
+                    Err(error) => mcp_agent_domain_error_result(error)?,
                 }
             } else if params.name == "centaur_agent_events" {
                 match mcp_agent_events_result(&state, &principal, params.arguments).await {
@@ -761,21 +758,6 @@ fn mcp_agent_request_fingerprint(
     Ok(hex::encode(Sha256::digest(encoded)))
 }
 
-fn mcp_agent_error_thread_key(principal: &McpPrincipal, arguments: &Value) -> Option<ThreadKey> {
-    let params = serde_json::from_value::<McpAgentStartArguments>(arguments.clone()).ok()?;
-    match params.thread_key.as_deref() {
-        Some(thread_key) => mcp_validate_agent_thread_key(principal, thread_key).ok(),
-        None => {
-            let idempotency_key = params.idempotency_key.trim();
-            (!idempotency_key.is_empty())
-                .then(|| mcp_generate_agent_thread_key(principal, idempotency_key))
-                .transpose()
-                .ok()
-                .flatten()
-        }
-    }
-}
-
 async fn mcp_centaur_tool_result(
     state: &AppState,
     principal: &McpPrincipal,
@@ -915,13 +897,6 @@ fn mcp_json_result(value: Value) -> Result<Value, ApiError> {
 }
 
 fn mcp_agent_domain_error_result(error: ApiError) -> Result<Value, ApiError> {
-    mcp_agent_domain_error_result_with_thread(error, None)
-}
-
-fn mcp_agent_domain_error_result_with_thread(
-    error: ApiError,
-    thread_key: Option<&ThreadKey>,
-) -> Result<Value, ApiError> {
     let is_domain_error = matches!(
         &error,
         ApiError::BadRequest(_) | ApiError::Forbidden(_) | ApiError::NotFound(_)
@@ -936,15 +911,6 @@ fn mcp_agent_domain_error_result_with_thread(
             ))
     );
     if is_domain_error {
-        if let Some(thread_key) = thread_key {
-            return Ok(mcp_text_result(
-                serde_json::to_string_pretty(&json!({
-                    "error": error.to_string(),
-                    "thread_key": thread_key,
-                }))?,
-                true,
-            ));
-        }
         return Ok(mcp_text_result(error.to_string(), true));
     }
     Err(error)
@@ -1415,21 +1381,6 @@ mod mcp_tests {
         );
         assert!(mcp_validate_agent_thread_key(&ada, thread_key.as_str()).is_ok());
         assert!(mcp_validate_agent_thread_key(&grace, thread_key.as_str()).is_err());
-    }
-
-    #[test]
-    fn mcp_agent_errors_can_return_the_retryable_thread_key() {
-        let principal = test_principal("principal-ada");
-        let arguments = json!({
-            "prompt": "hello",
-            "idempotency_key": "request-1",
-            "max_duration_ms": 0,
-        });
-
-        assert_eq!(
-            mcp_agent_error_thread_key(&principal, &arguments),
-            Some(mcp_generate_agent_thread_key(&principal, "request-1").unwrap())
-        );
     }
 
     #[test]

--- a/services/api-rs/crates/centaur-api-server/src/mcp.rs
+++ b/services/api-rs/crates/centaur-api-server/src/mcp.rs
@@ -15,7 +15,7 @@ use axum::{
 };
 use base64::{Engine as _, engine::general_purpose};
 use centaur_session_core::{
-    HarnessType, MessageRole, SessionEvent, SessionMessageInput, ThreadKey,
+    ExecutionStatus, HarnessType, MessageRole, SessionMessageInput, ThreadKey,
 };
 use centaur_session_runtime::{
     ExecuteSessionInput, HarnessConflictPolicy, SessionRuntime, SessionRuntimeError,
@@ -26,7 +26,6 @@ use serde::Deserialize;
 use serde_json::{Value, json};
 use sha2::{Digest, Sha256};
 use time::OffsetDateTime;
-use uuid::Uuid;
 
 use crate::{
     ApiError,
@@ -36,6 +35,7 @@ use crate::{
 };
 
 const MCP_AGENT_MAX_DURATION_MS: u64 = 24 * 60 * 60 * 1_000;
+const MCP_AGENT_IDEMPOTENCY_KEY_MAX_BYTES: usize = 256;
 
 pub(crate) async fn mcp_get() -> Response {
     (
@@ -87,6 +87,7 @@ struct CentaurToolMcpArguments {
 #[derive(Debug, Deserialize)]
 struct McpAgentStartArguments {
     prompt: String,
+    idempotency_key: String,
     #[serde(default)]
     harness: Option<String>,
     #[serde(default)]
@@ -175,9 +176,12 @@ pub(crate) async fn mcp_post(
             if params.name == "centaur_whoami" {
                 mcp_whoami_result(&principal, params.arguments)?
             } else if params.name == "centaur_agent_start" {
+                let error_thread_key = mcp_agent_error_thread_key(&principal, &params.arguments);
                 match mcp_agent_start_result(&state, &principal, params.arguments).await {
                     Ok(result) => result,
-                    Err(error) => mcp_agent_domain_error_result(error)?,
+                    Err(error) => {
+                        mcp_agent_domain_error_result_with_thread(error, error_thread_key.as_ref())?
+                    }
                 }
             } else if params.name == "centaur_agent_events" {
                 match mcp_agent_events_result(&state, &principal, params.arguments).await {
@@ -226,11 +230,17 @@ fn mcp_agent_tool_entries() -> Vec<Value> {
             "description": "Start a durable Centaur sub-agent execution in a sandbox and return its thread_key and execution_id. Use centaur_agent_events to read progress.",
             "inputSchema": {
                 "type": "object",
-                "required": ["prompt"],
+                "required": ["prompt", "idempotency_key"],
                 "properties": {
                     "prompt": {
                         "type": "string",
                         "description": "Instruction to run in the sub-agent sandbox."
+                    },
+                    "idempotency_key": {
+                        "type": "string",
+                        "minLength": 1,
+                        "maxLength": MCP_AGENT_IDEMPOTENCY_KEY_MAX_BYTES,
+                        "description": "Caller-generated key identifying this start request. Retrying the same key returns the same thread and execution without submitting the prompt again."
                     },
                     "harness": {
                         "type": "string",
@@ -507,27 +517,46 @@ async fn mcp_agent_start_result(
     if prompt.is_empty() {
         return Err(ApiError::BadRequest("prompt is required".to_owned()));
     }
-    let runtime = state.runtime()?;
+    let idempotency_key = params.idempotency_key.trim().to_owned();
+    if idempotency_key.is_empty() {
+        return Err(ApiError::BadRequest(
+            "idempotency_key is required".to_owned(),
+        ));
+    }
+    if idempotency_key.len() > MCP_AGENT_IDEMPOTENCY_KEY_MAX_BYTES {
+        return Err(ApiError::BadRequest(format!(
+            "idempotency_key cannot exceed {MCP_AGENT_IDEMPOTENCY_KEY_MAX_BYTES} bytes"
+        )));
+    }
+    let max_duration_ms =
+        mcp_agent_duration_options(params.idle_timeout_ms, params.max_duration_ms)?;
     let thread_key = match params.thread_key.as_deref() {
         Some(thread_key) => mcp_validate_agent_thread_key(principal, thread_key)?,
-        None => mcp_generate_agent_thread_key(principal)?,
+        None => mcp_generate_agent_thread_key(principal, &idempotency_key)?,
     };
+    let runtime = state.runtime()?;
     let harness = match params.harness.as_deref() {
         Some(harness) if !harness.trim().is_empty() => mcp_parse_agent_harness(harness)?,
         _ if params.thread_key.is_some() => runtime.session(&thread_key).await?.harness_type,
         _ => runtime.default_harness(),
     };
-    let idempotency_key = format!("mcp-agent-{}", Uuid::new_v4().simple());
-    let max_duration_ms = params.max_duration_ms.unwrap_or(MCP_AGENT_MAX_DURATION_MS);
-    if max_duration_ms > MCP_AGENT_MAX_DURATION_MS {
-        return Err(ApiError::BadRequest(format!(
-            "max_duration_ms cannot exceed {MCP_AGENT_MAX_DURATION_MS}"
-        )));
-    }
     let metadata = json!({
         "mcp_agent": true,
         "mcp_principal_id": principal.principal_id,
         "mcp_token_id": principal.token_id,
+    });
+    let request_fingerprint = mcp_agent_request_fingerprint(
+        &prompt,
+        &harness,
+        params.persona_id.as_deref(),
+        params.idle_timeout_ms,
+        max_duration_ms,
+    )?;
+    let execution_metadata = json!({
+        "mcp_agent": true,
+        "mcp_principal_id": principal.principal_id,
+        "mcp_token_id": principal.token_id,
+        "mcp_request_fingerprint": request_fingerprint,
     });
     let session = runtime
         .create_or_get_external_session(
@@ -539,11 +568,22 @@ async fn mcp_agent_start_result(
             &principal.principal_id,
         )
         .await?;
-    let message_ids = runtime
-        .append_messages(
+    let input_line = serde_json::to_string(&json!({
+        "type": "user",
+        "text": prompt,
+    }))?;
+    let execution = runtime
+        .execute_session_with_messages(
             &thread_key,
+            ExecuteSessionInput {
+                idempotency_key: Some(idempotency_key.clone()),
+                metadata: Some(execution_metadata),
+                input_lines: vec![input_line],
+                idle_timeout_ms: params.idle_timeout_ms,
+                max_duration_ms: Some(max_duration_ms),
+            },
             &[SessionMessageInput {
-                client_message_id: Some(idempotency_key.clone()),
+                client_message_id: Some(idempotency_key),
                 role: MessageRole::User,
                 parts: vec![json!({
                     "type": "text",
@@ -553,29 +593,12 @@ async fn mcp_agent_start_result(
             }],
         )
         .await?;
-    let input_line = serde_json::to_string(&json!({
-        "type": "user",
-        "text": prompt,
-    }))?;
-    let execution = runtime
-        .execute_session(
-            &thread_key,
-            ExecuteSessionInput {
-                idempotency_key: Some(idempotency_key),
-                metadata: Some(metadata),
-                input_lines: vec![input_line],
-                idle_timeout_ms: params.idle_timeout_ms,
-                max_duration_ms: Some(max_duration_ms),
-            },
-        )
-        .await?;
     mcp_json_result(json!({
         "thread_key": thread_key,
         "execution_id": execution.execution_id,
         "status": execution.status,
         "harness": session.session.harness_type,
         "harness_switched": session.harness_switched,
-        "message_ids": message_ids,
     }))
 }
 
@@ -605,9 +628,12 @@ async fn mcp_agent_events_result(
     let has_more = events.len() > limit as usize;
     events.truncate(limit as usize);
     let last_event_id = events.last().map(|event| event.event_id);
-    let terminal_status = (!has_more)
-        .then(|| mcp_terminal_status(&events, params.execution_id.as_deref()))
-        .flatten();
+    let terminal_status = mcp_terminal_status(
+        state
+            .runtime()?
+            .execution_status(&thread_key, params.execution_id.as_deref())
+            .await?,
+    );
     mcp_json_result(json!({
         "thread_key": thread_key,
         "execution_id": params.execution_id,
@@ -649,11 +675,15 @@ fn mcp_parse_agent_harness(value: &str) -> Result<HarnessType, ApiError> {
         .map_err(|_| ApiError::BadRequest(format!("unsupported harness {value:?}")))
 }
 
-fn mcp_generate_agent_thread_key(principal: &McpPrincipal) -> Result<ThreadKey, ApiError> {
+fn mcp_generate_agent_thread_key(
+    principal: &McpPrincipal,
+    idempotency_key: &str,
+) -> Result<ThreadKey, ApiError> {
+    let digest = Sha256::digest(idempotency_key.as_bytes());
     ThreadKey::parse(format!(
         "{}{}",
         mcp_agent_thread_prefix(principal),
-        Uuid::new_v4().simple()
+        hex::encode(&digest[..16])
     ))
     .map_err(Into::into)
 }
@@ -677,26 +707,73 @@ fn mcp_agent_thread_prefix(principal: &McpPrincipal) -> String {
     format!("mcp-agent:{}:", hex::encode(&digest[..12]))
 }
 
-fn mcp_terminal_status(
-    events: &[SessionEvent],
-    requested_execution_id: Option<&str>,
-) -> Option<&'static str> {
-    let execution_id = requested_execution_id.or_else(|| {
-        events
-            .iter()
-            .rev()
-            .find_map(|event| event.execution_id.as_deref())
-    })?;
-    events
-        .iter()
-        .rev()
-        .filter(|event| event.execution_id.as_deref() == Some(execution_id))
-        .find_map(|event| match event.event_type.as_str() {
-            "session.execution_completed" => Some("completed"),
-            "session.execution_failed" => Some("failed"),
-            "session.execution_cancelled" => Some("cancelled"),
-            _ => None,
-        })
+fn mcp_terminal_status(status: Option<ExecutionStatus>) -> Option<&'static str> {
+    match status {
+        Some(ExecutionStatus::Completed) => Some("completed"),
+        Some(ExecutionStatus::Failed) => Some("failed"),
+        Some(ExecutionStatus::Cancelled) => Some("cancelled"),
+        Some(ExecutionStatus::Queued | ExecutionStatus::Running) | None => None,
+    }
+}
+
+fn mcp_agent_duration_options(
+    idle_timeout_ms: Option<u64>,
+    max_duration_ms: Option<u64>,
+) -> Result<u64, ApiError> {
+    let max_duration_ms = max_duration_ms.unwrap_or(MCP_AGENT_MAX_DURATION_MS);
+    if max_duration_ms == 0 {
+        return Err(ApiError::BadRequest(
+            "max_duration_ms must be greater than zero".to_owned(),
+        ));
+    }
+    if max_duration_ms > MCP_AGENT_MAX_DURATION_MS {
+        return Err(ApiError::BadRequest(format!(
+            "max_duration_ms cannot exceed {MCP_AGENT_MAX_DURATION_MS}"
+        )));
+    }
+    if idle_timeout_ms == Some(0) {
+        return Err(ApiError::BadRequest(
+            "idle_timeout_ms must be greater than zero".to_owned(),
+        ));
+    }
+    if idle_timeout_ms.is_some_and(|idle_timeout_ms| idle_timeout_ms > max_duration_ms) {
+        return Err(ApiError::BadRequest(
+            "idle_timeout_ms must be less than or equal to max_duration_ms".to_owned(),
+        ));
+    }
+    Ok(max_duration_ms)
+}
+
+fn mcp_agent_request_fingerprint(
+    prompt: &str,
+    harness: &HarnessType,
+    persona_id: Option<&str>,
+    idle_timeout_ms: Option<u64>,
+    max_duration_ms: u64,
+) -> Result<String, ApiError> {
+    let encoded = serde_json::to_vec(&json!({
+        "prompt": prompt,
+        "harness": harness,
+        "persona_id": persona_id,
+        "idle_timeout_ms": idle_timeout_ms,
+        "max_duration_ms": max_duration_ms,
+    }))?;
+    Ok(hex::encode(Sha256::digest(encoded)))
+}
+
+fn mcp_agent_error_thread_key(principal: &McpPrincipal, arguments: &Value) -> Option<ThreadKey> {
+    let params = serde_json::from_value::<McpAgentStartArguments>(arguments.clone()).ok()?;
+    match params.thread_key.as_deref() {
+        Some(thread_key) => mcp_validate_agent_thread_key(principal, thread_key).ok(),
+        None => {
+            let idempotency_key = params.idempotency_key.trim();
+            (!idempotency_key.is_empty())
+                .then(|| mcp_generate_agent_thread_key(principal, idempotency_key))
+                .transpose()
+                .ok()
+                .flatten()
+        }
+    }
 }
 
 async fn mcp_centaur_tool_result(
@@ -838,6 +915,13 @@ fn mcp_json_result(value: Value) -> Result<Value, ApiError> {
 }
 
 fn mcp_agent_domain_error_result(error: ApiError) -> Result<Value, ApiError> {
+    mcp_agent_domain_error_result_with_thread(error, None)
+}
+
+fn mcp_agent_domain_error_result_with_thread(
+    error: ApiError,
+    thread_key: Option<&ThreadKey>,
+) -> Result<Value, ApiError> {
     let is_domain_error = matches!(
         &error,
         ApiError::BadRequest(_) | ApiError::Forbidden(_) | ApiError::NotFound(_)
@@ -852,6 +936,15 @@ fn mcp_agent_domain_error_result(error: ApiError) -> Result<Value, ApiError> {
             ))
     );
     if is_domain_error {
+        if let Some(thread_key) = thread_key {
+            return Ok(mcp_text_result(
+                serde_json::to_string_pretty(&json!({
+                    "error": error.to_string(),
+                    "thread_key": thread_key,
+                }))?,
+                true,
+            ));
+        }
         return Ok(mcp_text_result(error.to_string(), true));
     }
     Err(error)
@@ -1295,21 +1388,48 @@ mod mcp_tests {
             tools[0]["inputSchema"]["properties"]["max_duration_ms"]["maximum"],
             MCP_AGENT_MAX_DURATION_MS
         );
+        assert_eq!(
+            tools[0]["inputSchema"]["required"],
+            json!(["prompt", "idempotency_key"])
+        );
     }
 
     #[test]
     fn mcp_agent_thread_keys_are_scoped_to_principal() {
         let ada = test_principal("principal-ada");
         let grace = test_principal("principal-grace");
-        let thread_key = mcp_generate_agent_thread_key(&ada).unwrap();
+        let thread_key = mcp_generate_agent_thread_key(&ada, "request-1").unwrap();
 
         assert!(
             thread_key
                 .as_str()
                 .starts_with(&mcp_agent_thread_prefix(&ada))
         );
+        assert_eq!(
+            thread_key,
+            mcp_generate_agent_thread_key(&ada, "request-1").unwrap()
+        );
+        assert_ne!(
+            thread_key,
+            mcp_generate_agent_thread_key(&ada, "request-2").unwrap()
+        );
         assert!(mcp_validate_agent_thread_key(&ada, thread_key.as_str()).is_ok());
         assert!(mcp_validate_agent_thread_key(&grace, thread_key.as_str()).is_err());
+    }
+
+    #[test]
+    fn mcp_agent_errors_can_return_the_retryable_thread_key() {
+        let principal = test_principal("principal-ada");
+        let arguments = json!({
+            "prompt": "hello",
+            "idempotency_key": "request-1",
+            "max_duration_ms": 0,
+        });
+
+        assert_eq!(
+            mcp_agent_error_thread_key(&principal, &arguments),
+            Some(mcp_generate_agent_thread_key(&principal, "request-1").unwrap())
+        );
     }
 
     #[test]
@@ -1324,25 +1444,32 @@ mod mcp_tests {
     }
 
     #[test]
-    fn mcp_terminal_status_uses_latest_execution_when_unscoped() {
-        let thread_key = ThreadKey::parse("mcp-agent:test:thread").unwrap();
-        let event = |event_id, execution_id: &str, event_type: &str| SessionEvent {
-            event_id,
-            thread_key: thread_key.clone(),
-            execution_id: Some(execution_id.to_owned()),
-            event_type: event_type.to_owned(),
-            payload: json!({}),
-            created_at: OffsetDateTime::UNIX_EPOCH,
-        };
-        let events = vec![
-            event(1, "exe-old", "session.execution_completed"),
-            event(2, "exe-new", "session.execution_started"),
-        ];
-
-        assert_eq!(mcp_terminal_status(&events, None), None);
+    fn mcp_terminal_status_uses_durable_execution_status() {
         assert_eq!(
-            mcp_terminal_status(&events, Some("exe-old")),
+            mcp_terminal_status(Some(ExecutionStatus::Completed)),
             Some("completed")
+        );
+        assert_eq!(
+            mcp_terminal_status(Some(ExecutionStatus::Failed)),
+            Some("failed")
+        );
+        assert_eq!(
+            mcp_terminal_status(Some(ExecutionStatus::Cancelled)),
+            Some("cancelled")
+        );
+        assert_eq!(mcp_terminal_status(Some(ExecutionStatus::Running)), None);
+        assert_eq!(mcp_terminal_status(None), None);
+    }
+
+    #[test]
+    fn mcp_agent_durations_are_validated_before_start() {
+        assert!(mcp_agent_duration_options(Some(0), None).is_err());
+        assert!(mcp_agent_duration_options(None, Some(0)).is_err());
+        assert!(mcp_agent_duration_options(None, Some(MCP_AGENT_MAX_DURATION_MS + 1)).is_err());
+        assert!(mcp_agent_duration_options(Some(2), Some(1)).is_err());
+        assert_eq!(
+            mcp_agent_duration_options(None, None).unwrap(),
+            MCP_AGENT_MAX_DURATION_MS
         );
     }
 

--- a/services/api-rs/crates/centaur-api-server/src/mcp.rs
+++ b/services/api-rs/crates/centaur-api-server/src/mcp.rs
@@ -35,7 +35,7 @@ use crate::{
     tool_discovery::{DiscoveredTool, ToolDiscoveryConfig, discover_tool_catalog},
 };
 
-const MCP_AGENT_MAX_DURATION_MS: u64 = 10 * 60 * 1_000;
+const MCP_AGENT_MAX_DURATION_MS: u64 = 24 * 60 * 60 * 1_000;
 
 pub(crate) async fn mcp_get() -> Response {
     (
@@ -252,7 +252,7 @@ fn mcp_agent_tool_entries() -> Vec<Value> {
                         "type": "integer",
                         "minimum": 1,
                         "maximum": MCP_AGENT_MAX_DURATION_MS,
-                        "description": "Maximum execution duration. Defaults to 10 minutes and cannot exceed 10 minutes."
+                        "description": "Maximum execution duration. Defaults to 24 hours and cannot exceed 24 hours."
                     }
                 },
                 "additionalProperties": false
@@ -1278,8 +1278,9 @@ mod mcp_tests {
 
     #[test]
     fn mcp_agent_tools_are_listed_as_builtin_tools() {
-        let names = mcp_agent_tool_entries()
-            .into_iter()
+        let tools = mcp_agent_tool_entries();
+        let names = tools
+            .iter()
             .map(|tool| tool["name"].as_str().unwrap().to_owned())
             .collect::<Vec<_>>();
         assert_eq!(
@@ -1289,6 +1290,10 @@ mod mcp_tests {
                 "centaur_agent_events",
                 "centaur_agent_cancel"
             ]
+        );
+        assert_eq!(
+            tools[0]["inputSchema"]["properties"]["max_duration_ms"]["maximum"],
+            MCP_AGENT_MAX_DURATION_MS
         );
     }
 

--- a/services/api-rs/crates/centaur-api-server/src/mcp.rs
+++ b/services/api-rs/crates/centaur-api-server/src/mcp.rs
@@ -9,7 +9,7 @@ use std::{
 
 use axum::{
     Json,
-    extract::State,
+    extract::{Path, Query, State},
     http::{HeaderMap, HeaderValue, StatusCode},
     response::{IntoResponse, Response},
 };
@@ -18,8 +18,7 @@ use centaur_session_core::{
     ExecutionStatus, HarnessType, MessageRole, SessionMessageInput, ThreadKey,
 };
 use centaur_session_runtime::{
-    ExecuteSessionInput, HarnessConflictPolicy, SessionRuntime, SessionRuntimeError,
-    ToolHostCallInput,
+    ExecuteSessionInput, HarnessConflictPolicy, SessionRuntime, ToolHostCallInput,
 };
 use hmac::{Hmac, Mac};
 use serde::Deserialize;
@@ -60,6 +59,18 @@ pub(crate) async fn mcp_protected_resource_metadata(headers: HeaderMap) -> Json<
     }))
 }
 
+pub(crate) async fn agent_protected_resource_metadata(headers: HeaderMap) -> Json<Value> {
+    let authorization_servers = mcp_authorization_server_url()
+        .into_iter()
+        .collect::<Vec<_>>();
+    Json(json!({
+        "resource": agent_resource_url(&headers),
+        "authorization_servers": authorization_servers,
+        "bearer_methods_supported": ["header"],
+        "scopes_supported": ["agents:execute"],
+    }))
+}
+
 #[derive(Debug, Deserialize)]
 pub(crate) struct McpJsonRpcRequest {
     jsonrpc: Option<String>,
@@ -85,7 +96,7 @@ struct CentaurToolMcpArguments {
 }
 
 #[derive(Debug, Deserialize)]
-struct McpAgentStartArguments {
+pub(crate) struct AgentExecutionRequest {
     prompt: String,
     idempotency_key: String,
     #[serde(default)]
@@ -101,10 +112,7 @@ struct McpAgentStartArguments {
 }
 
 #[derive(Debug, Deserialize)]
-struct McpAgentEventsArguments {
-    thread_key: String,
-    #[serde(default)]
-    execution_id: Option<String>,
+pub(crate) struct AgentEventsQuery {
     #[serde(default)]
     after_event_id: Option<i64>,
     #[serde(default)]
@@ -112,9 +120,7 @@ struct McpAgentEventsArguments {
 }
 
 #[derive(Debug, Deserialize)]
-struct McpAgentCancelArguments {
-    thread_key: String,
-    execution_id: String,
+pub(crate) struct AgentCancelRequest {
     #[serde(default)]
     reason: Option<String>,
 }
@@ -164,7 +170,6 @@ pub(crate) async fn mcp_post(
         "tools/list" => {
             ensure_mcp_scope(&principal.scopes, "mcp:tools")?;
             let mut tools = vec![mcp_whoami_tool()];
-            tools.extend(mcp_agent_tool_entries());
             tools.extend(mcp_centaur_tool_entries()?);
             json!({
                 "tools": tools,
@@ -176,21 +181,6 @@ pub(crate) async fn mcp_post(
                 .map_err(|error| ApiError::BadRequest(error.to_string()))?;
             if params.name == "centaur_whoami" {
                 mcp_whoami_result(&principal, params.arguments)?
-            } else if params.name == "centaur_agent_start" {
-                match mcp_agent_start_result(&state, &principal, params.arguments).await {
-                    Ok(result) => result,
-                    Err(error) => mcp_agent_domain_error_result(error)?,
-                }
-            } else if params.name == "centaur_agent_events" {
-                match mcp_agent_events_result(&state, &principal, params.arguments).await {
-                    Ok(result) => result,
-                    Err(error) => mcp_agent_domain_error_result(error)?,
-                }
-            } else if params.name == "centaur_agent_cancel" {
-                match mcp_agent_cancel_result(&state, &principal, params.arguments).await {
-                    Ok(result) => result,
-                    Err(error) => mcp_agent_domain_error_result(error)?,
-                }
             } else {
                 let Some(tool) = mcp_find_centaur_tool(&params.name)? else {
                     return Ok(mcp_json_error(id, -32602, "unknown tool"));
@@ -209,6 +199,47 @@ pub(crate) async fn mcp_post(
     .into_response())
 }
 
+pub(crate) async fn agent_create_execution(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Json(request): Json<AgentExecutionRequest>,
+) -> Result<Response, ApiError> {
+    let Some(principal) = authenticate_agent_bearer(&headers)? else {
+        return Ok(agent_unauthorized(&headers));
+    };
+    ensure_scope(&principal.scopes, "agents:execute", "agents:*")?;
+    let body = agent_start_response(&state, &principal, request).await?;
+    Ok(Json(body).into_response())
+}
+
+pub(crate) async fn agent_execution_events(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Path(execution_id): Path<String>,
+    Query(query): Query<AgentEventsQuery>,
+) -> Result<Response, ApiError> {
+    let Some(principal) = authenticate_agent_bearer(&headers)? else {
+        return Ok(agent_unauthorized(&headers));
+    };
+    ensure_scope(&principal.scopes, "agents:execute", "agents:*")?;
+    let body = agent_events_response(&state, &principal, &execution_id, query).await?;
+    Ok(Json(body).into_response())
+}
+
+pub(crate) async fn agent_cancel_execution(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Path(execution_id): Path<String>,
+    Json(request): Json<AgentCancelRequest>,
+) -> Result<Response, ApiError> {
+    let Some(principal) = authenticate_agent_bearer(&headers)? else {
+        return Ok(agent_unauthorized(&headers));
+    };
+    ensure_scope(&principal.scopes, "agents:execute", "agents:*")?;
+    let body = agent_cancel_response(&state, &principal, &execution_id, request).await?;
+    Ok(Json(body).into_response())
+}
+
 fn mcp_whoami_tool() -> Value {
     json!({
         "name": "centaur_whoami",
@@ -219,106 +250,6 @@ fn mcp_whoami_tool() -> Value {
             "additionalProperties": false,
         },
     })
-}
-
-fn mcp_agent_tool_entries() -> Vec<Value> {
-    vec![
-        json!({
-            "name": "centaur_agent_start",
-            "description": "Start a durable Centaur sub-agent execution in a sandbox and return its thread_key and execution_id. Use centaur_agent_events to read progress.",
-            "inputSchema": {
-                "type": "object",
-                "required": ["prompt", "idempotency_key"],
-                "properties": {
-                    "prompt": {
-                        "type": "string",
-                        "description": "Instruction to run in the sub-agent sandbox."
-                    },
-                    "idempotency_key": {
-                        "type": "string",
-                        "minLength": 1,
-                        "maxLength": MCP_AGENT_IDEMPOTENCY_KEY_MAX_BYTES,
-                        "description": "Caller-generated key identifying this start request. Retrying the same key returns the same thread and execution without submitting the prompt again."
-                    },
-                    "harness": {
-                        "type": "string",
-                        "description": "Harness to run: codex, amp, or claudecode. New threads default to the deployment harness; existing threads keep their current harness."
-                    },
-                    "persona_id": {
-                        "type": "string",
-                        "description": "Optional Centaur persona id."
-                    },
-                    "thread_key": {
-                        "type": "string",
-                        "description": "Optional existing mcp-agent thread key returned by centaur_agent_start."
-                    },
-                    "idle_timeout_ms": {
-                        "type": "integer",
-                        "minimum": 1
-                    },
-                    "max_duration_ms": {
-                        "type": "integer",
-                        "minimum": 1,
-                        "maximum": MCP_AGENT_MAX_DURATION_MS,
-                        "description": "Maximum execution duration. Defaults to 30 minutes and cannot exceed 30 minutes."
-                    }
-                },
-                "additionalProperties": false
-            }
-        }),
-        json!({
-            "name": "centaur_agent_events",
-            "description": "Read durable events for a Centaur sub-agent execution.",
-            "inputSchema": {
-                "type": "object",
-                "required": ["thread_key"],
-                "properties": {
-                    "thread_key": {
-                        "type": "string",
-                        "description": "mcp-agent thread key returned by centaur_agent_start."
-                    },
-                    "execution_id": {
-                        "type": "string",
-                        "description": "Optional execution id returned by centaur_agent_start."
-                    },
-                    "after_event_id": {
-                        "type": "integer",
-                        "description": "Only return events with event_id greater than this value."
-                    },
-                    "limit": {
-                        "type": "integer",
-                        "minimum": 1,
-                        "maximum": 500,
-                        "description": "Maximum events to return. Defaults to 100."
-                    }
-                },
-                "additionalProperties": false
-            }
-        }),
-        json!({
-            "name": "centaur_agent_cancel",
-            "description": "Ask one exact active Centaur sub-agent execution for a thread to stop.",
-            "inputSchema": {
-                "type": "object",
-                "required": ["thread_key", "execution_id"],
-                "properties": {
-                    "thread_key": {
-                        "type": "string",
-                        "description": "mcp-agent thread key returned by centaur_agent_start."
-                    },
-                    "execution_id": {
-                        "type": "string",
-                        "description": "Execution id returned by centaur_agent_start. Cancellation is ignored if this execution is no longer active."
-                    },
-                    "reason": {
-                        "type": "string",
-                        "description": "Optional cancellation reason."
-                    }
-                },
-                "additionalProperties": false
-            }
-        }),
-    ]
 }
 
 fn mcp_centaur_tool_entries() -> Result<Vec<Value>, ApiError> {
@@ -508,13 +439,11 @@ fn mcp_whoami_result(principal: &McpPrincipal, arguments: Value) -> Result<Value
     ))
 }
 
-async fn mcp_agent_start_result(
+async fn agent_start_response(
     state: &AppState,
     principal: &McpPrincipal,
-    arguments: Value,
+    params: AgentExecutionRequest,
 ) -> Result<Value, ApiError> {
-    let params = serde_json::from_value::<McpAgentStartArguments>(arguments)
-        .map_err(|error| ApiError::BadRequest(error.to_string()))?;
     let prompt = params.prompt.trim().to_owned();
     if prompt.is_empty() {
         return Err(ApiError::BadRequest("prompt is required".to_owned()));
@@ -584,7 +513,7 @@ async fn mcp_agent_start_result(
             &principal.principal_id,
         )
         .await?;
-    mcp_json_result(json!({
+    Ok(json!({
         "thread_key": thread_key,
         "execution_id": execution.execution_id,
         "status": execution.status,
@@ -593,26 +522,38 @@ async fn mcp_agent_start_result(
     }))
 }
 
-async fn mcp_agent_events_result(
+async fn agent_events_response(
     state: &AppState,
     principal: &McpPrincipal,
-    arguments: Value,
+    execution_id: &str,
+    query: AgentEventsQuery,
 ) -> Result<Value, ApiError> {
-    let params = serde_json::from_value::<McpAgentEventsArguments>(arguments)
-        .map_err(|error| ApiError::BadRequest(error.to_string()))?;
-    let thread_key = mcp_validate_agent_thread_key(principal, &params.thread_key)?;
-    let limit = params.limit.unwrap_or(100);
+    let execution_id = execution_id.trim();
+    if execution_id.is_empty() {
+        return Err(ApiError::BadRequest("execution_id is required".to_owned()));
+    }
+    if query.after_event_id.is_some_and(|event_id| event_id < 0) {
+        return Err(ApiError::BadRequest(
+            "after_event_id must be greater than or equal to zero".to_owned(),
+        ));
+    }
+    let limit = query.limit.unwrap_or(100);
     if !(1..=500).contains(&limit) {
         return Err(ApiError::BadRequest(
             "limit must be between 1 and 500".to_owned(),
         ));
     }
     let runtime = state.runtime()?;
+    let execution = runtime
+        .external_execution(execution_id, &principal.principal_id)
+        .await?
+        .ok_or_else(|| ApiError::NotFound("execution not found".to_owned()))?;
+    let thread_key = execution.thread_key.clone();
     let mut events = runtime
         .list_external_events(
             &thread_key,
-            params.after_event_id.unwrap_or(0),
-            params.execution_id.as_deref(),
+            query.after_event_id.unwrap_or(0),
+            Some(execution_id),
             limit + 1,
             &principal.principal_id,
         )
@@ -620,65 +561,64 @@ async fn mcp_agent_events_result(
     let has_more = events.len() > limit as usize;
     events.truncate(limit as usize);
     let last_event_id = events.last().map(|event| event.event_id);
-    let execution_status = match params.execution_id.as_deref() {
-        Some(execution_id) => {
-            runtime
-                .external_execution_status(&thread_key, execution_id, &principal.principal_id)
-                .await?
-        }
-        None => None,
-    };
-    let terminal_status = mcp_terminal_status_from_execution_status(execution_status.as_ref());
-    let terminal_event_observed = match (params.execution_id.as_deref(), execution_status.as_ref())
-    {
-        (Some(execution_id), Some(status)) => {
-            mcp_terminal_event_visible_in_events(&events, execution_id, status)
+    let terminal_status = mcp_terminal_status_from_execution_status(Some(&execution.status));
+    let terminal_event_observed = match terminal_status {
+        Some(_) => {
+            mcp_terminal_event_visible_in_events(&events, execution_id, &execution.status)
                 || runtime
                     .external_terminal_event_observed(
                         &thread_key,
                         execution_id,
-                        status,
+                        &execution.status,
                         &principal.principal_id,
                     )
                     .await?
         }
-        _ => false,
+        None => false,
     };
-    mcp_json_result(json!({
+    Ok(json!({
         "thread_key": thread_key,
-        "execution_id": params.execution_id,
+        "execution_id": execution_id,
         "events": events,
         "last_event_id": last_event_id,
+        "status": execution.status,
         "terminal_status": terminal_status,
         "terminal_event_observed": terminal_event_observed,
         "has_more": has_more,
     }))
 }
 
-async fn mcp_agent_cancel_result(
+async fn agent_cancel_response(
     state: &AppState,
     principal: &McpPrincipal,
-    arguments: Value,
+    execution_id: &str,
+    params: AgentCancelRequest,
 ) -> Result<Value, ApiError> {
-    let params = serde_json::from_value::<McpAgentCancelArguments>(arguments)
-        .map_err(|error| ApiError::BadRequest(error.to_string()))?;
-    let thread_key = mcp_validate_agent_thread_key(principal, &params.thread_key)?;
+    let execution_id = execution_id.trim();
+    if execution_id.is_empty() {
+        return Err(ApiError::BadRequest("execution_id is required".to_owned()));
+    }
+    let runtime = state.runtime()?;
+    let execution = runtime
+        .external_execution(execution_id, &principal.principal_id)
+        .await?
+        .ok_or_else(|| ApiError::NotFound("execution not found".to_owned()))?;
     let reason = params
         .reason
         .as_deref()
         .map(str::trim)
         .filter(|value| !value.is_empty())
-        .unwrap_or("Interrupted from MCP");
-    let execution_id = params.execution_id.trim();
-    if execution_id.is_empty() {
-        return Err(ApiError::BadRequest("execution_id is required".to_owned()));
-    }
-    let outcome = state
-        .runtime()?
-        .interrupt_external_execution(&thread_key, execution_id, reason, &principal.principal_id)
+        .unwrap_or("Interrupted from agent API");
+    let outcome = runtime
+        .interrupt_external_execution(
+            &execution.thread_key,
+            execution_id,
+            reason,
+            &principal.principal_id,
+        )
         .await?;
-    mcp_json_result(json!({
-        "thread_key": thread_key,
+    Ok(json!({
+        "thread_key": execution.thread_key,
         "interrupted": outcome.interrupted,
         "execution_id": outcome.execution_id,
     }))
@@ -730,7 +670,7 @@ fn mcp_validate_agent_thread_key(
     let prefix = mcp_agent_thread_prefix(principal);
     if !thread_key.as_str().starts_with(&prefix) {
         return Err(ApiError::Forbidden(
-            "mcp agent thread_key does not belong to this principal".to_owned(),
+            "agent thread_key does not belong to this principal".to_owned(),
         ));
     }
     Ok(thread_key)
@@ -738,21 +678,21 @@ fn mcp_validate_agent_thread_key(
 
 fn mcp_agent_thread_prefix(principal: &McpPrincipal) -> String {
     let digest = Sha256::digest(principal.principal_id.as_bytes());
-    format!("mcp-agent:{}:", hex::encode(&digest[..12]))
+    format!("agent:{}:", hex::encode(&digest[..12]))
 }
 
 fn mcp_agent_session_metadata(principal: &McpPrincipal) -> Value {
     json!({
-        "mcp_agent": true,
-        "mcp_principal_id": principal.principal_id,
+        "agent_api": true,
+        "agent_principal_id": principal.principal_id,
     })
 }
 
 fn mcp_agent_execution_metadata(principal: &McpPrincipal, request_fingerprint: &str) -> Value {
     json!({
-        "mcp_agent": true,
-        "mcp_principal_id": principal.principal_id,
-        "mcp_request_fingerprint": request_fingerprint,
+        "agent_api": true,
+        "agent_principal_id": principal.principal_id,
+        "agent_request_fingerprint": request_fingerprint,
     })
 }
 
@@ -965,38 +905,18 @@ fn mcp_text_result(text: String, is_error: bool) -> Value {
     })
 }
 
-fn mcp_json_result(value: Value) -> Result<Value, ApiError> {
-    Ok(mcp_text_result(
-        serde_json::to_string_pretty(&value)?,
-        false,
-    ))
-}
-
-fn mcp_agent_domain_error_result(error: ApiError) -> Result<Value, ApiError> {
-    let is_domain_error = matches!(
-        &error,
-        ApiError::BadRequest(_) | ApiError::Forbidden(_) | ApiError::NotFound(_)
-    ) || matches!(
-        &error,
-        ApiError::Runtime(SessionRuntimeError::BadRequest(_))
-            | ApiError::Runtime(SessionRuntimeError::CapacityExceeded { .. })
-            | ApiError::Runtime(SessionRuntimeError::Store(
-                centaur_session_sqlx::SessionStoreError::NotFound { .. }
-                    | centaur_session_sqlx::SessionStoreError::HarnessConflict { .. }
-                    | centaur_session_sqlx::SessionStoreError::PersonaConflict { .. }
-            ))
-    );
-    if is_domain_error {
-        return Ok(mcp_text_result(error.to_string(), true));
-    }
-    Err(error)
-}
-
 fn authenticate_mcp_bearer(headers: &HeaderMap) -> Result<Option<McpPrincipal>, ApiError> {
     let Some(token) = bearer_token(headers) else {
         return Ok(None);
     };
-    verify_mcp_jwt(&token, headers)
+    verify_resource_jwt(&token, headers, mcp_resource_url(headers))
+}
+
+fn authenticate_agent_bearer(headers: &HeaderMap) -> Result<Option<McpPrincipal>, ApiError> {
+    let Some(token) = bearer_token(headers) else {
+        return Ok(None);
+    };
+    verify_resource_jwt(&token, headers, agent_resource_url(headers))
 }
 
 #[derive(Debug, Deserialize)]
@@ -1028,7 +948,11 @@ struct McpJwtClaims {
     sub: Option<String>,
 }
 
-fn verify_mcp_jwt(token: &str, headers: &HeaderMap) -> Result<Option<McpPrincipal>, ApiError> {
+fn verify_resource_jwt(
+    token: &str,
+    _headers: &HeaderMap,
+    resource_url: String,
+) -> Result<Option<McpPrincipal>, ApiError> {
     let secret = jwt_signing_secret()
         .filter(|secret| !secret.trim().is_empty())
         .ok_or_else(|| {
@@ -1078,7 +1002,7 @@ fn verify_mcp_jwt(token: &str, headers: &HeaderMap) -> Result<Option<McpPrincipa
     if !same_url(&claims.iss, &issuer) {
         return Ok(None);
     }
-    if !audience_contains(&claims.aud, &mcp_resource_url(headers)) {
+    if !audience_contains(&claims.aud, &resource_url) {
         return Ok(None);
     }
     if claims.principal_id.trim().is_empty() {
@@ -1173,9 +1097,13 @@ fn bearer_token(headers: &HeaderMap) -> Option<String> {
 }
 
 fn ensure_mcp_scope(scopes: &[String], required: &str) -> Result<(), ApiError> {
+    ensure_scope(scopes, required, "mcp:*")
+}
+
+fn ensure_scope(scopes: &[String], required: &str, wildcard: &str) -> Result<(), ApiError> {
     if scopes
         .iter()
-        .any(|scope| scope == "*" || scope == required || scope == "mcp:*")
+        .any(|scope| scope == "*" || scope == required || scope == wildcard)
     {
         Ok(())
     } else {
@@ -1231,6 +1159,26 @@ fn mcp_unauthorized(headers: &HeaderMap) -> Response {
     response
 }
 
+fn agent_unauthorized(headers: &HeaderMap) -> Response {
+    let metadata = format!(
+        "{}/.well-known/oauth-protected-resource/api/agents",
+        agent_public_base_url(headers)
+    );
+    let challenge = format!(r#"Bearer resource_metadata="{metadata}", scope="agents:execute""#);
+    let mut response = (
+        StatusCode::UNAUTHORIZED,
+        Json(json!({
+            "ok": false,
+            "error": "missing or invalid agent bearer token",
+        })),
+    )
+        .into_response();
+    if let Ok(value) = HeaderValue::from_str(&challenge) {
+        response.headers_mut().insert("WWW-Authenticate", value);
+    }
+    response
+}
+
 fn mcp_resource_url(headers: &HeaderMap) -> String {
     if let Some(url) = mcp_public_url_env()
         .as_deref()
@@ -1239,6 +1187,23 @@ fn mcp_resource_url(headers: &HeaderMap) -> String {
         return url;
     }
     format!("{}/mcp", request_base_url(headers))
+}
+
+fn agent_resource_url(headers: &HeaderMap) -> String {
+    if let Some(url) = console_public_url_env()
+        .as_deref()
+        .and_then(normalize_public_url)
+    {
+        return format!("{}/api/agents", url);
+    }
+    format!("{}/api/agents", request_base_url(headers))
+}
+
+fn agent_public_base_url(headers: &HeaderMap) -> String {
+    agent_resource_url(headers)
+        .strip_suffix("/api/agents")
+        .map(str::to_owned)
+        .unwrap_or_else(|| request_base_url(headers))
 }
 
 fn mcp_authorization_server_url() -> Option<String> {
@@ -1412,37 +1377,22 @@ mod mcp_tests {
     }
 
     #[test]
-    fn mcp_agent_tools_are_listed_as_builtin_tools() {
-        let tools = mcp_agent_tool_entries();
+    fn mcp_tools_list_does_not_advertise_agent_execution_tools() {
+        let mut tools = vec![mcp_whoami_tool()];
+        tools.extend(mcp_centaur_tool_entries().unwrap());
         let names = tools
             .iter()
-            .map(|tool| tool["name"].as_str().unwrap().to_owned())
+            .map(|tool| tool["name"].as_str().unwrap())
             .collect::<Vec<_>>();
-        assert_eq!(
-            names,
-            vec![
-                "centaur_agent_start",
-                "centaur_agent_events",
-                "centaur_agent_cancel"
-            ]
-        );
-        assert_eq!(
-            tools[0]["inputSchema"]["properties"]["max_duration_ms"]["maximum"],
-            MCP_AGENT_MAX_DURATION_MS
-        );
-        assert_eq!(
-            tools[0]["inputSchema"]["required"],
-            json!(["prompt", "idempotency_key"])
-        );
-        assert_eq!(
-            tools[2]["inputSchema"]["required"],
-            json!(["thread_key", "execution_id"])
-        );
+        assert!(names.contains(&"centaur_whoami"));
+        assert!(!names.contains(&"centaur_agent_start"));
+        assert!(!names.contains(&"centaur_agent_events"));
+        assert!(!names.contains(&"centaur_agent_cancel"));
     }
 
     #[test]
     fn mcp_agent_input_uses_harness_user_message_shape() {
-        let thread_key = ThreadKey::parse("mcp-agent:principal:request").unwrap();
+        let thread_key = ThreadKey::parse("agent:principal:request").unwrap();
         let line = mcp_agent_input_line(
             &thread_key,
             "inspect the failure",
@@ -1507,14 +1457,14 @@ mod mcp_tests {
         let refreshed_metadata = mcp_agent_execution_metadata(&refreshed, "fingerprint-1");
 
         assert_eq!(first_metadata, refreshed_metadata);
-        assert_eq!(first_metadata["mcp_principal_id"], "principal-ada");
-        assert_eq!(first_metadata["mcp_request_fingerprint"], "fingerprint-1");
+        assert_eq!(first_metadata["agent_principal_id"], "principal-ada");
+        assert_eq!(first_metadata["agent_request_fingerprint"], "fingerprint-1");
         assert!(first_metadata.get("mcp_token_id").is_none());
     }
 
     #[test]
     fn mcp_terminal_status_uses_execution_status_and_tracks_visible_event() {
-        let thread_key = ThreadKey::parse("mcp-agent:principal:request").unwrap();
+        let thread_key = ThreadKey::parse("agent:principal:request").unwrap();
         let completed = centaur_session_core::SessionEvent {
             event_id: 10,
             thread_key: thread_key.clone(),
@@ -1737,6 +1687,70 @@ def search(query, limit=20):
         assert_eq!(principal.name, "test@example.com");
         assert_eq!(principal.scopes, vec!["mcp:tools"]);
         assert!(principal.expires_at.is_some());
+    }
+
+    #[test]
+    fn agent_jwt_uses_console_api_agents_audience_and_scope() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _env = EnvGuard::set(&[
+            ("CENTAUR_JWT_SIGNING_SECRET", "test-secret"),
+            ("CENTAUR_MCP_PUBLIC_URL", "http://localhost:3000/mcp"),
+            (
+                "CENTAUR_CONSOLE_PUBLIC_URL",
+                "http://betterbuilder.bettermoney.com",
+            ),
+        ]);
+        let token = test_jwt(
+            "test-secret",
+            json!({
+                "iss": "http://betterbuilder.bettermoney.com",
+                "sub": "usr_test",
+                "aud": "http://betterbuilder.bettermoney.com/api/agents",
+                "exp": OffsetDateTime::now_utc().unix_timestamp() + 3600,
+                "iat": OffsetDateTime::now_utc().unix_timestamp(),
+                "jti": "agentjwt_test",
+                "scope": "agents:execute",
+                "principal_id": "prn_test",
+                "email": "test@example.com",
+            }),
+        );
+
+        let principal = authenticate_agent_bearer(&mcp_auth_headers(&token))
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(principal.token_id, "agentjwt_test");
+        assert_eq!(principal.principal_id, "prn_test");
+        assert_eq!(principal.scopes, vec!["agents:execute"]);
+    }
+
+    #[test]
+    fn agent_jwt_rejects_mcp_audience_even_with_agent_scope() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _env = EnvGuard::set(&[
+            ("CENTAUR_JWT_SIGNING_SECRET", "test-secret"),
+            ("CENTAUR_MCP_PUBLIC_URL", "http://localhost:3000/mcp"),
+            (
+                "CENTAUR_CONSOLE_PUBLIC_URL",
+                "http://betterbuilder.bettermoney.com",
+            ),
+        ]);
+        let token = test_jwt(
+            "test-secret",
+            json!({
+                "iss": "http://betterbuilder.bettermoney.com",
+                "aud": "http://localhost:3000/mcp",
+                "exp": OffsetDateTime::now_utc().unix_timestamp() + 3600,
+                "principal_id": "prn_test",
+                "scope": "agents:execute",
+            }),
+        );
+
+        assert!(
+            authenticate_agent_bearer(&mcp_auth_headers(&token))
+                .unwrap()
+                .is_none()
+        );
     }
 
     #[test]

--- a/services/api-rs/crates/centaur-api-server/src/routes.rs
+++ b/services/api-rs/crates/centaur-api-server/src/routes.rs
@@ -55,7 +55,10 @@ use uuid::Uuid;
 use crate::{
     ApiError,
     api_jwt::{bearer_jwt_from_headers, decode_jwt_payload, verify_console_jwt},
-    mcp::{mcp_get, mcp_post, mcp_protected_resource_metadata},
+    mcp::{
+        agent_cancel_execution, agent_create_execution, agent_execution_events,
+        agent_protected_resource_metadata, mcp_get, mcp_post, mcp_protected_resource_metadata,
+    },
     slack_proxy::slack_proxy_router,
     types::{
         AppendMessagesRequest, AppendMessagesResponse, CreateSessionRequest, CreateSessionResponse,
@@ -210,6 +213,20 @@ pub fn build_router_with_app_state(state: AppState) -> Router {
         .route(
             "/.well-known/oauth-protected-resource/mcp",
             get(mcp_protected_resource_metadata),
+        )
+        .route(
+            "/.well-known/oauth-protected-resource/api/agents",
+            get(agent_protected_resource_metadata),
+        )
+        .route("/api/agents", get(agent_protected_resource_metadata))
+        .route("/api/agents/executions", post(agent_create_execution))
+        .route(
+            "/api/agents/executions/{execution_id}/events",
+            get(agent_execution_events),
+        )
+        .route(
+            "/api/agents/executions/{execution_id}/cancel",
+            post(agent_cancel_execution),
         )
         .route(
             "/api/session/{thread_key}",

--- a/services/api-rs/crates/centaur-session-runtime/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-runtime/src/lib.rs
@@ -312,13 +312,22 @@ enum SessionPrincipalSource<'a> {
 }
 
 fn is_mcp_agent_thread(thread_key: &ThreadKey) -> bool {
-    thread_key.as_str().starts_with("mcp-agent:")
+    thread_key.as_str().starts_with("agent:")
 }
 
 fn reject_mcp_agent_raw_thread(thread_key: &ThreadKey) -> Result<(), SessionRuntimeError> {
     if is_mcp_agent_thread(thread_key) {
         return Err(SessionRuntimeError::BadRequest(
-            "mcp-agent threads require MCP-specific runtime APIs".to_owned(),
+            "agent threads require agent-specific runtime APIs".to_owned(),
+        ));
+    }
+    Ok(())
+}
+
+fn require_external_agent_thread(thread_key: &ThreadKey) -> Result<(), SessionRuntimeError> {
+    if !is_mcp_agent_thread(thread_key) {
+        return Err(SessionRuntimeError::BadRequest(
+            "external agent APIs require an agent thread".to_owned(),
         ));
     }
     Ok(())
@@ -347,7 +356,7 @@ fn validate_session_principal_source(
         && is_mcp_agent_thread(thread_key)
     {
         return Err(SessionRuntimeError::BadRequest(
-            "mcp-agent threads require an existing external principal".to_owned(),
+            "agent threads require an existing external principal".to_owned(),
         ));
     }
     Ok(())
@@ -1408,6 +1417,7 @@ impl SessionRuntime {
         on_harness_conflict: HarnessConflictPolicy,
         principal_id: &str,
     ) -> Result<CreateOrGetSessionOutcome, SessionRuntimeError> {
+        require_external_agent_thread(thread_key)?;
         let principal_id = principal_id.trim();
         if principal_id.is_empty() {
             return Err(SessionRuntimeError::BadRequest(
@@ -1980,6 +1990,7 @@ impl SessionRuntime {
         messages: &[SessionMessageInput],
         principal_id: &str,
     ) -> Result<SessionExecution, SessionRuntimeError> {
+        require_external_agent_thread(thread_key)?;
         let principal_id = principal_id.trim();
         if principal_id.is_empty() {
             return Err(SessionRuntimeError::BadRequest(
@@ -2318,12 +2329,35 @@ impl SessionRuntime {
             }))
     }
 
+    pub async fn external_execution(
+        &self,
+        execution_id: &str,
+        principal_id: &str,
+    ) -> Result<Option<SessionExecution>, SessionRuntimeError> {
+        let principal_id = principal_id.trim();
+        if principal_id.is_empty() {
+            return Err(SessionRuntimeError::BadRequest(
+                "external principal_id is required".to_owned(),
+            ));
+        }
+        let Some(execution) = self.store.execution(execution_id).await? else {
+            return Ok(None);
+        };
+        if !is_mcp_agent_thread(&execution.thread_key) {
+            return Ok(None);
+        }
+        let session = self.store.get_session(&execution.thread_key).await?;
+        validate_external_principal(&session, principal_id)?;
+        Ok(Some(execution))
+    }
+
     pub async fn external_execution_status(
         &self,
         thread_key: &ThreadKey,
         execution_id: &str,
         principal_id: &str,
     ) -> Result<Option<ExecutionStatus>, SessionRuntimeError> {
+        require_external_agent_thread(thread_key)?;
         let principal_id = principal_id.trim();
         if principal_id.is_empty() {
             return Err(SessionRuntimeError::BadRequest(
@@ -2346,6 +2380,7 @@ impl SessionRuntime {
         status: &ExecutionStatus,
         principal_id: &str,
     ) -> Result<bool, SessionRuntimeError> {
+        require_external_agent_thread(thread_key)?;
         let principal_id = principal_id.trim();
         if principal_id.is_empty() {
             return Err(SessionRuntimeError::BadRequest(
@@ -2507,6 +2542,7 @@ impl SessionRuntime {
         reason: &str,
         principal_id: &str,
     ) -> Result<InterruptExecutionOutcome, SessionRuntimeError> {
+        require_external_agent_thread(thread_key)?;
         let principal_id = principal_id.trim();
         if principal_id.is_empty() {
             return Err(SessionRuntimeError::BadRequest(
@@ -2518,7 +2554,7 @@ impl SessionRuntime {
         let Some(execution) = self.store.active_execution_for_thread(thread_key).await? else {
             return Ok(InterruptExecutionOutcome {
                 interrupted: false,
-                execution_id: None,
+                execution_id: Some(execution_id.to_owned()),
             });
         };
         if execution.execution_id != execution_id {
@@ -3460,6 +3496,7 @@ impl SessionRuntime {
         limit: i64,
         principal_id: &str,
     ) -> Result<Vec<SessionEvent>, SessionRuntimeError> {
+        require_external_agent_thread(thread_key)?;
         let principal_id = principal_id.trim();
         if principal_id.is_empty() {
             return Err(SessionRuntimeError::BadRequest(
@@ -6964,7 +7001,7 @@ fn tool_host_thread_key(principal_id: &str) -> Result<ThreadKey, SessionRuntimeE
 fn tool_host_session_metadata(principal_id: &str) -> Value {
     json!({
         "mcp_tool_host": true,
-        "mcp_principal_id": principal_id,
+        "agent_principal_id": principal_id,
     })
 }
 
@@ -7103,7 +7140,7 @@ mod tests {
 
     #[test]
     fn derived_principals_cannot_claim_mcp_agent_threads() {
-        let mcp_thread = ThreadKey::parse("mcp-agent:principal:request").unwrap();
+        let mcp_thread = ThreadKey::parse("agent:principal:request").unwrap();
         let ordinary_thread = ThreadKey::parse("slack:thread").unwrap();
 
         assert!(
@@ -7125,7 +7162,7 @@ mod tests {
 
     #[test]
     fn raw_runtime_entrypoints_reject_mcp_agent_threads() {
-        let mcp_thread = ThreadKey::parse("mcp-agent:principal:request").unwrap();
+        let mcp_thread = ThreadKey::parse("agent:principal:request").unwrap();
 
         assert!(reject_mcp_agent_raw_thread(&mcp_thread).is_err());
     }
@@ -7134,7 +7171,7 @@ mod tests {
     fn external_principal_validation_rejects_cross_principal_session() {
         let now = OffsetDateTime::now_utc();
         let session = Session {
-            thread_key: ThreadKey::parse("mcp-agent:principal:request").unwrap(),
+            thread_key: ThreadKey::parse("agent:principal:request").unwrap(),
             title: None,
             sandbox_id: None,
             sandbox_capabilities: None,
@@ -8917,15 +8954,14 @@ mod adoption_tests {
             Arc::new(MockBackend::new(SandboxStatus::Running, Vec::new())),
         )
         .with_iron_control(registrar);
-        let thread_key =
-            ThreadKey::parse(format!("mcp-agent:test:{}", uuid::Uuid::new_v4())).unwrap();
+        let thread_key = ThreadKey::parse(format!("agent:test:{}", uuid::Uuid::new_v4())).unwrap();
 
         let outcome = runtime
             .create_or_get_external_session(
                 &thread_key,
                 &HarnessType::Codex,
                 None,
-                Some(json!({"mcp_agent": true})),
+                Some(json!({"agent_api": true})),
                 HarnessConflictPolicy::Reject,
                 "prn_mcp_caller",
             )
@@ -8950,7 +8986,7 @@ mod adoption_tests {
         };
         let _serial = TEST_LOCK.lock().await;
         let thread_key =
-            ThreadKey::parse(format!("mcp-agent:test:stream-{}", uuid::Uuid::new_v4())).unwrap();
+            ThreadKey::parse(format!("agent:test:stream-{}", uuid::Uuid::new_v4())).unwrap();
         let runtime = runtime_with(
             &store,
             Arc::new(MockBackend::new(SandboxStatus::Running, Vec::new())),
@@ -8971,7 +9007,7 @@ mod adoption_tests {
         };
         let _serial = TEST_LOCK.lock().await;
         let thread_key =
-            ThreadKey::parse(format!("mcp-agent:test:cancel-{}", uuid::Uuid::new_v4())).unwrap();
+            ThreadKey::parse(format!("agent:test:cancel-{}", uuid::Uuid::new_v4())).unwrap();
         store
             .create_or_get_session(&thread_key, &HarnessType::Codex, None, json!({}))
             .await
@@ -9036,6 +9072,106 @@ mod adoption_tests {
             .await
             .expect("clean new execution");
     }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn external_agent_api_rejects_non_agent_executions() {
+        let Some(store) = test_store().await else {
+            return;
+        };
+        let _serial = TEST_LOCK.lock().await;
+        let thread_key =
+            ThreadKey::parse(format!("console:test:{}", uuid::Uuid::new_v4())).unwrap();
+        store
+            .create_or_get_session(&thread_key, &HarnessType::Codex, None, json!({}))
+            .await
+            .expect("create session");
+        store
+            .set_iron_control_principal(&thread_key, Some("principal-a"))
+            .await
+            .expect("persist principal");
+        let execution = store
+            .create_execution(&thread_key, Some("private"), json!({}))
+            .await
+            .expect("create execution")
+            .execution;
+        let runtime = runtime_with(
+            &store,
+            Arc::new(MockBackend::new(SandboxStatus::Running, Vec::new())),
+        );
+
+        assert!(
+            runtime
+                .external_execution(&execution.execution_id, "principal-a")
+                .await
+                .expect("look up execution")
+                .is_none()
+        );
+        assert!(
+            runtime
+                .list_external_events(
+                    &thread_key,
+                    0,
+                    Some(&execution.execution_id),
+                    100,
+                    "principal-a",
+                )
+                .await
+                .is_err()
+        );
+        store
+            .fail_execution_if_active(&execution.execution_id, "test cleanup")
+            .await
+            .expect("clean execution");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn external_cancel_preserves_terminal_target_execution_id() {
+        let Some(store) = test_store().await else {
+            return;
+        };
+        let _serial = TEST_LOCK.lock().await;
+        let thread_key = ThreadKey::parse(format!(
+            "agent:test:terminal-cancel-{}",
+            uuid::Uuid::new_v4()
+        ))
+        .unwrap();
+        store
+            .create_or_get_session(&thread_key, &HarnessType::Codex, None, json!({}))
+            .await
+            .expect("create session");
+        store
+            .set_iron_control_principal(&thread_key, Some("principal-a"))
+            .await
+            .expect("persist principal");
+        let execution = store
+            .create_execution(&thread_key, Some("terminal"), json!({}))
+            .await
+            .expect("create execution")
+            .execution;
+        store
+            .complete_execution(&execution.execution_id)
+            .await
+            .expect("complete execution");
+        let runtime = runtime_with(
+            &store,
+            Arc::new(MockBackend::new(SandboxStatus::Running, Vec::new())),
+        );
+
+        let outcome = runtime
+            .interrupt_external_execution(
+                &thread_key,
+                &execution.execution_id,
+                "too late",
+                "principal-a",
+            )
+            .await
+            .expect("cancel terminal execution");
+        assert!(!outcome.interrupted);
+        assert_eq!(
+            outcome.execution_id.as_deref(),
+            Some(execution.execution_id.as_str())
+        );
+    }
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn external_execution_status_survives_cursor_past_terminal_event() {
         let Some(store) = test_store().await else {
@@ -9043,7 +9179,7 @@ mod adoption_tests {
         };
         let _serial = TEST_LOCK.lock().await;
         let thread_key =
-            ThreadKey::parse(format!("mcp-agent:test:status-{}", uuid::Uuid::new_v4())).unwrap();
+            ThreadKey::parse(format!("agent:test:status-{}", uuid::Uuid::new_v4())).unwrap();
         store
             .create_or_get_session(&thread_key, &HarnessType::Codex, None, json!({}))
             .await

--- a/services/api-rs/crates/centaur-session-runtime/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-runtime/src/lib.rs
@@ -311,12 +311,40 @@ enum SessionPrincipalSource<'a> {
     Existing(&'a str),
 }
 
+fn is_mcp_agent_thread(thread_key: &ThreadKey) -> bool {
+    thread_key.as_str().starts_with("mcp-agent:")
+}
+
+fn reject_mcp_agent_raw_thread(thread_key: &ThreadKey) -> Result<(), SessionRuntimeError> {
+    if is_mcp_agent_thread(thread_key) {
+        return Err(SessionRuntimeError::BadRequest(
+            "mcp-agent threads require MCP-specific runtime APIs".to_owned(),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_external_principal(
+    session: &Session,
+    principal_id: &str,
+) -> Result<(), SessionRuntimeError> {
+    match session.iron_control_principal.as_deref() {
+        Some(persisted) if persisted == principal_id => Ok(()),
+        Some(_) => Err(SessionRuntimeError::BadRequest(
+            "session principal does not match authenticated caller".to_owned(),
+        )),
+        None => Err(SessionRuntimeError::BadRequest(
+            "session is missing persisted principal".to_owned(),
+        )),
+    }
+}
+
 fn validate_session_principal_source(
     thread_key: &ThreadKey,
     principal_source: SessionPrincipalSource<'_>,
 ) -> Result<(), SessionRuntimeError> {
     if matches!(principal_source, SessionPrincipalSource::Derived)
-        && thread_key.as_str().starts_with("mcp-agent:")
+        && is_mcp_agent_thread(thread_key)
     {
         return Err(SessionRuntimeError::BadRequest(
             "mcp-agent threads require an existing external principal".to_owned(),
@@ -1359,6 +1387,7 @@ impl SessionRuntime {
         metadata: Option<Value>,
         on_harness_conflict: HarnessConflictPolicy,
     ) -> Result<CreateOrGetSessionOutcome, SessionRuntimeError> {
+        reject_mcp_agent_raw_thread(thread_key)?;
         self.create_or_get_session_with_principal(
             thread_key,
             harness_type,
@@ -1508,11 +1537,46 @@ impl SessionRuntime {
                     .await?;
             }
             if let Some(principal) = resolved_principal {
+                if let SessionPrincipalSource::Existing(principal_id) = principal_source
+                    && let Some(persisted) = session.iron_control_principal.as_deref()
+                    && persisted != principal_id
+                {
+                    return Err(SessionRuntimeError::BadRequest(
+                        "session principal does not match authenticated caller".to_owned(),
+                    ));
+                }
                 // Persist the principal OID on the session row so a resumed session
                 // can recreate its sandbox after a restart without re-deriving it.
                 let session = self
                     .store
                     .set_iron_control_principal(thread_key, Some(&principal.id))
+                    .await?;
+                info!(
+                    component = COMPONENT_SESSION_RUNTIME,
+                    event = "session_create_or_get_completed",
+                    thread_key = %thread_key,
+                    harness_type = %harness_type,
+                    status = %session.status,
+                    iron_control_principal_persisted = true,
+                    harness_switched,
+                    "session ready"
+                );
+                return Ok(CreateOrGetSessionOutcome {
+                    session,
+                    harness_switched,
+                });
+            }
+            if let SessionPrincipalSource::Existing(principal_id) = principal_source {
+                if let Some(persisted) = session.iron_control_principal.as_deref()
+                    && persisted != principal_id
+                {
+                    return Err(SessionRuntimeError::BadRequest(
+                        "session principal does not match authenticated caller".to_owned(),
+                    ));
+                }
+                let session = self
+                    .store
+                    .set_iron_control_principal(thread_key, Some(principal_id))
                     .await?;
                 info!(
                     component = COMPONENT_SESSION_RUNTIME,
@@ -1619,6 +1683,7 @@ impl SessionRuntime {
         thread_key: &ThreadKey,
         messages: &[SessionMessageInput],
     ) -> Result<Vec<String>, SessionRuntimeError> {
+        reject_mcp_agent_raw_thread(thread_key)?;
         let span = info_span!(
             "centaur.api_rs.session.messages.append",
             component = COMPONENT_SESSION_RUNTIME,
@@ -1884,6 +1949,7 @@ impl SessionRuntime {
         thread_key: &ThreadKey,
         input: ExecuteSessionInput,
     ) -> Result<SessionExecution, SessionRuntimeError> {
+        reject_mcp_agent_raw_thread(thread_key)?;
         self.execute_session_with_initial_messages(thread_key, input, None)
             .await
     }
@@ -1897,6 +1963,31 @@ impl SessionRuntime {
         input: ExecuteSessionInput,
         messages: &[SessionMessageInput],
     ) -> Result<SessionExecution, SessionRuntimeError> {
+        reject_mcp_agent_raw_thread(thread_key)?;
+        if messages.is_empty() {
+            return Err(SessionRuntimeError::BadRequest(
+                "messages must not be empty".to_owned(),
+            ));
+        }
+        self.execute_session_with_initial_messages(thread_key, input, Some(messages))
+            .await
+    }
+
+    pub async fn execute_external_session_with_messages(
+        &self,
+        thread_key: &ThreadKey,
+        input: ExecuteSessionInput,
+        messages: &[SessionMessageInput],
+        principal_id: &str,
+    ) -> Result<SessionExecution, SessionRuntimeError> {
+        let principal_id = principal_id.trim();
+        if principal_id.is_empty() {
+            return Err(SessionRuntimeError::BadRequest(
+                "external principal_id is required".to_owned(),
+            ));
+        }
+        let session = self.store.get_session(thread_key).await?;
+        validate_external_principal(&session, principal_id)?;
         if messages.is_empty() {
             return Err(SessionRuntimeError::BadRequest(
                 "messages must not be empty".to_owned(),
@@ -2190,6 +2281,16 @@ impl SessionRuntime {
         thread_key: &ThreadKey,
         execution_id: Option<&str>,
     ) -> Result<Option<ExecutionStatus>, SessionRuntimeError> {
+        reject_mcp_agent_raw_thread(thread_key)?;
+        self.execution_status_unchecked(thread_key, execution_id)
+            .await
+    }
+
+    async fn execution_status_unchecked(
+        &self,
+        thread_key: &ThreadKey,
+        execution_id: Option<&str>,
+    ) -> Result<Option<ExecutionStatus>, SessionRuntimeError> {
         let latest = self.store.latest_execution_for_thread(thread_key).await?;
         if execution_id.is_none()
             || latest
@@ -2215,6 +2316,51 @@ impl SessionRuntime {
                 "session.execution_cancelled" => Some(ExecutionStatus::Cancelled),
                 _ => None,
             }))
+    }
+
+    pub async fn external_execution_status(
+        &self,
+        thread_key: &ThreadKey,
+        execution_id: &str,
+        principal_id: &str,
+    ) -> Result<Option<ExecutionStatus>, SessionRuntimeError> {
+        let principal_id = principal_id.trim();
+        if principal_id.is_empty() {
+            return Err(SessionRuntimeError::BadRequest(
+                "external principal_id is required".to_owned(),
+            ));
+        }
+        let session = self.store.get_session(thread_key).await?;
+        validate_external_principal(&session, principal_id)?;
+        Ok(self
+            .store
+            .execution_for_thread(thread_key, execution_id)
+            .await?
+            .map(|execution| execution.status))
+    }
+
+    pub async fn external_terminal_event_observed(
+        &self,
+        thread_key: &ThreadKey,
+        execution_id: &str,
+        status: &ExecutionStatus,
+        principal_id: &str,
+    ) -> Result<bool, SessionRuntimeError> {
+        let principal_id = principal_id.trim();
+        if principal_id.is_empty() {
+            return Err(SessionRuntimeError::BadRequest(
+                "external principal_id is required".to_owned(),
+            ));
+        }
+        let session = self.store.get_session(thread_key).await?;
+        validate_external_principal(&session, principal_id)?;
+        let Some(event_type) = terminal_event_type_for_status(status) else {
+            return Ok(false);
+        };
+        Ok(self
+            .store
+            .execution_event_exists(execution_id, event_type)
+            .await?)
     }
 
     async fn record_execution_failure(
@@ -2343,13 +2489,54 @@ impl SessionRuntime {
         thread_key: &ThreadKey,
         reason: &str,
     ) -> Result<InterruptExecutionOutcome, SessionRuntimeError> {
+        reject_mcp_agent_raw_thread(thread_key)?;
         let Some(execution) = self.store.active_execution_for_thread(thread_key).await? else {
             return Ok(InterruptExecutionOutcome {
                 interrupted: false,
                 execution_id: None,
             });
         };
+        self.interrupt_execution(thread_key, execution, reason)
+            .await
+    }
 
+    pub async fn interrupt_external_execution(
+        &self,
+        thread_key: &ThreadKey,
+        execution_id: &str,
+        reason: &str,
+        principal_id: &str,
+    ) -> Result<InterruptExecutionOutcome, SessionRuntimeError> {
+        let principal_id = principal_id.trim();
+        if principal_id.is_empty() {
+            return Err(SessionRuntimeError::BadRequest(
+                "external principal_id is required".to_owned(),
+            ));
+        }
+        let session = self.store.get_session(thread_key).await?;
+        validate_external_principal(&session, principal_id)?;
+        let Some(execution) = self.store.active_execution_for_thread(thread_key).await? else {
+            return Ok(InterruptExecutionOutcome {
+                interrupted: false,
+                execution_id: None,
+            });
+        };
+        if execution.execution_id != execution_id {
+            return Ok(InterruptExecutionOutcome {
+                interrupted: false,
+                execution_id: Some(execution_id.to_owned()),
+            });
+        }
+        self.interrupt_execution(thread_key, execution, reason)
+            .await
+    }
+
+    async fn interrupt_execution(
+        &self,
+        thread_key: &ThreadKey,
+        execution: SessionExecution,
+        reason: &str,
+    ) -> Result<InterruptExecutionOutcome, SessionRuntimeError> {
         let execution_span = self
             .execution_spans
             .lock()
@@ -2468,6 +2655,7 @@ impl SessionRuntime {
             execution_id = execution_id.unwrap_or(""),
         );
         let result = async {
+            reject_mcp_agent_raw_thread(thread_key)?;
             info!(
                 component = COMPONENT_SESSION_RUNTIME,
                 event = "session_events_stream_started",
@@ -3253,6 +3441,38 @@ impl SessionRuntime {
     }
 
     pub async fn list_events(
+        &self,
+        thread_key: &ThreadKey,
+        after_event_id: i64,
+        execution_id: Option<&str>,
+        limit: i64,
+    ) -> Result<Vec<SessionEvent>, SessionRuntimeError> {
+        reject_mcp_agent_raw_thread(thread_key)?;
+        self.list_events_unchecked(thread_key, after_event_id, execution_id, limit)
+            .await
+    }
+
+    pub async fn list_external_events(
+        &self,
+        thread_key: &ThreadKey,
+        after_event_id: i64,
+        execution_id: Option<&str>,
+        limit: i64,
+        principal_id: &str,
+    ) -> Result<Vec<SessionEvent>, SessionRuntimeError> {
+        let principal_id = principal_id.trim();
+        if principal_id.is_empty() {
+            return Err(SessionRuntimeError::BadRequest(
+                "external principal_id is required".to_owned(),
+            ));
+        }
+        let session = self.store.get_session(thread_key).await?;
+        validate_external_principal(&session, principal_id)?;
+        self.list_events_unchecked(thread_key, after_event_id, execution_id, limit)
+            .await
+    }
+
+    async fn list_events_unchecked(
         &self,
         thread_key: &ThreadKey,
         after_event_id: i64,
@@ -4055,6 +4275,15 @@ fn is_terminal_execution_event(event_type: &str) -> bool {
         event_type,
         "session.execution_completed" | "session.execution_failed" | "session.execution_cancelled"
     )
+}
+
+fn terminal_event_type_for_status(status: &ExecutionStatus) -> Option<&'static str> {
+    match status {
+        ExecutionStatus::Completed => Some("session.execution_completed"),
+        ExecutionStatus::Failed => Some("session.execution_failed"),
+        ExecutionStatus::Cancelled => Some("session.execution_cancelled"),
+        ExecutionStatus::Queued | ExecutionStatus::Running => None,
+    }
 }
 
 /// How a stdout pump pass ended once the attach stream closed.
@@ -6895,6 +7124,34 @@ mod tests {
     }
 
     #[test]
+    fn raw_runtime_entrypoints_reject_mcp_agent_threads() {
+        let mcp_thread = ThreadKey::parse("mcp-agent:principal:request").unwrap();
+
+        assert!(reject_mcp_agent_raw_thread(&mcp_thread).is_err());
+    }
+
+    #[test]
+    fn external_principal_validation_rejects_cross_principal_session() {
+        let now = OffsetDateTime::now_utc();
+        let session = Session {
+            thread_key: ThreadKey::parse("mcp-agent:principal:request").unwrap(),
+            title: None,
+            sandbox_id: None,
+            sandbox_capabilities: None,
+            harness_type: HarnessType::Codex,
+            harness_thread_id: None,
+            persona_id: None,
+            status: SessionStatus::Idle,
+            iron_control_principal: Some("principal-a".to_owned()),
+            sandbox_last_active_at: None,
+            created_at: now,
+            updated_at: now,
+        };
+
+        assert!(validate_external_principal(&session, "principal-a").is_ok());
+        assert!(validate_external_principal(&session, "principal-b").is_err());
+    }
+    #[test]
     fn sandbox_repo_cache_label_controls_access() {
         assert_eq!(
             sandbox_repo_cache_access_from_principal(&test_principal(
@@ -8684,6 +8941,169 @@ mod adoption_tests {
             ["GET /api/v1/principals/prn_mcp_caller HTTP/1.1"]
         );
         server.abort();
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn raw_stream_events_rejects_mcp_agent_threads() {
+        let Some(store) = test_store().await else {
+            return;
+        };
+        let _serial = TEST_LOCK.lock().await;
+        let thread_key =
+            ThreadKey::parse(format!("mcp-agent:test:stream-{}", uuid::Uuid::new_v4())).unwrap();
+        let runtime = runtime_with(
+            &store,
+            Arc::new(MockBackend::new(SandboxStatus::Running, Vec::new())),
+        );
+
+        let error = match runtime.stream_events(&thread_key, 0, None).await {
+            Ok(_) => panic!("raw stream_events must reject mcp-agent threads"),
+            Err(error) => error,
+        };
+
+        assert!(matches!(error, SessionRuntimeError::BadRequest(_)));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn delayed_external_cancel_does_not_interrupt_newer_active_execution() {
+        let Some(store) = test_store().await else {
+            return;
+        };
+        let _serial = TEST_LOCK.lock().await;
+        let thread_key =
+            ThreadKey::parse(format!("mcp-agent:test:cancel-{}", uuid::Uuid::new_v4())).unwrap();
+        store
+            .create_or_get_session(&thread_key, &HarnessType::Codex, None, json!({}))
+            .await
+            .expect("create session");
+        store
+            .set_iron_control_principal(&thread_key, Some("principal-a"))
+            .await
+            .expect("persist principal");
+        let old_execution = store
+            .create_execution(&thread_key, Some("old"), json!({}))
+            .await
+            .expect("create old execution")
+            .execution;
+        store
+            .mark_execution_running(&old_execution.execution_id)
+            .await
+            .expect("mark old running");
+        backdate_execution(&store, &old_execution.execution_id, 10.0).await;
+        let new_execution = store
+            .create_execution(&thread_key, Some("new"), json!({}))
+            .await
+            .expect("create new execution")
+            .execution;
+        store
+            .mark_execution_running(&new_execution.execution_id)
+            .await
+            .expect("mark new running");
+        let runtime = runtime_with(
+            &store,
+            Arc::new(MockBackend::new(SandboxStatus::Running, Vec::new())),
+        );
+
+        let outcome = runtime
+            .interrupt_external_execution(
+                &thread_key,
+                &old_execution.execution_id,
+                "too late",
+                "principal-a",
+            )
+            .await
+            .expect("cancel old execution");
+
+        assert!(!outcome.interrupted);
+        assert_eq!(
+            outcome.execution_id.as_deref(),
+            Some(old_execution.execution_id.as_str())
+        );
+        let delivered = store
+            .list_events_after(&thread_key, 0, Some(&new_execution.execution_id), 100)
+            .await
+            .expect("list new execution events")
+            .into_iter()
+            .any(|event| event.event_type == "session.interrupt_delivered");
+        assert!(!delivered, "new execution must not receive old cancel");
+
+        store
+            .fail_execution_if_active(&old_execution.execution_id, "test cleanup")
+            .await
+            .expect("clean old execution");
+        store
+            .fail_execution_if_active(&new_execution.execution_id, "test cleanup")
+            .await
+            .expect("clean new execution");
+    }
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn external_execution_status_survives_cursor_past_terminal_event() {
+        let Some(store) = test_store().await else {
+            return;
+        };
+        let _serial = TEST_LOCK.lock().await;
+        let thread_key =
+            ThreadKey::parse(format!("mcp-agent:test:status-{}", uuid::Uuid::new_v4())).unwrap();
+        store
+            .create_or_get_session(&thread_key, &HarnessType::Codex, None, json!({}))
+            .await
+            .expect("create session");
+        store
+            .set_iron_control_principal(&thread_key, Some("principal-a"))
+            .await
+            .expect("persist principal");
+        let execution = store
+            .create_execution(&thread_key, Some("terminal"), json!({}))
+            .await
+            .expect("create execution")
+            .execution;
+        store
+            .complete_execution(&execution.execution_id)
+            .await
+            .expect("complete execution");
+        let terminal_event = store
+            .append_event(
+                &thread_key,
+                Some(&execution.execution_id),
+                "session.execution_completed",
+                json!({"execution_id": execution.execution_id}),
+            )
+            .await
+            .expect("append terminal event");
+        let runtime = runtime_with(
+            &store,
+            Arc::new(MockBackend::new(SandboxStatus::Running, Vec::new())),
+        );
+
+        let page = runtime
+            .list_external_events(
+                &thread_key,
+                terminal_event.event_id,
+                Some(&execution.execution_id),
+                100,
+                "principal-a",
+            )
+            .await
+            .expect("list events after terminal cursor");
+        assert!(page.is_empty());
+        assert_eq!(
+            runtime
+                .external_execution_status(&thread_key, &execution.execution_id, "principal-a")
+                .await
+                .expect("read external status"),
+            Some(ExecutionStatus::Completed)
+        );
+        assert!(
+            runtime
+                .external_terminal_event_observed(
+                    &thread_key,
+                    &execution.execution_id,
+                    &ExecutionStatus::Completed,
+                    "principal-a",
+                )
+                .await
+                .expect("check terminal event")
+        );
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/services/api-rs/crates/centaur-session-runtime/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-runtime/src/lib.rs
@@ -311,6 +311,20 @@ enum SessionPrincipalSource<'a> {
     Existing(&'a str),
 }
 
+fn validate_session_principal_source(
+    thread_key: &ThreadKey,
+    principal_source: SessionPrincipalSource<'_>,
+) -> Result<(), SessionRuntimeError> {
+    if matches!(principal_source, SessionPrincipalSource::Derived)
+        && thread_key.as_str().starts_with("mcp-agent:")
+    {
+        return Err(SessionRuntimeError::BadRequest(
+            "mcp-agent threads require an existing external principal".to_owned(),
+        ));
+    }
+    Ok(())
+}
+
 /// Result of [`SessionRuntime::create_or_get_session`].
 #[derive(Clone, Debug)]
 pub struct CreateOrGetSessionOutcome {
@@ -1391,6 +1405,7 @@ impl SessionRuntime {
         on_harness_conflict: HarnessConflictPolicy,
         principal_source: SessionPrincipalSource<'_>,
     ) -> Result<CreateOrGetSessionOutcome, SessionRuntimeError> {
+        validate_session_principal_source(thread_key, principal_source)?;
         let span = info_span!(
             "centaur.api_rs.session.create_or_get",
             component = COMPONENT_SESSION_RUNTIME,
@@ -1869,6 +1884,34 @@ impl SessionRuntime {
         thread_key: &ThreadKey,
         input: ExecuteSessionInput,
     ) -> Result<SessionExecution, SessionRuntimeError> {
+        self.execute_session_with_initial_messages(thread_key, input, None)
+            .await
+    }
+
+    /// Starts an execution and uses the durable execution idempotency claim to
+    /// gate its initial messages. Retries never steer duplicate input, and a
+    /// retry can safely recover a queued execution left before message append.
+    pub async fn execute_session_with_messages(
+        &self,
+        thread_key: &ThreadKey,
+        input: ExecuteSessionInput,
+        messages: &[SessionMessageInput],
+    ) -> Result<SessionExecution, SessionRuntimeError> {
+        if messages.is_empty() {
+            return Err(SessionRuntimeError::BadRequest(
+                "messages must not be empty".to_owned(),
+            ));
+        }
+        self.execute_session_with_initial_messages(thread_key, input, Some(messages))
+            .await
+    }
+
+    async fn execute_session_with_initial_messages(
+        &self,
+        thread_key: &ThreadKey,
+        input: ExecuteSessionInput,
+        initial_messages: Option<&[SessionMessageInput]>,
+    ) -> Result<SessionExecution, SessionRuntimeError> {
         let ExecuteSessionInput {
             idempotency_key,
             metadata,
@@ -1911,12 +1954,14 @@ impl SessionRuntime {
             validate_input_lines(&input_lines)?;
             let (idle_timeout, max_duration) = duration_options(idle_timeout_ms, max_duration_ms)?;
 
+            let requested_execution_metadata =
+                execution_metadata(metadata, idle_timeout_ms, max_duration_ms);
             let execution = self
                 .store
                 .create_execution(
                     thread_key,
                     idempotency_key.as_deref(),
-                    execution_metadata(metadata, idle_timeout_ms, max_duration_ms),
+                    requested_execution_metadata.clone(),
                 )
                 .await?;
             span.record(
@@ -1924,6 +1969,51 @@ impl SessionRuntime {
                 execution.execution.execution_id.as_str(),
             );
             span.record("execution_id", execution.execution.execution_id.as_str());
+            if initial_messages.is_some()
+                && !execution.created
+                && execution.execution.metadata != requested_execution_metadata
+            {
+                return Err(SessionRuntimeError::BadRequest(
+                    "idempotency_key was already used with different agent inputs".to_owned(),
+                ));
+            }
+            if let Some(messages) = initial_messages {
+                if !execution.created && execution.execution.status != ExecutionStatus::Queued {
+                    info!(
+                        component = COMPONENT_SESSION_RUNTIME,
+                        event = "session_execute_idempotent_replay",
+                        thread_key = %thread_key,
+                        execution_id = %execution.execution.execution_id,
+                        status = %execution.execution.status,
+                        "returning existing execution without appending duplicate messages"
+                    );
+                    return Ok(execution.execution);
+                }
+                // A retry may observe a queued execution if the request that
+                // inserted it crashed before persisting the prompt. Message
+                // client ids make this direct store append idempotent, and it
+                // deliberately bypasses active-execution steering.
+                if let Err(error) = self.store.append_messages(thread_key, messages).await {
+                    let error = SessionRuntimeError::Store(error);
+                    self.record_execution_failure(
+                        thread_key,
+                        &execution.execution.execution_id,
+                        &error,
+                    )
+                    .await;
+                    return Err(error);
+                }
+                if let Err(error) = self.store.touch_session_sandbox_activity(thread_key).await {
+                    warn!(
+                        component = COMPONENT_SESSION_RUNTIME,
+                        event = "session_sandbox_activity_touch_failed",
+                        thread_key = %thread_key,
+                        %error,
+                        "failed to touch sandbox activity after initial message append"
+                    );
+                }
+                self.spawn_session_title_generation(thread_key);
+            }
             if !execution.created && execution.execution.status != ExecutionStatus::Queued {
                 info!(
                     component = COMPONENT_SESSION_RUNTIME,
@@ -2093,6 +2183,38 @@ impl SessionRuntime {
             );
         }
         result
+    }
+
+    pub async fn execution_status(
+        &self,
+        thread_key: &ThreadKey,
+        execution_id: Option<&str>,
+    ) -> Result<Option<ExecutionStatus>, SessionRuntimeError> {
+        let latest = self.store.latest_execution_for_thread(thread_key).await?;
+        if execution_id.is_none()
+            || latest
+                .as_ref()
+                .is_some_and(|execution| Some(execution.execution_id.as_str()) == execution_id)
+        {
+            return Ok(latest.map(|execution| execution.status));
+        }
+
+        // The store intentionally exposes only the latest execution row for a
+        // thread. For an older explicitly selected execution, terminal events
+        // are also durable state and cannot be skipped by a caller's cursor.
+        let events = self
+            .store
+            .list_events_after(thread_key, 0, execution_id, i64::MAX)
+            .await?;
+        Ok(events
+            .into_iter()
+            .rev()
+            .find_map(|event| match event.event_type.as_str() {
+                "session.execution_completed" => Some(ExecutionStatus::Completed),
+                "session.execution_failed" => Some(ExecutionStatus::Failed),
+                "session.execution_cancelled" => Some(ExecutionStatus::Cancelled),
+                _ => None,
+            }))
     }
 
     async fn record_execution_failure(
@@ -6751,6 +6873,28 @@ mod tests {
     use time::OffsetDateTime;
 
     #[test]
+    fn derived_principals_cannot_claim_mcp_agent_threads() {
+        let mcp_thread = ThreadKey::parse("mcp-agent:principal:request").unwrap();
+        let ordinary_thread = ThreadKey::parse("slack:thread").unwrap();
+
+        assert!(
+            validate_session_principal_source(&mcp_thread, SessionPrincipalSource::Derived)
+                .is_err()
+        );
+        assert!(
+            validate_session_principal_source(
+                &mcp_thread,
+                SessionPrincipalSource::Existing("principal"),
+            )
+            .is_ok()
+        );
+        assert!(
+            validate_session_principal_source(&ordinary_thread, SessionPrincipalSource::Derived)
+                .is_ok()
+        );
+    }
+
+    #[test]
     fn sandbox_repo_cache_label_controls_access() {
         assert_eq!(
             sandbox_repo_cache_access_from_principal(&test_principal(
@@ -8540,6 +8684,60 @@ mod adoption_tests {
             ["GET /api/v1/principals/prn_mcp_caller HTTP/1.1"]
         );
         server.abort();
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn execution_status_recovers_terminal_state_for_an_older_execution() {
+        let Some(store) = test_store().await else {
+            return;
+        };
+        let _serial = TEST_LOCK.lock().await;
+        let thread_key =
+            ThreadKey::parse(format!("test:terminal-status-{}", uuid::Uuid::new_v4())).unwrap();
+        store
+            .create_or_get_session(&thread_key, &HarnessType::Codex, None, json!({}))
+            .await
+            .expect("create session");
+        let terminal = store
+            .create_execution(&thread_key, Some("terminal"), json!({}))
+            .await
+            .expect("create terminal execution")
+            .execution;
+        store
+            .complete_execution(&terminal.execution_id)
+            .await
+            .expect("complete execution");
+        store
+            .append_event(
+                &thread_key,
+                Some(&terminal.execution_id),
+                "session.execution_completed",
+                json!({"execution_id": terminal.execution_id}),
+            )
+            .await
+            .expect("append terminal event");
+        let latest = store
+            .create_execution(&thread_key, Some("latest"), json!({}))
+            .await
+            .expect("create latest execution")
+            .execution;
+        let runtime = runtime_with(
+            &store,
+            Arc::new(MockBackend::new(SandboxStatus::Running, Vec::new())),
+        );
+
+        assert_eq!(
+            runtime
+                .execution_status(&thread_key, Some(&terminal.execution_id))
+                .await
+                .expect("read execution status"),
+            Some(ExecutionStatus::Completed)
+        );
+
+        store
+            .fail_execution_if_active(&latest.execution_id, "test cleanup")
+            .await
+            .expect("clean up latest execution");
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/services/api-rs/crates/centaur-session-runtime/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-runtime/src/lib.rs
@@ -305,6 +305,12 @@ pub enum HarnessConflictPolicy {
     Restart,
 }
 
+#[derive(Clone, Copy, Debug)]
+enum SessionPrincipalSource<'a> {
+    Derived,
+    Existing(&'a str),
+}
+
 /// Result of [`SessionRuntime::create_or_get_session`].
 #[derive(Clone, Debug)]
 pub struct CreateOrGetSessionOutcome {
@@ -842,11 +848,22 @@ impl SessionRuntime {
             .unwrap_or_default()
     }
 
+    pub fn default_harness(&self) -> HarnessType {
+        self.sandbox_runtime
+            .warm_harness
+            .clone()
+            .unwrap_or(HarnessType::Codex)
+    }
+
     pub async fn session_title(
         &self,
         thread_key: &ThreadKey,
     ) -> Result<Option<String>, SessionRuntimeError> {
         Ok(self.store.get_session_title(thread_key).await?)
+    }
+
+    pub async fn session(&self, thread_key: &ThreadKey) -> Result<Session, SessionRuntimeError> {
+        Ok(self.store.get_session(thread_key).await?)
     }
 
     fn resolve_persona_for_create(
@@ -1328,6 +1345,52 @@ impl SessionRuntime {
         metadata: Option<Value>,
         on_harness_conflict: HarnessConflictPolicy,
     ) -> Result<CreateOrGetSessionOutcome, SessionRuntimeError> {
+        self.create_or_get_session_with_principal(
+            thread_key,
+            harness_type,
+            persona_id,
+            metadata,
+            on_harness_conflict,
+            SessionPrincipalSource::Derived,
+        )
+        .await
+    }
+
+    pub async fn create_or_get_external_session(
+        &self,
+        thread_key: &ThreadKey,
+        harness_type: &HarnessType,
+        persona_id: Option<&str>,
+        metadata: Option<Value>,
+        on_harness_conflict: HarnessConflictPolicy,
+        principal_id: &str,
+    ) -> Result<CreateOrGetSessionOutcome, SessionRuntimeError> {
+        let principal_id = principal_id.trim();
+        if principal_id.is_empty() {
+            return Err(SessionRuntimeError::BadRequest(
+                "external principal_id is required".to_owned(),
+            ));
+        }
+        self.create_or_get_session_with_principal(
+            thread_key,
+            harness_type,
+            persona_id,
+            metadata,
+            on_harness_conflict,
+            SessionPrincipalSource::Existing(principal_id),
+        )
+        .await
+    }
+
+    async fn create_or_get_session_with_principal(
+        &self,
+        thread_key: &ThreadKey,
+        harness_type: &HarnessType,
+        persona_id: Option<&str>,
+        metadata: Option<Value>,
+        on_harness_conflict: HarnessConflictPolicy,
+        principal_source: SessionPrincipalSource<'_>,
+    ) -> Result<CreateOrGetSessionOutcome, SessionRuntimeError> {
         let span = info_span!(
             "centaur.api_rs.session.create_or_get",
             component = COMPONENT_SESSION_RUNTIME,
@@ -1355,11 +1418,18 @@ impl SessionRuntime {
             );
             let mut harness_switched = false;
             let mut session_metadata = default_metadata(metadata);
-            let (registered_principal, desired_capabilities) =
+            let (resolved_principal, desired_capabilities) =
                 if let Some(registrar) = &self.iron_control {
-                    let principal = registrar
-                        .register_session(thread_key.as_str(), Some(&session_metadata))
-                        .await?;
+                    let principal = match principal_source {
+                        SessionPrincipalSource::Derived => {
+                            registrar
+                                .register_session(thread_key.as_str(), Some(&session_metadata))
+                                .await?
+                        }
+                        SessionPrincipalSource::Existing(principal_id) => {
+                            registrar.get_principal(principal_id).await?
+                        }
+                    };
                     let desired_capabilities = sandbox_capabilities_from_principal(&principal);
                     (Some(principal), desired_capabilities)
                 } else {
@@ -1422,7 +1492,7 @@ impl SessionRuntime {
                     )
                     .await?;
             }
-            if let Some(principal) = registered_principal {
+            if let Some(principal) = resolved_principal {
                 // Persist the principal OID on the session row so a resumed session
                 // can recreate its sandbox after a restart without re-deriving it.
                 let session = self
@@ -3058,6 +3128,24 @@ impl SessionRuntime {
                 "orphan adoption scan found nothing adoptable"
             );
         }
+    }
+
+    pub async fn list_events(
+        &self,
+        thread_key: &ThreadKey,
+        after_event_id: i64,
+        execution_id: Option<&str>,
+        limit: i64,
+    ) -> Result<Vec<SessionEvent>, SessionRuntimeError> {
+        if limit <= 0 {
+            return Err(SessionRuntimeError::BadRequest(
+                "limit must be greater than zero".to_owned(),
+            ));
+        }
+        Ok(self
+            .store
+            .list_events_after(thread_key, after_event_id, execution_id, limit)
+            .await?)
     }
 
     async fn record_adoption_deferral(&self, execution: &SessionExecution) {
@@ -8021,8 +8109,9 @@ mod adoption_tests {
         sync::atomic::{AtomicBool, AtomicUsize, Ordering},
     };
 
+    use centaur_iron_control::{IronControlClient, SessionRegistrar};
     use centaur_sandbox_core::{ObservedSandbox, SandboxHandle, SandboxIo, SandboxResult};
-    use tokio::io::{AsyncWriteExt, DuplexStream};
+    use tokio::io::{AsyncReadExt, AsyncWriteExt, DuplexStream};
 
     use super::*;
 
@@ -8362,6 +8451,95 @@ mod adoption_tests {
             store.clone(),
             SandboxRuntime::backend(backend, SandboxSpec::new("mock")),
         )
+    }
+
+    async fn spawn_external_principal_stub() -> (
+        String,
+        Arc<std::sync::Mutex<Vec<String>>>,
+        tokio::task::JoinHandle<()>,
+    ) {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let base_url = format!("http://{}", listener.local_addr().unwrap());
+        let requests = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let seen = requests.clone();
+        let server = tokio::spawn(async move {
+            loop {
+                let Ok((mut stream, _)) = listener.accept().await else {
+                    return;
+                };
+                let mut request = Vec::new();
+                let mut buffer = [0u8; 1024];
+                while !request.windows(4).any(|window| window == b"\r\n\r\n") {
+                    match stream.read(&mut buffer).await {
+                        Ok(0) | Err(_) => break,
+                        Ok(read) => request.extend_from_slice(&buffer[..read]),
+                    }
+                }
+                let request = String::from_utf8_lossy(&request);
+                let first_line = request.lines().next().unwrap_or_default();
+                seen.lock().unwrap().push(first_line.to_owned());
+                let (status, body) = if first_line
+                    .starts_with("GET /api/v1/principals/prn_mcp_caller ")
+                {
+                    (
+                        "200 OK",
+                        r#"{"data":{"id":"prn_mcp_caller","namespace":"default","foreign_id":"mcp-user","name":"MCP User","labels":{"centaur.sandbox_repo_cache":"public"},"sandbox_observability_enabled":false,"sandbox_api_server_enabled":false}}"#,
+                    )
+                } else {
+                    ("500 Internal Server Error", r#"{"error":"unexpected"}"#)
+                };
+                let response = format!(
+                    "HTTP/1.1 {status}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                    body.len()
+                );
+                let _ = stream.write_all(response.as_bytes()).await;
+                let _ = stream.shutdown().await;
+            }
+        });
+        (base_url, requests, server)
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn external_session_uses_existing_principal_without_registering_thread_principal() {
+        let Some(store) = test_store().await else {
+            return;
+        };
+        let _serial = TEST_LOCK.lock().await;
+        let (base_url, requests, server) = spawn_external_principal_stub().await;
+        let registrar = SessionRegistrar::new(
+            IronControlClient::new(base_url, "test-key"),
+            "default",
+            vec!["role_default".to_owned()],
+        );
+        let runtime = runtime_with(
+            &store,
+            Arc::new(MockBackend::new(SandboxStatus::Running, Vec::new())),
+        )
+        .with_iron_control(registrar);
+        let thread_key =
+            ThreadKey::parse(format!("mcp-agent:test:{}", uuid::Uuid::new_v4())).unwrap();
+
+        let outcome = runtime
+            .create_or_get_external_session(
+                &thread_key,
+                &HarnessType::Codex,
+                None,
+                Some(json!({"mcp_agent": true})),
+                HarnessConflictPolicy::Reject,
+                "prn_mcp_caller",
+            )
+            .await
+            .expect("create external session");
+
+        assert_eq!(
+            outcome.session.iron_control_principal.as_deref(),
+            Some("prn_mcp_caller")
+        );
+        assert_eq!(
+            requests.lock().unwrap().as_slice(),
+            ["GET /api/v1/principals/prn_mcp_caller HTTP/1.1"]
+        );
+        server.abort();
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/services/api-rs/crates/centaur-session-sqlx/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-sqlx/src/lib.rs
@@ -451,6 +451,24 @@ impl PgSessionStore {
         row.map(TryInto::try_into).transpose()
     }
 
+    pub async fn execution(
+        &self,
+        execution_id: &str,
+    ) -> Result<Option<SessionExecution>, SessionStoreError> {
+        let row = sqlx::query_as::<_, SessionExecutionRow>(
+            r#"
+            select execution_id, idempotency_key, thread_key, status, metadata, error, created_at, updated_at, started_at, completed_at
+            from session_executions
+            where execution_id = $1
+            "#,
+        )
+        .bind(execution_id)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        row.map(TryInto::try_into).transpose()
+    }
+
     pub async fn mark_execution_running(
         &self,
         execution_id: &str,

--- a/services/api-rs/crates/centaur-session-sqlx/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-sqlx/src/lib.rs
@@ -431,6 +431,26 @@ impl PgSessionStore {
         row.map(TryInto::try_into).transpose()
     }
 
+    pub async fn execution_for_thread(
+        &self,
+        thread_key: &ThreadKey,
+        execution_id: &str,
+    ) -> Result<Option<SessionExecution>, SessionStoreError> {
+        let row = sqlx::query_as::<_, SessionExecutionRow>(
+            r#"
+            select execution_id, idempotency_key, thread_key, status, metadata, error, created_at, updated_at, started_at, completed_at
+            from session_executions
+            where thread_key = $1 and execution_id = $2
+            "#,
+        )
+        .bind(thread_key.as_str())
+        .bind(execution_id)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        row.map(TryInto::try_into).transpose()
+    }
+
     pub async fn mark_execution_running(
         &self,
         execution_id: &str,

--- a/services/console/app/controllers/mcp/oauth_controller.rb
+++ b/services/console/app/controllers/mcp/oauth_controller.rb
@@ -10,7 +10,7 @@ module Mcp
     skip_before_action :require_active_account, only: %i[metadata register authorize token]
     skip_forgery_protection only: %i[register token]
 
-    ACCESS_TOKEN_TTL_SECONDS = 2.hours.to_i
+    ACCESS_TOKEN_TTL_SECONDS = 1.hour.to_i
 
     # The shared role seeded onto new console-user principals. Admins attach
     # tool secrets to this role to define what every MCP user gets by default.

--- a/services/console/app/controllers/mcp/oauth_controller.rb
+++ b/services/console/app/controllers/mcp/oauth_controller.rb
@@ -27,7 +27,7 @@ module Mcp
         grant_types_supported: McpOauthClient::DEFAULT_GRANT_TYPES,
         code_challenge_methods_supported: [ "S256" ],
         token_endpoint_auth_methods_supported: [ "none" ],
-        scopes_supported: McpOauthClient::DEFAULT_SCOPES,
+        scopes_supported: McpOauthClient::SUPPORTED_SCOPES,
         resource_parameter_supported: true
       }
     end
@@ -143,7 +143,7 @@ module Mcp
       end
 
       scopes = normalize_scope_param(params[:scope], McpOauthClient::DEFAULT_SCOPES)
-      unsupported = scopes - McpOauthClient::DEFAULT_SCOPES
+      unsupported = scopes - McpOauthClient::SUPPORTED_SCOPES
       if unsupported.any?
         return authorization_request_error(
           client,
@@ -151,8 +151,16 @@ module Mcp
           "Unsupported scope: #{unsupported.join(' ')}."
         )
       end
+      unauthorized = scopes - client.scopes
+      if unauthorized.any?
+        return authorization_request_error(
+          client,
+          :invalid_scope,
+          "Client is not registered for scope: #{unauthorized.join(' ')}."
+        )
+      end
 
-      resource = resolve_requested_resource
+      resource = resolve_requested_resource(scopes)
       return authorization_request_error(client, :invalid_target, "resource is required.") if resource.blank?
 
       { client: client, scopes: scopes, resource: resource }
@@ -412,18 +420,41 @@ module Mcp
       McpOauthClient.find_by_oid(client_id)
     end
 
-    def resolve_requested_resource
-      # Fail closed: without a configured canonical resource URL we would
-      # otherwise mint tokens bound to any caller-supplied audience.
-      configured = normalize_mcp_resource_url(configured_mcp_resource_url)
-      return nil if configured.blank?
+    def resolve_requested_resource(scopes)
+      resources = supported_resource_scope_pairs
       requested = params[:resource].presence
-      return nil if requested.present? && normalize_mcp_resource_url(requested) != configured
-      configured
+      normalized = if requested.present?
+        normalize_resource_url(requested)
+      elsif scopes == McpOauthClient::DEFAULT_SCOPES
+        configured_mcp_resource_url
+      end
+      return nil if normalized.blank?
+
+      allowed_scopes = resources[normalized]
+      return nil unless allowed_scopes.present? && scopes.sort == allowed_scopes.sort
+
+      normalized
+    end
+
+    def supported_resource_scope_pairs
+      {}.tap do |resources|
+        resources[configured_mcp_resource_url] = McpOauthClient::MCP_SCOPES if configured_mcp_resource_url.present?
+        resources[configured_agent_resource_url] = McpOauthClient::AGENT_SCOPES
+      end
     end
 
     def configured_mcp_resource_url
-      ENV["CENTAUR_MCP_PUBLIC_URL"].presence || ConsoleEnv["MCP_PUBLIC_URL"].presence
+      normalize_mcp_resource_url(
+        ENV["CENTAUR_MCP_PUBLIC_URL"].presence || ConsoleEnv["MCP_PUBLIC_URL"].presence
+      )
+    end
+
+    def configured_agent_resource_url
+      URI.join(public_base_url, "/api/agents").to_s
+    end
+
+    def normalize_resource_url(value)
+      normalize_agent_resource_url(value) || normalize_mcp_resource_url(value)
     end
 
     def normalize_mcp_resource_url(value)
@@ -432,6 +463,18 @@ module Mcp
       uri.fragment = nil
       path = uri.path.to_s.sub(%r{/+\z}, "")
       uri.path = path.end_with?("/mcp") ? path : "#{path}/mcp"
+      uri.to_s.sub(/\?\z/, "")
+    rescue URI::InvalidURIError
+      nil
+    end
+
+    def normalize_agent_resource_url(value)
+      uri = URI.parse(value.to_s.strip)
+      return nil unless %w[http https].include?(uri.scheme) && uri.host.present?
+      uri.fragment = nil
+      path = uri.path.to_s.sub(%r{/+\z}, "")
+      return nil unless path.end_with?("/api/agents")
+      uri.path = path
       uri.to_s.sub(/\?\z/, "")
     rescue URI::InvalidURIError
       nil

--- a/services/console/app/controllers/mcp/oauth_controller.rb
+++ b/services/console/app/controllers/mcp/oauth_controller.rb
@@ -10,7 +10,7 @@ module Mcp
     skip_before_action :require_active_account, only: %i[metadata register authorize token]
     skip_forgery_protection only: %i[register token]
 
-    ACCESS_TOKEN_TTL_SECONDS = 1.hour.to_i
+    ACCESS_TOKEN_TTL_SECONDS = 2.hours.to_i
 
     # The shared role seeded onto new console-user principals. Admins attach
     # tool secrets to this role to define what every MCP user gets by default.

--- a/services/console/app/models/mcp_oauth_client.rb
+++ b/services/console/app/models/mcp_oauth_client.rb
@@ -6,8 +6,10 @@ class McpOauthClient < ApplicationRecord
 
   DEFAULT_GRANT_TYPES = %w[authorization_code refresh_token].freeze
   DEFAULT_RESPONSE_TYPES = %w[code].freeze
-  DEFAULT_SCOPES = %w[mcp:tools].freeze
-
+  MCP_SCOPES = %w[mcp:tools].freeze
+  AGENT_SCOPES = %w[agents:execute].freeze
+  DEFAULT_SCOPES = MCP_SCOPES.freeze
+  SUPPORTED_SCOPES = (MCP_SCOPES + AGENT_SCOPES).freeze
   has_many :authorization_codes, class_name: "McpOauthAuthorizationCode", dependent: :destroy
   has_many :refresh_tokens, class_name: "McpOauthRefreshToken", dependent: :destroy
 
@@ -60,7 +62,7 @@ class McpOauthClient < ApplicationRecord
 
   def scopes_supported
     return errors.add(:scopes, "must be an array") unless scopes.is_a?(Array)
-    unsupported = scopes - DEFAULT_SCOPES
+    unsupported = scopes - SUPPORTED_SCOPES
     errors.add(:scopes, "contains unsupported values: #{unsupported.join(', ')}") if unsupported.any?
   end
 

--- a/services/console/test/controllers/mcp/oauth_controller_test.rb
+++ b/services/console/test/controllers/mcp/oauth_controller_test.rb
@@ -10,11 +10,13 @@ module Mcp
       @saved_env = {
         "CENTAUR_JWT_SIGNING_SECRET" => ENV["CENTAUR_JWT_SIGNING_SECRET"],
         "CENTAUR_MCP_PUBLIC_URL" => ENV["CENTAUR_MCP_PUBLIC_URL"],
-        "CENTAUR_CONSOLE_PUBLIC_URL" => ENV["CENTAUR_CONSOLE_PUBLIC_URL"]
+        "CENTAUR_CONSOLE_PUBLIC_URL" => ENV["CENTAUR_CONSOLE_PUBLIC_URL"],
+        "CENTAUR_MCP_ACCESS_TOKEN_TTL_SECONDS" => ENV["CENTAUR_MCP_ACCESS_TOKEN_TTL_SECONDS"]
       }
       ENV["CENTAUR_JWT_SIGNING_SECRET"] = "test-secret"
       ENV["CENTAUR_MCP_PUBLIC_URL"] = "http://localhost:3000/mcp"
       ENV["CENTAUR_CONSOLE_PUBLIC_URL"] = "http://www.example.com"
+      ENV.delete("CENTAUR_MCP_ACCESS_TOKEN_TTL_SECONDS")
     end
 
     teardown do
@@ -162,6 +164,7 @@ module Mcp
       assert_response :ok
       body = JSON.parse(response.body)
       assert_equal "Bearer", body.fetch("token_type")
+      assert_equal 2.hours.to_i, body.fetch("expires_in")
       assert_equal "mcp:tools", body.fetch("scope")
       assert_match(/\Amcprt_/, body.fetch("refresh_token"))
 
@@ -171,6 +174,7 @@ module Mcp
       assert_equal stored_code.principal.oid, jwt_payload.fetch("principal_id")
       assert_equal @operator.email, jwt_payload.fetch("email")
       assert_equal "mcp:tools", jwt_payload.fetch("scope")
+      assert_equal 2.hours.to_i, jwt_payload.fetch("exp") - jwt_payload.fetch("iat")
     end
 
     test "authorization approval seeds new console principals with the user-mcp role" do

--- a/services/console/test/controllers/mcp/oauth_controller_test.rb
+++ b/services/console/test/controllers/mcp/oauth_controller_test.rb
@@ -37,6 +37,8 @@ module Mcp
       assert_equal "http://www.example.com/mcp/oauth/token", body.fetch("token_endpoint")
       assert_equal "http://www.example.com/mcp/oauth/register", body.fetch("registration_endpoint")
       assert_includes body.fetch("code_challenge_methods_supported"), "S256"
+      assert_includes body.fetch("scopes_supported"), "mcp:tools"
+      assert_includes body.fetch("scopes_supported"), "agents:execute"
     end
 
     test "dynamic client registration creates a public PKCE client" do
@@ -55,6 +57,22 @@ module Mcp
       assert_match(/\Amoc_/, body.fetch("client_id"))
       assert_equal "none", body.fetch("token_endpoint_auth_method")
       assert_equal "mcp:tools", body.fetch("scope")
+    end
+
+    test "dynamic client registration creates an agent API client" do
+      assert_difference -> { McpOauthClient.count }, 1 do
+        post "/mcp/oauth/register",
+             params: {
+               client_name: "OMP",
+               redirect_uris: [ "http://127.0.0.1:49152/callback" ],
+               scope: "agents:execute"
+             },
+             as: :json
+      end
+
+      assert_response :created
+      body = JSON.parse(response.body)
+      assert_equal "agents:execute", body.fetch("scope")
     end
 
     test "dynamic client registration creates a hosted HTTPS client" do
@@ -173,6 +191,49 @@ module Mcp
       assert_equal "mcp:tools", jwt_payload.fetch("scope")
     end
 
+    test "authorization code exchange returns a JWT access token for the agent API resource" do
+      client = create_client(scopes: McpOauthClient::AGENT_SCOPES)
+      code = authorize_code(
+        client,
+        scope: "agents:execute",
+        resource: "http://www.example.com/api/agents"
+      )
+      stored_code = McpOauthAuthorizationCode.find_usable(code)
+      assert_equal "http://www.example.com/api/agents", stored_code.resource
+
+      exchange_authorization_code(client, code)
+
+      assert_response :ok
+      body = JSON.parse(response.body)
+      assert_equal "agents:execute", body.fetch("scope")
+
+      jwt_payload = decode_jwt_payload(body.fetch("access_token"))
+      assert_equal "http://www.example.com/api/agents", jwt_payload.fetch("aud")
+      assert_equal "agents:execute", jwt_payload.fetch("scope")
+    end
+
+    test "authorization rejects cross-paired resource and scope" do
+      client = create_client(scopes: McpOauthClient::AGENT_SCOPES)
+      post login_url, params: { email: @operator.email, password: "password123456" }
+
+      assert_no_difference -> { McpOauthAuthorizationCode.count } do
+        get "/mcp/oauth/authorize",
+            params: authorize_params(
+              client,
+              scope: "agents:execute",
+              resource: "http://localhost:3000/mcp"
+            )
+      end
+
+      assert_response :found
+      redirect = URI.parse(response.location)
+      query = Rack::Utils.parse_query(redirect.query)
+      callback_url = "#{redirect.scheme}://#{redirect.host}:#{redirect.port}#{redirect.path}"
+      assert_equal "http://127.0.0.1:49152/callback", callback_url
+      assert_equal "invalid_target", query.fetch("error")
+      assert_equal "resource is required.", query.fetch("error_description")
+    end
+
     test "authorization approval seeds new console principals with the user-mcp role" do
       client = create_client
 
@@ -289,31 +350,31 @@ module Mcp
 
     private
 
-    def create_client(redirect_uris: [ redirect_uri ])
+    def create_client(redirect_uris: [ redirect_uri ], scopes: McpOauthClient::DEFAULT_SCOPES)
       McpOauthClient.create!(
         name: "Amp",
         redirect_uris: redirect_uris,
         grant_types: McpOauthClient::DEFAULT_GRANT_TYPES,
         response_types: McpOauthClient::DEFAULT_RESPONSE_TYPES,
-        scopes: McpOauthClient::DEFAULT_SCOPES
+        scopes: scopes
       )
     end
 
-    def authorize_params(client)
+    def authorize_params(client, scope: "mcp:tools", resource: "http://localhost:3000/mcp")
       {
         response_type: "code",
         client_id: client.public_client_id,
         redirect_uri: redirect_uri,
-        scope: "mcp:tools",
+        scope: scope,
         state: "state-test",
-        resource: "http://localhost:3000/mcp",
+        resource: resource,
         code_challenge: code_challenge,
         code_challenge_method: "S256"
       }
     end
 
-    def authorize_code(client)
-      approval_params = authorize_params(client)
+    def authorize_code(client, scope: "mcp:tools", resource: "http://localhost:3000/mcp")
+      approval_params = authorize_params(client, scope: scope, resource: resource)
       post login_url, params: { email: @operator.email, password: "password123456" }
 
       assert_no_difference -> { McpOauthAuthorizationCode.count } do

--- a/services/console/test/controllers/mcp/oauth_controller_test.rb
+++ b/services/console/test/controllers/mcp/oauth_controller_test.rb
@@ -10,13 +10,11 @@ module Mcp
       @saved_env = {
         "CENTAUR_JWT_SIGNING_SECRET" => ENV["CENTAUR_JWT_SIGNING_SECRET"],
         "CENTAUR_MCP_PUBLIC_URL" => ENV["CENTAUR_MCP_PUBLIC_URL"],
-        "CENTAUR_CONSOLE_PUBLIC_URL" => ENV["CENTAUR_CONSOLE_PUBLIC_URL"],
-        "CENTAUR_MCP_ACCESS_TOKEN_TTL_SECONDS" => ENV["CENTAUR_MCP_ACCESS_TOKEN_TTL_SECONDS"]
+        "CENTAUR_CONSOLE_PUBLIC_URL" => ENV["CENTAUR_CONSOLE_PUBLIC_URL"]
       }
       ENV["CENTAUR_JWT_SIGNING_SECRET"] = "test-secret"
       ENV["CENTAUR_MCP_PUBLIC_URL"] = "http://localhost:3000/mcp"
       ENV["CENTAUR_CONSOLE_PUBLIC_URL"] = "http://www.example.com"
-      ENV.delete("CENTAUR_MCP_ACCESS_TOKEN_TTL_SECONDS")
     end
 
     teardown do
@@ -164,7 +162,6 @@ module Mcp
       assert_response :ok
       body = JSON.parse(response.body)
       assert_equal "Bearer", body.fetch("token_type")
-      assert_equal 2.hours.to_i, body.fetch("expires_in")
       assert_equal "mcp:tools", body.fetch("scope")
       assert_match(/\Amcprt_/, body.fetch("refresh_token"))
 
@@ -174,7 +171,6 @@ module Mcp
       assert_equal stored_code.principal.oid, jwt_payload.fetch("principal_id")
       assert_equal @operator.email, jwt_payload.fetch("email")
       assert_equal "mcp:tools", jwt_payload.fetch("scope")
-      assert_equal 2.hours.to_i, jwt_payload.fetch("exp") - jwt_payload.fetch("iat")
     end
 
     test "authorization approval seeds new console principals with the user-mcp role" do

--- a/services/console/test/models/mcp_oauth_client_test.rb
+++ b/services/console/test/models/mcp_oauth_client_test.rb
@@ -35,4 +35,25 @@ class McpOauthClientTest < ActiveSupport::TestCase
     refute client.redirect_uri_allowed?("http://127.evil.com/callback")
     refute client.redirect_uri_allowed?("http://127.0.0.1.evil.com/callback")
   end
+
+  test "scopes supports mcp tools and agent execution only" do
+    assert McpOauthClient.new(
+      name: "OMP",
+      redirect_uris: [ "http://127.0.0.1/callback" ],
+      grant_types: McpOauthClient::DEFAULT_GRANT_TYPES,
+      response_types: McpOauthClient::DEFAULT_RESPONSE_TYPES,
+      scopes: [ "agents:execute" ]
+    ).valid?
+
+    client = McpOauthClient.new(
+      name: "Bad",
+      redirect_uris: [ "http://127.0.0.1/callback" ],
+      grant_types: McpOauthClient::DEFAULT_GRANT_TYPES,
+      response_types: McpOauthClient::DEFAULT_RESPONSE_TYPES,
+      scopes: [ "mcp:tools", "agents:execute", "admin:*" ]
+    )
+
+    refute client.valid?
+    assert_includes client.errors[:scopes].join, "admin:*"
+  end
 end


### PR DESCRIPTION
## Summary
- add OAuth-principal-scoped REST endpoints to start, observe, continue, and cancel durable agent executions
- extend console OAuth with the exact `agents:execute` scope and `/api/agents` resource while preserving MCP clients
- enforce agent-thread and principal ownership across every external runtime entry point

## Why
Local coding agents need a direct API boundary for durable remote delegation. The REST facade reuses Centaur's session runtime and BetterBuilder OAuth without routing work through Slack or treating agent execution as an MCP tool.