### PR TITLE
feat(console): make login session lifetime configurable

### DIFF
--- a/services/console/README.md
+++ b/services/console/README.md
@@ -100,7 +100,7 @@ The operator console always supports email and password sign-in. To add Google o
 | `CENTAUR_CONSOLE_PASSWORD_LOGIN_ENABLED` | no       | Set to `false` to disable email and password sign-in. Defaults to enabled.                    |
 | `CENTAUR_CONSOLE_PUBLIC_SLACK_THREADS_ENABLED` | no | Set to `true` to let every authenticated Console user browse public Slack channel conversations. Requires the Slack ETL channel catalog; access fails closed when it is unavailable. Private channels and DMs remain owner-only. Defaults to disabled. |
 | `CENTAUR_CONSOLE_BOOTSTRAP_ADMINS`       | no       | Comma- or whitespace-separated email allowlist. Matching users become active admins on first SSO login. Other accepted SSO users become active non-admin operators and land on the console directly. |
-| `CENTAUR_CONSOLE_SESSION_MAX_AGE`        | no       | Absolute lifetime of the login session cookie, in seconds. Defaults to `1209600` (14 days). Set `0` or `session` for a browser-session cookie that expires when the browser closes. Invalid values fall back to the default. |
+| `CENTAUR_CONSOLE_SESSION_MAX_AGE`        | no       | Idle (sliding) lifetime of the login session cookie, in seconds: the cookie is refreshed on each authenticated request, so an operator is signed out only after this much inactivity. Defaults to `1209600` (14 days). Set `0` or `session` for a browser-session cookie that expires when the browser closes. Invalid values fall back to the default. Read at boot; changing it takes effect on process restart. |
 
 Register these callback URLs with the provider:
 

--- a/services/console/README.md
+++ b/services/console/README.md
@@ -100,6 +100,7 @@ The operator console always supports email and password sign-in. To add Google o
 | `CENTAUR_CONSOLE_PASSWORD_LOGIN_ENABLED` | no       | Set to `false` to disable email and password sign-in. Defaults to enabled.                    |
 | `CENTAUR_CONSOLE_PUBLIC_SLACK_THREADS_ENABLED` | no | Set to `true` to let every authenticated Console user browse public Slack channel conversations. Requires the Slack ETL channel catalog; access fails closed when it is unavailable. Private channels and DMs remain owner-only. Defaults to disabled. |
 | `CENTAUR_CONSOLE_BOOTSTRAP_ADMINS`       | no       | Comma- or whitespace-separated email allowlist. Matching users become active admins on first SSO login. Other accepted SSO users become active non-admin operators and land on the console directly. |
+| `CENTAUR_CONSOLE_SESSION_MAX_AGE`        | no       | Absolute lifetime of the login session cookie, in seconds. Defaults to `1209600` (14 days). Set `0` or `session` for a browser-session cookie that expires when the browser closes. Invalid values fall back to the default. |
 
 Register these callback URLs with the provider:
 

--- a/services/console/config/application.rb
+++ b/services/console/config/application.rb
@@ -16,7 +16,7 @@ module IronControl
     # Please, add to the `ignore` list any other `lib` subdirectories that do
     # not contain `.rb` files, or that should not be reloaded or eager loaded.
     # Common ones are `templates`, `generators`, or `middleware`, for example.
-    config.autoload_lib(ignore: %w[assets tasks json_log_formatter.rb console_env.rb])
+    config.autoload_lib(ignore: %w[assets tasks json_log_formatter.rb console_env.rb console_session.rb])
 
     # Configuration for the application, engines, and railties goes here.
     #

--- a/services/console/config/initializers/session_store.rb
+++ b/services/console/config/initializers/session_store.rb
@@ -1,0 +1,10 @@
+require_relative "../../lib/console_session"
+
+# Configure the console login cookie session. The key preserves the historical
+# default Rails derived from the application module name (IronControl ->
+# "_iron_control_session"), so tuning the lifetime never invalidates operators'
+# existing sessions. The lifetime is operator-configurable via
+# CENTAUR_CONSOLE_SESSION_MAX_AGE; see ConsoleSession.
+Rails.application.config.session_store :cookie_store,
+  key: "_iron_control_session",
+  expire_after: ConsoleSession.expire_after

--- a/services/console/lib/console_session.rb
+++ b/services/console/lib/console_session.rb
@@ -1,0 +1,38 @@
+require_relative "console_env"
+
+# Cookie-session lifetime configuration for the console login session.
+#
+# The console signs an operator in by storing their user id in a Rails
+# cookie-store session (see ApplicationController#sign_in_console_user). With no
+# configured expiry Rails emits a *browser-session* cookie, which many browsers
+# drop as soon as the window closes -- operators then get signed out far sooner
+# than they expect.
+#
+# CENTAUR_CONSOLE_SESSION_MAX_AGE makes the absolute lifetime configurable:
+#   - unset            -> DEFAULT_MAX_AGE_SECONDS (a persistent cookie)
+#   - a positive integer number of seconds -> that lifetime
+#   - "0" or "session" -> a browser-session cookie (no Max-Age/Expires)
+#   - anything else     -> DEFAULT_MAX_AGE_SECONDS (invalid values never shorten
+#                          the session unexpectedly)
+#
+# Kept as a plain module (no Rails dependency) so config/initializers can require
+# it directly, matching ConsoleEnv.
+module ConsoleSession
+  # Persistent-by-default lifetime when CENTAUR_CONSOLE_SESSION_MAX_AGE is unset:
+  # two weeks, expressed in seconds.
+  DEFAULT_MAX_AGE_SECONDS = 14 * 24 * 60 * 60
+
+  module_function
+
+  # The value for config.session_store's :expire_after option: an integer number
+  # of seconds, or nil for a browser-session cookie. nil is what Rails treats as
+  # "no absolute expiry".
+  def expire_after
+    raw = ConsoleEnv["SESSION_MAX_AGE"].to_s.strip
+    return DEFAULT_MAX_AGE_SECONDS if raw.empty?
+    return nil if raw == "0" || raw.casecmp?("session")
+
+    seconds = Integer(raw, exception: false)
+    seconds&.positive? ? seconds : DEFAULT_MAX_AGE_SECONDS
+  end
+end

--- a/services/console/lib/console_session.rb
+++ b/services/console/lib/console_session.rb
@@ -8,12 +8,17 @@ require_relative "console_env"
 # drop as soon as the window closes -- operators then get signed out far sooner
 # than they expect.
 #
-# CENTAUR_CONSOLE_SESSION_MAX_AGE makes the absolute lifetime configurable:
+# CENTAUR_CONSOLE_SESSION_MAX_AGE makes the cookie lifetime configurable.
+# Because Rails' cookie_store re-emits the session cookie on every authenticated
+# response, this is an *idle* (sliding) lifetime: the expiry clock resets on each
+# visit, so an operator is signed out only after this much inactivity.
 #   - unset            -> DEFAULT_MAX_AGE_SECONDS (a persistent cookie)
-#   - a positive integer number of seconds -> that lifetime
+#   - a positive integer number of seconds (base 10) -> that lifetime
 #   - "0" or "session" -> a browser-session cookie (no Max-Age/Expires)
 #   - anything else     -> DEFAULT_MAX_AGE_SECONDS (invalid values never shorten
 #                          the session unexpectedly)
+#
+# The value is read once at boot; changing it takes effect on process restart.
 #
 # Kept as a plain module (no Rails dependency) so config/initializers can require
 # it directly, matching ConsoleEnv.
@@ -25,14 +30,14 @@ module ConsoleSession
   module_function
 
   # The value for config.session_store's :expire_after option: an integer number
-  # of seconds, or nil for a browser-session cookie. nil is what Rails treats as
-  # "no absolute expiry".
+  # of seconds, or nil for a browser-session cookie (Rails treats nil as "no
+  # expiry attribute"). Parsed base 10 so a leading zero is not read as octal.
   def expire_after
     raw = ConsoleEnv["SESSION_MAX_AGE"].to_s.strip
     return DEFAULT_MAX_AGE_SECONDS if raw.empty?
     return nil if raw == "0" || raw.casecmp?("session")
 
-    seconds = Integer(raw, exception: false)
+    seconds = Integer(raw, 10, exception: false)
     seconds&.positive? ? seconds : DEFAULT_MAX_AGE_SECONDS
   end
 end

--- a/services/console/test/controllers/sessions_controller_test.rb
+++ b/services/console/test/controllers/sessions_controller_test.rb
@@ -112,4 +112,19 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
     get pending_url
     assert_redirected_to console_principals_path
   end
+
+  test "the login session cookie is persistent with the historical key and configured lifetime" do
+    post login_url, params: { email: @operator.email, password: "password123456" }
+
+    set_cookie = Array(response.headers["Set-Cookie"]).join("\n")
+    assert_match(/_iron_control_session=/, set_cookie)
+    # A persistent (not browser-session) cookie: Rails emits the configured
+    # lifetime as an absolute Expires attribute. Without the session_store
+    # initializer this would be a session cookie with no Expires, and operators
+    # would be signed out on browser close.
+    expires = set_cookie[/expires=([^;]+)/i, 1]
+    assert expires, "session cookie should carry an Expires attribute, got: #{set_cookie}"
+    # Expires should land ~14 days out (the default), well beyond a short window.
+    assert_operator Time.httpdate(expires), :>, ConsoleSession::DEFAULT_MAX_AGE_SECONDS.seconds.from_now - 1.hour
+  end
 end

--- a/services/console/test/lib/console_session_test.rb
+++ b/services/console/test/lib/console_session_test.rb
@@ -43,6 +43,16 @@ class ConsoleSessionTest < ActiveSupport::TestCase
     assert_equal 3600, ConsoleSession.expire_after
   end
 
+  test "parses base 10, so a leading zero is not treated as octal" do
+    ENV["CENTAUR_CONSOLE_SESSION_MAX_AGE"] = "010"
+    assert_equal 10, ConsoleSession.expire_after
+  end
+
+  test "rejects non-decimal (hex/octal-prefixed) values" do
+    ENV["CENTAUR_CONSOLE_SESSION_MAX_AGE"] = "0xFF"
+    assert_equal ConsoleSession::DEFAULT_MAX_AGE_SECONDS, ConsoleSession.expire_after
+  end
+
   test "falls back to the default for non-integer values" do
     ENV["CENTAUR_CONSOLE_SESSION_MAX_AGE"] = "not-a-number"
     assert_equal ConsoleSession::DEFAULT_MAX_AGE_SECONDS, ConsoleSession.expire_after

--- a/services/console/test/lib/console_session_test.rb
+++ b/services/console/test/lib/console_session_test.rb
@@ -1,0 +1,60 @@
+require "test_helper"
+
+class ConsoleSessionTest < ActiveSupport::TestCase
+  KEYS = %w[CENTAUR_CONSOLE_SESSION_MAX_AGE IRON_CONTROL_SESSION_MAX_AGE].freeze
+
+  setup do
+    @prev_env = ENV.to_hash.slice(*KEYS)
+    KEYS.each { |k| ENV.delete(k) }
+  end
+
+  teardown do
+    KEYS.each { |k| ENV.delete(k) }
+    @prev_env.each { |k, v| ENV[k] = v }
+  end
+
+  test "defaults to two weeks when unset" do
+    assert_equal ConsoleSession::DEFAULT_MAX_AGE_SECONDS, ConsoleSession.expire_after
+    assert_equal 14 * 24 * 60 * 60, ConsoleSession.expire_after
+  end
+
+  test "reads a positive integer number of seconds" do
+    ENV["CENTAUR_CONSOLE_SESSION_MAX_AGE"] = "3600"
+    assert_equal 3600, ConsoleSession.expire_after
+  end
+
+  test "honors the legacy IRON_CONTROL_ variable" do
+    ENV["IRON_CONTROL_SESSION_MAX_AGE"] = "7200"
+    assert_equal 7200, ConsoleSession.expire_after
+  end
+
+  test "0 means a browser-session cookie (no absolute expiry)" do
+    ENV["CENTAUR_CONSOLE_SESSION_MAX_AGE"] = "0"
+    assert_nil ConsoleSession.expire_after
+  end
+
+  test "\"session\" means a browser-session cookie, case-insensitively" do
+    ENV["CENTAUR_CONSOLE_SESSION_MAX_AGE"] = "Session"
+    assert_nil ConsoleSession.expire_after
+  end
+
+  test "ignores surrounding whitespace" do
+    ENV["CENTAUR_CONSOLE_SESSION_MAX_AGE"] = "  3600  "
+    assert_equal 3600, ConsoleSession.expire_after
+  end
+
+  test "falls back to the default for non-integer values" do
+    ENV["CENTAUR_CONSOLE_SESSION_MAX_AGE"] = "not-a-number"
+    assert_equal ConsoleSession::DEFAULT_MAX_AGE_SECONDS, ConsoleSession.expire_after
+  end
+
+  test "falls back to the default for negative values" do
+    ENV["CENTAUR_CONSOLE_SESSION_MAX_AGE"] = "-100"
+    assert_equal ConsoleSession::DEFAULT_MAX_AGE_SECONDS, ConsoleSession.expire_after
+  end
+
+  test "falls back to the default for a blank value" do
+    ENV["CENTAUR_CONSOLE_SESSION_MAX_AGE"] = "   "
+    assert_equal ConsoleSession::DEFAULT_MAX_AGE_SECONDS, ConsoleSession.expire_after
+  end
+end


### PR DESCRIPTION
## Summary

The console login cookie had no configured expiry, so Rails emitted a browser-session cookie. Many browsers drop that on close, signing operators out far sooner than expected.

This adds a `config/initializers/session_store.rb` that sets an absolute cookie lifetime, configurable via `CENTAUR_CONSOLE_SESSION_MAX_AGE` (seconds, with the usual `IRON_CONTROL_` legacy fallback):

- unset → 14 days (persistent, the new default)
- positive integer → that many seconds
- `0` or `session` → browser-session cookie (previous behavior)
- invalid → falls back to the default (never silently shortens the session)

The cookie key is pinned to the historical `_iron_control_session` (the value Rails derived from the `IronControl` app module), so changing the lifetime does not invalidate operators' existing sessions.

## Why

Operators were being signed out of the console too quickly. This makes the session persistent by default and lets deployments tune the lifetime.

Parsing lives in a dependency-free `ConsoleSession` module (mirrors `ConsoleEnv`), unit-tested; an integration test asserts the login response sets a persistent cookie with the pinned key. New env var documented in `services/console/README.md`.