### PR TITLE
ci: run console gem audit on main

### DIFF
--- a/.github/workflows/console-ci.yml
+++ b/.github/workflows/console-ci.yml
@@ -62,9 +62,6 @@ jobs:
       - name: Scan for common Rails security vulnerabilities using static analysis
         run: bin/brakeman --no-pager
 
-      - name: Scan for known security vulnerabilities in gems used
-        run: bin/bundler-audit
-
   scan_js:
     runs-on: depot-ubuntu-24.04-16
     needs: console_changes

--- a/.github/workflows/console-gem-audit.yml
+++ b/.github/workflows/console-gem-audit.yml
@@ -1,0 +1,31 @@
+name: Console Gem Audit
+
+on:
+  push:
+    branches: [ main ]
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    working-directory: services/console
+
+jobs:
+  scan_gems:
+    runs-on: depot-ubuntu-24.04-16
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@12fd324f1d0b43274fdc8130f6980590a667c455 # v1.312.0
+        with:
+          working-directory: services/console
+          bundler-cache: true
+
+      - name: Scan for known security vulnerabilities in gems used
+        run: bin/bundler-audit


### PR DESCRIPTION
Moves the console gem vulnerability audit out of the pull request Console CI workflow and into a dedicated workflow that runs on pushes to main. PRs still run the remaining console security checks without bundler-audit.