### PR TITLE
feat(slack): read huddle transcripts securely

### DIFF
--- a/docs/pages/extend/tools.mdx
+++ b/docs/pages/extend/tools.mdx
@@ -91,6 +91,8 @@ Each entry in `secrets` declares one credential the tool can request with
   request the placeholder is allowed to appear. At least one is required.
 - `hosts` is the upstream allowlist for this secret. iron-proxy will only
   inject the real value on requests to these hosts.
+- `http_methods` and `paths` optionally narrow that allowlist to specific HTTP
+  methods and URL paths. Use them for high-authority credentials that serve one endpoint.
 
 Use `optional_secrets` for credentials the tool can run without.
 

--- a/docs/pages/operate/slack-huddle-transcripts.mdx
+++ b/docs/pages/operate/slack-huddle-transcripts.mdx
@@ -1,0 +1,102 @@
+---
+title: Slack huddle transcripts
+description: Read the verbatim, speaker-attributed transcript of a recorded Slack huddle — the one Slack record no bot token can reach.
+---
+
+# Slack huddle transcripts
+
+Slack records every huddle and saves a full, speaker-attributed transcript. **A bot token cannot read
+it, and no public API exposes it.** `files.info` on the transcript's file id returns metadata and no
+words, whatever scopes the app holds; Slack support confirms this is deliberate.
+
+That leaves a hole in an agent's view of a workspace, and it is the wrong hole. The huddle is where
+the standup sets the day's priorities, where the incident call finds the cause, where the design
+argument is actually settled. Channels get the summary; the huddle had the reasoning. An agent that
+reads every channel and no huddle is missing the part that mattered.
+
+Centaur's Slack tool can read them, given a **user web session**.
+
+## How it works
+
+The Slack *web client* reads transcripts perfectly well. It calls `files.info` with
+`include_transcription=true` against the **workspace host** (`<workspace>.slack.com` — never
+`slack.com`), authenticated by a user web session: an `xoxc` token paired with the `d` cookie.
+The tool replays exactly that call.
+
+This is not a scope escalation and not a permission bypass. A user session sees precisely what that
+user could already read by opening the huddle in their own Slack client. If they cannot see the
+huddle, neither can this.
+
+```bash
+slack huddle-transcript F0123456789
+```
+
+```
+34 turns, 3 speakers
+<@U01ABC> [0:04]: the migration is blocked on the schema review
+<@U02DEF> [0:11]: I can review it this afternoon
+<@U01ABC> [0:19]: then we ship Friday
+```
+
+The agent-facing method is `get_huddle_transcript(file_id)`. It returns `{file_id, speakers, turns,
+text}`. Speakers stay as **Slack ids**, not names — an id round-trips to a real mention and cannot
+drift, while a name resolved at read time silently rots when someone changes their display name.
+
+Find a `file_id` from the huddle's message in `conversations.history` (the room object references its
+transcript file), or from the huddle's AI-notes canvas, which names it.
+
+## The credentials
+
+Two optional secrets. Without them every other Slack method works exactly as before, and only
+`get_huddle_transcript` reports what is missing.
+
+| Secret | What it is |
+| --- | --- |
+| `SLACK_WEB_TOKEN` | The `xoxc` token from a signed-in Slack web session |
+| `SLACK_WEB_COOKIE` | The paired `d` cookie (`d=xoxd-…`) |
+
+Both are declared as header-injected HTTP secrets scoped to `*.slack.com`, so **the sandbox holds
+placeholders and never the real session** — iron-proxy swaps in the true values at the network
+boundary, and only for Slack hosts.
+
+:::warning[Scope these to a service account, not to a person]
+A user web session carries **that user's full Slack visibility**, including their DMs. Mint it from an
+account whose visibility you are content for agents to inherit. This is the same trust decision as
+`SLACK_SEARCH_TOKEN`, but the blast radius is larger, so make it deliberately.
+:::
+
+### Obtaining them
+
+From a browser signed in to the workspace:
+
+1. Open the workspace in Slack (web or the desktop app), then open developer tools.
+2. `SLACK_WEB_COOKIE` — copy the `d` cookie for `.slack.com`. Its value begins `xoxd-`. Store it in
+   the `d=xoxd-…` form.
+3. `SLACK_WEB_TOKEN` — the paired `xoxc` token is embedded in the workspace boot page. Find it in any
+   authenticated XHR to `/api/…` (the `token` form field), or search the page source for `xoxc-`.
+
+The two are a **pair**: an `xoxc` token only authenticates alongside the `d` cookie it was issued
+with. Rotating one without the other yields `invalid_auth`.
+
+## Sessions expire — and the failure is loud on purpose
+
+A web session lapses. When it does, the tool raises `needs_reauth` rather than returning an empty
+transcript.
+
+That distinction is the whole design. **A silent empty read looks exactly like "nobody spoke."** An
+agent that quietly concludes a meeting was silent is far worse than one that says it cannot see —
+the first fabricates an absence of evidence, the second reports a broken credential. So a lapsed
+session fails loudly, and a caller can tell "sign in again" apart from "this is broken":
+
+```json
+{
+  "error": "huddle_transcript_failed",
+  "message": "the Slack web session expired — a human must sign in again …",
+  "slack_error": "invalid_auth",
+  "needs_reauth": true
+}
+```
+
+Treat `needs_reauth` as an operational alert, not an empty result. Discovery — which huddles exist —
+runs on the ordinary bot token and never needs the session, so nothing is lost while a session is
+stale: refresh it and the backlog reads fine.

--- a/docs/pages/operate/slack-huddle-transcripts.mdx
+++ b/docs/pages/operate/slack-huddle-transcripts.mdx
@@ -21,7 +21,7 @@ Centaur's Slack tool can read them, given a **user web session**.
 The Slack *web client* reads transcripts perfectly well. It calls `files.info` with
 `include_transcription=true` against the **workspace host** (`<workspace>.slack.com` — never
 `slack.com`), authenticated by a user web session: an `xoxc` token paired with the `d` cookie.
-The tool replays exactly that call.
+The tool sends the equivalent authenticated `files.info` request.
 
 This is not a scope escalation and not a permission bypass. A user session sees precisely what that
 user could already read by opening the huddle in their own Slack client. If they cannot see the
@@ -55,14 +55,15 @@ Two optional secrets. Without them every other Slack method works exactly as bef
 | `SLACK_WEB_TOKEN` | The `xoxc` token from a signed-in Slack web session |
 | `SLACK_WEB_COOKIE` | The paired `d` cookie (`d=xoxd-…`) |
 
-Both are declared as header-injected HTTP secrets scoped to `*.slack.com`, so **the sandbox holds
-placeholders and never the real session** — iron-proxy swaps in the true values at the network
-boundary, and only for Slack hosts.
+Both are declared as header-replaced HTTP secrets scoped to `POST /api/files.info` on
+`*.slack.com`, so **the sandbox holds placeholders and never the real session** — iron-proxy swaps
+in the true values at the network boundary only for that read-only Slack endpoint.
 
 :::warning[Scope these to a service account, not to a person]
-A user web session carries **that user's full Slack visibility**, including their DMs. Mint it from an
-account whose visibility you are content for agents to inherit. This is the same trust decision as
-`SLACK_SEARCH_TOKEN`, but the blast radius is larger, so make it deliberately.
+The underlying web session carries **that user's full Slack visibility**, including their DMs. The
+proxy limits these placeholders to `files.info`, but that endpoint can still return huddle
+transcripts and other files the account can see, including files from DMs. Mint the session from an
+account whose file visibility you are content for agents to inherit.
 :::
 
 ### Obtaining them

--- a/docs/pages/reference/tool-directory.mdx
+++ b/docs/pages/reference/tool-directory.mdx
@@ -31,7 +31,7 @@ These are broadly useful across most deployments and are good candidates to conf
 |---|---|---|
 | `linear` | Search, create, update, and comment on Linear issues, projects, cycles, teams, and labels | `LINEAR_API_KEY` |
 | `notion` | Search and update Notion pages, databases, blocks, and comments | `NOTION_API_KEY` |
-| `slack` | Search Slack, read threads, inspect channels/users, and send or upload messages | `SLACK_BOT_TOKEN`; optional: `SLACK_SEARCH_TOKEN`, `SLACK_ETL_TOKEN` |
+| `slack` | Search Slack, read threads, inspect channels/users, read huddle transcripts, and send or upload messages | `SLACK_BOT_TOKEN`; optional: `SLACK_SEARCH_TOKEN`, `SLACK_ETL_TOKEN`, `SLACK_WEB_TOKEN` + `SLACK_WEB_COOKIE` (huddle transcripts) |
 | `gsuite` | Use Gmail, Calendar, Drive, Docs, Sheets, Slides, and Google Analytics | `GOOGLE_TOKEN_JSON` |
 | `websearch` | Free web search via Parallel and deep research | None; `PARALLEL_API_KEY` for `deep_research`; `ANTHROPIC_API_KEY` for search synthesis |
 | `company_context` | Search indexed company history, private Slack conversations, and Google Docs | None |
@@ -83,7 +83,7 @@ These are broadly useful across most deployments and are good candidates to conf
 | `linear` | Linear issues, projects, cycles, teams, workflow states, and labels | `LINEAR_API_KEY` |
 | `notion` | Notion pages, databases, blocks, comments, and users | `NOTION_API_KEY` |
 | `opentable` | Search OpenTable restaurant reservations | None |
-| `slack` | Slack messages, files, channels, threads, users, and usergroups | `SLACK_BOT_TOKEN`; optional: `SLACK_SEARCH_TOKEN`, `SLACK_ETL_TOKEN` |
+| `slack` | Slack messages, files, channels, threads, users, usergroups, and huddle transcripts | `SLACK_BOT_TOKEN`; optional: `SLACK_SEARCH_TOKEN`, `SLACK_ETL_TOKEN`, `SLACK_WEB_TOKEN` + `SLACK_WEB_COOKIE` (huddle transcripts) |
 
 ## Research
 

--- a/docs/public/md/extend/tools.md
+++ b/docs/public/md/extend/tools.md
@@ -91,6 +91,8 @@ Each entry in `secrets` declares one credential the tool can request with
   request the placeholder is allowed to appear. At least one is required.
 - `hosts` is the upstream allowlist for this secret. iron-proxy will only
   inject the real value on requests to these hosts.
+- `http_methods` and `paths` optionally narrow that allowlist to specific HTTP
+  methods and URL paths. Use them for high-authority credentials that serve one endpoint.
 
 Use `optional_secrets` for credentials the tool can run without.
 

--- a/docs/public/md/operate/slack-huddle-transcripts.md
+++ b/docs/public/md/operate/slack-huddle-transcripts.md
@@ -1,0 +1,102 @@
+---
+title: Slack huddle transcripts
+description: Read the verbatim, speaker-attributed transcript of a recorded Slack huddle — the one Slack record no bot token can reach.
+---
+
+# Slack huddle transcripts
+
+Slack records every huddle and saves a full, speaker-attributed transcript. **A bot token cannot read
+it, and no public API exposes it.** `files.info` on the transcript's file id returns metadata and no
+words, whatever scopes the app holds; Slack support confirms this is deliberate.
+
+That leaves a hole in an agent's view of a workspace, and it is the wrong hole. The huddle is where
+the standup sets the day's priorities, where the incident call finds the cause, where the design
+argument is actually settled. Channels get the summary; the huddle had the reasoning. An agent that
+reads every channel and no huddle is missing the part that mattered.
+
+Centaur's Slack tool can read them, given a **user web session**.
+
+## How it works
+
+The Slack *web client* reads transcripts perfectly well. It calls `files.info` with
+`include_transcription=true` against the **workspace host** (`<workspace>.slack.com` — never
+`slack.com`), authenticated by a user web session: an `xoxc` token paired with the `d` cookie.
+The tool replays exactly that call.
+
+This is not a scope escalation and not a permission bypass. A user session sees precisely what that
+user could already read by opening the huddle in their own Slack client. If they cannot see the
+huddle, neither can this.
+
+```bash
+slack huddle-transcript F0123456789
+```
+
+```
+34 turns, 3 speakers
+<@U01ABC> [0:04]: the migration is blocked on the schema review
+<@U02DEF> [0:11]: I can review it this afternoon
+<@U01ABC> [0:19]: then we ship Friday
+```
+
+The agent-facing method is `get_huddle_transcript(file_id)`. It returns `{file_id, speakers, turns,
+text}`. Speakers stay as **Slack ids**, not names — an id round-trips to a real mention and cannot
+drift, while a name resolved at read time silently rots when someone changes their display name.
+
+Find a `file_id` from the huddle's message in `conversations.history` (the room object references its
+transcript file), or from the huddle's AI-notes canvas, which names it.
+
+## The credentials
+
+Two optional secrets. Without them every other Slack method works exactly as before, and only
+`get_huddle_transcript` reports what is missing.
+
+| Secret | What it is |
+| --- | --- |
+| `SLACK_WEB_TOKEN` | The `xoxc` token from a signed-in Slack web session |
+| `SLACK_WEB_COOKIE` | The paired `d` cookie (`d=xoxd-…`) |
+
+Both are declared as header-injected HTTP secrets scoped to `*.slack.com`, so **the sandbox holds
+placeholders and never the real session** — iron-proxy swaps in the true values at the network
+boundary, and only for Slack hosts.
+
+:::warning[Scope these to a service account, not to a person]
+A user web session carries **that user's full Slack visibility**, including their DMs. Mint it from an
+account whose visibility you are content for agents to inherit. This is the same trust decision as
+`SLACK_SEARCH_TOKEN`, but the blast radius is larger, so make it deliberately.
+:::
+
+### Obtaining them
+
+From a browser signed in to the workspace:
+
+1. Open the workspace in Slack (web or the desktop app), then open developer tools.
+2. `SLACK_WEB_COOKIE` — copy the `d` cookie for `.slack.com`. Its value begins `xoxd-`. Store it in
+   the `d=xoxd-…` form.
+3. `SLACK_WEB_TOKEN` — the paired `xoxc` token is embedded in the workspace boot page. Find it in any
+   authenticated XHR to `/api/…` (the `token` form field), or search the page source for `xoxc-`.
+
+The two are a **pair**: an `xoxc` token only authenticates alongside the `d` cookie it was issued
+with. Rotating one without the other yields `invalid_auth`.
+
+## Sessions expire — and the failure is loud on purpose
+
+A web session lapses. When it does, the tool raises `needs_reauth` rather than returning an empty
+transcript.
+
+That distinction is the whole design. **A silent empty read looks exactly like "nobody spoke."** An
+agent that quietly concludes a meeting was silent is far worse than one that says it cannot see —
+the first fabricates an absence of evidence, the second reports a broken credential. So a lapsed
+session fails loudly, and a caller can tell "sign in again" apart from "this is broken":
+
+```json
+{
+  "error": "huddle_transcript_failed",
+  "message": "the Slack web session expired — a human must sign in again …",
+  "slack_error": "invalid_auth",
+  "needs_reauth": true
+}
+```
+
+Treat `needs_reauth` as an operational alert, not an empty result. Discovery — which huddles exist —
+runs on the ordinary bot token and never needs the session, so nothing is lost while a session is
+stale: refresh it and the backlog reads fine.

--- a/docs/public/md/operate/slack-huddle-transcripts.md
+++ b/docs/public/md/operate/slack-huddle-transcripts.md
@@ -21,7 +21,7 @@ Centaur's Slack tool can read them, given a **user web session**.
 The Slack *web client* reads transcripts perfectly well. It calls `files.info` with
 `include_transcription=true` against the **workspace host** (`<workspace>.slack.com` — never
 `slack.com`), authenticated by a user web session: an `xoxc` token paired with the `d` cookie.
-The tool replays exactly that call.
+The tool sends the equivalent authenticated `files.info` request.
 
 This is not a scope escalation and not a permission bypass. A user session sees precisely what that
 user could already read by opening the huddle in their own Slack client. If they cannot see the
@@ -55,14 +55,15 @@ Two optional secrets. Without them every other Slack method works exactly as bef
 | `SLACK_WEB_TOKEN` | The `xoxc` token from a signed-in Slack web session |
 | `SLACK_WEB_COOKIE` | The paired `d` cookie (`d=xoxd-…`) |
 
-Both are declared as header-injected HTTP secrets scoped to `*.slack.com`, so **the sandbox holds
-placeholders and never the real session** — iron-proxy swaps in the true values at the network
-boundary, and only for Slack hosts.
+Both are declared as header-replaced HTTP secrets scoped to `POST /api/files.info` on
+`*.slack.com`, so **the sandbox holds placeholders and never the real session** — iron-proxy swaps
+in the true values at the network boundary only for that read-only Slack endpoint.
 
 :::warning[Scope these to a service account, not to a person]
-A user web session carries **that user's full Slack visibility**, including their DMs. Mint it from an
-account whose visibility you are content for agents to inherit. This is the same trust decision as
-`SLACK_SEARCH_TOKEN`, but the blast radius is larger, so make it deliberately.
+The underlying web session carries **that user's full Slack visibility**, including their DMs. The
+proxy limits these placeholders to `files.info`, but that endpoint can still return huddle
+transcripts and other files the account can see, including files from DMs. Mint the session from an
+account whose file visibility you are content for agents to inherit.
 :::
 
 ### Obtaining them

--- a/docs/public/md/reference/tool-directory.md
+++ b/docs/public/md/reference/tool-directory.md
@@ -31,7 +31,7 @@ These are broadly useful across most deployments and are good candidates to conf
 |---|---|---|
 | `linear` | Search, create, update, and comment on Linear issues, projects, cycles, teams, and labels | `LINEAR_API_KEY` |
 | `notion` | Search and update Notion pages, databases, blocks, and comments | `NOTION_API_KEY` |
-| `slack` | Search Slack, read threads, inspect channels/users, and send or upload messages | `SLACK_BOT_TOKEN`; optional: `SLACK_SEARCH_TOKEN`, `SLACK_ETL_TOKEN` |
+| `slack` | Search Slack, read threads, inspect channels/users, read huddle transcripts, and send or upload messages | `SLACK_BOT_TOKEN`; optional: `SLACK_SEARCH_TOKEN`, `SLACK_ETL_TOKEN`, `SLACK_WEB_TOKEN` + `SLACK_WEB_COOKIE` (huddle transcripts) |
 | `gsuite` | Use Gmail, Calendar, Drive, Docs, Sheets, Slides, and Google Analytics | `GOOGLE_TOKEN_JSON` |
 | `websearch` | Free web search via Parallel and deep research | None; `PARALLEL_API_KEY` for `deep_research`; `ANTHROPIC_API_KEY` for search synthesis |
 | `company_context` | Search indexed company history, private Slack conversations, and Google Docs | None |
@@ -85,7 +85,7 @@ These are broadly useful across most deployments and are good candidates to conf
 | `linear` | Linear issues, projects, cycles, teams, workflow states, and labels | `LINEAR_API_KEY` |
 | `notion` | Notion pages, databases, blocks, comments, and users | `NOTION_API_KEY` |
 | `opentable` | Search OpenTable restaurant reservations | None |
-| `slack` | Slack messages, files, channels, threads, users, and usergroups | `SLACK_BOT_TOKEN`; optional: `SLACK_SEARCH_TOKEN`, `SLACK_ETL_TOKEN` |
+| `slack` | Slack messages, files, channels, threads, users, usergroups, and huddle transcripts | `SLACK_BOT_TOKEN`; optional: `SLACK_SEARCH_TOKEN`, `SLACK_ETL_TOKEN`, `SLACK_WEB_TOKEN` + `SLACK_WEB_COOKIE` (huddle transcripts) |
 
 ## Research
 

--- a/docs/sidebar.ts
+++ b/docs/sidebar.ts
@@ -15,6 +15,7 @@ export const sidebar = [
     text: 'Operate',
     items: [
       { text: 'Slack ETL', link: '/operate/slack-etl' },
+      { text: 'Slack huddle transcripts', link: '/operate/slack-huddle-transcripts' },
       { text: 'Expose Slackbot with Tailscale Funnel', link: '/operate/tailscale-funnel' },
     ],
   },

--- a/services/api-rs/crates/centaur-api-server/src/tool_discovery.rs
+++ b/services/api-rs/crates/centaur-api-server/src/tool_discovery.rs
@@ -613,6 +613,8 @@ struct HttpSecret {
     labels: BTreeMap<String, String>,
     mode: HttpSecretMode,
     hosts: Vec<String>,
+    http_methods: Vec<String>,
+    paths: Vec<String>,
     replacer: String,
     match_headers: Vec<String>,
     match_path: bool,
@@ -733,6 +735,8 @@ fn parse_secret(
             labels: labels.clone(),
             mode: HttpSecretMode::Replace,
             hosts: default_hosts.to_vec(),
+            http_methods: Vec::new(),
+            paths: Vec::new(),
             replacer: name,
             match_headers: DEFAULT_MATCH_HEADERS
                 .iter()
@@ -785,6 +789,13 @@ fn parse_http_secret(
              iron-proxy"
         )));
     }
+    let http_methods = optional_string_array(table.get("http_methods"))?.unwrap_or_default();
+    let paths = optional_string_array(table.get("paths"))?.unwrap_or_default();
+    if paths.iter().any(|path| !path.starts_with('/')) {
+        return Err(ToolDiscoveryError::Invalid(format!(
+            "HTTP secret {name:?} 'paths' entries must start with '/'"
+        )));
+    }
     let mode = optional_str(table, "mode").unwrap_or("replace");
     match mode {
         "replace" => {
@@ -804,6 +815,8 @@ fn parse_http_secret(
                 labels: labels.clone(),
                 mode: HttpSecretMode::Replace,
                 hosts,
+                http_methods,
+                paths,
                 replacer,
                 match_headers,
                 match_path,
@@ -839,6 +852,8 @@ fn parse_http_secret(
                 labels: labels.clone(),
                 mode: HttpSecretMode::Inject,
                 hosts,
+                http_methods,
+                paths,
                 replacer: String::new(),
                 match_headers: Vec::new(),
                 match_path: false,
@@ -1080,25 +1095,31 @@ fn fragment_from_secrets(secrets: Vec<ToolSecret>) -> Result<ProxyFragment, Tool
 
 fn http_secret_transform(secrets: &[ToolSecret]) -> Result<Option<Transform>, ToolDiscoveryError> {
     let mut grouped =
-        BTreeMap::<HttpSecretKey, (BTreeSet<String>, BTreeMap<String, String>)>::new();
+        BTreeMap::<HttpSecretKey, (BTreeSet<HttpSecretRule>, BTreeMap<String, String>)>::new();
     for secret in secrets {
         let ToolSecret::Http(secret) = secret else {
             continue;
         };
         let entry = grouped.entry(HttpSecretKey::from(secret)).or_default();
-        entry.0.extend(secret.hosts.iter().cloned());
+        entry
+            .0
+            .extend(secret.hosts.iter().map(|host| HttpSecretRule {
+                host: host.clone(),
+                http_methods: secret.http_methods.clone(),
+                paths: secret.paths.clone(),
+            }));
         merge_tool_labels(&mut entry.1, &secret.labels);
     }
     if grouped.is_empty() {
         return Ok(None);
     }
     let mut entries = Vec::new();
-    for (key, (hosts, labels)) in grouped {
+    for (key, (rules, labels)) in grouped {
         let mut extra = BTreeMap::new();
         let mut entry = Secret {
             id: Some(key.name.clone()),
             source: Some(yaml_map([("placeholder", yaml_string(&key.secret_ref))])?),
-            rules: host_rules(hosts)?,
+            rules: http_secret_rules(rules)?,
             ..Default::default()
         };
         entry.extra.insert("labels".to_owned(), yaml_value(labels)?);
@@ -1140,6 +1161,13 @@ fn http_secret_transform(secrets: &[ToolSecret]) -> Result<Option<Transform>, To
         },
         ..Default::default()
     }))
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+struct HttpSecretRule {
+    host: String,
+    http_methods: Vec<String>,
+    paths: Vec<String>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
@@ -1453,6 +1481,24 @@ fn host_rules(hosts: BTreeSet<String>) -> Result<Vec<YamlValue>, ToolDiscoveryEr
         .collect()
 }
 
+fn http_secret_rules(
+    rules: BTreeSet<HttpSecretRule>,
+) -> Result<Vec<YamlValue>, ToolDiscoveryError> {
+    rules
+        .into_iter()
+        .map(|rule| {
+            let mut value = BTreeMap::from([("host".to_owned(), yaml_string(&rule.host))]);
+            if !rule.http_methods.is_empty() {
+                value.insert("http_methods".to_owned(), yaml_value(rule.http_methods)?);
+            }
+            if !rule.paths.is_empty() {
+                value.insert("paths".to_owned(), yaml_value(rule.paths)?);
+            }
+            yaml_value(value)
+        })
+        .collect()
+}
+
 fn host_rules_set(hosts: &[String]) -> Result<Vec<YamlValue>, ToolDiscoveryError> {
     host_rules(hosts.iter().cloned().collect())
 }
@@ -1664,7 +1710,7 @@ secrets = [{type = "http", name = "BASE_TOKEN", match_headers = ["Authorization"
 description = "overlay alpha"
 
 [tool.centaur]
-secrets = [{type = "http", name = "OVERLAY_TOKEN", match_query = true, hosts = ["api.overlay.test"]}]
+secrets = [{type = "http", name = "OVERLAY_TOKEN", match_query = true, hosts = ["api.overlay.test"], http_methods = ["POST"], paths = ["/v1/search"]}]
 "#,
         );
         write_tool(
@@ -1687,6 +1733,11 @@ secrets = [
         let secrets = discovered.fragment.transforms[0].config.secrets.clone();
         assert_eq!(secrets.len(), 1);
         assert_eq!(secrets[0].id.as_deref(), Some("OVERLAY_TOKEN"));
+        assert_eq!(
+            secrets[0].rules[0]["http_methods"][0].as_str(),
+            Some("POST")
+        );
+        assert_eq!(secrets[0].rules[0]["paths"][0].as_str(), Some("/v1/search"));
         let labels = secrets[0]
             .extra
             .get("labels")

--- a/services/api-rs/crates/centaur-perms/src/tests.rs
+++ b/services/api-rs/crates/centaur-perms/src/tests.rs
@@ -50,7 +50,7 @@ fn secret_type_routes_by_oid_prefix() {
 #[test]
 fn parses_http_replace_secret() {
     let parsed = tools::parse_secret(
-        &entry(r#"{type = "http", name = "SLACK_BOT_TOKEN", match_headers = ["Authorization"], hosts = ["slack.com"]}"#),
+        &entry(r#"{type = "http", name = "SLACK_BOT_TOKEN", match_headers = ["Authorization"], hosts = ["slack.com"], http_methods = ["POST"], paths = ["/api/files.info"]}"#),
         &[],
     )
     .unwrap();
@@ -63,6 +63,19 @@ fn parses_http_replace_secret() {
     assert_eq!(http.replacer, "SLACK_BOT_TOKEN");
     assert_eq!(http.match_headers, vec!["Authorization".to_owned()]);
     assert_eq!(http.hosts, vec!["slack.com".to_owned()]);
+    assert_eq!(http.http_methods, vec!["POST".to_owned()]);
+    assert_eq!(http.paths, vec!["/api/files.info".to_owned()]);
+}
+
+#[test]
+fn rejects_malformed_http_rule_scopes() {
+    for raw in [
+        r#"{type = "http", name = "TOKEN", match_headers = ["Authorization"], hosts = ["api.example.com"], http_methods = "POST"}"#,
+        r#"{type = "http", name = "TOKEN", match_headers = ["Authorization"], hosts = ["api.example.com"], paths = [""]}"#,
+    ] {
+        let error = tools::parse_secret(&entry(raw), &[]).unwrap_err();
+        assert!(error.to_string().contains("array of non-empty strings"));
+    }
 }
 
 #[test]
@@ -426,7 +439,7 @@ fn legacy_string_shim_is_replace_secret() {
 fn translates_http_replace_to_static_input() {
     let secrets = vec![
         tools::parse_secret(
-            &entry(r#"{type = "http", name = "SLACK_BOT_TOKEN", match_headers = ["Authorization"], hosts = ["slack.com"]}"#),
+            &entry(r#"{type = "http", name = "SLACK_BOT_TOKEN", match_headers = ["Authorization"], hosts = ["slack.com"], http_methods = ["POST"], paths = ["/api/files.info"]}"#),
             &[],
         )
         .unwrap(),
@@ -448,6 +461,8 @@ fn translates_http_replace_to_static_input() {
     );
     assert_eq!(input.rules.len(), 1);
     assert_eq!(input.rules[0].host.as_deref(), Some("slack.com"));
+    assert_eq!(input.rules[0].http_methods, vec!["POST".to_owned()]);
+    assert_eq!(input.rules[0].paths, vec!["/api/files.info".to_owned()]);
 }
 
 #[test]
@@ -913,6 +928,20 @@ fn real_slack_tool_parses_and_translates() {
         ),
         "expected the SLACK_BOT_TOKEN static secret"
     );
+    for name in ["SLACK_WEB_TOKEN", "SLACK_WEB_COOKIE"] {
+        let secret = out
+            .inputs
+            .iter()
+            .find_map(|input| match input {
+                SecretInput::Static(secret) if secret.name == name => Some(secret),
+                _ => None,
+            })
+            .unwrap_or_else(|| panic!("expected the {name} static secret"));
+        assert_eq!(secret.rules.len(), 1);
+        assert_eq!(secret.rules[0].host.as_deref(), Some("*.slack.com"));
+        assert_eq!(secret.rules[0].http_methods, ["POST"]);
+        assert_eq!(secret.rules[0].paths, ["/api/files.info"]);
+    }
 }
 
 #[test]

--- a/services/api-rs/crates/centaur-perms/src/tools.rs
+++ b/services/api-rs/crates/centaur-perms/src/tools.rs
@@ -93,6 +93,8 @@ pub struct HttpSecret {
     pub secret_ref: String,
     pub mode: SecretMode,
     pub hosts: Vec<String>,
+    pub http_methods: Vec<String>,
+    pub paths: Vec<String>,
     // replace mode
     pub replacer: String,
     pub match_headers: Vec<String>,
@@ -429,6 +431,8 @@ pub fn parse_secret(entry: &Value, default_hosts: &[String]) -> Result<ParsedSec
             secret_ref: s.to_owned(),
             mode: SecretMode::Replace,
             hosts: default_hosts.to_vec(),
+            http_methods: vec![],
+            paths: vec![],
             replacer: s.to_owned(),
             match_headers: DEFAULT_MATCH_HEADERS
                 .iter()
@@ -511,6 +515,11 @@ fn parse_http(
              unscoped in iron-proxy"
         ),
     };
+    let http_methods = http_rule_str_array(table.get("http_methods"), name, "http_methods")?;
+    let paths = http_rule_str_array(table.get("paths"), name, "paths")?;
+    if paths.iter().any(|path| !path.starts_with('/')) {
+        bail!("HTTP secret {name:?} 'paths' entries must start with '/'");
+    }
 
     match mode {
         SecretMode::Replace => {
@@ -539,6 +548,8 @@ fn parse_http(
                 secret_ref: secret_ref.to_owned(),
                 mode,
                 hosts,
+                http_methods,
+                paths,
                 replacer,
                 match_headers,
                 match_path,
@@ -575,6 +586,8 @@ fn parse_http(
                 secret_ref: secret_ref.to_owned(),
                 mode,
                 hosts,
+                http_methods,
+                paths,
                 replacer: String::new(),
                 match_headers: vec![],
                 match_path: false,
@@ -1052,6 +1065,28 @@ fn non_empty_str_array(value: Option<&Value>) -> Option<Vec<String>> {
         out.push(s.to_owned());
     }
     Some(out)
+}
+
+/// An optional HTTP request-rule array. A malformed scope must fail closed:
+/// treating it as absent would widen the credential to every request on its hosts.
+fn http_rule_str_array(value: Option<&Value>, name: &str, key: &str) -> Result<Vec<String>> {
+    let Some(value) = value else {
+        return Ok(vec![]);
+    };
+    let array = value.as_array().ok_or_else(|| {
+        eyre!("HTTP secret {name:?} {key:?} must be an array of non-empty strings")
+    })?;
+    array
+        .iter()
+        .map(|item| {
+            item.as_str()
+                .filter(|value| !value.is_empty())
+                .map(str::to_owned)
+                .ok_or_else(|| {
+                    eyre!("HTTP secret {name:?} {key:?} must be an array of non-empty strings")
+                })
+        })
+        .collect()
 }
 
 fn validate_gcp_id_token_header(value: String) -> Result<String> {

--- a/services/api-rs/crates/centaur-perms/src/translate.rs
+++ b/services/api-rs/crates/centaur-perms/src/translate.rs
@@ -40,6 +40,19 @@ fn rules_from_hosts(hosts: &[String]) -> Vec<RequestRule> {
     hosts.iter().map(RequestRule::host).collect()
 }
 
+fn rules_from_http_secret(secret: &HttpSecret) -> Vec<RequestRule> {
+    secret
+        .hosts
+        .iter()
+        .map(|host| RequestRule {
+            host: Some(host.clone()),
+            http_methods: secret.http_methods.clone(),
+            paths: secret.paths.clone(),
+            ..Default::default()
+        })
+        .collect()
+}
+
 /// Translate every secret declared by a tool into iron-control inputs to grant
 /// to the tool's role (`role_foreign_id`, e.g. `tool-github`).
 #[cfg(test)]
@@ -209,7 +222,7 @@ fn static_input(
         inject_config,
         replace_config,
         source: source_from_placeholder(policy, &http.secret_ref, None),
-        rules: rules_from_hosts(&http.hosts),
+        rules: rules_from_http_secret(http),
     }
 }
 

--- a/tools/productivity/slack/.env.example
+++ b/tools/productivity/slack/.env.example
@@ -1,0 +1,20 @@
+# Bot User OAuth Token. Required.
+# https://api.slack.com/apps -> OAuth & Permissions -> Bot User OAuth Token
+SLACK_BOT_TOKEN=xoxb-your-bot-token
+
+# User token used for search.messages, which Slack does not expose to bot tokens. Optional.
+SLACK_SEARCH_TOKEN=xoxp-your-user-token
+
+# User token used by Slack ETL for history and file reads. Optional.
+SLACK_ETL_TOKEN=xoxp-your-user-token
+
+# A signed-in Slack WEB session, used only to read huddle transcripts. Optional, and a pair:
+# an xoxc token authenticates only alongside the d cookie it was issued with.
+#
+# Slack exposes no bot-token API for huddle transcripts and this is deliberate, so the web client's
+# own files.info call is the only way to read them. See operate/slack-huddle-transcripts.
+#
+# A web session carries that user's FULL Slack visibility, DMs included. Mint it from an account
+# whose visibility you are content for agents to inherit.
+SLACK_WEB_TOKEN=xoxc-your-web-token
+SLACK_WEB_COOKIE=d=xoxd-your-d-cookie

--- a/tools/productivity/slack/cli.py
+++ b/tools/productivity/slack/cli.py
@@ -1701,5 +1701,35 @@ def user_info(
         raise typer.Exit(1)
 
 
+@app.command("huddle-transcript")
+def huddle_transcript(
+    file_id: str = typer.Argument(..., help="The huddle_transcript file id (F...)"),
+    as_json: bool = typer.Option(False, "--json", help="Emit the raw payload"),
+):
+    """Read the verbatim transcript of a recorded huddle.
+
+    Needs a Slack user web session (SLACK_WEB_TOKEN + SLACK_WEB_COOKIE): Slack exposes no bot-token
+    API for huddle transcripts, so this replays the web client's own files.info call.
+    """
+    from .client import _client
+
+    try:
+        result = _client().get_huddle_transcript(file_id)
+    except Exception as exc:
+        payload = getattr(exc, "payload", {"error": str(exc)})
+        console.print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+        # A lapsed session is not a bug in this command — say which it is, so a caller (or an agent)
+        # can tell "sign in again" apart from "this is broken".
+        if payload.get("needs_reauth"):
+            console.print("[yellow]The Slack web session needs refreshing.[/]")
+        raise typer.Exit(1) from exc
+
+    if as_json:
+        console.print(json.dumps(result, indent=2, ensure_ascii=False, default=str))
+        return
+    console.print(f"[bold]{result['turns']}[/] turns, {len(result['speakers'])} speakers")
+    console.print(result["text"])
+
+
 if __name__ == "__main__":
     app()

--- a/tools/productivity/slack/cli.py
+++ b/tools/productivity/slack/cli.py
@@ -1717,18 +1717,14 @@ def huddle_transcript(
         result = _client().get_huddle_transcript(file_id)
     except Exception as exc:
         payload = getattr(exc, "payload", {"error": str(exc)})
-        console.print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
-        # A lapsed session is not a bug in this command — say which it is, so a caller (or an agent)
-        # can tell "sign in again" apart from "this is broken".
-        if payload.get("needs_reauth"):
-            console.print("[yellow]The Slack web session needs refreshing.[/]")
+        typer.echo(json.dumps(payload, indent=2, ensure_ascii=False, default=str), err=True)
         raise typer.Exit(1) from exc
 
     if as_json:
-        console.print(json.dumps(result, indent=2, ensure_ascii=False, default=str))
+        typer.echo(json.dumps(result, indent=2, ensure_ascii=False, default=str))
         return
-    console.print(f"[bold]{result['turns']}[/] turns, {len(result['speakers'])} speakers")
-    console.print(result["text"])
+    typer.echo(f"{result['turns']} turns, {len(result['speakers'])} speakers")
+    typer.echo(result["text"])
 
 
 if __name__ == "__main__":

--- a/tools/productivity/slack/client.py
+++ b/tools/productivity/slack/client.py
@@ -23,6 +23,8 @@ from slack_sdk.errors import SlackApiError
 
 from centaur_sdk.tool_sdk import secret
 
+from . import huddle_transcript
+
 # structlog so these lines render as JSON through the tool-server's
 # configure_structlog() pipeline, like the rest of the service's logs.
 logger = structlog.get_logger()
@@ -115,6 +117,8 @@ class SlackClient:
         self,
         bot_token: str | None = None,
         search_token: str | None = None,
+        web_token: str | None = None,
+        web_cookie: str | None = None,
     ):
         token = (bot_token or secret("SLACK_BOT_TOKEN", default="")).strip()
         if not token:
@@ -124,6 +128,11 @@ class SlackClient:
             )
         self.token = token
         self.search_token = (search_token or secret("SLACK_SEARCH_TOKEN", default="")).strip()
+        # The user web session that unlocks huddle transcripts. Optional: without it every other
+        # method works exactly as before and only `get_huddle_transcript` reports that it is missing.
+        self.web_token = (web_token or secret("SLACK_WEB_TOKEN", default="")).strip()
+        self.web_cookie = (web_cookie or secret("SLACK_WEB_COOKIE", default="")).strip()
+        self._workspace_host_cache: str | None = None
         timeout = self._api_timeout_seconds()
         self._client = WebClient(token=token, timeout=timeout)
         self._search_client = (
@@ -137,6 +146,66 @@ class SlackClient:
     def __getattr__(self, name: str):
         """Proxy raw Slack SDK methods when the higher-level wrapper does not define them."""
         return getattr(self._client, name)
+
+    def _workspace_host(self) -> str:
+        """The workspace's own Slack host, e.g. ``acme.slack.com``.
+
+        Huddle transcripts are served only from the workspace host, never from ``slack.com``. Rather
+        than ask a deployment to configure that, derive it from the bot token we already hold:
+        ``auth.test`` returns the workspace URL. Cached, because it cannot change within a process.
+        """
+        if self._workspace_host_cache is None:
+            url = (self._client.auth_test().data or {}).get("url", "")
+            host = urlparse(url).hostname
+            if not host:
+                raise huddle_transcript.HuddleTranscriptError(
+                    "could not determine the workspace host from auth.test"
+                )
+            self._workspace_host_cache = host
+        return self._workspace_host_cache
+
+    def get_huddle_transcript(self, file_id: str) -> dict:
+        """The verbatim, speaker-attributed transcript of one recorded huddle.
+
+        Slack saves a recorded huddle's transcript as a ``huddle_transcript`` file that is never
+        shared into a channel, so **a bot token cannot read it and no public API exposes it** — this
+        is deliberate on Slack's side. The web client reads it through ``files.info`` with
+        ``include_transcription=true`` on the workspace host, authenticated by a user web session.
+        This replays that call, so it returns exactly what the signed-in user could already read by
+        scrolling the huddle themselves. It is not a scope escalation.
+
+        Needs ``SLACK_WEB_TOKEN`` (an ``xoxc`` token) and ``SLACK_WEB_COOKIE`` (the ``d`` cookie).
+        Both are optional secrets: without them the rest of this tool is unaffected and this method
+        says plainly what is missing.
+
+        When the session lapses the failure is **loud** — ``needs_reauth`` — never an empty
+        transcript. An agent that quietly believes a meeting was silent is worse than one that admits
+        it cannot see.
+
+        Find a ``file_id`` from the huddle's message in ``conversations.history`` (the huddle's room
+        object references its transcript file), or from the huddle's AI-notes canvas, which names it.
+        """
+        if not self.web_token or not self.web_cookie:
+            missing = [
+                name
+                for name, value in (
+                    ("SLACK_WEB_TOKEN", self.web_token),
+                    ("SLACK_WEB_COOKIE", self.web_cookie),
+                )
+                if not value
+            ]
+            raise huddle_transcript.HuddleTranscriptError(
+                "huddle transcripts need a Slack user web session; Slack exposes no bot-token API "
+                "for them",
+                missing=missing,
+                needs_reauth=True,
+            )
+        return huddle_transcript.fetch(
+            file_id,
+            host=self._workspace_host(),
+            token=self.web_token,
+            cookie=self.web_cookie,
+        )
 
     def _is_ratelimit_error(self, error: SlackApiError) -> bool:
         """Detect Slack rate limit responses from either payload or status code."""
@@ -2717,3 +2786,7 @@ def search_users(*args, **kwargs):
 
 def get_user_profile(*args, **kwargs):
     return _client().get_user_profile(*args, **kwargs)
+
+
+def get_huddle_transcript(*args, **kwargs):
+    return _client().get_huddle_transcript(*args, **kwargs)

--- a/tools/productivity/slack/client.py
+++ b/tools/productivity/slack/client.py
@@ -156,10 +156,11 @@ class SlackClient:
         """
         if self._workspace_host_cache is None:
             url = (self._client.auth_test().data or {}).get("url", "")
-            host = urlparse(url).hostname
-            if not host:
+            parsed = urlparse(url)
+            host = (parsed.hostname or "").lower()
+            if parsed.scheme != "https" or not host.endswith(".slack.com"):
                 raise huddle_transcript.HuddleTranscriptError(
-                    "could not determine the workspace host from auth.test"
+                    "auth.test returned an invalid Slack workspace URL"
                 )
             self._workspace_host_cache = host
         return self._workspace_host_cache
@@ -2788,5 +2789,5 @@ def get_user_profile(*args, **kwargs):
     return _client().get_user_profile(*args, **kwargs)
 
 
-def get_huddle_transcript(*args, **kwargs):
-    return _client().get_huddle_transcript(*args, **kwargs)
+def get_huddle_transcript(file_id: str) -> dict:
+    return _client().get_huddle_transcript(file_id)

--- a/tools/productivity/slack/huddle_transcript.py
+++ b/tools/productivity/slack/huddle_transcript.py
@@ -130,12 +130,18 @@ def speakers(segments: list[dict]) -> list[str]:
 def _call(host: str, token: str, cookie: str, **params: str) -> dict:
     """One ``files.info`` call against the workspace host.
 
-    The token rides in the ``Authorization`` header and the session in ``Cookie``. Both are places
-    iron-proxy is allowed to look (``match_headers``), so in a sandbox the tool holds only
-    placeholders and the real session never leaves the proxy. That is the reason this does not simply
-    post the token as a form field the way the browser does: a request body is the one place the
-    firewall cannot reach, and a user session token sitting in a sandbox is exactly the exposure the
-    injection model exists to prevent.
+    The token rides in the ``Authorization`` header and the session in ``Cookie``, and that choice is
+    the whole security story. Slack's web client posts the token as a **form field**, and it would be
+    the obvious thing to copy — but a request body is the one place iron-proxy cannot look
+    (``match_headers`` / ``match_query`` / ``match_path``, and there is no ``match_body``). Copying
+    the browser would therefore force a real user web session to sit inside the sandbox, which is
+    precisely the exposure the injection model exists to prevent.
+
+    Verified against the live API before choosing: Slack accepts this token in the form body, in the
+    query string, **and** in the ``Authorization`` header — all three authenticate. Since they are
+    equivalent to Slack, take the one the firewall can reach. Both credentials are then declared as
+    header-injected secrets, the sandbox holds only placeholders, and the real session never leaves
+    the proxy.
     """
     url = f"https://{host}/api/files.info?" + urllib.parse.urlencode(params)
     request = urllib.request.Request(

--- a/tools/productivity/slack/huddle_transcript.py
+++ b/tools/productivity/slack/huddle_transcript.py
@@ -1,0 +1,198 @@
+"""The verbatim transcript of a recorded Slack huddle.
+
+Slack records every huddle and saves the full, speaker-attributed transcript as a
+``huddle_transcript`` file. That file is never shared into a channel, so **a bot token cannot
+download it, and there is no public API for it** — Slack support confirms this is deliberate.
+``files.info`` on the id returns metadata and no words, whatever scopes the bot holds. So the richest
+record a company produces about its own decisions — the standup where the priority was set, the
+incident call where the cause was found — is the one thing an agent in that workspace cannot read.
+
+The Slack *web client* reads it perfectly well. It calls ``files.info`` on the **workspace host**
+(``<workspace>.slack.com``, never ``slack.com``) with ``include_transcription=true``, authenticated by
+a user web session: an ``xoxc`` token paired with the ``d`` cookie. This module replays exactly that
+call. Nothing here is a scope trick or a permission bypass — a user session sees precisely what that
+user could already read by scrolling the huddle in their own Slack client.
+
+Two halves, deliberately separate, because they fail in completely different ways:
+
+* **Discovery** — which huddles exist, and which transcript file belongs to each — runs on the
+  ordinary bot token and is stable. It never needs the session.
+* **Fetch** — the words themselves — is the session-bound half. When a session lapses it fails
+  **loudly** (``needs_reauth``), never by returning an empty transcript. That distinction is the whole
+  ballgame: a silent empty read looks exactly like "nobody said anything", and an agent that quietly
+  believes a meeting was silent is worse than one that admits it cannot see.
+
+The parsing below is pure and unit-tested against real Slack payloads; the network call is a thin
+shell around it.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import urllib.parse
+import urllib.request
+
+# Slack marks each spoken turn with a bold ` [mm:ss]: ` between the speaker and their words — how far
+# into the call the turn happened. Long huddles use `[h:mm:ss]`.
+_STAMP = re.compile(r"\[(\d{1,2}:\d{2}(?::\d{2})?)\]")
+
+_PAGE = 1000  # turns per page; long huddles paginate
+_MAX_PAGES = 60  # ~60k turns — a backstop against a pathological response, never hit by a real huddle
+
+# The failures that mean "the human must sign in again", as opposed to "this code is wrong". Only
+# these set ``needs_reauth``; everything else is a bug and should read like one.
+_REAUTH_ERRORS = frozenset(
+    {"not_authed", "invalid_auth", "token_revoked", "token_expired", "account_inactive"}
+)
+
+
+class HuddleTranscriptError(RuntimeError):
+    """A structured failure that survives stringification through the tool boundary.
+
+    ``needs_reauth=True`` marks the one failure that is not a defect: the user web session expired,
+    and only a human signing in again can restore it. Callers should surface that verbatim rather than
+    treating it as an empty result.
+    """
+
+    def __init__(self, message: str, **detail: object) -> None:
+        self.payload = {"error": "huddle_transcript_failed", "message": message, **detail}
+        super().__init__(str(self.payload))
+
+
+# ── parsing (pure) ──────────────────────────────────────────────────────────────────────────────
+
+
+def parse_segments(files_info: dict) -> list[dict]:
+    """The transcript as ordered turns: ``{"user_id", "at", "text"}``.
+
+    Slack returns it as one ``rich_text`` block whose elements are a ``rich_text_section`` per spoken
+    turn. Each section carries a ``user`` element (the speaker's id), a **bold** ``text`` element
+    holding the ` [mm:ss]: ` mark, and one or more plain ``text`` elements with the words.
+
+    Speakers stay as **Slack ids, never names**. An id round-trips to a real mention and cannot drift;
+    a name resolved at parse time silently rots when someone changes their display name.
+    """
+    block = ((files_info.get("file") or {}).get("huddle_transcription") or {}).get("blocks") or {}
+    out: list[dict] = []
+    for section in block.get("elements", []):
+        if section.get("type") != "rich_text_section":
+            continue
+        user_id: str | None = None
+        at: str | None = None
+        words: list[str] = []
+        for element in section.get("elements", []):
+            if element.get("type") == "user":
+                user_id = element.get("user_id")
+            elif element.get("type") == "text":
+                text = element.get("text", "")
+                stamp = _STAMP.search(text)
+                # The bold element that *is* a timestamp is the marker, not speech. A bold word inside
+                # the speech itself carries no [mm:ss] and must survive.
+                if stamp and (element.get("style") or {}).get("bold"):
+                    at = stamp.group(1)
+                else:
+                    words.append(text)
+        said = "".join(words).strip()
+        if said:
+            out.append({"user_id": user_id, "at": at, "text": said})
+    return out
+
+
+def render(segments: list[dict]) -> str:
+    """Turns → a readable transcript, one line each: ``<@U…> [mm:ss]: words``.
+
+    The ``<@U…>`` form is what Slack renders as a real mention, so a verbatim quote names the person
+    instead of printing id soup.
+    """
+    lines = []
+    for segment in segments:
+        who = f"<@{segment['user_id']}>" if segment.get("user_id") else "someone"
+        at = f" [{segment['at']}]" if segment.get("at") else ""
+        lines.append(f"{who}{at}: {segment['text']}")
+    return "\n".join(lines)
+
+
+def speakers(segments: list[dict]) -> list[str]:
+    """Distinct speaker ids in first-spoke order — an attendee list drawn from who actually *talked*,
+    which is not the same as who Slack listed as present."""
+    seen: list[str] = []
+    for segment in segments:
+        uid = segment.get("user_id")
+        if uid and uid not in seen:
+            seen.append(uid)
+    return seen
+
+
+# ── the session-bound fetch (thin shell) ────────────────────────────────────────────────────────
+
+
+def _call(host: str, token: str, cookie: str, **params: str) -> dict:
+    """One ``files.info`` call against the workspace host.
+
+    The token rides in the ``Authorization`` header and the session in ``Cookie``. Both are places
+    iron-proxy is allowed to look (``match_headers``), so in a sandbox the tool holds only
+    placeholders and the real session never leaves the proxy. That is the reason this does not simply
+    post the token as a form field the way the browser does: a request body is the one place the
+    firewall cannot reach, and a user session token sitting in a sandbox is exactly the exposure the
+    injection model exists to prevent.
+    """
+    url = f"https://{host}/api/files.info?" + urllib.parse.urlencode(params)
+    request = urllib.request.Request(
+        url,
+        data=b"",  # Slack wants a POST; the parameters ride in the query string
+        headers={"Authorization": f"Bearer {token}", "Cookie": cookie},
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=60) as response:
+            body = json.load(response)
+    except OSError as exc:  # network/TLS, not Slack saying no
+        raise HuddleTranscriptError(f"could not reach {host}", cause=str(exc)) from exc
+
+    if not body.get("ok"):
+        error = body.get("error")
+        if error in _REAUTH_ERRORS:
+            raise HuddleTranscriptError(
+                "the Slack web session expired — a human must sign in again and refresh the "
+                "SLACK_WEB_TOKEN / SLACK_WEB_COOKIE pair; huddle transcripts stay unreadable until "
+                "they do",
+                slack_error=error,
+                needs_reauth=True,
+            )
+        raise HuddleTranscriptError("Slack returned not-ok", slack_error=error)
+    return body
+
+
+def fetch(file_id: str, *, host: str, token: str, cookie: str) -> dict:
+    """The full verbatim transcript for one ``huddle_transcript`` file id.
+
+    Returns ``{"file_id", "speakers", "turns", "text"}``. Raises :class:`HuddleTranscriptError` with
+    ``needs_reauth=True`` when the session has lapsed — the loud signal that keeps a stale cookie from
+    ever reading as "this huddle had no transcript".
+
+    Only the rendered ``text`` comes back, not the parsed segments as well. They are the same words
+    twice, and this is the largest single payload the tool can produce: returning both writes the
+    whole huddle into the model's context a second time, and it is then re-read on every request of
+    the turn. Callers that need the structure can call :func:`parse_segments` themselves.
+    """
+    segments: list[dict] = []
+    for page in range(1, _MAX_PAGES + 1):
+        body = _call(
+            host,
+            token,
+            cookie,
+            file=file_id,
+            include_transcription="true",
+            page=str(page),
+            count=str(_PAGE),
+        )
+        chunk = parse_segments(body)
+        segments += chunk
+        if len(chunk) < _PAGE:  # a short page is the last page — also the no-pagination case
+            break
+    return {
+        "file_id": file_id,
+        "speakers": speakers(segments),
+        "turns": len(segments),
+        "text": render(segments),
+    }

--- a/tools/productivity/slack/huddle_transcript.py
+++ b/tools/productivity/slack/huddle_transcript.py
@@ -30,15 +30,18 @@ from __future__ import annotations
 
 import json
 import re
+import urllib.error
 import urllib.parse
 import urllib.request
 
-# Slack marks each spoken turn with a bold ` [mm:ss]: ` between the speaker and their words — how far
-# into the call the turn happened. Long huddles use `[h:mm:ss]`.
+# Current payloads expose canonical ``lines`` entries. Older workspaces also emitted rich-text
+# blocks, where Slack marks each spoken turn with a bold ` [mm:ss]: ` between the speaker and words.
 _STAMP = re.compile(r"\[(\d{1,2}:\d{2}(?::\d{2})?)\]")
 
 _PAGE = 1000  # turns per page; long huddles paginate
-_MAX_PAGES = 60  # ~60k turns — a backstop against a pathological response, never hit by a real huddle
+_MAX_PAGES = (
+    60  # ~60k turns — a backstop against a pathological response, never hit by a real huddle
+)
 
 # The failures that mean "the human must sign in again", as opposed to "this code is wrong". Only
 # these set ``needs_reauth``; everything else is a bug and should read like one.
@@ -60,32 +63,136 @@ class HuddleTranscriptError(RuntimeError):
         super().__init__(str(self.payload))
 
 
+class _NoRedirect(urllib.request.HTTPRedirectHandler):
+    """A fixed credentialed API call must not carry its headers through a redirect."""
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        return None
+
+
+_OPENER = urllib.request.build_opener(_NoRedirect)
+
+
 # ── parsing (pure) ──────────────────────────────────────────────────────────────────────────────
+
+
+def _transcription(files_info: dict) -> dict | None:
+    file = files_info.get("file")
+    if not isinstance(file, dict):
+        return None
+    transcription = file.get("huddle_transcription")
+    return transcription if isinstance(transcription, dict) else None
+
+
+def _format_timestamp(value: object) -> str | None:
+    if isinstance(value, str):
+        candidate = value.strip().strip("[]")
+        if re.fullmatch(r"\d{1,2}:\d{2}(?::\d{2})?", candidate):
+            return candidate
+    if isinstance(value, bool):
+        return None
+    try:
+        milliseconds = int(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return None
+    if milliseconds < 0:
+        return None
+    seconds = milliseconds // 1000
+    hours, remainder = divmod(seconds, 3600)
+    minutes, seconds = divmod(remainder, 60)
+    if hours:
+        return f"{hours}:{minutes:02d}:{seconds:02d}"
+    return f"{minutes}:{seconds:02d}"
+
+
+def _line_segments(transcription: dict) -> list[dict]:
+    lines = transcription.get("lines")
+    if not isinstance(lines, list):
+        return []
+    out: list[dict] = []
+    for line in lines:
+        if not isinstance(line, dict):
+            raise HuddleTranscriptError("Slack returned a malformed huddle transcript line")
+        text = line.get("contents", line.get("text"))
+        if text is None:
+            continue
+        if not isinstance(text, str):
+            raise HuddleTranscriptError("Slack returned non-text huddle transcript contents")
+        said = text.strip()
+        if not said:
+            continue
+        user_id = line.get("user_id", line.get("speaker_id"))
+        if not isinstance(user_id, str) or not user_id:
+            user_id = None
+        at = _format_timestamp(line.get("start_time_ms", line.get("start_time")))
+        out.append({"user_id": user_id, "at": at, "text": said})
+    return out
+
+
+def _rich_text_sections(value: object) -> list[dict]:
+    """Normalize both direct and list-wrapped Slack rich-text block shapes."""
+    if isinstance(value, list):
+        out: list[dict] = []
+        for item in value:
+            out.extend(_rich_text_sections(item))
+        return out
+    if not isinstance(value, dict):
+        return []
+    if value.get("type") == "rich_text_section":
+        return [value]
+    return _rich_text_sections(value.get("elements"))
+
+
+def _raw_turn_count(files_info: dict) -> int | None:
+    """Count unfiltered Slack entries so noise/empty turns cannot end pagination early."""
+    transcription = _transcription(files_info)
+    if transcription is None:
+        return None
+    lines = transcription.get("lines")
+    if isinstance(lines, list) and lines:
+        return len(lines)
+    blocks = transcription.get("blocks")
+    if isinstance(lines, list) or isinstance(blocks, (dict, list)):
+        return len(_rich_text_sections(blocks))
+    return None
 
 
 def parse_segments(files_info: dict) -> list[dict]:
     """The transcript as ordered turns: ``{"user_id", "at", "text"}``.
 
-    Slack returns it as one ``rich_text`` block whose elements are a ``rich_text_section`` per spoken
-    turn. Each section carries a ``user`` element (the speaker's id), a **bold** ``text`` element
-    holding the ` [mm:ss]: ` mark, and one or more plain ``text`` elements with the words.
+    Slack's canonical payload is ``huddle_transcription.lines[]`` with ``user_id``,
+    ``start_time_ms``, and ``contents``. The rich-text representation emitted by older workspaces is
+    retained as a fallback: each section carries a ``user`` element, a bold timestamp marker, and
+    one or more text elements with the words.
 
     Speakers stay as **Slack ids, never names**. An id round-trips to a real mention and cannot drift;
     a name resolved at parse time silently rots when someone changes their display name.
     """
-    block = ((files_info.get("file") or {}).get("huddle_transcription") or {}).get("blocks") or {}
+    transcription = _transcription(files_info)
+    if transcription is None:
+        return []
+    line_segments = _line_segments(transcription)
+    if line_segments:
+        return line_segments
+
     out: list[dict] = []
-    for section in block.get("elements", []):
-        if section.get("type") != "rich_text_section":
-            continue
+    for section in _rich_text_sections(transcription.get("blocks")):
         user_id: str | None = None
         at: str | None = None
         words: list[str] = []
-        for element in section.get("elements", []):
+        elements = section.get("elements")
+        if not isinstance(elements, list):
+            continue
+        for element in elements:
+            if not isinstance(element, dict):
+                continue
             if element.get("type") == "user":
-                user_id = element.get("user_id")
+                candidate = element.get("user_id")
+                user_id = candidate if isinstance(candidate, str) else None
             elif element.get("type") == "text":
                 text = element.get("text", "")
+                if not isinstance(text, str):
+                    raise HuddleTranscriptError("Slack returned non-text rich transcript contents")
                 stamp = _STAMP.search(text)
                 # The bold element that *is* a timestamp is the marker, not speech. A bold word inside
                 # the speech itself carries no [mm:ss] and must survive.
@@ -150,10 +257,26 @@ def _call(host: str, token: str, cookie: str, **params: str) -> dict:
         headers={"Authorization": f"Bearer {token}", "Cookie": cookie},
     )
     try:
-        with urllib.request.urlopen(request, timeout=60) as response:
+        with _OPENER.open(request, timeout=60) as response:
             body = json.load(response)
-    except OSError as exc:  # network/TLS, not Slack saying no
+    except urllib.error.HTTPError as exc:
+        try:
+            body = json.load(exc)
+        except (UnicodeDecodeError, ValueError):
+            raise HuddleTranscriptError(
+                "Slack returned an HTTP error", status_code=exc.code
+            ) from exc
+        if not isinstance(body, dict) or body.get("ok"):
+            raise HuddleTranscriptError(
+                "Slack returned an HTTP error", status_code=exc.code
+            ) from exc
+    except urllib.error.URLError as exc:  # network/TLS, not Slack saying no
         raise HuddleTranscriptError(f"could not reach {host}", cause=str(exc)) from exc
+    except (UnicodeDecodeError, ValueError) as exc:
+        raise HuddleTranscriptError("Slack returned invalid JSON") from exc
+
+    if not isinstance(body, dict):
+        raise HuddleTranscriptError("Slack returned a non-object response")
 
     if not body.get("ok"):
         error = body.get("error")
@@ -182,6 +305,7 @@ def fetch(file_id: str, *, host: str, token: str, cookie: str) -> dict:
     the turn. Callers that need the structure can call :func:`parse_segments` themselves.
     """
     segments: list[dict] = []
+    seen_pages: set[str] = set()
     for page in range(1, _MAX_PAGES + 1):
         body = _call(
             host,
@@ -192,10 +316,36 @@ def fetch(file_id: str, *, host: str, token: str, cookie: str) -> dict:
             page=str(page),
             count=str(_PAGE),
         )
+        transcription = _transcription(body)
+        raw_count = _raw_turn_count(body)
+        if transcription is None or raw_count is None:
+            raise HuddleTranscriptError(
+                "Slack returned no huddle transcription; the file may not be a transcript or it "
+                "may not be ready",
+                file_id=file_id,
+            )
+        fingerprint = json.dumps(transcription, sort_keys=True, separators=(",", ":"))
+        if fingerprint in seen_pages:
+            raise HuddleTranscriptError(
+                "Slack transcript pagination did not advance", file_id=file_id, page=page
+            )
+        seen_pages.add(fingerprint)
         chunk = parse_segments(body)
         segments += chunk
-        if len(chunk) < _PAGE:  # a short page is the last page — also the no-pagination case
+        # Slack's undocumented transcript pagination uses the raw entry count. Parsed turns are the
+        # wrong signal because valid pages can contain empty/noise entries that we intentionally drop.
+        # A response larger than the requested page size means Slack returned the complete payload.
+        if raw_count != _PAGE:
             break
+    else:
+        raise HuddleTranscriptError(
+            "Slack transcript exceeded the pagination safety limit", file_id=file_id
+        )
+    if not segments:
+        raise HuddleTranscriptError(
+            "Slack returned an empty huddle transcription; it may not be ready",
+            file_id=file_id,
+        )
     return {
         "file_id": file_id,
         "speakers": speakers(segments),

--- a/tools/productivity/slack/pyproject.toml
+++ b/tools/productivity/slack/pyproject.toml
@@ -33,4 +33,10 @@ secrets = [
 optional_secrets = [
     {type = "http", name = "SLACK_SEARCH_TOKEN", match_headers = ["Authorization"], hosts = ["slack.com"]},
     {type = "http", name = "SLACK_ETL_TOKEN", match_headers = ["Authorization"], hosts = ["slack.com", "files.slack.com"]},
+    # The user web session that unlocks huddle transcripts. Slack serves them ONLY from the
+    # workspace host (`<workspace>.slack.com`), never `slack.com`, so these are scoped there and
+    # nowhere else — a wildcard is what lets one leaked credential ride to every Slack endpoint.
+    # Both are injected as headers, so the sandbox holds placeholders and never the real session.
+    {type = "http", name = "SLACK_WEB_TOKEN", match_headers = ["Authorization"], hosts = ["*.slack.com"]},
+    {type = "http", name = "SLACK_WEB_COOKIE", match_headers = ["Cookie"], hosts = ["*.slack.com"]},
 ]

--- a/tools/productivity/slack/pyproject.toml
+++ b/tools/productivity/slack/pyproject.toml
@@ -34,9 +34,8 @@ optional_secrets = [
     {type = "http", name = "SLACK_SEARCH_TOKEN", match_headers = ["Authorization"], hosts = ["slack.com"]},
     {type = "http", name = "SLACK_ETL_TOKEN", match_headers = ["Authorization"], hosts = ["slack.com", "files.slack.com"]},
     # The user web session that unlocks huddle transcripts. Slack serves them ONLY from the
-    # workspace host (`<workspace>.slack.com`), never `slack.com`, so these are scoped there and
-    # nowhere else — a wildcard is what lets one leaked credential ride to every Slack endpoint.
-    # Both are injected as headers, so the sandbox holds placeholders and never the real session.
-    {type = "http", name = "SLACK_WEB_TOKEN", match_headers = ["Authorization"], hosts = ["*.slack.com"]},
-    {type = "http", name = "SLACK_WEB_COOKIE", match_headers = ["Cookie"], hosts = ["*.slack.com"]},
+    # workspace host (`<workspace>.slack.com`), never `slack.com`. Limit replacement to the one
+    # read-only endpoint as well as Slack hosts; the sandbox holds placeholders, not the session.
+    {type = "http", name = "SLACK_WEB_TOKEN", match_headers = ["Authorization"], hosts = ["*.slack.com"], http_methods = ["POST"], paths = ["/api/files.info"]},
+    {type = "http", name = "SLACK_WEB_COOKIE", match_headers = ["Cookie"], hosts = ["*.slack.com"], http_methods = ["POST"], paths = ["/api/files.info"]},
 ]

--- a/tools/productivity/slack/tests/test_cli.py
+++ b/tools/productivity/slack/tests/test_cli.py
@@ -1,4 +1,5 @@
 import base64
+import json
 import sys
 import types
 from pathlib import Path
@@ -582,3 +583,52 @@ def test_thread_direct_calls_direct_client(monkeypatch) -> None:
             },
         )
     ]
+
+
+def test_huddle_transcript_prints_verbatim_text(monkeypatch) -> None:
+    payload = {
+        "file_id": "F123",
+        "speakers": ["U1"],
+        "turns": 1,
+        "text": "<@U1> [0:01]: [red]literal markup[/red]",
+    }
+    fake_client = types.SimpleNamespace(
+        _client=lambda: types.SimpleNamespace(get_huddle_transcript=lambda file_id: payload)
+    )
+    monkeypatch.setitem(sys.modules, "slack.client", fake_client)
+
+    result = CliRunner().invoke(app, ["huddle-transcript", "F123"])
+
+    assert result.exit_code == 0
+    assert result.stdout == "1 turns, 1 speakers\n<@U1> [0:01]: [red]literal markup[/red]\n"
+
+
+def test_huddle_transcript_json_is_machine_readable(monkeypatch) -> None:
+    payload = {"file_id": "F123", "speakers": ["U1"], "turns": 1, "text": "hello"}
+    fake_client = types.SimpleNamespace(
+        _client=lambda: types.SimpleNamespace(get_huddle_transcript=lambda file_id: payload)
+    )
+    monkeypatch.setitem(sys.modules, "slack.client", fake_client)
+
+    result = CliRunner().invoke(app, ["huddle-transcript", "F123", "--json"])
+
+    assert result.exit_code == 0
+    assert json.loads(result.stdout) == payload
+
+
+def test_huddle_transcript_errors_go_to_stderr(monkeypatch) -> None:
+    from slack.huddle_transcript import HuddleTranscriptError
+
+    def fail(file_id):
+        raise HuddleTranscriptError("refresh", needs_reauth=True)
+
+    fake_client = types.SimpleNamespace(
+        _client=lambda: types.SimpleNamespace(get_huddle_transcript=fail)
+    )
+    monkeypatch.setitem(sys.modules, "slack.client", fake_client)
+
+    result = CliRunner().invoke(app, ["huddle-transcript", "F123"])
+
+    assert result.exit_code == 1
+    assert result.stdout == ""
+    assert json.loads(result.stderr)["needs_reauth"] is True

--- a/tools/productivity/slack/tests/test_huddle_transcript.py
+++ b/tools/productivity/slack/tests/test_huddle_transcript.py
@@ -1,0 +1,132 @@
+"""Tests for huddle-transcript parsing and its failure modes.
+
+The parser is pure, so it is tested against real payload shapes. The fetch is a thin shell, so what
+matters about it is not the happy path but the *failures*: a lapsed session must be impossible to
+mistake for a silent meeting, and a missing credential must say so rather than returning nothing.
+"""
+
+from __future__ import annotations
+
+import pytest
+from slack.huddle_transcript import (
+    HuddleTranscriptError,
+    parse_segments,
+    render,
+    speakers,
+)
+
+
+def _section(user: str | None, stamp: str | None, *words: str) -> dict:
+    elements: list[dict] = []
+    if user:
+        elements.append({"type": "user", "user_id": user})
+    if stamp:
+        # Slack marks the timestamp with a BOLD text element — that is what distinguishes the marker
+        # from speech, not its position.
+        elements.append({"type": "text", "text": f" [{stamp}]: ", "style": {"bold": True}})
+    elements += [{"type": "text", "text": w} for w in words]
+    return {"type": "rich_text_section", "elements": elements}
+
+
+def _payload(*sections: dict) -> dict:
+    return {"file": {"huddle_transcription": {"blocks": {"elements": list(sections)}}}}
+
+
+def test_it_reads_speaker_time_and_words():
+    segments = parse_segments(
+        _payload(
+            _section("U1", "0:04", "we ship on Friday"),
+            _section("U2", "0:11", "the migration is not done"),
+        )
+    )
+    assert segments == [
+        {"user_id": "U1", "at": "0:04", "text": "we ship on Friday"},
+        {"user_id": "U2", "at": "0:11", "text": "the migration is not done"},
+    ]
+
+
+def test_a_long_huddle_keeps_its_hour():
+    (segment,) = parse_segments(_payload(_section("U1", "1:02:33", "still here")))
+    assert segment["at"] == "1:02:33"
+
+
+def test_bold_speech_is_not_mistaken_for_the_timestamp():
+    """The marker is the bold element that IS a timestamp. A bold word inside the speech is speech,
+    and dropping it would silently delete words from the record."""
+    section = _section("U1", "0:07", "we are ")
+    section["elements"].append({"type": "text", "text": "not", "style": {"bold": True}})
+    section["elements"].append({"type": "text", "text": " shipping"})
+    (segment,) = parse_segments(_payload(section))
+    assert segment["text"] == "we are not shipping"
+    assert segment["at"] == "0:07"
+
+
+def test_words_split_across_elements_are_rejoined():
+    (segment,) = parse_segments(_payload(_section("U1", "0:01", "roll ", "it ", "back")))
+    assert segment["text"] == "roll it back"
+
+
+def test_an_empty_turn_is_dropped():
+    """Slack emits sections with no words (a join, a noise blip). They are not turns."""
+    assert parse_segments(_payload(_section("U1", "0:01", "   "))) == []
+
+
+def test_a_speakerless_turn_survives():
+    """Attribution can be missing; the words still happened and must not be discarded."""
+    (segment,) = parse_segments(_payload(_section(None, "0:02", "someone said this")))
+    assert segment["user_id"] is None
+    assert segment["text"] == "someone said this"
+
+
+def test_a_transcriptless_payload_is_empty_not_an_error():
+    assert parse_segments({}) == []
+    assert parse_segments({"file": {}}) == []
+    assert parse_segments({"file": {"huddle_transcription": {}}}) == []
+
+
+def test_non_section_blocks_are_ignored():
+    payload = _payload({"type": "rich_text_preformatted", "elements": []})
+    assert parse_segments(payload) == []
+
+
+def test_render_uses_the_mention_form_so_a_quote_names_the_person():
+    text = render([{"user_id": "U1", "at": "0:04", "text": "we ship Friday"}])
+    assert text == "<@U1> [0:04]: we ship Friday"
+
+
+def test_render_tolerates_a_missing_speaker_or_stamp():
+    assert render([{"user_id": None, "at": None, "text": "hi"}]) == "someone: hi"
+
+
+def test_speakers_are_first_spoke_order_and_deduplicated():
+    segments = [
+        {"user_id": "U2", "at": None, "text": "a"},
+        {"user_id": "U1", "at": None, "text": "b"},
+        {"user_id": "U2", "at": None, "text": "c"},
+    ]
+    assert speakers(segments) == ["U2", "U1"]
+
+
+def test_the_error_payload_survives_stringification():
+    """The tool boundary stringifies exceptions, so the structure has to live in the payload — a
+    caller must still be able to tell `needs_reauth` from a bug after that round trip."""
+    err = HuddleTranscriptError("session expired", slack_error="invalid_auth", needs_reauth=True)
+    assert err.payload["needs_reauth"] is True
+    assert err.payload["slack_error"] == "invalid_auth"
+    assert "session expired" in str(err)
+
+
+def test_a_missing_session_is_loud_rather_than_an_empty_transcript():
+    """The failure that matters. A silent empty read looks exactly like "nobody spoke", and an agent
+    that believes a meeting was silent is worse than one that admits it cannot see."""
+    from slack.client import SlackClient
+
+    client = SlackClient.__new__(SlackClient)  # no network, no bot token needed for this branch
+    client.web_token = ""
+    client.web_cookie = ""
+
+    with pytest.raises(HuddleTranscriptError) as caught:
+        client.get_huddle_transcript("F123")
+
+    assert caught.value.payload["needs_reauth"] is True
+    assert set(caught.value.payload["missing"]) == {"SLACK_WEB_TOKEN", "SLACK_WEB_COOKIE"}

--- a/tools/productivity/slack/tests/test_huddle_transcript.py
+++ b/tools/productivity/slack/tests/test_huddle_transcript.py
@@ -7,9 +7,16 @@ mistake for a silent meeting, and a missing credential must say so rather than r
 
 from __future__ import annotations
 
+import io
+import json
+import types
+import urllib.error
+
 import pytest
+import slack.huddle_transcript as huddle_transcript
 from slack.huddle_transcript import (
     HuddleTranscriptError,
+    fetch,
     parse_segments,
     render,
     speakers,
@@ -32,11 +39,19 @@ def _payload(*sections: dict) -> dict:
     return {"file": {"huddle_transcription": {"blocks": {"elements": list(sections)}}}}
 
 
+def _line(user: str | None, at_ms: int, text: str) -> dict:
+    return {"user_id": user, "start_time_ms": at_ms, "contents": text}
+
+
+def _line_payload(*lines: dict) -> dict:
+    return {"ok": True, "file": {"huddle_transcription": {"lines": list(lines), "blocks": []}}}
+
+
 def test_it_reads_speaker_time_and_words():
     segments = parse_segments(
-        _payload(
-            _section("U1", "0:04", "we ship on Friday"),
-            _section("U2", "0:11", "the migration is not done"),
+        _line_payload(
+            _line("U1", 4_000, "we ship on Friday"),
+            _line("U2", 11_000, "the migration is not done"),
         )
     )
     assert segments == [
@@ -46,7 +61,7 @@ def test_it_reads_speaker_time_and_words():
 
 
 def test_a_long_huddle_keeps_its_hour():
-    (segment,) = parse_segments(_payload(_section("U1", "1:02:33", "still here")))
+    (segment,) = parse_segments(_line_payload(_line("U1", 3_753_000, "still here")))
     assert segment["at"] == "1:02:33"
 
 
@@ -87,6 +102,17 @@ def test_a_transcriptless_payload_is_empty_not_an_error():
 def test_non_section_blocks_are_ignored():
     payload = _payload({"type": "rich_text_preformatted", "elements": []})
     assert parse_segments(payload) == []
+
+
+def test_list_wrapped_rich_text_blocks_are_supported():
+    payload = {
+        "file": {
+            "huddle_transcription": {
+                "blocks": [{"type": "rich_text", "elements": [_section("U1", "0:03", "hi")]}]
+            }
+        }
+    }
+    assert parse_segments(payload) == [{"user_id": "U1", "at": "0:03", "text": "hi"}]
 
 
 def test_render_uses_the_mention_form_so_a_quote_names_the_person():
@@ -130,3 +156,104 @@ def test_a_missing_session_is_loud_rather_than_an_empty_transcript():
 
     assert caught.value.payload["needs_reauth"] is True
     assert set(caught.value.payload["missing"]) == {"SLACK_WEB_TOKEN", "SLACK_WEB_COOKIE"}
+
+
+def test_fetch_rejects_a_missing_transcription(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(
+        huddle_transcript, "_call", lambda *args, **kwargs: {"ok": True, "file": {}}
+    )
+
+    with pytest.raises(HuddleTranscriptError, match="no huddle transcription"):
+        fetch("F123", host="workspace.slack.com", token="token", cookie="cookie")
+
+
+def test_fetch_rejects_an_empty_transcription(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(huddle_transcript, "_call", lambda *args, **kwargs: _line_payload())
+
+    with pytest.raises(HuddleTranscriptError, match="empty huddle transcription"):
+        fetch("F123", host="workspace.slack.com", token="token", cookie="cookie")
+
+
+def test_pagination_counts_raw_lines_not_filtered_speech(monkeypatch: pytest.MonkeyPatch):
+    first_page = [_line("U1", index * 1000, f"line {index}") for index in range(999)]
+    first_page.append(_line(None, 999_000, ""))
+    pages = {1: _line_payload(*first_page), 2: _line_payload(_line("U2", 1_000_000, "last"))}
+    calls: list[int] = []
+
+    def fake_call(*args, **params):
+        page = int(params["page"])
+        calls.append(page)
+        return pages[page]
+
+    monkeypatch.setattr(huddle_transcript, "_call", fake_call)
+
+    result = fetch("F123", host="workspace.slack.com", token="token", cookie="cookie")
+
+    assert calls == [1, 2]
+    assert result["turns"] == 1000
+    assert result["text"].endswith("<@U2> [16:40]: last")
+
+
+class _JsonResponse(io.BytesIO):
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        self.close()
+
+
+def test_call_posts_placeholders_in_scoped_headers(monkeypatch: pytest.MonkeyPatch):
+    requests = []
+
+    def fake_open(request, timeout):
+        requests.append((request, timeout))
+        return _JsonResponse(json.dumps({"ok": True}).encode())
+
+    monkeypatch.setattr(huddle_transcript._OPENER, "open", fake_open)
+
+    assert huddle_transcript._call(
+        "workspace.slack.com", "TOKEN", "d=COOKIE", file="F123", include_transcription="true"
+    ) == {"ok": True}
+    request, timeout = requests[0]
+    assert request.get_method() == "POST"
+    assert request.full_url.startswith("https://workspace.slack.com/api/files.info?")
+    assert request.get_header("Authorization") == "Bearer TOKEN"
+    assert request.get_header("Cookie") == "d=COOKIE"
+    assert timeout == 60
+
+
+def test_http_auth_error_keeps_the_reauth_signal(monkeypatch: pytest.MonkeyPatch):
+    def fake_open(request, timeout):
+        raise urllib.error.HTTPError(
+            request.full_url,
+            401,
+            "Unauthorized",
+            {},
+            io.BytesIO(b'{"ok":false,"error":"invalid_auth"}'),
+        )
+
+    monkeypatch.setattr(huddle_transcript._OPENER, "open", fake_open)
+
+    with pytest.raises(HuddleTranscriptError) as caught:
+        huddle_transcript._call("workspace.slack.com", "TOKEN", "d=COOKIE", file="F123")
+
+    assert caught.value.payload["needs_reauth"] is True
+    assert caught.value.payload["slack_error"] == "invalid_auth"
+
+
+def test_workspace_host_is_derived_and_validated():
+    from slack.client import SlackClient
+
+    client = SlackClient.__new__(SlackClient)
+    client._workspace_host_cache = None
+    client._client = types.SimpleNamespace(
+        auth_test=lambda: types.SimpleNamespace(data={"url": "https://Example.slack.com/"})
+    )
+    assert client._workspace_host() == "example.slack.com"
+
+    client._workspace_host_cache = None
+    client._client = types.SimpleNamespace(
+        auth_test=lambda: types.SimpleNamespace(data={"url": "https://example.invalid/"})
+    )
+    with pytest.raises(HuddleTranscriptError, match="invalid Slack workspace URL"):
+        client._workspace_host()


### PR DESCRIPTION
## Summary

Rebased and reviewed successor to #1050 on the latest `main`.

- adds `get_huddle_transcript(file_id)` and `slack huddle-transcript` using the workspace-scoped Slack web session flow
- supports Slack's current `huddle_transcription.lines[]` payload and the legacy rich-text shape
- keeps transcript text verbatim and returns structured failures on stderr
- documents credential setup, trust boundaries, and operational reauthentication

## Review updates

The review found and fixed several correctness and security issues before publication:

- malformed, missing, or empty transcription payloads now fail loudly instead of looking like silent meetings
- pagination counts raw Slack entries, detects repeated pages, and has a hard safety limit
- credential-bearing redirects are disabled
- the workspace URL from `auth.test` must be HTTPS on a Slack hostname
- both web-session placeholders are restricted to `POST /api/files.info` on `*.slack.com`
- method/path restrictions now survive both api-rs discovery and `centaur-perms` translation; malformed scope declarations fail closed
- the real Slack manifest test asserts both web credentials translate to the expected host, method, and path rules

## Validation

- Slack tool tests: `102 passed`
- `cargo test -p centaur-perms`: `51 passed`
- `cargo clippy -p centaur-perms --all-targets -- -D warnings`
- targeted api-rs tool-discovery test
- Ruff checks and format checks for the changed Python paths
- CLI packaging validation and `slack huddle-transcript --help`
- Slack wheel build includes the new module
- `cargo fmt --all --check` and `git diff --check`

The original change's live Slack transport verification is retained; this review did not place real Slack credentials in the worktree or test output.