### PR TITLE
fix: surface Granola MCP tool errors

### DIFF
--- a/services/console/app/services/granola/sync_credential.rb
+++ b/services/console/app/services/granola/sync_credential.rb
@@ -274,11 +274,16 @@ module Granola
       raise GranolaApiError, "Granola MCP returned #{payload['error']}" if payload["error"]
 
       result = payload.fetch("result", {})
-      raise GranolaApiError, "Granola MCP tool #{name} failed" if result["isError"]
-
-      Array(result["content"])
+      content_text = Array(result["content"])
         .filter_map { |content| content["text"] if content["type"] == "text" }
         .join("\n")
+      if result["isError"]
+        detail = content_text.squish.truncate(1_000)
+        suffix = detail.present? ? ": #{detail}" : ""
+        raise GranolaApiError, "Granola MCP tool #{name} failed#{suffix}"
+      end
+
+      content_text
     end
 
     def initialize_mcp_session

--- a/services/console/test/services/granola/sync_credential_test.rb
+++ b/services/console/test/services/granola/sync_credential_test.rb
@@ -115,6 +115,34 @@ module Granola
       assert_includes failed[:run][:error_text], "rate limited"
     end
 
+    test "includes MCP tool error content in the raised error" do
+      sync = SyncCredential.new(credential, api_client: FakeApiClient.new)
+      sync.instance_variable_set(:@mcp_initialized, true)
+      sync.define_singleton_method(:mcp_request) do |*|
+        Struct.new(:body) do
+          def [](header)
+            "application/json" if header == "content-type"
+          end
+        end.new(
+          {
+            result: {
+              isError: true,
+              content: [ { type: "text", text: "Invalid meeting_ids: maximum 10" } ]
+            }
+          }.to_json
+        )
+      end
+
+      error = assert_raises(SyncCredential::GranolaApiError) do
+        sync.send(:mcp_tool, "get_meetings", "meeting_ids" => %w[meeting-1 meeting-2])
+      end
+
+      assert_equal(
+        "Granola MCP tool get_meetings failed: Invalid meeting_ids: maximum 10",
+        error.message
+      )
+    end
+
     private
 
     def meeting_xml


### PR DESCRIPTION
## Summary
- preserve text returned by failed Granola MCP tool calls
- normalize and truncate upstream details before including them in the raised error
- add regression coverage for `isError` responses

## Validation
- `git diff --check`
- Rails test not run locally: Ruby is unavailable in the sandbox; Console CI will run the focused behavior

Prompted by: mslipper