### PR TITLE
feat(linear): support updating project leads

### DIFF
--- a/tools/productivity/linear/cli.py
+++ b/tools/productivity/linear/cli.py
@@ -499,6 +499,52 @@ def project_detail(
     console.print(f"\n[dim]{result.get('url')}[/]")
 
 
+@app.command("update-project-lead")
+def update_project_lead(
+    project_name: str = typer.Argument(..., help="Project name (unique partial match supported)"),
+    lead: str = typer.Option(..., "--lead", help="New project lead name, email, or 'me'"),
+):
+    """Change only a project's lead; issue assignees are not modified."""
+    client = get_client()
+
+    project_matches = [
+        project
+        for project in client.projects()
+        if project_name.lower() in project.get("name", "").lower()
+    ]
+    if len(project_matches) != 1:
+        console.print(
+            f"[red]Project '{project_name}' matched {len(project_matches)} projects; provide a unique name.[/]"
+        )
+        raise typer.Exit(1)
+
+    if lead.lower() == "me":
+        lead_match = client.me()
+    else:
+        normalized_lead = lead.casefold()
+        lead_matches = [
+            user
+            for user in client.users()
+            if normalized_lead == str(user.get("email", "")).casefold()
+            or normalized_lead == str(user.get("name", "")).casefold()
+        ]
+        if len(lead_matches) != 1:
+            console.print(
+                f"[red]Lead '{lead}' matched {len(lead_matches)} users; provide an exact name or email.[/]"
+            )
+            raise typer.Exit(1)
+        lead_match = lead_matches[0]
+
+    result = client.update_project_lead(project_matches[0]["id"], lead_match["id"])
+    require_mutation_success(result, "project lead update")
+
+    console.print(
+        f"[green]Updated project lead:[/] [bold]{result.get('name')}[/] → "
+        f"{result.get('lead', {}).get('name', '')}"
+    )
+    console.print(f"[dim]{result.get('url')}[/]")
+
+
 @app.command()
 def cycles(
     team: str = typer.Option(None, "--team", "-t", help="Filter by team key"),

--- a/tools/productivity/linear/client.py
+++ b/tools/productivity/linear/client.py
@@ -180,6 +180,19 @@ class LinearClient(LinearReadonlyClient):
         result = self._query(mutation, {"id": issue_id, "input": input_data})
         return self._mutation_result(result, "issueUpdate")
 
+    def update_project_lead(self, project_id: str, lead_id: str) -> dict[str, Any]:
+        """Set a project's lead without changing any issue assignees."""
+        mutation = """
+        mutation ProjectUpdateLead($id: String!, $input: ProjectUpdateInput!) {
+            projectUpdate(id: $id, input: $input) {
+                success
+                project { id name url lead { id name email } }
+            }
+        }
+        """
+        result = self._query(mutation, {"id": project_id, "input": {"leadId": lead_id}})
+        return self._mutation_result(result, "projectUpdate", "project")
+
     def add_comment(self, issue_id: str, body: str) -> dict[str, Any]:
         """Add a comment to an issue."""
         mutation = """

--- a/tools/productivity/linear/test_cli.py
+++ b/tools/productivity/linear/test_cli.py
@@ -33,9 +33,7 @@ if "centaur_sdk" not in sys.modules:
     sdk_mod.Table = Table
     sys.modules["centaur_sdk"] = sdk_mod
 
-spec = importlib.util.spec_from_file_location(
-    "linear_cli", Path(__file__).with_name("cli.py")
-)
+spec = importlib.util.spec_from_file_location("linear_cli", Path(__file__).with_name("cli.py"))
 assert spec and spec.loader
 cli = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(cli)
@@ -47,6 +45,26 @@ class FakeClient:
 
     def labels(self, team_key: str | None = None) -> list[dict[str, Any]]:
         return self._labels
+
+
+class FakeProjectLeadClient:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str]] = []
+
+    def projects(self) -> list[dict[str, Any]]:
+        return [{"id": "project-1", "name": "Tetra"}]
+
+    def users(self) -> list[dict[str, Any]]:
+        return [{"id": "user-1", "name": "Vijith", "email": "vijith@tempo.xyz"}]
+
+    def update_project_lead(self, project_id: str, lead_id: str) -> dict[str, Any]:
+        self.calls.append((project_id, lead_id))
+        return {
+            "success": True,
+            "name": "Tetra",
+            "url": "https://linear.app/tempoxyz/project/tetra",
+            "lead": {"id": lead_id, "name": "Vijith"},
+        }
 
 
 def _run_labels(monkeypatch, labels: list[dict[str, Any]]):
@@ -78,3 +96,16 @@ def test_labels_handles_missing_team_key(monkeypatch):
 
     assert result.exit_code == 0, result.output
     assert ("org", "loose") in RECORDED_ROWS
+
+
+def test_update_project_lead_does_not_update_issues(monkeypatch):
+    from typer.testing import CliRunner
+
+    client = FakeProjectLeadClient()
+    monkeypatch.setattr(cli, "get_client", lambda: client)
+
+    result = CliRunner().invoke(cli.app, ["update-project-lead", "Tetra", "--lead", "Vijith"])
+
+    assert result.exit_code == 0, result.output
+    assert client.calls == [("project-1", "user-1")]
+    assert "Updated project lead" in result.output

--- a/tools/productivity/linear/test_client.py
+++ b/tools/productivity/linear/test_client.py
@@ -88,6 +88,31 @@ def test_update_issue_merges_success_into_issue_fields():
     assert updated["success"] is True
 
 
+def test_update_project_lead_changes_only_project_lead():
+    client = RecordingLinearClient(
+        {
+            "projectUpdate": {
+                "success": True,
+                "project": {
+                    "id": "project-1",
+                    "name": "Tetra",
+                    "lead": {"id": "user-1", "name": "Vijith"},
+                },
+            }
+        }
+    )
+
+    updated = client.update_project_lead("project-1", "user-1")
+
+    assert updated["success"] is True
+    assert updated["lead"]["name"] == "Vijith"
+    assert client.calls[0]["variables"] == {
+        "id": "project-1",
+        "input": {"leadId": "user-1"},
+    }
+    assert "issueUpdate" not in client.calls[0]["query"]
+
+
 def test_add_comment_merges_success_into_comment_fields():
     client = RecordingLinearClient(
         {"commentCreate": {"success": True, "comment": {"id": "comment-1", "body": "hi"}}}
@@ -104,6 +129,7 @@ def test_mutations_surface_failure():
         {
             "issueCreate": {"success": False, "issue": None},
             "issueUpdate": {"success": False, "issue": None},
+            "projectUpdate": {"success": False, "project": None},
             "commentCreate": {"success": False, "comment": None},
         }
     )
@@ -111,4 +137,5 @@ def test_mutations_surface_failure():
     # Callers (e.g. workflow helpers) key on result["success"] is False.
     assert client.create_issue("Test", team_id="team-1") == {"success": False}
     assert client.update_issue("ENG-1", title="New title") == {"success": False}
+    assert client.update_project_lead("project-1", "user-1") == {"success": False}
     assert client.add_comment("ENG-1", "hello") == {"success": False}


### PR DESCRIPTION
## Summary
- add a Linear `projectUpdate` mutation that changes only `leadId`
- expose `linear update-project-lead <project> --lead <name|email|me>`
- fail closed on ambiguous project or user matches
- test that no issue update or reassignment occurs

## Validation
- `3 passed, 5 deselected` for focused project-lead/mutation tests
- Ruff formatting and lint checks pass
- Full isolated CLI file: 6 passed, 2 pre-existing table-rendering failures caused by the installed SDK overriding the test stub

Prompted by: vijith