### PR TITLE
feat: add idempotent Linear project creation

### DIFF
--- a/tools/productivity/linear/cli.py
+++ b/tools/productivity/linear/cli.py
@@ -447,8 +447,8 @@ def create_project(
     """Create a project, or reuse an exact-name project in the same team.
 
     Examples:
-        linear create-project "Upshift" --team INT
-        linear create-project "Upshift" --team INT --json
+        linear create-project "Customer Integration" --team INT
+        linear create-project "Customer Integration" --team INT --json
     """
     client = get_client()
     try:

--- a/tools/productivity/linear/cli.py
+++ b/tools/productivity/linear/cli.py
@@ -437,6 +437,40 @@ def projects(
     console.print(table)
 
 
+@app.command("create-project")
+def create_project(
+    name: str = typer.Argument(..., help="Project name"),
+    team: str = typer.Option(..., "--team", "-t", help="Owning team key (e.g., INT)"),
+    description: str = typer.Option(None, "--description", "-d", help="Project description"),
+    json_output: bool = typer.Option(False, "--json", help="Output as JSON"),
+):
+    """Create a project, or reuse an exact-name project in the same team.
+
+    Examples:
+        linear create-project "Upshift" --team INT
+        linear create-project "Upshift" --team INT --json
+    """
+    client = get_client()
+    try:
+        result = client.create_project(name=name, team_key=team, description=description)
+    except ValueError as exc:
+        console.print(f"[red]{exc}[/]")
+        raise typer.Exit(1) from exc
+
+    require_mutation_success(result, "project creation")
+    if json_output:
+        print(json.dumps(result, indent=2, default=str), file=sys.stdout)
+        raise typer.Exit()
+
+    action = "Created" if result.get("created") else "Reused"
+    console.print(
+        f"[green]{action} project {result.get('name')} in team "
+        f"{result.get('team', {}).get('key')}[/]"
+    )
+    if result.get("url"):
+        console.print(f"[dim]{result['url']}[/]")
+
+
 @app.command("project")
 def project_detail(
     project_name: str = typer.Argument(..., help="Project name (partial match supported)"),

--- a/tools/productivity/linear/client.py
+++ b/tools/productivity/linear/client.py
@@ -137,6 +137,82 @@ class LinearClient(LinearReadonlyClient):
         result = self._query(mutation, {"input": input_data})
         return self._mutation_result(result, "issueCreate")
 
+    def create_project(
+        self,
+        name: str,
+        team_key: str,
+        description: str | None = None,
+    ) -> dict[str, Any]:
+        """Create or reuse an exact-name project in a Linear team.
+
+        The preflight makes retries idempotent. Ambiguous team or project
+        matches fail before any mutation is attempted.
+        """
+        normalized_team = team_key.strip().casefold()
+        team_matches = [
+            team
+            for team in self.teams(limit=250)
+            if team.get("key", "").casefold() == normalized_team
+        ]
+        if len(team_matches) != 1:
+            raise ValueError(
+                f"Expected exactly one Linear team with key {team_key!r}; found {len(team_matches)}"
+            )
+        team = team_matches[0]
+
+        normalized_name = name.strip().casefold()
+        project_matches = [
+            project
+            for project in self.projects(limit=10_000)
+            if project.get("name", "").strip().casefold() == normalized_name
+            and any(
+                project_team.get("id") == team["id"]
+                for project_team in (project.get("teams", {}).get("nodes") or [])
+            )
+        ]
+        if len(project_matches) > 1:
+            raise ValueError(
+                f"Multiple projects named {name!r} exist in Linear team {team['key']}; refusing to choose"
+            )
+        if project_matches:
+            return {
+                "success": True,
+                "created": False,
+                "reused": True,
+                "team": team,
+                **project_matches[0],
+            }
+
+        mutation = """
+        mutation ProjectCreate($input: ProjectCreateInput!) {
+            projectCreate(input: $input) {
+                success
+                project {
+                    id
+                    name
+                    description
+                    teams { nodes { id name key } }
+                    url
+                }
+            }
+        }
+        """
+        input_data: dict[str, Any] = {"name": name.strip(), "teamIds": [team["id"]]}
+        if description:
+            input_data["description"] = description
+
+        result = self._mutation_result(
+            self._query(mutation, {"input": input_data}),
+            "projectCreate",
+            "project",
+        )
+        return {
+            **result,
+            "created": result.get("success", False),
+            "reused": False,
+            "team": team,
+        }
+
     def update_issue(
         self,
         issue_id: str,

--- a/tools/productivity/linear/test_cli.py
+++ b/tools/productivity/linear/test_cli.py
@@ -48,6 +48,19 @@ class FakeClient:
     def labels(self, team_key: str | None = None) -> list[dict[str, Any]]:
         return self._labels
 
+    def create_project(
+        self, name: str, team_key: str, description: str | None = None
+    ) -> dict[str, Any]:
+        return {
+            "success": True,
+            "created": True,
+            "reused": False,
+            "id": "project-1",
+            "name": name,
+            "url": "https://linear/project-1",
+            "team": {"key": team_key},
+        }
+
 
 def _run_labels(monkeypatch, labels: list[dict[str, Any]]):
     from typer.testing import CliRunner
@@ -78,3 +91,14 @@ def test_labels_handles_missing_team_key(monkeypatch):
 
     assert result.exit_code == 0, result.output
     assert ("org", "loose") in RECORDED_ROWS
+
+
+def test_create_project_command_outputs_structured_result(monkeypatch):
+    from typer.testing import CliRunner
+
+    monkeypatch.setattr(cli, "get_client", lambda: FakeClient([]))
+    result = CliRunner().invoke(cli.app, ["create-project", "Upshift", "--team", "INT", "--json"])
+
+    assert result.exit_code == 0, result.output
+    assert '"created": true' in result.output
+    assert '"key": "INT"' in result.output

--- a/tools/productivity/linear/test_client.py
+++ b/tools/productivity/linear/test_client.py
@@ -39,9 +39,23 @@ LinearClient = module.LinearClient
 class RecordingLinearClient(LinearClient):
     """Returns canned mutation payloads keyed by substring, records calls."""
 
-    def __init__(self, responses: dict[str, Any]) -> None:
+    def __init__(
+        self,
+        responses: dict[str, Any],
+        *,
+        teams: list[dict[str, Any]] | None = None,
+        projects: list[dict[str, Any]] | None = None,
+    ) -> None:
         self.responses = responses
         self.calls: list[dict[str, Any]] = []
+        self._teams = teams or []
+        self._projects = projects or []
+
+    def teams(self, limit: int = 50) -> list[dict[str, Any]]:
+        return self._teams[:limit]
+
+    def projects(self, limit: int = 50) -> list[dict[str, Any]]:
+        return self._projects[:limit]
 
     def _query(self, query: str, variables: dict | None = None) -> dict:
         self.calls.append({"query": query, "variables": variables})
@@ -70,6 +84,77 @@ def test_create_issue_merges_success_into_issue_fields():
         "teamId": "team-1",
         "priority": 2,
     }
+
+
+def test_create_project_creates_in_resolved_team():
+    client = RecordingLinearClient(
+        {
+            "projectCreate": {
+                "success": True,
+                "project": {"id": "project-1", "name": "Upshift", "url": "https://linear/Upshift"},
+            }
+        },
+        teams=[{"id": "team-1", "key": "INT", "name": "Integrations"}],
+    )
+
+    result = client.create_project("Upshift", team_key="INT", description="Vault integration")
+
+    assert result["created"] is True
+    assert result["reused"] is False
+    assert result["team"]["key"] == "INT"
+    assert client.calls[0]["variables"]["input"] == {
+        "name": "Upshift",
+        "teamIds": ["team-1"],
+        "description": "Vault integration",
+    }
+
+
+def test_create_project_reuses_exact_project_without_mutation():
+    existing = {
+        "id": "project-1",
+        "name": "Upshift",
+        "url": "https://linear/Upshift",
+        "teams": {"nodes": [{"id": "team-1", "key": "INT"}]},
+    }
+    client = RecordingLinearClient(
+        {},
+        teams=[{"id": "team-1", "key": "INT", "name": "Integrations"}],
+        projects=[existing],
+    )
+
+    result = client.create_project("upshift", team_key="int")
+
+    assert result["created"] is False
+    assert result["reused"] is True
+    assert result["id"] == "project-1"
+    assert client.calls == []
+
+
+def test_create_project_rejects_missing_team_and_duplicate_projects():
+    missing_team = RecordingLinearClient({})
+    try:
+        missing_team.create_project("Upshift", team_key="INT")
+    except ValueError as exc:
+        assert "found 0" in str(exc)
+    else:
+        raise AssertionError("missing team should fail")
+
+    duplicate = {
+        "name": "Upshift",
+        "teams": {"nodes": [{"id": "team-1", "key": "INT"}]},
+    }
+    ambiguous = RecordingLinearClient(
+        {},
+        teams=[{"id": "team-1", "key": "INT"}],
+        projects=[{"id": "project-1", **duplicate}, {"id": "project-2", **duplicate}],
+    )
+    try:
+        ambiguous.create_project("Upshift", team_key="INT")
+    except ValueError as exc:
+        assert "Multiple projects" in str(exc)
+    else:
+        raise AssertionError("duplicate projects should fail")
+    assert ambiguous.calls == []
 
 
 def test_update_issue_merges_success_into_issue_fields():


### PR DESCRIPTION
## Summary
- add `linear create-project <name> --team <team-key>`
- reuse an exact-name project in the requested team and fail safely on ambiguity
- return structured project, team, and created/reused metadata

## Testing
- `uv run --no-project --with ruff ruff check tools/productivity/linear/client.py tools/productivity/linear/cli.py tools/productivity/linear/test_client.py tools/productivity/linear/test_cli.py`
- `uv run --no-project --with pytest --with typer --with rich --with httpx --with python-dotenv pytest tools/productivity/linear/test_client.py tools/productivity/linear/test_cli.py::test_create_project_command_outputs_structured_result -q` (8 passed)

Prompted by: vijith