### PR TITLE
feat: add native Nanocodex harness

### DIFF
--- a/contrib/chart/templates/slackbotv2.yaml
+++ b/contrib/chart/templates/slackbotv2.yaml
@@ -42,8 +42,8 @@ spec:
               value: "3001"
             - name: CENTAUR_API_URL
               value: {{ printf "http://%s:%v" $apiRsName .Values.apiRs.port | quote }}
-            # New threads without an explicit harness flag (including
-            # --nanocodex) run the deployment's default harness.
+            # New threads without an explicit --claude/--amp/--codex flag run
+            # the deployment's default harness.
             - name: SLACKBOTV2_DEFAULT_HARNESS
               value: {{ .Values.sandbox.harnessEngine | quote }}
             - name: SLACK_BOT_TOKEN

--- a/contrib/chart/templates/slackbotv2.yaml
+++ b/contrib/chart/templates/slackbotv2.yaml
@@ -42,8 +42,8 @@ spec:
               value: "3001"
             - name: CENTAUR_API_URL
               value: {{ printf "http://%s:%v" $apiRsName .Values.apiRs.port | quote }}
-            # New threads without an explicit --claude/--amp/--codex flag run
-            # the deployment's default harness.
+            # New threads without an explicit harness flag (including
+            # --nanocodex) run the deployment's default harness.
             - name: SLACKBOTV2_DEFAULT_HARNESS
               value: {{ .Values.sandbox.harnessEngine | quote }}
             - name: SLACK_BOT_TOKEN

--- a/crates/harness-server/Cargo.lock
+++ b/crates/harness-server/Cargo.lock
@@ -61,7 +61,7 @@ checksum = "fe233a377643e0fc1a56421d7c90acdec45c291b30345eb9f08e8d0ddce5a4ab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -177,7 +177,7 @@ checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
  "synstructure",
 ]
 
@@ -189,7 +189,7 @@ checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -200,7 +200,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -306,6 +306,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "bm25"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cbd8ffdfb7b4c2ff038726178a780a94f90525ed0ad264c0afaa75dd8c18a64"
+dependencies = [
+ "cached",
+ "deunicode",
+ "fxhash",
+ "rust-stemmers",
+ "stop-words",
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "borsh"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -365,6 +388,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "cached"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "801927ee168e17809ab8901d9f01f700cd7d8d6a6527997fee44e4b0327a253c"
+dependencies = [
+ "ahash",
+ "cached_proc_macro",
+ "cached_proc_macro_types",
+ "hashbrown 0.15.5",
+ "once_cell",
+ "thiserror 2.0.18",
+ "web-time",
+]
+
+[[package]]
+name = "cached_proc_macro"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9225bdcf4e4a9a4c08bf16607908eb2fbf746828d5e0b5e019726dbf6571f201"
+dependencies = [
+ "darling 0.20.11",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "cached_proc_macro_types"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ade8366b8bd5ba243f0a58f036cc0ca8a2f069cff1a2351ef1cac6b083e16fc0"
+
+[[package]]
 name = "cc"
 version = "1.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -393,6 +449,17 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
 
 [[package]]
 name = "chardetng"
@@ -450,7 +517,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -540,7 +607,7 @@ source = "git+https://github.com/openai/codex?rev=e93dc98a48d597df322436ffe8d03b
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -593,7 +660,7 @@ dependencies = [
  "icu_provider",
  "landlock",
  "quick-xml",
- "reqwest",
+ "reqwest 0.12.28",
  "schemars 0.8.22",
  "seccompiler",
  "serde",
@@ -647,7 +714,7 @@ version = "0.0.0"
 source = "git+https://github.com/openai/codex?rev=e93dc98a48d597df322436ffe8d03bfd7ec63b3b#e93dc98a48d597df322436ffe8d03bfd7ec63b3b"
 dependencies = [
  "lru",
- "sha1",
+ "sha1 0.10.6",
  "tokio",
 ]
 
@@ -702,6 +769,22 @@ name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "const_format"
@@ -798,6 +881,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -853,6 +945,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "csv"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -885,12 +986,36 @@ dependencies = [
 
 [[package]]
 name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
+]
+
+[[package]]
+name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim 0.11.1",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -903,7 +1028,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.11.1",
- "syn 2.0.117",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core 0.20.11",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -912,9 +1048,9 @@ version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
- "darling_core",
+ "darling_core 0.23.0",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -987,9 +1123,15 @@ dependencies = [
  "convert_case",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
  "unicode-xid",
 ]
+
+[[package]]
+name = "deunicode"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abd57806937c9cc163efc8ea3910e00a62e2aeb0b8119f1793a978088f8f6b04"
 
 [[package]]
 name = "diff"
@@ -1003,8 +1145,19 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "const-oid",
+ "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -1035,7 +1188,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1067,7 +1220,7 @@ checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1078,6 +1231,12 @@ checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
 dependencies = [
  "litrs",
 ]
+
+[[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "dunce"
@@ -1102,7 +1261,7 @@ checksum = "83e195b4945e88836d826124af44fdcb262ec01ef94d44f14f4fb5103f19892a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1156,7 +1315,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1176,7 +1335,7 @@ checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1201,7 +1360,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1237,6 +1396,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
 dependencies = [
  "simd-adler32",
+]
+
+[[package]]
+name = "filedescriptor"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e40758ed24c9b2eeb76c35fb0aebc66c626084edd827e07e1552279814c6682d"
+dependencies = [
+ "libc",
+ "thiserror 1.0.69",
+ "winapi",
 ]
 
 [[package]]
@@ -1388,7 +1558,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1461,8 +1631,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1486,10 +1658,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1545,12 +1720,14 @@ dependencies = [
  "codex-protocol",
  "codex-utils-absolute-path",
  "image",
+ "nanocodex",
  "opentelemetry-proto",
  "prost",
  "serde",
  "serde_json",
  "sha2",
  "thiserror 2.0.18",
+ "tokio",
  "url",
  "uuid",
 ]
@@ -1577,6 +1754,8 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash 0.1.5",
 ]
 
@@ -1596,6 +1775,30 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
+name = "headers"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3314d5adb5d94bcdf56771f2e50dbbc80bb4bdf88967526706205ac9eff24eb"
+dependencies = [
+ "base64",
+ "bytes",
+ "headers-core",
+ "http",
+ "httpdate",
+ "mime",
+ "sha1 0.10.6",
+]
+
+[[package]]
+name = "headers-core"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
+dependencies = [
+ "http",
+]
 
 [[package]]
 name = "heck"
@@ -1631,7 +1834,7 @@ dependencies = [
  "idna",
  "ipnet",
  "once_cell",
- "rand",
+ "rand 0.9.4",
  "ring",
  "thiserror 2.0.18",
  "tinyvec",
@@ -1653,7 +1856,7 @@ dependencies = [
  "moka",
  "once_cell",
  "parking_lot",
- "rand",
+ "rand 0.9.4",
  "resolv-conf",
  "smallvec",
  "thiserror 2.0.18",
@@ -1722,6 +1925,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
+name = "hybrid-array"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
 name = "hyper"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1755,6 +1967,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -2106,7 +2319,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2147,6 +2360,55 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.119",
+]
 
 [[package]]
 name = "jobserver"
@@ -2336,6 +2598,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "lsp-types"
 version = "0.94.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2470,6 +2738,124 @@ dependencies = [
 ]
 
 [[package]]
+name = "nanocodex"
+version = "0.1.0"
+source = "git+https://github.com/gakonst/nanocodex?rev=bd670d7c749fd1cdcb5ff925c36a5f2bbc95dbfe#bd670d7c749fd1cdcb5ff925c36a5f2bbc95dbfe"
+dependencies = [
+ "async-trait",
+ "base64",
+ "chrono",
+ "iana-time-zone",
+ "image",
+ "js-sys",
+ "nanocodex-core",
+ "nanocodex-macros",
+ "nanocodex-mcp",
+ "nanocodex-service",
+ "nanocodex-tools",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "sha1 0.11.0",
+ "thiserror 2.0.18",
+ "tokio",
+ "tower",
+ "tracing",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-time",
+]
+
+[[package]]
+name = "nanocodex-core"
+version = "0.1.0"
+source = "git+https://github.com/gakonst/nanocodex?rev=bd670d7c749fd1cdcb5ff925c36a5f2bbc95dbfe#bd670d7c749fd1cdcb5ff925c36a5f2bbc95dbfe"
+dependencies = [
+ "serde",
+ "serde_json",
+ "smallvec",
+ "thiserror 2.0.18",
+ "tokio",
+]
+
+[[package]]
+name = "nanocodex-macros"
+version = "0.1.0"
+source = "git+https://github.com/gakonst/nanocodex?rev=bd670d7c749fd1cdcb5ff925c36a5f2bbc95dbfe#bd670d7c749fd1cdcb5ff925c36a5f2bbc95dbfe"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "nanocodex-mcp"
+version = "0.1.0"
+source = "git+https://github.com/gakonst/nanocodex?rev=bd670d7c749fd1cdcb5ff925c36a5f2bbc95dbfe#bd670d7c749fd1cdcb5ff925c36a5f2bbc95dbfe"
+dependencies = [
+ "async-trait",
+ "bm25",
+ "http",
+ "nanocodex-core",
+ "nanocodex-tools",
+ "rmcp",
+ "rustls",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "nanocodex-service"
+version = "0.1.0"
+source = "git+https://github.com/gakonst/nanocodex?rev=bd670d7c749fd1cdcb5ff925c36a5f2bbc95dbfe#bd670d7c749fd1cdcb5ff925c36a5f2bbc95dbfe"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "nanocodex-core",
+ "rustls",
+ "serde",
+ "serde_json",
+ "smallvec",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-tungstenite",
+ "tower",
+ "tracing",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-time",
+]
+
+[[package]]
+name = "nanocodex-tools"
+version = "0.1.0"
+source = "git+https://github.com/gakonst/nanocodex?rev=bd670d7c749fd1cdcb5ff925c36a5f2bbc95dbfe#bd670d7c749fd1cdcb5ff925c36a5f2bbc95dbfe"
+dependencies = [
+ "async-trait",
+ "base64",
+ "futures-util",
+ "image",
+ "js-sys",
+ "nanocodex-core",
+ "nix 0.30.1",
+ "portable-pty",
+ "reqwest 0.12.28",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "sha1 0.11.0",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+]
+
+[[package]]
 name = "native-tls"
 version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2514,6 +2900,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags 2.11.1",
+ "cfg-if",
+ "cfg_aliases 0.2.1",
+ "libc",
+]
+
+[[package]]
+name = "nix"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
+dependencies = [
+ "bitflags 2.11.1",
+ "cfg-if",
+ "cfg_aliases 0.2.1",
+ "libc",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2538,7 +2948,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2622,7 +3032,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2679,7 +3089,7 @@ dependencies = [
  "opentelemetry",
  "percent-encoding",
  "portable-atomic",
- "rand",
+ "rand 0.9.4",
  "thiserror 2.0.18",
 ]
 
@@ -2797,6 +3207,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
+name = "portable-pty"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4a596a2b3d2752d94f51fac2d4a96737b8705dddd311a32b9af47211f08671e"
+dependencies = [
+ "anyhow",
+ "bitflags 1.3.2",
+ "downcast-rs",
+ "filedescriptor",
+ "lazy_static",
+ "libc",
+ "log",
+ "nix 0.28.0",
+ "serial2",
+ "shared_library",
+ "shell-words",
+ "winapi",
+ "winreg",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2835,7 +3266,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2854,6 +3285,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "process-wrap"
+version = "9.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e842efad9119158434d193c6682e2ebee4b44d6ad801d7b349623b3f57cdf55"
+dependencies = [
+ "futures",
+ "indexmap 2.14.0",
+ "nix 0.31.3",
+ "tokio",
+ "tracing",
+ "windows",
 ]
 
 [[package]]
@@ -2876,7 +3321,7 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2927,10 +3372,66 @@ dependencies = [
 ]
 
 [[package]]
-name = "quote"
-version = "1.0.45"
+name = "quinn"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
+dependencies = [
+ "bytes",
+ "cfg_aliases 0.2.1",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
+dependencies = [
+ "bytes",
+ "getrandom 0.4.2",
+ "lru-slab",
+ "rand 0.10.2",
+ "rand_pcg",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
+dependencies = [
+ "cfg_aliases 0.2.1",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
@@ -3038,7 +3539,7 @@ dependencies = [
  "rama-http-types",
  "rama-net",
  "rama-utils",
- "rand",
+ "rand 0.9.4",
  "serde",
  "serde_html_form",
  "serde_json",
@@ -3108,9 +3609,9 @@ dependencies = [
  "rama-macros",
  "rama-net",
  "rama-utils",
- "rand",
+ "rand 0.9.4",
  "serde",
- "sha1",
+ "sha1 0.10.6",
 ]
 
 [[package]]
@@ -3136,7 +3637,7 @@ dependencies = [
  "rama-error",
  "rama-macros",
  "rama-utils",
- "rand",
+ "rand 0.9.4",
  "serde",
  "serde_json",
  "sync_wrapper",
@@ -3152,7 +3653,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3210,7 +3711,7 @@ dependencies = [
  "rama-http-types",
  "rama-net",
  "rama-utils",
- "rand",
+ "rand 0.9.4",
  "tokio",
 ]
 
@@ -3284,7 +3785,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
- "rand_core",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -3294,7 +3806,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -3304,6 +3816,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -3368,7 +3895,7 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3438,6 +3965,8 @@ dependencies = [
  "native-tls",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -3445,12 +3974,53 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-native-tls",
+ "tokio-rustls",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
+ "serde",
+ "serde_json",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
 ]
 
@@ -3476,37 +4046,67 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0810a9f717d9828f475fe1f629f4c305c8464b7f496c3a854b58d29e65f4058e"
+checksum = "1d1f571c72940a19d9532fe52dbea8bc9912bf1d766c2970bb824056b86f3f59"
 dependencies = [
  "async-trait",
  "base64",
  "chrono",
  "futures",
+ "http",
  "pastey",
  "pin-project-lite",
+ "process-wrap",
+ "reqwest 0.13.4",
  "rmcp-macros",
  "schemars 1.2.1",
  "serde",
  "serde_json",
+ "sse-stream",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-stream",
  "tokio-util",
  "tracing",
 ]
 
 [[package]]
 name = "rmcp-macros"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aefac48c364756e97f04c0401ba3231e8607882c7c1d92da0437dc16307904d"
+checksum = "1aad0035b69380782d78ea95b508327e6deaa2235909053e596eea8f27b5e1d5"
 dependencies = [
- "darling",
+ "darling 0.23.0",
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 2.0.117",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "rust-stemmers"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e46a2036019fdb888131db7a4c847a1063a7493f971ed94ea82c67eada63ca54"
+dependencies = [
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
 ]
 
 [[package]]
@@ -3528,14 +4128,14 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.23.40"
+version = "0.23.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -3565,8 +4165,36 @@ version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -3600,7 +4228,7 @@ dependencies = [
  "libc",
  "log",
  "memchr",
- "nix",
+ "nix 0.28.0",
  "radix_trie 0.2.1",
  "unicode-segmentation",
  "unicode-width",
@@ -3613,6 +4241,15 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "schannel"
@@ -3712,7 +4349,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3724,7 +4361,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3804,7 +4441,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3815,7 +4452,7 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3853,7 +4490,7 @@ checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3894,10 +4531,21 @@ version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b90c488738ecb4fb0262f41f43bc40efc5868d9fb744319ddf5f5317f417bfac"
 dependencies = [
- "darling",
+ "darling 0.23.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "serial2"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9eb6ea5562eeaed6936b8b54e086aa0f88b9e5b1bef45beb038e2519fa1185b1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3907,8 +4555,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha1"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -3918,8 +4577,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -3930,6 +4589,22 @@ checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
+
+[[package]]
+name = "shared_library"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a9e7e0f2bfae24d8a5b5a66c5b257a83c7412304311512a0c054cd5e619da11"
+dependencies = [
+ "lazy_static",
+ "libc",
+]
+
+[[package]]
+name = "shell-words"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
 name = "shlex"
@@ -3958,6 +4633,22 @@ name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "simd_cesu8"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "siphasher"
@@ -4007,6 +4698,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 dependencies = [
  "lock_api",
+]
+
+[[package]]
+name = "sse-stream"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39f24a9b78c40b90817bbcd1821c74ddfd74916aadd29403d001532a9195532d"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http-body",
+ "http-body-util",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -4064,7 +4768,7 @@ dependencies = [
  "dupe",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4112,6 +4816,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "stop-words"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645a3d441ccf4bf47f2e4b7681461986681a6eeea9937d4c3bc9febd61d17c71"
+dependencies = [
+ "serde_json",
+]
+
+[[package]]
 name = "streaming-iterator"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4156,7 +4869,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4178,9 +4891,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4204,7 +4917,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4253,7 +4966,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4311,7 +5024,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4322,7 +5035,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4438,7 +5151,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4481,6 +5194,21 @@ dependencies = [
  "futures-core",
  "tokio",
  "tokio-stream",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.28.0"
+source = "git+https://github.com/openai-oss-forks/tokio-tungstenite?rev=0e5b2d73aa18dd9f0a50ee9ff199d5aef7594186#0e5b2d73aa18dd9f0a50ee9ff199d5aef7594186"
+dependencies = [
+ "futures-util",
+ "log",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tungstenite",
 ]
 
 [[package]]
@@ -4537,8 +5265,10 @@ dependencies = [
  "pin-project-lite",
  "sync_wrapper",
  "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -4590,7 +5320,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4688,8 +5418,27 @@ checksum = "ee6ff59666c9cbaec3533964505d39154dc4e0a56151fdea30a09ed0301f62e2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
  "termcolor",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.27.0"
+source = "git+https://github.com/openai-oss-forks/tungstenite-rs?rev=4fffad30fe373adbdcffab9545e9e9bf4f2fc19f#4fffad30fe373adbdcffab9545e9e9bf4f2fc19f"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "headers",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.9.4",
+ "rustls",
+ "rustls-pki-types",
+ "sha1 0.10.6",
+ "thiserror 2.0.18",
+ "utf-8",
 ]
 
 [[package]]
@@ -4754,6 +5503,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4794,6 +5549,16 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
 
 [[package]]
 name = "want"
@@ -4870,7 +5635,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
  "wasm-bindgen-shared",
 ]
 
@@ -4906,6 +5671,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-streams"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "wasmparser"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4925,6 +5703,25 @@ checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -4994,7 +5791,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5002,6 +5799,27 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core",
+]
 
 [[package]]
 name = "windows-core"
@@ -5017,6 +5835,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core",
+ "windows-link",
+ "windows-threading",
+]
+
+[[package]]
 name = "windows-implement"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5024,7 +5853,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5035,7 +5864,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5043,6 +5872,16 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core",
+ "windows-link",
+]
 
 [[package]]
 name = "windows-registry"
@@ -5117,6 +5956,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
 name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5174,6 +6022,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "winreg"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5209,7 +6066,7 @@ dependencies = [
  "heck",
  "indexmap 2.14.0",
  "prettyplease",
- "syn 2.0.117",
+ "syn 2.0.119",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -5225,7 +6082,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -5321,7 +6178,7 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
  "synstructure",
 ]
 
@@ -5342,7 +6199,7 @@ checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5362,7 +6219,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
  "synstructure",
 ]
 
@@ -5404,7 +6261,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]

--- a/crates/harness-server/Cargo.lock
+++ b/crates/harness-server/Cargo.lock
@@ -1188,7 +1188,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1360,7 +1360,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1775,30 +1775,6 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
-
-[[package]]
-name = "headers"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3314d5adb5d94bcdf56771f2e50dbbc80bb4bdf88967526706205ac9eff24eb"
-dependencies = [
- "base64",
- "bytes",
- "headers-core",
- "http",
- "httpdate",
- "mime",
- "sha1 0.10.6",
-]
-
-[[package]]
-name = "headers-core"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
-dependencies = [
- "http",
-]
 
 [[package]]
 name = "heck"
@@ -2319,7 +2295,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2740,7 +2716,7 @@ dependencies = [
 [[package]]
 name = "nanocodex"
 version = "0.1.0"
-source = "git+https://github.com/gakonst/nanocodex?rev=bd670d7c749fd1cdcb5ff925c36a5f2bbc95dbfe#bd670d7c749fd1cdcb5ff925c36a5f2bbc95dbfe"
+source = "git+https://github.com/gakonst/nanocodex?rev=d2df7bfe25d05efc235f464aae38117708befe0e#d2df7bfe25d05efc235f464aae38117708befe0e"
 dependencies = [
  "async-trait",
  "base64",
@@ -2769,7 +2745,7 @@ dependencies = [
 [[package]]
 name = "nanocodex-core"
 version = "0.1.0"
-source = "git+https://github.com/gakonst/nanocodex?rev=bd670d7c749fd1cdcb5ff925c36a5f2bbc95dbfe#bd670d7c749fd1cdcb5ff925c36a5f2bbc95dbfe"
+source = "git+https://github.com/gakonst/nanocodex?rev=d2df7bfe25d05efc235f464aae38117708befe0e#d2df7bfe25d05efc235f464aae38117708befe0e"
 dependencies = [
  "serde",
  "serde_json",
@@ -2781,7 +2757,7 @@ dependencies = [
 [[package]]
 name = "nanocodex-macros"
 version = "0.1.0"
-source = "git+https://github.com/gakonst/nanocodex?rev=bd670d7c749fd1cdcb5ff925c36a5f2bbc95dbfe#bd670d7c749fd1cdcb5ff925c36a5f2bbc95dbfe"
+source = "git+https://github.com/gakonst/nanocodex?rev=d2df7bfe25d05efc235f464aae38117708befe0e#d2df7bfe25d05efc235f464aae38117708befe0e"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -2792,7 +2768,7 @@ dependencies = [
 [[package]]
 name = "nanocodex-mcp"
 version = "0.1.0"
-source = "git+https://github.com/gakonst/nanocodex?rev=bd670d7c749fd1cdcb5ff925c36a5f2bbc95dbfe#bd670d7c749fd1cdcb5ff925c36a5f2bbc95dbfe"
+source = "git+https://github.com/gakonst/nanocodex?rev=d2df7bfe25d05efc235f464aae38117708befe0e#d2df7bfe25d05efc235f464aae38117708befe0e"
 dependencies = [
  "async-trait",
  "bm25",
@@ -2811,9 +2787,11 @@ dependencies = [
 [[package]]
 name = "nanocodex-service"
 version = "0.1.0"
-source = "git+https://github.com/gakonst/nanocodex?rev=bd670d7c749fd1cdcb5ff925c36a5f2bbc95dbfe#bd670d7c749fd1cdcb5ff925c36a5f2bbc95dbfe"
+source = "git+https://github.com/gakonst/nanocodex?rev=d2df7bfe25d05efc235f464aae38117708befe0e#d2df7bfe25d05efc235f464aae38117708befe0e"
 dependencies = [
+ "base64",
  "futures-util",
+ "http",
  "js-sys",
  "nanocodex-core",
  "rustls",
@@ -2833,7 +2811,7 @@ dependencies = [
 [[package]]
 name = "nanocodex-tools"
 version = "0.1.0"
-source = "git+https://github.com/gakonst/nanocodex?rev=bd670d7c749fd1cdcb5ff925c36a5f2bbc95dbfe#bd670d7c749fd1cdcb5ff925c36a5f2bbc95dbfe"
+source = "git+https://github.com/gakonst/nanocodex?rev=d2df7bfe25d05efc235f464aae38117708befe0e#d2df7bfe25d05efc235f464aae38117708befe0e"
 dependencies = [
  "async-trait",
  "base64",
@@ -2948,7 +2926,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3424,7 +3402,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4128,7 +4106,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4187,7 +4165,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4966,7 +4944,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5198,8 +5176,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.28.0"
-source = "git+https://github.com/openai-oss-forks/tokio-tungstenite?rev=0e5b2d73aa18dd9f0a50ee9ff199d5aef7594186#0e5b2d73aa18dd9f0a50ee9ff199d5aef7594186"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17a073bfed563fa236697a068031408a93cd9522e08abf9933ead3e73411bd71"
 dependencies = [
  "futures-util",
  "log",
@@ -5424,21 +5403,20 @@ dependencies = [
 
 [[package]]
 name = "tungstenite"
-version = "0.27.0"
-source = "git+https://github.com/openai-oss-forks/tungstenite-rs?rev=4fffad30fe373adbdcffab9545e9e9bf4f2fc19f#4fffad30fe373adbdcffab9545e9e9bf4f2fc19f"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e48ac77174b19c110a50ab2128b24215ac9cb40e0e12e093fb602d175c569d22"
 dependencies = [
  "bytes",
  "data-encoding",
- "headers",
  "http",
  "httparse",
  "log",
- "rand 0.9.4",
+ "rand 0.10.2",
  "rustls",
  "rustls-pki-types",
- "sha1 0.10.6",
+ "sha1 0.11.0",
  "thiserror 2.0.18",
- "utf-8",
 ]
 
 [[package]]
@@ -5501,12 +5479,6 @@ dependencies = [
  "serde",
  "serde_derive",
 ]
-
-[[package]]
-name = "utf-8"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8_iter"
@@ -5791,7 +5763,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/harness-server/Cargo.toml
+++ b/crates/harness-server/Cargo.toml
@@ -23,7 +23,7 @@ codex-utils-absolute-path = { git = "https://github.com/openai/codex", rev = "e9
 # provider's per-image caps (Bedrock/mantle rejects images past ~5 MB / 8000 px).
 # Scoped to the formats chat clients actually paste to keep the build lean.
 image = { version = "0.25", default-features = false, features = ["png", "jpeg", "webp"] }
-nanocodex = { git = "https://github.com/gakonst/nanocodex", rev = "bd670d7c749fd1cdcb5ff925c36a5f2bbc95dbfe" }
+nanocodex = { git = "https://github.com/gakonst/nanocodex", rev = "d2df7bfe25d05efc235f464aae38117708befe0e" }
 opentelemetry-proto = { version = "0.32.0", default-features = false, features = ["trace", "gen-tonic-messages"] }
 prost = "0.14"
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/harness-server/Cargo.toml
+++ b/crates/harness-server/Cargo.toml
@@ -23,11 +23,13 @@ codex-utils-absolute-path = { git = "https://github.com/openai/codex", rev = "e9
 # provider's per-image caps (Bedrock/mantle rejects images past ~5 MB / 8000 px).
 # Scoped to the formats chat clients actually paste to keep the build lean.
 image = { version = "0.25", default-features = false, features = ["png", "jpeg", "webp"] }
+nanocodex = { git = "https://github.com/gakonst/nanocodex", rev = "bd670d7c749fd1cdcb5ff925c36a5f2bbc95dbfe" }
 opentelemetry-proto = { version = "0.32.0", default-features = false, features = ["trace", "gen-tonic-messages"] }
 prost = "0.14"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"
 thiserror = "2.0"
+tokio = { version = "1.49", features = ["rt-multi-thread", "sync"] }
 url = "2.5"
 uuid = { version = "1.19", features = ["v4"] }

--- a/crates/harness-server/src/error.rs
+++ b/crates/harness-server/src/error.rs
@@ -25,6 +25,10 @@ pub enum HarnessServerError {
     },
     #[error("invalid blocks-mode input: {message}")]
     InvalidBlocksInput { message: String },
+    #[error("required environment variable {name} is not set")]
+    MissingEnvironment { name: &'static str },
+    #[error("Nanocodex error: {0}")]
+    Nanocodex(String),
     #[error("unknown threadId {thread_id}")]
     UnknownThread { thread_id: String },
     #[error("cwd must be absolute: {path}")]

--- a/crates/harness-server/src/lib.rs
+++ b/crates/harness-server/src/lib.rs
@@ -4,6 +4,7 @@ pub mod claude;
 pub mod codex;
 mod error;
 mod nanocodex;
+mod nanocodex_subagents;
 mod otel;
 mod server;
 mod traits;

--- a/crates/harness-server/src/lib.rs
+++ b/crates/harness-server/src/lib.rs
@@ -3,6 +3,7 @@ pub mod anthropic;
 pub mod claude;
 pub mod codex;
 mod error;
+mod nanocodex;
 mod otel;
 mod server;
 mod traits;
@@ -12,6 +13,7 @@ mod validation;
 pub mod wire;
 
 pub use error::{HarnessServerError, Result};
+pub use nanocodex::run_nanocodex_blocks_server;
 pub use server::{run_blocks_server, run_harness_server, run_validate_jsonrpc, server_for};
 pub use traits::{
     AppServerNormalizer, AppServerRuntime, HarnessKind, HarnessServer, NormalizedContent,

--- a/crates/harness-server/src/main.rs
+++ b/crates/harness-server/src/main.rs
@@ -1,13 +1,13 @@
 use clap::{Parser, Subcommand, ValueEnum};
 use harness_server::{
-    HarnessKind, Result, run_blocks_server, run_harness_server, run_validate_agent_deltas,
-    run_validate_jsonrpc,
+    HarnessKind, Result, run_blocks_server, run_harness_server, run_nanocodex_blocks_server,
+    run_validate_agent_deltas, run_validate_jsonrpc,
 };
 
 #[derive(Debug, Parser)]
 #[command(
     version,
-    about = "Serve harness CLIs through the Codex App Server V2 protocol."
+    about = "Serve agent harnesses over Centaur's streaming protocols."
 )]
 struct Cli {
     #[command(subcommand)]
@@ -21,6 +21,8 @@ enum CliCommand {
     #[command(alias = "claude")]
     ClaudeCode(HarnessCommand),
     Amp(HarnessCommand),
+    /// Run Nanocodex directly as a library and stream its native typed events.
+    Nanocodex,
     ValidateJsonrpc,
     ValidateAgentDeltas,
 }
@@ -53,6 +55,7 @@ fn run() -> Result<()> {
         CliCommand::Codex(command) => run_mode(HarnessKind::Codex, command.mode),
         CliCommand::ClaudeCode(command) => run_mode(HarnessKind::ClaudeCode, command.mode),
         CliCommand::Amp(command) => run_mode(HarnessKind::Amp, command.mode),
+        CliCommand::Nanocodex => run_nanocodex_blocks_server(),
         CliCommand::ValidateJsonrpc => run_validate_jsonrpc(),
         CliCommand::ValidateAgentDeltas => run_validate_agent_deltas(),
     }

--- a/crates/harness-server/src/nanocodex.rs
+++ b/crates/harness-server/src/nanocodex.rs
@@ -3,15 +3,17 @@ use std::env;
 use std::fs::OpenOptions;
 use std::io::{self, BufRead, Write};
 use std::path::PathBuf;
+use std::sync::Arc;
 
 use base64::Engine;
 use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
-use nanocodex::{AgentEvent, AgentEvents, Nanocodex, Prompt, Turn, UserInput};
+use nanocodex::{AgentEvent, AgentEvents, Nanocodex, Prompt, Tools, Turn, UserInput};
 use serde::Deserialize;
 use serde_json::Value;
 use tokio::sync::mpsc;
 use uuid::Uuid;
 
+use crate::nanocodex_subagents::{ChildAgents, with_subagents};
 use crate::{HarnessServerError, Result};
 
 /// Runs the Centaur blocks adapter while preserving Nanocodex's native event
@@ -31,9 +33,13 @@ async fn run() -> Result<()> {
         })?;
     let cwd = env::current_dir()?;
     let session_id = format!("nanocodex-{}", Uuid::new_v4().simple());
+    let child_agents = Arc::new(ChildAgents::default());
+    let tools_agents = Arc::downgrade(&child_agents);
+    let tools = Tools::default();
     let (agent, mut events) = Nanocodex::builder(api_key)
         .workspace(&cwd)
         .session_id(session_id)
+        .tools_factory(move |agent| with_subagents(tools.clone(), agent, tools_agents.clone()))
         .build()
         .map_err(nanocodex_error)?;
 
@@ -73,6 +79,7 @@ async fn run() -> Result<()> {
             }
         }
     }
+    child_agents.shutdown().await;
     Ok(())
 }
 

--- a/crates/harness-server/src/nanocodex.rs
+++ b/crates/harness-server/src/nanocodex.rs
@@ -1,0 +1,365 @@
+use std::collections::HashMap;
+use std::env;
+use std::fs::OpenOptions;
+use std::io::{self, BufRead, Write};
+use std::path::PathBuf;
+
+use base64::Engine;
+use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
+use nanocodex::{AgentEvent, AgentEvents, Nanocodex, Prompt, Turn, UserInput};
+use serde::Deserialize;
+use serde_json::Value;
+use tokio::sync::mpsc;
+use uuid::Uuid;
+
+use crate::{HarnessServerError, Result};
+
+/// Runs the Centaur blocks adapter while preserving Nanocodex's native event
+/// protocol on stdout. This path intentionally does not import or construct a
+/// Codex App Server protocol value.
+pub fn run_nanocodex_blocks_server() -> Result<()> {
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()?;
+    runtime.block_on(run())
+}
+
+async fn run() -> Result<()> {
+    let api_key =
+        env::var("OPENAI_API_KEY").map_err(|_| HarnessServerError::MissingEnvironment {
+            name: "OPENAI_API_KEY",
+        })?;
+    let cwd = env::current_dir()?;
+    let session_id = format!("nanocodex-{}", Uuid::new_v4().simple());
+    let (agent, mut events) = Nanocodex::builder(api_key)
+        .workspace(&cwd)
+        .session_id(session_id)
+        .build()
+        .map_err(nanocodex_error)?;
+
+    let (sender, mut receiver) = mpsc::unbounded_channel();
+    std::thread::spawn(move || {
+        let stdin = io::stdin();
+        for line in stdin.lock().lines() {
+            if sender.send(line).is_err() {
+                break;
+            }
+        }
+    });
+
+    let mut stdout = io::stdout().lock();
+    let mut staged = HashMap::new();
+    while let Some(line) = receiver.recv().await {
+        let line = line?;
+        if line.trim().is_empty() {
+            continue;
+        }
+        match parse_blocks_line(&line, &mut staged)? {
+            BlocksCommand::User(prompt) => {
+                let turn = agent.prompt(prompt).await.map_err(nanocodex_error)?;
+                run_turn(
+                    &agent,
+                    &mut events,
+                    turn,
+                    &mut receiver,
+                    &mut staged,
+                    &mut stdout,
+                )
+                .await?;
+            }
+            BlocksCommand::AttachmentChunk => {}
+            BlocksCommand::Interrupt => {
+                eprintln!("nanocodex interrupt ignored: no cancellation API is exposed");
+            }
+        }
+    }
+    Ok(())
+}
+
+async fn run_turn(
+    agent: &Nanocodex,
+    events: &mut AgentEvents,
+    turn: Turn,
+    receiver: &mut mpsc::UnboundedReceiver<io::Result<String>>,
+    staged: &mut HashMap<String, PathBuf>,
+    stdout: &mut impl Write,
+) -> Result<()> {
+    let mut input_open = true;
+    loop {
+        tokio::select! {
+            event = events.recv() => {
+                let event = event.ok_or_else(|| HarnessServerError::Nanocodex(
+                    "event stream closed before the turn completed".to_owned()
+                ))?;
+                let terminal = event.kind.is_terminal();
+                write_event(stdout, &event)?;
+                if terminal {
+                    break;
+                }
+            }
+            line = receiver.recv(), if input_open => {
+                let Some(line) = line else {
+                    input_open = false;
+                    continue;
+                };
+                let line = line?;
+                if line.trim().is_empty() {
+                    continue;
+                }
+                match parse_blocks_line(&line, staged)? {
+                    BlocksCommand::User(prompt) => {
+                        agent.steer(prompt).await.map_err(nanocodex_error)?;
+                    }
+                    BlocksCommand::AttachmentChunk => {}
+                    BlocksCommand::Interrupt => {
+                        return Err(HarnessServerError::Nanocodex(
+                            "turn interrupted; Nanocodex does not expose cancellation yet".to_owned()
+                        ));
+                    }
+                }
+            }
+        }
+    }
+
+    if let Err(error) = turn.result().await {
+        eprintln!("nanocodex turn failed: {error:#}");
+    }
+    Ok(())
+}
+
+fn write_event(output: &mut impl Write, event: &AgentEvent) -> Result<()> {
+    serde_json::to_writer(&mut *output, event)?;
+    output.write_all(b"\n")?;
+    output.flush()?;
+    Ok(())
+}
+
+fn nanocodex_error(error: nanocodex::NanocodexError) -> HarnessServerError {
+    HarnessServerError::Nanocodex(error.to_string())
+}
+
+enum BlocksCommand {
+    User(Prompt),
+    AttachmentChunk,
+    Interrupt,
+}
+
+#[derive(Deserialize)]
+struct BlocksLine {
+    #[serde(rename = "type")]
+    kind: String,
+    #[serde(default)]
+    text: Option<String>,
+    #[serde(default)]
+    content: Option<Value>,
+    #[serde(default)]
+    message: Option<BlocksMessage>,
+    #[serde(rename = "attachmentId", default)]
+    attachment_id: Option<String>,
+    #[serde(rename = "localPath", alias = "path", default)]
+    local_path: Option<PathBuf>,
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(rename = "mimeType", default)]
+    mime_type: Option<String>,
+    #[serde(rename = "dataBase64", default)]
+    data_base64: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct BlocksMessage {
+    #[serde(default)]
+    content: Option<Value>,
+}
+
+fn parse_blocks_line(line: &str, staged: &mut HashMap<String, PathBuf>) -> Result<BlocksCommand> {
+    let parsed: BlocksLine =
+        serde_json::from_str(line).map_err(|source| HarnessServerError::InvalidBlocksInput {
+            message: source.to_string(),
+        })?;
+    match parsed.kind.as_str() {
+        "user" => {
+            let content = parsed
+                .message
+                .as_ref()
+                .and_then(|message| message.content.as_ref())
+                .or(parsed.content.as_ref());
+            let mut inputs = content
+                .map(|content| parse_content(content, staged))
+                .transpose()?
+                .unwrap_or_default();
+            if inputs.is_empty()
+                && let Some(text) = parsed.text
+            {
+                inputs.push(UserInput::Text { text });
+            }
+            if inputs.is_empty() {
+                inputs.push(UserInput::Text {
+                    text: "continue".to_owned(),
+                });
+            }
+            Ok(BlocksCommand::User(Prompt::content(inputs)))
+        }
+        "attachment.chunk" => {
+            let id = required_string(parsed.attachment_id, "attachmentId")?;
+            if let Some(path) = parsed.local_path {
+                staged.insert(id, path);
+                return Ok(BlocksCommand::AttachmentChunk);
+            }
+            let path = if let Some(path) = staged.get(&id) {
+                path.clone()
+            } else {
+                let name = parsed.name.as_deref().unwrap_or("attachment");
+                let suffix = PathBuf::from(name)
+                    .extension()
+                    .and_then(|extension| extension.to_str())
+                    .map(|extension| format!(".{extension}"))
+                    .unwrap_or_default();
+                let path = env::temp_dir().join(format!(
+                    "centaur-nanocodex-{}{}",
+                    Uuid::new_v4().simple(),
+                    suffix
+                ));
+                staged.insert(id.clone(), path.clone());
+                path
+            };
+            if let Some(data) = parsed.data_base64.filter(|data| !data.is_empty()) {
+                let bytes = BASE64_STANDARD.decode(data).map_err(|source| {
+                    HarnessServerError::InvalidBlocksInput {
+                        message: format!("invalid attachment chunk for {id}: {source}"),
+                    }
+                })?;
+                OpenOptions::new()
+                    .create(true)
+                    .append(true)
+                    .open(path)?
+                    .write_all(&bytes)?;
+            }
+            let _mime_type = parsed.mime_type;
+            Ok(BlocksCommand::AttachmentChunk)
+        }
+        "interrupt" => Ok(BlocksCommand::Interrupt),
+        kind => Err(HarnessServerError::InvalidBlocksInput {
+            message: format!("unsupported blocks input type `{kind}`"),
+        }),
+    }
+}
+
+fn parse_content(value: &Value, staged: &HashMap<String, PathBuf>) -> Result<Vec<UserInput>> {
+    if let Some(text) = value.as_str() {
+        return Ok(vec![UserInput::Text {
+            text: text.to_owned(),
+        }]);
+    }
+    let items = value
+        .as_array()
+        .ok_or_else(|| HarnessServerError::InvalidBlocksInput {
+            message: "user content must be a string or array".to_owned(),
+        })?;
+    items.iter().map(|item| parse_input(item, staged)).collect()
+}
+
+fn parse_input(value: &Value, staged: &HashMap<String, PathBuf>) -> Result<UserInput> {
+    let kind = value.get("type").and_then(Value::as_str).unwrap_or("text");
+    match kind {
+        "text" | "input_text" => Ok(UserInput::Text {
+            text: required_value_string(value, "text")?,
+        }),
+        "image" | "input_image" => Ok(UserInput::Image {
+            image_url: required_value_string_alias(value, "image_url", "url")?,
+            detail: None,
+        }),
+        "local_image" | "localImage" => Ok(UserInput::LocalImage {
+            path: PathBuf::from(required_value_string_alias(value, "path", "localPath")?),
+            detail: None,
+        }),
+        "audio" | "input_audio" => Ok(UserInput::Audio {
+            audio_url: required_value_string_alias(value, "audio_url", "url")?,
+        }),
+        "local_audio" | "localAudio" => Ok(UserInput::LocalAudio {
+            path: PathBuf::from(required_value_string_alias(value, "path", "localPath")?),
+        }),
+        "attachment" => attachment_input(value, staged),
+        "attachment_ref" => Ok(UserInput::Text {
+            text: "[Attachment reference was not provided to this sandbox]".to_owned(),
+        }),
+        other => Err(HarnessServerError::InvalidBlocksInput {
+            message: format!("unsupported Nanocodex input type `{other}`"),
+        }),
+    }
+}
+
+fn attachment_input(value: &Value, staged: &HashMap<String, PathBuf>) -> Result<UserInput> {
+    let path = value
+        .get("localPath")
+        .or_else(|| value.get("path"))
+        .and_then(Value::as_str)
+        .map(PathBuf::from)
+        .or_else(|| {
+            value
+                .get("stagedAttachmentId")
+                .and_then(Value::as_str)
+                .and_then(|id| staged.get(id).cloned())
+        })
+        .ok_or_else(|| HarnessServerError::InvalidBlocksInput {
+            message: "Nanocodex attachment requires localPath or stagedAttachmentId".to_owned(),
+        })?;
+    let mime = value
+        .get("mimeType")
+        .or_else(|| value.get("mime_type"))
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    if mime.starts_with("image/") {
+        Ok(UserInput::LocalImage { path, detail: None })
+    } else if mime.starts_with("audio/") {
+        Ok(UserInput::LocalAudio { path })
+    } else {
+        Ok(UserInput::Text {
+            text: format!("[Attached file saved to {}]", path.display()),
+        })
+    }
+}
+
+fn required_string(value: Option<String>, name: &str) -> Result<String> {
+    value
+        .filter(|value| !value.trim().is_empty())
+        .ok_or_else(|| HarnessServerError::InvalidBlocksInput {
+            message: format!("missing {name}"),
+        })
+}
+
+fn required_value_string(value: &Value, name: &str) -> Result<String> {
+    required_value_string_alias(value, name, name)
+}
+
+fn required_value_string_alias(value: &Value, name: &str, alias: &str) -> Result<String> {
+    required_string(
+        value
+            .get(name)
+            .or_else(|| value.get(alias))
+            .and_then(Value::as_str)
+            .map(ToOwned::to_owned),
+        name,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_text_without_codex_protocol_types() {
+        let command = parse_blocks_line(
+            r#"{"type":"user","message":{"content":[{"type":"text","text":"hello"}]}}"#,
+            &mut HashMap::new(),
+        )
+        .unwrap();
+        let BlocksCommand::User(prompt) = command else {
+            panic!("expected user prompt");
+        };
+        assert_eq!(
+            serde_json::to_value(prompt).unwrap()["instruction"][0]["text"],
+            "hello"
+        );
+    }
+}

--- a/crates/harness-server/src/nanocodex.rs
+++ b/crates/harness-server/src/nanocodex.rs
@@ -63,15 +63,7 @@ async fn run() -> Result<()> {
         match parse_blocks_line(&line, &mut staged)? {
             BlocksCommand::User(prompt) => {
                 let turn = agent.prompt(prompt).await.map_err(nanocodex_error)?;
-                run_turn(
-                    &agent,
-                    &mut events,
-                    turn,
-                    &mut receiver,
-                    &mut staged,
-                    &mut stdout,
-                )
-                .await?;
+                run_turn(&mut events, turn, &mut receiver, &mut staged, &mut stdout).await?;
             }
             BlocksCommand::AttachmentChunk => {}
             BlocksCommand::Interrupt => {
@@ -84,7 +76,6 @@ async fn run() -> Result<()> {
 }
 
 async fn run_turn(
-    agent: &Nanocodex,
     events: &mut AgentEvents,
     turn: Turn,
     receiver: &mut mpsc::UnboundedReceiver<io::Result<String>>,
@@ -115,13 +106,12 @@ async fn run_turn(
                 }
                 match parse_blocks_line(&line, staged)? {
                     BlocksCommand::User(prompt) => {
-                        agent.steer(prompt).await.map_err(nanocodex_error)?;
+                        turn.steer(prompt).await.map_err(nanocodex_error)?;
                     }
                     BlocksCommand::AttachmentChunk => {}
                     BlocksCommand::Interrupt => {
-                        return Err(HarnessServerError::Nanocodex(
-                            "turn interrupted; Nanocodex does not expose cancellation yet".to_owned()
-                        ));
+                        turn.cancel().await.map_err(nanocodex_error)?;
+                        input_open = false;
                     }
                 }
             }
@@ -216,17 +206,7 @@ fn parse_blocks_line(line: &str, staged: &mut HashMap<String, PathBuf>) -> Resul
             let path = if let Some(path) = staged.get(&id) {
                 path.clone()
             } else {
-                let name = parsed.name.as_deref().unwrap_or("attachment");
-                let suffix = PathBuf::from(name)
-                    .extension()
-                    .and_then(|extension| extension.to_str())
-                    .map(|extension| format!(".{extension}"))
-                    .unwrap_or_default();
-                let path = env::temp_dir().join(format!(
-                    "centaur-nanocodex-{}{}",
-                    Uuid::new_v4().simple(),
-                    suffix
-                ));
+                let path = temporary_attachment_path(parsed.name.as_deref());
                 staged.insert(id.clone(), path.clone());
                 path
             };
@@ -307,10 +287,17 @@ fn attachment_input(value: &Value, staged: &HashMap<String, PathBuf>) -> Result<
                 .get("stagedAttachmentId")
                 .and_then(Value::as_str)
                 .and_then(|id| staged.get(id).cloned())
-        })
-        .ok_or_else(|| HarnessServerError::InvalidBlocksInput {
-            message: "Nanocodex attachment requires localPath or stagedAttachmentId".to_owned(),
-        })?;
+        });
+    let path = match path {
+        Some(path) => path,
+        None => inline_attachment_path(value)?.ok_or_else(|| {
+            HarnessServerError::InvalidBlocksInput {
+                message:
+                    "Nanocodex attachment requires localPath, stagedAttachmentId, or dataBase64"
+                        .to_owned(),
+            }
+        })?,
+    };
     let mime = value
         .get("mimeType")
         .or_else(|| value.get("mime_type"))
@@ -325,6 +312,38 @@ fn attachment_input(value: &Value, staged: &HashMap<String, PathBuf>) -> Result<
             text: format!("[Attached file saved to {}]", path.display()),
         })
     }
+}
+
+fn inline_attachment_path(value: &Value) -> Result<Option<PathBuf>> {
+    let Some(data) = value
+        .get("dataBase64")
+        .and_then(Value::as_str)
+        .filter(|data| !data.is_empty())
+    else {
+        return Ok(None);
+    };
+    let bytes =
+        BASE64_STANDARD
+            .decode(data)
+            .map_err(|source| HarnessServerError::InvalidBlocksInput {
+                message: format!("invalid attachment dataBase64: {source}"),
+            })?;
+    let path = temporary_attachment_path(value.get("name").and_then(Value::as_str));
+    std::fs::write(&path, bytes)?;
+    Ok(Some(path))
+}
+
+fn temporary_attachment_path(name: Option<&str>) -> PathBuf {
+    let suffix = PathBuf::from(name.unwrap_or("attachment"))
+        .extension()
+        .and_then(|extension| extension.to_str())
+        .map(|extension| format!(".{extension}"))
+        .unwrap_or_default();
+    env::temp_dir().join(format!(
+        "centaur-nanocodex-{}{}",
+        Uuid::new_v4().simple(),
+        suffix
+    ))
 }
 
 fn required_string(value: Option<String>, name: &str) -> Result<String> {
@@ -368,5 +387,28 @@ mod tests {
             serde_json::to_value(prompt).unwrap()["instruction"][0]["text"],
             "hello"
         );
+    }
+
+    #[test]
+    fn materializes_inline_attachment_without_codex_protocol_types() {
+        let command = parse_blocks_line(
+            r#"{"type":"user","message":{"content":[{"type":"attachment","attachment_type":"document","dataBase64":"aGVsbG8=","name":"notes.txt","mimeType":"text/plain"}]}}"#,
+            &mut HashMap::new(),
+        )
+        .unwrap();
+        let BlocksCommand::User(prompt) = command else {
+            panic!("expected user prompt");
+        };
+        let text = serde_json::to_value(prompt).unwrap()["instruction"][0]["text"]
+            .as_str()
+            .unwrap()
+            .to_owned();
+        let path = text
+            .strip_prefix("[Attached file saved to ")
+            .and_then(|text| text.strip_suffix(']'))
+            .map(PathBuf::from)
+            .unwrap();
+        assert_eq!(std::fs::read(&path).unwrap(), b"hello");
+        std::fs::remove_file(path).unwrap();
     }
 }

--- a/crates/harness-server/src/nanocodex_subagents.rs
+++ b/crates/harness-server/src/nanocodex_subagents.rs
@@ -1,0 +1,314 @@
+use std::{
+    collections::HashMap,
+    sync::{
+        Weak,
+        atomic::{AtomicU64, Ordering},
+    },
+};
+
+use nanocodex::{
+    AgentEventKind, AgentEvents, AgentHandle, Nanocodex, Tool, ToolContext, ToolDefinition,
+    ToolExecution, ToolInput, ToolResult, Tools, ToolsBuildError, async_trait,
+};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use tokio::task::JoinHandle;
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct AgentTask {
+    role: String,
+    task: String,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct FollowUpTask {
+    agent_id: u64,
+    task: String,
+}
+
+#[derive(Serialize)]
+struct WorkerResult {
+    agent_id: u64,
+    kind: &'static str,
+    role: String,
+    report: String,
+}
+
+#[derive(Serialize)]
+struct FollowUpResult {
+    agent_id: u64,
+    report: String,
+}
+
+struct ChildSession {
+    agent: Nanocodex,
+    event_task: JoinHandle<()>,
+}
+
+#[derive(Default)]
+pub(crate) struct ChildAgents {
+    next_id: AtomicU64,
+    agents: tokio::sync::Mutex<HashMap<u64, ChildSession>>,
+}
+
+impl ChildAgents {
+    fn next_id(&self) -> u64 {
+        self.next_id.fetch_add(1, Ordering::Relaxed) + 1
+    }
+
+    async fn insert(&self, id: u64, agent: Nanocodex, event_task: JoinHandle<()>) {
+        self.agents
+            .lock()
+            .await
+            .insert(id, ChildSession { agent, event_task });
+    }
+
+    async fn get(&self, id: u64) -> Option<Nanocodex> {
+        self.agents
+            .lock()
+            .await
+            .get(&id)
+            .map(|session| session.agent.clone())
+    }
+
+    pub(crate) async fn shutdown(&self) {
+        let sessions = std::mem::take(&mut *self.agents.lock().await);
+        let mut event_tasks = Vec::with_capacity(sessions.len());
+        for session in sessions.into_values() {
+            event_tasks.push(session.event_task);
+            drop(session.agent);
+        }
+        for event_task in event_tasks {
+            drop(event_task.await);
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+enum ChildKind {
+    Spawn,
+    Fork,
+}
+
+impl ChildKind {
+    const fn name(self) -> &'static str {
+        match self {
+            Self::Spawn => "spawn_agent",
+            Self::Fork => "fork_agent",
+        }
+    }
+
+    const fn result_name(self) -> &'static str {
+        match self {
+            Self::Spawn => "independent",
+            Self::Fork => "fork",
+        }
+    }
+
+    const fn description(self) -> &'static str {
+        match self {
+            Self::Spawn => {
+                "Starts a reusable clean child agent without the invoking agent's conversation history, runs its first task, and returns its agent_id and report. The child may inspect the shared workspace but is instructed not to modify it."
+            }
+            Self::Fork => {
+                "Starts a reusable read-only child agent from the invoking agent's latest completed checkpoint, runs its first task, and returns its agent_id and report. This is unavailable until the invoking agent has completed at least one turn."
+            }
+        }
+    }
+
+    fn prompt(self, task: &str) -> String {
+        let context = match self {
+            Self::Spawn => "You have no inherited conversation context.",
+            Self::Fork => "Use the inherited conversation only as context for this delegation.",
+        };
+        format!(
+            "Act as a read-only specialist child agent. {context} Inspect the shared workspace as \
+             needed, but do not modify files or run destructive commands. Return a compact, \
+             evidence-backed report to the parent agent.\n\nDelegated task:\n{task}"
+        )
+    }
+}
+
+struct ChildAgent {
+    agent: AgentHandle,
+    agents: Weak<ChildAgents>,
+    kind: ChildKind,
+}
+
+impl ChildAgent {
+    const fn new(agent: AgentHandle, agents: Weak<ChildAgents>, kind: ChildKind) -> Self {
+        Self {
+            agent,
+            agents,
+            kind,
+        }
+    }
+}
+
+fn drain_events(
+    agent_id: u64,
+    role: String,
+    kind: &'static str,
+    mut events: AgentEvents,
+) -> JoinHandle<()> {
+    let log_jsonl = std::env::var_os("NANOCODEX_SUBAGENT_JSONL").is_some();
+    tokio::spawn(async move {
+        while let Some(event) = events.recv().await {
+            if log_jsonl
+                && matches!(
+                    event.kind,
+                    AgentEventKind::RunStarted
+                        | AgentEventKind::RunCompleted
+                        | AgentEventKind::RunFailed
+                )
+            {
+                eprintln!(
+                    "{}",
+                    json!({
+                        "agent_id": agent_id,
+                        "role": role,
+                        "kind": kind,
+                        "event": event,
+                    })
+                );
+            }
+        }
+    })
+}
+
+#[async_trait]
+impl Tool for ChildAgent {
+    fn name(&self) -> &'static str {
+        self.kind.name()
+    }
+
+    fn definition(&self) -> ToolDefinition {
+        ToolDefinition::function(
+            self.name(),
+            self.kind.description(),
+            json!({
+                "type": "object",
+                "properties": {
+                    "role": {
+                        "type": "string",
+                        "description": "A short worker role for result attribution."
+                    },
+                    "task": {
+                        "type": "string",
+                        "description": "A complete, focused task for the child agent."
+                    }
+                },
+                "required": ["role", "task"],
+                "additionalProperties": false
+            }),
+        )
+    }
+
+    async fn execute(&self, input: ToolInput, _context: ToolContext<'_>) -> ToolResult {
+        let AgentTask { role, task } = input.decode_json()?;
+        let agents = self
+            .agents
+            .upgrade()
+            .ok_or_else(|| std::io::Error::other("child-agent registry stopped"))?;
+        let agent_id = agents.next_id();
+        let (child, events) = match self.kind {
+            ChildKind::Spawn => self.agent.spawn().await,
+            ChildKind::Fork => self.agent.fork().await,
+        }?;
+        let event_task = drain_events(agent_id, role.clone(), self.kind.result_name(), events);
+
+        let result = child
+            .prompt(self.kind.prompt(&task))
+            .await?
+            .result()
+            .await?;
+        agents.insert(agent_id, child, event_task).await;
+        Ok(ToolExecution::json(&WorkerResult {
+            agent_id,
+            kind: self.kind.result_name(),
+            role,
+            report: result.final_message,
+        }))
+    }
+}
+
+struct PromptAgent {
+    agents: Weak<ChildAgents>,
+}
+
+#[async_trait]
+impl Tool for PromptAgent {
+    fn name(&self) -> &'static str {
+        "prompt_agent"
+    }
+
+    fn definition(&self) -> ToolDefinition {
+        ToolDefinition::function(
+            self.name(),
+            "Runs a follow-up turn on a previously spawned or forked child, preserving that child's conversation, response chain, cache lineage, WebSocket, and tools.",
+            json!({
+                "type": "object",
+                "properties": {
+                    "agent_id": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "description": "The agent_id returned by spawn_agent or fork_agent."
+                    },
+                    "task": {
+                        "type": "string",
+                        "description": "The next prompt for that child agent."
+                    }
+                },
+                "required": ["agent_id", "task"],
+                "additionalProperties": false
+            }),
+        )
+    }
+
+    async fn execute(&self, input: ToolInput, _context: ToolContext<'_>) -> ToolResult {
+        let FollowUpTask { agent_id, task } = input.decode_json()?;
+        let agents = self
+            .agents
+            .upgrade()
+            .ok_or_else(|| std::io::Error::other("child-agent registry stopped"))?;
+        let child = agents
+            .get(agent_id)
+            .await
+            .ok_or_else(|| std::io::Error::other(format!("unknown agent_id {agent_id}")))?;
+        let result = child.prompt(task).await?.result().await?;
+        Ok(ToolExecution::json(&FollowUpResult {
+            agent_id,
+            report: result.final_message,
+        }))
+    }
+}
+
+pub(crate) fn with_subagents(
+    tools: Tools,
+    agent: AgentHandle,
+    agents: Weak<ChildAgents>,
+) -> Result<Tools, ToolsBuildError> {
+    tools
+        .into_builder()
+        .tool(ChildAgent::new(
+            agent.clone(),
+            agents.clone(),
+            ChildKind::Spawn,
+        ))
+        .tool(ChildAgent::new(agent, agents.clone(), ChildKind::Fork))
+        .tool(PromptAgent { agents })
+        .build()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ChildKind;
+
+    #[test]
+    fn child_tool_names_are_stable() {
+        assert_eq!(ChildKind::Spawn.name(), "spawn_agent");
+        assert_eq!(ChildKind::Fork.name(), "fork_agent");
+    }
+}

--- a/packages/rendering/src/index.ts
+++ b/packages/rendering/src/index.ts
@@ -7,6 +7,11 @@ export {
 } from './codex-app-server'
 export { ChatSDKRenderer, EMPTY_FINAL_ANSWER_TEXT } from './chat-sdk'
 export type { CodexAppServerToChatStreamOptions } from './codex-app-server'
+export {
+  NanocodexRendererEventMapper,
+  harnessToChatSdkStream,
+  isNanocodexEvent
+} from './nanocodex'
 export type { RendererInterface, RendererSession } from './interface'
 export { rendererEventTypes } from './schema'
 export type { RendererEventType, RendererSessionOpenInput } from './schema'

--- a/packages/rendering/src/nanocodex.test.ts
+++ b/packages/rendering/src/nanocodex.test.ts
@@ -65,4 +65,17 @@ describe('NanocodexRendererEventMapper', () => {
       }
     ])
   })
+
+  test('renders a cancelled run through the stock interruption path', () => {
+    const mapper = new NanocodexRendererEventMapper()
+    expect(mapper.process(native('run.error', { message: 'turn cancelled' }))).toEqual([])
+    expect(mapper.process(native('run.failed', { status: 'cancelled' }, 2))).toEqual([
+      {
+        type: 'renderer.done',
+        answerMarkdown: 'Execution interrupted',
+        streamFinalUpdates: true,
+        threadId: 'nano-session'
+      }
+    ])
+  })
 })

--- a/packages/rendering/src/nanocodex.test.ts
+++ b/packages/rendering/src/nanocodex.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from 'bun:test'
+import { NanocodexRendererEventMapper, isNanocodexEvent } from './nanocodex'
+
+const native = (type: string, payload: Record<string, unknown>, seq = 1) => ({
+  eventKind: 'session.output.line',
+  data: JSON.stringify({
+    protocol_version: 1,
+    request_id: 'nano-session',
+    seq,
+    type,
+    payload
+  })
+})
+
+describe('NanocodexRendererEventMapper', () => {
+  test('streams native assistant events and completes with the canonical answer', () => {
+    const mapper = new NanocodexRendererEventMapper()
+    expect(isNanocodexEvent(native('run.started', {}))).toBe(true)
+    expect(mapper.process(native('assistant.delta', { text: 'hello' }, 2))).toEqual([
+      { type: 'renderer.message.delta', delta: 'hello' }
+    ])
+    expect(mapper.process(native('assistant.message', { text: 'hello world' }, 3))).toEqual([
+      { type: 'renderer.message.delta', delta: ' world' }
+    ])
+    expect(mapper.process(native('run.completed', {}, 4))).toEqual([
+      {
+        type: 'renderer.done',
+        answerMarkdown: 'hello world',
+        streamFinalUpdates: true,
+        threadId: 'nano-session'
+      }
+    ])
+  })
+
+  test('renders native tool lifecycle without an app-server conversion', () => {
+    const mapper = new NanocodexRendererEventMapper()
+    expect(
+      mapper.process(
+        native('tool.call', { call_id: 'call-1', tool: 'shell', arguments: { cmd: 'pwd' } })
+      )[0]
+    ).toMatchObject({
+      type: 'renderer.task.update',
+      task: { id: 'call-1', title: 'shell', status: 'in_progress' }
+    })
+    expect(
+      mapper.process(
+        native('tool.result', { call_id: 'call-1', tool: 'shell', status: 'completed', result: 'ok' })
+      )[0]
+    ).toMatchObject({
+      type: 'renderer.task.update',
+      task: { id: 'call-1', title: 'shell', status: 'complete' }
+    })
+  })
+
+  test('carries run.error into the terminal failure', () => {
+    const mapper = new NanocodexRendererEventMapper()
+    expect(mapper.process(native('run.error', { message: 'proxy refused' }))).toEqual([])
+    expect(mapper.process(native('run.failed', {}, 2))).toEqual([
+      {
+        type: 'renderer.done',
+        answerMarkdown: undefined,
+        error: 'proxy refused',
+        streamFinalUpdates: true,
+        threadId: 'nano-session'
+      }
+    ])
+  })
+})

--- a/packages/rendering/src/nanocodex.ts
+++ b/packages/rendering/src/nanocodex.ts
@@ -1,0 +1,245 @@
+import type { RustSessionStreamEvent } from '@centaur/harness-events'
+import {
+  ChatSDKRenderer,
+  type ChatSDKOutput,
+  type ChatSDKStreamChunk
+} from './chat-sdk'
+import {
+  CodexAppServerRendererEventMapper,
+  type CodexAppServerToChatStreamOptions
+} from './codex-app-server'
+import type {
+  RendererEvent,
+  RendererSourceMapper,
+  RendererTaskStatus
+} from './types'
+
+type NativeEvent = {
+  protocol_version: number
+  request_id: string
+  seq: number
+  type: string
+  payload: Record<string, unknown>
+}
+
+export class NanocodexRendererEventMapper
+  implements RendererSourceMapper<RustSessionStreamEvent | unknown>
+{
+  private answer = ''
+  private error = ''
+  private requestId = ''
+  private done = false
+
+  process(source: RustSessionStreamEvent | unknown): RendererEvent[] {
+    if (this.done) return []
+    const event = nanocodexEvent(source)
+    if (!event) return this.processSessionEnvelope(source)
+    this.requestId = event.request_id || this.requestId
+
+    switch (event.type) {
+      case 'assistant.delta': {
+        const delta = stringField(event.payload, 'text')
+        if (!delta) return []
+        this.answer += delta
+        return [{ type: 'renderer.message.delta', delta }]
+      }
+      case 'assistant.message': {
+        const markdown = stringField(event.payload, 'text')
+        if (!markdown || markdown === this.answer) return []
+        if (markdown.startsWith(this.answer)) {
+          const delta = markdown.slice(this.answer.length)
+          this.answer = markdown
+          return delta ? [{ type: 'renderer.message.delta', delta }] : []
+        }
+        this.answer = markdown
+        return [{ type: 'renderer.message.snapshot', markdown }]
+      }
+      case 'tool.call':
+        return [
+          {
+            type: 'renderer.task.update',
+            task: {
+              id: stringField(event.payload, 'call_id') || `tool-${event.seq}`,
+              title: stringField(event.payload, 'tool') || 'Tool',
+              status: 'in_progress',
+              details: blocks(event.payload.arguments)
+            }
+          }
+        ]
+      case 'tool.result': {
+        const status = toolStatus(event.payload)
+        return [
+          {
+            type: 'renderer.task.update',
+            task: {
+              id: stringField(event.payload, 'call_id') || `tool-${event.seq}`,
+              title: stringField(event.payload, 'tool') || 'Tool',
+              status,
+              output: blocks(event.payload.result)
+            }
+          }
+        ]
+      }
+      case 'run.error':
+        this.error = stringField(event.payload, 'message') || 'Nanocodex run failed'
+        return []
+      case 'run.completed':
+        return this.complete()
+      case 'run.failed':
+        return this.fail(this.error || 'Nanocodex run failed')
+      default:
+        return []
+    }
+  }
+
+  flush(): RendererEvent[] {
+    return this.done ? [] : this.complete()
+  }
+
+  isDone(): boolean {
+    return this.done
+  }
+
+  threadId(): string {
+    return this.requestId
+  }
+
+  private processSessionEnvelope(source: unknown): RendererEvent[] {
+    if (!isRecord(source)) return []
+    const kind = String(source.eventKind ?? source.event ?? '')
+    const data = isRecord(source.data) ? source.data : source
+    if (kind === 'session.activity_summary') {
+      const status = String(data.summary ?? data.status ?? '').trim()
+      return status ? [{ type: 'renderer.status', status }] : []
+    }
+    if (
+      kind === 'session.execution_failed' ||
+      kind === 'session.stream_error' ||
+      kind === 'session.stdout_pump_failed'
+    ) {
+      return this.fail(String(data.error ?? 'Execution failed'))
+    }
+    if (kind === 'session.execution_completed') return this.complete()
+    return []
+  }
+
+  private complete(): RendererEvent[] {
+    if (this.done) return []
+    this.done = true
+    return [
+      {
+        type: 'renderer.done',
+        answerMarkdown: this.answer,
+        streamFinalUpdates: true,
+        threadId: this.requestId || undefined
+      }
+    ]
+  }
+
+  private fail(error: string): RendererEvent[] {
+    if (this.done) return []
+    this.done = true
+    return [
+      {
+        type: 'renderer.done',
+        answerMarkdown: this.answer || undefined,
+        error,
+        streamFinalUpdates: true,
+        threadId: this.requestId || undefined
+      }
+    ]
+  }
+}
+
+export async function* harnessToChatSdkStream(
+  sources: AsyncIterable<RustSessionStreamEvent | unknown>,
+  options: CodexAppServerToChatStreamOptions = {}
+): AsyncIterable<ChatSDKStreamChunk> {
+  const codex = new CodexAppServerRendererEventMapper(options)
+  const nano = new NanocodexRendererEventMapper()
+  const renderer = new ChatSDKRenderer()
+  let selected: 'codex' | 'nanocodex' | null = null
+
+  for await (const source of sources) {
+    if (nanocodexEvent(source)) selected = 'nanocodex'
+    const mapper = selected === 'nanocodex' ? nano : codex
+    for (const event of mapper.process(source)) {
+      yield* render(renderer, mapper.threadId(), event, options)
+    }
+    if (mapper.isDone()) return
+  }
+
+  const mapper = selected === 'nanocodex' ? nano : codex
+  for (const event of mapper.flush()) {
+    yield* render(renderer, mapper.threadId(), event, options)
+  }
+}
+
+export function isNanocodexEvent(source: unknown): boolean {
+  return nanocodexEvent(source) !== null
+}
+
+function nanocodexEvent(source: unknown): NativeEvent | null {
+  let candidate = source
+  if (isRecord(source)) {
+    const kind = String(source.eventKind ?? source.event ?? '')
+    if (kind === 'session.output.line') {
+      const data = source.data
+      if (typeof data === 'string') {
+        try {
+          candidate = JSON.parse(data)
+        } catch {
+          return null
+        }
+      } else if (isRecord(data)) {
+        candidate = data.raw ?? data
+        if (typeof candidate === 'string') {
+          try {
+            candidate = JSON.parse(candidate)
+          } catch {
+            return null
+          }
+        }
+      }
+    }
+  }
+  if (!isRecord(candidate)) return null
+  if (candidate.protocol_version !== 1 || typeof candidate.request_id !== 'string') return null
+  if (typeof candidate.type !== 'string' || !isRecord(candidate.payload)) return null
+  return candidate as NativeEvent
+}
+
+async function* render(
+  renderer: ChatSDKRenderer,
+  sessionId: string,
+  event: RendererEvent,
+  options: CodexAppServerToChatStreamOptions
+): AsyncIterable<ChatSDKStreamChunk> {
+  await options.onRendererEvent?.(event)
+  const outputs = renderer.render(sessionId, event)
+  for (const output of outputs) {
+    await options.onOutput?.(output as ChatSDKOutput, event)
+    if (output.type !== 'chat.stream.append') continue
+    for (const chunk of output.chunks) yield chunk
+  }
+}
+
+function blocks(value: unknown): Array<{ type: 'code'; text: string; language: string }> {
+  if (value === undefined || value === null) return []
+  const text = typeof value === 'string' ? value : JSON.stringify(value, null, 2)
+  return text ? [{ type: 'code', text, language: 'json' }] : []
+}
+
+function toolStatus(payload: Record<string, unknown>): RendererTaskStatus {
+  const status = stringField(payload, 'status').toLowerCase()
+  return status === 'failed' || status === 'error' ? 'error' : 'complete'
+}
+
+function stringField(value: Record<string, unknown>, key: string): string {
+  const field = value[key]
+  return typeof field === 'string' ? field : ''
+}
+
+function isRecord(value: unknown): value is Record<string, any> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}

--- a/packages/rendering/src/nanocodex.ts
+++ b/packages/rendering/src/nanocodex.ts
@@ -86,6 +86,9 @@ export class NanocodexRendererEventMapper
       case 'run.completed':
         return this.complete()
       case 'run.failed':
+        if (['cancelled', 'canceled'].includes(stringField(event.payload, 'status'))) {
+          return this.interrupt()
+        }
         return this.fail(this.error || 'Nanocodex run failed')
       default:
         return []
@@ -119,8 +122,14 @@ export class NanocodexRendererEventMapper
     ) {
       return this.fail(String(data.error ?? 'Execution failed'))
     }
+    if (kind === 'session.execution_cancelled') return this.interrupt()
     if (kind === 'session.execution_completed') return this.complete()
     return []
+  }
+
+  private interrupt(): RendererEvent[] {
+    if (!this.answer) this.answer = 'Execution interrupted'
+    return this.complete()
   }
 
   private complete(): RendererEvent[] {

--- a/services/api-rs/crates/centaur-api-integration-test/src/main.rs
+++ b/services/api-rs/crates/centaur-api-integration-test/src/main.rs
@@ -222,6 +222,7 @@ async fn test_harness_wire_values(http: &HttpClient, base_url: &str) -> Result<(
         (HarnessType::Codex, "codex"),
         (HarnessType::Amp, "amp"),
         (HarnessType::ClaudeCode, "claudecode"),
+        (HarnessType::Nanocodex, "nanocodex"),
     ];
 
     for (harness_type, expected_wire_value) in cases {

--- a/services/api-rs/crates/centaur-api-server/src/args.rs
+++ b/services/api-rs/crates/centaur-api-server/src/args.rs
@@ -1844,7 +1844,7 @@ impl IronProxyHarnessArgs {
             HarnessType::ClaudeCode,
             HarnessType::Amp,
         ] {
-            if engine == self.engine {
+            if harness_fragment_engine_name(&engine) == harness_fragment_engine_name(&self.engine) {
                 continue;
             }
             let auth_mode = harness_auth_mode_env(&engine).unwrap_or_else(|| "api_key".to_owned());
@@ -1926,6 +1926,7 @@ fn harness_fragment_engine_name(engine: &HarnessType) -> &'static str {
         HarnessType::Codex => "codex",
         HarnessType::Amp => "amp",
         HarnessType::ClaudeCode => "claude-code",
+        HarnessType::Nanocodex => "codex",
     }
 }
 
@@ -1943,6 +1944,7 @@ fn harness_auth_mode_env(engine: &HarnessType) -> Option<String> {
         HarnessType::Codex => env::var("CODEX_AUTH_MODE").ok(),
         HarnessType::ClaudeCode => env::var("CLAUDE_CODE_AUTH_MODE").ok(),
         HarnessType::Amp => None,
+        HarnessType::Nanocodex => Some("api_key".to_owned()),
     }
 }
 
@@ -2925,6 +2927,18 @@ mod tests {
         assert_eq!(
             args.sandbox.iron_proxy.harness.engine,
             HarnessType::ClaudeCode
+        );
+    }
+
+    #[test]
+    fn nanocodex_reuses_the_codex_proxy_fragment() {
+        assert_eq!(
+            harness_fragment_engine_name(&HarnessType::Nanocodex),
+            harness_fragment_engine_name(&HarnessType::Codex)
+        );
+        assert_eq!(
+            harness_auth_mode_env(&HarnessType::Nanocodex).as_deref(),
+            Some("api_key")
         );
     }
 }

--- a/services/api-rs/crates/centaur-session-cli/src/main.rs
+++ b/services/api-rs/crates/centaur-session-cli/src/main.rs
@@ -575,6 +575,7 @@ enum HarnessTypeArg {
     Amp,
     #[value(name = "claudecode")]
     ClaudeCode,
+    Nanocodex,
 }
 
 impl From<HarnessTypeArg> for HarnessType {
@@ -583,6 +584,7 @@ impl From<HarnessTypeArg> for HarnessType {
             HarnessTypeArg::Codex => Self::Codex,
             HarnessTypeArg::Amp => Self::Amp,
             HarnessTypeArg::ClaudeCode => Self::ClaudeCode,
+            HarnessTypeArg::Nanocodex => Self::Nanocodex,
         }
     }
 }

--- a/services/api-rs/crates/centaur-session-core/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-core/src/lib.rs
@@ -360,6 +360,7 @@ pub enum HarnessType {
     Codex,
     Amp,
     ClaudeCode,
+    Nanocodex,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, AsRefStr, Display, EnumString)]
@@ -855,6 +856,10 @@ mod tests {
     fn harness_type_accepts_supported_values() {
         assert_eq!(HarnessType::from_str("codex").unwrap(), HarnessType::Codex);
         assert_eq!(HarnessType::from_str("amp").unwrap(), HarnessType::Amp);
+        assert_eq!(
+            HarnessType::from_str("nanocodex").unwrap(),
+            HarnessType::Nanocodex
+        );
         assert_eq!(
             HarnessType::from_str("claudecode").unwrap(),
             HarnessType::ClaudeCode

--- a/services/api-rs/crates/centaur-session-runtime/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-runtime/src/lib.rs
@@ -3700,6 +3700,7 @@ fn harness_server_subcommand(harness: &HarnessType) -> &'static str {
         HarnessType::Codex => "codex",
         HarnessType::ClaudeCode => "claude-code",
         HarnessType::Amp => "amp",
+        HarnessType::Nanocodex => "nanocodex",
     }
 }
 
@@ -5733,7 +5734,10 @@ fn terminal_output(value: &Value, prior_final_answer_text: &str) -> Option<Termi
     let event_type = value.get("type").and_then(Value::as_str);
 
     if matches!(method, Some("error" | "turn/failed"))
-        || matches!(event_type, Some("error" | "turn.failed"))
+        || matches!(
+            event_type,
+            Some("error" | "turn.failed" | "run.error" | "run.failed")
+        )
     {
         return Some(TerminalOutput::Failed {
             error: terminal_error_text(value),
@@ -5748,6 +5752,11 @@ fn terminal_output(value: &Value, prior_final_answer_text: &str) -> Option<Termi
     }
 
     match event_type {
+        Some("run.completed") => Some(completed_terminal_output_with_fallback(
+            value,
+            "run_completed",
+            prior_final_answer_text,
+        )),
         Some("turn.completed") => Some(completed_turn_terminal_output(
             value,
             prior_final_answer_text,
@@ -5834,6 +5843,24 @@ enum FinalAnswerTextUpdate {
 fn output_line_final_answer_text(value: &Value) -> Option<FinalAnswerTextUpdate> {
     let method = value.get("method").and_then(Value::as_str);
     let event_type = value.get("type").and_then(Value::as_str);
+    if event_type == Some("assistant.delta") {
+        let text = value
+            .get("payload")
+            .and_then(|payload| payload.get("text"))
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_owned();
+        return (!text.is_empty()).then_some(FinalAnswerTextUpdate::Append(text));
+    }
+    if event_type == Some("assistant.message") {
+        let text = value
+            .get("payload")
+            .and_then(|payload| payload.get("text"))
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_owned();
+        return (!text.is_empty()).then_some(FinalAnswerTextUpdate::Replace(text));
+    }
     if matches!(method, Some("item/agentMessage/delta"))
         || matches!(event_type, Some("item.agentMessage.delta"))
     {
@@ -5939,6 +5966,7 @@ fn terminal_payload_text(value: &Value) -> String {
                 "delta",
                 "content",
                 "params",
+                "payload",
             ] {
                 if let Some(text) = object.get(key).map(terminal_payload_text)
                     && !text.trim().is_empty()
@@ -6448,6 +6476,14 @@ fn is_transient_steering_startup_error(error: &SessionRuntimeError) -> bool {
 fn harness_thread_id_from_output_line(line: &str) -> Option<String> {
     let value: Value = serde_json::from_str(line).ok()?;
     let event_type = value.get("type").and_then(Value::as_str);
+    if event_type == Some("run.started") {
+        return value
+            .get("request_id")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|request_id| !request_id.is_empty())
+            .map(ToOwned::to_owned);
+    }
     if event_type != Some("thread.started") {
         return None;
     }
@@ -6960,6 +6996,53 @@ mod tests {
             Some(TerminalOutput::Completed {
                 reason: "turn_completed",
                 result_text: Some("Final answer".to_owned())
+            })
+        );
+    }
+
+    #[test]
+    fn nanocodex_native_events_supply_answer_and_terminal_output() {
+        let delta = json!({
+            "protocol_version": 1,
+            "request_id": "nano-1",
+            "seq": 2,
+            "type": "assistant.delta",
+            "payload": {"text": "Final answer"},
+        });
+        let terminal = json!({
+            "protocol_version": 1,
+            "request_id": "nano-1",
+            "seq": 3,
+            "type": "run.completed",
+            "payload": {"status": "completed"},
+        });
+
+        let Some(FinalAnswerTextUpdate::Append(answer)) = output_line_final_answer_text(&delta)
+        else {
+            panic!("Nanocodex delta should append final-answer text")
+        };
+        assert_eq!(
+            terminal_output(&terminal, &answer),
+            Some(TerminalOutput::Completed {
+                reason: "run_completed",
+                result_text: Some("Final answer".to_owned())
+            })
+        );
+    }
+
+    #[test]
+    fn nanocodex_run_error_is_terminal_with_native_message() {
+        let event = json!({
+            "protocol_version": 1,
+            "request_id": "nano-1",
+            "seq": 2,
+            "type": "run.error",
+            "payload": {"message": "proxy refused"},
+        });
+        assert_eq!(
+            terminal_output(&event, ""),
+            Some(TerminalOutput::Failed {
+                error: "proxy refused".to_owned()
             })
         );
     }

--- a/services/api-rs/crates/centaur-session-runtime/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-runtime/src/lib.rs
@@ -5733,11 +5733,19 @@ fn terminal_output(value: &Value, prior_final_answer_text: &str) -> Option<Termi
     let method = value.get("method").and_then(Value::as_str);
     let event_type = value.get("type").and_then(Value::as_str);
 
-    if matches!(method, Some("error" | "turn/failed"))
-        || matches!(
-            event_type,
-            Some("error" | "turn.failed" | "run.error" | "run.failed")
+    if event_type == Some("run.failed")
+        && matches!(
+            value.pointer("/payload/status").and_then(Value::as_str),
+            Some("cancelled" | "canceled")
         )
+    {
+        return Some(TerminalOutput::Cancelled {
+            reason: "turn_interrupted",
+        });
+    }
+
+    if matches!(method, Some("error" | "turn/failed"))
+        || matches!(event_type, Some("error" | "turn.failed" | "run.failed"))
     {
         return Some(TerminalOutput::Failed {
             error: terminal_error_text(value),
@@ -7031,7 +7039,7 @@ mod tests {
     }
 
     #[test]
-    fn nanocodex_run_error_is_terminal_with_native_message() {
+    fn nanocodex_run_error_waits_for_run_failed() {
         let event = json!({
             "protocol_version": 1,
             "request_id": "nano-1",
@@ -7039,10 +7047,36 @@ mod tests {
             "type": "run.error",
             "payload": {"message": "proxy refused"},
         });
+        assert_eq!(terminal_output(&event, ""), None);
+
+        let terminal = json!({
+            "protocol_version": 1,
+            "request_id": "nano-1",
+            "seq": 3,
+            "type": "run.failed",
+            "payload": {"status": "failed"},
+        });
         assert_eq!(
-            terminal_output(&event, ""),
+            terminal_output(&terminal, ""),
             Some(TerminalOutput::Failed {
-                error: "proxy refused".to_owned()
+                error: "terminal harness output reported failure".to_owned()
+            })
+        );
+    }
+
+    #[test]
+    fn nanocodex_cancelled_run_uses_the_existing_cancellation_path() {
+        let terminal = json!({
+            "protocol_version": 1,
+            "request_id": "nano-1",
+            "seq": 2,
+            "type": "run.failed",
+            "payload": {"status": "cancelled"},
+        });
+        assert_eq!(
+            terminal_output(&terminal, ""),
+            Some(TerminalOutput::Cancelled {
+                reason: "turn_interrupted"
             })
         );
     }

--- a/services/api-rs/crates/centaur-session-sqlx/migrations/0046_nanocodex_harness.sql
+++ b/services/api-rs/crates/centaur-session-sqlx/migrations/0046_nanocodex_harness.sql
@@ -1,0 +1,6 @@
+alter table sessions
+    drop constraint sessions_harness_type_supported;
+
+alter table sessions
+    add constraint sessions_harness_type_supported
+    check (harness_type in ('codex', 'amp', 'claudecode', 'nanocodex'));

--- a/services/console/app/controllers/console/threads_controller.rb
+++ b/services/console/app/controllers/console/threads_controller.rb
@@ -26,6 +26,8 @@ class Console::ThreadsController < ApplicationController
     tool_use
     toolresult
     tool_result
+    tool.call
+    tool.result
   ].freeze
   COMPLETED_TRACE_METHOD_PATTERNS = %w[
     item/completed
@@ -110,6 +112,8 @@ class Console::ThreadsController < ApplicationController
     ComposerAgent.new(value: "gpt-5.6-sol", label: "GPT-5.6 Sol",
                       harness: "codex", model: "gpt-5.6-sol",
                       efforts: CODEX_EFFORTS + [ %w[max Max] ]),
+    ComposerAgent.new(value: "nanocodex", label: "Nanocodex (GPT-5.6 Sol)",
+                      harness: "nanocodex", model: nil, efforts: []),
     ComposerAgent.new(value: "gpt-5.5", label: "GPT-5.5",
                       harness: "codex", model: "gpt-5.5",
                       efforts: CODEX_EFFORTS),
@@ -1003,6 +1007,16 @@ class Console::ThreadsController < ApplicationController
   end
 
   def compact_trace_items(items)
+    items = items.each_with_object([]) do |item, compacted|
+      previous = compacted.last
+      if item[:trace_kind] == "reasoning_delta" &&
+          previous&.dig(:trace_kind) == "reasoning_delta" && same_trace_group?(previous, item)
+        previous[:text] += item[:text]
+      else
+        compacted << item.dup
+      end
+    end
+
     grouped = []
     command_group = []
 
@@ -1095,13 +1109,18 @@ class Console::ThreadsController < ApplicationController
 
   def reasoning_trace(value)
     text = reasoning_event_text(value)
-    return nil if text.blank?
+    kind = value["type"].to_s == "reasoning.summary.delta" ? "reasoning_delta" : nil
+    return nil if text.nil? || (kind.nil? && text.blank?)
 
-    { label: "Thinking", text: text }
+    { label: "Thinking", text: text, kind: kind }
   end
 
   def reasoning_event_text(value)
     method = (value["method"] || value["type"]).to_s.tr("/", ".")
+    if method == "reasoning.summary.delta"
+      text = value.dig("payload", "text").to_s
+      return text.empty? ? nil : text
+    end
     return nil unless method == "item.completed"
 
     item = value.dig("params", "item") || value["item"]
@@ -1137,7 +1156,24 @@ class Console::ThreadsController < ApplicationController
   end
 
   def tool_trace(value)
-    completed_item_trace(value) || claude_tool_use_trace(value) || claude_tool_result_trace(value)
+    nanocodex_tool_trace(value) || completed_item_trace(value) ||
+      claude_tool_use_trace(value) || claude_tool_result_trace(value)
+  end
+
+  def nanocodex_tool_trace(value)
+    type = value["type"].to_s
+    return nil unless %w[tool.call tool.result].include?(type)
+
+    payload = value["payload"]
+    return nil unless payload.is_a?(Hash)
+
+    item = {
+      "name" => payload["tool"],
+      "status" => type == "tool.call" ? "in_progress" : payload["status"],
+      "arguments" => payload["arguments"],
+      "result" => payload["result"]
+    }
+    generic_tool_item_trace(item)
   end
 
   def completed_item_trace(value)
@@ -1420,6 +1456,7 @@ class Console::ThreadsController < ApplicationController
     when "codex" then "Codex"
     when "claudecode" then "Claude Code"
     when "amp" then "Amp"
+    when "nanocodex" then "Nanocodex"
     else source_label(session.harness_type)
     end
   end

--- a/services/console/app/helpers/application_helper.rb
+++ b/services/console/app/helpers/application_helper.rb
@@ -50,6 +50,7 @@ module ApplicationHelper
     when "codex" then "Codex"
     when "claudecode" then "Claude Code"
     when "amp" then "Amp"
+    when "nanocodex" then "Nanocodex"
     when "" then nil
     else harness_type.to_s.tr("_-", " ").squish.split.map(&:capitalize).join(" ")
     end

--- a/services/console/test/controllers/console/threads_controller_test.rb
+++ b/services/console/test/controllers/console/threads_controller_test.rb
@@ -601,6 +601,8 @@ class Console::ThreadsControllerTest < ActionDispatch::IntegrationTest
     assert_equal "Slack", controller.send(:thread_source_label, session)
     assert_equal "slack", controller.send(:thread_source_icon, session)
     assert_equal "Codex", controller.send(:thread_harness_label, session)
+    session.harness_type = "nanocodex"
+    assert_equal "Nanocodex", controller.send(:thread_harness_label, session)
   end
 
   test "thread model label prefers the latest execution's recorded model override" do
@@ -1340,6 +1342,61 @@ class Console::ThreadsControllerTest < ActionDispatch::IntegrationTest
   end
 
   OutputLineEvent = Struct.new(:payload, :created_at, :execution_id, :event_id, keyword_init: true)
+
+  test "thinking transcript item consumes native nanocodex events" do
+    controller = Console::ThreadsController.new
+    now = Time.zone.now
+    reasoning = OutputLineEvent.new(
+      payload: {
+        protocol_version: 1,
+        request_id: "nano-1",
+        seq: 2,
+        type: "reasoning.summary.delta",
+        payload: { text: "Checking the runtime." }
+      }.to_json,
+      created_at: now
+    )
+    tool = OutputLineEvent.new(
+      payload: {
+        protocol_version: 1,
+        request_id: "nano-1",
+        seq: 3,
+        type: "tool.call",
+        payload: { call_id: "call-1", tool: "shell", arguments: { cmd: "pwd" } }
+      }.to_json,
+      created_at: now
+    )
+
+    assert_equal "Checking the runtime.", controller.send(:thinking_transcript_item, reasoning)[:text]
+    tool_item = controller.send(:thinking_transcript_item, tool)
+    assert_equal "Tool call", tool_item[:label]
+    assert_includes tool_item[:text], "shell"
+    assert_includes tool_item[:text], '"cmd": "pwd"'
+  end
+
+  test "compact trace grouping joins native nanocodex reasoning deltas" do
+    controller = Console::ThreadsController.new
+    now = Time.zone.now
+    items = [ "Checking ", "the ", "runtime." ].map.with_index do |text, index|
+      event = OutputLineEvent.new(
+        payload: {
+          protocol_version: 1,
+          request_id: "nano-1",
+          seq: index + 1,
+          type: "reasoning.summary.delta",
+          payload: { text: text }
+        }.to_json,
+        execution_id: "exe-1",
+        event_id: index + 1,
+        created_at: now
+      )
+      controller.send(:thinking_transcript_item, event)
+    end
+
+    grouped = controller.send(:compact_trace_items, items)
+    assert_equal 1, grouped.length
+    assert_equal "Checking the runtime.", grouped.first[:text]
+  end
 
   test "thinking transcript item is extracted from a completed reasoning output line" do
     controller = Console::ThreadsController.new

--- a/services/discordbot/src/index.ts
+++ b/services/discordbot/src/index.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 import {
-  codexAppServerToChatSdkStream,
+  harnessToChatSdkStream,
   type ChatSDKStreamChunk,
   type CodexAppServerToChatStreamOptions,
   type RendererEvent,
@@ -1244,7 +1244,7 @@ async function renderSplitExecutionStreams(
   let answerPost: Promise<unknown> | null = null;
   let sourceFailed = false;
   try {
-    for await (const chunk of codexAppServerToChatSdkStream(
+    for await (const chunk of harnessToChatSdkStream(
       stream,
       rendererOptions(options, narrator),
     )) {
@@ -1428,7 +1428,7 @@ async function renderPlainTextExecutionStream(
   let sawError = false;
   try {
     const chatStream = fallback.collectChatSdk(
-      codexAppServerToChatSdkStream(
+      harnessToChatSdkStream(
         fallback.collectSource(stream),
         rendererOptions(options),
       ),

--- a/services/githubbot/src/overrides.ts
+++ b/services/githubbot/src/overrides.ts
@@ -25,6 +25,7 @@ const HARNESS_FLAGS: Record<string, string> = {
   "claude-code": "claudecode",
   claudecode: "claudecode",
   codex: "codex",
+  nanocodex: "nanocodex",
 };
 
 // Claude model aliases, usable both as bare flags (--opus) and as --model

--- a/services/githubbot/src/turn.ts
+++ b/services/githubbot/src/turn.ts
@@ -1,5 +1,5 @@
 import {
-  codexAppServerToChatSdkStream,
+  harnessToChatSdkStream,
   type CodexAppServerToChatStreamOptions,
   type RendererEvent,
 } from "@centaur/rendering";
@@ -204,7 +204,7 @@ async function runTurnStreamInner(
       );
       const collector = new CommentReplyCollector();
       const fallback = new GithubRenderFallback();
-      for await (const chunk of codexAppServerToChatSdkStream(
+      for await (const chunk of harnessToChatSdkStream(
         fallback.collectSource(streamSessionAfterHandoff(options, forwardInput)),
         rendererOptions(options),
       )) {

--- a/services/githubbot/test/overrides.test.ts
+++ b/services/githubbot/test/overrides.test.ts
@@ -28,6 +28,9 @@ describe("extractMessageOverrides", () => {
     expect(extractMessageOverrides("--codex review this").harnessType).toBe(
       "codex",
     );
+    expect(extractMessageOverrides("--nanocodex review this").harnessType).toBe(
+      "nanocodex",
+    );
   });
 
   test("parses harness flag anywhere in the message", () => {

--- a/services/linearbot/src/index.ts
+++ b/services/linearbot/src/index.ts
@@ -1,6 +1,6 @@
 import { AsyncLocalStorage } from "node:async_hooks";
 import {
-  codexAppServerToChatSdkStream,
+  harnessToChatSdkStream,
   type CodexAppServerToChatStreamOptions,
   type RendererEvent,
 } from "@centaur/rendering";
@@ -917,7 +917,7 @@ async function runThreadTurn(input: {
       );
       const collector = new CommentReplyCollector();
       const fallback = new LinearRenderFallback();
-      for await (const chunk of codexAppServerToChatSdkStream(
+      for await (const chunk of harnessToChatSdkStream(
         fallback.collectSource(
           streamSessionAfterHandoff(options, forwardInput),
         ),

--- a/services/linearbot/src/overrides.ts
+++ b/services/linearbot/src/overrides.ts
@@ -27,6 +27,7 @@ const HARNESS_FLAGS: Record<string, string> = {
   "claude-code": "claudecode",
   claudecode: "claudecode",
   codex: "codex",
+  nanocodex: "nanocodex",
 };
 
 const PROVIDER_FLAGS: Record<string, { provider: string; harnessType: string }> = {

--- a/services/linearbot/test/overrides.test.ts
+++ b/services/linearbot/test/overrides.test.ts
@@ -28,6 +28,9 @@ describe("extractMessageOverrides", () => {
     expect(extractMessageOverrides("--codex review this").harnessType).toBe(
       "codex",
     );
+    expect(extractMessageOverrides("--nanocodex review this").harnessType).toBe(
+      "nanocodex",
+    );
   });
 
   test("parses harness flag anywhere in the message", () => {

--- a/services/slackbotv2/src/index.ts
+++ b/services/slackbotv2/src/index.ts
@@ -18,7 +18,7 @@ import { fetchSlackThreadReplies } from '@chat-adapter/slack/api'
 import { createPostgresState } from '@chat-adapter/state-pg'
 import pg from 'pg'
 import {
-  codexAppServerToChatSdkStream,
+  harnessToChatSdkStream,
   EMPTY_FINAL_ANSWER_TEXT,
   type CodexAppServerToChatStreamOptions,
   type ChatSDKStreamChunk,
@@ -1520,7 +1520,7 @@ async function renderFallbackFinalAnswer(
     const fallback = new SlackRenderFallback()
     const chatStream = fallback.collectChatSdk(
       slackSafeChatSdkStream(
-        codexAppServerToChatSdkStream(
+        harnessToChatSdkStream(
           fallback.collectSource(stream),
           fallbackRendererOptions(options)
         )
@@ -2146,7 +2146,7 @@ async function renderExecutionStream(
       conflateChatSdkStream(
         slackSafeChatSdkStream(
           slackVisibleChatSdkStream(
-            codexAppServerToChatSdkStream(
+            harnessToChatSdkStream(
               stream,
               rendererOptions(thread, options, capture, trace)
             ),
@@ -2201,7 +2201,7 @@ async function renderRecoveredExecutionStream(
       conflateChatSdkStream(
         slackSafeChatSdkStream(
           slackVisibleChatSdkStream(
-            codexAppServerToChatSdkStream(
+            harnessToChatSdkStream(
               stream,
               rendererOptions(thread, options, capture, trace)
             ),
@@ -2252,7 +2252,7 @@ async function renderPlainTextExecutionStream(
   try {
     const chatStream = fallback.collectChatSdk(
       slackSafeChatSdkStream(
-        codexAppServerToChatSdkStream(
+        harnessToChatSdkStream(
           fallback.collectSource(stream),
           rendererOptions(thread, options, undefined, trace)
         )

--- a/services/slackbotv2/src/message-overrides-strategy.ts
+++ b/services/slackbotv2/src/message-overrides-strategy.ts
@@ -13,7 +13,7 @@ const SYSTEM_PROMPT = [
   'Decide whether the Slack message asks to use a specific AI harness, model, provider, or reasoning effort.',
   'Return only canonical override values from the schema.',
   'Use null for every field when the message does not ask to change model selection.',
-  'Allowed harness values: codex, claudecode, amp.',
+  'Allowed harness values: codex, claudecode, amp, nanocodex.',
   'Allowed provider values: responses, amazon-bedrock, openrouter.',
   'Allowed reasoning values: none, minimal, low, medium, high, xhigh, max.',
   'Map fuzzy effort words to the nearest reasoning value by magnitude. Examples: tiny/cheap/fast -> low or minimal; normal/default -> medium; deep/strong/intense -> high or xhigh; maximum/superduper/biggest -> max.',
@@ -49,7 +49,7 @@ const MESSAGE_OVERRIDES_SCHEMA = {
   additionalProperties: false,
   properties: {
     harness: {
-      enum: ['codex', 'claudecode', 'amp', null],
+      enum: ['codex', 'claudecode', 'amp', 'nanocodex', null],
       type: ['string', 'null']
     },
     model: {
@@ -103,6 +103,15 @@ export function createOpenAiMessageOverridesStrategy(
   const fetchFn = options.fetch ?? fetch
 
   return async ({ text }) => {
+    // Explicit flags are a deterministic user command, even when the deployment
+    // enables the LLM strategy for natural-language model requests. Handle them
+    // first so a strict strategy schema or model failure cannot discard the
+    // selection, and so flags never leak into the harness prompt.
+    const { cleanedText, ...explicitOverrides } = extractMessageOverrides(text)
+    if (Object.values(explicitOverrides).some(value => value !== undefined)) {
+      return { cleanedText, overrides: explicitOverrides }
+    }
+
     const controller = new AbortController()
     const timeout = setTimeout(() => controller.abort(), timeoutMs)
     try {

--- a/services/slackbotv2/src/overrides.ts
+++ b/services/slackbotv2/src/overrides.ts
@@ -42,7 +42,8 @@ const HARNESS_FLAGS: Record<string, string> = {
   claude: 'claudecode',
   'claude-code': 'claudecode',
   claudecode: 'claudecode',
-  codex: 'codex'
+  codex: 'codex',
+  nanocodex: 'nanocodex'
 }
 
 // Provider flags select a model provider within the codex harness (and imply
@@ -70,7 +71,7 @@ const MODEL_SHORTCUTS: Record<string, { harnessType: string; model: string }> =
     ])
   )
 
-const STRATEGY_HARNESSES = new Set(['amp', 'claudecode', 'codex'])
+const STRATEGY_HARNESSES = new Set(['amp', 'claudecode', 'codex', 'nanocodex'])
 const STRATEGY_PROVIDERS = new Set(['amazon-bedrock', 'openrouter', 'responses'])
 const STRATEGY_REASONING_EFFORTS = new Set([
   'none',

--- a/services/slackbotv2/src/overrides.ts
+++ b/services/slackbotv2/src/overrides.ts
@@ -1,6 +1,7 @@
 /**
  * Inline message directives, restored from the v1 slackbot:
- *   --claude | --claude-code | --amp | --codex   pick the harness for the thread
+ *   --claude | --claude-code | --amp | --codex | --nanocodex
+ *                                                  pick the harness for the thread
  *   --bedrock                                    codex via the AWS Bedrock provider
  *   --meta                                       codex via Meta AI direct
  *   --model <name> (or --model=<name>)           pick the model within that harness

--- a/services/slackbotv2/src/session-api.ts
+++ b/services/slackbotv2/src/session-api.ts
@@ -168,7 +168,8 @@ type ForwardSessionApiCallbacks = {
   onMessagesAppended?(): Promise<void>
   /**
    * Fires when session creation restarted the thread onto a new harness
-   * (sticky --claude/--amp/--codex state on a thread pinned to another harness).
+   * (sticky --claude/--amp/--codex/--nanocodex state on a thread pinned to
+   * another harness).
    * Runs before append/execute, so the callback may set
    * `input.contextPreamble` to re-feed thread history to the fresh harness.
    */
@@ -758,8 +759,8 @@ async function createSession(
   message?: SlackbotV2ApiMessage
 ): Promise<CreateSessionOutcome> {
   const requested = harnessType ?? options.defaultHarnessType ?? DEFAULT_HARNESS_TYPE
-  // A sticky --claude/--amp/--codex selection restarts a thread pinned to
-  // another harness; the implicit default never forces a switch.
+  // A sticky --claude/--amp/--codex/--nanocodex selection restarts a thread
+  // pinned to another harness; the implicit default never forces a switch.
   const response = await postCreateSession(
     options,
     threadId,

--- a/services/slackbotv2/src/types.ts
+++ b/services/slackbotv2/src/types.ts
@@ -143,8 +143,9 @@ export type SlackbotV2Options = {
    */
   channelDefaults?: ChannelDefaults
   /**
-   * Harness for new threads when no --claude/--amp/--codex flag is given
-   * (HarnessType wire value: codex | amp | claudecode). Defaults to codex.
+   * Harness for new threads when no --claude/--amp/--codex/--nanocodex flag is
+   * given (HarnessType wire value: codex | amp | claudecode | nanocodex).
+   * Defaults to codex.
    */
   defaultHarnessType?: string
   fetch?: SlackbotV2Fetch
@@ -255,7 +256,7 @@ export type ForwardSessionInput = {
   contextPreamble?: string
   executionId?: string
   executeMessage?: SlackbotV2ApiMessage
-  /** Effective harness selected by sticky thread flags (--claude/--amp/--codex). */
+  /** Effective harness selected by sticky thread flags (including --nanocodex). */
   harnessType?: string
   messages: SlackbotV2ApiMessage[]
   /** Effective model selected by sticky thread flags (--model/--opus/...). */

--- a/services/slackbotv2/test/chat-sdk-emulate.test.ts
+++ b/services/slackbotv2/test/chat-sdk-emulate.test.ts
@@ -582,6 +582,76 @@ describe('slackbotv2', () => {
     )
   })
 
+  it('opts one Slack thread into nanocodex without changing the configured default', async () => {
+    const sharedState = createMemoryState()
+    await sharedState.connect()
+    bot = createTestBot({ defaultHarnessType: 'claudecode', state: sharedState })
+
+    const sendMention = async (parentTs: string, text: string, eventId: string) => {
+      const mention = await postUserMessage(`<@${BOT_USER_ID}> ${text}`, parentTs)
+      const waits: Promise<unknown>[] = []
+      const response = await bot.app.request(
+        '/api/webhooks/slack',
+        signedSlackEvent({
+          event_id: eventId,
+          event: {
+            type: 'app_mention',
+            user: USER_ID,
+            channel: CHANNEL_ID,
+            team: TEAM_ID,
+            ts: mention.ts,
+            thread_ts: parentTs,
+            text: `<@${BOT_USER_ID}> ${text}`
+          }
+        }),
+        {},
+        waitUntilContext(waits)
+      )
+      expect(response.status).toBe(200)
+      await Promise.all(waits)
+    }
+
+    const nanocodexParent = await postUserMessage('Nanocodex thread context.')
+    await sendMention(
+      nanocodexParent.ts,
+      '--nanocodex start with the native harness',
+      'Ev-slackbotv2-nanocodex-opt-in'
+    )
+    await sendMention(
+      nanocodexParent.ts,
+      'continue without another flag',
+      'Ev-slackbotv2-nanocodex-sticky'
+    )
+
+    const defaultParent = await postUserMessage('Default harness thread context.')
+    await sendMention(
+      defaultParent.ts,
+      'use the configured default',
+      'Ev-slackbotv2-default-after-nanocodex'
+    )
+
+    expect(codexApi.creates.map(create => create.body.harness_type)).toEqual([
+      'nanocodex',
+      'nanocodex',
+      'claudecode'
+    ])
+    expect(codexApi.creates[0]!.body.on_harness_conflict).toBe('restart')
+    expect(codexApi.creates[2]!.body.on_harness_conflict).toBeUndefined()
+    expect(JSON.stringify(codexApi.executes[0]!.body)).not.toContain('--nanocodex')
+    expect(JSON.stringify(codexApi.executes[0]!.body)).toContain(
+      'start with the native harness'
+    )
+
+    const nanocodexState = await sharedState.get<Record<string, unknown>>(
+      `thread-state:${threadKey(nanocodexParent.ts)}`
+    )
+    const defaultState = await sharedState.get<Record<string, unknown>>(
+      `thread-state:${threadKey(defaultParent.ts)}`
+    )
+    expect(nanocodexState?.harnessType).toBe('nanocodex')
+    expect(defaultState?.harnessType).toBeUndefined()
+  })
+
   it('appends an Open-session-in-Console context block to the first assistant message only', async () => {
     const sharedState = createMemoryState()
     await sharedState.connect()

--- a/services/slackbotv2/test/chat-sdk-emulate.test.ts
+++ b/services/slackbotv2/test/chat-sdk-emulate.test.ts
@@ -24,6 +24,7 @@ import {
 } from '../src/index'
 import { clearRequesterIdentityCacheForTests } from '../src/session-api'
 import { slackbotMetrics } from '../src/metrics'
+import { createOpenAiMessageOverridesStrategy } from '../src/message-overrides-strategy'
 import claudeSettings from '../../../harness/claude/settings.json'
 
 const BOT_TOKEN = 'xoxb-slackbotv2-emulate'
@@ -585,7 +586,34 @@ describe('slackbotv2', () => {
   it('opts one Slack thread into nanocodex without changing the configured default', async () => {
     const sharedState = createMemoryState()
     await sharedState.connect()
-    bot = createTestBot({ defaultHarnessType: 'claudecode', state: sharedState })
+    let strategyRequestCount = 0
+    bot = createTestBot({
+      defaultHarnessType: 'claudecode',
+      messageOverridesStrategy: createOpenAiMessageOverridesStrategy({
+        apiKey: 'test-key',
+        fetch: (async () => {
+          strategyRequestCount += 1
+          return Response.json({
+            output: [
+              {
+                content: [
+                  {
+                    text: JSON.stringify({
+                      harness: null,
+                      model: null,
+                      provider: null,
+                      reasoning: null
+                    })
+                  }
+                ]
+              }
+            ]
+          })
+        }) as unknown as typeof fetch,
+        model: 'gpt-5.4-nano'
+      }),
+      state: sharedState
+    })
 
     const sendMention = async (parentTs: string, text: string, eventId: string) => {
       const mention = await postUserMessage(`<@${BOT_USER_ID}> ${text}`, parentTs)
@@ -637,6 +665,9 @@ describe('slackbotv2', () => {
     ])
     expect(codexApi.creates[0]!.body.on_harness_conflict).toBe('restart')
     expect(codexApi.creates[2]!.body.on_harness_conflict).toBeUndefined()
+    // The explicit flag bypasses the deployed LLM strategy. Only the two
+    // unflagged messages consult it.
+    expect(strategyRequestCount).toBe(2)
     expect(JSON.stringify(codexApi.executes[0]!.body)).not.toContain('--nanocodex')
     expect(JSON.stringify(codexApi.executes[0]!.body)).toContain(
       'start with the native harness'

--- a/services/slackbotv2/test/overrides.test.ts
+++ b/services/slackbotv2/test/overrides.test.ts
@@ -493,6 +493,66 @@ describe('messageOverridesForText strategy invocation', () => {
       )
     ).resolves.toEqual({ overrides: {} })
   })
+
+  test('handles --nanocodex deterministically before the OpenAI strategy', async () => {
+    let requestCount = 0
+    const strategy = createOpenAiMessageOverridesStrategy({
+      apiKey: 'test-key',
+      fetch: (async () => {
+        requestCount += 1
+        throw new Error('the explicit flag must not call the strategy model')
+      }) as unknown as typeof fetch,
+      model: 'gpt-5.4-nano'
+    })
+
+    await expect(strategy({ text: '--nanocodex review this' })).resolves.toEqual({
+      cleanedText: 'review this',
+      overrides: {
+        harnessType: 'nanocodex',
+        model: undefined,
+        provider: undefined,
+        reasoning: undefined
+      }
+    })
+    expect(requestCount).toBe(0)
+  })
+
+  test('allows the OpenAI strategy to select nanocodex from natural language', async () => {
+    let requestBody: Record<string, unknown> | undefined
+    const strategy = createOpenAiMessageOverridesStrategy({
+      apiKey: 'test-key',
+      fetch: (async (_input: RequestInfo | URL, init?: RequestInit) => {
+        requestBody = JSON.parse(String(init?.body)) as Record<string, unknown>
+        return Response.json({
+          output: [
+            {
+              content: [
+                {
+                  text: JSON.stringify({
+                    harness: 'nanocodex',
+                    model: null,
+                    provider: null,
+                    reasoning: null
+                  })
+                }
+              ]
+            }
+          ]
+        })
+      }) as unknown as typeof fetch,
+      model: 'gpt-5.4-nano'
+    })
+
+    await expect(strategy({ text: 'use nanocodex for this' })).resolves.toEqual({
+      overrides: {
+        harnessType: 'nanocodex',
+        model: undefined,
+        provider: undefined,
+        reasoning: undefined
+      }
+    })
+    expect(JSON.stringify(requestBody)).toContain('nanocodex')
+  })
 })
 
 function slackOptions(overrides: Partial<SlackbotV2Options>): SlackbotV2Options {

--- a/services/slackbotv2/test/overrides.test.ts
+++ b/services/slackbotv2/test/overrides.test.ts
@@ -30,6 +30,7 @@ describe('extractMessageOverrides', () => {
     expect(extractMessageOverrides('--claude-code review this').harnessType).toBe('claudecode')
     expect(extractMessageOverrides('--amp review this').harnessType).toBe('amp')
     expect(extractMessageOverrides('--codex review this').harnessType).toBe('codex')
+    expect(extractMessageOverrides('--nanocodex review this').harnessType).toBe('nanocodex')
   })
 
   test('parses harness flag anywhere in the message', () => {

--- a/services/teamsbot/src/teamsbot.ts
+++ b/services/teamsbot/src/teamsbot.ts
@@ -1,4 +1,4 @@
-import { codexAppServerToChatSdkStream, type ChatSDKStreamChunk } from '@centaur/rendering';
+import { harnessToChatSdkStream, type ChatSDKStreamChunk } from '@centaur/rendering';
 import type { TeamsAdapter } from '@chat-adapter/teams';
 import type { Logger, Message as ChatMessage, Thread } from 'chat';
 import type { TeamsbotConfig } from './config.js';
@@ -647,7 +647,7 @@ export class TeamsbotService {
       'open Teams recovery stream',
     );
 
-    const mappedStream = chatSdkChunksToTeamsRenderChunks(codexAppServerToChatSdkStream(stream));
+    const mappedStream = chatSdkChunksToTeamsRenderChunks(harnessToChatSdkStream(stream));
 
     const iterator = conflateTeamsRenderStream(mappedStream)[Symbol.asyncIterator]();
     while (true) {


### PR DESCRIPTION
## Summary

- add harness-server nanocodex backed directly by the Nanocodex Rust library pinned at bd670d7
- preserve native typed Nanocodex events through the Rust session runtime and shared chat rendering package
- expose nanocodex harness selection in the API, Console, Slack, Linear, and GitHub flag parsers
- reuse the existing Codex Iron Proxy credential policy without using Codex App Server or converting Nanocodex events into Codex protocol values

## Validation

- just build and focused just build-one api-rs / agent builds
- harness-server cargo test --locked: 80 passed, 4 ignored
- Rust API fmt, Clippy with warnings denied, and workspace tests
- rendering tests and typecheck; changed bot typechecks and override tests
- Console Brakeman, importmap audit, RuboCop, and full Rails test suite: 1263 passed, 34 skipped
- isolated OrbStack Helm deployment and real Kubernetes turn through Iron Proxy using the real OpenAI API key
- native assistant.message and run.completed both returned exactly CENTAUR NANOCODEX PROXY OK; Centaur emitted the same canonical session.execution_completed result

## Architecture

Nanocodex reads Centaur blocks input directly and writes AgentEvent JSONL directly. The chat integrations select a native Nanocodex mapper in packages/rendering; the Rails Console consumes the same stored native events through its independent renderer. There is no App Server process, JSON-RPC bridge, or Codex event conversion in the Nanocodex path.

## Known boundary

Nanocodex steering is native and works during an active turn. Its public library API does not currently expose cancellation, so an active Centaur interrupt terminates this harness process instead of preserving the session; follow-up cancellation support belongs in Nanocodex itself.