### PR TITLE
fix: clarify slackbot claude model selection

### DIFF
--- a/services/slackbotv2/src/message-overrides-strategy.ts
+++ b/services/slackbotv2/src/message-overrides-strategy.ts
@@ -16,6 +16,8 @@ const SYSTEM_PROMPT = [
   'Allowed harness values: codex, claudecode, amp.',
   'Allowed provider values: responses, amazon-bedrock, openrouter.',
   'Allowed reasoning values: none, minimal, low, medium, high, xhigh, max.',
+  'Treat inline flags such as "--claude", "--claude --model=fable", and "--fable" as model selection requests.',
+  'In this Slackbot, a request to use Claude without another named Claude model means harness claudecode and model claude-opus-4-8. Examples: "--claude what model are you?" and "using claude:" select harness claudecode and model claude-opus-4-8. Explicit Fable requests such as "--claude --model=fable" and "using claude fable:" select harness claudecode and model claude-fable-5.',
   'Map fuzzy effort words to the nearest reasoning value by magnitude. Examples: tiny/cheap/fast -> low or minimal; normal/default -> medium; deep/strong/intense -> high or xhigh; maximum/superduper/biggest -> max.',
   'Return reasoning even when the requested model is not Codex; validation will ignore reasoning that cannot apply.',
   'Map OpenAI model aliases to canonical IDs: sol -> gpt-5.6-sol, terra -> gpt-5.6-terra, luna -> gpt-5.6-luna, 5.5 -> gpt-5.5, 5.5 pro -> gpt-5.5-pro, 5.4 -> gpt-5.4, 5.4 pro -> gpt-5.4-pro, 5.4 mini -> gpt-5.4-mini, 5.4 nano -> gpt-5.4-nano.',

--- a/services/slackbotv2/src/message-overrides-strategy.ts
+++ b/services/slackbotv2/src/message-overrides-strategy.ts
@@ -6,7 +6,7 @@ import {
 import type { JsonObject, MessageOverridesStrategy } from './types'
 import { errorMessage, isJsonObject } from './utils'
 
-const DEFAULT_TIMEOUT_MS = 1_500
+const DEFAULT_TIMEOUT_MS = 2_000
 const DEFAULT_MAX_OUTPUT_TOKENS = 300
 
 const SYSTEM_PROMPT = [

--- a/services/slackbotv2/src/message-overrides-strategy.ts
+++ b/services/slackbotv2/src/message-overrides-strategy.ts
@@ -21,7 +21,7 @@ const SYSTEM_PROMPT = [
   'Map fuzzy effort words to the nearest reasoning value by magnitude. Examples: tiny/cheap/fast -> low or minimal; normal/default -> medium; deep/strong/intense -> high or xhigh; maximum/superduper/biggest -> max.',
   'Return reasoning even when the requested model is not Codex; validation will ignore reasoning that cannot apply.',
   'Map OpenAI model aliases to canonical IDs: sol -> gpt-5.6-sol, terra -> gpt-5.6-terra, luna -> gpt-5.6-luna, 5.5 -> gpt-5.5, 5.5 pro -> gpt-5.5-pro, 5.4 -> gpt-5.4, 5.4 pro -> gpt-5.4-pro, 5.4 mini -> gpt-5.4-mini, 5.4 nano -> gpt-5.4-nano.',
-  'Map Claude model aliases to canonical IDs: fable -> claude-fable-5, opus -> claude-opus-4-8, sonnet -> claude-sonnet-4-6, sonnet 5 -> claude-sonnet-5, haiku -> claude-haiku-4-5.',
+  'Map Claude model aliases to canonical IDs: fable -> claude-fable-5, opus -> claude-opus-4-8, opus 4.7 -> claude-opus-4-7, sonnet -> claude-sonnet-4-6, sonnet 5 -> claude-sonnet-5, haiku -> claude-haiku-4-5.',
   'Map Amp model aliases to canonical IDs: deep -> deep, fast -> fast.',
   'For example, "use max effort and the sol model" should return model "gpt-5.6-sol" and reasoning "max".',
   'Do not treat ordinary discussion of model names as a selection request.'
@@ -30,6 +30,7 @@ const SYSTEM_PROMPT = [
 const MODEL_VALUES = [
   'claude-fable-5',
   'claude-haiku-4-5',
+  'claude-opus-4-7',
   'claude-opus-4-8',
   'claude-sonnet-4-6',
   'claude-sonnet-5',

--- a/services/slackbotv2/src/overrides.ts
+++ b/services/slackbotv2/src/overrides.ts
@@ -85,6 +85,7 @@ const STRATEGY_REASONING_EFFORTS = new Set([
 const STRATEGY_MODEL_HARNESSES: Record<string, string> = {
   'claude-fable-5': 'claudecode',
   'claude-haiku-4-5': 'claudecode',
+  'claude-opus-4-7': 'claudecode',
   'claude-opus-4-8': 'claudecode',
   'claude-sonnet-4-6': 'claudecode',
   'claude-sonnet-5': 'claudecode',

--- a/services/slackbotv2/test/overrides.test.ts
+++ b/services/slackbotv2/test/overrides.test.ts
@@ -347,6 +347,12 @@ describe('validateStrategyOverrides', () => {
   })
 
   test('canonical strategy model ids imply their compatible harness', () => {
+    expect(validateStrategyOverrides({ model: 'claude-opus-4-7' })).toEqual({
+      harnessType: 'claudecode',
+      model: 'claude-opus-4-7',
+      provider: undefined,
+      reasoning: undefined
+    })
     expect(
       validateStrategyOverrides({
         model: 'claude-opus-4-8'


### PR DESCRIPTION
Updates the Slackbot LLM model-selection prompt so Claude-style inline flags and natural-language Claude requests resolve to the Claude Code harness, with bare Claude defaulting to claude-opus-4-8, explicit Fable requests selecting claude-fable-5, and Opus 4.7 requests mapping to claude-opus-4-7.