### PR TITLE
fix(console): show current theme in selector

### DIFF
--- a/services/console/app/views/layouts/console.html.erb
+++ b/services/console/app/views/layouts/console.html.erb
@@ -1958,11 +1958,11 @@
                       class="console-account-menu-button"
                       data-console-theme-toggle
                       role="menuitem"
-                      aria-label="Switch to light mode">
-                <span data-console-theme-action-icon="light"><%= console_icon("sun", classes: "size-4") %></span>
-                <span data-console-theme-action-icon="dark" hidden><%= console_icon("moon", classes: "size-4") %></span>
-                <span data-console-theme-action-icon="system" hidden><%= console_icon("computer", classes: "size-4") %></span>
-                <span data-console-theme-label>Light mode</span>
+                      aria-label="Current theme: system. Switch to light mode">
+                <span data-console-theme-icon="light" hidden><%= console_icon("sun", classes: "size-4") %></span>
+                <span data-console-theme-icon="dark" hidden><%= console_icon("moon", classes: "size-4") %></span>
+                <span data-console-theme-icon="system"><%= console_icon("computer", classes: "size-4") %></span>
+                <span data-console-theme-label>System mode</span>
               </button>
               <% if acting_admin? %>
                 <%= button_to console_descope_path,
@@ -2114,10 +2114,15 @@
 
         const root = document.documentElement;
         const label = themeToggle.querySelector("[data-console-theme-label]");
-        const lightIcon = themeToggle.querySelector("[data-console-theme-action-icon='light']");
-        const darkIcon = themeToggle.querySelector("[data-console-theme-action-icon='dark']");
-        const systemIcon = themeToggle.querySelector("[data-console-theme-action-icon='system']");
+        const lightIcon = themeToggle.querySelector("[data-console-theme-icon='light']");
+        const darkIcon = themeToggle.querySelector("[data-console-theme-icon='dark']");
+        const systemIcon = themeToggle.querySelector("[data-console-theme-icon='system']");
         const themePreferences = ["system", "light", "dark"];
+        const themeLabels = {
+          system: "System mode",
+          light: "Light mode",
+          dark: "Dark mode"
+        };
 
         const nextThemePreference = (preference) => {
           const currentIndex = themePreferences.indexOf(preference);
@@ -2126,16 +2131,15 @@
 
         const syncThemeControl = (preference) => {
           const nextPreference = nextThemePreference(preference);
-          const nextLabel = `${nextPreference[0].toUpperCase()}${nextPreference.slice(1)} mode`;
-          if (label) label.textContent = nextLabel;
+          if (label) label.textContent = themeLabels[preference];
           themeToggle.setAttribute(
             "aria-label",
-            `Switch to ${nextPreference} mode`
+            `Current theme: ${preference}. Switch to ${nextPreference} mode`
           );
           themeToggle.dataset.consoleThemePreference = preference;
-          if (lightIcon) lightIcon.hidden = nextPreference !== "light";
-          if (darkIcon) darkIcon.hidden = nextPreference !== "dark";
-          if (systemIcon) systemIcon.hidden = nextPreference !== "system";
+          if (lightIcon) lightIcon.hidden = preference !== "light";
+          if (darkIcon) darkIcon.hidden = preference !== "dark";
+          if (systemIcon) systemIcon.hidden = preference !== "system";
         };
 
         const applyTheme = (preference, persist = false) => {

--- a/services/console/test/controllers/console/users_controller_test.rb
+++ b/services/console/test/controllers/console/users_controller_test.rb
@@ -30,8 +30,10 @@ module Console
       assert_select ".console-nav-link", text: "Users", count: 0
       assert_select ".console-control-tab", text: "Apps"
       assert_select ".console-control-tab-active", text: "Users"
-      assert_select "button[data-console-theme-toggle]", text: "Light mode"
-      assert_select "[data-console-theme-action-icon='system']", count: 1
+      assert_select "button[data-console-theme-toggle]", text: "System mode"
+      assert_select "[data-console-theme-icon='system']:not([hidden])", count: 1
+      assert_select "[data-console-theme-icon='light'][hidden]", count: 1
+      assert_select "[data-console-theme-icon='dark'][hidden]", count: 1
       assert_select "link[data-console-favicon][href=?]", "/icon-dark.svg"
       assert_includes response.body, "/icon-light.svg"
       assert_includes response.body, "prefers-color-scheme: light"


### PR DESCRIPTION
## Summary
- show the active theme preference in the account menu instead of the next theme action
- pair System, Light, and Dark with their own current-state icons
- retain the existing click cycle and describe its next action only in the accessibility label

## Root cause
The three-mode selector inherited the old two-state toggle behavior from #1131. Its visible label and icon represented the next click target, making a light page appear to be set to Dark and a dark page appear to be set to System.

## Testing
- `bin/rails test test/controllers/console/users_controller_test.rb`
- `bin/rubocop test/controllers/console/users_controller_test.rb`
- JavaScript syntax checks
- JavaScript theme-cycle simulation covering labels, icons, effective theme, accessibility text, and system preference changes
- `git diff --check`