### PR TITLE
fix(slackbotv2): preserve pinned thread harness

### DIFF
--- a/services/slackbotv2/src/index.ts
+++ b/services/slackbotv2/src/index.ts
@@ -52,7 +52,7 @@ import {
   type SlackContextBlock
 } from './console-session-link'
 import { resolveChannelDefault } from './channel-defaults'
-import { type HarnessOverrides } from './overrides'
+import { extractMessageOverrides, type HarnessOverrides } from './overrides'
 import { createFlagMessageOverridesStrategy } from './message-overrides-strategy'
 import {
   isAllowedSlackMessage,
@@ -192,6 +192,10 @@ function stickyThreadOverrideUpdate(
     if (!overrides.model) update.model = null
   }
   return Object.keys(update).length > 0 ? update : undefined
+}
+
+function hasStickyThreadOverride(overrides: StickyThreadOverrides): boolean {
+  return Boolean(overrides.harnessType || overrides.model || overrides.provider)
 }
 
 function resolveStickyThreadOverrides(
@@ -900,6 +904,9 @@ async function syncThreadMessageToSession(
 
   const serializeStartedAtMs = nowMs()
   const serializedMessage = await serializeMessage(message, input.options)
+  // Inspect the original text before the strategy strips recognized flags.
+  // This is the authority for whether a sticky thread selection may change.
+  const explicitOverrides = extractMessageOverrides(serializedMessage.text)
   const messageOverrides =
     input.resolvedMessageOverrides ??
     (input.resolvedMessageOverrides = await messageOverridesForText(
@@ -911,7 +918,23 @@ async function syncThreadMessageToSession(
     setMessageText(serializedMessage, messageOverrides.cleanedText)
   }
   const overrides = messageOverrides.overrides
-  const stickyOverridesUpdate = stickyThreadOverrideUpdate(overrides)
+  const requestedStickyOverrides = stickyThreadOverrideUpdate(overrides)
+  // Once a thread is pinned, only another explicit flag may move it. The LLM
+  // strategy can still infer per-turn reasoning, but a false-positive harness,
+  // model, or provider selection must not replace --claude/--amp/--codex/
+  // --nanocodex state.
+  const preserveStickyOverrides = Boolean(
+    requestedStickyOverrides &&
+      hasStickyThreadOverride(state) &&
+      !hasStickyThreadOverride(explicitOverrides)
+  )
+  const stickyOverridesUpdate = preserveStickyOverrides ? undefined : requestedStickyOverrides
+  if (preserveStickyOverrides) {
+    traceLog(input.options, 'slackbotv2_forward_sticky_overrides_preserved', trace, {
+      pinned_harness_type: state.harnessType,
+      requested_harness_type: requestedStickyOverrides?.harnessType
+    })
+  }
   const effectiveOverrides = resolveStickyThreadOverrides(state, stickyOverridesUpdate)
   // Slack-only "Open chat in Console" link on the FIRST assistant message in
   // a thread (the reply to the first message that starts an execution). The

--- a/services/slackbotv2/test/chat-sdk-emulate.test.ts
+++ b/services/slackbotv2/test/chat-sdk-emulate.test.ts
@@ -583,7 +583,7 @@ describe('slackbotv2', () => {
     )
   })
 
-  it('opts one Slack thread into nanocodex without changing the configured default', async () => {
+  it('keeps a top-level harness flag pinned when the LLM strategy guesses another harness', async () => {
     const sharedState = createMemoryState()
     await sharedState.connect()
     let strategyRequestCount = 0
@@ -599,10 +599,12 @@ describe('slackbotv2', () => {
                 content: [
                   {
                     text: JSON.stringify({
-                      harness: null,
-                      model: null,
-                      provider: null,
-                      reasoning: null
+                      // Model the production false positive: an ordinary
+                      // follow-up is classified as a different harness.
+                      harness: strategyRequestCount === 1 ? 'codex' : null,
+                      model: strategyRequestCount === 1 ? 'gpt-5.6-sol' : null,
+                      provider: strategyRequestCount === 1 ? 'responses' : null,
+                      reasoning: strategyRequestCount === 1 ? 'high' : null
                     })
                   }
                 ]
@@ -615,8 +617,8 @@ describe('slackbotv2', () => {
       state: sharedState
     })
 
-    const sendMention = async (parentTs: string, text: string, eventId: string) => {
-      const mention = await postUserMessage(`<@${BOT_USER_ID}> ${text}`, parentTs)
+    const sendMention = async (threadTs: string | undefined, text: string, eventId: string) => {
+      const mention = await postUserMessage(`<@${BOT_USER_ID}> ${text}`, threadTs)
       const waits: Promise<unknown>[] = []
       const response = await bot.app.request(
         '/api/webhooks/slack',
@@ -628,7 +630,7 @@ describe('slackbotv2', () => {
             channel: CHANNEL_ID,
             team: TEAM_ID,
             ts: mention.ts,
-            thread_ts: parentTs,
+            thread_ts: threadTs,
             text: `<@${BOT_USER_ID}> ${text}`
           }
         }),
@@ -637,23 +639,22 @@ describe('slackbotv2', () => {
       )
       expect(response.status).toBe(200)
       await Promise.all(waits)
+      return mention
     }
 
-    const nanocodexParent = await postUserMessage('Nanocodex thread context.')
-    await sendMention(
-      nanocodexParent.ts,
+    const nanocodexRoot = await sendMention(
+      undefined,
       '--nanocodex start with the native harness',
       'Ev-slackbotv2-nanocodex-opt-in'
     )
     await sendMention(
-      nanocodexParent.ts,
+      nanocodexRoot.ts,
       'continue without another flag',
       'Ev-slackbotv2-nanocodex-sticky'
     )
 
-    const defaultParent = await postUserMessage('Default harness thread context.')
-    await sendMention(
-      defaultParent.ts,
+    const defaultRoot = await sendMention(
+      undefined,
       'use the configured default',
       'Ev-slackbotv2-default-after-nanocodex'
     )
@@ -672,12 +673,20 @@ describe('slackbotv2', () => {
     expect(JSON.stringify(codexApi.executes[0]!.body)).toContain(
       'start with the native harness'
     )
+    const followUpInput = JSON.parse(
+      codexApi.executes[1]!.body.input_lines.at(-1)!
+    ) as Record<string, unknown>
+    expect(followUpInput.model).toBeUndefined()
+    expect(followUpInput.provider).toBeUndefined()
+    // Reasoning remains a per-turn setting; only the sticky harness/model/
+    // provider selection is protected by the root flag.
+    expect(followUpInput.reasoning).toBe('high')
 
     const nanocodexState = await sharedState.get<Record<string, unknown>>(
-      `thread-state:${threadKey(nanocodexParent.ts)}`
+      `thread-state:${threadKey(nanocodexRoot.ts)}`
     )
     const defaultState = await sharedState.get<Record<string, unknown>>(
-      `thread-state:${threadKey(defaultParent.ts)}`
+      `thread-state:${threadKey(defaultRoot.ts)}`
     )
     expect(nanocodexState?.harnessType).toBe('nanocodex')
     expect(defaultState?.harnessType).toBeUndefined()


### PR DESCRIPTION
## What changed

- preserve a Slack thread's sticky harness, model, and provider when the LLM override strategy infers a different selection on an unflagged follow-up
- allow only deterministic inline flags to replace an existing thread pin
- add an end-to-end regression for a root `--nanocodex` flag followed by the production-shaped false Codex inference
- emit a structured log when an inferred override is ignored

## Why

The optional LLM override strategy treated inferred selections exactly like explicit flags. In production, “show me code mode” was classified as Codex and silently restarted a thread originally pinned with `--nanocodex`.

This restores the intended precedence: explicit thread flag > persisted thread selection > inferred override > deployment default. The behavior is shared by `--claude`, `--amp`, `--codex`, and `--nanocodex`.

## Validation

- Slackbot test suite on the pinned Bun 1.3.13: 209 passed, 1 skipped
- Slackbot TypeScript type-check
- `just build-one slackbotv2`
