### PR TITLE
Make Nanocodex commentary and subagents explicit

### DIFF
--- a/crates/harness-server/Cargo.lock
+++ b/crates/harness-server/Cargo.lock
@@ -2716,7 +2716,7 @@ dependencies = [
 [[package]]
 name = "nanocodex"
 version = "0.1.0"
-source = "git+https://github.com/gakonst/nanocodex?rev=d2df7bfe25d05efc235f464aae38117708befe0e#d2df7bfe25d05efc235f464aae38117708befe0e"
+source = "git+https://github.com/gakonst/nanocodex?rev=936584e0dbcb956110cf4314192bf28ce8b4b9f7#936584e0dbcb956110cf4314192bf28ce8b4b9f7"
 dependencies = [
  "async-trait",
  "base64",
@@ -2745,7 +2745,7 @@ dependencies = [
 [[package]]
 name = "nanocodex-core"
 version = "0.1.0"
-source = "git+https://github.com/gakonst/nanocodex?rev=d2df7bfe25d05efc235f464aae38117708befe0e#d2df7bfe25d05efc235f464aae38117708befe0e"
+source = "git+https://github.com/gakonst/nanocodex?rev=936584e0dbcb956110cf4314192bf28ce8b4b9f7#936584e0dbcb956110cf4314192bf28ce8b4b9f7"
 dependencies = [
  "serde",
  "serde_json",
@@ -2757,7 +2757,7 @@ dependencies = [
 [[package]]
 name = "nanocodex-macros"
 version = "0.1.0"
-source = "git+https://github.com/gakonst/nanocodex?rev=d2df7bfe25d05efc235f464aae38117708befe0e#d2df7bfe25d05efc235f464aae38117708befe0e"
+source = "git+https://github.com/gakonst/nanocodex?rev=936584e0dbcb956110cf4314192bf28ce8b4b9f7#936584e0dbcb956110cf4314192bf28ce8b4b9f7"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -2768,7 +2768,7 @@ dependencies = [
 [[package]]
 name = "nanocodex-mcp"
 version = "0.1.0"
-source = "git+https://github.com/gakonst/nanocodex?rev=d2df7bfe25d05efc235f464aae38117708befe0e#d2df7bfe25d05efc235f464aae38117708befe0e"
+source = "git+https://github.com/gakonst/nanocodex?rev=936584e0dbcb956110cf4314192bf28ce8b4b9f7#936584e0dbcb956110cf4314192bf28ce8b4b9f7"
 dependencies = [
  "async-trait",
  "bm25",
@@ -2787,7 +2787,7 @@ dependencies = [
 [[package]]
 name = "nanocodex-service"
 version = "0.1.0"
-source = "git+https://github.com/gakonst/nanocodex?rev=d2df7bfe25d05efc235f464aae38117708befe0e#d2df7bfe25d05efc235f464aae38117708befe0e"
+source = "git+https://github.com/gakonst/nanocodex?rev=936584e0dbcb956110cf4314192bf28ce8b4b9f7#936584e0dbcb956110cf4314192bf28ce8b4b9f7"
 dependencies = [
  "base64",
  "futures-util",
@@ -2811,7 +2811,7 @@ dependencies = [
 [[package]]
 name = "nanocodex-tools"
 version = "0.1.0"
-source = "git+https://github.com/gakonst/nanocodex?rev=d2df7bfe25d05efc235f464aae38117708befe0e#d2df7bfe25d05efc235f464aae38117708befe0e"
+source = "git+https://github.com/gakonst/nanocodex?rev=936584e0dbcb956110cf4314192bf28ce8b4b9f7#936584e0dbcb956110cf4314192bf28ce8b4b9f7"
 dependencies = [
  "async-trait",
  "base64",

--- a/crates/harness-server/Cargo.toml
+++ b/crates/harness-server/Cargo.toml
@@ -23,7 +23,7 @@ codex-utils-absolute-path = { git = "https://github.com/openai/codex", rev = "e9
 # provider's per-image caps (Bedrock/mantle rejects images past ~5 MB / 8000 px).
 # Scoped to the formats chat clients actually paste to keep the build lean.
 image = { version = "0.25", default-features = false, features = ["png", "jpeg", "webp"] }
-nanocodex = { git = "https://github.com/gakonst/nanocodex", rev = "d2df7bfe25d05efc235f464aae38117708befe0e" }
+nanocodex = { git = "https://github.com/gakonst/nanocodex", rev = "936584e0dbcb956110cf4314192bf28ce8b4b9f7" }
 opentelemetry-proto = { version = "0.32.0", default-features = false, features = ["trace", "gen-tonic-messages"] }
 prost = "0.14"
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/harness-server/src/nanocodex.rs
+++ b/crates/harness-server/src/nanocodex.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 
 use base64::Engine;
 use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
-use nanocodex::{AgentEvent, AgentEvents, Nanocodex, Prompt, Tools, Turn, UserInput};
+use nanocodex::{AgentEvent, AgentEvents, Nanocodex, Prompt, Thinking, Tools, Turn, UserInput};
 use serde::Deserialize;
 use serde_json::Value;
 use tokio::sync::mpsc;
@@ -34,14 +34,6 @@ async fn run() -> Result<()> {
     let cwd = env::current_dir()?;
     let session_id = format!("nanocodex-{}", Uuid::new_v4().simple());
     let child_agents = Arc::new(ChildAgents::default());
-    let tools_agents = Arc::downgrade(&child_agents);
-    let tools = Tools::default();
-    let (agent, mut events) = Nanocodex::builder(api_key)
-        .workspace(&cwd)
-        .session_id(session_id)
-        .tools_factory(move |agent| with_subagents(tools.clone(), agent, tools_agents.clone()))
-        .build()
-        .map_err(nanocodex_error)?;
 
     let (sender, mut receiver) = mpsc::unbounded_channel();
     std::thread::spawn(move || {
@@ -55,15 +47,41 @@ async fn run() -> Result<()> {
 
     let mut stdout = io::stdout().lock();
     let mut staged = HashMap::new();
+    let mut agent = None;
+    let mut events = None;
+    let mut subagents_enabled = false;
     while let Some(line) = receiver.recv().await {
         let line = line?;
         if line.trim().is_empty() {
             continue;
         }
         match parse_blocks_line(&line, &mut staged)? {
-            BlocksCommand::User(prompt) => {
+            BlocksCommand::User { prompt, subagents } => {
+                if agent.is_none() {
+                    let (new_agent, new_events) =
+                        build_agent(&api_key, &cwd, &session_id, &child_agents, subagents)?;
+                    agent = Some(new_agent);
+                    events = Some(new_events);
+                    subagents_enabled = subagents;
+                } else if subagents && !subagents_enabled {
+                    eprintln!("nanocodex --subagents only applies to the first session message");
+                }
+                let agent = agent.as_ref().ok_or_else(|| {
+                    HarnessServerError::Nanocodex("agent was not initialized".to_owned())
+                })?;
                 let turn = agent.prompt(prompt).await.map_err(nanocodex_error)?;
-                run_turn(&mut events, turn, &mut receiver, &mut staged, &mut stdout).await?;
+                let events = events.as_mut().ok_or_else(|| {
+                    HarnessServerError::Nanocodex("event stream was not initialized".to_owned())
+                })?;
+                run_turn(
+                    events,
+                    turn,
+                    &mut receiver,
+                    &mut staged,
+                    &mut stdout,
+                    subagents_enabled,
+                )
+                .await?;
             }
             BlocksCommand::AttachmentChunk => {}
             BlocksCommand::Interrupt => {
@@ -75,12 +93,36 @@ async fn run() -> Result<()> {
     Ok(())
 }
 
+fn build_agent(
+    api_key: &str,
+    cwd: &std::path::Path,
+    session_id: &str,
+    child_agents: &Arc<ChildAgents>,
+    subagents: bool,
+) -> Result<(Nanocodex, AgentEvents)> {
+    let builder = Nanocodex::builder(api_key)
+        .thinking(Thinking::Low)
+        .workspace(cwd)
+        .session_id(session_id);
+    let result = if subagents {
+        let tools_agents = Arc::downgrade(child_agents);
+        let tools = Tools::default();
+        builder
+            .tools_factory(move |agent| with_subagents(tools.clone(), agent, tools_agents.clone()))
+            .build()
+    } else {
+        builder.build()
+    };
+    result.map_err(nanocodex_error)
+}
+
 async fn run_turn(
     events: &mut AgentEvents,
     turn: Turn,
     receiver: &mut mpsc::UnboundedReceiver<io::Result<String>>,
     staged: &mut HashMap<String, PathBuf>,
     stdout: &mut impl Write,
+    subagents_enabled: bool,
 ) -> Result<()> {
     let mut input_open = true;
     loop {
@@ -105,7 +147,10 @@ async fn run_turn(
                     continue;
                 }
                 match parse_blocks_line(&line, staged)? {
-                    BlocksCommand::User(prompt) => {
+                    BlocksCommand::User { prompt, subagents } => {
+                        if subagents && !subagents_enabled {
+                            eprintln!("nanocodex --subagents only applies to the first session message");
+                        }
                         turn.steer(prompt).await.map_err(nanocodex_error)?;
                     }
                     BlocksCommand::AttachmentChunk => {}
@@ -136,7 +181,7 @@ fn nanocodex_error(error: nanocodex::NanocodexError) -> HarnessServerError {
 }
 
 enum BlocksCommand {
-    User(Prompt),
+    User { prompt: Prompt, subagents: bool },
     AttachmentChunk,
     Interrupt,
 }
@@ -195,7 +240,11 @@ fn parse_blocks_line(line: &str, staged: &mut HashMap<String, PathBuf>) -> Resul
                     text: "continue".to_owned(),
                 });
             }
-            Ok(BlocksCommand::User(Prompt::content(inputs)))
+            let subagents = take_subagents_flag(&mut inputs);
+            Ok(BlocksCommand::User {
+                prompt: Prompt::content(inputs),
+                subagents,
+            })
         }
         "attachment.chunk" => {
             let id = required_string(parsed.attachment_id, "attachmentId")?;
@@ -230,6 +279,44 @@ fn parse_blocks_line(line: &str, staged: &mut HashMap<String, PathBuf>) -> Resul
             message: format!("unsupported blocks input type `{kind}`"),
         }),
     }
+}
+
+fn take_subagents_flag(inputs: &mut [UserInput]) -> bool {
+    let mut enabled = false;
+    for input in inputs {
+        let UserInput::Text { text } = input else {
+            continue;
+        };
+        enabled |= strip_standalone_flag(text, "--subagents");
+    }
+    enabled
+}
+
+fn strip_standalone_flag(text: &mut String, flag: &str) -> bool {
+    let mut found = false;
+    let mut search_from = 0;
+    while let Some(relative_start) = text[search_from..].find(flag) {
+        let start = search_from + relative_start;
+        let end = start + flag.len();
+        let starts_token = start == 0
+            || text[..start]
+                .chars()
+                .next_back()
+                .is_some_and(char::is_whitespace);
+        let ends_token =
+            end == text.len() || text[end..].chars().next().is_some_and(char::is_whitespace);
+        if starts_token && ends_token {
+            text.replace_range(start..end, "");
+            found = true;
+            search_from = start;
+        } else {
+            search_from = end;
+        }
+    }
+    if found {
+        *text = text.trim().to_owned();
+    }
+    found
 }
 
 fn parse_content(value: &Value, staged: &HashMap<String, PathBuf>) -> Result<Vec<UserInput>> {
@@ -380,9 +467,10 @@ mod tests {
             &mut HashMap::new(),
         )
         .unwrap();
-        let BlocksCommand::User(prompt) = command else {
+        let BlocksCommand::User { prompt, subagents } = command else {
             panic!("expected user prompt");
         };
+        assert!(!subagents);
         assert_eq!(
             serde_json::to_value(prompt).unwrap()["instruction"][0]["text"],
             "hello"
@@ -396,9 +484,10 @@ mod tests {
             &mut HashMap::new(),
         )
         .unwrap();
-        let BlocksCommand::User(prompt) = command else {
+        let BlocksCommand::User { prompt, subagents } = command else {
             panic!("expected user prompt");
         };
+        assert!(!subagents);
         let text = serde_json::to_value(prompt).unwrap()["instruction"][0]["text"]
             .as_str()
             .unwrap()
@@ -410,5 +499,39 @@ mod tests {
             .unwrap();
         assert_eq!(std::fs::read(&path).unwrap(), b"hello");
         std::fs::remove_file(path).unwrap();
+    }
+
+    #[test]
+    fn subagents_are_opt_in_on_the_first_prompt() {
+        let command = parse_blocks_line(
+            r#"{"type":"user","message":{"content":[{"type":"text","text":"--subagents inspect the repo"}]}}"#,
+            &mut HashMap::new(),
+        )
+        .unwrap();
+        let BlocksCommand::User { prompt, subagents } = command else {
+            panic!("expected user prompt");
+        };
+        assert!(subagents);
+        assert_eq!(
+            serde_json::to_value(prompt).unwrap()["instruction"][0]["text"],
+            "inspect the repo"
+        );
+    }
+
+    #[test]
+    fn subagent_flag_requires_a_standalone_token() {
+        let command = parse_blocks_line(
+            r#"{"type":"user","text":"keep --subagents=false literal"}"#,
+            &mut HashMap::new(),
+        )
+        .unwrap();
+        let BlocksCommand::User { prompt, subagents } = command else {
+            panic!("expected user prompt");
+        };
+        assert!(!subagents);
+        assert_eq!(
+            serde_json::to_value(prompt).unwrap()["instruction"][0]["text"],
+            "keep --subagents=false literal"
+        );
     }
 }

--- a/packages/rendering/src/nanocodex.test.ts
+++ b/packages/rendering/src/nanocodex.test.ts
@@ -32,6 +32,44 @@ describe('NanocodexRendererEventMapper', () => {
     ])
   })
 
+  test('suppresses commentary and streams only the final-answer item', () => {
+    const mapper = new NanocodexRendererEventMapper()
+    expect(
+      mapper.process(
+        native('assistant.delta', {
+          item_id: 'commentary-1',
+          phase: 'commentary',
+          text: 'I’ll verify.'
+        })
+      )
+    ).toEqual([])
+    expect(
+      mapper.process(
+        native('assistant.delta', {
+          item_id: 'answer-1',
+          phase: 'final_answer',
+          text: 'Done.'
+        }, 2)
+      )
+    ).toEqual([{ type: 'renderer.message.delta', delta: 'Done.' }])
+    expect(
+      mapper.process(
+        native('assistant.message', {
+          phase: 'final_answer',
+          text: 'Done.'
+        }, 3)
+      )
+    ).toEqual([])
+    expect(mapper.process(native('run.completed', {}, 4))).toEqual([
+      {
+        type: 'renderer.done',
+        answerMarkdown: 'Done.',
+        streamFinalUpdates: true,
+        threadId: 'nano-session'
+      }
+    ])
+  })
+
   test('renders native tool lifecycle without an app-server conversion', () => {
     const mapper = new NanocodexRendererEventMapper()
     expect(

--- a/packages/rendering/src/nanocodex.ts
+++ b/packages/rendering/src/nanocodex.ts
@@ -38,12 +38,14 @@ export class NanocodexRendererEventMapper
 
     switch (event.type) {
       case 'assistant.delta': {
+        if (stringField(event.payload, 'phase') === 'commentary') return []
         const delta = stringField(event.payload, 'text')
         if (!delta) return []
         this.answer += delta
         return [{ type: 'renderer.message.delta', delta }]
       }
       case 'assistant.message': {
+        if (stringField(event.payload, 'phase') === 'commentary') return []
         const markdown = stringField(event.payload, 'text')
         if (!markdown || markdown === this.answer) return []
         if (markdown.startsWith(this.answer)) {

--- a/services/slackbotv2/test/chat-sdk-emulate.test.ts
+++ b/services/slackbotv2/test/chat-sdk-emulate.test.ts
@@ -644,7 +644,7 @@ describe('slackbotv2', () => {
 
     const nanocodexRoot = await sendMention(
       undefined,
-      '--nanocodex start with the native harness',
+      '--nanocodex --subagents start with the native harness',
       'Ev-slackbotv2-nanocodex-opt-in'
     )
     await sendMention(
@@ -670,6 +670,7 @@ describe('slackbotv2', () => {
     // unflagged messages consult it.
     expect(strategyRequestCount).toBe(2)
     expect(JSON.stringify(codexApi.executes[0]!.body)).not.toContain('--nanocodex')
+    expect(JSON.stringify(codexApi.executes[0]!.body)).toContain('--subagents')
     expect(JSON.stringify(codexApi.executes[0]!.body)).toContain(
       'start with the native harness'
     )


### PR DESCRIPTION
## Summary

- pin the Nanocodex revision that preserves assistant commentary/final-answer phases
- suppress commentary from the shared Nanocodex renderer while streaming final-answer deltas
- run Nanocodex at the same low thinking effort already used by stock Codex
- disable Nanocodex subagent tools by default and enable them when the root prompt includes standalone `--subagents`
- preserve `--subagents` across the Slack override boundary while keeping `--nanocodex` sticky for the thread

## Behavior

`--nanocodex request` starts a low-effort Nanocodex session without child-agent tools. `--nanocodex --subagents request` enables child-agent tools for that session. The opt-in is selected by the first/root prompt and remains fixed for the session.

## Validation

- harness-server formatting and complete test suite: 64 unit + 20 integration passed, 4 network tests ignored
- rendering tests: 32 passed
- rendering and Slackbot typechecks
- Slackbot tests: 209 passed, 1 skipped
- agent and Slackbot Docker image builds
- `git diff --check`