### PR TITLE
Render Nanocodex commentary as Slack progress

### DIFF
--- a/crates/harness-server/Cargo.lock
+++ b/crates/harness-server/Cargo.lock
@@ -2716,7 +2716,7 @@ dependencies = [
 [[package]]
 name = "nanocodex"
 version = "0.1.0"
-source = "git+https://github.com/gakonst/nanocodex?rev=936584e0dbcb956110cf4314192bf28ce8b4b9f7#936584e0dbcb956110cf4314192bf28ce8b4b9f7"
+source = "git+https://github.com/gakonst/nanocodex?rev=c99b521ef101c3ee4382d2a3301a77cca80d19ac#c99b521ef101c3ee4382d2a3301a77cca80d19ac"
 dependencies = [
  "async-trait",
  "base64",
@@ -2745,7 +2745,7 @@ dependencies = [
 [[package]]
 name = "nanocodex-core"
 version = "0.1.0"
-source = "git+https://github.com/gakonst/nanocodex?rev=936584e0dbcb956110cf4314192bf28ce8b4b9f7#936584e0dbcb956110cf4314192bf28ce8b4b9f7"
+source = "git+https://github.com/gakonst/nanocodex?rev=c99b521ef101c3ee4382d2a3301a77cca80d19ac#c99b521ef101c3ee4382d2a3301a77cca80d19ac"
 dependencies = [
  "serde",
  "serde_json",
@@ -2757,7 +2757,7 @@ dependencies = [
 [[package]]
 name = "nanocodex-macros"
 version = "0.1.0"
-source = "git+https://github.com/gakonst/nanocodex?rev=936584e0dbcb956110cf4314192bf28ce8b4b9f7#936584e0dbcb956110cf4314192bf28ce8b4b9f7"
+source = "git+https://github.com/gakonst/nanocodex?rev=c99b521ef101c3ee4382d2a3301a77cca80d19ac#c99b521ef101c3ee4382d2a3301a77cca80d19ac"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -2768,7 +2768,7 @@ dependencies = [
 [[package]]
 name = "nanocodex-mcp"
 version = "0.1.0"
-source = "git+https://github.com/gakonst/nanocodex?rev=936584e0dbcb956110cf4314192bf28ce8b4b9f7#936584e0dbcb956110cf4314192bf28ce8b4b9f7"
+source = "git+https://github.com/gakonst/nanocodex?rev=c99b521ef101c3ee4382d2a3301a77cca80d19ac#c99b521ef101c3ee4382d2a3301a77cca80d19ac"
 dependencies = [
  "async-trait",
  "bm25",
@@ -2787,7 +2787,7 @@ dependencies = [
 [[package]]
 name = "nanocodex-service"
 version = "0.1.0"
-source = "git+https://github.com/gakonst/nanocodex?rev=936584e0dbcb956110cf4314192bf28ce8b4b9f7#936584e0dbcb956110cf4314192bf28ce8b4b9f7"
+source = "git+https://github.com/gakonst/nanocodex?rev=c99b521ef101c3ee4382d2a3301a77cca80d19ac#c99b521ef101c3ee4382d2a3301a77cca80d19ac"
 dependencies = [
  "base64",
  "futures-util",
@@ -2811,7 +2811,7 @@ dependencies = [
 [[package]]
 name = "nanocodex-tools"
 version = "0.1.0"
-source = "git+https://github.com/gakonst/nanocodex?rev=936584e0dbcb956110cf4314192bf28ce8b4b9f7#936584e0dbcb956110cf4314192bf28ce8b4b9f7"
+source = "git+https://github.com/gakonst/nanocodex?rev=c99b521ef101c3ee4382d2a3301a77cca80d19ac#c99b521ef101c3ee4382d2a3301a77cca80d19ac"
 dependencies = [
  "async-trait",
  "base64",

--- a/crates/harness-server/Cargo.toml
+++ b/crates/harness-server/Cargo.toml
@@ -23,7 +23,7 @@ codex-utils-absolute-path = { git = "https://github.com/openai/codex", rev = "e9
 # provider's per-image caps (Bedrock/mantle rejects images past ~5 MB / 8000 px).
 # Scoped to the formats chat clients actually paste to keep the build lean.
 image = { version = "0.25", default-features = false, features = ["png", "jpeg", "webp"] }
-nanocodex = { git = "https://github.com/gakonst/nanocodex", rev = "936584e0dbcb956110cf4314192bf28ce8b4b9f7" }
+nanocodex = { git = "https://github.com/gakonst/nanocodex", rev = "c99b521ef101c3ee4382d2a3301a77cca80d19ac" }
 opentelemetry-proto = { version = "0.32.0", default-features = false, features = ["trace", "gen-tonic-messages"] }
 prost = "0.14"
 serde = { version = "1.0", features = ["derive"] }

--- a/packages/rendering/src/nanocodex.test.ts
+++ b/packages/rendering/src/nanocodex.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from 'bun:test'
-import { NanocodexRendererEventMapper, isNanocodexEvent } from './nanocodex'
+import type { ChatSDKStreamChunk } from './chat-sdk'
+import {
+  NanocodexRendererEventMapper,
+  harnessToChatSdkStream,
+  isNanocodexEvent
+} from './nanocodex'
 
 const native = (type: string, payload: Record<string, unknown>, seq = 1) => ({
   eventKind: 'session.output.line',
@@ -32,7 +37,7 @@ describe('NanocodexRendererEventMapper', () => {
     ])
   })
 
-  test('suppresses commentary and streams only the final-answer item', () => {
+  test('renders completed commentary as progress before streaming the final answer', () => {
     const mapper = new NanocodexRendererEventMapper()
     expect(
       mapper.process(
@@ -45,11 +50,30 @@ describe('NanocodexRendererEventMapper', () => {
     ).toEqual([])
     expect(
       mapper.process(
+        native('assistant.message', {
+          item_id: 'commentary-1',
+          phase: 'commentary',
+          text: 'I’ll verify.'
+        }, 2)
+      )
+    ).toEqual([
+      {
+        type: 'renderer.task.update',
+        task: {
+          id: 'commentary-1',
+          title: 'Thinking',
+          status: 'complete',
+          details: [{ type: 'text', text: 'I’ll verify.' }]
+        }
+      }
+    ])
+    expect(
+      mapper.process(
         native('assistant.delta', {
           item_id: 'answer-1',
           phase: 'final_answer',
           text: 'Done.'
-        }, 2)
+        }, 3)
       )
     ).toEqual([{ type: 'renderer.message.delta', delta: 'Done.' }])
     expect(
@@ -57,10 +81,10 @@ describe('NanocodexRendererEventMapper', () => {
         native('assistant.message', {
           phase: 'final_answer',
           text: 'Done.'
-        }, 3)
+        }, 4)
       )
     ).toEqual([])
-    expect(mapper.process(native('run.completed', {}, 4))).toEqual([
+    expect(mapper.process(native('run.completed', {}, 5))).toEqual([
       {
         type: 'renderer.done',
         answerMarkdown: 'Done.',
@@ -88,6 +112,47 @@ describe('NanocodexRendererEventMapper', () => {
       type: 'renderer.task.update',
       task: { id: 'call-1', title: 'shell', status: 'complete' }
     })
+  })
+
+  test('keeps commentary and tools interleaved ahead of the final answer', async () => {
+    async function* events() {
+      yield native('assistant.delta', {
+        item_id: 'commentary-1', phase: 'commentary', text: 'Checking.'
+      }, 1)
+      yield native('assistant.message', {
+        item_id: 'commentary-1', phase: 'commentary', text: 'Checking.'
+      }, 2)
+      yield native('tool.call', { call_id: 'call-1', tool: 'shell', arguments: 'pwd' }, 3)
+      yield native('tool.result', {
+        call_id: 'call-1', tool: 'shell', status: 'completed', result: '/workspace'
+      }, 4)
+      yield native('assistant.delta', {
+        item_id: 'commentary-2', phase: 'commentary', text: 'Found it.'
+      }, 5)
+      yield native('assistant.message', {
+        item_id: 'commentary-2', phase: 'commentary', text: 'Found it.'
+      }, 6)
+      yield native('assistant.delta', {
+        item_id: 'answer-1', phase: 'final_answer', text: 'Done.'
+      }, 7)
+      yield native('assistant.message', {
+        item_id: 'answer-1', phase: 'final_answer', text: 'Done.'
+      }, 8)
+      yield native('run.completed', {}, 9)
+    }
+
+    const chunks: ChatSDKStreamChunk[] = []
+    for await (const chunk of harnessToChatSdkStream(events())) chunks.push(chunk)
+    expect(chunks.map(chunk => chunk.type === 'task_update'
+      ? `${chunk.id}:${chunk.status}`
+      : `${chunk.type}:${chunk.type === 'markdown_text' ? chunk.text : chunk.title}`
+    )).toEqual([
+      'commentary-1:complete',
+      'call-1:in_progress',
+      'call-1:complete',
+      'commentary-2:complete',
+      'markdown_text:Done.'
+    ])
   })
 
   test('carries run.error into the terminal failure', () => {

--- a/packages/rendering/src/nanocodex.ts
+++ b/packages/rendering/src/nanocodex.ts
@@ -45,7 +45,21 @@ export class NanocodexRendererEventMapper
         return [{ type: 'renderer.message.delta', delta }]
       }
       case 'assistant.message': {
-        if (stringField(event.payload, 'phase') === 'commentary') return []
+        if (stringField(event.payload, 'phase') === 'commentary') {
+          const text = stringField(event.payload, 'text')
+          if (!text) return []
+          return [
+            {
+              type: 'renderer.task.update',
+              task: {
+                id: stringField(event.payload, 'item_id') || `commentary-${event.seq}`,
+                title: 'Thinking',
+                status: 'complete',
+                details: [{ type: 'text', text }]
+              }
+            }
+          ]
+        }
         const markdown = stringField(event.payload, 'text')
         if (!markdown || markdown === this.answer) return []
         if (markdown.startsWith(this.answer)) {

--- a/services/api-rs/crates/centaur-session-runtime/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-runtime/src/lib.rs
@@ -5852,6 +5852,9 @@ fn output_line_final_answer_text(value: &Value) -> Option<FinalAnswerTextUpdate>
     let method = value.get("method").and_then(Value::as_str);
     let event_type = value.get("type").and_then(Value::as_str);
     if event_type == Some("assistant.delta") {
+        if nanocodex_message_phase(value) == Some("commentary") {
+            return None;
+        }
         let text = value
             .get("payload")
             .and_then(|payload| payload.get("text"))
@@ -5861,6 +5864,9 @@ fn output_line_final_answer_text(value: &Value) -> Option<FinalAnswerTextUpdate>
         return (!text.is_empty()).then_some(FinalAnswerTextUpdate::Append(text));
     }
     if event_type == Some("assistant.message") {
+        if nanocodex_message_phase(value) == Some("commentary") {
+            return None;
+        }
         let text = value
             .get("payload")
             .and_then(|payload| payload.get("text"))
@@ -5898,6 +5904,13 @@ fn output_line_final_answer_text(value: &Value) -> Option<FinalAnswerTextUpdate>
         }
     }
     None
+}
+
+fn nanocodex_message_phase(value: &Value) -> Option<&str> {
+    value
+        .get("payload")
+        .and_then(|payload| payload.get("phase"))
+        .and_then(Value::as_str)
 }
 
 fn turn_ids(value: &Value) -> Vec<String> {
@@ -7065,6 +7078,42 @@ mod tests {
                 result_text: Some("Final answer".to_owned())
             })
         );
+    }
+
+    #[test]
+    fn nanocodex_commentary_is_not_terminal_answer_text() {
+        for event_type in ["assistant.delta", "assistant.message"] {
+            let commentary = json!({
+                "protocol_version": 1,
+                "request_id": "nano-1",
+                "seq": 2,
+                "type": event_type,
+                "payload": {
+                    "item_id": "commentary-1",
+                    "phase": "commentary",
+                    "text": "I’ll verify."
+                },
+            });
+            assert!(output_line_final_answer_text(&commentary).is_none());
+        }
+
+        let final_answer = json!({
+            "protocol_version": 1,
+            "request_id": "nano-1",
+            "seq": 3,
+            "type": "assistant.message",
+            "payload": {
+                "item_id": "answer-1",
+                "phase": "final_answer",
+                "text": "Done."
+            },
+        });
+        let Some(FinalAnswerTextUpdate::Replace(text)) =
+            output_line_final_answer_text(&final_answer)
+        else {
+            panic!("final Nanocodex message should replace terminal answer text")
+        };
+        assert_eq!(text, "Done.");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- pin harness-server to Nanocodex `c99b521`, which emits canonical completed assistant items directly from `response.output_item.done`
- render completed commentary items as structured `Thinking` progress cards keyed by their native item IDs
- preserve native ordering with tool cards and keep only final-answer events in durable terminal text
- retain the raw Nanocodex stdout path; no Codex App Server types or conversion layer

## Stock Codex invariant copied
Codex keys deltas from `output_item.added` and treats `output_item.done` as the canonical item completion carrying the full text and phase. Nanocodex now exposes that same lifecycle directly in its typed events.

## Validation
- rendering: 33 tests passed and TypeScript typecheck passed
- api-rs: 4 focused Nanocodex terminal extraction tests passed; warnings-denied Clippy passed
- harness-server: 84 tests passed (64 unit + 20 integration, 4 live-network tests ignored)
- live real-API smoke through `harness-server nanocodex` produced: commentary completion (seq 53) → nested tool calls/results (seq 119-122) → final-answer completion (seq 139) → run completed (seq 142)
- full harness-server warnings-denied Clippy remains blocked by pre-existing unrelated lints in Codex/server/OTel files