### PR TITLE
fix(harness-server): steer active Blocks turns

### DIFF
--- a/crates/harness-server/src/codex.rs
+++ b/crates/harness-server/src/codex.rs
@@ -153,6 +153,21 @@ pub(crate) fn run_codex_blocks_server(config: CodexHarnessServer) -> Result<()> 
                             break;
                         }
                     }
+                    Ok(BlocksCommand::User {
+                        input,
+                        client_user_message_id,
+                        ..
+                    }) if turn_active.load(Ordering::SeqCst) => {
+                        if active_turn_tx
+                            .send(CodexActiveTurnRequest::Steer {
+                                input,
+                                client_user_message_id,
+                            })
+                            .is_err()
+                        {
+                            break;
+                        }
+                    }
                     Ok(command @ BlocksCommand::User { .. }) => {
                         turn_active.store(true, Ordering::SeqCst);
                         if command_tx
@@ -258,6 +273,10 @@ enum CodexBlocksReaderInput {
 }
 
 enum CodexActiveTurnRequest {
+    Steer {
+        input: Vec<UserInput>,
+        client_user_message_id: Option<String>,
+    },
     Interrupt,
 }
 
@@ -588,10 +607,18 @@ impl CodexJsonRpcChild {
         let mut guard = TurnGuard::default();
         let mut interrupt_request_id = None;
         loop {
+            self.forward_pending_active_turn_requests(
+                active_turn_rx,
+                &mut interrupt_request_id,
+                request_id,
+                thread_id,
+                turn_id,
+                traceparent,
+            )?;
             let value = match self.read_value_timeout(Duration::from_millis(50))? {
                 Some(value) => value,
                 None => {
-                    self.forward_pending_interrupt(
+                    self.forward_pending_active_turn_requests(
                         active_turn_rx,
                         &mut interrupt_request_id,
                         request_id,
@@ -637,7 +664,7 @@ impl CodexJsonRpcChild {
                     return Ok(TurnTermination::Done);
                 }
             }
-            self.forward_pending_interrupt(
+            self.forward_pending_active_turn_requests(
                 active_turn_rx,
                 &mut interrupt_request_id,
                 request_id,
@@ -648,7 +675,7 @@ impl CodexJsonRpcChild {
         }
     }
 
-    fn forward_pending_interrupt(
+    fn forward_pending_active_turn_requests(
         &mut self,
         active_turn_rx: &Receiver<CodexActiveTurnRequest>,
         interrupt_request_id: &mut Option<i64>,
@@ -657,22 +684,41 @@ impl CodexJsonRpcChild {
         turn_id: &str,
         traceparent: Option<&str>,
     ) -> Result<()> {
-        while let Ok(CodexActiveTurnRequest::Interrupt) = active_turn_rx.try_recv() {
-            if interrupt_request_id.is_some() {
-                eprintln!("Codex blocks interrupt ignored: interrupt already requested");
-                continue;
+        while let Ok(request) = active_turn_rx.try_recv() {
+            match request {
+                CodexActiveTurnRequest::Steer {
+                    input,
+                    client_user_message_id,
+                } => {
+                    let id = next_request_id(request_id);
+                    let mut params = json!({
+                        "threadId": thread_id,
+                        "expectedTurnId": turn_id,
+                        "input": input,
+                    });
+                    if let Some(client_user_message_id) = client_user_message_id {
+                        params["clientUserMessageId"] = Value::String(client_user_message_id);
+                    }
+                    self.send_request(id, "turn/steer", params, traceparent)?;
+                }
+                CodexActiveTurnRequest::Interrupt => {
+                    if interrupt_request_id.is_some() {
+                        eprintln!("Codex blocks interrupt ignored: interrupt already requested");
+                        continue;
+                    }
+                    let id = next_request_id(request_id);
+                    self.send_request(
+                        id,
+                        "turn/interrupt",
+                        json!({
+                            "threadId": thread_id,
+                            "turnId": turn_id,
+                        }),
+                        traceparent,
+                    )?;
+                    *interrupt_request_id = Some(id);
+                }
             }
-            let id = next_request_id(request_id);
-            self.send_request(
-                id,
-                "turn/interrupt",
-                json!({
-                    "threadId": thread_id,
-                    "turnId": turn_id,
-                }),
-                traceparent,
-            )?;
-            *interrupt_request_id = Some(id);
         }
         Ok(())
     }

--- a/crates/harness-server/src/server.rs
+++ b/crates/harness-server/src/server.rs
@@ -108,6 +108,21 @@ pub(crate) fn run_blocks_app_server<H: HarnessServer>(harness: &H) -> Result<()>
                             break;
                         }
                     }
+                    Ok(BlocksCommand::User {
+                        input,
+                        client_user_message_id,
+                        ..
+                    }) if turn_active.load(Ordering::SeqCst) => {
+                        if request_tx
+                            .send(ActiveTurnRequest::BlocksSteer {
+                                input,
+                                client_user_message_id,
+                            })
+                            .is_err()
+                        {
+                            break;
+                        }
+                    }
                     Ok(command @ BlocksCommand::User { .. }) => {
                         turn_active.store(true, Ordering::SeqCst);
                         if command_tx
@@ -230,6 +245,9 @@ pub(crate) fn run_app_server<H: HarnessServer>(harness: &H) -> Result<()> {
             ActiveTurnRequest::BlocksInterrupt => {
                 eprintln!("blocks interrupt ignored: no active turn runs");
             }
+            ActiveTurnRequest::BlocksSteer { .. } => {
+                eprintln!("blocks steer ignored: no active turn runs");
+            }
         }
     }
 
@@ -276,6 +294,10 @@ enum BlocksReaderInput {
 
 enum ActiveTurnRequest {
     JsonRpc(JSONRPCRequest),
+    BlocksSteer {
+        input: Vec<UserInput>,
+        client_user_message_id: Option<String>,
+    },
     BlocksInterrupt,
 }
 
@@ -1088,9 +1110,23 @@ fn handle_active_turn_request<H: HarnessServer, W: Write>(
     request: ActiveTurnRequest,
     stdout: &mut W,
 ) -> Result<bool> {
-    let ActiveTurnRequest::JsonRpc(request) = request else {
-        process.kill_and_wait()?;
-        return Ok(true);
+    let request = match request {
+        ActiveTurnRequest::BlocksSteer {
+            input,
+            client_user_message_id,
+        } => {
+            process.stdin.write_all(&harness.stdin_for_steer(&input)?)?;
+            process.stdin.flush()?;
+            for notification in normalizer.emit_user_message(client_user_message_id, input)? {
+                write_value(stdout, &notification_to_wire_value(&notification)?)?;
+            }
+            return Ok(false);
+        }
+        ActiveTurnRequest::BlocksInterrupt => {
+            process.kill_and_wait()?;
+            return Ok(true);
+        }
+        ActiveTurnRequest::JsonRpc(request) => request,
     };
 
     match request.method.as_str() {

--- a/crates/harness-server/tests/app_server_stdio.rs
+++ b/crates/harness-server/tests/app_server_stdio.rs
@@ -504,6 +504,40 @@ fn fake_amp_blocks_mode_accepts_user_blocks_by_default() {
 }
 
 #[test]
+fn fake_claude_blocks_mode_steers_active_turn() {
+    let fake_claude = concat!(
+        "printf '%s\\n' '{\"type\":\"system\",\"subtype\":\"init\",\"session_id\":\"claude-session\"}'; ",
+        "IFS= read -r _; ",
+        "IFS= read -r steer; ",
+        "printf '%s\\n' ",
+        "'{\"type\":\"assistant\",\"is_partial\":false,\"message\":{\"id\":\"msg_1\",\"content\":[{\"type\":\"text\",\"text\":\"steered blocks\"}]}}' ",
+        "'{\"type\":\"result\",\"subtype\":\"success\",\"result\":\"steered blocks\"}'"
+    );
+    let mut bridge = BridgeProcess::spawn_harness_blocks(
+        Harness::ClaudeCode,
+        Some(fake_claude.to_string()),
+        None,
+    );
+    let turn = bridge.run_blocks_steered_turn(
+        "start a long turn",
+        "use this update",
+        Duration::from_secs(10),
+    );
+    let _ = bridge.finish_successfully();
+
+    assert_completed_turn(&turn);
+    assert_eq!(turn.text_from_deltas, "steered blocks");
+    assert_eq!(
+        turn.methods
+            .iter()
+            .filter(|method| method.as_str() == "item/started")
+            .count(),
+        3,
+        "initial user, steered user, and assistant items should all start"
+    );
+}
+
+#[test]
 fn fake_claude_blocks_mode_interrupts_back_to_back_stop() {
     let fake_claude = concat!(
         "printf '%s\\n' ",
@@ -658,6 +692,65 @@ fn fake_codex_blocks_mode_interrupts_active_turn() {
     assert_eq!(
         interrupt.pointer("/params/turnId").and_then(Value::as_str),
         Some("turn-1")
+    );
+
+    let _ = std::fs::remove_file(fake_codex);
+    let _ = std::fs::remove_file(fake_codex_log);
+}
+
+#[test]
+fn fake_codex_blocks_mode_steers_active_turn() {
+    let fake_codex = temp_path("fake-steerable-codex.sh");
+    let fake_codex_log = temp_path("fake-steerable-codex-requests.jsonl");
+    let script = fake_codex_steerable_app_server_script(&fake_codex_log);
+    std::fs::write(&fake_codex, script).expect("write fake codex script");
+    let mut permissions = std::fs::metadata(&fake_codex)
+        .expect("fake codex metadata")
+        .permissions();
+    permissions.set_mode(0o755);
+    std::fs::set_permissions(&fake_codex, permissions).expect("chmod fake codex script");
+
+    let mut bridge = BridgeProcess::spawn_harness_blocks(
+        Harness::Codex,
+        None,
+        Some((
+            "CODEX_BIN",
+            fake_codex.to_str().expect("utf-8 fake codex path"),
+        )),
+    );
+    let turn = bridge.run_blocks_steered_turn(
+        "start a long turn",
+        "use this update",
+        Duration::from_secs(10),
+    );
+    let _ = bridge.finish_successfully();
+
+    assert_completed_turn(&turn);
+    assert_eq!(turn.text_from_deltas, "steered answer");
+    let requests = std::fs::read_to_string(&fake_codex_log).expect("read fake codex request log");
+    let requests: Vec<Value> = requests
+        .lines()
+        .map(|line| serde_json::from_str(line).expect("fake codex request JSON"))
+        .collect();
+    let steer = requests
+        .iter()
+        .find(|value| value.get("method").and_then(Value::as_str) == Some("turn/steer"))
+        .unwrap_or_else(|| panic!("blocks mode did not send turn/steer; requests={requests:?}"));
+    assert_eq!(
+        steer.pointer("/params/threadId").and_then(Value::as_str),
+        Some("thread-1")
+    );
+    assert_eq!(
+        steer
+            .pointer("/params/expectedTurnId")
+            .and_then(Value::as_str),
+        Some("turn-1")
+    );
+    assert_eq!(
+        steer
+            .pointer("/params/input/0/text")
+            .and_then(Value::as_str),
+        Some("use this update")
     );
 
     let _ = std::fs::remove_file(fake_codex);
@@ -1752,6 +1845,42 @@ impl BridgeProcess {
         capture
     }
 
+    fn run_blocks_steered_turn(
+        &mut self,
+        prompt: &str,
+        steer: &str,
+        timeout: Duration,
+    ) -> TurnCapture {
+        for (text, action) in [(prompt, "execute"), (steer, "steer_active_execution")] {
+            self.send(json!({
+                "type": "user",
+                "thread_key": "slack:C123:123.456",
+                "trace_metadata": { "source": "test", "action": action },
+                "message": {
+                    "role": "user",
+                    "content": [{"type": "text", "text": text}],
+                },
+            }));
+        }
+
+        let deadline = Instant::now() + timeout;
+        let mut capture = TurnCapture::default();
+        loop {
+            let value = self.read_json(deadline);
+            assert!(
+                response_id(&value).is_none(),
+                "blocks mode emitted response: {value}"
+            );
+            if let Some(method) = value.get("method").and_then(Value::as_str) {
+                capture.consume_notification(method, &value);
+                if method == "turn/completed" {
+                    break;
+                }
+            }
+        }
+        capture
+    }
+
     fn send(&mut self, value: Value) {
         eprintln!("stdin JSON: {value}");
         let stdin = self.stdin.as_mut().expect("stdin still open");
@@ -2277,6 +2406,55 @@ while IFS= read -r line; do
       printf '%s\n' '{"method":"item/agentMessage/delta","params":{"threadId":"thread-1","turnId":"turn-1","itemId":"answer-1","delta":"codex blocks"}}'
       printf '%s\n' '{"method":"item/completed","params":{"threadId":"thread-1","turnId":"turn-1","item":{"type":"agentMessage","id":"answer-1","text":"codex blocks","phase":null,"memoryCitation":null},"completedAtMs":2}}'
       printf '%s\n' '{"method":"turn/completed","params":{"threadId":"thread-1","turn":{"id":"turn-1","items":[{"type":"agentMessage","id":"answer-1","text":"codex blocks","phase":null,"memoryCitation":null}],"itemsView":"full","status":"completed","error":null,"startedAt":1,"completedAt":2,"durationMs":1}}}'
+      ;;
+    *)
+      printf '%s\n' "unexpected request: $line" >&2
+      exit 65
+      ;;
+  esac
+done
+"#,
+    );
+    script
+}
+
+fn fake_codex_steerable_app_server_script(log_path: &Path) -> String {
+    let mut script = String::new();
+    script.push_str("#!/bin/sh\n");
+    script.push_str("log=");
+    script.push_str(&shell_quote(log_path));
+    script.push_str(
+        r#"
+touch "$log"
+if [ "${1:-}" = "app-server" ] && [ "${2:-}" = "--help" ]; then
+  printf '%s\n' '--listen stdio://'
+  exit 0
+fi
+request_id() {
+  printf '%s' "$1" | sed -n 's/.*"id":\([0-9][0-9]*\).*/\1/p'
+}
+while IFS= read -r line; do
+  printf '%s\n' "$line" >> "$log"
+  case "$line" in
+    *'"method":"initialize"'*)
+      id=$(request_id "$line")
+      printf '{"id":%s,"result":{"userAgent":"fake-codex"}}\n' "$id"
+      ;;
+    *'"method":"thread/start"'*)
+      id=$(request_id "$line")
+      printf '{"id":%s,"result":{"thread":{"id":"thread-1"}}}\n' "$id"
+      ;;
+    *'"method":"turn/start"'*)
+      id=$(request_id "$line")
+      printf '{"id":%s,"result":{"turn":{"id":"turn-1"}}}\n' "$id"
+      printf '%s\n' '{"method":"turn/started","params":{"threadId":"thread-1","turn":{"id":"turn-1","items":[],"itemsView":"full","status":"inProgress","error":null,"startedAt":1,"completedAt":null,"durationMs":null}}}'
+      ;;
+    *'"method":"turn/steer"'*)
+      id=$(request_id "$line")
+      printf '{"id":%s,"result":{"turnId":"turn-1"}}\n' "$id"
+      printf '%s\n' '{"method":"item/agentMessage/delta","params":{"threadId":"thread-1","turnId":"turn-1","itemId":"answer-1","delta":"steered answer"}}'
+      printf '%s\n' '{"method":"item/completed","params":{"threadId":"thread-1","turnId":"turn-1","item":{"type":"agentMessage","id":"answer-1","text":"steered answer","phase":null,"memoryCitation":null},"completedAtMs":2}}'
+      printf '%s\n' '{"method":"turn/completed","params":{"threadId":"thread-1","turn":{"id":"turn-1","items":[{"type":"agentMessage","id":"answer-1","text":"steered answer","phase":null,"memoryCitation":null}],"itemsView":"full","status":"completed","error":null,"startedAt":1,"completedAt":2,"durationMs":1}}}'
       ;;
     *)
       printf '%s\n' "unexpected request: $line" >&2


### PR DESCRIPTION
## Summary
- route follow-up Blocks user messages into the active harness turn
- translate Codex follow-ups to native `turn/steer` requests
- preserve steered user-message events for Claude Code and Amp
- add production-path steering regression tests

## Testing
- `cargo test --manifest-path crates/harness-server/Cargo.toml` (84 passed, 4 ignored real-network tests)
- `cargo +nightly fmt --manifest-path crates/harness-server/Cargo.toml -- --check`

Prompted by: @DaniPopes