### PR TITLE
feat: add per-proxy labels

### DIFF
--- a/services/api-rs/crates/centaur-api-server/src/tool_discovery.rs
+++ b/services/api-rs/crates/centaur-api-server/src/tool_discovery.rs
@@ -985,9 +985,17 @@ fn parse_pg_dsn_setting_value_from(
     let principal_label = optional_str(table, "principal_label").map(ToOwned::to_owned);
     let principal_field = optional_str(table, "principal_field").map(ToOwned::to_owned);
     let proxy_label = optional_str(table, "proxy_label").map(ToOwned::to_owned);
-    if principal_label.is_none() && principal_field.is_none() && proxy_label.is_none() {
+    let declared = [
+        principal_label.as_ref(),
+        principal_field.as_ref(),
+        proxy_label.as_ref(),
+    ]
+    .into_iter()
+    .filter(|value| value.is_some())
+    .count();
+    if declared != 1 {
         return Err(ToolDiscoveryError::Invalid(
-            "pg_dsn setting value_from must declare principal_label, principal_field, or proxy_label".to_owned(),
+            "pg_dsn setting value_from must declare exactly one of principal_label, principal_field, or proxy_label".to_owned(),
         ));
     }
     Ok(Some(PgDsnSettingValueFrom {
@@ -1661,6 +1669,31 @@ mod tests {
                 .as_ref()
                 .and_then(|value_from| value_from.proxy_label.as_deref()),
             Some("centaur.slack_user_id")
+        );
+    }
+
+    #[test]
+    fn rejects_pg_dsn_value_from_with_multiple_selectors() {
+        let value: TomlValue = toml::from_str(
+            r#"
+database = "warehouse"
+settings = [
+  { name = "centaur.slack_user_id", value_from = { principal_label = "slack_user_id", proxy_label = "centaur.slack_user_id" } }
+]
+"#,
+        )
+        .unwrap();
+        let err = parse_pg_dsn_secret(
+            value.as_table().unwrap(),
+            "RESHIFT_DSN".to_owned(),
+            "RESHIFT_DSN".to_owned(),
+            &BTreeMap::new(),
+        )
+        .unwrap_err();
+
+        assert!(
+            err.to_string().contains("must declare exactly one"),
+            "{err}"
         );
     }
 

--- a/services/api-rs/crates/centaur-api-server/src/tool_discovery.rs
+++ b/services/api-rs/crates/centaur-api-server/src/tool_discovery.rs
@@ -984,14 +984,16 @@ fn parse_pg_dsn_setting_value_from(
     })?;
     let principal_label = optional_str(table, "principal_label").map(ToOwned::to_owned);
     let principal_field = optional_str(table, "principal_field").map(ToOwned::to_owned);
-    if principal_label.is_none() && principal_field.is_none() {
+    let proxy_label = optional_str(table, "proxy_label").map(ToOwned::to_owned);
+    if principal_label.is_none() && principal_field.is_none() && proxy_label.is_none() {
         return Err(ToolDiscoveryError::Invalid(
-            "pg_dsn setting value_from must declare principal_label or principal_field".to_owned(),
+            "pg_dsn setting value_from must declare principal_label, principal_field, or proxy_label".to_owned(),
         ));
     }
     Ok(Some(PgDsnSettingValueFrom {
         principal_label,
         principal_field,
+        proxy_label,
     }))
 }
 
@@ -1620,14 +1622,26 @@ mod tests {
             labels: tool_labels("company_context", "centaur"),
             database: "warehouse".to_owned(),
             role: Some("centaur_slack_reader".to_owned()),
-            settings: vec![PgDsnSetting {
-                name: "centaur.slack_channel_id".to_owned(),
-                value: None,
-                value_from: Some(PgDsnSettingValueFrom {
-                    principal_label: Some("slack_channel_id".to_owned()),
-                    principal_field: None,
-                }),
-            }],
+            settings: vec![
+                PgDsnSetting {
+                    name: "centaur.slack_channel_id".to_owned(),
+                    value: None,
+                    value_from: Some(PgDsnSettingValueFrom {
+                        principal_label: Some("slack_channel_id".to_owned()),
+                        principal_field: None,
+                        proxy_label: None,
+                    }),
+                },
+                PgDsnSetting {
+                    name: "centaur.slack_user_id".to_owned(),
+                    value: None,
+                    value_from: Some(PgDsnSettingValueFrom {
+                        principal_label: None,
+                        principal_field: None,
+                        proxy_label: Some("centaur.slack_user_id".to_owned()),
+                    }),
+                },
+            ],
         })])
         .unwrap();
 
@@ -1638,8 +1652,16 @@ mod tests {
             listeners[0].extra.get("role").and_then(YamlValue::as_str),
             Some("centaur_slack_reader")
         );
-        assert_eq!(listeners[0].settings.len(), 1);
+        assert_eq!(listeners[0].settings.len(), 2);
         assert_eq!(listeners[0].settings[0].name, "centaur.slack_channel_id");
+        assert_eq!(listeners[0].settings[1].name, "centaur.slack_user_id");
+        assert_eq!(
+            listeners[0].settings[1]
+                .value_from
+                .as_ref()
+                .and_then(|value_from| value_from.proxy_label.as_deref()),
+            Some("centaur.slack_user_id")
+        );
     }
 
     #[test]

--- a/services/api-rs/crates/centaur-iron-control/src/client.rs
+++ b/services/api-rs/crates/centaur-iron-control/src/client.rs
@@ -459,12 +459,8 @@ impl IronControlClient {
         labels: &std::collections::BTreeMap<String, String>,
     ) -> Result<Proxy> {
         let path = format!("{API_PREFIX}/proxies/{}", urlencoding::encode(id));
-        self.write(
-            Method::PATCH,
-            &path,
-            &json!({ "principal_id": principal_id, "labels": labels }),
-        )
-        .await
+        let body = proxy_assignment_payload(principal_id, labels);
+        self.write(Method::PATCH, &path, &body).await
     }
 
     /// Deregister a proxy by OID.
@@ -518,6 +514,20 @@ impl IronControlClient {
                 source,
             })
     }
+}
+
+fn proxy_assignment_payload(
+    principal_id: &str,
+    labels: &std::collections::BTreeMap<String, String>,
+) -> Value {
+    let mut body = serde_json::Map::from_iter([(
+        "principal_id".to_owned(),
+        Value::String(principal_id.to_owned()),
+    )]);
+    if !labels.is_empty() {
+        body.insert("labels".to_owned(), json!(labels));
+    }
+    Value::Object(body)
 }
 
 fn grant_body(grantee: &Grantee, secret: &GrantSecret) -> Value {
@@ -860,6 +870,30 @@ mod tests {
             serde_json::to_value(input).unwrap(),
             json!({
                 "name": "edge",
+                "principal_id": "prn_1",
+                "labels": { "centaur.slack_user_id": "U1" }
+            })
+        );
+    }
+
+    #[test]
+    fn proxy_assignment_payload_omits_empty_labels() {
+        assert_eq!(
+            proxy_assignment_payload("prn_1", &std::collections::BTreeMap::new()),
+            json!({ "principal_id": "prn_1" })
+        );
+    }
+
+    #[test]
+    fn proxy_assignment_payload_includes_non_empty_labels() {
+        let labels = std::collections::BTreeMap::from([(
+            "centaur.slack_user_id".to_owned(),
+            "U1".to_owned(),
+        )]);
+
+        assert_eq!(
+            proxy_assignment_payload("prn_1", &labels),
+            json!({
                 "principal_id": "prn_1",
                 "labels": { "centaur.slack_user_id": "U1" }
             })

--- a/services/api-rs/crates/centaur-iron-control/src/client.rs
+++ b/services/api-rs/crates/centaur-iron-control/src/client.rs
@@ -436,10 +436,12 @@ impl IronControlClient {
         &self,
         name: impl Into<String>,
         principal_id: impl Into<String>,
+        labels: std::collections::BTreeMap<String, String>,
     ) -> Result<Proxy> {
         let input = ProxyInput {
             name: name.into(),
             principal_id: principal_id.into(),
+            labels,
         };
         self.write(Method::POST, &collection_path("proxies"), &input)
             .await
@@ -450,12 +452,17 @@ impl IronControlClient {
     /// `/proxy/sync` (the config hash changes). This is how a warm-pool proxy,
     /// booted under a bootstrap principal, is bound to a session's principal at
     /// checkout without a restart or token swap.
-    pub async fn assign_proxy_principal(&self, id: &str, principal_id: &str) -> Result<Proxy> {
+    pub async fn assign_proxy_principal(
+        &self,
+        id: &str,
+        principal_id: &str,
+        labels: &std::collections::BTreeMap<String, String>,
+    ) -> Result<Proxy> {
         let path = format!("{API_PREFIX}/proxies/{}", urlencoding::encode(id));
         self.write(
             Method::PATCH,
             &path,
-            &json!({ "principal_id": principal_id }),
+            &json!({ "principal_id": principal_id, "labels": labels }),
         )
         .await
     }
@@ -815,10 +822,18 @@ mod tests {
             "id": "prx_1",
             "name": "edge",
             "principal_id": "prn_1",
+            "labels": { "centaur.slack_user_id": "U1" },
             "token": "iprx_secret"
         }))
         .unwrap();
         assert_eq!(created.token.as_deref(), Some("iprx_secret"));
+        assert_eq!(
+            created
+                .labels
+                .get("centaur.slack_user_id")
+                .map(String::as_str),
+            Some("U1")
+        );
 
         let listed: Proxy = serde_json::from_value(json!({
             "id": "prx_1",
@@ -827,5 +842,27 @@ mod tests {
         }))
         .unwrap();
         assert_eq!(listed.token, None);
+        assert!(listed.labels.is_empty());
+    }
+
+    #[test]
+    fn proxy_input_serializes_labels() {
+        let input = ProxyInput {
+            name: "edge".to_owned(),
+            principal_id: "prn_1".to_owned(),
+            labels: std::collections::BTreeMap::from([(
+                "centaur.slack_user_id".to_owned(),
+                "U1".to_owned(),
+            )]),
+        };
+
+        assert_eq!(
+            serde_json::to_value(input).unwrap(),
+            json!({
+                "name": "edge",
+                "principal_id": "prn_1",
+                "labels": { "centaur.slack_user_id": "U1" }
+            })
+        );
     }
 }

--- a/services/api-rs/crates/centaur-iron-control/src/models.rs
+++ b/services/api-rs/crates/centaur-iron-control/src/models.rs
@@ -709,6 +709,8 @@ pub struct Proxy {
     #[serde(default)]
     pub labels: BTreeMap<String, String>,
     #[serde(default)]
+    pub config_hash: Option<String>,
+    #[serde(default)]
     pub token: Option<String>,
 }
 

--- a/services/api-rs/crates/centaur-iron-control/src/models.rs
+++ b/services/api-rs/crates/centaur-iron-control/src/models.rs
@@ -344,6 +344,8 @@ pub struct PgDsnSettingValueFromInput {
     pub principal_label: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub principal_field: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub proxy_label: Option<String>,
 }
 
 // ---------------------------------------------------------------------------
@@ -693,6 +695,8 @@ impl Grant {
 pub struct ProxyInput {
     pub name: String,
     pub principal_id: String,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub labels: BTreeMap<String, String>,
 }
 
 /// A registered proxy. ``token`` (the plaintext ``iprx_`` bearer) is only
@@ -702,6 +706,8 @@ pub struct Proxy {
     pub id: String,
     pub name: String,
     pub principal_id: String,
+    #[serde(default)]
+    pub labels: BTreeMap<String, String>,
     #[serde(default)]
     pub token: Option<String>,
 }

--- a/services/api-rs/crates/centaur-iron-control/src/registry.rs
+++ b/services/api-rs/crates/centaur-iron-control/src/registry.rs
@@ -565,10 +565,12 @@ fn pg_setting_from_listener(setting: &PgDsnSetting) -> PgDsnSettingInput {
             |PgDsnSettingValueFrom {
                  principal_label,
                  principal_field,
+                 proxy_label,
              }| {
                 PgDsnSettingValueFromInput {
                     principal_label: principal_label.clone(),
                     principal_field: principal_field.clone(),
+                    proxy_label: proxy_label.clone(),
                 }
             },
         ),
@@ -1120,6 +1122,9 @@ postgres:
       - name: centaur.slack_channel_id
         value_from:
           principal_label: slack_channel_id
+      - name: centaur.slack_user_id
+        value_from:
+          proxy_label: centaur.slack_user_id
 "#,
         )
         .unwrap();
@@ -1133,7 +1138,7 @@ postgres:
         assert_eq!(input.name, "analytics");
         assert_eq!(input.database, "analytics_db");
         assert_eq!(input.role.as_deref(), Some("readonly"));
-        assert_eq!(input.settings.len(), 1);
+        assert_eq!(input.settings.len(), 2);
         assert_eq!(input.settings[0].name, "centaur.slack_channel_id");
         assert_eq!(
             input.settings[0]
@@ -1141,6 +1146,14 @@ postgres:
                 .as_ref()
                 .and_then(|value_from| value_from.principal_label.as_deref()),
             Some("slack_channel_id")
+        );
+        assert_eq!(input.settings[1].name, "centaur.slack_user_id");
+        assert_eq!(
+            input.settings[1]
+                .value_from
+                .as_ref()
+                .and_then(|value_from| value_from.proxy_label.as_deref()),
+            Some("centaur.slack_user_id")
         );
         assert_eq!(input.dsn.source_type, "env");
         assert_eq!(input.dsn.config, json!({ "var": "PG_ANALYTICS_DSN" }));

--- a/services/api-rs/crates/centaur-iron-proxy/src/model/postgres.rs
+++ b/services/api-rs/crates/centaur-iron-proxy/src/model/postgres.rs
@@ -64,6 +64,8 @@ pub struct PgDsnSettingValueFrom {
     pub principal_label: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub principal_field: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub proxy_label: Option<String>,
 }
 
 /// The iron-control `pg_dsn` secret foreign_id for a listener name. Shared so

--- a/services/api-rs/crates/centaur-perms/src/tests.rs
+++ b/services/api-rs/crates/centaur-perms/src/tests.rs
@@ -372,7 +372,7 @@ fn aws_auth_requires_hosts() {
 #[test]
 fn parses_pg_dsn_secret() {
     let parsed = tools::parse_secret(
-        &entry(r#"{ type = "pg_dsn", name = "RESHIFT_DSN", database = "pmadmin", secret_ref = "RESHIFT_DSN", role = "centaur_slack_reader", settings = [{ name = "centaur.slack_channel_id", value_from = { principal_label = "slack_channel_id" } }] }"#),
+        &entry(r#"{ type = "pg_dsn", name = "RESHIFT_DSN", database = "pmadmin", secret_ref = "RESHIFT_DSN", role = "centaur_slack_reader", settings = [{ name = "centaur.slack_channel_id", value_from = { principal_label = "slack_channel_id" } }, { name = "centaur.slack_user_id", value_from = { proxy_label = "centaur.slack_user_id" } }] }"#),
         &[],
     )
     .unwrap();
@@ -383,7 +383,7 @@ fn parses_pg_dsn_secret() {
     assert_eq!(pg.database, "pmadmin");
     assert_eq!(pg.secret_ref, "RESHIFT_DSN");
     assert_eq!(pg.role.as_deref(), Some("centaur_slack_reader"));
-    assert_eq!(pg.settings.len(), 1);
+    assert_eq!(pg.settings.len(), 2);
     assert_eq!(pg.settings[0].name, "centaur.slack_channel_id");
     assert_eq!(
         pg.settings[0]
@@ -391,6 +391,14 @@ fn parses_pg_dsn_secret() {
             .as_ref()
             .and_then(|value_from| value_from.principal_label.as_deref()),
         Some("slack_channel_id")
+    );
+    assert_eq!(pg.settings[1].name, "centaur.slack_user_id");
+    assert_eq!(
+        pg.settings[1]
+            .value_from
+            .as_ref()
+            .and_then(|value_from| value_from.proxy_label.as_deref()),
+        Some("centaur.slack_user_id")
     );
 }
 
@@ -541,7 +549,7 @@ fn translates_oauth_with_json_key_fields() {
 fn translates_pg_dsn_to_input_with_roundtrip_foreign_id() {
     let secrets = vec![
         tools::parse_secret(
-            &entry(r#"{ type = "pg_dsn", name = "RESHIFT_DSN", database = "pmadmin", secret_ref = "RESHIFT_DSN", role = "centaur_slack_reader", settings = [{ name = "centaur.slack_channel_id", value_from = { principal_label = "slack_channel_id" } }] }"#),
+            &entry(r#"{ type = "pg_dsn", name = "RESHIFT_DSN", database = "pmadmin", secret_ref = "RESHIFT_DSN", role = "centaur_slack_reader", settings = [{ name = "centaur.slack_channel_id", value_from = { principal_label = "slack_channel_id" } }, { name = "centaur.slack_user_id", value_from = { proxy_label = "centaur.slack_user_id" } }] }"#),
             &[],
         )
         .unwrap(),
@@ -557,13 +565,20 @@ fn translates_pg_dsn_to_input_with_roundtrip_foreign_id() {
     assert_eq!(input.name, "RESHIFT_DSN");
     assert_eq!(input.database, "pmadmin");
     assert_eq!(input.role.as_deref(), Some("centaur_slack_reader"));
-    assert_eq!(input.settings.len(), 1);
+    assert_eq!(input.settings.len(), 2);
     assert_eq!(
         input.settings[0]
             .value_from
             .as_ref()
             .and_then(|value_from| value_from.principal_label.as_deref()),
         Some("slack_channel_id")
+    );
+    assert_eq!(
+        input.settings[1]
+            .value_from
+            .as_ref()
+            .and_then(|value_from| value_from.proxy_label.as_deref()),
+        Some("centaur.slack_user_id")
     );
     assert_eq!(input.dsn.source_type, "env");
     assert_eq!(

--- a/services/api-rs/crates/centaur-perms/src/tests.rs
+++ b/services/api-rs/crates/centaur-perms/src/tests.rs
@@ -403,6 +403,20 @@ fn parses_pg_dsn_secret() {
 }
 
 #[test]
+fn rejects_pg_dsn_value_from_with_multiple_selectors() {
+    let err = tools::parse_secret(
+        &entry(r#"{ type = "pg_dsn", name = "RESHIFT_DSN", database = "pmadmin", secret_ref = "RESHIFT_DSN", settings = [{ name = "centaur.slack_user_id", value_from = { principal_label = "slack_user_id", proxy_label = "centaur.slack_user_id" } }] }"#),
+        &[],
+    )
+    .unwrap_err();
+
+    assert!(
+        err.to_string().contains("must declare exactly one"),
+        "{err}"
+    );
+}
+
+#[test]
 fn pg_dsn_requires_database() {
     let err = tools::parse_secret(&entry(r#"{ type = "pg_dsn", name = "RESHIFT_DSN" }"#), &[])
         .unwrap_err();

--- a/services/api-rs/crates/centaur-perms/src/tools.rs
+++ b/services/api-rs/crates/centaur-perms/src/tools.rs
@@ -741,12 +741,16 @@ fn parse_pg_dsn_setting_value_from(value: Option<&Value>) -> Result<Option<PgDsn
         .ok_or_else(|| eyre!("pg_dsn setting value_from must be a table"))?;
     let principal_label = opt_str(table, "principal_label");
     let principal_field = opt_str(table, "principal_field");
-    if principal_label.is_none() && principal_field.is_none() {
-        bail!("pg_dsn setting value_from must declare principal_label or principal_field");
+    let proxy_label = opt_str(table, "proxy_label");
+    if principal_label.is_none() && principal_field.is_none() && proxy_label.is_none() {
+        bail!(
+            "pg_dsn setting value_from must declare principal_label, principal_field, or proxy_label"
+        );
     }
     Ok(Some(PgDsnSettingValueFrom {
         principal_label,
         principal_field,
+        proxy_label,
     }))
 }
 

--- a/services/api-rs/crates/centaur-perms/src/tools.rs
+++ b/services/api-rs/crates/centaur-perms/src/tools.rs
@@ -742,9 +742,17 @@ fn parse_pg_dsn_setting_value_from(value: Option<&Value>) -> Result<Option<PgDsn
     let principal_label = opt_str(table, "principal_label");
     let principal_field = opt_str(table, "principal_field");
     let proxy_label = opt_str(table, "proxy_label");
-    if principal_label.is_none() && principal_field.is_none() && proxy_label.is_none() {
+    let declared = [
+        principal_label.as_ref(),
+        principal_field.as_ref(),
+        proxy_label.as_ref(),
+    ]
+    .into_iter()
+    .filter(|value| value.is_some())
+    .count();
+    if declared != 1 {
         bail!(
-            "pg_dsn setting value_from must declare principal_label, principal_field, or proxy_label"
+            "pg_dsn setting value_from must declare exactly one of principal_label, principal_field, or proxy_label"
         );
     }
     Ok(Some(PgDsnSettingValueFrom {

--- a/services/api-rs/crates/centaur-perms/src/translate.rs
+++ b/services/api-rs/crates/centaur-perms/src/translate.rs
@@ -322,10 +322,12 @@ fn pg_setting_input(setting: &PgDsnSetting) -> PgDsnSettingInput {
             |PgDsnSettingValueFrom {
                  principal_label,
                  principal_field,
+                 proxy_label,
              }| {
                 PgDsnSettingValueFromInput {
                     principal_label: principal_label.clone(),
                     principal_field: principal_field.clone(),
+                    proxy_label: proxy_label.clone(),
                 }
             },
         ),

--- a/services/api-rs/crates/centaur-sandbox-agent-k8s/src/iron_proxy.rs
+++ b/services/api-rs/crates/centaur-sandbox-agent-k8s/src/iron_proxy.rs
@@ -127,6 +127,9 @@ pub(crate) struct ResolvedIronProxy {
     console_url: String,
     // iron-control principal OID this sandbox's proxy binds to.
     principal_id: String,
+    // Labels applied to the iron-control proxy row and used by proxy-specific
+    // config rendering in the control plane.
+    labels: BTreeMap<String, String>,
     // The single Postgres listener the proxy multiplexes all upstreams through,
     // derived from the principal's effective config. `None` when the principal
     // resolves to no Postgres upstreams. The upstream DSN/role/database are
@@ -200,10 +203,12 @@ impl AgentSandboxBackend {
         })?;
         let pg = self.resolved_pg();
         let replace_placeholders = self.effective_replace_placeholders(&principal_id).await?;
+        let labels = spec.iron_control_proxy_labels.clone();
 
         Ok(Some(self.resolved_iron_proxy_for_principal(
             id,
             principal_id,
+            labels,
             pg,
             replace_placeholders,
             spec.capabilities.observability_enabled,
@@ -301,6 +306,7 @@ impl AgentSandboxBackend {
         Ok(Some(self.resolved_iron_proxy_for_principal(
             id,
             principal_id,
+            BTreeMap::new(),
             pg,
             replace_placeholders,
             observability_enabled,
@@ -312,6 +318,7 @@ impl AgentSandboxBackend {
         &self,
         id: &SandboxId,
         principal_id: String,
+        labels: BTreeMap<String, String>,
         pg: Option<ResolvedPg>,
         replace_placeholders: BTreeMap<String, String>,
         observability_enabled: bool,
@@ -328,6 +335,7 @@ impl AgentSandboxBackend {
                 .map(|settings| settings.control_url.clone())
                 .unwrap_or_default(),
             principal_id,
+            labels,
             pg,
             replace_placeholders,
             management_api_key: new_proxy_management_api_key(),
@@ -397,7 +405,7 @@ impl AgentSandboxBackend {
         })?;
         let proxy = iron_control
             .client
-            .create_proxy(id.as_str(), &resolved.principal_id)
+            .create_proxy(id.as_str(), &resolved.principal_id, resolved.labels.clone())
             .await
             .map_err(|err| SandboxError::backend_source("iron-control create proxy", err))?;
         let token = proxy
@@ -505,6 +513,7 @@ impl AgentSandboxBackend {
         &self,
         id: &SandboxId,
         principal_id: &str,
+        labels: &BTreeMap<String, String>,
     ) -> SandboxResult<()> {
         let iron_control = self
             .config
@@ -522,7 +531,7 @@ impl AgentSandboxBackend {
                 "iron-proxy resources are missing or not running; recreating before assignment"
             );
             proxy_id = Some(
-                self.recreate_iron_proxy_resources_for_principal(id, principal_id)
+                self.recreate_iron_proxy_resources_for_principal(id, principal_id, labels)
                     .await?,
             );
         }
@@ -534,7 +543,7 @@ impl AgentSandboxBackend {
         })?;
         let proxy = iron_control
             .client
-            .assign_proxy_principal(&proxy_id, principal_id)
+            .assign_proxy_principal(&proxy_id, principal_id, labels)
             .await
             .map_err(|err| SandboxError::backend_source("iron-control assign proxy", err))?;
         self.proxy_ids
@@ -552,6 +561,7 @@ impl AgentSandboxBackend {
         &self,
         id: &SandboxId,
         principal_id: &str,
+        labels: &BTreeMap<String, String>,
     ) -> SandboxResult<()> {
         if self.config.iron_proxy.is_none() {
             return Ok(());
@@ -564,6 +574,17 @@ impl AgentSandboxBackend {
         }
         let proxy_id = self.proxy_id_for_sandbox(id).await?;
         if proxy_id.is_some() && self.has_usable_iron_proxy_resources(id).await? {
+            let iron_control = self.config.iron_control.as_ref().ok_or_else(|| {
+                SandboxError::backend("iron-proxy requires iron-control to be configured")
+            })?;
+            let proxy_id = proxy_id.expect("proxy_id checked as Some above");
+            iron_control
+                .client
+                .assign_proxy_principal(&proxy_id, principal_id, labels)
+                .await
+                .map_err(|err| SandboxError::backend_source("iron-control assign proxy", err))?;
+            self.wait_for_proxy_principal_applied(id, principal_id)
+                .await;
             return Ok(());
         }
 
@@ -572,7 +593,7 @@ impl AgentSandboxBackend {
             principal_id,
             "iron-proxy resources are missing or not running; recreating before reuse"
         );
-        self.recreate_iron_proxy_resources_for_principal(id, principal_id)
+        self.recreate_iron_proxy_resources_for_principal(id, principal_id, labels)
             .await?;
         self.patch_iron_control_principal_annotation(id, principal_id)
             .await?;
@@ -583,6 +604,7 @@ impl AgentSandboxBackend {
         &self,
         id: &SandboxId,
         principal_id: &str,
+        labels: &BTreeMap<String, String>,
     ) -> SandboxResult<String> {
         if self.config.iron_proxy.is_none() {
             return Err(SandboxError::Unsupported {
@@ -623,6 +645,7 @@ impl AgentSandboxBackend {
         let resolved = self.resolved_iron_proxy_for_principal(
             id,
             principal_id,
+            labels.clone(),
             pg,
             replace_placeholders,
             observability_enabled,

--- a/services/api-rs/crates/centaur-sandbox-agent-k8s/src/iron_proxy.rs
+++ b/services/api-rs/crates/centaur-sandbox-agent-k8s/src/iron_proxy.rs
@@ -178,6 +178,7 @@ struct ProxySyncEnv {
     proxy_id: String,
     control_url: String,
     token: String,
+    config_hash: Option<String>,
 }
 
 struct ControlPlaneEgressTarget {
@@ -395,8 +396,12 @@ impl AgentSandboxBackend {
             .await
             .map_err(|err| map_kube_error("create iron-proxy pod", err))?;
         self.wait_until_proxy_running(resolved).await?;
-        self.wait_for_cold_proxy_principal_applied(id, &resolved.principal_id)
-            .await;
+        self.wait_for_cold_proxy_principal_applied(
+            id,
+            &resolved.principal_id,
+            sync.config_hash.as_deref(),
+        )
+        .await;
         Ok(())
     }
 
@@ -427,6 +432,7 @@ impl AgentSandboxBackend {
             proxy_id: proxy.id,
             control_url: iron_control.control_url.clone(),
             token,
+            config_hash: proxy.config_hash,
         })
     }
 
@@ -560,7 +566,7 @@ impl AgentSandboxBackend {
             .insert(id.as_str().to_owned(), proxy.id);
         self.patch_iron_control_principal_annotation(id, principal_id)
             .await?;
-        self.wait_for_proxy_principal_applied(id, principal_id)
+        self.wait_for_proxy_principal_applied(id, principal_id, proxy.config_hash.as_deref())
             .await;
         Ok(())
     }
@@ -594,19 +600,19 @@ impl AgentSandboxBackend {
                 .annotations
                 .as_ref()
                 .and_then(|annotations| annotations.get(crate::IRON_CONTROL_PRINCIPAL_ANNOTATION));
-            if assigned_principal.map(String::as_str) == Some(principal_id) {
+            if assigned_principal.map(String::as_str) == Some(principal_id) && labels.is_empty() {
                 return Ok(());
             }
 
             let iron_control = self.config.iron_control.as_ref().ok_or_else(|| {
                 SandboxError::backend("iron-proxy requires iron-control to be configured")
             })?;
-            iron_control
+            let proxy = iron_control
                 .client
                 .assign_proxy_principal(&proxy_id, principal_id, labels)
                 .await
                 .map_err(|err| SandboxError::backend_source("iron-control assign proxy", err))?;
-            self.wait_for_proxy_principal_applied(id, principal_id)
+            self.wait_for_proxy_principal_applied(id, principal_id, proxy.config_hash.as_deref())
                 .await;
             return Ok(());
         }
@@ -728,10 +734,15 @@ impl AgentSandboxBackend {
     /// managed-mode management API fall back to a fixed delay. Never fails the
     /// claim: managed proxies fail closed until synced, so the worst case is a
     /// brief 503 window rather than a failed execution.
-    async fn wait_for_proxy_principal_applied(&self, id: &SandboxId, principal_id: &str) {
+    async fn wait_for_proxy_principal_applied(
+        &self,
+        id: &SandboxId,
+        principal_id: &str,
+        config_hash: Option<&str>,
+    ) {
         let started = Instant::now();
         match self
-            .proxy_principal_ack(id, principal_id, "claim barrier")
+            .proxy_principal_ack(id, principal_id, config_hash, "claim barrier")
             .await
         {
             Ok(ProxyAck::Applied) => {
@@ -779,10 +790,15 @@ impl AgentSandboxBackend {
     /// returns. Ask the proxy to report the requested principal's config before
     /// creating the sandbox pod. If the management API cannot prove readiness,
     /// fall back to the fixed delay instead of failing the sandbox create.
-    async fn wait_for_cold_proxy_principal_applied(&self, id: &SandboxId, principal_id: &str) {
+    async fn wait_for_cold_proxy_principal_applied(
+        &self,
+        id: &SandboxId,
+        principal_id: &str,
+        config_hash: Option<&str>,
+    ) {
         let started = Instant::now();
         match self
-            .proxy_principal_ack(id, principal_id, "cold create barrier")
+            .proxy_principal_ack(id, principal_id, config_hash, "cold create barrier")
             .await
         {
             Ok(ProxyAck::Applied) => {
@@ -829,6 +845,7 @@ impl AgentSandboxBackend {
         &self,
         id: &SandboxId,
         principal_id: &str,
+        config_hash: Option<&str>,
         barrier: &'static str,
     ) -> SandboxResult<ProxyAck> {
         let endpoint = match self.proxy_management_endpoint(id).await {
@@ -856,6 +873,7 @@ impl AgentSandboxBackend {
             &client,
             &endpoint,
             principal_id,
+            config_hash,
             PROXY_ACK_TIMEOUT,
             PROXY_ACK_PROBE_WINDOW,
             PROXY_ACK_POLL_INTERVAL,
@@ -1027,6 +1045,8 @@ struct ProxyManagementEndpoint {
 #[derive(serde::Deserialize)]
 struct ProxyManagedStatus {
     #[serde(default)]
+    config_hash: Option<String>,
+    #[serde(default)]
     principal_id: String,
     #[serde(default)]
     synced_once: bool,
@@ -1057,6 +1077,7 @@ async fn wait_for_proxy_ack(
     client: &reqwest::Client,
     endpoint: &ProxyManagementEndpoint,
     principal_id: &str,
+    config_hash: Option<&str>,
     ack_timeout: Duration,
     probe_window: Duration,
     poll_interval: Duration,
@@ -1090,6 +1111,10 @@ async fn wait_for_proxy_ack(
             if let Ok(status) = response.json::<ProxyManagedStatus>().await
                 && status.synced_once
                 && status.principal_id == principal_id
+                && status
+                    .config_hash
+                    .as_deref()
+                    .is_none_or(|applied_hash| config_hash.is_none_or(|hash| applied_hash == hash))
             {
                 return ProxyAck::Applied;
             }
@@ -2137,6 +2162,7 @@ mod tests {
             proxy_id: "iprx_test".to_owned(),
             control_url: "http://console:3000".to_owned(),
             token: "proxy-token".to_owned(),
+            config_hash: None,
         };
 
         let pod = build_iron_proxy_pod(&id, &iron_proxy, &resolved, &sync);
@@ -2319,6 +2345,7 @@ mod tests {
             proxy_id: "proxy-id".to_owned(),
             control_url: "http://iron-control".to_owned(),
             token: "proxy-token".to_owned(),
+            config_hash: None,
         };
 
         let env = iron_proxy_env_vars(&iron_proxy, &resolved(), &sync);
@@ -2343,6 +2370,7 @@ mod tests {
             proxy_id: "proxy-id".to_owned(),
             control_url: "http://iron-control".to_owned(),
             token: "proxy-token".to_owned(),
+            config_hash: None,
         };
 
         let env = iron_proxy_env_vars(&iron_proxy, &resolved(), &sync);
@@ -2594,6 +2622,7 @@ mod tests {
             &barrier_client(),
             &endpoint,
             "prin_claimed",
+            None,
             Duration::from_secs(5),
             Duration::from_secs(5),
             Duration::from_millis(10),
@@ -2620,9 +2649,33 @@ mod tests {
             &barrier_client(),
             &endpoint,
             "prin_claimed",
+            None,
             Duration::from_millis(400),
             Duration::from_millis(200),
             Duration::from_millis(25),
+        )
+        .await;
+
+        assert_eq!(ack, ProxyAck::TimedOut);
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn proxy_ack_rejects_matching_principal_with_stale_config_hash() {
+        let (base_url, _sync_calls, server) = spawn_management_stub("test-key", 0).await;
+        let endpoint = ProxyManagementEndpoint {
+            base_url,
+            api_key: "test-key".to_owned(),
+        };
+
+        let ack = wait_for_proxy_ack(
+            &barrier_client(),
+            &endpoint,
+            "prin_claimed",
+            Some("sha256:expected"),
+            Duration::from_millis(200),
+            Duration::from_millis(200),
+            Duration::from_millis(10),
         )
         .await;
 
@@ -2646,6 +2699,7 @@ mod tests {
             &barrier_client(),
             &endpoint,
             "prin_claimed",
+            None,
             Duration::from_secs(2),
             Duration::from_millis(300),
             Duration::from_millis(50),

--- a/services/api-rs/crates/centaur-sandbox-agent-k8s/src/iron_proxy.rs
+++ b/services/api-rs/crates/centaur-sandbox-agent-k8s/src/iron_proxy.rs
@@ -148,6 +148,13 @@ pub(crate) struct ResolvedIronProxy {
     api_server_enabled: bool,
 }
 
+struct ResolvedIronProxyRuntime {
+    pg: Option<ResolvedPg>,
+    replace_placeholders: BTreeMap<String, String>,
+    observability_enabled: bool,
+    api_server_enabled: bool,
+}
+
 /// The single Postgres listener the proxy multiplexes every upstream through.
 /// iron-control owns each upstream DSN/role/database and routes by database
 /// name; api-rs only assigns the local listen port and the shared client
@@ -209,10 +216,12 @@ impl AgentSandboxBackend {
             id,
             principal_id,
             labels,
-            pg,
-            replace_placeholders,
-            spec.capabilities.observability_enabled,
-            spec.capabilities.api_server_enabled,
+            ResolvedIronProxyRuntime {
+                pg,
+                replace_placeholders,
+                observability_enabled: spec.capabilities.observability_enabled,
+                api_server_enabled: spec.capabilities.api_server_enabled,
+            },
         )))
     }
 
@@ -307,10 +316,12 @@ impl AgentSandboxBackend {
             id,
             principal_id,
             BTreeMap::new(),
-            pg,
-            replace_placeholders,
-            observability_enabled,
-            api_server_enabled,
+            ResolvedIronProxyRuntime {
+                pg,
+                replace_placeholders,
+                observability_enabled,
+                api_server_enabled,
+            },
         )))
     }
 
@@ -319,10 +330,7 @@ impl AgentSandboxBackend {
         id: &SandboxId,
         principal_id: String,
         labels: BTreeMap<String, String>,
-        pg: Option<ResolvedPg>,
-        replace_placeholders: BTreeMap<String, String>,
-        observability_enabled: bool,
-        api_server_enabled: bool,
+        runtime: ResolvedIronProxyRuntime,
     ) -> ResolvedIronProxy {
         ResolvedIronProxy {
             proxy_host: iron_proxy_service_name(id),
@@ -336,11 +344,11 @@ impl AgentSandboxBackend {
                 .unwrap_or_default(),
             principal_id,
             labels,
-            pg,
-            replace_placeholders,
+            pg: runtime.pg,
+            replace_placeholders: runtime.replace_placeholders,
             management_api_key: new_proxy_management_api_key(),
-            observability_enabled,
-            api_server_enabled,
+            observability_enabled: runtime.observability_enabled,
+            api_server_enabled: runtime.api_server_enabled,
         }
     }
 
@@ -573,11 +581,12 @@ impl AgentSandboxBackend {
             });
         }
         let proxy_id = self.proxy_id_for_sandbox(id).await?;
-        if proxy_id.is_some() && self.has_usable_iron_proxy_resources(id).await? {
+        if let Some(proxy_id) = proxy_id
+            && self.has_usable_iron_proxy_resources(id).await?
+        {
             let iron_control = self.config.iron_control.as_ref().ok_or_else(|| {
                 SandboxError::backend("iron-proxy requires iron-control to be configured")
             })?;
-            let proxy_id = proxy_id.expect("proxy_id checked as Some above");
             iron_control
                 .client
                 .assign_proxy_principal(&proxy_id, principal_id, labels)
@@ -646,10 +655,12 @@ impl AgentSandboxBackend {
             id,
             principal_id,
             labels.clone(),
-            pg,
-            replace_placeholders,
-            observability_enabled,
-            api_server_enabled,
+            ResolvedIronProxyRuntime {
+                pg,
+                replace_placeholders,
+                observability_enabled,
+                api_server_enabled,
+            },
         );
         self.create_iron_proxy_resources(id, Some(&resolved))
             .await?;
@@ -1980,6 +1991,7 @@ mod tests {
             proxy_port: 8080,
             console_url: "http://console:3000".to_owned(),
             principal_id: "principal".to_owned(),
+            labels: BTreeMap::new(),
             pg: None,
             replace_placeholders: BTreeMap::new(),
             management_api_key: "test-management-key".to_owned(),

--- a/services/api-rs/crates/centaur-sandbox-agent-k8s/src/iron_proxy.rs
+++ b/services/api-rs/crates/centaur-sandbox-agent-k8s/src/iron_proxy.rs
@@ -584,6 +584,20 @@ impl AgentSandboxBackend {
         if let Some(proxy_id) = proxy_id
             && self.has_usable_iron_proxy_resources(id).await?
         {
+            let sandbox = self
+                .sandboxes()
+                .get(id.as_str())
+                .await
+                .map_err(|err| map_kube_error("get sandbox for proxy principal check", err))?;
+            let assigned_principal = sandbox
+                .metadata
+                .annotations
+                .as_ref()
+                .and_then(|annotations| annotations.get(crate::IRON_CONTROL_PRINCIPAL_ANNOTATION));
+            if assigned_principal.map(String::as_str) == Some(principal_id) {
+                return Ok(());
+            }
+
             let iron_control = self.config.iron_control.as_ref().ok_or_else(|| {
                 SandboxError::backend("iron-proxy requires iron-control to be configured")
             })?;

--- a/services/api-rs/crates/centaur-sandbox-agent-k8s/src/lib.rs
+++ b/services/api-rs/crates/centaur-sandbox-agent-k8s/src/lib.rs
@@ -446,16 +446,18 @@ impl SandboxBackend for AgentSandboxBackend {
         &self,
         id: &SandboxId,
         principal_id: &str,
+        labels: &BTreeMap<String, String>,
     ) -> SandboxResult<()> {
-        self.assign_proxy_principal(id, principal_id).await
+        self.assign_proxy_principal(id, principal_id, labels).await
     }
 
     async fn ensure_iron_control_proxy_resources(
         &self,
         id: &SandboxId,
         principal_id: &str,
+        labels: &BTreeMap<String, String>,
     ) -> SandboxResult<()> {
-        self.ensure_proxy_resources_for_principal(id, principal_id)
+        self.ensure_proxy_resources_for_principal(id, principal_id, labels)
             .await
     }
 

--- a/services/api-rs/crates/centaur-sandbox-core/src/backend.rs
+++ b/services/api-rs/crates/centaur-sandbox-core/src/backend.rs
@@ -1,4 +1,5 @@
 use async_trait::async_trait;
+use std::collections::BTreeMap;
 
 use crate::{
     ObservedSandbox, SandboxHandle, SandboxId, SandboxIo, SandboxResult, SandboxSpec, SandboxStatus,
@@ -59,6 +60,7 @@ pub trait SandboxBackend: Send + Sync {
         &self,
         _id: &SandboxId,
         _principal_id: &str,
+        _labels: &BTreeMap<String, String>,
     ) -> SandboxResult<()> {
         Err(crate::SandboxError::Unsupported {
             backend: self.name(),
@@ -73,6 +75,7 @@ pub trait SandboxBackend: Send + Sync {
         &self,
         _id: &SandboxId,
         _principal_id: &str,
+        _labels: &BTreeMap<String, String>,
     ) -> SandboxResult<()> {
         Ok(())
     }

--- a/services/api-rs/crates/centaur-sandbox-core/src/spec.rs
+++ b/services/api-rs/crates/centaur-sandbox-core/src/spec.rs
@@ -67,6 +67,11 @@ pub struct SandboxSpec {
     /// proxy for the sandbox instead of rendering a static proxy config.
     #[serde(default)]
     pub iron_control_principal: Option<String>,
+    /// Labels applied to the iron-control proxy registered for this sandbox.
+    /// These are distinct from Kubernetes labels and are used by iron-control
+    /// when rendering proxy-specific config.
+    #[serde(default)]
+    pub iron_control_proxy_labels: std::collections::BTreeMap<String, String>,
     #[serde(default)]
     pub capabilities: SandboxCapabilities,
 }
@@ -83,6 +88,7 @@ impl SandboxSpec {
             mounts: Vec::new(),
             resources: None,
             iron_control_principal: None,
+            iron_control_proxy_labels: std::collections::BTreeMap::new(),
             capabilities: SandboxCapabilities::default_enabled(),
         }
     }

--- a/services/api-rs/crates/centaur-sandbox-manager/src/manager.rs
+++ b/services/api-rs/crates/centaur-sandbox-manager/src/manager.rs
@@ -1,4 +1,4 @@
-use std::{sync::Arc, time::Duration};
+use std::{collections::BTreeMap, sync::Arc, time::Duration};
 
 use centaur_sandbox_core::{
     DesiredSandboxState, ObservedSandbox, SandboxBackend, SandboxHandle, SandboxId, SandboxIo,
@@ -243,9 +243,10 @@ where
         &self,
         id: &SandboxId,
         principal_id: &str,
+        labels: &BTreeMap<String, String>,
     ) -> SandboxResult<()> {
         self.backend
-            .assign_iron_control_proxy_principal(id, principal_id)
+            .assign_iron_control_proxy_principal(id, principal_id, labels)
             .await
     }
 
@@ -253,9 +254,10 @@ where
         &self,
         id: &SandboxId,
         principal_id: &str,
+        labels: &BTreeMap<String, String>,
     ) -> SandboxResult<()> {
         self.backend
-            .ensure_iron_control_proxy_resources(id, principal_id)
+            .ensure_iron_control_proxy_resources(id, principal_id, labels)
             .await
     }
 

--- a/services/api-rs/crates/centaur-sandbox-manager/src/warm_pool.rs
+++ b/services/api-rs/crates/centaur-sandbox-manager/src/warm_pool.rs
@@ -1,4 +1,4 @@
-use std::{sync::Arc, time::Duration};
+use std::{collections::BTreeMap, sync::Arc, time::Duration};
 
 use centaur_sandbox_core::{SandboxError, SandboxId, SandboxSpec, SandboxStatus};
 use centaur_session_sqlx::{PgSessionStore, SessionStoreError};
@@ -65,6 +65,7 @@ impl WarmPoolManager {
         &self,
         thread_key: &str,
         iron_control_principal: Option<&str>,
+        proxy_labels: &BTreeMap<String, String>,
     ) -> Result<Option<String>, WarmPoolError> {
         loop {
             let Some(sandbox_id) = self
@@ -85,7 +86,7 @@ impl WarmPoolManager {
                     if let Some(principal_id) = iron_control_principal
                         && let Err(error) = self
                             .manager
-                            .assign_iron_control_proxy_principal(&id, principal_id)
+                            .assign_iron_control_proxy_principal(&id, principal_id, proxy_labels)
                             .await
                     {
                         let error_message = error.to_string();

--- a/services/api-rs/crates/centaur-session-core/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-core/src/lib.rs
@@ -3,7 +3,7 @@
 //! A session is the public control-plane object for one ongoing agent
 //! conversation. `thread_key` is the canonical identifier.
 
-use std::{fmt, str::FromStr};
+use std::{collections::BTreeMap, fmt, str::FromStr};
 
 use serde::{Deserialize, Deserializer, Serialize, Serializer, de};
 use serde_json::Value;
@@ -462,6 +462,10 @@ pub struct Session {
     /// iron-control principal OID this session's egress proxy binds to,
     /// captured at registration so a resumed session can recreate its sandbox.
     pub iron_control_principal: Option<String>,
+    /// Per-proxy labels captured at session creation and applied whenever this
+    /// session's egress proxy is created, repaired, or rebound.
+    #[serde(default)]
+    pub proxy_labels: BTreeMap<String, String>,
     /// Last meaningful activity for the currently assigned sandbox. This is
     /// the eviction signal for capacity pressure and intentionally separate
     /// from `updated_at`, which also changes for metadata/status writes.

--- a/services/api-rs/crates/centaur-session-runtime/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-runtime/src/lib.rs
@@ -760,6 +760,7 @@ struct EnsureSessionSandboxRequest<'a> {
     existing_sandbox_id: Option<&'a str>,
     existing_sandbox_capabilities: Option<&'a SessionSandboxCapabilities>,
     iron_control_principal: Option<&'a str>,
+    proxy_labels: &'a BTreeMap<String, String>,
     desired_capabilities: &'a SessionSandboxCapabilities,
     execution_id: &'a str,
 }
@@ -1040,7 +1041,7 @@ impl SessionRuntime {
         let metadata = tool_host_session_metadata(principal_id);
         let session = self
             .store
-            .create_or_get_session(thread_key, &harness, None, metadata)
+            .create_or_get_session(thread_key, &harness, None, metadata, BTreeMap::new())
             .await?;
         if self.iron_control.is_some()
             && session.iron_control_principal.as_deref() != Some(principal_id)
@@ -1355,6 +1356,7 @@ impl SessionRuntime {
             );
             let mut harness_switched = false;
             let mut session_metadata = default_metadata(metadata);
+            let proxy_labels = proxy_labels_from_session_metadata(thread_key, &session_metadata);
             let (registered_principal, desired_capabilities) =
                 if let Some(registrar) = &self.iron_control {
                     let principal = registrar
@@ -1377,6 +1379,7 @@ impl SessionRuntime {
                     harness_type,
                     persona_resolution.persona_id.as_deref(),
                     session_metadata.clone(),
+                    proxy_labels.clone(),
                 )
                 .await
             {
@@ -1390,6 +1393,7 @@ impl SessionRuntime {
                             harness_type,
                             existing.as_deref(),
                             default_metadata(None),
+                            BTreeMap::new(),
                         )
                         .await?
                 }
@@ -1939,6 +1943,7 @@ impl SessionRuntime {
                     existing_sandbox_id: session.sandbox_id.as_deref(),
                     existing_sandbox_capabilities: session.sandbox_capabilities.as_ref(),
                     iron_control_principal: session.iron_control_principal.as_deref(),
+                    proxy_labels: &session.proxy_labels,
                     desired_capabilities: &desired_capabilities,
                     execution_id: &execution.execution_id,
                 })
@@ -2328,6 +2333,7 @@ impl SessionRuntime {
             existing_sandbox_id,
             existing_sandbox_capabilities,
             iron_control_principal,
+            proxy_labels,
             desired_capabilities,
             execution_id,
         } = request;
@@ -2398,7 +2404,11 @@ impl SessionRuntime {
                             if let Some(principal_id) = iron_control_principal {
                                 self.sandbox_runtime
                                     .manager
-                                    .ensure_iron_control_proxy_resources(&id, principal_id)
+                                    .ensure_iron_control_proxy_resources(
+                                        &id,
+                                        principal_id,
+                                        proxy_labels,
+                                    )
                                     .await?;
                             }
                             span.record("centaur.sandbox_id", sandbox_id);
@@ -2446,6 +2456,16 @@ impl SessionRuntime {
                                 .await
                             {
                                 Ok(()) => {
+                                    if let Some(principal_id) = iron_control_principal {
+                                        self.sandbox_runtime
+                                            .manager
+                                            .ensure_iron_control_proxy_resources(
+                                                &id,
+                                                principal_id,
+                                                proxy_labels,
+                                            )
+                                            .await?;
+                                    }
                                     span.record("centaur.sandbox_id", sandbox_id);
                                     span.record("sandbox_id", sandbox_id);
                                     let ready_duration = ensure_started.elapsed();
@@ -2566,7 +2586,7 @@ impl SessionRuntime {
                 })
             {
                 match warm_pool
-                    .claim(thread_key.as_str(), iron_control_principal)
+                    .claim(thread_key.as_str(), iron_control_principal, proxy_labels)
                     .await
                 {
                     Ok(Some(sandbox_id)) => {
@@ -2634,6 +2654,7 @@ impl SessionRuntime {
             );
             if let Some(principal) = iron_control_principal {
                 spec.iron_control_principal = Some(principal.to_owned());
+                spec.iron_control_proxy_labels = proxy_labels.clone();
             }
             apply_sandbox_boot_mode(&mut spec, &boot_mode);
             apply_sandbox_capabilities(&mut spec, desired_capabilities);
@@ -6615,6 +6636,56 @@ fn tool_host_session_metadata(principal_id: &str) -> Value {
     })
 }
 
+fn proxy_labels_from_session_metadata(
+    thread_key: &ThreadKey,
+    metadata: &Value,
+) -> BTreeMap<String, String> {
+    let mut labels = BTreeMap::new();
+    insert_metadata_string_label(
+        &mut labels,
+        "centaur.slack_user_id",
+        metadata.get("slack_user_id"),
+    );
+    insert_metadata_string_label(
+        &mut labels,
+        "centaur.slack_team_id",
+        metadata.get("slack_team_id"),
+    );
+    insert_metadata_string_label(
+        &mut labels,
+        "centaur.slack_channel_id",
+        metadata.get("slack_channel_id"),
+    );
+    if !labels.contains_key("centaur.slack_channel_id") {
+        if let Some(channel_id) = slack_conversation_id(thread_key.as_str()) {
+            labels.insert("centaur.slack_channel_id".to_owned(), channel_id.to_owned());
+        }
+    }
+    labels
+}
+
+fn insert_metadata_string_label(
+    labels: &mut BTreeMap<String, String>,
+    label: &str,
+    value: Option<&Value>,
+) {
+    let Some(value) = value.and_then(Value::as_str).map(str::trim) else {
+        return;
+    };
+    if !value.is_empty() {
+        labels.insert(label.to_owned(), value.to_owned());
+    }
+}
+
+fn slack_conversation_id(thread_key: &str) -> Option<&str> {
+    for segment in thread_key.split(':').skip(1) {
+        if matches!(segment.as_bytes().first(), Some(b'C' | b'D' | b'G')) {
+            return Some(segment);
+        }
+    }
+    None
+}
+
 fn sandbox_boot_mode_for_thread(
     thread_key: &ThreadKey,
     iron_control_principal: Option<&str>,
@@ -8157,6 +8228,29 @@ mod tests {
         assert_ne!(thread_trace_parent_span_id(&thread_key), "0000000000000000");
     }
 
+    #[test]
+    fn proxy_labels_from_session_metadata_use_centaur_slack_keys() {
+        let thread_key = ThreadKey::parse("slack:T123:C123:1700000000.000000").unwrap();
+        let labels = proxy_labels_from_session_metadata(
+            &thread_key,
+            &json!({
+                "slack_user_id": "U123",
+                "slack_team_id": "T123",
+                "slack_channel_id": "C456",
+                "slack_user_email": "ada@example.com"
+            }),
+        );
+
+        assert_eq!(
+            labels,
+            BTreeMap::from([
+                ("centaur.slack_channel_id".to_owned(), "C456".to_owned()),
+                ("centaur.slack_team_id".to_owned(), "T123".to_owned()),
+                ("centaur.slack_user_id".to_owned(), "U123".to_owned()),
+            ])
+        );
+    }
+
     fn session_with_sandbox(sandbox_id: &str) -> Session {
         let thread_key = ThreadKey::parse("cli:test-idle").unwrap();
         let now = OffsetDateTime::now_utc();
@@ -8170,6 +8264,7 @@ mod tests {
             persona_id: None,
             status: SessionStatus::Idle,
             iron_control_principal: None,
+            proxy_labels: BTreeMap::new(),
             sandbox_last_active_at: Some(now),
             created_at: now,
             updated_at: now,
@@ -8247,7 +8342,7 @@ mod adoption_tests {
         created_specs: std::sync::Mutex<Vec<SandboxSpec>>,
         resume_fails: AtomicBool,
         stopped: std::sync::Mutex<Vec<String>>,
-        proxy_ensures: std::sync::Mutex<Vec<(String, String)>>,
+        proxy_ensures: std::sync::Mutex<Vec<(String, String, BTreeMap<String, String>)>>,
         missing_on_stop: std::sync::Mutex<BTreeSet<String>>,
     }
 
@@ -8314,7 +8409,7 @@ mod adoption_tests {
             self.stopped.lock().unwrap().clone()
         }
 
-        fn proxy_ensures(&self) -> Vec<(String, String)> {
+        fn proxy_ensures(&self) -> Vec<(String, String, BTreeMap<String, String>)> {
             self.proxy_ensures.lock().unwrap().clone()
         }
 
@@ -8390,11 +8485,13 @@ mod adoption_tests {
             &self,
             id: &SandboxId,
             principal_id: &str,
+            labels: &BTreeMap<String, String>,
         ) -> SandboxResult<()> {
-            self.proxy_ensures
-                .lock()
-                .unwrap()
-                .push((id.as_str().to_owned(), principal_id.to_owned()));
+            self.proxy_ensures.lock().unwrap().push((
+                id.as_str().to_owned(),
+                principal_id.to_owned(),
+                labels.clone(),
+            ));
             Ok(())
         }
 
@@ -8466,7 +8563,13 @@ mod adoption_tests {
         running: bool,
     ) -> String {
         store
-            .create_or_get_session(thread_key, &HarnessType::Codex, None, json!({}))
+            .create_or_get_session(
+                thread_key,
+                &HarnessType::Codex,
+                None,
+                json!({}),
+                Default::default(),
+            )
             .await
             .expect("create session");
         if sandbox_id.is_some() {
@@ -8656,7 +8759,13 @@ mod adoption_tests {
         let _serial = TEST_LOCK.lock().await;
         let thread_key = ThreadKey::parse(format!("test:title-{}", uuid::Uuid::new_v4())).unwrap();
         store
-            .create_or_get_session(&thread_key, &HarnessType::Codex, None, json!({}))
+            .create_or_get_session(
+                &thread_key,
+                &HarnessType::Codex,
+                None,
+                json!({}),
+                Default::default(),
+            )
             .await
             .expect("create session");
 
@@ -8827,7 +8936,13 @@ mod adoption_tests {
         let thread_key =
             ThreadKey::parse(format!("test:cap-replace-{}", uuid::Uuid::new_v4())).unwrap();
         store
-            .create_or_get_session(&thread_key, &HarnessType::Codex, None, json!({}))
+            .create_or_get_session(
+                &thread_key,
+                &HarnessType::Codex,
+                None,
+                json!({}),
+                Default::default(),
+            )
             .await
             .expect("create session");
         store
@@ -8852,6 +8967,7 @@ mod adoption_tests {
                 existing_sandbox_id: session.sandbox_id.as_deref(),
                 existing_sandbox_capabilities: session.sandbox_capabilities.as_ref(),
                 iron_control_principal: None,
+                proxy_labels: &BTreeMap::new(),
                 desired_capabilities: &restricted_capabilities(),
                 execution_id: &execution_id,
             })
@@ -8904,7 +9020,13 @@ mod adoption_tests {
         let thread_key =
             ThreadKey::parse(format!("test:cap-warm-skip-{}", uuid::Uuid::new_v4())).unwrap();
         store
-            .create_or_get_session(&thread_key, &HarnessType::Codex, None, json!({}))
+            .create_or_get_session(
+                &thread_key,
+                &HarnessType::Codex,
+                None,
+                json!({}),
+                Default::default(),
+            )
             .await
             .expect("create session");
         let execution_id = store
@@ -8936,6 +9058,7 @@ mod adoption_tests {
                 existing_sandbox_id: None,
                 existing_sandbox_capabilities: None,
                 iron_control_principal: None,
+                proxy_labels: &BTreeMap::new(),
                 desired_capabilities: &restricted_capabilities(),
                 execution_id: &execution_id,
             })
@@ -8970,7 +9093,13 @@ mod adoption_tests {
         let thread_key =
             ThreadKey::parse(format!("test:proxy-reuse-{}", uuid::Uuid::new_v4())).unwrap();
         store
-            .create_or_get_session(&thread_key, &HarnessType::Codex, None, json!({}))
+            .create_or_get_session(
+                &thread_key,
+                &HarnessType::Codex,
+                None,
+                json!({}),
+                Default::default(),
+            )
             .await
             .expect("create session");
         let execution_id = store
@@ -8982,6 +9111,8 @@ mod adoption_tests {
 
         let backend = Arc::new(MockBackend::new(SandboxStatus::Running, Vec::new()));
         let runtime = runtime_with(&store, backend.clone());
+        let proxy_labels =
+            BTreeMap::from([("centaur.slack_user_id".to_owned(), "U0123456789".to_owned())]);
         let sandbox_id = runtime
             .ensure_session_sandbox(EnsureSessionSandboxRequest {
                 thread_key: &thread_key,
@@ -8990,6 +9121,7 @@ mod adoption_tests {
                 existing_sandbox_id: Some("sbx-existing"),
                 existing_sandbox_capabilities: None,
                 iron_control_principal: Some("principal-existing"),
+                proxy_labels: &proxy_labels,
                 desired_capabilities: &SessionSandboxCapabilities::default_enabled(),
                 execution_id: &execution_id,
             })
@@ -8999,7 +9131,11 @@ mod adoption_tests {
         assert_eq!(sandbox_id, "sbx-existing");
         assert_eq!(
             backend.proxy_ensures(),
-            vec![("sbx-existing".to_owned(), "principal-existing".to_owned())]
+            vec![(
+                "sbx-existing".to_owned(),
+                "principal-existing".to_owned(),
+                proxy_labels
+            )]
         );
     }
 
@@ -9031,7 +9167,13 @@ mod adoption_tests {
             ThreadKey::parse(format!("test:capacity-trigger-{}", uuid::Uuid::new_v4())).unwrap();
 
         store
-            .create_or_get_session(&stale_thread, &HarnessType::Codex, None, json!({}))
+            .create_or_get_session(
+                &stale_thread,
+                &HarnessType::Codex,
+                None,
+                json!({}),
+                Default::default(),
+            )
             .await
             .expect("create stale session");
         store
@@ -9039,7 +9181,13 @@ mod adoption_tests {
             .await
             .expect("assign stale sandbox");
         store
-            .create_or_get_session(&paused_thread, &HarnessType::Codex, None, json!({}))
+            .create_or_get_session(
+                &paused_thread,
+                &HarnessType::Codex,
+                None,
+                json!({}),
+                Default::default(),
+            )
             .await
             .expect("create paused session");
         store
@@ -9060,7 +9208,13 @@ mod adoption_tests {
             .await
             .expect("append paused event");
         store
-            .create_or_get_session(&old_thread, &HarnessType::Codex, None, json!({}))
+            .create_or_get_session(
+                &old_thread,
+                &HarnessType::Codex,
+                None,
+                json!({}),
+                Default::default(),
+            )
             .await
             .expect("create old session");
         store
@@ -9068,7 +9222,13 @@ mod adoption_tests {
             .await
             .expect("assign old sandbox");
         store
-            .create_or_get_session(&hot_thread, &HarnessType::Codex, None, json!({}))
+            .create_or_get_session(
+                &hot_thread,
+                &HarnessType::Codex,
+                None,
+                json!({}),
+                Default::default(),
+            )
             .await
             .expect("create hot session");
         store
@@ -9158,6 +9318,7 @@ mod adoption_tests {
                     "workflow_run_id": workflow_run_id,
                     "workflow_owned_thread": true,
                 }),
+                Default::default(),
             )
             .await
             .expect("create session");
@@ -9230,6 +9391,7 @@ mod adoption_tests {
                     "source": "absurd_workflow",
                     "workflow_run_id": workflow_run_id,
                 }),
+                Default::default(),
             )
             .await
             .expect("create session");
@@ -9272,6 +9434,7 @@ mod adoption_tests {
                     "workflow_run_id": workflow_run_id,
                     "workflow_owned_thread": true,
                 }),
+                Default::default(),
             )
             .await
             .expect("create session");
@@ -9304,7 +9467,13 @@ mod adoption_tests {
         let thread_key =
             ThreadKey::parse(format!("test:resume-failed-{}", uuid::Uuid::new_v4())).unwrap();
         store
-            .create_or_get_session(&thread_key, &HarnessType::Codex, None, json!({}))
+            .create_or_get_session(
+                &thread_key,
+                &HarnessType::Codex,
+                None,
+                json!({}),
+                Default::default(),
+            )
             .await
             .expect("create session");
         store
@@ -9333,6 +9502,7 @@ mod adoption_tests {
                 existing_sandbox_id: Some("sbx-old"),
                 existing_sandbox_capabilities: None,
                 iron_control_principal: None,
+                proxy_labels: &BTreeMap::new(),
                 desired_capabilities: &SessionSandboxCapabilities::default_enabled(),
                 execution_id: &execution_id,
             })

--- a/services/api-rs/crates/centaur-session-runtime/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-runtime/src/lib.rs
@@ -6657,7 +6657,7 @@ fn proxy_labels_from_session_metadata(
         metadata.get("slack_channel_id"),
     );
     if !labels.contains_key("centaur.slack_channel_id")
-        && let Some(channel_id) = slack_conversation_id(thread_key.as_str())
+        && let Some(channel_id) = slack_conversation_id(thread_key)
     {
         labels.insert("centaur.slack_channel_id".to_owned(), channel_id.to_owned());
     }
@@ -6677,11 +6677,9 @@ fn insert_metadata_string_label(
     }
 }
 
-fn slack_conversation_id(thread_key: &str) -> Option<&str> {
-    for segment in thread_key.split(':').skip(1) {
-        if matches!(segment.as_bytes().first(), Some(b'C' | b'D' | b'G')) {
-            return Some(segment);
-        }
+fn slack_conversation_id(thread_key: &ThreadKey) -> Option<String> {
+    if let Some(ChatDestination::Slack { channel_id, .. }) = thread_key.chat_destination() {
+        return Some(channel_id);
     }
     None
 }
@@ -8245,6 +8243,26 @@ mod tests {
             labels,
             BTreeMap::from([
                 ("centaur.slack_channel_id".to_owned(), "C456".to_owned()),
+                ("centaur.slack_team_id".to_owned(), "T123".to_owned()),
+                ("centaur.slack_user_id".to_owned(), "U123".to_owned()),
+            ])
+        );
+    }
+
+    #[test]
+    fn proxy_labels_from_session_metadata_does_not_infer_slack_channel_for_linear_keys() {
+        let thread_key = ThreadKey::parse("linear:CEN-123:s:agent-session").unwrap();
+        let labels = proxy_labels_from_session_metadata(
+            &thread_key,
+            &json!({
+                "slack_user_id": "U123",
+                "slack_team_id": "T123",
+            }),
+        );
+
+        assert_eq!(
+            labels,
+            BTreeMap::from([
                 ("centaur.slack_team_id".to_owned(), "T123".to_owned()),
                 ("centaur.slack_user_id".to_owned(), "U123".to_owned()),
             ])

--- a/services/api-rs/crates/centaur-session-runtime/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-runtime/src/lib.rs
@@ -6656,10 +6656,10 @@ fn proxy_labels_from_session_metadata(
         "centaur.slack_channel_id",
         metadata.get("slack_channel_id"),
     );
-    if !labels.contains_key("centaur.slack_channel_id") {
-        if let Some(channel_id) = slack_conversation_id(thread_key.as_str()) {
-            labels.insert("centaur.slack_channel_id".to_owned(), channel_id.to_owned());
-        }
+    if !labels.contains_key("centaur.slack_channel_id")
+        && let Some(channel_id) = slack_conversation_id(thread_key.as_str())
+    {
+        labels.insert("centaur.slack_channel_id".to_owned(), channel_id.to_owned());
     }
     labels
 }
@@ -8332,6 +8332,8 @@ mod adoption_tests {
     /// fully terminalizes its own executions before releasing the lock.
     static TEST_LOCK: Mutex<()> = Mutex::const_new(());
 
+    type ProxyEnsure = (String, String, BTreeMap<String, String>);
+
     struct MockBackend {
         ios: Mutex<VecDeque<SandboxIo>>,
         recorded_output: std::sync::Mutex<Vec<String>>,
@@ -8342,7 +8344,7 @@ mod adoption_tests {
         created_specs: std::sync::Mutex<Vec<SandboxSpec>>,
         resume_fails: AtomicBool,
         stopped: std::sync::Mutex<Vec<String>>,
-        proxy_ensures: std::sync::Mutex<Vec<(String, String, BTreeMap<String, String>)>>,
+        proxy_ensures: std::sync::Mutex<Vec<ProxyEnsure>>,
         missing_on_stop: std::sync::Mutex<BTreeSet<String>>,
     }
 
@@ -8409,7 +8411,7 @@ mod adoption_tests {
             self.stopped.lock().unwrap().clone()
         }
 
-        fn proxy_ensures(&self) -> Vec<(String, String, BTreeMap<String, String>)> {
+        fn proxy_ensures(&self) -> Vec<ProxyEnsure> {
             self.proxy_ensures.lock().unwrap().clone()
         }
 

--- a/services/api-rs/crates/centaur-session-sqlx/migrations/0047_session_proxy_labels.sql
+++ b/services/api-rs/crates/centaur-session-sqlx/migrations/0047_session_proxy_labels.sql
@@ -1,0 +1,2 @@
+alter table sessions
+    add column if not exists proxy_labels jsonb not null default '{}'::jsonb;

--- a/services/api-rs/crates/centaur-session-sqlx/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-sqlx/src/lib.rs
@@ -1,6 +1,6 @@
 //! SQLx-backed session repository.
 
-use std::{str::FromStr, time::Duration};
+use std::{collections::BTreeMap, str::FromStr, time::Duration};
 
 use centaur_session_core::{
     ExecutionStatus, HarnessType, MessageRole, SandboxCapabilities, SandboxRepoCacheAccess,
@@ -12,6 +12,7 @@ use serde_json::Value;
 use sqlx::{
     FromRow, PgPool,
     postgres::{PgListener, PgPoolOptions},
+    types::Json,
 };
 use thiserror::Error;
 use time::{Duration as TimeDuration, OffsetDateTime};
@@ -121,11 +122,12 @@ impl PgSessionStore {
         harness_type: &HarnessType,
         persona_id: Option<&str>,
         metadata: Value,
+        proxy_labels: BTreeMap<String, String>,
     ) -> Result<Session, SessionStoreError> {
         sqlx::query(
             r#"
-            insert into sessions (thread_key, harness_type, persona_id, status, metadata)
-            values ($1, $2, $3, $4, $5)
+            insert into sessions (thread_key, harness_type, persona_id, status, metadata, proxy_labels)
+            values ($1, $2, $3, $4, $5, $6)
             on conflict (thread_key) do nothing
             "#,
         )
@@ -134,8 +136,23 @@ impl PgSessionStore {
         .bind(persona_id)
         .bind(SessionStatus::Idle.as_ref())
         .bind(metadata)
+        .bind(Json(proxy_labels.clone()))
         .execute(&self.pool)
         .await?;
+
+        if !proxy_labels.is_empty() {
+            sqlx::query(
+                r#"
+                update sessions
+                set proxy_labels = $2, updated_at = now()
+                where thread_key = $1 and proxy_labels = '{}'::jsonb
+                "#,
+            )
+            .bind(thread_key.as_str())
+            .bind(Json(proxy_labels))
+            .execute(&self.pool)
+            .await?;
+        }
 
         let session = self.get_session(thread_key).await?;
         if session.harness_type != *harness_type {
@@ -158,7 +175,7 @@ impl PgSessionStore {
     pub async fn get_session(&self, thread_key: &ThreadKey) -> Result<Session, SessionStoreError> {
         let row = sqlx::query_as::<_, SessionRow>(
             r#"
-            select thread_key, title, sandbox_id, sandbox_repo_cache_enabled, sandbox_repo_cache_access, sandbox_observability_enabled, sandbox_api_server_enabled, harness_type, harness_thread_id, persona_id, status, iron_control_principal, sandbox_last_active_at, created_at, updated_at
+            select thread_key, title, sandbox_id, sandbox_repo_cache_enabled, sandbox_repo_cache_access, sandbox_observability_enabled, sandbox_api_server_enabled, harness_type, harness_thread_id, persona_id, status, iron_control_principal, proxy_labels, sandbox_last_active_at, created_at, updated_at
             from sessions
             where thread_key = $1
             "#,
@@ -1167,7 +1184,7 @@ impl PgSessionStore {
                 end,
                 updated_at = now()
             where thread_key = $1
-            returning thread_key, title, sandbox_id, sandbox_repo_cache_enabled, sandbox_repo_cache_access, sandbox_observability_enabled, sandbox_api_server_enabled, harness_type, harness_thread_id, persona_id, status, iron_control_principal, sandbox_last_active_at, created_at, updated_at
+            returning thread_key, title, sandbox_id, sandbox_repo_cache_enabled, sandbox_repo_cache_access, sandbox_observability_enabled, sandbox_api_server_enabled, harness_type, harness_thread_id, persona_id, status, iron_control_principal, proxy_labels, sandbox_last_active_at, created_at, updated_at
             "#,
         )
         .bind(thread_key.as_str())
@@ -1196,7 +1213,7 @@ impl PgSessionStore {
                 sandbox_last_active_at = now(),
                 updated_at = now()
             where thread_key = $1
-            returning thread_key, title, sandbox_id, sandbox_repo_cache_enabled, sandbox_repo_cache_access, sandbox_observability_enabled, sandbox_api_server_enabled, harness_type, harness_thread_id, persona_id, status, iron_control_principal, sandbox_last_active_at, created_at, updated_at
+            returning thread_key, title, sandbox_id, sandbox_repo_cache_enabled, sandbox_repo_cache_access, sandbox_observability_enabled, sandbox_api_server_enabled, harness_type, harness_thread_id, persona_id, status, iron_control_principal, proxy_labels, sandbox_last_active_at, created_at, updated_at
             "#,
         )
         .bind(thread_key.as_str())
@@ -1260,7 +1277,7 @@ impl PgSessionStore {
                 status = $3,
                 updated_at = now()
             where thread_key = $1
-            returning thread_key, title, sandbox_id, sandbox_repo_cache_enabled, sandbox_repo_cache_access, sandbox_observability_enabled, sandbox_api_server_enabled, harness_type, harness_thread_id, persona_id, status, iron_control_principal, sandbox_last_active_at, created_at, updated_at
+            returning thread_key, title, sandbox_id, sandbox_repo_cache_enabled, sandbox_repo_cache_access, sandbox_observability_enabled, sandbox_api_server_enabled, harness_type, harness_thread_id, persona_id, status, iron_control_principal, proxy_labels, sandbox_last_active_at, created_at, updated_at
             "#,
         )
         .bind(thread_key.as_str())
@@ -1285,7 +1302,7 @@ impl PgSessionStore {
             update sessions
             set iron_control_principal = $2, updated_at = now()
             where thread_key = $1
-            returning thread_key, title, sandbox_id, sandbox_repo_cache_enabled, sandbox_repo_cache_access, sandbox_observability_enabled, sandbox_api_server_enabled, harness_type, harness_thread_id, persona_id, status, iron_control_principal, sandbox_last_active_at, created_at, updated_at
+            returning thread_key, title, sandbox_id, sandbox_repo_cache_enabled, sandbox_repo_cache_access, sandbox_observability_enabled, sandbox_api_server_enabled, harness_type, harness_thread_id, persona_id, status, iron_control_principal, proxy_labels, sandbox_last_active_at, created_at, updated_at
             "#,
         )
         .bind(thread_key.as_str())
@@ -1455,7 +1472,7 @@ impl PgSessionStore {
             update sessions
             set harness_thread_id = $2, updated_at = now()
             where thread_key = $1
-            returning thread_key, title, sandbox_id, sandbox_repo_cache_enabled, sandbox_repo_cache_access, sandbox_observability_enabled, sandbox_api_server_enabled, harness_type, harness_thread_id, persona_id, status, iron_control_principal, sandbox_last_active_at, created_at, updated_at
+            returning thread_key, title, sandbox_id, sandbox_repo_cache_enabled, sandbox_repo_cache_access, sandbox_observability_enabled, sandbox_api_server_enabled, harness_type, harness_thread_id, persona_id, status, iron_control_principal, proxy_labels, sandbox_last_active_at, created_at, updated_at
             "#,
         )
         .bind(thread_key.as_str())
@@ -1602,6 +1619,7 @@ struct SessionRow {
     persona_id: Option<String>,
     status: String,
     iron_control_principal: Option<String>,
+    proxy_labels: Json<BTreeMap<String, String>>,
     sandbox_last_active_at: Option<OffsetDateTime>,
     created_at: OffsetDateTime,
     updated_at: OffsetDateTime,
@@ -1643,6 +1661,7 @@ impl TryFrom<SessionRow> for Session {
             persona_id: row.persona_id,
             status: parse_persisted(row.status)?,
             iron_control_principal: row.iron_control_principal,
+            proxy_labels: row.proxy_labels.0,
             sandbox_last_active_at: row.sandbox_last_active_at,
             created_at: row.created_at,
             updated_at: row.updated_at,
@@ -1895,7 +1914,7 @@ fn stdout_lease_expires_at(lease: Duration) -> OffsetDateTime {
 
 #[cfg(test)]
 mod tests {
-    use std::time::Duration;
+    use std::{collections::BTreeMap, time::Duration};
 
     use centaur_session_core::{HarnessType, ThreadKey};
     use serde_json::json;
@@ -1994,6 +2013,40 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn sessions_round_trip_proxy_labels() {
+        let Some(store) = test_store().await else {
+            return;
+        };
+        let thread_key = ThreadKey::parse(format!("test:proxy-labels-{}", Uuid::new_v4())).unwrap();
+        let labels = BTreeMap::from([
+            ("centaur.slack_user_id".to_owned(), "U123".to_owned()),
+            ("centaur.slack_team_id".to_owned(), "T123".to_owned()),
+            ("centaur.slack_channel_id".to_owned(), "C123".to_owned()),
+        ]);
+
+        let created = store
+            .create_or_get_session(
+                &thread_key,
+                &HarnessType::Codex,
+                None,
+                json!({}),
+                labels.clone(),
+            )
+            .await
+            .expect("create session");
+
+        assert_eq!(created.proxy_labels, labels);
+        assert_eq!(
+            store
+                .get_session(&thread_key)
+                .await
+                .expect("get session")
+                .proxy_labels,
+            labels
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn idle_candidates_use_persisted_execution_idle_timeout() {
         let Some(store) = test_store().await else {
             return;
@@ -2001,7 +2054,13 @@ mod tests {
         let thread_key = ThreadKey::parse(format!("test:idle-cleanup-{}", Uuid::new_v4())).unwrap();
         let sandbox_id = format!("sbx-idle-{}", Uuid::new_v4());
         store
-            .create_or_get_session(&thread_key, &HarnessType::Codex, None, json!({}))
+            .create_or_get_session(
+                &thread_key,
+                &HarnessType::Codex,
+                None,
+                json!({}),
+                Default::default(),
+            )
             .await
             .expect("create session");
         store
@@ -2051,7 +2110,13 @@ mod tests {
         };
         let thread_key = ThreadKey::parse(format!("test:stdout-owner-{}", Uuid::new_v4())).unwrap();
         store
-            .create_or_get_session(&thread_key, &HarnessType::Codex, None, json!({}))
+            .create_or_get_session(
+                &thread_key,
+                &HarnessType::Codex,
+                None,
+                json!({}),
+                Default::default(),
+            )
             .await
             .expect("create session");
         let execution_id = store
@@ -2151,7 +2216,13 @@ mod tests {
             let thread_key =
                 ThreadKey::parse(format!("test:handoff-{label}-{}", Uuid::new_v4())).unwrap();
             store
-                .create_or_get_session(&thread_key, &HarnessType::Codex, None, json!({}))
+                .create_or_get_session(
+                    &thread_key,
+                    &HarnessType::Codex,
+                    None,
+                    json!({}),
+                    Default::default(),
+                )
                 .await
                 .expect("create session");
             let execution_id = store
@@ -2176,7 +2247,13 @@ mod tests {
         let bystander_thread =
             ThreadKey::parse(format!("test:handoff-bystander-{}", Uuid::new_v4())).unwrap();
         store
-            .create_or_get_session(&bystander_thread, &HarnessType::Codex, None, json!({}))
+            .create_or_get_session(
+                &bystander_thread,
+                &HarnessType::Codex,
+                None,
+                json!({}),
+                Default::default(),
+            )
             .await
             .expect("create bystander session");
         let bystander_execution = store

--- a/services/console/app/controllers/api/v1/proxies_controller.rb
+++ b/services/console/app/controllers/api/v1/proxies_controller.rb
@@ -25,12 +25,12 @@ module Api
       end
 
       def create
-        attrs = data_params.permit(:name, :principal_id, labels: {})
+        attrs = data_params.permit(:name, :principal_id)
         # principal_id is optional: a proxy may boot unassigned and be assigned later.
         principal = attrs[:principal_id].present? ? Principal.find_by_oid!(attrs[:principal_id]) : nil
-        proxy = ::Proxy.new(name: attrs[:name], principal: principal, labels: attrs[:labels] || {})
+        proxy = ::Proxy.new(name: attrs[:name], principal: principal, labels: labels_param)
         proxy.save!
-        render status: :created, json: { data: record_payload(proxy).merge(token: proxy.token) }
+        render status: :created, json: { data: record_payload(proxy, include_config_hash: true).merge(token: proxy.token) }
       rescue ActiveRecord::RecordInvalid => e
         render_validation_error(e.record)
       end
@@ -47,7 +47,7 @@ module Api
         proxy.name = data_params[:name] if data_params.key?(:name)
         proxy.labels = permitted_labels if data_params.key?(:labels)
         proxy.save!
-        render json: { data: record_payload(proxy) }
+        render json: { data: record_payload(proxy, include_config_hash: true) }
       rescue ActiveRecord::RecordInvalid => e
         render_validation_error(e.record)
       end
@@ -65,13 +65,23 @@ module Api
       end
 
       def permitted_labels
-        return {} if data_params[:labels].nil?
-
-        data_params.permit(labels: {})[:labels] || {}
+        labels_param
       end
 
-      def record_payload(proxy)
-        {
+      def labels_param
+        labels = data_params[:labels]
+        return {} if labels.nil?
+        return labels.permit!.to_h if labels.is_a?(ActionController::Parameters)
+
+        labels
+      end
+
+      def sandbox_entitlements_hosts
+        [ Principal.host_from_url(ENV["CENTAUR_CONSOLE_URL"]) ]
+      end
+
+      def record_payload(proxy, include_config_hash: false)
+        payload = {
           id: proxy.oid,
           name: proxy.name,
           principal_id: proxy.principal&.oid,
@@ -81,6 +91,13 @@ module Api
           created_at: proxy.created_at,
           updated_at: proxy.updated_at
         }
+        if include_config_hash
+          payload[:config_hash] = proxy.sync_config_snapshot(
+            sandbox_entitlements_hosts: sandbox_entitlements_hosts,
+            include_config: false
+          )[:config_hash]
+        end
+        payload
       end
     end
   end

--- a/services/console/app/controllers/api/v1/proxies_controller.rb
+++ b/services/console/app/controllers/api/v1/proxies_controller.rb
@@ -76,10 +76,6 @@ module Api
         labels
       end
 
-      def sandbox_entitlements_hosts
-        [ Principal.host_from_url(ENV["CENTAUR_CONSOLE_URL"]) ]
-      end
-
       def record_payload(proxy, include_config_hash: false)
         payload = {
           id: proxy.oid,
@@ -91,12 +87,7 @@ module Api
           created_at: proxy.created_at,
           updated_at: proxy.updated_at
         }
-        if include_config_hash
-          payload[:config_hash] = proxy.sync_config_snapshot(
-            sandbox_entitlements_hosts: sandbox_entitlements_hosts,
-            include_config: false
-          )[:config_hash]
-        end
+        payload[:config_hash] = proxy.config_hash if include_config_hash
         payload
       end
     end

--- a/services/console/app/controllers/api/v1/proxies_controller.rb
+++ b/services/console/app/controllers/api/v1/proxies_controller.rb
@@ -4,6 +4,8 @@ module Api
       def index
         scope = ::Proxy.all
         scope = scope.where(principal: principal_filter) if params[:principal_id].present?
+        labels = label_filter_params
+        scope = scope.where("labels @> ?", labels.to_json) if labels.any?
         scope = scope.order(created_at: :asc, id: :asc)
 
         limit = pagination_limit
@@ -23,10 +25,10 @@ module Api
       end
 
       def create
-        attrs = data_params.permit(:name, :principal_id)
+        attrs = data_params.permit(:name, :principal_id, labels: {})
         # principal_id is optional: a proxy may boot unassigned and be assigned later.
         principal = attrs[:principal_id].present? ? Principal.find_by_oid!(attrs[:principal_id]) : nil
-        proxy = ::Proxy.new(name: attrs[:name], principal: principal)
+        proxy = ::Proxy.new(name: attrs[:name], principal: principal, labels: attrs[:labels] || {})
         proxy.save!
         render status: :created, json: { data: record_payload(proxy).merge(token: proxy.token) }
       rescue ActiveRecord::RecordInvalid => e
@@ -43,6 +45,7 @@ module Api
           proxy.principal = oid.present? ? Principal.find_by_oid!(oid) : nil
         end
         proxy.name = data_params[:name] if data_params.key?(:name)
+        proxy.labels = permitted_labels if data_params.key?(:labels)
         proxy.save!
         render json: { data: record_payload(proxy) }
       rescue ActiveRecord::RecordInvalid => e
@@ -61,12 +64,19 @@ module Api
         Principal.find_by_oid!(params[:principal_id])
       end
 
+      def permitted_labels
+        return {} if data_params[:labels].nil?
+
+        data_params.permit(labels: {})[:labels] || {}
+      end
+
       def record_payload(proxy)
         {
           id: proxy.oid,
           name: proxy.name,
           principal_id: proxy.principal&.oid,
           status: proxy.status,
+          labels: proxy.labels,
           principal_assigned_at: proxy.principal_assigned_at,
           created_at: proxy.created_at,
           updated_at: proxy.updated_at

--- a/services/console/app/controllers/api/v1/proxy_sync_controller.rb
+++ b/services/console/app/controllers/api/v1/proxy_sync_controller.rb
@@ -20,13 +20,18 @@ module Api
     class ProxySyncController < Api::ProxyBaseController
       def create
         snapshot = current_proxy.sync_config_snapshot(
-          sandbox_entitlements_hosts: sandbox_entitlements_hosts
+          sandbox_entitlements_hosts: sandbox_entitlements_hosts,
+          include_config: false
         )
         current_hash = snapshot[:config_hash]
 
         if params[:config_hash].presence == current_hash
           render json: { config_hash: current_hash }
         else
+          snapshot = current_proxy.sync_config_snapshot(
+            sandbox_entitlements_hosts: sandbox_entitlements_hosts
+          )
+          current_hash = snapshot[:config_hash]
           # The config is assembled from the proxy's principal (empty when
           # unassigned). status and principal_id let an unassigned proxy tell "no
           # config yet" apart from "config is genuinely empty", and detect a swap.

--- a/services/console/app/controllers/api/v1/proxy_sync_controller.rb
+++ b/services/console/app/controllers/api/v1/proxy_sync_controller.rb
@@ -19,19 +19,12 @@ module Api
     # yet. Each secret still carries its own per-secret `rules`.
     class ProxySyncController < Api::ProxyBaseController
       def create
-        snapshot = current_proxy.sync_config_snapshot(
-          sandbox_entitlements_hosts: sandbox_entitlements_hosts,
-          include_config: false
-        )
+        snapshot = current_proxy.sync_config_snapshot
         current_hash = snapshot[:config_hash]
 
         if params[:config_hash].presence == current_hash
           render json: { config_hash: current_hash }
         else
-          snapshot = current_proxy.sync_config_snapshot(
-            sandbox_entitlements_hosts: sandbox_entitlements_hosts
-          )
-          current_hash = snapshot[:config_hash]
           # The config is assembled from the proxy's principal (empty when
           # unassigned). status and principal_id let an unassigned proxy tell "no
           # config yet" apart from "config is genuinely empty", and detect a swap.
@@ -45,16 +38,6 @@ module Api
             postgres: config["postgres"]
           }
         end
-      end
-
-      private
-
-      # Host for the entitlements secret's injection rule. It must match the
-      # host sandboxes dial, and that comes from the control URL: api-rs gets
-      # it as IRON_CONTROL_URL and the chart wires the same value here as
-      # CENTAUR_CONSOLE_URL, so both sides share one source of truth.
-      def sandbox_entitlements_hosts
-        [ Principal.host_from_url(ENV["CENTAUR_CONSOLE_URL"]) ]
       end
     end
   end

--- a/services/console/app/controllers/api/v1/sandbox_permissions_controller.rb
+++ b/services/console/app/controllers/api/v1/sandbox_permissions_controller.rb
@@ -15,9 +15,8 @@ module Api
         # principal.effective_config (the snapshot stores the unredacted
         # config) but skips the expensive per-request grant rebuild, under
         # the same freshness model the proxy sync path accepts.
-        permissions_payload = PrincipalSyncConfigSnapshot.fetch_for(principal).payload.deep_dup
-        permissions_payload.delete("_postgres_setting_templates")
-        permissions = Principal.redact_live_secrets(permissions_payload)
+        snapshot = PrincipalSyncConfigSnapshot.fetch_for(principal)
+        permissions = Principal.redact_live_secrets(snapshot.config)
         body = {
           data: {
             sandbox_id: sandbox_claims.fetch("sandbox_id"),

--- a/services/console/app/controllers/api/v1/sandbox_permissions_controller.rb
+++ b/services/console/app/controllers/api/v1/sandbox_permissions_controller.rb
@@ -15,9 +15,9 @@ module Api
         # principal.effective_config (the snapshot stores the unredacted
         # config) but skips the expensive per-request grant rebuild, under
         # the same freshness model the proxy sync path accepts.
-        permissions = Principal.redact_live_secrets(
-          PrincipalSyncConfigSnapshot.fetch_for(principal).payload
-        )
+        permissions_payload = PrincipalSyncConfigSnapshot.fetch_for(principal).payload.deep_dup
+        permissions_payload.delete("_postgres_setting_templates")
+        permissions = Principal.redact_live_secrets(permissions_payload)
         body = {
           data: {
             sandbox_id: sandbox_claims.fetch("sandbox_id"),

--- a/services/console/app/models/pg_dsn_secret.rb
+++ b/services/console/app/models/pg_dsn_secret.rb
@@ -67,6 +67,17 @@ class PgDsnSecret < ApplicationRecord
     end
   end
 
+  def proxy_label_settings?
+    Array(settings).any? do |setting|
+      next false unless setting.is_a?(Hash)
+
+      ref = setting["value_from"] || setting[:value_from]
+      next false unless ref.is_a?(Hash)
+
+      (ref["proxy_label"] || ref[:proxy_label]).present?
+    end
+  end
+
   validates :namespace, presence: true, format: { with: URL_SAFE_FORMAT, message: URL_SAFE_MESSAGE }
   validates :foreign_id, presence: true, uniqueness: { scope: :namespace },
             format: { with: URL_SAFE_FORMAT, message: URL_SAFE_MESSAGE }
@@ -96,11 +107,13 @@ class PgDsnSecret < ApplicationRecord
     proxy_label = ref["proxy_label"] || ref[:proxy_label]
     return proxy&.labels&.fetch(proxy_label.to_s, "").to_s if proxy_label.present?
 
+    return "" unless principal
+
     case (ref["principal_field"] || ref[:principal_field]).to_s
-    when "id" then principal ? principal.oid : ""
-    when "namespace" then principal ? principal.namespace.to_s : ""
-    when "foreign_id" then principal ? principal.foreign_id.to_s : ""
-    when "name" then principal ? principal.name.to_s : ""
+    when "id" then principal.oid
+    when "namespace" then principal.namespace.to_s
+    when "foreign_id" then principal.foreign_id.to_s
+    when "name" then principal.name.to_s
     else "" # unreachable for saved records; settings_are_valid rejects others
     end
   end

--- a/services/console/app/models/pg_dsn_secret.rb
+++ b/services/console/app/models/pg_dsn_secret.rb
@@ -28,7 +28,7 @@ class PgDsnSecret < ApplicationRecord
   RESERVED_SETTING_NAMES = %w[role session_authorization].freeze
 
   # A setting's `value_from` reference takes exactly one of these keys.
-  VALUE_FROM_KEYS = %w[principal_label principal_field].freeze
+  VALUE_FROM_KEYS = %w[principal_label principal_field proxy_label].freeze
   # Principal attributes a `principal_field` reference may name, matching how
   # the API serializes principals (`id` is the opaque oid).
   PRINCIPAL_FIELDS = %w[id namespace foreign_id name].freeze
@@ -41,7 +41,7 @@ class PgDsnSecret < ApplicationRecord
   # `database`. The opaque id is carried too so the proxy can refer back to the
   # canonical resource (it ignores fields it does not use). The DSN reuses the
   # shared secrets source shape.
-  def to_proxy_dsn(principal: nil)
+  def to_proxy_dsn(principal: nil, proxy: nil)
     entry = {
       "id" => oid,
       "foreign_id" => foreign_id,
@@ -49,7 +49,7 @@ class PgDsnSecret < ApplicationRecord
       "dsn" => dsn_source&.to_proxy_source
     }
     entry["role"] = role if role.present?
-    rendered_settings = proxy_settings(principal: principal)
+    rendered_settings = proxy_settings(principal: principal, proxy: proxy)
     entry["settings"] = rendered_settings if rendered_settings.present?
     entry
   end
@@ -57,13 +57,13 @@ class PgDsnSecret < ApplicationRecord
   # The pinned session settings as the proxy expects them: an ordered array of
   # { "name", "value" } objects. Normalizes whatever shape was stored (string
   # keys, blank rows) into the canonical form, dropping entries without a name,
-  # and resolves `value_from` references against the given principal.
-  def proxy_settings(principal: nil)
+  # and resolves `value_from` references against the given principal/proxy.
+  def proxy_settings(principal: nil, proxy: nil)
     Array(settings).filter_map do |s|
       next unless s.is_a?(Hash)
       name = s["name"].presence || s[:name].presence
       next if name.blank?
-      { "name" => name, "value" => setting_value(s, principal) }
+      { "name" => name, "value" => setting_value(s, principal, proxy) }
     end
   end
 
@@ -83,22 +83,24 @@ class PgDsnSecret < ApplicationRecord
   end
 
   # The concrete value the proxy should pin: the stored literal, or the
-  # principal attribute/label a `value_from` reference names. References
-  # resolve to "" when no principal is given or the label is absent, so
+  # principal/proxy attribute or label a `value_from` reference names. References
+  # resolve to "" when no principal/proxy is given or the label is absent, so
   # RLS-style policies fail closed rather than seeing a literal placeholder.
-  def setting_value(setting, principal)
+  def setting_value(setting, principal, proxy)
     ref = setting["value_from"] || setting[:value_from]
     return (setting["value"] || setting[:value]).to_s unless ref.is_a?(Hash)
-    return "" unless principal
 
     label = ref["principal_label"] || ref[:principal_label]
-    return principal.labels.fetch(label.to_s, "").to_s if label.present?
+    return principal&.labels&.fetch(label.to_s, "").to_s if label.present?
+
+    proxy_label = ref["proxy_label"] || ref[:proxy_label]
+    return proxy&.labels&.fetch(proxy_label.to_s, "").to_s if proxy_label.present?
 
     case (ref["principal_field"] || ref[:principal_field]).to_s
-    when "id" then principal.oid
-    when "namespace" then principal.namespace.to_s
-    when "foreign_id" then principal.foreign_id.to_s
-    when "name" then principal.name.to_s
+    when "id" then principal ? principal.oid : ""
+    when "namespace" then principal ? principal.namespace.to_s : ""
+    when "foreign_id" then principal ? principal.foreign_id.to_s : ""
+    when "name" then principal ? principal.name.to_s : ""
     else "" # unreachable for saved records; settings_are_valid rejects others
     end
   end
@@ -151,6 +153,8 @@ class PgDsnSecret < ApplicationRecord
     label = ref["principal_label"] || ref[:principal_label]
     field = ref["principal_field"] || ref[:principal_field]
     return "principal_label can't be blank" if keys.first == "principal_label" && label.to_s.blank?
+    proxy_label = ref["proxy_label"] || ref[:proxy_label]
+    return "proxy_label can't be blank" if keys.first == "proxy_label" && proxy_label.to_s.blank?
     if keys.first == "principal_field" && !PRINCIPAL_FIELDS.include?(field.to_s)
       return "unknown principal_field #{field.to_s.inspect} (one of: #{PRINCIPAL_FIELDS.join(", ")})"
     end

--- a/services/console/app/models/principal.rb
+++ b/services/console/app/models/principal.rb
@@ -118,33 +118,23 @@ class Principal < ApplicationRecord
   def sync_config_snapshot_payload
     served = served_credentials
     postgres, templates = sync_postgres_entries_with_templates
-    config = {
-      "secrets" => proxy_secrets_for(served) + generated_proxy_secrets,
-      "transforms" => proxy_transforms_for(served),
-      "postgres" => postgres
+    {
+      "config" => {
+        "secrets" => proxy_secrets_for(served) + generated_proxy_secrets,
+        "transforms" => proxy_transforms_for(served),
+        "postgres" => postgres
+      },
+      "postgres_setting_templates" => templates
     }
-    config["_postgres_setting_templates"] = templates if templates.any?
-    config
   end
 
   def sync_postgres_entries(proxy: nil)
-    winners = {}
-    granted_pg_dsn_secrets.each do |pg|
-      next unless pg.dsn_source
-      winners[pg.database] = pg
-    end
-    winners.values.map { |pg| pg.to_proxy_dsn(principal: self, proxy: proxy) }
+    effective_pg_dsn_secrets.map { |pg| pg.to_proxy_dsn(principal: self, proxy: proxy) }
   end
 
   def sync_postgres_entries_with_templates
-    winners = {}
-    granted_pg_dsn_secrets.each do |pg|
-      next unless pg.dsn_source
-      winners[pg.database] = pg
-    end
-
     templates = {}
-    entries = winners.values.map do |pg|
+    entries = effective_pg_dsn_secrets.map do |pg|
       templates[pg.oid] = pg.settings if pg.proxy_label_settings?
       pg.to_proxy_dsn(principal: self)
     end
@@ -243,6 +233,12 @@ class Principal < ApplicationRecord
   end
 
   private
+
+  def effective_pg_dsn_secrets
+    granted_pg_dsn_secrets.each_with_object({}) do |pg, winners|
+      winners[pg.database] = pg if pg.dsn_source
+    end.values
+  end
 
   def auto_grant_matching_oauth_credentials
     PrincipalCredentialReconciliation.new.apply_for_principal(self)

--- a/services/console/app/models/principal.rb
+++ b/services/console/app/models/principal.rb
@@ -112,12 +112,43 @@ class Principal < ApplicationRecord
   # the same database, existing grant priority ordering decides the winner:
   # higher-priority grants appear later and overwrite lower-priority routes.
   def sync_postgres(proxy: nil)
+    sync_postgres_entries(proxy: proxy)
+  end
+
+  def sync_config_snapshot_payload
+    served = served_credentials
+    postgres, templates = sync_postgres_entries_with_templates
+    config = {
+      "secrets" => proxy_secrets_for(served) + generated_proxy_secrets,
+      "transforms" => proxy_transforms_for(served),
+      "postgres" => postgres
+    }
+    config["_postgres_setting_templates"] = templates if templates.any?
+    config
+  end
+
+  def sync_postgres_entries(proxy: nil)
     winners = {}
     granted_pg_dsn_secrets.each do |pg|
       next unless pg.dsn_source
       winners[pg.database] = pg
     end
     winners.values.map { |pg| pg.to_proxy_dsn(principal: self, proxy: proxy) }
+  end
+
+  def sync_postgres_entries_with_templates
+    winners = {}
+    granted_pg_dsn_secrets.each do |pg|
+      next unless pg.dsn_source
+      winners[pg.database] = pg
+    end
+
+    templates = {}
+    entries = winners.values.map do |pg|
+      templates[pg.oid] = pg.settings if pg.proxy_label_settings?
+      pg.to_proxy_dsn(principal: self)
+    end
+    [ entries, templates ]
   end
 
   # The config this principal resolves to, in the same shape iron-proxy receives

--- a/services/console/app/models/principal.rb
+++ b/services/console/app/models/principal.rb
@@ -111,13 +111,13 @@ class Principal < ApplicationRecord
   # proxy can't dial an upstream without one. When several granted PG DSNs route
   # the same database, existing grant priority ordering decides the winner:
   # higher-priority grants appear later and overwrite lower-priority routes.
-  def sync_postgres
+  def sync_postgres(proxy: nil)
     winners = {}
     granted_pg_dsn_secrets.each do |pg|
       next unless pg.dsn_source
       winners[pg.database] = pg
     end
-    winners.values.map { |pg| pg.to_proxy_dsn(principal: self) }
+    winners.values.map { |pg| pg.to_proxy_dsn(principal: self, proxy: proxy) }
   end
 
   # The config this principal resolves to, in the same shape iron-proxy receives

--- a/services/console/app/models/principal_sync_config_snapshot.rb
+++ b/services/console/app/models/principal_sync_config_snapshot.rb
@@ -1,7 +1,6 @@
 class PrincipalSyncConfigSnapshot < ApplicationRecord
   TTL = 10.minutes
   RETENTION = 1.hour
-  LEGACY_POSTGRES_SETTING_TEMPLATES_KEY = "_postgres_setting_templates".freeze
 
   belongs_to :principal
 
@@ -12,13 +11,11 @@ class PrincipalSyncConfigSnapshot < ApplicationRecord
   validates :principal_id, uniqueness: { scope: :principal_cache_version }
 
   def config
-    return payload.fetch("config") if payload.key?("config")
-
-    payload.except(LEGACY_POSTGRES_SETTING_TEMPLATES_KEY)
+    payload.fetch("config", payload)
   end
 
   def postgres_setting_templates
-    payload["postgres_setting_templates"] || payload[LEGACY_POSTGRES_SETTING_TEMPLATES_KEY] || {}
+    payload.fetch("postgres_setting_templates", {})
   end
 
   # Returns the freshest usable snapshot, stale-while-revalidate style. When

--- a/services/console/app/models/principal_sync_config_snapshot.rb
+++ b/services/console/app/models/principal_sync_config_snapshot.rb
@@ -1,6 +1,7 @@
 class PrincipalSyncConfigSnapshot < ApplicationRecord
   TTL = 10.minutes
   RETENTION = 1.hour
+  LEGACY_POSTGRES_SETTING_TEMPLATES_KEY = "_postgres_setting_templates".freeze
 
   belongs_to :principal
 
@@ -9,6 +10,16 @@ class PrincipalSyncConfigSnapshot < ApplicationRecord
 
   validates :principal_cache_version, presence: true
   validates :principal_id, uniqueness: { scope: :principal_cache_version }
+
+  def config
+    return payload.fetch("config") if payload.key?("config")
+
+    payload.except(LEGACY_POSTGRES_SETTING_TEMPLATES_KEY)
+  end
+
+  def postgres_setting_templates
+    payload["postgres_setting_templates"] || payload[LEGACY_POSTGRES_SETTING_TEMPLATES_KEY] || {}
+  end
 
   # Returns the freshest usable snapshot, stale-while-revalidate style. When
   # the current-version snapshot is stale or missing, exactly one caller

--- a/services/console/app/models/principal_sync_config_snapshot.rb
+++ b/services/console/app/models/principal_sync_config_snapshot.rb
@@ -76,7 +76,7 @@ class PrincipalSyncConfigSnapshot < ApplicationRecord
     snapshot = find_or_initialize_by(principal: principal, principal_cache_version: version)
     return snapshot if snapshot.persisted? && snapshot.fresh_for?(principal)
 
-    snapshot.payload = principal.effective_config(redact_secrets: false)
+    snapshot.payload = principal.sync_config_snapshot_payload
     if snapshot.changed?
       snapshot.save!
     else

--- a/services/console/app/models/proxy.rb
+++ b/services/console/app/models/proxy.rb
@@ -14,8 +14,10 @@ class Proxy < ApplicationRecord
 
   validates :name, presence: true
   validates :bearer_token_hash, presence: true, uniqueness: true
+  validate :labels_are_string_map
   validate :token_matches_format, on: :create
 
+  before_validation :normalize_labels
   before_validation :issue_token, on: :create
   before_save :stamp_principal_assignment, if: :will_save_change_to_principal_id?
 
@@ -43,11 +45,12 @@ class Proxy < ApplicationRecord
   # proxy carries no authority and resolves to the empty config. Live secret
   # values are kept inline here because the proxy needs them to resolve.
   def sync_config
-    principal&.effective_config(redact_secrets: false) || Principal::EMPTY_CONFIG
+    proxy_specific_config(principal&.effective_config(redact_secrets: false) || Principal::EMPTY_CONFIG)
   end
 
   def sync_config_snapshot(sandbox_entitlements_hosts: [])
     config = principal ? PrincipalSyncConfigSnapshot.fetch_for(principal).payload : Principal::EMPTY_CONFIG
+    config = proxy_specific_config(config)
     config = with_sandbox_entitlements_secret(config, sandbox_entitlements_hosts: sandbox_entitlements_hosts)
     { config_hash: config_hash_for(config), config: config }
   end
@@ -67,7 +70,8 @@ class Proxy < ApplicationRecord
   def config_hash_for(config)
     payload = config.merge(
       "principal" => principal&.oid,
-      "principal_assigned_at" => principal_assigned_at&.utc&.iso8601
+      "principal_assigned_at" => principal_assigned_at&.utc&.iso8601,
+      "proxy_labels" => labels || {}
     )
     "sha256:#{Digest::SHA256.hexdigest(self.class.canonical_json(payload))}"
   end
@@ -111,6 +115,25 @@ class Proxy < ApplicationRecord
   end
 
   private
+
+  def normalize_labels
+    self.labels = {} if labels.nil?
+  end
+
+  def labels_are_string_map
+    return errors.add(:labels, "must be a hash") unless labels.is_a?(Hash)
+
+    labels.each do |key, value|
+      errors.add(:labels, "keys must be strings") unless key.is_a?(String)
+      errors.add(:labels, "values must be strings") unless value.is_a?(String)
+    end
+  end
+
+  def proxy_specific_config(config)
+    copy = config.deep_dup
+    copy["postgres"] = principal ? principal.sync_postgres(proxy: self) : []
+    copy
+  end
 
   def with_sandbox_entitlements_secret(config, sandbox_entitlements_hosts:)
     secret = sandbox_entitlements_secret(hosts: sandbox_entitlements_hosts)

--- a/services/console/app/models/proxy.rb
+++ b/services/console/app/models/proxy.rb
@@ -48,11 +48,15 @@ class Proxy < ApplicationRecord
     proxy_specific_config(principal&.effective_config(redact_secrets: false) || Principal::EMPTY_CONFIG)
   end
 
-  def sync_config_snapshot(sandbox_entitlements_hosts: [])
+  def sync_config_snapshot(sandbox_entitlements_hosts: [], include_config: true)
     config = principal ? PrincipalSyncConfigSnapshot.fetch_for(principal).payload : Principal::EMPTY_CONFIG
+    hash_config = with_sandbox_entitlements_secret(config, sandbox_entitlements_hosts: sandbox_entitlements_hosts)
+    snapshot = { config_hash: config_hash_for(hash_config) }
+    return snapshot unless include_config
+
     config = proxy_specific_config(config)
     config = with_sandbox_entitlements_secret(config, sandbox_entitlements_hosts: sandbox_entitlements_hosts)
-    { config_hash: config_hash_for(config), config: config }
+    snapshot.merge(config: config)
   end
 
   # Opaque, deterministic fingerprint of the base (principal-derived) config.

--- a/services/console/app/models/proxy.rb
+++ b/services/console/app/models/proxy.rb
@@ -45,12 +45,13 @@ class Proxy < ApplicationRecord
   # proxy carries no authority and resolves to the empty config. Live secret
   # values are kept inline here because the proxy needs them to resolve.
   def sync_config
-    proxy_specific_config(principal&.effective_config(redact_secrets: false) || Principal::EMPTY_CONFIG)
+    proxy_specific_config(principal&.sync_config_snapshot_payload || Principal::EMPTY_CONFIG)
   end
 
   def sync_config_snapshot(sandbox_entitlements_hosts: [], include_config: true)
     config = principal ? PrincipalSyncConfigSnapshot.fetch_for(principal).payload : Principal::EMPTY_CONFIG
-    hash_config = with_sandbox_entitlements_secret(config, sandbox_entitlements_hosts: sandbox_entitlements_hosts)
+    hash_config = proxy_specific_config(config)
+    hash_config = with_sandbox_entitlements_secret(hash_config, sandbox_entitlements_hosts: sandbox_entitlements_hosts)
     snapshot = { config_hash: config_hash_for(hash_config) }
     return snapshot unless include_config
 
@@ -135,8 +136,51 @@ class Proxy < ApplicationRecord
 
   def proxy_specific_config(config)
     copy = config.deep_dup
-    copy["postgres"] = principal ? principal.sync_postgres(proxy: self) : []
+    templates = copy.delete("_postgres_setting_templates") || {}
+    copy["postgres"] = proxy_specific_postgres(copy["postgres"], templates) if templates.any?
     copy
+  end
+
+  def proxy_specific_postgres(postgres, templates)
+    Array(postgres).map do |entry|
+      next entry unless entry.is_a?(Hash)
+
+      template = templates[entry["id"].to_s]
+      next entry unless template
+
+      rendered_settings = proxy_specific_postgres_settings(entry["settings"], template)
+      entry.merge("settings" => rendered_settings)
+    end
+  end
+
+  def proxy_specific_postgres_settings(rendered_settings, template_settings)
+    rendered_by_name = Array(rendered_settings).each_with_object({}) do |setting, values|
+      next unless setting.is_a?(Hash)
+
+      name = setting["name"].presence || setting[:name].presence
+      values[name] = setting["value"] || setting[:value] if name.present?
+    end
+
+    Array(template_settings).filter_map do |setting|
+      next unless setting.is_a?(Hash)
+
+      name = setting["name"].presence || setting[:name].presence
+      next if name.blank?
+
+      value = proxy_label_setting_value(setting)
+      value = rendered_by_name.fetch(name, "") if value.nil?
+      { "name" => name, "value" => value }
+    end
+  end
+
+  def proxy_label_setting_value(setting)
+    ref = setting["value_from"] || setting[:value_from]
+    return nil unless ref.is_a?(Hash)
+
+    proxy_label = ref["proxy_label"] || ref[:proxy_label]
+    return nil if proxy_label.blank?
+
+    labels&.fetch(proxy_label.to_s, "").to_s
   end
 
   def with_sandbox_entitlements_secret(config, sandbox_entitlements_hosts:)

--- a/services/console/app/models/proxy.rb
+++ b/services/console/app/models/proxy.rb
@@ -40,14 +40,6 @@ class Proxy < ApplicationRecord
     Digest::SHA256.hexdigest(plaintext)
   end
 
-  # The config this proxy delivers, in the iron-proxy sync shape. The assembly
-  # lives on Principal (it is a function of effective grants); an unassigned
-  # proxy carries no authority and resolves to the empty config. Live secret
-  # values are kept inline here because the proxy needs them to resolve.
-  def sync_config
-    sync_config_snapshot.fetch(:config)
-  end
-
   def sync_config_snapshot(sandbox_entitlements_hosts: self.class.sandbox_entitlements_hosts)
     config = rendered_principal_config
     config = with_sandbox_entitlements_secret(config, sandbox_entitlements_hosts: sandbox_entitlements_hosts)

--- a/services/console/app/models/proxy.rb
+++ b/services/console/app/models/proxy.rb
@@ -45,31 +45,23 @@ class Proxy < ApplicationRecord
   # proxy carries no authority and resolves to the empty config. Live secret
   # values are kept inline here because the proxy needs them to resolve.
   def sync_config
-    proxy_specific_config(principal&.sync_config_snapshot_payload || Principal::EMPTY_CONFIG)
+    sync_config_snapshot.fetch(:config)
   end
 
-  def sync_config_snapshot(sandbox_entitlements_hosts: [], include_config: true)
-    config = principal ? PrincipalSyncConfigSnapshot.fetch_for(principal).payload : Principal::EMPTY_CONFIG
-    hash_config = proxy_specific_config(config)
-    hash_config = with_sandbox_entitlements_secret(hash_config, sandbox_entitlements_hosts: sandbox_entitlements_hosts)
-    snapshot = { config_hash: config_hash_for(hash_config) }
-    return snapshot unless include_config
-
-    config = proxy_specific_config(config)
+  def sync_config_snapshot(sandbox_entitlements_hosts: self.class.sandbox_entitlements_hosts)
+    config = rendered_principal_config
     config = with_sandbox_entitlements_secret(config, sandbox_entitlements_hosts: sandbox_entitlements_hosts)
-    snapshot.merge(config: config)
+    { config_hash: config_hash_for(config), config: config }
   end
 
-  # Opaque, deterministic fingerprint of the base (principal-derived) config.
-  # Note this is not necessarily the hash the proxy echoes on sync: the sync
-  # path hashes the delivered config, which also folds in the per-proxy
-  # sandbox entitlements secret when one is configured (see
-  # #sync_config_snapshot).
+  # Opaque, deterministic fingerprint of the exact config delivered by the
+  # proxy sync endpoint.
   def config_hash
-    # The principal identity and assignment time are folded in so that any
-    # assignment change forces a refresh, even a swap between principals whose
-    # effective secrets happen to be identical (or an unassign to empty).
-    config_hash_for(sync_config)
+    sync_config_snapshot.fetch(:config_hash)
+  end
+
+  def self.sandbox_entitlements_hosts
+    [ Principal.host_from_url(ENV["CENTAUR_CONSOLE_URL"]) ]
   end
 
   def config_hash_for(config)
@@ -134,9 +126,12 @@ class Proxy < ApplicationRecord
     end
   end
 
-  def proxy_specific_config(config)
-    copy = config.deep_dup
-    templates = copy.delete("_postgres_setting_templates") || {}
+  def rendered_principal_config
+    return Principal::EMPTY_CONFIG.deep_dup unless principal
+
+    snapshot = PrincipalSyncConfigSnapshot.fetch_for(principal)
+    copy = snapshot.config.deep_dup
+    templates = snapshot.postgres_setting_templates
     copy["postgres"] = proxy_specific_postgres(copy["postgres"], templates) if templates.any?
     copy
   end

--- a/services/console/db/migrate/20260721213228_add_labels_to_proxies.rb
+++ b/services/console/db/migrate/20260721213228_add_labels_to_proxies.rb
@@ -1,0 +1,6 @@
+class AddLabelsToProxies < ActiveRecord::Migration[8.1]
+  def change
+    add_column :proxies, :labels, :jsonb, null: false, default: {}
+    add_index :proxies, :labels, using: :gin
+  end
+end

--- a/services/console/db/schema.rb
+++ b/services/console/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_14_175437) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_21_213228) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -323,10 +323,12 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_14_175437) do
   create_table "proxies", force: :cascade do |t|
     t.string "bearer_token_hash", null: false
     t.datetime "created_at", null: false
+    t.jsonb "labels", default: {}, null: false
     t.string "name", null: false
     t.datetime "principal_assigned_at"
     t.bigint "principal_id"
     t.datetime "updated_at", null: false
+    t.index ["labels"], name: "index_proxies_on_labels", using: :gin
     t.index ["principal_id"], name: "index_proxies_on_principal_id"
   end
 

--- a/services/console/db/schema.rb
+++ b/services/console/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_14_175437) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_21_213228) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -323,10 +323,12 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_14_175437) do
   create_table "proxies", force: :cascade do |t|
     t.string "bearer_token_hash", null: false
     t.datetime "created_at", null: false
+    t.jsonb "labels", default: {}, null: false
     t.string "name", null: false
     t.datetime "principal_assigned_at"
     t.bigint "principal_id"
     t.datetime "updated_at", null: false
+    t.index ["labels"], name: "index_proxies_on_labels", using: :gin
     t.index ["principal_id"], name: "index_proxies_on_principal_id"
   end
 
@@ -401,10 +403,12 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_14_175437) do
     t.datetime "created_at", null: false
     t.boolean "download_enabled", default: false, null: false
     t.boolean "history_enabled", default: false, null: false
+    t.string "managed_by"
     t.bigint "principal_id", null: false
     t.datetime "updated_at", null: false
     t.boolean "upload_enabled", default: false, null: false
     t.index ["principal_id", "channel_id"], name: "index_slack_channel_permissions_on_principal_id_and_channel_id", unique: true
+    t.index ["principal_id", "managed_by"], name: "index_slack_channel_permissions_on_principal_id_and_managed_by"
     t.index ["principal_id"], name: "index_slack_channel_permissions_on_principal_id"
   end
 

--- a/services/console/db/schema.rb
+++ b/services/console/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_21_213228) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_14_175437) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -323,12 +323,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_21_213228) do
   create_table "proxies", force: :cascade do |t|
     t.string "bearer_token_hash", null: false
     t.datetime "created_at", null: false
-    t.jsonb "labels", default: {}, null: false
     t.string "name", null: false
     t.datetime "principal_assigned_at"
     t.bigint "principal_id"
     t.datetime "updated_at", null: false
-    t.index ["labels"], name: "index_proxies_on_labels", using: :gin
     t.index ["principal_id"], name: "index_proxies_on_principal_id"
   end
 
@@ -403,12 +401,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_21_213228) do
     t.datetime "created_at", null: false
     t.boolean "download_enabled", default: false, null: false
     t.boolean "history_enabled", default: false, null: false
-    t.string "managed_by"
     t.bigint "principal_id", null: false
     t.datetime "updated_at", null: false
     t.boolean "upload_enabled", default: false, null: false
     t.index ["principal_id", "channel_id"], name: "index_slack_channel_permissions_on_principal_id_and_channel_id", unique: true
-    t.index ["principal_id", "managed_by"], name: "index_slack_channel_permissions_on_principal_id_and_managed_by"
     t.index ["principal_id"], name: "index_slack_channel_permissions_on_principal_id"
   end
 

--- a/services/console/docs/API.md
+++ b/services/console/docs/API.md
@@ -630,7 +630,7 @@ Listener and client knobs (bind address, client auth) are deliberately not model
 | `labels`      | optional    | Object; defaults to `{}`. |
 | `database`    | required    | Database name clients connect to through the proxy. Must match the upstream DSN's database. If several granted secrets use the same database, grant priority selects the effective route. |
 | `role`        | optional    | Upstream `SET ROLE` applied to the session. |
-| `settings`    | optional    | Ordered array of session variables (GUCs) the proxy SETs at session start, before the `SET ROLE`, and pins so clients cannot override them. Each entry is `{ "name", "value" }` for a literal value, or `{ "name", "value_from" }` to resolve the value from the assigned proxy principal at sync time (see [principal-derived values](#principal-derived-setting-values)). Names must be a bare or dotted identifier; `role` and `session_authorization` are reserved. Replaced wholesale on update. |
+| `settings`    | optional    | Ordered array of session variables (GUCs) the proxy SETs at session start, before the `SET ROLE`, and pins so clients cannot override them. Each entry is `{ "name", "value" }` for a literal value, or `{ "name", "value_from" }` to resolve the value from the assigned proxy principal or proxy labels at sync time (see [derived setting values](#derived-setting-values)). Names must be a bare or dotted identifier; `role` and `session_authorization` are reserved. Replaced wholesale on update. |
 | `dsn`         | required    | A [secret source](#secret-sources) resolving to the connection string. Replaced wholesale on update. |
 
 ### Create
@@ -676,10 +676,10 @@ Returns `201` with the created resource. Response shape:
 
 The `dsn` in responses never includes a `control_plane` `secret` value.
 
-### Principal-derived setting values
+### Derived setting values
 
-A setting may take its value from the proxy's assigned principal instead of
-storing a literal, by replacing `value` with `value_from`:
+A setting may take its value from the proxy's assigned principal or proxy
+labels instead of storing a literal, by replacing `value` with `value_from`:
 
 ```json
 { "name": "centaur.slack_channel_id", "value_from": { "principal_label": "slack_channel_id" } }
@@ -691,9 +691,10 @@ storing a literal, by replacing `value` with `value_from`:
 | ----------------- | ----------- |
 | `principal_label` | The named label on the assigned principal. A label the principal does not carry resolves to an empty string, so RLS-style policies fail closed. |
 | `principal_field` | One of the principal's identity fields: `id` (the opaque `prn_...` id), `namespace`, `foreign_id`, or `name`. |
+| `proxy_label`     | The named label on the proxy. A label the proxy does not carry resolves to an empty string, so RLS-style policies fail closed. |
 
 A setting has either `value` or `value_from`, never both; unknown
-`principal_field` names and blank `principal_label` keys are rejected at create
+`principal_field` names and blank label keys are rejected at create
 and update time. References are resolved only in the proxy sync and
 effective-config payloads; create, update, show, and list responses echo the
 stored reference.
@@ -1429,7 +1430,17 @@ A proxy's `status` is `assigned` when it currently holds a principal and `unassi
 `POST /api/v1/proxies`
 
 ```json
-{ "data": { "name": "Edge Proxy - US", "principal_id": "prn_..." } }
+{
+  "data": {
+    "name": "Edge Proxy - US",
+    "principal_id": "prn_...",
+    "labels": {
+      "centaur.slack_user_id": "U0123456789",
+      "centaur.slack_team_id": "T0123456789",
+      "centaur.slack_channel_id": "C0123456789"
+    }
+  }
+}
 ```
 
 Returns `201`. The plaintext proxy `token` (`iprx_...`) is included **only** in this create response: save it immediately. The proxy uses it to authenticate to [proxy sync](#proxy-sync).
@@ -1441,6 +1452,11 @@ Returns `201`. The plaintext proxy `token` (`iprx_...`) is included **only** in 
     "name": "Edge Proxy - US",
     "principal_id": "prn_...",
     "status": "assigned",
+    "labels": {
+      "centaur.slack_user_id": "U0123456789",
+      "centaur.slack_team_id": "T0123456789",
+      "centaur.slack_channel_id": "C0123456789"
+    },
     "principal_assigned_at": "2026-06-01T10:00:00Z",
     "created_at": "2026-06-01T10:00:00Z",
     "updated_at": "2026-06-01T10:00:00Z"
@@ -1448,7 +1464,7 @@ Returns `201`. The plaintext proxy `token` (`iprx_...`) is included **only** in 
 }
 ```
 
-`name` is required. `principal_id` is optional: omit it to create an unassigned proxy (`status` is then `unassigned`, `principal_id` and `principal_assigned_at` are `null`). When supplied, a missing principal returns `404`.
+`name` is required. `principal_id` is optional: omit it to create an unassigned proxy (`status` is then `unassigned`, `principal_id` and `principal_assigned_at` are `null`). `labels` is optional and defaults to `{}`; keys and values must be strings. Labels initialized by Centaur's Slack API path use the `centaur.` prefix. When supplied, a missing principal returns `404`.
 
 ### Assign, swap, or clear the principal
 
@@ -1458,13 +1474,13 @@ Returns `201`. The plaintext proxy `token` (`iprx_...`) is included **only** in 
 { "data": { "principal_id": "prn_..." } }
 ```
 
-Assigns the principal when the proxy is unassigned, or swaps it when already assigned. The token is unchanged; the proxy picks up the new config on its next [sync](#proxy-sync). Send `"principal_id": null` to unassign. Omitting `principal_id` leaves the assignment unchanged; `name` may also be updated. A missing principal returns `404`. Returns `200` with the updated proxy.
+Assigns the principal when the proxy is unassigned, or swaps it when already assigned. The token is unchanged; the proxy picks up the new config on its next [sync](#proxy-sync). Send `"principal_id": null` to unassign. Omitting `principal_id` leaves the assignment unchanged; `name` and `labels` may also be updated. Omitting `labels` leaves labels unchanged, `"labels": null` clears labels, and an object replaces labels. A missing principal returns `404`. Returns `200` with the updated proxy.
 
 ### Other operations
 
 | Method   | Path | Notes |
 | -------- | ---- | ----- |
-| `GET`    | `/api/v1/proxies` | List. Optional `principal_id` filter; paginated. Tokens are never returned. |
+| `GET`    | `/api/v1/proxies` | List. Optional `principal_id` and `labels[k]=v` filters; paginated. Tokens are never returned. |
 | `GET`    | `/api/v1/proxies/:id` | Fetch one (no token). |
 | `DELETE` | `/api/v1/proxies/:id` | Deregister. Returns `204`. |
 

--- a/services/console/test/controllers/api/v1/proxies_controller_test.rb
+++ b/services/console/test/controllers/api/v1/proxies_controller_test.rb
@@ -75,6 +75,33 @@ class ProxiesControllerTest < ActionDispatch::IntegrationTest
     assert_equal({ "centaur.slack_user_id" => "U123" }, data["labels"])
   end
 
+  test "POST returns the sync config hash including sandbox entitlements" do
+    body = {
+      data: {
+        name: "edge-proxy-with-entitlements",
+        principal_id: principals(:acme_channel).oid
+      }
+    }
+
+    expected_hash = nil
+    with_env(
+      "CENTAUR_JWT_SIGNING_SECRET" => "test-secret",
+      "CENTAUR_CONSOLE_URL" => "http://centaur-console:3000"
+    ) do
+      post api_v1_proxies_url, params: body.to_json, headers: auth_headers
+      proxy = Proxy.find_by_token(json_body.dig("data", "token"))
+      expected_hash = proxy.sync_config_snapshot(
+        sandbox_entitlements_hosts: [ "centaur-console" ],
+        include_config: false
+      )[:config_hash]
+      refute_equal proxy.config_hash, expected_hash
+    end
+    assert_response :created
+
+    data = json_body.fetch("data")
+    assert_equal expected_hash, data.fetch("config_hash")
+  end
+
   test "POST with invalid labels returns a validation error" do
     body = { data: { name: "bad-labels", labels: { "slack_user_id" => 123 } } }
     post api_v1_proxies_url, params: body.to_json, headers: auth_headers
@@ -129,6 +156,17 @@ class ProxiesControllerTest < ActionDispatch::IntegrationTest
     assert_equal principals(:globex_user), proxy.reload.principal
   end
 
+  test "PATCH omitting labels leaves labels unchanged" do
+    proxy = proxies(:acme_proxy)
+    proxy.update!(labels: { "centaur.slack_user_id" => "U1" })
+    body = { data: { principal_id: principals(:globex_user).oid } }
+
+    patch api_v1_proxy_url(id: proxy.oid), params: body.to_json, headers: auth_headers
+    assert_response :ok
+    assert_equal({ "centaur.slack_user_id" => "U1" }, json_body.dig("data", "labels"))
+    assert_equal({ "centaur.slack_user_id" => "U1" }, proxy.reload.labels)
+  end
+
   test "PATCH replaces labels" do
     proxy = proxies(:acme_proxy)
     proxy.update!(labels: { "centaur.slack_user_id" => "U1" })
@@ -140,6 +178,27 @@ class ProxiesControllerTest < ActionDispatch::IntegrationTest
     assert_equal({ "centaur.slack_user_id" => "U2" }, proxy.reload.labels)
   end
 
+  test "PATCH returns the sync config hash including sandbox entitlements" do
+    proxy = proxies(:acme_proxy)
+    body = { data: { labels: { "centaur.slack_user_id" => "U2" } } }
+
+    expected_hash = nil
+    with_env(
+      "CENTAUR_JWT_SIGNING_SECRET" => "test-secret",
+      "CENTAUR_CONSOLE_URL" => "http://centaur-console:3000"
+    ) do
+      patch api_v1_proxy_url(id: proxy.oid), params: body.to_json, headers: auth_headers
+      expected_hash = proxy.reload.sync_config_snapshot(
+        sandbox_entitlements_hosts: [ "centaur-console" ],
+        include_config: false
+      )[:config_hash]
+      refute_equal proxy.config_hash, expected_hash
+    end
+    assert_response :ok
+
+    assert_equal expected_hash, json_body.dig("data", "config_hash")
+  end
+
   test "PATCH with null labels clears labels" do
     proxy = proxies(:acme_proxy)
     proxy.update!(labels: { "centaur.slack_user_id" => "U1" })
@@ -149,6 +208,18 @@ class ProxiesControllerTest < ActionDispatch::IntegrationTest
     assert_response :ok
     assert_equal({}, json_body.dig("data", "labels"))
     assert_equal({}, proxy.reload.labels)
+  end
+
+  test "PATCH with non-hash labels returns a validation error" do
+    proxy = proxies(:acme_proxy)
+    proxy.update!(labels: { "centaur.slack_user_id" => "U1" })
+    body = { data: { labels: "U2" } }
+
+    patch api_v1_proxy_url(id: proxy.oid), params: body.to_json, headers: auth_headers
+    assert_response :unprocessable_entity
+    assert_equal "validation failed", json_body.dig("error", "message")
+    assert_includes json_body.dig("error", "details", "labels"), "must be a hash"
+    assert_equal({ "centaur.slack_user_id" => "U1" }, proxy.reload.labels)
   end
 
   test "PATCH with a null principal_id unassigns the proxy" do
@@ -185,5 +256,17 @@ class ProxiesControllerTest < ActionDispatch::IntegrationTest
       delete api_v1_proxy_url(id: proxy.oid), headers: auth_headers
     end
     assert_response :no_content
+  end
+
+  def with_env(values)
+    previous = values.keys.to_h { |key| [ key, ENV[key] ] }
+    values.each do |key, value|
+      value.nil? ? ENV.delete(key) : ENV[key] = value
+    end
+    yield
+  ensure
+    previous.each do |key, value|
+      value.nil? ? ENV.delete(key) : ENV[key] = value
+    end
   end
 end

--- a/services/console/test/controllers/api/v1/proxies_controller_test.rb
+++ b/services/console/test/controllers/api/v1/proxies_controller_test.rb
@@ -2,6 +2,7 @@ require "test_helper"
 
 class ProxiesControllerTest < ActionDispatch::IntegrationTest
   ACME_TOKEN = "iak_acme-ci-token".freeze
+  ACME_PROXY_TOKEN = "iprx_#{'a' * 64}".freeze
 
   def auth_headers(token = ACME_TOKEN)
     { "Authorization" => "Bearer #{token}", "Content-Type" => "application/json" }
@@ -83,23 +84,18 @@ class ProxiesControllerTest < ActionDispatch::IntegrationTest
       }
     }
 
-    expected_hash = nil
     with_env(
       "CENTAUR_JWT_SIGNING_SECRET" => "test-secret",
       "CENTAUR_CONSOLE_URL" => "http://centaur-console:3000"
     ) do
       post api_v1_proxies_url, params: body.to_json, headers: auth_headers
-      proxy = Proxy.find_by_token(json_body.dig("data", "token"))
-      expected_hash = proxy.sync_config_snapshot(
-        sandbox_entitlements_hosts: [ "centaur-console" ],
-        include_config: false
-      )[:config_hash]
-      refute_equal proxy.config_hash, expected_hash
-    end
-    assert_response :created
+      assert_response :created
+      data = json_body.fetch("data")
 
-    data = json_body.fetch("data")
-    assert_equal expected_hash, data.fetch("config_hash")
+      post api_v1_proxy_sync_url, params: {}.to_json, headers: proxy_auth_headers(data.fetch("token"))
+      assert_response :ok
+      assert_equal data.fetch("config_hash"), json_body.fetch("config_hash")
+    end
   end
 
   test "POST with invalid labels returns a validation error" do
@@ -182,21 +178,18 @@ class ProxiesControllerTest < ActionDispatch::IntegrationTest
     proxy = proxies(:acme_proxy)
     body = { data: { labels: { "centaur.slack_user_id" => "U2" } } }
 
-    expected_hash = nil
     with_env(
       "CENTAUR_JWT_SIGNING_SECRET" => "test-secret",
       "CENTAUR_CONSOLE_URL" => "http://centaur-console:3000"
     ) do
       patch api_v1_proxy_url(id: proxy.oid), params: body.to_json, headers: auth_headers
-      expected_hash = proxy.reload.sync_config_snapshot(
-        sandbox_entitlements_hosts: [ "centaur-console" ],
-        include_config: false
-      )[:config_hash]
-      refute_equal proxy.config_hash, expected_hash
-    end
-    assert_response :ok
+      assert_response :ok
+      mutation_hash = json_body.dig("data", "config_hash")
 
-    assert_equal expected_hash, json_body.dig("data", "config_hash")
+      post api_v1_proxy_sync_url, params: {}.to_json, headers: proxy_auth_headers(ACME_PROXY_TOKEN)
+      assert_response :ok
+      assert_equal mutation_hash, json_body.fetch("config_hash")
+    end
   end
 
   test "PATCH with null labels clears labels" do
@@ -268,5 +261,9 @@ class ProxiesControllerTest < ActionDispatch::IntegrationTest
     previous.each do |key, value|
       value.nil? ? ENV.delete(key) : ENV[key] = value
     end
+  end
+
+  def proxy_auth_headers(token)
+    { "Authorization" => "Bearer #{token}", "Content-Type" => "application/json" }
   end
 end

--- a/services/console/test/controllers/api/v1/proxies_controller_test.rb
+++ b/services/console/test/controllers/api/v1/proxies_controller_test.rb
@@ -32,6 +32,18 @@ class ProxiesControllerTest < ActionDispatch::IntegrationTest
     refute_includes ids, proxies(:globex_proxy).oid
   end
 
+  test "GET index filters by labels" do
+    proxies(:acme_proxy).update!(labels: { "centaur.slack_user_id" => "U123" })
+    get api_v1_proxies_url,
+        params: { labels: { "centaur.slack_user_id" => "U123" } },
+        headers: auth_headers
+    assert_response :ok
+
+    ids = json_body.fetch("data").map { |d| d["id"] }
+    assert_includes ids, proxies(:acme_proxy).oid
+    refute_includes ids, proxies(:globex_proxy).oid
+  end
+
   test "GET show returns a proxy" do
     proxy = proxies(:acme_proxy)
     get api_v1_proxy_url(id: proxy.oid), headers: auth_headers
@@ -39,11 +51,18 @@ class ProxiesControllerTest < ActionDispatch::IntegrationTest
     data = json_body.fetch("data")
     assert_equal proxy.oid, data["id"]
     assert_equal proxy.principal.oid, data["principal_id"]
+    assert_equal proxy.labels, data["labels"]
     refute data.key?("token")
   end
 
   test "POST creates a proxy and returns the plaintext token once" do
-    body = { data: { name: "edge-proxy", principal_id: principals(:acme_channel).oid } }
+    body = {
+      data: {
+        name: "edge-proxy",
+        principal_id: principals(:acme_channel).oid,
+        labels: { "centaur.slack_user_id" => "U123" }
+      }
+    }
     assert_difference -> { Proxy.count }, 1 do
       post api_v1_proxies_url, params: body.to_json, headers: auth_headers
     end
@@ -53,6 +72,15 @@ class ProxiesControllerTest < ActionDispatch::IntegrationTest
     token = data.fetch("token")
     assert_match Proxy::TOKEN_FORMAT, token
     assert_equal Proxy.find_by_token(token).oid, data["id"]
+    assert_equal({ "centaur.slack_user_id" => "U123" }, data["labels"])
+  end
+
+  test "POST with invalid labels returns a validation error" do
+    body = { data: { name: "bad-labels", labels: { "slack_user_id" => 123 } } }
+    post api_v1_proxies_url, params: body.to_json, headers: auth_headers
+    assert_response :unprocessable_entity
+    assert_equal "validation failed", json_body.dig("error", "message")
+    assert_includes json_body.dig("error", "details", "labels"), "values must be strings"
   end
 
   test "POST with a missing name returns a validation error" do
@@ -99,6 +127,28 @@ class ProxiesControllerTest < ActionDispatch::IntegrationTest
     assert_response :ok
     assert_equal principals(:globex_user).oid, json_body.dig("data", "principal_id")
     assert_equal principals(:globex_user), proxy.reload.principal
+  end
+
+  test "PATCH replaces labels" do
+    proxy = proxies(:acme_proxy)
+    proxy.update!(labels: { "centaur.slack_user_id" => "U1" })
+    body = { data: { labels: { "centaur.slack_user_id" => "U2" } } }
+
+    patch api_v1_proxy_url(id: proxy.oid), params: body.to_json, headers: auth_headers
+    assert_response :ok
+    assert_equal({ "centaur.slack_user_id" => "U2" }, json_body.dig("data", "labels"))
+    assert_equal({ "centaur.slack_user_id" => "U2" }, proxy.reload.labels)
+  end
+
+  test "PATCH with null labels clears labels" do
+    proxy = proxies(:acme_proxy)
+    proxy.update!(labels: { "centaur.slack_user_id" => "U1" })
+    body = { data: { labels: nil } }
+
+    patch api_v1_proxy_url(id: proxy.oid), params: body.to_json, headers: auth_headers
+    assert_response :ok
+    assert_equal({}, json_body.dig("data", "labels"))
+    assert_equal({}, proxy.reload.labels)
   end
 
   test "PATCH with a null principal_id unassigns the proxy" do

--- a/services/console/test/controllers/api/v1/proxy_sync_controller_test.rb
+++ b/services/console/test/controllers/api/v1/proxy_sync_controller_test.rb
@@ -319,6 +319,26 @@ class ProxySyncControllerTest < ActionDispatch::IntegrationTest
     )
   end
 
+  test "postgres entries resolve value_from settings against proxy labels" do
+    @proxy.update!(labels: { "centaur.slack_user_id" => "U0123456789" })
+    pg = pg_dsn_secrets(:acme_analytics_pg)
+    pg.update!(settings: [
+      {
+        "name" => "centaur.slack_user_id",
+        "value_from" => { "proxy_label" => "centaur.slack_user_id" }
+      }
+    ])
+
+    post api_v1_proxy_sync_url, params: {}.to_json, headers: auth_headers
+    assert_response :ok
+
+    entry = json_body.fetch("postgres").find { |e| e["foreign_id"] == pg.foreign_id }
+    assert_equal(
+      [ { "name" => "centaur.slack_user_id", "value" => "U0123456789" } ],
+      entry["settings"]
+    )
+  end
+
   test "directly-granted secrets are emitted after role-granted ones" do
     # acme_channel holds github_token_inject and db_password_replace directly
     # (priority 100) and resolves acme_prod_api_key through the acme_infra role

--- a/services/console/test/controllers/api/v1/proxy_sync_controller_test.rb
+++ b/services/console/test/controllers/api/v1/proxy_sync_controller_test.rb
@@ -102,7 +102,7 @@ class ProxySyncControllerTest < ActionDispatch::IntegrationTest
 
     snapshot = PrincipalSyncConfigSnapshot.find_by!(principal: @proxy.principal)
     assert_equal @proxy.principal.sync_config_cache_version, snapshot.principal_cache_version
-    assert_equal "s3cr3t-db-pass", snapshot.payload.dig("secrets", 1, "source", "value")
+    assert_equal "s3cr3t-db-pass", snapshot.config.dig("secrets", 1, "source", "value")
 
     raw = PrincipalSyncConfigSnapshot.connection.select_value(
       "SELECT payload FROM principal_sync_config_snapshots WHERE id = #{snapshot.id}"
@@ -228,7 +228,7 @@ class ProxySyncControllerTest < ActionDispatch::IntegrationTest
 
     original_hash = json_body.fetch("config_hash")
     snapshot = PrincipalSyncConfigSnapshot.find_by!(principal: @proxy.principal)
-    transform = snapshot.payload.fetch("transforms").find { |t| t["name"] == "gcp_id_token" }
+    transform = snapshot.config.fetch("transforms").find { |t| t["name"] == "gcp_id_token" }
     assert_equal secret.audience, transform.dig("config", "audience")
     assert_equal "CLOUD_RUN_SA_KEYFILE", transform.dig("config", "keyfile", "var")
 

--- a/services/console/test/controllers/api/v1/sandbox_permissions_controller_test.rb
+++ b/services/console/test/controllers/api/v1/sandbox_permissions_controller_test.rb
@@ -20,6 +20,10 @@ module Api
       end
 
       test "returns redacted sandbox permissions for a valid sandbox token" do
+        pg = pg_dsn_secrets(:acme_analytics_pg)
+        pg.update!(settings: [
+          { "name" => "centaur.slack_user_id", "value_from" => { "proxy_label" => "centaur.slack_user_id" } }
+        ])
         credential = BrokerCredential.create!(
           namespace: @proxy.principal.namespace,
           foreign_id: "google-personal",
@@ -76,6 +80,8 @@ module Api
         refute_includes response.body, "s3cr3t-db-pass"
         assert_equal "no-store", response.headers["Cache-Control"]
         assert_match(/\A"[0-9a-f]{64}"\z/, response.headers["ETag"])
+        refute data.fetch("permissions").key?("_postgres_setting_templates")
+        refute_includes response.body, "_postgres_setting_templates"
       end
 
       test "rejects requests without a sandbox token" do

--- a/services/console/test/controllers/api/v1/sandbox_permissions_controller_test.rb
+++ b/services/console/test/controllers/api/v1/sandbox_permissions_controller_test.rb
@@ -82,9 +82,7 @@ module Api
         assert_match(/\A"[0-9a-f]{64}"\z/, response.headers["ETag"])
         permissions = data.fetch("permissions")
         refute permissions.key?("postgres_setting_templates")
-        refute permissions.key?("_postgres_setting_templates")
         refute_includes response.body, "postgres_setting_templates"
-        refute_includes response.body, "_postgres_setting_templates"
       end
 
       test "rejects requests without a sandbox token" do

--- a/services/console/test/controllers/api/v1/sandbox_permissions_controller_test.rb
+++ b/services/console/test/controllers/api/v1/sandbox_permissions_controller_test.rb
@@ -80,7 +80,10 @@ module Api
         refute_includes response.body, "s3cr3t-db-pass"
         assert_equal "no-store", response.headers["Cache-Control"]
         assert_match(/\A"[0-9a-f]{64}"\z/, response.headers["ETag"])
-        refute data.fetch("permissions").key?("_postgres_setting_templates")
+        permissions = data.fetch("permissions")
+        refute permissions.key?("postgres_setting_templates")
+        refute permissions.key?("_postgres_setting_templates")
+        refute_includes response.body, "postgres_setting_templates"
         refute_includes response.body, "_postgres_setting_templates"
       end
 

--- a/services/console/test/models/pg_dsn_secret_test.rb
+++ b/services/console/test/models/pg_dsn_secret_test.rb
@@ -161,6 +161,36 @@ class PgDsnSecretTest < ActiveSupport::TestCase
     )
   end
 
+  test "to_proxy_dsn resolves value_from proxy labels" do
+    principal = principals(:acme_channel)
+    proxy = Proxy.create!(
+      name: "proxy-labels",
+      principal: principal,
+      labels: { "centaur.slack_user_id" => "U0123456789" }
+    )
+    secret = with_dsn(PgDsnSecret.new(base_attrs(settings: [
+      {
+        "name" => "centaur.slack_user_id",
+        "value_from" => { "proxy_label" => "centaur.slack_user_id" }
+      }
+    ])))
+    assert secret.valid?
+
+    assert_equal(
+      [ { "name" => "centaur.slack_user_id", "value" => "U0123456789" } ],
+      secret.to_proxy_dsn(principal: principal, proxy: proxy)["settings"]
+    )
+  end
+
+  test "to_proxy_dsn resolves a proxy label the proxy does not carry as an empty string" do
+    secret = with_dsn(PgDsnSecret.new(base_attrs(settings: [
+      { "name" => "centaur.slack_user_id", "value_from" => { "proxy_label" => "centaur.slack_user_id" } }
+    ])))
+
+    value = secret.to_proxy_dsn(principal: principals(:acme_channel), proxy: proxies(:acme_proxy)).dig("settings", 0, "value")
+    assert_equal "", value
+  end
+
   test "to_proxy_dsn resolves a label the principal does not carry as an empty string" do
     secret = with_dsn(PgDsnSecret.new(base_attrs(settings: [
       { "name" => "centaur.slack_admin", "value_from" => { "principal_label" => "centaur_slack_admin" } }
@@ -203,7 +233,7 @@ class PgDsnSecretTest < ActiveSupport::TestCase
       secret = with_dsn(PgDsnSecret.new(base_attrs(settings: [ { "name" => "app.tenant", "value_from" => ref } ])))
       assert_not secret.valid?
       assert_includes secret.errors[:settings],
-        "[0] value_from must have exactly one of principal_label or principal_field"
+        "[0] value_from must have exactly one of principal_label or principal_field or proxy_label"
     end
   end
 
@@ -213,6 +243,14 @@ class PgDsnSecretTest < ActiveSupport::TestCase
     ])))
     assert_not secret.valid?
     assert_includes secret.errors[:settings], "[0] principal_label can't be blank"
+  end
+
+  test "a value_from with a blank proxy_label is rejected" do
+    secret = with_dsn(PgDsnSecret.new(base_attrs(settings: [
+      { "name" => "app.tenant", "value_from" => { "proxy_label" => "" } }
+    ])))
+    assert_not secret.valid?
+    assert_includes secret.errors[:settings], "[0] proxy_label can't be blank"
   end
 
   test "a value_from with an unknown principal_field is rejected" do

--- a/services/console/test/models/principal_sync_config_snapshot_test.rb
+++ b/services/console/test/models/principal_sync_config_snapshot_test.rb
@@ -20,11 +20,47 @@ class PrincipalSyncConfigSnapshotTest < ActiveSupport::TestCase
     singleton.define_method(:try_build_for, original)
   end
 
+  def without_live_sync_postgres
+    original = Principal.instance_method(:sync_postgres)
+    Principal.class_eval do
+      define_method(:sync_postgres) do |*_args|
+        raise "live sync_postgres should not be called"
+      end
+    end
+    yield
+  ensure
+    Principal.class_eval { define_method(:sync_postgres, original) }
+  end
+
   test "fetch_for builds a snapshot on cold start" do
     assert_difference -> { PrincipalSyncConfigSnapshot.count }, 1 do
       snapshot = PrincipalSyncConfigSnapshot.fetch_for(@principal)
       assert_equal @principal.sync_config_cache_version, snapshot.principal_cache_version
-      assert_equal @principal.effective_config(redact_secrets: false), snapshot.payload
+      assert_equal @principal.sync_config_snapshot_payload, snapshot.payload
+    end
+  end
+
+  test "proxy sync renders proxy labels from the snapshot without recomputing postgres" do
+    pg = pg_dsn_secrets(:acme_analytics_pg)
+    pg.update!(settings: [
+      { "name" => "centaur.principal", "value_from" => { "principal_field" => "foreign_id" } },
+      { "name" => "centaur.slack_user_id", "value_from" => { "proxy_label" => "centaur.slack_user_id" } }
+    ])
+    proxy = proxies(:acme_proxy)
+    proxy.update!(labels: { "centaur.slack_user_id" => "U0123456789" })
+    PrincipalSyncConfigSnapshot.fetch_for(@principal)
+
+    without_live_sync_postgres do
+      snapshot = proxy.reload.sync_config_snapshot
+      entry = snapshot.fetch(:config).fetch("postgres").find { |item| item["foreign_id"] == pg.foreign_id }
+
+      assert_equal(
+        [
+          { "name" => "centaur.principal", "value" => @principal.foreign_id },
+          { "name" => "centaur.slack_user_id", "value" => "U0123456789" }
+        ],
+        entry.fetch("settings")
+      )
     end
   end
 

--- a/services/console/test/models/principal_sync_config_snapshot_test.rb
+++ b/services/console/test/models/principal_sync_config_snapshot_test.rb
@@ -37,6 +37,8 @@ class PrincipalSyncConfigSnapshotTest < ActiveSupport::TestCase
       snapshot = PrincipalSyncConfigSnapshot.fetch_for(@principal)
       assert_equal @principal.sync_config_cache_version, snapshot.principal_cache_version
       assert_equal @principal.sync_config_snapshot_payload, snapshot.payload
+      assert_equal @principal.effective_config(redact_secrets: false), snapshot.config
+      assert_equal({}, snapshot.postgres_setting_templates)
     end
   end
 
@@ -48,7 +50,9 @@ class PrincipalSyncConfigSnapshotTest < ActiveSupport::TestCase
     ])
     proxy = proxies(:acme_proxy)
     proxy.update!(labels: { "centaur.slack_user_id" => "U0123456789" })
-    PrincipalSyncConfigSnapshot.fetch_for(@principal)
+    cached = PrincipalSyncConfigSnapshot.fetch_for(@principal)
+    assert cached.postgres_setting_templates.key?(pg.oid)
+    refute cached.config.key?("postgres_setting_templates")
 
     without_live_sync_postgres do
       snapshot = proxy.reload.sync_config_snapshot
@@ -62,6 +66,17 @@ class PrincipalSyncConfigSnapshotTest < ActiveSupport::TestCase
         entry.fetch("settings")
       )
     end
+  end
+
+  test "snapshot accessors read legacy flat payloads" do
+    config = { "secrets" => [], "transforms" => [], "postgres" => [] }
+    templates = { "pgd_legacy" => [ { "name" => "app.user" } ] }
+    snapshot = PrincipalSyncConfigSnapshot.new(
+      payload: config.merge("_postgres_setting_templates" => templates)
+    )
+
+    assert_equal config, snapshot.config
+    assert_equal templates, snapshot.postgres_setting_templates
   end
 
   test "fetch_for returns the fresh snapshot without rebuilding" do
@@ -100,14 +115,14 @@ class PrincipalSyncConfigSnapshotTest < ActiveSupport::TestCase
 
       snapshot = PrincipalSyncConfigSnapshot.fetch_for(@principal)
       original_hash = proxy.sync_config_snapshot.fetch(:config_hash)
-      original_token = snapshot.payload.fetch("secrets").find do |secret|
+      original_token = snapshot.config.fetch("secrets").find do |secret|
         secret.dig("inject", "header") == "Authorization"
       end.dig("source", "value")
       snapshot.update_columns(updated_at: previous_window_time)
 
       travel_to current_time do
         refreshed = PrincipalSyncConfigSnapshot.fetch_for(@principal)
-        refreshed_token = refreshed.payload.fetch("secrets").find do |secret|
+        refreshed_token = refreshed.config.fetch("secrets").find do |secret|
           secret.dig("inject", "header") == "Authorization"
         end.dig("source", "value")
 

--- a/services/console/test/models/principal_sync_config_snapshot_test.rb
+++ b/services/console/test/models/principal_sync_config_snapshot_test.rb
@@ -68,15 +68,12 @@ class PrincipalSyncConfigSnapshotTest < ActiveSupport::TestCase
     end
   end
 
-  test "snapshot accessors read legacy flat payloads" do
+  test "snapshot accessors read flat payloads created before the snapshot envelope" do
     config = { "secrets" => [], "transforms" => [], "postgres" => [] }
-    templates = { "pgd_legacy" => [ { "name" => "app.user" } ] }
-    snapshot = PrincipalSyncConfigSnapshot.new(
-      payload: config.merge("_postgres_setting_templates" => templates)
-    )
+    snapshot = PrincipalSyncConfigSnapshot.new(payload: config)
 
     assert_equal config, snapshot.config
-    assert_equal templates, snapshot.postgres_setting_templates
+    assert_empty snapshot.postgres_setting_templates
   end
 
   test "fetch_for returns the fresh snapshot without rebuilding" do

--- a/services/console/test/models/proxy_test.rb
+++ b/services/console/test/models/proxy_test.rb
@@ -14,6 +14,25 @@ class ProxyTest < ActiveSupport::TestCase
     assert proxy.valid?
   end
 
+  test "labels default to an empty hash and accept string labels" do
+    proxy = Proxy.create!(
+      name: "labels",
+      principal: principals(:globex_user),
+      labels: { "slack_user_id" => "U123" }
+    )
+
+    assert_equal({ "slack_user_id" => "U123" }, proxy.reload.labels)
+  end
+
+  test "labels require string values" do
+    invalid = Proxy.new(valid_attrs(labels: {
+      "centaur.slack_team_id" => 123
+    }))
+
+    assert_not invalid.valid?
+    assert_includes invalid.errors[:labels], "values must be strings"
+  end
+
   test "requires name" do
     proxy = Proxy.new(valid_attrs(name: nil))
     assert_not proxy.valid?
@@ -52,6 +71,13 @@ class ProxyTest < ActiveSupport::TestCase
     proxy = Proxy.create!(name: "swap", principal: principals(:globex_user))
     before = proxy.config_hash
     proxy.update!(principal: principals(:acme_channel))
+    refute_equal before, proxy.config_hash
+  end
+
+  test "config_hash changes when labels change" do
+    proxy = Proxy.create!(name: "label-hash", principal: principals(:globex_user))
+    before = proxy.config_hash
+    proxy.update!(labels: { "centaur.slack_user_id" => "U123" })
     refute_equal before, proxy.config_hash
   end
 

--- a/services/console/test/models/proxy_test.rb
+++ b/services/console/test/models/proxy_test.rb
@@ -61,7 +61,7 @@ class ProxyTest < ActiveSupport::TestCase
 
   test "an unassigned proxy delivers an empty config" do
     proxy = Proxy.create!(name: "idle", principal: nil)
-    config = proxy.sync_config
+    config = proxy.sync_config_snapshot.fetch(:config)
     assert_empty config["secrets"]
     assert_empty config["transforms"]
     assert_empty config["postgres"]

--- a/services/console/test/models/proxy_test.rb
+++ b/services/console/test/models/proxy_test.rb
@@ -132,7 +132,7 @@ class ProxyTest < ActiveSupport::TestCase
     before = proxy.config_hash
     Grant.create!(principal: proxy.principal, pg_dsn_secret: pg_dsn_secrets(:acme_analytics_pg),
                   created_by: users(:globex_admin))
-    refute_equal before, proxy.config_hash
+    refute_equal before, proxy.reload.config_hash
   end
 
   test "config_hash changes when a transform grant is added" do
@@ -140,7 +140,7 @@ class ProxyTest < ActiveSupport::TestCase
     before = proxy.config_hash
     Grant.create!(principal: proxy.principal, gcp_auth_secret: gcp_auth_secrets(:acme_bigquery),
                   created_by: users(:globex_admin))
-    refute_equal before, proxy.config_hash
+    refute_equal before, proxy.reload.config_hash
   end
 
   test "config_hash changes when a role grant becomes reachable" do

--- a/services/slackbotv2/src/session-api.ts
+++ b/services/slackbotv2/src/session-api.ts
@@ -869,12 +869,14 @@ function sessionRequesterMetadata(
 ): JsonObject {
   const slackUserId = identity?.slackUserId ?? messageRequesterUserId(message)
   const slackTeamId = identity?.slackTeamId ?? messageSlackTeamId(message)
+  const slackChannelId = slackConversationId(message)
   const slackUserName = identity?.slackUserName ?? message?.author.userName
   const slackDisplayName = identity?.slackDisplayName ?? message?.author.fullName
   const slackEmail = identity?.slackEmail
   return {
     ...(slackUserId ? { slack_user_id: slackUserId } : {}),
     ...(slackTeamId ? { slack_team_id: slackTeamId } : {}),
+    ...(slackChannelId ? { slack_channel_id: slackChannelId } : {}),
     ...(slackUserName ? { slack_user_name: slackUserName } : {}),
     ...(slackDisplayName ? { slack_display_name: slackDisplayName } : {}),
     ...(slackEmail ? { slack_user_email: slackEmail } : {}),

--- a/services/slackbotv2/test/session-api.test.ts
+++ b/services/slackbotv2/test/session-api.test.ts
@@ -811,19 +811,21 @@ describe('session principal display name', () => {
     }
   }
 
-  function createBody(requests: RecordedRequest[]): {
-    metadata?: {
-      slack_conversation_name?: string
-      slack_team_id?: string
-      slack_user_email?: string
+	  function createBody(requests: RecordedRequest[]): {
+	    metadata?: {
+	      slack_channel_id?: string
+	      slack_conversation_name?: string
+	      slack_team_id?: string
+	      slack_user_email?: string
       slack_user_id?: string
     }
-  } {
-    return (requests.find(request => request.url.endsWith('.000100'))?.body ?? {}) as {
-      metadata?: {
-        slack_conversation_name?: string
-        slack_team_id?: string
-        slack_user_email?: string
+	  } {
+	    return (requests.find(request => request.url.endsWith('.000100'))?.body ?? {}) as {
+	      metadata?: {
+	        slack_channel_id?: string
+	        slack_conversation_name?: string
+	        slack_team_id?: string
+	        slack_user_email?: string
         slack_user_id?: string
       }
     }
@@ -933,9 +935,10 @@ describe('session principal display name', () => {
       async () => {
         await forwardToSessionApi(slackOptions(fetchFn), forwardInput(apiMessage('hi')))
       }
-    )
-    expect(createBody(requests).metadata?.slack_conversation_name).toBe('eng-oncall')
-  })
+	    )
+	    expect(createBody(requests).metadata?.slack_conversation_name).toBe('eng-oncall')
+	    expect(createBody(requests).metadata?.slack_channel_id).toBe('C1')
+	  })
 
   test('continues creating the session when the channel lookup never settles', async () => {
     const { fetchFn, requests } = fakeApi()
@@ -981,9 +984,10 @@ describe('session principal display name', () => {
       async () => {
         await forwardToSessionApi(slackOptions(fetchFn), forwardInput(dm))
       }
-    )
-    expect(createBody(requests).metadata?.slack_conversation_name).toBe('Ada Lovelace')
-    expect(createBody(requests).metadata?.slack_team_id).toBe('T1')
+	    )
+	    expect(createBody(requests).metadata?.slack_conversation_name).toBe('Ada Lovelace')
+	    expect(createBody(requests).metadata?.slack_channel_id).toBe('D9')
+	    expect(createBody(requests).metadata?.slack_team_id).toBe('T1')
     expect(createBody(requests).metadata?.slack_user_email).toBe('ada@example.com')
     expect(createBody(requests).metadata?.slack_user_id).toBe('U1')
   })


### PR DESCRIPTION
Adds proxy labels to the console API and sync path, including proxy-label derived Postgres settings. Persists Slack-derived proxy labels on sessions and threads them through sandbox proxy creation, assignment, reuse, repair, warm-pool claim, and resume handling.