### PR TITLE
feat: support gsuite full-text Drive search

### DIFF
--- a/tools/productivity/gsuite/cli.py
+++ b/tools/productivity/gsuite/cli.py
@@ -479,7 +479,17 @@ def calendar_rsvp_cmd(
 def drive_list(
     limit: int = typer.Option(50, "--limit", "-n", help="Max results"),
     folder: str = typer.Option(None, "--folder", "-f", help="Folder ID to list"),
-    query: str = typer.Option(None, "--query", "-q", help="Search by name"),
+    query: str = typer.Option(
+        None,
+        "--query",
+        "-q",
+        help="Search by name unless --full-text is set",
+    ),
+    full_text: bool = typer.Option(
+        False,
+        "--full-text",
+        help="Search file contents and metadata with Drive fullText contains",
+    ),
     file_type: str = typer.Option(None, "--type", "-t", help="Filter by MIME type"),
 ):
     """List files in Google Drive.
@@ -487,6 +497,7 @@ def drive_list(
     Examples:
         gsuite drive list
         gsuite drive list -q "report"
+        gsuite drive list -q "contract language" --full-text
         gsuite drive list --folder "1234abc" -n 20
         gsuite drive list --type "application/pdf"
     """
@@ -497,6 +508,7 @@ def drive_list(
         folder_id=folder,
         max_results=limit,
         file_type=file_type,
+        full_text=full_text,
     )
 
     if not results:

--- a/tools/productivity/gsuite/client.py
+++ b/tools/productivity/gsuite/client.py
@@ -646,19 +646,27 @@ def calendar_rsvp(
 # Drive functions
 
 
+def _drive_query_literal(value: str) -> str:
+    escaped = value.replace("\\", "\\\\").replace("'", "\\'")
+    return f"'{escaped}'"
+
+
 def drive_list(
     query: str | None = None,
     folder_id: str | None = None,
     max_results: int = 50,
     file_type: str | None = None,
+    full_text: bool = False,
 ) -> list[dict]:
     """List files in Google Drive.
 
     Args:
-        query: Search query (Drive query syntax)
+        query: Search query to match against file names by default, or full text
+            when full_text is true
         folder_id: Folder ID to list contents
         max_results: Maximum number of results
         file_type: Filter by MIME type prefix (e.g., "image/", "application/pdf")
+        full_text: Use Drive's fullText contains query term instead of name contains
 
     Returns:
         List of file dicts with id, name, mimeType, size, modifiedTime, webViewLink
@@ -667,14 +675,15 @@ def drive_list(
 
     q_parts = []
     if query:
-        q_parts.append(f"name contains '{query}'")
+        query_term = "fullText" if full_text else "name"
+        q_parts.append(f"{query_term} contains {_drive_query_literal(query)}")
     if folder_id:
-        q_parts.append(f"'{folder_id}' in parents")
+        q_parts.append(f"{_drive_query_literal(folder_id)} in parents")
     if file_type:
         if file_type.endswith("/"):
-            q_parts.append(f"mimeType contains '{file_type}'")
+            q_parts.append(f"mimeType contains {_drive_query_literal(file_type)}")
         else:
-            q_parts.append(f"mimeType = '{file_type}'")
+            q_parts.append(f"mimeType = {_drive_query_literal(file_type)}")
 
     q_parts.append("trashed = false")
 
@@ -2692,14 +2701,17 @@ class GSuiteClient:
         folder_id: str | None = None,
         max_results: int = 50,
         file_type: str | None = None,
+        full_text: bool = False,
     ) -> list[dict]:
         """List files in Google Drive.
 
         Args:
-            query: Search query (Drive query syntax)
+            query: Search query to match against file names by default, or full text
+                when full_text is true
             folder_id: Folder ID to list contents
             max_results: Maximum number of results
             file_type: Filter by MIME type prefix (e.g., "image/", "application/pdf")
+            full_text: Use Drive's fullText contains query term instead of name contains
 
         Returns:
             List of file dicts with id, name, mimeType, size, modifiedTime, webViewLink
@@ -2709,19 +2721,24 @@ class GSuiteClient:
             folder_id=folder_id,
             max_results=max_results,
             file_type=file_type,
+            full_text=full_text,
         )
 
-    def drive_search(self, query: str, max_results: int = 50) -> list[dict]:
-        """Search files in Google Drive by name.
+    def drive_search(
+        self, query: str, max_results: int = 50, full_text: bool = False
+    ) -> list[dict]:
+        """Search files in Google Drive by name or full text.
 
         Args:
-            query: Search query (matches file names)
+            query: Search query to match against file names by default, or full text
+                when full_text is true
             max_results: Maximum number of results
+            full_text: Use Drive's fullText contains query term instead of name contains
 
         Returns:
             List of file dicts with id, name, mimeType, size, modifiedTime, webViewLink
         """
-        return drive_list(query=query, max_results=max_results)
+        return drive_list(query=query, max_results=max_results, full_text=full_text)
 
     def drive_get(self, file_id: str) -> dict:
         """Get file metadata from Google Drive.

--- a/tools/productivity/gsuite/test_cli.py
+++ b/tools/productivity/gsuite/test_cli.py
@@ -6,6 +6,42 @@ from gsuite.cli import app
 runner = CliRunner()
 
 
+def test_drive_list_full_text_flag_is_passed_to_client(monkeypatch):
+    calls: list[dict] = []
+
+    def fake_drive_list(**kwargs):
+        calls.append(kwargs)
+        return [
+            {
+                "id": "file-123",
+                "name": "Contract Notes",
+                "mime_type": "application/vnd.google-apps.document",
+                "size": 0,
+                "modified_time": "2026-07-21T10:00:00Z",
+                "web_view_link": "https://drive.google.com/file/file-123",
+                "parent_ids": [],
+            }
+        ]
+
+    monkeypatch.setattr(client, "drive_list", fake_drive_list)
+
+    result = runner.invoke(
+        app,
+        ["drive", "list", "--query", "contract language", "--full-text", "--limit", "5"],
+    )
+
+    assert result.exit_code == 0
+    assert calls == [
+        {
+            "query": "contract language",
+            "folder_id": None,
+            "max_results": 5,
+            "file_type": None,
+            "full_text": True,
+        }
+    ]
+
+
 def test_docs_bullets_command_prints_verification_summary(monkeypatch):
     monkeypatch.setattr(
         client,

--- a/tools/productivity/gsuite/test_client.py
+++ b/tools/productivity/gsuite/test_client.py
@@ -16,6 +16,7 @@ class _CreateRequest:
 class _FakeFilesApi:
     def __init__(self):
         self.create_calls: list[dict] = []
+        self.list_calls: list[dict] = []
 
     def create(self, **kwargs):
         self.create_calls.append(kwargs)
@@ -34,6 +35,24 @@ class _FakeFilesApi:
                 "id": "file-123",
                 "name": kwargs["body"]["name"],
                 "webViewLink": "https://drive.google.com/file/file-123",
+            }
+        )
+
+    def list(self, **kwargs):
+        self.list_calls.append(kwargs)
+        return _CreateRequest(
+            {
+                "files": [
+                    {
+                        "id": "file-123",
+                        "name": "Quinn's paper",
+                        "mimeType": "application/pdf",
+                        "size": "1024",
+                        "modifiedTime": "2026-07-21T10:00:00Z",
+                        "webViewLink": "https://drive.google.com/file/file-123",
+                        "parents": ["folder-123"],
+                    }
+                ]
             }
         )
 
@@ -232,6 +251,55 @@ def test_gmail_read_returns_plain_html_and_raw_content(monkeypatch):
     assert fake_service.messages_api.get_calls == [
         {"userId": "me", "id": "msg-1", "format": "full"},
         {"userId": "me", "id": "msg-1", "format": "raw"},
+    ]
+
+
+def test_drive_list_searches_name_by_default(monkeypatch):
+    fake_service = _FakeDriveService()
+    monkeypatch.setattr(client, "get_drive_service", lambda: fake_service)
+
+    result = client.drive_list(query="report")
+
+    list_call = fake_service.files_api.list_calls[0]
+    assert list_call["q"] == "name contains 'report' and trashed = false"
+    assert list_call["includeItemsFromAllDrives"] is True
+    assert list_call["supportsAllDrives"] is True
+    assert result[0]["id"] == "file-123"
+    assert result[0]["size"] == 1024
+
+
+def test_drive_list_supports_full_text_contains_and_escapes_literals(monkeypatch):
+    fake_service = _FakeDriveService()
+    monkeypatch.setattr(client, "get_drive_service", lambda: fake_service)
+
+    client.drive_list(
+        query="quinn's paper\\essay",
+        folder_id="folder'123",
+        file_type="application/pdf",
+        full_text=True,
+    )
+
+    list_call = fake_service.files_api.list_calls[0]
+    assert list_call["q"] == (
+        "fullText contains 'quinn\\'s paper\\\\essay' and "
+        "'folder\\'123' in parents and "
+        "mimeType = 'application/pdf' and "
+        "trashed = false"
+    )
+
+
+def test_gsuite_client_drive_search_supports_full_text(monkeypatch):
+    calls: list[dict] = []
+
+    def fake_drive_list(**kwargs):
+        calls.append(kwargs)
+        return []
+
+    monkeypatch.setattr(client, "drive_list", fake_drive_list)
+
+    assert client.GSuiteClient().drive_search("contract language", full_text=True) == []
+    assert calls == [
+        {"query": "contract language", "max_results": 50, "full_text": True}
     ]
 
 


### PR DESCRIPTION
Adds a full-text Drive search mode to the gsuite tool so callers can search file contents and metadata with Drive's fullText contains query term. The Drive list CLI now exposes --full-text, and the client escapes Drive query literals for safer query construction.