### PR TITLE
fix: use X search pagination token

### DIFF
--- a/tools/comms/twitter/client.py
+++ b/tools/comms/twitter/client.py
@@ -140,6 +140,7 @@ class XClient:
         params: dict[str, Any] | None = None,
         max_page_size: int = 100,
         min_page_size: int = 1,
+        token_param: str = "pagination_token",
     ) -> tuple[list[dict[str, Any]], dict[str, Any], dict[str, Any]]:
         params = dict(params or {})
         results: list[dict[str, Any]] = []
@@ -148,7 +149,7 @@ class XClient:
         token: str | None = None
         while len(results) < limit:
             page_size = self._limit(limit - len(results), minimum=min_page_size, maximum=max_page_size)
-            request_params = {**params, "max_results": page_size, "pagination_token": token}
+            request_params = {**params, "max_results": page_size, token_param: token}
             data = self._request(endpoint, request_params)
             meta = data.get("meta") or {}
             for key, value in (data.get("includes") or {}).items():
@@ -227,7 +228,13 @@ class XClient:
             "sort_order": "relevancy" if search_type == "top" else "recency",
         }
         tweets, meta, includes = self._paged(
-            endpoint, "data", limit, params, max_page_size=100, min_page_size=10
+            endpoint,
+            "data",
+            limit,
+            params,
+            max_page_size=100,
+            min_page_size=10,
+            token_param="next_token",
         )
         return [self._normalize_tweet(tweet, includes) for tweet in tweets[:limit]], meta
 
@@ -243,7 +250,7 @@ class XClient:
         tweet = data.get("data")
         return self._normalize_tweet(tweet, data.get("includes")) if tweet else None
 
-    def get_timeline(
+    def get_user_posts(
         self, handle: str, limit: int = 20
     ) -> tuple[dict[str, Any] | None, list[dict[str, Any]], dict[str, Any] | None]:
         """Get a user's recent posts by handle."""
@@ -253,6 +260,12 @@ class XClient:
         params = {**self._tweet_params(), "exclude": "retweets"}
         tweets, meta, includes = self._paged(f"/users/{user['user_id']}/tweets", "data", limit, params)
         return user, [self._normalize_tweet(tweet, includes) for tweet in tweets], meta
+
+    def get_timeline(
+        self, handle: str, limit: int = 20
+    ) -> tuple[dict[str, Any] | None, list[dict[str, Any]], dict[str, Any] | None]:
+        """Get a specific user's authored posts timeline by handle."""
+        return self.get_user_posts(handle, limit=limit)
 
     def get_mentions(self, handle: str, limit: int = 20) -> tuple[list[dict[str, Any]], dict[str, Any]]:
         """Get recent mentions for a user."""

--- a/tools/comms/twitter/test_client.py
+++ b/tools/comms/twitter/test_client.py
@@ -1,0 +1,115 @@
+import sys
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from client import XClient
+
+
+class StubXClient(XClient):
+    def __init__(self, responses: list[dict[str, Any]]) -> None:
+        super().__init__(api_key="unused")
+        self.responses = responses
+        self.requests: list[tuple[str, dict[str, Any] | None]] = []
+
+    def _request(self, endpoint: str, params: dict[str, Any] | None = None) -> dict[str, Any]:
+        self.requests.append((endpoint, params))
+        if not self.responses:
+            raise AssertionError("unexpected request")
+        return self.responses.pop(0)
+
+
+def test_search_uses_recent_search_endpoint_and_next_token() -> None:
+    client = StubXClient(
+        [
+            {
+                "data": [{"id": "1", "author_id": "10", "text": "one"}],
+                "meta": {"next_token": "abc"},
+            },
+            {
+                "data": [{"id": "2", "author_id": "10", "text": "two"}],
+                "meta": {},
+            },
+        ]
+    )
+
+    tweets, _ = client.search_tweets("from:openai", limit=11)
+
+    assert [tweet["tweet_id"] for tweet in tweets] == ["1", "2"]
+    assert client.requests[0][0] == "/tweets/search/recent"
+    assert client.requests[0][1]["query"] == "from:openai"
+    assert client.requests[0][1]["sort_order"] == "recency"
+    assert client.requests[0][1]["max_results"] == 11
+    assert "pagination_token" not in client.requests[0][1]
+    assert client.requests[1][1]["next_token"] == "abc"
+
+
+def test_top_search_uses_relevancy_sort_order() -> None:
+    client = StubXClient([{"data": [], "meta": {}}])
+
+    client.search_tweets("openai", search_type="top", limit=10)
+
+    assert client.requests[0][0] == "/tweets/search/recent"
+    assert client.requests[0][1]["sort_order"] == "relevancy"
+
+
+def test_full_archive_search_uses_all_endpoint() -> None:
+    client = StubXClient([{"data": [], "meta": {}}])
+
+    client.search_tweets("openai", search_type="all", limit=10)
+
+    assert client.requests[0][0] == "/tweets/search/all"
+
+
+def test_timeline_uses_specific_user_posts_endpoint() -> None:
+    client = StubXClient(
+        [
+            {
+                "data": {
+                    "id": "10",
+                    "username": "ada",
+                    "name": "Ada",
+                }
+            },
+            {
+                "data": [{"id": "1", "author_id": "10", "text": "home"}],
+                "meta": {},
+                "includes": {"users": [{"id": "10", "username": "ada", "name": "Ada"}]},
+            },
+        ]
+    )
+
+    user, tweets, _ = client.get_timeline("ada", limit=1)
+
+    assert user["user_id"] == "10"
+    assert tweets[0]["screen_name"] == "ada"
+    assert client.requests[0][0] == "/users/by/username/ada"
+    assert client.requests[1][0] == "/users/10/tweets"
+    assert client.requests[1][1]["max_results"] == 1
+    assert client.requests[1][1]["pagination_token"] is None
+
+
+def test_user_posts_keeps_authored_posts_endpoint() -> None:
+    client = StubXClient(
+        [
+            {
+                "data": {
+                    "id": "10",
+                    "username": "ada",
+                    "name": "Ada",
+                }
+            },
+            {
+                "data": [{"id": "1", "author_id": "10", "text": "post"}],
+                "meta": {},
+            },
+        ]
+    )
+
+    client.get_user_posts("ada", limit=5)
+
+    assert client.requests[0][0] == "/users/by/username/ada"
+    assert client.requests[1][0] == "/users/10/tweets"
+    assert client.requests[1][1]["exclude"] == "retweets"
+    assert client.requests[1][1]["pagination_token"] is None


### PR DESCRIPTION
Updates the Twitter/X tool to paginate search requests with X's search next_token parameter while preserving the existing specific-user timeline behavior via /2/users/{id}/tweets. Adds focused client tests for search endpoint selection, search pagination, and user timeline request construction.