### PR TITLE
fix(slack): send DMs without im:write scope

### DIFF
--- a/tools/productivity/slack/client.py
+++ b/tools/productivity/slack/client.py
@@ -584,7 +584,10 @@ class SlackClient:
     def _resolve_message_destination(self, channel: str) -> str:
         """Resolve a send_message destination from channel, channel ID, or user ID."""
         if self._looks_like_user_id(channel):
-            return self._open_dm_channel(channel)
+            # chat.postMessage accepts a user ID directly and opens the bot's
+            # one-on-one DM when needed. Calling conversations.open first adds
+            # an unnecessary im:write scope requirement.
+            return self._clean_user_ref(channel).upper()
         return self._resolve_channel(channel)
 
     def _resolve_mentions(self, text: str, user_cache: dict[str, str]) -> str:
@@ -1862,10 +1865,11 @@ class SlackClient:
             if unfurl_media is not None:
                 kwargs["unfurl_media"] = unfurl_media
             response = self._client.chat_postMessage(**kwargs)
+            response_channel = str(response.get("channel") or channel_id)
             return {
-                "channel": channel_id,
+                "channel": response_channel,
                 "ts": response.get("ts", ""),
-                "permalink": f"https://slack.com/archives/{channel_id}/p{response.get('ts', '').replace('.', '')}",
+                "permalink": f"https://slack.com/archives/{response_channel}/p{response.get('ts', '').replace('.', '')}",
             }
         except SlackApiError as e:
             raise RuntimeError(f"Slack API error: {e.response['error']}") from e

--- a/tools/productivity/slack/tests/test_client.py
+++ b/tools/productivity/slack/tests/test_client.py
@@ -49,7 +49,8 @@ class _FakeWebClient:
 
     def chat_postMessage(self, **kwargs):
         self.last_kwargs = kwargs
-        return {"ts": "123.456"}
+        channel = "D123" if kwargs["channel"].startswith("U") else kwargs["channel"]
+        return {"channel": channel, "ts": "123.456"}
 
     def conversations_history(self, **kwargs):
         self.history_calls.append(kwargs)
@@ -180,27 +181,27 @@ def test_send_message_normalizes_escaped_line_breaks() -> None:
     assert fake_web_client.last_kwargs["text"] == "*Title*\n- one\n- two"
 
 
-def test_send_message_opens_dm_for_user_id_destination() -> None:
+def test_send_message_posts_directly_to_user_id_without_im_write_scope() -> None:
     client, fake_web_client = _make_client()
 
     result = client.send_message("<@U123ABC>", "hello", no_attribution=True)
 
-    assert fake_web_client.open_calls == [{"users": "U123ABC"}]
+    assert fake_web_client.open_calls == []
     assert fake_web_client.last_kwargs is not None
-    assert fake_web_client.last_kwargs["channel"] == "D123"
+    assert fake_web_client.last_kwargs["channel"] == "U123ABC"
     assert fake_web_client.last_kwargs["text"] == "hello"
     assert result["channel"] == "D123"
     assert result["permalink"] == "https://slack.com/archives/D123/p123456"
 
 
-def test_send_dm_opens_dm_and_posts_message() -> None:
+def test_send_dm_posts_directly_to_user_id() -> None:
     client, fake_web_client = _make_client()
 
     client.send_dm("U234ABC", "hello", no_attribution=True, unfurl_links=False)
 
-    assert fake_web_client.open_calls == [{"users": "U234ABC"}]
+    assert fake_web_client.open_calls == []
     assert fake_web_client.last_kwargs is not None
-    assert fake_web_client.last_kwargs["channel"] == "D123"
+    assert fake_web_client.last_kwargs["channel"] == "U234ABC"
     assert fake_web_client.last_kwargs["unfurl_links"] is False
 
 


### PR DESCRIPTION
## What changed

- pass Slack user IDs directly to `chat.postMessage` for outbound DMs
- use the channel ID returned by Slack for the result and permalink
- update focused regressions so DM sends do not call `conversations.open`

## Why

Centaur's seeded Slack credential allows `chat:write`, `channels:history`,
`channels:read`, and `users:read`; it does not declare `im:write`. The current
DM path nevertheless calls `conversations.open`, which requires that additional
scope.

Slack supports passing a user ID directly to `chat.postMessage` to start a
one-to-one DM. This makes the tool match Centaur's existing credential contract
instead of imposing an undocumented scope requirement.

Channel-name resolution and upload behavior are unchanged. Installations that
already grant `im:write` continue to work, but no longer need it for this path.

## Validation

- Slack tool test suite: 79 passed
- Ruff lint on changed files
- CLI packaging validation
- `git diff --check`
