### PR TITLE
fix(figma): align credential contract

### DIFF
--- a/tools/productivity/figma/.env.example
+++ b/tools/productivity/figma/.env.example
@@ -1,1 +1,1 @@
-FIGMA=
+FIGMA_ACCESS_TOKEN=figd_your-read-only-access-token-here

--- a/tools/productivity/figma/cli.py
+++ b/tools/productivity/figma/cli.py
@@ -44,7 +44,7 @@ def crawl(
     """Crawl a Figma file and extract design system info.
 
     Extracts colors, typography, components, variables, and frames from any Figma URL.
-    Uses FIGMA env var for authentication (personal access token).
+    Uses FIGMA_ACCESS_TOKEN for authentication.
     """
     from .client import FigmaClient
 

--- a/tools/productivity/figma/client.py
+++ b/tools/productivity/figma/client.py
@@ -28,9 +28,9 @@ class FigmaClient:
     BASE_URL = "https://api.figma.com/v1"
 
     def __init__(self, token: str | None = None):
-        self.token = token or secret("FIGMA_ACCESS_TOKEN", "") or secret("FIGMA", "")
+        self.token = token or secret("FIGMA_ACCESS_TOKEN", "")
         if not self.token:
-            raise ValueError("FIGMA token not found. Set FIGMA_ACCESS_TOKEN env var or pass token.")
+            raise ValueError("Figma token not found. Set FIGMA_ACCESS_TOKEN or pass token.")
 
     def _request(self, endpoint: str, retries: int = 3) -> dict:
         """Make authenticated request to Figma API with retry on rate limit."""

--- a/tools/productivity/figma/test_credentials.py
+++ b/tools/productivity/figma/test_credentials.py
@@ -1,0 +1,115 @@
+"""Credential contract tests for the Figma tool.
+
+Run from this directory:
+    uv run --no-project --python 3.11 --with pytest pytest test_credentials.py
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import tomllib
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+TOOL_DIR = Path(__file__).parent
+REPO_ROOT = TOOL_DIR.parents[2]
+sys.path.insert(0, str(REPO_ROOT))
+
+
+def _load_client_module():
+    client_path = TOOL_DIR / "client.py"
+    spec = importlib.util.spec_from_file_location("test_figma_client_module", client_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_manifest_limits_token_injection_to_figma_api() -> None:
+    metadata = tomllib.loads((TOOL_DIR / "pyproject.toml").read_text())
+    secrets = metadata["tool"]["centaur"]["secrets"]
+
+    assert secrets == [
+        {
+            "type": "http",
+            "name": "FIGMA_ACCESS_TOKEN",
+            "mode": "inject",
+            "inject_header": "X-Figma-Token",
+            "hosts": ["api.figma.com"],
+        }
+    ]
+
+
+def test_example_environment_uses_declared_secret_name() -> None:
+    example = (TOOL_DIR / ".env.example").read_text().split("=", maxsplit=1)
+
+    assert example[0] == "FIGMA_ACCESS_TOKEN"
+
+
+def test_client_resolves_only_the_declared_secret(monkeypatch) -> None:
+    client_module = _load_client_module()
+    requested_secrets: list[tuple[str, str]] = []
+
+    def fake_secret(name: str, default: str) -> str:
+        requested_secrets.append((name, default))
+        return "placeholder-token"
+
+    monkeypatch.setattr(client_module, "secret", fake_secret)
+
+    client = client_module.FigmaClient()
+
+    assert client.token == "placeholder-token"
+    assert requested_secrets == [("FIGMA_ACCESS_TOKEN", "")]
+
+
+def test_client_does_not_resolve_undeclared_legacy_secret(monkeypatch) -> None:
+    client_module = _load_client_module()
+    requested_secrets: list[tuple[str, str]] = []
+
+    def fake_secret(name: str, default: str) -> str:
+        requested_secrets.append((name, default))
+        return "legacy-token" if name == "FIGMA" else default
+
+    monkeypatch.setattr(client_module, "secret", fake_secret)
+
+    with pytest.raises(ValueError, match="Set FIGMA_ACCESS_TOKEN or pass token"):
+        client_module.FigmaClient()
+
+    assert requested_secrets == [("FIGMA_ACCESS_TOKEN", "")]
+
+
+def test_client_sends_token_only_to_figma_api(monkeypatch) -> None:
+    client_module = _load_client_module()
+    captured_request: dict[str, Any] = {}
+
+    class FakeResponse:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args: object) -> None:
+            return None
+
+        def read(self) -> bytes:
+            return json.dumps({"id": "test-user"}).encode()
+
+    def fake_urlopen(request, timeout: int):
+        captured_request["url"] = request.full_url
+        captured_request["token"] = request.get_header("X-figma-token")
+        captured_request["timeout"] = timeout
+        return FakeResponse()
+
+    monkeypatch.setattr(client_module, "urlopen", fake_urlopen)
+
+    result = client_module.FigmaClient(token="placeholder-token")._request("/me")
+
+    assert result == {"id": "test-user"}
+    assert captured_request == {
+        "url": "https://api.figma.com/v1/me",
+        "token": "placeholder-token",
+        "timeout": 60,
+    }


### PR DESCRIPTION
## What changed

- standardize the Figma tool on its declared `FIGMA_ACCESS_TOKEN` secret
- remove the undeclared `FIGMA` fallback
- align the example environment and CLI help with that credential name
- add focused credential-contract and host-scoping tests

## Why

The tool manifest only declares `FIGMA_ACCESS_TOKEN`, so a sandbox cannot
materialize the legacy `FIGMA` fallback through Centaur's secret injection
path. Keeping one declared name makes the CLI, reusable client, example, and
proxy contract agree.

## Validation

- credential contract tests: 5 passed
- focused Ruff lint and formatting checks
- CLI packaging validation
- source distribution and wheel build
- installed `figma --help` smoke test
- `git diff --check`

The existing `RUF059` finding in `client.py` predates this change and is not
touched here.
