### PR TITLE
fix(slack): preserve upload context for DMs

### DIFF
--- a/services/slackbotv2/src/session-api.ts
+++ b/services/slackbotv2/src/session-api.ts
@@ -1647,7 +1647,7 @@ function codexInputContent(
   contextPreamble?: string
 ): JsonValue[] {
   const content: JsonValue[] = []
-  const slackSessionContext = slackUploadSessionContext(message.threadId)
+  const slackSessionContext = slackUploadSessionContext(message.threadId, message.id)
   if (slackSessionContext) {
     content.push({ type: 'text', text: slackSessionContext })
   }
@@ -1690,8 +1690,8 @@ type SlackThreadDestination = {
   threadTs: string
 }
 
-function slackUploadSessionContext(threadId: string): string | undefined {
-  const destination = slackThreadDestination(threadId)
+function slackUploadSessionContext(threadId: string, rootMessageTs: string): string | undefined {
+  const destination = slackThreadDestination(threadId, rootMessageTs)
   if (!destination) return undefined
 
   const lines = [
@@ -1711,9 +1711,18 @@ function slackUploadSessionContext(threadId: string): string | undefined {
   return lines.join('\n')
 }
 
-function slackThreadDestination(threadId: string): SlackThreadDestination | undefined {
+function slackThreadDestination(
+  threadId: string,
+  rootMessageTs: string
+): SlackThreadDestination | undefined {
   const parts = threadId.split(':')
+  if (parts.length === 2 && isSlackConversationId(parts[0]) && parts[1]) {
+    return { channelId: parts[0], threadTs: parts[1] }
+  }
   if (parts[0] !== 'slack') return undefined
+  if (parts.length === 3 && isSlackDmId(parts[1]) && !parts[2] && rootMessageTs) {
+    return { channelId: parts[1], threadTs: rootMessageTs }
+  }
   if (parts.length === 3 && parts[1] && parts[2]) {
     return { channelId: parts[1], threadTs: parts[2] }
   }
@@ -1721,6 +1730,14 @@ function slackThreadDestination(threadId: string): SlackThreadDestination | unde
     return { teamId: parts[1], channelId: parts[2], threadTs: parts[3] }
   }
   return undefined
+}
+
+function isSlackConversationId(value: string | undefined): value is string {
+  return Boolean(value && /^[CDG][A-Z0-9]+$/.test(value))
+}
+
+function isSlackDmId(value: string | undefined): value is string {
+  return Boolean(value && /^D[A-Z0-9]+$/.test(value))
 }
 
 function slackThreadContext(

--- a/services/slackbotv2/test/session-api.test.ts
+++ b/services/slackbotv2/test/session-api.test.ts
@@ -361,6 +361,36 @@ describe('Slack display text fallback', () => {
     expect(context?.text).toContain('thread_key: slack:T1:C1:1700000000.000100')
   })
 
+  test('includes API-owned Slack upload destination for legacy DM thread keys', async () => {
+    const { fetchFn, requests } = fakeApi()
+    await forwardToSessionApi(
+      options(fetchFn),
+      forwardInput(apiMessage('upload this', { threadId: 'D000000001:1700000000.000100' }))
+    )
+
+    const context = lineContent(executeLine(requests)).find(part =>
+      typeof part.text === 'string' && part.text.includes('# Slack Session Context')
+    )
+    expect(context?.text).toContain('session_context.slack.channel_id: D000000001')
+    expect(context?.text).toContain('session_context.slack.thread_ts: 1700000000.000100')
+    expect(context?.text).toContain('thread_key: D000000001:1700000000.000100')
+  })
+
+  test('uses the root message timestamp for Slack DM session keys without a thread timestamp', async () => {
+    const { fetchFn, requests } = fakeApi()
+    await forwardToSessionApi(
+      options(fetchFn),
+      forwardInput(apiMessage('upload this', { threadId: 'slack:D000000001:' }))
+    )
+
+    const context = lineContent(executeLine(requests)).find(part =>
+      typeof part.text === 'string' && part.text.includes('# Slack Session Context')
+    )
+    expect(context?.text).toContain('session_context.slack.channel_id: D000000001')
+    expect(context?.text).toContain('session_context.slack.thread_ts: 1700000000.000100')
+    expect(context?.text).toContain('thread_key: slack:D000000001:')
+  })
+
   test('uses raw Slack block text in prior thread context instead of no text', async () => {
     const { fetchFn, requests } = fakeApi()
     const root = apiMessage('', {


### PR DESCRIPTION
## What changed

- recognize legacy Slack DM thread keys shaped as `<channel>:<thread_ts>`
- use the root message timestamp for root-DM keys shaped as `slack:<D-channel>:`
- include the API-owned Slack upload destination in both cases
- add regressions for both session-key formats

## Why

DM sessions can reach the session API in either format. Previously neither
format produced the Slack session context that tells the sandbox where uploads
belong, so file delivery from those sessions could lose its channel/thread
destination.

## Validation

- Slackbot v2 tests: 211 passed, 1 skipped
- Slackbot v2 typecheck
- `git diff --check`
