### PR TITLE
fix(deps): override Undici to patched 6.27.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,10 @@
 {
   "name": "centaur",
   "private": true,
-  "packageManager": "pnpm@10.28.1"
+  "packageManager": "pnpm@10.28.1",
+  "pnpm": {
+    "overrides": {
+      "undici": "^6.27.0"
+    }
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  undici: ^6.27.0
+
 patchedDependencies:
   '@chat-adapter/discord@4.31.0':
     hash: 8f4fbb770159f924570fbad681297fcb9f8f7a6353a705cfcb78e39ef9e3a3ab
@@ -1784,8 +1787,8 @@ packages:
   undici-types@7.24.6:
     resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
 
-  undici@6.24.1:
-    resolution: {integrity: sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==}
+  undici@6.27.0:
+    resolution: {integrity: sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==}
     engines: {node: '>=18.17'}
 
   unified@11.0.5:
@@ -2072,7 +2075,7 @@ snapshots:
       discord-api-types: 0.38.48
       magic-bytes.js: 1.13.0
       tslib: 2.8.1
-      undici: 6.24.1
+      undici: 6.27.0
 
   '@discordjs/util@1.2.0':
     dependencies:
@@ -2811,7 +2814,7 @@ snapshots:
       lodash.snakecase: 4.1.1
       magic-bytes.js: 1.13.0
       tslib: 2.8.1
-      undici: 6.24.1
+      undici: 6.27.0
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -3742,7 +3745,7 @@ snapshots:
 
   undici-types@7.24.6: {}
 
-  undici@6.24.1: {}
+  undici@6.27.0: {}
 
   unified@11.0.5:
     dependencies:


### PR DESCRIPTION
## What changed

- add a root pnpm override so transitive Discord dependencies resolve Undici
  6.27.0
- regenerate the lockfile with the repository's pinned pnpm 10.28.1

## Why

The Discord dependency graph currently resolves Undici 6.24.1. Current Undici
security advisories set 6.27.0 as the patched floor for the 6.x line, including
the high-severity WebSocket fragment-count denial of service
([GHSA-vxpw-j846-p89q](https://github.com/nodejs/undici/security/advisories/GHSA-vxpw-j846-p89q)).

The affected packages are transitive, so a root override is the smallest way
to move the existing Discord graph to the final patched 6.x release without a
broader dependency upgrade.

## Validation

- RED/GREEN lockfile assertion: 6.24.1 -> 6.27.0
- `pnpm install --frozen-lockfile`
- Discord dependency resolution audit: only Undici 6.27.0
- Discordbot typecheck and tests
- Slackbot v2 typecheck and tests: 209 passed, 1 skipped
- `git diff --check`

`pnpm audit` retains unrelated Hono findings; this PR only addresses the Undici
resolution.
