### PR TITLE
feat: expose quote and retweet lookups

### DIFF
--- a/tools/comms/twitter/cli.py
+++ b/tools/comms/twitter/cli.py
@@ -413,6 +413,94 @@ def tweets(
         )
 
 
+@app.command("quote-tweets")
+def quote_tweets(
+    tweet_id: str = typer.Argument(..., help="ID of the quoted tweet"),
+    limit: int = typer.Option(20, "--limit", "-n", help="Max quote tweets to fetch"),
+    json_output: bool = typer.Option(False, "--json", help="Output as JSON"),
+    markdown: bool = typer.Option(False, "--markdown", "-m", help="Output as markdown"),
+):
+    """Get posts that quote a tweet."""
+    client = _client()
+    quote_posts, meta = client.get_quote_tweets(tweet_id, limit=limit)
+
+    if json_output:
+        print(json.dumps(quote_posts, indent=2))
+        return
+
+    if not quote_posts:
+        console.print(f"[yellow]No quote tweets found for {tweet_id}[/yellow]")
+        return
+
+    if markdown:
+        print(f"# Quote Tweets for {tweet_id}\n")
+        for tweet in quote_posts:
+            print(
+                f"---\n**@{tweet.get('screen_name')}** "
+                f"({format_timestamp(tweet.get('published_at'))})"
+            )
+            print(f"> {tweet.get('text', '')}\n")
+        return
+
+    table = Table(title=f"Quote Tweets for {tweet_id}")
+    table.add_column("Author", style="cyan")
+    table.add_column("Date", style="dim")
+    table.add_column("Post", style="white", max_width=80)
+    for tweet in quote_posts:
+        table.add_row(
+            f"@{tweet.get('screen_name') or 'N/A'}",
+            format_timestamp(tweet.get("published_at")),
+            truncate(tweet.get("text"), 80),
+        )
+    console.print(table)
+    print_metadata(meta)
+
+
+@app.command("retweeted-by")
+def retweeted_by(
+    tweet_id: str = typer.Argument(..., help="ID of the retweeted tweet"),
+    limit: int = typer.Option(100, "--limit", "-n", help="Max users to fetch"),
+    json_output: bool = typer.Option(False, "--json", help="Output as JSON"),
+    markdown: bool = typer.Option(False, "--markdown", "-m", help="Output as markdown"),
+):
+    """Get users who retweeted a tweet."""
+    client = _client()
+    users, meta = client.get_retweeted_by(tweet_id, limit=limit)
+
+    if json_output:
+        print(json.dumps(users, indent=2))
+        return
+
+    if not users:
+        console.print(f"[yellow]No retweets found for {tweet_id}[/yellow]")
+        return
+
+    if markdown:
+        print(f"# Retweeted By for {tweet_id}\n")
+        print("| Handle | Name | Followers |")
+        print("|--------|------|-----------|")
+        for user_data in users:
+            print(
+                f"| @{user_data.get('screen_name') or 'N/A'} | "
+                f"{user_data.get('name') or 'N/A'} | "
+                f"{format_number(user_data.get('followers_count'))} |"
+            )
+        return
+
+    table = Table(title=f"Retweeted By for {tweet_id}")
+    table.add_column("Handle", style="cyan")
+    table.add_column("Name", style="white", max_width=25)
+    table.add_column("Followers", justify="right", style="green")
+    for user_data in users:
+        table.add_row(
+            f"@{user_data.get('screen_name') or 'N/A'}",
+            truncate(user_data.get("name"), 25),
+            format_number(user_data.get("followers_count")),
+        )
+    console.print(table)
+    print_metadata(meta)
+
+
 @app.command()
 def timeline(
     handle: str = typer.Argument(..., help="Twitter handle (without @)"),

--- a/tools/comms/twitter/client.py
+++ b/tools/comms/twitter/client.py
@@ -17,7 +17,9 @@ TWEET_FIELDS = (
     "attachments,author_id,conversation_id,created_at,entities,geo,id,in_reply_to_user_id,"
     "lang,possibly_sensitive,public_metrics,referenced_tweets,reply_settings,source,text"
 )
-MEDIA_FIELDS = "alt_text,duration_ms,height,media_key,preview_image_url,public_metrics,type,url,width"
+MEDIA_FIELDS = (
+    "alt_text,duration_ms,height,media_key,preview_image_url,public_metrics,type,url,width"
+)
 POLL_FIELDS = "duration_minutes,end_datetime,id,options,voting_status"
 PLACE_FIELDS = "contained_within,country,country_code,full_name,geo,id,name,place_type"
 DEFAULT_EXPANSIONS = "author_id,attachments.media_keys,attachments.poll_ids,geo.place_id"
@@ -148,7 +150,9 @@ class XClient:
         meta: dict[str, Any] = {}
         token: str | None = None
         while len(results) < limit:
-            page_size = self._limit(limit - len(results), minimum=min_page_size, maximum=max_page_size)
+            page_size = self._limit(
+                limit - len(results), minimum=min_page_size, maximum=max_page_size
+            )
             request_params = {**params, "max_results": page_size, token_param: token}
             data = self._request(endpoint, request_params)
             meta = data.get("meta") or {}
@@ -194,7 +198,9 @@ class XClient:
         if not user:
             return [], {}
         params = {"user.fields": USER_FIELDS}
-        followers, meta, _ = self._paged(f"/users/{user['user_id']}/followers", "data", limit, params)
+        followers, meta, _ = self._paged(
+            f"/users/{user['user_id']}/followers", "data", limit, params
+        )
         normalized = [self._normalize_user(item) for item in followers]
         if ids_only:
             return [item["user_id"] for item in normalized if item.get("user_id")], meta
@@ -208,7 +214,9 @@ class XClient:
         if not user:
             return [], {}
         params = {"user.fields": USER_FIELDS}
-        following, meta, _ = self._paged(f"/users/{user['user_id']}/following", "data", limit, params)
+        following, meta, _ = self._paged(
+            f"/users/{user['user_id']}/following", "data", limit, params
+        )
         normalized = [self._normalize_user(item) for item in following]
         if ids_only:
             return [item["user_id"] for item in normalized if item.get("user_id")], meta
@@ -258,7 +266,9 @@ class XClient:
         if not user:
             return None, [], None
         params = {**self._tweet_params(), "exclude": "retweets"}
-        tweets, meta, includes = self._paged(f"/users/{user['user_id']}/tweets", "data", limit, params)
+        tweets, meta, includes = self._paged(
+            f"/users/{user['user_id']}/tweets", "data", limit, params
+        )
         return user, [self._normalize_tweet(tweet, includes) for tweet in tweets], meta
 
     def get_timeline(
@@ -267,7 +277,9 @@ class XClient:
         """Get a specific user's authored posts timeline by handle."""
         return self.get_user_posts(handle, limit=limit)
 
-    def get_mentions(self, handle: str, limit: int = 20) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    def get_mentions(
+        self, handle: str, limit: int = 20
+    ) -> tuple[list[dict[str, Any]], dict[str, Any]]:
         """Get recent mentions for a user."""
         user = self.get_user(handle)
         if not user:
@@ -295,11 +307,27 @@ class XClient:
         )
         return [self._normalize_user(user) for user in users], meta
 
+    def get_quote_tweets(
+        self, tweet_id: str, limit: int = 20
+    ) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+        """Get posts that quote a post."""
+        tweets, meta, includes = self._paged(
+            f"/tweets/{tweet_id}/quote_tweets",
+            "data",
+            limit,
+            self._tweet_params(),
+            max_page_size=100,
+            min_page_size=10,
+        )
+        return [self._normalize_tweet(tweet, includes) for tweet in tweets], meta
+
     def get_list_tweets(
         self, list_id: str, limit: int = 20
     ) -> tuple[list[dict[str, Any]], dict[str, Any]]:
         """Get posts from a List."""
-        tweets, meta, includes = self._paged(f"/lists/{list_id}/tweets", "data", limit, self._tweet_params())
+        tweets, meta, includes = self._paged(
+            f"/lists/{list_id}/tweets", "data", limit, self._tweet_params()
+        )
         return [self._normalize_tweet(tweet, includes) for tweet in tweets], meta
 
     def get_list_members(

--- a/tools/comms/twitter/test_client.py
+++ b/tools/comms/twitter/test_client.py
@@ -113,3 +113,40 @@ def test_user_posts_keeps_authored_posts_endpoint() -> None:
     assert client.requests[1][0] == "/users/10/tweets"
     assert client.requests[1][1]["exclude"] == "retweets"
     assert client.requests[1][1]["pagination_token"] is None
+
+
+def test_quote_tweets_uses_quote_tweets_endpoint_and_normalizes_authors() -> None:
+    client = StubXClient(
+        [
+            {
+                "data": [{"id": "2", "author_id": "20", "text": "quoted"}],
+                "includes": {"users": [{"id": "20", "username": "grace", "name": "Grace"}]},
+                "meta": {},
+            }
+        ]
+    )
+
+    tweets, _ = client.get_quote_tweets("1", limit=3)
+
+    assert tweets[0]["tweet_id"] == "2"
+    assert tweets[0]["screen_name"] == "grace"
+    assert client.requests[0][0] == "/tweets/1/quote_tweets"
+    assert client.requests[0][1]["max_results"] == 10
+
+
+def test_retweeted_by_uses_retweeted_by_endpoint_and_normalizes_users() -> None:
+    client = StubXClient(
+        [
+            {
+                "data": [{"id": "20", "username": "grace", "name": "Grace"}],
+                "meta": {},
+            }
+        ]
+    )
+
+    users, _ = client.get_retweeted_by("1", limit=3)
+
+    assert users[0]["user_id"] == "20"
+    assert users[0]["screen_name"] == "grace"
+    assert client.requests[0][0] == "/tweets/1/retweeted_by"
+    assert client.requests[0][1]["max_results"] == 3


### PR DESCRIPTION
## Summary
- add quote-post lookup via `GET /2/tweets/{id}/quote_tweets`
- expose CLI commands for quote posts and users who retweeted
- cover endpoint selection, pagination sizing, and response normalization

## Validation
- `uv run --with pytest --with httpx --with typer --with rich --with python-dotenv pytest tools/comms/twitter/test_client.py -q`
- `uvx ruff check tools/comms/twitter/client.py tools/comms/twitter/cli.py tools/comms/twitter/test_client.py`
- `git diff --check`

Prompted by: mslipper