### PR TITLE
fix(deps): upgrade Hono past security advisories

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,8 +90,8 @@ importers:
         specifier: ^14.25.1
         version: 14.26.4
       hono:
-        specifier: ^4.12.18
-        version: 4.12.25
+        specifier: ^4.12.27
+        version: 4.12.31
       pg:
         specifier: ^8.21.0
         version: 8.21.0
@@ -139,8 +139,8 @@ importers:
         specifier: ^4.31.0
         version: 4.31.0(zod@4.4.3)
       hono:
-        specifier: ^4.12.18
-        version: 4.12.25
+        specifier: ^4.12.27
+        version: 4.12.31
       pg:
         specifier: ^8.21.0
         version: 8.21.0
@@ -185,8 +185,8 @@ importers:
         specifier: ^4.31.0
         version: 4.31.0(zod@4.4.3)
       hono:
-        specifier: ^4.12.18
-        version: 4.12.25
+        specifier: ^4.12.27
+        version: 4.12.31
       pg:
         specifier: ^8.21.0
         version: 8.21.0
@@ -228,8 +228,8 @@ importers:
         specifier: ^4.31.0
         version: 4.31.0(zod@4.4.3)
       hono:
-        specifier: ^4.12.18
-        version: 4.12.25
+        specifier: ^4.12.27
+        version: 4.12.31
       pg:
         specifier: ^8.21.0
         version: 8.21.0
@@ -254,7 +254,7 @@ importers:
         version: 7.0.0-dev.20260616.1
       emulate:
         specifier: ^0.5.0
-        version: 0.5.0(hono@4.12.25)
+        version: 0.5.0(hono@4.12.31)
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -1178,8 +1178,8 @@ packages:
     resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
 
-  hono@4.12.25:
-    resolution: {integrity: sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==}
+  hono@4.12.31:
+    resolution: {integrity: sha512-zJIHFrl6bq3RDd2YusFNCDlM8qUprxKswyi/OPzPyzKDdyBXDqWx8bZlZ7R+saTdSTatUmb3O7K4SspGPaEOQg==}
     engines: {node: '>=16.9.0'}
 
   http-errors@2.0.1:
@@ -2113,9 +2113,9 @@ snapshots:
     dependencies:
       graphql: 17.0.0
 
-  '@hono/node-server@1.19.14(hono@4.12.25)':
+  '@hono/node-server@1.19.14(hono@4.12.31)':
     dependencies:
-      hono: 4.12.25
+      hono: 4.12.31
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
 
@@ -2830,9 +2830,9 @@ snapshots:
 
   ee-first@1.1.1: {}
 
-  emulate@0.5.0(hono@4.12.25):
+  emulate@0.5.0(hono@4.12.31):
     dependencies:
-      '@hono/node-server': 1.19.14(hono@4.12.25)
+      '@hono/node-server': 1.19.14(hono@4.12.31)
       commander: 14.0.3
       picocolors: 1.1.1
       yaml: 2.9.0
@@ -2979,7 +2979,7 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
-  hono@4.12.25: {}
+  hono@4.12.31: {}
 
   http-errors@2.0.1:
     dependencies:

--- a/services/discordbot/package.json
+++ b/services/discordbot/package.json
@@ -16,7 +16,7 @@
     "@chat-adapter/state-pg": "^4.31.0",
     "chat": "^4.31.0",
     "discord.js": "^14.25.1",
-    "hono": "^4.12.18",
+    "hono": "^4.12.27",
     "pg": "^8.21.0"
   },
   "devDependencies": {

--- a/services/githubbot/package.json
+++ b/services/githubbot/package.json
@@ -17,7 +17,7 @@
     "@octokit/auth-app": "^7.1.5",
     "@octokit/rest": "^21.1.1",
     "chat": "^4.31.0",
-    "hono": "^4.12.18",
+    "hono": "^4.12.27",
     "pg": "^8.21.0"
   },
   "devDependencies": {

--- a/services/linearbot/package.json
+++ b/services/linearbot/package.json
@@ -16,7 +16,7 @@
     "@chat-adapter/state-pg": "^4.31.0",
     "@linear/sdk": "^76.0.0",
     "chat": "^4.31.0",
-    "hono": "^4.12.18",
+    "hono": "^4.12.27",
     "pg": "^8.21.0"
   },
   "devDependencies": {

--- a/services/slackbotv2/package.json
+++ b/services/slackbotv2/package.json
@@ -15,7 +15,7 @@
     "@chat-adapter/slack": "^4.31.0",
     "@chat-adapter/state-pg": "^4.31.0",
     "chat": "^4.31.0",
-    "hono": "^4.12.18",
+    "hono": "^4.12.27",
     "pg": "^8.21.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

- raise all four Hono-based bot services to `^4.12.27`
- resolve the workspace to Hono 4.12.31
- clear the three moderate Hono advisories reported on the previous lockfile

This is intentionally limited to the direct dependency ranges and lockfile resolution.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm audit --json` reports zero Hono advisories
- Slackbot: 209 passed, 1 skipped
- Discordbot: 140 passed
- GitHubbot: 77 passed
- Linearbot: 103 passed
- Discordbot, GitHubbot, and Linearbot typechecks pass
- `git diff --check`

## Current-main baseline

Slackbot's typecheck currently fails in unchanged code from #1141 at `src/session-api.ts:872` because an indexed message may be `undefined`. This branch does not modify that file; the Slackbot test suite passes.
