### PR TITLE
fix(slack): upgrade API emulator

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -253,8 +253,8 @@ importers:
         specifier: ^7.0.0-dev.20260512.1
         version: 7.0.0-dev.20260616.1
       emulate:
-        specifier: ^0.5.0
-        version: 0.5.0(hono@4.12.25)
+        specifier: ^0.9.0
+        version: 0.9.0
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -391,12 +391,6 @@ packages:
     resolution: {integrity: sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==}
     peerDependencies:
       graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
-
-  '@hono/node-server@1.19.14':
-    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
-    engines: {node: '>=18.14.1'}
-    peerDependencies:
-      hono: ^4
 
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
@@ -1044,8 +1038,8 @@ packages:
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
-  emulate@0.5.0:
-    resolution: {integrity: sha512-2LrOE8sqa1ITQ1aRR3kZhAhOCNz8hu+Kea9oBKdG/jEK6I/RYlMgHbsvQmbTTtr+nx6+fOOWkL6wqvfLeF5vuA==}
+  emulate@0.9.0:
+    resolution: {integrity: sha512-wgOFQSrjAt0NqPDnYUFyCcCwAVw01aNS3M24SZ2C5ViLQW8ECi0qIyUsW+y2uvflBD48JFqomB+jRox+ktKK/w==}
     hasBin: true
 
   encodeurl@2.0.0:
@@ -2113,10 +2107,6 @@ snapshots:
     dependencies:
       graphql: 17.0.0
 
-  '@hono/node-server@1.19.14(hono@4.12.25)':
-    dependencies:
-      hono: 4.12.25
-
   '@jridgewell/sourcemap-codec@1.5.5': {}
 
   '@linear/sdk@76.0.0(graphql@17.0.0)':
@@ -2830,14 +2820,11 @@ snapshots:
 
   ee-first@1.1.1: {}
 
-  emulate@0.5.0(hono@4.12.25):
+  emulate@0.9.0:
     dependencies:
-      '@hono/node-server': 1.19.14(hono@4.12.25)
       commander: 14.0.3
       picocolors: 1.1.1
       yaml: 2.9.0
-    transitivePeerDependencies:
-      - hono
 
   encodeurl@2.0.0: {}
 

--- a/services/slackbotv2/package.json
+++ b/services/slackbotv2/package.json
@@ -25,7 +25,7 @@
     "@types/bun": "^1.3.13",
     "@types/node": "^25.7.0",
     "@typescript/native-preview": "^7.0.0-dev.20260512.1",
-    "emulate": "^0.5.0",
+    "emulate": "^0.9.0",
     "typescript": "^6.0.3"
   }
 }

--- a/services/slackbotv2/test/chat-sdk-emulate.test.ts
+++ b/services/slackbotv2/test/chat-sdk-emulate.test.ts
@@ -4718,7 +4718,7 @@ describe('slackbotv2', () => {
     bot = createTestBot({ triggerBotAllowlist: ['UOTHERBOT'] })
     codexApi.reset()
     slackApi.reset()
-    const richBotMessage = await postUserMessage('')
+    const richBotMessage = await postUserMessage('attachment-only event placeholder')
     const richBotWaits: Promise<unknown>[] = []
     const richBotResponse = await bot.app.request(
       '/api/webhooks/slack',
@@ -4761,7 +4761,7 @@ describe('slackbotv2', () => {
 
     bot = createTestBot()
     codexApi.reset()
-    const deniedRichBotMessage = await postUserMessage('')
+    const deniedRichBotMessage = await postUserMessage('attachment-only event placeholder')
     const deniedRichBotWaits: Promise<unknown>[] = []
     const deniedRichBotResponse = await bot.app.request(
       '/api/webhooks/slack',
@@ -5895,6 +5895,8 @@ async function sendWebResponse(res: ServerResponse, response: Response): Promise
   res.statusCode = response.status
   res.statusMessage = response.statusText
   response.headers.forEach((value, key) => {
+    // The proxy buffers the body, so let Node choose framing for the buffered response.
+    if (key === 'transfer-encoding') return
     res.setHeader(key, value)
   })
   if (response.body === null || response.status === 204) {


### PR DESCRIPTION
## Summary

- upgrade the Slack API emulator from 0.5.0 to 0.9.0
- remove the vulnerable `@hono/node-server` transitive dependency from the lockfile
- adapt the buffered test response bridge to let Node calculate response framing
- give attachment-only backing messages valid placeholder text while keeping the webhook event attachment-only

The response helper removes `transfer-encoding` only after buffering the emulator response; forwarding that framing header with a buffered body causes Node to emit an invalid response.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm --filter slackbotv2 test` (209 passed, 1 skipped)
- `pnpm --filter slackbotv2 exec emulate --help`
- lockfile contains no `@hono/node-server` resolution
- `git diff --check`

## Current-main baseline

Slackbot's typecheck currently fails in unchanged code from #1141 at `src/session-api.ts:872` because an indexed message may be `undefined`. This branch does not modify that file; the Slackbot test suite passes.
