### PR TITLE
feat(slack): join public channels on mention

### DIFF
--- a/docs/pages/quickstart.mdx
+++ b/docs/pages/quickstart.mdx
@@ -167,7 +167,9 @@ value and sanitized Slack user, team, channel, thread, and message metadata.
 
 Subscribe to the `app_mention` bot event. For a minimal channel-mention test,
 the app also needs Bot Token Scopes that let it read mentions and write replies,
-for example `app_mentions:read` and `chat:write`. If you enable DM events such
+for example `app_mentions:read` and `chat:write`. Add `channels:join` to let the
+bot join a public channel automatically when Slack delivers an invite-style
+mention. If you enable DM events such
 as `message.im`, Slack will also require direct-message scopes such as
 `im:history`.
 

--- a/docs/public/md/quickstart.md
+++ b/docs/public/md/quickstart.md
@@ -167,7 +167,9 @@ value and sanitized Slack user, team, channel, thread, and message metadata.
 
 Subscribe to the `app_mention` bot event. For a minimal channel-mention test,
 the app also needs Bot Token Scopes that let it read mentions and write replies,
-for example `app_mentions:read` and `chat:write`. If you enable DM events such
+for example `app_mentions:read` and `chat:write`. Add `channels:join` to let the
+bot join a public channel automatically when Slack delivers an invite-style
+mention. If you enable DM events such
 as `message.im`, Slack will also require direct-message scopes such as
 `im:history`.
 

--- a/services/slackbotv2/src/index.ts
+++ b/services/slackbotv2/src/index.ts
@@ -14,7 +14,7 @@ import {
   type Thread
 } from 'chat'
 import { createSlackAdapter } from '@chat-adapter/slack'
-import { fetchSlackThreadReplies } from '@chat-adapter/slack/api'
+import { callSlackApi, fetchSlackThreadReplies } from '@chat-adapter/slack/api'
 import { createPostgresState } from '@chat-adapter/state-pg'
 import pg from 'pg'
 import {
@@ -86,6 +86,8 @@ import {
   traceLog,
   traceWarn
 } from './utils'
+
+const SLACK_CHANNEL_JOIN_CACHE_TTL_MS = 6 * 60 * 60 * 1000
 
 export type {
   SlackbotV2,
@@ -252,6 +254,7 @@ export function createSlackbotV2(options: SlackbotV2Options): SlackbotV2 {
     onLockConflict: 'force',
     logger
   })
+  const slackChannelJoinCache = new Map<string, number>()
   const lateSlackFiles = createLateSlackFileRepair(options, state)
 
   chat.onAction(async event => {
@@ -318,6 +321,7 @@ export function createSlackbotV2(options: SlackbotV2Options): SlackbotV2 {
 
   chat.onNewMention(async (thread, message) => {
     if (!(await isAllowedSlackMessage(message, options, logger))) return
+    await ensureSlackChannelMembership(message, options, slackChannelJoinCache)
     lateSlackFiles.rememberFilelessMention(thread, message)
     await handleSlackMessageHandoff(thread, message, {
       assistantStatusRequested: true,
@@ -348,6 +352,7 @@ export function createSlackbotV2(options: SlackbotV2Options): SlackbotV2 {
 
   chat.onSubscribedMessage(async (thread, message) => {
     if (!(await isAllowedSlackMessage(message, options, logger))) return
+    await ensureSlackChannelMembership(message, options, slackChannelJoinCache)
     if (slackRichTextMentionsUser(message.raw, options.botUserId)) message.isMention = true
     lateSlackFiles.rememberFilelessMention(thread, message)
     await handleSlackMessageHandoff(thread, message, {
@@ -520,6 +525,42 @@ async function handleSlackMessageHandoff(
         .catch(() => undefined)
     )
     throw error
+  }
+}
+
+async function ensureSlackChannelMembership(
+  message: ChatMessage,
+  options: SlackbotV2Options,
+  channelJoinCache: Map<string, number>
+): Promise<void> {
+  if (message.isMention !== true) return
+  const raw = slackRawRecord(message)
+  if (stringField(raw.type) !== 'app_mention') return
+  const channel = stringField(raw.channel)
+  if (!channel.startsWith('C')) return
+  if ((channelJoinCache.get(channel) ?? 0) > Date.now()) return
+
+  try {
+    const response = await withSlackApiTimeout(options, 'join Slack channel', () =>
+      callSlackApi(
+        'conversations.join',
+        { channel },
+        { apiUrl: options.slackApiUrl, token: options.botToken }
+      )
+    )
+    if (response.ok === true || response.error === 'already_in_channel') {
+      channelJoinCache.set(channel, Date.now() + SLACK_CHANNEL_JOIN_CACHE_TTL_MS)
+      return
+    }
+    traceWarn(options, 'slackbotv2_channel_join_rejected', undefined, {
+      error: stringField(response.error) || 'unknown_error',
+      slack_channel: channel
+    })
+  } catch (error) {
+    traceWarn(options, 'slackbotv2_channel_join_failed', undefined, {
+      error: errorMessage(error),
+      slack_channel: channel
+    })
   }
 }
 

--- a/services/slackbotv2/test/chat-sdk-emulate.test.ts
+++ b/services/slackbotv2/test/chat-sdk-emulate.test.ts
@@ -116,6 +116,58 @@ afterAll(async () => {
 })
 
 describe('slackbotv2', () => {
+  it('joins a public channel before handling an app mention', async () => {
+    const mention = await postUserMessage(`<@${BOT_USER_ID}> join this channel`)
+    const waits: Promise<unknown>[] = []
+    const response = await bot.app.request(
+      '/api/webhooks/slack',
+      signedSlackEvent({
+        event_id: 'Ev-slackbotv2-public-channel-join',
+        event: {
+          type: 'app_mention',
+          user: USER_ID,
+          channel: CHANNEL_ID,
+          team: TEAM_ID,
+          ts: mention.ts,
+          text: `<@${BOT_USER_ID}> join this channel`
+        }
+      }),
+      {},
+      waitUntilContext(waits)
+    )
+
+    expect(response.status).toBe(200)
+    await Promise.all(waits)
+
+    const secondMention = await postUserMessage(`<@${BOT_USER_ID}> still in this channel`)
+    const secondWaits: Promise<unknown>[] = []
+    const secondResponse = await bot.app.request(
+      '/api/webhooks/slack',
+      signedSlackEvent({
+        event_id: 'Ev-slackbotv2-public-channel-join-cached',
+        event: {
+          type: 'app_mention',
+          user: USER_ID,
+          channel: CHANNEL_ID,
+          team: TEAM_ID,
+          ts: secondMention.ts,
+          text: `<@${BOT_USER_ID}> still in this channel`
+        }
+      }),
+      {},
+      waitUntilContext(secondWaits)
+    )
+    expect(secondResponse.status).toBe(200)
+    await Promise.all(secondWaits)
+
+    expect(
+      slackApi.calls.filter(call => call.method === 'conversations.join')
+    ).toEqual([
+      expect.objectContaining({ body: expect.objectContaining({ channel: CHANNEL_ID }) })
+    ])
+    expect(codexApi.executes).toHaveLength(2)
+  })
+
   it('accepts Slack events on the legacy route', async () => {
     const parent = await postUserMessage('Legacy route context.')
     const mention = await postUserMessage(`<@${BOT_USER_ID}> use the legacy route`, parent.ts)
@@ -5572,6 +5624,7 @@ type StreamCall = {
     | 'chat.startStream'
     | 'chat.appendStream'
     | 'chat.stopStream'
+    | 'conversations.join'
   streamTs?: string
 }
 
@@ -5736,6 +5789,12 @@ async function handlePatchedSlackRequest(
   }
 
   const path = normalizeApiPath(url.pathname)
+  if (path === '/api/conversations.join') {
+    const body = await requestBody(request)
+    input.calls.push({ method: 'conversations.join', body })
+    await sendWebResponse(res, Response.json({ ok: true, channel: { id: stringField(body.channel) } }))
+    return
+  }
   if (path === '/api/assistant.threads.setStatus') {
     const body = await requestBody(request)
     input.calls.push({ method: 'assistant.threads.setStatus', body })


### PR DESCRIPTION
## Summary

- call `conversations.join` for public-channel `app_mention` events before the normal handoff
- cache successful or already-joined results for six hours per process
- keep join failures non-fatal and visible in structured warning logs
- document the required `channels:join` bot scope

The behavior is limited to public channel IDs (`C…`). Private channels and rich-text mentions delivered as ordinary message events are unchanged.

## Validation

- regression proved the join call was absent before implementation
- focused signed-webhook/emulated-Slack regression passes and proves repeated mentions issue one join
- `pnpm --filter slackbotv2 test` (210 passed, 1 skipped)
- `git diff --check`

## Current-main baseline

`pnpm --filter slackbotv2 run check:types` reaches only the existing current-main error at `src/session-api.ts:872`, introduced by #1141. This PR does not modify that file and adds no typecheck errors.
