### PR TITLE
feat(slack): include bounded root file context

### DIFF
--- a/docs/pages/deploying-in-production.mdx
+++ b/docs/pages/deploying-in-production.mdx
@@ -205,7 +205,9 @@ Create the Slackbot app at [api.slack.com/apps](https://api.slack.com/apps).
 Use the app page to install the bot, copy the Bot User OAuth Token for
 `SLACK_BOT_TOKEN`, and copy the Signing Secret for `SLACK_SIGNING_SECRET`.
 
-1. Add the bot scopes required by the Slackbot features you enable.
+1. Add the bot scopes required by the Slackbot features you enable. Root-mention
+   file context needs `channels:history` for public channels and `groups:history`
+   for private channels.
 2. Install the app to the workspace.
 3. Store the Bot User OAuth Token as `SLACK_BOT_TOKEN`.
 4. Store the app Signing Secret as `SLACK_SIGNING_SECRET`.

--- a/docs/public/md/deploying-in-production.md
+++ b/docs/public/md/deploying-in-production.md
@@ -205,7 +205,9 @@ Create the Slackbot app at [api.slack.com/apps](https://api.slack.com/apps).
 Use the app page to install the bot, copy the Bot User OAuth Token for
 `SLACK_BOT_TOKEN`, and copy the Signing Secret for `SLACK_SIGNING_SECRET`.
 
-1. Add the bot scopes required by the Slackbot features you enable.
+1. Add the bot scopes required by the Slackbot features you enable. Root-mention
+   file context needs `channels:history` for public channels and `groups:history`
+   for private channels.
 2. Install the app to the workspace.
 3. Store the Bot User OAuth Token as `SLACK_BOT_TOKEN`.
 4. Store the app Signing Secret as `SLACK_SIGNING_SECRET`.

--- a/services/slackbotv2/src/index.ts
+++ b/services/slackbotv2/src/index.ts
@@ -14,7 +14,7 @@ import {
   type Thread
 } from 'chat'
 import { createSlackAdapter } from '@chat-adapter/slack'
-import { fetchSlackThreadReplies } from '@chat-adapter/slack/api'
+import { assertSlackOk, callSlackApi, fetchSlackThreadReplies } from '@chat-adapter/slack/api'
 import { createPostgresState } from '@chat-adapter/state-pg'
 import pg from 'pg'
 import {
@@ -86,6 +86,10 @@ import {
   traceLog,
   traceWarn
 } from './utils'
+
+const ROOT_SLACK_CHANNEL_CONTEXT_HISTORY_LIMIT = 10
+const ROOT_SLACK_CHANNEL_CONTEXT_MAX_AGE_MS = 10 * 60 * 1000
+const ROOT_SLACK_CHANNEL_CONTEXT_MAX_MESSAGES = 5
 
 export type {
   SlackbotV2,
@@ -1001,8 +1005,8 @@ async function syncThreadMessageToSession(
         ? await withSlackApiTimeout(input.options, 'collect Slack thread context', () =>
             collectSlackThreadContext(input.options, message)
           )
-        : await withSlackApiTimeout(input.options, 'collect initial thread context', () =>
-            collectInitialContext(thread, message, input.options)
+        : await withSlackApiTimeout(input.options, 'collect initial Slack context', () =>
+            collectInitialSlackContext(thread, message, input.options)
           )
     } catch (error) {
       contextDegraded = true
@@ -2851,6 +2855,77 @@ function isSlackThreadReply(message: ChatMessage): boolean {
   const threadTs = typeof item.thread_ts === 'string' ? item.thread_ts : ''
   const ts = typeof item.ts === 'string' ? item.ts : message.id
   return Boolean(threadTs && ts && threadTs !== ts)
+}
+
+async function collectInitialSlackContext(
+  thread: Thread<SlackbotV2ThreadState>,
+  currentMessage: ChatMessage,
+  options: SlackbotV2Options
+): Promise<SlackbotV2ApiMessage[]> {
+  if (!isRootSlackChannelMention(currentMessage)) {
+    return collectInitialContext(thread, currentMessage, options)
+  }
+
+  const raw = slackRawRecord(currentMessage)
+  const channel = stringField(raw.channel)
+  const currentTs = stringField(raw.ts) || currentMessage.id
+  const currentUser = stringField(raw.user)
+  if (!channel || !currentTs || !currentUser) {
+    return [await serializeMessage(currentMessage, options)]
+  }
+
+  const response = await callSlackApi<{
+    error?: string
+    messages?: unknown[]
+    ok: boolean
+  }>(
+    'conversations.history',
+    {
+      channel,
+      inclusive: true,
+      latest: currentTs,
+      limit: ROOT_SLACK_CHANNEL_CONTEXT_HISTORY_LIMIT
+    },
+    { apiUrl: options.slackApiUrl, token: options.botToken }
+  )
+  assertSlackOk('conversations.history', response)
+
+  const minimumTsMs = Math.max(
+    0,
+    slackTsToMs(currentTs) - ROOT_SLACK_CHANNEL_CONTEXT_MAX_AGE_MS
+  )
+  const selected = (Array.isArray(response.messages) ? response.messages : [])
+    .filter(isJsonObject)
+    .filter(message => {
+      const messageTs = stringField(message.ts)
+      if (!messageTs || compareSlackTs(messageTs, currentTs) > 0) return false
+      if (isSelfSlackBotMessage(options, message)) return false
+      return messageTs !== currentTs
+        && slackActorId(message) === currentUser
+        && slackFiles(message).length > 0
+        && slackTsToMs(messageTs) >= minimumTsMs
+    })
+    .sort((left, right) => compareSlackTs(stringField(left.ts), stringField(right.ts)))
+    .slice(-(ROOT_SLACK_CHANNEL_CONTEXT_MAX_MESSAGES - 1))
+
+  const messages: SlackbotV2ApiMessage[] = []
+  for (const message of selected) {
+    messages.push(await slackApiMessageFromSlack(options, message, currentMessage))
+  }
+
+  messages.push(await serializeMessage(currentMessage, options))
+  return messages
+}
+
+function isRootSlackChannelMention(message: ChatMessage): boolean {
+  if (message.isMention !== true) return false
+  const raw = slackRawRecord(message)
+  if (stringField(raw.type) !== 'app_mention') return false
+  const channel = stringField(raw.channel)
+  if (!channel.startsWith('C') && !channel.startsWith('G')) return false
+  const threadTs = stringField(raw.thread_ts)
+  const ts = stringField(raw.ts) || message.id
+  return Boolean(ts && (!threadTs || threadTs === ts))
 }
 
 async function collectSlackThreadContext(

--- a/services/slackbotv2/test/chat-sdk-emulate.test.ts
+++ b/services/slackbotv2/test/chat-sdk-emulate.test.ts
@@ -116,6 +116,141 @@ afterAll(async () => {
 })
 
 describe('slackbotv2', () => {
+  it('includes a recent same-user file message for a root channel mention', async () => {
+    const recording = await postUserMessage('Recording for the incident review')
+    const fileUrl = `${slackApi.url}/files/captured.png`
+    slackApi.addFileToMessage(CHANNEL_ID, recording.ts, {
+      id: 'F-root-context-recording',
+      mimetype: 'image/png',
+      name: 'incident-recording.png',
+      size: 14,
+      url_private: fileUrl,
+      url_private_download: fileUrl
+    })
+    const mention = await postUserMessage(`<@${BOT_USER_ID}> summarize the recording above`)
+    const waits: Promise<unknown>[] = []
+    const response = await bot.app.request(
+      '/api/webhooks/slack',
+      signedSlackEvent({
+        event_id: 'Ev-slackbotv2-root-mention-file-context',
+        event: {
+          type: 'app_mention',
+          user: USER_ID,
+          channel: CHANNEL_ID,
+          team: TEAM_ID,
+          ts: mention.ts,
+          text: `<@${BOT_USER_ID}> summarize the recording above`
+        }
+      }),
+      {},
+      waitUntilContext(waits)
+    )
+
+    expect(response.status).toBe(200)
+    await Promise.all(waits)
+    expect(codexApi.appends[0]?.body.messages.map(message => message.client_message_id)).toEqual([
+      recording.ts,
+      mention.ts
+    ])
+    const executeInput = codexApi.executes[0]?.body.input_lines.at(-1) ?? ''
+    expect(executeInput).toContain('Recording for the incident review')
+    expect(executeInput).toContain('incident-recording.png')
+    expect(executeInput).toContain('summarize the recording above')
+  })
+
+  it('excludes stale, other-user, and text-only root channel history', async () => {
+    const textOnly = await postUserMessage('Same user but no file')
+    const mention = await postUserMessage(`<@${BOT_USER_ID}> inspect only relevant files`)
+    const file = {
+      id: 'F-excluded-root-context',
+      mimetype: 'image/png',
+      name: 'excluded.png',
+      size: 14,
+      url_private: `${slackApi.url}/files/captured.png`
+    }
+    slackApi.addHistoryMessage({
+      files: [file],
+      text: 'Too old',
+      ts: incrementSlackTs(mention.ts, -601),
+      user: USER_ID
+    })
+    slackApi.addHistoryMessage({
+      files: [file],
+      text: 'Another user',
+      ts: incrementSlackTs(mention.ts, -1),
+      user: USER_B_ID
+    })
+
+    const waits: Promise<unknown>[] = []
+    const response = await bot.app.request(
+      '/api/webhooks/slack',
+      signedSlackEvent({
+        event_id: 'Ev-slackbotv2-root-mention-file-context-exclusions',
+        event: {
+          type: 'app_mention',
+          user: USER_ID,
+          channel: CHANNEL_ID,
+          team: TEAM_ID,
+          ts: mention.ts,
+          text: `<@${BOT_USER_ID}> inspect only relevant files`
+        }
+      }),
+      {},
+      waitUntilContext(waits)
+    )
+
+    expect(response.status).toBe(200)
+    await Promise.all(waits)
+    expect(codexApi.appends[0]?.body.messages.map(message => message.client_message_id)).toEqual([
+      mention.ts
+    ])
+    expect(codexApi.appends[0]?.body.messages.map(message => message.client_message_id)).not
+      .toContain(textOnly.ts)
+    expect(
+      slackApi.calls.find(call => call.method === 'conversations.history')?.body
+    ).toEqual(expect.objectContaining({ inclusive: 'true', latest: mention.ts, limit: '10' }))
+  })
+
+  it('caps root channel context at five messages including the mention', async () => {
+    const fileMessages: Array<{ ts: string }> = []
+    for (let index = 0; index < 6; index += 1) {
+      const message = await postUserMessage(`File context ${index}`)
+      fileMessages.push(message)
+      slackApi.addFileToMessage(CHANNEL_ID, message.ts, {
+        id: `F-root-context-${index}`,
+        mimetype: 'image/png',
+        name: `context-${index}.png`,
+        size: 14,
+        url_private: `${slackApi.url}/files/captured.png`
+      })
+    }
+    const mention = await postUserMessage(`<@${BOT_USER_ID}> inspect recent files`)
+    const waits: Promise<unknown>[] = []
+    const response = await bot.app.request(
+      '/api/webhooks/slack',
+      signedSlackEvent({
+        event_id: 'Ev-slackbotv2-root-mention-file-context-cap',
+        event: {
+          type: 'app_mention',
+          user: USER_ID,
+          channel: CHANNEL_ID,
+          team: TEAM_ID,
+          ts: mention.ts,
+          text: `<@${BOT_USER_ID}> inspect recent files`
+        }
+      }),
+      {},
+      waitUntilContext(waits)
+    )
+
+    expect(response.status).toBe(200)
+    await Promise.all(waits)
+    expect(codexApi.appends[0]?.body.messages.map(message => message.client_message_id)).toEqual([
+      ...fileMessages.slice(-4).map(message => message.ts),
+      mention.ts
+    ])
+  })
+
   it('accepts Slack events on the legacy route', async () => {
     const parent = await postUserMessage('Legacy route context.')
     const mention = await postUserMessage(`<@${BOT_USER_ID}> use the legacy route`, parent.ts)
@@ -5549,6 +5684,7 @@ function writeMockSseEvent(stream: ServerResponse, event: MockSessionEvent): voi
 
 type PatchedSlackApi = {
   addFileToMessage(channel: string, ts: string, file: Record<string, unknown>): void
+  addHistoryMessage(message: Record<string, unknown>): void
   calls: StreamCall[]
   close(): Promise<void>
   failRepliesWithThreadNotFound(channel: string, ts: string): void
@@ -5572,6 +5708,7 @@ type StreamCall = {
     | 'chat.startStream'
     | 'chat.appendStream'
     | 'chat.stopStream'
+    | 'conversations.history'
   streamTs?: string
 }
 
@@ -5596,6 +5733,7 @@ async function startPatchedSlackApi(emulatorUrl: string): Promise<PatchedSlackAp
   const calls: StreamCall[] = []
   const fileInfo = new Map<string, Record<string, unknown>>()
   const fileInfoRequests = new Map<string, number>()
+  const historyMessages: Record<string, unknown>[] = []
   const threadMessageFiles = new Map<string, Record<string, unknown>[]>()
   const userProfiles = new Map<string, Record<string, unknown>>()
   const userProfileRequests = new Map<string, number>()
@@ -5619,6 +5757,7 @@ async function startPatchedSlackApi(emulatorUrl: string): Promise<PatchedSlackAp
       calls,
       fileInfo,
       fileInfoRequests,
+      historyMessages,
       maxStreamStopChars,
       port,
       streams,
@@ -5637,6 +5776,9 @@ async function startPatchedSlackApi(emulatorUrl: string): Promise<PatchedSlackAp
     addFileToMessage(channel: string, ts: string, file: Record<string, unknown>) {
       const key = slackReplyKey(channel, ts)
       threadMessageFiles.set(key, [...(threadMessageFiles.get(key) ?? []), file])
+    },
+    addHistoryMessage(message: Record<string, unknown>) {
+      historyMessages.push(message)
     },
     calls,
     url: `http://127.0.0.1:${port}`,
@@ -5670,6 +5812,7 @@ async function startPatchedSlackApi(emulatorUrl: string): Promise<PatchedSlackAp
       threadMessageFiles.clear()
       fileInfo.clear()
       fileInfoRequests.clear()
+      historyMessages.length = 0
       streams.clear()
       userProfiles.clear()
       userProfileRequests.clear()
@@ -5699,6 +5842,7 @@ async function handlePatchedSlackRequest(
     calls: StreamCall[]
     fileInfo: Map<string, Record<string, unknown>>
     fileInfoRequests: Map<string, number>
+    historyMessages: Record<string, unknown>[]
     maxStreamStopChars: number | null
     port: number
     streams: Map<string, StreamRecord>
@@ -5818,9 +5962,10 @@ async function handlePatchedSlackRequest(
     )
     return
   }
-  if (path === '/api/conversations.replies') {
+  if (path === '/api/conversations.replies' || path === '/api/conversations.history') {
     const body = await requestBody(request.clone())
     if (
+      path === '/api/conversations.replies' &&
       input.threadNotFoundReplies.has(
         slackReplyKey(stringField(body.channel), stringField(body.ts))
       )
@@ -5828,7 +5973,10 @@ async function handlePatchedSlackRequest(
       await sendWebResponse(res, Response.json({ ok: false, error: 'thread_not_found' }))
       return
     }
-    if (input.threadMessageFiles.size > 0) {
+    if (input.threadMessageFiles.size > 0 || input.historyMessages.length > 0) {
+      if (path === '/api/conversations.history') {
+        input.calls.push({ method: 'conversations.history', body })
+      }
       const rawBody = await request.arrayBuffer()
       const proxied = await fetch(new URL(`${path}${url.search}`, input.upstreamUrl), {
         method: request.method,
@@ -5837,7 +5985,11 @@ async function handlePatchedSlackRequest(
       })
       const payload = await proxied.json() as Record<string, unknown>
       if (Array.isArray(payload.messages)) {
-        payload.messages = payload.messages.map(message => {
+        let messages = payload.messages
+        if (path === '/api/conversations.history') {
+          messages = [...messages, ...input.historyMessages]
+        }
+        payload.messages = messages.map(message => {
           if (!message || typeof message !== 'object' || Array.isArray(message)) return message
           const item = message as Record<string, unknown>
           const files = input.threadMessageFiles.get(


### PR DESCRIPTION
## Summary

- query bounded channel history when a user starts a root channel mention
- include only that user's preceding messages that contain files
- limit history to ten results, a ten-minute window, and four prior files plus the current mention
- preserve chronological ordering and exclude stale, other-user, text-only, future, and bot-authored messages
- document the required public/private channel history scopes

Thread replies keep the existing full thread-context path. If history collection fails, the existing degraded-context fallback sends only the current mention.

## Validation

- regression proved the preceding file was absent before implementation
- focused signed-webhook/emulated-Slack regressions cover inclusion, exclusions, ordering, and caps
- `pnpm --filter slackbotv2 test` (212 passed, 1 skipped)
- `git diff --check`

## Current-main baseline

`pnpm --filter slackbotv2 run check:types` reaches only the existing current-main error at `src/session-api.ts:872`, introduced by #1141. This PR does not modify that file and adds no typecheck errors.
