### PR TITLE
Fix Twitter API response handling

### DIFF
--- a/tools/comms/twitter/cli.py
+++ b/tools/comms/twitter/cli.py
@@ -563,7 +563,7 @@ def usage():
     api_usage = client.get_usage()
 
     console.print("\n[bold]API Usage[/bold]\n")
-    console.print(api_usage.get("message", "No usage information returned."))
+    print(json.dumps(api_usage, indent=2, ensure_ascii=False, default=str))
 
 
 if __name__ == "__main__":

--- a/tools/comms/twitter/client.py
+++ b/tools/comms/twitter/client.py
@@ -14,15 +14,31 @@ USER_FIELDS = (
     "profile_image_url,protected,public_metrics,url,username,verified,verified_type"
 )
 TWEET_FIELDS = (
-    "attachments,author_id,conversation_id,created_at,entities,geo,id,in_reply_to_user_id,"
-    "lang,possibly_sensitive,public_metrics,referenced_tweets,reply_settings,source,text"
+    "article,attachments,author_id,conversation_id,created_at,entities,geo,id,in_reply_to_user_id,"
+    "lang,note_tweet,possibly_sensitive,public_metrics,referenced_tweets,reply_settings,source,text"
 )
 MEDIA_FIELDS = (
-    "alt_text,duration_ms,height,media_key,preview_image_url,public_metrics,type,url,width"
+    "alt_text,duration_ms,height,media_key,preview_image_url,public_metrics,type,url,variants,width"
 )
 POLL_FIELDS = "duration_minutes,end_datetime,id,options,voting_status"
 PLACE_FIELDS = "contained_within,country,country_code,full_name,geo,id,name,place_type"
-DEFAULT_EXPANSIONS = "author_id,attachments.media_keys,attachments.poll_ids,geo.place_id"
+DEFAULT_EXPANSIONS = (
+    "article.cover_media,article.media_entities,attachments.media_keys,attachments.poll_ids,"
+    "author_id,geo.place_id,referenced_tweets.id,referenced_tweets.id.attachments.media_keys,"
+    "referenced_tweets.id.author_id"
+)
+
+
+class XAPIResponseError(RuntimeError):
+    """An X API response contained item-level errors, possibly alongside data."""
+
+    def __init__(self, errors: list[dict[str, Any]], data: Any = None) -> None:
+        self.errors = errors
+        self.data = data
+        details = "; ".join(
+            str(error.get("detail") or error.get("title") or error) for error in errors
+        )
+        super().__init__(f"X API response contained errors: {details}")
 
 
 class XClient:
@@ -53,11 +69,18 @@ class XClient:
         try:
             response = self.client.get(url, params=self._clean_params(params), headers=headers)
             response.raise_for_status()
-            return response.json()
+            return self._validate_response(response.json())
         except httpx.HTTPStatusError as e:
             raise RuntimeError(f"X API error: {e.response.status_code} - {e.response.text}") from e
         except httpx.RequestError as e:
             raise RuntimeError(f"X API request failed: {e}") from e
+
+    @staticmethod
+    def _validate_response(payload: dict[str, Any]) -> dict[str, Any]:
+        errors = payload.get("errors") or []
+        if errors:
+            raise XAPIResponseError(errors, payload.get("data"))
+        return payload
 
     @staticmethod
     def _clean_params(params: dict[str, Any] | None) -> dict[str, Any] | None:
@@ -78,6 +101,15 @@ class XClient:
         return max(minimum, min(maximum, value))
 
     @staticmethod
+    def _chunks(values: list[str], size: int = 100) -> list[list[str]]:
+        return [values[start : start + size] for start in range(0, len(values), size)]
+
+    @staticmethod
+    def _merge_includes(target: dict[str, Any], source: dict[str, Any] | None) -> None:
+        for key, values in (source or {}).items():
+            target.setdefault(key, []).extend(values)
+
+    @staticmethod
     def _epoch_ms(value: str | None) -> int | None:
         if not value:
             return None
@@ -96,7 +128,7 @@ class XClient:
             "following_count": metrics.get("following_count"),
             "statuses_count": metrics.get("tweet_count"),
             "listed_count": metrics.get("listed_count"),
-            "is_blue_verified": bool(user.get("verified")),
+            "is_blue_verified": user.get("verified_type") == "blue",
             "website_url": user.get("url"),
         }
 
@@ -104,14 +136,67 @@ class XClient:
         users = (includes or {}).get("users") or []
         return {str(user.get("id")): self._normalize_user(user) for user in users}
 
+    @staticmethod
+    def _includes_by_id(
+        includes: dict[str, Any] | None, key: str, id_key: str
+    ) -> dict[str, dict[str, Any]]:
+        items = (includes or {}).get(key) or []
+        return {str(item.get(id_key)): item for item in items if item.get(id_key) is not None}
+
     def _normalize_tweet(
-        self, tweet: dict[str, Any], includes: dict[str, Any] | None = None
+        self,
+        tweet: dict[str, Any],
+        includes: dict[str, Any] | None = None,
+        *,
+        hydrate_references: bool = True,
     ) -> dict[str, Any]:
         metrics = tweet.get("public_metrics") or {}
         author = self._users_by_id(includes).get(str(tweet.get("author_id")), {})
         created_at = tweet.get("created_at")
+        note_tweet = tweet.get("note_tweet") or {}
+        attachments = tweet.get("attachments") or {}
+        media_by_key = self._includes_by_id(includes, "media", "media_key")
+        polls_by_id = self._includes_by_id(includes, "polls", "id")
+        places_by_id = self._includes_by_id(includes, "places", "id")
+        media = [
+            media_by_key[str(key)]
+            for key in attachments.get("media_keys") or []
+            if str(key) in media_by_key
+        ]
+        polls = [
+            polls_by_id[str(poll_id)]
+            for poll_id in attachments.get("poll_ids") or []
+            if str(poll_id) in polls_by_id
+        ]
+        place = places_by_id.get(str((tweet.get("geo") or {}).get("place_id")))
+        referenced_tweets = tweet.get("referenced_tweets")
+        if hydrate_references and referenced_tweets:
+            tweets_by_id = self._includes_by_id(includes, "tweets", "id")
+            referenced_tweets = [
+                {
+                    **reference,
+                    **(
+                        {
+                            "tweet": self._normalize_tweet(
+                                expanded,
+                                includes,
+                                hydrate_references=False,
+                            )
+                        }
+                        if (expanded := tweets_by_id.get(str(reference.get("id"))))
+                        else {}
+                    ),
+                }
+                for reference in referenced_tweets
+            ]
         return {
             **tweet,
+            "text": note_tweet.get("text") or tweet.get("text"),
+            "entities": note_tweet.get("entities", tweet.get("entities")),
+            "referenced_tweets": referenced_tweets,
+            "media": media,
+            "polls": polls,
+            "place": place,
             "tweet_id": tweet.get("id"),
             "published_at": self._epoch_ms(created_at),
             "author": author or None,
@@ -155,14 +240,25 @@ class XClient:
             )
             request_params = {**params, "max_results": page_size, token_param: token}
             data = self._request(endpoint, request_params)
-            meta = data.get("meta") or {}
-            for key, value in (data.get("includes") or {}).items():
-                includes.setdefault(key, []).extend(value)
-            results.extend(data.get(data_key) or [])
-            token = meta.get("next_token")
+            page_meta = data.get("meta") or {}
+            if "newest_id" not in meta and page_meta.get("newest_id") is not None:
+                meta["newest_id"] = page_meta["newest_id"]
+            if page_meta.get("oldest_id") is not None:
+                meta["oldest_id"] = page_meta["oldest_id"]
+            for key, value in page_meta.items():
+                if key not in {"newest_id", "oldest_id", "next_token", "result_count"}:
+                    meta[key] = value
+            self._merge_includes(includes, data.get("includes"))
+            page_results = data.get(data_key) or []
+            results.extend(page_results)
+            token = page_meta.get("next_token")
             if not token or not data.get(data_key):
                 break
-        return results[:limit], meta, includes
+        limited_results = results[:limit]
+        meta["result_count"] = len(limited_results)
+        if token:
+            meta["next_token"] = token
+        return limited_results, meta, includes
 
     def get_user(self, handle: str) -> dict[str, Any] | None:
         """Get a user profile by username/handle."""
@@ -181,14 +277,20 @@ class XClient:
 
     def lookup_users(self, ids: list[str]) -> list[dict[str, Any]]:
         """Lookup users by IDs."""
-        data = self._request("/users", {"ids": ids, "user.fields": USER_FIELDS})
-        return [self._normalize_user(user) for user in data.get("data") or []]
+        users: list[dict[str, Any]] = []
+        for id_chunk in self._chunks(ids):
+            data = self._request("/users", {"ids": id_chunk, "user.fields": USER_FIELDS})
+            users.extend(data.get("data") or [])
+        return [self._normalize_user(user) for user in users]
 
     def lookup_users_by_usernames(self, usernames: list[str]) -> list[dict[str, Any]]:
         """Lookup users by usernames/handles."""
         names = [name.lstrip("@") for name in usernames]
-        data = self._request("/users/by", {"usernames": names, "user.fields": USER_FIELDS})
-        return [self._normalize_user(user) for user in data.get("data") or []]
+        users: list[dict[str, Any]] = []
+        for name_chunk in self._chunks(names):
+            data = self._request("/users/by", {"usernames": name_chunk, "user.fields": USER_FIELDS})
+            users.extend(data.get("data") or [])
+        return [self._normalize_user(user) for user in users]
 
     def get_followers(
         self, handle: str, limit: int = 100, ids_only: bool = False
@@ -248,9 +350,13 @@ class XClient:
 
     def lookup_tweets(self, ids: list[str]) -> list[dict[str, Any]]:
         """Lookup posts by IDs."""
-        data = self._request("/tweets", {"ids": ids, **self._tweet_params()})
-        includes = data.get("includes")
-        return [self._normalize_tweet(tweet, includes) for tweet in data.get("data") or []]
+        tweets: list[dict[str, Any]] = []
+        includes: dict[str, Any] = {}
+        for id_chunk in self._chunks(ids):
+            data = self._request("/tweets", {"ids": id_chunk, **self._tweet_params()})
+            tweets.extend(data.get("data") or [])
+            self._merge_includes(includes, data.get("includes"))
+        return [self._normalize_tweet(tweet, includes) for tweet in tweets]
 
     def get_tweet(self, tweet_id: str) -> dict[str, Any] | None:
         """Lookup a single post by ID."""
@@ -348,9 +454,9 @@ class XClient:
         )
         return [self._normalize_user(user) for user in users], meta
 
-    def get_usage(self) -> dict[str, str]:
-        """Return a note about X API usage reporting."""
-        return {"message": "X API v2 does not expose a general usage endpoint for bearer tokens."}
+    def get_usage(self) -> dict[str, Any]:
+        """Get project usage so health checks exercise X connectivity and auth."""
+        return self._request("/usage/tweets")
 
     def close(self) -> None:
         if self._client:

--- a/tools/comms/twitter/test_client.py
+++ b/tools/comms/twitter/test_client.py
@@ -4,7 +4,7 @@ from typing import Any
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
-from client import XClient
+from client import DEFAULT_EXPANSIONS, MEDIA_FIELDS, XAPIResponseError, XClient
 
 
 class StubXClient(XClient):
@@ -17,7 +17,7 @@ class StubXClient(XClient):
         self.requests.append((endpoint, params))
         if not self.responses:
             raise AssertionError("unexpected request")
-        return self.responses.pop(0)
+        return self._validate_response(self.responses.pop(0))
 
 
 def test_search_uses_recent_search_endpoint_and_next_token() -> None:
@@ -43,6 +43,32 @@ def test_search_uses_recent_search_endpoint_and_next_token() -> None:
     assert client.requests[0][1]["max_results"] == 11
     assert "pagination_token" not in client.requests[0][1]
     assert client.requests[1][1]["next_token"] == "abc"
+
+
+def test_pagination_metadata_describes_returned_results() -> None:
+    client = StubXClient(
+        [
+            {
+                "data": [{"id": "1"}, {"id": "2"}],
+                "meta": {
+                    "newest_id": "1",
+                    "oldest_id": "2",
+                    "result_count": 2,
+                    "next_token": "abc",
+                },
+            }
+        ]
+    )
+
+    tweets, meta = client.search_tweets("openai", limit=1)
+
+    assert [tweet["tweet_id"] for tweet in tweets] == ["1"]
+    assert meta == {
+        "newest_id": "1",
+        "oldest_id": "2",
+        "result_count": 1,
+        "next_token": "abc",
+    }
 
 
 def test_top_search_uses_relevancy_sort_order() -> None:
@@ -113,6 +139,190 @@ def test_user_posts_keeps_authored_posts_endpoint() -> None:
     assert client.requests[1][0] == "/users/10/tweets"
     assert client.requests[1][1]["exclude"] == "retweets"
     assert client.requests[1][1]["pagination_token"] is None
+
+
+def test_get_tweet_promotes_long_form_text_and_entities() -> None:
+    client = StubXClient(
+        [
+            {
+                "data": {
+                    "id": "1",
+                    "text": "A long post that stops early, and",
+                    "entities": {"hashtags": [{"tag": "short"}]},
+                    "note_tweet": {
+                        "text": "A long post that stops early, and then continues to the end.",
+                        "entities": {"hashtags": [{"tag": "complete"}]},
+                    },
+                }
+            }
+        ]
+    )
+
+    tweet = client.get_tweet("1")
+
+    assert tweet is not None
+    assert tweet["text"] == "A long post that stops early, and then continues to the end."
+    assert tweet["entities"] == {"hashtags": [{"tag": "complete"}]}
+    assert tweet["note_tweet"]["text"].endswith("continues to the end.")
+    assert "note_tweet" in client.requests[0][1]["tweet.fields"].split(",")
+
+
+def test_get_tweet_keeps_standard_text_without_note_tweet() -> None:
+    client = StubXClient([{"data": {"id": "1", "text": "A standard post."}}])
+
+    tweet = client.get_tweet("1")
+
+    assert tweet is not None
+    assert tweet["text"] == "A standard post."
+    assert tweet["entities"] is None
+
+
+def test_tweet_fields_request_articles_video_variants_and_reference_expansions() -> None:
+    client = StubXClient([{"data": {"id": "1", "text": "post"}}])
+
+    client.get_tweet("1")
+
+    params = client.requests[0][1]
+    assert "article" in params["tweet.fields"].split(",")
+    assert "variants" in MEDIA_FIELDS.split(",")
+    assert "article.cover_media" in DEFAULT_EXPANSIONS.split(",")
+    assert "article.media_entities" in DEFAULT_EXPANSIONS.split(",")
+    assert "referenced_tweets.id" in DEFAULT_EXPANSIONS.split(",")
+    assert "referenced_tweets.id.author_id" in DEFAULT_EXPANSIONS.split(",")
+
+
+def test_get_tweet_hydrates_media_poll_place_and_referenced_tweet() -> None:
+    client = StubXClient(
+        [
+            {
+                "data": {
+                    "id": "1",
+                    "author_id": "10",
+                    "text": "quote",
+                    "attachments": {"media_keys": ["3_1"], "poll_ids": ["30"]},
+                    "geo": {"place_id": "40"},
+                    "referenced_tweets": [{"type": "quoted", "id": "2"}],
+                },
+                "includes": {
+                    "users": [
+                        {"id": "10", "username": "ada"},
+                        {"id": "20", "username": "grace"},
+                    ],
+                    "media": [
+                        {
+                            "media_key": "3_1",
+                            "type": "video",
+                            "variants": [{"url": "https://video.example/post.mp4"}],
+                        },
+                        {"media_key": "3_2", "type": "photo"},
+                    ],
+                    "polls": [{"id": "30", "voting_status": "open"}],
+                    "places": [{"id": "40", "full_name": "London"}],
+                    "tweets": [
+                        {
+                            "id": "2",
+                            "author_id": "20",
+                            "text": "original",
+                            "attachments": {"media_keys": ["3_2"]},
+                        }
+                    ],
+                },
+            }
+        ]
+    )
+
+    tweet = client.get_tweet("1")
+
+    assert tweet is not None
+    assert tweet["media"][0]["variants"][0]["url"].endswith("post.mp4")
+    assert tweet["polls"] == [{"id": "30", "voting_status": "open"}]
+    assert tweet["place"] == {"id": "40", "full_name": "London"}
+    referenced = tweet["referenced_tweets"][0]["tweet"]
+    assert referenced["text"] == "original"
+    assert referenced["screen_name"] == "grace"
+    assert referenced["media"] == [{"media_key": "3_2", "type": "photo"}]
+
+
+def test_blue_verification_is_distinct_from_organization_verification() -> None:
+    client = StubXClient(
+        [
+            {"data": {"id": "1", "username": "blue", "verified_type": "blue"}},
+            {
+                "data": {
+                    "id": "2",
+                    "username": "business",
+                    "verified": True,
+                    "verified_type": "business",
+                }
+            },
+        ]
+    )
+
+    blue = client.get_user("blue")
+    business = client.get_user("business")
+
+    assert blue is not None and blue["is_blue_verified"] is True
+    assert business is not None and business["is_blue_verified"] is False
+
+
+def test_partial_api_errors_are_not_silently_dropped() -> None:
+    client = StubXClient(
+        [
+            {
+                "data": [{"id": "1", "text": "valid"}],
+                "errors": [
+                    {
+                        "value": "missing",
+                        "title": "Not Found Error",
+                        "detail": "Could not find post missing.",
+                    }
+                ],
+            }
+        ]
+    )
+
+    try:
+        client.lookup_tweets(["1", "missing"])
+    except XAPIResponseError as error:
+        assert error.data == [{"id": "1", "text": "valid"}]
+        assert error.errors[0]["value"] == "missing"
+        assert "Could not find post missing" in str(error)
+    else:
+        raise AssertionError("partial X API errors must be surfaced")
+
+
+def test_batch_lookup_chunks_requests_at_api_limit() -> None:
+    ids = [str(index) for index in range(101)]
+    client = StubXClient(
+        [
+            {"data": [{"id": value, "text": value} for value in ids[:100]]},
+            {"data": [{"id": ids[100], "text": ids[100]}]},
+        ]
+    )
+
+    tweets = client.lookup_tweets(ids)
+
+    assert len(tweets) == 101
+    assert client.requests[0][1]["ids"] == ids[:100]
+    assert client.requests[1][1]["ids"] == ids[100:]
+
+
+def test_empty_batch_lookup_makes_no_request() -> None:
+    client = StubXClient([])
+
+    assert client.lookup_tweets([]) == []
+    assert client.lookup_users([]) == []
+    assert client.lookup_users_by_usernames([]) == []
+    assert client.requests == []
+
+
+def test_usage_calls_real_api_endpoint() -> None:
+    client = StubXClient([{"data": {"project_usage": 42}}])
+
+    usage = client.get_usage()
+
+    assert usage == {"data": {"project_usage": 42}}
+    assert client.requests == [("/usage/tweets", None)]
 
 
 def test_quote_tweets_uses_quote_tweets_endpoint_and_normalizes_authors() -> None:


### PR DESCRIPTION
## What changed

- return complete long-form posts from `note_tweet`
- request and hydrate Articles, referenced posts, media variants, polls, and places
- distinguish Blue verification from organization verification
- surface partial X API errors instead of silently dropping them
- chunk batch lookups at the API's 100-item limit
- report pagination metadata for the results actually returned
- make health checks call the real `/2/usage/tweets` endpoint

## Why

The Twitter tool requested only the legacy `text` field, causing long posts to be truncated. Several other X API response fields and constraints were also not handled, which could hide errors, omit referenced/media content, and return misleading metadata.

## Impact

Twitter reads now return complete long posts and richer hydrated data. Invalid items in partial batch responses are explicit failures with the partial data retained on the exception. Health checks now verify real X connectivity and authentication.

## Validation

- `env PYTHONPATH=/Users/georgios/github/paradigmxyz/centaur-twitter-long-posts uv run --with pytest --with httpx pytest tools/comms/twitter/test_client.py` (17 passed)
- `uv run ruff check tools/comms/twitter/client.py tools/comms/twitter/cli.py tools/comms/twitter/test_client.py`
- `git diff --check`
- built the Twitter wheel and smoke-tested the source CLI
- confirmed the requested X field/expansion set and `/2/usage/tweets` through read-only live API calls
