### PR TITLE
fix: support proxy labels in pg dsn form

### DIFF
--- a/services/console/app/views/console/base_secrets/_form_pg_dsn.html.erb
+++ b/services/console/app/views/console/base_secrets/_form_pg_dsn.html.erb
@@ -25,7 +25,7 @@
         <h2 class="form-section-heading mb-0">Session Settings</h2>
         <button type="button" data-action="nested-fields#add" class="btn-secondary">Add setting</button>
       </div>
-      <p class="form-hint mb-3">Pinned session variables (GUCs) the proxy SETs at session start, in order, before SET ROLE. Clients can't override them. Names must be a bare or dotted identifier (e.g. <code>app.tenant</code>); <code>role</code> and <code>session_authorization</code> are reserved. A value is a literal, or resolved from the assigned principal at sync time: a label key, or a field (<code>id</code>, <code>namespace</code>, <code>foreign_id</code>, <code>name</code>).</p>
+      <p class="form-hint mb-3">Pinned session variables (GUCs) the proxy SETs at session start, in order, before SET ROLE. Clients can't override them. Names must be a bare or dotted identifier (e.g. <code>app.tenant</code>); <code>role</code> and <code>session_authorization</code> are reserved. A value is a literal, or resolved at sync time from an assigned principal label, an assigned principal field (<code>id</code>, <code>namespace</code>, <code>foreign_id</code>, <code>name</code>), or a proxy label.</p>
 
       <div class="space-y-2" data-nested-fields-target="container">
         <% Array(secret.settings).each_with_index do |s, i| %>

--- a/services/console/app/views/console/base_secrets/_setting_row.html.erb
+++ b/services/console/app/views/console/base_secrets/_setting_row.html.erb
@@ -2,7 +2,12 @@
   <%= text_field_tag "settings[#{index}][name]", name, class: "form-input", placeholder: "app.tenant" %>
   <span class="text-zinc-600">=</span>
   <%= select_tag "settings[#{index}][kind]",
-        options_for_select([ [ "Literal", "literal" ], [ "Principal label", "principal_label" ], [ "Principal field", "principal_field" ] ], kind),
+        options_for_select([
+          [ "Literal", "literal" ],
+          [ "Principal label", "principal_label" ],
+          [ "Principal field", "principal_field" ],
+          [ "Proxy label", "proxy_label" ]
+        ], kind),
         class: "form-input w-44 shrink-0" %>
   <%= text_field_tag "settings[#{index}][value]", value, class: "form-input", placeholder: "centaur" %>
   <button type="button" data-action="nested-fields#remove" class="shrink-0 text-xs text-zinc-500 transition-colors hover:text-red-400">Remove</button>

--- a/services/console/test/controllers/console/secrets_controller_test.rb
+++ b/services/console/test/controllers/console/secrets_controller_test.rb
@@ -221,6 +221,24 @@ module Console
       )
     end
 
+    test "POST create captures proxy label settings via the kind select" do
+      post console_pg_dsn_secrets_url, params: {
+        secret: { namespace: "acme", foreign_id: "ui-proxy-label", database: "proxylabeldb" },
+        settings: {
+          "0" => { name: "centaur.slack_user_id", kind: "proxy_label", value: "centaur.slack_user_id" }
+        },
+        source: { source_type: "env", reference: "PROXY_LABEL_DSN" }
+      }
+      secret = PgDsnSecret.find_by!(namespace: "acme", foreign_id: "ui-proxy-label")
+      assert_redirected_to console_secret_path("pg_dsn", secret.oid)
+      assert_equal(
+        [
+          { "name" => "centaur.slack_user_id", "value_from" => { "proxy_label" => "centaur.slack_user_id" } }
+        ],
+        secret.settings
+      )
+    end
+
     test "POST create rejects an unknown principal_field from the console form" do
       assert_no_difference "PgDsnSecret.count" do
         post console_pg_dsn_secrets_url, params: {


### PR DESCRIPTION
Adds Proxy label as a supported source for PG DSN session settings in the console form and updates the helper text to describe it. Covers the form submission path so proxy labels are persisted as value_from entries.