### PR TITLE
security: harden sandbox and ingress boundaries

### DIFF
--- a/contrib/chart/charts/agent-sandbox/templates/_helpers.tpl
+++ b/contrib/chart/charts/agent-sandbox/templates/_helpers.tpl
@@ -21,7 +21,7 @@ app.kubernetes.io/name: {{ include "agent-sandbox.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- if .Values.image.tag }}
-app.kubernetes.io/version: {{ .Values.image.tag | quote }}
+app.kubernetes.io/version: {{ .Values.image.tag | trunc 63 | trimSuffix "-" | quote }}
 {{- end }}
 {{- end }}
 

--- a/contrib/chart/templates/apirs.yaml
+++ b/contrib/chart/templates/apirs.yaml
@@ -352,7 +352,7 @@ spec:
             - name: KUBERNETES_FIREWALL_CA_KEY_SECRET_NAME
               value: {{ include "centaur.trustedCaKeySecretName" . | quote }}
             - name: KUBERNETES_SECRET_ENV_NAME
-              value: {{ include "centaur.secretEnvName" . | quote }}
+              value: {{ default (include "centaur.secretEnvName" .) .Values.ironProxy.secretEnvName | quote }}
 {{- if .Values.secrets.bootstrapSecretName }}
             - name: KUBERNETES_BOOTSTRAP_SECRET_NAME
               value: {{ .Values.secrets.bootstrapSecretName | quote }}

--- a/contrib/chart/templates/slackbotv2.yaml
+++ b/contrib/chart/templates/slackbotv2.yaml
@@ -129,9 +129,6 @@ spec:
             - name: {{ $name }}
               value: {{ $value | quote }}
 {{- end }}
-          envFrom:
-            - secretRef:
-                name: {{ include "centaur.secretEnvName" . }}
           ports:
             - containerPort: 3001
               name: http

--- a/contrib/chart/values.yaml
+++ b/contrib/chart/values.yaml
@@ -16,6 +16,9 @@ firewall:
     keyPem: ""
 
 ironProxy:
+  # Optional narrow Secret imported by per-sandbox proxies. Empty preserves the
+  # legacy shared secretManager.existingSecretName behavior.
+  secretEnvName: ""
   image:
     repository: centaur-iron-proxy
     tag: latest

--- a/services/api-rs/crates/centaur-sandbox-agent-k8s/src/lib.rs
+++ b/services/api-rs/crates/centaur-sandbox-agent-k8s/src/lib.rs
@@ -591,6 +591,14 @@ fn build_agent_sandbox(
         "stdin": true,
         "stdinOnce": false,
         "tty": false,
+        "securityContext": {
+            "allowPrivilegeEscalation": false,
+            "runAsNonRoot": true,
+            "runAsUser": 1001,
+            "runAsGroup": 1001,
+            "capabilities": { "drop": ["ALL"] },
+            "seccompProfile": { "type": "RuntimeDefault" },
+        },
     });
     insert_optional(
         &mut container,
@@ -914,6 +922,19 @@ mod tests {
         );
         assert_eq!(container.image.as_deref(), Some("centaur-agent:latest"));
         assert_eq!(container.stdin, Some(true));
+        let security = container.security_context.as_ref().unwrap();
+        assert_eq!(security.allow_privilege_escalation, Some(false));
+        assert_eq!(security.run_as_non_root, Some(true));
+        assert_eq!(security.run_as_user, Some(1001));
+        assert_eq!(security.run_as_group, Some(1001));
+        assert_eq!(
+            security.capabilities.as_ref().unwrap().drop.as_deref(),
+            Some(["ALL".to_owned()].as_slice())
+        );
+        assert_eq!(
+            security.seccomp_profile.as_ref().unwrap().type_,
+            "RuntimeDefault"
+        );
         assert_eq!(container.volume_mounts.as_ref().unwrap().len(), 2);
         assert!(container.resources.as_ref().unwrap().limits.is_some());
     }

--- a/services/iron-proxy/iron-proxy.yaml
+++ b/services/iron-proxy/iron-proxy.yaml
@@ -22,7 +22,20 @@ transforms:
   - name: allowlist
     config:
       domains:
-        - "*"
+        - "api.ai.meta.com"
+        - "api.anthropic.com"
+        - "api.github.com"
+        - "api.openai.com"
+        - "codeload.github.com"
+        - "files.pythonhosted.org"
+        - "github.com"
+        - "objects.githubusercontent.com"
+        - "openrouter.ai"
+        - "pypi.org"
+        - "raw.githubusercontent.com"
+        - "registry.npmjs.org"
+        - "release-assets.githubusercontent.com"
+        - "static.crates.io"
   - name: header_allowlist
     config:
       headers:

--- a/services/slackbotv2/src/index.ts
+++ b/services/slackbotv2/src/index.ts
@@ -369,7 +369,14 @@ export function createSlackbotV2(options: SlackbotV2Options): SlackbotV2 {
   const handleSlackWebhook = async (c: Context) => {
     const webhookStartedAtMs = nowMs()
     const route = c.req.path
+    const declaredLength = Number.parseInt(c.req.header('content-length') ?? '0', 10)
+    if (Number.isFinite(declaredLength) && declaredLength > 1_048_576) {
+      return new globalThis.Response('payload too large', { status: 413 })
+    }
     const rawBody = await c.req.raw.clone().text()
+    if (new TextEncoder().encode(rawBody).byteLength > 1_048_576) {
+      return new globalThis.Response('payload too large', { status: 413 })
+    }
     const eventType = slackWebhookEventType(rawBody)
     let outcome = 'success'
     try {

--- a/services/slackbotv2/test/chat-sdk-emulate.test.ts
+++ b/services/slackbotv2/test/chat-sdk-emulate.test.ts
@@ -116,6 +116,19 @@ afterAll(async () => {
 })
 
 describe('slackbotv2', () => {
+  it('rejects oversized webhook bodies before signature processing', async () => {
+    const response = await bot.app.request('/api/webhooks/slack', {
+      method: 'POST',
+      headers: {
+        'content-length': '1048577',
+        'content-type': 'application/json'
+      },
+      body: '{}'
+    })
+
+    expect(response.status).toBe(413)
+  })
+
   it('accepts Slack events on the legacy route', async () => {
     const parent = await postUserMessage('Legacy route context.')
     const mention = await postUserMessage(`<@${BOT_USER_ID}> use the legacy route`, parent.ts)


### PR DESCRIPTION
## Summary

- enforce the restricted Kubernetes security context on agent containers
- replace wildcard iron-proxy egress with an explicit production domain allowlist
- reject Slack webhook bodies larger than 1 MiB before signature processing
- support least-privilege proxy Secrets and digest-pinned agent-sandbox controller images

## Evidence

- live usw-dev audit detected all three boundaries
- 2 MiB signed Slack payload currently returns 200 before this patch
- fresh agent pod currently lacks a container securityContext
- unlisted `https://example.com` currently succeeds through iron-proxy
- Helm manifests were rendered and the chart changes are deployed on usw-dev

## Validation

- `git diff --check`
- chart rendered with the production values
- runtime TypeScript/Rust test execution is delegated to CI because the deployment VPS is explicitly prohibited from running Cargo and does not have the Bun workspace dependencies installed
