### PR TITLE
fix: append mounted overlay system prompts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
     outputs:
       migration_order: ${{ steps.filter.outputs.migration_order }}
       rust_api: ${{ steps.filter.outputs.rust_api }}
+      sandbox_tests: ${{ steps.filter.outputs.sandbox_tests }}
       slackbotv2_tests: ${{ steps.filter.outputs.slackbotv2_tests }}
       discordbot_checks: ${{ steps.filter.outputs.discordbot_checks }}
       githubbot_checks: ${{ steps.filter.outputs.githubbot_checks }}
@@ -69,6 +70,9 @@ jobs:
             '^\.github/workflows/ci\.yml$'
           set_output rust_api \
             '^services/api-rs/' \
+            '^\.github/workflows/ci\.yml$'
+          set_output sandbox_tests \
+            '^services/sandbox/' \
             '^\.github/workflows/ci\.yml$'
           set_output slackbotv2_tests \
             '^services/slackbotv2/' \
@@ -214,6 +218,26 @@ jobs:
             kill "$(cat "$RUNNER_TEMP/centaur-api-server.pid")" 2>/dev/null || true
           fi
           docker rm -f centaur-api-integration-test-postgres || true
+
+  sandbox-tests:
+    name: Sandbox Python tests
+    runs-on: ubuntu-latest
+    needs: ci_changes
+    if: needs.ci_changes.outputs.sandbox_tests == 'true'
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.11"
+
+      - name: Sandbox Python tests
+        env:
+          GIT_CONFIG_GLOBAL: /dev/null
+          PYTHONPATH: ${{ github.workspace }}
+        run: python -m unittest discover -s services/sandbox -p 'test_*.py'
 
   slackbotv2-tests:
     name: Slackbot v2 tests
@@ -381,6 +405,7 @@ jobs:
       - ci_changes
       - migration-order
       - rust-api
+      - sandbox-tests
       - slackbotv2-tests
       - discordbot-checks
       - githubbot-checks
@@ -390,5 +415,5 @@ jobs:
       - name: Decide whether the needed jobs succeeded or failed
         uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # release/v1
         with:
-          allowed-skips: migration-order, rust-api, slackbotv2-tests, discordbot-checks, githubbot-checks, teamsbot-checks
+          allowed-skips: migration-order, rust-api, sandbox-tests, slackbotv2-tests, discordbot-checks, githubbot-checks, teamsbot-checks
           jobs: ${{ toJSON(needs) }}

--- a/docs/pages/extend/overlay.mdx
+++ b/docs/pages/extend/overlay.mdx
@@ -67,11 +67,11 @@ It defaults to `private`. Set `visibility: public` only for repos whose full
 contents are safe to expose to principals configured with
 `sandbox_repo_cache=public`; invalid or missing values are treated as `private`.
 
-Each source defaults to the conventional layout — `toolsSubdir: tools`,
-`workflowsSubdir: workflows`, `skillsSubdir: .agents/skills` — and directories
-a repo does not contain are skipped at runtime, so a skills-only overlay needs
-no extra configuration. Set a subdir to a non-default path to relocate it, or
-to `""` to explicitly disable that surface for a source:
+Each source defaults to the conventional layout: `toolsSubdir: tools`,
+`workflowsSubdir: workflows`, `skillsSubdir: .agents/skills`. Directories a
+repo does not contain are skipped at runtime, so a skills-only overlay needs no
+extra configuration. Set a subdir to a non-default path to relocate it, or to
+`""` to explicitly disable that surface for a source:
 
 ```yaml
     - repo: your-org/workflows-only
@@ -135,8 +135,9 @@ overlay:
     Add deployment-specific agent guidance here.
 ```
 
-For larger prompt/persona sets, keep files in an overlay repo and expose their
-paths through `overlays.sources` as that surface is wired into your deployment.
+For larger prompt/persona sets, keep files in overlay repos. The sandbox starts
+with the root prompt, then appends every mounted
+`/home/agent/github/<owner>/<repo>/services/sandbox/SYSTEM_PROMPT.md` it finds.
 Do not rely on `overlay.image.*`; repo-cache-backed overlays are the default
 delivery path.
 

--- a/docs/public/md/extend/overlay.md
+++ b/docs/public/md/extend/overlay.md
@@ -67,11 +67,11 @@ It defaults to `private`. Set `visibility: public` only for repos whose full
 contents are safe to expose to principals configured with
 `sandbox_repo_cache=public`; invalid or missing values are treated as `private`.
 
-Each source defaults to the conventional layout — `toolsSubdir: tools`,
-`workflowsSubdir: workflows`, `skillsSubdir: .agents/skills` — and directories
-a repo does not contain are skipped at runtime, so a skills-only overlay needs
-no extra configuration. Set a subdir to a non-default path to relocate it, or
-to `""` to explicitly disable that surface for a source:
+Each source defaults to the conventional layout: `toolsSubdir: tools`,
+`workflowsSubdir: workflows`, `skillsSubdir: .agents/skills`. Directories a
+repo does not contain are skipped at runtime, so a skills-only overlay needs no
+extra configuration. Set a subdir to a non-default path to relocate it, or to
+`""` to explicitly disable that surface for a source:
 
 ```yaml
     - repo: your-org/workflows-only
@@ -135,8 +135,9 @@ overlay:
     Add deployment-specific agent guidance here.
 ```
 
-For larger prompt/persona sets, keep files in an overlay repo and expose their
-paths through `overlays.sources` as that surface is wired into your deployment.
+For larger prompt/persona sets, keep files in overlay repos. The sandbox starts
+with the root prompt, then appends every mounted
+`/home/agent/github/<owner>/<repo>/services/sandbox/SYSTEM_PROMPT.md` it finds.
 Do not rely on `overlay.image.*`; repo-cache-backed overlays are the default
 delivery path.
 

--- a/services/sandbox/Dockerfile
+++ b/services/sandbox/Dockerfile
@@ -240,6 +240,7 @@ COPY --link services/workflow-python/api/ /usr/local/bin/api/
 COPY --link --chmod=755 services/sandbox/git-branch.sh /usr/local/bin/git-branch
 COPY --link --chmod=755 services/sandbox/install_tool_shims.py /usr/local/bin/install-tool-shims
 COPY --link --chmod=755 services/sandbox/centaur_tool_host.py /usr/local/bin/centaur-tool-host
+COPY --link --chmod=755 services/sandbox/compose_system_prompt.py /usr/local/bin/compose-system-prompt
 COPY --link --chmod=755 services/sandbox/repo_cache_sync.py /usr/local/bin/repo-cache-sync
 COPY --link --chmod=755 services/sandbox/repo_cache_watch.py /usr/local/bin/repo-cache-watch
 COPY --link --chmod=755 services/sandbox/entrypoint.sh /entrypoint.sh

--- a/services/sandbox/compose_system_prompt.py
+++ b/services/sandbox/compose_system_prompt.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import os
+from pathlib import Path
+
+
+SEPARATOR = "\n\n---\n\n"
+OVERLAY_PROMPT = Path("services/sandbox/SYSTEM_PROMPT.md")
+
+
+def _append_prompt(target: Path, source: Path) -> bool:
+    if not source.is_file() or not target.is_file():
+        return False
+    with target.open("a") as target_file:
+        target_file.write(SEPARATOR)
+        target_file.write(source.read_text())
+    return True
+
+
+def _mounted_overlay_prompts(repo_mount: Path, baked_prompt: Path) -> list[Path]:
+    if not repo_mount.is_dir():
+        return []
+    prompts = sorted(repo_mount.glob(f"*/*/{OVERLAY_PROMPT}"))
+    if not baked_prompt.is_file():
+        return prompts
+
+    root_text = baked_prompt.read_text()
+    return [prompt for prompt in prompts if prompt.read_text() != root_text]
+
+
+def compose_system_prompt(
+    *,
+    home_dir: Path,
+    target_prompt: Path,
+    repo_mount: Path,
+) -> None:
+    base_prompt = home_dir / "AGENTS_BASE.md"
+    baked_prompt = home_dir / "AGENTS.md"
+    if base_prompt.is_file():
+        target_prompt.write_text(base_prompt.read_text())
+    elif baked_prompt.is_file():
+        target_prompt.write_text(baked_prompt.read_text())
+    else:
+        return
+
+    appended: set[Path] = set()
+
+    home_overlay = home_dir / "AGENTS_OVERLAY.md"
+    if _append_prompt(target_prompt, home_overlay):
+        appended.add(home_overlay.resolve())
+
+    for prompt_path in _mounted_overlay_prompts(repo_mount, baked_prompt):
+        if not prompt_path.is_file():
+            continue
+        resolved = prompt_path.resolve()
+        if resolved in appended:
+            continue
+        if _append_prompt(target_prompt, prompt_path):
+            appended.add(resolved)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--home-dir", default=os.path.expanduser("~"))
+    parser.add_argument("--repo-mount")
+    parser.add_argument("--target-prompt", required=True)
+    args = parser.parse_args()
+
+    home_dir = Path(args.home_dir)
+    compose_system_prompt(
+        home_dir=home_dir,
+        target_prompt=Path(args.target_prompt),
+        repo_mount=Path(args.repo_mount) if args.repo_mount else home_dir / "github",
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/sandbox/entrypoint.sh
+++ b/services/sandbox/entrypoint.sh
@@ -407,27 +407,9 @@ unset _centaur_tools_auto_reload
 
 # ── Assemble system prompt from bind mounts ──────────────────────────────────
 # Base prompt: mounted as AGENTS_BASE.md when present, fallback to baked-in AGENTS.md.
-# Org/persona overlays are mounted alongside the base prompt when present.
+# Prompt overlays from mounted repos are appended when present.
 TARGET_PROMPT="$WORKSPACE_DIR/AGENTS.md"
-if [ -f "$HOME_DIR/AGENTS_BASE.md" ]; then
-    cp "$HOME_DIR/AGENTS_BASE.md" "$TARGET_PROMPT"
-elif [ -f "$HOME_DIR/AGENTS.md" ]; then
-    cp "$HOME_DIR/AGENTS.md" "$TARGET_PROMPT"
-fi
-
-if [ -f "$HOME_DIR/AGENTS_OVERLAY.md" ] && [ -f "$TARGET_PROMPT" ]; then
-    printf '\n\n---\n\n' >> "$TARGET_PROMPT"
-    cat "$HOME_DIR/AGENTS_OVERLAY.md" >> "$TARGET_PROMPT"
-# Repo-cache-era org prompt: with overlay images gone, point CENTAUR_OVERLAY_DIR
-# at the org repo's clone under the repos mount (e.g. ~/github/<owner>/<repo>)
-# and its SYSTEM_PROMPT.md is appended here, same contract the overlay-bootstrap
-# init container used to fulfil by staging $HOME/AGENTS_OVERLAY.md.
-elif [ -n "${CENTAUR_OVERLAY_DIR:-}" ] \
-    && [ -f "${CENTAUR_OVERLAY_DIR}/services/sandbox/SYSTEM_PROMPT.md" ] \
-    && [ -f "$TARGET_PROMPT" ]; then
-    printf '\n\n---\n\n' >> "$TARGET_PROMPT"
-    cat "${CENTAUR_OVERLAY_DIR}/services/sandbox/SYSTEM_PROMPT.md" >> "$TARGET_PROMPT"
-fi
+compose-system-prompt --home-dir "$HOME_DIR" --target-prompt "$TARGET_PROMPT"
 
 if [ "${CENTAUR_SANDBOX_OBSERVABILITY_ENABLED:-true}" = "false" ] && [ -f "$TARGET_PROMPT" ]; then
     cat >> "$TARGET_PROMPT" <<'EOF'

--- a/services/sandbox/git-hooks/commit-msg
+++ b/services/sandbox/git-hooks/commit-msg
@@ -16,10 +16,8 @@ EOF
   exit 1
 fi
 
-if rg -i -q \
-  -e 'generated with (claude|codex|amp)' \
-  -e 'co-authored-by:.*(claude|codex|anthropic|openai|amp)' \
-  -e 'co-authored-by:.*(centaur[[:space:]]+ai|ai@centaur\.local)' \
+if grep -Eiq \
+  'generated with (claude|codex|amp)|co-authored-by:.*(claude|codex|anthropic|openai|amp)|co-authored-by:.*(centaur[[:space:]]+ai|ai@centaur\.local)' \
   "$message_file"; then
   cat >&2 <<'EOF'
 Commit message contains generated-by or AI co-author attribution.

--- a/services/sandbox/test_compose_system_prompt.py
+++ b/services/sandbox/test_compose_system_prompt.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+import compose_system_prompt
+
+
+class ComposeSystemPromptTest(unittest.TestCase):
+    def test_appends_multiple_overlay_prompts_in_order(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            home = root / "home"
+            workspace = root / "workspace"
+            home.mkdir()
+            workspace.mkdir()
+            (home / "AGENTS.md").write_text("base\n")
+
+            repo_mount = home / "github"
+            first = repo_mount / "acme" / "first" / "services" / "sandbox" / "SYSTEM_PROMPT.md"
+            second = repo_mount / "acme" / "second" / "services" / "sandbox" / "SYSTEM_PROMPT.md"
+            first.parent.mkdir(parents=True)
+            second.parent.mkdir(parents=True)
+            first.write_text("first overlay\n")
+            second.write_text("second overlay\n")
+
+            target = workspace / "AGENTS.md"
+            compose_system_prompt.compose_system_prompt(
+                home_dir=home,
+                target_prompt=target,
+                repo_mount=repo_mount,
+            )
+
+            self.assertEqual(
+                target.read_text(),
+                "base\n\n\n---\n\nfirst overlay\n\n\n---\n\nsecond overlay\n",
+            )
+
+    def test_uses_agents_base_and_appends_home_overlay_before_repo_overlays(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            home = root / "home"
+            workspace = root / "workspace"
+            home.mkdir()
+            workspace.mkdir()
+            (home / "AGENTS.md").write_text("baked\n")
+            (home / "AGENTS_BASE.md").write_text("persona base\n")
+            (home / "AGENTS_OVERLAY.md").write_text("home overlay\n")
+
+            repo_mount = home / "github"
+            prompt = repo_mount / "acme" / "overlay" / "services" / "sandbox" / "SYSTEM_PROMPT.md"
+            prompt.parent.mkdir(parents=True)
+            prompt.write_text("repo overlay\n")
+
+            target = workspace / "AGENTS.md"
+            compose_system_prompt.compose_system_prompt(
+                home_dir=home,
+                target_prompt=target,
+                repo_mount=repo_mount,
+            )
+
+            self.assertEqual(
+                target.read_text(),
+                "persona base\n\n\n---\n\nhome overlay\n\n\n---\n\nrepo overlay\n",
+            )
+
+    def test_skips_mounted_copy_of_baked_root_prompt(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            home = root / "home"
+            workspace = root / "workspace"
+            home.mkdir()
+            workspace.mkdir()
+            (home / "AGENTS.md").write_text("base\n")
+
+            repo_mount = home / "github"
+            root_prompt = (
+                repo_mount
+                / "paradigmxyz"
+                / "centaur"
+                / "services"
+                / "sandbox"
+                / "SYSTEM_PROMPT.md"
+            )
+            overlay_prompt = (
+                repo_mount
+                / "acme"
+                / "overlay"
+                / "services"
+                / "sandbox"
+                / "SYSTEM_PROMPT.md"
+            )
+            root_prompt.parent.mkdir(parents=True)
+            overlay_prompt.parent.mkdir(parents=True)
+            root_prompt.write_text("base\n")
+            overlay_prompt.write_text("overlay\n")
+
+            target = workspace / "AGENTS.md"
+            compose_system_prompt.compose_system_prompt(
+                home_dir=home,
+                target_prompt=target,
+                repo_mount=repo_mount,
+            )
+
+            self.assertEqual(
+                target.read_text(),
+                "base\n\n\n---\n\noverlay\n",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Moves sandbox system prompt composition into a small helper that starts from the root prompt and appends mounted overlay prompts found at services/sandbox/SYSTEM_PROMPT.md under sandbox repo checkouts. Adds sandbox Python tests to CI so this behavior is covered on PRs that touch sandbox startup.