### PR TITLE
Increase Codex project instruction limit to 128 KiB

### DIFF
--- a/harness/codex/config.toml
+++ b/harness/codex/config.toml
@@ -6,6 +6,7 @@ service_tier = "fast"
 approval_policy = "never"
 sandbox_mode = "danger-full-access"
 suppress_unstable_features_warning = true
+project_doc_max_bytes = 131072
 
 [features]
 goals = true


### PR DESCRIPTION
## Summary

- raise `project_doc_max_bytes` from the Codex default of 32 KiB to 128 KiB
- prevent the assembled Centaur `AGENTS.md` prompt from truncating before Paradigm overlay instructions

## Validation

- parsed `harness/codex/config.toml` with Python `tomllib` and asserted the value is `131072`
- verified the current 43,829-byte assembled prompt fits under the new limit
- ran `git diff --check`

Prompted by: mslipper