### PR TITLE
fix: implement Python workflow event waits

### DIFF
--- a/services/api-rs/crates/centaur-api-server/src/routes.rs
+++ b/services/api-rs/crates/centaur-api-server/src/routes.rs
@@ -2410,9 +2410,24 @@ async fn emit_workflow_event(
     Json(request): Json<EmitWorkflowEventRequest>,
 ) -> Result<Json<serde_json::Value>, ApiError> {
     let workflows = workflow_runtime(&state)?;
-    workflows
-        .emit_event(&request.event_name, request.payload)
-        .await?;
+    let event_name = match (
+        request.event_name.as_deref(),
+        request.event_type.as_deref(),
+        request.correlation_id.as_deref(),
+    ) {
+        (Some(event_name), None, None) if !event_name.trim().is_empty() => event_name.to_owned(),
+        (None, Some(event_type), Some(correlation_id))
+            if !event_type.trim().is_empty() && !correlation_id.trim().is_empty() =>
+        {
+            centaur_workflows::python_workflow_event_name(event_type, correlation_id)
+        }
+        _ => {
+            return Err(ApiError::BadRequest(
+                "provide either event_name or both event_type and correlation_id".to_owned(),
+            ));
+        }
+    };
+    workflows.emit_event(&event_name, request.payload).await?;
     Ok(Json(json!({ "ok": true })))
 }
 

--- a/services/api-rs/crates/centaur-api-server/src/types.rs
+++ b/services/api-rs/crates/centaur-api-server/src/types.rs
@@ -140,7 +140,9 @@ pub struct ListWorkflowRunsQuery {
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct EmitWorkflowEventRequest {
-    pub event_name: String,
+    pub event_name: Option<String>,
+    pub event_type: Option<String>,
+    pub correlation_id: Option<String>,
     #[serde(default)]
     pub payload: Value,
 }

--- a/services/api-rs/crates/centaur-workflows/src/lib.rs
+++ b/services/api-rs/crates/centaur-workflows/src/lib.rs
@@ -8,8 +8,8 @@ use std::{
 };
 
 use absurd::{
-    Client, ClientOptions, CreateQueueOptions, RetryKind, RetryStrategy, SpawnOptions, StepHandle,
-    TaskContext, TaskRegistrationOptions, Worker, WorkerOptions,
+    AwaitEventOptions, Client, ClientOptions, CreateQueueOptions, RetryKind, RetryStrategy,
+    SpawnOptions, StepHandle, TaskContext, TaskRegistrationOptions, Worker, WorkerOptions,
 };
 use centaur_iron_control::{IdentityInput, IronControlClient, IronControlError, slugify};
 use centaur_sandbox_core::SandboxSpec;
@@ -58,6 +58,15 @@ const WORKFLOW_ALLOWED_NAMES_ENV: &str = "WORKFLOW_ALLOWED_NAMES";
 const WORKFLOW_REAP_REMOVED_AFTER_TICKS_ENV: &str = "WORKFLOW_REAP_REMOVED_AFTER_TICKS";
 const DEFAULT_WORKFLOW_REAP_REMOVED_AFTER_TICKS: u32 = 3;
 const ABSURD_TERMINAL_TASK_STATES: &str = "('completed', 'failed', 'cancelled')";
+
+pub fn python_workflow_event_name(event_type: &str, correlation_id: &str) -> String {
+    // JSON string encoding is unambiguous even when either component contains a delimiter.
+    format!(
+        "python:{}",
+        serde_json::to_string(&(event_type, correlation_id))
+            .expect("serializing two strings cannot fail")
+    )
+}
 
 /// Per-queue worker concurrency. The defaults preserve historical behavior; each
 /// can be overridden via its env var to scale a queue independently (e.g. raise
@@ -3333,6 +3342,28 @@ async fn handle_python_context_request(
                 Err(error) => Err(error),
             }
         }
+        Some("ctx.event.wait") => {
+            let step = required_python_string(message, "step", "ctx.event.wait")?;
+            let event_type = required_python_string(message, "event_type", "ctx.event.wait")?;
+            let correlation_id =
+                required_python_string(message, "correlation_id", "ctx.event.wait")?;
+            let timeout = parse_optional_python_duration_seconds(message, "timeout_seconds")?;
+            let event_name = python_workflow_event_name(event_type, correlation_id);
+            match ctx
+                .await_event::<Value>(
+                    &event_name,
+                    AwaitEventOptions {
+                        step_name: Some(step.to_owned()),
+                        timeout,
+                    },
+                )
+                .await
+            {
+                Ok(value) => Ok(value),
+                Err(absurd::Error::Suspend) => return Err(WorkflowRuntimeError::Suspend),
+                Err(error) => Err(error.to_string()),
+            }
+        }
         Some("ctx.agent_turn") => {
             let args = message.get("args").cloned().unwrap_or_else(|| json!({}));
             match run_python_agent_turn(session_runtime.clone(), ctx, input, args, &request_id)
@@ -3441,6 +3472,39 @@ fn parse_python_duration_seconds(message: &Value) -> Result<Duration, String> {
         return Err("ctx.sleep duration_seconds must be a finite non-negative number".to_owned());
     }
     Ok(Duration::from_secs_f64(seconds))
+}
+
+fn required_python_string<'a>(
+    message: &'a Value,
+    field: &str,
+    request_type: &str,
+) -> Result<&'a str, WorkflowRuntimeError> {
+    message
+        .get(field)
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| {
+            WorkflowRuntimeError::BadRequest(format!("{request_type} requires a non-empty {field}"))
+        })
+}
+
+fn parse_optional_python_duration_seconds(
+    message: &Value,
+    field: &str,
+) -> Result<Option<Duration>, WorkflowRuntimeError> {
+    let Some(value) = message.get(field) else {
+        return Ok(None);
+    };
+    let seconds = value.as_f64().ok_or_else(|| {
+        WorkflowRuntimeError::BadRequest(format!("ctx.event.wait {field} must be numeric"))
+    })?;
+    if !seconds.is_finite() || seconds < 0.0 {
+        return Err(WorkflowRuntimeError::BadRequest(format!(
+            "ctx.event.wait {field} must be a finite non-negative number"
+        )));
+    }
+    Ok(Some(Duration::from_secs_f64(seconds)))
 }
 
 fn parse_python_wake_at(message: &Value) -> Result<DateTime<Utc>, String> {
@@ -4100,6 +4164,18 @@ pub enum WorkflowRuntimeError {
 mod tests {
     use super::*;
     use chrono::TimeZone;
+
+    #[test]
+    fn python_event_names_are_collision_free() {
+        assert_ne!(
+            python_workflow_event_name("review:a", "b"),
+            python_workflow_event_name("review", "a:b")
+        );
+        assert_eq!(
+            python_workflow_event_name("review", "change:42"),
+            "python:[\"review\",\"change:42\"]"
+        );
+    }
 
     #[test]
     fn agent_turn_input_line_omits_unset_harness_knobs() {

--- a/services/workflow-python/api/workflow_engine.py
+++ b/services/workflow-python/api/workflow_engine.py
@@ -101,6 +101,25 @@ class WorkflowContext:
             }
         )
 
+    async def wait_for_event(
+        self,
+        name: str,
+        event_type: str,
+        correlation_id: str,
+        *,
+        timeout: dt.timedelta | int | float | None = None,
+    ) -> Any:
+        """Suspend until the matching durable workflow event is delivered."""
+        request: dict[str, Any] = {
+            "type": "ctx.event.wait",
+            "step": name,
+            "event_type": event_type,
+            "correlation_id": correlation_id,
+        }
+        if timeout is not None:
+            request["timeout_seconds"] = duration_seconds(timeout)
+        return await self._rpc.request(request)
+
     async def agent_turn(self, text: str | None = None, **kwargs: Any) -> Any:
         # Per-workflow AGENT_DEFAULTS (model / provider / reasoning / harness,
         # ...) form the base; explicit per-call kwargs override them key by key.

--- a/services/workflow-python/tests/test_workflow_host.py
+++ b/services/workflow-python/tests/test_workflow_host.py
@@ -69,6 +69,8 @@ class RequestRpc(FakeRpc):
             }
         if message_type == "ctx.sleep":
             return {"slept": True}
+        if message_type == "ctx.event.wait":
+            return {"approved": True}
         raise AssertionError(f"unexpected request {payload}")
 
 
@@ -131,6 +133,34 @@ class WorkflowHostTests(unittest.TestCase):
         self.assertEqual(
             rpc.requests,
             [{"type": "ctx.sleep", "step": "pause", "duration_seconds": 2.5}],
+        )
+
+    def test_wait_for_event_sends_durable_event_identity_and_timeout(self) -> None:
+        host = load_workflow_host()
+        rpc = RequestRpc()
+        ctx = host.WorkflowContext(
+            rpc,
+            run_id="run-123",
+            task_id="task-456",
+            workflow_name="sample",
+        )
+
+        result = asyncio.run(
+            ctx.wait_for_event("approval", "review", "change:42", timeout=30)
+        )
+
+        self.assertEqual(result, {"approved": True})
+        self.assertEqual(
+            rpc.requests,
+            [
+                {
+                    "type": "ctx.event.wait",
+                    "step": "approval",
+                    "event_type": "review",
+                    "correlation_id": "change:42",
+                    "timeout_seconds": 30.0,
+                }
+            ],
         )
 
     def test_tools_proxy_calls_tool_manager(self) -> None:


### PR DESCRIPTION
Implements the documented `WorkflowContext.wait_for_event(...)` primitive by bridging Python context RPC to Absurd durable event waits. Also accepts `event_type` + `correlation_id` on the event emission endpoint using a collision-free mapping while preserving `event_name`.

Tests:
- `uv run --project services/workflow-python python -m unittest discover -s services/workflow-python/tests -p 'test_*.py'`
- `cargo test -p centaur-workflows python_event_names_are_collision_free`
- `cargo check -p centaur-api-server`
- `cargo +nightly fmt --all -- --check`

Prompted by: @goksu