### PR TITLE
feat: support client credentials broker refresh

### DIFF
--- a/services/console/app/controllers/api/v1/broker_credentials_controller.rb
+++ b/services/console/app/controllers/api/v1/broker_credentials_controller.rb
@@ -80,7 +80,10 @@ module Api
 
       def apply_client_secret(ref, attrs)
         secret = attrs[:client_secret]
-        ref.client_secret = secret if secret.present?
+        return if secret.blank?
+
+        ref.client_secret = secret
+        reset_refresh_state(ref) if ref.grant == "client_credentials"
       end
 
       # These fields are write-only initial/re-auth values. Supplying any
@@ -98,6 +101,13 @@ module Api
         end
         return unless changed
 
+        ref.dead = false
+        ref.dead_reason = nil
+        ref.failure_count = 0
+        ref.next_attempt_at = Time.current
+      end
+
+      def reset_refresh_state(ref)
         ref.dead = false
         ref.dead_reason = nil
         ref.failure_count = 0

--- a/services/console/app/controllers/console/broker_credentials_controller.rb
+++ b/services/console/app/controllers/console/broker_credentials_controller.rb
@@ -69,7 +69,10 @@ module Console
       credential.labels = label_params
 
       secret = credential_params[:client_secret]
-      credential.client_secret = secret if secret.present?
+      if secret.present?
+        credential.client_secret = secret
+        reset_refresh_state(credential) if credential.grant == "client_credentials"
+      end
       apply_initial_values(credential)
     end
 
@@ -95,6 +98,13 @@ module Console
       end
       return unless changed
 
+      credential.dead = false
+      credential.dead_reason = nil
+      credential.failure_count = 0
+      credential.next_attempt_at = Time.current
+    end
+
+    def reset_refresh_state(credential)
       credential.dead = false
       credential.dead_reason = nil
       credential.failure_count = 0

--- a/services/console/app/views/console/broker_credentials/_form.html.erb
+++ b/services/console/app/views/console/broker_credentials/_form.html.erb
@@ -103,6 +103,10 @@
       </div>
       <%= field_error(credential, :grant) %>
 
+      <div data-toggle-target="panel" data-toggle-key="client_credentials">
+        <p class="form-hint">Uses the client ID and client secret above to mint each access token. No refresh token is required.</p>
+      </div>
+
       <div data-toggle-target="panel" data-toggle-key="refresh_token">
         <label class="form-label" for="credential_refresh_token">Refresh Token</label>
         <%= text_area_tag "credential[refresh_token]", nil, id: "credential_refresh_token", rows: 3, class: "form-input", autocomplete: "off", placeholder: credential.new_record? ? "initial refresh token for the loop" : "•••••••• (unchanged)" %>

--- a/services/console/docs/API.md
+++ b/services/console/docs/API.md
@@ -817,13 +817,13 @@ The token credentials it refreshes with are fields on the credential, resolved b
 | `foreign_id`                   | optional    | Unique per namespace. Immutable. |
 | `name`, `description`          | optional    | |
 | `labels`                       | optional    | |
-| `grant`                        | optional    | One of `refresh_token`, `password`, or `preqin`. Defaults to `refresh_token`. |
+| `grant`                        | optional    | One of `refresh_token`, `client_credentials`, `password`, or `preqin`. Defaults to `refresh_token`. |
 | `token_endpoint`               | conditional | Token endpoint the refresh request is sent to. Required except `preqin`, which uses the fixed `https://api.preqin.com/connect/token` endpoint. |
 | `scopes`                       | optional    | Array of strings. |
-| `client_id`                    | conditional | OAuth client id. Required for standalone `refresh_token` and `password` credentials. Returned in responses. Not used for `preqin`. |
-| `client_secret`                | optional    | OAuth client secret. Write-only and encrypted at rest; omit for public clients. Never returned. |
+| `client_id`                    | conditional | OAuth client id. Required for standalone `refresh_token`, `client_credentials`, and `password` credentials. Returned in responses. Not used for `preqin`. |
+| `client_secret`                | conditional | OAuth client secret. Required for `client_credentials`, optional for `refresh_token` and `password`, and not used for `preqin`. Write-only and encrypted at rest; omit for public clients. Never returned. |
 | `token_endpoint_headers`       | optional    | Object mapping header name to a string value, sent on the refresh request. Values are write-only and encrypted; only the header names are returned (as `token_endpoint_header_names`). |
-| `refresh_token`                | optional    | Write-only initial value for `refresh_token` credentials. Also used by `password` credentials when the provider returns one. Supplying a value schedules the credential immediately and clears dead state. Never returned. |
+| `refresh_token`                | optional    | Write-only initial value for `refresh_token` credentials. Also used by `password` credentials when the provider returns one. Not used by `client_credentials` credentials. Supplying a value schedules the credential immediately and clears dead state. Never returned. |
 | `username`                     | conditional | Required for `password` credentials. Write-only and encrypted at rest. Never returned. |
 | `password`                     | conditional | Required for `password` credentials. Write-only and encrypted at rest. Never returned. |
 | `api_key`                      | conditional | Required for `preqin` credentials. Write-only and encrypted at rest. Never returned. |
@@ -852,6 +852,8 @@ Read-only fields are returned but never accepted in requests:
 The minted `access_token`, the `refresh_token`, `username`, `password`, `api_key`, the `client_secret`, and the `token_endpoint_headers` values are never returned in any response.
 
 Password-grant credentials first use the stored initial values with `grant_type=password`. If the token endpoint returns a `refresh_token`, iron-control stores it and uses `grant_type=refresh_token` on later scheduled refreshes. If that stored refresh token is rejected with an unrecoverable OAuth error, iron-control retries once with `grant_type=password`; retryable network, 5xx, rate-limit, and parse failures keep the existing backoff behavior and do not fall back to password.
+
+Client-credentials credentials use the stored `client_id` and encrypted `client_secret` with `grant_type=client_credentials` every time they mint an access token. Providers that return only `access_token`, `token_type`, and `expires_in` are supported; no `refresh_token` is required or stored.
 
 Credentials minted by the [OAuth consent flow](#oauth-consent-flow) are linked to an OAuth app and delegate their `client_id` and `client_secret` to it: rotating the app's secret applies to every credential it minted. Such a credential needs no `client_id`/`client_secret` of its own, and its `scopes` reflect exactly what the IdP granted.
 
@@ -923,6 +925,22 @@ Password-grant providers use the same endpoint with `grant: "password"`:
     "username": "user@example.com",
     "password": "account-password",
     "token_endpoint_headers": { "x-api-key": "api-key" }
+  }
+}
+```
+
+Client-credentials providers use the same endpoint with `grant: "client_credentials"`:
+
+```json
+{
+  "data": {
+    "namespace": "default",
+    "foreign_id": "bloomberg-dl",
+    "name": "Bloomberg DL",
+    "grant": "client_credentials",
+    "token_endpoint": "https://bsso.blpprofessional.com/ext/api/as/token.oauth2",
+    "client_id": "client-id",
+    "client_secret": "client-secret"
   }
 }
 ```

--- a/services/console/lib/broker/credential_grants.rb
+++ b/services/console/lib/broker/credential_grants.rb
@@ -6,8 +6,8 @@ module Broker
     PREQIN_TOKEN_ENDPOINT = "https://api.preqin.com/connect/token".freeze
     PREQIN_REFRESH_TOKEN_ENDPOINT = "https://api.preqin.com/connect/refresh_token".freeze
 
-    GRANTS = %w[refresh_token password preqin].freeze
-    REFRESHABLE_WITHOUT_TOKEN_GRANTS = %w[password preqin].freeze
+    GRANTS = %w[refresh_token client_credentials password preqin].freeze
+    REFRESHABLE_WITHOUT_TOKEN_GRANTS = %w[client_credentials password preqin].freeze
 
     Outcome = Data.define(:result, :clear_refresh_token, :dead_reason)
 
@@ -22,6 +22,8 @@ module Broker
 
       def validate(credential)
         case credential.grant
+        when "client_credentials"
+          validate_client_credentials(credential)
         when "password"
           validate_password(credential)
         when "preqin"
@@ -31,6 +33,8 @@ module Broker
 
       def refresh(credential)
         case credential.grant
+        when "client_credentials"
+          refresh_client_credentials(credential)
         when "password"
           refresh_password(credential)
         when "preqin"
@@ -78,6 +82,15 @@ module Broker
         result = post_token_form(credential, url: credential.token_endpoint,
                                              form: password_form(credential))
         success(result, clear_refresh_token: clear_stale_refresh_token && result.refresh_token.blank?)
+      end
+
+      def refresh_client_credentials(credential)
+        result = post_token_form(
+          credential,
+          url: credential.token_endpoint,
+          form: client_credentials_form(credential)
+        )
+        success(result)
       end
 
       def refresh_preqin(credential)
@@ -161,6 +174,18 @@ module Broker
         add_oauth_optional_fields(form, credential)
       end
 
+      def client_credentials_form(credential)
+        require_value!("client_id", credential.effective_client_id)
+        require_value!("client_secret", credential.effective_client_secret)
+
+        form = {
+          "grant_type" => "client_credentials",
+          "client_id" => credential.effective_client_id,
+          "client_secret" => credential.effective_client_secret
+        }
+        add_oauth_optional_fields(form, credential)
+      end
+
       def preqin_token_form(credential)
         require_value!("username", credential.username)
         require_value!("api_key", credential.api_key)
@@ -192,6 +217,12 @@ module Broker
       def validate_password(credential)
         credential.errors.add(:username, "can't be blank for the password grant") if credential.username.blank?
         credential.errors.add(:password, "can't be blank for the password grant") if credential.password.blank?
+      end
+
+      def validate_client_credentials(credential)
+        if credential.effective_client_secret.blank?
+          credential.errors.add(:client_secret, "can't be blank for the client_credentials grant")
+        end
       end
 
       def validate_preqin(credential)

--- a/services/console/test/controllers/api/v1/broker_credentials_controller_test.rb
+++ b/services/console/test/controllers/api/v1/broker_credentials_controller_test.rb
@@ -119,6 +119,33 @@ module Api
         assert created.next_attempt_at.present?
       end
 
+      test "create client_credentials grant stores client secret and schedules refresh" do
+        body = {
+          data: {
+            namespace: "acme", foreign_id: "bloomberg",
+            grant: "client_credentials",
+            token_endpoint: "https://bsso.blpprofessional.com/ext/api/as/token.oauth2",
+            client_id: "bloomberg-client",
+            client_secret: "bloomberg-secret"
+          }
+        }
+
+        assert_difference -> { BrokerCredential.count } => 1 do
+          post api_v1_broker_credentials_url, params: body.to_json, headers: auth_headers
+        end
+        assert_response :created
+        data = json_body.fetch("data")
+        assert_equal "client_credentials", data["grant"]
+        assert_equal "bloomberg-client", data["client_id"]
+        refute data.key?("client_secret")
+        refute data.key?("refresh_token")
+
+        created = BrokerCredential.find_by_oid(data["id"])
+        assert_equal "bloomberg-secret", created.client_secret
+        assert_nil created.refresh_token
+        assert created.next_attempt_at.present?
+      end
+
       test "create preqin grant stores username and API key and redacts secrets" do
         body = {
           data: {
@@ -175,6 +202,22 @@ module Api
         end
         assert_response :unprocessable_entity
         assert json_body.dig("error", "details", "password").present?
+      end
+
+      test "create client_credentials grant rejects missing client secret" do
+        body = {
+          data: {
+            namespace: "acme", foreign_id: "client-credentials-incomplete",
+            grant: "client_credentials",
+            token_endpoint: "https://idp.example/token",
+            client_id: "cid"
+          }
+        }
+        assert_no_difference -> { BrokerCredential.count } do
+          post api_v1_broker_credentials_url, params: body.to_json, headers: auth_headers
+        end
+        assert_response :unprocessable_entity
+        assert json_body.dig("error", "details", "client_secret").present?
       end
 
       test "create preqin grant rejects missing API key" do
@@ -237,6 +280,25 @@ module Api
         bc.reload
         assert_equal "new-user", bc.username
         assert_equal "new-pass", bc.password
+        refute bc.dead?
+        assert_nil bc.dead_reason
+        assert_equal 0, bc.failure_count
+        assert bc.next_attempt_at.present?
+      end
+
+      test "client_credentials client secret update clears dead state and reschedules" do
+        bc = BrokerCredential.create!(namespace: "acme", foreign_id: "client-credentials-dead",
+                                      grant: "client_credentials", token_endpoint: "https://idp.example/token",
+                                      client_id: "cid", client_secret: "old",
+                                      dead: true, dead_reason: "invalid_client", failure_count: 3,
+                                      created_by: users(:acme_admin))
+
+        body = { data: { client_secret: "new-secret" } }
+        patch api_v1_broker_credential_url(id: bc.oid), params: body.to_json, headers: auth_headers
+        assert_response :ok
+
+        bc.reload
+        assert_equal "new-secret", bc.client_secret
         refute bc.dead?
         assert_nil bc.dead_reason
         assert_equal 0, bc.failure_count

--- a/services/console/test/controllers/console/broker_credentials_controller_test.rb
+++ b/services/console/test/controllers/console/broker_credentials_controller_test.rb
@@ -80,6 +80,29 @@ module Console
       assert_equal({ "x-api-key" => "password-key" }, cred.token_endpoint_headers)
     end
 
+    test "POST create builds a client_credentials credential with a client secret" do
+      assert_difference -> { BrokerCredential.count } => 1 do
+        post console_broker_credentials_url, params: {
+          credential: {
+            namespace: "acme", foreign_id: "bloomberg", name: "Bloomberg",
+            grant: "client_credentials",
+            token_endpoint: "https://bsso.blpprofessional.com/ext/api/as/token.oauth2",
+            client_id: "bloomberg-client", client_secret: "bloomberg-secret",
+            early_refresh_fraction: "0.5", early_refresh_slack_seconds: "120",
+            max_refresh_interval_seconds: "3600", refresh_timeout_seconds: "10"
+          }
+        }
+      end
+
+      cred = BrokerCredential.find_by!(namespace: "acme", foreign_id: "bloomberg")
+      assert_redirected_to console_credential_path(cred.oid)
+      assert_equal "client_credentials", cred.grant
+      assert_equal "bloomberg-client", cred.client_id
+      assert_equal "bloomberg-secret", cred.client_secret
+      assert_nil cred.refresh_token
+      assert cred.next_attempt_at.present?
+    end
+
     test "POST create builds a preqin credential with write-only API key" do
       assert_difference -> { BrokerCredential.count } => 1 do
         post console_broker_credentials_url, params: {
@@ -180,6 +203,33 @@ module Console
       assert_equal "secret", cred.client_secret
       assert_equal "user", cred.username
       assert_equal "pass", cred.password
+    end
+
+    test "PATCH update with a fresh client_credentials client secret reschedules the credential" do
+      cred = BrokerCredential.create!(namespace: "acme", foreign_id: "client-credentials-console",
+                                      grant: "client_credentials", token_endpoint: "https://idp.example/token",
+                                      client_id: "cid", client_secret: "old-secret",
+                                      dead: true, dead_reason: "invalid_client", failure_count: 3,
+                                      created_by: @operator)
+
+      patch console_broker_credential_url(cred.oid), params: {
+        credential: {
+          namespace: cred.namespace, foreign_id: cred.foreign_id,
+          grant: "client_credentials", token_endpoint: cred.token_endpoint,
+          client_id: cred.client_id, client_secret: "new-secret",
+          early_refresh_fraction: cred.early_refresh_fraction,
+          early_refresh_slack_seconds: cred.early_refresh_slack_seconds,
+          max_refresh_interval_seconds: cred.max_refresh_interval_seconds,
+          refresh_timeout_seconds: cred.refresh_timeout_seconds
+        }
+      }
+      assert_redirected_to console_credential_path(cred.oid)
+      cred.reload
+      assert_equal "new-secret", cred.client_secret
+      assert_not cred.dead?
+      assert_nil cred.dead_reason
+      assert_equal 0, cred.failure_count
+      assert cred.next_attempt_at.present?
     end
 
     test "PATCH update with blank preqin fields leaves them in place" do

--- a/services/console/test/models/broker_credential_test.rb
+++ b/services/console/test/models/broker_credential_test.rb
@@ -59,6 +59,19 @@ class BrokerCredentialTest < ActiveSupport::TestCase
     assert bc.valid?, bc.errors.full_messages.to_sentence
   end
 
+  test "client_credentials grant is valid with client credentials and no refresh token" do
+    bc = build_credential(grant: "client_credentials", refresh_token: nil,
+                          client_id: "cid", client_secret: "sec")
+    assert bc.valid?, bc.errors.full_messages.to_sentence
+  end
+
+  test "client_credentials grant requires a client secret" do
+    bc = build_credential(grant: "client_credentials", refresh_token: nil,
+                          client_id: "cid", client_secret: nil)
+    refute bc.valid?
+    assert bc.errors[:client_secret].any? { |m| m.include?("client_credentials grant") }
+  end
+
   test "password grant requires username and password" do
     bc = build_credential(grant: "password", username: "user", password: nil, refresh_token: nil)
     refute bc.valid?
@@ -275,6 +288,29 @@ class BrokerCredentialTest < ActiveSupport::TestCase
     assert_equal "AT", bc.access_token
   end
 
+  test "client_credentials grant refreshes without a refresh_token" do
+    now = Time.current
+    captured = {}
+    bc = create_credential(grant: "client_credentials", refresh_token: nil,
+                           client_id: "bloomberg-client", client_secret: "bloomberg-secret",
+                           scopes: [])
+    bc.refresh_client = StubClient.new do |**kw|
+      captured = kw
+      result(access_token: "AT-client", refresh_token: nil, expires_in: 7199)
+    end
+    bc.refresh!(now: now)
+    bc.reload
+
+    assert_equal "client_credentials", request_grant(captured)
+    assert_equal "bloomberg-client", captured[:form]["client_id"]
+    assert_equal "bloomberg-secret", captured[:form]["client_secret"]
+    refute captured[:form].key?("refresh_token")
+    assert_equal "AT-client", bc.access_token
+    assert_nil bc.refresh_token
+    assert_in_delta (now + 7199).to_f, bc.expires_at.to_f, 1
+    refute bc.dead?
+  end
+
   test "password grant prefers a stored refresh_token" do
     captured = {}
     bc = create_credential(grant: "password", username: "user", password: "pass", refresh_token: "RT-old")
@@ -446,6 +482,14 @@ class BrokerCredentialTest < ActiveSupport::TestCase
   test "refreshable includes preqin credentials without a refresh_token" do
     bc = create_credential(grant: "preqin", client_id: nil, username: "user",
                            api_key: "api-key", refresh_token: nil)
+    bc.update_columns(last_refresh: 1.hour.ago, next_attempt_at: 1.minute.ago)
+
+    assert_includes BrokerCredential.refreshable.pluck(:id), bc.id
+  end
+
+  test "refreshable includes client_credentials without a refresh_token after a prior refresh" do
+    bc = create_credential(grant: "client_credentials", refresh_token: nil,
+                           client_id: "cid", client_secret: "sec")
     bc.update_columns(last_refresh: 1.hour.ago, next_attempt_at: 1.minute.ago)
 
     assert_includes BrokerCredential.refreshable.pluck(:id), bc.id


### PR DESCRIPTION
Adds a generic client_credentials broker grant for OAuth providers that mint short-lived access tokens without issuing refresh tokens. The credential manager now polls those credentials using the stored client ID and encrypted client secret, supports token responses with access_token and expires_in only.