### PR TITLE
feat: add Claude Opus 5 model and Fast effort

### DIFF
--- a/services/console/app/controllers/console/threads_controller.rb
+++ b/services/console/app/controllers/console/threads_controller.rb
@@ -95,9 +95,10 @@ class Console::ThreadsController < ApplicationController
   # serde lowercase); the model ids are the ones the bots' --model flags
   # expand to (services/slackbotv2/src/overrides.ts). Amp appears as a plain
   # entry with no model: it picks its own model per turn. `efforts` are the
-  # per-turn reasoning efforts the harness accepts for the model (codex only —
-  # harness-server discards `reasoning` for claude/amp; enum per
-  # crates/harness-server/src/codex.rs, `max` being 5.6-specific).
+  # per-turn reasoning efforts the harness accepts for the model, except
+  # Claude Opus 5's `fast` choice, which selects OpenRouter's native fast model
+  # variant. Codex's enum lives in crates/harness-server/src/codex.rs, with
+  # `max` being 5.6-specific.
   ComposerAgent = Struct.new(:value, :label, :harness, :model, :efforts, keyword_init: true)
   CODEX_EFFORTS = [
     %w[minimal Minimal],
@@ -106,6 +107,9 @@ class Console::ThreadsController < ApplicationController
     %w[high High],
     [ "xhigh", "Extra High" ]
   ].freeze
+  MODEL_EFFORT_OVERRIDES = {
+    [ "claude-opus-5", "fast" ] => "claude-opus-5-fast"
+  }.freeze
   # First entry doubles as the default pick (unless the deploy's default-model
   # resolution for its harness names another listed model).
   COMPOSER_AGENTS = [
@@ -117,6 +121,9 @@ class Console::ThreadsController < ApplicationController
     ComposerAgent.new(value: "gpt-5.5", label: "GPT-5.5",
                       harness: "codex", model: "gpt-5.5",
                       efforts: CODEX_EFFORTS),
+    ComposerAgent.new(value: "claude-opus-5", label: "Claude Opus 5",
+                      harness: "claudecode", model: "claude-opus-5",
+                      efforts: [ %w[fast Fast] ]),
     ComposerAgent.new(value: "claude-opus-4-8", label: "Claude Opus 4.8",
                       harness: "claudecode", model: "claude-opus-4-8", efforts: []),
     ComposerAgent.new(value: "claude-sonnet-4-6", label: "Claude Sonnet 4.6",
@@ -323,6 +330,10 @@ class Console::ThreadsController < ApplicationController
     agent.efforts.map(&:first).include?(effort) ? effort : nil
   end
 
+  def composer_model_for(agent, effort)
+    MODEL_EFFORT_OVERRIDES.fetch([ agent.model, effort ], agent.model)
+  end
+
   def composer_agent_for(raw)
     value = raw.to_s.strip
     value = composer_default_agent_value if value.blank?
@@ -337,13 +348,18 @@ class Console::ThreadsController < ApplicationController
       return
     end
 
+    effort = composer_effort_param(agent)
+    model = composer_model_for(agent, effort)
+    # A model-variant effort is already encoded in the model slug. Only Codex
+    # consumes the blocks protocol's reasoning field.
+    reasoning = agent.harness == "codex" ? effort : nil
     thread_key = "console:#{SecureRandom.uuid}"
     api_client.create_session(
       thread_key: thread_key,
       harness_type: agent.harness,
-      metadata: console_actor_metadata.merge(agent.model.present? ? { model: agent.model } : {})
+      metadata: console_actor_metadata.merge(model.present? ? { model: model } : {})
     )
-    send_prompt(thread_key, prompt, model: agent.model, effort: composer_effort_param(agent))
+    send_prompt(thread_key, prompt, model: model, effort: reasoning)
     # A new-chat pane in a split view swaps the sentinel for the created
     # thread so the other panes stay open.
     open_keys = params[:open_threads].to_s.split(",").map(&:strip).reject(&:blank?)

--- a/services/console/test/controllers/console/threads_controller_test.rb
+++ b/services/console/test/controllers/console/threads_controller_test.rb
@@ -849,8 +849,15 @@ class Console::ThreadsControllerTest < ActionDispatch::IntegrationTest
       # through a hidden field, not a native select.
       assert_select "input[type=hidden][name=model]", count: 1
       assert_select "[data-console-model-option][data-value=?]", "amp"
+      assert_select "[data-console-model-option][data-value=?]", "claude-opus-5"
       assert_select "select", count: 0
     end
+    picker = css_select("[data-console-model-picker]").first
+    agents = JSON.parse(picker["data-agents"])
+    assert_equal(
+      { "label" => "Claude Opus 5", "efforts" => [ %w[fast Fast] ] },
+      agents["claude-opus-5"]
+    )
     # Submitting replaces the centered empty state with a full-height,
     # bottom-aligned optimistic transcript while the request is in flight.
     assert_includes response.body, 'container.classList.add("console-new-chat--optimistic")'
@@ -1148,10 +1155,46 @@ class Console::ThreadsControllerTest < ActionDispatch::IntegrationTest
     assert_equal "max", line["reasoning"]
   end
 
+  test "Claude Opus 5 Fast selects the native fast model variant" do
+    client = RecordingApiClient.new
+    with_composer(client: client) do
+      post console_threads_url,
+           params: { prompt: "Reply with PONG.", model: "claude-opus-5", effort: "fast" }
+    end
+
+    create = client.calls[0].last
+    assert_equal "claudecode", create[:harness_type]
+    assert_equal "claude-opus-5-fast", create[:metadata][:model]
+
+    execute = client.calls[2].last
+    assert_equal "claude-opus-5-fast", execute[:metadata][:model]
+    assert_not execute[:metadata].key?(:reasoning)
+    line = JSON.parse(execute[:input_lines].first)
+    assert_equal "claude-opus-5-fast", line["model"]
+    assert_not line.key?("reasoning")
+  end
+
+  test "Claude Opus 5 uses the standard model by default" do
+    client = RecordingApiClient.new
+    with_composer(client: client) do
+      post console_threads_url,
+           params: { prompt: "Reply with PONG.", model: "claude-opus-5" }
+    end
+
+    create = client.calls[0].last
+    assert_equal "claudecode", create[:harness_type]
+    assert_equal "claude-opus-5", create[:metadata][:model]
+
+    execute = client.calls[2].last
+    assert_equal "claude-opus-5", execute[:metadata][:model]
+    line = JSON.parse(execute[:input_lines].first)
+    assert_equal "claude-opus-5", line["model"]
+  end
+
   test "an effort the model does not offer is dropped" do
     client = RecordingApiClient.new
     with_composer(client: client) do
-      # max is 5.6-only; claude models take no effort at all.
+      # max is 5.6-only; Opus 4.8 does not offer model-variant efforts.
       post console_threads_url,
            params: { prompt: "Reply with PONG.", model: "gpt-5.5", effort: "max" }
       post console_threads_url,

--- a/services/slackbotv2/src/message-overrides-strategy.ts
+++ b/services/slackbotv2/src/message-overrides-strategy.ts
@@ -21,7 +21,7 @@ const SYSTEM_PROMPT = [
   'Map fuzzy effort words to the nearest reasoning value by magnitude. Examples: tiny/cheap/fast -> low or minimal; normal/default -> medium; deep/strong/intense -> high or xhigh; maximum/superduper/biggest -> max.',
   'Return reasoning even when the requested model is not Codex; validation will ignore reasoning that cannot apply.',
   'Map OpenAI model aliases to canonical IDs: sol -> gpt-5.6-sol, terra -> gpt-5.6-terra, luna -> gpt-5.6-luna, 5.5 -> gpt-5.5, 5.5 pro -> gpt-5.5-pro, 5.4 -> gpt-5.4, 5.4 pro -> gpt-5.4-pro, 5.4 mini -> gpt-5.4-mini, 5.4 nano -> gpt-5.4-nano.',
-  'Map Claude model aliases to canonical IDs: fable -> claude-fable-5, opus -> claude-opus-4-8, opus 4.7 -> claude-opus-4-7, sonnet -> claude-sonnet-4-6, sonnet 5 -> claude-sonnet-5, haiku -> claude-haiku-4-5.',
+  'Map Claude model aliases to canonical IDs: fable -> claude-fable-5, opus -> claude-opus-4-8, opus 4.7 -> claude-opus-4-7, opus 5 -> claude-opus-5, opus 5 fast -> claude-opus-5-fast, sonnet -> claude-sonnet-4-6, sonnet 5 -> claude-sonnet-5, haiku -> claude-haiku-4-5.',
   'Map Amp model aliases to canonical IDs: deep -> deep, fast -> fast.',
   'For example, "use max effort and the sol model" should return model "gpt-5.6-sol" and reasoning "max".',
   'Do not treat ordinary discussion of model names as a selection request.'
@@ -32,6 +32,8 @@ const MODEL_VALUES = [
   'claude-haiku-4-5',
   'claude-opus-4-7',
   'claude-opus-4-8',
+  'claude-opus-5',
+  'claude-opus-5-fast',
   'claude-sonnet-4-6',
   'claude-sonnet-5',
   'deep',

--- a/services/slackbotv2/src/overrides.ts
+++ b/services/slackbotv2/src/overrides.ts
@@ -89,6 +89,8 @@ const STRATEGY_MODEL_HARNESSES: Record<string, string> = {
   'claude-haiku-4-5': 'claudecode',
   'claude-opus-4-7': 'claudecode',
   'claude-opus-4-8': 'claudecode',
+  'claude-opus-5': 'claudecode',
+  'claude-opus-5-fast': 'claudecode',
   'claude-sonnet-4-6': 'claudecode',
   'claude-sonnet-5': 'claudecode',
   deep: 'amp',

--- a/services/slackbotv2/test/overrides.test.ts
+++ b/services/slackbotv2/test/overrides.test.ts
@@ -364,6 +364,18 @@ describe('validateStrategyOverrides', () => {
       provider: undefined,
       reasoning: undefined
     })
+    expect(validateStrategyOverrides({ model: 'claude-opus-5' })).toEqual({
+      harnessType: 'claudecode',
+      model: 'claude-opus-5',
+      provider: undefined,
+      reasoning: undefined
+    })
+    expect(validateStrategyOverrides({ model: 'claude-opus-5-fast' })).toEqual({
+      harnessType: 'claudecode',
+      model: 'claude-opus-5-fast',
+      provider: undefined,
+      reasoning: undefined
+    })
     expect(validateStrategyOverrides({ model: 'claude-sonnet-4-6' })).toEqual({
       harnessType: 'claudecode',
       model: 'claude-sonnet-4-6',


### PR DESCRIPTION
## Summary

- add Claude Opus 5 to the Console and Slack model selectors
- expose Fast as a Console effort for Claude Opus 5
- resolve Fast to the native `claude-opus-5-fast` model variant

## Validation

- `pnpm exec bun test test/overrides.test.ts` (45 passed)
- focused Rails controller tests (3 passed, 27 assertions)
- RuboCop on the changed Rails controller and tests
- `git diff --check`

## Known issue

- `pnpm --filter slackbotv2 run check:types` remains blocked by the
  pre-existing `services/slackbotv2/src/session-api.ts:872` error

Closes [paradigmxyz/centaur#1174](https://github.com/paradigmxyz/centaur/pull/1174)
