### PR TITLE
fix(slackbotv2): show resolved harness in footer

### DIFF
--- a/services/slackbotv2/src/console-session-link.ts
+++ b/services/slackbotv2/src/console-session-link.ts
@@ -167,16 +167,13 @@ export function buildConsoleSessionContextBlock(params: {
   harnessType?: string | null
   model?: string | null
   reasoning?: string | null
-  abTested?: boolean
 }): SlackContextBlock | undefined {
   const url = consoleSessionUrl(params.consoleBaseUrl, params.threadKey)
   if (!url) return undefined
   const segments = [`<${url}|Open chat in Console>`]
   const model = params.model?.trim()
   if (model) segments.push(escapeSlackMrkdwn(model.toUpperCase()))
-  // Keep experiment assignment unobtrusive in Slack. The asterisk identifies
-  // an A/B-assigned Codex request without exposing its internal cohort.
-  const harness = params.abTested ? 'Codex*' : harnessDisplayName(params.harnessType)
+  const harness = harnessDisplayName(params.harnessType)
   if (harness) segments.push(escapeSlackMrkdwn(harness))
   const reasoning = reasoningDisplayName(params.reasoning)
   if (reasoning) segments.push(escapeSlackMrkdwn(reasoning))

--- a/services/slackbotv2/src/index.ts
+++ b/services/slackbotv2/src/index.ts
@@ -1201,8 +1201,7 @@ async function syncThreadMessageToSession(
             threadKey: thread.id,
             harnessType,
             model,
-            reasoning,
-            abTested
+            reasoning
           })
         }
         traceLog(input.options, 'slackbotv2_session_harness_resolved', trace, {

--- a/services/slackbotv2/test/chat-sdk-emulate.test.ts
+++ b/services/slackbotv2/test/chat-sdk-emulate.test.ts
@@ -775,7 +775,7 @@ describe('slackbotv2', () => {
     expect(consoleBlockTexts(slackApi.calls)).toHaveLength(0)
   })
 
-  it('marks API-assigned cohorts subtly in Slack and retains execution metadata', async () => {
+  it('shows the API-assigned harness in Slack and retains execution metadata', async () => {
     const sharedState = createMemoryState()
     await sharedState.connect()
     codexApi.resolvedHarnessType = 'nanocodex'
@@ -818,10 +818,9 @@ describe('slackbotv2', () => {
       .flatMap(call => (Array.isArray(call.body.blocks) ? (call.body.blocks as unknown[]) : []))
       .map(block => JSON.stringify(block))
       .find(text => text.includes('Open chat in Console'))
-    expect(footer).toContain('Codex*')
+    expect(footer).toContain('Nanocodex')
     expect(footer).toContain('Low')
-    expect(footer).not.toContain('Nanocodex')
-    expect(footer).not.toContain('A/B test')
+    expect(footer).not.toContain('Codex*')
     expect(codexApi.creates[0]?.body.harness_type).toBe('codex')
     expect(codexApi.executes[0]?.body.metadata).toMatchObject({
       harness_type: 'nanocodex',

--- a/services/slackbotv2/test/console-session-link.test.ts
+++ b/services/slackbotv2/test/console-session-link.test.ts
@@ -144,18 +144,17 @@ describe('buildConsoleSessionContextBlock', () => {
     )
   })
 
-  test('marks experiment assignments as Codex without exposing the cohort', () => {
+  test('shows the resolved Nanocodex harness', () => {
     const block = buildConsoleSessionContextBlock({
       consoleBaseUrl: 'https://console.centaur.dev',
       threadKey: 'slack:C1:1',
       harnessType: 'nanocodex',
       model: 'gpt-5.6-sol',
-      reasoning: 'low',
-      abTested: true
+      reasoning: 'low'
     })
 
     expect(block?.elements[0]?.text).toBe(
-      '<https://console.centaur.dev/console/threads?thread=slack%3AC1%3A1|Open chat in Console> · GPT-5.6-SOL · Codex* · Low'
+      '<https://console.centaur.dev/console/threads?thread=slack%3AC1%3A1|Open chat in Console> · GPT-5.6-SOL · Nanocodex · Low'
     )
   })
 


### PR DESCRIPTION
## Summary

- show the actual resolved harness in the Slack Console footer for Codex/Nanocodex A/B sessions
- keep A/B assignment provenance in structured logs and execution metadata
- update unit and Slack emulation coverage for the Nanocodex cohort

## Root cause

The footer renderer treated any A/B-assigned session as `Codex*`, even after api-rs returned the persisted resolved harness. This made Nanocodex and Codex runs indistinguishable in Slack.

## User impact

A/B replies now display `Nanocodex` or `Codex` according to the harness that actually ran.

## Validation

- `npx --yes bun@1.3.13 tsgo --project tsconfig.json --noEmit`
- `npx --yes bun@1.3.13 test test` (215 passed, 1 skipped)