### PR TITLE
feat: add Linear project milestone support

### DIFF
--- a/tools/productivity/linear/cli.py
+++ b/tools/productivity/linear/cli.py
@@ -177,6 +177,8 @@ def issue(
         console.print(f"Assignee: {result['assignee'].get('name', '')}")
     if result.get("project"):
         console.print(f"Project: {result['project'].get('name', '')}")
+    if result.get("projectMilestone"):
+        console.print(f"Milestone: {result['projectMilestone'].get('name', '')}")
     if result.get("cycle"):
         console.print(f"Cycle: {result['cycle'].get('name', '')}")
 
@@ -307,6 +309,7 @@ def update(
     due_date: str = typer.Option(None, "--due-date", help="Due date as YYYY-MM-DD"),
     priority: int = typer.Option(None, "--priority", "-p", help="Priority (0-4)"),
     project: str = typer.Option(None, "--project", help="Project name to add issue to"),
+    milestone: str = typer.Option(None, "--milestone", help="Project milestone name"),
 ):
     """Update an existing issue.
 
@@ -314,6 +317,7 @@ def update(
         linear update ENG-123 --state "In Progress"
         linear update ENG-123 --assignee me
         linear update ENG-123 --project "Q1 Roadmap"
+        linear update ENG-123 --milestone "Public beta"
     """
     client = get_client()
 
@@ -363,6 +367,25 @@ def update(
             console.print(f"[red]Project '{project}' not found.[/]")
             raise typer.Exit(1)
 
+    project_milestone_id = None
+    if milestone:
+        issue_project = project_id or (current.get("project") or {}).get("id")
+        if not issue_project:
+            console.print("[red]A milestone requires the issue to belong to a project.[/]")
+            raise typer.Exit(1)
+        milestone_match = next(
+            (
+                item
+                for item in client.project_milestones(project_id=issue_project)
+                if milestone.lower() == item.get("name", "").lower()
+            ),
+            None,
+        )
+        if not milestone_match:
+            console.print(f"[red]Milestone '{milestone}' not found in the issue's project.[/]")
+            raise typer.Exit(1)
+        project_milestone_id = milestone_match.get("id")
+
     result = client.update_issue(
         issue_id=issue_id,
         title=title,
@@ -371,6 +394,7 @@ def update(
         due_date=due_date,
         priority=priority,
         project_id=project_id,
+        project_milestone_id=project_milestone_id,
     )
 
     require_mutation_success(result, "issue update")
@@ -379,6 +403,8 @@ def update(
     console.print(f"State: {result.get('state', {}).get('name', '')}")
     if result.get("project"):
         console.print(f"Project: {result.get('project', {}).get('name', '')}")
+    if result.get("projectMilestone"):
+        console.print(f"Milestone: {result.get('projectMilestone', {}).get('name', '')}")
     console.print(f"[dim]{result.get('url')}[/]")
 
 
@@ -434,6 +460,48 @@ def projects(
             proj.get("targetDate") or "",
         )
 
+    console.print(table)
+
+
+@app.command("milestones")
+def milestones(
+    project: str = typer.Option(None, "--project", "-p", help="Filter by project name"),
+    limit: int = typer.Option(50, "--limit", "-n", help="Max results"),
+    json_output: bool = typer.Option(False, "--json", help="Output as JSON"),
+):
+    """List project milestones."""
+    client = get_client()
+    project_id = None
+    if project:
+        project_match = next(
+            (p for p in client.projects() if project.lower() in p.get("name", "").lower()),
+            None,
+        )
+        if not project_match:
+            console.print(f"[red]Project '{project}' not found.[/]")
+            raise typer.Exit(1)
+        project_id = project_match["id"]
+
+    result = client.project_milestones(project_id=project_id, limit=limit)
+    if json_output:
+        print(json.dumps(result, indent=2, default=str), file=sys.stdout)
+        raise typer.Exit()
+    if not result:
+        console.print("[yellow]No milestones found.[/]")
+        raise typer.Exit()
+
+    table = Table(title=f"Project milestones ({len(result)})")
+    table.add_column("Project", style="cyan", max_width=30)
+    table.add_column("Milestone", style="white", max_width=30)
+    table.add_column("Progress", style="yellow", max_width=10)
+    table.add_column("Target", style="dim", max_width=12)
+    for item in result:
+        table.add_row(
+            (item.get("project") or {}).get("name", ""),
+            item.get("name", ""),
+            f"{int(item.get('progress', 0) * 100)}%",
+            item.get("targetDate") or "",
+        )
     console.print(table)
 
 

--- a/tools/productivity/linear/cli.py
+++ b/tools/productivity/linear/cli.py
@@ -61,6 +61,23 @@ def require_mutation_success(result: dict, action: str) -> None:
         raise typer.Exit(1)
 
 
+def find_project(client, name: str) -> dict | None:
+    """Resolve a project by exact name before falling back to a partial match."""
+    projects = client.projects(limit=None)
+    normalized = name.casefold()
+    return next(
+        (project for project in projects if project.get("name", "").casefold() == normalized),
+        next(
+            (
+                project
+                for project in projects
+                if normalized in project.get("name", "").casefold()
+            ),
+            None,
+        ),
+    )
+
+
 @app.command()
 def me():
     """Show authenticated user info."""
@@ -356,11 +373,7 @@ def update(
 
     project_id = None
     if project:
-        projects_list = client.projects()
-        project_match = next(
-            (p for p in projects_list if project.lower() in p.get("name", "").lower()),
-            None,
-        )
+        project_match = find_project(client, project)
         if project_match:
             project_id = project_match.get("id")
         else:
@@ -473,10 +486,7 @@ def milestones(
     client = get_client()
     project_id = None
     if project:
-        project_match = next(
-            (p for p in client.projects() if project.lower() in p.get("name", "").lower()),
-            None,
-        )
+        project_match = find_project(client, project)
         if not project_match:
             console.print(f"[red]Project '{project}' not found.[/]")
             raise typer.Exit(1)
@@ -499,7 +509,7 @@ def milestones(
         table.add_row(
             (item.get("project") or {}).get("name", ""),
             item.get("name", ""),
-            f"{int(item.get('progress', 0) * 100)}%",
+            f"{item.get('progress', 0):g}%",
             item.get("targetDate") or "",
         )
     console.print(table)
@@ -517,12 +527,7 @@ def project_detail(
         linear project roadmap --json
     """
     client = get_client()
-    projects_list = client.projects()
-
-    project_match = next(
-        (p for p in projects_list if project_name.lower() in p.get("name", "").lower()),
-        None,
-    )
+    project_match = find_project(client, project_name)
     if not project_match:
         console.print(f"[red]Project '{project_name}' not found.[/]")
         raise typer.Exit(1)

--- a/tools/productivity/linear/cli.py
+++ b/tools/productivity/linear/cli.py
@@ -129,6 +129,8 @@ def issues(
         None, "--assignee", "-a", help="Filter by assignee (use 'me' for self)"
     ),
     state: str = typer.Option(None, "--state", "-s", help="Filter by state name"),
+    project: str = typer.Option(None, "--project", help="Filter by project name"),
+    milestone: str = typer.Option(None, "--milestone", help="Filter by project milestone"),
     limit: int = typer.Option(25, "--limit", "-n", help="Max results"),
     full: bool = typer.Option(False, "--full", "-f", help="Show full details"),
     json_output: bool = typer.Option(False, "--json", help="Output as JSON"),
@@ -139,9 +141,36 @@ def issues(
         linear issues --team ENG --assignee me
         linear issues --state "In Progress" -n 50
         linear issues -t ENG -s Done --json
+        linear issues --project Solar --milestone LSP
     """
     client = get_client()
-    result = client.issues(team_key=team, assignee=assignee, state=state, limit=limit)
+    project_id = None
+    if project:
+        project_match = find_project(client, project)
+        if not project_match:
+            console.print(f"[red]Project '{project}' not found.[/]")
+            raise typer.Exit(1)
+        project_id = project_match["id"]
+
+    project_milestone_id = None
+    if milestone:
+        if not project_id:
+            console.print("[red]--milestone requires --project when listing issues.[/]")
+            raise typer.Exit(1)
+        milestone_match = find_project_milestone(client, project_id, milestone)
+        if not milestone_match:
+            console.print(f"[red]Milestone '{milestone}' not found in project '{project}'.[/]")
+            raise typer.Exit(1)
+        project_milestone_id = milestone_match["id"]
+
+    result = client.issues(
+        team_key=team,
+        assignee=assignee,
+        state=state,
+        project_id=project_id,
+        project_milestone_id=project_milestone_id,
+        limit=limit,
+    )
 
     if not result:
         console.print("[yellow]No issues found.[/]")
@@ -159,6 +188,11 @@ def issues(
             )
             console.print(f"\n[bold cyan]{issue.get('identifier')}[/] {issue.get('title')}")
             console.print(f"  State: [green]{state_name}[/]  Assignee: {assignee_name or '-'}")
+            if issue.get("project"):
+                project_name = issue["project"].get("name", "")
+                milestone_name = (issue.get("projectMilestone") or {}).get("name")
+                suffix = f" / {milestone_name}" if milestone_name else ""
+                console.print(f"  Project: {project_name}{suffix}")
             if issue.get("description"):
                 desc = issue["description"][:200].replace("\n", " ")
                 console.print(f"  {desc}{'...' if len(issue['description']) > 200 else ''}")
@@ -615,8 +649,11 @@ def project_detail(
     if issues:
         console.print(f"\n[bold]Issues ({len(issues)}):[/]")
         for iss in issues[:10]:
+            milestone = (iss.get("projectMilestone") or {}).get("name")
+            milestone_suffix = f" — {milestone}" if milestone else ""
             console.print(
-                f"  {iss.get('identifier')} - {iss.get('title')[:50]} [{iss.get('state', {}).get('name', '')}]"
+                f"  {iss.get('identifier')} - {iss.get('title')[:50]} "
+                f"[{iss.get('state', {}).get('name', '')}]{milestone_suffix}"
             )
         if len(issues) > 10:
             console.print(f"  ... and {len(issues) - 10} more")

--- a/tools/productivity/linear/cli.py
+++ b/tools/productivity/linear/cli.py
@@ -78,6 +78,19 @@ def find_project(client, name: str) -> dict | None:
     )
 
 
+def find_project_milestone(client, project_id: str, name: str) -> dict | None:
+    """Resolve a milestone by exact name within one project."""
+    normalized = name.casefold()
+    return next(
+        (
+            milestone
+            for milestone in client.project_milestones(project_id=project_id, limit=None)
+            if milestone.get("name", "").casefold() == normalized
+        ),
+        None,
+    )
+
+
 @app.command()
 def me():
     """Show authenticated user info."""
@@ -263,6 +276,8 @@ def create(
     parent: str = typer.Option(
         None, "--parent", help="Parent issue identifier (e.g., ENG-123) for sub-issues"
     ),
+    project: str = typer.Option(None, "--project", help="Project name"),
+    milestone: str = typer.Option(None, "--milestone", help="Project milestone name"),
 ):
     """Create a new issue.
 
@@ -270,6 +285,7 @@ def create(
         linear create "Fix login bug" --team ENG
         linear create "New feature" -t ENG -d "Description here" -p 2
         linear create "Sub-task" -t ENG --parent ENG-123
+        linear create "Beta task" -t ENG --project "Q1 Roadmap" --milestone "Public beta"
     """
     client = get_client()
 
@@ -301,6 +317,25 @@ def create(
             raise typer.Exit(1)
         parent_id = parent_issue.get("id")
 
+    project_id = None
+    if project:
+        project_match = find_project(client, project)
+        if not project_match:
+            console.print(f"[red]Project '{project}' not found.[/]")
+            raise typer.Exit(1)
+        project_id = project_match["id"]
+
+    project_milestone_id = None
+    if milestone:
+        if not project_id:
+            console.print("[red]--milestone requires --project when creating an issue.[/]")
+            raise typer.Exit(1)
+        milestone_match = find_project_milestone(client, project_id, milestone)
+        if not milestone_match:
+            console.print(f"[red]Milestone '{milestone}' not found in project '{project}'.[/]")
+            raise typer.Exit(1)
+        project_milestone_id = milestone_match["id"]
+
     result = client.create_issue(
         title=title,
         team_id=team_match["id"],
@@ -309,11 +344,17 @@ def create(
         due_date=due_date,
         priority=priority,
         parent_id=parent_id,
+        project_id=project_id,
+        project_milestone_id=project_milestone_id,
     )
 
     require_mutation_success(result, "issue creation")
 
     console.print(f"[green]Created:[/] [bold]{result.get('identifier')}[/] {result.get('title')}")
+    if result.get("project"):
+        console.print(f"Project: {result['project'].get('name', '')}")
+    if result.get("projectMilestone"):
+        console.print(f"Milestone: {result['projectMilestone'].get('name', '')}")
     console.print(f"[dim]{result.get('url')}[/]")
 
 
@@ -327,6 +368,9 @@ def update(
     priority: int = typer.Option(None, "--priority", "-p", help="Priority (0-4)"),
     project: str = typer.Option(None, "--project", help="Project name to add issue to"),
     milestone: str = typer.Option(None, "--milestone", help="Project milestone name"),
+    clear_milestone: bool = typer.Option(
+        False, "--clear-milestone", help="Remove the issue's project milestone"
+    ),
 ):
     """Update an existing issue.
 
@@ -335,6 +379,7 @@ def update(
         linear update ENG-123 --assignee me
         linear update ENG-123 --project "Q1 Roadmap"
         linear update ENG-123 --milestone "Public beta"
+        linear update ENG-123 --clear-milestone
     """
     client = get_client()
 
@@ -380,20 +425,17 @@ def update(
             console.print(f"[red]Project '{project}' not found.[/]")
             raise typer.Exit(1)
 
+    if milestone and clear_milestone:
+        console.print("[red]--milestone and --clear-milestone are mutually exclusive.[/]")
+        raise typer.Exit(1)
+
     project_milestone_id = None
     if milestone:
         issue_project = project_id or (current.get("project") or {}).get("id")
         if not issue_project:
             console.print("[red]A milestone requires the issue to belong to a project.[/]")
             raise typer.Exit(1)
-        milestone_match = next(
-            (
-                item
-                for item in client.project_milestones(project_id=issue_project)
-                if milestone.lower() == item.get("name", "").lower()
-            ),
-            None,
-        )
+        milestone_match = find_project_milestone(client, issue_project, milestone)
         if not milestone_match:
             console.print(f"[red]Milestone '{milestone}' not found in the issue's project.[/]")
             raise typer.Exit(1)
@@ -408,6 +450,7 @@ def update(
         priority=priority,
         project_id=project_id,
         project_milestone_id=project_milestone_id,
+        clear_project_milestone=clear_milestone,
     )
 
     require_mutation_success(result, "issue update")
@@ -558,6 +601,15 @@ def project_detail(
     if teams:
         team_names = ", ".join(t.get("key", "") for t in teams)
         console.print(f"Teams: {team_names}")
+
+    milestones = result.get("projectMilestones", {}).get("nodes", [])
+    if milestones:
+        console.print(f"\n[bold]Milestones ({len(milestones)}):[/]")
+        for milestone in milestones:
+            target = f" — {milestone['targetDate']}" if milestone.get("targetDate") else ""
+            console.print(
+                f"  {milestone.get('name')} ({milestone.get('progress', 0):g}%){target}"
+            )
 
     issues = result.get("issues", {}).get("nodes", [])
     if issues:

--- a/tools/productivity/linear/client.py
+++ b/tools/productivity/linear/client.py
@@ -55,7 +55,7 @@ class LinearClient(LinearReadonlyClient):
         return super().projects(limit=limit)
 
     def project_milestones(
-        self, project_id: str | None = None, limit: int = 50
+        self, project_id: str | None = None, limit: int | None = 50
     ) -> list[dict[str, Any]]:
         """List project milestones, optionally filtered by project ID."""
         return super().project_milestones(project_id=project_id, limit=limit)
@@ -117,7 +117,11 @@ class LinearClient(LinearReadonlyClient):
         mutation IssueCreate($input: IssueCreateInput!) {
             issueCreate(input: $input) {
                 success
-                issue { id identifier title dueDate url }
+                issue {
+                    id identifier title dueDate project { id name }
+                    projectMilestone { id name targetDate }
+                    url
+                }
             }
         }
         """
@@ -156,6 +160,7 @@ class LinearClient(LinearReadonlyClient):
         priority: int | None = None,
         project_id: str | None = None,
         project_milestone_id: str | None = None,
+        clear_project_milestone: bool = False,
         due_date: str | None = None,
     ) -> dict[str, Any]:
         """Update an existing issue.
@@ -188,8 +193,14 @@ class LinearClient(LinearReadonlyClient):
             input_data["priority"] = priority
         if project_id:
             input_data["projectId"] = project_id
+        if project_milestone_id and clear_project_milestone:
+            raise ValueError(
+                "project_milestone_id and clear_project_milestone are mutually exclusive"
+            )
         if project_milestone_id:
             input_data["projectMilestoneId"] = project_milestone_id
+        elif clear_project_milestone:
+            input_data["projectMilestoneId"] = None
         if due_date:
             input_data["dueDate"] = due_date
 

--- a/tools/productivity/linear/client.py
+++ b/tools/productivity/linear/client.py
@@ -50,7 +50,7 @@ class LinearClient(LinearReadonlyClient):
         """Download a Linear-hosted asset such as an embedded screenshot."""
         return super().fetch_asset(url, filename=filename)
 
-    def projects(self, limit: int = 50) -> list[dict[str, Any]]:
+    def projects(self, limit: int | None = 50) -> list[dict[str, Any]]:
         """List projects."""
         return super().projects(limit=limit)
 

--- a/tools/productivity/linear/client.py
+++ b/tools/productivity/linear/client.py
@@ -30,6 +30,8 @@ class LinearClient(LinearReadonlyClient):
         team_key: str | None = None,
         assignee: str | None = None,
         state: str | None = None,
+        project_id: str | None = None,
+        project_milestone_id: str | None = None,
         limit: int = 50,
         include_archived: bool = False,
     ) -> list[dict[str, Any]]:
@@ -38,6 +40,8 @@ class LinearClient(LinearReadonlyClient):
             team_key=team_key,
             assignee=assignee,
             state=state,
+            project_id=project_id,
+            project_milestone_id=project_milestone_id,
             limit=limit,
             include_archived=include_archived,
         )

--- a/tools/productivity/linear/client.py
+++ b/tools/productivity/linear/client.py
@@ -54,6 +54,12 @@ class LinearClient(LinearReadonlyClient):
         """List projects."""
         return super().projects(limit=limit)
 
+    def project_milestones(
+        self, project_id: str | None = None, limit: int = 50
+    ) -> list[dict[str, Any]]:
+        """List project milestones, optionally filtered by project ID."""
+        return super().project_milestones(project_id=project_id, limit=limit)
+
     def project(self, project_id: str) -> dict[str, Any]:
         """Get a single project."""
         return super().project(project_id)
@@ -97,6 +103,7 @@ class LinearClient(LinearReadonlyClient):
         priority: int | None = None,
         label_ids: list[str] | None = None,
         project_id: str | None = None,
+        project_milestone_id: str | None = None,
         cycle_id: str | None = None,
         parent_id: str | None = None,
         due_date: str | None = None,
@@ -127,6 +134,8 @@ class LinearClient(LinearReadonlyClient):
             input_data["labelIds"] = label_ids
         if project_id:
             input_data["projectId"] = project_id
+        if project_milestone_id:
+            input_data["projectMilestoneId"] = project_milestone_id
         if cycle_id:
             input_data["cycleId"] = cycle_id
         if parent_id:
@@ -146,6 +155,7 @@ class LinearClient(LinearReadonlyClient):
         assignee_id: str | None = None,
         priority: int | None = None,
         project_id: str | None = None,
+        project_milestone_id: str | None = None,
         due_date: str | None = None,
     ) -> dict[str, Any]:
         """Update an existing issue.
@@ -157,7 +167,11 @@ class LinearClient(LinearReadonlyClient):
         mutation IssueUpdate($id: String!, $input: IssueUpdateInput!) {
             issueUpdate(id: $id, input: $input) {
                 success
-                issue { id identifier title dueDate state { name } project { id name } url }
+                issue {
+                    id identifier title dueDate state { name } project { id name }
+                    projectMilestone { id name targetDate }
+                    url
+                }
             }
         }
         """
@@ -174,6 +188,8 @@ class LinearClient(LinearReadonlyClient):
             input_data["priority"] = priority
         if project_id:
             input_data["projectId"] = project_id
+        if project_milestone_id:
+            input_data["projectMilestoneId"] = project_milestone_id
         if due_date:
             input_data["dueDate"] = due_date
 

--- a/tools/productivity/linear/pyproject.toml
+++ b/tools/productivity/linear/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "linear"
-description = "Linear issue tracking — issues, projects, cycles, teams"
+description = "Linear issue tracking — issues, projects, milestones, cycles, teams"
 version = "0.1.0"
 requires-python = ">=3.11"
 dependencies = [

--- a/tools/productivity/linear/readonly.py
+++ b/tools/productivity/linear/readonly.py
@@ -62,6 +62,8 @@ class LinearReadonlyClient(LinearGraphQLClient):
         team_key: str | None = None,
         assignee: str | None = None,
         state: str | None = None,
+        project_id: str | None = None,
+        project_milestone_id: str | None = None,
         limit: int = 50,
         include_archived: bool = False,
     ) -> list[dict[str, Any]]:
@@ -79,6 +81,15 @@ class LinearReadonlyClient(LinearGraphQLClient):
         if state:
             filters.append(
                 f"state: {{ name: {{ containsIgnoreCase: {_linear_string_literal(state)} }} }}"
+            )
+        if project_id:
+            filters.append(
+                f"project: {{ id: {{ eq: {_linear_string_literal(project_id)} }} }}"
+            )
+        if project_milestone_id:
+            filters.append(
+                "projectMilestone: "
+                f"{{ id: {{ eq: {_linear_string_literal(project_milestone_id)} }} }}"
             )
 
         filter_arg = f"filter: {{ {', '.join(filters)} }}, " if filters else ""
@@ -325,7 +336,12 @@ class LinearReadonlyClient(LinearGraphQLClient):
                 projectMilestones {
                     nodes { id name description targetDate progress }
                 }
-                issues { nodes { id identifier title state { name } } }
+                issues {
+                    nodes {
+                        id identifier title state { name }
+                        projectMilestone { id name targetDate }
+                    }
+                }
                 url
             }
         }
@@ -431,6 +447,8 @@ class LinearReadonlyClient(LinearGraphQLClient):
                     state { name }
                     assignee { name }
                     team { key }
+                    project { id name }
+                    projectMilestone { id name targetDate }
                     dueDate
                     url
                 }

--- a/tools/productivity/linear/readonly.py
+++ b/tools/productivity/linear/readonly.py
@@ -102,6 +102,7 @@ class LinearReadonlyClient(LinearGraphQLClient):
                     assignee {{ id name }}
                     team {{ id name key }}
                     project {{ id name }}
+                    projectMilestone {{ id name targetDate }}
                     cycle {{ id name number }}
                     labels {{ nodes {{ id name color }} }}
                     dueDate
@@ -135,6 +136,7 @@ class LinearReadonlyClient(LinearGraphQLClient):
                 assignee { id name }
                 team { id name key }
                 project { id name }
+                projectMilestone { id name targetDate }
                 cycle { id name number }
                 labels { nodes { id name color } }
                 comments { nodes { id body user { name } createdAt } }
@@ -207,6 +209,46 @@ class LinearReadonlyClient(LinearGraphQLClient):
         }
         """
         return self._connection_nodes(query, connection_path=("projects",), limit=limit)
+
+    def project_milestones(
+        self, project_id: str | None = None, limit: int = 50
+    ) -> list[dict[str, Any]]:
+        """List project milestones, optionally filtered by project ID."""
+        filter_arg = "filter: { project: { id: { eq: $projectId } } }," if project_id else ""
+        project_id_var = "$projectId: ID,\n" if project_id else ""
+        query = f"""
+        query ProjectMilestones(
+            {project_id_var}
+            $first: Int!,
+            $after: String
+        ) {{
+            projectMilestones(
+                {filter_arg}
+                first: $first,
+                after: $after,
+                orderBy: updatedAt
+            ) {{
+                nodes {{
+                    id
+                    name
+                    description
+                    targetDate
+                    progress
+                    project {{ id name }}
+                    createdAt
+                    updatedAt
+                }}
+                pageInfo {{ hasNextPage endCursor }}
+            }}
+        }}
+        """
+        variables = {"projectId": project_id} if project_id else None
+        return self._connection_nodes(
+            query,
+            connection_path=("projectMilestones",),
+            variables=variables,
+            limit=limit,
+        )
 
     def list_etl_projects(
         self,

--- a/tools/productivity/linear/readonly.py
+++ b/tools/productivity/linear/readonly.py
@@ -211,7 +211,7 @@ class LinearReadonlyClient(LinearGraphQLClient):
         return self._connection_nodes(query, connection_path=("projects",), limit=limit)
 
     def project_milestones(
-        self, project_id: str | None = None, limit: int = 50
+        self, project_id: str | None = None, limit: int | None = 50
     ) -> list[dict[str, Any]]:
         """List project milestones, optionally filtered by project ID."""
         filter_arg = "filter: { project: { id: { eq: $projectId } } }," if project_id else ""
@@ -322,6 +322,9 @@ class LinearReadonlyClient(LinearGraphQLClient):
                 targetDate
                 lead { id name }
                 teams { nodes { id name key } }
+                projectMilestones {
+                    nodes { id name description targetDate progress }
+                }
                 issues { nodes { id identifier title state { name } } }
                 url
             }

--- a/tools/productivity/linear/readonly.py
+++ b/tools/productivity/linear/readonly.py
@@ -187,7 +187,7 @@ class LinearReadonlyClient(LinearGraphQLClient):
             "byte_length": len(content),
         }
 
-    def projects(self, limit: int = 50) -> list[dict[str, Any]]:
+    def projects(self, limit: int | None = 50) -> list[dict[str, Any]]:
         """List projects."""
         query = """
         query Projects($first: Int!, $after: String) {

--- a/tools/productivity/linear/test_client.py
+++ b/tools/productivity/linear/test_client.py
@@ -88,6 +88,21 @@ def test_update_issue_merges_success_into_issue_fields():
     assert updated["success"] is True
 
 
+def test_update_issue_sets_project_milestone():
+    client = RecordingLinearClient(
+        {
+            "issueUpdate": {
+                "success": True,
+                "issue": {"id": "issue-1", "identifier": "ENG-1"},
+            }
+        }
+    )
+
+    client.update_issue("ENG-1", project_milestone_id="milestone-1")
+
+    assert client.calls[0]["variables"]["input"] == {"projectMilestoneId": "milestone-1"}
+
+
 def test_add_comment_merges_success_into_comment_fields():
     client = RecordingLinearClient(
         {"commentCreate": {"success": True, "comment": {"id": "comment-1", "body": "hi"}}}

--- a/tools/productivity/linear/test_client.py
+++ b/tools/productivity/linear/test_client.py
@@ -72,6 +72,31 @@ def test_create_issue_merges_success_into_issue_fields():
     }
 
 
+def test_create_issue_sets_project_and_milestone():
+    client = RecordingLinearClient(
+        {
+            "issueCreate": {
+                "success": True,
+                "issue": {"id": "issue-1", "identifier": "ENG-1"},
+            }
+        }
+    )
+
+    client.create_issue(
+        "Test",
+        team_id="team-1",
+        project_id="project-1",
+        project_milestone_id="milestone-1",
+    )
+
+    assert client.calls[0]["variables"]["input"] == {
+        "title": "Test",
+        "teamId": "team-1",
+        "projectId": "project-1",
+        "projectMilestoneId": "milestone-1",
+    }
+
+
 def test_update_issue_merges_success_into_issue_fields():
     client = RecordingLinearClient(
         {
@@ -101,6 +126,36 @@ def test_update_issue_sets_project_milestone():
     client.update_issue("ENG-1", project_milestone_id="milestone-1")
 
     assert client.calls[0]["variables"]["input"] == {"projectMilestoneId": "milestone-1"}
+
+
+def test_update_issue_clears_project_milestone():
+    client = RecordingLinearClient(
+        {
+            "issueUpdate": {
+                "success": True,
+                "issue": {"id": "issue-1", "identifier": "ENG-1"},
+            }
+        }
+    )
+
+    client.update_issue("ENG-1", clear_project_milestone=True)
+
+    assert client.calls[0]["variables"]["input"] == {"projectMilestoneId": None}
+
+
+def test_update_issue_rejects_set_and_clear_project_milestone():
+    client = RecordingLinearClient({})
+
+    try:
+        client.update_issue(
+            "ENG-1",
+            project_milestone_id="milestone-1",
+            clear_project_milestone=True,
+        )
+    except ValueError as exc:
+        assert "mutually exclusive" in str(exc)
+    else:
+        raise AssertionError("expected ValueError")
 
 
 def test_add_comment_merges_success_into_comment_fields():

--- a/tools/productivity/linear/test_readonly.py
+++ b/tools/productivity/linear/test_readonly.py
@@ -23,6 +23,13 @@ class RecordingReadonlyClient(LinearReadonlyClient):
 
     def _query(self, query: str, variables: dict[str, Any] | None = None) -> dict[str, Any]:
         self.calls.append({"query": query, "variables": variables})
+        if "projectMilestones" in query:
+            return {
+                "projectMilestones": {
+                    "nodes": [{"id": "milestone-1", "name": "Beta"}],
+                    "pageInfo": {"hasNextPage": False, "endCursor": None},
+                }
+            }
         return {
             "searchIssues": {
                 "nodes": [{"identifier": "ENG-1", "title": "Search result"}],
@@ -40,3 +47,18 @@ def test_search_issues_uses_linear_term_argument():
     assert "searchIssues(term: $term" in client.calls[0]["query"]
     assert "query:" not in client.calls[0]["query"]
     assert client.calls[0]["variables"] == {"term": "auth", "first": 1, "after": None}
+
+
+def test_project_milestones_filters_by_project_id():
+    client = RecordingReadonlyClient()
+
+    result = client.project_milestones(project_id="project-1", limit=10)
+
+    assert result == [{"id": "milestone-1", "name": "Beta"}]
+    call = client.calls[0]
+    assert "project: { id: { eq: $projectId } }" in call["query"]
+    assert call["variables"] == {
+        "projectId": "project-1",
+        "first": 10,
+        "after": None,
+    }

--- a/tools/productivity/linear/test_readonly.py
+++ b/tools/productivity/linear/test_readonly.py
@@ -30,6 +30,13 @@ class RecordingReadonlyClient(LinearReadonlyClient):
                     "pageInfo": {"hasNextPage": False, "endCursor": None},
                 }
             }
+        if "query Issues" in query:
+            return {
+                "issues": {
+                    "nodes": [{"identifier": "ENG-1", "title": "Filtered"}],
+                    "pageInfo": {"hasNextPage": False, "endCursor": None},
+                }
+            }
         return {
             "searchIssues": {
                 "nodes": [{"identifier": "ENG-1", "title": "Search result"}],
@@ -62,3 +69,18 @@ def test_project_milestones_filters_by_project_id():
         "first": 10,
         "after": None,
     }
+
+
+def test_issues_filters_by_project_and_milestone_ids():
+    client = RecordingReadonlyClient()
+
+    result = client.issues(
+        project_id="project-1",
+        project_milestone_id="milestone-1",
+        limit=10,
+    )
+
+    assert result == [{"identifier": "ENG-1", "title": "Filtered"}]
+    query = client.calls[0]["query"]
+    assert 'project: { id: { eq: "project-1" } }' in query
+    assert 'projectMilestone: { id: { eq: "milestone-1" } }' in query


### PR DESCRIPTION
## Summary

- expose project milestones through the Linear client and CLI
- include milestone metadata in issue reads and updates
- support assigning an issue milestone with project-scoped name resolution
- add focused tests for milestone listing and assignment

## Validation

- `uv run --no-project --with pytest pytest tools/productivity/linear/test_client.py`
- `PYTHONPATH=/tmp/linear-testpkg uv run --no-project --with pytest --with httpx pytest tools/productivity/linear/test_readonly.py`
- `uvx ruff check` on all changed Python files
- live read-only `linear milestones --limit 1` query

Prompted by: @DaniPopes