### PR TITLE
fix: preserve rich bot app mentions after empty events

### DIFF
--- a/services/slackbotv2/src/slack-events.ts
+++ b/services/slackbotv2/src/slack-events.ts
@@ -11,12 +11,16 @@ type RawSlackBotProfile = {
 
 type RawSlackEvent = {
   app_id?: JsonValue
+  attachments?: JsonValue
   bot_id?: JsonValue
   bot_profile?: RawSlackBotProfile
+  blocks?: JsonValue
   source_team?: JsonValue
   subtype?: JsonValue
   team?: JsonValue
   team_id?: JsonValue
+  text?: JsonValue
+  type?: JsonValue
   user?: JsonValue
   user_team?: JsonValue
 }
@@ -70,6 +74,13 @@ export function isAllowedSlackWebhookBody(
     logger.warn('slackbotv2_event_ignored_external_org_not_allowlisted', {
       event_id: stringValue(payload.event_id),
       external_team_id: externalTeamId,
+      team_id: stringValue(payload.team_id)
+    })
+    return false
+  }
+  if (shouldIgnoreEmptyBotMessageBeforeMentionEvent(event)) {
+    logger.debug('slackbotv2_empty_bot_message_ignored_before_app_mention', {
+      event_id: stringValue(payload.event_id),
       team_id: stringValue(payload.team_id)
     })
     return false
@@ -171,6 +182,16 @@ function externalSlackTeamIdForHome(
 
 function isBotAuthoredSlackEvent(event: RawSlackEvent): boolean {
   return Boolean(event.bot_id || event.bot_profile || event.subtype === 'bot_message')
+}
+
+function shouldIgnoreEmptyBotMessageBeforeMentionEvent(event: RawSlackEvent): boolean {
+  if (stringValue(event.type) !== 'message' || !isBotAuthoredSlackEvent(event)) return false
+  if ((stringValue(event.text) ?? '').trim()) return false
+  return !hasItems(event.attachments) && !hasItems(event.blocks)
+}
+
+function hasItems(value: JsonValue | undefined): boolean {
+  return Array.isArray(value) && value.length > 0
 }
 
 function isRawSlackInteraction(value: unknown): value is RawSlackInteraction {

--- a/services/slackbotv2/test/chat-sdk-emulate.test.ts
+++ b/services/slackbotv2/test/chat-sdk-emulate.test.ts
@@ -4782,22 +4782,25 @@ describe('slackbotv2', () => {
           app_id: 'AOTHERBOT',
           attachments: [
             {
-              pretext: `<@${BOT_USER_ID}> investigate`,
-              title: ':red_circle: Validator stalled',
-              text: '*Cluster:* stg-na\n*Tenant:* luganodes'
+              blocks: [
+                {
+                  type: 'section',
+                  text: {
+                    type: 'mrkdwn',
+                    text: `*Validator stalled*\n*Cluster:* stg-na\n<@${BOT_USER_ID}> investigate`
+                  }
+                }
+              ],
+              color: '#E01E5A',
+              fallback: `Validator stalled. <@${BOT_USER_ID}> investigate.`
             }
           ],
           bot_id: 'BOTHERBOT',
-          bot_profile: {
-            app_id: 'AOTHERBOT',
-            id: 'BOTHERBOT',
-            user_id: 'UOTHERBOT'
-          },
           channel: CHANNEL_ID,
-          subtype: 'bot_message',
           team: TEAM_ID,
           text: '',
           ts: richBotMessage.ts,
+          user: 'UOTHERBOT',
           username: 'otherbot'
         }
       }),
@@ -4806,6 +4809,75 @@ describe('slackbotv2', () => {
     )
     expect(richBotResponse.status).toBe(200)
     await Promise.all(richBotWaits)
+    expect(codexApi.appends).toHaveLength(1)
+    expect(codexApi.executes).toHaveLength(1)
+    expect(sessionMessageTexts(codexApi.appends[0]!.body.messages).join('\n')).toContain(
+      'Validator stalled'
+    )
+
+    bot = createTestBot({ triggerBotAllowlist: ['bot:BOTHERBOT'] })
+    codexApi.reset()
+    const splitBotMessage = await postUserMessage('')
+    const emptyMessageWaits: Promise<unknown>[] = []
+    const emptyMessageResponse = await bot.app.request(
+      '/api/webhooks/slack',
+      signedSlackEvent({
+        event_id: 'Ev-slackbotv2-empty-bot-message-before-rich-mention',
+        event: {
+          type: 'message',
+          app_id: 'AOTHERBOT',
+          bot_id: 'BOTHERBOT',
+          channel: CHANNEL_ID,
+          team: TEAM_ID,
+          text: '',
+          ts: splitBotMessage.ts,
+          user: 'UOTHERBOT',
+          username: 'otherbot'
+        }
+      }),
+      {},
+      waitUntilContext(emptyMessageWaits)
+    )
+    expect(emptyMessageResponse.status).toBe(200)
+    await Promise.all(emptyMessageWaits)
+
+    const splitMentionWaits: Promise<unknown>[] = []
+    const splitMentionResponse = await bot.app.request(
+      '/api/webhooks/slack',
+      signedSlackEvent({
+        event_id: 'Ev-slackbotv2-rich-app-mention-after-empty-message',
+        event: {
+          type: 'app_mention',
+          app_id: 'AOTHERBOT',
+          attachments: [
+            {
+              blocks: [
+                {
+                  type: 'section',
+                  text: {
+                    type: 'mrkdwn',
+                    text: `*Validator stalled*\n*Cluster:* stg-na\n<@${BOT_USER_ID}> investigate`
+                  }
+                }
+              ],
+              color: '#E01E5A',
+              fallback: `Validator stalled. <@${BOT_USER_ID}> investigate.`
+            }
+          ],
+          bot_id: 'BOTHERBOT',
+          channel: CHANNEL_ID,
+          team: TEAM_ID,
+          text: '',
+          ts: splitBotMessage.ts,
+          user: 'UOTHERBOT',
+          username: 'otherbot'
+        }
+      }),
+      {},
+      waitUntilContext(splitMentionWaits)
+    )
+    expect(splitMentionResponse.status).toBe(200)
+    await Promise.all(splitMentionWaits)
     expect(codexApi.appends).toHaveLength(1)
     expect(codexApi.executes).toHaveLength(1)
     expect(sessionMessageTexts(codexApi.appends[0]!.body.messages).join('\n')).toContain(


### PR DESCRIPTION
## Summary

- ignore empty bot-authored `message` events that contain no text, blocks, or attachments before Chat SDK deduplication
- allow the paired rich `app_mention` event at the same timestamp to reach Centaur
- preserve handling for rich bot messages that carry blocks or attachments

Slack sends Hermes Block Kit alerts as an empty bot `message` followed by a rich `app_mention` with the same timestamp. Previously the empty event consumed the timestamp dedupe key, so the mention never triggered an investigation.

## Validation

- added an exact regression for the empty-message → rich-app-mention sequence
- full Slackbot v2 suite: 215 passed, 1 skipped
- `tsgo --project services/slackbotv2/tsconfig.json --noEmit`
- `git diff --check`