### PR TITLE
fix(harness-server): forward sandbox credentials to nanocodex tools

### DIFF
--- a/crates/harness-server/src/nanocodex.rs
+++ b/crates/harness-server/src/nanocodex.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::env;
+use std::ffi::{OsStr, OsString};
 use std::fs::OpenOptions;
 use std::io::{self, BufRead, Write};
 use std::path::PathBuf;
@@ -108,6 +109,49 @@ async fn run() -> Result<()> {
     Ok(())
 }
 
+/// Name parts that nanocodex's shell tool treats as sensitive, removing the
+/// variable from every tool subprocess.
+///
+/// Mirrors `SENSITIVE_ENV_PARTS` in nanocodex-tools `shell/process.rs`, which is
+/// private. Keep the two in step: a part added there and missed here silently
+/// stops forwarding that variable, which is the exact failure this avoids.
+const SENSITIVE_ENV_PARTS: [&str; 11] = [
+    "AUTH",
+    "AUTHORIZATION",
+    "COOKIE",
+    "CREDENTIAL",
+    "CREDENTIALS",
+    "KEY",
+    "PASS",
+    "PASSWD",
+    "PASSWORD",
+    "SECRET",
+    "TOKEN",
+];
+
+fn is_sensitive_name(name: &OsStr) -> bool {
+    name.to_string_lossy()
+        .to_ascii_uppercase()
+        .split('_')
+        .any(|part| SENSITIVE_ENV_PARTS.contains(&part))
+}
+
+/// The sandbox credentials nanocodex's shell tool would otherwise strip from
+/// every tool subprocess.
+///
+/// Most of these values are not secrets: iron-proxy injects the real credential
+/// at the network boundary, so what the sandbox holds is a placeholder whose
+/// value is its own variable name, and a tool that cannot send it cannot
+/// authenticate at all — `git push` gets a 401 challenge it can never answer.
+/// Forwarding is the intended opt-in rather than a hole in the filter:
+/// nanocodex's own CLI forwards the mpp-egress proxy password the same way, and
+/// overrides still join the redaction list, so values stay masked in tool output.
+fn sandbox_tool_environment() -> Vec<(OsString, OsString)> {
+    env::vars_os()
+        .filter(|(name, _)| is_sensitive_name(name))
+        .collect()
+}
+
 fn build_agent(
     api_key: &str,
     cwd: &std::path::Path,
@@ -120,14 +164,18 @@ fn build_agent(
         .thinking(thinking)
         .workspace(cwd)
         .session_id(session_id);
+    // Built once so both tool paths below carry the forwarded environment.
+    let tools = Tools::builder()
+        .process_environment(sandbox_tool_environment())
+        .build()
+        .map_err(|error| nanocodex_error(error.into()))?;
     let result = if subagents {
         let tools_agents = Arc::downgrade(child_agents);
-        let tools = Tools::default();
         builder
             .tools_factory(move |agent| with_subagents(tools.clone(), agent, tools_agents.clone()))
             .build()
     } else {
-        builder.build()
+        builder.tools(tools).build()
     };
     result.map_err(nanocodex_error)
 }
@@ -623,5 +671,49 @@ mod tests {
             panic!("expected user prompt");
         };
         assert_eq!(thinking, Some(Thinking::High));
+    }
+
+    #[test]
+    fn sensitive_names_cover_the_sandbox_credentials() {
+        // The credentials api-rs puts in every sandbox, which tools cannot
+        // authenticate without.
+        for name in [
+            "GITHUB_TOKEN",
+            "SLACK_BOT_TOKEN",
+            "OPENAI_API_KEY",
+            "ANTHROPIC_API_KEY",
+            "GOOGLE_APPLICATION_CREDENTIALS",
+        ] {
+            assert!(
+                is_sensitive_name(OsStr::new(name)),
+                "{name} would not be forwarded"
+            );
+        }
+    }
+
+    #[test]
+    fn sensitive_names_exclude_the_normalized_shell_variables() {
+        // nanocodex normalizes these for child shells (TERM=dumb, PAGER=cat, ...)
+        // *before* applying overrides, so forwarding any of them would clobber
+        // the normalization and give tools a pager and colour output.
+        for name in [
+            "PATH",
+            "HOME",
+            "TERM",
+            "PAGER",
+            "GIT_PAGER",
+            "GH_PAGER",
+            "NO_COLOR",
+            "COLORTERM",
+            "LANG",
+            "LC_ALL",
+            "LC_CTYPE",
+            "CODEX_CI",
+        ] {
+            assert!(
+                !is_sensitive_name(OsStr::new(name)),
+                "{name} must not be forwarded"
+            );
+        }
     }
 }


### PR DESCRIPTION
Per Slack with @gakonst. Companion: gakonst/nanocodex#59.

## Problem

The shell tool spawns children with `env_clear()` and re-adds only what survives `sanitized_environment`, dropping any name whose `_`-split parts match `SENSITIVE_ENV_PARTS`. In a Centaur sandbox that removes the credentials tools authenticate with — and most are not secrets: iron-proxy substitutes the real credential at the network boundary, so the sandbox holds a marker whose value is its own variable name.

`GITHUB_TOKEN` matches on `TOKEN`, so `git push` gets a 401 challenge it can never answer and `gh` reports no credential. The agent finishes the job and can then only report a patch. Sandboxes on the codex harness are unaffected, which is what made it read as a bad token rather than a missing variable.

## Fix

Forward them via `Tools::process_environment` — the documented opt-in, and what the CLI already does for the mpp-egress proxy password (`bin/nanocodex/src/config.rs`). Overrides are applied after the filter but still join the redaction list, so forwarded values stay masked in tool output.

Two details:

- **Only sensitive-named variables, not the whole environment.** `NORMALIZED_ENVIRONMENT` (`TERM=dumb`, `PAGER=cat`, `NO_COLOR=1`, …) is applied *before* overrides, so a blanket forward would clobber it and give tools a pager and colour output. The two sets are disjoint; a test pins that.
- **`build_agent` builds tools on two paths** (`tools_factory` when subagents are on, plain `build()` otherwise), so the selection is built once and threaded into both — setting it on one silently misses the other.

## The copied predicate

`SENSITIVE_ENV_PARTS` and `is_sensitive_name` are private in nanocodex-tools, so this copies them, and that copy drifts in the dangerous direction — a part added upstream and missed here silently stops forwarding that variable, which is this bug again. gakonst/nanocodex#59 exposes the set as `ambient_sensitive_environment()`; once it lands this becomes a `rev` bump and one call, deleting the constant, the local predicate, and two of the three tests. Drafted for that reason — please don't merge this version.

## Validated

`crates/harness-server` is not covered by CI (the Rust job in `ci.yml` is scoped to `services/api-rs`), so these were run locally: `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test` — 67 unit, 20 integration (4 pre-existing ignored), including two new tests covering that the sandbox credentials match the predicate and that the predicate is disjoint from the normalized shell variables.

Not exercised on a live nanocodex session — our rollout is pinned to 0 while this is open, so end-to-end is a canary once it deploys. The mechanism itself is verified separately: a probe at the pinned rev confirms a `process_environment` override reaches the child intact, string-compared shell-side so output redaction cannot fake a pass.
