### PR TITLE
fix(api-rs): disable Nanocodex A/B when Codex auth is not api_key

### DIFF
--- a/services/api-rs/crates/centaur-api-server/src/args.rs
+++ b/services/api-rs/crates/centaur-api-server/src/args.rs
@@ -114,7 +114,10 @@ impl Args {
     }
 
     pub(crate) fn codex_nanocodex_rollout_percent(&self) -> u8 {
-        self.server.codex_nanocodex_rollout_percent
+        effective_codex_nanocodex_rollout_percent(
+            self.server.codex_nanocodex_rollout_percent,
+            env::var("CODEX_AUTH_MODE").ok().as_deref(),
+        )
     }
 
     pub(crate) fn execution_adoption_interval(&self) -> Option<Duration> {
@@ -1996,6 +1999,40 @@ fn clean_optional_value(value: Option<&str>) -> Option<String> {
     non_empty(value).map(ToOwned::to_owned)
 }
 
+/// Nanocodex requires `OPENAI_API_KEY`, which the sandbox env only injects when
+/// Codex auth is `api_key`. When `CODEX_AUTH_MODE` is set to anything else
+/// (e.g. `access_token` / `chatgpt`), force the Codex↔Nanocodex A/B percent to
+/// 0 so cohort sandboxes never start without that key.
+pub(crate) fn effective_codex_nanocodex_rollout_percent(
+    configured: u8,
+    codex_auth_mode: Option<&str>,
+) -> u8 {
+    if configured == 0 {
+        return 0;
+    }
+    if nanocodex_compatible_with_codex_auth(codex_auth_mode) {
+        return configured;
+    }
+    let normalized = normalize_codex_auth_mode(codex_auth_mode).unwrap_or_default();
+    tracing::warn!(
+        configured_percent = configured,
+        codex_auth_mode = %normalized,
+        "disabling Nanocodex A/B rollout because CODEX_AUTH_MODE is not api_key"
+    );
+    0
+}
+
+pub(crate) fn nanocodex_compatible_with_codex_auth(codex_auth_mode: Option<&str>) -> bool {
+    match normalize_codex_auth_mode(codex_auth_mode) {
+        None => true,
+        Some(mode) => mode == "api_key",
+    }
+}
+
+fn normalize_codex_auth_mode(codex_auth_mode: Option<&str>) -> Option<String> {
+    clean_optional_value(codex_auth_mode).map(|mode| mode.replace('-', "_"))
+}
+
 fn upsert_spec_env(spec: &mut SandboxSpec, name: String, value: String) {
     if let Some(existing) = spec.env.iter_mut().find(|env| env.name == name) {
         existing.value = value;
@@ -2048,6 +2085,20 @@ mod tests {
                 // cannot observe partial mutations.
                 unsafe {
                     env::set_var(name, value);
+                }
+            }
+            Self { saved }
+        }
+
+        fn clear(names: &[&'static str]) -> Self {
+            let saved = names
+                .iter()
+                .map(|name| (*name, env::var(name).ok()))
+                .collect();
+            for name in names {
+                // SAFETY: see EnvGuard::set; the lock outlives the guard.
+                unsafe {
+                    env::remove_var(name);
                 }
             }
             Self { saved }
@@ -2172,6 +2223,8 @@ mod tests {
 
     #[test]
     fn parses_codex_nanocodex_rollout_percent() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _env = EnvGuard::clear(&["CODEX_AUTH_MODE"]);
         let args = Args::try_parse_from([
             "centaur-api-server",
             "--database-url",
@@ -2182,6 +2235,34 @@ mod tests {
         .unwrap();
 
         assert_eq!(args.codex_nanocodex_rollout_percent(), 50);
+    }
+
+    #[test]
+    fn nanocodex_rollout_is_disabled_when_codex_auth_is_not_api_key() {
+        assert_eq!(
+            effective_codex_nanocodex_rollout_percent(50, Some("access_token")),
+            0
+        );
+        assert_eq!(
+            effective_codex_nanocodex_rollout_percent(50, Some("access-token")),
+            0
+        );
+        assert_eq!(
+            effective_codex_nanocodex_rollout_percent(50, Some("chatgpt")),
+            0
+        );
+        assert_eq!(
+            effective_codex_nanocodex_rollout_percent(50, Some("api_key")),
+            50
+        );
+        assert_eq!(
+            effective_codex_nanocodex_rollout_percent(50, Some("api-key")),
+            50
+        );
+        assert_eq!(effective_codex_nanocodex_rollout_percent(50, None), 50);
+        assert!(!nanocodex_compatible_with_codex_auth(Some("access_token")));
+        assert!(nanocodex_compatible_with_codex_auth(Some("api_key")));
+        assert!(nanocodex_compatible_with_codex_auth(None));
     }
 
     #[test]

--- a/services/api-rs/crates/centaur-api-server/src/routes.rs
+++ b/services/api-rs/crates/centaur-api-server/src/routes.rs
@@ -446,6 +446,8 @@ async fn create_or_get_session(
     let thread_key = ThreadKey::try_from(raw_thread_key)?;
     let requested_harness = request.harness_type;
     let runtime = state.runtime()?;
+    let allow_nanocodex =
+        nanocodex_compatible_with_codex_auth(std::env::var("CODEX_AUTH_MODE").ok().as_deref());
     let existing_rollout_harness = if requested_harness == HarnessType::Codex {
         runtime
             .existing_session_harness(&thread_key)
@@ -459,8 +461,10 @@ async fn create_or_get_session(
             &thread_key,
             &requested_harness,
             state.codex_nanocodex_rollout_percent,
+            allow_nanocodex,
         )
     });
+    let harness_type = guard_nanocodex_harness(harness_type, allow_nanocodex);
     let harness_assignment = codex_nanocodex_assignment(
         &requested_harness,
         &harness_type,
@@ -546,8 +550,12 @@ fn rollout_harness_for_thread(
     thread_key: &ThreadKey,
     requested_harness: &HarnessType,
     nanocodex_percent: u8,
+    allow_nanocodex: bool,
 ) -> HarnessType {
-    if *requested_harness != HarnessType::Codex || nanocodex_percent == 0 {
+    if *requested_harness == HarnessType::Nanocodex {
+        return guard_nanocodex_harness(HarnessType::Nanocodex, allow_nanocodex);
+    }
+    if *requested_harness != HarnessType::Codex || nanocodex_percent == 0 || !allow_nanocodex {
         return requested_harness.clone();
     }
     if nanocodex_percent >= 100 {
@@ -564,6 +572,25 @@ fn rollout_harness_for_thread(
     }
 }
 
+fn guard_nanocodex_harness(harness: HarnessType, allow_nanocodex: bool) -> HarnessType {
+    if harness == HarnessType::Nanocodex && !allow_nanocodex {
+        HarnessType::Codex
+    } else {
+        harness
+    }
+}
+
+fn nanocodex_compatible_with_codex_auth(codex_auth_mode: Option<&str>) -> bool {
+    match codex_auth_mode
+        .map(str::trim)
+        .filter(|mode| !mode.is_empty())
+        .map(|mode| mode.replace('-', "_"))
+    {
+        None => true,
+        Some(mode) => mode == "api_key",
+    }
+}
+
 #[cfg(test)]
 mod harness_rollout_tests {
     use super::*;
@@ -575,15 +602,15 @@ mod harness_rollout_tests {
             ThreadKey::try_from("slack:C1:1700000000.000104".to_owned()).unwrap();
 
         assert_eq!(
-            rollout_harness_for_thread(&codex_thread, &HarnessType::Codex, 50),
+            rollout_harness_for_thread(&codex_thread, &HarnessType::Codex, 50, true),
             HarnessType::Codex
         );
         assert_eq!(
-            rollout_harness_for_thread(&nanocodex_thread, &HarnessType::Codex, 50),
+            rollout_harness_for_thread(&nanocodex_thread, &HarnessType::Codex, 50, true),
             HarnessType::Nanocodex
         );
         assert_eq!(
-            rollout_harness_for_thread(&nanocodex_thread, &HarnessType::Codex, 50),
+            rollout_harness_for_thread(&nanocodex_thread, &HarnessType::Codex, 50, true),
             HarnessType::Nanocodex
         );
     }
@@ -593,19 +620,19 @@ mod harness_rollout_tests {
         let thread_key = ThreadKey::try_from("cli:rollout-boundaries".to_owned()).unwrap();
 
         assert_eq!(
-            rollout_harness_for_thread(&thread_key, &HarnessType::Codex, 0),
+            rollout_harness_for_thread(&thread_key, &HarnessType::Codex, 0, true),
             HarnessType::Codex
         );
         assert_eq!(
-            rollout_harness_for_thread(&thread_key, &HarnessType::Codex, 100),
+            rollout_harness_for_thread(&thread_key, &HarnessType::Codex, 100, true),
             HarnessType::Nanocodex
         );
         assert_eq!(
-            rollout_harness_for_thread(&thread_key, &HarnessType::ClaudeCode, 50),
+            rollout_harness_for_thread(&thread_key, &HarnessType::ClaudeCode, 50, true),
             HarnessType::ClaudeCode
         );
         assert_eq!(
-            rollout_harness_for_thread(&thread_key, &HarnessType::Nanocodex, 50),
+            rollout_harness_for_thread(&thread_key, &HarnessType::Nanocodex, 50, true),
             HarnessType::Nanocodex
         );
     }
@@ -615,7 +642,7 @@ mod harness_rollout_tests {
         let nanocodex = (0..10_000)
             .filter(|index| {
                 let thread_key = ThreadKey::try_from(format!("cli:rollout-{index}")).unwrap();
-                rollout_harness_for_thread(&thread_key, &HarnessType::Codex, 50)
+                rollout_harness_for_thread(&thread_key, &HarnessType::Codex, 50, true)
                     == HarnessType::Nanocodex
             })
             .count();
@@ -623,6 +650,35 @@ mod harness_rollout_tests {
         assert!(
             (4_900..=5_100).contains(&nanocodex),
             "nanocodex={nanocodex}"
+        );
+    }
+
+    #[test]
+    fn access_token_auth_disables_nanocodex_rollout_and_remaps_explicit_request() {
+        let nanocodex_thread =
+            ThreadKey::try_from("slack:C1:1700000000.000104".to_owned()).unwrap();
+
+        assert!(!nanocodex_compatible_with_codex_auth(Some("access_token")));
+        assert!(!nanocodex_compatible_with_codex_auth(Some("access-token")));
+        assert!(nanocodex_compatible_with_codex_auth(Some("api_key")));
+        assert!(nanocodex_compatible_with_codex_auth(Some("api-key")));
+        assert!(nanocodex_compatible_with_codex_auth(None));
+
+        assert_eq!(
+            rollout_harness_for_thread(&nanocodex_thread, &HarnessType::Codex, 50, false),
+            HarnessType::Codex
+        );
+        assert_eq!(
+            rollout_harness_for_thread(&nanocodex_thread, &HarnessType::Codex, 50, true),
+            HarnessType::Nanocodex
+        );
+        assert_eq!(
+            rollout_harness_for_thread(&nanocodex_thread, &HarnessType::Nanocodex, 50, false),
+            HarnessType::Codex
+        );
+        assert_eq!(
+            guard_nanocodex_harness(HarnessType::Nanocodex, false),
+            HarnessType::Codex
         );
     }
 


### PR DESCRIPTION
## Summary
- Clamp Nanocodex A/B rollout to 0 when `CODEX_AUTH_MODE` is not `api_key`.
- Remap explicit Nanocodex harness requests to Codex under the same auth modes so sandboxes are not started without `OPENAI_API_KEY`.

## Problem
Nanocodex requires `OPENAI_API_KEY` at harness startup. The shared sandbox env template only injects that placeholder when `CODEX_AUTH_MODE=api_key`. With ChatGPT/`access_token` auth and a non-zero Nanocodex rollout, assigned Nanocodex sessions fail with MissingEnvironment. Injecting the placeholder in access_token mode would incorrectly push Codex onto the API-key path.

## Fix
Treat Nanocodex as incompatible with non-`api_key` Codex auth: disable A/B assignment and fall back to Codex for explicit Nanocodex requests when auth mode cannot support Nanocodex.

## Verification
- `rustup run 1.95 cargo test -p centaur-api-server harness_rollout` (passed)
- `rustup run 1.95 cargo test -p centaur-api-server nanocodex_rollout` (passed)