### PR TITLE
fix(harness-events): parse team-qualified Slack thread keys

### DIFF
--- a/packages/harness-events/package.json
+++ b/packages/harness-events/package.json
@@ -5,7 +5,7 @@
   "main": "src/index.ts",
   "types": "src/index.ts",
   "scripts": {
-    "test": "vitest run --passWithNoTests",
+    "test": "vitest run",
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {

--- a/packages/harness-events/src/thread-key.test.ts
+++ b/packages/harness-events/src/thread-key.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizeThreadKey, splitThreadKey } from "./thread-key";
+
+describe("splitThreadKey", () => {
+  it("parses two-part channel:ts keys", () => {
+    expect(splitThreadKey("C123:1700000000.000100")).toEqual({
+      channel: "C123",
+      threadTs: "1700000000.000100",
+    });
+  });
+
+  it("parses three-part slack:channel:ts keys", () => {
+    expect(splitThreadKey("slack:C123:1700000000.000100")).toEqual({
+      channel: "C123",
+      threadTs: "1700000000.000100",
+    });
+  });
+
+  it("parses four-part team-qualified Slack keys", () => {
+    expect(splitThreadKey("slack:T1:C123:1700000000.000100")).toEqual({
+      channel: "C123",
+      threadTs: "1700000000.000100",
+    });
+  });
+
+  it("rejects malformed keys", () => {
+    expect(() => splitThreadKey("incomplete")).toThrow(/Invalid thread key format/);
+    expect(() => splitThreadKey("slack:team:channel:ts:extra")).toThrow(
+      /Invalid thread key format/
+    );
+    expect(() => splitThreadKey("")).toThrow(/Invalid thread key format/);
+  });
+});
+
+describe("normalizeThreadKey", () => {
+  it("normalizes all supported Slack shapes to channel:ts", () => {
+    expect(normalizeThreadKey("C123:1700000000.000100")).toBe("C123:1700000000.000100");
+    expect(normalizeThreadKey("slack:C123:1700000000.000100")).toBe("C123:1700000000.000100");
+    expect(normalizeThreadKey("slack:T1:C123:1700000000.000100")).toBe(
+      "C123:1700000000.000100"
+    );
+  });
+});

--- a/packages/harness-events/src/thread-key.ts
+++ b/packages/harness-events/src/thread-key.ts
@@ -3,6 +3,10 @@ export function splitThreadKey(threadKey: string): { channel: string; threadTs: 
   if (parts.length === 2 && parts[0] && parts[1]) {
     return { channel: parts[0], threadTs: parts[1] };
   }
+  // Modern Slack keys are `slack:TEAM:CHANNEL:TS` (4 parts).
+  if (parts[0] === "slack" && parts.length === 4 && parts[2] && parts[3]) {
+    return { channel: parts[2], threadTs: parts[3] };
+  }
   if (parts.length === 3 && parts[1] && parts[2]) {
     return { channel: parts[1], threadTs: parts[2] };
   }


### PR DESCRIPTION
## Summary
- Accept modern `slack:TEAM:CHANNEL:TS` thread keys in `@centaur/harness-events`.
- Add focused vitest coverage and require real tests (drop passWithNoTests).

## Problem
`splitThreadKey` only handled 2- or 3-segment keys. Production Slack thread keys include a team id (`slack:T…:C…:ts`), which slackbotv2 already parses but the shared package rejected.

## Fix
Recognize 4-part `slack:team:channel:ts` keys and keep existing 2-/3-part behavior. Add unit tests for valid and invalid shapes.

## Verification
- `pnpm --filter @centaur/harness-events test` (5 passed)
- `pnpm --filter @centaur/harness-events typecheck` (passed)