### PR TITLE
fix: ellipsize long console secret names

### DIFF
--- a/services/console/app/assets/tailwind/application.css
+++ b/services/console/app/assets/tailwind/application.css
@@ -87,6 +87,10 @@
     @apply min-w-full text-sm;
   }
 
+  .console-table-fixed {
+    @apply w-full table-fixed;
+  }
+
   .console-table > thead {
     @apply border-b border-ink-600;
   }
@@ -105,6 +109,18 @@
 
   .console-td-nowrap {
     @apply px-5 py-3 whitespace-nowrap;
+  }
+
+  .console-td-truncate {
+    @apply min-w-0 px-5 py-3 whitespace-nowrap;
+  }
+
+  .console-cell-truncate {
+    @apply block min-w-0 truncate;
+  }
+
+  .console-cell-inline-truncate {
+    @apply inline-block max-w-full truncate align-bottom;
   }
 
   .console-row-hover {

--- a/services/console/app/views/console/principal.html.erb
+++ b/services/console/app/views/console/principal.html.erb
@@ -267,7 +267,14 @@
 
   <% if @direct_grants.any? %>
     <div class="console-panel mb-4">
-      <table class="console-table">
+      <table class="console-table console-table-fixed">
+        <colgroup>
+          <col class="w-40">
+          <col class="w-32">
+          <col class="w-[28%]">
+          <col>
+          <col class="w-28">
+        </colgroup>
         <thead class="console-table-head">
           <tr>
             <th class="console-th">Type</th>
@@ -288,8 +295,20 @@
               <td class="console-td-nowrap">
                 <%= link_to s.oid, console_secret_path(kind, s.oid), class: "console-link" %>
               </td>
-              <td class="console-td-nowrap text-zinc-300"><%= s.foreign_id || "—" %></td>
-              <td class="console-td-nowrap text-zinc-100"><%= s.try(:name).presence || %(<span class="text-zinc-600">unnamed</span>).html_safe %></td>
+              <td class="console-td-truncate text-zinc-300">
+                <% if s.foreign_id.present? %>
+                  <span class="console-cell-truncate" title="<%= s.foreign_id %>"><%= s.foreign_id %></span>
+                <% else %>
+                  <span class="text-zinc-600">—</span>
+                <% end %>
+              </td>
+              <td class="console-td-truncate text-zinc-100">
+                <% if (secret_name = s.try(:name).presence) %>
+                  <span class="console-cell-truncate" title="<%= secret_name %>"><%= secret_name %></span>
+                <% else %>
+                  <span class="text-zinc-600">unnamed</span>
+                <% end %>
+              </td>
               <td class="console-td-nowrap text-right">
                 <%= button_to "Revoke", console_principal_revoke_grant_path(@principal.oid, grant.oid), method: :delete,
                       form: { data: { turbo_confirm: "Revoke this grant?" } },
@@ -335,7 +354,14 @@
     </div>
   <% else %>
     <div class="console-panel">
-      <table class="console-table">
+      <table class="console-table console-table-fixed">
+        <colgroup>
+          <col class="w-40">
+          <col class="w-32">
+          <col class="w-[28%]">
+          <col>
+          <col class="w-56">
+        </colgroup>
         <thead class="console-table-head">
           <tr>
             <th class="console-th">Type</th>
@@ -357,16 +383,31 @@
                 <td class="console-td-nowrap">
                   <%= link_to s.oid, console_secret_path(kind, s.oid), class: "console-link" %>
                 </td>
-                <td class="console-td-nowrap text-zinc-300"><%= s.foreign_id || "—" %></td>
-                <td class="console-td-nowrap text-zinc-100"><%= s.try(:name).presence || %(<span class="text-zinc-600">unnamed</span>).html_safe %></td>
-                <td class="console-td-nowrap">
+                <td class="console-td-truncate text-zinc-300">
+                  <% if s.foreign_id.present? %>
+                    <span class="console-cell-truncate" title="<%= s.foreign_id %>"><%= s.foreign_id %></span>
+                  <% else %>
+                    <span class="text-zinc-600">—</span>
+                  <% end %>
+                </td>
+                <td class="console-td-truncate text-zinc-100">
+                  <% if (secret_name = s.try(:name).presence) %>
+                    <span class="console-cell-truncate" title="<%= secret_name %>"><%= secret_name %></span>
+                  <% else %>
+                    <span class="text-zinc-600">unnamed</span>
+                  <% end %>
+                </td>
+                <td class="console-td-truncate">
                   <div class="flex flex-wrap gap-1">
                     <% if sources.any? { |x| x[:type] == :direct } %>
                       <span class="inline-flex items-center rounded bg-centaur-500/10 px-2 py-0.5 text-[11px] text-centaur-300 ring-1 ring-centaur-500/30">direct</span>
                     <% end %>
                     <% roles.each do |r| %>
-                      <span class="inline-flex items-center rounded bg-ink-700 px-2 py-0.5 text-[11px] text-zinc-300 ring-1 ring-ink-600"
-                            title="<%= r.oid %>">via <%= r.name.presence || r.foreign_id || r.oid %></span>
+                      <% role_label = r.name.presence || r.foreign_id || r.oid %>
+                      <span class="inline-flex min-w-0 max-w-full items-center rounded bg-ink-700 px-2 py-0.5 text-[11px] text-zinc-300 ring-1 ring-ink-600"
+                            title="<%= role_label %> (<%= r.oid %>)">
+                        <span class="console-cell-inline-truncate">via <%= role_label %></span>
+                      </span>
                     <% end %>
                   </div>
                 </td>

--- a/services/console/app/views/console/roles/show.html.erb
+++ b/services/console/app/views/console/roles/show.html.erb
@@ -52,7 +52,14 @@
 
   <% if @grants.any? %>
     <div class="console-panel">
-      <table class="console-table">
+      <table class="console-table console-table-fixed">
+        <colgroup>
+          <col class="w-40">
+          <col class="w-32">
+          <col class="w-[28%]">
+          <col>
+          <col class="w-28">
+        </colgroup>
         <thead class="console-table-head">
           <tr>
             <th class="console-th">Type</th>
@@ -73,8 +80,20 @@
               <td class="console-td-nowrap">
                 <%= link_to secret.oid, console_secret_path(kind, secret.oid), class: "console-link" %>
               </td>
-              <td class="console-td-nowrap text-zinc-300"><%= secret.foreign_id || "—" %></td>
-              <td class="console-td-nowrap text-zinc-100"><%= secret.try(:name).presence || %(<span class="text-zinc-600">unnamed</span>).html_safe %></td>
+              <td class="console-td-truncate text-zinc-300">
+                <% if secret.foreign_id.present? %>
+                  <span class="console-cell-truncate" title="<%= secret.foreign_id %>"><%= secret.foreign_id %></span>
+                <% else %>
+                  <span class="text-zinc-600">—</span>
+                <% end %>
+              </td>
+              <td class="console-td-truncate text-zinc-100">
+                <% if (secret_name = secret.try(:name).presence) %>
+                  <span class="console-cell-truncate" title="<%= secret_name %>"><%= secret_name %></span>
+                <% else %>
+                  <span class="text-zinc-600">unnamed</span>
+                <% end %>
+              </td>
               <td class="console-td-nowrap text-right">
                 <%= button_to "Revoke", revoke_grant_console_role_path(@role.oid, grant.oid), method: :delete,
                       form: { data: { turbo_confirm: "Revoke this grant?" } },

--- a/services/console/app/views/console/secrets.html.erb
+++ b/services/console/app/views/console/secrets.html.erb
@@ -36,7 +36,13 @@
         <p class="empty-state">No <%= secret_kind_label(kind).downcase %> secrets.</p>
       <% else %>
         <div class="console-scroll-panel">
-          <table class="console-table">
+          <table class="console-table console-table-fixed">
+            <colgroup>
+              <col class="w-64">
+              <col>
+              <col class="w-48">
+              <col class="w-[28%]">
+            </colgroup>
             <thead class="console-table-head">
               <tr>
                 <th class="console-th">ID</th>
@@ -57,17 +63,19 @@
                       <%= id_meta_line(s.namespace) %>
                     <% end %>
                   </td>
-                  <td class="console-td-nowrap">
-                    <% name = s.try(:name).presence %>
-                    <% if name %>
-                      <span class="text-zinc-100" title="<%= name %>"><%= truncate_middle(name) %></span>
-                    <% else %>
-                      <span class="text-zinc-600">unnamed</span>
-                    <% end %>
-                    <% if (cred = managed_credential(s)) %>
-                      <span class="ml-2 inline-flex items-center rounded bg-centaur-500/10 px-1.5 py-0.5 text-[11px] text-centaur-300 ring-1 ring-centaur-500/30"
-                            title="Managed by the <%= cred.oauth_app&.slug %> OAuth integration">managed</span>
-                    <% end %>
+                  <td class="console-td-truncate">
+                    <div class="flex min-w-0 items-center gap-2">
+                      <% name = s.try(:name).presence %>
+                      <% if name %>
+                        <span class="console-cell-truncate text-zinc-100" title="<%= name %>"><%= name %></span>
+                      <% else %>
+                        <span class="shrink-0 text-zinc-600">unnamed</span>
+                      <% end %>
+                      <% if (cred = managed_credential(s)) %>
+                        <span class="inline-flex shrink-0 items-center rounded bg-centaur-500/10 px-1.5 py-0.5 text-[11px] text-centaur-300 ring-1 ring-centaur-500/30"
+                              title="Managed by the <%= cred.oauth_app&.slug %> OAuth integration">managed</span>
+                      <% end %>
+                    </div>
                   </td>
                   <td class="console-td-nowrap">
                     <% types = secret_source_types(s) %>


### PR DESCRIPTION
Adds fixed-layout console tables and truncating cell utilities for secrets and grant listings so long names and foreign IDs ellipsize instead of pushing table content off-screen. Full values remain available in hover titles where truncated.