### PR TITLE
fix: always run console workers when enabled

### DIFF
--- a/contrib/chart/Chart.yaml
+++ b/contrib/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: centaur
 description: Helm chart for the trusted Centaur control plane
 type: application
-version: 0.1.107
+version: 0.1.108
 appVersion: "0.1.0"
 dependencies:
   - name: connect

--- a/contrib/chart/templates/console-worker.yaml
+++ b/contrib/chart/templates/console-worker.yaml
@@ -1,5 +1,5 @@
 {{- $console := include "centaur.consoleValues" . | fromYaml }}
-{{- if and $console.enabled $console.worker.enabled }}
+{{- if $console.enabled }}
 {{- $secretEnv := include "centaur.secretEnvName" . }}
 {{- $prefix := .Values.secretManager.envPrefix }}
 {{- $apiRsName := include "centaur.componentName" (dict "root" . "component" "api-rs") }}

--- a/contrib/chart/templates/networkpolicy.yaml
+++ b/contrib/chart/templates/networkpolicy.yaml
@@ -90,12 +90,10 @@ spec:
         - podSelector:
             matchLabels:
 {{ include "centaur.componentSelectorLabels" (dict "root" . "component" "console") | nindent 14 }}
-{{- if $console.worker.enabled }}
         # console Solid Queue worker (bin/jobs) reaches the app + queue DBs.
         - podSelector:
             matchLabels:
 {{ include "centaur.componentSelectorLabels" (dict "root" . "component" "console-worker") | nindent 14 }}
-{{- end }}
 {{- end }}
         # iron-proxy pods forward the tool-server sidecar's pool to Postgres
         # (the sidecar reaches the core DB through the per-sandbox proxy, not
@@ -187,12 +185,10 @@ spec:
         - podSelector:
             matchLabels:
 {{ include "centaur.componentSelectorLabels" (dict "root" . "component" "console") | nindent 14 }}
-{{- if $console.worker.enabled }}
         # Console background jobs call api-rs for sync ingestion/checkpoints.
         - podSelector:
             matchLabels:
 {{ include "centaur.componentSelectorLabels" (dict "root" . "component" "console-worker") | nindent 14 }}
-{{- end }}
 {{- end }}
         # New sandboxes call back into the control plane only when their
         # principal has the API server sandbox capability.

--- a/contrib/chart/values.schema.json
+++ b/contrib/chart/values.schema.json
@@ -49,7 +49,6 @@
         "worker": {
           "type": "object",
           "properties": {
-            "enabled": { "type": "boolean" },
             "replicaCount": { "type": "integer" },
             "resources": { "type": "object" }
           }

--- a/contrib/chart/values.yaml
+++ b/contrib/chart/values.yaml
@@ -184,9 +184,8 @@ console:
   # most importantly the broker-credential OAuth refresh loop that mints and
   # refreshes the access tokens delivered inline via `token_broker` sources
   # (e.g. the `openai-codex` brokered token). The web Puma pod runs no worker, so
-  # without this those jobs never execute. Active only when console.enabled.
+  # without this those jobs never execute. Active when console.enabled.
   worker:
-    enabled: true
     replicaCount: 1
     resources: {}
 


### PR DESCRIPTION
Removes the Helm values flag that allowed disabling the Rails console Solid Queue worker. The worker deployment and its network policy access now render whenever Console is enabled, while replica count and resources remain configurable.