### PR TITLE
fix: submit slack permission trash buttons with delete forms

### DIFF
--- a/services/console/app/views/console/shared/_slack_channel_permissions.html.erb
+++ b/services/console/app/views/console/shared/_slack_channel_permissions.html.erb
@@ -60,6 +60,7 @@
                   <% else %>
                     <%= form.fields_for :slack_channel_permissions, permission do |permission_fields| %>
                       <% channel_name = @slack_channel_names&.fetch(permission.channel_id, nil) %>
+                      <% delete_form_id = "delete_slack_channel_permission_#{permission.oid}" %>
                       <td class="console-td min-w-80">
                         <%= permission_fields.hidden_field :id %>
                         <div class="text-sm text-zinc-100"><%= channel_name.present? ? "##{channel_name}" : permission.channel_id %></div>
@@ -75,10 +76,12 @@
                         </td>
                       <% end %>
                       <td class="console-td">
-                        <%= link_to console_slack_channel_permission_path(permission),
-                                    data: { turbo_method: :delete },
-                                    class: "grid size-8 place-items-center rounded text-zinc-500 transition-colors hover:bg-red-500/10 hover:text-red-300 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-red-400",
-                                    title: "Delete #{permission.channel_id}" do %>
+                        <%= button_tag type: "submit",
+                                       name: nil,
+                                       form: delete_form_id,
+                                       class: "grid size-8 place-items-center rounded text-zinc-500 transition-colors hover:bg-red-500/10 hover:text-red-300 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-red-400",
+                                       title: "Delete #{permission.channel_id}",
+                                       aria: { label: "Delete #{permission.channel_id}" } do %>
                           <%= console_icon("trash", classes: "size-4") %>
                         <% end %>
                       </td>
@@ -121,6 +124,16 @@
       <div class="px-5 pb-5">
         <%= submit_tag "Save Slack channel permissions", class: "btn-primary" %>
       </div>
+    <% end %>
+
+    <% permissions.each do |permission| %>
+      <% next if api_managed_direct_messages && permission.channel_id.to_s.start_with?("D") %>
+      <%= form_with url: console_slack_channel_permission_path(permission),
+                    method: :delete,
+                    id: "delete_slack_channel_permission_#{permission.oid}",
+                    data: { turbo: false },
+                    class: "hidden" do %>
+      <% end %>
     <% end %>
   </div>
 

--- a/services/console/test/controllers/console/roles_controller_test.rb
+++ b/services/console/test/controllers/console/roles_controller_test.rb
@@ -44,23 +44,6 @@ module Console
       end
     end
 
-    test "show renders Slack channel permission delete buttons" do
-      role = roles(:acme_infra)
-      permission = role.slack_channel_permissions.create!(
-        channel_id: "C0123456789",
-        upload_enabled: true
-      )
-
-      get console_role_url(role.oid)
-      assert_response :ok
-
-      assert_select(
-        "a[href=?][data-turbo-method=delete][title=?]",
-        console_slack_channel_permission_path(permission.oid),
-        "Delete #{permission.channel_id}"
-      )
-    end
-
     test "update_slack_channel_permissions stores role permissions" do
       role = roles(:acme_infra)
 

--- a/services/console/test/controllers/console_controller_test.rb
+++ b/services/console/test/controllers/console_controller_test.rb
@@ -177,23 +177,6 @@ class ConsoleControllerTest < ActionDispatch::IntegrationTest
     assert_select "td", text: "API-managed"
   end
 
-  test "principal detail page renders Slack channel permission delete buttons" do
-    principal = principals(:acme_user_bob)
-    permission = principal.slack_channel_permissions.create!(
-      channel_id: "C0123456789",
-      upload_enabled: true
-    )
-
-    get console_principal_url(principal.oid)
-    assert_response :ok
-
-    assert_select(
-      "a[href=?][data-turbo-method=delete][title=?]",
-      console_slack_channel_permission_path(permission.oid),
-      "Delete #{permission.channel_id}"
-    )
-  end
-
   test "principal detail page resolves direct and inherited Slack channel names from the catalog" do
     principal = principals(:acme_channel)
     principal.slack_channel_permissions.create!(


### PR DESCRIPTION
Replaces Slack channel permission trash links with submit buttons targeting separate DELETE forms so destructive actions do not depend on Turbo method emulation inside the non-Turbo edit form. 