### PR TITLE
feat: add Loki log queries to grafana tool

### DIFF
--- a/docs/pages/reference/tool-directory.mdx
+++ b/docs/pages/reference/tool-directory.mdx
@@ -35,7 +35,7 @@ These are broadly useful across most deployments and are good candidates to conf
 | `gsuite` | Use Gmail, Calendar, Drive, Docs, Sheets, Slides, and Google Analytics | `GOOGLE_TOKEN_JSON` |
 | `websearch` | Free web search via Parallel and deep research | None; `PARALLEL_API_KEY` for `deep_research`; `ANTHROPIC_API_KEY` for search synthesis |
 | `company_context` | Search indexed company history, private Slack conversations, and Google Docs | None |
-| `grafana` | Query dashboards, alerts, VictoriaMetrics, VictoriaLogs, and annotations | `GRAFANA_URL`, `GRAFANA_API_KEY` |
+| `grafana` | Query dashboards, alerts, VictoriaMetrics, VictoriaLogs, Loki, and annotations | `GRAFANA_URL`, `GRAFANA_API_KEY` |
 | `posthog` | Query product analytics, events, pageviews, breakdowns, and user agents | `POSTHOG_API_KEY`, `POSTHOG_PROJECT_ID` |
 | `attio` | Work with CRM objects, records, lists, notes, tasks, calls, and meetings | `ATTIO_API_KEY` |
 | `pylon` | Read and manage support issues, accounts, contacts, teams, tags, and users | `PYLON_API_KEY` |
@@ -62,7 +62,7 @@ These are broadly useful across most deployments and are good candidates to conf
 | `centaur-console` | Inspect the current sandbox's redacted permissions and capabilities | None |
 | `chart` | Render charts as PNG images for Slack or reports | None |
 | `demo` | Test tool hot-reload and basic tool plumbing | None |
-| `grafana` | Grafana dashboards, alerts, VictoriaMetrics, VictoriaLogs, and annotations | `GRAFANA_URL`, `GRAFANA_API_KEY` |
+| `grafana` | Grafana dashboards, alerts, VictoriaMetrics, VictoriaLogs, Loki, and annotations | `GRAFANA_URL`, `GRAFANA_API_KEY` |
 | `posthog` | Product analytics through HogQL, events, pageviews, and breakdowns | `POSTHOG_API_KEY`, `POSTHOG_PROJECT_ID` |
 | `profslice` | Extract Firefox Profiler data for analysis | None |
 | `reth` | Reth execution timing and performance metrics | None |

--- a/docs/public/md/reference/tool-directory.md
+++ b/docs/public/md/reference/tool-directory.md
@@ -35,7 +35,7 @@ These are broadly useful across most deployments and are good candidates to conf
 | `gsuite` | Use Gmail, Calendar, Drive, Docs, Sheets, Slides, and Google Analytics | `GOOGLE_TOKEN_JSON` |
 | `websearch` | Free web search via Parallel and deep research | None; `PARALLEL_API_KEY` for `deep_research`; `ANTHROPIC_API_KEY` for search synthesis |
 | `company_context` | Search indexed company history, private Slack conversations, and Google Docs | None |
-| `grafana` | Query dashboards, alerts, VictoriaMetrics, VictoriaLogs, and annotations | `GRAFANA_URL`, `GRAFANA_API_KEY` |
+| `grafana` | Query dashboards, alerts, VictoriaMetrics, VictoriaLogs, Loki, and annotations | `GRAFANA_URL`, `GRAFANA_API_KEY` |
 | `posthog` | Query product analytics, events, pageviews, breakdowns, and user agents | `POSTHOG_API_KEY`, `POSTHOG_PROJECT_ID` |
 | `amplitude` | Query product analytics — event segmentation, funnels, retention, user activity, and taxonomy | `AMPLITUDE_API_KEY`, `AMPLITUDE_SECRET_KEY` |
 | `attio` | Work with CRM objects, records, lists, notes, tasks, calls, and meetings | `ATTIO_API_KEY` |
@@ -63,7 +63,7 @@ These are broadly useful across most deployments and are good candidates to conf
 | `centaur-console` | Inspect the current sandbox's redacted permissions and capabilities | None |
 | `chart` | Render charts as PNG images for Slack or reports | None |
 | `demo` | Test tool hot-reload and basic tool plumbing | None |
-| `grafana` | Grafana dashboards, alerts, VictoriaMetrics, VictoriaLogs, and annotations | `GRAFANA_URL`, `GRAFANA_API_KEY` |
+| `grafana` | Grafana dashboards, alerts, VictoriaMetrics, VictoriaLogs, Loki, and annotations | `GRAFANA_URL`, `GRAFANA_API_KEY` |
 | `posthog` | Product analytics through HogQL, events, pageviews, and breakdowns | `POSTHOG_API_KEY`, `POSTHOG_PROJECT_ID` |
 | `amplitude` | Amplitude event segmentation, funnels, retention, user activity, realtime, and taxonomy | `AMPLITUDE_API_KEY`, `AMPLITUDE_SECRET_KEY` |
 | `profslice` | Extract Firefox Profiler data for analysis | None |

--- a/tools/infra/grafana/cli.py
+++ b/tools/infra/grafana/cli.py
@@ -176,6 +176,34 @@ def query_victorialogs(
         console.print(f"[dim]{time}[/] [cyan]{stream}[/] {msg}")
 
 
+@app.command("loki")
+def query_loki(
+    query: str = typer.Argument(..., help="LogQL expression"),
+    datasource: str = typer.Option("loki", "--ds", help="Datasource UID"),
+    start: str = typer.Option(None, "--start", "-s", help="Range start"),
+    end: str = typer.Option(None, "--end", "-e", help="Range end"),
+    limit: int = typer.Option(100, "--limit", "-n", help="Max log lines"),
+    json_output: bool = typer.Option(False, "--json", help="Output as JSON"),
+):
+    """Run a LogQL query via Loki datasource proxy."""
+    client = get_client()
+    results = client.query_loki(
+        query=query, datasource_uid=datasource, start=start, end=end, limit=limit
+    )
+
+    if json_output:
+        print(json.dumps(results, indent=2))
+        return
+
+    if not results:
+        console.print("[yellow]No results[/]")
+        return
+
+    for entry in results:
+        labels = ", ".join(f"{k}={v}" for k, v in entry.get("stream", {}).items())
+        console.print(f"[dim]{entry.get('time', '')}[/] [cyan]{labels}[/] {entry.get('line', '')}")
+
+
 @app.command("alerts")
 def get_alerts(
     json_output: bool = typer.Option(False, "--json", help="Output as JSON"),

--- a/tools/infra/grafana/client.py
+++ b/tools/infra/grafana/client.py
@@ -3,6 +3,7 @@
 import json as _json
 import os
 import re
+from datetime import UTC, datetime
 from typing import Any
 from urllib.parse import SplitResult, quote, urlsplit, urlunsplit
 
@@ -53,11 +54,22 @@ def _normalize_thread_key_input(value: str) -> str:
     raise ValueError(f"Could not parse Slack thread input: {value}")
 
 
+def _parse_loki_timestamp(ts: Any) -> tuple[int, str]:
+    """Parse a Loki Unix-nanosecond timestamp into a sort key and an RFC3339 string."""
+    try:
+        ns = int(ts)
+    except (TypeError, ValueError):
+        return 0, str(ts)
+    seconds, remainder = divmod(ns, 1_000_000_000)
+    stamp = datetime.fromtimestamp(seconds, tz=UTC).replace(microsecond=remainder // 1000)
+    return ns, stamp.isoformat()
+
+
 class GrafanaClient:
     """Client for the Grafana HTTP API.
 
-    Supports dashboard search, VictoriaMetrics/VictoriaLogs datasource proxy queries,
-    alert rules, and annotations. Authenticates via service-account token
+    Supports dashboard search, VictoriaMetrics/VictoriaLogs/Loki datasource proxy
+    queries, alert rules, and annotations. Authenticates via service-account token
     (GRAFANA_API_KEY) or basic auth (GRAFANA_USER / GRAFANA_PASSWORD).
     """
 
@@ -284,6 +296,69 @@ class GrafanaClient:
         )
         result = resp.json()
         return [v["value"] for v in result.get("values", [])]
+
+    # -- Loki queries via datasource proxy ------------------------------------
+
+    def query_loki(
+        self,
+        query: str,
+        datasource_uid: str = "loki",
+        start: str | None = None,
+        end: str | None = None,
+        limit: int = 100,
+    ) -> list[dict]:
+        """Run a LogQL log query via the Loki datasource proxy.
+
+        Args:
+            query: LogQL log-selector expression (e.g. '{app="api"} |= "error"').
+                Metric LogQL queries (rate, count_over_time, ...) are rejected.
+            datasource_uid: Datasource UID (default: 'loki').
+            start: Range start (RFC3339 or Unix nanoseconds). Omit for Loki's default window.
+            end: Range end.
+            limit: Max log lines.
+        """
+        params: dict[str, Any] = {"query": query, "limit": limit}
+        if start:
+            params["start"] = start
+        if end:
+            params["end"] = end
+        data = self._request(
+            "GET",
+            f"/api/datasources/proxy/uid/{datasource_uid}/loki/api/v1/query_range",
+            params=params,
+        )
+        result_type = data.get("data", {}).get("resultType")
+        if result_type != "streams":
+            raise ValueError(
+                f"query_loki supports log queries only (got resultType {result_type!r}); "
+                "use a log-selector LogQL expression instead of a metric query"
+            )
+        rows: list[tuple[int, dict]] = []
+        for result in data.get("data", {}).get("result", []):
+            labels = result.get("stream", {})
+            for value in result.get("values", []):
+                if len(value) < 2:
+                    continue
+                sort_key, stamp = _parse_loki_timestamp(value[0])
+                rows.append((sort_key, {"time": stamp, "stream": labels, "line": value[1]}))
+        rows.sort(key=lambda row: row[0])
+        return [entry for _, entry in rows]
+
+    def loki_labels(self, datasource_uid: str = "loki") -> list[str]:
+        """List all Loki label names."""
+        data = self._request(
+            "GET",
+            f"/api/datasources/proxy/uid/{datasource_uid}/loki/api/v1/labels",
+        )
+        return data.get("data", [])
+
+    def loki_label_values(self, label: str, datasource_uid: str = "loki") -> list[str]:
+        """Get values for a Loki label."""
+        data = self._request(
+            "GET",
+            f"/api/datasources/proxy/uid/{datasource_uid}/loki/api/v1/label/{label}/values",
+        )
+        return data.get("data", [])
 
     # -- Alerts --------------------------------------------------------------
 

--- a/tools/infra/grafana/pyproject.toml
+++ b/tools/infra/grafana/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "grafana"
-description = "Grafana observability — dashboards, VictoriaMetrics, VictoriaLogs, alerts, annotations"
+description = "Grafana observability — dashboards, VictoriaMetrics, VictoriaLogs, Loki, alerts, annotations"
 version = "0.1.0"
 requires-python = ">=3.11"
 dependencies = [

--- a/tools/infra/grafana/test_client.py
+++ b/tools/infra/grafana/test_client.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import httpx
+import pytest
+
+ROOT = Path(__file__).resolve().parents[3]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+spec = importlib.util.spec_from_file_location(
+    "grafana_client", Path(__file__).with_name("client.py")
+)
+assert spec and spec.loader
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+GrafanaClient = module.GrafanaClient
+
+LOKI_STREAMS = {
+    "status": "success",
+    "data": {
+        "resultType": "streams",
+        "result": [
+            {
+                "stream": {"app": "api", "level": "error"},
+                "values": [
+                    ["1722180003000000000", "third"],
+                    ["1722180001000000000", "first"],
+                ],
+            },
+            {
+                "stream": {"app": "worker"},
+                "values": [["1722180001500000000", "second", {"trace_id": "abc123"}]],
+            },
+        ],
+    },
+}
+
+EMPTY_STREAMS = {"status": "success", "data": {"resultType": "streams", "result": []}}
+
+
+def make_client(handler) -> GrafanaClient:
+    client = GrafanaClient(url="http://grafana.test", api_key="test-token")
+    client._client = httpx.Client(
+        base_url="http://grafana.test", transport=httpx.MockTransport(handler)
+    )
+    return client
+
+
+def test_query_loki_builds_query_range_request() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.method == "GET"
+        assert request.url.path == "/api/datasources/proxy/uid/loki/loki/api/v1/query_range"
+        assert dict(request.url.params) == {"query": '{app="api"}', "limit": "100"}
+        return httpx.Response(200, json=EMPTY_STREAMS)
+
+    client = make_client(handler)
+
+    assert client.query_loki('{app="api"}') == []
+
+
+def test_query_loki_passes_range_and_datasource_uid() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/api/datasources/proxy/uid/loki-prod/loki/api/v1/query_range"
+        params = dict(request.url.params)
+        assert params["start"] == "2024-07-28T00:00:00Z"
+        assert params["end"] == "2024-07-28T16:00:00Z"
+        assert params["limit"] == "10"
+        return httpx.Response(200, json=EMPTY_STREAMS)
+
+    client = make_client(handler)
+
+    client.query_loki(
+        '{app="api"}',
+        datasource_uid="loki-prod",
+        start="2024-07-28T00:00:00Z",
+        end="2024-07-28T16:00:00Z",
+        limit=10,
+    )
+
+
+def test_query_loki_flattens_streams_sorted_by_time() -> None:
+    client = make_client(lambda _: httpx.Response(200, json=LOKI_STREAMS))
+
+    assert client.query_loki('{app=~".+"}') == [
+        {
+            "time": "2024-07-28T15:20:01+00:00",
+            "stream": {"app": "api", "level": "error"},
+            "line": "first",
+        },
+        {
+            "time": "2024-07-28T15:20:01.500000+00:00",
+            "stream": {"app": "worker"},
+            "line": "second",
+        },
+        {
+            "time": "2024-07-28T15:20:03+00:00",
+            "stream": {"app": "api", "level": "error"},
+            "line": "third",
+        },
+    ]
+
+
+def test_query_loki_rejects_matrix_results() -> None:
+    matrix = {
+        "status": "success",
+        "data": {
+            "resultType": "matrix",
+            "result": [{"metric": {"app": "api"}, "values": [[1722180001, "0.5"]]}],
+        },
+    }
+    client = make_client(lambda _: httpx.Response(200, json=matrix))
+
+    with pytest.raises(ValueError, match="resultType 'matrix'"):
+        client.query_loki('rate({app="api"}[5m])')
+
+
+def test_query_loki_raises_on_http_error() -> None:
+    client = make_client(lambda _: httpx.Response(500, text="boom"))
+
+    with pytest.raises(RuntimeError, match=r"Grafana API error \(500\)"):
+        client.query_loki('{app="api"}')
+
+
+def test_loki_labels_returns_names() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/api/datasources/proxy/uid/loki/loki/api/v1/labels"
+        return httpx.Response(200, json={"status": "success", "data": ["app", "level"]})
+
+    client = make_client(handler)
+
+    assert client.loki_labels() == ["app", "level"]
+
+
+def test_loki_label_values_returns_values() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/api/datasources/proxy/uid/loki/loki/api/v1/label/app/values"
+        return httpx.Response(200, json={"status": "success", "data": ["api", "worker"]})
+
+    client = make_client(handler)
+
+    assert client.loki_label_values("app") == ["api", "worker"]


### PR DESCRIPTION
## Why

The grafana tool queries VictoriaMetrics (`query`) and VictoriaLogs (`vlogs`) through the Grafana datasource proxy, but has no path for Grafana Loki: `query` builds Prometheus-style paths (`/api/v1/query[_range]`) and `vlogs` builds VictoriaLogs paths (`/select/logsql/...`), so neither works against a Loki datasource UID. Loki serves logs at `/loki/api/v1/query_range` with LogQL.

## What

- `GrafanaClient.query_loki(query, datasource_uid="loki", start, end, limit)` runs LogQL range queries via `/api/datasources/proxy/uid/<uid>/loki/api/v1/query_range` and flattens `streams` responses into time-sorted entries (RFC3339 `time`, `stream` labels, `line`), tolerating Loki 3.x structured-metadata value tuples.
- Metric LogQL responses (`resultType: matrix`) are rejected with a clear error instead of being misparsed as logs (seconds-vs-nanoseconds timestamps, dropped labels).
- `GrafanaClient.loki_labels()` / `loki_label_values(label)` mirror the metric label helpers.
- `loki` CLI command mirroring `vlogs` (`--ds/--start/--end/--limit/--json`), same output shape (time, labels, line).
- Docs: grafana rows in the tool directory mention Loki; md mirror regenerated.

## Testing

- `test_client.py`: 7 `httpx.MockTransport` tests covering request construction (path, params, start/end handling, datasource UID), stream flattening and time sorting, matrix rejection, label endpoints, and HTTP error propagation.
- `ruff check` clean; `ruff format` clean on the new/changed files.
- Validated live against a self-hosted Grafana + Loki through the datasource proxy (host-scoped API key, real LogQL queries).