### PR TITLE
fix: exit workflow host promptly after failures

### DIFF
--- a/services/workflow-python/tests/test_workflow_host.py
+++ b/services/workflow-python/tests/test_workflow_host.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import asyncio
 import importlib.util
+import json
 import os
+import subprocess
 import sys
 import tempfile
 import types
@@ -430,6 +432,57 @@ class WorkflowHostTests(unittest.TestCase):
 
         assert registered is not None
         self.assertEqual(host.normalize_principal(registered), True)
+
+    def test_failed_workflow_host_exits_even_when_stdin_remains_open(self) -> None:
+        host_path = Path(__file__).resolve().parents[1] / "workflow_host.py"
+        with tempfile.TemporaryDirectory() as tmp:
+            workflow_path = Path(tmp) / "failing_workflow.py"
+            workflow_path.write_text(
+                "WORKFLOW_NAME = 'failing_workflow'\n"
+                "async def handler(inp, ctx):\n"
+                "    raise RuntimeError('boom')\n"
+            )
+
+            env = os.environ.copy()
+            env["WORKFLOW_DIRS"] = tmp
+            proc = subprocess.Popen(
+                [sys.executable, str(host_path)],
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                env=env,
+            )
+            assert proc.stdin is not None
+            assert proc.stdout is not None
+            try:
+                proc.stdin.write(
+                    json.dumps(
+                        {
+                            "type": "workflow.start",
+                            "run_id": "run-123",
+                            "task_id": "task-456",
+                            "workflow_name": "failing_workflow",
+                            "input": {},
+                        },
+                        separators=(",", ":"),
+                    )
+                    + "\n"
+                )
+                proc.stdin.flush()
+
+                line = proc.stdout.readline()
+                self.assertTrue(line, "workflow host did not emit a response")
+                payload = json.loads(line)
+                self.assertEqual(payload["type"], "workflow.error")
+                self.assertEqual(payload["message"], "boom")
+
+                proc.wait(timeout=2)
+                self.assertEqual(proc.returncode, 0)
+            finally:
+                if proc.poll() is None:
+                    proc.kill()
+                proc.communicate(timeout=2)
 
 
 if __name__ == "__main__":

--- a/services/workflow-python/workflow_host.py
+++ b/services/workflow-python/workflow_host.py
@@ -396,12 +396,19 @@ async def main() -> int:
     active_workflow: asyncio.Task[dict[str, Any]] | None = None
 
     async def read_stdin() -> None:
-        while True:
-            line = await asyncio.to_thread(sys.stdin.readline)
-            if line == "":
-                await stdin_queue.put(None)
-                return
-            await stdin_queue.put(json.loads(line))
+        loop = asyncio.get_running_loop()
+        reader = asyncio.StreamReader()
+        protocol = asyncio.StreamReaderProtocol(reader)
+        transport, _ = await loop.connect_read_pipe(lambda: protocol, sys.stdin)
+        try:
+            while True:
+                line = await reader.readline()
+                if line == b"":
+                    await stdin_queue.put(None)
+                    return
+                await stdin_queue.put(json.loads(line))
+        finally:
+            transport.close()
 
     asyncio.create_task(read_stdin())
 
@@ -436,9 +443,7 @@ async def main() -> int:
         if message is None:
             if active_workflow is not None:
                 continue
-            await asyncio.sleep(0.1)
-            asyncio.create_task(read_stdin())
-            continue
+            return 0
         message_type = message.get("type")
         try:
             if message_type == "ctx.response":


### PR DESCRIPTION
Use asyncio pipe transports for workflow host stdin so failed workflows do not leave a blocked default-executor thread during interpreter shutdown. Add a subprocess regression that keeps stdin open after a workflow error and asserts the host exits promptly.