### PR TITLE
refactor: centralize console http requests

### DIFF
--- a/services/console/Gemfile
+++ b/services/console/Gemfile
@@ -70,5 +70,6 @@ end
 group :test do
   # Use system testing [https://guides.rubyonrails.org/testing.html#system-testing]
   gem "capybara"
+  gem "minitest-mock", "~> 5.27", require: false
   gem "selenium-webdriver"
 end

--- a/services/console/Gemfile.lock
+++ b/services/console/Gemfile.lock
@@ -164,6 +164,7 @@ GEM
     minitest (6.0.6)
       drb (~> 2.0)
       prism (~> 1.5)
+    minitest-mock (5.27.0)
     msgpack (1.8.3)
     net-imap (0.6.4.1)
       date
@@ -390,6 +391,7 @@ DEPENDENCIES
   json_schemer (~> 2.3)
   jwt (~> 3.1)
   lograge
+  minitest-mock (~> 5.27)
   pg (~> 1.5)
   propshaft
   puma (>= 5.0)

--- a/services/console/app/jobs/oauth/enrich_attio_credential_identity_job.rb
+++ b/services/console/app/jobs/oauth/enrich_attio_credential_identity_job.rb
@@ -1,6 +1,4 @@
 require "json"
-require "net/http"
-require "uri"
 
 module Oauth
   class EnrichAttioCredentialIdentityJob < ApplicationJob
@@ -89,19 +87,14 @@ module Oauth
         )
       end
 
-      uri = URI.parse(SELF_ENDPOINT)
-      req = Net::HTTP::Get.new(uri)
-      req["Accept"] = "application/json"
-      req["Authorization"] = "Bearer #{access_token}"
-      req["User-Agent"] = "centaur-console"
-
-      http = Net::HTTP.new(uri.host, uri.port)
-      http.use_ssl = uri.scheme == "https"
-      http.open_timeout = 5
-      http.read_timeout = 5
-
-      response = http.request(req)
-      status = response.code.to_i
+      response = HttpClient.new.get(
+        SELF_ENDPOINT,
+        headers: {
+          "Authorization" => "Bearer #{access_token}",
+          "User-Agent" => "centaur-console"
+        }
+      )
+      status = response.status
       if status == 429 || status >= 500
         raise AttioSelfRetryableError, "attio self lookup http #{status}"
       end
@@ -110,7 +103,7 @@ module Oauth
         return nil
       end
 
-      parsed = JSON.parse(response.body.to_s)
+      parsed = response.json
       parsed.is_a?(Hash) ? parsed : nil
     rescue AttioSelfRetryableError
       raise

--- a/services/console/app/jobs/oauth/enrich_credential_identity_job.rb
+++ b/services/console/app/jobs/oauth/enrich_credential_identity_job.rb
@@ -1,7 +1,3 @@
-require "json"
-require "net/http"
-require "uri"
-
 module Oauth
   class EnrichCredentialIdentityJob < ApplicationJob
     queue_as :default
@@ -79,18 +75,11 @@ module Oauth
         )
       end
 
-      uri = URI.parse(url)
-      req = Net::HTTP::Post.new(uri)
-      req["Authorization"] = "Bearer #{access_token}"
-      req["Accept"] = "application/json"
-      req.set_form_data(params) if params.any?
-
-      http = Net::HTTP.new(uri.host, uri.port)
-      http.use_ssl = uri.scheme == "https"
-      http.open_timeout = 5
-      http.read_timeout = 5
-
-      JSON.parse(http.request(req).body.to_s)
+      HttpClient.new.post(
+        url,
+        form: (params if params.any?),
+        headers: { "Authorization" => "Bearer #{access_token}" }
+      ).json
     end
   end
 end

--- a/services/console/app/jobs/oauth/enrich_github_credential_identity_job.rb
+++ b/services/console/app/jobs/oauth/enrich_github_credential_identity_job.rb
@@ -1,6 +1,4 @@
 require "json"
-require "net/http"
-require "uri"
 
 module Oauth
   class EnrichGithubCredentialIdentityJob < ApplicationJob
@@ -91,20 +89,16 @@ module Oauth
         )
       end
 
-      uri = URI.parse(USER_ENDPOINT)
-      req = Net::HTTP::Get.new(uri)
-      req["Accept"] = "application/vnd.github+json"
-      req["Authorization"] = "Bearer #{access_token}"
-      req["X-GitHub-Api-Version"] = "2022-11-28"
-      req["User-Agent"] = "centaur-console"
-
-      http = Net::HTTP.new(uri.host, uri.port)
-      http.use_ssl = uri.scheme == "https"
-      http.open_timeout = 5
-      http.read_timeout = 5
-
-      response = http.request(req)
-      status = response.code.to_i
+      response = HttpClient.new.get(
+        USER_ENDPOINT,
+        headers: {
+          "Accept" => "application/vnd.github+json",
+          "Authorization" => "Bearer #{access_token}",
+          "X-GitHub-Api-Version" => "2022-11-28",
+          "User-Agent" => "centaur-console"
+        }
+      )
+      status = response.status
       if status == 429 || status >= 500
         raise GithubProfileRetryableError, "github user lookup http #{status}"
       end
@@ -113,7 +107,7 @@ module Oauth
         return nil
       end
 
-      parsed = JSON.parse(response.body.to_s)
+      parsed = response.json
       parsed.is_a?(Hash) ? parsed : nil
     rescue GithubProfileRetryableError
       raise

--- a/services/console/app/jobs/oauth/enrich_linear_credential_identity_job.rb
+++ b/services/console/app/jobs/oauth/enrich_linear_credential_identity_job.rb
@@ -1,6 +1,4 @@
 require "json"
-require "net/http"
-require "uri"
 
 module Oauth
   class EnrichLinearCredentialIdentityJob < ApplicationJob
@@ -91,21 +89,15 @@ module Oauth
         )
       end
 
-      uri = URI.parse(GRAPHQL_ENDPOINT)
-      req = Net::HTTP::Post.new(uri)
-      req["Accept"] = "application/json"
-      req["Authorization"] = "Bearer #{access_token}"
-      req["Content-Type"] = "application/json"
-      req["User-Agent"] = "centaur-console"
-      req.body = { query: VIEWER_QUERY }.to_json
-
-      http = Net::HTTP.new(uri.host, uri.port)
-      http.use_ssl = uri.scheme == "https"
-      http.open_timeout = 5
-      http.read_timeout = 5
-
-      response = http.request(req)
-      status = response.code.to_i
+      response = HttpClient.new.post(
+        GRAPHQL_ENDPOINT,
+        json: { query: VIEWER_QUERY },
+        headers: {
+          "Authorization" => "Bearer #{access_token}",
+          "User-Agent" => "centaur-console"
+        }
+      )
+      status = response.status
       if status == 429 || status >= 500
         raise LinearProfileRetryableError, "linear viewer lookup http #{status}"
       end
@@ -114,7 +106,7 @@ module Oauth
         return nil
       end
 
-      parsed = JSON.parse(response.body.to_s)
+      parsed = response.json
       parsed.is_a?(Hash) ? parsed : nil
     rescue LinearProfileRetryableError
       raise

--- a/services/console/app/services/centaur_api_client.rb
+++ b/services/console/app/services/centaur_api_client.rb
@@ -12,7 +12,6 @@ class CentaurApiClient
     @base_url = (base_url.presence || ConsoleEnv["CENTAUR_API_URL"].presence || "http://localhost:8080").delete_suffix("/")
     @api_key = api_key.presence || ConsoleEnv["CENTAUR_API_KEY"].presence
     @api = HttpClient.new(http: http, open_timeout: timeout, read_timeout: timeout)
-    @timeout = timeout
   end
 
   def list_slack_archive_imports(limit: 100)
@@ -131,8 +130,7 @@ class CentaurApiClient
       method: method,
       url: URI.join("#{@base_url}/", path.delete_prefix("/")).to_s,
       json: payload,
-      headers: request_headers,
-      timeout: @timeout
+      headers: request_headers
     )
     parsed = parse_body(response.body)
     return parsed if response.status.between?(200, 299)

--- a/services/console/app/services/centaur_api_client.rb
+++ b/services/console/app/services/centaur_api_client.rb
@@ -2,7 +2,6 @@ require "cgi"
 require "uri"
 
 class CentaurApiClient
-  Response = HttpClient::Response
   Error = Class.new(StandardError)
 
   DEFAULT_TIMEOUT_SECONDS = 20

--- a/services/console/app/services/centaur_api_client.rb
+++ b/services/console/app/services/centaur_api_client.rb
@@ -128,10 +128,10 @@ class CentaurApiClient
   end
 
   def request(method, path, payload = nil)
-    response = @api.request(
+    response = @api.request_json(
       method: method,
       url: URI.join("#{@base_url}/", path.delete_prefix("/")).to_s,
-      json: payload.nil? ? HttpClient::UNSET : payload,
+      body: payload,
       headers: request_headers,
       timeout: @timeout
     )

--- a/services/console/app/services/centaur_api_client.rb
+++ b/services/console/app/services/centaur_api_client.rb
@@ -128,10 +128,10 @@ class CentaurApiClient
   end
 
   def request(method, path, payload = nil)
-    response = @api.request_json(
+    response = @api.request(
       method: method,
       url: URI.join("#{@base_url}/", path.delete_prefix("/")).to_s,
-      body: payload,
+      json: payload,
       headers: request_headers,
       timeout: @timeout
     )

--- a/services/console/app/services/centaur_api_client.rb
+++ b/services/console/app/services/centaur_api_client.rb
@@ -1,10 +1,8 @@
 require "cgi"
-require "json"
-require "net/http"
 require "uri"
 
 class CentaurApiClient
-  Response = Struct.new(:status, :body, keyword_init: true)
+  Response = HttpClient::Response
   Error = Class.new(StandardError)
 
   DEFAULT_TIMEOUT_SECONDS = 20
@@ -14,7 +12,7 @@ class CentaurApiClient
   def initialize(base_url: nil, api_key: nil, http: nil, timeout: DEFAULT_TIMEOUT_SECONDS)
     @base_url = (base_url.presence || ConsoleEnv["CENTAUR_API_URL"].presence || "http://localhost:8080").delete_suffix("/")
     @api_key = api_key.presence || ConsoleEnv["CENTAUR_API_KEY"].presence
-    @http = http || method(:net_http_request)
+    @api = HttpClient.new(http: http, open_timeout: timeout, read_timeout: timeout)
     @timeout = timeout
   end
 
@@ -130,10 +128,10 @@ class CentaurApiClient
   end
 
   def request(method, path, payload = nil)
-    response = @http.call(
+    response = @api.request(
       method: method,
       url: URI.join("#{@base_url}/", path.delete_prefix("/")).to_s,
-      body: payload&.to_json,
+      json: payload.nil? ? HttpClient::UNSET : payload,
       headers: request_headers,
       timeout: @timeout
     )
@@ -152,30 +150,9 @@ class CentaurApiClient
   end
 
   def parse_body(body)
-    return {} if body.blank?
-
-    JSON.parse(body)
+    HttpClient.decode_json_body(body)
   rescue JSON::ParserError
     { "raw" => body.to_s }
-  end
-
-  def net_http_request(method:, url:, body:, headers:, timeout:)
-    uri = URI.parse(url)
-    request_class = {
-      get: Net::HTTP::Get,
-      post: Net::HTTP::Post,
-      delete: Net::HTTP::Delete
-    }.fetch(method)
-    request = request_class.new(uri)
-    headers.each { |key, value| request[key] = value }
-    request.body = body if body
-
-    http = Net::HTTP.new(uri.host, uri.port)
-    http.use_ssl = uri.scheme == "https"
-    http.open_timeout = timeout
-    http.read_timeout = timeout
-    response = http.request(request)
-    Response.new(status: response.code.to_i, body: response.body.to_s)
   end
 
   def escape_path(value)

--- a/services/console/app/services/google_docs/sync_credential.rb
+++ b/services/console/app/services/google_docs/sync_credential.rb
@@ -1,8 +1,6 @@
 require "digest"
 require "cgi"
 require "json"
-require "net/http"
-require "uri"
 
 module GoogleDocs
   class SyncCredential
@@ -358,32 +356,27 @@ module GoogleDocs
     end
 
     def google_api(endpoint, params = {})
-      uri = URI.parse(endpoint)
-      query = URI.decode_www_form(uri.query.to_s) + params.compact.map { |key, value| [ key, value.to_s ] }
-      uri.query = URI.encode_www_form(query)
       response = if @google_api_http
         @google_api_http.call(endpoint: endpoint, params: params, access_token: @credential.access_token)
       else
-        net_http_get(uri)
+        net_http_get(endpoint, params)
       end
       return response if response.is_a?(Hash)
 
       raise GoogleApiError, "Google API returned invalid response"
     end
 
-    def net_http_get(uri)
-      request = Net::HTTP::Get.new(uri)
-      request["Accept"] = "application/json"
-      request["Authorization"] = "Bearer #{@credential.access_token}"
-      response = Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == "https") do |http|
-        http.request(request)
-      end
-      body = response.body.to_s
-      parsed = body.present? ? JSON.parse(body) : {}
-      return parsed if response.code.to_i.between?(200, 299)
+    def net_http_get(endpoint, params)
+      response = HttpClient.new.get(
+        endpoint,
+        params: params,
+        headers: { "Authorization" => "Bearer #{@credential.access_token}" }
+      )
+      parsed = response.json
+      return parsed if response.success?
 
       message = parsed.dig("error", "message") if parsed.is_a?(Hash)
-      raise GoogleApiError, message.presence || "Google API returned HTTP #{response.code}"
+      raise GoogleApiError, message.presence || "Google API returned HTTP #{response.status}"
     rescue JSON::ParserError
       raise GoogleApiError, "Google API returned invalid JSON"
     end

--- a/services/console/app/services/granola/sync_credential.rb
+++ b/services/console/app/services/granola/sync_credential.rb
@@ -1,9 +1,7 @@
 require "cgi"
 require "date"
 require "json"
-require "net/http"
 require "time"
-require "uri"
 
 module Granola
   # Syncs one user's connected Granola MCP account. This runs in the console so
@@ -315,24 +313,22 @@ module Granola
 
     def mcp_request(method, params, session_id: nil, notification: false)
       @rpc_id += 1 unless notification
-      uri = URI.parse(MCP_URL)
-      request = Net::HTTP::Post.new(uri)
-      request["Authorization"] = "Bearer #{@credential.access_token}"
-      request["Content-Type"] = "application/json"
-      request["Accept"] = "application/json, text/event-stream"
-      request["MCP-Protocol-Version"] = "2025-03-26" if session_id.present?
-      request["MCP-Session-Id"] = session_id if session_id.present?
+      headers = {
+        "Authorization" => "Bearer #{@credential.access_token}",
+        "Accept" => "application/json, text/event-stream"
+      }
+      headers["MCP-Protocol-Version"] = "2025-03-26" if session_id.present?
+      headers["MCP-Session-Id"] = session_id if session_id.present?
       payload = { jsonrpc: "2.0", method: method, params: params }
       payload[:id] = @rpc_id unless notification
-      request.body = payload.to_json
 
-      http = Net::HTTP.new(uri.host, uri.port)
-      http.use_ssl = true
-      http.open_timeout = 30
-      http.read_timeout = 60
-      response = http.request(request)
-      unless response.code.to_i.between?(200, 299)
-        raise GranolaApiError, "Granola MCP returned HTTP #{response.code}"
+      response = HttpClient.new(open_timeout: 30, read_timeout: 60).post(
+        MCP_URL,
+        json: payload,
+        headers: headers
+      )
+      unless response.success?
+        raise GranolaApiError, "Granola MCP returned HTTP #{response.status}"
       end
 
       response

--- a/services/console/app/services/slack_channel_catalog.rb
+++ b/services/console/app/services/slack_channel_catalog.rb
@@ -1,7 +1,5 @@
 require "digest"
 require "json"
-require "net/http"
-require "uri"
 
 class SlackChannelCatalog
   Channel = Data.define(:id, :name, :private)
@@ -61,9 +59,14 @@ class SlackChannelCatalog
     Result.new(channels: channels, error: payload["error"], configured: payload["configured"])
   end
 
-  def initialize(token:, api_url:)
+  def initialize(token:, api_url:, api: nil)
     @token = token
     @api_url = api_url.to_s.delete_suffix("/")
+    @api = api || HttpClient.new(
+      open_timeout: OPEN_TIMEOUT_SECONDS,
+      read_timeout: READ_TIMEOUT_SECONDS,
+      write_timeout: WRITE_TIMEOUT_SECONDS
+    )
   end
 
   def fetch
@@ -92,32 +95,21 @@ class SlackChannelCatalog
   private
 
   def request_page(cursor)
-    uri = URI("#{@api_url}/conversations.list")
     params = {
       types: DEFAULT_TYPES,
       exclude_archived: "true",
       limit: "1000"
     }
     params[:cursor] = cursor if cursor.present?
-    uri.query = URI.encode_www_form(params)
 
-    request = Net::HTTP::Get.new(uri)
-    request["Authorization"] = "Bearer #{@token}"
-    request["Accept"] = "application/json"
+    response = @api.get(
+      "#{@api_url}/conversations.list",
+      params: params,
+      headers: { "Authorization" => "Bearer #{@token}" }
+    )
+    return { "ok" => false, "error" => "HTTP #{response.status}" } unless response.success?
 
-    response = Net::HTTP.start(
-      uri.host,
-      uri.port,
-      use_ssl: uri.scheme == "https",
-      open_timeout: OPEN_TIMEOUT_SECONDS,
-      read_timeout: READ_TIMEOUT_SECONDS,
-      write_timeout: WRITE_TIMEOUT_SECONDS
-    ) do |http|
-      http.request(request)
-    end
-    return { "ok" => false, "error" => "HTTP #{response.code}" } unless response.code.to_i.between?(200, 299)
-
-    JSON.parse(response.body)
+    response.json
   end
 
   def parse_channel(channel)

--- a/services/console/app/services/slack_dm/sync_credential.rb
+++ b/services/console/app/services/slack_dm/sync_credential.rb
@@ -1,7 +1,3 @@
-require "json"
-require "net/http"
-require "uri"
-
 module SlackDm
   class SyncCredential
     DM_REQUIRED_SCOPES = %w[im:read im:history].freeze
@@ -326,21 +322,15 @@ module SlackDm
         )
       end
 
-      uri = URI.parse(endpoint)
-      uri.query = URI.encode_www_form(params) if params.any?
-      request = Net::HTTP::Get.new(uri)
-      request["Authorization"] = "Bearer #{@credential.access_token}"
-      request["Accept"] = "application/json"
+      response = HttpClient.new(open_timeout: slack_timeout, read_timeout: slack_timeout).get(
+        endpoint,
+        params: params,
+        headers: { "Authorization" => "Bearer #{@credential.access_token}" }
+      )
+      raise SlackApiError, "Slack API rate limited" if response.status == 429
 
-      http = Net::HTTP.new(uri.host, uri.port)
-      http.use_ssl = uri.scheme == "https"
-      http.open_timeout = slack_timeout
-      http.read_timeout = slack_timeout
-      response = http.request(request)
-      raise SlackApiError, "Slack API rate limited" if response.code.to_i == 429
-
-      parsed = JSON.parse(response.body.to_s)
-      raise SlackApiError, "Slack API returned HTTP #{response.code}" unless response.code.to_i.between?(200, 299)
+      parsed = response.json
+      raise SlackApiError, "Slack API returned HTTP #{response.status}" unless response.success?
       raise SlackApiError, "Slack API returned #{parsed['error']}" unless parsed["ok"] == true
 
       parsed

--- a/services/console/app/services/slack_requester_identity.rb
+++ b/services/console/app/services/slack_requester_identity.rb
@@ -1,7 +1,3 @@
-require "json"
-require "net/http"
-require "uri"
-
 # Resolves a Console user's GitHub handle through the same authoritative source
 # as slackbotv2: the GitHub custom field on the human requester's Slack profile.
 class SlackRequesterIdentity
@@ -21,9 +17,10 @@ class SlackRequesterIdentity
       Result.new(handle: nil, source: nil, reason: "no GitHub custom field found on Slack profile")
   end
 
-  def initialize(token:, api_url:)
+  def initialize(token:, api_url:, api: nil)
     @token = token
     @api_url = api_url.to_s.delete_suffix("/")
+    @api = api || HttpClient.new
   end
 
   def resolve(user_id)
@@ -39,14 +36,11 @@ class SlackRequesterIdentity
   private
 
   def slack_get(method, params)
-    uri = URI("#{@api_url}/#{method}")
-    uri.query = URI.encode_www_form(params)
-    request = Net::HTTP::Get.new(uri)
-    request["Authorization"] = "Bearer #{@token}"
-    request["Accept"] = "application/json"
-    response = Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == "https",
-                               open_timeout: 2, read_timeout: 5) { |http| http.request(request) }
-    JSON.parse(response.body)
+    @api.get(
+      "#{@api_url}/#{method}",
+      params: params,
+      headers: { "Authorization" => "Bearer #{@token}" }
+    ).json
   end
 
   def github_field(profile)

--- a/services/console/lib/broker/authorization_code_client.rb
+++ b/services/console/lib/broker/authorization_code_client.rb
@@ -17,10 +17,6 @@ module Broker
     # the parsed provider response for provider-specific metadata.
     Result = Data.define(:access_token, :refresh_token, :expires_in, :scope, :id_token, :response)
 
-    # The minimal HTTP response shape consumed, so tests can inject a double
-    # without Net::HTTP.
-    Response = Data.define(:status, :body)
-
     DEFAULT_TIMEOUT = 30
     MAX_BODY_BYTES = 64 * 1024
 
@@ -76,7 +72,7 @@ module Broker
         url,
         form: form
       )
-      Response.new(status: response.status, body: response.body)
+      response
     rescue StandardError => e
       raise ExchangeError.new("token endpoint request failed: #{e.class}", stage: "network")
     end

--- a/services/console/lib/broker/authorization_code_client.rb
+++ b/services/console/lib/broker/authorization_code_client.rb
@@ -1,6 +1,4 @@
-require "net/http"
 require "json"
-require "uri"
 
 module Broker
   # Performs the RFC 6749 4.1.3 authorization_code grant POST (optionally with PKCE) and
@@ -70,19 +68,15 @@ module Broker
         return @http.call(url: url, form: form, headers: {}, timeout: timeout)
       end
 
-      uri = URI.parse(url)
-      req = Net::HTTP::Post.new(uri)
-      req.set_form_data(form)
-      req["Content-Type"] = "application/x-www-form-urlencoded"
-      req["Accept"] = "application/json"
-
-      http = Net::HTTP.new(uri.host, uri.port)
-      http.use_ssl = uri.scheme == "https"
-      http.open_timeout = timeout
-      http.read_timeout = timeout
-
-      res = http.request(req)
-      Response.new(status: res.code.to_i, body: res.body.to_s.byteslice(0, MAX_BODY_BYTES))
+      response = HttpClient.new(
+        open_timeout: timeout,
+        read_timeout: timeout,
+        max_body_bytes: MAX_BODY_BYTES
+      ).post(
+        url,
+        form: form
+      )
+      Response.new(status: response.status, body: response.body)
     rescue StandardError => e
       raise ExchangeError.new("token endpoint request failed: #{e.class}", stage: "network")
     end

--- a/services/console/lib/broker/refresh_client.rb
+++ b/services/console/lib/broker/refresh_client.rb
@@ -1,6 +1,4 @@
-require "net/http"
 require "json"
-require "uri"
 
 module Broker
   # RefreshClient performs raw token POSTs and returns the parsed response. It
@@ -61,24 +59,17 @@ module Broker
                           form_encoding: form_encoding)
       end
 
-      uri = URI.parse(url)
-      req = Net::HTTP::Post.new(uri)
-      if form_encoding == :multipart
-        req.set_form(form.to_a, "multipart/form-data")
-      else
-        req.set_form_data(form)
-        req["Content-Type"] = "application/x-www-form-urlencoded"
-      end
-      req["Accept"] = "application/json"
-      headers.each { |name, value| req[name] = value }
-
-      http = Net::HTTP.new(uri.host, uri.port)
-      http.use_ssl = uri.scheme == "https"
-      http.open_timeout = timeout
-      http.read_timeout = timeout
-
-      res = http.request(req)
-      Response.new(status: res.code.to_i, body: res.body.to_s.byteslice(0, MAX_BODY_BYTES))
+      response = HttpClient.new(
+        open_timeout: timeout,
+        read_timeout: timeout,
+        max_body_bytes: MAX_BODY_BYTES
+      ).post(
+        url,
+        form: form,
+        multipart: form_encoding == :multipart,
+        headers: headers
+      )
+      Response.new(status: response.status, body: response.body)
     rescue StandardError => e
       # Network/transport failures are transient: a brief outage must not mark the
       # credential dead. Backoff exhaustion is the louder signal.

--- a/services/console/lib/broker/refresh_client.rb
+++ b/services/console/lib/broker/refresh_client.rb
@@ -13,10 +13,6 @@ module Broker
     # it -- the caller picks a conservative default).
     Result = Data.define(:access_token, :refresh_token, :expires_in)
 
-    # The minimal HTTP response shape RefreshClient consumes, so tests can inject
-    # a double without Net::HTTP.
-    Response = Data.define(:status, :body)
-
     DEFAULT_TIMEOUT = 30
     MAX_BODY_BYTES = 64 * 1024
 
@@ -69,7 +65,7 @@ module Broker
         multipart: form_encoding == :multipart,
         headers: headers
       )
-      Response.new(status: response.status, body: response.body)
+      response
     rescue StandardError => e
       # Network/transport failures are transient: a brief outage must not mark the
       # credential dead. Backoff exhaustion is the louder signal.

--- a/services/console/lib/http_client.rb
+++ b/services/console/lib/http_client.rb
@@ -145,8 +145,8 @@ class HttpClient
              form:, multipart:)
       uri = URI.parse(url)
       request = REQUEST_CLASSES.fetch(method).new(uri)
-      headers.each { |key, value| request[key] = value }
       apply_body(request, body: body, form: form, multipart: multipart)
+      headers.each { |key, value| request[key] = value }
 
       http = Net::HTTP.new(uri.host, uri.port)
       http.use_ssl = uri.scheme == "https"

--- a/services/console/lib/http_client.rb
+++ b/services/console/lib/http_client.rb
@@ -36,7 +36,7 @@ class HttpClient
   def initialize(http: nil, open_timeout: DEFAULT_OPEN_TIMEOUT, read_timeout: DEFAULT_READ_TIMEOUT,
                  write_timeout: nil, max_body_bytes: nil)
     @http = if http
-      InjectedTransport.new(http, default_timeout: read_timeout || open_timeout || write_timeout)
+      InjectedTransport.new(http, timeout: read_timeout || open_timeout || write_timeout)
     else
       NetHttpTransport.new(
         open_timeout: open_timeout,
@@ -47,22 +47,16 @@ class HttpClient
     end
   end
 
-  def get(url, params: {}, headers: {}, timeout: nil, open_timeout: nil, read_timeout: nil,
-          write_timeout: nil)
+  def get(url, params: {}, headers: {})
     request(
       method: :get,
       url: url,
       params: params,
-      headers: headers,
-      timeout: timeout,
-      open_timeout: open_timeout,
-      read_timeout: read_timeout,
-      write_timeout: write_timeout
+      headers: headers
     )
   end
 
-  def post(url, params: {}, json: nil, form: nil, multipart: false, headers: {}, timeout: nil,
-           open_timeout: nil, read_timeout: nil, write_timeout: nil)
+  def post(url, params: {}, json: nil, form: nil, multipart: false, headers: {})
     request(
       method: :post,
       url: url,
@@ -70,30 +64,20 @@ class HttpClient
       json: json,
       form: form,
       multipart: multipart,
-      headers: headers,
-      timeout: timeout,
-      open_timeout: open_timeout,
-      read_timeout: read_timeout,
-      write_timeout: write_timeout
+      headers: headers
     )
   end
 
-  def delete(url, params: {}, headers: {}, timeout: nil, open_timeout: nil, read_timeout: nil,
-             write_timeout: nil)
+  def delete(url, params: {}, headers: {})
     request(
       method: :delete,
       url: url,
       params: params,
-      headers: headers,
-      timeout: timeout,
-      open_timeout: open_timeout,
-      read_timeout: read_timeout,
-      write_timeout: write_timeout
+      headers: headers
     )
   end
 
-  def request(method:, url:, params: {}, json: nil, form: nil, multipart: false, headers: {},
-              timeout: nil, open_timeout: nil, read_timeout: nil, write_timeout: nil)
+  def request(method:, url:, params: {}, json: nil, form: nil, multipart: false, headers: {})
     uri = build_uri(url, params)
     request_headers = default_headers.merge(headers)
     apply_content_type(request_headers, json: json, form: form, multipart: multipart)
@@ -105,44 +89,40 @@ class HttpClient
       body: body,
       form: form,
       multipart: multipart,
-      headers: request_headers,
-      timeout: timeout,
-      open_timeout: open_timeout,
-      read_timeout: read_timeout,
-      write_timeout: write_timeout
+      headers: request_headers
     )
   end
 
   private
 
   class InjectedTransport
-    def initialize(http, default_timeout:)
+    def initialize(http, timeout:)
       @http = http
-      @default_timeout = default_timeout
+      @timeout = timeout
     end
 
-    def call(method:, url:, body:, headers:, timeout:, open_timeout:, read_timeout:, write_timeout:,
-             form:, multipart:)
+    def call(method:, url:, body:, headers:, form:, multipart:)
       @http.call(
         method: method,
         url: url,
         body: body,
         headers: headers,
-        timeout: timeout || read_timeout || open_timeout || write_timeout || @default_timeout
+        timeout: @timeout
       )
     end
   end
 
   class NetHttpTransport
     def initialize(open_timeout:, read_timeout:, write_timeout:, max_body_bytes:)
-      @open_timeout = open_timeout
-      @read_timeout = read_timeout
-      @write_timeout = write_timeout
+      @default_timeouts = {
+        open: open_timeout,
+        read: read_timeout,
+        write: write_timeout
+      }
       @max_body_bytes = max_body_bytes
     end
 
-    def call(method:, url:, body:, headers:, timeout:, open_timeout:, read_timeout:, write_timeout:,
-             form:, multipart:)
+    def call(method:, url:, body:, headers:, form:, multipart:)
       uri = URI.parse(url)
       request = REQUEST_CLASSES.fetch(method).new(uri)
       apply_body(request, body: body, form: form, multipart: multipart)
@@ -150,10 +130,7 @@ class HttpClient
 
       http = Net::HTTP.new(uri.host, uri.port)
       http.use_ssl = uri.scheme == "https"
-      http.open_timeout = open_timeout || timeout || @open_timeout
-      http.read_timeout = read_timeout || timeout || @read_timeout
-      resolved_write_timeout = write_timeout || timeout || @write_timeout
-      http.write_timeout = resolved_write_timeout if resolved_write_timeout
+      apply_timeouts(http)
 
       response = http.request(request)
       Response.new(
@@ -164,6 +141,14 @@ class HttpClient
     end
 
     private
+
+    def apply_timeouts(http)
+      http.open_timeout = @default_timeouts.fetch(:open)
+      http.read_timeout = @default_timeouts.fetch(:read)
+
+      write_timeout = @default_timeouts.fetch(:write)
+      http.write_timeout = write_timeout if write_timeout
+    end
 
     def response_body(response)
       body = response.body.to_s

--- a/services/console/lib/http_client.rb
+++ b/services/console/lib/http_client.rb
@@ -122,6 +122,22 @@ class HttpClient
     normalize_response(raw_response)
   end
 
+  def request_json(method:, url:, params: {}, body: nil, headers: {}, timeout: nil, open_timeout: nil,
+                   read_timeout: nil, write_timeout: nil)
+    options = {
+      method: method,
+      url: url,
+      params: params,
+      headers: headers,
+      timeout: timeout,
+      open_timeout: open_timeout,
+      read_timeout: read_timeout,
+      write_timeout: write_timeout
+    }
+    options[:json] = body unless body.nil?
+    request(**options)
+  end
+
   private
 
   def build_uri(url, params)

--- a/services/console/lib/http_client.rb
+++ b/services/console/lib/http_client.rb
@@ -114,7 +114,7 @@ class HttpClient
 
   class NetHttpTransport
     def initialize(open_timeout:, read_timeout:, write_timeout:, max_body_bytes:)
-      @default_timeouts = {
+      @timeouts = {
         open: open_timeout,
         read: read_timeout,
         write: write_timeout
@@ -143,10 +143,10 @@ class HttpClient
     private
 
     def apply_timeouts(http)
-      http.open_timeout = @default_timeouts.fetch(:open)
-      http.read_timeout = @default_timeouts.fetch(:read)
+      http.open_timeout = @timeouts.fetch(:open)
+      http.read_timeout = @timeouts.fetch(:read)
 
-      write_timeout = @default_timeouts.fetch(:write)
+      write_timeout = @timeouts.fetch(:write)
       http.write_timeout = write_timeout if write_timeout
     end
 

--- a/services/console/lib/http_client.rb
+++ b/services/console/lib/http_client.rb
@@ -35,10 +35,15 @@ class HttpClient
 
   def initialize(http: nil, open_timeout: DEFAULT_OPEN_TIMEOUT, read_timeout: DEFAULT_READ_TIMEOUT,
                  write_timeout: nil, max_body_bytes: nil)
-    @http = http
-    @open_timeout = open_timeout
-    @read_timeout = read_timeout
-    @write_timeout = write_timeout
+    @http = if http
+      InjectedTransport.new(http, default_timeout: read_timeout || open_timeout || write_timeout)
+    else
+      NetHttpTransport.new(
+        open_timeout: open_timeout,
+        read_timeout: read_timeout,
+        write_timeout: write_timeout
+      )
+    end
     @max_body_bytes = max_body_bytes
   end
 
@@ -94,34 +99,80 @@ class HttpClient
     apply_content_type(request_headers, json: json, form: form, multipart: multipart)
     body = request_body(json: json, form: form)
 
-    raw_response = if @http
-      @http.call(
-        method: method,
-        url: uri.to_s,
-        body: body,
-        headers: request_headers,
-        timeout: timeout || read_timeout || @read_timeout || @open_timeout || @write_timeout
-      )
-    else
-      net_http_request(
-        method: method,
-        uri: uri,
-        headers: request_headers,
-        json: json,
-        form: form,
-        multipart: multipart,
-        body: body,
-        timeout: timeout,
-        open_timeout: open_timeout,
-        read_timeout: read_timeout,
-        write_timeout: write_timeout
-      )
-    end
+    raw_response = @http.call(
+      method: method,
+      url: uri.to_s,
+      body: body,
+      form: form,
+      multipart: multipart,
+      headers: request_headers,
+      timeout: timeout,
+      open_timeout: open_timeout,
+      read_timeout: read_timeout,
+      write_timeout: write_timeout
+    )
 
     normalize_response(raw_response)
   end
 
   private
+
+  class InjectedTransport
+    def initialize(http, default_timeout:)
+      @http = http
+      @default_timeout = default_timeout
+    end
+
+    def call(method:, url:, body:, headers:, timeout:, open_timeout:, read_timeout:, write_timeout:,
+             form:, multipart:)
+      @http.call(
+        method: method,
+        url: url,
+        body: body,
+        headers: headers,
+        timeout: timeout || read_timeout || open_timeout || write_timeout || @default_timeout
+      )
+    end
+  end
+
+  class NetHttpTransport
+    def initialize(open_timeout:, read_timeout:, write_timeout:)
+      @open_timeout = open_timeout
+      @read_timeout = read_timeout
+      @write_timeout = write_timeout
+    end
+
+    def call(method:, url:, body:, headers:, timeout:, open_timeout:, read_timeout:, write_timeout:,
+             form:, multipart:)
+      uri = URI.parse(url)
+      request = REQUEST_CLASSES.fetch(method).new(uri)
+      headers.each { |key, value| request[key] = value }
+      apply_body(request, body: body, form: form, multipart: multipart)
+
+      http = Net::HTTP.new(uri.host, uri.port)
+      http.use_ssl = uri.scheme == "https"
+      http.open_timeout = open_timeout || timeout || @open_timeout
+      http.read_timeout = read_timeout || timeout || @read_timeout
+      resolved_write_timeout = write_timeout || timeout || @write_timeout
+      http.write_timeout = resolved_write_timeout if resolved_write_timeout
+
+      http.request(request)
+    end
+
+    private
+
+    def apply_body(request, body:, form:, multipart:)
+      if form
+        if multipart
+          request.set_form(form.to_a, "multipart/form-data")
+        else
+          request.set_form_data(form)
+        end
+      elsif body
+        request.body = body
+      end
+    end
+  end
 
   def build_uri(url, params)
     uri = URI.parse(url)
@@ -138,34 +189,6 @@ class HttpClient
     return URI.encode_www_form(form) if form
 
     nil
-  end
-
-  def net_http_request(method:, uri:, headers:, json:, form:, multipart:, body:, timeout:,
-                       open_timeout:, read_timeout:, write_timeout:)
-    request = REQUEST_CLASSES.fetch(method).new(uri)
-    headers.each { |key, value| request[key] = value }
-    apply_body(request, json: json, form: form, multipart: multipart, body: body)
-
-    http = Net::HTTP.new(uri.host, uri.port)
-    http.use_ssl = uri.scheme == "https"
-    http.open_timeout = open_timeout || timeout || @open_timeout
-    http.read_timeout = read_timeout || timeout || @read_timeout
-    resolved_write_timeout = write_timeout || timeout || @write_timeout
-    http.write_timeout = resolved_write_timeout if resolved_write_timeout
-
-    http.request(request)
-  end
-
-  def apply_body(request, json:, form:, multipart:, body:)
-    if !json.nil?
-      request.body = body
-    elsif form
-      if multipart
-        request.set_form(form.to_a, "multipart/form-data")
-      else
-        request.set_form_data(form)
-      end
-    end
   end
 
   def apply_content_type(headers, json:, form:, multipart:)

--- a/services/console/lib/http_client.rb
+++ b/services/console/lib/http_client.rb
@@ -3,7 +3,6 @@ require "net/http"
 require "uri"
 
 class HttpClient
-  UNSET = Object.new.freeze
   DEFAULT_OPEN_TIMEOUT = 5
   DEFAULT_READ_TIMEOUT = 5
 
@@ -57,7 +56,7 @@ class HttpClient
     )
   end
 
-  def post(url, params: {}, json: UNSET, form: nil, multipart: false, headers: {}, timeout: nil,
+  def post(url, params: {}, json: nil, form: nil, multipart: false, headers: {}, timeout: nil,
            open_timeout: nil, read_timeout: nil, write_timeout: nil)
     request(
       method: :post,
@@ -88,7 +87,7 @@ class HttpClient
     )
   end
 
-  def request(method:, url:, params: {}, json: UNSET, form: nil, multipart: false, headers: {},
+  def request(method:, url:, params: {}, json: nil, form: nil, multipart: false, headers: {},
               timeout: nil, open_timeout: nil, read_timeout: nil, write_timeout: nil)
     uri = build_uri(url, params)
     request_headers = default_headers.merge(headers)
@@ -122,22 +121,6 @@ class HttpClient
     normalize_response(raw_response)
   end
 
-  def request_json(method:, url:, params: {}, body: nil, headers: {}, timeout: nil, open_timeout: nil,
-                   read_timeout: nil, write_timeout: nil)
-    options = {
-      method: method,
-      url: url,
-      params: params,
-      headers: headers,
-      timeout: timeout,
-      open_timeout: open_timeout,
-      read_timeout: read_timeout,
-      write_timeout: write_timeout
-    }
-    options[:json] = body unless body.nil?
-    request(**options)
-  end
-
   private
 
   def build_uri(url, params)
@@ -151,7 +134,7 @@ class HttpClient
   end
 
   def request_body(json:, form:)
-    return json.to_json unless json.equal?(UNSET)
+    return json.to_json unless json.nil?
     return URI.encode_www_form(form) if form
 
     nil
@@ -174,7 +157,7 @@ class HttpClient
   end
 
   def apply_body(request, json:, form:, multipart:, body:)
-    if !json.equal?(UNSET)
+    if !json.nil?
       request.body = body
     elsif form
       if multipart
@@ -188,7 +171,7 @@ class HttpClient
   def apply_content_type(headers, json:, form:, multipart:)
     return if header?(headers, "Content-Type")
 
-    if !json.equal?(UNSET)
+    if !json.nil?
       headers["Content-Type"] = "application/json"
     elsif form && !multipart
       headers["Content-Type"] = "application/x-www-form-urlencoded"

--- a/services/console/lib/http_client.rb
+++ b/services/console/lib/http_client.rb
@@ -41,10 +41,10 @@ class HttpClient
       NetHttpTransport.new(
         open_timeout: open_timeout,
         read_timeout: read_timeout,
-        write_timeout: write_timeout
+        write_timeout: write_timeout,
+        max_body_bytes: max_body_bytes
       )
     end
-    @max_body_bytes = max_body_bytes
   end
 
   def get(url, params: {}, headers: {}, timeout: nil, open_timeout: nil, read_timeout: nil,
@@ -99,7 +99,7 @@ class HttpClient
     apply_content_type(request_headers, json: json, form: form, multipart: multipart)
     body = request_body(json: json, form: form)
 
-    raw_response = @http.call(
+    @http.call(
       method: method,
       url: uri.to_s,
       body: body,
@@ -111,8 +111,6 @@ class HttpClient
       read_timeout: read_timeout,
       write_timeout: write_timeout
     )
-
-    normalize_response(raw_response)
   end
 
   private
@@ -136,10 +134,11 @@ class HttpClient
   end
 
   class NetHttpTransport
-    def initialize(open_timeout:, read_timeout:, write_timeout:)
+    def initialize(open_timeout:, read_timeout:, write_timeout:, max_body_bytes:)
       @open_timeout = open_timeout
       @read_timeout = read_timeout
       @write_timeout = write_timeout
+      @max_body_bytes = max_body_bytes
     end
 
     def call(method:, url:, body:, headers:, timeout:, open_timeout:, read_timeout:, write_timeout:,
@@ -156,10 +155,28 @@ class HttpClient
       resolved_write_timeout = write_timeout || timeout || @write_timeout
       http.write_timeout = resolved_write_timeout if resolved_write_timeout
 
-      http.request(request)
+      response = http.request(request)
+      Response.new(
+        status: response.code.to_i,
+        body: response_body(response),
+        headers: response_headers(response)
+      )
     end
 
     private
+
+    def response_body(response)
+      body = response.body.to_s
+      @max_body_bytes ? body.byteslice(0, @max_body_bytes) : body
+    end
+
+    def response_headers(response)
+      return {} unless response.respond_to?(:to_hash)
+
+      response.to_hash.to_h do |key, value|
+        [ key.to_s.downcase, Array(value).join(", ") ]
+      end
+    end
 
     def apply_body(request, body:, form:, multipart:)
       if form
@@ -203,20 +220,6 @@ class HttpClient
 
   def header?(headers, name)
     headers.any? { |key, _value| key.to_s.casecmp?(name) }
-  end
-
-  def normalize_response(response)
-    return response if response.is_a?(Response)
-
-    headers = {}
-    if response.respond_to?(:to_hash)
-      response.to_hash.each do |key, value|
-        headers[key.to_s.downcase] = Array(value).join(", ")
-      end
-    end
-    body = response.body.to_s
-    body = body.byteslice(0, @max_body_bytes) if @max_body_bytes
-    Response.new(status: response.code.to_i, body: body, headers: headers)
   end
 
   def default_headers

--- a/services/console/lib/http_client.rb
+++ b/services/console/lib/http_client.rb
@@ -1,0 +1,203 @@
+require "json"
+require "net/http"
+require "uri"
+
+class HttpClient
+  UNSET = Object.new.freeze
+  DEFAULT_OPEN_TIMEOUT = 5
+  DEFAULT_READ_TIMEOUT = 5
+
+  REQUEST_CLASSES = {
+    delete: Net::HTTP::Delete,
+    get: Net::HTTP::Get,
+    post: Net::HTTP::Post
+  }.freeze
+
+  Response = Struct.new(:status, :body, :headers, keyword_init: true) do
+    def [](name)
+      (headers || {}).fetch(name.to_s.downcase, nil)
+    end
+
+    def success?
+      status.between?(200, 299)
+    end
+
+    def json
+      @json ||= HttpClient.decode_json_body(body)
+    end
+  end
+
+  def self.decode_json_body(body)
+    text = body.to_s
+    return {} if text.blank?
+
+    JSON.parse(text)
+  end
+
+  def initialize(http: nil, open_timeout: DEFAULT_OPEN_TIMEOUT, read_timeout: DEFAULT_READ_TIMEOUT,
+                 write_timeout: nil, max_body_bytes: nil)
+    @http = http
+    @open_timeout = open_timeout
+    @read_timeout = read_timeout
+    @write_timeout = write_timeout
+    @max_body_bytes = max_body_bytes
+  end
+
+  def get(url, params: {}, headers: {}, timeout: nil, open_timeout: nil, read_timeout: nil,
+          write_timeout: nil)
+    request(
+      method: :get,
+      url: url,
+      params: params,
+      headers: headers,
+      timeout: timeout,
+      open_timeout: open_timeout,
+      read_timeout: read_timeout,
+      write_timeout: write_timeout
+    )
+  end
+
+  def post(url, params: {}, json: UNSET, form: nil, multipart: false, headers: {}, timeout: nil,
+           open_timeout: nil, read_timeout: nil, write_timeout: nil)
+    request(
+      method: :post,
+      url: url,
+      params: params,
+      json: json,
+      form: form,
+      multipart: multipart,
+      headers: headers,
+      timeout: timeout,
+      open_timeout: open_timeout,
+      read_timeout: read_timeout,
+      write_timeout: write_timeout
+    )
+  end
+
+  def delete(url, params: {}, headers: {}, timeout: nil, open_timeout: nil, read_timeout: nil,
+             write_timeout: nil)
+    request(
+      method: :delete,
+      url: url,
+      params: params,
+      headers: headers,
+      timeout: timeout,
+      open_timeout: open_timeout,
+      read_timeout: read_timeout,
+      write_timeout: write_timeout
+    )
+  end
+
+  def request(method:, url:, params: {}, json: UNSET, form: nil, multipart: false, headers: {},
+              timeout: nil, open_timeout: nil, read_timeout: nil, write_timeout: nil)
+    uri = build_uri(url, params)
+    request_headers = default_headers.merge(headers)
+    apply_content_type(request_headers, json: json, form: form, multipart: multipart)
+    body = request_body(json: json, form: form)
+
+    raw_response = if @http
+      @http.call(
+        method: method,
+        url: uri.to_s,
+        body: body,
+        headers: request_headers,
+        timeout: timeout || read_timeout || @read_timeout || @open_timeout || @write_timeout
+      )
+    else
+      net_http_request(
+        method: method,
+        uri: uri,
+        headers: request_headers,
+        json: json,
+        form: form,
+        multipart: multipart,
+        body: body,
+        timeout: timeout,
+        open_timeout: open_timeout,
+        read_timeout: read_timeout,
+        write_timeout: write_timeout
+      )
+    end
+
+    normalize_response(raw_response)
+  end
+
+  private
+
+  def build_uri(url, params)
+    uri = URI.parse(url)
+    compact_params = params.compact
+    return uri if compact_params.empty?
+
+    existing = uri.query.present? ? URI.decode_www_form(uri.query) : []
+    uri.query = URI.encode_www_form(existing + compact_params.map { |key, value| [ key, value.to_s ] })
+    uri
+  end
+
+  def request_body(json:, form:)
+    return json.to_json unless json.equal?(UNSET)
+    return URI.encode_www_form(form) if form
+
+    nil
+  end
+
+  def net_http_request(method:, uri:, headers:, json:, form:, multipart:, body:, timeout:,
+                       open_timeout:, read_timeout:, write_timeout:)
+    request = REQUEST_CLASSES.fetch(method).new(uri)
+    headers.each { |key, value| request[key] = value }
+    apply_body(request, json: json, form: form, multipart: multipart, body: body)
+
+    http = Net::HTTP.new(uri.host, uri.port)
+    http.use_ssl = uri.scheme == "https"
+    http.open_timeout = open_timeout || timeout || @open_timeout
+    http.read_timeout = read_timeout || timeout || @read_timeout
+    resolved_write_timeout = write_timeout || timeout || @write_timeout
+    http.write_timeout = resolved_write_timeout if resolved_write_timeout
+
+    http.request(request)
+  end
+
+  def apply_body(request, json:, form:, multipart:, body:)
+    if !json.equal?(UNSET)
+      request.body = body
+    elsif form
+      if multipart
+        request.set_form(form.to_a, "multipart/form-data")
+      else
+        request.set_form_data(form)
+      end
+    end
+  end
+
+  def apply_content_type(headers, json:, form:, multipart:)
+    return if header?(headers, "Content-Type")
+
+    if !json.equal?(UNSET)
+      headers["Content-Type"] = "application/json"
+    elsif form && !multipart
+      headers["Content-Type"] = "application/x-www-form-urlencoded"
+    end
+  end
+
+  def header?(headers, name)
+    headers.any? { |key, _value| key.to_s.casecmp?(name) }
+  end
+
+  def normalize_response(response)
+    return response if response.is_a?(Response)
+
+    headers = {}
+    if response.respond_to?(:to_hash)
+      response.to_hash.each do |key, value|
+        headers[key.to_s.downcase] = Array(value).join(", ")
+      end
+    end
+    body = response.body.to_s
+    body = body.byteslice(0, @max_body_bytes) if @max_body_bytes
+    Response.new(status: response.code.to_i, body: body, headers: headers)
+  end
+
+  def default_headers
+    { "Accept" => "application/json" }
+  end
+end

--- a/services/console/test/controllers/oauth/flows_controller_test.rb
+++ b/services/console/test/controllers/oauth/flows_controller_test.rb
@@ -39,7 +39,7 @@ module Oauth
       end
 
       def call(url:, form:, headers:, timeout:)
-        Broker::AuthorizationCodeClient::Response.new(status: @status, body: @body)
+        HttpClient::Response.new(status: @status, body: @body)
       end
     end
 

--- a/services/console/test/controllers/session_oauth_controller_test.rb
+++ b/services/console/test/controllers/session_oauth_controller_test.rb
@@ -37,7 +37,7 @@ class SessionOauthControllerTest < ActionDispatch::IntegrationTest
 
     def call(url:, form:, headers:, timeout:)
       @captured = { url: url, form: form, headers: headers, timeout: timeout }
-      Broker::AuthorizationCodeClient::Response.new(status: @status, body: @body)
+      HttpClient::Response.new(status: @status, body: @body)
     end
   end
 

--- a/services/console/test/lib/broker/authorization_code_client_test.rb
+++ b/services/console/test/lib/broker/authorization_code_client_test.rb
@@ -14,7 +14,7 @@ module Broker
 
       def call(url:, form:, headers:, timeout:)
         @captured = { url: url, form: form, headers: headers, timeout: timeout }
-        AuthorizationCodeClient::Response.new(status: @status, body: @body)
+        HttpClient::Response.new(status: @status, body: @body)
       end
     end
 

--- a/services/console/test/lib/broker/refresh_client_test.rb
+++ b/services/console/test/lib/broker/refresh_client_test.rb
@@ -14,7 +14,7 @@ module Broker
 
       def call(url:, form:, headers:, timeout:, form_encoding:)
         @captured = { url: url, form: form, headers: headers, timeout: timeout, form_encoding: form_encoding }
-        Broker::RefreshClient::Response.new(status: @status, body: @body)
+        HttpClient::Response.new(status: @status, body: @body)
       end
     end
 

--- a/services/console/test/lib/http_client_test.rb
+++ b/services/console/test/lib/http_client_test.rb
@@ -73,11 +73,11 @@ class HttpClientTest < ActiveSupport::TestCase
     assert_equal "application/x-www-form-urlencoded", request[:headers]["Content-Type"]
   end
 
-  test "omits optional JSON request bodies when no body is provided" do
+  test "omits JSON request bodies when JSON is nil" do
     http = StubHTTP.new(HttpClient::Response.new(status: 204, body: ""))
     client = HttpClient.new(http: http)
 
-    client.request_json(method: :delete, url: "https://api.test/widgets/1")
+    client.request(method: :delete, url: "https://api.test/widgets/1", json: nil)
 
     request = http.requests.first
     assert_nil request[:body]

--- a/services/console/test/lib/http_client_test.rb
+++ b/services/console/test/lib/http_client_test.rb
@@ -48,8 +48,7 @@ class HttpClientTest < ActiveSupport::TestCase
       "https://api.test/widgets?existing=1",
       params: { page: 2, empty: nil },
       json: { name: "demo" },
-      headers: { "Authorization" => "Bearer token" },
-      timeout: 7
+      headers: { "Authorization" => "Bearer token" }
     )
 
     assert_equal({ "ok" => true }, response.json)
@@ -60,7 +59,7 @@ class HttpClientTest < ActiveSupport::TestCase
     assert_equal "application/json", request[:headers]["Accept"]
     assert_equal "application/json", request[:headers]["Content-Type"]
     assert_equal "Bearer token", request[:headers]["Authorization"]
-    assert_equal 7, request[:timeout]
+    assert_equal 5, request[:timeout]
   end
 
   test "serializes form requests" do

--- a/services/console/test/lib/http_client_test.rb
+++ b/services/console/test/lib/http_client_test.rb
@@ -73,6 +73,17 @@ class HttpClientTest < ActiveSupport::TestCase
     assert_equal "application/x-www-form-urlencoded", request[:headers]["Content-Type"]
   end
 
+  test "omits optional JSON request bodies when no body is provided" do
+    http = StubHTTP.new(HttpClient::Response.new(status: 204, body: ""))
+    client = HttpClient.new(http: http)
+
+    client.request_json(method: :delete, url: "https://api.test/widgets/1")
+
+    request = http.requests.first
+    assert_nil request[:body]
+    assert_nil request[:headers]["Content-Type"]
+  end
+
   test "supports custom accept headers" do
     http = StubHTTP.new(HttpClient::Response.new(status: 200, body: "{}"))
     client = HttpClient.new(http: http)

--- a/services/console/test/lib/http_client_test.rb
+++ b/services/console/test/lib/http_client_test.rb
@@ -1,0 +1,95 @@
+require "test_helper"
+
+class HttpClientTest < ActiveSupport::TestCase
+  FakeResponse = Struct.new(:code, :body)
+
+  class StubHTTP
+    attr_reader :requests
+
+    def initialize(response)
+      @response = response
+      @requests = []
+    end
+
+    def call(method:, url:, body:, headers:, timeout:)
+      @requests << { method: method, url: url, body: body, headers: headers, timeout: timeout }
+      @response
+    end
+  end
+
+  class FakeNetHTTP
+    attr_reader :open_timeout, :read_timeout
+
+    def initialize(response)
+      @response = response
+    end
+
+    attr_writer :use_ssl
+
+    def open_timeout=(value)
+      @open_timeout = value
+    end
+
+    def read_timeout=(value)
+      @read_timeout = value
+    end
+
+    def request(_request)
+      @response
+    end
+  end
+
+  test "serializes JSON requests and parses JSON responses" do
+    http = StubHTTP.new(HttpClient::Response.new(status: 200, body: { "ok" => true }.to_json))
+    client = HttpClient.new(http: http, open_timeout: 3, read_timeout: 5)
+
+    response = client.post(
+      "https://api.test/widgets?existing=1",
+      params: { page: 2, empty: nil },
+      json: { name: "demo" },
+      headers: { "Authorization" => "Bearer token" },
+      timeout: 7
+    )
+
+    assert_equal({ "ok" => true }, response.json)
+    request = http.requests.first
+    assert_equal :post, request[:method]
+    assert_equal "https://api.test/widgets?existing=1&page=2", request[:url]
+    assert_equal({ "name" => "demo" }, JSON.parse(request[:body]))
+    assert_equal "application/json", request[:headers]["Accept"]
+    assert_equal "application/json", request[:headers]["Content-Type"]
+    assert_equal "Bearer token", request[:headers]["Authorization"]
+    assert_equal 7, request[:timeout]
+  end
+
+  test "serializes form requests" do
+    http = StubHTTP.new(HttpClient::Response.new(status: 200, body: "{}"))
+    client = HttpClient.new(http: http)
+
+    client.post("https://api.test/token", form: { "grant_type" => "refresh_token" })
+
+    request = http.requests.first
+    assert_equal "grant_type=refresh_token", request[:body]
+    assert_equal "application/x-www-form-urlencoded", request[:headers]["Content-Type"]
+  end
+
+  test "supports custom accept headers" do
+    http = StubHTTP.new(HttpClient::Response.new(status: 200, body: "{}"))
+    client = HttpClient.new(http: http)
+
+    client.get("https://api.test/user", headers: { "Accept" => "application/vnd.github+json" })
+
+    assert_equal "application/vnd.github+json", http.requests.first[:headers]["Accept"]
+  end
+
+  test "uses default timeouts for net http requests" do
+    http = FakeNetHTTP.new(FakeResponse.new("200", "{}"))
+
+    Net::HTTP.stub(:new, ->(_host, _port) { http }) do
+      HttpClient.new.get("https://api.test/user")
+    end
+
+    assert_equal HttpClient::DEFAULT_OPEN_TIMEOUT, http.open_timeout
+    assert_equal HttpClient::DEFAULT_READ_TIMEOUT, http.read_timeout
+  end
+end

--- a/services/console/test/lib/http_client_test.rb
+++ b/services/console/test/lib/http_client_test.rb
@@ -18,7 +18,7 @@ class HttpClientTest < ActiveSupport::TestCase
   end
 
   class FakeNetHTTP
-    attr_reader :open_timeout, :read_timeout
+    attr_reader :open_timeout, :read_timeout, :captured_request
 
     def initialize(response)
       @response = response
@@ -34,7 +34,8 @@ class HttpClientTest < ActiveSupport::TestCase
       @read_timeout = value
     end
 
-    def request(_request)
+    def request(request)
+      @captured_request = request
       @response
     end
   end
@@ -102,5 +103,19 @@ class HttpClientTest < ActiveSupport::TestCase
 
     assert_equal HttpClient::DEFAULT_OPEN_TIMEOUT, http.open_timeout
     assert_equal HttpClient::DEFAULT_READ_TIMEOUT, http.read_timeout
+  end
+
+  test "preserves caller content type for encoded form requests" do
+    http = FakeNetHTTP.new(FakeResponse.new("200", "{}"))
+
+    Net::HTTP.stub(:new, ->(_host, _port) { http }) do
+      HttpClient.new.post(
+        "https://api.test/token",
+        form: { "grant_type" => "refresh_token" },
+        headers: { "Content-Type" => "application/custom-form" }
+      )
+    end
+
+    assert_equal "application/custom-form", http.captured_request["Content-Type"]
   end
 end

--- a/services/console/test/services/centaur_api_client_test.rb
+++ b/services/console/test/services/centaur_api_client_test.rb
@@ -12,7 +12,7 @@ class CentaurApiClientTest < ActiveSupport::TestCase
 
     def call(method:, url:, body:, headers:, timeout:)
       @requests << { method: method, url: url, body: body, headers: headers, timeout: timeout }
-      CentaurApiClient::Response.new(status: @status, body: @body)
+      HttpClient::Response.new(status: @status, body: @body)
     end
   end
 

--- a/services/console/test/services/slack_channel_catalog_test.rb
+++ b/services/console/test/services/slack_channel_catalog_test.rb
@@ -3,27 +3,23 @@ require "test_helper"
 class SlackChannelCatalogTest < ActiveSupport::TestCase
   test "fetch caches slack channel catalog lookups" do
     cache = ActiveSupport::Cache::MemoryStore.new
-    calls = 0
     result = SlackChannelCatalog::Result.new(
       channels: [ SlackChannelCatalog::Channel.new(id: "C0123456789", name: "general", private: false) ],
       error: nil,
       configured: true
     )
-    catalog = Object.new
-    catalog.define_singleton_method(:fetch) do
-      calls += 1
-      result
-    end
+    catalog = Minitest::Mock.new
+    catalog.expect(:fetch, result)
 
     with_env("CENTAUR_CONSOLE_SLACK_BOT_TOKEN" => "xoxb-test-token", "SLACK_API_URL" => "https://slack.test/api") do
-      with_singleton_method(Rails, :cache, -> { cache }) do
-        with_singleton_method(SlackChannelCatalog, :new, ->(token:, api_url:) { catalog }) do
+      Rails.stub(:cache, cache) do
+        SlackChannelCatalog.stub(:new, ->(token:, api_url:) { catalog }) do
           first = SlackChannelCatalog.fetch
           second = SlackChannelCatalog.fetch
 
-          assert_equal 1, calls
           assert_equal [ "C0123456789" ], first.channels.map(&:id)
           assert_equal [ "C0123456789" ], second.channels.map(&:id)
+          catalog.verify
         end
       end
     end
@@ -31,22 +27,19 @@ class SlackChannelCatalogTest < ActiveSupport::TestCase
 
   test "fetch does not cache slack channel catalog errors" do
     cache = ActiveSupport::Cache::MemoryStore.new
-    calls = 0
     error = SlackChannelCatalog::Result.new(channels: [], error: "Slack API request failed.", configured: true)
     success = SlackChannelCatalog::Result.new(
       channels: [ SlackChannelCatalog::Channel.new(id: "C0123456789", name: "general", private: false) ],
       error: nil,
       configured: true
     )
-    catalog = Object.new
-    catalog.define_singleton_method(:fetch) do
-      calls += 1
-      calls == 1 ? error : success
-    end
+    catalog = Minitest::Mock.new
+    catalog.expect(:fetch, error)
+    catalog.expect(:fetch, success)
 
     with_env("CENTAUR_CONSOLE_SLACK_BOT_TOKEN" => "xoxb-test-token", "SLACK_API_URL" => "https://slack.test/api") do
-      with_singleton_method(Rails, :cache, -> { cache }) do
-        with_singleton_method(SlackChannelCatalog, :new, ->(token:, api_url:) { catalog }) do
+      Rails.stub(:cache, cache) do
+        SlackChannelCatalog.stub(:new, ->(token:, api_url:) { catalog }) do
           first = SlackChannelCatalog.fetch
           second = SlackChannelCatalog.fetch
           third = SlackChannelCatalog.fetch
@@ -54,25 +47,25 @@ class SlackChannelCatalogTest < ActiveSupport::TestCase
           assert_equal "Slack API request failed.", first.error
           assert_nil second.error
           assert_nil third.error
-          assert_equal 2, calls
+          catalog.verify
         end
       end
     end
   end
 
   test "fetch configures short slack api timeouts" do
-    response = Struct.new(:code, :body).new(
-      "200",
-      { ok: true, channels: [] }.to_json
-    )
-    http = Object.new
-    http.define_singleton_method(:request) { |_request| response }
+    api = Minitest::Mock.new
+    api.expect(:get, HttpClient::Response.new(status: 200, body: { ok: true, channels: [] }.to_json),
+               [ "https://slack.test/api/conversations.list" ],
+               params: { types: SlackChannelCatalog::DEFAULT_TYPES, exclude_archived: "true", limit: "1000" },
+               headers: { "Authorization" => "Bearer xoxb-test-token" })
     captured_options = nil
-
-    with_singleton_method(Net::HTTP, :start, lambda { |_host, _port, **options, &block|
+    factory = lambda do |**options|
       captured_options = options
-      block.call(http)
-    }) do
+      api
+    end
+
+    HttpClient.stub(:new, factory) do
       result = SlackChannelCatalog.new(token: "xoxb-test-token", api_url: "https://slack.test/api").fetch
 
       assert_predicate result, :ok?
@@ -81,6 +74,7 @@ class SlackChannelCatalogTest < ActiveSupport::TestCase
     assert_equal SlackChannelCatalog::OPEN_TIMEOUT_SECONDS, captured_options.fetch(:open_timeout)
     assert_equal SlackChannelCatalog::READ_TIMEOUT_SECONDS, captured_options.fetch(:read_timeout)
     assert_equal SlackChannelCatalog::WRITE_TIMEOUT_SECONDS, captured_options.fetch(:write_timeout)
+    api.verify
   end
 
   private
@@ -91,14 +85,5 @@ class SlackChannelCatalogTest < ActiveSupport::TestCase
     yield
   ensure
     previous.each { |key, value| value.nil? ? ENV.delete(key) : ENV[key] = value }
-  end
-
-  def with_singleton_method(object, method_name, replacement)
-    singleton = object.singleton_class
-    original = singleton.instance_method(method_name)
-    singleton.define_method(method_name, replacement)
-    yield
-  ensure
-    singleton.define_method(method_name, original)
   end
 end

--- a/services/console/test/services/slack_requester_identity_test.rb
+++ b/services/console/test/services/slack_requester_identity_test.rb
@@ -2,29 +2,17 @@ require "test_helper"
 
 class SlackRequesterIdentityTest < ActiveSupport::TestCase
   test "resolves a verified GitHub handle from the requester's labeled Slack profile field" do
-    response = Struct.new(:body).new({
+    api = Minitest::Mock.new
+    api.expect(:get, HttpClient::Response.new(status: 200, body: {
       ok: true,
       profile: { fields: { "XfGithub" => { label: "GitHub", value: "https://github.com/ada" } } }
-    }.to_json)
-    http = Object.new
-    http.define_singleton_method(:request) { |_request| response }
+    }.to_json), [ "https://slack.test/api/users.profile.get" ], params: { user: "UADA", include_labels: "true" },
+                                                            headers: { "Authorization" => "Bearer xoxb-test" })
 
-    with_singleton_method(Net::HTTP, :start, ->(*_args, **_options, &block) { block.call(http) }) do
-      result = SlackRequesterIdentity.new(token: "xoxb-test", api_url: "https://slack.test/api").resolve("UADA")
+    result = SlackRequesterIdentity.new(token: "xoxb-test", api_url: "https://slack.test/api", api: api).resolve("UADA")
 
-      assert_equal "@ada", result.handle
-      assert_equal 'Slack profile custom field "GitHub"', result.source
-    end
-  end
-
-  private
-
-  def with_singleton_method(object, method_name, replacement)
-    singleton = object.singleton_class
-    original = singleton.instance_method(method_name)
-    singleton.define_method(method_name, replacement)
-    yield
-  ensure
-    singleton.define_method(method_name, original)
+    assert_equal "@ada", result.handle
+    assert_equal 'Slack profile custom field "GitHub"', result.source
+    api.verify
   end
 end

--- a/services/console/test/test_helper.rb
+++ b/services/console/test/test_helper.rb
@@ -4,6 +4,7 @@ ENV["RAILS_ENV"] ||= "test"
 ENV["PGGSSENCMODE"] ||= "disable"
 require_relative "../config/environment"
 require "rails/test_help"
+require "minitest/mock"
 
 module ActiveSupport
   class TestCase


### PR DESCRIPTION
Adds a shared console HttpClient for Net::HTTP request construction, default timeouts, response normalization, and lazy JSON parsing. Refactors the existing console API callers to use it while preserving their service-specific error handling and timeout overrides.