### PR TITLE
test: use minitest mocks in console tests

### DIFF
--- a/services/console/test/controllers/oauth/flows_controller_test.rb
+++ b/services/console/test/controllers/oauth/flows_controller_test.rb
@@ -36,11 +36,7 @@ module Oauth
 
     def stub_exchange(status:, body:, expected: true)
       http = Minitest::Mock.new
-      if expected
-        http.expect(:call, HttpClient::Response.new(status: status, body: body)) do |**_kwargs|
-          true
-        end
-      end
+      expect_http_call(http, status: status, body: body) if expected
       @exchange_http_mocks << http
       FlowsController.exchange_client_factory = -> { Broker::AuthorizationCodeClient.new(http: http) }
     end

--- a/services/console/test/controllers/oauth/flows_controller_test.rb
+++ b/services/console/test/controllers/oauth/flows_controller_test.rb
@@ -16,6 +16,7 @@ module Oauth
     LINEAR_CLIENT_ID = "acme-linear-client-id".freeze
 
     setup do
+      @exchange_http_mocks = []
       @app = oauth_apps(:acme_google) # slug "google"
       @app.update!(client_secret: "app-secret")
       oauth_apps(:acme_slack).update!(client_secret: "slack-secret")
@@ -30,21 +31,18 @@ module Oauth
     teardown do
       FlowsController.exchange_client_factory = -> { Broker::AuthorizationCodeClient.new }
       clear_enqueued_jobs
+      @exchange_http_mocks.each(&:verify)
     end
 
-    class StubHTTP
-      def initialize(status:, body:)
-        @status = status
-        @body = body
+    def stub_exchange(status:, body:, expected: true)
+      http = Minitest::Mock.new
+      if expected
+        http.expect(:call, HttpClient::Response.new(status: status, body: body)) do |**_kwargs|
+          true
+        end
       end
-
-      def call(url:, form:, headers:, timeout:)
-        HttpClient::Response.new(status: @status, body: @body)
-      end
-    end
-
-    def stub_exchange(status:, body:)
-      FlowsController.exchange_client_factory = -> { Broker::AuthorizationCodeClient.new(http: StubHTTP.new(status: status, body: body)) }
+      @exchange_http_mocks << http
+      FlowsController.exchange_client_factory = -> { Broker::AuthorizationCodeClient.new(http: http) }
     end
 
     def id_token(claims)
@@ -550,7 +548,7 @@ module Oauth
     test "callback redirects signed-out users to login and mints nothing" do
       state = start_flow
       sign_out
-      stub_exchange(status: 200, body: token_body)
+      stub_exchange(status: 200, body: token_body, expected: false)
 
       assert_no_difference -> { BrokerCredential.count } do
         get oauth_callback_url(slug: "google"), params: { state: state, code: "auth-code" }
@@ -564,7 +562,7 @@ module Oauth
       user = users(:member_user)
       state = start_flow
       user.update!(status: :disabled)
-      stub_exchange(status: 200, body: token_body)
+      stub_exchange(status: 200, body: token_body, expected: false)
 
       assert_no_difference -> { BrokerCredential.count } do
         get oauth_callback_url(slug: "google"), params: { state: state, code: "auth-code" }

--- a/services/console/test/controllers/session_oauth_controller_test.rb
+++ b/services/console/test/controllers/session_oauth_controller_test.rb
@@ -30,11 +30,7 @@ class SessionOauthControllerTest < ActionDispatch::IntegrationTest
   end
 
   def stub_exchange(status:, body:)
-    http = Minitest::Mock.new
-    http.expect(:call, HttpClient::Response.new(status: status, body: body)) do |**request|
-      yield request if block_given?
-      true
-    end
+    http = expect_http_call(status: status, body: body) { |request| yield request if block_given? }
     @exchange_http_mocks << http
     SessionOauthController.exchange_client_factory = -> { Broker::AuthorizationCodeClient.new(http: http) }
   end

--- a/services/console/test/controllers/session_oauth_controller_test.rb
+++ b/services/console/test/controllers/session_oauth_controller_test.rb
@@ -15,6 +15,7 @@ class SessionOauthControllerTest < ActionDispatch::IntegrationTest
   ].freeze
 
   setup do
+    @exchange_http_mocks = []
     @prev_env = ENV.to_hash.slice(*ENV_KEYS)
     ENV["CENTAUR_CONSOLE_GOOGLE_CLIENT_ID"] = GOOGLE_CLIENT_ID
     ENV["CENTAUR_CONSOLE_GOOGLE_CLIENT_SECRET"] = "google-login-secret"
@@ -25,26 +26,19 @@ class SessionOauthControllerTest < ActionDispatch::IntegrationTest
     ENV_KEYS.each { |k| ENV.delete(k) }
     @prev_env.each { |k, v| ENV[k] = v }
     SessionOauthController.exchange_client_factory = -> { Broker::AuthorizationCodeClient.new }
-  end
-
-  class StubHTTP
-    attr_reader :captured
-
-    def initialize(status:, body:)
-      @status = status
-      @body = body
-    end
-
-    def call(url:, form:, headers:, timeout:)
-      @captured = { url: url, form: form, headers: headers, timeout: timeout }
-      HttpClient::Response.new(status: @status, body: @body)
-    end
+    @exchange_http_mocks.each(&:verify)
   end
 
   def stub_exchange(status:, body:)
-    http = StubHTTP.new(status: status, body: body)
+    http = Minitest::Mock.new
+    captured = {}
+    http.expect(:call, HttpClient::Response.new(status: status, body: body)) do |url:, form:, headers:, timeout:|
+      captured.replace(url: url, form: form, headers: headers, timeout: timeout)
+      true
+    end
+    @exchange_http_mocks << http
     SessionOauthController.exchange_client_factory = -> { Broker::AuthorizationCodeClient.new(http: http) }
-    http
+    captured
   end
 
   def id_token(claims)
@@ -140,8 +134,8 @@ class SessionOauthControllerTest < ActionDispatch::IntegrationTest
     get auth_callback_url(provider: "slack"), params: { code: "the-code", state: state }
 
     assert_redirected_to console_threads_path
-    assert_equal "slack-login-secret", exchange.captured.dig(:form, "client_secret")
-    assert_nil exchange.captured.dig(:form, "code_verifier")
+    assert_equal "slack-login-secret", exchange.dig(:form, "client_secret")
+    assert_nil exchange.dig(:form, "code_verifier")
     user = User.find_by!(email: "rotating@example.com")
     assert_equal "Rotating User", user.name
     assert_equal [ [ "slack", "U123ROTATING" ] ], user.user_identities.pluck(:provider, :subject)

--- a/services/console/test/controllers/session_oauth_controller_test.rb
+++ b/services/console/test/controllers/session_oauth_controller_test.rb
@@ -31,14 +31,12 @@ class SessionOauthControllerTest < ActionDispatch::IntegrationTest
 
   def stub_exchange(status:, body:)
     http = Minitest::Mock.new
-    captured = {}
-    http.expect(:call, HttpClient::Response.new(status: status, body: body)) do |url:, form:, headers:, timeout:|
-      captured.replace(url: url, form: form, headers: headers, timeout: timeout)
+    http.expect(:call, HttpClient::Response.new(status: status, body: body)) do |**request|
+      yield request if block_given?
       true
     end
     @exchange_http_mocks << http
     SessionOauthController.exchange_client_factory = -> { Broker::AuthorizationCodeClient.new(http: http) }
-    captured
   end
 
   def id_token(claims)
@@ -120,7 +118,7 @@ class SessionOauthControllerTest < ActionDispatch::IntegrationTest
       "email_verified" => true,
       "name" => "Rotating User"
     }
-    exchange = stub_exchange(
+    stub_exchange(
       status: 200,
       body: {
         ok: true,
@@ -129,13 +127,14 @@ class SessionOauthControllerTest < ActionDispatch::IntegrationTest
         expires_in: 43_200,
         id_token: id_token(claims)
       }.to_json
-    )
+    ) do |request|
+      assert_equal "slack-login-secret", request.dig(:form, "client_secret")
+      assert_nil request.dig(:form, "code_verifier")
+    end
 
     get auth_callback_url(provider: "slack"), params: { code: "the-code", state: state }
 
     assert_redirected_to console_threads_path
-    assert_equal "slack-login-secret", exchange.dig(:form, "client_secret")
-    assert_nil exchange.dig(:form, "code_verifier")
     user = User.find_by!(email: "rotating@example.com")
     assert_equal "Rotating User", user.name
     assert_equal [ [ "slack", "U123ROTATING" ] ], user.user_identities.pluck(:provider, :subject)

--- a/services/console/test/lib/broker/authorization_code_client_test.rb
+++ b/services/console/test/lib/broker/authorization_code_client_test.rb
@@ -4,12 +4,11 @@ module Broker
   class AuthorizationCodeClientTest < ActiveSupport::TestCase
     def client_with(status:, body:)
       http = Minitest::Mock.new
-      captured = {}
-      http.expect(:call, HttpClient::Response.new(status: status, body: body)) do |url:, form:, headers:, timeout:|
-        captured.replace(url: url, form: form, headers: headers, timeout: timeout)
+      http.expect(:call, HttpClient::Response.new(status: status, body: body)) do |**request|
+        yield request if block_given?
         true
       end
-      [ AuthorizationCodeClient.new(http: http), captured, http ]
+      [ AuthorizationCodeClient.new(http: http), http ]
     end
 
     def base_args(**overrides)
@@ -29,7 +28,15 @@ module Broker
     end
 
     test "happy path parses the authorization_code response" do
-      client, captured, http = client_with(status: 200, body: success_body)
+      client, http = client_with(status: 200, body: success_body) do |request|
+        form = request[:form]
+        assert_equal "authorization_code", form["grant_type"]
+        assert_equal "auth-code", form["code"]
+        assert_equal "cid", form["client_id"]
+        assert_equal "sec", form["client_secret"]
+        assert_equal "https://control.example/oauth/google/callback", form["redirect_uri"]
+        assert_equal "verifier", form["code_verifier"]
+      end
       result = client.exchange(**base_args)
       http.verify
       assert_equal "AT", result.access_token
@@ -38,24 +45,16 @@ module Broker
       assert_equal "openid email", result.scope
       assert_equal "the.id.token", result.id_token
       assert_equal "AT", result.response["access_token"]
-
-      form = captured[:form]
-      assert_equal "authorization_code", form["grant_type"]
-      assert_equal "auth-code", form["code"]
-      assert_equal "cid", form["client_id"]
-      assert_equal "sec", form["client_secret"]
-      assert_equal "https://control.example/oauth/google/callback", form["redirect_uri"]
-      assert_equal "verifier", form["code_verifier"]
     end
 
     test "missing expires_in yields nil" do
-      client, _, http = client_with(status: 200, body: success_body(expires_in: nil))
+      client, http = client_with(status: 200, body: success_body(expires_in: nil))
       assert_nil client.exchange(**base_args).expires_in
       http.verify
     end
 
     test "OAuth error body raises an oauth ExchangeError" do
-      client, _, http = client_with(status: 400, body: { error: "invalid_grant" }.to_json)
+      client, http = client_with(status: 400, body: { error: "invalid_grant" }.to_json)
       err = assert_raises(ExchangeError) { client.exchange(**base_args) }
       http.verify
       assert_equal "oauth", err.stage
@@ -64,7 +63,7 @@ module Broker
     end
 
     test "Slack-style ok false response raises an oauth ExchangeError" do
-      client, _, http = client_with(status: 200, body: { ok: false, error: "invalid_code" }.to_json)
+      client, http = client_with(status: 200, body: { ok: false, error: "invalid_code" }.to_json)
       err = assert_raises(ExchangeError) { client.exchange(**base_args) }
       http.verify
       assert_equal "oauth", err.stage
@@ -72,7 +71,7 @@ module Broker
     end
 
     test "5xx raises an http ExchangeError" do
-      client, _, http = client_with(status: 503, body: "upstream down")
+      client, http = client_with(status: 503, body: "upstream down")
       err = assert_raises(ExchangeError) { client.exchange(**base_args) }
       http.verify
       assert_equal "http", err.stage
@@ -80,14 +79,14 @@ module Broker
     end
 
     test "missing refresh_token is a misconfiguration error" do
-      client, _, http = client_with(status: 200, body: success_body(refresh_token: nil))
+      client, http = client_with(status: 200, body: success_body(refresh_token: nil))
       err = assert_raises(ExchangeError) { client.exchange(**base_args) }
       http.verify
       assert_equal "missing_refresh_token", err.code
     end
 
     test "require_refresh_token: false tolerates a missing refresh_token (login flow)" do
-      client, _, http = client_with(status: 200, body: success_body(refresh_token: nil))
+      client, http = client_with(status: 200, body: success_body(refresh_token: nil))
       result = client.exchange(**base_args, require_refresh_token: false)
       http.verify
       assert_equal "AT", result.access_token
@@ -95,10 +94,11 @@ module Broker
     end
 
     test "omits code_verifier when the caller does not use PKCE" do
-      client, captured, http = client_with(status: 200, body: success_body)
+      client, http = client_with(status: 200, body: success_body) do |request|
+        assert_nil request[:form]["code_verifier"]
+      end
       client.exchange(**base_args(code_verifier: nil))
       http.verify
-      assert_nil captured[:form]["code_verifier"]
     end
 
     test "parses Slack nested authed_user token payload" do
@@ -117,7 +117,7 @@ module Broker
         }
       }.to_json
 
-      client, _, http = client_with(status: 200, body: body)
+      client, http = client_with(status: 200, body: body)
       result = client.exchange(**base_args)
       http.verify
       assert_equal "USER", result.access_token
@@ -127,14 +127,14 @@ module Broker
     end
 
     test "empty access_token raises a parse error" do
-      client, _, http = client_with(status: 200, body: success_body(access_token: ""))
+      client, http = client_with(status: 200, body: success_body(access_token: ""))
       err = assert_raises(ExchangeError) { client.exchange(**base_args) }
       http.verify
       assert_equal "parse", err.stage
     end
 
     test "unparseable body raises a parse error" do
-      client, _, http = client_with(status: 200, body: "not json{")
+      client, http = client_with(status: 200, body: "not json{")
       err = assert_raises(ExchangeError) { client.exchange(**base_args) }
       http.verify
       assert_equal "parse", err.stage

--- a/services/console/test/lib/broker/authorization_code_client_test.rb
+++ b/services/console/test/lib/broker/authorization_code_client_test.rb
@@ -3,11 +3,7 @@ require "test_helper"
 module Broker
   class AuthorizationCodeClientTest < ActiveSupport::TestCase
     def client_with(status:, body:)
-      http = Minitest::Mock.new
-      http.expect(:call, HttpClient::Response.new(status: status, body: body)) do |**request|
-        yield request if block_given?
-        true
-      end
+      http = expect_http_call(status: status, body: body) { |request| yield request if block_given? }
       [ AuthorizationCodeClient.new(http: http), http ]
     end
 

--- a/services/console/test/lib/broker/authorization_code_client_test.rb
+++ b/services/console/test/lib/broker/authorization_code_client_test.rb
@@ -2,25 +2,14 @@ require "test_helper"
 
 module Broker
   class AuthorizationCodeClientTest < ActiveSupport::TestCase
-    # A stub HTTP backend matching the injected contract. Captures the request so
-    # tests can assert the form without a real socket.
-    class StubHTTP
-      attr_reader :captured
-
-      def initialize(status:, body:)
-        @status = status
-        @body = body
-      end
-
-      def call(url:, form:, headers:, timeout:)
-        @captured = { url: url, form: form, headers: headers, timeout: timeout }
-        HttpClient::Response.new(status: @status, body: @body)
-      end
-    end
-
     def client_with(status:, body:)
-      http = StubHTTP.new(status: status, body: body)
-      [ AuthorizationCodeClient.new(http: http), http ]
+      http = Minitest::Mock.new
+      captured = {}
+      http.expect(:call, HttpClient::Response.new(status: status, body: body)) do |url:, form:, headers:, timeout:|
+        captured.replace(url: url, form: form, headers: headers, timeout: timeout)
+        true
+      end
+      [ AuthorizationCodeClient.new(http: http), captured, http ]
     end
 
     def base_args(**overrides)
@@ -40,8 +29,9 @@ module Broker
     end
 
     test "happy path parses the authorization_code response" do
-      client, http = client_with(status: 200, body: success_body)
+      client, captured, http = client_with(status: 200, body: success_body)
       result = client.exchange(**base_args)
+      http.verify
       assert_equal "AT", result.access_token
       assert_equal "RT", result.refresh_token
       assert_equal 3600, result.expires_in
@@ -49,7 +39,7 @@ module Broker
       assert_equal "the.id.token", result.id_token
       assert_equal "AT", result.response["access_token"]
 
-      form = http.captured[:form]
+      form = captured[:form]
       assert_equal "authorization_code", form["grant_type"]
       assert_equal "auth-code", form["code"]
       assert_equal "cid", form["client_id"]
@@ -59,49 +49,56 @@ module Broker
     end
 
     test "missing expires_in yields nil" do
-      client, _ = client_with(status: 200, body: success_body(expires_in: nil))
+      client, _, http = client_with(status: 200, body: success_body(expires_in: nil))
       assert_nil client.exchange(**base_args).expires_in
+      http.verify
     end
 
     test "OAuth error body raises an oauth ExchangeError" do
-      client, _ = client_with(status: 400, body: { error: "invalid_grant" }.to_json)
+      client, _, http = client_with(status: 400, body: { error: "invalid_grant" }.to_json)
       err = assert_raises(ExchangeError) { client.exchange(**base_args) }
+      http.verify
       assert_equal "oauth", err.stage
       assert_equal "invalid_grant", err.code
       assert_equal "invalid_grant", err.reason
     end
 
     test "Slack-style ok false response raises an oauth ExchangeError" do
-      client, _ = client_with(status: 200, body: { ok: false, error: "invalid_code" }.to_json)
+      client, _, http = client_with(status: 200, body: { ok: false, error: "invalid_code" }.to_json)
       err = assert_raises(ExchangeError) { client.exchange(**base_args) }
+      http.verify
       assert_equal "oauth", err.stage
       assert_equal "invalid_code", err.code
     end
 
     test "5xx raises an http ExchangeError" do
-      client, _ = client_with(status: 503, body: "upstream down")
+      client, _, http = client_with(status: 503, body: "upstream down")
       err = assert_raises(ExchangeError) { client.exchange(**base_args) }
+      http.verify
       assert_equal "http", err.stage
       assert_equal 503, err.status
     end
 
     test "missing refresh_token is a misconfiguration error" do
-      client, _ = client_with(status: 200, body: success_body(refresh_token: nil))
+      client, _, http = client_with(status: 200, body: success_body(refresh_token: nil))
       err = assert_raises(ExchangeError) { client.exchange(**base_args) }
+      http.verify
       assert_equal "missing_refresh_token", err.code
     end
 
     test "require_refresh_token: false tolerates a missing refresh_token (login flow)" do
-      client, _ = client_with(status: 200, body: success_body(refresh_token: nil))
+      client, _, http = client_with(status: 200, body: success_body(refresh_token: nil))
       result = client.exchange(**base_args, require_refresh_token: false)
+      http.verify
       assert_equal "AT", result.access_token
       assert_nil result.refresh_token
     end
 
     test "omits code_verifier when the caller does not use PKCE" do
-      client, http = client_with(status: 200, body: success_body)
+      client, captured, http = client_with(status: 200, body: success_body)
       client.exchange(**base_args(code_verifier: nil))
-      assert_nil http.captured[:form]["code_verifier"]
+      http.verify
+      assert_nil captured[:form]["code_verifier"]
     end
 
     test "parses Slack nested authed_user token payload" do
@@ -120,8 +117,9 @@ module Broker
         }
       }.to_json
 
-      client, _ = client_with(status: 200, body: body)
+      client, _, http = client_with(status: 200, body: body)
       result = client.exchange(**base_args)
+      http.verify
       assert_equal "USER", result.access_token
       assert_equal "USER-RT", result.refresh_token
       assert_equal "channels:history,im:history", result.scope
@@ -129,19 +127,21 @@ module Broker
     end
 
     test "empty access_token raises a parse error" do
-      client, _ = client_with(status: 200, body: success_body(access_token: ""))
+      client, _, http = client_with(status: 200, body: success_body(access_token: ""))
       err = assert_raises(ExchangeError) { client.exchange(**base_args) }
+      http.verify
       assert_equal "parse", err.stage
     end
 
     test "unparseable body raises a parse error" do
-      client, _ = client_with(status: 200, body: "not json{")
+      client, _, http = client_with(status: 200, body: "not json{")
       err = assert_raises(ExchangeError) { client.exchange(**base_args) }
+      http.verify
       assert_equal "parse", err.stage
     end
 
     test "validates required inputs" do
-      client, _ = client_with(status: 200, body: success_body)
+      client = AuthorizationCodeClient.new(http: Minitest::Mock.new)
       assert_raises(ArgumentError) { client.exchange(**base_args(code: "")) }
       assert_raises(ArgumentError) { client.exchange(**base_args(redirect_uri: "")) }
     end

--- a/services/console/test/lib/broker/refresh_client_test.rb
+++ b/services/console/test/lib/broker/refresh_client_test.rb
@@ -2,25 +2,14 @@ require "test_helper"
 
 module Broker
   class RefreshClientTest < ActiveSupport::TestCase
-    # A stub HTTP backend matching RefreshClient's injected contract. Captures the
-    # request so tests can assert the form/headers without a real socket.
-    class StubHTTP
-      attr_reader :captured
-
-      def initialize(status:, body:)
-        @status = status
-        @body = body
-      end
-
-      def call(url:, form:, headers:, timeout:, form_encoding:)
-        @captured = { url: url, form: form, headers: headers, timeout: timeout, form_encoding: form_encoding }
-        HttpClient::Response.new(status: @status, body: @body)
-      end
-    end
-
     def client_with(status:, body:)
-      http = StubHTTP.new(status: status, body: body)
-      [ Broker::RefreshClient.new(http: http), http ]
+      http = Minitest::Mock.new
+      captured = {}
+      http.expect(:call, HttpClient::Response.new(status: status, body: body)) do |url:, form:, headers:, timeout:, form_encoding:|
+        captured.replace(url: url, form: form, headers: headers, timeout: timeout, form_encoding: form_encoding)
+        true
+      end
+      [ Broker::RefreshClient.new(http: http), captured, http ]
     end
 
     def base_request(**overrides)
@@ -35,15 +24,16 @@ module Broker
     end
 
     test "successful refresh parses the RFC 6749 body" do
-      client, _ = client_with(status: 200, body: { access_token: "AT", refresh_token: "RT", expires_in: 3600 }.to_json)
+      client, _, http = client_with(status: 200, body: { access_token: "AT", refresh_token: "RT", expires_in: 3600 }.to_json)
       result = client.refresh(**base_request)
+      http.verify
       assert_equal "AT", result.access_token
       assert_equal "RT", result.refresh_token
       assert_equal 3600, result.expires_in
     end
 
     test "posts supplied URL-encoded form and headers" do
-      client, http = client_with(status: 200, body: { access_token: "AT", expires_in: 60 }.to_json)
+      client, captured, http = client_with(status: 200, body: { access_token: "AT", expires_in: 60 }.to_json)
       form = {
         "grant_type" => "refresh_token",
         "refresh_token" => "rt-old",
@@ -52,81 +42,92 @@ module Broker
         "scope" => "a b"
       }
       client.refresh(**base_request(form: form, headers: { "X-Api-Key" => "k" }))
-      assert_equal "https://idp.example/token", http.captured[:url]
-      assert_equal form, http.captured[:form]
-      assert_equal "k", http.captured[:headers]["X-Api-Key"]
-      assert_equal :urlencoded, http.captured[:form_encoding]
+      http.verify
+      assert_equal "https://idp.example/token", captured[:url]
+      assert_equal form, captured[:form]
+      assert_equal "k", captured[:headers]["X-Api-Key"]
+      assert_equal :urlencoded, captured[:form_encoding]
     end
 
     test "posts supplied multipart form" do
-      client, http = client_with(status: 200, body: { access_token: "AT", expires_in: 60 }.to_json)
+      client, captured, http = client_with(status: 200, body: { access_token: "AT", expires_in: 60 }.to_json)
       form = { "username" => "user", "apikey" => "key" }
       client.refresh(**base_request(form: form, form_encoding: :multipart))
-      assert_equal form, http.captured[:form]
-      assert_equal :multipart, http.captured[:form_encoding]
+      http.verify
+      assert_equal form, captured[:form]
+      assert_equal :multipart, captured[:form_encoding]
     end
 
     test "absent refresh_token in response means no rotation" do
-      client, _ = client_with(status: 200, body: { access_token: "AT", expires_in: 60 }.to_json)
+      client, _, http = client_with(status: 200, body: { access_token: "AT", expires_in: 60 }.to_json)
       result = client.refresh(**base_request)
+      http.verify
       assert_nil result.refresh_token
     end
 
     test "missing expires_in yields nil so the caller defaults it" do
-      client, _ = client_with(status: 200, body: { access_token: "AT" }.to_json)
+      client, _, http = client_with(status: 200, body: { access_token: "AT" }.to_json)
       assert_nil client.refresh(**base_request).expires_in
+      http.verify
     end
 
     test "invalid_grant is unrecoverable" do
-      client, _ = client_with(status: 400, body: { error: "invalid_grant" }.to_json)
+      client, _, http = client_with(status: 400, body: { error: "invalid_grant" }.to_json)
       err = assert_raises(Broker::RefreshError) { client.refresh(**base_request) }
+      http.verify
       refute err.retryable?
       assert_equal "invalid_grant", err.code
       assert_equal "invalid_grant", err.reason
     end
 
     test "Slack-style ok false response is unrecoverable" do
-      client, _ = client_with(status: 200, body: { ok: false, error: "invalid_refresh_token" }.to_json)
+      client, _, http = client_with(status: 200, body: { ok: false, error: "invalid_refresh_token" }.to_json)
       err = assert_raises(Broker::RefreshError) { client.refresh(**base_request) }
+      http.verify
       refute err.retryable?
       assert_equal "oauth", err.stage
       assert_equal "invalid_refresh_token", err.code
     end
 
     test "5xx is retryable" do
-      client, _ = client_with(status: 503, body: "upstream down")
+      client, _, http = client_with(status: 503, body: "upstream down")
       err = assert_raises(Broker::RefreshError) { client.refresh(**base_request) }
+      http.verify
       assert err.retryable?
     end
 
     test "bodyless 4xx is retryable by default" do
-      client, _ = client_with(status: 429, body: "")
+      client, _, http = client_with(status: 429, body: "")
       err = assert_raises(Broker::RefreshError) { client.refresh(**base_request) }
+      http.verify
       assert err.retryable?
     end
 
     test "bodyless 4xx can be strict and unrecoverable" do
-      client, _ = client_with(status: 400, body: "")
+      client, _, http = client_with(status: 400, body: "")
       err = assert_raises(Broker::RefreshError) { client.refresh(**base_request(strict_4xx: true)) }
+      http.verify
       refute err.retryable?
       assert_equal "http_400", err.code
     end
 
     test "malformed 2xx body is retryable parse failure" do
-      client, _ = client_with(status: 200, body: "not json{")
+      client, _, http = client_with(status: 200, body: "not json{")
       err = assert_raises(Broker::RefreshError) { client.refresh(**base_request) }
+      http.verify
       assert err.retryable?
       assert_equal "parse", err.stage
     end
 
     test "empty access_token in 2xx is retryable" do
-      client, _ = client_with(status: 200, body: { access_token: "", expires_in: 60 }.to_json)
+      client, _, http = client_with(status: 200, body: { access_token: "", expires_in: 60 }.to_json)
       err = assert_raises(Broker::RefreshError) { client.refresh(**base_request) }
+      http.verify
       assert err.retryable?
     end
 
     test "validates request inputs" do
-      client, _ = client_with(status: 200, body: "{}")
+      client = Broker::RefreshClient.new(http: Minitest::Mock.new)
       assert_raises(ArgumentError) { client.refresh(**base_request(url: "")) }
       assert_raises(ArgumentError) { client.refresh(**base_request(form: nil)) }
       assert_raises(ArgumentError) { client.refresh(**base_request(form_encoding: :xml)) }

--- a/services/console/test/lib/broker/refresh_client_test.rb
+++ b/services/console/test/lib/broker/refresh_client_test.rb
@@ -3,11 +3,7 @@ require "test_helper"
 module Broker
   class RefreshClientTest < ActiveSupport::TestCase
     def client_with(status:, body:)
-      http = Minitest::Mock.new
-      http.expect(:call, HttpClient::Response.new(status: status, body: body)) do |**request|
-        yield request if block_given?
-        true
-      end
+      http = expect_http_call(status: status, body: body) { |request| yield request if block_given? }
       [ Broker::RefreshClient.new(http: http), http ]
     end
 

--- a/services/console/test/lib/broker/refresh_client_test.rb
+++ b/services/console/test/lib/broker/refresh_client_test.rb
@@ -4,12 +4,11 @@ module Broker
   class RefreshClientTest < ActiveSupport::TestCase
     def client_with(status:, body:)
       http = Minitest::Mock.new
-      captured = {}
-      http.expect(:call, HttpClient::Response.new(status: status, body: body)) do |url:, form:, headers:, timeout:, form_encoding:|
-        captured.replace(url: url, form: form, headers: headers, timeout: timeout, form_encoding: form_encoding)
+      http.expect(:call, HttpClient::Response.new(status: status, body: body)) do |**request|
+        yield request if block_given?
         true
       end
-      [ Broker::RefreshClient.new(http: http), captured, http ]
+      [ Broker::RefreshClient.new(http: http), http ]
     end
 
     def base_request(**overrides)
@@ -24,7 +23,7 @@ module Broker
     end
 
     test "successful refresh parses the RFC 6749 body" do
-      client, _, http = client_with(status: 200, body: { access_token: "AT", refresh_token: "RT", expires_in: 3600 }.to_json)
+      client, http = client_with(status: 200, body: { access_token: "AT", refresh_token: "RT", expires_in: 3600 }.to_json)
       result = client.refresh(**base_request)
       http.verify
       assert_equal "AT", result.access_token
@@ -33,7 +32,6 @@ module Broker
     end
 
     test "posts supplied URL-encoded form and headers" do
-      client, captured, http = client_with(status: 200, body: { access_token: "AT", expires_in: 60 }.to_json)
       form = {
         "grant_type" => "refresh_token",
         "refresh_token" => "rt-old",
@@ -41,38 +39,41 @@ module Broker
         "client_secret" => "sec",
         "scope" => "a b"
       }
+      client, http = client_with(status: 200, body: { access_token: "AT", expires_in: 60 }.to_json) do |request|
+        assert_equal "https://idp.example/token", request[:url]
+        assert_equal form, request[:form]
+        assert_equal "k", request[:headers]["X-Api-Key"]
+        assert_equal :urlencoded, request[:form_encoding]
+      end
       client.refresh(**base_request(form: form, headers: { "X-Api-Key" => "k" }))
       http.verify
-      assert_equal "https://idp.example/token", captured[:url]
-      assert_equal form, captured[:form]
-      assert_equal "k", captured[:headers]["X-Api-Key"]
-      assert_equal :urlencoded, captured[:form_encoding]
     end
 
     test "posts supplied multipart form" do
-      client, captured, http = client_with(status: 200, body: { access_token: "AT", expires_in: 60 }.to_json)
       form = { "username" => "user", "apikey" => "key" }
+      client, http = client_with(status: 200, body: { access_token: "AT", expires_in: 60 }.to_json) do |request|
+        assert_equal form, request[:form]
+        assert_equal :multipart, request[:form_encoding]
+      end
       client.refresh(**base_request(form: form, form_encoding: :multipart))
       http.verify
-      assert_equal form, captured[:form]
-      assert_equal :multipart, captured[:form_encoding]
     end
 
     test "absent refresh_token in response means no rotation" do
-      client, _, http = client_with(status: 200, body: { access_token: "AT", expires_in: 60 }.to_json)
+      client, http = client_with(status: 200, body: { access_token: "AT", expires_in: 60 }.to_json)
       result = client.refresh(**base_request)
       http.verify
       assert_nil result.refresh_token
     end
 
     test "missing expires_in yields nil so the caller defaults it" do
-      client, _, http = client_with(status: 200, body: { access_token: "AT" }.to_json)
+      client, http = client_with(status: 200, body: { access_token: "AT" }.to_json)
       assert_nil client.refresh(**base_request).expires_in
       http.verify
     end
 
     test "invalid_grant is unrecoverable" do
-      client, _, http = client_with(status: 400, body: { error: "invalid_grant" }.to_json)
+      client, http = client_with(status: 400, body: { error: "invalid_grant" }.to_json)
       err = assert_raises(Broker::RefreshError) { client.refresh(**base_request) }
       http.verify
       refute err.retryable?
@@ -81,7 +82,7 @@ module Broker
     end
 
     test "Slack-style ok false response is unrecoverable" do
-      client, _, http = client_with(status: 200, body: { ok: false, error: "invalid_refresh_token" }.to_json)
+      client, http = client_with(status: 200, body: { ok: false, error: "invalid_refresh_token" }.to_json)
       err = assert_raises(Broker::RefreshError) { client.refresh(**base_request) }
       http.verify
       refute err.retryable?
@@ -90,21 +91,21 @@ module Broker
     end
 
     test "5xx is retryable" do
-      client, _, http = client_with(status: 503, body: "upstream down")
+      client, http = client_with(status: 503, body: "upstream down")
       err = assert_raises(Broker::RefreshError) { client.refresh(**base_request) }
       http.verify
       assert err.retryable?
     end
 
     test "bodyless 4xx is retryable by default" do
-      client, _, http = client_with(status: 429, body: "")
+      client, http = client_with(status: 429, body: "")
       err = assert_raises(Broker::RefreshError) { client.refresh(**base_request) }
       http.verify
       assert err.retryable?
     end
 
     test "bodyless 4xx can be strict and unrecoverable" do
-      client, _, http = client_with(status: 400, body: "")
+      client, http = client_with(status: 400, body: "")
       err = assert_raises(Broker::RefreshError) { client.refresh(**base_request(strict_4xx: true)) }
       http.verify
       refute err.retryable?
@@ -112,7 +113,7 @@ module Broker
     end
 
     test "malformed 2xx body is retryable parse failure" do
-      client, _, http = client_with(status: 200, body: "not json{")
+      client, http = client_with(status: 200, body: "not json{")
       err = assert_raises(Broker::RefreshError) { client.refresh(**base_request) }
       http.verify
       assert err.retryable?
@@ -120,7 +121,7 @@ module Broker
     end
 
     test "empty access_token in 2xx is retryable" do
-      client, _, http = client_with(status: 200, body: { access_token: "", expires_in: 60 }.to_json)
+      client, http = client_with(status: 200, body: { access_token: "", expires_in: 60 }.to_json)
       err = assert_raises(Broker::RefreshError) { client.refresh(**base_request) }
       http.verify
       assert err.retryable?

--- a/services/console/test/lib/http_client_test.rb
+++ b/services/console/test/lib/http_client_test.rb
@@ -3,45 +3,18 @@ require "test_helper"
 class HttpClientTest < ActiveSupport::TestCase
   FakeResponse = Struct.new(:code, :body)
 
-  class StubHTTP
-    attr_reader :requests
-
-    def initialize(response)
-      @response = response
-      @requests = []
+  def expect_transport_call(response)
+    http = Minitest::Mock.new
+    requests = []
+    http.expect(:call, response) do |method:, url:, body:, headers:, timeout:|
+      requests << { method: method, url: url, body: body, headers: headers, timeout: timeout }
+      true
     end
-
-    def call(method:, url:, body:, headers:, timeout:)
-      @requests << { method: method, url: url, body: body, headers: headers, timeout: timeout }
-      @response
-    end
-  end
-
-  class FakeNetHTTP
-    attr_reader :open_timeout, :read_timeout, :captured_request
-
-    def initialize(response)
-      @response = response
-    end
-
-    attr_writer :use_ssl
-
-    def open_timeout=(value)
-      @open_timeout = value
-    end
-
-    def read_timeout=(value)
-      @read_timeout = value
-    end
-
-    def request(request)
-      @captured_request = request
-      @response
-    end
+    [ http, requests ]
   end
 
   test "serializes JSON requests and parses JSON responses" do
-    http = StubHTTP.new(HttpClient::Response.new(status: 200, body: { "ok" => true }.to_json))
+    http, requests = expect_transport_call(HttpClient::Response.new(status: 200, body: { "ok" => true }.to_json))
     client = HttpClient.new(http: http, open_timeout: 3, read_timeout: 5)
 
     response = client.post(
@@ -52,7 +25,8 @@ class HttpClientTest < ActiveSupport::TestCase
     )
 
     assert_equal({ "ok" => true }, response.json)
-    request = http.requests.first
+    http.verify
+    request = requests.first
     assert_equal :post, request[:method]
     assert_equal "https://api.test/widgets?existing=1&page=2", request[:url]
     assert_equal({ "name" => "demo" }, JSON.parse(request[:body]))
@@ -63,49 +37,67 @@ class HttpClientTest < ActiveSupport::TestCase
   end
 
   test "serializes form requests" do
-    http = StubHTTP.new(HttpClient::Response.new(status: 200, body: "{}"))
+    http, requests = expect_transport_call(HttpClient::Response.new(status: 200, body: "{}"))
     client = HttpClient.new(http: http)
 
     client.post("https://api.test/token", form: { "grant_type" => "refresh_token" })
 
-    request = http.requests.first
+    http.verify
+    request = requests.first
     assert_equal "grant_type=refresh_token", request[:body]
     assert_equal "application/x-www-form-urlencoded", request[:headers]["Content-Type"]
   end
 
   test "omits JSON request bodies when JSON is nil" do
-    http = StubHTTP.new(HttpClient::Response.new(status: 204, body: ""))
+    http, requests = expect_transport_call(HttpClient::Response.new(status: 204, body: ""))
     client = HttpClient.new(http: http)
 
     client.request(method: :delete, url: "https://api.test/widgets/1", json: nil)
 
-    request = http.requests.first
+    http.verify
+    request = requests.first
     assert_nil request[:body]
     assert_nil request[:headers]["Content-Type"]
   end
 
   test "supports custom accept headers" do
-    http = StubHTTP.new(HttpClient::Response.new(status: 200, body: "{}"))
+    http, requests = expect_transport_call(HttpClient::Response.new(status: 200, body: "{}"))
     client = HttpClient.new(http: http)
 
     client.get("https://api.test/user", headers: { "Accept" => "application/vnd.github+json" })
 
-    assert_equal "application/vnd.github+json", http.requests.first[:headers]["Accept"]
+    http.verify
+    assert_equal "application/vnd.github+json", requests.first[:headers]["Accept"]
   end
 
   test "uses default timeouts for net http requests" do
-    http = FakeNetHTTP.new(FakeResponse.new("200", "{}"))
+    http = Minitest::Mock.new
+    requested = false
+    http.expect(:use_ssl=, true, [ true ])
+    http.expect(:open_timeout=, HttpClient::DEFAULT_OPEN_TIMEOUT, [ HttpClient::DEFAULT_OPEN_TIMEOUT ])
+    http.expect(:read_timeout=, HttpClient::DEFAULT_READ_TIMEOUT, [ HttpClient::DEFAULT_READ_TIMEOUT ])
+    http.expect(:request, FakeResponse.new("200", "{}")) do |_request|
+      requested = true
+    end
 
     Net::HTTP.stub(:new, ->(_host, _port) { http }) do
       HttpClient.new.get("https://api.test/user")
     end
 
-    assert_equal HttpClient::DEFAULT_OPEN_TIMEOUT, http.open_timeout
-    assert_equal HttpClient::DEFAULT_READ_TIMEOUT, http.read_timeout
+    http.verify
+    assert requested
   end
 
   test "preserves caller content type for encoded form requests" do
-    http = FakeNetHTTP.new(FakeResponse.new("200", "{}"))
+    http = Minitest::Mock.new
+    captured_request = nil
+    http.expect(:use_ssl=, true, [ true ])
+    http.expect(:open_timeout=, HttpClient::DEFAULT_OPEN_TIMEOUT, [ HttpClient::DEFAULT_OPEN_TIMEOUT ])
+    http.expect(:read_timeout=, HttpClient::DEFAULT_READ_TIMEOUT, [ HttpClient::DEFAULT_READ_TIMEOUT ])
+    http.expect(:request, FakeResponse.new("200", "{}")) do |request|
+      captured_request = request
+      true
+    end
 
     Net::HTTP.stub(:new, ->(_host, _port) { http }) do
       HttpClient.new.post(
@@ -115,6 +107,7 @@ class HttpClientTest < ActiveSupport::TestCase
       )
     end
 
-    assert_equal "application/custom-form", http.captured_request["Content-Type"]
+    http.verify
+    assert_equal "application/custom-form", captured_request["Content-Type"]
   end
 end

--- a/services/console/test/lib/http_client_test.rb
+++ b/services/console/test/lib/http_client_test.rb
@@ -5,16 +5,23 @@ class HttpClientTest < ActiveSupport::TestCase
 
   def expect_transport_call(response)
     http = Minitest::Mock.new
-    requests = []
     http.expect(:call, response) do |method:, url:, body:, headers:, timeout:|
-      requests << { method: method, url: url, body: body, headers: headers, timeout: timeout }
+      yield({ method: method, url: url, body: body, headers: headers, timeout: timeout }) if block_given?
       true
     end
-    [ http, requests ]
+    http
   end
 
   test "serializes JSON requests and parses JSON responses" do
-    http, requests = expect_transport_call(HttpClient::Response.new(status: 200, body: { "ok" => true }.to_json))
+    http = expect_transport_call(HttpClient::Response.new(status: 200, body: { "ok" => true }.to_json)) do |request|
+      assert_equal :post, request[:method]
+      assert_equal "https://api.test/widgets?existing=1&page=2", request[:url]
+      assert_equal({ "name" => "demo" }, JSON.parse(request[:body]))
+      assert_equal "application/json", request[:headers]["Accept"]
+      assert_equal "application/json", request[:headers]["Content-Type"]
+      assert_equal "Bearer token", request[:headers]["Authorization"]
+      assert_equal 5, request[:timeout]
+    end
     client = HttpClient.new(http: http, open_timeout: 3, read_timeout: 5)
 
     response = client.post(
@@ -26,58 +33,50 @@ class HttpClientTest < ActiveSupport::TestCase
 
     assert_equal({ "ok" => true }, response.json)
     http.verify
-    request = requests.first
-    assert_equal :post, request[:method]
-    assert_equal "https://api.test/widgets?existing=1&page=2", request[:url]
-    assert_equal({ "name" => "demo" }, JSON.parse(request[:body]))
-    assert_equal "application/json", request[:headers]["Accept"]
-    assert_equal "application/json", request[:headers]["Content-Type"]
-    assert_equal "Bearer token", request[:headers]["Authorization"]
-    assert_equal 5, request[:timeout]
   end
 
   test "serializes form requests" do
-    http, requests = expect_transport_call(HttpClient::Response.new(status: 200, body: "{}"))
+    http = expect_transport_call(HttpClient::Response.new(status: 200, body: "{}")) do |request|
+      assert_equal "grant_type=refresh_token", request[:body]
+      assert_equal "application/x-www-form-urlencoded", request[:headers]["Content-Type"]
+    end
     client = HttpClient.new(http: http)
 
     client.post("https://api.test/token", form: { "grant_type" => "refresh_token" })
 
     http.verify
-    request = requests.first
-    assert_equal "grant_type=refresh_token", request[:body]
-    assert_equal "application/x-www-form-urlencoded", request[:headers]["Content-Type"]
   end
 
   test "omits JSON request bodies when JSON is nil" do
-    http, requests = expect_transport_call(HttpClient::Response.new(status: 204, body: ""))
+    http = expect_transport_call(HttpClient::Response.new(status: 204, body: "")) do |request|
+      assert_nil request[:body]
+      assert_nil request[:headers]["Content-Type"]
+    end
     client = HttpClient.new(http: http)
 
     client.request(method: :delete, url: "https://api.test/widgets/1", json: nil)
 
     http.verify
-    request = requests.first
-    assert_nil request[:body]
-    assert_nil request[:headers]["Content-Type"]
   end
 
   test "supports custom accept headers" do
-    http, requests = expect_transport_call(HttpClient::Response.new(status: 200, body: "{}"))
+    http = expect_transport_call(HttpClient::Response.new(status: 200, body: "{}")) do |request|
+      assert_equal "application/vnd.github+json", request[:headers]["Accept"]
+    end
     client = HttpClient.new(http: http)
 
     client.get("https://api.test/user", headers: { "Accept" => "application/vnd.github+json" })
 
     http.verify
-    assert_equal "application/vnd.github+json", requests.first[:headers]["Accept"]
   end
 
   test "uses default timeouts for net http requests" do
     http = Minitest::Mock.new
-    requested = false
     http.expect(:use_ssl=, true, [ true ])
     http.expect(:open_timeout=, HttpClient::DEFAULT_OPEN_TIMEOUT, [ HttpClient::DEFAULT_OPEN_TIMEOUT ])
     http.expect(:read_timeout=, HttpClient::DEFAULT_READ_TIMEOUT, [ HttpClient::DEFAULT_READ_TIMEOUT ])
     http.expect(:request, FakeResponse.new("200", "{}")) do |_request|
-      requested = true
+      assert true
     end
 
     Net::HTTP.stub(:new, ->(_host, _port) { http }) do
@@ -85,17 +84,15 @@ class HttpClientTest < ActiveSupport::TestCase
     end
 
     http.verify
-    assert requested
   end
 
   test "preserves caller content type for encoded form requests" do
     http = Minitest::Mock.new
-    captured_request = nil
     http.expect(:use_ssl=, true, [ true ])
     http.expect(:open_timeout=, HttpClient::DEFAULT_OPEN_TIMEOUT, [ HttpClient::DEFAULT_OPEN_TIMEOUT ])
     http.expect(:read_timeout=, HttpClient::DEFAULT_READ_TIMEOUT, [ HttpClient::DEFAULT_READ_TIMEOUT ])
     http.expect(:request, FakeResponse.new("200", "{}")) do |request|
-      captured_request = request
+      assert_equal "application/custom-form", request["Content-Type"]
       true
     end
 
@@ -108,6 +105,5 @@ class HttpClientTest < ActiveSupport::TestCase
     end
 
     http.verify
-    assert_equal "application/custom-form", captured_request["Content-Type"]
   end
 end

--- a/services/console/test/lib/http_client_test.rb
+++ b/services/console/test/lib/http_client_test.rb
@@ -4,12 +4,7 @@ class HttpClientTest < ActiveSupport::TestCase
   FakeResponse = Struct.new(:code, :body)
 
   def expect_transport_call(response)
-    http = Minitest::Mock.new
-    http.expect(:call, response) do |method:, url:, body:, headers:, timeout:|
-      yield({ method: method, url: url, body: body, headers: headers, timeout: timeout }) if block_given?
-      true
-    end
-    http
+    expect_http_call(status: response.status, body: response.body, headers: response.headers) { |request| yield request if block_given? }
   end
 
   test "serializes JSON requests and parses JSON responses" do

--- a/services/console/test/models/broker_credential_test.rb
+++ b/services/console/test/models/broker_credential_test.rb
@@ -5,9 +5,8 @@ class BrokerCredentialTest < ActiveSupport::TestCase
     Broker::RefreshClient::Result.new(access_token: access_token, refresh_token: refresh_token, expires_in: expires_in)
   end
 
-  def expect_refresh(client, returns:, capture: nil)
+  def expect_refresh(client, returns:)
     client.expect(:refresh, returns) do |**kw|
-      capture.replace(kw) if capture
       yield kw if block_given?
       true
     end
@@ -139,23 +138,24 @@ class BrokerCredentialTest < ActiveSupport::TestCase
   end
 
   test "refresh uses the app's client secret for an app-linked credential" do
-    captured = {}
     client = Minitest::Mock.new
-    expect_refresh(client, returns: result, capture: captured)
+    expect_refresh(client, returns: result) do |request|
+      assert_equal "app-cid", request[:form]["client_id"]
+      assert_equal "app-secret", request[:form]["client_secret"]
+    end
     app = build_app(client_id: "app-cid", client_secret: "app-secret")
     bc = create_credential(client_id: nil, client_secret: nil, oauth_app: app,
                            provider_subject: "sub-4", created_by: nil, refresh_token: "rt")
     bc.refresh_client = client
     bc.refresh!
     client.verify
-    assert_equal "app-cid", captured[:form]["client_id"]
-    assert_equal "app-secret", captured[:form]["client_secret"]
   end
 
   test "refresh lets the provider choose refresh scopes" do
-    captured = {}
     client = Minitest::Mock.new
-    expect_refresh(client, returns: result, capture: captured)
+    expect_refresh(client, returns: result) do |request|
+      refute request[:form].key?("scope")
+    end
     app = build_app(provider: "slack", client_id: "app-cid", client_secret: "app-secret",
                     allowed_scopes: %w[chat:write])
     bc = create_credential(client_id: nil, client_secret: nil, oauth_app: app,
@@ -164,7 +164,6 @@ class BrokerCredentialTest < ActiveSupport::TestCase
     bc.refresh_client = client
     bc.refresh!
     client.verify
-    refute captured[:form].key?("scope")
   end
 
   test "external_user_key must be url-safe and bounded" do
@@ -295,52 +294,52 @@ class BrokerCredentialTest < ActiveSupport::TestCase
   end
 
   test "refresh passes client credentials and token-endpoint headers to the client" do
-    captured = {}
     client = Minitest::Mock.new
-    expect_refresh(client, returns: result, capture: captured)
+    expect_refresh(client, returns: result) do |request|
+      assert_equal "the-id", request[:form]["client_id"]
+      assert_equal "the-secret", request[:form]["client_secret"]
+      assert_equal({ "X-Api-Key" => "k" }, request[:headers])
+    end
     bc = create_credential(client_id: "the-id", client_secret: "the-secret",
                            token_endpoint_headers: { "X-Api-Key" => "k" })
     bc.refresh_client = client
     bc.refresh!
     client.verify
-    assert_equal "the-id", captured[:form]["client_id"]
-    assert_equal "the-secret", captured[:form]["client_secret"]
-    assert_equal({ "X-Api-Key" => "k" }, captured[:headers])
   end
 
   test "password grant uses initial values and stores returned refresh_token" do
-    captured = {}
     client = Minitest::Mock.new
-    expect_refresh(client, returns: result(access_token: "AT", refresh_token: "RT-new"), capture: captured)
+    expect_refresh(client, returns: result(access_token: "AT", refresh_token: "RT-new")) do |request|
+      assert_equal "password", request_grant(request)
+      assert_equal "user", request[:form]["username"]
+      assert_equal "pass", request[:form]["password"]
+    end
     bc = create_credential(grant: "password", username: "user", password: "pass", refresh_token: nil)
     bc.refresh_client = client
     bc.refresh!
     client.verify
     bc.reload
-    assert_equal "password", request_grant(captured)
-    assert_equal "user", captured[:form]["username"]
-    assert_equal "pass", captured[:form]["password"]
     assert_equal "RT-new", bc.refresh_token
     assert_equal "AT", bc.access_token
   end
 
   test "client_credentials grant refreshes without a refresh_token" do
     now = Time.current
-    captured = {}
     bc = create_credential(grant: "client_credentials", refresh_token: nil,
                            client_id: "bloomberg-client", client_secret: "bloomberg-secret",
                            scopes: [])
     client = Minitest::Mock.new
-    expect_refresh(client, returns: result(access_token: "AT-client", refresh_token: nil, expires_in: 7199), capture: captured)
+    expect_refresh(client, returns: result(access_token: "AT-client", refresh_token: nil, expires_in: 7199)) do |request|
+      assert_equal "client_credentials", request_grant(request)
+      assert_equal "bloomberg-client", request[:form]["client_id"]
+      assert_equal "bloomberg-secret", request[:form]["client_secret"]
+      refute request[:form].key?("refresh_token")
+    end
     bc.refresh_client = client
     bc.refresh!(now: now)
     client.verify
     bc.reload
 
-    assert_equal "client_credentials", request_grant(captured)
-    assert_equal "bloomberg-client", captured[:form]["client_id"]
-    assert_equal "bloomberg-secret", captured[:form]["client_secret"]
-    refute captured[:form].key?("refresh_token")
     assert_equal "AT-client", bc.access_token
     assert_nil bc.refresh_token
     assert_in_delta (now + 7199).to_f, bc.expires_at.to_f, 1
@@ -348,16 +347,16 @@ class BrokerCredentialTest < ActiveSupport::TestCase
   end
 
   test "password grant prefers a stored refresh_token" do
-    captured = {}
     client = Minitest::Mock.new
-    expect_refresh(client, returns: result(access_token: "AT", refresh_token: nil), capture: captured)
+    expect_refresh(client, returns: result(access_token: "AT", refresh_token: nil)) do |request|
+      assert_equal "refresh_token", request_grant(request)
+      assert_equal "RT-old", request[:form]["refresh_token"]
+    end
     bc = create_credential(grant: "password", username: "user", password: "pass", refresh_token: "RT-old")
     bc.refresh_client = client
     bc.refresh!
     client.verify
     bc.reload
-    assert_equal "refresh_token", request_grant(captured)
-    assert_equal "RT-old", captured[:form]["refresh_token"]
     assert_equal "RT-old", bc.refresh_token
   end
 
@@ -417,41 +416,41 @@ class BrokerCredentialTest < ActiveSupport::TestCase
   end
 
   test "preqin grant uses username and API key when no refresh token exists" do
-    captured = {}
     client = Minitest::Mock.new
-    expect_refresh(client, returns: result(access_token: "AT", refresh_token: "RT-new"), capture: captured)
+    expect_refresh(client, returns: result(access_token: "AT", refresh_token: "RT-new")) do |request|
+      assert_equal "preqin", request_grant(request)
+      assert_equal BrokerCredential::PREQIN_TOKEN_ENDPOINT, request[:url]
+      assert_equal "user", request[:form]["username"]
+      assert_equal "api-key", request[:form]["apikey"]
+      refute request[:form].key?("client_id")
+      assert_equal :multipart, request[:form_encoding]
+      assert_equal true, request[:strict_4xx]
+    end
     bc = create_credential(grant: "preqin", client_id: nil, username: "user",
                            api_key: "api-key", refresh_token: nil)
     bc.refresh_client = client
     bc.refresh!
     client.verify
     bc.reload
-    assert_equal "preqin", request_grant(captured)
-    assert_equal BrokerCredential::PREQIN_TOKEN_ENDPOINT, captured[:url]
-    assert_equal "user", captured[:form]["username"]
-    assert_equal "api-key", captured[:form]["apikey"]
-    refute captured[:form].key?("client_id")
-    assert_equal :multipart, captured[:form_encoding]
-    assert_equal true, captured[:strict_4xx]
     assert_equal "RT-new", bc.refresh_token
     assert_equal "AT", bc.access_token
   end
 
   test "preqin grant prefers the Preqin refresh endpoint when it has a refresh token" do
-    captured = {}
     client = Minitest::Mock.new
-    expect_refresh(client, returns: result(access_token: "AT", refresh_token: nil), capture: captured)
+    expect_refresh(client, returns: result(access_token: "AT", refresh_token: nil)) do |request|
+      assert_equal "preqin_refresh_token", request_grant(request)
+      assert_equal Broker::CredentialGrants::PREQIN_REFRESH_TOKEN_ENDPOINT, request[:url]
+      assert_equal "RT-old", request[:form]["refresh_token"]
+      assert_equal :multipart, request[:form_encoding]
+      assert_equal true, request[:strict_4xx]
+    end
     bc = create_credential(grant: "preqin", client_id: nil, username: "user",
                            api_key: "api-key", refresh_token: "RT-old")
     bc.refresh_client = client
     bc.refresh!
     client.verify
     bc.reload
-    assert_equal "preqin_refresh_token", request_grant(captured)
-    assert_equal Broker::CredentialGrants::PREQIN_REFRESH_TOKEN_ENDPOINT, captured[:url]
-    assert_equal "RT-old", captured[:form]["refresh_token"]
-    assert_equal :multipart, captured[:form_encoding]
-    assert_equal true, captured[:strict_4xx]
     assert_equal "RT-old", bc.refresh_token
   end
 

--- a/services/console/test/models/broker_credential_test.rb
+++ b/services/console/test/models/broker_credential_test.rb
@@ -1,14 +1,23 @@
 require "test_helper"
 
 class BrokerCredentialTest < ActiveSupport::TestCase
-  # A stub refresh client returning a fixed Result or raising a fixed error.
-  class StubClient
-    def initialize(&block) = (@block = block)
-    def refresh(**kw) = @block.call(**kw)
-  end
-
   def result(access_token: "AT", refresh_token: "RT", expires_in: 3600)
     Broker::RefreshClient::Result.new(access_token: access_token, refresh_token: refresh_token, expires_in: expires_in)
+  end
+
+  def expect_refresh(client, returns:, capture: nil)
+    client.expect(:refresh, returns) do |**kw|
+      capture.replace(kw) if capture
+      yield kw if block_given?
+      true
+    end
+  end
+
+  def expect_refresh_error(client, error)
+    client.expect(:refresh, nil) do |**kw|
+      yield kw if block_given?
+      raise error
+    end
   end
 
   def build_credential(refresh_token: "seed-rt", **overrides)
@@ -131,24 +140,30 @@ class BrokerCredentialTest < ActiveSupport::TestCase
 
   test "refresh uses the app's client secret for an app-linked credential" do
     captured = {}
+    client = Minitest::Mock.new
+    expect_refresh(client, returns: result, capture: captured)
     app = build_app(client_id: "app-cid", client_secret: "app-secret")
     bc = create_credential(client_id: nil, client_secret: nil, oauth_app: app,
                            provider_subject: "sub-4", created_by: nil, refresh_token: "rt")
-    bc.refresh_client = StubClient.new { |**kw| captured = kw; result }
+    bc.refresh_client = client
     bc.refresh!
+    client.verify
     assert_equal "app-cid", captured[:form]["client_id"]
     assert_equal "app-secret", captured[:form]["client_secret"]
   end
 
   test "refresh lets the provider choose refresh scopes" do
     captured = {}
+    client = Minitest::Mock.new
+    expect_refresh(client, returns: result, capture: captured)
     app = build_app(provider: "slack", client_id: "app-cid", client_secret: "app-secret",
                     allowed_scopes: %w[chat:write])
     bc = create_credential(client_id: nil, client_secret: nil, oauth_app: app,
                            provider_subject: "U123", created_by: nil, refresh_token: "rt",
                            scopes: %w[chat:write openid])
-    bc.refresh_client = StubClient.new { |**kw| captured = kw; result }
+    bc.refresh_client = client
     bc.refresh!
+    client.verify
     refute captured[:form].key?("scope")
   end
 
@@ -215,9 +230,12 @@ class BrokerCredentialTest < ActiveSupport::TestCase
 
   test "successful refresh advances the blob and schedules the next attempt" do
     now = Time.current
+    client = Minitest::Mock.new
+    expect_refresh(client, returns: result(access_token: "AT-1", refresh_token: "RT-2", expires_in: 3600))
     bc = create_credential
-    bc.refresh_client = StubClient.new { result(access_token: "AT-1", refresh_token: "RT-2", expires_in: 3600) }
+    bc.refresh_client = client
     bc.refresh!(now: now)
+    client.verify
     bc.reload
     assert_equal "live", bc.status
     assert_equal "AT-1", bc.access_token
@@ -228,27 +246,36 @@ class BrokerCredentialTest < ActiveSupport::TestCase
   end
 
   test "refresh carries the previous refresh_token forward when the IdP omits it" do
+    client = Minitest::Mock.new
+    expect_refresh(client, returns: result(refresh_token: nil, expires_in: nil))
     bc = create_credential(refresh_token: "RT-keep")
-    bc.refresh_client = StubClient.new { result(refresh_token: nil, expires_in: nil) }
+    bc.refresh_client = client
     bc.refresh!
+    client.verify
     bc.reload
     assert_equal "RT-keep", bc.refresh_token
   end
 
   test "refresh defaults expiry when the IdP omits expires_in" do
     now = Time.current
+    client = Minitest::Mock.new
+    expect_refresh(client, returns: result(expires_in: nil))
     bc = create_credential
-    bc.refresh_client = StubClient.new { result(expires_in: nil) }
+    bc.refresh_client = client
     bc.refresh!(now: now)
+    client.verify
     bc.reload
     assert_in_delta (now + BrokerCredential::DEFAULT_EXPIRES_IN_SECONDS).to_f, bc.expires_at.to_f, 1
   end
 
   test "retryable failure schedules a backoff and does not mark dead" do
     now = Time.current
+    client = Minitest::Mock.new
+    expect_refresh_error(client, Broker::RefreshError.new("net", stage: "network", retryable: true))
     bc = create_credential
-    bc.refresh_client = StubClient.new { raise Broker::RefreshError.new("net", stage: "network", retryable: true) }
+    bc.refresh_client = client
     bc.refresh!(now: now)
+    client.verify
     bc.reload
     refute bc.dead?
     assert_equal 1, bc.failure_count
@@ -256,9 +283,12 @@ class BrokerCredentialTest < ActiveSupport::TestCase
   end
 
   test "unrecoverable failure marks the credential dead" do
+    client = Minitest::Mock.new
+    expect_refresh_error(client, Broker::RefreshError.new("bad", stage: "oauth", code: "invalid_grant", retryable: false))
     bc = create_credential
-    bc.refresh_client = StubClient.new { raise Broker::RefreshError.new("bad", stage: "oauth", code: "invalid_grant", retryable: false) }
+    bc.refresh_client = client
     bc.refresh!
+    client.verify
     bc.reload
     assert bc.dead?
     assert_equal "invalid_grant", bc.dead_reason
@@ -266,10 +296,13 @@ class BrokerCredentialTest < ActiveSupport::TestCase
 
   test "refresh passes client credentials and token-endpoint headers to the client" do
     captured = {}
+    client = Minitest::Mock.new
+    expect_refresh(client, returns: result, capture: captured)
     bc = create_credential(client_id: "the-id", client_secret: "the-secret",
                            token_endpoint_headers: { "X-Api-Key" => "k" })
-    bc.refresh_client = StubClient.new { |**kw| captured = kw; result }
+    bc.refresh_client = client
     bc.refresh!
+    client.verify
     assert_equal "the-id", captured[:form]["client_id"]
     assert_equal "the-secret", captured[:form]["client_secret"]
     assert_equal({ "X-Api-Key" => "k" }, captured[:headers])
@@ -277,9 +310,12 @@ class BrokerCredentialTest < ActiveSupport::TestCase
 
   test "password grant uses initial values and stores returned refresh_token" do
     captured = {}
+    client = Minitest::Mock.new
+    expect_refresh(client, returns: result(access_token: "AT", refresh_token: "RT-new"), capture: captured)
     bc = create_credential(grant: "password", username: "user", password: "pass", refresh_token: nil)
-    bc.refresh_client = StubClient.new { |**kw| captured = kw; result(access_token: "AT", refresh_token: "RT-new") }
+    bc.refresh_client = client
     bc.refresh!
+    client.verify
     bc.reload
     assert_equal "password", request_grant(captured)
     assert_equal "user", captured[:form]["username"]
@@ -294,11 +330,11 @@ class BrokerCredentialTest < ActiveSupport::TestCase
     bc = create_credential(grant: "client_credentials", refresh_token: nil,
                            client_id: "bloomberg-client", client_secret: "bloomberg-secret",
                            scopes: [])
-    bc.refresh_client = StubClient.new do |**kw|
-      captured = kw
-      result(access_token: "AT-client", refresh_token: nil, expires_in: 7199)
-    end
+    client = Minitest::Mock.new
+    expect_refresh(client, returns: result(access_token: "AT-client", refresh_token: nil, expires_in: 7199), capture: captured)
+    bc.refresh_client = client
     bc.refresh!(now: now)
+    client.verify
     bc.reload
 
     assert_equal "client_credentials", request_grant(captured)
@@ -313,9 +349,12 @@ class BrokerCredentialTest < ActiveSupport::TestCase
 
   test "password grant prefers a stored refresh_token" do
     captured = {}
+    client = Minitest::Mock.new
+    expect_refresh(client, returns: result(access_token: "AT", refresh_token: nil), capture: captured)
     bc = create_credential(grant: "password", username: "user", password: "pass", refresh_token: "RT-old")
-    bc.refresh_client = StubClient.new { |**kw| captured = kw; result(access_token: "AT", refresh_token: nil) }
+    bc.refresh_client = client
     bc.refresh!
+    client.verify
     bc.reload
     assert_equal "refresh_token", request_grant(captured)
     assert_equal "RT-old", captured[:form]["refresh_token"]
@@ -324,15 +363,17 @@ class BrokerCredentialTest < ActiveSupport::TestCase
 
   test "password grant falls back to password when stored refresh_token is rejected" do
     grants = []
-    bc = create_credential(grant: "password", username: "user", password: "pass", refresh_token: "RT-bad")
-    bc.refresh_client = StubClient.new do |**kw|
+    client = Minitest::Mock.new
+    expect_refresh_error(client, Broker::RefreshError.new("bad", stage: "oauth", code: "invalid_grant", retryable: false)) do |kw|
       grants << request_grant(kw)
-      if request_grant(kw) == "refresh_token"
-        raise Broker::RefreshError.new("bad", stage: "oauth", code: "invalid_grant", retryable: false)
-      end
-      result(access_token: "AT-password", refresh_token: "RT-good")
     end
+    expect_refresh(client, returns: result(access_token: "AT-password", refresh_token: "RT-good")) do |kw|
+      grants << request_grant(kw)
+    end
+    bc = create_credential(grant: "password", username: "user", password: "pass", refresh_token: "RT-bad")
+    bc.refresh_client = client
     bc.refresh!
+    client.verify
     bc.reload
     assert_equal %w[refresh_token password], grants
     assert_equal "AT-password", bc.access_token
@@ -342,15 +383,17 @@ class BrokerCredentialTest < ActiveSupport::TestCase
 
   test "password grant clears stale refresh_token when password fallback succeeds without rotation" do
     grants = []
-    bc = create_credential(grant: "password", username: "user", password: "pass", refresh_token: "RT-bad")
-    bc.refresh_client = StubClient.new do |**kw|
+    client = Minitest::Mock.new
+    expect_refresh_error(client, Broker::RefreshError.new("bad", stage: "oauth", code: "invalid_grant", retryable: false)) do |kw|
       grants << request_grant(kw)
-      if request_grant(kw) == "refresh_token"
-        raise Broker::RefreshError.new("bad", stage: "oauth", code: "invalid_grant", retryable: false)
-      end
-      result(access_token: "AT-password", refresh_token: nil)
     end
+    expect_refresh(client, returns: result(access_token: "AT-password", refresh_token: nil)) do |kw|
+      grants << request_grant(kw)
+    end
+    bc = create_credential(grant: "password", username: "user", password: "pass", refresh_token: "RT-bad")
+    bc.refresh_client = client
     bc.refresh!
+    client.verify
     bc.reload
     assert_equal %w[refresh_token password], grants
     assert_nil bc.refresh_token
@@ -359,12 +402,14 @@ class BrokerCredentialTest < ActiveSupport::TestCase
 
   test "password grant does not fall back on retryable refresh_token failure" do
     grants = []
-    bc = create_credential(grant: "password", username: "user", password: "pass", refresh_token: "RT-old")
-    bc.refresh_client = StubClient.new do |**kw|
+    client = Minitest::Mock.new
+    expect_refresh_error(client, Broker::RefreshError.new("net", stage: "network", retryable: true)) do |kw|
       grants << request_grant(kw)
-      raise Broker::RefreshError.new("net", stage: "network", retryable: true)
     end
+    bc = create_credential(grant: "password", username: "user", password: "pass", refresh_token: "RT-old")
+    bc.refresh_client = client
     bc.refresh!
+    client.verify
     bc.reload
     assert_equal [ "refresh_token" ], grants
     refute bc.dead?
@@ -373,10 +418,13 @@ class BrokerCredentialTest < ActiveSupport::TestCase
 
   test "preqin grant uses username and API key when no refresh token exists" do
     captured = {}
+    client = Minitest::Mock.new
+    expect_refresh(client, returns: result(access_token: "AT", refresh_token: "RT-new"), capture: captured)
     bc = create_credential(grant: "preqin", client_id: nil, username: "user",
                            api_key: "api-key", refresh_token: nil)
-    bc.refresh_client = StubClient.new { |**kw| captured = kw; result(access_token: "AT", refresh_token: "RT-new") }
+    bc.refresh_client = client
     bc.refresh!
+    client.verify
     bc.reload
     assert_equal "preqin", request_grant(captured)
     assert_equal BrokerCredential::PREQIN_TOKEN_ENDPOINT, captured[:url]
@@ -391,10 +439,13 @@ class BrokerCredentialTest < ActiveSupport::TestCase
 
   test "preqin grant prefers the Preqin refresh endpoint when it has a refresh token" do
     captured = {}
+    client = Minitest::Mock.new
+    expect_refresh(client, returns: result(access_token: "AT", refresh_token: nil), capture: captured)
     bc = create_credential(grant: "preqin", client_id: nil, username: "user",
                            api_key: "api-key", refresh_token: "RT-old")
-    bc.refresh_client = StubClient.new { |**kw| captured = kw; result(access_token: "AT", refresh_token: nil) }
+    bc.refresh_client = client
     bc.refresh!
+    client.verify
     bc.reload
     assert_equal "preqin_refresh_token", request_grant(captured)
     assert_equal Broker::CredentialGrants::PREQIN_REFRESH_TOKEN_ENDPOINT, captured[:url]
@@ -406,16 +457,18 @@ class BrokerCredentialTest < ActiveSupport::TestCase
 
   test "preqin grant falls back to username and API key when stored refresh token is rejected" do
     grants = []
+    client = Minitest::Mock.new
+    expect_refresh_error(client, Broker::RefreshError.new("bad", stage: "http", code: "http_400", retryable: false)) do |kw|
+      grants << request_grant(kw)
+    end
+    expect_refresh(client, returns: result(access_token: "AT-preqin", refresh_token: "RT-good")) do |kw|
+      grants << request_grant(kw)
+    end
     bc = create_credential(grant: "preqin", client_id: nil, username: "user",
                            api_key: "api-key", refresh_token: "RT-bad")
-    bc.refresh_client = StubClient.new do |**kw|
-      grants << request_grant(kw)
-      if request_grant(kw) == "preqin_refresh_token"
-        raise Broker::RefreshError.new("bad", stage: "http", code: "http_400", retryable: false)
-      end
-      result(access_token: "AT-preqin", refresh_token: "RT-good")
-    end
+    bc.refresh_client = client
     bc.refresh!
+    client.verify
     bc.reload
     assert_equal %w[preqin_refresh_token preqin], grants
     assert_equal "AT-preqin", bc.access_token

--- a/services/console/test/services/centaur_api_client_test.rb
+++ b/services/console/test/services/centaur_api_client_test.rb
@@ -2,10 +2,7 @@ require "test_helper"
 
 class CentaurApiClientTest < ActiveSupport::TestCase
   def expect_request(http, status:, body:)
-    http.expect(:call, HttpClient::Response.new(status: status, body: body)) do |method:, url:, body:, headers:, timeout:|
-      yield({ method: method, url: url, body: body, headers: headers, timeout: timeout }) if block_given?
-      true
-    end
+    expect_http_call(http, status: status, body: body) { |request| yield request if block_given? }
   end
 
   test "lists Slack archive imports with query params" do

--- a/services/console/test/services/centaur_api_client_test.rb
+++ b/services/console/test/services/centaur_api_client_test.rb
@@ -1,31 +1,35 @@
 require "test_helper"
 
 class CentaurApiClientTest < ActiveSupport::TestCase
-  def expect_request(http, requests, status:, body:)
+  def expect_request(http, status:, body:)
     http.expect(:call, HttpClient::Response.new(status: status, body: body)) do |method:, url:, body:, headers:, timeout:|
-      requests << { method: method, url: url, body: body, headers: headers, timeout: timeout }
+      yield({ method: method, url: url, body: body, headers: headers, timeout: timeout }) if block_given?
       true
     end
   end
 
   test "lists Slack archive imports with query params" do
     http = Minitest::Mock.new
-    requests = []
-    expect_request(http, requests, status: 200, body: { imports: [] }.to_json)
+    expect_request(http, status: 200, body: { imports: [] }.to_json) do |request|
+      assert_equal :get, request[:method]
+      assert_equal "http://api.internal:8080/api/admin/slack/archive-imports?limit=25", request[:url]
+      assert_equal "application/json", request[:headers]["Accept"]
+    end
     client = CentaurApiClient.new(base_url: "http://api.internal:8080", http: http)
 
     assert_equal({ "imports" => [] }, client.list_slack_archive_imports(limit: 25))
     http.verify
-    request = requests.first
-    assert_equal :get, request[:method]
-    assert_equal "http://api.internal:8080/api/admin/slack/archive-imports?limit=25", request[:url]
-    assert_equal "application/json", request[:headers]["Accept"]
   end
 
   test "creates Slack archive imports with optional bearer auth" do
     http = Minitest::Mock.new
-    requests = []
-    expect_request(http, requests, status: 201, body: { ok: true }.to_json)
+    expect_request(http, status: 201, body: { ok: true }.to_json) do |request|
+      assert_equal :post, request[:method]
+      assert_equal "Bearer secret-key", request[:headers]["Authorization"]
+      body = JSON.parse(request[:body])
+      assert_equal "export.zip", body["filename"]
+      assert_equal({ "source" => "test" }, body["metadata"])
+    end
     client = CentaurApiClient.new(
       base_url: "http://api.internal:8080/",
       api_key: "secret-key",
@@ -40,18 +44,11 @@ class CentaurApiClientTest < ActiveSupport::TestCase
     )
 
     http.verify
-    request = requests.first
-    assert_equal :post, request[:method]
-    assert_equal "Bearer secret-key", request[:headers]["Authorization"]
-    body = JSON.parse(request[:body])
-    assert_equal "export.zip", body["filename"]
-    assert_equal({ "source" => "test" }, body["metadata"])
   end
 
   test "raises useful errors for non-2xx responses" do
     http = Minitest::Mock.new
-    requests = []
-    expect_request(http, requests, status: 400, body: { error: "bad archive" }.to_json)
+    expect_request(http, status: 400, body: { error: "bad archive" }.to_json)
     client = CentaurApiClient.new(base_url: "http://api.internal:8080", http: http)
 
     error = assert_raises(CentaurApiClient::Error) do
@@ -63,8 +60,13 @@ class CentaurApiClientTest < ActiveSupport::TestCase
 
   test "lists Slack DM sync checkpoints for a broker credential" do
     http = Minitest::Mock.new
-    requests = []
-    expect_request(http, requests, status: 200, body: { checkpoints: [] }.to_json)
+    expect_request(http, status: 200, body: { checkpoints: [] }.to_json) do |request|
+      assert_equal :get, request[:method]
+      assert_equal(
+        "http://api.internal:8080/api/admin/slack/dm-sync/checkpoints?broker_credential_id=bcr_123&home_team_id=T123",
+        request[:url]
+      )
+    end
     client = CentaurApiClient.new(base_url: "http://api.internal:8080", http: http)
 
     client.list_slack_dm_sync_checkpoints(
@@ -73,65 +75,62 @@ class CentaurApiClientTest < ActiveSupport::TestCase
     )
 
     http.verify
-    request = requests.first
-    assert_equal :get, request[:method]
-    assert_equal(
-      "http://api.internal:8080/api/admin/slack/dm-sync/checkpoints?broker_credential_id=bcr_123&home_team_id=T123",
-      request[:url]
-    )
   end
 
   test "posts Slack DM sync batches" do
     http = Minitest::Mock.new
-    requests = []
-    expect_request(http, requests, status: 200, body: { ok: true }.to_json)
+    expect_request(http, status: 200, body: { ok: true }.to_json) do |request|
+      assert_equal :post, request[:method]
+      assert_equal "http://api.internal:8080/api/admin/slack/dm-sync/batch", request[:url]
+      assert_equal({ "run" => { "run_id" => "sdms_1" }, "messages" => [] }, JSON.parse(request[:body]))
+    end
     client = CentaurApiClient.new(base_url: "http://api.internal:8080", http: http)
 
     client.ingest_slack_dm_sync_batch(run: { run_id: "sdms_1" }, messages: [])
 
     http.verify
-    request = requests.first
-    assert_equal :post, request[:method]
-    assert_equal "http://api.internal:8080/api/admin/slack/dm-sync/batch", request[:url]
-    assert_equal({ "run" => { "run_id" => "sdms_1" }, "messages" => [] }, JSON.parse(request[:body]))
   end
 
   test "gets Google Docs sync checkpoint for a broker credential" do
     http = Minitest::Mock.new
-    requests = []
-    expect_request(http, requests, status: 200, body: { checkpoint: nil }.to_json)
+    expect_request(http, status: 200, body: { checkpoint: nil }.to_json) do |request|
+      assert_equal :get, request[:method]
+      assert_equal(
+        "http://api.internal:8080/api/admin/google/docs-sync/checkpoint?broker_credential_id=bcr_123",
+        request[:url]
+      )
+    end
     client = CentaurApiClient.new(base_url: "http://api.internal:8080", http: http)
 
     client.get_google_docs_sync_checkpoint(broker_credential_id: "bcr_123")
 
     http.verify
-    request = requests.first
-    assert_equal :get, request[:method]
-    assert_equal(
-      "http://api.internal:8080/api/admin/google/docs-sync/checkpoint?broker_credential_id=bcr_123",
-      request[:url]
-    )
   end
 
   test "posts Google Docs sync batches" do
     http = Minitest::Mock.new
-    requests = []
-    expect_request(http, requests, status: 200, body: { ok: true }.to_json)
+    expect_request(http, status: 200, body: { ok: true }.to_json) do |request|
+      assert_equal :post, request[:method]
+      assert_equal "http://api.internal:8080/api/admin/google/docs-sync/batch", request[:url]
+      assert_equal({ "run" => { "run_id" => "gdocs_1" }, "files" => [] }, JSON.parse(request[:body]))
+    end
     client = CentaurApiClient.new(base_url: "http://api.internal:8080", http: http)
 
     client.ingest_google_docs_sync_batch(run: { run_id: "gdocs_1" }, files: [])
 
     http.verify
-    request = requests.first
-    assert_equal :post, request[:method]
-    assert_equal "http://api.internal:8080/api/admin/google/docs-sync/batch", request[:url]
-    assert_equal({ "run" => { "run_id" => "gdocs_1" }, "files" => [] }, JSON.parse(request[:body]))
   end
 
   test "creates app sessions with encoded thread keys" do
     http = Minitest::Mock.new
-    requests = []
-    expect_request(http, requests, status: 200, body: { ok: true }.to_json)
+    expect_request(http, status: 200, body: { ok: true }.to_json) do |request|
+      assert_equal :post, request[:method]
+      assert_equal "http://api.internal:8080/api/session/console%3Aabc-123", request[:url]
+      body = JSON.parse(request[:body])
+      assert_equal "codex", body["harness_type"]
+      assert_equal({ "source" => "console" }, body["metadata"])
+      assert_equal "reject", body["on_harness_conflict"]
+    end
     client = CentaurApiClient.new(base_url: "http://api.internal:8080", http: http)
 
     client.create_session(
@@ -142,20 +141,22 @@ class CentaurApiClientTest < ActiveSupport::TestCase
     )
 
     http.verify
-    request = requests.first
-    assert_equal :post, request[:method]
-    assert_equal "http://api.internal:8080/api/session/console%3Aabc-123", request[:url]
-    body = JSON.parse(request[:body])
-    assert_equal "codex", body["harness_type"]
-    assert_equal({ "source" => "console" }, body["metadata"])
-    assert_equal "reject", body["on_harness_conflict"]
   end
 
   test "appends and executes app session messages" do
     http = Minitest::Mock.new
-    requests = []
-    expect_request(http, requests, status: 200, body: { ok: true }.to_json)
-    expect_request(http, requests, status: 200, body: { ok: true }.to_json)
+    expect_request(http, status: 200, body: { ok: true }.to_json) do |request|
+      assert_equal :post, request[:method]
+      assert_equal "http://api.internal:8080/api/session/console%3Aabc-123/messages", request[:url]
+      assert_equal "user", JSON.parse(request[:body]).dig("messages", 0, "role")
+    end
+    expect_request(http, status: 200, body: { ok: true }.to_json) do |request|
+      assert_equal :post, request[:method]
+      assert_equal "http://api.internal:8080/api/session/console%3Aabc-123/execute", request[:url]
+      body = JSON.parse(request[:body])
+      assert_equal [ '{"type":"user"}' ], body["input_lines"]
+      assert_equal "idem-1", body["idempotency_key"]
+    end
     client = CentaurApiClient.new(base_url: "http://api.internal:8080", http: http)
 
     client.append_session_messages(
@@ -170,56 +171,44 @@ class CentaurApiClientTest < ActiveSupport::TestCase
     )
 
     http.verify
-    append = requests.first
-    assert_equal :post, append[:method]
-    assert_equal "http://api.internal:8080/api/session/console%3Aabc-123/messages", append[:url]
-    assert_equal "user", JSON.parse(append[:body]).dig("messages", 0, "role")
-
-    execute = requests.second
-    assert_equal :post, execute[:method]
-    assert_equal "http://api.internal:8080/api/session/console%3Aabc-123/execute", execute[:url]
-    body = JSON.parse(execute[:body])
-    assert_equal [ '{"type":"user"}' ], body["input_lines"]
-    assert_equal "idem-1", body["idempotency_key"]
   end
 
   test "lists workflow schedules and fetches run details" do
     http = Minitest::Mock.new
-    requests = []
-    expect_request(http, requests, status: 200, body: { ok: true, schedules: [] }.to_json)
-    expect_request(http, requests, status: 200, body: { ok: true, schedules: [] }.to_json)
+    expect_request(http, status: 200, body: { ok: true, schedules: [] }.to_json) do |request|
+      assert_equal :get, request[:method]
+      assert_equal "http://api.internal:8080/api/workflows/schedules", request[:url]
+    end
+    expect_request(http, status: 200, body: { ok: true, schedules: [] }.to_json) do |request|
+      assert_equal :get, request[:method]
+      assert_equal "http://api.internal:8080/api/workflows/runs/run%3A1", request[:url]
+    end
     client = CentaurApiClient.new(base_url: "http://api.internal:8080", http: http)
 
     client.list_workflow_schedules
     client.get_workflow_run("run:1")
 
     http.verify
-    schedules = requests.first
-    assert_equal :get, schedules[:method]
-    assert_equal "http://api.internal:8080/api/workflows/schedules", schedules[:url]
-
-    run = requests.second
-    assert_equal :get, run[:method]
-    assert_equal "http://api.internal:8080/api/workflows/runs/run%3A1", run[:url]
   end
 
   test "creates workflow runs with optional input" do
     http = Minitest::Mock.new
-    requests = []
-    expect_request(http, requests, status: 200, body: { ok: true, run_id: "r1" }.to_json)
-    expect_request(http, requests, status: 200, body: { ok: true, run_id: "r1" }.to_json)
+    expect_request(http, status: 200, body: { ok: true, run_id: "r1" }.to_json) do |request|
+      assert_equal :post, request[:method]
+      assert_equal "http://api.internal:8080/api/workflows/runs", request[:url]
+      assert_equal({ "workflow_name" => "slack_sync" }, JSON.parse(request[:body]))
+    end
+    expect_request(http, status: 200, body: { ok: true, run_id: "r1" }.to_json) do |request|
+      assert_equal(
+        { "workflow_name" => "slack_sync", "input" => { "mode" => "full" } },
+        JSON.parse(request[:body])
+      )
+    end
     client = CentaurApiClient.new(base_url: "http://api.internal:8080", http: http)
 
     client.create_workflow_run(workflow_name: "slack_sync")
     client.create_workflow_run(workflow_name: "slack_sync", input: { "mode" => "full" })
 
     http.verify
-    bare = requests.first
-    assert_equal :post, bare[:method]
-    assert_equal "http://api.internal:8080/api/workflows/runs", bare[:url]
-    assert_equal({ "workflow_name" => "slack_sync" }, JSON.parse(bare[:body]))
-
-    with_input = requests.second
-    assert_equal({ "workflow_name" => "slack_sync", "input" => { "mode" => "full" } }, JSON.parse(with_input[:body]))
   end
 end

--- a/services/console/test/services/centaur_api_client_test.rb
+++ b/services/console/test/services/centaur_api_client_test.rb
@@ -1,34 +1,31 @@
 require "test_helper"
 
 class CentaurApiClientTest < ActiveSupport::TestCase
-  class StubHTTP
-    attr_reader :requests
-
-    def initialize(status:, body:)
-      @status = status
-      @body = body
-      @requests = []
-    end
-
-    def call(method:, url:, body:, headers:, timeout:)
-      @requests << { method: method, url: url, body: body, headers: headers, timeout: timeout }
-      HttpClient::Response.new(status: @status, body: @body)
+  def expect_request(http, requests, status:, body:)
+    http.expect(:call, HttpClient::Response.new(status: status, body: body)) do |method:, url:, body:, headers:, timeout:|
+      requests << { method: method, url: url, body: body, headers: headers, timeout: timeout }
+      true
     end
   end
 
   test "lists Slack archive imports with query params" do
-    http = StubHTTP.new(status: 200, body: { imports: [] }.to_json)
+    http = Minitest::Mock.new
+    requests = []
+    expect_request(http, requests, status: 200, body: { imports: [] }.to_json)
     client = CentaurApiClient.new(base_url: "http://api.internal:8080", http: http)
 
     assert_equal({ "imports" => [] }, client.list_slack_archive_imports(limit: 25))
-    request = http.requests.first
+    http.verify
+    request = requests.first
     assert_equal :get, request[:method]
     assert_equal "http://api.internal:8080/api/admin/slack/archive-imports?limit=25", request[:url]
     assert_equal "application/json", request[:headers]["Accept"]
   end
 
   test "creates Slack archive imports with optional bearer auth" do
-    http = StubHTTP.new(status: 201, body: { ok: true }.to_json)
+    http = Minitest::Mock.new
+    requests = []
+    expect_request(http, requests, status: 201, body: { ok: true }.to_json)
     client = CentaurApiClient.new(
       base_url: "http://api.internal:8080/",
       api_key: "secret-key",
@@ -42,7 +39,8 @@ class CentaurApiClientTest < ActiveSupport::TestCase
       metadata: { source: "test" }
     )
 
-    request = http.requests.first
+    http.verify
+    request = requests.first
     assert_equal :post, request[:method]
     assert_equal "Bearer secret-key", request[:headers]["Authorization"]
     body = JSON.parse(request[:body])
@@ -51,17 +49,22 @@ class CentaurApiClientTest < ActiveSupport::TestCase
   end
 
   test "raises useful errors for non-2xx responses" do
-    http = StubHTTP.new(status: 400, body: { error: "bad archive" }.to_json)
+    http = Minitest::Mock.new
+    requests = []
+    expect_request(http, requests, status: 400, body: { error: "bad archive" }.to_json)
     client = CentaurApiClient.new(base_url: "http://api.internal:8080", http: http)
 
     error = assert_raises(CentaurApiClient::Error) do
       client.start_slack_archive_import("sai_bad")
     end
+    http.verify
     assert_equal "bad archive", error.message
   end
 
   test "lists Slack DM sync checkpoints for a broker credential" do
-    http = StubHTTP.new(status: 200, body: { checkpoints: [] }.to_json)
+    http = Minitest::Mock.new
+    requests = []
+    expect_request(http, requests, status: 200, body: { checkpoints: [] }.to_json)
     client = CentaurApiClient.new(base_url: "http://api.internal:8080", http: http)
 
     client.list_slack_dm_sync_checkpoints(
@@ -69,7 +72,8 @@ class CentaurApiClientTest < ActiveSupport::TestCase
       home_team_id: "T123"
     )
 
-    request = http.requests.first
+    http.verify
+    request = requests.first
     assert_equal :get, request[:method]
     assert_equal(
       "http://api.internal:8080/api/admin/slack/dm-sync/checkpoints?broker_credential_id=bcr_123&home_team_id=T123",
@@ -78,24 +82,30 @@ class CentaurApiClientTest < ActiveSupport::TestCase
   end
 
   test "posts Slack DM sync batches" do
-    http = StubHTTP.new(status: 200, body: { ok: true }.to_json)
+    http = Minitest::Mock.new
+    requests = []
+    expect_request(http, requests, status: 200, body: { ok: true }.to_json)
     client = CentaurApiClient.new(base_url: "http://api.internal:8080", http: http)
 
     client.ingest_slack_dm_sync_batch(run: { run_id: "sdms_1" }, messages: [])
 
-    request = http.requests.first
+    http.verify
+    request = requests.first
     assert_equal :post, request[:method]
     assert_equal "http://api.internal:8080/api/admin/slack/dm-sync/batch", request[:url]
     assert_equal({ "run" => { "run_id" => "sdms_1" }, "messages" => [] }, JSON.parse(request[:body]))
   end
 
   test "gets Google Docs sync checkpoint for a broker credential" do
-    http = StubHTTP.new(status: 200, body: { checkpoint: nil }.to_json)
+    http = Minitest::Mock.new
+    requests = []
+    expect_request(http, requests, status: 200, body: { checkpoint: nil }.to_json)
     client = CentaurApiClient.new(base_url: "http://api.internal:8080", http: http)
 
     client.get_google_docs_sync_checkpoint(broker_credential_id: "bcr_123")
 
-    request = http.requests.first
+    http.verify
+    request = requests.first
     assert_equal :get, request[:method]
     assert_equal(
       "http://api.internal:8080/api/admin/google/docs-sync/checkpoint?broker_credential_id=bcr_123",
@@ -104,19 +114,24 @@ class CentaurApiClientTest < ActiveSupport::TestCase
   end
 
   test "posts Google Docs sync batches" do
-    http = StubHTTP.new(status: 200, body: { ok: true }.to_json)
+    http = Minitest::Mock.new
+    requests = []
+    expect_request(http, requests, status: 200, body: { ok: true }.to_json)
     client = CentaurApiClient.new(base_url: "http://api.internal:8080", http: http)
 
     client.ingest_google_docs_sync_batch(run: { run_id: "gdocs_1" }, files: [])
 
-    request = http.requests.first
+    http.verify
+    request = requests.first
     assert_equal :post, request[:method]
     assert_equal "http://api.internal:8080/api/admin/google/docs-sync/batch", request[:url]
     assert_equal({ "run" => { "run_id" => "gdocs_1" }, "files" => [] }, JSON.parse(request[:body]))
   end
 
   test "creates app sessions with encoded thread keys" do
-    http = StubHTTP.new(status: 200, body: { ok: true }.to_json)
+    http = Minitest::Mock.new
+    requests = []
+    expect_request(http, requests, status: 200, body: { ok: true }.to_json)
     client = CentaurApiClient.new(base_url: "http://api.internal:8080", http: http)
 
     client.create_session(
@@ -126,7 +141,8 @@ class CentaurApiClientTest < ActiveSupport::TestCase
       on_harness_conflict: "reject"
     )
 
-    request = http.requests.first
+    http.verify
+    request = requests.first
     assert_equal :post, request[:method]
     assert_equal "http://api.internal:8080/api/session/console%3Aabc-123", request[:url]
     body = JSON.parse(request[:body])
@@ -136,7 +152,10 @@ class CentaurApiClientTest < ActiveSupport::TestCase
   end
 
   test "appends and executes app session messages" do
-    http = StubHTTP.new(status: 200, body: { ok: true }.to_json)
+    http = Minitest::Mock.new
+    requests = []
+    expect_request(http, requests, status: 200, body: { ok: true }.to_json)
+    expect_request(http, requests, status: 200, body: { ok: true }.to_json)
     client = CentaurApiClient.new(base_url: "http://api.internal:8080", http: http)
 
     client.append_session_messages(
@@ -150,12 +169,13 @@ class CentaurApiClientTest < ActiveSupport::TestCase
       metadata: { source: "console" }
     )
 
-    append = http.requests.first
+    http.verify
+    append = requests.first
     assert_equal :post, append[:method]
     assert_equal "http://api.internal:8080/api/session/console%3Aabc-123/messages", append[:url]
     assert_equal "user", JSON.parse(append[:body]).dig("messages", 0, "role")
 
-    execute = http.requests.second
+    execute = requests.second
     assert_equal :post, execute[:method]
     assert_equal "http://api.internal:8080/api/session/console%3Aabc-123/execute", execute[:url]
     body = JSON.parse(execute[:body])
@@ -164,34 +184,42 @@ class CentaurApiClientTest < ActiveSupport::TestCase
   end
 
   test "lists workflow schedules and fetches run details" do
-    http = StubHTTP.new(status: 200, body: { ok: true, schedules: [] }.to_json)
+    http = Minitest::Mock.new
+    requests = []
+    expect_request(http, requests, status: 200, body: { ok: true, schedules: [] }.to_json)
+    expect_request(http, requests, status: 200, body: { ok: true, schedules: [] }.to_json)
     client = CentaurApiClient.new(base_url: "http://api.internal:8080", http: http)
 
     client.list_workflow_schedules
     client.get_workflow_run("run:1")
 
-    schedules = http.requests.first
+    http.verify
+    schedules = requests.first
     assert_equal :get, schedules[:method]
     assert_equal "http://api.internal:8080/api/workflows/schedules", schedules[:url]
 
-    run = http.requests.second
+    run = requests.second
     assert_equal :get, run[:method]
     assert_equal "http://api.internal:8080/api/workflows/runs/run%3A1", run[:url]
   end
 
   test "creates workflow runs with optional input" do
-    http = StubHTTP.new(status: 200, body: { ok: true, run_id: "r1" }.to_json)
+    http = Minitest::Mock.new
+    requests = []
+    expect_request(http, requests, status: 200, body: { ok: true, run_id: "r1" }.to_json)
+    expect_request(http, requests, status: 200, body: { ok: true, run_id: "r1" }.to_json)
     client = CentaurApiClient.new(base_url: "http://api.internal:8080", http: http)
 
     client.create_workflow_run(workflow_name: "slack_sync")
     client.create_workflow_run(workflow_name: "slack_sync", input: { "mode" => "full" })
 
-    bare = http.requests.first
+    http.verify
+    bare = requests.first
     assert_equal :post, bare[:method]
     assert_equal "http://api.internal:8080/api/workflows/runs", bare[:url]
     assert_equal({ "workflow_name" => "slack_sync" }, JSON.parse(bare[:body]))
 
-    with_input = http.requests.second
+    with_input = requests.second
     assert_equal({ "workflow_name" => "slack_sync", "input" => { "mode" => "full" } }, JSON.parse(with_input[:body]))
   end
 end

--- a/services/console/test/services/granola/sync_credential_test.rb
+++ b/services/console/test/services/granola/sync_credential_test.rb
@@ -118,29 +118,34 @@ module Granola
     test "includes MCP tool error content in the raised error" do
       sync = SyncCredential.new(credential, api_client: FakeApiClient.new)
       sync.instance_variable_set(:@mcp_initialized, true)
-      sync.define_singleton_method(:mcp_request) do |*|
-        Struct.new(:body) do
-          def [](header)
-            "application/json" if header == "content-type"
-          end
-        end.new(
-          {
-            result: {
-              isError: true,
-              content: [ { type: "text", text: "Invalid meeting_ids: maximum 10" } ]
-            }
-          }.to_json
+
+      response = HttpClient::Response.new(
+        status: 200,
+        headers: { "content-type" => "application/json" },
+        body: {
+          result: {
+            isError: true,
+            content: [ { type: "text", text: "Invalid meeting_ids: maximum 10" } ]
+          }
+        }.to_json
+      )
+      mcp_request = Minitest::Mock.new
+      mcp_request.expect(:call, response) do |*_args|
+        true
+      end
+
+      sync.stub(:mcp_request, ->(*_args) { mcp_request.call }) do
+        error = assert_raises(SyncCredential::GranolaApiError) do
+          sync.send(:mcp_tool, "get_meetings", "meeting_ids" => %w[meeting-1 meeting-2])
+        end
+
+        assert_equal(
+          "Granola MCP tool get_meetings failed: Invalid meeting_ids: maximum 10",
+          error.message
         )
       end
 
-      error = assert_raises(SyncCredential::GranolaApiError) do
-        sync.send(:mcp_tool, "get_meetings", "meeting_ids" => %w[meeting-1 meeting-2])
-      end
-
-      assert_equal(
-        "Granola MCP tool get_meetings failed: Invalid meeting_ids: maximum 10",
-        error.message
-      )
+      mcp_request.verify
     end
 
     private

--- a/services/console/test/test_helper.rb
+++ b/services/console/test/test_helper.rb
@@ -14,6 +14,12 @@ module ActiveSupport
     # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.
     fixtures :all
 
-    # Add more helper methods to be used by all tests here...
+    def expect_http_call(http = Minitest::Mock.new, status:, body:, headers: nil)
+      http.expect(:call, HttpClient::Response.new(status: status, body: body, headers: headers)) do |**request|
+        yield request if block_given?
+        true
+      end
+      http
+    end
   end
 end


### PR DESCRIPTION
Replaces hand-rolled Ruby test doubles with Minitest::Mock where the tests only need behavior verification or request capture. Leaves stateful fake API clients in place where they serve as in-memory fixtures.