### PR TITLE
test: share console with_env helper

### DIFF
--- a/services/console/test/controllers/api/v1/proxies_controller_test.rb
+++ b/services/console/test/controllers/api/v1/proxies_controller_test.rb
@@ -251,18 +251,6 @@ class ProxiesControllerTest < ActionDispatch::IntegrationTest
     assert_response :no_content
   end
 
-  def with_env(values)
-    previous = values.keys.to_h { |key| [ key, ENV[key] ] }
-    values.each do |key, value|
-      value.nil? ? ENV.delete(key) : ENV[key] = value
-    end
-    yield
-  ensure
-    previous.each do |key, value|
-      value.nil? ? ENV.delete(key) : ENV[key] = value
-    end
-  end
-
   def proxy_auth_headers(token)
     { "Authorization" => "Bearer #{token}", "Content-Type" => "application/json" }
   end

--- a/services/console/test/controllers/api/v1/proxy_sync_controller_test.rb
+++ b/services/console/test/controllers/api/v1/proxy_sync_controller_test.rb
@@ -438,16 +438,4 @@ class ProxySyncControllerTest < ActionDispatch::IntegrationTest
     _header, payload, _signature = token.split(".")
     JSON.parse(Base64.urlsafe_decode64(payload))
   end
-
-  def with_env(values)
-    previous = values.keys.to_h { |key| [ key, ENV[key] ] }
-    values.each do |key, value|
-      value.nil? ? ENV.delete(key) : ENV[key] = value
-    end
-    yield
-  ensure
-    previous.each do |key, value|
-      value.nil? ? ENV.delete(key) : ENV[key] = value
-    end
-  end
 end

--- a/services/console/test/controllers/api/v1/sandbox_oauth_apps_controller_test.rb
+++ b/services/console/test/controllers/api/v1/sandbox_oauth_apps_controller_test.rb
@@ -70,18 +70,6 @@ module Api
       def json_body
         JSON.parse(response.body)
       end
-
-      def with_env(values)
-        previous = values.keys.to_h { |key| [ key, ENV[key] ] }
-        values.each do |key, value|
-          value.nil? ? ENV.delete(key) : ENV[key] = value
-        end
-        yield
-      ensure
-        previous.each do |key, value|
-          value.nil? ? ENV.delete(key) : ENV[key] = value
-        end
-      end
     end
   end
 end

--- a/services/console/test/controllers/api/v1/sandbox_permissions_controller_test.rb
+++ b/services/console/test/controllers/api/v1/sandbox_permissions_controller_test.rb
@@ -141,18 +141,6 @@ module Api
       def json_body
         JSON.parse(response.body)
       end
-
-      def with_env(values)
-        previous = values.keys.to_h { |key| [ key, ENV[key] ] }
-        values.each do |key, value|
-          value.nil? ? ENV.delete(key) : ENV[key] = value
-        end
-        yield
-      ensure
-        previous.each do |key, value|
-          value.nil? ? ENV.delete(key) : ENV[key] = value
-        end
-      end
     end
   end
 end

--- a/services/console/test/controllers/console/threads_controller_test.rb
+++ b/services/console/test/controllers/console/threads_controller_test.rb
@@ -1918,16 +1918,6 @@ class Console::ThreadsControllerTest < ActionDispatch::IntegrationTest
     Console::ThreadsController.client_factory = original_factory
   end
 
-  # Sets each env var for the block (nil deletes) and restores the previous
-  # values afterwards.
-  def with_env(overrides)
-    previous = overrides.keys.index_with { |name| ENV[name] }
-    overrides.each { |name, value| value.nil? ? ENV.delete(name) : ENV[name] = value }
-    yield
-  ensure
-    previous.each { |name, value| value.nil? ? ENV.delete(name) : ENV[name] = value }
-  end
-
   def with_recent_first_error
     singleton = class << CentaurSession; self; end
     original = CentaurSession.method(:recent_first)

--- a/services/console/test/models/centaur_session_record_test.rb
+++ b/services/console/test/models/centaur_session_record_test.rb
@@ -19,21 +19,6 @@ class CentaurSessionRecordTest < ActiveSupport::TestCase
     CentaurSessionRecord.send(:session_database_configuration)
   end
 
-  def with_env(overrides)
-    originals = {}
-    overrides.each do |key, value|
-      originals[key] = ENV[key]
-      if value.nil?
-        ENV.delete(key)
-      else
-        ENV[key] = value
-      end
-    end
-    yield
-  ensure
-    originals.each { |key, value| value.nil? ? ENV.delete(key) : ENV[key] = value }
-  end
-
   # Override the (private) primary-config source without touching the live
   # connection, matching the define_singleton_method pattern used elsewhere in
   # the suite.

--- a/services/console/test/models/principal_sync_config_snapshot_test.rb
+++ b/services/console/test/models/principal_sync_config_snapshot_test.rb
@@ -639,16 +639,4 @@ class PrincipalSyncConfigSnapshotTest < ActiveSupport::TestCase
     _header, payload, _signature = token.split(".")
     JSON.parse(Base64.urlsafe_decode64(payload))
   end
-
-  def with_env(values)
-    previous = values.keys.to_h { |key| [ key, ENV[key] ] }
-    values.each do |key, value|
-      value.nil? ? ENV.delete(key) : ENV[key] = value
-    end
-    yield
-  ensure
-    previous.each do |key, value|
-      value.nil? ? ENV.delete(key) : ENV[key] = value
-    end
-  end
 end

--- a/services/console/test/models/principal_test.rb
+++ b/services/console/test/models/principal_test.rb
@@ -407,18 +407,6 @@ class PrincipalTest < ActiveSupport::TestCase
     assert_equal static_secrets(:acme_prod_api_key).id, ids.last
   end
 
-  def with_env(values)
-    previous = values.keys.to_h { |key| [ key, ENV[key] ] }
-    values.each do |key, value|
-      value.nil? ? ENV.delete(key) : ENV[key] = value
-    end
-    yield
-  ensure
-    previous.each do |key, value|
-      value.nil? ? ENV.delete(key) : ENV[key] = value
-    end
-  end
-
   def jwt_payload(token)
     _header, payload, _signature = token.split(".")
     JSON.parse(Base64.urlsafe_decode64(payload))

--- a/services/console/test/services/slack_channel_catalog_test.rb
+++ b/services/console/test/services/slack_channel_catalog_test.rb
@@ -76,14 +76,4 @@ class SlackChannelCatalogTest < ActiveSupport::TestCase
     assert_equal SlackChannelCatalog::WRITE_TIMEOUT_SECONDS, captured_options.fetch(:write_timeout)
     api.verify
   end
-
-  private
-
-  def with_env(values)
-    previous = values.keys.to_h { |key| [ key, ENV[key] ] }
-    values.each { |key, value| value.nil? ? ENV.delete(key) : ENV[key] = value }
-    yield
-  ensure
-    previous.each { |key, value| value.nil? ? ENV.delete(key) : ENV[key] = value }
-  end
 end

--- a/services/console/test/test_helper.rb
+++ b/services/console/test/test_helper.rb
@@ -21,5 +21,13 @@ module ActiveSupport
       end
       http
     end
+
+    def with_env(overrides)
+      previous = overrides.keys.index_with { |name| ENV[name] }
+      overrides.each { |name, value| value.nil? ? ENV.delete(name) : ENV[name] = value }
+      yield
+    ensure
+      previous.each { |name, value| value.nil? ? ENV.delete(name) : ENV[name] = value }
+    end
   end
 end


### PR DESCRIPTION
Adds a shared console test helper for temporary ENV overrides. Removes duplicate per-test with_env implementations while keeping existing call sites and behavior unchanged.