### PR TITLE
fix: gate slackbotv2 health on database connection

### DIFF
--- a/services/slackbotv2/src/index.ts
+++ b/services/slackbotv2/src/index.ts
@@ -130,6 +130,12 @@ type SlackbotV2RequestContext = {
   waitUntil(promise: Promise<unknown>): void
 }
 
+type StateConnectionStatus = {
+  attempts: number
+  connected: boolean
+  lastError?: string
+}
+
 const requestContext = new AsyncLocalStorage<SlackbotV2RequestContext>()
 const RENDER_OBLIGATION_INDEX_KEY = 'slackbotv2:render:index'
 const RENDER_OBLIGATION_INDEX_MAX_LENGTH = 2000
@@ -260,6 +266,9 @@ export function createSlackbotV2(options: SlackbotV2Options): SlackbotV2 {
     logger
   })
   const lateSlackFiles = createLateSlackFileRepair(options, state)
+  const stateConnectionStatus: StateConnectionStatus = { attempts: 0, connected: false }
+  const stateConnected = ensureStateConnected(state, options, stateConnectionStatus)
+  backgroundWaitUntil(stateConnected)
 
   chat.onAction(async event => {
     const payload = slackBlockActionPayload(event)
@@ -367,7 +376,7 @@ export function createSlackbotV2(options: SlackbotV2Options): SlackbotV2 {
   })
 
   const app = new Hono()
-  app.get('/health', c => c.json({ ok: true, service: 'slackbotv2' }))
+  app.get('/health', c => healthResponse(c, stateConnectionStatus))
   app.get('/metrics', c =>
     c.text(slackbotMetrics.expose(), 200, {
       'Content-Type': 'text/plain; version=0.0.4; charset=utf-8'
@@ -459,7 +468,7 @@ export function createSlackbotV2(options: SlackbotV2Options): SlackbotV2 {
   app.post('/api/slack/commands', handleSlackWebhook)
 
   if (options.recoverRenderObligationsOnStart !== false) {
-    scheduleRenderObligationRecovery(chat, state, options)
+    scheduleRenderObligationRecovery(chat, state, options, stateConnected)
   }
 
   return { app, chat }
@@ -849,6 +858,26 @@ function createDefaultState(options: SlackbotV2Options, logger: Logger): StateAd
   })
 }
 
+function healthResponse(c: Context, stateConnectionStatus: StateConnectionStatus): Response {
+  if (stateConnectionStatus.connected) {
+    return c.json({
+      ok: true,
+      service: 'slackbotv2',
+      database_connected: true
+    })
+  }
+  return c.json(
+    {
+      ok: false,
+      service: 'slackbotv2',
+      database_connected: false,
+      database_status: 'connecting',
+      database_connect_attempts: stateConnectionStatus.attempts
+    },
+    503
+  )
+}
+
 /**
  * Blocks until the state backend accepts a connection, retrying with exponential
  * backoff. The first DB connection fires within milliseconds of process start and
@@ -856,15 +885,24 @@ function createDefaultState(options: SlackbotV2Options, logger: Logger): StateAd
  * Retrying instead of throwing absorbs that race; the first successful connect
  * also flips the adapter's `connected` flag, so the message path comes alive too.
  */
-async function ensureStateConnected(state: StateAdapter, options: SlackbotV2Options): Promise<void> {
+async function ensureStateConnected(
+  state: StateAdapter,
+  options: SlackbotV2Options,
+  status: StateConnectionStatus
+): Promise<void> {
   for (let attempt = 0; ; attempt++) {
+    status.attempts = attempt + 1
     try {
       await state.connect()
+      status.connected = true
+      status.lastError = undefined
       if (attempt > 0) {
         traceLog(options, 'slackbotv2_postgres_connected', undefined, { attempts: attempt + 1 })
       }
       return
     } catch (error) {
+      status.connected = false
+      status.lastError = errorMessage(error)
       const delayMs = Math.min(
         POSTGRES_CONNECT_INITIAL_DELAY_MS * 2 ** attempt,
         POSTGRES_CONNECT_MAX_DELAY_MS
@@ -872,7 +910,7 @@ async function ensureStateConnected(state: StateAdapter, options: SlackbotV2Opti
       traceLog(options, 'slackbotv2_postgres_connect_retry', undefined, {
         attempt: attempt + 1,
         delay_ms: delayMs,
-        error: errorMessage(error)
+        error: status.lastError
       })
       await sleep(delayMs)
     }
@@ -1733,21 +1771,22 @@ async function renderFallbackFinalAnswer(
 function scheduleRenderObligationRecovery(
   chat: Chat<Record<string, Adapter>, SlackbotV2ThreadState>,
   state: StateAdapter,
-  options: SlackbotV2Options
+  options: SlackbotV2Options,
+  stateConnected: Promise<void>
 ): void {
   backgroundWaitUntil(
-    recoverRenderObligationsWithRetry(chat, state, options)
+    recoverRenderObligationsWithRetry(chat, state, options, stateConnected)
   )
 }
 
 async function recoverRenderObligationsWithRetry(
   chat: Chat<Record<string, Adapter>, SlackbotV2ThreadState>,
   state: StateAdapter,
-  options: SlackbotV2Options
+  options: SlackbotV2Options,
+  stateConnected: Promise<void>
 ): Promise<void> {
-  // Wait for Postgres before scanning for obligations. This is also what warms the
-  // shared pool at startup, so transient connect failures don't wedge the bot.
-  await ensureStateConnected(state, options)
+  // Wait for the startup Postgres connection before scanning for obligations.
+  await stateConnected
   const failureCounts = new Map<string, number>()
   let attempt = 0
   while (true) {

--- a/services/slackbotv2/test/metrics.test.ts
+++ b/services/slackbotv2/test/metrics.test.ts
@@ -4,6 +4,44 @@ import { createSlackbotV2 } from '../src/index'
 import { resetSlackbotMetricsForTests, slackbotMetrics } from '../src/metrics'
 
 describe('slackbotv2 metrics', () => {
+  test('withholds health until state connects', async () => {
+    const state = createMemoryState()
+    const originalConnect = state.connect.bind(state)
+    let releaseConnect!: () => void
+    const connectGate = new Promise<void>(resolve => {
+      releaseConnect = resolve
+    })
+    state.connect = async () => {
+      await connectGate
+      await originalConnect()
+    }
+    const bot = createSlackbotV2({
+      apiUrl: 'http://api.test',
+      botToken: 'xoxb-test',
+      recoverRenderObligationsOnStart: false,
+      signingSecret: 'secret',
+      state
+    })
+
+    const notReadyResponse = await bot.app.request('/health')
+    expect(notReadyResponse.status).toBe(503)
+    await expect(notReadyResponse.json()).resolves.toMatchObject({
+      ok: false,
+      service: 'slackbotv2',
+      database_connected: false,
+      database_status: 'connecting'
+    })
+
+    releaseConnect()
+    const readyResponse = await waitForHealthy(bot)
+    expect(readyResponse.status).toBe(200)
+    await expect(readyResponse.json()).resolves.toMatchObject({
+      ok: true,
+      service: 'slackbotv2',
+      database_connected: true
+    })
+  })
+
   test('serves Prometheus text metrics', async () => {
     resetSlackbotMetricsForTests()
     slackbotMetrics.webhookRequests.inc({
@@ -38,3 +76,16 @@ describe('slackbotv2 metrics', () => {
     )
   })
 })
+
+async function waitForHealthy(bot: ReturnType<typeof createSlackbotV2>): Promise<Response> {
+  for (let attempt = 0; attempt < 20; attempt++) {
+    const response = await bot.app.request('/health')
+    if (response.status === 200) return response
+    await sleep(5)
+  }
+  return bot.app.request('/health')
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}


### PR DESCRIPTION
Updates slackbotv2 health so Kubernetes does not consider the pod healthy until the Chat SDK state backend has successfully connected. Startup render recovery now waits on the same connection task instead of issuing a separate initial connect.