### PR TITLE
fix(sandbox): load hyphenated tool packages

### DIFF
--- a/services/sandbox/install_tool_shims.py
+++ b/services/sandbox/install_tool_shims.py
@@ -516,10 +516,21 @@ payload = json.loads(sys.argv[4])
 module_path = project_dir / client_module
 package_name = project_dir.name.replace("-", "_")
 if (project_dir / "__init__.py").is_file() and package_name.isidentifier() and module_path.suffix == ".py":
-    parent = str(project_dir.parent)
-    if parent not in sys.path:
-        sys.path.insert(0, parent)
-    module = importlib.import_module(f"{{package_name}}.{{module_path.stem}}")
+    package_path = project_dir / "__init__.py"
+    package_spec = importlib.util.spec_from_file_location(
+        package_name,
+        package_path,
+        submodule_search_locations=[str(project_dir)],
+    )
+    if package_spec is None or package_spec.loader is None:
+        raise RuntimeError(f"cannot load tool package from {{package_path}}")
+    package = importlib.util.module_from_spec(package_spec)
+    sys.modules[package_name] = package
+    package_spec.loader.exec_module(package)
+
+    relative_module = module_path.relative_to(project_dir).with_suffix("")
+    module_name = ".".join((package_name, *relative_module.parts))
+    module = importlib.import_module(module_name)
 else:
     spec = importlib.util.spec_from_file_location("_centaur_tool_client", module_path)
     if spec is None or spec.loader is None:

--- a/services/sandbox/test_install_tool_shims.py
+++ b/services/sandbox/test_install_tool_shims.py
@@ -5,6 +5,7 @@ import io
 import json
 import os
 import subprocess
+import sys
 import tempfile
 import unittest
 from pathlib import Path
@@ -310,6 +311,82 @@ class GeneratedShimTest(unittest.TestCase):
 
             self.assertEqual(result.returncode, 2)
             self.assertIn("usage: centaur-tools", result.stderr)
+
+    def test_call_runner_loads_hyphenated_tool_as_normalized_package(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            bin_dir = root / "bin"
+            fake_bin = root / "fake-bin"
+            project_dir = root / "data-query-and-viz"
+            bin_dir.mkdir()
+            fake_bin.mkdir()
+            project_dir.mkdir()
+            (project_dir / "__init__.py").write_text("")
+            (project_dir / "helper.py").write_text('VALUE = "package-loaded"\n')
+            (project_dir / "client.py").write_text(
+                "from .helper import VALUE\n"
+                "\n"
+                "class Client:\n"
+                "    def ping(self, suffix):\n"
+                "        return f'{VALUE}:{suffix}'\n"
+                "\n"
+                "def _client():\n"
+                "    return Client()\n"
+            )
+
+            index_path = bin_dir / ".centaur-tools.json"
+            index_path.write_text(
+                json.dumps(
+                    [
+                        {
+                            "name": "data-query-and-viz",
+                            "project_dir": str(project_dir),
+                            "package": "data-query-and-viz",
+                            "entrypoint": "cli:app",
+                            "client_module": "client.py",
+                        }
+                    ]
+                )
+                + "\n"
+            )
+            install_tool_shims._write_catalog(
+                bin_dir / "centaur-tools",
+                index_path,
+                str(Path(__file__).resolve().parents[2]),
+            )
+
+            fake_uvx = fake_bin / "uvx"
+            fake_uvx.write_text(
+                f"#!{sys.executable}\n"
+                "import subprocess\n"
+                "import sys\n"
+                "\n"
+                "args = sys.argv[1:]\n"
+                "if len(args) < 3 or args[0] != '--from' or args[2] != 'python':\n"
+                "    raise SystemExit(2)\n"
+                "raise SystemExit(subprocess.call([sys.executable, *args[3:]]))\n"
+            )
+            fake_uvx.chmod(0o755)
+
+            env = os.environ.copy()
+            env["PATH"] = f"{fake_bin}{os.pathsep}{env.get('PATH', '')}"
+            env["CENTAUR_TOOL_ANALYTICS_LOG_PATH"] = "off"
+            result = subprocess.run(
+                [
+                    str(bin_dir / "centaur-tools"),
+                    "call",
+                    "data-query-and-viz",
+                    "ping",
+                    json.dumps({"suffix": "ok"}),
+                ],
+                check=False,
+                env=env,
+                text=True,
+                capture_output=True,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual(json.loads(result.stdout), "package-loaded:ok")
 
 
 class RefreshInstallTest(unittest.TestCase):


### PR DESCRIPTION
## Summary

- load tool directories as normalized Python packages from their physical source paths
- preserve package-relative imports for tools whose directory names contain hyphens
- add regression coverage through the generated `centaur-tools call` execution path

## Root cause

The sandbox call runner normalized a directory such as `data-query-and-viz` to `data_query_and_viz`, then asked Python to import that package from the directory parent. Python could not resolve the normalized name because the physical directory remained hyphenated, causing `ModuleNotFoundError` before tool execution or credential egress.

## Impact

Hyphenated tools can keep their existing package layouts and `pyproject.toml` files. Calls now load the physical directory under the normalized package name, including support for relative imports.

## Validation

- `uv run --python 3.12 python -m unittest test_install_tool_shims.py`
- real `data-query-and-viz` package smoke test through generated `centaur-tools call`
- `uvx ruff check --ignore EXE001,I001,TRY004 services/sandbox/install_tool_shims.py services/sandbox/test_install_tool_shims.py`
- `git diff --check`