### PR TITLE
fix(slackbot): require mentions for thread steering

### DIFF
--- a/services/slackbotv2/AGENTS.md
+++ b/services/slackbotv2/AGENTS.md
@@ -30,9 +30,11 @@ lifecycle, harness formatting, and durable execution state belong in `api-rs`.
   message, block, attachment, and rate limits, including fallback text.
 - Avoid serializing raw webhook bodies on the hot path or in normal logs. Never
   log bot tokens, signing secrets, private file URLs, or user file contents.
-- Preserve stop commands, harness/model overrides, late-file repair, initial
-  thread context, and subscribed-message append semantics when refactoring the
-  main callback flow.
+- Preserve mentioned stop commands, harness/model overrides, late-file repair,
+  initial thread context, and mention-gated subscribed-message semantics when
+  refactoring the main callback flow. Unmentioned replies must not be appended
+  to or interrupt an active execution; collect them when the next mention
+  refreshes the Slack thread context.
 
 ## Validation
 

--- a/services/slackbotv2/src/index.ts
+++ b/services/slackbotv2/src/index.ts
@@ -365,10 +365,19 @@ export function createSlackbotV2(options: SlackbotV2Options): SlackbotV2 {
   chat.onSubscribedMessage(async (thread, message) => {
     if (!(await isAllowedSlackMessage(message, options, logger))) return
     if (slackRichTextMentionsUser(message.raw, options.botUserId)) message.isMention = true
+    if (message.isMention !== true) {
+      traceLog(
+        options,
+        'slackbotv2_subscribed_message_without_mention_ignored',
+        createHandoffTrace(thread, message, 'append'),
+        { trigger: 'subscribed_message' }
+      )
+      return
+    }
     lateSlackFiles.rememberFilelessMention(thread, message)
     await handleSlackMessageHandoff(thread, message, {
-      assistantStatusRequested: message.isMention === true,
-      mode: message.isMention === true ? 'execute' : 'append',
+      assistantStatusRequested: true,
+      mode: 'execute',
       options,
       state,
       trigger: 'subscribed_message'

--- a/services/slackbotv2/test/chat-sdk-emulate.test.ts
+++ b/services/slackbotv2/test/chat-sdk-emulate.test.ts
@@ -434,7 +434,7 @@ describe('slackbotv2', () => {
     expect(codexApi.workflowEvents).toHaveLength(1)
   })
 
-  it('syncs thread context, forwards subscribed messages, and renders execute streams', async () => {
+  it('collects ignored subscribed messages when the bot is next mentioned', async () => {
     const parent = await postUserMessage('The deploy context is above.')
     const firstMention = await postUserMessage(
       `<@${BOT_USER_ID}> run with this screenshot`,
@@ -496,6 +496,8 @@ describe('slackbotv2', () => {
 
     expect(followUpResponse.status).toBe(200)
     await Promise.all(followUpWaits)
+    expect(codexApi.appends).toHaveLength(1)
+    expect(codexApi.executes).toHaveLength(1)
 
     const secondMention = await postUserMessage(`<@${BOT_USER_ID}> now execute with the latest`, parent.ts)
     const secondMentionWaits: Promise<unknown>[] = []
@@ -520,9 +522,8 @@ describe('slackbotv2', () => {
     expect(secondMentionResponse.status).toBe(200)
     await Promise.all(secondMentionWaits)
 
-    expect(codexApi.appends).toHaveLength(3)
+    expect(codexApi.appends).toHaveLength(2)
     expect(codexApi.creates.map(create => create.threadKey)).toEqual([
-      threadKey(parent.ts),
       threadKey(parent.ts),
       threadKey(parent.ts)
     ])
@@ -579,15 +580,16 @@ describe('slackbotv2', () => {
     )
     expect(JSON.stringify(firstInputLine)).not.toContain('data:image/png;base64')
 
-    const followUpAppend = codexApi.appends[1]!
-    expect(followUpAppend.threadKey).toBe(threadKey(parent.ts))
-    expect(followUpAppend.body.messages[0]?.client_message_id).toBe(followUp.ts)
-    expect(sessionMessageTexts(followUpAppend.body.messages)).toEqual([
-      'Additional detail for the subscribed thread.'
+    const secondMentionAppend = codexApi.appends[1]!
+    expect(secondMentionAppend.threadKey).toBe(threadKey(parent.ts))
+    expect(secondMentionAppend.body.messages.map(message => message.client_message_id)).toEqual([
+      followUp.ts,
+      secondMention.ts
     ])
-
-    const secondMentionAppend = codexApi.appends[2]!
-    expect(sessionMessageTexts(secondMentionAppend.body.messages)[0]).toContain(
+    expect(sessionMessageTexts(secondMentionAppend.body.messages)[0]).toBe(
+      'Additional detail for the subscribed thread.'
+    )
+    expect(sessionMessageTexts(secondMentionAppend.body.messages)[1]).toContain(
       'now execute with the latest'
     )
     const secondExecute = codexApi.executes[1]!
@@ -2065,7 +2067,7 @@ describe('slackbotv2', () => {
     )
   })
 
-  it('forwards subscribed messages to /messages without executing during a stream', async () => {
+  it('ignores unmentioned subscribed messages during a stream, including stop', async () => {
     codexApi.autoRespond = false
 
     const parent = await postUserMessage('Context before the long run.')
@@ -2115,11 +2117,32 @@ describe('slackbotv2', () => {
 
     expect(followUpResponse.status).toBe(200)
     await Promise.all(followUpWaits)
-    expect(codexApi.appends).toHaveLength(2)
+
+    const stop = await postUserMessage('stop', parent.ts)
+    const stopWaits: Promise<unknown>[] = []
+    const stopResponse = await bot.app.request(
+      '/api/webhooks/slack',
+      signedSlackEvent({
+        event_id: 'Ev-slackbotv2-unmentioned-stop-during-stream',
+        event: {
+          type: 'message',
+          user: USER_ID,
+          channel: CHANNEL_ID,
+          team: TEAM_ID,
+          ts: stop.ts,
+          thread_ts: parent.ts,
+          text: 'stop'
+        }
+      }),
+      {},
+      waitUntilContext(stopWaits)
+    )
+
+    expect(stopResponse.status).toBe(200)
+    await Promise.all(stopWaits)
+    expect(codexApi.creates).toHaveLength(1)
+    expect(codexApi.appends).toHaveLength(1)
     expect(codexApi.executes).toHaveLength(1)
-    expect(sessionMessageTexts(codexApi.appends[1]!.body.messages)).toEqual([
-      'Actually queue this extra constraint.'
-    ])
 
     codexApi.closeStreams()
     await Promise.all(firstWaits)


### PR DESCRIPTION
## Summary

- ignore subscribed Slack thread replies unless they explicitly mention the bot
- ignore unmentioned stop commands instead of interrupting an active execution
- retain intervening replies in Slack so the next explicit mention collects them during thread-context refresh
- document and test the mention-gated behavior

## Root cause

Slackbot subscribed to a thread after the first mention and forwarded every later human reply through the session messages endpoint. The session runtime treats appended user messages as live input when an execution is active, so ordinary unmentioned discussion could steer the running agent.

## Impact

Users can continue discussing inside a Centaur thread without changing or stopping the active agent. A later explicit mention still receives the intervening conversation as context, and explicitly mentioned stop commands continue through the normal command path.

## Validation

- `pnpm --filter slackbotv2 test` — 220 passed, 1 skipped
- `pnpm --filter slackbotv2 run check:types`
- `git diff --check`
