### PR TITLE
fix: restore light code block contrast

### DIFF
--- a/services/console/app/views/layouts/console.html.erb
+++ b/services/console/app/views/layouts/console.html.erb
@@ -1564,6 +1564,7 @@
       html[data-console-theme="light"] .bg-ink-950,
       html[data-console-theme="light"] .bg-ink-950\/15,
       html[data-console-theme="light"] .bg-ink-950\/35,
+      html[data-console-theme="light"] .bg-ink-950\/80,
       html[data-console-theme="light"] .bg-ink-900,
       html[data-console-theme="light"] .bg-ink-900\/25,
       html[data-console-theme="light"] .bg-ink-900\/35,

--- a/services/console/test/controllers/console/users_controller_test.rb
+++ b/services/console/test/controllers/console/users_controller_test.rb
@@ -39,6 +39,7 @@ module Console
       assert_includes response.body, "prefers-color-scheme: light"
       assert_includes response.body, "localStorage.removeItem(storageKey)"
       assert_includes response.body, "centaur-console-theme-source"
+      assert_includes response.body, 'html[data-console-theme="light"] .bg-ink-950\\/80'
     end
 
     test "the index shows IdP chips for linked identities and a password chip otherwise" do


### PR DESCRIPTION
## Summary
- map `bg-ink-950/80` to the light-theme background palette
- add a layout regression assertion for the selector

## Testing
- `git diff --check`
- Rails tests not run: Ruby is unavailable in the sandbox

Prompted by: @shekhirin