### PR TITLE
fix(harness): use ChatGPT auth for Nanocodex

### DIFF
--- a/crates/harness-server/src/nanocodex.rs
+++ b/crates/harness-server/src/nanocodex.rs
@@ -7,13 +7,17 @@ use std::sync::Arc;
 
 use base64::Engine;
 use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
-use nanocodex::{AgentEvent, AgentEvents, Nanocodex, Prompt, Thinking, Tools, Turn, UserInput};
+use nanocodex::{
+    AgentEvent, AgentEvents, Nanocodex, OpenAiAuth, Prompt, Thinking, Tools, Turn, UserInput,
+    load_chatgpt_auth,
+};
 use serde::Deserialize;
 use serde_json::Value;
 use tokio::sync::mpsc;
 use uuid::Uuid;
 
 use crate::nanocodex_subagents::{ChildAgents, with_subagents};
+use crate::util::default_codex_home;
 use crate::{HarnessServerError, Result};
 
 /// Runs the Centaur blocks adapter while preserving Nanocodex's native event
@@ -27,10 +31,7 @@ pub fn run_nanocodex_blocks_server() -> Result<()> {
 }
 
 async fn run() -> Result<()> {
-    let api_key =
-        env::var("OPENAI_API_KEY").map_err(|_| HarnessServerError::MissingEnvironment {
-            name: "OPENAI_API_KEY",
-        })?;
+    let auth = configured_openai_auth()?;
     let cwd = env::current_dir()?;
     let session_id = format!("nanocodex-{}", Uuid::new_v4().simple());
     let child_agents = Arc::new(ChildAgents::default());
@@ -64,7 +65,7 @@ async fn run() -> Result<()> {
             } => {
                 if agent.is_none() {
                     let (new_agent, new_events) = build_agent(
-                        &api_key,
+                        &auth,
                         &cwd,
                         &session_id,
                         &child_agents,
@@ -108,15 +109,44 @@ async fn run() -> Result<()> {
     Ok(())
 }
 
+fn configured_openai_auth() -> Result<OpenAiAuth> {
+    let auth_mode = env::var("CODEX_AUTH_MODE").ok();
+    let api_key = env::var("OPENAI_API_KEY").ok();
+    let codex_home = env::var_os("CODEX_HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(default_codex_home);
+    openai_auth(auth_mode.as_deref(), api_key, codex_home)
+}
+
+fn openai_auth(
+    auth_mode: Option<&str>,
+    api_key: Option<String>,
+    codex_home: PathBuf,
+) -> Result<OpenAiAuth> {
+    match auth_mode.unwrap_or("api_key").trim() {
+        "access_token" | "chatgpt" => load_chatgpt_auth(codex_home.join("auth.json"))
+            .map_err(|error| HarnessServerError::Nanocodex(error.to_string())),
+        "api_key" | "" => api_key
+            .filter(|value| !value.trim().is_empty())
+            .map(OpenAiAuth::api_key)
+            .ok_or(HarnessServerError::MissingEnvironment {
+                name: "OPENAI_API_KEY",
+            }),
+        mode => Err(HarnessServerError::Nanocodex(format!(
+            "unsupported CODEX_AUTH_MODE `{mode}`"
+        ))),
+    }
+}
+
 fn build_agent(
-    api_key: &str,
+    auth: &OpenAiAuth,
     cwd: &std::path::Path,
     session_id: &str,
     child_agents: &Arc<ChildAgents>,
     subagents: bool,
     thinking: Thinking,
 ) -> Result<(Nanocodex, AgentEvents)> {
-    let builder = Nanocodex::builder(api_key)
+    let builder = Nanocodex::builder(auth.clone())
         .thinking(thinking)
         .workspace(cwd)
         .session_id(session_id);
@@ -521,6 +551,7 @@ fn required_value_string_alias(value: &Value, name: &str, alias: &str) -> Result
 #[cfg(test)]
 mod tests {
     use super::*;
+    use nanocodex::OpenAiAuthMode;
 
     #[test]
     fn parses_text_without_codex_protocol_types() {
@@ -623,5 +654,63 @@ mod tests {
             panic!("expected user prompt");
         };
         assert_eq!(thinking, Some(Thinking::High));
+    }
+
+    #[test]
+    fn api_key_auth_remains_the_default() {
+        let auth = openai_auth(None, Some("test-api-key".to_owned()), PathBuf::new()).unwrap();
+
+        assert_eq!(auth.mode(), OpenAiAuthMode::ApiKey);
+    }
+
+    #[test]
+    fn access_token_auth_loads_the_shared_codex_login() {
+        let codex_home = env::temp_dir().join(format!(
+            "centaur-nanocodex-auth-{}",
+            Uuid::new_v4().simple()
+        ));
+        std::fs::create_dir_all(&codex_home).unwrap();
+        std::fs::write(
+            codex_home.join("auth.json"),
+            include_str!("../../../services/sandbox/codex-auth.json"),
+        )
+        .unwrap();
+
+        let auth = openai_auth(Some("access_token"), None, codex_home.clone()).unwrap();
+
+        assert_eq!(auth.mode(), OpenAiAuthMode::ChatGpt);
+        std::fs::remove_dir_all(codex_home).unwrap();
+    }
+
+    #[test]
+    fn chatgpt_auth_mode_alias_loads_the_shared_codex_login() {
+        let codex_home = env::temp_dir().join(format!(
+            "centaur-nanocodex-auth-{}",
+            Uuid::new_v4().simple()
+        ));
+        std::fs::create_dir_all(&codex_home).unwrap();
+        std::fs::write(
+            codex_home.join("auth.json"),
+            include_str!("../../../services/sandbox/codex-auth.json"),
+        )
+        .unwrap();
+
+        let auth = openai_auth(Some("chatgpt"), None, codex_home.clone()).unwrap();
+
+        assert_eq!(auth.mode(), OpenAiAuthMode::ChatGpt);
+        std::fs::remove_dir_all(codex_home).unwrap();
+    }
+
+    #[test]
+    fn api_key_auth_requires_a_non_empty_key() {
+        let error =
+            openai_auth(Some("api_key"), Some("  ".to_owned()), PathBuf::new()).unwrap_err();
+
+        assert!(matches!(
+            error,
+            HarnessServerError::MissingEnvironment {
+                name: "OPENAI_API_KEY"
+            }
+        ));
     }
 }

--- a/services/api-rs/crates/centaur-api-server/src/args.rs
+++ b/services/api-rs/crates/centaur-api-server/src/args.rs
@@ -1955,10 +1955,9 @@ fn merge_fragment(target: &mut ProxyFragment, source: ProxyFragment) {
 
 fn harness_auth_mode_env(engine: &HarnessType) -> Option<String> {
     match engine {
-        HarnessType::Codex => env::var("CODEX_AUTH_MODE").ok(),
+        HarnessType::Codex | HarnessType::Nanocodex => env::var("CODEX_AUTH_MODE").ok(),
         HarnessType::ClaudeCode => env::var("CLAUDE_CODE_AUTH_MODE").ok(),
         HarnessType::Amp => None,
-        HarnessType::Nanocodex => Some("api_key".to_owned()),
     }
 }
 
@@ -2973,13 +2972,16 @@ mod tests {
 
     #[test]
     fn nanocodex_reuses_the_codex_proxy_fragment() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let _env = EnvGuard::set(&[("CODEX_AUTH_MODE", "access_token")]);
+
         assert_eq!(
             harness_fragment_engine_name(&HarnessType::Nanocodex),
             harness_fragment_engine_name(&HarnessType::Codex)
         );
         assert_eq!(
             harness_auth_mode_env(&HarnessType::Nanocodex).as_deref(),
-            Some("api_key")
+            Some("access_token")
         );
     }
 }


### PR DESCRIPTION
## What changed

- select Nanocodex authentication from `CODEX_AUTH_MODE`
- load the shared Codex `auth.json` for `access_token`/`chatgpt` mode
- preserve API-key auth as the default
- make a Nanocodex-default control plane register the same Codex auth mode and proxy fragment
- cover both modes, proxy selection, and missing-key behavior with unit tests

## Why

The sandbox was configured for brokered ChatGPT/Codex subscription auth, but the Nanocodex adapter always constructed its client from `OPENAI_API_KEY`. That sent Nanocodex traffic to API-key billing and produced `429 insufficient_quota` even when the ChatGPT plan had available quota.

This aligns Nanocodex with the existing sandbox Codex auth mode so iron-proxy can inject the brokered ChatGPT credential and account ID for `chatgpt.com`.

## Related PRs

- **Supersedes #1196**, which addresses the same failure by clamping the Nanocodex A/B rollout to 0 and remapping explicit Nanocodex requests to Codex whenever `CODEX_AUTH_MODE` is not `api_key`. With this PR, Nanocodex works under `access_token` auth, so that guard is no longer needed — and if #1196 lands first, its clamp/remap must be reverted here or Nanocodex stays silently disabled under ChatGPT auth despite supporting it. The two should not both merge as-is.

Notes for reviewers:
- The `chatgpt` value is accepted by the harness as an alias of `access_token` (it matches the `auth_mode` field inside `auth.json`), but the iron-proxy fragment layer and sandbox entrypoint only know `api_key`/`access_token`, so `access_token` is the value deployments should set.
- The sandbox entrypoint already installs the ChatGPT `auth.json` and skips `codex login --with-api-key` under `access_token` mode, so no entrypoint changes are needed.

## Validation

- `cargo +1.97.0 fmt --manifest-path crates/harness-server/Cargo.toml -- --check`
- `cargo +1.97.0 test --manifest-path crates/harness-server/Cargo.toml` (89 passed, 4 ignored)
- `cargo +1.97.0 fmt --all --check` from `services/api-rs`
- `cargo +1.97.0 test -p centaur-api-server` (137 passed)
- `just build-one agent`
- `just build-one api-rs`
- built API image starts and renders `--help`
- built agent image smoke confirmed `responses_websocket_v2` targets `wss://chatgpt.com/backend-api/codex/responses` and opens `CONNECT chatgpt.com:443`
- rebased onto latest `main` and re-ran harness + api-server tests

Note: the failing `build (*)` CI jobs fail at Depot setup with `permission_denied: Invalid token` because this PR is from a fork — same-repo PRs (e.g. #1217) build fine. Not related to this change.
