### PR TITLE
fix: deliver Slack root DM replies

### DIFF
--- a/services/slackbotv2/src/index.ts
+++ b/services/slackbotv2/src/index.ts
@@ -2317,7 +2317,7 @@ async function renderExecutionStream(
   consoleSessionBlock?: SlackContextBlock
 ): Promise<{ diverged: boolean; messageId?: string }> {
   const promptText = slackMessagePromptText(message)
-  if (isPlainTextOnlyRequest(promptText)) {
+  if (isPlainTextOnlyRequest(promptText) || isSlackRootDirectMessage(thread)) {
     await renderPlainTextExecutionStream(
       thread,
       stream,
@@ -2382,7 +2382,7 @@ async function renderRecoveredExecutionStream(
   trace?: SlackbotV2Trace
 ): Promise<{ diverged: boolean; messageId?: string }> {
   const promptText = slackMessagePromptText(message)
-  if (isPlainTextOnlyRequest(promptText)) {
+  if (isPlainTextOnlyRequest(promptText) || isSlackRootDirectMessage(thread)) {
     await renderPlainTextExecutionStream(thread, stream, message, options, trace)
     return { diverged: false }
   }
@@ -3470,6 +3470,11 @@ function slackAssistantTarget(thread: Thread): { channel: string; threadTs: stri
   const parts = thread.id.split(':')
   if (parts[0] !== 'slack' || !parts[1] || !parts[2]) return null
   return { channel: parts[1], threadTs: parts[2] }
+}
+
+function isSlackRootDirectMessage(thread: Thread): boolean {
+  const parts = thread.id.split(':')
+  return parts[0] === 'slack' && parts[1]?.startsWith('D') === true && parts[2] === ''
 }
 
 function titleFromMessage(text: string, userName = 'centaur'): string {

--- a/services/slackbotv2/test/chat-sdk-emulate.test.ts
+++ b/services/slackbotv2/test/chat-sdk-emulate.test.ts
@@ -36,6 +36,7 @@ const USER_ID = 'USLACKBOTV2USER'
 const USER_B_ID = 'USLACKBOTV2USERB'
 const TEAM_ID = 'T000000001'
 const CHANNEL_ID = 'C000000001'
+const DM_CHANNEL_ID = 'D000000001'
 /** How real Slack renders a streamed message whose stream broke or was never stopped. */
 const BROKEN_STREAM_TEXT = ':warning: Something went wrong'
 
@@ -3802,6 +3803,45 @@ describe('slackbotv2', () => {
     expect(text).not.toContain('pnpm test')
   })
 
+  it('renders root direct-message replies without Slack thread streaming', async () => {
+    const logs: CapturedLog[] = []
+    bot = createTestBot({ logger: captureLogger(logs) })
+    const message = await postUserMessage('Reply to this direct message.')
+    const waits: Promise<unknown>[] = []
+    const response = await bot.app.request(
+      '/api/webhooks/slack',
+      signedSlackEvent({
+        event_id: 'Ev-slackbotv2-root-direct-message',
+        event: {
+          type: 'message',
+          user: USER_ID,
+          channel: DM_CHANNEL_ID,
+          channel_type: 'im',
+          team: TEAM_ID,
+          ts: message.ts,
+          text: 'Reply to this direct message.'
+        }
+      }),
+      {},
+      waitUntilContext(waits)
+    )
+
+    expect(response.status).toBe(200)
+    await Promise.all(waits)
+
+    expect(codexApi.creates).toHaveLength(1)
+    expect(codexApi.creates[0]?.threadKey).toBe(`slack:${DM_CHANNEL_ID}:`)
+    expect(hasLog(logs, 'slackbotv2_render_failed')).toBe(false)
+    expect(slackApi.calls.some(call => call.method === 'chat.startStream')).toBe(false)
+    expect(slackApi.calls).toContainEqual(expect.objectContaining({
+      method: 'chat.postMessage',
+      body: expect.objectContaining({
+        channel: DM_CHANNEL_ID,
+        text: expect.stringContaining('Executed request 1.')
+      })
+    }))
+  })
+
   it('shows assistant status while waiting for slow session execute', async () => {
     const logs: CapturedLog[] = []
     bot = createTestBot({ logger: captureLogger(logs) })
@@ -5802,6 +5842,7 @@ type StreamCall = {
   method:
     | 'assistant.threads.setStatus'
     | 'assistant.threads.setTitle'
+    | 'chat.postMessage'
     | 'chat.startStream'
     | 'chat.appendStream'
     | 'chat.stopStream'
@@ -6064,6 +6105,20 @@ async function handlePatchedSlackRequest(
     await sendWebResponse(
       res,
       await startStream(input.upstreamUrl, request, input.streams, input.calls)
+    )
+    return
+  }
+  if (path === '/api/chat.postMessage') {
+    const body = await requestBody(request)
+    input.calls.push({ method: 'chat.postMessage', body })
+    await sendWebResponse(
+      res,
+      Response.json(
+        await postSlack(input.upstreamUrl, request, path, {
+          ...body,
+          channel: stringField(body.channel) === DM_CHANNEL_ID ? CHANNEL_ID : body.channel
+        })
+      )
     )
     return
   }


### PR DESCRIPTION
## What changed

- route root Slack DMs through the normal top-level message delivery path
- preserve the stable `slack:<channel>:` session key for continuous DM context
- use the same DM-safe delivery behavior during render recovery
- add an emulated root-DM regression test

## Root cause

The Slack adapter intentionally represents a root DM with an empty thread timestamp so every message in that DM shares one durable Centaur session. Slack's native streaming API rejects that empty timestamp because streaming requires a thread. The execution completed, but the first render attempt failed before a message became visible and had to fall through the generic recovery path.

Root DMs now collect the durable renderer output and post the final answer as a normal top-level message. Channel threads continue to use native Slack streaming.

## Validation

- `bun run --cwd services/slackbotv2 check:types`
- `bun test services/slackbotv2/test`
  - 221 passed, 1 skipped
- built `services/slackbotv2/Dockerfile` for `linux/amd64`
- imported the image into the home-lab k3s node
- rolled out `centaur-centaur-slackbotv2` successfully

Live DM delivery verification is pending a post-rollout user message.
