### PR TITLE
fix: skip unchanged secret replacements

### DIFF
--- a/services/console/app/controllers/api/base_controller.rb
+++ b/services/console/app/controllers/api/base_controller.rb
@@ -105,21 +105,11 @@ module Api
       end
     end
 
-    def sync_config_replacement_unchanged?(record, attributes, **associations)
-      return false if record.new_record?
-
-      SyncConfigReplacement.equivalent?(record, attributes, associations)
-    end
-
     def with_sync_config_replacement_guard(record, attributes, **associations)
       record.lock! unless record.new_record?
-      if sync_config_replacement_unchanged?(record, attributes, **associations)
-        raise ActiveRecord::RecordInvalid, record unless record.valid?
+      return record if !record.new_record? && SyncConfigReplacement.equivalent?(record, attributes, associations)
 
-        record
-      else
-        yield
-      end
+      yield
     end
 
     DEFAULT_PAGE_LIMIT = 50

--- a/services/console/app/controllers/api/base_controller.rb
+++ b/services/console/app/controllers/api/base_controller.rb
@@ -105,6 +105,23 @@ module Api
       end
     end
 
+    def sync_config_replacement_unchanged?(record, attributes, **associations)
+      return false if record.new_record?
+
+      SyncConfigReplacement.equivalent?(record, attributes, associations)
+    end
+
+    def with_sync_config_replacement_guard(record, attributes, **associations)
+      record.lock! unless record.new_record?
+      if sync_config_replacement_unchanged?(record, attributes, **associations)
+        raise ActiveRecord::RecordInvalid, record unless record.valid?
+
+        record.reload
+      else
+        yield
+      end
+    end
+
     DEFAULT_PAGE_LIMIT = 50
     MAX_PAGE_LIMIT = 200
 

--- a/services/console/app/controllers/api/base_controller.rb
+++ b/services/console/app/controllers/api/base_controller.rb
@@ -116,7 +116,7 @@ module Api
       if sync_config_replacement_unchanged?(record, attributes, **associations)
         raise ActiveRecord::RecordInvalid, record unless record.valid?
 
-        record.reload
+        record
       else
         yield
       end

--- a/services/console/app/controllers/api/v1/aws_auth_secrets_controller.rb
+++ b/services/console/app/controllers/api/v1/aws_auth_secrets_controller.rb
@@ -58,11 +58,13 @@ module Api
         rules_attrs = build_rules(attrs)
 
         AwsAuthSecret.transaction do
-          ref.assign_attributes(base)
-          ref.sources = sources
-          ref.rules = rules_attrs
-          ref.save!
-          ref.reload
+          with_sync_config_replacement_guard(ref, base, sources: sources, rules: rules_attrs) do
+            ref.assign_attributes(base)
+            ref.sources = sources
+            ref.rules = rules_attrs
+            ref.save!
+            ref.reload
+          end
         end
       end
 

--- a/services/console/app/controllers/api/v1/gcp_auth_secrets_controller.rb
+++ b/services/console/app/controllers/api/v1/gcp_auth_secrets_controller.rb
@@ -60,11 +60,13 @@ module Api
         rules_attrs = build_rules(attrs)
 
         GcpAuthSecret.transaction do
-          ref.assign_attributes(base)
-          ref.keyfile_source = keyfile_attrs ? SecretSource.new(keyfile_attrs.to_h) : nil
-          ref.rules = rules_attrs
-          ref.save!
-          ref.reload
+          with_sync_config_replacement_guard(ref, base, keyfile_source: keyfile_attrs, rules: rules_attrs) do
+            ref.assign_attributes(base)
+            ref.keyfile_source = keyfile_attrs ? SecretSource.new(keyfile_attrs.to_h) : nil
+            ref.rules = rules_attrs
+            ref.save!
+            ref.reload
+          end
         end
       end
 

--- a/services/console/app/controllers/api/v1/gcp_auth_secrets_controller.rb
+++ b/services/console/app/controllers/api/v1/gcp_auth_secrets_controller.rb
@@ -57,12 +57,13 @@ module Api
           attrs.require(:keyfile).permit(:source_type, :secret, config: {})
         end
 
+        keyfile_source = keyfile_attrs ? SecretSource.new(keyfile_attrs.to_h) : nil
         rules_attrs = build_rules(attrs)
 
         GcpAuthSecret.transaction do
-          with_sync_config_replacement_guard(ref, base, keyfile_source: keyfile_attrs, rules: rules_attrs) do
+          with_sync_config_replacement_guard(ref, base, keyfile_source: keyfile_source, rules: rules_attrs) do
             ref.assign_attributes(base)
-            ref.keyfile_source = keyfile_attrs ? SecretSource.new(keyfile_attrs.to_h) : nil
+            ref.keyfile_source = keyfile_source
             ref.rules = rules_attrs
             ref.save!
             ref.reload

--- a/services/console/app/controllers/api/v1/gcp_id_token_secrets_controller.rb
+++ b/services/console/app/controllers/api/v1/gcp_id_token_secrets_controller.rb
@@ -50,11 +50,13 @@ module Api
         rules_attrs = build_rules(attrs)
 
         GcpIdTokenSecret.transaction do
-          ref.assign_attributes(base)
-          ref.keyfile_source = keyfile_attrs ? SecretSource.new(keyfile_attrs.to_h) : nil
-          ref.rules = rules_attrs
-          ref.save!
-          ref.reload
+          with_sync_config_replacement_guard(ref, base, keyfile_source: keyfile_attrs, rules: rules_attrs) do
+            ref.assign_attributes(base)
+            ref.keyfile_source = keyfile_attrs ? SecretSource.new(keyfile_attrs.to_h) : nil
+            ref.rules = rules_attrs
+            ref.save!
+            ref.reload
+          end
         end
       end
 

--- a/services/console/app/controllers/api/v1/gcp_id_token_secrets_controller.rb
+++ b/services/console/app/controllers/api/v1/gcp_id_token_secrets_controller.rb
@@ -47,12 +47,13 @@ module Api
           attrs.require(:keyfile).permit(:source_type, :secret, config: {})
         end
 
+        keyfile_source = keyfile_attrs ? SecretSource.new(keyfile_attrs.to_h) : nil
         rules_attrs = build_rules(attrs)
 
         GcpIdTokenSecret.transaction do
-          with_sync_config_replacement_guard(ref, base, keyfile_source: keyfile_attrs, rules: rules_attrs) do
+          with_sync_config_replacement_guard(ref, base, keyfile_source: keyfile_source, rules: rules_attrs) do
             ref.assign_attributes(base)
-            ref.keyfile_source = keyfile_attrs ? SecretSource.new(keyfile_attrs.to_h) : nil
+            ref.keyfile_source = keyfile_source
             ref.rules = rules_attrs
             ref.save!
             ref.reload

--- a/services/console/app/controllers/api/v1/hmac_secrets_controller.rb
+++ b/services/console/app/controllers/api/v1/hmac_secrets_controller.rb
@@ -59,11 +59,13 @@ module Api
         rules_attrs = build_rules(attrs)
 
         HmacSecret.transaction do
-          ref.assign_attributes(base)
-          ref.sources = sources
-          ref.rules = rules_attrs
-          ref.save!
-          ref.reload
+          with_sync_config_replacement_guard(ref, base, sources: sources, rules: rules_attrs) do
+            ref.assign_attributes(base)
+            ref.sources = sources
+            ref.rules = rules_attrs
+            ref.save!
+            ref.reload
+          end
         end
       end
 

--- a/services/console/app/controllers/api/v1/oauth_token_secrets_controller.rb
+++ b/services/console/app/controllers/api/v1/oauth_token_secrets_controller.rb
@@ -58,11 +58,13 @@ module Api
         rules_attrs = build_rules(attrs)
 
         OauthTokenSecret.transaction do
-          ref.assign_attributes(base)
-          ref.sources = sources
-          ref.rules = rules_attrs
-          ref.save!
-          ref.reload
+          with_sync_config_replacement_guard(ref, base, sources: sources, rules: rules_attrs) do
+            ref.assign_attributes(base)
+            ref.sources = sources
+            ref.rules = rules_attrs
+            ref.save!
+            ref.reload
+          end
         end
       end
 

--- a/services/console/app/controllers/api/v1/pg_dsn_secrets_controller.rb
+++ b/services/console/app/controllers/api/v1/pg_dsn_secrets_controller.rb
@@ -59,13 +59,15 @@ module Api
           attrs.require(:dsn).permit(:source_type, :secret, config: {})
         end
 
+        dsn_source = source_attrs ? SecretSource.new(source_attrs.to_h) : nil
+
         # Build the whole graph in memory and save once so the cross-record
         # validation (dsn_source_present) sees the source. Assigning the has_one
         # replaces (and destroys) any prior source; a PUT is a full replace.
         PgDsnSecret.transaction do
-          with_sync_config_replacement_guard(ref, base, dsn_source: source_attrs) do
+          with_sync_config_replacement_guard(ref, base, dsn_source: dsn_source) do
             ref.assign_attributes(base)
-            ref.dsn_source = source_attrs ? SecretSource.new(source_attrs.to_h) : nil
+            ref.dsn_source = dsn_source
             ref.save!
             ref.reload
           end

--- a/services/console/app/controllers/api/v1/pg_dsn_secrets_controller.rb
+++ b/services/console/app/controllers/api/v1/pg_dsn_secrets_controller.rb
@@ -63,10 +63,12 @@ module Api
         # validation (dsn_source_present) sees the source. Assigning the has_one
         # replaces (and destroys) any prior source; a PUT is a full replace.
         PgDsnSecret.transaction do
-          ref.assign_attributes(base)
-          ref.dsn_source = source_attrs ? SecretSource.new(source_attrs.to_h) : nil
-          ref.save!
-          ref.reload
+          with_sync_config_replacement_guard(ref, base, dsn_source: source_attrs) do
+            ref.assign_attributes(base)
+            ref.dsn_source = source_attrs ? SecretSource.new(source_attrs.to_h) : nil
+            ref.save!
+            ref.reload
+          end
         end
       end
 

--- a/services/console/app/controllers/api/v1/static_secrets_controller.rb
+++ b/services/console/app/controllers/api/v1/static_secrets_controller.rb
@@ -71,21 +71,24 @@ module Api
           attrs.require(:source).permit(:source_type, :secret, config: {})
         end
 
-        rules_attrs = request_rule_attributes(attrs)
+        source = source_attrs ? SecretSource.new(source_attrs.to_h) : nil
+        rules = build_rules(attrs)
 
         StaticSecret.transaction do
-          with_sync_config_replacement_guard(ref, ss_attrs, source: source_attrs, rules: rules_attrs) do
+          with_sync_config_replacement_guard(ref, ss_attrs, source: source, rules: rules) do
             ref.assign_attributes(ss_attrs)
             ref.save!
 
             ref.source&.destroy!
-            if source_attrs
-              SecretSource.create!(source_attrs.to_h.merge(static_secret: ref))
+            if source
+              source.static_secret = ref
+              source.save!
             end
 
             ref.rules.destroy_all
-            rules_attrs.each do |r|
-              RequestRule.create!(r.merge(static_secret: ref))
+            rules.each do |rule|
+              rule.static_secret = ref
+              rule.save!
             end
 
             ref.reload

--- a/services/console/app/controllers/api/v1/static_secrets_controller.rb
+++ b/services/console/app/controllers/api/v1/static_secrets_controller.rb
@@ -74,21 +74,22 @@ module Api
         rules_attrs = request_rule_attributes(attrs)
 
         StaticSecret.transaction do
-          ref.lock! unless ref.new_record?
-          ref.assign_attributes(ss_attrs)
-          ref.save!
+          with_sync_config_replacement_guard(ref, ss_attrs, source: source_attrs, rules: rules_attrs) do
+            ref.assign_attributes(ss_attrs)
+            ref.save!
 
-          ref.source&.destroy!
-          if source_attrs
-            SecretSource.create!(source_attrs.to_h.merge(static_secret: ref))
+            ref.source&.destroy!
+            if source_attrs
+              SecretSource.create!(source_attrs.to_h.merge(static_secret: ref))
+            end
+
+            ref.rules.destroy_all
+            rules_attrs.each do |r|
+              RequestRule.create!(r.merge(static_secret: ref))
+            end
+
+            ref.reload
           end
-
-          ref.rules.destroy_all
-          rules_attrs.each do |r|
-            RequestRule.create!(r.merge(static_secret: ref))
-          end
-
-          ref.reload
         end
       end
 

--- a/services/console/app/models/concerns/sync_config_cache_invalidation.rb
+++ b/services/console/app/models/concerns/sync_config_cache_invalidation.rb
@@ -2,10 +2,32 @@ module SyncConfigCacheInvalidation
   extend ActiveSupport::Concern
 
   included do
-    before_commit :bump_sync_config_cache_for_record
+    before_save :mark_sync_config_cache_invalidation_for_save
+    before_destroy :mark_sync_config_cache_invalidation
+    before_commit :bump_sync_config_cache_for_record, if: :sync_config_cache_invalidation_needed?
+    after_commit :clear_sync_config_cache_invalidation
+    after_rollback :clear_sync_config_cache_invalidation
   end
 
   private
+
+  def mark_sync_config_cache_invalidation_for_save
+    changes = changes_to_save.except("created_at", "updated_at")
+    mark_sync_config_cache_invalidation if new_record? || changes.present?
+  end
+
+  def mark_sync_config_cache_invalidation
+    @sync_config_cache_invalidation_needed = true
+  end
+
+  def sync_config_cache_invalidation_needed?
+    @sync_config_cache_invalidation_needed == true
+  end
+
+  def clear_sync_config_cache_invalidation
+    remove_instance_variable(:@sync_config_cache_invalidation_needed) if
+      instance_variable_defined?(:@sync_config_cache_invalidation_needed)
+  end
 
   def bump_sync_config_cache_for_record
     Principal.bump_sync_config_cache_versions(sync_config_affected_principals)

--- a/services/console/app/models/concerns/sync_config_replacement.rb
+++ b/services/console/app/models/concerns/sync_config_replacement.rb
@@ -1,10 +1,11 @@
 module SyncConfigReplacement
-  SOURCE_ATTRIBUTES = %w[source_type config secret role role_kind].freeze
-  RULE_ATTRIBUTES = %w[position host cidr http_methods paths].freeze
+  IGNORED_ASSOCIATION_ATTRIBUTES = %w[id created_at updated_at].freeze
+  REPLACEMENT_ASSOCIATION_CLASSES = [ SecretSource, RequestRule ].freeze
 
   module_function
 
   def equivalent?(record, attributes, associations)
+    validate_association_coverage!(record, associations)
     current_document(record, attributes, associations) == replacement_document(record, attributes, associations)
   end
 
@@ -45,29 +46,32 @@ module SyncConfigReplacement
     documents = records.map { |record| record_document(record, record_class) }
     return documents unless record_class == SecretSource
 
-    documents.sort_by { |document| JSON.generate(document) }
+    documents.sort_by { |document| JSON.generate(normalize(document)) }
   end
 
   def record_document(record, record_class)
-    fields = case record_class.name
-    when "SecretSource" then SOURCE_ATTRIBUTES
-    when "RequestRule" then RULE_ATTRIBUTES
-    else raise ArgumentError, "unsupported association class #{record_class.name}"
-    end
+    raise ArgumentError, "unsupported association class #{record_class.name}" unless
+      REPLACEMENT_ASSOCIATION_CLASSES.include?(record_class)
 
-    attributes = if record.is_a?(record_class)
-      fields.index_with { |name| record.public_send(name) }
-    else
-      normalize(record.to_h)
-    end
+    record = record_class.new(record.to_h) unless record.is_a?(record_class)
+    association_attribute_names(record_class).index_with { |name| record.public_send(name) }
+  end
 
-    fields.index_with { |field| attributes[field] }.tap do |document|
-      document["config"] ||= {} if record_class == SecretSource
-      if record_class == RequestRule
-        document["http_methods"] ||= []
-        document["paths"] ||= []
-      end
+  def association_attribute_names(record_class)
+    owner_foreign_keys = record_class.const_get(:OWNER_ASSOCIATIONS).map do |association|
+      record_class.reflect_on_association(association).foreign_key.to_s
     end
+    record_class.attribute_names - IGNORED_ASSOCIATION_ATTRIBUTES - owner_foreign_keys
+  end
+
+  def validate_association_coverage!(record, associations)
+    expected = record.class.reflect_on_all_associations.filter_map do |reflection|
+      reflection.name if REPLACEMENT_ASSOCIATION_CLASSES.include?(reflection.klass)
+    end
+    missing = expected - associations.keys.map(&:to_sym)
+    return if missing.empty?
+
+    raise ArgumentError, "missing replacement associations: #{missing.join(", ")}"
   end
 
   def attribute_names(attributes)

--- a/services/console/app/models/concerns/sync_config_replacement.rb
+++ b/services/console/app/models/concerns/sync_config_replacement.rb
@@ -1,10 +1,15 @@
 module SyncConfigReplacement
-  REPLACEMENT_ASSOCIATION_CLASSES = [ SecretSource, RequestRule ].freeze
+  ASSOCIATION_CLASSES = {
+    source: SecretSource,
+    sources: SecretSource,
+    keyfile_source: SecretSource,
+    dsn_source: SecretSource,
+    rules: RequestRule
+  }.freeze
 
   module_function
 
   def equivalent?(record, attributes, associations)
-    validate_association_coverage!(record, associations)
     current_document(record, attributes, associations) == replacement_document(record, attributes, associations)
   end
 
@@ -26,19 +31,19 @@ module SyncConfigReplacement
     normalize(
       "record" => attribute_names.index_with { |name| record.public_send(name) },
       "associations" => associations.to_h do |name, association|
-        reflection = record.class.reflect_on_association(name)
-        [ name, association_document(reflection, association) ]
+        [ name, association_document(name, association) ]
       end
     )
   end
 
-  def association_document(reflection, association)
-    raise ArgumentError, "unknown association" unless reflection
+  def association_document(name, association)
+    record_class = ASSOCIATION_CLASSES.fetch(name.to_sym)
 
-    return collection_document(Array(association), reflection.klass) if reflection.collection?
+    return collection_document(Array(association), record_class) if association.is_a?(Array) ||
+                                                                    association.is_a?(ActiveRecord::Associations::CollectionProxy)
     return nil if association.nil?
 
-    record_document(association, reflection.klass)
+    record_document(association, record_class)
   end
 
   def collection_document(records, record_class)
@@ -49,27 +54,12 @@ module SyncConfigReplacement
   end
 
   def record_document(record, record_class)
-    raise ArgumentError, "unsupported association class #{record_class.name}" unless
-      REPLACEMENT_ASSOCIATION_CLASSES.include?(record_class)
-
     record = record_class.new(record.to_h) unless record.is_a?(record_class)
     association_attribute_names(record_class).index_with { |name| record.public_send(name) }
   end
 
   def association_attribute_names(record_class)
     record_class.const_get(:SYNC_CONFIG_REPLACEMENT_ATTRIBUTES)
-  end
-
-  def validate_association_coverage!(record, associations)
-    expected = record.class.reflect_on_all_associations.filter_map do |reflection|
-      next if reflection.polymorphic?
-
-      reflection.name if REPLACEMENT_ASSOCIATION_CLASSES.include?(reflection.klass)
-    end
-    missing = expected - associations.keys.map(&:to_sym)
-    return if missing.empty?
-
-    raise ArgumentError, "missing replacement associations: #{missing.join(", ")}"
   end
 
   def attribute_names(attributes)

--- a/services/console/app/models/concerns/sync_config_replacement.rb
+++ b/services/console/app/models/concerns/sync_config_replacement.rb
@@ -1,5 +1,4 @@
 module SyncConfigReplacement
-  IGNORED_ASSOCIATION_ATTRIBUTES = %w[id created_at updated_at].freeze
   REPLACEMENT_ASSOCIATION_CLASSES = [ SecretSource, RequestRule ].freeze
 
   module_function
@@ -58,14 +57,13 @@ module SyncConfigReplacement
   end
 
   def association_attribute_names(record_class)
-    owner_foreign_keys = record_class.const_get(:OWNER_ASSOCIATIONS).map do |association|
-      record_class.reflect_on_association(association).foreign_key.to_s
-    end
-    record_class.attribute_names - IGNORED_ASSOCIATION_ATTRIBUTES - owner_foreign_keys
+    record_class.const_get(:SYNC_CONFIG_REPLACEMENT_ATTRIBUTES)
   end
 
   def validate_association_coverage!(record, associations)
     expected = record.class.reflect_on_all_associations.filter_map do |reflection|
+      next if reflection.polymorphic?
+
       reflection.name if REPLACEMENT_ASSOCIATION_CLASSES.include?(reflection.klass)
     end
     missing = expected - associations.keys.map(&:to_sym)

--- a/services/console/app/models/concerns/sync_config_replacement.rb
+++ b/services/console/app/models/concerns/sync_config_replacement.rb
@@ -1,81 +1,28 @@
 module SyncConfigReplacement
-  ASSOCIATION_CLASSES = {
-    source: SecretSource,
-    sources: SecretSource,
-    keyfile_source: SecretSource,
-    dsn_source: SecretSource,
-    rules: RequestRule
-  }.freeze
-
+  # Association values must be model instances (or arrays of them) whose class
+  # defines SYNC_CONFIG_REPLACEMENT_ATTRIBUTES — controllers pass the same
+  # instances they persist when the replacement turns out not to be a no-op.
   module_function
 
   def equivalent?(record, attributes, associations)
-    current_document(record, attributes, associations) == replacement_document(record, attributes, associations)
-  end
-
-  def current_document(record, attributes, associations)
-    document(
-      record,
-      attribute_names(attributes),
-      associations.to_h { |association, _| [ association, record.public_send(association) ] }
-    )
-  end
-
-  def replacement_document(record, attributes, associations)
     replacement = record.dup
     replacement.assign_attributes(attributes)
-    document(replacement, attribute_names(attributes), associations)
-  end
+    names = attributes.to_h.keys.map(&:to_s)
+    return false unless names.index_with { |name| record.public_send(name).as_json } ==
+                        names.index_with { |name| replacement.public_send(name).as_json }
 
-  def document(record, attribute_names, associations)
-    normalize(
-      "record" => attribute_names.index_with { |name| record.public_send(name) },
-      "associations" => associations.to_h do |name, association|
-        [ name, association_document(name, association) ]
-      end
-    )
-  end
-
-  def association_document(name, association)
-    record_class = ASSOCIATION_CLASSES.fetch(name.to_sym)
-
-    return collection_document(Array(association), record_class) if association.is_a?(Array) ||
-                                                                    association.is_a?(ActiveRecord::Associations::CollectionProxy)
-    return nil if association.nil?
-
-    record_document(association, record_class)
-  end
-
-  def collection_document(records, record_class)
-    documents = records.map { |record| record_document(record, record_class) }
-    return documents if record_class == RequestRule
-
-    documents.sort_by { |document| JSON.generate(normalize(document)) }
-  end
-
-  def record_document(record, record_class)
-    record = record_class.new(record.to_h) unless record.is_a?(record_class)
-    association_attribute_names(record_class).index_with { |name| record.public_send(name) }
-  end
-
-  def association_attribute_names(record_class)
-    record_class.const_get(:SYNC_CONFIG_REPLACEMENT_ATTRIBUTES)
-  end
-
-  def attribute_names(attributes)
-    attributes.to_h.keys.map(&:to_s)
-  end
-
-  def normalize(value)
-    case value
-    when Hash
-      value.to_h.each_with_object({}) do |(key, nested), normalized|
-        normalized[key.to_s] = normalize(nested)
-      end.sort.to_h
-    when Array
-      value.map { |nested| normalize(nested) }
-    else
-      value
+    associations.all? do |name, replacement_records|
+      documents(record.public_send(name)) == documents(replacement_records)
     end
+  end
+
+  # Hash#== ignores key order, so as_json (deep string keys) is the only
+  # normalization needed. Sorting by role/position is equality-preserving
+  # because both are part of the document: roles are unique within a secret's
+  # sources and rule positions are assigned 0..n from the request body.
+  def documents(records)
+    Array(records)
+      .map { |record| record.slice(*record.class::SYNC_CONFIG_REPLACEMENT_ATTRIBUTES).as_json }
+      .sort_by { |document| [ document["role"].to_s, document["position"].to_i ] }
   end
 end

--- a/services/console/app/models/concerns/sync_config_replacement.rb
+++ b/services/console/app/models/concerns/sync_config_replacement.rb
@@ -1,0 +1,89 @@
+module SyncConfigReplacement
+  SOURCE_ATTRIBUTES = %w[source_type config secret role role_kind].freeze
+  RULE_ATTRIBUTES = %w[position host cidr http_methods paths].freeze
+
+  module_function
+
+  def equivalent?(record, attributes, associations)
+    current_document(record, attributes, associations) == replacement_document(record, attributes, associations)
+  end
+
+  def current_document(record, attributes, associations)
+    document(
+      record,
+      attribute_names(attributes),
+      associations.to_h { |association, _| [ association, record.public_send(association) ] }
+    )
+  end
+
+  def replacement_document(record, attributes, associations)
+    replacement = record.dup
+    replacement.assign_attributes(attributes)
+    document(replacement, attribute_names(attributes), associations)
+  end
+
+  def document(record, attribute_names, associations)
+    normalize(
+      "record" => attribute_names.index_with { |name| record.public_send(name) },
+      "associations" => associations.to_h do |name, association|
+        reflection = record.class.reflect_on_association(name)
+        [ name, association_document(reflection, association) ]
+      end
+    )
+  end
+
+  def association_document(reflection, association)
+    raise ArgumentError, "unknown association" unless reflection
+
+    return collection_document(Array(association), reflection.klass) if reflection.collection?
+    return nil if association.nil?
+
+    record_document(association, reflection.klass)
+  end
+
+  def collection_document(records, record_class)
+    documents = records.map { |record| record_document(record, record_class) }
+    return documents unless record_class == SecretSource
+
+    documents.sort_by { |document| JSON.generate(document) }
+  end
+
+  def record_document(record, record_class)
+    fields = case record_class.name
+    when "SecretSource" then SOURCE_ATTRIBUTES
+    when "RequestRule" then RULE_ATTRIBUTES
+    else raise ArgumentError, "unsupported association class #{record_class.name}"
+    end
+
+    attributes = if record.is_a?(record_class)
+      fields.index_with { |name| record.public_send(name) }
+    else
+      normalize(record.to_h)
+    end
+
+    fields.index_with { |field| attributes[field] }.tap do |document|
+      document["config"] ||= {} if record_class == SecretSource
+      if record_class == RequestRule
+        document["http_methods"] ||= []
+        document["paths"] ||= []
+      end
+    end
+  end
+
+  def attribute_names(attributes)
+    attributes.to_h.keys.map(&:to_s)
+  end
+
+  def normalize(value)
+    case value
+    when Hash
+      value.to_h.each_with_object({}) do |(key, nested), normalized|
+        normalized[key.to_s] = normalize(nested)
+      end.sort.to_h
+    when Array
+      value.map { |nested| normalize(nested) }
+    else
+      value
+    end
+  end
+end

--- a/services/console/app/models/concerns/sync_config_replacement.rb
+++ b/services/console/app/models/concerns/sync_config_replacement.rb
@@ -48,7 +48,7 @@ module SyncConfigReplacement
 
   def collection_document(records, record_class)
     documents = records.map { |record| record_document(record, record_class) }
-    return documents unless record_class == SecretSource
+    return documents if record_class == RequestRule
 
     documents.sort_by { |document| JSON.generate(normalize(document)) }
   end

--- a/services/console/app/models/gcp_id_token_secret.rb
+++ b/services/console/app/models/gcp_id_token_secret.rb
@@ -15,7 +15,7 @@ class GcpIdTokenSecret < ApplicationRecord
   has_many :grants, dependent: :destroy
   belongs_to :created_by, class_name: "User"
 
-  before_validation :normalize_header
+  normalizes :header, with: ->(value) { value.to_s.strip.downcase.presence }
 
   # Maps to one entry in the iron-proxy `transforms` array as a gcp_id_token
   # transform. The proxy defaults to Authorization when header is omitted.
@@ -43,10 +43,6 @@ class GcpIdTokenSecret < ApplicationRecord
   validate :at_least_one_rule
 
   private
-
-  def normalize_header
-    self.header = header.to_s.strip.downcase.presence
-  end
 
   def labels_is_a_hash
     errors.add(:labels, "must be a hash") unless labels.is_a?(Hash)

--- a/services/console/app/models/request_rule.rb
+++ b/services/console/app/models/request_rule.rb
@@ -7,6 +7,7 @@ class RequestRule < ApplicationRecord
 
   HTTP_METHODS = %w[GET HEAD POST PUT PATCH DELETE OPTIONS CONNECT].freeze
   METHOD_WILDCARD = "*".freeze
+  SYNC_CONFIG_REPLACEMENT_ATTRIBUTES = %w[position host cidr http_methods paths].freeze
 
   # A rule hangs off exactly one credential type.
   belongs_to :static_secret, optional: true

--- a/services/console/app/models/secret_source.rb
+++ b/services/console/app/models/secret_source.rb
@@ -4,6 +4,7 @@ class SecretSource < ApplicationRecord
   include SyncConfigOwnerInvalidation
 
   SOURCE_TYPES = %w[env aws_sm aws_ssm 1password 1password_connect control_plane token_broker].freeze
+  SYNC_CONFIG_REPLACEMENT_ATTRIBUTES = %w[source_type config secret role role_kind].freeze
 
   UNIVERSAL_OPTIONAL = %w[json_key ttl].freeze
 

--- a/services/console/test/controllers/api/v1/aws_auth_secrets_controller_test.rb
+++ b/services/console/test/controllers/api/v1/aws_auth_secrets_controller_test.rb
@@ -3,8 +3,6 @@ require "test_helper"
 module Api
   module V1
     class AwsAuthSecretsControllerTest < ActionDispatch::IntegrationTest
-      include ActiveJob::TestHelper
-
       ACME_TOKEN = "iak_acme-ci-token".freeze
 
       def auth_headers(token = ACME_TOKEN)
@@ -115,7 +113,7 @@ module Api
         assert_equal "NEW_AK", secret.sources.find { |s| s.role == "access_key_id" }.config["var"]
       end
 
-      test "PUT with an unchanged document does not enqueue snapshot warm jobs" do
+      test "PUT with an unchanged document does not bump the sync config cache version" do
         secret = aws_auth_secrets(:acme_cloudwatch_aws)
         principal = principals(:acme_channel)
         Grant.create!(
@@ -127,7 +125,6 @@ module Api
         source_ids = secret.sources.pluck(:role, :id).to_h
         rule_ids = secret.rules.pluck(:id)
         version = principal.reload.sync_config_cache_version
-        clear_enqueued_jobs
 
         body = {
           data: {
@@ -145,15 +142,43 @@ module Api
           }
         }
 
-        assert_no_enqueued_jobs only: PrincipalSyncConfigSnapshotWarmJob do
-          put api_v1_aws_auth_secret_url(id: secret.oid), params: body.to_json, headers: auth_headers
-        end
+        put api_v1_aws_auth_secret_url(id: secret.oid), params: body.to_json, headers: auth_headers
         assert_response :ok
 
         secret.reload
         assert_equal source_ids, secret.sources.pluck(:role, :id).to_h
         assert_equal rule_ids, secret.rules.pluck(:id)
         assert_equal version, principal.reload.sync_config_cache_version
+      end
+
+      test "PUT that only reorders rules is not treated as a no-op" do
+        secret = aws_auth_secrets(:acme_cloudwatch_aws)
+        body = {
+          data: {
+            namespace: secret.namespace,
+            foreign_id: secret.foreign_id,
+            name: secret.name,
+            labels: secret.labels,
+            allowed_regions: secret.allowed_regions,
+            allowed_services: secret.allowed_services,
+            access_key_id: { source_type: "env", config: { var: "AWS_ACCESS_KEY_ID" } },
+            secret_access_key: { source_type: "env", config: { var: "AWS_SECRET_ACCESS_KEY" } },
+            rules: [
+              { host: "logs.us-west-2.amazonaws.com", http_methods: [ "POST" ], paths: [] },
+              { host: "metrics.us-west-2.amazonaws.com", http_methods: [ "POST" ], paths: [] }
+            ]
+          }
+        }
+
+        put api_v1_aws_auth_secret_url(id: secret.oid), params: body.to_json, headers: auth_headers
+        assert_response :ok
+
+        body[:data][:rules].reverse!
+        put api_v1_aws_auth_secret_url(id: secret.oid), params: body.to_json, headers: auth_headers
+        assert_response :ok
+
+        assert_equal [ "metrics.us-west-2.amazonaws.com", "logs.us-west-2.amazonaws.com" ],
+                     secret.reload.rules.map(&:host)
       end
 
       test "PUT clears fields omitted from the body" do

--- a/services/console/test/controllers/api/v1/aws_auth_secrets_controller_test.rb
+++ b/services/console/test/controllers/api/v1/aws_auth_secrets_controller_test.rb
@@ -3,6 +3,8 @@ require "test_helper"
 module Api
   module V1
     class AwsAuthSecretsControllerTest < ActionDispatch::IntegrationTest
+      include ActiveJob::TestHelper
+
       ACME_TOKEN = "iak_acme-ci-token".freeze
 
       def auth_headers(token = ACME_TOKEN)
@@ -111,6 +113,47 @@ module Api
 
         secret.reload
         assert_equal "NEW_AK", secret.sources.find { |s| s.role == "access_key_id" }.config["var"]
+      end
+
+      test "PUT with an unchanged document does not enqueue snapshot warm jobs" do
+        secret = aws_auth_secrets(:acme_cloudwatch_aws)
+        principal = principals(:acme_channel)
+        Grant.create!(
+          principal: principal,
+          aws_auth_secret: secret,
+          created_by: users(:acme_admin),
+          priority: Grant::DEFAULT_DIRECT_PRIORITY
+        )
+        source_ids = secret.sources.pluck(:role, :id).to_h
+        rule_ids = secret.rules.pluck(:id)
+        version = principal.reload.sync_config_cache_version
+        clear_enqueued_jobs
+
+        body = {
+          data: {
+            namespace: secret.namespace,
+            foreign_id: secret.foreign_id,
+            name: secret.name,
+            labels: secret.labels,
+            allowed_regions: secret.allowed_regions,
+            allowed_services: secret.allowed_services,
+            access_key_id: { source_type: "env", config: { var: "AWS_ACCESS_KEY_ID" } },
+            secret_access_key: { source_type: "env", config: { var: "AWS_SECRET_ACCESS_KEY" } },
+            rules: [
+              { host: "logs.us-west-2.amazonaws.com", http_methods: [ "POST" ], paths: [] }
+            ]
+          }
+        }
+
+        assert_no_enqueued_jobs only: PrincipalSyncConfigSnapshotWarmJob do
+          put api_v1_aws_auth_secret_url(id: secret.oid), params: body.to_json, headers: auth_headers
+        end
+        assert_response :ok
+
+        secret.reload
+        assert_equal source_ids, secret.sources.pluck(:role, :id).to_h
+        assert_equal rule_ids, secret.rules.pluck(:id)
+        assert_equal version, principal.reload.sync_config_cache_version
       end
 
       test "PUT clears fields omitted from the body" do

--- a/services/console/test/controllers/api/v1/gcp_auth_secrets_controller_test.rb
+++ b/services/console/test/controllers/api/v1/gcp_auth_secrets_controller_test.rb
@@ -29,6 +29,21 @@ module Api
         assert_equal "storage-bot@acme.example", data["subject"]
       end
 
+      test "PUT with an unchanged document preserves keyfile and rule records" do
+        secret = gcp_auth_secrets(:acme_gcs_keyfile)
+        source_id = secret.keyfile_source.id
+        rule_ids = secret.rules.ids
+
+        get api_v1_gcp_auth_secret_url(id: secret.oid), headers: auth_headers
+        data = json_body.fetch("data").except("id", "created_at", "updated_at")
+        put api_v1_gcp_auth_secret_url(id: secret.oid), params: { data: data }.to_json, headers: auth_headers
+
+        assert_response :ok
+        secret.reload
+        assert_equal source_id, secret.keyfile_source.id
+        assert_equal rule_ids, secret.rules.ids
+      end
+
       test "GET lookup finds a gcp_auth secret by namespace and foreign_id" do
         secret = gcp_auth_secrets(:acme_gcs_keyfile)
         get lookup_api_v1_gcp_auth_secrets_url(namespace: secret.namespace, foreign_id: secret.foreign_id),

--- a/services/console/test/controllers/api/v1/gcp_auth_secrets_controller_test.rb
+++ b/services/console/test/controllers/api/v1/gcp_auth_secrets_controller_test.rb
@@ -44,6 +44,20 @@ module Api
         assert_equal rule_ids, secret.rules.ids
       end
 
+      test "PUT with an unchanged credentials_provider document is not rewritten" do
+        secret = gcp_auth_secrets(:acme_bigquery)
+        updated_at = secret.updated_at
+
+        get api_v1_gcp_auth_secret_url(id: secret.oid), headers: auth_headers
+        data = json_body.fetch("data").except("id", "created_at", "updated_at")
+        put api_v1_gcp_auth_secret_url(id: secret.oid), params: { data: data }.to_json, headers: auth_headers
+
+        assert_response :ok
+        secret.reload
+        assert_nil secret.keyfile_source
+        assert_equal updated_at, secret.updated_at
+      end
+
       test "GET lookup finds a gcp_auth secret by namespace and foreign_id" do
         secret = gcp_auth_secrets(:acme_gcs_keyfile)
         get lookup_api_v1_gcp_auth_secrets_url(namespace: secret.namespace, foreign_id: secret.foreign_id),

--- a/services/console/test/controllers/api/v1/gcp_id_token_secrets_controller_test.rb
+++ b/services/console/test/controllers/api/v1/gcp_id_token_secrets_controller_test.rb
@@ -32,6 +32,22 @@ module Api
         assert_equal 1, data["rules"].length
       end
 
+      test "PUT with an unchanged document preserves keyfile and rule records" do
+        secret = gcp_id_token_secrets(:acme_cloud_run)
+        source_id = secret.keyfile_source.id
+        rule_ids = secret.rules.ids
+
+        get api_v1_gcp_id_token_secret_url(id: secret.oid), headers: auth_headers
+        data = json_body.fetch("data").except("id", "created_at", "updated_at")
+        data["header"] = data.fetch("header").upcase
+        put api_v1_gcp_id_token_secret_url(id: secret.oid), params: { data: data }.to_json, headers: auth_headers
+
+        assert_response :ok
+        secret.reload
+        assert_equal source_id, secret.keyfile_source.id
+        assert_equal rule_ids, secret.rules.ids
+      end
+
       test "GET lookup finds a gcp_id_token secret by namespace and foreign_id" do
         secret = gcp_id_token_secrets(:acme_cloud_run)
         get lookup_api_v1_gcp_id_token_secrets_url(namespace: secret.namespace, foreign_id: secret.foreign_id),

--- a/services/console/test/controllers/api/v1/hmac_secrets_controller_test.rb
+++ b/services/console/test/controllers/api/v1/hmac_secrets_controller_test.rb
@@ -48,6 +48,21 @@ module Api
         assert_equal 1, data["rules"].length
       end
 
+      test "PUT with an unchanged document preserves credential and rule records" do
+        secret = hmac_secrets(:acme_webhook_hmac)
+        source_ids = secret.sources.ids
+        rule_ids = secret.rules.ids
+
+        get api_v1_hmac_secret_url(id: secret.oid), headers: auth_headers
+        data = json_body.fetch("data").except("id", "created_at", "updated_at")
+        put api_v1_hmac_secret_url(id: secret.oid), params: { data: data }.to_json, headers: auth_headers
+
+        assert_response :ok
+        secret.reload
+        assert_equal source_ids, secret.sources.ids
+        assert_equal rule_ids, secret.rules.ids
+      end
+
       test "GET lookup finds an hmac secret by namespace and foreign_id" do
         secret = hmac_secrets(:acme_webhook_hmac)
         get lookup_api_v1_hmac_secrets_url(namespace: secret.namespace, foreign_id: secret.foreign_id),

--- a/services/console/test/controllers/api/v1/hmac_secrets_controller_test.rb
+++ b/services/console/test/controllers/api/v1/hmac_secrets_controller_test.rb
@@ -63,6 +63,28 @@ module Api
         assert_equal rule_ids, secret.rules.ids
       end
 
+      test "PUT changing only a credential source is not treated as a no-op" do
+        secret = hmac_secrets(:acme_webhook_hmac)
+        principal = principals(:acme_channel)
+        Grant.create!(
+          principal: principal,
+          hmac_secret: secret,
+          created_by: users(:acme_admin),
+          priority: Grant::DEFAULT_DIRECT_PRIORITY
+        )
+        version = principal.reload.sync_config_cache_version
+
+        get api_v1_hmac_secret_url(id: secret.oid), headers: auth_headers
+        data = json_body.fetch("data").except("id", "created_at", "updated_at")
+        data["credentials"]["secret"]["config"]["var"] = "ROTATED_HMAC_KEY"
+        put api_v1_hmac_secret_url(id: secret.oid), params: { data: data }.to_json, headers: auth_headers
+
+        assert_response :ok
+        assert_equal "ROTATED_HMAC_KEY",
+                     secret.reload.sources.find { |s| s.role == "secret" }.config["var"]
+        assert_operator principal.reload.sync_config_cache_version, :>, version
+      end
+
       test "GET lookup finds an hmac secret by namespace and foreign_id" do
         secret = hmac_secrets(:acme_webhook_hmac)
         get lookup_api_v1_hmac_secrets_url(namespace: secret.namespace, foreign_id: secret.foreign_id),

--- a/services/console/test/controllers/api/v1/oauth_token_secrets_controller_test.rb
+++ b/services/console/test/controllers/api/v1/oauth_token_secrets_controller_test.rb
@@ -30,6 +30,21 @@ module Api
         assert data.dig("credentials", "refresh_token").present?
       end
 
+      test "PUT with an unchanged document preserves credential and rule records" do
+        secret = oauth_token_secrets(:acme_gmail_oauth)
+        source_ids = secret.sources.ids
+        rule_ids = secret.rules.ids
+
+        get api_v1_oauth_token_secret_url(id: secret.oid), headers: auth_headers
+        data = json_body.fetch("data").except("id", "created_at", "updated_at")
+        put api_v1_oauth_token_secret_url(id: secret.oid), params: { data: data }.to_json, headers: auth_headers
+
+        assert_response :ok
+        secret.reload
+        assert_equal source_ids, secret.sources.ids
+        assert_equal rule_ids, secret.rules.ids
+      end
+
       test "GET lookup finds an oauth_token secret by namespace and foreign_id" do
         secret = oauth_token_secrets(:acme_gmail_oauth)
         get lookup_api_v1_oauth_token_secrets_url(namespace: secret.namespace, foreign_id: secret.foreign_id),

--- a/services/console/test/controllers/api/v1/pg_dsn_secrets_controller_test.rb
+++ b/services/console/test/controllers/api/v1/pg_dsn_secrets_controller_test.rb
@@ -33,6 +33,18 @@ module Api
         refute data.key?("client_user")
       end
 
+      test "PUT with an unchanged document preserves the dsn source record" do
+        secret = pg_dsn_secrets(:acme_analytics_pg)
+        source_id = secret.dsn_source.id
+
+        get api_v1_pg_dsn_secret_url(id: secret.oid), headers: auth_headers
+        data = json_body.fetch("data").except("id", "created_at", "updated_at")
+        put api_v1_pg_dsn_secret_url(id: secret.oid), params: { data: data }.to_json, headers: auth_headers
+
+        assert_response :ok
+        assert_equal source_id, secret.reload.dsn_source.id
+      end
+
       test "GET lookup finds a pg_dsn secret by namespace and foreign_id" do
         secret = pg_dsn_secrets(:acme_analytics_pg)
         get lookup_api_v1_pg_dsn_secrets_url(namespace: secret.namespace, foreign_id: secret.foreign_id),

--- a/services/console/test/controllers/api/v1/static_secrets_controller_test.rb
+++ b/services/console/test/controllers/api/v1/static_secrets_controller_test.rb
@@ -3,8 +3,6 @@ require "test_helper"
 module Api
   module V1
     class StaticSecretsControllerTest < ActionDispatch::IntegrationTest
-      include ActiveJob::TestHelper
-
       ACME_TOKEN = "iak_acme-ci-token".freeze
 
       def auth_headers(token = ACME_TOKEN)
@@ -301,7 +299,7 @@ module Api
         assert_nil RequestRule.find_by(id: old_rule.id), "old rule should be deleted"
       end
 
-      test "PUT with an unchanged document does not enqueue snapshot warm jobs" do
+      test "PUT with an unchanged document does not bump the sync config cache version" do
         ref = static_secrets(:github_token_inject)
         source = SecretSource.create!(source_type: "control_plane", secret: "same-secret",
                                       static_secret: ref)
@@ -309,7 +307,6 @@ module Api
                                    paths: [ "/" ], position: 0, static_secret: ref)
         principal = principals(:acme_channel)
         version = principal.reload.sync_config_cache_version
-        clear_enqueued_jobs
 
         body = {
           data: {
@@ -323,9 +320,7 @@ module Api
           }
         }
 
-        assert_no_enqueued_jobs only: PrincipalSyncConfigSnapshotWarmJob do
-          put api_v1_static_secret_url(id: ref.oid), params: body.to_json, headers: auth_headers
-        end
+        put api_v1_static_secret_url(id: ref.oid), params: body.to_json, headers: auth_headers
         assert_response :ok
 
         ref.reload

--- a/services/console/test/controllers/api/v1/static_secrets_controller_test.rb
+++ b/services/console/test/controllers/api/v1/static_secrets_controller_test.rb
@@ -3,6 +3,8 @@ require "test_helper"
 module Api
   module V1
     class StaticSecretsControllerTest < ActionDispatch::IntegrationTest
+      include ActiveJob::TestHelper
+
       ACME_TOKEN = "iak_acme-ci-token".freeze
 
       def auth_headers(token = ACME_TOKEN)
@@ -297,6 +299,39 @@ module Api
         assert_equal [ "new.example.com" ], ref.rules.map(&:host)
         assert_nil SecretSource.find_by(id: old_source.id), "old source should be deleted"
         assert_nil RequestRule.find_by(id: old_rule.id), "old rule should be deleted"
+      end
+
+      test "PUT with an unchanged document does not enqueue snapshot warm jobs" do
+        ref = static_secrets(:github_token_inject)
+        source = SecretSource.create!(source_type: "control_plane", secret: "same-secret",
+                                      static_secret: ref)
+        rule = RequestRule.create!(host: "api.github.com", http_methods: [ "GET" ],
+                                   paths: [ "/" ], position: 0, static_secret: ref)
+        principal = principals(:acme_channel)
+        version = principal.reload.sync_config_cache_version
+        clear_enqueued_jobs
+
+        body = {
+          data: {
+            namespace: ref.namespace,
+            name: ref.name,
+            description: ref.description,
+            labels: ref.labels,
+            inject_config: ref.inject_config,
+            source: { source_type: "control_plane", secret: "same-secret" },
+            rules: [ { host: "api.github.com", http_methods: [ "GET" ], paths: [ "/" ] } ]
+          }
+        }
+
+        assert_no_enqueued_jobs only: PrincipalSyncConfigSnapshotWarmJob do
+          put api_v1_static_secret_url(id: ref.oid), params: body.to_json, headers: auth_headers
+        end
+        assert_response :ok
+
+        ref.reload
+        assert_equal source.id, ref.source.id
+        assert_equal [ rule.id ], ref.rules.pluck(:id)
+        assert_equal version, principal.reload.sync_config_cache_version
       end
 
       test "PUT does not retain omitted source fields" do

--- a/services/console/test/models/concerns/sync_config_cache_invalidation_test.rb
+++ b/services/console/test/models/concerns/sync_config_cache_invalidation_test.rb
@@ -1,0 +1,51 @@
+require "test_helper"
+
+class SyncConfigCacheInvalidationTest < ActiveSupport::TestCase
+  include ActiveJob::TestHelper
+
+  class TestRecord < ApplicationRecord
+    self.table_name = "roles"
+
+    include SyncConfigCacheInvalidation
+
+    attr_accessor :affected_principal_ids
+
+    private
+
+    def sync_config_affected_principal_ids
+      affected_principal_ids
+    end
+  end
+
+  def build_test_record(principal)
+    TestRecord.find(roles(:acme_infra).id).tap do |record|
+      record.affected_principal_ids = [ principal.id ]
+    end
+  end
+
+  test "unchanged save does not enqueue a snapshot warm job" do
+    principal = principals(:acme_channel)
+    record = build_test_record(principal)
+    version = principal.reload.sync_config_cache_version
+    clear_enqueued_jobs
+
+    assert_no_enqueued_jobs only: PrincipalSyncConfigSnapshotWarmJob do
+      record.save!
+    end
+
+    assert_equal version, principal.reload.sync_config_cache_version
+  end
+
+  test "a later touch does not hide an earlier invalidating save in the same transaction" do
+    principal = principals(:acme_channel)
+    record = build_test_record(principal)
+    version = principal.reload.sync_config_cache_version
+
+    TestRecord.transaction do
+      record.update!(name: "Updated")
+      record.touch
+    end
+
+    assert_equal version + 1, principal.reload.sync_config_cache_version
+  end
+end

--- a/services/console/test/models/concerns/sync_config_cache_invalidation_test.rb
+++ b/services/console/test/models/concerns/sync_config_cache_invalidation_test.rb
@@ -1,17 +1,12 @@
 require "test_helper"
 
 class SyncConfigCacheInvalidationTest < ActiveSupport::TestCase
-  include ActiveJob::TestHelper
-
-  test "unchanged save does not enqueue a snapshot warm job" do
+  test "unchanged save does not bump the sync config cache version" do
     principal = principals(:acme_channel)
     record = static_secrets(:github_token_inject)
     version = principal.reload.sync_config_cache_version
-    clear_enqueued_jobs
 
-    assert_no_enqueued_jobs only: PrincipalSyncConfigSnapshotWarmJob do
-      record.save!
-    end
+    record.save!
 
     assert_equal version, principal.reload.sync_config_cache_version
   end

--- a/services/console/test/models/concerns/sync_config_cache_invalidation_test.rb
+++ b/services/console/test/models/concerns/sync_config_cache_invalidation_test.rb
@@ -3,29 +3,9 @@ require "test_helper"
 class SyncConfigCacheInvalidationTest < ActiveSupport::TestCase
   include ActiveJob::TestHelper
 
-  class TestRecord < ApplicationRecord
-    self.table_name = "roles"
-
-    include SyncConfigCacheInvalidation
-
-    attr_accessor :affected_principal_ids
-
-    private
-
-    def sync_config_affected_principal_ids
-      affected_principal_ids
-    end
-  end
-
-  def build_test_record(principal)
-    TestRecord.find(roles(:acme_infra).id).tap do |record|
-      record.affected_principal_ids = [ principal.id ]
-    end
-  end
-
   test "unchanged save does not enqueue a snapshot warm job" do
     principal = principals(:acme_channel)
-    record = build_test_record(principal)
+    record = static_secrets(:github_token_inject)
     version = principal.reload.sync_config_cache_version
     clear_enqueued_jobs
 
@@ -38,11 +18,11 @@ class SyncConfigCacheInvalidationTest < ActiveSupport::TestCase
 
   test "a later touch does not hide an earlier invalidating save in the same transaction" do
     principal = principals(:acme_channel)
-    record = build_test_record(principal)
+    record = static_secrets(:github_token_inject)
     version = principal.reload.sync_config_cache_version
 
-    TestRecord.transaction do
-      record.update!(name: "Updated")
+    StaticSecret.transaction do
+      record.update!(description: "Updated")
       record.touch
     end
 

--- a/services/console/test/models/concerns/sync_config_replacement_test.rb
+++ b/services/console/test/models/concerns/sync_config_replacement_test.rb
@@ -1,0 +1,50 @@
+require "test_helper"
+
+class SyncConfigReplacementTest < ActiveSupport::TestCase
+  def source(role, secret_id:, region:)
+    SecretSource.new(
+      source_type: "aws_sm",
+      config: { "secret_id" => secret_id, "region" => region },
+      role: role,
+      role_kind: "credential_field"
+    )
+  end
+
+  def replacement_source(role, secret_id:, region:)
+    SecretSource.new(
+      source_type: "aws_sm",
+      config: { "region" => region, "secret_id" => secret_id },
+      role: role,
+      role_kind: "credential_field"
+    )
+  end
+
+  test "multi-source comparison ignores source and config key order" do
+    record = AwsAuthSecret.new(namespace: "acme")
+    record.sources = [
+      source("access_key_id", secret_id: "a", region: "z"),
+      source("secret_access_key", secret_id: "z", region: "a")
+    ]
+
+    replacement_sources = [
+      replacement_source("secret_access_key", secret_id: "z", region: "a"),
+      replacement_source("access_key_id", secret_id: "a", region: "z")
+    ]
+
+    assert SyncConfigReplacement.equivalent?(
+      record,
+      { namespace: "acme" },
+      { sources: replacement_sources, rules: [] }
+    )
+  end
+
+  test "comparison rejects missing replacement associations" do
+    record = AwsAuthSecret.new(namespace: "acme")
+
+    error = assert_raises(ArgumentError) do
+      SyncConfigReplacement.equivalent?(record, { namespace: "acme" }, { sources: [] })
+    end
+
+    assert_equal "missing replacement associations: rules", error.message
+  end
+end

--- a/services/console/test/models/concerns/sync_config_replacement_test.rb
+++ b/services/console/test/models/concerns/sync_config_replacement_test.rb
@@ -1,10 +1,6 @@
 require "test_helper"
 
 class SyncConfigReplacementTest < ActiveSupport::TestCase
-  class PolymorphicAwsAuthSecret < AwsAuthSecret
-    belongs_to :metadata_owner, polymorphic: true, optional: true
-  end
-
   def source(role, secret_id:, region:)
     SecretSource.new(
       source_type: "aws_sm",
@@ -39,26 +35,6 @@ class SyncConfigReplacementTest < ActiveSupport::TestCase
       record,
       { namespace: "acme" },
       { sources: replacement_sources, rules: [] }
-    )
-  end
-
-  test "comparison rejects missing replacement associations" do
-    record = AwsAuthSecret.new(namespace: "acme")
-
-    error = assert_raises(ArgumentError) do
-      SyncConfigReplacement.equivalent?(record, { namespace: "acme" }, { sources: [] })
-    end
-
-    assert_equal "missing replacement associations: rules", error.message
-  end
-
-  test "association coverage ignores polymorphic associations" do
-    record = PolymorphicAwsAuthSecret.new(namespace: "acme")
-
-    assert SyncConfigReplacement.equivalent?(
-      record,
-      { namespace: "acme" },
-      { sources: [], rules: [] }
     )
   end
 

--- a/services/console/test/models/concerns/sync_config_replacement_test.rb
+++ b/services/console/test/models/concerns/sync_config_replacement_test.rb
@@ -38,17 +38,29 @@ class SyncConfigReplacementTest < ActiveSupport::TestCase
     )
   end
 
-  test "secret source replacement fields are explicit" do
+  # A new column must be explicitly classified: either compared (add it to
+  # SYNC_CONFIG_REPLACEMENT_ATTRIBUTES) or excluded here. Without this check a
+  # forgotten column is invisible to the comparison on both sides, so a PUT
+  # changing only that column would be silently skipped as a no-op.
+  test "secret source replacement fields cover the schema" do
+    owner_foreign_keys = SecretSource::OWNER_ASSOCIATIONS.map do |association|
+      SecretSource.reflect_on_association(association).foreign_key.to_s
+    end
+
     assert_equal(
-      %w[config role role_kind secret source_type],
-      SyncConfigReplacement.association_attribute_names(SecretSource).sort
+      (SecretSource.attribute_names - %w[id created_at updated_at] - owner_foreign_keys).sort,
+      SecretSource::SYNC_CONFIG_REPLACEMENT_ATTRIBUTES.sort
     )
   end
 
-  test "request rule replacement fields are explicit" do
+  test "request rule replacement fields cover the schema" do
+    owner_foreign_keys = RequestRule::OWNER_ASSOCIATIONS.map do |association|
+      RequestRule.reflect_on_association(association).foreign_key.to_s
+    end
+
     assert_equal(
-      %w[cidr host http_methods paths position],
-      SyncConfigReplacement.association_attribute_names(RequestRule).sort
+      (RequestRule.attribute_names - %w[id created_at updated_at] - owner_foreign_keys).sort,
+      RequestRule::SYNC_CONFIG_REPLACEMENT_ATTRIBUTES.sort
     )
   end
 end

--- a/services/console/test/models/concerns/sync_config_replacement_test.rb
+++ b/services/console/test/models/concerns/sync_config_replacement_test.rb
@@ -1,6 +1,10 @@
 require "test_helper"
 
 class SyncConfigReplacementTest < ActiveSupport::TestCase
+  class PolymorphicAwsAuthSecret < AwsAuthSecret
+    belongs_to :metadata_owner, polymorphic: true, optional: true
+  end
+
   def source(role, secret_id:, region:)
     SecretSource.new(
       source_type: "aws_sm",
@@ -46,5 +50,29 @@ class SyncConfigReplacementTest < ActiveSupport::TestCase
     end
 
     assert_equal "missing replacement associations: rules", error.message
+  end
+
+  test "association coverage ignores polymorphic associations" do
+    record = PolymorphicAwsAuthSecret.new(namespace: "acme")
+
+    assert SyncConfigReplacement.equivalent?(
+      record,
+      { namespace: "acme" },
+      { sources: [], rules: [] }
+    )
+  end
+
+  test "secret source replacement fields are explicit" do
+    assert_equal(
+      %w[config role role_kind secret source_type],
+      SyncConfigReplacement.association_attribute_names(SecretSource).sort
+    )
+  end
+
+  test "request rule replacement fields are explicit" do
+    assert_equal(
+      %w[cidr host http_methods paths position],
+      SyncConfigReplacement.association_attribute_names(RequestRule).sort
+    )
   end
 end

--- a/services/console/test/models/static_secret_test.rb
+++ b/services/console/test/models/static_secret_test.rb
@@ -1,6 +1,8 @@
 require "test_helper"
 
 class StaticSecretTest < ActiveSupport::TestCase
+  include ActiveJob::TestHelper
+
   def valid_inject_attrs(overrides = {})
     {
       namespace: "acme",
@@ -165,6 +167,32 @@ class StaticSecretTest < ActiveSupport::TestCase
     r1 = RequestRule.create!(host: "api.github.com", static_secret: ref)
     r2 = RequestRule.create!(host: "api.example.com", static_secret: ref, position: 1)
     assert_equal [ r1, r2 ], ref.reload.rules.to_a
+  end
+
+  test "unchanged save does not enqueue a snapshot warm job" do
+    ref = static_secrets(:github_token_inject)
+    principal = principals(:acme_channel)
+    version = principal.reload.sync_config_cache_version
+    clear_enqueued_jobs
+
+    assert_no_enqueued_jobs only: PrincipalSyncConfigSnapshotWarmJob do
+      ref.save!
+    end
+
+    assert_equal version, principal.reload.sync_config_cache_version
+  end
+
+  test "a later touch does not hide an earlier invalidating save in the same transaction" do
+    ref = static_secrets(:github_token_inject)
+    principal = principals(:acme_channel)
+    version = principal.reload.sync_config_cache_version
+
+    StaticSecret.transaction do
+      ref.update!(description: "updated")
+      ref.touch
+    end
+
+    assert_equal version + 1, principal.reload.sync_config_cache_version
   end
 
   test "declares ssr as its oid prefix" do

--- a/services/console/test/models/static_secret_test.rb
+++ b/services/console/test/models/static_secret_test.rb
@@ -1,8 +1,6 @@
 require "test_helper"
 
 class StaticSecretTest < ActiveSupport::TestCase
-  include ActiveJob::TestHelper
-
   def valid_inject_attrs(overrides = {})
     {
       namespace: "acme",
@@ -167,32 +165,6 @@ class StaticSecretTest < ActiveSupport::TestCase
     r1 = RequestRule.create!(host: "api.github.com", static_secret: ref)
     r2 = RequestRule.create!(host: "api.example.com", static_secret: ref, position: 1)
     assert_equal [ r1, r2 ], ref.reload.rules.to_a
-  end
-
-  test "unchanged save does not enqueue a snapshot warm job" do
-    ref = static_secrets(:github_token_inject)
-    principal = principals(:acme_channel)
-    version = principal.reload.sync_config_cache_version
-    clear_enqueued_jobs
-
-    assert_no_enqueued_jobs only: PrincipalSyncConfigSnapshotWarmJob do
-      ref.save!
-    end
-
-    assert_equal version, principal.reload.sync_config_cache_version
-  end
-
-  test "a later touch does not hide an earlier invalidating save in the same transaction" do
-    ref = static_secrets(:github_token_inject)
-    principal = principals(:acme_channel)
-    version = principal.reload.sync_config_cache_version
-
-    StaticSecret.transaction do
-      ref.update!(description: "updated")
-      ref.touch
-    end
-
-    assert_equal version + 1, principal.reload.sync_config_cache_version
   end
 
   test "declares ssr as its oid prefix" do


### PR DESCRIPTION
Skips full replacement writes when incoming secret documents are semantically unchanged, preserving nested records and avoiding redundant sync snapshot warm jobs. Centralizes replacement comparison across secret types, normalizes GCP ID token headers at assignment time, and tracks cache invalidation across multi-save transactions. Adds coverage for unchanged PUTs across all secret APIs and transaction-level invalidation.