### PR TITLE
fix: warm sync config snapshots on demand

### DIFF
--- a/services/console/app/models/broker_credential.rb
+++ b/services/console/app/models/broker_credential.rb
@@ -234,11 +234,11 @@ class BrokerCredential < ApplicationRecord
   end
 
   def bump_referencing_principal_sync_config_versions
-    ids = SecretSource.referencing_broker_credential(self).flat_map do |source|
+    scopes = SecretSource.referencing_broker_credential(self).filter_map do |source|
       owner = source.sync_config_owner
-      owner ? Principal.effective_grantee_ids_for_grantable(owner) : []
+      Principal.effective_grantees_for_grantable(owner) if owner
     end
-    Principal.bump_sync_config_cache_versions(ids)
+    Principal.bump_sync_config_cache_versions(Principal.combine_scopes(scopes))
   end
 
   def labels_is_a_hash

--- a/services/console/app/models/concerns/sync_config_cache_invalidation.rb
+++ b/services/console/app/models/concerns/sync_config_cache_invalidation.rb
@@ -8,13 +8,13 @@ module SyncConfigCacheInvalidation
   private
 
   def bump_sync_config_cache_for_record
-    Principal.bump_sync_config_cache_versions(sync_config_affected_principal_ids)
+    Principal.bump_sync_config_cache_versions(sync_config_affected_principals)
   end
 
   # Grantable secret models intentionally use broad invalidation. Admin writes to
   # these rows are rare compared with proxy sync polling, and over-invalidation is
   # safer than maintaining a per-model list of config-affecting columns.
-  def sync_config_affected_principal_ids
-    Principal.effective_grantee_ids_for_grantable(self)
+  def sync_config_affected_principals
+    Principal.effective_grantees_for_grantable(self)
   end
 end

--- a/services/console/app/models/concerns/sync_config_owner_invalidation.rb
+++ b/services/console/app/models/concerns/sync_config_owner_invalidation.rb
@@ -15,8 +15,8 @@ module SyncConfigOwnerInvalidation
 
   private
 
-  def sync_config_affected_principal_ids
+  def sync_config_affected_principals
     owner = sync_config_owner
-    owner ? Principal.effective_grantee_ids_for_grantable(owner) : []
+    owner ? Principal.effective_grantees_for_grantable(owner) : Principal.none
   end
 end

--- a/services/console/app/models/grant.rb
+++ b/services/console/app/models/grant.rb
@@ -50,11 +50,11 @@ class Grant < ApplicationRecord
 
   private
 
-  def sync_config_affected_principal_ids
-    ids = []
-    ids << principal_id if principal_id.present?
-    ids += PrincipalRole.where(role_id: role_id).pluck(:principal_id) if role_id.present?
-    ids
+  def sync_config_affected_principals
+    return Principal.where(id: principal_id) if principal_id.present?
+    return Principal.where(id: PrincipalRole.where(role_id: role_id).select(:principal_id)) if role_id.present?
+
+    Principal.none
   end
 
   # A grant left without an explicit priority defaults by grantee: direct grants

--- a/services/console/app/models/principal.rb
+++ b/services/console/app/models/principal.rb
@@ -151,12 +151,11 @@ class Principal < ApplicationRecord
     end
   end
 
-  def self.bump_sync_config_cache_versions(ids)
-    ids = Array(ids).compact.uniq
-    return if ids.empty?
+  def self.bump_sync_config_cache_versions(targets)
+    scope = sync_config_cache_bump_scope(targets)
+    return unless scope
 
-    where(id: ids).update_all("sync_config_cache_version = sync_config_cache_version + 1")
-    enqueue_sync_config_snapshot_warm(ids)
+    scope.update_all("sync_config_cache_version = sync_config_cache_version + 1")
   end
 
   def self.enqueue_sync_config_snapshot_warm(ids)
@@ -165,13 +164,20 @@ class Principal < ApplicationRecord
     end
   end
 
-  def self.effective_grantee_ids_for_grantable(grantable)
+  def self.effective_grantees_for_grantable(grantable)
     association = grantable.model_name.singular.to_sym
     grants = Grant.where(association => grantable)
-    direct_ids = grants.where.not(principal_id: nil).pluck(:principal_id)
-    role_ids = grants.where.not(role_id: nil).pluck(:role_id)
-    role_principal_ids = role_ids.empty? ? [] : PrincipalRole.where(role_id: role_ids).pluck(:principal_id)
-    direct_ids + role_principal_ids
+    direct = where(id: grants.where.not(principal_id: nil).select(:principal_id))
+    role_members = where(
+      id: PrincipalRole.where(
+        role_id: grants.where.not(role_id: nil).select(:role_id)
+      ).select(:principal_id)
+    )
+    direct.or(role_members)
+  end
+
+  def self.combine_scopes(scopes)
+    scopes.compact.reduce(none) { |combined, scope| combined.or(scope) }
   end
 
   # Deep-walk a config payload and blank out the inline value of every
@@ -251,6 +257,17 @@ class Principal < ApplicationRecord
       .reject(&:blank?)
       .uniq
   end
+
+  def self.sync_config_cache_bump_scope(targets)
+    case targets
+    when ActiveRecord::Relation
+      targets
+    else
+      ids = Array(targets).compact.uniq
+      where(id: ids) if ids.any?
+    end
+  end
+  private_class_method :sync_config_cache_bump_scope
 
   # The single place secret order is decided for every sync array. iron-proxy
   # applies matching transforms in array order and the LAST one wins, so we emit

--- a/services/console/app/models/principal_role.rb
+++ b/services/console/app/models/principal_role.rb
@@ -11,8 +11,8 @@ class PrincipalRole < ApplicationRecord
 
   private
 
-  def sync_config_affected_principal_ids
-    [ principal_id ]
+  def sync_config_affected_principals
+    Principal.where(id: principal_id)
   end
 
   # A principal may only hold roles from its own namespace; roles are scoped to

--- a/services/console/app/models/principal_sync_config_snapshot.rb
+++ b/services/console/app/models/principal_sync_config_snapshot.rb
@@ -76,9 +76,10 @@ class PrincipalSyncConfigSnapshot < ApplicationRecord
   end
 
   # Returns the freshest usable snapshot, stale-while-revalidate style. Config
-  # invalidations enqueue a background rebuild, so polling requests serve stale
-  # snapshots immediately instead of using request threads and DB connections to
-  # rebuild the effective config.
+  # invalidations only bump the principal cache version; polling requests serve
+  # stale snapshots immediately and enqueue the background rebuild on demand
+  # instead of using request threads and DB connections to rebuild the effective
+  # config.
   #
   # Serving a stale snapshot is safe: iron-proxy treats the config hash as an
   # ETag and re-applies on its next 5s poll once the rebuild lands. Only a

--- a/services/console/app/models/slack_channel_permission.rb
+++ b/services/console/app/models/slack_channel_permission.rb
@@ -42,7 +42,7 @@ class SlackChannelPermission < ApplicationRecord
   def self.replace_for!(grantee, permission_rows)
     association = grantee.slack_channel_permissions
     rows_by_channel = normalized_permission_rows(permission_rows)
-    affected_principal_ids = principal_ids_for_grantee(grantee)
+    affected_principals = principals_for_grantee(grantee)
 
     transaction do
       association.delete_all
@@ -54,18 +54,18 @@ class SlackChannelPermission < ApplicationRecord
 
       now = Time.current
       insert_all!(records.map { |record| bulk_insert_attributes(record, now) }) if records.any?
-      Principal.bump_sync_config_cache_versions(affected_principal_ids)
+      Principal.bump_sync_config_cache_versions(affected_principals)
     end
   ensure
     grantee&.reset_slack_channel_permissions_cache! if grantee.respond_to?(:reset_slack_channel_permissions_cache!)
     association&.reset
   end
 
-  def self.principal_ids_for_grantee(grantee)
+  def self.principals_for_grantee(grantee)
     case grantee
-    when Principal then [ grantee.id ]
-    when Role then PrincipalRole.where(role_id: grantee.id).pluck(:principal_id)
-    else []
+    when Principal then Principal.where(id: grantee.id)
+    when Role then Principal.where(id: PrincipalRole.where(role_id: grantee.id).select(:principal_id))
+    else Principal.none
     end
   end
 
@@ -117,7 +117,7 @@ class SlackChannelPermission < ApplicationRecord
     errors.add(:base, "must reference exactly one of principal, role")
   end
 
-  def sync_config_affected_principal_ids
-    self.class.principal_ids_for_grantee(principal || role)
+  def sync_config_affected_principals
+    self.class.principals_for_grantee(principal || role)
   end
 end

--- a/services/console/test/controllers/api/v1/proxy_sync_controller_test.rb
+++ b/services/console/test/controllers/api/v1/proxy_sync_controller_test.rb
@@ -122,11 +122,17 @@ class ProxySyncControllerTest < ActionDispatch::IntegrationTest
     assert_response :ok
     original_version = @proxy.principal.reload.sync_config_cache_version
 
-    perform_enqueued_jobs(only: PrincipalSyncConfigSnapshotWarmJob) do
-      @replace.source.update!(secret: "rotated-db-pass")
-    end
+    @replace.source.update!(secret: "rotated-db-pass")
 
     assert_operator @proxy.principal.reload.sync_config_cache_version, :>, original_version
+    assert_no_difference -> { PrincipalSyncConfigSnapshot.count } do
+      assert_enqueued_with(job: PrincipalSyncConfigSnapshotWarmJob, args: [ @proxy.principal.id ]) do
+        post api_v1_proxy_sync_url, params: {}.to_json, headers: auth_headers
+      end
+    end
+    assert_response :ok
+
+    perform_enqueued_jobs(only: PrincipalSyncConfigSnapshotWarmJob)
     assert_no_difference -> { PrincipalSyncConfigSnapshot.count } do
       post api_v1_proxy_sync_url, params: {}.to_json, headers: auth_headers
     end
@@ -250,11 +256,17 @@ class ProxySyncControllerTest < ActionDispatch::IntegrationTest
     assert_equal secret.audience, transform.dig("config", "audience")
 
     original_version = @proxy.principal.reload.sync_config_cache_version
-    perform_enqueued_jobs(only: PrincipalSyncConfigSnapshotWarmJob) do
-      secret.update!(audience: "https://updated-service-abc123-uc.a.run.app")
-    end
+    secret.update!(audience: "https://updated-service-abc123-uc.a.run.app")
 
     assert_operator @proxy.principal.reload.sync_config_cache_version, :>, original_version
+    assert_no_difference -> { PrincipalSyncConfigSnapshot.count } do
+      assert_enqueued_with(job: PrincipalSyncConfigSnapshotWarmJob, args: [ @proxy.principal.id ]) do
+        post api_v1_proxy_sync_url, params: { config_hash: original_hash }.to_json, headers: auth_headers
+      end
+    end
+    assert_response :ok
+
+    perform_enqueued_jobs(only: PrincipalSyncConfigSnapshotWarmJob)
     assert_no_difference -> { PrincipalSyncConfigSnapshot.count } do
       post api_v1_proxy_sync_url, params: { config_hash: original_hash }.to_json, headers: auth_headers
     end
@@ -370,9 +382,13 @@ class ProxySyncControllerTest < ActionDispatch::IntegrationTest
     end
 
     # Promote the role grant above the direct grants and it now sorts last.
-    perform_enqueued_jobs(only: PrincipalSyncConfigSnapshotWarmJob) do
-      grants(:acme_infra_prod_api_key).update!(priority: 500)
+    grants(:acme_infra_prod_api_key).update!(priority: 500)
+    assert_enqueued_with(job: PrincipalSyncConfigSnapshotWarmJob, args: [ @proxy.principal.id ]) do
+      post api_v1_proxy_sync_url, params: {}.to_json, headers: auth_headers
     end
+    assert_response :ok
+
+    perform_enqueued_jobs(only: PrincipalSyncConfigSnapshotWarmJob)
     post api_v1_proxy_sync_url, params: {}.to_json, headers: auth_headers
     assert_response :ok
     bumped = json_body.fetch("secrets").map { |s| s.dig("source", "var") || s.dig("source", "type") }
@@ -422,11 +438,15 @@ class ProxySyncControllerTest < ActionDispatch::IntegrationTest
     assert_response :ok
     original_version = @proxy.principal.reload.sync_config_cache_version
 
-    perform_enqueued_jobs(only: PrincipalSyncConfigSnapshotWarmJob) do
-      credential.update!(access_token: "token-2", expires_at: 2.hours.from_now, last_refresh: Time.current)
-    end
+    credential.update!(access_token: "token-2", expires_at: 2.hours.from_now, last_refresh: Time.current)
 
     assert_operator @proxy.principal.reload.sync_config_cache_version, :>, original_version
+    assert_enqueued_with(job: PrincipalSyncConfigSnapshotWarmJob, args: [ @proxy.principal.id ]) do
+      post api_v1_proxy_sync_url, params: {}.to_json, headers: auth_headers
+    end
+    assert_response :ok
+
+    perform_enqueued_jobs(only: PrincipalSyncConfigSnapshotWarmJob)
     post api_v1_proxy_sync_url, params: {}.to_json, headers: auth_headers
     assert_response :ok
 

--- a/services/console/test/controllers/console/roles_controller_test.rb
+++ b/services/console/test/controllers/console/roles_controller_test.rb
@@ -136,13 +136,14 @@ module Console
       assert_equal "C0123456789", permission.reload.channel_id
     end
 
-    test "update_slack_channel_permissions batches warm jobs" do
+    test "update_slack_channel_permissions bumps versions without warm jobs" do
       role = roles(:acme_infra)
       first = role.slack_channel_permissions.create!(channel_id: "C0123456789", upload_enabled: true)
       second = role.slack_channel_permissions.create!(channel_id: "G9876543210", download_enabled: true)
+      versions = Principal.where(id: role.principal_ids).pluck(:id, :sync_config_cache_version).to_h
       clear_enqueued_jobs
 
-      assert_enqueued_jobs role.principal_ids.uniq.size, only: PrincipalSyncConfigSnapshotWarmJob do
+      assert_no_enqueued_jobs only: PrincipalSyncConfigSnapshotWarmJob do
         patch slack_channel_permissions_console_role_url(role.oid),
               params: {
                 role: {
@@ -170,6 +171,9 @@ module Console
 
       assert_redirected_to console_role_path(role.oid)
       assert_equal %w[C0123456789 C2222222222], role.slack_channel_permissions.reload.pluck(:channel_id).sort
+      Principal.where(id: role.principal_ids).find_each do |principal|
+        assert_equal versions.fetch(principal.id) + 1, principal.sync_config_cache_version
+      end
     end
 
     test "update_slack_channel_permissions skips unchanged submissions" do

--- a/services/console/test/models/principal_sync_config_snapshot_test.rb
+++ b/services/console/test/models/principal_sync_config_snapshot_test.rb
@@ -534,10 +534,40 @@ class PrincipalSyncConfigSnapshotTest < ActiveSupport::TestCase
     end
   end
 
-  test "cache version bump enqueues a snapshot warm job" do
-    assert_enqueued_with(job: PrincipalSyncConfigSnapshotWarmJob, args: [ @principal.id ]) do
+  test "cache version bump does not enqueue a snapshot warm job" do
+    version = @principal.sync_config_cache_version
+
+    assert_no_enqueued_jobs only: PrincipalSyncConfigSnapshotWarmJob do
       Principal.bump_sync_config_cache_versions(@principal.id)
     end
+
+    assert_equal version + 1, @principal.reload.sync_config_cache_version
+  end
+
+  test "relation cache version bump updates direct and role grantees without warm jobs" do
+    secret = static_secrets(:acme_prod_api_key)
+    Grant.create!(
+      principal: principals(:acme_user_bob),
+      static_secret: secret,
+      created_by: users(:acme_admin)
+    )
+    affected = [
+      principals(:acme_channel),
+      principals(:acme_user_alice),
+      principals(:acme_user_bob)
+    ]
+    unaffected = principals(:globex_user)
+    versions = Principal.where(id: (affected + [ unaffected ]).map(&:id)).pluck(:id, :sync_config_cache_version).to_h
+    clear_enqueued_jobs
+
+    assert_no_enqueued_jobs only: PrincipalSyncConfigSnapshotWarmJob do
+      Principal.bump_sync_config_cache_versions(Principal.effective_grantees_for_grantable(secret))
+    end
+
+    affected.each do |principal|
+      assert_equal versions.fetch(principal.id) + 1, principal.reload.sync_config_cache_version
+    end
+    assert_equal versions.fetch(unaffected.id), unaffected.reload.sync_config_cache_version
   end
 
   test "fetch_for serves the previous-version snapshot after a cache version bump" do

--- a/services/console/test/models/proxy_test.rb
+++ b/services/console/test/models/proxy_test.rb
@@ -138,20 +138,28 @@ class ProxyTest < ActiveSupport::TestCase
   test "config_hash changes when a pg_dsn grant is added" do
     proxy = Proxy.create!(name: "pg-hashing", principal: principals(:globex_user))
     before = proxy.config_hash
-    perform_enqueued_jobs(only: PrincipalSyncConfigSnapshotWarmJob) do
-      Grant.create!(principal: proxy.principal, pg_dsn_secret: pg_dsn_secrets(:acme_analytics_pg),
-                    created_by: users(:globex_admin))
+    Grant.create!(principal: proxy.principal, pg_dsn_secret: pg_dsn_secrets(:acme_analytics_pg),
+                  created_by: users(:globex_admin))
+
+    assert_enqueued_with(job: PrincipalSyncConfigSnapshotWarmJob, args: [ proxy.principal.id ]) do
+      assert_equal before, proxy.reload.config_hash
     end
+
+    perform_enqueued_jobs(only: PrincipalSyncConfigSnapshotWarmJob)
     refute_equal before, proxy.reload.config_hash
   end
 
   test "config_hash changes when a transform grant is added" do
     proxy = Proxy.create!(name: "hashing", principal: principals(:globex_user))
     before = proxy.config_hash
-    perform_enqueued_jobs(only: PrincipalSyncConfigSnapshotWarmJob) do
-      Grant.create!(principal: proxy.principal, gcp_auth_secret: gcp_auth_secrets(:acme_bigquery),
-                    created_by: users(:globex_admin))
+    Grant.create!(principal: proxy.principal, gcp_auth_secret: gcp_auth_secrets(:acme_bigquery),
+                  created_by: users(:globex_admin))
+
+    assert_enqueued_with(job: PrincipalSyncConfigSnapshotWarmJob, args: [ proxy.principal.id ]) do
+      assert_equal before, proxy.reload.config_hash
     end
+
+    perform_enqueued_jobs(only: PrincipalSyncConfigSnapshotWarmJob)
     refute_equal before, proxy.reload.config_hash
   end
 
@@ -159,11 +167,15 @@ class ProxyTest < ActiveSupport::TestCase
     role = Role.create!(namespace: "acme", foreign_id: "extra", created_by: users(:acme_admin))
     proxy = proxies(:acme_proxy)
     before = proxy.config_hash
-    perform_enqueued_jobs(only: PrincipalSyncConfigSnapshotWarmJob) do
-      Grant.create!(role: role, gcp_auth_secret: gcp_auth_secrets(:acme_bigquery),
-                    created_by: users(:acme_admin))
-      principals(:acme_channel).principal_roles.create!(role: role)
+    Grant.create!(role: role, gcp_auth_secret: gcp_auth_secrets(:acme_bigquery),
+                  created_by: users(:acme_admin))
+    principals(:acme_channel).principal_roles.create!(role: role)
+
+    assert_enqueued_with(job: PrincipalSyncConfigSnapshotWarmJob, args: [ proxy.principal.id ]) do
+      assert_equal before, proxy.reload.config_hash
     end
+
+    perform_enqueued_jobs(only: PrincipalSyncConfigSnapshotWarmJob)
     refute_equal before, proxy.reload.config_hash
   end
 end


### PR DESCRIPTION
Removes invalidation-time sync config warm job fanout so broad secret or role changes only bump affected principal cache versions. Broad invalidation paths now use relation-based principal scopes where practical, and active proxy syncs continue to enqueue snapshot warming on demand when they encounter stale snapshots.