### PR TITLE
feat: thread node steering into sandbox pods

### DIFF
--- a/contrib/chart/templates/apirs.yaml
+++ b/contrib/chart/templates/apirs.yaml
@@ -330,6 +330,21 @@ spec:
             - name: SESSION_SANDBOX_IMAGE_PULL_SECRETS
               value: "{{- range $index, $secret := .Values.global.imagePullSecrets }}{{- if $index }},{{ end -}}{{ $secret.name }}{{- end }}"
 {{- end }}
+            # Node steering for sandbox pods. Passed to the control plane rather
+            # than templated onto a pod: api-rs creates sandbox pods at runtime,
+            # so nothing this chart renders can reach them.
+{{- with .Values.sandbox.nodeSelector }}
+            - name: SESSION_SANDBOX_NODE_SELECTOR
+              value: {{ toJson . | quote }}
+{{- end }}
+{{- with .Values.sandbox.tolerations }}
+            - name: SESSION_SANDBOX_TOLERATIONS
+              value: {{ toJson . | quote }}
+{{- end }}
+{{- with .Values.sandbox.runtimeClassName }}
+            - name: SESSION_SANDBOX_RUNTIME_CLASS_NAME
+              value: {{ . | quote }}
+{{- end }}
             # Sandboxes call back into this control plane via the in-cluster Service.
             - name: SESSION_SANDBOX_CENTAUR_API_URL
               value: {{ printf "http://%s:%v" $apiRsName .Values.apiRs.port | quote }}

--- a/contrib/chart/values.schema.json
+++ b/contrib/chart/values.schema.json
@@ -164,6 +164,8 @@
     "sandbox": {
       "type": "object",
       "properties": {
+        "nodeSelector": { "type": "object" },
+        "tolerations": { "type": "array" },
         "runtimeClassName": { "type": "string" },
         "reposPath": { "type": "string" },
         "resources": { "type": "object" }

--- a/contrib/chart/values.yaml
+++ b/contrib/chart/values.yaml
@@ -241,6 +241,24 @@ sandbox:
     repository: centaur-agent
     tag: latest
     pullPolicy: Always
+  # Node steering for sandbox pods. These reach the pod through the control
+  # plane, not through this chart's templates: sandbox pods are created at
+  # runtime by api-rs, so a Helm or kustomize patch cannot touch them. They are
+  # passed through to `Sandbox.spec.podTemplate.spec`, which already accepts all
+  # three.
+  #
+  # Set these to keep sandboxes on a dedicated node pool — commonly a tainted,
+  # sandbox-only pool, so untrusted agent workloads never share a node with the
+  # control plane, and so a preemption/spot reclaim cannot take out a live
+  # session. Empty leaves placement to the default scheduler.
+  nodeSelector: {}
+  #   workload: centaur-sandbox
+  tolerations: []
+  # - key: centaur.ai/sandbox
+  #   operator: Exists
+  #   effect: NoSchedule
+  # RuntimeClass for sandbox pods, e.g. a gVisor class for stronger isolation of
+  # untrusted agent code.
   runtimeClassName: ""
   reposPath: ""
   # How the in-sandbox harness authenticates upstream. Single source of truth:

--- a/services/api-rs/crates/centaur-api-server/src/args.rs
+++ b/services/api-rs/crates/centaur-api-server/src/args.rs
@@ -651,6 +651,35 @@ struct SandboxArgs {
     /// `OTEL_SERVICE_NAME`, NO_PROXY extras) into every codex sandbox.
     #[arg(long = "session-sandbox-extra-env", env = "SESSION_SANDBOX_EXTRA_ENV")]
     extra_env_json: Option<String>,
+    /// Node steering for sandbox pods, as a JSON object of label key/value
+    /// pairs. The chart renders `sandbox.nodeSelector` into this. Sandbox pods
+    /// are created at runtime rather than by the chart, so a Helm or kustomize
+    /// patch cannot reach them — this is the only path.
+    ///
+    /// Unlike `SESSION_SANDBOX_EXTRA_ENV`, malformed input here is a hard error
+    /// rather than a warning: silently dropping node steering would place
+    /// sandboxes on whatever the default scheduler picks, which is exactly the
+    /// outcome an operator setting it is trying to prevent.
+    #[arg(
+        long = "session-sandbox-node-selector",
+        env = "SESSION_SANDBOX_NODE_SELECTOR"
+    )]
+    node_selector_json: Option<String>,
+    /// Sandbox pod tolerations as a JSON array in the Kubernetes toleration
+    /// shape, so sandboxes can run on a tainted, sandbox-only node pool. The
+    /// chart renders `sandbox.tolerations` into this.
+    #[arg(
+        long = "session-sandbox-tolerations",
+        env = "SESSION_SANDBOX_TOLERATIONS"
+    )]
+    tolerations_json: Option<String>,
+    /// `runtimeClassName` for sandbox pods, e.g. a gVisor class. The chart
+    /// renders `sandbox.runtimeClassName` into this.
+    #[arg(
+        long = "session-sandbox-runtime-class-name",
+        env = "SESSION_SANDBOX_RUNTIME_CLASS_NAME"
+    )]
+    runtime_class_name: Option<String>,
     #[command(flatten)]
     tools: ToolDiscoveryArgs,
     #[command(flatten)]
@@ -1061,6 +1090,50 @@ impl SandboxArgs {
         Ok(envs)
     }
 
+    /// `SESSION_SANDBOX_NODE_SELECTOR` parsed as a JSON object of label
+    /// key/value pairs. Empty or unset yields no selector.
+    ///
+    /// Invalid input fails startup rather than warning, unlike
+    /// [`Self::sandbox_extra_env`]: an ignored node selector silently schedules
+    /// sandboxes wherever the default scheduler chooses, and an operator setting
+    /// this is trying to prevent exactly that.
+    fn node_selector(&self) -> Result<BTreeMap<String, String>, ServerError> {
+        let Some(raw) = self
+            .node_selector_json
+            .as_deref()
+            .map(str::trim)
+            .filter(|raw| !raw.is_empty())
+        else {
+            return Ok(BTreeMap::new());
+        };
+        serde_json::from_str::<BTreeMap<String, String>>(raw).map_err(|error| {
+            ServerError::UnsupportedConfig(format!(
+                "SESSION_SANDBOX_NODE_SELECTOR must be a JSON object of string \
+                 key/value pairs: {error}"
+            ))
+        })
+    }
+
+    /// `SESSION_SANDBOX_TOLERATIONS` parsed as a JSON array of tolerations.
+    /// Shape is validated when the Sandbox CR is deserialized; this only
+    /// enforces that the value is a JSON array, for the same fail-fast reason as
+    /// [`Self::node_selector`].
+    fn tolerations(&self) -> Result<Vec<serde_json::Value>, ServerError> {
+        let Some(raw) = self
+            .tolerations_json
+            .as_deref()
+            .map(str::trim)
+            .filter(|raw| !raw.is_empty())
+        else {
+            return Ok(Vec::new());
+        };
+        serde_json::from_str::<Vec<serde_json::Value>>(raw).map_err(|error| {
+            ServerError::UnsupportedConfig(format!(
+                "SESSION_SANDBOX_TOLERATIONS must be a JSON array of tolerations: {error}"
+            ))
+        })
+    }
+
     /// `SESSION_SANDBOX_EXTRA_ENV` parsed as a JSON list of `{"name","value"}`
     /// objects. Invalid JSON or shapes are ignored (with a warning) rather than
     /// failing startup, matching the Python control plane's behavior.
@@ -1375,6 +1448,14 @@ impl TryFrom<&SandboxArgs> for AgentSandboxConfig {
             .filter(|secret| !secret.is_empty())
             .map(str::to_owned)
             .collect();
+        config.node_selector = args.node_selector()?;
+        config.tolerations = args.tolerations()?;
+        config.runtime_class_name = args
+            .runtime_class_name
+            .as_deref()
+            .map(str::trim)
+            .filter(|name| !name.is_empty())
+            .map(str::to_owned);
         config.ready_timeout = Duration::from_secs(args.ready_timeout_secs);
         config.iron_proxy = args.iron_proxy.to_config()?;
         if let Some(proxy) = config.iron_proxy.as_mut() {
@@ -2687,6 +2768,68 @@ mod tests {
         .unwrap();
 
         assert!(args.sandbox.sandbox_extra_env().is_empty());
+    }
+
+    #[test]
+    fn node_steering_parses_from_json() {
+        let args = Args::try_parse_from([
+            "centaur-api-server",
+            "--database-url",
+            "postgres://postgres:postgres@localhost/centaur",
+            "--session-sandbox-node-selector",
+            r#"{"workload":"centaur-sandbox"}"#,
+            "--session-sandbox-tolerations",
+            r#"[{"key":"example.com/sandbox","operator":"Exists","effect":"NoSchedule"}]"#,
+            "--session-sandbox-runtime-class-name",
+            "gvisor",
+        ])
+        .unwrap();
+
+        assert_eq!(
+            args.sandbox.node_selector().unwrap().get("workload"),
+            Some(&"centaur-sandbox".to_owned())
+        );
+        assert_eq!(args.sandbox.tolerations().unwrap().len(), 1);
+        assert_eq!(args.sandbox.runtime_class_name.as_deref(), Some("gvisor"));
+    }
+
+    #[test]
+    fn node_steering_is_empty_when_unset() {
+        let args = Args::try_parse_from([
+            "centaur-api-server",
+            "--database-url",
+            "postgres://postgres:postgres@localhost/centaur",
+        ])
+        .unwrap();
+
+        assert!(args.sandbox.node_selector().unwrap().is_empty());
+        assert!(args.sandbox.tolerations().unwrap().is_empty());
+    }
+
+    /// Unlike `SESSION_SANDBOX_EXTRA_ENV`, bad node steering fails startup:
+    /// silently ignoring it would schedule sandboxes wherever the default
+    /// scheduler chooses, which is what setting it is meant to prevent.
+    #[test]
+    fn invalid_node_steering_is_rejected() {
+        let args = Args::try_parse_from([
+            "centaur-api-server",
+            "--database-url",
+            "postgres://postgres:postgres@localhost/centaur",
+            "--session-sandbox-node-selector",
+            "not-json",
+        ])
+        .unwrap();
+        assert!(args.sandbox.node_selector().is_err());
+
+        let args = Args::try_parse_from([
+            "centaur-api-server",
+            "--database-url",
+            "postgres://postgres:postgres@localhost/centaur",
+            "--session-sandbox-tolerations",
+            r#"{"not":"an array"}"#,
+        ])
+        .unwrap();
+        assert!(args.sandbox.tolerations().is_err());
     }
 
     #[test]

--- a/services/api-rs/crates/centaur-sandbox-agent-k8s/src/lib.rs
+++ b/services/api-rs/crates/centaur-sandbox-agent-k8s/src/lib.rs
@@ -59,6 +59,18 @@ pub struct AgentSandboxConfig {
     pub annotations: BTreeMap<String, String>,
     pub image_pull_policy: Option<String>,
     pub image_pull_secrets: Vec<String>,
+    /// Node steering for every sandbox pod. `Sandbox.spec.podTemplate.spec`
+    /// already accepts `nodeSelector`, `tolerations`, and `runtimeClassName`, so
+    /// these pass straight through to the CR. Without them a sandbox lands
+    /// wherever the default scheduler puts it, which is wrong for deployments
+    /// that keep sandboxes on a dedicated (usually tainted) node pool, and
+    /// `runtimeClassName` is the only way to ask for a stronger sandbox runtime
+    /// such as gVisor.
+    pub node_selector: BTreeMap<String, String>,
+    /// Tolerations as raw JSON, matching the CRD's toleration shape. Invalid
+    /// entries surface as an `InvalidSpec` error when the CR is deserialized.
+    pub tolerations: Vec<Value>,
+    pub runtime_class_name: Option<String>,
     pub state_volume: Option<StateVolumeConfig>,
     pub iron_proxy: Option<IronProxyConfig>,
     pub iron_control: Option<IronControlSettings>,
@@ -106,6 +118,9 @@ impl AgentSandboxConfig {
             annotations: BTreeMap::new(),
             image_pull_policy: None,
             image_pull_secrets: Vec::new(),
+            node_selector: BTreeMap::new(),
+            tolerations: Vec::new(),
+            runtime_class_name: None,
             state_volume: None,
             iron_proxy: None,
             iron_control: None,
@@ -721,6 +736,26 @@ fn build_agent_sandbox(
                 .collect::<Vec<_>>()
         }),
     );
+    // Node steering, passed through to the CRD's own podTemplate fields.
+    insert_optional(
+        &mut pod_spec,
+        "nodeSelector",
+        (!config.node_selector.is_empty()).then(|| config.node_selector.clone()),
+    );
+    insert_optional(
+        &mut pod_spec,
+        "tolerations",
+        (!config.tolerations.is_empty()).then(|| config.tolerations.clone()),
+    );
+    insert_optional(
+        &mut pod_spec,
+        "runtimeClassName",
+        config
+            .runtime_class_name
+            .as_deref()
+            .map(str::trim)
+            .filter(|name| !name.is_empty()),
+    );
 
     let mut agent_spec = json!({
         "replicas": 1,
@@ -918,6 +953,53 @@ mod tests {
         assert_eq!(container.stdin, Some(true));
         assert_eq!(container.volume_mounts.as_ref().unwrap().len(), 2);
         assert!(container.resources.as_ref().unwrap().limits.is_some());
+    }
+
+    #[test]
+    fn node_steering_reaches_the_sandbox_pod_template() {
+        let spec = SandboxSpec::new("centaur-agent:latest");
+        let mut config = AgentSandboxConfig::new("centaur");
+        config.node_selector =
+            BTreeMap::from([("workload".to_owned(), "centaur-sandbox".to_owned())]);
+        config.tolerations = vec![json!({
+            "key": "example.com/sandbox",
+            "operator": "Exists",
+            "effect": "NoSchedule",
+        })];
+        config.runtime_class_name = Some("gvisor".to_owned());
+
+        let sandbox = build_agent_sandbox(&SandboxId::new("asbx-test"), &spec, &config).unwrap();
+        let pod_spec = &sandbox.spec.pod_template.spec;
+
+        assert_eq!(
+            pod_spec
+                .node_selector
+                .as_ref()
+                .and_then(|selector| selector.get("workload"))
+                .map(String::as_str),
+            Some("centaur-sandbox")
+        );
+        let tolerations = pod_spec
+            .tolerations
+            .as_ref()
+            .expect("tolerations should be set");
+        assert_eq!(tolerations.len(), 1);
+        assert_eq!(tolerations[0].key.as_deref(), Some("example.com/sandbox"));
+        assert_eq!(tolerations[0].effect.as_deref(), Some("NoSchedule"));
+        assert_eq!(pod_spec.runtime_class_name.as_deref(), Some("gvisor"));
+    }
+
+    #[test]
+    fn node_steering_is_omitted_when_unset() {
+        let spec = SandboxSpec::new("centaur-agent:latest");
+        let config = AgentSandboxConfig::new("centaur");
+
+        let sandbox = build_agent_sandbox(&SandboxId::new("asbx-test"), &spec, &config).unwrap();
+        let pod_spec = &sandbox.spec.pod_template.spec;
+
+        assert!(pod_spec.node_selector.is_none());
+        assert!(pod_spec.tolerations.is_none());
+        assert!(pod_spec.runtime_class_name.is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Problem

Sandbox pods are created at runtime by `api-rs`, not by the chart. So nothing the chart renders can reach them, and neither a Helm nor a kustomize patch can touch them either. That leaves an operator with no way to:

- keep sandboxes on a **dedicated node pool** — commonly a tainted, sandbox-only pool, so untrusted agent workloads never share a node with the control plane, and so a spot reclaim cannot take out a live session; or
- select a **stronger sandbox runtime** via `runtimeClassName` (e.g. gVisor) for untrusted agent code.

Related: `sandbox.runtimeClassName` already exists in `values.yaml` and `values.schema.json`, but is referenced by no template — setting it silently does nothing today.

## Approach

`Sandbox.spec.podTemplate.spec` already accepts `nodeSelector`, `tolerations` and `runtimeClassName`, so this is plumbing rather than new API — no CRD change, no new abstraction. Three chart values reach `api-rs` as env and are passed straight through to the CR:

| Chart value | Env | Shape |
| -- | -- | -- |
| `sandbox.nodeSelector` | `SESSION_SANDBOX_NODE_SELECTOR` | JSON object of label key/value pairs |
| `sandbox.tolerations` | `SESSION_SANDBOX_TOLERATIONS` | JSON array, Kubernetes toleration shape |
| `sandbox.runtimeClassName` | `SESSION_SANDBOX_RUNTIME_CLASS_NAME` | string (existing value, now wired up) |

```yaml
sandbox:
  nodeSelector:
    workload: centaur-sandbox
  tolerations:
    - key: example.com/sandbox
      operator: Exists
      effect: NoSchedule
  runtimeClassName: gvisor
```

## Two decisions worth flagging for review

**Malformed input fails startup rather than warning-and-ignoring**, which differs from `SESSION_SANDBOX_EXTRA_ENV` deliberately. Silently dropping a `nodeSelector` schedules sandboxes wherever the default scheduler chooses — precisely the outcome an operator setting it is trying to prevent, and a silent one. The asymmetry is commented at both call sites so it does not later read as an inconsistency. Happy to switch to warn-and-ignore for consistency if you would rather.

**Tolerations are carried as raw JSON** (`Vec<serde_json::Value>`) rather than a typed struct, so the toleration shape stays defined in one place — the CRD types. Malformed entries surface as the existing `InvalidSpec` error when the CR is deserialized. If you would prefer a typed value in `AgentSandboxConfig`, that is an easy change.

## Compatibility

All three fields are omitted from the CR when unset, so default behaviour is unchanged.

## Tests

- `node_steering_reaches_the_sandbox_pod_template` — all three land in `podTemplate.spec`
- `node_steering_is_omitted_when_unset` — nothing emitted by default
- `node_steering_parses_from_json`, `node_steering_is_empty_when_unset`, `invalid_node_steering_is_rejected` — arg parsing and the fail-fast behaviour

`cargo test -p centaur-sandbox-agent-k8s -p centaur-api-server` passes (48 + 90 + 50), `cargo fmt --check` clean, and `helm template` verified to emit all three env vars when set and none at defaults.