### PR TITLE
feat: add user-scoped MPP wallet onboarding

### DIFF
--- a/contrib/chart/templates/console.yaml
+++ b/contrib/chart/templates/console.yaml
@@ -183,6 +183,15 @@ spec:
             # matches regardless of what Host the sync request carried.
             - name: CENTAUR_CONSOLE_URL
               value: {{ include "centaur.consoleUrl" . | quote }}
+{{- if $console.mppSignerUrl }}
+            - name: MPP_SIGNER_URL
+              value: {{ $console.mppSignerUrl | quote }}
+            - name: MPP_SIGNER_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secretEnv }}
+                  key: {{ printf "%sMPP_SIGNER_TOKEN" $prefix }}
+{{- end }}
 {{- if $console.publicUrl }}
             - name: CENTAUR_CONSOLE_PUBLIC_URL
               value: {{ $console.publicUrl | quote }}

--- a/contrib/chart/values.yaml
+++ b/contrib/chart/values.yaml
@@ -100,6 +100,10 @@ toolServer:
 console:
   enabled: false
   replicaCount: 1
+  # Trusted service that generates Tempo access keys, verifies wallet Key
+  # Authorizations, and signs bounded MPP Credentials. Private keys remain in
+  # that service; Console stores only its opaque key handle.
+  mppSignerUrl: ""
   # Public URL users reach in a browser (e.g. https://console.example.com), used
   # as CENTAUR_CONSOLE_PUBLIC_URL. Set this when console is exposed behind
   # Tailscale/Ingress so MCP OAuth issuer metadata and JWT validation agree.

--- a/services/api-rs/crates/centaur-sandbox-agent-k8s/src/iron_proxy.rs
+++ b/services/api-rs/crates/centaur-sandbox-agent-k8s/src/iron_proxy.rs
@@ -1328,6 +1328,20 @@ fn iron_proxy_env_vars(
         env_var("IRON_CONTROL_PLANE_URL", &sync.control_url),
     );
     env.insert(
+        "IRON_RESPONSE_RETRY_HANDLER_URL".to_owned(),
+        env_var(
+            "IRON_RESPONSE_RETRY_HANDLER_URL",
+            &format!(
+                "{}/api/v1/proxy/mpp/authorize",
+                sync.control_url.trim_end_matches('/')
+            ),
+        ),
+    );
+    env.insert(
+        "IRON_RESPONSE_RETRY_STATUSES".to_owned(),
+        env_var("IRON_RESPONSE_RETRY_STATUSES", "402"),
+    );
+    env.insert(
         "IRON_PROXY_TOKEN".to_owned(),
         env_var("IRON_PROXY_TOKEN", &sync.token),
     );
@@ -2523,6 +2537,34 @@ mod tests {
             .and_then(|var| var.value.as_deref());
 
         assert_eq!(timeout, Some("120s"));
+    }
+
+    #[test]
+    fn managed_proxy_env_routes_response_retries_to_control_plane() {
+        let iron_proxy = IronProxyConfig::new("proxy:test", "ca-cert", "ca-key");
+        let sync = ProxySyncEnv {
+            proxy_id: "proxy-id".to_owned(),
+            control_url: "https://console.example/".to_owned(),
+            token: "proxy-token".to_owned(),
+            config_hash: None,
+        };
+
+        let env = iron_proxy_env_vars(&iron_proxy, &resolved(), &sync);
+        let handler_url = env
+            .iter()
+            .find(|var| var.name == "IRON_RESPONSE_RETRY_HANDLER_URL")
+            .and_then(|var| var.value.as_deref());
+
+        assert_eq!(
+            handler_url,
+            Some("https://console.example/api/v1/proxy/mpp/authorize")
+        );
+        assert_eq!(
+            env.iter()
+                .find(|var| var.name == "IRON_RESPONSE_RETRY_STATUSES")
+                .and_then(|var| var.value.as_deref()),
+            Some("402")
+        );
     }
 
     #[test]

--- a/services/console/app/controllers/api/v1/proxy_mpp_authorizations_controller.rb
+++ b/services/console/app/controllers/api/v1/proxy_mpp_authorizations_controller.rb
@@ -1,0 +1,36 @@
+module Api
+  module V1
+    class ProxyMppAuthorizationsController < Api::ProxyBaseController
+      def create
+        return render json: { retry: false } unless params[:status].to_i == 402
+
+        principal = current_proxy.principal
+        return render_error(status: :forbidden, message: "proxy is not assigned") unless principal
+
+        slack_user_id = principal.labels["slack_user_id"]
+        slack_team_id = principal.labels["slack_team_id"]
+        identity = UserIdentity.find_by(provider: UserIdentity::SLACK_PROVIDER, subject: slack_user_id, team_id: slack_team_id)
+        access_key = identity&.mpp_access_key
+        return render_error(status: :payment_required, message: "Slack user has no active MPP wallet") unless access_key&.revoked_at.nil? && access_key.expires_at.future?
+
+        challenge = Array(params.require(:response_headers)["Www-Authenticate"] || params[:response_headers]["WWW-Authenticate"]).find do |value|
+          value.start_with?("Payment ")
+        end
+        return render json: { retry: false } unless challenge
+
+        result = MppSignerClient.new.payment_credential(
+          key_handle: access_key.key_handle,
+          challenge: challenge,
+          host: params.require(:host),
+          method: params.require(:method),
+          path: params.require(:path)
+        )
+        render json: { retry: true, headers: { "Authorization" => result.fetch("authorization") } }
+      rescue ActionController::ParameterMissing => e
+        render_error(status: :unprocessable_entity, message: e.message)
+      rescue MppSignerClient::Error => e
+        render_error(status: :bad_gateway, message: e.message)
+      end
+    end
+  end
+end

--- a/services/console/app/controllers/console/mpp_wallets_controller.rb
+++ b/services/console/app/controllers/console/mpp_wallets_controller.rb
@@ -1,0 +1,25 @@
+module Console
+  class MppWalletsController < ApplicationController
+    def create
+      identity = current_user.user_identities.find_by(provider: UserIdentity::SLACK_PROVIDER)
+      return render json: { error: "connect Slack SSO before configuring an MPP wallet" }, status: :unprocessable_entity unless identity
+
+      key = MppSignerClient.new.create_access_key
+      link = MppWalletLink.create!(
+        user_identity: identity,
+        key_handle: key.fetch("key_handle"),
+        access_key_address: key.fetch("access_key_address"),
+        access_key_public_key: key.fetch("access_key_public_key")
+      )
+      render json: { connect_url: mpp_wallet_link_url(link.token), expires_at: link.expires_at }
+    rescue MppSignerClient::Error => e
+      render json: { error: e.message }, status: :bad_gateway
+    end
+
+    def destroy
+      identity = current_user.user_identities.find_by(provider: UserIdentity::SLACK_PROVIDER)
+      identity&.mpp_access_key&.update!(revoked_at: Time.current)
+      head :no_content
+    end
+  end
+end

--- a/services/console/app/controllers/mpp_wallet_links_controller.rb
+++ b/services/console/app/controllers/mpp_wallet_links_controller.rb
@@ -1,0 +1,40 @@
+class MppWalletLinksController < ActionController::API
+  def show
+    link = MppWalletLink.find_active(params[:token])
+    return render json: { error: "connection link is invalid or expired" }, status: :not_found unless link
+
+    render json: {
+      access_key_address: link.access_key_address,
+      access_key_public_key: link.access_key_public_key,
+      expires_at: link.expires_at
+    }
+  end
+
+  def update
+    link = MppWalletLink.find_active(params[:token])
+    return render json: { error: "connection link is invalid or expired" }, status: :not_found unless link
+
+    result = MppSignerClient.new.authorize_access_key(
+      key_handle: link.key_handle,
+      wallet_address: params.require(:wallet_address),
+      key_authorization: params.require(:key_authorization)
+    )
+    MppAccessKey.transaction do
+      link.user_identity.mpp_access_key&.update!(revoked_at: Time.current)
+      MppAccessKey.create!(
+        user_identity: link.user_identity,
+        wallet_address: result.fetch("wallet_address"),
+        key_handle: link.key_handle,
+        access_key_address: link.access_key_address,
+        key_authorization: result.fetch("key_authorization"),
+        expires_at: Time.iso8601(result.fetch("expires_at"))
+      )
+      link.update!(used_at: Time.current)
+    end
+    render json: { connected: true, wallet_address: result.fetch("wallet_address") }
+  rescue ActionController::ParameterMissing => e
+    render json: { error: e.message }, status: :unprocessable_entity
+  rescue MppSignerClient::Error => e
+    render json: { error: e.message }, status: :bad_gateway
+  end
+end

--- a/services/console/app/models/mpp_access_key.rb
+++ b/services/console/app/models/mpp_access_key.rb
@@ -1,0 +1,8 @@
+class MppAccessKey < ApplicationRecord
+  belongs_to :user_identity
+
+  validates :wallet_address, :key_handle, :access_key_address, :key_authorization, :expires_at, presence: true
+  validates :key_handle, uniqueness: true
+
+  scope :current, -> { where(revoked_at: nil) }
+end

--- a/services/console/app/models/mpp_wallet_link.rb
+++ b/services/console/app/models/mpp_wallet_link.rb
@@ -1,0 +1,27 @@
+class MppWalletLink < ApplicationRecord
+  TTL = 10.minutes
+
+  belongs_to :user_identity
+
+  attr_accessor :token
+
+  validates :token_digest, :key_handle, :access_key_address, :access_key_public_key, :expires_at, presence: true
+
+  before_validation :issue_token, on: :create
+
+  def self.find_active(token)
+    find_by(token_digest: Digest::SHA256.hexdigest(token.to_s))&.then do |link|
+      link if link.used_at.nil? && link.expires_at.future?
+    end
+  end
+
+  private
+
+  def issue_token
+    return if token_digest.present?
+
+    self.token = SecureRandom.urlsafe_base64(32)
+    self.token_digest = Digest::SHA256.hexdigest(token)
+    self.expires_at ||= TTL.from_now
+  end
+end

--- a/services/console/app/models/user_identity.rb
+++ b/services/console/app/models/user_identity.rb
@@ -7,6 +7,9 @@ class UserIdentity < ApplicationRecord
 
   belongs_to :user
 
+  has_one :mpp_access_key, -> { current }, dependent: :destroy
+  has_many :mpp_wallet_links, dependent: :destroy
+
   PROVIDERS = %w[google slack].freeze
   SLACK_PROVIDER = "slack".freeze
 

--- a/services/console/app/services/mpp_signer_client.rb
+++ b/services/console/app/services/mpp_signer_client.rb
@@ -1,0 +1,58 @@
+require "net/http"
+
+class MppSignerClient
+  class Error < StandardError; end
+
+  def initialize(url: ENV["MPP_SIGNER_URL"], token: ENV["MPP_SIGNER_TOKEN"])
+    @base_url = URI.parse(url.to_s)
+    @token = token.to_s
+    validate_configuration!
+  end
+
+  def create_access_key
+    post("/v1/access_keys", {})
+  end
+
+  def authorize_access_key(key_handle:, wallet_address:, key_authorization:)
+    post("/v1/access_keys/#{CGI.escapeURIComponent(key_handle)}/authorize", {
+      wallet_address: wallet_address,
+      key_authorization: key_authorization
+    })
+  end
+
+  def payment_credential(key_handle:, challenge:, host:, method:, path:)
+    post("/v1/credentials", {
+      key_handle: key_handle,
+      challenge: challenge,
+      host: host,
+      method: method,
+      path: path
+    })
+  end
+
+  private
+
+  def post(path, payload)
+    uri = @base_url + path
+    request = Net::HTTP::Post.new(uri)
+    request["Authorization"] = "Bearer #{@token}"
+    request["Content-Type"] = "application/json"
+    request.body = JSON.generate(payload)
+    response = Net::HTTP.start(uri.hostname, uri.port, use_ssl: uri.scheme == "https", open_timeout: 5, read_timeout: 30) do |http|
+      http.request(request)
+    end
+    raise Error, "MPP signer rejected request with status #{response.code}" unless response.is_a?(Net::HTTPSuccess)
+
+    JSON.parse(response.body)
+  rescue JSON::ParserError, SocketError, SystemCallError, Timeout::Error => e
+    raise Error, "MPP signer request failed: #{e.class}"
+  end
+
+  def validate_configuration!
+    raise Error, "MPP signer is not configured" if @base_url.host.blank? || @token.blank?
+    return if @base_url.scheme == "https"
+    return if @base_url.scheme == "http" && [ "localhost", "127.0.0.1", "::1" ].include?(@base_url.hostname)
+
+    raise Error, "MPP signer URL must use HTTPS unless it is loopback"
+  end
+end

--- a/services/console/config/routes.rb
+++ b/services/console/config/routes.rb
@@ -41,6 +41,7 @@ Rails.application.routes.draw do
   root "console#principals"
   get "console/principals", to: "console#principals", as: :console_principals
   namespace :console do
+    resource :mpp_wallet, only: %i[create destroy]
     get  "principals/new", to: "principals#new",    as: :new_principal
     post "principals",     to: "principals#create", as: :create_principal
   end
@@ -216,6 +217,7 @@ Rails.application.routes.draw do
 
       # Called by iron-proxy instances (proxy bearer auth, not ApiKey auth).
       post "proxy/sync", to: "proxy_sync#create"
+      post "proxy/mpp/authorize", to: "proxy_mpp_authorizations#create"
 
       # Called from inside sandboxes through their assigned iron-proxy. The
       # proxy injects a short-lived sandbox entitlement JWT scoped to these paths.
@@ -223,6 +225,9 @@ Rails.application.routes.draw do
       get "sandbox/oauth_apps", to: "sandbox_oauth_apps#index"
     end
   end
+
+  get "mpp/connect/:token", to: "mpp_wallet_links#show", as: :mpp_wallet_link
+  patch "mpp/connect/:token", to: "mpp_wallet_links#update"
 
   # OAuth consent flow, keyed by the app's well-known slug (/oauth/google/start).
   # Requires an active console session; the provider is derived from the app.

--- a/services/console/db/migrate/20260730190000_create_mpp_wallet_connections.rb
+++ b/services/console/db/migrate/20260730190000_create_mpp_wallet_connections.rb
@@ -1,0 +1,28 @@
+class CreateMppWalletConnections < ActiveRecord::Migration[8.0]
+  def change
+    create_table :mpp_wallet_links do |t|
+      t.references :user_identity, null: false, foreign_key: true
+      t.string :token_digest, null: false
+      t.string :key_handle, null: false
+      t.string :access_key_address, null: false
+      t.string :access_key_public_key, null: false
+      t.datetime :expires_at, null: false
+      t.datetime :used_at
+      t.timestamps
+    end
+    add_index :mpp_wallet_links, :token_digest, unique: true
+
+    create_table :mpp_access_keys do |t|
+      t.references :user_identity, null: false, foreign_key: true
+      t.string :wallet_address, null: false
+      t.string :key_handle, null: false
+      t.string :access_key_address, null: false
+      t.jsonb :key_authorization, null: false, default: {}
+      t.datetime :expires_at, null: false
+      t.datetime :revoked_at
+      t.timestamps
+    end
+    add_index :mpp_access_keys, :key_handle, unique: true
+    add_index :mpp_access_keys, :user_identity_id, unique: true, where: "revoked_at IS NULL"
+  end
+end

--- a/services/console/db/schema.rb
+++ b/services/console/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_27_233739) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_30_190000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -194,6 +194,34 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_27_233739) do
     t.index ["mcp_oauth_client_id"], name: "index_mcp_oauth_authorization_codes_on_mcp_oauth_client_id"
     t.index ["principal_id"], name: "index_mcp_oauth_authorization_codes_on_principal_id"
     t.index ["user_id"], name: "index_mcp_oauth_authorization_codes_on_user_id"
+  end
+
+  create_table "mpp_access_keys", force: :cascade do |t|
+    t.string "access_key_address", null: false
+    t.datetime "created_at", null: false
+    t.datetime "expires_at", null: false
+    t.jsonb "key_authorization", default: {}, null: false
+    t.string "key_handle", null: false
+    t.datetime "revoked_at"
+    t.datetime "updated_at", null: false
+    t.bigint "user_identity_id", null: false
+    t.string "wallet_address", null: false
+    t.index ["key_handle"], name: "index_mpp_access_keys_on_key_handle", unique: true
+    t.index ["user_identity_id"], name: "index_mpp_access_keys_on_user_identity_id", unique: true, where: "(revoked_at IS NULL)"
+  end
+
+  create_table "mpp_wallet_links", force: :cascade do |t|
+    t.string "access_key_address", null: false
+    t.string "access_key_public_key", null: false
+    t.datetime "created_at", null: false
+    t.datetime "expires_at", null: false
+    t.string "key_handle", null: false
+    t.string "token_digest", null: false
+    t.datetime "updated_at", null: false
+    t.datetime "used_at"
+    t.bigint "user_identity_id", null: false
+    t.index ["token_digest"], name: "index_mpp_wallet_links_on_token_digest", unique: true
+    t.index ["user_identity_id"], name: "index_mpp_wallet_links_on_user_identity_id"
   end
 
   create_table "mcp_oauth_clients", force: :cascade do |t|
@@ -499,6 +527,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_27_233739) do
   add_foreign_key "mcp_oauth_refresh_tokens", "mcp_oauth_clients"
   add_foreign_key "mcp_oauth_refresh_tokens", "principals"
   add_foreign_key "mcp_oauth_refresh_tokens", "users"
+  add_foreign_key "mpp_access_keys", "user_identities"
+  add_foreign_key "mpp_wallet_links", "user_identities"
   add_foreign_key "oauth_apps", "users", column: "created_by_id"
   add_foreign_key "oauth_token_secrets", "users", column: "created_by_id"
   add_foreign_key "pg_dsn_secrets", "users", column: "created_by_id"

--- a/services/console/test/controllers/api/v1/proxy_mpp_authorizations_controller_test.rb
+++ b/services/console/test/controllers/api/v1/proxy_mpp_authorizations_controller_test.rb
@@ -1,0 +1,55 @@
+require "test_helper"
+
+class ProxyMppAuthorizationsControllerTest < ActionDispatch::IntegrationTest
+  TOKEN = "iprx_#{'b' * 64}".freeze
+
+  test "selects the access key from authenticated proxy Slack labels" do
+    identity = user_identities(:pending_user_slack)
+    principal = Principal.create!(
+      namespace: "default",
+      foreign_id: "slack-user-test",
+      name: "Slack user",
+      labels: { "slack_user_id" => identity.subject },
+      created_by: users(:acme_admin)
+    )
+    proxy = Proxy.create!(name: "mpp-test", principal: principal, token: TOKEN)
+    key = MppAccessKey.create!(
+      user_identity: identity,
+      wallet_address: "0x1111111111111111111111111111111111111111",
+      key_handle: "key-1",
+      access_key_address: "0x2222222222222222222222222222222222222222",
+      key_authorization: { "authorization" => "signed" },
+      expires_at: 1.day.from_now
+    )
+    signer = Minitest::Mock.new
+    signer.expect(
+      :payment_credential,
+      { "authorization" => "Payment credential" },
+      [],
+      key_handle: key.key_handle,
+      challenge: "Payment challenge",
+      host: "api.example",
+      method: "POST",
+      path: "/paid"
+    )
+
+    MppSignerClient.stub(:new, signer) do
+      post api_v1_proxy_mpp_authorize_url,
+        params: {
+          status: 402,
+          response_headers: { "Www-Authenticate" => [ "Payment challenge" ] },
+          host: "api.example",
+          method: "POST",
+          path: "/paid"
+        }.to_json,
+        headers: { "Authorization" => "Bearer #{proxy.token}", "Content-Type" => "application/json" }
+    end
+
+    assert_response :ok
+    assert_equal(
+      { "retry" => true, "headers" => { "Authorization" => "Payment credential" } },
+      JSON.parse(response.body)
+    )
+    signer.verify
+  end
+end

--- a/services/console/test/models/mpp_wallet_link_test.rb
+++ b/services/console/test/models/mpp_wallet_link_test.rb
@@ -1,0 +1,19 @@
+require "test_helper"
+
+class MppWalletLinkTest < ActiveSupport::TestCase
+  test "issues a single-use hashed connection token" do
+    link = MppWalletLink.create!(
+      user_identity: user_identities(:pending_user_slack),
+      key_handle: "key-1",
+      access_key_address: "0x1111111111111111111111111111111111111111",
+      access_key_public_key: "0x04abc"
+    )
+
+    assert link.token.present?
+    assert_not_equal link.token, link.token_digest
+    assert_equal link, MppWalletLink.find_active(link.token)
+
+    link.update!(used_at: Time.current)
+    assert_nil MppWalletLink.find_active(link.token)
+  end
+end


### PR DESCRIPTION
## Summary

- Add tip.bot-style single-use wallet connection links backed by delegated Tempo access keys.
- Map Slack SSO identity `(team_id, user_id)` to an opaque signer key handle and wallet address.
- Configure iron-proxy’s protocol-neutral response-retry hook for status `402`.
- Keep all MPP Challenge parsing, payer selection, payment policy, and Credential signing in Centaur; iron-proxy only performs one exact bounded replay.
- Keep private access keys in a dedicated signer service rather than Console, iron-proxy, or the sandbox.

## Dependencies

- Depends on the generic retry hook in [ironsh/iron-proxy#213](https://github.com/ironsh/iron-proxy/pull/213).
- The `MPP_SIGNER_URL` service contract is included, but its mpp-rs implementation and the wallet-facing connection page still need to land before this can ship; this PR is intentionally draft.

## Validation

- `cargo +nightly fmt --all -- --check`
- `cargo test -p centaur-sandbox-agent-k8s managed_proxy_env_routes_response_retries_to_control_plane`
- `git diff --check`
- Rails and Helm CLIs are unavailable in the current sandbox; their suites remain required.

Prompted by: @gakonst