### PR TITLE
fix(workflows): cleanly shut down Python workflow host

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,7 +222,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: "3.12"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,7 +164,7 @@ jobs:
           RUN_MIGRATIONS: "true"
           RUST_LOG: info
           WORKFLOW_DIRS: ${{ runner.temp }}/api-integration-workflows
-          WORKFLOW_HOST_SANDBOX: "false"
+          WORKFLOW_HOST_SANDBOX: "true"
           WORKFLOW_REAP_REMOVED_AFTER_TICKS: "1"
           WORKFLOW_RECONCILE_INTERVAL_SECS: "1"
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,7 +202,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: "3.11"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,7 +222,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4c4022e16d87065 # v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
     outputs:
       migration_order: ${{ steps.filter.outputs.migration_order }}
       rust_api: ${{ steps.filter.outputs.rust_api }}
+      workflow_python_tests: ${{ steps.filter.outputs.workflow_python_tests }}
       sandbox_tests: ${{ steps.filter.outputs.sandbox_tests }}
       slackbotv2_tests: ${{ steps.filter.outputs.slackbotv2_tests }}
       discordbot_checks: ${{ steps.filter.outputs.discordbot_checks }}
@@ -70,6 +71,10 @@ jobs:
             '^\.github/workflows/ci\.yml$'
           set_output rust_api \
             '^services/api-rs/' \
+            '^services/workflow-python/' \
+            '^\.github/workflows/ci\.yml$'
+          set_output workflow_python_tests \
+            '^services/workflow-python/' \
             '^\.github/workflows/ci\.yml$'
           set_output sandbox_tests \
             '^services/sandbox/' \
@@ -206,6 +211,25 @@ jobs:
           GIT_CONFIG_GLOBAL: /dev/null
           PYTHONPATH: ${{ github.workspace }}
         run: python -m unittest discover -s services/sandbox -p 'test_*.py'
+
+  workflow-python-tests:
+    name: Workflow Host Python tests
+    runs-on: ubuntu-latest
+    needs: ci_changes
+    if: needs.ci_changes.outputs.workflow_python_tests == 'true'
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4c4022e16d87065 # v5
+        with:
+          python-version: "3.12"
+
+      - name: Workflow Host Python tests
+        env:
+          PYTHONPATH: ${{ github.workspace }}/services/workflow-python
+        run: python -m unittest discover -s services/workflow-python/tests -p 'test_*.py'
 
   slackbotv2-tests:
     name: Slackbot v2 tests

--- a/services/api-rs/crates/centaur-api-integration-test/src/main.rs
+++ b/services/api-rs/crates/centaur-api-integration-test/src/main.rs
@@ -566,6 +566,7 @@ async fn test_workflows_api(http: &HttpClient, base_url: &str) -> Result<()> {
         bail!("agent-turn workflow returned unexpected result: {agent_run}");
     }
 
+    let started_marker = workflow_dir.join(format!("{workflow_name}.started"));
     let removed_run_id = create_workflow_run(
         http,
         base_url,
@@ -573,6 +574,7 @@ async fn test_workflows_api(http: &HttpClient, base_url: &str) -> Result<()> {
         json!({
             "case": "removed-workflow-run",
             "sleep_ms": 60_000,
+            "started_marker_path": started_marker,
         }),
     )
     .await
@@ -580,6 +582,9 @@ async fn test_workflows_api(http: &HttpClient, base_url: &str) -> Result<()> {
     wait_for_workflow_run_status(http, base_url, &removed_run_id, &["running"])
         .await
         .context("wait for long-running workflow run to start")?;
+    wait_for_file(&started_marker)
+        .await
+        .context("wait for long-running workflow handler to start")?;
 
     fs::remove_file(&workflow_path)
         .with_context(|| format!("remove workflow file {}", workflow_path.display()))?;
@@ -592,6 +597,17 @@ async fn test_workflows_api(http: &HttpClient, base_url: &str) -> Result<()> {
         .context("wait for removed workflow run to be cancelled")?;
 
     Ok(())
+}
+
+async fn wait_for_file(path: &Path) -> Result<()> {
+    let deadline = Instant::now() + Duration::from_secs(15);
+    while Instant::now() < deadline {
+        if path.is_file() {
+            return Ok(());
+        }
+        sleep(Duration::from_millis(100)).await;
+    }
+    bail!("file {} was not created before timeout", path.display())
 }
 
 fn integration_workflow_dir() -> Result<PathBuf> {
@@ -649,6 +665,10 @@ async def handler(params, ctx):
 
     sleep_ms = int(params.get("sleep_ms") or 0)
     if sleep_ms:
+        started_marker_path = str(params.get("started_marker_path") or "")
+        if started_marker_path:
+            with open(started_marker_path, "w") as marker:
+                marker.write("started")
         await asyncio.sleep(sleep_ms / 1000)
     return {{
         "workflow_name": ctx.workflow_name,

--- a/services/api-rs/crates/centaur-api-integration-test/src/main.rs
+++ b/services/api-rs/crates/centaur-api-integration-test/src/main.rs
@@ -62,7 +62,7 @@ async fn main() -> Result<()> {
     let line = line!() + 1;
     record_result(
         &mut results,
-        "Workflows API runs added workflows and cancels removed workflows",
+        "Workflows API runs Python workflows with agent turns and cancels removed workflows",
         line,
         test_workflows_api(&http, &base_url).await,
     );
@@ -534,6 +534,38 @@ async fn test_workflows_api(http: &HttpClient, base_url: &str) -> Result<()> {
         bail!("completed workflow output did not echo input: {completed_run}");
     }
 
+    let agent_run_id = create_workflow_run(
+        http,
+        base_url,
+        &workflow_name,
+        json!({
+            "case": "agent-turn-workflow-run",
+            "agent_turn": true,
+            "model": TEST_MODEL,
+        }),
+    )
+    .await
+    .context("create workflow run with an agent turn")?;
+    let agent_run = wait_for_workflow_run_status(http, base_url, &agent_run_id, &["completed"])
+        .await
+        .context("wait for workflow run with an agent turn to complete")?;
+    let agent_result = agent_run
+        .pointer("/result/output/agent_result")
+        .context("agent-turn workflow run missing agent result")?;
+    if agent_result.get("status").and_then(Value::as_str) != Some("completed") {
+        bail!("agent-turn workflow did not complete its agent session: {agent_run}");
+    }
+    let result_text = agent_result
+        .get("result_text")
+        .and_then(Value::as_str)
+        .context("agent-turn workflow result missing result text")?;
+    if !result_text.contains("PONG")
+        || !result_text.contains(TEST_MODEL)
+        || !result_text.contains("harness=codex")
+    {
+        bail!("agent-turn workflow returned unexpected result: {agent_run}");
+    }
+
     let removed_run_id = create_workflow_run(
         http,
         base_url,
@@ -602,6 +634,19 @@ SCHEDULE = {{
 
 
 async def handler(params, ctx):
+    if params.get("agent_turn"):
+        agent_result = await ctx.agent_turn(
+            "Reply with PONG, the model, and the harness.",
+            model=params.get("model"),
+            idle_timeout_ms=5_000,
+            max_duration_ms=15_000,
+        )
+        return {{
+            "workflow_name": ctx.workflow_name,
+            "received": params,
+            "agent_result": agent_result,
+        }}
+
     sleep_ms = int(params.get("sleep_ms") or 0)
     if sleep_ms:
         await asyncio.sleep(sleep_ms / 1000)

--- a/services/workflow-python/tests/test_workflow_host.py
+++ b/services/workflow-python/tests/test_workflow_host.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import asyncio
 import importlib.util
+import json
 import os
+import subprocess
 import sys
 import tempfile
 import types
@@ -431,6 +433,131 @@ class WorkflowHostTests(unittest.TestCase):
         assert registered is not None
         self.assertEqual(host.normalize_principal(registered), True)
 
+    def test_failed_workflow_host_exits_even_when_stdin_remains_open(self) -> None:
+        host_path = Path(__file__).resolve().parents[1] / "workflow_host.py"
+        with tempfile.TemporaryDirectory() as tmp:
+            workflow_path = Path(tmp) / "failing_workflow.py"
+            workflow_path.write_text(
+                "WORKFLOW_NAME = 'failing_workflow'\n"
+                "async def handler(inp, ctx):\n"
+                "    raise RuntimeError('boom')\n"
+            )
+
+            env = os.environ.copy()
+            env["WORKFLOW_DIRS"] = tmp
+            proc = subprocess.Popen(
+                [sys.executable, str(host_path)],
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                env=env,
+            )
+            assert proc.stdin is not None
+            assert proc.stdout is not None
+            try:
+                proc.stdin.write(
+                    json.dumps(
+                        {
+                            "type": "workflow.start",
+                            "run_id": "run-123",
+                            "task_id": "task-456",
+                            "workflow_name": "failing_workflow",
+                            "input": {},
+                        },
+                        separators=(",", ":"),
+                    )
+                    + "\n"
+                )
+                proc.stdin.flush()
+
+                line = proc.stdout.readline()
+                self.assertTrue(line, "workflow host did not emit a response")
+                payload = json.loads(line)
+                self.assertEqual(payload["type"], "workflow.error")
+                self.assertEqual(payload["message"], "boom")
+
+                proc.wait(timeout=2)
+                self.assertEqual(proc.returncode, 0)
+                assert proc.stderr is not None
+                self.assertEqual(proc.stderr.read(), "")
+            finally:
+                if proc.poll() is None:
+                    proc.kill()
+                proc.communicate(timeout=2)
+
+    def test_workflow_host_returns_result_after_context_response(self) -> None:
+        host_path = Path(__file__).resolve().parents[1] / "workflow_host.py"
+        with tempfile.TemporaryDirectory() as tmp:
+            workflow_path = Path(tmp) / "agent_workflow.py"
+            workflow_path.write_text(
+                "WORKFLOW_NAME = 'agent_workflow'\n"
+                "async def handler(inp, ctx):\n"
+                "    result = await ctx.agent_turn('summarize this')\n"
+                "    return {'agent_result': result}\n"
+            )
+
+            env = os.environ.copy()
+            env["WORKFLOW_DIRS"] = tmp
+            proc = subprocess.Popen(
+                [sys.executable, str(host_path)],
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                env=env,
+            )
+            assert proc.stdin is not None
+            assert proc.stdout is not None
+            assert proc.stderr is not None
+            try:
+                proc.stdin.write(
+                    json.dumps(
+                        {
+                            "type": "workflow.start",
+                            "run_id": "run-123",
+                            "task_id": "task-456",
+                            "workflow_name": "agent_workflow",
+                            "input": {},
+                        },
+                        separators=(",", ":"),
+                    )
+                    + "\n"
+                )
+                proc.stdin.flush()
+
+                request_line = proc.stdout.readline()
+                self.assertTrue(request_line, "workflow host did not request an agent turn")
+                request = json.loads(request_line)
+                self.assertEqual(request["type"], "ctx.agent_turn")
+
+                proc.stdin.write(
+                    json.dumps(
+                        {
+                            "type": "ctx.response",
+                            "request_id": request["request_id"],
+                            "ok": True,
+                            "value": {"text": "daily digest"},
+                        },
+                        separators=(",", ":"),
+                    )
+                    + "\n"
+                )
+                proc.stdin.flush()
+
+                result_line = proc.stdout.readline()
+                self.assertTrue(result_line, "workflow host did not emit a result")
+                result = json.loads(result_line)
+                self.assertEqual(result["type"], "workflow.result")
+                self.assertEqual(result["result"], {"agent_result": {"text": "daily digest"}})
+
+                proc.wait(timeout=2)
+                self.assertEqual(proc.returncode, 0)
+                self.assertEqual(proc.stderr.read(), "")
+            finally:
+                if proc.poll() is None:
+                    proc.kill()
+                proc.communicate(timeout=2)
 
 if __name__ == "__main__":
     unittest.main()

--- a/services/workflow-python/tests/test_workflow_host.py
+++ b/services/workflow-python/tests/test_workflow_host.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
+import dataclasses
 import importlib.util
+import io
 import json
 import os
 import subprocess
@@ -74,6 +77,26 @@ class RequestRpc(FakeRpc):
         if message_type == "ctx.event.wait":
             return {"approved": True}
         raise AssertionError(f"unexpected request {payload}")
+
+
+class NotificationRpc(FakeRpc):
+    def __init__(self) -> None:
+        super().__init__()
+        self.notifications = []
+
+    def notify(self, payload) -> None:
+        self.notifications.append(payload)
+
+
+@dataclasses.dataclass
+class NestedInputForTest:
+    name: str
+
+
+@dataclasses.dataclass
+class WorkflowInputForTest:
+    nested: NestedInputForTest
+    limit: int = 10
 
 
 class WorkflowHostTests(unittest.TestCase):
@@ -297,6 +320,105 @@ class WorkflowHostTests(unittest.TestCase):
         self.assertEqual(calls, ["postgresql://example/db"] * 3)
         self.assertEqual(sleeps, [0.25, 0.5])
 
+    def test_create_pool_raises_after_all_connection_attempts(self) -> None:
+        host = load_workflow_host()
+        calls = []
+        sleeps = []
+
+        async def create_pool(database_url):
+            calls.append(database_url)
+            raise ConnectionRefusedError("postgres is unavailable")
+
+        async def sleep(delay):
+            sleeps.append(delay)
+
+        fake_asyncpg = types.SimpleNamespace(create_pool=create_pool)
+
+        with (
+            patch.dict(os.environ, {"DATABASE_URL": "postgresql://example/db"}, clear=False),
+            patch.dict(sys.modules, {"asyncpg": fake_asyncpg}),
+            patch.object(host.asyncio, "sleep", sleep),
+        ):
+            with self.assertRaisesRegex(ConnectionRefusedError, "postgres is unavailable"):
+                asyncio.run(host.create_pool())
+
+        self.assertEqual(calls, ["postgresql://example/db"] * 5)
+        self.assertEqual(sleeps, [0.25, 0.5, 1.0, 2.0])
+
+    def test_coerce_input_hydrates_nested_dataclasses(self) -> None:
+        host = load_workflow_host()
+
+        result = host.coerce_input(
+            {"nested": {"name": "digest"}, "limit": 5, "ignored": True},
+            WorkflowInputForTest,
+        )
+
+        self.assertEqual(
+            result,
+            WorkflowInputForTest(nested=NestedInputForTest(name="digest"), limit=5),
+        )
+
+    def test_discover_workflows_filters_allowlist_and_load_errors(self) -> None:
+        host = load_workflow_host()
+        with tempfile.TemporaryDirectory() as tmp:
+            first_dir = Path(tmp) / "first"
+            second_dir = Path(tmp) / "second"
+            first_dir.mkdir()
+            second_dir.mkdir()
+            (first_dir / "allowed.py").write_text(
+                "WORKFLOW_NAME = 'allowed'\n"
+                "def handler(inp, ctx):\n"
+                "    return None\n"
+            )
+            (second_dir / "filtered.py").write_text(
+                "WORKFLOW_NAME = 'filtered'\n"
+                "def handler(inp, ctx):\n"
+                "    return None\n"
+            )
+            (second_dir / "broken.py").write_text(
+                "WORKFLOW_NAME = 'broken'\n"
+                "raise RuntimeError('broken import')\n"
+            )
+            stderr = io.StringIO()
+            with (
+                patch.dict(
+                    os.environ,
+                    {
+                        "WORKFLOW_DIRS": f"{first_dir}:{second_dir}",
+                        "WORKFLOW_ENABLE_MODE": "allowlist",
+                        "WORKFLOW_ALLOWED_NAMES": "allowed",
+                    },
+                    clear=False,
+                ),
+                contextlib.redirect_stderr(stderr),
+            ):
+                workflows = host.discover_workflows()
+
+        self.assertEqual(set(workflows), {"allowed"})
+        self.assertIn("workflow_load_error", stderr.getvalue())
+        self.assertIn("broken.py", stderr.getvalue())
+
+    def test_discover_workflows_rejects_duplicate_names(self) -> None:
+        host = load_workflow_host()
+        with tempfile.TemporaryDirectory() as tmp:
+            first_dir = Path(tmp) / "first"
+            second_dir = Path(tmp) / "second"
+            first_dir.mkdir()
+            second_dir.mkdir()
+            for directory in (first_dir, second_dir):
+                (directory / "duplicate.py").write_text(
+                    "WORKFLOW_NAME = 'duplicate'\n"
+                    "def handler(inp, ctx):\n"
+                    "    return None\n"
+                )
+            with patch.dict(
+                os.environ,
+                {"WORKFLOW_DIRS": f"{first_dir}:{second_dir}"},
+                clear=False,
+            ):
+                with self.assertRaisesRegex(RuntimeError, "duplicate workflow name 'duplicate'"):
+                    host.discover_workflows()
+
     def test_workflow_result_includes_grouping_identifiers(self) -> None:
         host = load_workflow_host()
         pool = FakePool()
@@ -353,6 +475,112 @@ class WorkflowHostTests(unittest.TestCase):
         )
         self.assertTrue(rpc.drained)
         self.assertTrue(pool.closed)
+
+    def test_run_workflow_closes_pool_after_handler_failure(self) -> None:
+        host = load_workflow_host()
+        pool = FakePool()
+        rpc = FakeRpc()
+
+        async def handler(inp, ctx):
+            raise RuntimeError("handler failed")
+
+        registered = host.RegisteredWorkflow(
+            workflow_name="sample_workflow",
+            source_path="workflows/sample.py",
+            handler=handler,
+            input_cls=None,
+            webhooks=None,
+            schedule=None,
+        )
+
+        async def create_pool():
+            return pool
+
+        with (
+            patch.object(
+                host,
+                "discover_workflows",
+                return_value={"sample_workflow": registered},
+            ),
+            patch.object(host, "create_pool", create_pool),
+        ):
+            with self.assertRaisesRegex(RuntimeError, "handler failed"):
+                asyncio.run(
+                    host.run_workflow(
+                        {
+                            "type": "workflow.start",
+                            "workflow_name": "sample_workflow",
+                            "run_id": "run-123",
+                            "task_id": "task-456",
+                            "input": {},
+                        },
+                        rpc,
+                    )
+                )
+
+        self.assertTrue(rpc.drained)
+        self.assertTrue(pool.closed)
+
+    def test_run_workflow_drains_notifications_before_returning_result(self) -> None:
+        host = load_workflow_host()
+        rpc = NotificationRpc()
+
+        async def handler(inp, ctx):
+            ctx.log("daily_digest_started", recipient_count=3)
+            return {"ok": True}
+
+        registered = host.RegisteredWorkflow(
+            workflow_name="sample_workflow",
+            source_path="workflows/sample.py",
+            handler=handler,
+            input_cls=None,
+            webhooks=None,
+            schedule=None,
+        )
+
+        async def create_pool():
+            return None
+
+        with (
+            patch.object(
+                host,
+                "discover_workflows",
+                return_value={"sample_workflow": registered},
+            ),
+            patch.object(host, "create_pool", create_pool),
+        ):
+            result = asyncio.run(
+                host.run_workflow(
+                    {
+                        "type": "workflow.start",
+                        "workflow_name": "sample_workflow",
+                        "run_id": "run-123",
+                        "task_id": "task-456",
+                        "input": {},
+                    },
+                    rpc,
+                )
+            )
+
+        self.assertEqual(result["result"], {"ok": True})
+        self.assertEqual(
+            rpc.notifications,
+            [
+                {
+                    "type": "ctx.log",
+                    "message": "daily_digest_started",
+                    "fields": {"recipient_count": 3},
+                }
+            ],
+        )
+        self.assertTrue(rpc.drained)
+
+    def test_rpc_rejects_response_for_unknown_request(self) -> None:
+        host = load_workflow_host()
+        rpc = host.RpcClient()
+
+        with self.assertRaisesRegex(host.ProtocolError, "unknown request_id 'missing'"):
+            rpc.resolve({"type": "ctx.response", "request_id": "missing", "ok": True})
 
     def test_run_workflow_threads_agent_defaults_into_context(self) -> None:
         host = load_workflow_host()
@@ -484,7 +712,12 @@ class WorkflowHostTests(unittest.TestCase):
             finally:
                 if proc.poll() is None:
                     proc.kill()
-                proc.communicate(timeout=2)
+                if proc.stdin is not None and not proc.stdin.closed:
+                    proc.communicate(timeout=2)
+                else:
+                    proc.wait(timeout=2)
+                    proc.stdout.close()
+                    proc.stderr.close()
 
     def test_workflow_host_returns_result_after_context_response(self) -> None:
         host_path = Path(__file__).resolve().parents[1] / "workflow_host.py"
@@ -557,7 +790,222 @@ class WorkflowHostTests(unittest.TestCase):
             finally:
                 if proc.poll() is None:
                     proc.kill()
+                if proc.stdin is not None and not proc.stdin.closed:
+                    proc.communicate(timeout=2)
+                else:
+                    proc.wait(timeout=2)
+                    proc.stdout.close()
+                    proc.stderr.close()
+
+    def test_workflow_host_rejects_malformed_input(self) -> None:
+        host_path = Path(__file__).resolve().parents[1] / "workflow_host.py"
+        proc = subprocess.Popen(
+            [sys.executable, str(host_path)],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        assert proc.stdin is not None
+        assert proc.stdout is not None
+        assert proc.stderr is not None
+        try:
+            proc.stdin.write("this is not JSON\n")
+            proc.stdin.flush()
+
+            line = proc.stdout.readline()
+            self.assertTrue(line, "workflow host did not reject malformed input")
+            payload = json.loads(line)
+            self.assertEqual(payload["type"], "host.error")
+            self.assertIn("invalid workflow host input", payload["message"])
+
+            proc.wait(timeout=2)
+            self.assertEqual(proc.returncode, 1)
+            self.assertEqual(proc.stderr.read(), "")
+        finally:
+            if proc.poll() is None:
+                proc.kill()
+            proc.communicate(timeout=2)
+
+    def test_workflow_host_returns_workflow_error_for_failed_context_response(self) -> None:
+        host_path = Path(__file__).resolve().parents[1] / "workflow_host.py"
+        with tempfile.TemporaryDirectory() as tmp:
+            workflow_path = Path(tmp) / "agent_workflow.py"
+            workflow_path.write_text(
+                "WORKFLOW_NAME = 'agent_workflow'\n"
+                "async def handler(inp, ctx):\n"
+                "    return await ctx.agent_turn('summarize this')\n"
+            )
+            proc = subprocess.Popen(
+                [sys.executable, str(host_path)],
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                env={**os.environ, "WORKFLOW_DIRS": tmp},
+            )
+            assert proc.stdin is not None
+            assert proc.stdout is not None
+            assert proc.stderr is not None
+            try:
+                proc.stdin.write(
+                    json.dumps(
+                        {
+                            "type": "workflow.start",
+                            "run_id": "run-123",
+                            "task_id": "task-456",
+                            "workflow_name": "agent_workflow",
+                            "input": {},
+                        },
+                        separators=(",", ":"),
+                    )
+                    + "\n"
+                )
+                proc.stdin.flush()
+                request = json.loads(proc.stdout.readline())
+                self.assertEqual(request["type"], "ctx.agent_turn")
+
+                proc.stdin.write(
+                    json.dumps(
+                        {
+                            "type": "ctx.response",
+                            "request_id": request["request_id"],
+                            "ok": False,
+                            "error": "agent unavailable",
+                        },
+                        separators=(",", ":"),
+                    )
+                    + "\n"
+                )
+                proc.stdin.flush()
+
+                response = json.loads(proc.stdout.readline())
+                self.assertEqual(response["type"], "workflow.error")
+                self.assertEqual(response["message"], "agent unavailable")
+                proc.wait(timeout=2)
+                self.assertEqual(proc.returncode, 0)
+                self.assertEqual(proc.stderr.read(), "")
+            finally:
+                if proc.poll() is None:
+                    proc.kill()
+                if proc.stdin is not None and not proc.stdin.closed:
+                    proc.stdin.close()
+                proc.wait(timeout=2)
+                proc.stdout.close()
+                proc.stderr.close()
+
+    def test_workflow_host_rejects_concurrent_start(self) -> None:
+        host_path = Path(__file__).resolve().parents[1] / "workflow_host.py"
+        with tempfile.TemporaryDirectory() as tmp:
+            workflow_path = Path(tmp) / "agent_workflow.py"
+            workflow_path.write_text(
+                "WORKFLOW_NAME = 'agent_workflow'\n"
+                "async def handler(inp, ctx):\n"
+                "    return await ctx.agent_turn('summarize this')\n"
+            )
+            proc = subprocess.Popen(
+                [sys.executable, str(host_path)],
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                env={**os.environ, "WORKFLOW_DIRS": tmp},
+            )
+            assert proc.stdin is not None
+            assert proc.stdout is not None
+            assert proc.stderr is not None
+            start = {
+                "type": "workflow.start",
+                "run_id": "run-123",
+                "task_id": "task-456",
+                "workflow_name": "agent_workflow",
+                "input": {},
+            }
+            try:
+                proc.stdin.write(json.dumps(start, separators=(",", ":")) + "\n")
+                proc.stdin.flush()
+                request = json.loads(proc.stdout.readline())
+                self.assertEqual(request["type"], "ctx.agent_turn")
+
+                proc.stdin.write(json.dumps(start, separators=(",", ":")) + "\n")
+                proc.stdin.flush()
+                rejection = json.loads(proc.stdout.readline())
+                self.assertEqual(rejection["type"], "workflow.error")
+                self.assertEqual(rejection["message"], "workflow host already has an active workflow")
+
+                proc.stdin.write(
+                    json.dumps(
+                        {
+                            "type": "ctx.response",
+                            "request_id": request["request_id"],
+                            "ok": True,
+                            "value": {"text": "done"},
+                        },
+                        separators=(",", ":"),
+                    )
+                    + "\n"
+                )
+                proc.stdin.flush()
+                result = json.loads(proc.stdout.readline())
+                self.assertEqual(result["type"], "workflow.result")
+                proc.wait(timeout=2)
+                self.assertEqual(proc.returncode, 0)
+                self.assertEqual(proc.stderr.read(), "")
+            finally:
+                if proc.poll() is None:
+                    proc.kill()
                 proc.communicate(timeout=2)
 
+    def test_workflow_host_finishes_active_workflow_after_stdin_eof(self) -> None:
+        host_path = Path(__file__).resolve().parents[1] / "workflow_host.py"
+        with tempfile.TemporaryDirectory() as tmp:
+            workflow_path = Path(tmp) / "slow_workflow.py"
+            workflow_path.write_text(
+                "import asyncio\n"
+                "WORKFLOW_NAME = 'slow_workflow'\n"
+                "async def handler(inp, ctx):\n"
+                "    await asyncio.sleep(0.05)\n"
+                "    return {'done': True}\n"
+            )
+            proc = subprocess.Popen(
+                [sys.executable, str(host_path)],
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                env={**os.environ, "WORKFLOW_DIRS": tmp},
+            )
+            assert proc.stdin is not None
+            assert proc.stdout is not None
+            assert proc.stderr is not None
+            try:
+                proc.stdin.write(
+                    json.dumps(
+                        {
+                            "type": "workflow.start",
+                            "run_id": "run-123",
+                            "task_id": "task-456",
+                            "workflow_name": "slow_workflow",
+                            "input": {},
+                        },
+                        separators=(",", ":"),
+                    )
+                    + "\n"
+                )
+                proc.stdin.flush()
+                proc.stdin.close()
+
+                result = json.loads(proc.stdout.readline())
+                self.assertEqual(result["type"], "workflow.result")
+                self.assertEqual(result["result"], {"done": True})
+                proc.wait(timeout=2)
+                self.assertEqual(proc.returncode, 0)
+                self.assertEqual(proc.stderr.read(), "")
+            finally:
+                if proc.poll() is None:
+                    proc.kill()
+                proc.wait(timeout=2)
+                proc.stdout.close()
+                proc.stderr.close()
 if __name__ == "__main__":
     unittest.main()

--- a/services/workflow-python/workflow_host.py
+++ b/services/workflow-python/workflow_host.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import asyncio
 import ast
+import contextlib
 import dataclasses
 import importlib.util
 import inspect
@@ -396,14 +397,23 @@ async def main() -> int:
     active_workflow: asyncio.Task[dict[str, Any]] | None = None
 
     async def read_stdin() -> None:
-        while True:
-            line = await asyncio.to_thread(sys.stdin.readline)
-            if line == "":
-                await stdin_queue.put(None)
-                return
-            await stdin_queue.put(json.loads(line))
+        loop = asyncio.get_running_loop()
+        reader = asyncio.StreamReader()
+        protocol = asyncio.StreamReaderProtocol(reader)
+        transport, _ = await loop.connect_read_pipe(lambda: protocol, sys.stdin)
+        try:
+            while True:
+                line = await reader.readline()
+                if line == b"":
+                    await stdin_queue.put(None)
+                    return
+                await stdin_queue.put(json.loads(line))
+        finally:
+            transport.close()
 
-    asyncio.create_task(read_stdin())
+    stdin_reader = asyncio.create_task(read_stdin())
+    stdin_get = asyncio.create_task(stdin_queue.get())
+    completion_get = asyncio.create_task(completion_queue.get())
 
     def watch_workflow(task: asyncio.Task[dict[str, Any]]) -> None:
         try:
@@ -417,57 +427,59 @@ async def main() -> int:
                 }
             )
 
-    while True:
-        stdin_get = asyncio.create_task(stdin_queue.get())
-        completion_get = asyncio.create_task(completion_queue.get())
-        done, pending = await asyncio.wait(
-            {stdin_get, completion_get},
-            return_when=asyncio.FIRST_COMPLETED,
-        )
-        for task in pending:
-            task.cancel()
-
-        if completion_get in done:
-            active_workflow = None
-            await rpc.write(completion_get.result())
-            return 0
-
-        message = stdin_get.result()
-        if message is None:
-            if active_workflow is not None:
-                continue
-            await asyncio.sleep(0.1)
-            asyncio.create_task(read_stdin())
-            continue
-        message_type = message.get("type")
-        try:
-            if message_type == "ctx.response":
-                rpc.resolve(message)
-                continue
-            if message_type == "workflow.discover":
-                await rpc.write(discovery_payload())
-                return 0
-            if message_type == "workflow.start":
-                if active_workflow is not None:
-                    await rpc.write(
-                        {
-                            "type": "workflow.error",
-                            "message": "workflow host already has an active workflow",
-                        }
-                    )
-                    continue
-                active_workflow = asyncio.create_task(run_workflow(message, rpc))
-                active_workflow.add_done_callback(watch_workflow)
-                continue
-            raise ProtocolError(f"unknown message type {message_type!r}")
-        except Exception as exc:
-            await rpc.write(
-                {
-                    "type": "host.error",
-                    "message": str(exc),
-                    "traceback": traceback.format_exc(),
-                }
+    try:
+        while True:
+            done, _ = await asyncio.wait(
+                {stdin_get, completion_get},
+                return_when=asyncio.FIRST_COMPLETED,
             )
+
+            if completion_get in done:
+                active_workflow = None
+                await rpc.write(completion_get.result())
+                return 0
+
+            message = stdin_get.result()
+            stdin_get = asyncio.create_task(stdin_queue.get())
+            if message is None:
+                if active_workflow is not None:
+                    continue
+                return 0
+            message_type = message.get("type")
+            try:
+                if message_type == "ctx.response":
+                    rpc.resolve(message)
+                    continue
+                if message_type == "workflow.discover":
+                    await rpc.write(discovery_payload())
+                    return 0
+                if message_type == "workflow.start":
+                    if active_workflow is not None:
+                        await rpc.write(
+                            {
+                                "type": "workflow.error",
+                                "message": "workflow host already has an active workflow",
+                            }
+                        )
+                        continue
+                    active_workflow = asyncio.create_task(run_workflow(message, rpc))
+                    active_workflow.add_done_callback(watch_workflow)
+                    continue
+                raise ProtocolError(f"unknown message type {message_type!r}")
+            except Exception as exc:
+                await rpc.write(
+                    {
+                        "type": "host.error",
+                        "message": str(exc),
+                        "traceback": traceback.format_exc(),
+                    }
+                )
+    finally:
+        for task in (stdin_reader, stdin_get, completion_get):
+            if not task.done():
+                task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await asyncio.gather(stdin_reader, stdin_get, completion_get)
 
 
 if __name__ == "__main__":

--- a/services/workflow-python/workflow_host.py
+++ b/services/workflow-python/workflow_host.py
@@ -209,16 +209,17 @@ def coerce_value(value: Any, target_type: type) -> Any:
         return value
     if not isinstance(value, dict):
         return value
-    fields = {field.name for field in dataclasses.fields(target_type)}
+    fields = {field.name: field for field in dataclasses.fields(target_type)}
     try:
         hints = typing.get_type_hints(target_type)
     except Exception:
         hints = {}
     coerced = {}
     for key, raw in value.items():
-        if key not in fields:
+        field = fields.get(key)
+        if field is None:
             continue
-        hint = hints.get(key)
+        hint = hints.get(key, field.type)
         if isinstance(hint, type) and dataclasses.is_dataclass(hint) and isinstance(raw, dict):
             coerced[key] = coerce_value(raw, hint)
         else:
@@ -392,24 +393,33 @@ def discovery_payload() -> dict[str, Any]:
 
 async def main() -> int:
     rpc = RpcClient()
-    stdin_queue: asyncio.Queue[dict[str, Any] | None] = asyncio.Queue()
+    stdin_queue: asyncio.Queue[dict[str, Any] | ProtocolError | None] = asyncio.Queue()
     completion_queue: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
     active_workflow: asyncio.Task[dict[str, Any]] | None = None
 
     async def read_stdin() -> None:
-        loop = asyncio.get_running_loop()
-        reader = asyncio.StreamReader()
-        protocol = asyncio.StreamReaderProtocol(reader)
-        transport, _ = await loop.connect_read_pipe(lambda: protocol, sys.stdin)
+        transport: asyncio.ReadTransport | None = None
         try:
+            loop = asyncio.get_running_loop()
+            reader = asyncio.StreamReader()
+            protocol = asyncio.StreamReaderProtocol(reader)
+            transport, _ = await loop.connect_read_pipe(lambda: protocol, sys.stdin)
             while True:
                 line = await reader.readline()
                 if line == b"":
                     await stdin_queue.put(None)
                     return
-                await stdin_queue.put(json.loads(line))
+                message = json.loads(line)
+                if not isinstance(message, dict):
+                    raise ProtocolError("workflow host input must be a JSON object")
+                await stdin_queue.put(message)
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            await stdin_queue.put(ProtocolError(f"invalid workflow host input: {exc}"))
         finally:
-            transport.close()
+            if transport is not None:
+                transport.close()
 
     stdin_reader = asyncio.create_task(read_stdin())
     stdin_get = asyncio.create_task(stdin_queue.get())
@@ -445,6 +455,9 @@ async def main() -> int:
                 if active_workflow is not None:
                     continue
                 return 0
+            if isinstance(message, ProtocolError):
+                await rpc.write({"type": "host.error", "message": str(message)})
+                return 1
             message_type = message.get("type")
             try:
                 if message_type == "ctx.response":


### PR DESCRIPTION
Tracks and joins workflow-host stdin and completion tasks so RPC-backed workflows can return their terminal result without pending-task shutdown warnings. Adds agent-turn integration coverage and runs the workflow host test suite in CI.