### PR TITLE
feat: upgrade Codex harness to GPT-5.6 Sol

### DIFF
--- a/harness/codex/config.toml
+++ b/harness/codex/config.toml
@@ -1,4 +1,4 @@
-model = "gpt-5.5"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "low"
 personality = "pragmatic"
 model_verbosity = "low"

--- a/services/sandbox/Dockerfile
+++ b/services/sandbox/Dockerfile
@@ -47,7 +47,7 @@ RUN useradd -m -s /bin/bash -u 1001 agent \
     && echo "agent ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers.d/agent
 
 ARG CLAUDE_CODE_VERSION=2.1.143
-ARG CODEX_VERSION=0.130.0
+ARG CODEX_VERSION=0.146.0
 ARG PI_CODING_AGENT_VERSION=0.67.2
 
 # ── Global npm CLIs (root) ──────────────────────────────────────────────────


### PR DESCRIPTION
## What changed

- Switch the Codex harness default from `gpt-5.5` to `gpt-5.6-sol`.
- Upgrade the sandbox Codex CLI from `0.130.0` to `0.146.0` so the runtime supports the GPT-5.6 model family.
- Preserve the existing `low` reasoning effort, low verbosity, and Fast service tier.

## Why

GPT-5.6 Sol is the flagship GPT-5.6 model and provides a stronger intelligence baseline than GPT-5.5. The old Codex CLI pin predates GPT-5.6 and can be rejected by the model endpoint as requiring a newer runtime.

## Impact

New Codex sandbox sessions use GPT-5.6 Sol. Existing harness behavior and latency settings remain unchanged apart from the model and compatible CLI version.

## Validation

- `8 passed` in the focused sandbox entrypoint and Codex app-wrapper tests.
- `just build-one sandbox` completed successfully.
- `just deploy` applied successfully to the local `docker-desktop` Kubernetes cluster.
- The built sandbox reported `codex-cli 0.146.0` and loaded `gpt-5.6-sol`, `low`, and `fast`.
- A live OpenAI request through the built sandbox completed successfully with `SOL_OK`.

The full control-plane `just smoke` path was not runnable because the pre-existing local API deployment has an unrelated stale database/schema mismatch. No production resources were modified manually.
