### PR TITLE
chore(codex): default to Luna at high effort

### DIFF
--- a/harness/codex/config.toml
+++ b/harness/codex/config.toml
@@ -1,5 +1,5 @@
-model = "gpt-5.6-sol"
-model_reasoning_effort = "low"
+model = "gpt-5.6-luna"
+model_reasoning_effort = "high"
 personality = "pragmatic"
 model_verbosity = "low"
 service_tier = "fast"

--- a/services/slackbotv2/test/chat-sdk-emulate.test.ts
+++ b/services/slackbotv2/test/chat-sdk-emulate.test.ts
@@ -971,7 +971,7 @@ describe('slackbotv2', () => {
       .map(block => JSON.stringify(block))
       .find(text => text.includes('Open chat in Console'))
     expect(footer).toContain('Nanocodex')
-    expect(footer).toContain('Low')
+    expect(footer).toContain('High')
     expect(footer).not.toContain('Codex*')
     expect(codexApi.creates[0]?.body.harness_type).toBe('codex')
     expect(codexApi.executes[0]?.body.metadata).toMatchObject({

--- a/services/slackbotv2/test/console-session-link.test.ts
+++ b/services/slackbotv2/test/console-session-link.test.ts
@@ -133,7 +133,7 @@ describe('defaultReasoningForHarness', () => {
     .model_reasoning_effort
 
   test('shares the baked Codex reasoning default with Nanocodex', () => {
-    expect(bakedCodexReasoning).toBe('low')
+    expect(bakedCodexReasoning).toBe('high')
     expect(defaultReasoningForHarness('codex')).toBe(bakedCodexReasoning)
     expect(defaultReasoningForHarness('nanocodex')).toBe(bakedCodexReasoning)
     expect(defaultReasoningForHarness('claudecode')).toBeUndefined()


### PR DESCRIPTION
## Summary

- Switch the baked Codex default from GPT-5.6 Sol at low effort to GPT-5.6 Luna at high effort.
- Keep the Slack console metadata test aligned with the new reasoning default.

## Why

OpenAI's [July 30 price-performance update](https://openai.com/index/advancing-the-price-performance-frontier-with-gpt-5-6/) cut Luna pricing by 80%% to $0.20/M input tokens and $1.20/M output tokens. That is 25x below Sol's $5/M input and $30/M output pricing, leaving substantial headroom for high reasoning effort while reducing default cost. OpenAI also highlights Luna for routine implementation, tests, and background agent automation.

## Validation

- `bun test test/console-session-link.test.ts` (22 passed)
- `bun run check:types` could not run because `tsgo` is not installed in this checkout.

Prompted by: @DaniPopes
