### PR TITLE
feat: add raw company context queries

### DIFF
--- a/.agents/skills/company-context/SKILL.md
+++ b/.agents/skills/company-context/SKILL.md
@@ -1,11 +1,19 @@
 ---
 name: company-context
-description: "Use Centaur's indexed company context together with direct Slack, Linear, Google Docs, Drive, Calendar, or Granola searches when answering internal company-history, prior-decision, project-context, meeting-context, roadmap/status, or cross-source memory questions. Indexed context includes Slack channels, user-visible Slack DMs, Google Docs, Google Calendar, Linear, and user-visible Granola notes. Use for questions like what was discussed, decided, planned, mentioned, or documented internally, especially when the user did not name one exact source."
+description: "Use Centaur's indexed company context and scoped read-only SQL together with direct Slack, Linear, Google Docs, Drive, Calendar, or Granola searches when answering internal company-history, prior-decision, project-context, meeting-context, roadmap/status, or cross-source memory questions. Indexed context includes Slack channels, user-visible Slack DMs, Google Docs, Google Calendar, Linear, and user-visible Granola notes. Use for questions like what was discussed, decided, planned, mentioned, or documented internally, especially when the user did not name one exact source."
 ---
 
 # Company Context
 
 Use `company_context` as the first retrieval step for internal historical context. Its `search` command queries indexed company memory across enabled sources such as Slack channels, Google Docs (`--source docs`), Google Calendar, Linear, and user-visible Granola notes (`--source granola`). It also has dedicated commands for user-visible Slack DMs and DM conversations. Always pair indexed results with the relevant direct source tools, then reconcile and collate both evidence sets before answering.
+
+For aggregation, grouping, joins, or fields that the search surface does not expose, use the scoped read-only SQL command. Database grants and row-level security still apply, and output is capped:
+
+```bash
+company_context query "SELECT source, count(*) FROM company_context_documents GROUP BY source" --limit 100 --json
+```
+
+Use one row-returning query. The command runs it inside a read-only transaction with a bounded timeout, so writes and multiple statements are rejected.
 
 ## Default Workflow
 

--- a/tools/productivity/company_context/cli.py
+++ b/tools/productivity/company_context/cli.py
@@ -17,7 +17,7 @@ load_dotenv()
 
 app = typer.Typer(
     name="company_context",
-    help="Search indexed company history, Slack DMs, Google Docs, and Granola notes.",
+    help="Search or run scoped SQL over company history, Slack DMs, Google Docs, and Granola notes.",
 )
 
 
@@ -66,6 +66,51 @@ def _add_result_rows(table: Table, results: list[dict[str, Any]]) -> None:
             str(item.get("title") or ""),
             str(item.get("preview") or ""),
         )
+
+
+@app.command("query")
+def query(
+    sql: str = typer.Argument(..., help="Read-only SQL query to execute."),
+    limit: int = typer.Option(100, "--limit", "-n", help="Maximum rows to return."),
+    timeout_seconds: int = typer.Option(
+        10,
+        "--timeout-seconds",
+        help="Query timeout in seconds, capped at 30.",
+    ),
+    json_output: bool = typer.Option(False, "--json", help="Output raw JSON."),
+) -> None:
+    """Run raw read-only SQL against the scoped company-context database."""
+    result = CompanyContextClient().query(
+        sql=sql,
+        limit=limit,
+        timeout_seconds=timeout_seconds,
+    )
+    _require_ok(result)
+    if json_output:
+        _print_json(result)
+        return
+
+    rows = result.get("rows") or []
+    columns = result.get("columns") or []
+    if not rows:
+        console.print("[yellow]Query returned no rows.[/yellow]")
+        return
+
+    table = Table(title=f"Company Context Query ({len(rows)})")
+    for column in columns:
+        table.add_column(str(column), overflow="fold")
+    for row in rows:
+        table.add_row(
+            *[
+                json.dumps(row.get(column), default=str)
+                if isinstance(row.get(column), (dict, list))
+                else str(row.get(column))
+                for column in columns
+            ]
+        )
+    console.print(table)
+    if result.get("truncated"):
+        console.print(f"[yellow]Results truncated at {result.get('limit')} rows.[/yellow]")
 
 
 @app.command("search")

--- a/tools/productivity/company_context/client.py
+++ b/tools/productivity/company_context/client.py
@@ -20,6 +20,10 @@ from centaur_sdk.tool_sdk import secret
 
 DEFAULT_SEARCH_LIMIT = 10
 MAX_SEARCH_LIMIT = 50
+DEFAULT_QUERY_LIMIT = 100
+MAX_QUERY_LIMIT = 1_000
+DEFAULT_QUERY_TIMEOUT_SECONDS = 10
+MAX_QUERY_TIMEOUT_SECONDS = 30
 TITLE_MATCH_BOOST = 4
 EXACT_QUERY_TITLE_BOOST = 8
 EXACT_QUERY_BODY_BOOST = 2
@@ -564,6 +568,73 @@ class CompanyContextClient:
             _database_url_with_name(self._require_database_url(), _postgres_database_name()),
             command_timeout=30,
         )
+
+    async def _query_async(
+        self,
+        *,
+        sql: str,
+        limit: int,
+        timeout_seconds: int,
+    ) -> dict[str, Any]:
+        conn = await self._connect()
+        try:
+            rows = []
+            async with conn.transaction(readonly=True):
+                await conn.execute(
+                    "SELECT set_config('statement_timeout', $1, true)",
+                    f"{timeout_seconds}s",
+                )
+                cursor = conn.cursor(
+                    sql,
+                    prefetch=min(limit + 1, 100),
+                    timeout=timeout_seconds,
+                )
+                async for row in cursor:
+                    rows.append(row)
+                    if len(rows) > limit:
+                        break
+
+            truncated = len(rows) > limit
+            visible_rows = rows[:limit]
+            columns = list(visible_rows[0].keys()) if visible_rows else []
+            return {
+                "status": "ok",
+                "row_count": len(visible_rows),
+                "limit": limit,
+                "truncated": truncated,
+                "columns": columns,
+                "rows": [dict(row) for row in visible_rows],
+            }
+        finally:
+            await conn.close()
+
+    def query(
+        self,
+        sql: str,
+        limit: int = DEFAULT_QUERY_LIMIT,
+        timeout_seconds: int = DEFAULT_QUERY_TIMEOUT_SECONDS,
+    ) -> dict:
+        """Run one read-only SQL query against the scoped company-context database."""
+        normalized_sql = sql.strip()
+        if not normalized_sql:
+            return {"status": "error", "error": "sql cannot be empty"}
+        if normalized_sql.endswith(";"):
+            normalized_sql = normalized_sql[:-1].rstrip()
+
+        try:
+            return asyncio.run(
+                self._query_async(
+                    sql=normalized_sql,
+                    limit=_clamp(limit, minimum=1, maximum=MAX_QUERY_LIMIT),
+                    timeout_seconds=_clamp(
+                        timeout_seconds,
+                        minimum=1,
+                        maximum=MAX_QUERY_TIMEOUT_SECONDS,
+                    ),
+                )
+            )
+        except Exception as exc:
+            return {"status": "error", "error": str(exc)}
 
     async def _search_async(
         self,

--- a/tools/productivity/company_context/pyproject.toml
+++ b/tools/productivity/company_context/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "company_context"
-description = "Search indexed company history, user-visible Slack DMs, Google Docs, and Granola notes. Prefer this over direct Slack, Drive, or Granola search for historical queries. Current sources: Slack, Slack DMs, Google Docs, Google Calendar, Linear, Granola."
+description = "Search and run scoped read-only SQL over indexed company history, user-visible Slack DMs, Google Docs, and Granola notes. Prefer this over direct Slack, Drive, or Granola search for historical queries. Current sources: Slack, Slack DMs, Google Docs, Google Calendar, Linear, Granola."
 version = "0.1.0"
 requires-python = ">=3.11"
 dependencies = [

--- a/tools/productivity/company_context/tests/test_client.py
+++ b/tools/productivity/company_context/tests/test_client.py
@@ -34,6 +34,9 @@ class _FakeConnection:
         self.fetch_calls = []
         self.fetchrow_calls = []
         self.fetchval_calls = []
+        self.execute_calls = []
+        self.cursor_calls = []
+        self.transaction_calls = []
         self.closed = False
 
     async def fetch(self, query, *args):
@@ -52,8 +55,41 @@ class _FakeConnection:
         self.fetchval_calls.append((query, args))
         return self.val
 
+    async def execute(self, query, *args):
+        self.execute_calls.append((query, args))
+
+    def cursor(self, query, *args, **kwargs):
+        self.cursor_calls.append((query, args, kwargs))
+        return _FakeCursor(self.rows)
+
     async def close(self):
         self.closed = True
+
+    def transaction(self, **kwargs):
+        self.transaction_calls.append(kwargs)
+        return _FakeTransaction()
+
+
+class _FakeTransaction:
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, traceback):
+        return False
+
+
+class _FakeCursor:
+    def __init__(self, rows):
+        self._rows = iter(rows)
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        try:
+            return next(self._rows)
+        except StopIteration as exc:
+            raise StopAsyncIteration from exc
 
 
 @pytest.fixture(autouse=True)
@@ -123,6 +159,87 @@ def test_postgres_database_name_uses_default_for_blank_override(monkeypatch):
     monkeypatch.setenv("COMPANY_CONTEXT_POSTGRES_DATABASE", " ")
 
     assert company_context_client._postgres_database_name() == "ai_v2"
+
+
+@pytest.mark.parametrize("sql", ["", "   "])
+def test_query_rejects_empty_sql(sql):
+    result = CompanyContextClient("postgresql://example").query(sql)
+
+    assert result == {"status": "error", "error": "sql cannot be empty"}
+
+
+def test_query_runs_in_read_only_transaction_with_bounded_results(monkeypatch):
+    fake = _FakeConnection(
+        rows=[
+            {"source": "slack", "count": 3},
+            {"source": "linear", "count": 2},
+            {"source": "docs", "count": 1},
+        ]
+    )
+
+    async def fake_connect(*args, **kwargs):
+        return fake
+
+    monkeypatch.setattr(company_context_client.asyncpg, "connect", fake_connect)
+
+    result = CompanyContextClient("postgresql://example").query(
+        "SELECT source, count(*) AS count FROM company_context_documents GROUP BY source;",
+        limit=2,
+        timeout_seconds=7,
+    )
+
+    assert result == {
+        "status": "ok",
+        "row_count": 2,
+        "limit": 2,
+        "truncated": True,
+        "columns": ["source", "count"],
+        "rows": [
+            {"source": "slack", "count": 3},
+            {"source": "linear", "count": 2},
+        ],
+    }
+    assert fake.transaction_calls == [{"readonly": True}]
+    assert fake.execute_calls == [
+        ("SELECT set_config('statement_timeout', $1, true)", ("7s",))
+    ]
+    assert fake.cursor_calls == [
+        (
+            "SELECT source, count(*) AS count "
+            "FROM company_context_documents GROUP BY source",
+            (),
+            {"prefetch": 3, "timeout": 7},
+        )
+    ]
+    assert fake.closed is True
+
+
+def test_query_clamps_limit_and_timeout(monkeypatch):
+    fake = _FakeConnection(rows=[])
+
+    async def fake_connect(*args, **kwargs):
+        return fake
+
+    monkeypatch.setattr(company_context_client.asyncpg, "connect", fake_connect)
+
+    result = CompanyContextClient("postgresql://example").query(
+        "SELECT 1 AS value",
+        limit=10_000,
+        timeout_seconds=600,
+    )
+
+    assert result["status"] == "ok"
+    assert result["limit"] == 1_000
+    assert fake.execute_calls == [
+        ("SELECT set_config('statement_timeout', $1, true)", ("30s",))
+    ]
+    assert fake.cursor_calls == [
+        (
+            "SELECT 1 AS value",
+            (),
+            {"prefetch": 100, "timeout": 30},
+        )
+    ]
 
 
 def test_search_queries_bm25_and_returns_compact_results(monkeypatch):


### PR DESCRIPTION
Adds a raw read-only SQL query surface to the company context client and CLI. Queries continue to use the scoped Postgres role and row-level security, with bounded execution time and result counts. Updates the company-context skill guidance and adds focused coverage for validation, truncation, and query bounds.