### PR TITLE
fix(workflows): shut down Python host cleanly

### DIFF
--- a/services/workflow-python/tests/test_workflow_host.py
+++ b/services/workflow-python/tests/test_workflow_host.py
@@ -787,6 +787,72 @@ class WorkflowHostTests(unittest.TestCase):
             assert proc.stderr is not None
             self.assertEqual(proc.stderr.read(), "")
 
+    def test_workflow_host_accepts_large_start_input(self) -> None:
+        source = (
+            "WORKFLOW_NAME = 'large_input_workflow'\n"
+            "async def handler(inp, ctx):\n"
+            "    return {'size': len(inp['payload'])}\n"
+        )
+        payload = "x" * (128 * 1024)
+        with self.workflow_host(source) as proc:
+            self.send_host_message(
+                proc,
+                {
+                    "type": "workflow.start",
+                    "run_id": "run-123",
+                    "task_id": "task-456",
+                    "workflow_name": "large_input_workflow",
+                    "input": {"payload": payload},
+                },
+            )
+
+            response = self.read_host_message(proc)
+            self.assertEqual(response["type"], "workflow.result")
+            self.assertEqual(response["result"], {"size": len(payload)})
+            proc.wait(timeout=2)
+            self.assertEqual(proc.returncode, 0)
+            assert proc.stderr is not None
+            self.assertEqual(proc.stderr.read(), "")
+
+    def test_workflow_host_accepts_large_context_response(self) -> None:
+        source = (
+            "WORKFLOW_NAME = 'agent_workflow'\n"
+            "async def handler(inp, ctx):\n"
+            "    result = await ctx.agent_turn('return a large result')\n"
+            "    return {'size': len(result['text'])}\n"
+        )
+        result_text = "x" * (128 * 1024)
+        with self.workflow_host(source) as proc:
+            self.send_host_message(
+                proc,
+                {
+                    "type": "workflow.start",
+                    "run_id": "run-123",
+                    "task_id": "task-456",
+                    "workflow_name": "agent_workflow",
+                    "input": {},
+                },
+            )
+            request = self.read_host_message(proc)
+            self.assertEqual(request["type"], "ctx.agent_turn")
+            self.send_host_message(
+                proc,
+                {
+                    "type": "ctx.response",
+                    "request_id": request["request_id"],
+                    "ok": True,
+                    "value": {"text": result_text},
+                },
+            )
+
+            response = self.read_host_message(proc)
+            self.assertEqual(response["type"], "workflow.result")
+            self.assertEqual(response["result"], {"size": len(result_text)})
+            proc.wait(timeout=2)
+            self.assertEqual(proc.returncode, 0)
+            assert proc.stderr is not None
+            self.assertEqual(proc.stderr.read(), "")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/services/workflow-python/tests/test_workflow_host.py
+++ b/services/workflow-python/tests/test_workflow_host.py
@@ -1,12 +1,17 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import importlib.util
+import json
 import os
+import select
+import subprocess
 import sys
 import tempfile
 import types
 import unittest
+from collections.abc import Iterator
 from pathlib import Path
 from unittest.mock import patch
 
@@ -75,6 +80,63 @@ class RequestRpc(FakeRpc):
 
 
 class WorkflowHostTests(unittest.TestCase):
+    @contextlib.contextmanager
+    def workflow_host(
+        self,
+        source: str | None = None,
+        *,
+        filename: str = "workflow.py",
+    ) -> Iterator[subprocess.Popen[str]]:
+        host_path = Path(__file__).resolve().parents[1] / "workflow_host.py"
+        with tempfile.TemporaryDirectory() as tmp:
+            if source is not None:
+                (Path(tmp) / filename).write_text(source)
+            proc = subprocess.Popen(
+                [sys.executable, str(host_path)],
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                env={**os.environ, "WORKFLOW_DIRS": tmp},
+            )
+            assert proc.stdin is not None
+            assert proc.stdout is not None
+            assert proc.stderr is not None
+            try:
+                yield proc
+            finally:
+                self.stop_host(proc)
+
+    def send_host_message(
+        self,
+        proc: subprocess.Popen[str],
+        message: dict,
+    ) -> None:
+        assert proc.stdin is not None
+        proc.stdin.write(json.dumps(message) + "\n")
+        proc.stdin.flush()
+
+    def read_host_message(
+        self,
+        proc: subprocess.Popen[str],
+        *,
+        timeout: float = 2,
+    ) -> dict:
+        assert proc.stdout is not None
+        readable, _, _ = select.select([proc.stdout], [], [], timeout)
+        self.assertTrue(readable, "workflow host did not emit a response")
+        line = proc.stdout.readline()
+        self.assertTrue(line, "workflow host closed stdout before emitting a response")
+        return json.loads(line)
+
+    def stop_host(self, proc: subprocess.Popen[str]) -> None:
+        if proc.poll() is None:
+            proc.kill()
+        proc.wait(timeout=2)
+        for stream in (proc.stdin, proc.stdout, proc.stderr):
+            if stream is not None and not stream.closed:
+                stream.close()
+
     def test_workflow_api_modules_are_importable(self) -> None:
         load_workflow_host()
 
@@ -430,6 +492,300 @@ class WorkflowHostTests(unittest.TestCase):
 
         assert registered is not None
         self.assertEqual(host.normalize_principal(registered), True)
+
+    def test_failed_workflow_host_exits_with_stdin_open(self) -> None:
+        source = (
+            "WORKFLOW_NAME = 'failing_workflow'\n"
+            "async def handler(inp, ctx):\n"
+            "    raise RuntimeError('boom')\n"
+        )
+        with self.workflow_host(source) as proc:
+            self.send_host_message(
+                proc,
+                {
+                    "type": "workflow.start",
+                    "run_id": "run-123",
+                    "task_id": "task-456",
+                    "workflow_name": "failing_workflow",
+                    "input": {},
+                },
+            )
+
+            response = self.read_host_message(proc)
+            self.assertEqual(response["type"], "workflow.error")
+            self.assertEqual(response["message"], "boom")
+            proc.wait(timeout=2)
+            self.assertEqual(proc.returncode, 0)
+            assert proc.stderr is not None
+            self.assertEqual(proc.stderr.read(), "")
+
+    def test_workflow_host_returns_result_after_context_response(self) -> None:
+        source = (
+            "WORKFLOW_NAME = 'agent_workflow'\n"
+            "async def handler(inp, ctx):\n"
+            "    result = await ctx.agent_turn('summarize this')\n"
+            "    return {'agent_result': result}\n"
+        )
+        with self.workflow_host(source) as proc:
+            self.send_host_message(
+                proc,
+                {
+                    "type": "workflow.start",
+                    "run_id": "run-123",
+                    "task_id": "task-456",
+                    "workflow_name": "agent_workflow",
+                    "input": {},
+                },
+            )
+
+            request = self.read_host_message(proc)
+            self.assertEqual(request["type"], "ctx.agent_turn")
+            self.send_host_message(
+                proc,
+                {
+                    "type": "ctx.response",
+                    "request_id": request["request_id"],
+                    "ok": True,
+                    "value": {"text": "daily digest"},
+                },
+            )
+
+            response = self.read_host_message(proc)
+            self.assertEqual(response["type"], "workflow.result")
+            self.assertEqual(
+                response["result"],
+                {"agent_result": {"text": "daily digest"}},
+            )
+            proc.wait(timeout=2)
+            self.assertEqual(proc.returncode, 0)
+            assert proc.stderr is not None
+            self.assertEqual(proc.stderr.read(), "")
+
+    def test_workflow_host_returns_error_after_failed_context_response(self) -> None:
+        source = (
+            "WORKFLOW_NAME = 'agent_workflow'\n"
+            "async def handler(inp, ctx):\n"
+            "    return await ctx.agent_turn('summarize this')\n"
+        )
+        with self.workflow_host(source) as proc:
+            self.send_host_message(
+                proc,
+                {
+                    "type": "workflow.start",
+                    "run_id": "run-123",
+                    "task_id": "task-456",
+                    "workflow_name": "agent_workflow",
+                    "input": {},
+                },
+            )
+
+            request = self.read_host_message(proc)
+            self.assertEqual(request["type"], "ctx.agent_turn")
+            self.send_host_message(
+                proc,
+                {
+                    "type": "ctx.response",
+                    "request_id": request["request_id"],
+                    "ok": False,
+                    "error": "agent unavailable",
+                },
+            )
+
+            response = self.read_host_message(proc)
+            self.assertEqual(response["type"], "workflow.error")
+            self.assertEqual(response["message"], "agent unavailable")
+            proc.wait(timeout=2)
+            self.assertEqual(proc.returncode, 0)
+            assert proc.stderr is not None
+            self.assertEqual(proc.stderr.read(), "")
+
+    def test_workflow_host_finishes_active_workflow_after_stdin_eof(self) -> None:
+        source = (
+            "import asyncio\n"
+            "WORKFLOW_NAME = 'slow_workflow'\n"
+            "async def handler(inp, ctx):\n"
+            "    await asyncio.sleep(0.05)\n"
+            "    return {'done': True}\n"
+        )
+        with self.workflow_host(source) as proc:
+            self.send_host_message(
+                proc,
+                {
+                    "type": "workflow.start",
+                    "run_id": "run-123",
+                    "task_id": "task-456",
+                    "workflow_name": "slow_workflow",
+                    "input": {},
+                },
+            )
+            assert proc.stdin is not None
+            proc.stdin.close()
+
+            response = self.read_host_message(proc)
+            self.assertEqual(response["type"], "workflow.result")
+            self.assertEqual(response["result"], {"done": True})
+            proc.wait(timeout=2)
+            self.assertEqual(proc.returncode, 0)
+            assert proc.stderr is not None
+            self.assertEqual(proc.stderr.read(), "")
+
+    def test_malformed_input_cancels_active_workflow_cleanly(self) -> None:
+        source = (
+            "WORKFLOW_NAME = 'agent_workflow'\n"
+            "async def handler(inp, ctx):\n"
+            "    return await ctx.agent_turn('summarize this')\n"
+        )
+        with self.workflow_host(source) as proc:
+            self.send_host_message(
+                proc,
+                {
+                    "type": "workflow.start",
+                    "run_id": "run-123",
+                    "task_id": "task-456",
+                    "workflow_name": "agent_workflow",
+                    "input": {},
+                },
+            )
+            request = self.read_host_message(proc)
+            self.assertEqual(request["type"], "ctx.agent_turn")
+            assert proc.stdin is not None
+            proc.stdin.write("this is not JSON\n")
+            proc.stdin.flush()
+
+            response = self.read_host_message(proc)
+            self.assertEqual(response["type"], "host.error")
+            self.assertIn("invalid workflow host input", response["message"])
+            proc.wait(timeout=2)
+            self.assertEqual(proc.returncode, 1)
+            assert proc.stderr is not None
+            self.assertEqual(proc.stderr.read(), "")
+
+    def test_concurrent_start_does_not_interrupt_active_workflow(self) -> None:
+        source = (
+            "WORKFLOW_NAME = 'agent_workflow'\n"
+            "async def handler(inp, ctx):\n"
+            "    return await ctx.agent_turn('summarize this')\n"
+        )
+        start = {
+            "type": "workflow.start",
+            "run_id": "run-123",
+            "task_id": "task-456",
+            "workflow_name": "agent_workflow",
+            "input": {},
+        }
+        with self.workflow_host(source) as proc:
+            self.send_host_message(proc, start)
+            request = self.read_host_message(proc)
+            self.assertEqual(request["type"], "ctx.agent_turn")
+
+            self.send_host_message(proc, start)
+            rejection = self.read_host_message(proc)
+            self.assertEqual(rejection["type"], "workflow.error")
+            self.assertEqual(
+                rejection["message"],
+                "workflow host already has an active workflow",
+            )
+
+            self.send_host_message(
+                proc,
+                {
+                    "type": "ctx.response",
+                    "request_id": request["request_id"],
+                    "ok": True,
+                    "value": {"text": "done"},
+                },
+            )
+            response = self.read_host_message(proc)
+            self.assertEqual(response["type"], "workflow.result")
+            self.assertEqual(response["result"], {"text": "done"})
+            proc.wait(timeout=2)
+            self.assertEqual(proc.returncode, 0)
+            assert proc.stderr is not None
+            self.assertEqual(proc.stderr.read(), "")
+
+    def test_workflow_host_handles_multiple_context_responses(self) -> None:
+        source = (
+            "WORKFLOW_NAME = 'agent_workflow'\n"
+            "async def handler(inp, ctx):\n"
+            "    first = await ctx.agent_turn('first')\n"
+            "    second = await ctx.agent_turn('second')\n"
+            "    return {'first': first, 'second': second}\n"
+        )
+        with self.workflow_host(source) as proc:
+            self.send_host_message(
+                proc,
+                {
+                    "type": "workflow.start",
+                    "run_id": "run-123",
+                    "task_id": "task-456",
+                    "workflow_name": "agent_workflow",
+                    "input": {},
+                },
+            )
+            for expected_prompt in ("first", "second"):
+                request = self.read_host_message(proc)
+                self.assertEqual(request["type"], "ctx.agent_turn")
+                self.assertEqual(request["args"]["text"], expected_prompt)
+                self.send_host_message(
+                    proc,
+                    {
+                        "type": "ctx.response",
+                        "request_id": request["request_id"],
+                        "ok": True,
+                        "value": {"text": f"{expected_prompt} result"},
+                    },
+                )
+
+            response = self.read_host_message(proc)
+            self.assertEqual(response["type"], "workflow.result")
+            self.assertEqual(
+                response["result"],
+                {
+                    "first": {"text": "first result"},
+                    "second": {"text": "second result"},
+                },
+            )
+            proc.wait(timeout=2)
+            self.assertEqual(proc.returncode, 0)
+            assert proc.stderr is not None
+            self.assertEqual(proc.stderr.read(), "")
+
+    def test_workflow_completion_wins_when_more_input_is_buffered(self) -> None:
+        source = (
+            "WORKFLOW_NAME = 'agent_workflow'\n"
+            "async def handler(inp, ctx):\n"
+            "    return await ctx.agent_turn('summarize this')\n"
+        )
+        start = {
+            "type": "workflow.start",
+            "run_id": "run-123",
+            "task_id": "task-456",
+            "workflow_name": "agent_workflow",
+            "input": {},
+        }
+        with self.workflow_host(source) as proc:
+            self.send_host_message(proc, start)
+            request = self.read_host_message(proc)
+            self.assertEqual(request["type"], "ctx.agent_turn")
+
+            assert proc.stdin is not None
+            context_response = {
+                "type": "ctx.response",
+                "request_id": request["request_id"],
+                "ok": True,
+                "value": {"text": "done"},
+            }
+            proc.stdin.write(json.dumps(context_response) + "\n")
+            proc.stdin.write(json.dumps(start) + "\n")
+            proc.stdin.flush()
+
+            response = self.read_host_message(proc)
+            self.assertEqual(response["type"], "workflow.result")
+            self.assertEqual(response["result"], {"text": "done"})
+            proc.wait(timeout=2)
+            self.assertEqual(proc.returncode, 0)
+            assert proc.stderr is not None
+            self.assertEqual(proc.stderr.read(), "")
 
 
 if __name__ == "__main__":

--- a/services/workflow-python/workflow_host.py
+++ b/services/workflow-python/workflow_host.py
@@ -389,6 +389,27 @@ def discovery_payload() -> dict[str, Any]:
     }
 
 
+async def read_protocol_line(reader: asyncio.StreamReader, buffer: bytearray) -> bytes:
+    search_from = 0
+    while True:
+        newline = buffer.find(b"\n", search_from)
+        if newline >= 0:
+            line = bytes(buffer[: newline + 1])
+            del buffer[: newline + 1]
+            return line
+
+        search_from = len(buffer)
+        chunk = await reader.read(64 * 1024)
+        if chunk:
+            buffer.extend(chunk)
+            continue
+        if buffer:
+            line = bytes(buffer)
+            buffer.clear()
+            return line
+        return b""
+
+
 async def main() -> int:
     rpc = RpcClient()
     active_workflow: asyncio.Task[dict[str, Any]] | None = None
@@ -419,13 +440,16 @@ async def main() -> int:
         return 1
 
     stdin_read: asyncio.Task[bytes] | None = None
+    stdin_buffer = bytearray()
 
     try:
         while True:
             if active_workflow is None:
-                line = await reader.readline()
+                line = await read_protocol_line(reader, stdin_buffer)
             else:
-                stdin_read = asyncio.create_task(reader.readline())
+                stdin_read = asyncio.create_task(
+                    read_protocol_line(reader, stdin_buffer)
+                )
                 done, _ = await asyncio.wait(
                     {stdin_read, active_workflow},
                     return_when=asyncio.FIRST_COMPLETED,

--- a/services/workflow-python/workflow_host.py
+++ b/services/workflow-python/workflow_host.py
@@ -391,83 +391,107 @@ def discovery_payload() -> dict[str, Any]:
 
 async def main() -> int:
     rpc = RpcClient()
-    stdin_queue: asyncio.Queue[dict[str, Any] | None] = asyncio.Queue()
-    completion_queue: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
     active_workflow: asyncio.Task[dict[str, Any]] | None = None
 
-    async def read_stdin() -> None:
-        while True:
-            line = await asyncio.to_thread(sys.stdin.readline)
-            if line == "":
-                await stdin_queue.put(None)
-                return
-            await stdin_queue.put(json.loads(line))
-
-    asyncio.create_task(read_stdin())
-
-    def watch_workflow(task: asyncio.Task[dict[str, Any]]) -> None:
+    async def workflow_response(task: asyncio.Task[dict[str, Any]]) -> dict[str, Any]:
         try:
-            completion_queue.put_nowait(task.result())
+            return await task
         except Exception as exc:
-            completion_queue.put_nowait(
-                {
-                    "type": "workflow.error",
-                    "message": str(exc),
-                    "traceback": traceback.format_exc(),
-                }
-            )
+            return {
+                "type": "workflow.error",
+                "message": str(exc),
+                "traceback": traceback.format_exc(),
+            }
 
-    while True:
-        stdin_get = asyncio.create_task(stdin_queue.get())
-        completion_get = asyncio.create_task(completion_queue.get())
-        done, pending = await asyncio.wait(
-            {stdin_get, completion_get},
-            return_when=asyncio.FIRST_COMPLETED,
+    loop = asyncio.get_running_loop()
+    reader = asyncio.StreamReader()
+    protocol = asyncio.StreamReaderProtocol(reader)
+    try:
+        transport, _ = await loop.connect_read_pipe(lambda: protocol, sys.stdin)
+    except Exception as exc:
+        await rpc.write(
+            {
+                "type": "host.error",
+                "message": f"failed to read workflow host input: {exc}",
+                "traceback": traceback.format_exc(),
+            }
         )
-        for task in pending:
-            task.cancel()
+        return 1
 
-        if completion_get in done:
-            active_workflow = None
-            await rpc.write(completion_get.result())
-            return 0
+    stdin_read: asyncio.Task[bytes] | None = None
 
-        message = stdin_get.result()
-        if message is None:
-            if active_workflow is not None:
-                continue
-            await asyncio.sleep(0.1)
-            asyncio.create_task(read_stdin())
-            continue
-        message_type = message.get("type")
-        try:
-            if message_type == "ctx.response":
-                rpc.resolve(message)
-                continue
-            if message_type == "workflow.discover":
-                await rpc.write(discovery_payload())
-                return 0
-            if message_type == "workflow.start":
+    try:
+        while True:
+            if active_workflow is None:
+                line = await reader.readline()
+            else:
+                stdin_read = asyncio.create_task(reader.readline())
+                done, _ = await asyncio.wait(
+                    {stdin_read, active_workflow},
+                    return_when=asyncio.FIRST_COMPLETED,
+                )
+                if active_workflow in done:
+                    await rpc.write(await workflow_response(active_workflow))
+                    active_workflow = None
+                    return 0
+                line = stdin_read.result()
+                stdin_read = None
+
+            if line == b"":
                 if active_workflow is not None:
-                    await rpc.write(
-                        {
-                            "type": "workflow.error",
-                            "message": "workflow host already has an active workflow",
-                        }
-                    )
+                    await rpc.write(await workflow_response(active_workflow))
+                    active_workflow = None
+                return 0
+
+            try:
+                message = json.loads(line)
+                if not isinstance(message, dict):
+                    raise ProtocolError("workflow host input must be a JSON object")
+            except Exception as exc:
+                await rpc.write(
+                    {
+                        "type": "host.error",
+                        "message": f"invalid workflow host input: {exc}",
+                        "traceback": traceback.format_exc(),
+                    }
+                )
+                return 1
+
+            message_type = message.get("type")
+            try:
+                if message_type == "ctx.response":
+                    rpc.resolve(message)
                     continue
-                active_workflow = asyncio.create_task(run_workflow(message, rpc))
-                active_workflow.add_done_callback(watch_workflow)
-                continue
-            raise ProtocolError(f"unknown message type {message_type!r}")
-        except Exception as exc:
-            await rpc.write(
-                {
-                    "type": "host.error",
-                    "message": str(exc),
-                    "traceback": traceback.format_exc(),
-                }
-            )
+                if message_type == "workflow.discover":
+                    await rpc.write(discovery_payload())
+                    return 0
+                if message_type == "workflow.start":
+                    if active_workflow is not None:
+                        await rpc.write(
+                            {
+                                "type": "workflow.error",
+                                "message": "workflow host already has an active workflow",
+                            }
+                        )
+                        continue
+                    active_workflow = asyncio.create_task(run_workflow(message, rpc))
+                    continue
+                raise ProtocolError(f"unknown message type {message_type!r}")
+            except Exception as exc:
+                await rpc.write(
+                    {
+                        "type": "host.error",
+                        "message": str(exc),
+                        "traceback": traceback.format_exc(),
+                    }
+                )
+    finally:
+        transport.close()
+        remaining = [task for task in (stdin_read, active_workflow) if task is not None]
+        for task in remaining:
+            if not task.done():
+                task.cancel()
+        await asyncio.gather(*remaining, return_exceptions=True)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Replaces the queue-and-thread stdin loop with a direct async pipe read raced against the active workflow, and explicitly cancels and awaits pending tasks during shutdown. Adds subprocess regression coverage for workflow failures, context responses, EOF, malformed input, concurrent starts, and buffered-input races.