### PR TITLE
fix(console): restore inline markdown links

### DIFF
--- a/services/console/app/helpers/application_helper.rb
+++ b/services/console/app/helpers/application_helper.rb
@@ -582,8 +582,8 @@ module ApplicationHelper
     text = text.gsub(/(?<!\*)\*([^*\n]+)\*(?!\*)/, '<em>\1</em>')
     text = text.gsub(/(?<!_)_([^_\n]+)_(?!_)/, '<em>\1</em>')
 
-    placeholders.each_with_index do |html, offset|
-      text = text.gsub(markdown_token(offset), html)
+    text.gsub(/%%MDPH(\d+)%%/) do |token|
+      placeholders[Regexp.last_match(1).to_i] || token
     end
 
     text

--- a/services/console/app/helpers/application_helper.rb
+++ b/services/console/app/helpers/application_helper.rb
@@ -582,7 +582,7 @@ module ApplicationHelper
     text = text.gsub(/(?<!\*)\*([^*\n]+)\*(?!\*)/, '<em>\1</em>')
     text = text.gsub(/(?<!_)_([^_\n]+)_(?!_)/, '<em>\1</em>')
 
-    text.gsub(/%%MDPH(\d+)%%/) do |token|
+    text = text.gsub(/%%MDPH(\d+)%%/) do |token|
       offset = token.delete_prefix("%%MDPH").delete_suffix("%%").to_i
       placeholders[offset] || token
     end

--- a/services/console/app/helpers/application_helper.rb
+++ b/services/console/app/helpers/application_helper.rb
@@ -583,7 +583,8 @@ module ApplicationHelper
     text = text.gsub(/(?<!_)_([^_\n]+)_(?!_)/, '<em>\1</em>')
 
     text.gsub(/%%MDPH(\d+)%%/) do |token|
-      placeholders[Regexp.last_match(1).to_i] || token
+      offset = token.delete_prefix("%%MDPH").delete_suffix("%%").to_i
+      placeholders[offset] || token
     end
 
     text

--- a/services/console/test/helpers/application_helper_test.rb
+++ b/services/console/test/helpers/application_helper_test.rb
@@ -67,14 +67,14 @@ class ApplicationHelperTest < ActionView::TestCase
 
   test "console_markdown restores every inline markdown link" do
     html = console_markdown(<<~MARKDOWN)
-      Compare [Centaur](https://github.com/paradigmxyz/centaur),
-      [Tempo](https://github.com/tempoxyz/tempo), and [QM](https://github.com/yc-software/qm).
+      Compare [First resource](https://example.com/first),
+      [Second resource](https://example.com/second), and [Third resource](https://example.com/third).
     MARKDOWN
 
     assert_select_in html, "a.console-markdown-link", count: 3
-    assert_select_in html, "a.console-markdown-link[href='https://github.com/paradigmxyz/centaur']", text: "Centaur"
-    assert_select_in html, "a.console-markdown-link[href='https://github.com/tempoxyz/tempo']", text: "Tempo"
-    assert_select_in html, "a.console-markdown-link[href='https://github.com/yc-software/qm']", text: "QM"
+    assert_select_in html, "a.console-markdown-link[href='https://example.com/first']", text: "First resource"
+    assert_select_in html, "a.console-markdown-link[href='https://example.com/second']", text: "Second resource"
+    assert_select_in html, "a.console-markdown-link[href='https://example.com/third']", text: "Third resource"
     refute_match(/%%MDPH\d+%%/, html)
   end
 

--- a/services/console/test/helpers/application_helper_test.rb
+++ b/services/console/test/helpers/application_helper_test.rb
@@ -65,6 +65,19 @@ class ApplicationHelperTest < ActionView::TestCase
                      text: "https://github.com/paradigmxyz/centaur/issues/792"
   end
 
+  test "console_markdown restores every inline markdown link" do
+    html = console_markdown(<<~MARKDOWN)
+      Compare [Centaur](https://github.com/paradigmxyz/centaur),
+      [Tempo](https://github.com/tempoxyz/tempo), and [QM](https://github.com/yc-software/qm).
+    MARKDOWN
+
+    assert_select_in html, "a.console-markdown-link", count: 3
+    assert_select_in html, "a.console-markdown-link[href='https://github.com/paradigmxyz/centaur']", text: "Centaur"
+    assert_select_in html, "a.console-markdown-link[href='https://github.com/tempoxyz/tempo']", text: "Tempo"
+    assert_select_in html, "a.console-markdown-link[href='https://github.com/yc-software/qm']", text: "QM"
+    refute_match(/%%MDPH\d+%%/, html)
+  end
+
   test "console_markdown renders gfm tables with alignment" do
     html = console_markdown(<<~MARKDOWN)
       Before the table.


### PR DESCRIPTION
## Summary

- restore protected inline Markdown fragments in one pass so `%%MDPH…%%` sentinels cannot leak into Console transcripts
- add regression coverage for multiple inline Markdown links

## Validation

- `git diff --check`
- Rails test suite not run locally: Ruby/Bundler is not installed in the sandbox; Console CI should run on this PR

Prompted by: @gorried