### PR TITLE
fix(slack): seed historical backfill bootstrap

### DIFF
--- a/workflows/slack/sync.py
+++ b/workflows/slack/sync.py
@@ -43,6 +43,7 @@ from workflows.slack.shared import (
     positive_int,
     record_run_finish,
     record_run_start,
+    seed_channel_bootstrap_job,
     upsert_messages,
     widen_channel_bootstrap_job,
     workflow_run_id_to_sync_run_id,
@@ -674,15 +675,40 @@ async def handler(inp: Input, ctx: WorkflowContext) -> dict[str, Any]:
             bootstrap_widened = False
             if checkpoint_watermark is not None and inp.oldest is None:
                 desired_oldest = _ts_now_minus_days(lookback_days)
-                bootstrap_widened = await widen_channel_bootstrap_job(
+                initial_backfill_seeded = await seed_channel_bootstrap_job(
                     ctx._pool,
                     channel_id=channel_id,
                     window_oldest=desired_oldest,
+                    window_latest=str(oldest),
                     lookback_days=lookback_days,
                     thread_lookback_days=thread_lookback_days,
                     run_id=run_id,
                     priority=150,
                 )
+                if not initial_backfill_seeded:
+                    bootstrap_widened = await widen_channel_bootstrap_job(
+                        ctx._pool,
+                        channel_id=channel_id,
+                        window_oldest=desired_oldest,
+                        lookback_days=lookback_days,
+                        thread_lookback_days=thread_lookback_days,
+                        run_id=run_id,
+                        priority=150,
+                    )
+                if initial_backfill_seeded:
+                    record_etl_items_enqueued(
+                        "slack", "channel", "channel_bootstrap_job", 1
+                    )
+                    ctx.log(
+                        "slack_sync_bootstrap_seeded",
+                        channel_id=channel_id,
+                        channel_name=channel_name,
+                        job_type=BACKFILL_JOB_CHANNEL_BOOTSTRAP,
+                        job_key=_bootstrap_backfill_job_key(channel_id),
+                        lookback_days=lookback_days,
+                        window_oldest_ts=desired_oldest,
+                        window_latest_ts=str(oldest),
+                    )
                 if bootstrap_widened:
                     record_etl_items_enqueued(
                         "slack", "channel", "channel_bootstrap_widened_job", 1

--- a/workflows/slack/tests/test_sync_cold_start.py
+++ b/workflows/slack/tests/test_sync_cold_start.py
@@ -128,6 +128,7 @@ def _patch_handler_io(monkeypatch, sync, *, checkpoint=None, client=None):
         "enqueued": [],
         "finish": [],
         "run_start": [],
+        "seeded": [],
         "widened": [],
     }
     fake_client = client or FakeClient()
@@ -160,6 +161,10 @@ def _patch_handler_io(monkeypatch, sync, *, checkpoint=None, client=None):
         calls["widened"].append(kwargs)
         return False
 
+    async def fake_seed_channel_bootstrap_job(_pool, **kwargs):
+        calls["seeded"].append(kwargs)
+        return True
+
     monkeypatch.setattr(sync, "_client", lambda: fake_client)
     monkeypatch.setattr(sync, "_upsert_channels", _noop)
     monkeypatch.setattr(sync, "_upsert_users", _zero)
@@ -176,6 +181,11 @@ def _patch_handler_io(monkeypatch, sync, *, checkpoint=None, client=None):
         sync,
         "widen_channel_bootstrap_job",
         fake_widen_channel_bootstrap_job,
+    )
+    monkeypatch.setattr(
+        sync,
+        "seed_channel_bootstrap_job",
+        fake_seed_channel_bootstrap_job,
     )
 
     return fake_client, calls
@@ -202,6 +212,7 @@ def test_cold_start_channel_uses_full_lookback_window(monkeypatch):
         }
     ]
     assert calls["enqueued"] == []
+    assert calls["seeded"] == []
     assert calls["widened"] == []
 
 
@@ -225,11 +236,51 @@ def test_watermarked_channel_keeps_incremental_overlap(monkeypatch):
 
     assert result["status"] == "completed"
     assert client.history_calls[0]["oldest"] == "minus:1771000000.000100:3"
-    assert calls["widened"] == [
+    assert calls["seeded"] == [
         {
             "channel_id": "C123",
             "window_oldest": "days:30",
+            "window_latest": "minus:1771000000.000100:3",
             "lookback_days": 30,
+            "thread_lookback_days": 3,
+            "run_id": "slack_sync_wfr_test",
+            "priority": 150,
+        }
+    ]
+    assert calls["widened"] == []
+
+
+def test_watermarked_channel_widens_existing_bootstrap(monkeypatch):
+    monkeypatch.setenv("SLACK_ETL_ENABLED", "true")
+    sync = _load_sync()
+    client, calls = _patch_handler_io(
+        monkeypatch,
+        sync,
+        checkpoint={"watermark_ts": "1771000000.000100", "last_error": ""},
+    )
+
+    async def fake_seed(_pool, **kwargs):
+        calls["seeded"].append(kwargs)
+        return False
+
+    async def fake_widen(_pool, **kwargs):
+        calls["widened"].append(kwargs)
+        return True
+
+    monkeypatch.setattr(sync, "seed_channel_bootstrap_job", fake_seed)
+    monkeypatch.setattr(sync, "widen_channel_bootstrap_job", fake_widen)
+    monkeypatch.setattr(sync, "_ts_minus_days", lambda ts, days: f"minus:{ts}:{days}")
+    monkeypatch.setattr(sync, "_ts_now_minus_days", lambda days: f"days:{days}")
+
+    result = asyncio.run(sync.handler(sync.Input(lookback_days=210), FakeContext()))
+
+    assert result["status"] == "completed"
+    assert len(calls["seeded"]) == 1
+    assert calls["widened"] == [
+        {
+            "channel_id": "C123",
+            "window_oldest": "days:210",
+            "lookback_days": 210,
             "thread_lookback_days": 3,
             "run_id": "slack_sync_wfr_test",
             "priority": 150,

--- a/workflows/slack/tests/test_sync_head_probe.py
+++ b/workflows/slack/tests/test_sync_head_probe.py
@@ -174,6 +174,9 @@ def _patch_handler_io(monkeypatch, sync, *, checkpoint=None, client=None):
     async def fake_widen(_pool, **_kwargs):
         return False
 
+    async def fake_seed(_pool, **_kwargs):
+        return False
+
     monkeypatch.setattr(sync, "_client", lambda: fake_client)
     monkeypatch.setattr(sync, "_upsert_channels", _noop)
     monkeypatch.setattr(sync, "_upsert_users", _zero)
@@ -187,6 +190,7 @@ def _patch_handler_io(monkeypatch, sync, *, checkpoint=None, client=None):
     monkeypatch.setattr(sync, "record_run_start", _noop)
     monkeypatch.setattr(sync, "record_run_finish", _noop)
     monkeypatch.setattr(sync, "widen_channel_bootstrap_job", fake_widen)
+    monkeypatch.setattr(sync, "seed_channel_bootstrap_job", fake_seed)
 
     return calls
 


### PR DESCRIPTION
## Summary
- seed missing channel bootstrap jobs for checkpointed Slack channels
- widen existing bootstrap jobs without disturbing active cursors
- add regression coverage for seeding and widening

## Test plan
- `SLACK_SYNC_INDEX_PRIVATE_CHANNELS=false uv run --with pytest pytest workflows/slack/tests/test_sync_cold_start.py workflows/slack/tests/test_sync_head_probe.py`

Prompted by: mslipper