### PR TITLE
fix(console): schedule Google Docs sync

### DIFF
--- a/services/console/config/recurring.yml
+++ b/services/console/config/recurring.yml
@@ -24,6 +24,7 @@ production:
     schedule: every 10 minutes
   google_docs_poll_sync:
     class: "GoogleDocs::PollSyncJob"
+    schedule: every 30 minutes
   granola_poll_sync:
     class: "Granola::PollSyncJob"
     schedule: every 30 minutes


### PR DESCRIPTION
Schedules the existing Google Docs OAuth polling job every 30 minutes, matching the Granola sync cadence. Deployments without an enabled Google OAuth app and eligible credentials continue to no-op through the job's existing guards.