### PR TITLE
fix: reuse workflow principals for agent turns

### DIFF
--- a/docs/pages/extend/workflows-v2.mdx
+++ b/docs/pages/extend/workflows-v2.mdx
@@ -109,7 +109,6 @@ Use `ctx.agent_turn(...)` when the workflow needs an agent sandbox:
 ```python
 result = await ctx.agent_turn(
     "Investigate this alert and return the next action.",
-    thread_key=f"workflow:{ctx.run_id}:agent",
     harness="codex",
     model="gpt-5.2",
     reasoning="high",
@@ -119,7 +118,10 @@ result = await ctx.agent_turn(
 
 The workflow host sandbox is separate from the agent sandbox. The workflow
 handler coordinates the run; the agent turn runs through the normal Centaur
-session runtime.
+session runtime. Without an explicit `thread_key`, Centaur creates a
+run-specific session and binds it to the stable `workflow-<name>` principal.
+An explicit `thread_key` instead uses the normal session-derived principal and
+persistent session lifecycle.
 
 #### Declare Workflow-Host Permissions
 
@@ -131,9 +133,11 @@ WORKFLOW_NAME = "nightly_report"
 WORKFLOW_PRINCIPAL = True
 ```
 
-The API derives and registers the `workflow-nightly-report` principal in the
-Centaur Console and runs that workflow's host sandbox under it. Grant only the
-roles or secrets that workflow needs:
+The API derives the `workflow-nightly-report` principal in the Centaur Console.
+Automatic agent turns use this principal even without `WORKFLOW_PRINCIPAL`.
+Setting `WORKFLOW_PRINCIPAL = True` also runs the workflow's host sandbox under
+it, so direct `ctx.call_tool(...)` calls share the same grants. Grant only the
+roles or secrets that the workflow needs:
 
 ```bash
 cargo run -p centaur-perms -- \

--- a/docs/pages/extend/workflows-v2.mdx
+++ b/docs/pages/extend/workflows-v2.mdx
@@ -137,11 +137,14 @@ The API derives the `workflow-nightly-report` principal in the Centaur Console.
 Automatic agent turns use this principal even without `WORKFLOW_PRINCIPAL`.
 Setting `WORKFLOW_PRINCIPAL = True` also runs the workflow's host sandbox under
 it, so direct `ctx.call_tool(...)` calls share the same grants. Grant only the
-roles or secrets that the workflow needs:
+roles or secrets that the workflow needs. Centaur does not assign channel-style
+default roles to workflow principals, so agent turns also need an explicit
+model or harness credential role such as `infra`:
 
 ```bash
 cargo run -p centaur-perms -- \
   principals grant workflow-nightly-report \
+  --role infra \
   --tool slack
 ```
 

--- a/docs/pages/extend/workflows-v2.mdx
+++ b/docs/pages/extend/workflows-v2.mdx
@@ -150,8 +150,8 @@ cargo run -p centaur-perms -- \
 
 The principal id is always `workflow-` plus the slugged `WORKFLOW_NAME`.
 Workflow code cannot choose another principal id, display name, or labels.
-Workflow discovery rejects duplicate principal slugs and the reserved
-`workflow-host` principal id.
+Workflow discovery rejects duplicate principal slugs. A workflow that resolves
+to the reserved `workflow-host` principal id is ignored and cannot be started.
 `WORKFLOW_PRINCIPAL = True` requires `apiRs.workflowHostSandbox=true`, which
 renders `WORKFLOW_HOST_SANDBOX=true`; startup fails if a workflow declares a
 principal while workflow-host sandboxing is disabled.

--- a/docs/pages/extend/workflows-v2.mdx
+++ b/docs/pages/extend/workflows-v2.mdx
@@ -137,14 +137,14 @@ The API derives the `workflow-nightly-report` principal in the Centaur Console.
 Automatic agent turns use this principal even without `WORKFLOW_PRINCIPAL`.
 Setting `WORKFLOW_PRINCIPAL = True` also runs the workflow's host sandbox under
 it, so direct `ctx.call_tool(...)` calls share the same grants. Grant only the
-roles or secrets that the workflow needs. Centaur does not assign channel-style
-default roles to workflow principals, so agent turns also need an explicit
-model or harness credential role such as `infra`:
+roles or secrets that the workflow needs. When the principal is first created,
+Console assigns its configured default roles. The default configuration
+includes `infra` for model and harness credentials. Existing principals are not
+backfilled if defaults later change. Grant additional tool roles explicitly:
 
 ```bash
 cargo run -p centaur-perms -- \
   principals grant workflow-nightly-report \
-  --role infra \
   --tool slack
 ```
 

--- a/docs/pages/extend/workflows-v2.mdx
+++ b/docs/pages/extend/workflows-v2.mdx
@@ -150,8 +150,12 @@ cargo run -p centaur-perms -- \
 
 The principal id is always `workflow-` plus the slugged `WORKFLOW_NAME`.
 Workflow code cannot choose another principal id, display name, or labels.
-Workflow discovery rejects duplicate principal slugs. A workflow that resolves
-to the reserved `workflow-host` principal id is ignored and cannot be started.
+If multiple Python workflow names resolve to the same principal id, discovery
+ignores every workflow in that collision group. Python workflows that resolve
+to the reserved `workflow-host` principal id or a built-in native workflow
+identity are also ignored. Their schedules and webhooks are not registered. An
+exact native name still invokes the native implementation; a different
+spelling with the same principal slug is rejected when a run is created.
 `WORKFLOW_PRINCIPAL = True` requires `apiRs.workflowHostSandbox=true`, which
 renders `WORKFLOW_HOST_SANDBOX=true`; startup fails if a workflow declares a
 principal while workflow-host sandboxing is disabled.

--- a/docs/pages/extend/workflows-v2.mdx
+++ b/docs/pages/extend/workflows-v2.mdx
@@ -150,6 +150,8 @@ cargo run -p centaur-perms -- \
 
 The principal id is always `workflow-` plus the slugged `WORKFLOW_NAME`.
 Workflow code cannot choose another principal id, display name, or labels.
+Workflow discovery rejects duplicate principal slugs and the reserved
+`workflow-host` principal id.
 `WORKFLOW_PRINCIPAL = True` requires `apiRs.workflowHostSandbox=true`, which
 renders `WORKFLOW_HOST_SANDBOX=true`; startup fails if a workflow declares a
 principal while workflow-host sandboxing is disabled.

--- a/docs/pages/extend/workflows.mdx
+++ b/docs/pages/extend/workflows.mdx
@@ -71,6 +71,10 @@ run. Centaur does not assign channel-style default roles to workflow
 principals. Grant every required model, harness, and tool role or secret to the
 principal explicitly.
 
+Workflow names must produce unique slugs. Discovery fails if two names resolve
+to the same principal id or if a name resolves to the reserved `workflow-host`
+principal.
+
 `WORKFLOW_PRINCIPAL` is optional. Set it to `True` when the workflow host calls
 tools directly with `ctx.call_tool(...)`; this opts the host sandbox into the
 same workflow principal. Workflow code cannot choose another principal id,

--- a/docs/pages/extend/workflows.mdx
+++ b/docs/pages/extend/workflows.mdx
@@ -72,9 +72,13 @@ default roles. The default configuration includes `infra` for model and harness
 credentials. Existing principals are not backfilled if defaults later change.
 Grant every additional tool role or secret to the principal explicitly.
 
-Workflow names must produce unique slugs. Discovery fails if two names resolve
-to the same principal id. A workflow name that resolves to the reserved
-`workflow-host` principal is ignored during discovery and cannot be started.
+Workflow names must produce unique slugs. If multiple Python workflow names
+resolve to the same principal id, discovery ignores every workflow in that
+collision group. Python workflows that resolve to the reserved `workflow-host`
+principal or a built-in native workflow identity are also ignored. Their
+schedules and webhooks are not registered. An exact native name still invokes
+the native implementation; a different spelling with the same principal slug
+is rejected when a run is created.
 
 `WORKFLOW_PRINCIPAL` is optional. Set it to `True` when the workflow host calls
 tools directly with `ctx.call_tool(...)`; this opts the host sandbox into the

--- a/docs/pages/extend/workflows.mdx
+++ b/docs/pages/extend/workflows.mdx
@@ -72,8 +72,8 @@ principals. Grant every required model, harness, and tool role or secret to the
 principal explicitly.
 
 Workflow names must produce unique slugs. Discovery fails if two names resolve
-to the same principal id or if a name resolves to the reserved `workflow-host`
-principal.
+to the same principal id. A workflow name that resolves to the reserved
+`workflow-host` principal is ignored during discovery and cannot be started.
 
 `WORKFLOW_PRINCIPAL` is optional. Set it to `True` when the workflow host calls
 tools directly with `ctx.call_tool(...)`; this opts the host sandbox into the

--- a/docs/pages/extend/workflows.mdx
+++ b/docs/pages/extend/workflows.mdx
@@ -64,15 +64,17 @@ async def handler(inp: Input, ctx: WorkflowContext) -> dict[str, Any]:
     return {"channel": inp.channel, "report": result}
 ```
 
-`WORKFLOW_PRINCIPAL` is optional. Use it when the workflow host calls tools
-directly with `ctx.call_tool(...)` and should have its own credential boundary.
-The API derives and registers the `workflow-nightly-report` principal from
-`WORKFLOW_NAME` and runs that workflow-host sandbox under it. Workflow code
-cannot choose another principal id, display name, or labels. Grant the required
-tool roles or secrets to the derived principal. `WORKFLOW_PRINCIPAL = True`
-requires `apiRs.workflowHostSandbox=true`, which renders
-`WORKFLOW_HOST_SANDBOX=true`; startup fails if workflow-host sandboxing is
-disabled.
+The API derives the stable `workflow-nightly-report` principal from
+`WORKFLOW_NAME`. Automatic `ctx.agent_turn(...)` and `ctx.run_agent(...)`
+sessions use this principal while keeping a separate session for each workflow
+run. Grant the required agent tool roles or secrets to this principal.
+
+`WORKFLOW_PRINCIPAL` is optional. Set it to `True` when the workflow host calls
+tools directly with `ctx.call_tool(...)`; this opts the host sandbox into the
+same workflow principal. Workflow code cannot choose another principal id,
+display name, or labels. `WORKFLOW_PRINCIPAL = True` requires
+`apiRs.workflowHostSandbox=true`, which renders `WORKFLOW_HOST_SANDBOX=true`;
+startup fails if workflow-host sandboxing is disabled.
 
 ## Durable primitives
 

--- a/docs/pages/extend/workflows.mdx
+++ b/docs/pages/extend/workflows.mdx
@@ -67,9 +67,10 @@ async def handler(inp: Input, ctx: WorkflowContext) -> dict[str, Any]:
 The API derives the stable `workflow-nightly-report` principal from
 `WORKFLOW_NAME`. Automatic `ctx.agent_turn(...)` and `ctx.run_agent(...)`
 sessions use this principal while keeping a separate session for each workflow
-run. Centaur does not assign channel-style default roles to workflow
-principals. Grant every required model, harness, and tool role or secret to the
-principal explicitly.
+run. When the principal is first created, Console assigns its configured
+default roles. The default configuration includes `infra` for model and harness
+credentials. Existing principals are not backfilled if defaults later change.
+Grant every additional tool role or secret to the principal explicitly.
 
 Workflow names must produce unique slugs. Discovery fails if two names resolve
 to the same principal id. A workflow name that resolves to the reserved

--- a/docs/pages/extend/workflows.mdx
+++ b/docs/pages/extend/workflows.mdx
@@ -67,7 +67,9 @@ async def handler(inp: Input, ctx: WorkflowContext) -> dict[str, Any]:
 The API derives the stable `workflow-nightly-report` principal from
 `WORKFLOW_NAME`. Automatic `ctx.agent_turn(...)` and `ctx.run_agent(...)`
 sessions use this principal while keeping a separate session for each workflow
-run. Grant the required agent tool roles or secrets to this principal.
+run. Centaur does not assign channel-style default roles to workflow
+principals. Grant every required model, harness, and tool role or secret to the
+principal explicitly.
 
 `WORKFLOW_PRINCIPAL` is optional. Set it to `True` when the workflow host calls
 tools directly with `ctx.call_tool(...)`; this opts the host sandbox into the

--- a/services/api-rs/crates/centaur-api-integration-test/src/main.rs
+++ b/services/api-rs/crates/centaur-api-integration-test/src/main.rs
@@ -553,9 +553,9 @@ async fn test_workflows_api(http: &HttpClient, base_url: &str) -> Result<()> {
     )
     .await
     .context("create long-running workflow run")?;
-    wait_for_workflow_run_status(http, base_url, &removed_run_id, &["running"])
+    wait_for_workflow_run_status(http, base_url, &removed_run_id, &["sleeping"])
         .await
-        .context("wait for long-running workflow run to start")?;
+        .context("wait for long-running workflow run to suspend")?;
 
     fs::remove_file(&workflow_path)
         .with_context(|| format!("remove workflow file {}", workflow_path.display()))?;
@@ -696,8 +696,6 @@ async def handler(params, ctx):
 fn write_test_workflow(path: &Path, workflow_name: &str) -> Result<()> {
     let source = format!(
         r#"
-import asyncio
-
 WORKFLOW_NAME = "{workflow_name}"
 SCHEDULE = {{
     "schedule_id": "{workflow_name}",
@@ -711,7 +709,7 @@ SCHEDULE = {{
 async def handler(params, ctx):
     sleep_ms = int(params.get("sleep_ms") or 0)
     if sleep_ms:
-        await asyncio.sleep(sleep_ms / 1000)
+        await ctx.sleep("integration-hold", sleep_ms / 1000)
     return {{
         "workflow_name": ctx.workflow_name,
         "run_id": ctx.run_id,

--- a/services/api-rs/crates/centaur-api-server/src/args.rs
+++ b/services/api-rs/crates/centaur-api-server/src/args.rs
@@ -719,7 +719,7 @@ impl SandboxArgs {
         let workflow_host = client
             .upsert_principal(&IdentityInput {
                 namespace: namespace.clone(),
-                foreign_id: "workflow-host".to_owned(),
+                foreign_id: centaur_iron_control::WORKFLOW_HOST_PRINCIPAL_FOREIGN_ID.to_owned(),
                 name: "Workflow host".to_owned(),
                 labels: BTreeMap::from([
                     ("managed-by".to_owned(), "centaur".to_owned()),

--- a/services/api-rs/crates/centaur-api-server/src/args.rs
+++ b/services/api-rs/crates/centaur-api-server/src/args.rs
@@ -727,11 +727,12 @@ impl SandboxArgs {
                 ]),
             })
             .await?;
+        let registrar = SessionRegistrar::new(client, namespace);
         Ok(Some(IronControlRuntime {
-            registrar: SessionRegistrar::new(client.clone(), namespace.clone()),
+            registrar: registrar.clone(),
             warm_pool_bootstrap_principal: bootstrap.id,
             workflow_host_principal: workflow_host.id,
-            workflow_principal_registrar: WorkflowPrincipalRegistrar::new(client, namespace),
+            workflow_principal_registrar: WorkflowPrincipalRegistrar::new(registrar),
         }))
     }
 

--- a/services/api-rs/crates/centaur-iron-control/src/lib.rs
+++ b/services/api-rs/crates/centaur-iron-control/src/lib.rs
@@ -25,7 +25,9 @@ pub use models::{
     RequestRule, Role, SECRET_TYPES, SecretRecord, SecretSource, StaticSecretInput,
     normalize_gcp_id_token_header,
 };
-pub use principal::{PrincipalRef, derive_principal, derive_workflow_principal};
+pub use principal::{
+    PrincipalRef, WORKFLOW_HOST_PRINCIPAL_FOREIGN_ID, derive_principal, derive_workflow_principal,
+};
 pub use registry::{
     GCP_AUTH_DEFAULT_SCOPE, RegisterError, RoleSpec, SecretInput, TranslateError,
     gcp_auth_scopes_or_default, grant_inputs_to_role, register_role, secret_inputs_from_fragment,

--- a/services/api-rs/crates/centaur-iron-control/src/lib.rs
+++ b/services/api-rs/crates/centaur-iron-control/src/lib.rs
@@ -25,7 +25,7 @@ pub use models::{
     RequestRule, Role, SECRET_TYPES, SecretRecord, SecretSource, StaticSecretInput,
     normalize_gcp_id_token_header,
 };
-pub use principal::{PrincipalRef, derive_principal};
+pub use principal::{PrincipalRef, derive_principal, derive_workflow_principal};
 pub use registry::{
     GCP_AUTH_DEFAULT_SCOPE, RegisterError, RoleSpec, SecretInput, TranslateError,
     gcp_auth_scopes_or_default, grant_inputs_to_role, register_role, secret_inputs_from_fragment,

--- a/services/api-rs/crates/centaur-iron-control/src/lib.rs
+++ b/services/api-rs/crates/centaur-iron-control/src/lib.rs
@@ -27,6 +27,7 @@ pub use models::{
 };
 pub use principal::{
     PrincipalRef, WORKFLOW_HOST_PRINCIPAL_FOREIGN_ID, derive_principal, derive_workflow_principal,
+    workflow_principal_is_reserved,
 };
 pub use registry::{
     GCP_AUTH_DEFAULT_SCOPE, RegisterError, RoleSpec, SecretInput, TranslateError,

--- a/services/api-rs/crates/centaur-iron-control/src/principal.rs
+++ b/services/api-rs/crates/centaur-iron-control/src/principal.rs
@@ -33,6 +33,7 @@ const LINEAR_ISSUE_KIND: &str = "linear_issue";
 const TEAMS_USER_KIND: &str = "teams_user";
 const TEAMS_CONVERSATION_KIND: &str = "teams_conversation";
 const WORKFLOW_KIND: &str = "workflow";
+pub const WORKFLOW_HOST_PRINCIPAL_FOREIGN_ID: &str = "workflow-host";
 
 /// The principal a session resolves to, as a stable upsert key plus a label.
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/services/api-rs/crates/centaur-iron-control/src/principal.rs
+++ b/services/api-rs/crates/centaur-iron-control/src/principal.rs
@@ -32,6 +32,7 @@ const DISCORD_CHANNEL_KIND: &str = "discord_channel";
 const LINEAR_ISSUE_KIND: &str = "linear_issue";
 const TEAMS_USER_KIND: &str = "teams_user";
 const TEAMS_CONVERSATION_KIND: &str = "teams_conversation";
+const WORKFLOW_KIND: &str = "workflow";
 
 /// The principal a session resolves to, as a stable upsert key plus a label.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -53,6 +54,20 @@ impl PrincipalRef {
             name: self.name.clone(),
             labels,
         }
+    }
+}
+
+/// Resolve the stable principal shared by a workflow host and its automatic
+/// agent turns. Workflow session thread keys remain run-specific; only the
+/// credential identity is shared across runs.
+pub fn derive_workflow_principal(workflow_name: &str) -> PrincipalRef {
+    PrincipalRef {
+        foreign_id: format!("workflow-{}", slugify(workflow_name)),
+        name: format!("Workflow {workflow_name}"),
+        labels: BTreeMap::from([
+            (KIND_LABEL.to_owned(), WORKFLOW_KIND.to_owned()),
+            ("workflow_name".to_owned(), workflow_name.to_owned()),
+        ]),
     }
 }
 
@@ -630,6 +645,30 @@ mod tests {
         assert_eq!(
             input.labels.get("kind").map(String::as_str),
             Some("slack_channel")
+        );
+    }
+
+    #[test]
+    fn workflow_principal_is_stable_and_managed() {
+        let principal = derive_workflow_principal("Managing Partner Daily Briefing");
+        assert_eq!(
+            principal.foreign_id,
+            "workflow-managing-partner-daily-briefing"
+        );
+        assert_eq!(principal.name, "Workflow Managing Partner Daily Briefing");
+        assert_eq!(
+            principal.labels.get("kind").map(String::as_str),
+            Some("workflow")
+        );
+        assert_eq!(
+            principal.labels.get("workflow_name").map(String::as_str),
+            Some("Managing Partner Daily Briefing")
+        );
+
+        let input = principal.to_identity_input("default");
+        assert_eq!(
+            input.labels.get("managed-by").map(String::as_str),
+            Some("centaur")
         );
     }
 }

--- a/services/api-rs/crates/centaur-iron-control/src/principal.rs
+++ b/services/api-rs/crates/centaur-iron-control/src/principal.rs
@@ -72,6 +72,12 @@ pub fn derive_workflow_principal(workflow_name: &str) -> PrincipalRef {
     }
 }
 
+/// Return whether a workflow name would collide with an infrastructure-owned
+/// principal rather than receiving its own workflow identity.
+pub fn workflow_principal_is_reserved(workflow_name: &str) -> bool {
+    derive_workflow_principal(workflow_name).foreign_id == WORKFLOW_HOST_PRINCIPAL_FOREIGN_ID
+}
+
 /// Resolve the principal for a thread.
 ///
 /// ``actor_user_id`` is the acting user, when known (carried in session
@@ -671,5 +677,12 @@ mod tests {
             input.labels.get("managed-by").map(String::as_str),
             Some("centaur")
         );
+    }
+
+    #[test]
+    fn workflow_host_principal_name_is_reserved_after_slugging() {
+        assert!(workflow_principal_is_reserved("host"));
+        assert!(workflow_principal_is_reserved(" HOST! "));
+        assert!(!workflow_principal_is_reserved("host report"));
     }
 }

--- a/services/api-rs/crates/centaur-iron-control/src/session.rs
+++ b/services/api-rs/crates/centaur-iron-control/src/session.rs
@@ -125,7 +125,7 @@ impl SessionRegistrar {
         let exists = existing.is_some();
         if let Some(existing) = existing {
             let mut labels = existing.labels;
-            labels.extend(input.labels.clone());
+            labels.extend(std::mem::take(&mut input.labels));
             input.labels = labels;
         }
         Ok(exists)
@@ -296,21 +296,23 @@ mod tests {
             .unwrap();
 
         let requests = requests.lock().unwrap();
+        assert!(request_was(
+            &requests,
+            "GET",
+            "/api/v1/principals/lookup/default/slack-channel-t123-c123"
+        ));
+        assert!(request_was(
+            &requests,
+            "PUT",
+            "/api/v1/principals/slack-channel-t123-c123"
+        ));
+        assert!(request_was(
+            &requests,
+            "POST",
+            "/api/v1/principals/prn_channel/slack_channel_permissions"
+        ));
         assert!(
-            requests.contains(
-                &"GET /api/v1/principals/lookup/default/slack-channel-t123-c123".to_owned()
-            )
-        );
-        assert!(requests.contains(&"PUT /api/v1/principals/slack-channel-t123-c123".to_owned()));
-        assert!(
-            requests.contains(
-                &"POST /api/v1/principals/prn_channel/slack_channel_permissions".to_owned()
-            )
-        );
-        assert!(
-            !requests
-                .iter()
-                .any(|request| request == "POST /api/v1/principals/prn_channel/roles"),
+            !request_was(&requests, "POST", "/api/v1/principals/prn_channel/roles"),
             "iron-control assigns configured default roles during principal creation"
         );
         server.abort();
@@ -333,22 +335,24 @@ mod tests {
             .unwrap();
 
         let requests = requests.lock().unwrap();
-        assert!(
-            requests.contains(
-                &"GET /api/v1/principals/lookup/default/slack-channel-t123-c123".to_owned()
-            )
-        );
-        assert!(requests.contains(&"PUT /api/v1/principals/slack-channel-t123-c123".to_owned()));
+        assert!(request_was(
+            &requests,
+            "GET",
+            "/api/v1/principals/lookup/default/slack-channel-t123-c123"
+        ));
+        assert!(request_was(
+            &requests,
+            "PUT",
+            "/api/v1/principals/slack-channel-t123-c123"
+        ));
         assert!(
             !requests
                 .iter()
-                .any(|request| request.ends_with("/slack_channel_permissions")),
+                .any(|request| request.path.ends_with("/slack_channel_permissions")),
             "existing principals must not have Slack permissions reset"
         );
         assert!(
-            !requests
-                .iter()
-                .any(|request| request == "POST /api/v1/principals/prn_channel/roles"),
+            !request_was(&requests, "POST", "/api/v1/principals/prn_channel/roles"),
             "existing principals must not have manually removed roles restored"
         );
         server.abort();
@@ -371,11 +375,16 @@ mod tests {
             .unwrap();
 
         let requests = requests.lock().unwrap();
-        assert!(requests.contains(&"PUT /api/v1/principals/slack-user-t123-u123".to_owned()));
-        assert!(
-            requests
-                .contains(&"POST /api/v1/principals/prn_user/slack_channel_permissions".to_owned())
-        );
+        assert!(request_was(
+            &requests,
+            "PUT",
+            "/api/v1/principals/slack-user-t123-u123"
+        ));
+        assert!(request_was(
+            &requests,
+            "POST",
+            "/api/v1/principals/prn_user/slack_channel_permissions"
+        ));
         server.abort();
     }
 
@@ -396,15 +405,18 @@ mod tests {
             .unwrap();
 
         let requests = requests.lock().unwrap();
-        assert!(requests.contains(&"PUT /api/v1/principals/slack-user-t123-u123".to_owned()));
+        assert!(request_was(
+            &requests,
+            "PUT",
+            "/api/v1/principals/slack-user-t123-u123"
+        ));
+        assert!(request_was(
+            &requests,
+            "POST",
+            "/api/v1/principals/prn_user/slack_channel_permissions"
+        ));
         assert!(
-            requests
-                .contains(&"POST /api/v1/principals/prn_user/slack_channel_permissions".to_owned())
-        );
-        assert!(
-            !requests
-                .iter()
-                .any(|request| request == "POST /api/v1/principals/prn_user/roles"),
+            !request_was(&requests, "POST", "/api/v1/principals/prn_user/roles"),
             "existing DM principals must not have manually removed roles restored"
         );
         server.abort();
@@ -448,74 +460,48 @@ mod tests {
 
     async fn spawn_iron_control_stub(
         principal_exists: bool,
-    ) -> (String, Arc<Mutex<Vec<String>>>, tokio::task::JoinHandle<()>) {
-        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let base_url = format!("http://{}", listener.local_addr().unwrap());
-        let requests = Arc::new(Mutex::new(Vec::new()));
-        let seen = requests.clone();
-        let handle = tokio::spawn(async move {
-            loop {
-                let Ok((mut stream, _)) = listener.accept().await else {
-                    return;
-                };
-                let mut request = Vec::new();
-                let mut buf = [0u8; 1024];
-                while !request.windows(4).any(|window| window == b"\r\n\r\n") {
-                    match stream.read(&mut buf).await {
-                        Ok(0) | Err(_) => break,
-                        Ok(read) => request.extend_from_slice(&buf[..read]),
-                    }
+    ) -> (
+        String,
+        Arc<Mutex<Vec<RecordedRequest>>>,
+        tokio::task::JoinHandle<()>,
+    ) {
+        spawn_http_stub(
+            move |request| match (request.method.as_str(), request.path.as_str()) {
+                ("GET", "/api/v1/principals/lookup/default/slack-channel-t123-c123")
+                    if principal_exists =>
+                {
+                    ("200 OK", channel_principal_body())
                 }
-                let request = String::from_utf8_lossy(&request);
-                let first_line = request.lines().next().unwrap_or_default();
-                let mut parts = first_line.split_whitespace();
-                let method = parts.next().unwrap_or_default();
-                let path = parts.next().unwrap_or_default();
-                seen.lock().unwrap().push(format!("{method} {path}"));
-
-                let (status_line, body) = match (method, path) {
-                    ("GET", "/api/v1/principals/lookup/default/slack-channel-t123-c123")
-                        if principal_exists =>
-                    {
-                        ("200 OK", channel_principal_body())
-                    }
-                    ("GET", "/api/v1/principals/lookup/default/slack-user-t123-u123")
-                        if principal_exists =>
-                    {
-                        ("200 OK", user_principal_body())
-                    }
-                    ("GET", "/api/v1/principals/lookup/default/slack-channel-t123-c123")
-                    | ("GET", "/api/v1/principals/lookup/default/slack-user-t123-u123") => {
-                        ("404 Not Found", r#"{"error":"not found"}"#.to_owned())
-                    }
-                    ("PUT", "/api/v1/principals/slack-channel-t123-c123") => {
-                        ("200 OK", channel_principal_body())
-                    }
-                    ("PUT", "/api/v1/principals/slack-user-t123-u123") => {
-                        ("200 OK", user_principal_body())
-                    }
-                    (
-                        "POST",
-                        "/api/v1/principals/prn_channel/slack_channel_permissions"
-                        | "/api/v1/principals/prn_user/slack_channel_permissions",
-                    ) => ("200 OK", r#"{"data":{"ok":true}}"#.to_owned()),
-                    ("POST", "/api/v1/principals/prn_channel/roles") => {
-                        ("200 OK", r#"{"data":{"ok":true}}"#.to_owned())
-                    }
-                    _ => (
-                        "500 Internal Server Error",
-                        r#"{"error":"unexpected"}"#.to_owned(),
-                    ),
-                };
-                let response = format!(
-                    "HTTP/1.1 {status_line}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
-                    body.len(),
-                );
-                let _ = stream.write_all(response.as_bytes()).await;
-                let _ = stream.shutdown().await;
-            }
-        });
-        (base_url, requests, handle)
+                ("GET", "/api/v1/principals/lookup/default/slack-user-t123-u123")
+                    if principal_exists =>
+                {
+                    ("200 OK", user_principal_body())
+                }
+                ("GET", "/api/v1/principals/lookup/default/slack-channel-t123-c123")
+                | ("GET", "/api/v1/principals/lookup/default/slack-user-t123-u123") => {
+                    ("404 Not Found", r#"{"error":"not found"}"#.to_owned())
+                }
+                ("PUT", "/api/v1/principals/slack-channel-t123-c123") => {
+                    ("200 OK", channel_principal_body())
+                }
+                ("PUT", "/api/v1/principals/slack-user-t123-u123") => {
+                    ("200 OK", user_principal_body())
+                }
+                (
+                    "POST",
+                    "/api/v1/principals/prn_channel/slack_channel_permissions"
+                    | "/api/v1/principals/prn_user/slack_channel_permissions",
+                ) => ("200 OK", r#"{"data":{"ok":true}}"#.to_owned()),
+                ("POST", "/api/v1/principals/prn_channel/roles") => {
+                    ("200 OK", r#"{"data":{"ok":true}}"#.to_owned())
+                }
+                _ => (
+                    "500 Internal Server Error",
+                    r#"{"error":"unexpected"}"#.to_owned(),
+                ),
+            },
+        )
+        .await
     }
 
     fn channel_principal_body() -> String {
@@ -529,11 +515,53 @@ mod tests {
     #[derive(Clone, Debug)]
     struct RecordedRequest {
         method: String,
+        path: String,
         body: Value,
+    }
+
+    fn request_was(requests: &[RecordedRequest], method: &str, path: &str) -> bool {
+        requests
+            .iter()
+            .any(|request| request.method == method && request.path == path)
     }
 
     async fn spawn_workflow_principal_stub(
         existing_labels: Option<BTreeMap<String, String>>,
+    ) -> (
+        String,
+        Arc<Mutex<Vec<RecordedRequest>>>,
+        tokio::task::JoinHandle<()>,
+    ) {
+        spawn_http_stub(move |request| {
+            let workflow_lookup =
+                "/api/v1/principals/lookup/default/workflow-newsletter-daily-digest";
+            let workflow_upsert = "/api/v1/principals/workflow-newsletter-daily-digest";
+            match (request.method.as_str(), request.path.as_str()) {
+                ("GET", path) if path == workflow_lookup => match &existing_labels {
+                    Some(labels) => ("200 OK", workflow_principal_body(labels.clone())),
+                    None => ("404 Not Found", r#"{"error":"not found"}"#.to_owned()),
+                },
+                ("PUT", path) if path == workflow_upsert => {
+                    let labels = request.body["data"]["labels"]
+                        .as_object()
+                        .cloned()
+                        .unwrap_or_default()
+                        .into_iter()
+                        .filter_map(|(key, value)| Some((key, value.as_str()?.to_owned())))
+                        .collect();
+                    ("200 OK", workflow_principal_body(labels))
+                }
+                _ => (
+                    "500 Internal Server Error",
+                    r#"{"error":"unexpected"}"#.to_owned(),
+                ),
+            }
+        })
+        .await
+    }
+
+    async fn spawn_http_stub(
+        route: impl Fn(&RecordedRequest) -> (&'static str, String) + Send + 'static,
     ) -> (
         String,
         Arc<Mutex<Vec<RecordedRequest>>>,
@@ -590,34 +618,9 @@ mod tests {
                     &request[header_end..request.len().min(header_end + content_length)],
                 )
                 .unwrap_or(Value::Null);
-                seen.lock().unwrap().push(RecordedRequest {
-                    method: method.clone(),
-                    body: body.clone(),
-                });
-
-                let workflow_lookup =
-                    "/api/v1/principals/lookup/default/workflow-newsletter-daily-digest";
-                let workflow_upsert = "/api/v1/principals/workflow-newsletter-daily-digest";
-                let (status_line, response_body) = match (method.as_str(), path.as_str()) {
-                    ("GET", path) if path == workflow_lookup => match &existing_labels {
-                        Some(labels) => ("200 OK", workflow_principal_body(labels.clone())),
-                        None => ("404 Not Found", r#"{"error":"not found"}"#.to_owned()),
-                    },
-                    ("PUT", path) if path == workflow_upsert => {
-                        let labels = body["data"]["labels"]
-                            .as_object()
-                            .cloned()
-                            .unwrap_or_default()
-                            .into_iter()
-                            .filter_map(|(key, value)| Some((key, value.as_str()?.to_owned())))
-                            .collect();
-                        ("200 OK", workflow_principal_body(labels))
-                    }
-                    _ => (
-                        "500 Internal Server Error",
-                        r#"{"error":"unexpected"}"#.to_owned(),
-                    ),
-                };
+                let request = RecordedRequest { method, path, body };
+                seen.lock().unwrap().push(request.clone());
+                let (status_line, response_body) = route(&request);
                 let response = format!(
                     "HTTP/1.1 {status_line}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{response_body}",
                     response_body.len(),

--- a/services/api-rs/crates/centaur-iron-control/src/session.rs
+++ b/services/api-rs/crates/centaur-iron-control/src/session.rs
@@ -14,8 +14,11 @@ use crate::IronControlClient;
 use crate::error::{IronControlError, Result};
 use crate::models::{Principal, SlackChannelPermissionInput};
 use crate::principal::{
-    derive_principal_with_slack_team, is_direct_message, slack_conversation_id,
+    derive_principal_with_slack_team, derive_workflow_principal, is_direct_message,
+    slack_conversation_id,
 };
+
+const WORKFLOW_AGENT_DEFAULT_ROLES_SEEDED_LABEL: &str = "workflow_agent_default_roles_seeded";
 
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 struct SessionPrincipalMetadata<'a> {
@@ -87,21 +90,7 @@ impl SessionRegistrar {
         );
         let mut input = principal.to_identity_input(&self.namespace);
         apply_slack_dm_email_label(thread_key, metadata.slack_user_email, &mut input.labels);
-        let existing = match self
-            .client
-            .get_principal(&self.namespace, &input.foreign_id)
-            .await
-        {
-            Ok(existing) => Some(existing),
-            Err(error) if is_status(&error, 404) => None,
-            Err(error) => return Err(error),
-        };
-        let exists = existing.is_some();
-        if let Some(existing) = existing {
-            let mut labels = existing.labels;
-            labels.extend(input.labels);
-            input.labels = labels;
-        }
+        let exists = self.merge_existing_labels(&mut input).await?;
         let slack_permission = slack_permission_for_thread(thread_key, &input.labels);
         let should_upsert_slack_permission = !exists
             || slack_permission
@@ -114,6 +103,68 @@ impl SessionRegistrar {
                 .await?;
         }
         Ok(record)
+    }
+
+    /// Ensure the stable principal for ``workflow_name`` exists without
+    /// granting the default roles used by agent sandboxes. Workflow discovery
+    /// uses this for host-only ``WORKFLOW_PRINCIPAL`` opt-ins.
+    pub async fn ensure_workflow_principal(&self, workflow_name: &str) -> Result<Principal> {
+        let mut input = derive_workflow_principal(workflow_name).to_identity_input(&self.namespace);
+        self.merge_existing_labels(&mut input).await?;
+        self.client.upsert_principal(&input).await
+    }
+
+    /// Ensure the stable principal for ``workflow_name`` has received the
+    /// default session roles once. The durable marker keeps later operator
+    /// revocations sticky, matching ordinary session-principal behavior.
+    pub async fn ensure_workflow_agent_principal(&self, workflow_name: &str) -> Result<Principal> {
+        let mut input = derive_workflow_principal(workflow_name).to_identity_input(&self.namespace);
+        self.merge_existing_labels(&mut input).await?;
+        let roles_seeded = input
+            .labels
+            .get(WORKFLOW_AGENT_DEFAULT_ROLES_SEEDED_LABEL)
+            .is_some_and(|value| value == "true");
+        let record = self.client.upsert_principal(&input).await?;
+        if roles_seeded {
+            return Ok(record);
+        }
+
+        self.assign_default_roles(&record.id).await?;
+        input.labels.insert(
+            WORKFLOW_AGENT_DEFAULT_ROLES_SEEDED_LABEL.to_owned(),
+            "true".to_owned(),
+        );
+        self.client.upsert_principal(&input).await
+    }
+
+    async fn merge_existing_labels(&self, input: &mut crate::IdentityInput) -> Result<bool> {
+        let existing = match self
+            .client
+            .get_principal(&self.namespace, &input.foreign_id)
+            .await
+        {
+            Ok(existing) => Some(existing),
+            Err(error) if is_status(&error, 404) => None,
+            Err(error) => return Err(error),
+        };
+        let exists = existing.is_some();
+        if let Some(existing) = existing {
+            let mut labels = existing.labels;
+            labels.extend(input.labels.clone());
+            input.labels = labels;
+        }
+        Ok(exists)
+    }
+
+    async fn assign_default_roles(&self, principal_id: &str) -> Result<()> {
+        for role_id in &self.assign_role_ids {
+            match self.client.assign_role(principal_id, role_id).await {
+                Ok(()) => {}
+                Err(error) if is_status(&error, 409) || is_status(&error, 422) => {}
+                Err(error) => return Err(error),
+            }
+        }
+        Ok(())
     }
 
     pub async fn get_principal(&self, principal: &str) -> Result<Principal> {
@@ -174,7 +225,7 @@ fn is_status(err: &IronControlError, code: u16) -> bool {
 mod tests {
     use std::sync::{Arc, Mutex};
 
-    use serde_json::json;
+    use serde_json::{Value, json};
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
     use super::*;
@@ -395,6 +446,156 @@ mod tests {
         server.abort();
     }
 
+    #[tokio::test]
+    async fn ensure_workflow_principal_preserves_labels_without_seeding_roles() {
+        let existing_labels = BTreeMap::from([("operator_label".to_owned(), "keep".to_owned())]);
+        let (base_url, requests, server) =
+            spawn_workflow_principal_stub(Some(existing_labels), 200).await;
+        let registrar = SessionRegistrar::new(
+            IronControlClient::new(base_url, "test-key"),
+            "default",
+            vec!["role_infra".to_owned()],
+        );
+
+        registrar
+            .ensure_workflow_principal("newsletter_daily_digest")
+            .await
+            .unwrap();
+
+        let requests = requests.lock().unwrap();
+        let put = requests
+            .iter()
+            .find(|request| request.method == "PUT")
+            .expect("workflow principal upsert");
+        assert_eq!(put.body["data"]["labels"]["operator_label"], "keep");
+        assert_eq!(put.body["data"]["labels"]["kind"], "workflow");
+        assert_eq!(
+            put.body["data"]["labels"]["workflow_name"],
+            "newsletter_daily_digest"
+        );
+        assert!(!requests.iter().any(|request| request.method == "POST"));
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn ensure_workflow_agent_principal_seeds_roles_and_marks_the_principal() {
+        let existing_labels = BTreeMap::from([("operator_label".to_owned(), "keep".to_owned())]);
+        let (base_url, requests, server) =
+            spawn_workflow_principal_stub(Some(existing_labels), 200).await;
+        let registrar = SessionRegistrar::new(
+            IronControlClient::new(base_url, "test-key"),
+            "default",
+            vec!["role_infra".to_owned()],
+        );
+
+        registrar
+            .ensure_workflow_agent_principal("newsletter_daily_digest")
+            .await
+            .unwrap();
+
+        let requests = requests.lock().unwrap();
+        let puts = requests
+            .iter()
+            .filter(|request| request.method == "PUT")
+            .collect::<Vec<_>>();
+        assert_eq!(puts.len(), 2);
+        assert_eq!(puts[1].body["data"]["labels"]["operator_label"], "keep");
+        assert_eq!(
+            puts[1].body["data"]["labels"][WORKFLOW_AGENT_DEFAULT_ROLES_SEEDED_LABEL],
+            "true"
+        );
+        assert!(requests.iter().any(|request| {
+            request.method == "POST" && request.path == "/api/v1/principals/prn_workflow/roles"
+        }));
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn ensure_workflow_agent_principal_preserves_revoked_roles_after_seeding() {
+        let existing_labels = BTreeMap::from([(
+            WORKFLOW_AGENT_DEFAULT_ROLES_SEEDED_LABEL.to_owned(),
+            "true".to_owned(),
+        )]);
+        let (base_url, requests, server) =
+            spawn_workflow_principal_stub(Some(existing_labels), 200).await;
+        let registrar = SessionRegistrar::new(
+            IronControlClient::new(base_url, "test-key"),
+            "default",
+            vec!["role_infra".to_owned()],
+        );
+
+        registrar
+            .ensure_workflow_agent_principal("newsletter_daily_digest")
+            .await
+            .unwrap();
+
+        let requests = requests.lock().unwrap();
+        assert_eq!(
+            requests
+                .iter()
+                .filter(|request| request.method == "PUT")
+                .count(),
+            1
+        );
+        assert!(!requests.iter().any(|request| request.method == "POST"));
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn ensure_workflow_agent_principal_marks_only_after_role_assignment_succeeds() {
+        let (base_url, requests, server) = spawn_workflow_principal_stub(None, 500).await;
+        let registrar = SessionRegistrar::new(
+            IronControlClient::new(base_url, "test-key"),
+            "default",
+            vec!["role_infra".to_owned()],
+        );
+
+        assert!(
+            registrar
+                .ensure_workflow_agent_principal("newsletter_daily_digest")
+                .await
+                .is_err()
+        );
+
+        let requests = requests.lock().unwrap();
+        let puts = requests
+            .iter()
+            .filter(|request| request.method == "PUT")
+            .collect::<Vec<_>>();
+        assert_eq!(puts.len(), 1);
+        assert!(
+            puts[0].body["data"]["labels"]
+                .get(WORKFLOW_AGENT_DEFAULT_ROLES_SEEDED_LABEL)
+                .is_none()
+        );
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn ensure_workflow_agent_principal_accepts_concurrent_role_conflicts() {
+        let (base_url, requests, server) = spawn_workflow_principal_stub(None, 409).await;
+        let registrar = SessionRegistrar::new(
+            IronControlClient::new(base_url, "test-key"),
+            "default",
+            vec!["role_infra".to_owned()],
+        );
+
+        registrar
+            .ensure_workflow_agent_principal("newsletter_daily_digest")
+            .await
+            .unwrap();
+
+        let requests = requests.lock().unwrap();
+        assert_eq!(
+            requests
+                .iter()
+                .filter(|request| request.method == "PUT")
+                .count(),
+            2
+        );
+        server.abort();
+    }
+
     #[test]
     fn slack_permission_for_thread_skips_dm_channel_fallback_without_user() {
         let mut labels = BTreeMap::new();
@@ -481,5 +682,132 @@ mod tests {
 
     fn user_principal_body() -> String {
         r#"{"data":{"id":"prn_user","namespace":"default","foreign_id":"slack-user-t123-u123","name":"Slack DM @Ada Lovelace","labels":{}}}"#.to_owned()
+    }
+
+    #[derive(Clone, Debug)]
+    struct RecordedRequest {
+        method: String,
+        path: String,
+        body: Value,
+    }
+
+    async fn spawn_workflow_principal_stub(
+        existing_labels: Option<BTreeMap<String, String>>,
+        role_status: u16,
+    ) -> (
+        String,
+        Arc<Mutex<Vec<RecordedRequest>>>,
+        tokio::task::JoinHandle<()>,
+    ) {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let base_url = format!("http://{}", listener.local_addr().unwrap());
+        let requests = Arc::new(Mutex::new(Vec::new()));
+        let seen = requests.clone();
+        let handle = tokio::spawn(async move {
+            loop {
+                let Ok((mut stream, _)) = listener.accept().await else {
+                    return;
+                };
+                let mut request = Vec::new();
+                let mut buf = [0u8; 1024];
+                let (header_end, content_length) = loop {
+                    match stream.read(&mut buf).await {
+                        Ok(0) | Err(_) => return,
+                        Ok(read) => request.extend_from_slice(&buf[..read]),
+                    }
+                    let Some(header_end) = request
+                        .windows(4)
+                        .position(|window| window == b"\r\n\r\n")
+                        .map(|position| position + 4)
+                    else {
+                        continue;
+                    };
+                    let headers = String::from_utf8_lossy(&request[..header_end]);
+                    let content_length = headers
+                        .lines()
+                        .find_map(|line| {
+                            let (name, value) = line.split_once(':')?;
+                            name.eq_ignore_ascii_case("content-length")
+                                .then(|| value.trim().parse::<usize>().ok())
+                                .flatten()
+                        })
+                        .unwrap_or(0);
+                    break (header_end, content_length);
+                };
+                while request.len() < header_end + content_length {
+                    match stream.read(&mut buf).await {
+                        Ok(0) | Err(_) => break,
+                        Ok(read) => request.extend_from_slice(&buf[..read]),
+                    }
+                }
+
+                let headers = String::from_utf8_lossy(&request[..header_end]);
+                let first_line = headers.lines().next().unwrap_or_default();
+                let mut parts = first_line.split_whitespace();
+                let method = parts.next().unwrap_or_default().to_owned();
+                let path = parts.next().unwrap_or_default().to_owned();
+                let body = serde_json::from_slice(
+                    &request[header_end..request.len().min(header_end + content_length)],
+                )
+                .unwrap_or(Value::Null);
+                seen.lock().unwrap().push(RecordedRequest {
+                    method: method.clone(),
+                    path: path.clone(),
+                    body: body.clone(),
+                });
+
+                let workflow_lookup =
+                    "/api/v1/principals/lookup/default/workflow-newsletter-daily-digest";
+                let workflow_upsert = "/api/v1/principals/workflow-newsletter-daily-digest";
+                let (status_line, response_body) = match (method.as_str(), path.as_str()) {
+                    ("GET", path) if path == workflow_lookup => match &existing_labels {
+                        Some(labels) => ("200 OK", workflow_principal_body(labels.clone())),
+                        None => ("404 Not Found", r#"{"error":"not found"}"#.to_owned()),
+                    },
+                    ("PUT", path) if path == workflow_upsert => {
+                        let labels = body["data"]["labels"]
+                            .as_object()
+                            .cloned()
+                            .unwrap_or_default()
+                            .into_iter()
+                            .filter_map(|(key, value)| Some((key, value.as_str()?.to_owned())))
+                            .collect();
+                        ("200 OK", workflow_principal_body(labels))
+                    }
+                    ("POST", "/api/v1/principals/prn_workflow/roles") => match role_status {
+                        200 => ("200 OK", r#"{"data":{"ok":true}}"#.to_owned()),
+                        409 => ("409 Conflict", r#"{"error":"duplicate"}"#.to_owned()),
+                        _ => (
+                            "500 Internal Server Error",
+                            r#"{"error":"assignment failed"}"#.to_owned(),
+                        ),
+                    },
+                    _ => (
+                        "500 Internal Server Error",
+                        r#"{"error":"unexpected"}"#.to_owned(),
+                    ),
+                };
+                let response = format!(
+                    "HTTP/1.1 {status_line}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{response_body}",
+                    response_body.len(),
+                );
+                let _ = stream.write_all(response.as_bytes()).await;
+                let _ = stream.shutdown().await;
+            }
+        });
+        (base_url, requests, handle)
+    }
+
+    fn workflow_principal_body(labels: BTreeMap<String, String>) -> String {
+        json!({
+            "data": {
+                "id": "prn_workflow",
+                "namespace": "default",
+                "foreign_id": "workflow-newsletter-daily-digest",
+                "name": "Workflow newsletter_daily_digest",
+                "labels": labels,
+            }
+        })
+        .to_string()
     }
 }

--- a/services/api-rs/crates/centaur-iron-control/src/session.rs
+++ b/services/api-rs/crates/centaur-iron-control/src/session.rs
@@ -1,11 +1,11 @@
 //! Per-session principal registration.
 //!
-//! Roles are registered once at startup (see [`crate::register_role`]); a
 //! When a session starts, [`SessionRegistrar`] upserts the session's principal.
 //! Iron-control owns default role assignment for brand-new principals, while
 //! existing principals keep their current assignments so operator revocations
-//! in console or ``centaur-perms`` remain sticky. The principal is derived from
-//! the thread key (see [`crate::derive_principal`]).
+//! in Console or ``centaur-perms`` remain sticky. Workflow principals use the
+//! same creation behavior. Other principals are derived from the thread key
+//! (see [`crate::derive_principal`]).
 
 use serde_json::Value;
 use std::collections::BTreeMap;
@@ -17,8 +17,6 @@ use crate::principal::{
     derive_principal_with_slack_team, derive_workflow_principal, is_direct_message,
     slack_conversation_id,
 };
-
-const WORKFLOW_AGENT_DEFAULT_ROLES_SEEDED_LABEL: &str = "workflow_agent_default_roles_seeded";
 
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 struct SessionPrincipalMetadata<'a> {
@@ -106,34 +104,11 @@ impl SessionRegistrar {
     }
 
     /// Ensure the stable principal for ``workflow_name`` exists without
-    /// granting the default roles used by agent sandboxes. Workflow discovery
-    /// uses this for host-only ``WORKFLOW_PRINCIPAL`` opt-ins.
+    /// assigning any roles. Workflow discovery and automatic agent turns share
+    /// this path so workflow permissions remain operator-managed.
     pub async fn ensure_workflow_principal(&self, workflow_name: &str) -> Result<Principal> {
         let mut input = derive_workflow_principal(workflow_name).to_identity_input(&self.namespace);
         self.merge_existing_labels(&mut input).await?;
-        self.client.upsert_principal(&input).await
-    }
-
-    /// Ensure the stable principal for ``workflow_name`` has received the
-    /// default session roles once. The durable marker keeps later operator
-    /// revocations sticky, matching ordinary session-principal behavior.
-    pub async fn ensure_workflow_agent_principal(&self, workflow_name: &str) -> Result<Principal> {
-        let mut input = derive_workflow_principal(workflow_name).to_identity_input(&self.namespace);
-        self.merge_existing_labels(&mut input).await?;
-        let roles_seeded = input
-            .labels
-            .get(WORKFLOW_AGENT_DEFAULT_ROLES_SEEDED_LABEL)
-            .is_some_and(|value| value == "true");
-        let record = self.client.upsert_principal(&input).await?;
-        if roles_seeded {
-            return Ok(record);
-        }
-
-        self.assign_default_roles(&record.id).await?;
-        input.labels.insert(
-            WORKFLOW_AGENT_DEFAULT_ROLES_SEEDED_LABEL.to_owned(),
-            "true".to_owned(),
-        );
         self.client.upsert_principal(&input).await
     }
 
@@ -154,17 +129,6 @@ impl SessionRegistrar {
             input.labels = labels;
         }
         Ok(exists)
-    }
-
-    async fn assign_default_roles(&self, principal_id: &str) -> Result<()> {
-        for role_id in &self.assign_role_ids {
-            match self.client.assign_role(principal_id, role_id).await {
-                Ok(()) => {}
-                Err(error) if is_status(&error, 409) || is_status(&error, 422) => {}
-                Err(error) => return Err(error),
-            }
-        }
-        Ok(())
     }
 
     pub async fn get_principal(&self, principal: &str) -> Result<Principal> {
@@ -450,12 +414,9 @@ mod tests {
     async fn ensure_workflow_principal_preserves_labels_without_seeding_roles() {
         let existing_labels = BTreeMap::from([("operator_label".to_owned(), "keep".to_owned())]);
         let (base_url, requests, server) =
-            spawn_workflow_principal_stub(Some(existing_labels), 200).await;
-        let registrar = SessionRegistrar::new(
-            IronControlClient::new(base_url, "test-key"),
-            "default",
-            vec!["role_infra".to_owned()],
-        );
+            spawn_workflow_principal_stub(Some(existing_labels)).await;
+        let registrar =
+            SessionRegistrar::new(IronControlClient::new(base_url, "test-key"), "default");
 
         registrar
             .ensure_workflow_principal("newsletter_daily_digest")
@@ -474,125 +435,6 @@ mod tests {
             "newsletter_daily_digest"
         );
         assert!(!requests.iter().any(|request| request.method == "POST"));
-        server.abort();
-    }
-
-    #[tokio::test]
-    async fn ensure_workflow_agent_principal_seeds_roles_and_marks_the_principal() {
-        let existing_labels = BTreeMap::from([("operator_label".to_owned(), "keep".to_owned())]);
-        let (base_url, requests, server) =
-            spawn_workflow_principal_stub(Some(existing_labels), 200).await;
-        let registrar = SessionRegistrar::new(
-            IronControlClient::new(base_url, "test-key"),
-            "default",
-            vec!["role_infra".to_owned()],
-        );
-
-        registrar
-            .ensure_workflow_agent_principal("newsletter_daily_digest")
-            .await
-            .unwrap();
-
-        let requests = requests.lock().unwrap();
-        let puts = requests
-            .iter()
-            .filter(|request| request.method == "PUT")
-            .collect::<Vec<_>>();
-        assert_eq!(puts.len(), 2);
-        assert_eq!(puts[1].body["data"]["labels"]["operator_label"], "keep");
-        assert_eq!(
-            puts[1].body["data"]["labels"][WORKFLOW_AGENT_DEFAULT_ROLES_SEEDED_LABEL],
-            "true"
-        );
-        assert!(requests.iter().any(|request| {
-            request.method == "POST" && request.path == "/api/v1/principals/prn_workflow/roles"
-        }));
-        server.abort();
-    }
-
-    #[tokio::test]
-    async fn ensure_workflow_agent_principal_preserves_revoked_roles_after_seeding() {
-        let existing_labels = BTreeMap::from([(
-            WORKFLOW_AGENT_DEFAULT_ROLES_SEEDED_LABEL.to_owned(),
-            "true".to_owned(),
-        )]);
-        let (base_url, requests, server) =
-            spawn_workflow_principal_stub(Some(existing_labels), 200).await;
-        let registrar = SessionRegistrar::new(
-            IronControlClient::new(base_url, "test-key"),
-            "default",
-            vec!["role_infra".to_owned()],
-        );
-
-        registrar
-            .ensure_workflow_agent_principal("newsletter_daily_digest")
-            .await
-            .unwrap();
-
-        let requests = requests.lock().unwrap();
-        assert_eq!(
-            requests
-                .iter()
-                .filter(|request| request.method == "PUT")
-                .count(),
-            1
-        );
-        assert!(!requests.iter().any(|request| request.method == "POST"));
-        server.abort();
-    }
-
-    #[tokio::test]
-    async fn ensure_workflow_agent_principal_marks_only_after_role_assignment_succeeds() {
-        let (base_url, requests, server) = spawn_workflow_principal_stub(None, 500).await;
-        let registrar = SessionRegistrar::new(
-            IronControlClient::new(base_url, "test-key"),
-            "default",
-            vec!["role_infra".to_owned()],
-        );
-
-        assert!(
-            registrar
-                .ensure_workflow_agent_principal("newsletter_daily_digest")
-                .await
-                .is_err()
-        );
-
-        let requests = requests.lock().unwrap();
-        let puts = requests
-            .iter()
-            .filter(|request| request.method == "PUT")
-            .collect::<Vec<_>>();
-        assert_eq!(puts.len(), 1);
-        assert!(
-            puts[0].body["data"]["labels"]
-                .get(WORKFLOW_AGENT_DEFAULT_ROLES_SEEDED_LABEL)
-                .is_none()
-        );
-        server.abort();
-    }
-
-    #[tokio::test]
-    async fn ensure_workflow_agent_principal_accepts_concurrent_role_conflicts() {
-        let (base_url, requests, server) = spawn_workflow_principal_stub(None, 409).await;
-        let registrar = SessionRegistrar::new(
-            IronControlClient::new(base_url, "test-key"),
-            "default",
-            vec!["role_infra".to_owned()],
-        );
-
-        registrar
-            .ensure_workflow_agent_principal("newsletter_daily_digest")
-            .await
-            .unwrap();
-
-        let requests = requests.lock().unwrap();
-        assert_eq!(
-            requests
-                .iter()
-                .filter(|request| request.method == "PUT")
-                .count(),
-            2
-        );
         server.abort();
     }
 
@@ -687,13 +529,11 @@ mod tests {
     #[derive(Clone, Debug)]
     struct RecordedRequest {
         method: String,
-        path: String,
         body: Value,
     }
 
     async fn spawn_workflow_principal_stub(
         existing_labels: Option<BTreeMap<String, String>>,
-        role_status: u16,
     ) -> (
         String,
         Arc<Mutex<Vec<RecordedRequest>>>,
@@ -752,7 +592,6 @@ mod tests {
                 .unwrap_or(Value::Null);
                 seen.lock().unwrap().push(RecordedRequest {
                     method: method.clone(),
-                    path: path.clone(),
                     body: body.clone(),
                 });
 
@@ -774,14 +613,6 @@ mod tests {
                             .collect();
                         ("200 OK", workflow_principal_body(labels))
                     }
-                    ("POST", "/api/v1/principals/prn_workflow/roles") => match role_status {
-                        200 => ("200 OK", r#"{"data":{"ok":true}}"#.to_owned()),
-                        409 => ("409 Conflict", r#"{"error":"duplicate"}"#.to_owned()),
-                        _ => (
-                            "500 Internal Server Error",
-                            r#"{"error":"assignment failed"}"#.to_owned(),
-                        ),
-                    },
                     _ => (
                         "500 Internal Server Error",
                         r#"{"error":"unexpected"}"#.to_owned(),

--- a/services/api-rs/crates/centaur-iron-control/src/session.rs
+++ b/services/api-rs/crates/centaur-iron-control/src/session.rs
@@ -1,7 +1,7 @@
 //! Per-session principal registration.
 //!
 //! When a session starts, [`SessionRegistrar`] upserts the session's principal.
-//! Iron-control owns default role assignment for brand-new principals, while
+//! Console owns default role assignment for brand-new principals, while
 //! existing principals keep their current assignments so operator revocations
 //! in Console or ``centaur-perms`` remain sticky. Workflow principals use the
 //! same creation behavior. Other principals are derived from the thread key
@@ -103,9 +103,10 @@ impl SessionRegistrar {
         Ok(record)
     }
 
-    /// Ensure the stable principal for ``workflow_name`` exists without
-    /// assigning any roles. Workflow discovery and automatic agent turns share
-    /// this path so workflow permissions remain operator-managed.
+    /// Ensure the stable principal for ``workflow_name`` exists. ``api-rs``
+    /// does not assign roles here; Console applies its configured defaults if
+    /// the upsert creates the principal. Workflow discovery and automatic agent
+    /// turns share this path.
     pub async fn ensure_workflow_principal(&self, workflow_name: &str) -> Result<Principal> {
         let mut input = derive_workflow_principal(workflow_name).to_identity_input(&self.namespace);
         self.merge_existing_labels(&mut input).await?;
@@ -280,7 +281,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn register_session_leaves_default_roles_to_iron_control() {
+    async fn register_session_leaves_default_roles_to_console() {
         let (base_url, requests, server) = spawn_iron_control_stub(false).await;
         let registrar =
             SessionRegistrar::new(IronControlClient::new(base_url, "test-key"), "default");
@@ -313,7 +314,7 @@ mod tests {
         ));
         assert!(
             !request_was(&requests, "POST", "/api/v1/principals/prn_channel/roles"),
-            "iron-control assigns configured default roles during principal creation"
+            "Console assigns configured default roles during principal creation"
         );
         server.abort();
     }
@@ -423,7 +424,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn ensure_workflow_principal_preserves_labels_without_seeding_roles() {
+    async fn ensure_workflow_principal_preserves_labels_and_leaves_roles_to_console() {
         let existing_labels = BTreeMap::from([("operator_label".to_owned(), "keep".to_owned())]);
         let (base_url, requests, server) =
             spawn_workflow_principal_stub(Some(existing_labels)).await;
@@ -446,7 +447,10 @@ mod tests {
             put.body["data"]["labels"]["workflow_name"],
             "newsletter_daily_digest"
         );
-        assert!(!requests.iter().any(|request| request.method == "POST"));
+        assert!(
+            !requests.iter().any(|request| request.method == "POST"),
+            "Console assigns configured default roles during principal creation"
+        );
         server.abort();
     }
 

--- a/services/api-rs/crates/centaur-session-runtime/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-runtime/src/lib.rs
@@ -1366,12 +1366,6 @@ impl SessionRuntime {
         metadata: Option<Value>,
         on_harness_conflict: HarnessConflictPolicy,
     ) -> Result<CreateOrGetSessionOutcome, SessionRuntimeError> {
-        let workflow_name = workflow_name.trim();
-        if workflow_name.is_empty() {
-            return Err(SessionRuntimeError::BadRequest(
-                "workflow_name must not be empty".to_owned(),
-            ));
-        }
         self.create_or_get_session_with_workflow_principal(
             thread_key,
             harness_type,
@@ -1383,7 +1377,7 @@ impl SessionRuntime {
         .await
     }
 
-    async fn create_or_get_session_with_workflow_principal(
+    pub async fn create_or_get_session_with_workflow_principal(
         &self,
         thread_key: &ThreadKey,
         harness_type: &HarnessType,
@@ -1392,6 +1386,12 @@ impl SessionRuntime {
         on_harness_conflict: HarnessConflictPolicy,
         workflow_name: Option<&str>,
     ) -> Result<CreateOrGetSessionOutcome, SessionRuntimeError> {
+        let workflow_name = workflow_name.map(str::trim);
+        if workflow_name.is_some_and(str::is_empty) {
+            return Err(SessionRuntimeError::BadRequest(
+                "workflow_name must not be empty".to_owned(),
+            ));
+        }
         let span = info_span!(
             "centaur.api_rs.session.create_or_get",
             component = COMPONENT_SESSION_RUNTIME,

--- a/services/api-rs/crates/centaur-session-runtime/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-runtime/src/lib.rs
@@ -1343,6 +1343,55 @@ impl SessionRuntime {
         metadata: Option<Value>,
         on_harness_conflict: HarnessConflictPolicy,
     ) -> Result<CreateOrGetSessionOutcome, SessionRuntimeError> {
+        self.create_or_get_session_with_workflow_principal(
+            thread_key,
+            harness_type,
+            persona_id,
+            metadata,
+            on_harness_conflict,
+            None,
+        )
+        .await
+    }
+
+    /// Create or load an automatic workflow agent session and bind it to the
+    /// workflow's stable principal instead of deriving a principal from the
+    /// run-specific thread key.
+    pub async fn create_or_get_workflow_agent_session(
+        &self,
+        thread_key: &ThreadKey,
+        workflow_name: &str,
+        harness_type: &HarnessType,
+        persona_id: Option<&str>,
+        metadata: Option<Value>,
+        on_harness_conflict: HarnessConflictPolicy,
+    ) -> Result<CreateOrGetSessionOutcome, SessionRuntimeError> {
+        let workflow_name = workflow_name.trim();
+        if workflow_name.is_empty() {
+            return Err(SessionRuntimeError::BadRequest(
+                "workflow_name must not be empty".to_owned(),
+            ));
+        }
+        self.create_or_get_session_with_workflow_principal(
+            thread_key,
+            harness_type,
+            persona_id,
+            metadata,
+            on_harness_conflict,
+            Some(workflow_name),
+        )
+        .await
+    }
+
+    async fn create_or_get_session_with_workflow_principal(
+        &self,
+        thread_key: &ThreadKey,
+        harness_type: &HarnessType,
+        persona_id: Option<&str>,
+        metadata: Option<Value>,
+        on_harness_conflict: HarnessConflictPolicy,
+        workflow_name: Option<&str>,
+    ) -> Result<CreateOrGetSessionOutcome, SessionRuntimeError> {
         let span = info_span!(
             "centaur.api_rs.session.create_or_get",
             component = COMPONENT_SESSION_RUNTIME,
@@ -1373,9 +1422,15 @@ impl SessionRuntime {
             let proxy_labels = proxy_labels_from_session_metadata(thread_key, &session_metadata);
             let (registered_principal, desired_capabilities) =
                 if let Some(registrar) = &self.iron_control {
-                    let principal = registrar
-                        .register_session(thread_key.as_str(), Some(&session_metadata))
-                        .await?;
+                    let principal = if let Some(workflow_name) = workflow_name {
+                        registrar
+                            .ensure_workflow_agent_principal(workflow_name)
+                            .await?
+                    } else {
+                        registrar
+                            .register_session(thread_key.as_str(), Some(&session_metadata))
+                            .await?
+                    };
                     let desired_capabilities = sandbox_capabilities_from_principal(&principal);
                     (Some(principal), desired_capabilities)
                 } else {

--- a/services/api-rs/crates/centaur-session-runtime/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-runtime/src/lib.rs
@@ -1423,9 +1423,7 @@ impl SessionRuntime {
             let (registered_principal, desired_capabilities) =
                 if let Some(registrar) = &self.iron_control {
                     let principal = if let Some(workflow_name) = workflow_name {
-                        registrar
-                            .ensure_workflow_agent_principal(workflow_name)
-                            .await?
+                        registrar.ensure_workflow_principal(workflow_name).await?
                     } else {
                         registrar
                             .register_session(thread_key.as_str(), Some(&session_metadata))

--- a/services/api-rs/crates/centaur-workflows/src/lib.rs
+++ b/services/api-rs/crates/centaur-workflows/src/lib.rs
@@ -12,8 +12,7 @@ use absurd::{
     SpawnOptions, StepHandle, TaskContext, TaskRegistrationOptions, Worker, WorkerOptions,
 };
 use centaur_iron_control::{
-    IronControlError, SessionRegistrar, WORKFLOW_HOST_PRINCIPAL_FOREIGN_ID,
-    derive_workflow_principal,
+    IronControlError, SessionRegistrar, derive_workflow_principal, workflow_principal_is_reserved,
 };
 use centaur_sandbox_core::SandboxSpec;
 use centaur_session_core::{HarnessType, MessageRole, SessionMessageInput, ThreadKey};
@@ -826,6 +825,7 @@ impl WorkflowRuntime {
                 "workflow_name must not be empty".to_owned(),
             ));
         }
+        reject_reserved_workflow_name(workflow_name)?;
         WorkflowEnablement::from_env()?.ensure_enabled(workflow_name)?;
         let client = self.client_for_workflow(workflow_name);
         let spawn = client
@@ -1666,11 +1666,14 @@ fn metadata_from_discovery_payload(
     let mut principal_names = BTreeMap::new();
     for workflow in payload.workflows {
         let principal = derive_workflow_principal(&workflow.workflow_name);
-        if principal.foreign_id == WORKFLOW_HOST_PRINCIPAL_FOREIGN_ID {
-            return Err(WorkflowRuntimeError::BadRequest(format!(
-                "workflow {:?} resolves to reserved principal {WORKFLOW_HOST_PRINCIPAL_FOREIGN_ID:?}",
-                workflow.workflow_name
-            )));
+        if workflow_principal_is_reserved(&workflow.workflow_name) {
+            warn!(
+                workflow_name = %workflow.workflow_name,
+                source_path = %workflow.source_path,
+                principal_id = %principal.foreign_id,
+                "ignoring workflow with reserved principal identity"
+            );
+            continue;
         }
         if let Some(existing_name) =
             principal_names.insert(principal.foreign_id.clone(), workflow.workflow_name.clone())
@@ -2614,6 +2617,7 @@ async fn run_centaur_workflow_inner(
     let _heartbeat_guard = start_workflow_task_heartbeat(ctx.clone())
         .await
         .map_err(absurd_error)?;
+    reject_reserved_workflow_name(&input.workflow_name).map_err(absurd_error)?;
     WorkflowEnablement::from_env()
         .and_then(|enablement| enablement.ensure_enabled(&input.workflow_name))
         .map_err(absurd_error)?;
@@ -2788,6 +2792,17 @@ async fn run_centaur_workflow_inner(
             })
         }
     }
+}
+
+fn reject_reserved_workflow_name(workflow_name: &str) -> Result<(), WorkflowRuntimeError> {
+    if workflow_principal_is_reserved(workflow_name) {
+        let principal = derive_workflow_principal(workflow_name);
+        return Err(WorkflowRuntimeError::BadRequest(format!(
+            "workflow {workflow_name:?} resolves to reserved principal {:?}",
+            principal.foreign_id
+        )));
+    }
+    Ok(())
 }
 
 struct WorkflowSandboxCleanupGuard {
@@ -4552,20 +4567,39 @@ mod tests {
     }
 
     #[test]
-    fn discovery_rejects_workflow_host_principal_collision() {
+    fn discovery_ignores_workflow_host_principal_collision() {
         let payload: PythonWorkflowDiscoveryPayload = serde_json::from_value(json!({
-            "workflows": [{
-                "workflow_name": "host",
-                "source_path": "workflows/host.py",
-            }],
+            "workflows": [
+                {
+                    "workflow_name": "host",
+                    "source_path": "workflows/host.py",
+                    "schedule": {"schedule_id": "host", "cron": "*/5 * * * *"},
+                    "principal": true,
+                },
+                {
+                    "workflow_name": "daily_report",
+                    "source_path": "workflows/daily_report.py",
+                },
+            ],
         }))
         .unwrap();
 
-        let error = metadata_from_discovery_payload(payload).unwrap_err();
+        let metadata = metadata_from_discovery_payload(payload).unwrap();
+        assert_eq!(
+            metadata.workflow_names,
+            BTreeSet::from(["daily_report".to_owned()])
+        );
+        assert!(metadata.schedules.is_empty());
+        assert!(metadata.principals.is_empty());
+    }
+
+    #[test]
+    fn direct_ingestion_rejects_reserved_workflow_name_after_slugging() {
+        let error = reject_reserved_workflow_name(" HOST! ").unwrap_err();
         assert!(
             error
                 .to_string()
-                .contains("resolves to reserved principal \"workflow-host\"")
+                .contains("reserved principal \"workflow-host\"")
         );
     }
 

--- a/services/api-rs/crates/centaur-workflows/src/lib.rs
+++ b/services/api-rs/crates/centaur-workflows/src/lib.rs
@@ -11,7 +11,7 @@ use absurd::{
     AwaitEventOptions, Client, ClientOptions, CreateQueueOptions, RetryKind, RetryStrategy,
     SpawnOptions, StepHandle, TaskContext, TaskRegistrationOptions, Worker, WorkerOptions,
 };
-use centaur_iron_control::{IdentityInput, IronControlClient, IronControlError, slugify};
+use centaur_iron_control::{IronControlError, SessionRegistrar};
 use centaur_sandbox_core::SandboxSpec;
 use centaur_session_core::{HarnessType, MessageRole, SessionMessageInput, ThreadKey};
 use centaur_session_runtime::{
@@ -291,16 +291,12 @@ impl WorkflowHostSandboxRuntime {
 
 #[derive(Clone)]
 pub struct WorkflowPrincipalRegistrar {
-    client: IronControlClient,
-    namespace: String,
+    registrar: SessionRegistrar,
 }
 
 impl WorkflowPrincipalRegistrar {
-    pub fn new(client: IronControlClient, namespace: impl Into<String>) -> Self {
-        Self {
-            client,
-            namespace: namespace.into(),
-        }
+    pub fn new(registrar: SessionRegistrar) -> Self {
+        Self { registrar }
     }
 
     async fn register_workflow_principals(
@@ -309,32 +305,14 @@ impl WorkflowPrincipalRegistrar {
     ) -> Result<BTreeMap<String, String>, WorkflowRuntimeError> {
         let mut registered = BTreeMap::new();
         for workflow_name in principals {
-            let foreign_id = canonical_workflow_principal_foreign_id(workflow_name);
             let record = self
-                .client
-                .upsert_principal(&IdentityInput {
-                    namespace: self.namespace.clone(),
-                    foreign_id,
-                    name: format!("Workflow {workflow_name}"),
-                    labels: workflow_principal_labels(workflow_name),
-                })
+                .registrar
+                .ensure_workflow_principal(workflow_name)
                 .await?;
             registered.insert(workflow_name.clone(), record.id);
         }
         Ok(registered)
     }
-}
-
-fn canonical_workflow_principal_foreign_id(workflow_name: &str) -> String {
-    format!("workflow-{}", slugify(workflow_name))
-}
-
-fn workflow_principal_labels(workflow_name: &str) -> BTreeMap<String, String> {
-    BTreeMap::from([
-        ("kind".to_owned(), "workflow".to_owned()),
-        ("managed-by".to_owned(), "centaur".to_owned()),
-        ("workflow_name".to_owned(), workflow_name.to_owned()),
-    ])
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -2679,7 +2657,7 @@ async fn run_centaur_workflow_inner(
                     let session_runtime = session_runtime.clone();
                     let harness_type = input.harness_type.clone();
                     let thread_key =
-                        format!("wf:{}:agent:agent_turn", ctx.task_id().replace('-', ""));
+                        automatic_workflow_agent_thread_key(ctx.task_id(), "agent_turn");
                     let task_id = ctx.task_id().to_owned();
                     let run_id = ctx.run_id().to_owned();
                     async move {
@@ -2705,6 +2683,7 @@ async fn run_centaur_workflow_inner(
                                     "absurd-workflow-agent-turn:{client_message_id}"
                                 ),
                                 workflow_owned_thread: true,
+                                workflow_principal_name: Some("agent_turn".to_owned()),
                                 idle_timeout_ms,
                                 max_duration_ms,
                                 model: None,
@@ -3553,11 +3532,7 @@ async fn run_python_agent_turn(
         .map(ToOwned::to_owned);
     let workflow_owned_thread = explicit_thread_key.is_none();
     let thread_key = explicit_thread_key.unwrap_or_else(|| {
-        format!(
-            "wf:{}:agent:{}",
-            ctx.task_id().replace('-', ""),
-            input.workflow_name
-        )
+        automatic_workflow_agent_thread_key(ctx.task_id(), &input.workflow_name)
     });
     let harness_type = parse_agent_harness(&args)?.unwrap_or_else(|| input.harness_type.clone());
     let persona_id = args
@@ -3632,6 +3607,10 @@ async fn run_python_agent_turn(
             execution_metadata,
             execution_idempotency_key,
             workflow_owned_thread,
+            workflow_principal_name: workflow_agent_principal_name(
+                workflow_owned_thread,
+                &input.workflow_name,
+            ),
             idle_timeout_ms,
             max_duration_ms,
             model,
@@ -3641,6 +3620,17 @@ async fn run_python_agent_turn(
     )
     .await?;
     serde_json::to_value(result).map_err(WorkflowRuntimeError::from)
+}
+
+fn automatic_workflow_agent_thread_key(task_id: &str, workflow_name: &str) -> String {
+    format!("wf:{}:agent:{workflow_name}", task_id.replace('-', ""))
+}
+
+fn workflow_agent_principal_name(
+    workflow_owned_thread: bool,
+    workflow_name: &str,
+) -> Option<String> {
+    workflow_owned_thread.then(|| workflow_name.to_owned())
 }
 
 /// Returns the first arg key that holds a non-empty (trimmed) string, owned.
@@ -3924,6 +3914,7 @@ struct AgentTurnRequest {
     execution_metadata: Value,
     execution_idempotency_key: String,
     workflow_owned_thread: bool,
+    workflow_principal_name: Option<String>,
     idle_timeout_ms: u64,
     max_duration_ms: u64,
     // Optional per-turn model / provider / reasoning-effort overrides. When set
@@ -3979,6 +3970,7 @@ async fn run_agent_session_turn(
         execution_metadata,
         execution_idempotency_key,
         workflow_owned_thread,
+        workflow_principal_name,
         idle_timeout_ms,
         max_duration_ms,
         model,
@@ -3990,15 +3982,28 @@ async fn run_agent_session_turn(
     if workflow_owned_thread {
         object_insert(&mut session_metadata, "workflow_owned_thread", json!(true));
     }
-    session_runtime
-        .create_or_get_session(
-            &thread_key,
-            &harness_type,
-            persona_id.as_deref(),
-            Some(session_metadata),
-            HarnessConflictPolicy::Reject,
-        )
-        .await?;
+    if let Some(workflow_name) = workflow_principal_name.as_deref() {
+        session_runtime
+            .create_or_get_workflow_agent_session(
+                &thread_key,
+                workflow_name,
+                &harness_type,
+                persona_id.as_deref(),
+                Some(session_metadata),
+                HarnessConflictPolicy::Reject,
+            )
+            .await?;
+    } else {
+        session_runtime
+            .create_or_get_session(
+                &thread_key,
+                &harness_type,
+                persona_id.as_deref(),
+                Some(session_metadata),
+                HarnessConflictPolicy::Reject,
+            )
+            .await?;
+    }
     session_runtime
         .append_messages(
             &thread_key,
@@ -4174,6 +4179,32 @@ mod tests {
         assert_eq!(
             python_workflow_event_name("review", "change:42"),
             "python:[\"review\",\"change:42\"]"
+        );
+    }
+
+    #[test]
+    fn automatic_agent_threads_are_per_task_but_share_the_workflow_identity() {
+        let first = automatic_workflow_agent_thread_key(
+            "019f9511-cfb6-7c4a-bcb9-ea74651c0e30",
+            "newsletter_daily_digest",
+        );
+        let second = automatic_workflow_agent_thread_key(
+            "019f9511-cfb6-7c4a-bcb9-ea74651c0e31",
+            "newsletter_daily_digest",
+        );
+
+        assert_ne!(first, second);
+        assert_eq!(
+            workflow_agent_principal_name(true, "newsletter_daily_digest").as_deref(),
+            Some("newsletter_daily_digest")
+        );
+    }
+
+    #[test]
+    fn explicit_agent_threads_keep_session_derived_principals() {
+        assert_eq!(
+            workflow_agent_principal_name(false, "newsletter_daily_digest"),
+            None
         );
     }
 
@@ -4506,30 +4537,6 @@ mod tests {
             Some(&json!("scheduled_workflow"))
         );
         assert!(metadata.principals.contains("scheduled_workflow"));
-    }
-
-    #[test]
-    fn workflow_principal_foreign_id_is_derived_from_workflow_name() {
-        assert_eq!(
-            canonical_workflow_principal_foreign_id("nightly_report"),
-            "workflow-nightly-report"
-        );
-        assert_eq!(
-            canonical_workflow_principal_foreign_id("Managing Partner Daily Briefing"),
-            "workflow-managing-partner-daily-briefing"
-        );
-    }
-
-    #[test]
-    fn workflow_principal_labels_identify_workflow_kind() {
-        let labels = workflow_principal_labels("nightly_report");
-
-        assert_eq!(labels.get("kind").map(String::as_str), Some("workflow"));
-        assert!(!labels.contains_key("purpose"));
-        assert_eq!(
-            labels.get("workflow_name").map(String::as_str),
-            Some("nightly_report")
-        );
     }
 
     #[test]

--- a/services/api-rs/crates/centaur-workflows/src/lib.rs
+++ b/services/api-rs/crates/centaur-workflows/src/lib.rs
@@ -11,7 +11,10 @@ use absurd::{
     AwaitEventOptions, Client, ClientOptions, CreateQueueOptions, RetryKind, RetryStrategy,
     SpawnOptions, StepHandle, TaskContext, TaskRegistrationOptions, Worker, WorkerOptions,
 };
-use centaur_iron_control::{IronControlError, SessionRegistrar};
+use centaur_iron_control::{
+    IronControlError, SessionRegistrar, WORKFLOW_HOST_PRINCIPAL_FOREIGN_ID,
+    derive_workflow_principal,
+};
 use centaur_sandbox_core::SandboxSpec;
 use centaur_session_core::{HarnessType, MessageRole, SessionMessageInput, ThreadKey};
 use centaur_session_runtime::{
@@ -1658,9 +1661,26 @@ struct PythonWorkflowMetadata {
 
 fn metadata_from_discovery_payload(
     payload: PythonWorkflowDiscoveryPayload,
-) -> PythonWorkflowMetadata {
+) -> Result<PythonWorkflowMetadata, WorkflowRuntimeError> {
     let mut metadata = PythonWorkflowMetadata::default();
+    let mut principal_names = BTreeMap::new();
     for workflow in payload.workflows {
+        let principal = derive_workflow_principal(&workflow.workflow_name);
+        if principal.foreign_id == WORKFLOW_HOST_PRINCIPAL_FOREIGN_ID {
+            return Err(WorkflowRuntimeError::BadRequest(format!(
+                "workflow {:?} resolves to reserved principal {WORKFLOW_HOST_PRINCIPAL_FOREIGN_ID:?}",
+                workflow.workflow_name
+            )));
+        }
+        if let Some(existing_name) =
+            principal_names.insert(principal.foreign_id.clone(), workflow.workflow_name.clone())
+            && existing_name != workflow.workflow_name
+        {
+            return Err(WorkflowRuntimeError::BadRequest(format!(
+                "workflows {existing_name:?} and {:?} resolve to the same principal {:?}",
+                workflow.workflow_name, principal.foreign_id
+            )));
+        }
         metadata
             .workflow_names
             .insert(workflow.workflow_name.clone());
@@ -1680,7 +1700,7 @@ fn metadata_from_discovery_payload(
             metadata.principals.insert(workflow.workflow_name);
         }
     }
-    metadata
+    Ok(metadata)
 }
 
 async fn prepare_workflow_host_sandbox(
@@ -1795,7 +1815,7 @@ async fn discover_python_workflow_metadata() -> Result<PythonWorkflowMetadata, W
             Some("workflow.discovery") => {
                 let _ = child.wait().await;
                 let payload: PythonWorkflowDiscoveryPayload = serde_json::from_value(message)?;
-                let mut metadata = metadata_from_discovery_payload(payload);
+                let mut metadata = metadata_from_discovery_payload(payload)?;
                 WorkflowEnablement::from_env()?.filter_metadata(&mut metadata);
                 return Ok(metadata);
             }
@@ -2656,15 +2676,16 @@ async fn run_centaur_workflow_inner(
                 .step("agent_turn", || {
                     let session_runtime = session_runtime.clone();
                     let harness_type = input.harness_type.clone();
+                    let workflow_name = input.workflow_name.clone();
                     let thread_key =
-                        automatic_workflow_agent_thread_key(ctx.task_id(), "agent_turn");
+                        automatic_workflow_agent_thread_key(ctx.task_id(), &workflow_name);
                     let task_id = ctx.task_id().to_owned();
                     let run_id = ctx.run_id().to_owned();
                     async move {
                         let client_message_id = format!("absurd-workflow:{task_id}:native:user");
                         let metadata = json!({
                             "source": "absurd_workflow",
-                            "workflow_name": "agent_turn",
+                            "workflow_name": workflow_name.clone(),
                             "workflow_task_id": task_id,
                             "workflow_run_id": run_id,
                         });
@@ -2683,7 +2704,10 @@ async fn run_centaur_workflow_inner(
                                     "absurd-workflow-agent-turn:{client_message_id}"
                                 ),
                                 workflow_owned_thread: true,
-                                workflow_principal_name: Some("agent_turn".to_owned()),
+                                workflow_principal_name: workflow_agent_principal_name(
+                                    true,
+                                    &workflow_name,
+                                ),
                                 idle_timeout_ms,
                                 max_duration_ms,
                                 model: None,
@@ -3982,28 +4006,16 @@ async fn run_agent_session_turn(
     if workflow_owned_thread {
         object_insert(&mut session_metadata, "workflow_owned_thread", json!(true));
     }
-    if let Some(workflow_name) = workflow_principal_name.as_deref() {
-        session_runtime
-            .create_or_get_workflow_agent_session(
-                &thread_key,
-                workflow_name,
-                &harness_type,
-                persona_id.as_deref(),
-                Some(session_metadata),
-                HarnessConflictPolicy::Reject,
-            )
-            .await?;
-    } else {
-        session_runtime
-            .create_or_get_session(
-                &thread_key,
-                &harness_type,
-                persona_id.as_deref(),
-                Some(session_metadata),
-                HarnessConflictPolicy::Reject,
-            )
-            .await?;
-    }
+    session_runtime
+        .create_or_get_session_with_workflow_principal(
+            &thread_key,
+            &harness_type,
+            persona_id.as_deref(),
+            Some(session_metadata),
+            HarnessConflictPolicy::Reject,
+            workflow_principal_name.as_deref(),
+        )
+        .await?;
     session_runtime
         .append_messages(
             &thread_key,
@@ -4523,7 +4535,7 @@ mod tests {
             ],
         }))
         .unwrap();
-        let metadata = metadata_from_discovery_payload(payload);
+        let metadata = metadata_from_discovery_payload(payload).unwrap();
         assert_eq!(
             metadata.workflow_names,
             BTreeSet::from([
@@ -4537,6 +4549,47 @@ mod tests {
             Some(&json!("scheduled_workflow"))
         );
         assert!(metadata.principals.contains("scheduled_workflow"));
+    }
+
+    #[test]
+    fn discovery_rejects_workflow_host_principal_collision() {
+        let payload: PythonWorkflowDiscoveryPayload = serde_json::from_value(json!({
+            "workflows": [{
+                "workflow_name": "host",
+                "source_path": "workflows/host.py",
+            }],
+        }))
+        .unwrap();
+
+        let error = metadata_from_discovery_payload(payload).unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("resolves to reserved principal \"workflow-host\"")
+        );
+    }
+
+    #[test]
+    fn discovery_rejects_colliding_workflow_principal_slugs() {
+        let payload: PythonWorkflowDiscoveryPayload = serde_json::from_value(json!({
+            "workflows": [
+                {
+                    "workflow_name": "Daily Report",
+                    "source_path": "workflows/daily_report_title.py",
+                },
+                {
+                    "workflow_name": "daily_report",
+                    "source_path": "workflows/daily_report_snake.py",
+                },
+            ],
+        }))
+        .unwrap();
+
+        let error = metadata_from_discovery_payload(payload).unwrap_err();
+        let message = error.to_string();
+        assert!(message.contains("\"Daily Report\""));
+        assert!(message.contains("\"daily_report\""));
+        assert!(message.contains("\"workflow-daily-report\""));
     }
 
     #[test]
@@ -4640,7 +4693,7 @@ mod tests {
         }))
         .unwrap();
 
-        let metadata = metadata_from_discovery_payload(payload);
+        let metadata = metadata_from_discovery_payload(payload).unwrap();
         let filter = metadata.webhooks[0].spec.filter.as_ref().unwrap();
         let all = filter.all.as_ref().unwrap();
         assert_eq!(all.len(), 2);
@@ -4770,7 +4823,7 @@ mod tests {
             ],
         }))
         .unwrap();
-        let mut metadata = metadata_from_discovery_payload(payload);
+        let mut metadata = metadata_from_discovery_payload(payload).unwrap();
         WorkflowEnablement::allowlist("allowed_workflow").filter_metadata(&mut metadata);
 
         assert_eq!(

--- a/services/api-rs/crates/centaur-workflows/src/lib.rs
+++ b/services/api-rs/crates/centaur-workflows/src/lib.rs
@@ -825,7 +825,7 @@ impl WorkflowRuntime {
                 "workflow_name must not be empty".to_owned(),
             ));
         }
-        reject_reserved_workflow_name(workflow_name)?;
+        validate_workflow_name_for_run(workflow_name)?;
         WorkflowEnablement::from_env()?.ensure_enabled(workflow_name)?;
         let client = self.client_for_workflow(workflow_name);
         let spawn = client
@@ -1034,6 +1034,49 @@ enum WorkflowQueueClass {
     SlackLive,
     Etl,
     EtlBackfill,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum NativeWorkflow {
+    Echo,
+    SleepEcho,
+    AgentTurn,
+    ToolAndSlack,
+}
+
+impl NativeWorkflow {
+    const ALL: [Self; 4] = [
+        Self::Echo,
+        Self::SleepEcho,
+        Self::AgentTurn,
+        Self::ToolAndSlack,
+    ];
+
+    fn from_name(workflow_name: &str) -> Option<Self> {
+        match workflow_name {
+            "echo" => Some(Self::Echo),
+            "sleep_echo" => Some(Self::SleepEcho),
+            "agent_turn" => Some(Self::AgentTurn),
+            "tool_and_slack" => Some(Self::ToolAndSlack),
+            _ => None,
+        }
+    }
+
+    fn name(self) -> &'static str {
+        match self {
+            Self::Echo => "echo",
+            Self::SleepEcho => "sleep_echo",
+            Self::AgentTurn => "agent_turn",
+            Self::ToolAndSlack => "tool_and_slack",
+        }
+    }
+
+    fn for_principal_name(workflow_name: &str) -> Option<Self> {
+        let foreign_id = derive_workflow_principal(workflow_name).foreign_id;
+        Self::ALL
+            .into_iter()
+            .find(|native| derive_workflow_principal(native.name()).foreign_id == foreign_id)
+    }
 }
 
 fn workflow_queue_class(workflow_name: &str) -> WorkflowQueueClass {
@@ -1663,7 +1706,33 @@ fn metadata_from_discovery_payload(
     payload: PythonWorkflowDiscoveryPayload,
 ) -> Result<PythonWorkflowMetadata, WorkflowRuntimeError> {
     let mut metadata = PythonWorkflowMetadata::default();
-    let mut principal_names = BTreeMap::new();
+    let mut principal_names = BTreeMap::<String, BTreeSet<String>>::new();
+    for workflow in &payload.workflows {
+        if workflow_principal_is_reserved(&workflow.workflow_name)
+            || NativeWorkflow::for_principal_name(&workflow.workflow_name).is_some()
+        {
+            continue;
+        }
+        let principal = derive_workflow_principal(&workflow.workflow_name);
+        principal_names
+            .entry(principal.foreign_id)
+            .or_default()
+            .insert(workflow.workflow_name.clone());
+    }
+    let colliding_principals = principal_names
+        .into_iter()
+        .filter_map(|(principal_id, workflow_names)| {
+            (workflow_names.len() > 1).then(|| {
+                warn!(
+                    principal_id,
+                    workflow_names = ?workflow_names,
+                    "ignoring Python workflows with colliding principal identity"
+                );
+                principal_id
+            })
+        })
+        .collect::<BTreeSet<_>>();
+
     for workflow in payload.workflows {
         let principal = derive_workflow_principal(&workflow.workflow_name);
         if workflow_principal_is_reserved(&workflow.workflow_name) {
@@ -1675,14 +1744,18 @@ fn metadata_from_discovery_payload(
             );
             continue;
         }
-        if let Some(existing_name) =
-            principal_names.insert(principal.foreign_id.clone(), workflow.workflow_name.clone())
-            && existing_name != workflow.workflow_name
-        {
-            return Err(WorkflowRuntimeError::BadRequest(format!(
-                "workflows {existing_name:?} and {:?} resolve to the same principal {:?}",
-                workflow.workflow_name, principal.foreign_id
-            )));
+        if let Some(native) = NativeWorkflow::for_principal_name(&workflow.workflow_name) {
+            warn!(
+                workflow_name = %workflow.workflow_name,
+                source_path = %workflow.source_path,
+                native_workflow_name = native.name(),
+                principal_id = %principal.foreign_id,
+                "ignoring Python workflow with native workflow identity"
+            );
+            continue;
+        }
+        if colliding_principals.contains(&principal.foreign_id) {
+            continue;
         }
         metadata
             .workflow_names
@@ -2200,9 +2273,10 @@ impl RemovedWorkflowReaper {
             .iter()
             .map(|(queue, task_id, name)| (format!("{queue}:{task_id}"), name.clone()))
             .collect::<Vec<_>>();
+        let known_workflow_names = known_workflow_names(&metadata.workflow_names);
         let stale_runs = select_stale_cancellations(
             &run_keyed,
-            &metadata.workflow_names,
+            &known_workflow_names,
             &mut self.workflow_miss_counts,
             self.threshold,
         );
@@ -2257,6 +2331,16 @@ impl RemovedWorkflowReaper {
         }
         Ok(())
     }
+}
+
+fn known_workflow_names(discovered: &BTreeSet<String>) -> BTreeSet<String> {
+    let mut known = discovered.clone();
+    known.extend(
+        NativeWorkflow::ALL
+            .into_iter()
+            .map(|workflow| workflow.name().to_owned()),
+    );
+    known
 }
 
 /// Returns `(task_id, name)` for every non-terminal task in the queue, where
@@ -2617,12 +2701,12 @@ async fn run_centaur_workflow_inner(
     let _heartbeat_guard = start_workflow_task_heartbeat(ctx.clone())
         .await
         .map_err(absurd_error)?;
-    reject_reserved_workflow_name(&input.workflow_name).map_err(absurd_error)?;
+    validate_workflow_name_for_run(&input.workflow_name).map_err(absurd_error)?;
     WorkflowEnablement::from_env()
         .and_then(|enablement| enablement.ensure_enabled(&input.workflow_name))
         .map_err(absurd_error)?;
-    match input.workflow_name.as_str() {
-        "echo" => {
+    match NativeWorkflow::from_name(&input.workflow_name) {
+        Some(NativeWorkflow::Echo) => {
             let output = ctx
                 .step("echo", || async {
                     Ok(json!({
@@ -2640,7 +2724,7 @@ async fn run_centaur_workflow_inner(
                 output,
             })
         }
-        "sleep_echo" => {
+        Some(NativeWorkflow::SleepEcho) => {
             let sleep_ms = input
                 .input
                 .get("sleep_ms")
@@ -2659,7 +2743,7 @@ async fn run_centaur_workflow_inner(
                 output,
             })
         }
-        "agent_turn" => {
+        Some(NativeWorkflow::AgentTurn) => {
             let prompt = input
                 .input
                 .get("prompt")
@@ -2732,7 +2816,7 @@ async fn run_centaur_workflow_inner(
                 output: serde_json::to_value(agent).map_err(absurd::Error::Json)?,
             })
         }
-        "tool_and_slack" => {
+        Some(NativeWorkflow::ToolAndSlack) => {
             let slack_channel = input
                 .input
                 .get("slack_channel")
@@ -2772,7 +2856,7 @@ async fn run_centaur_workflow_inner(
                 }),
             })
         }
-        _ => {
+        None => {
             let workflow_name = input.workflow_name.clone();
             let output = run_python_workflow_host(
                 input,
@@ -2794,12 +2878,22 @@ async fn run_centaur_workflow_inner(
     }
 }
 
-fn reject_reserved_workflow_name(workflow_name: &str) -> Result<(), WorkflowRuntimeError> {
+fn validate_workflow_name_for_run(workflow_name: &str) -> Result<(), WorkflowRuntimeError> {
     if workflow_principal_is_reserved(workflow_name) {
         let principal = derive_workflow_principal(workflow_name);
         return Err(WorkflowRuntimeError::BadRequest(format!(
             "workflow {workflow_name:?} resolves to reserved principal {:?}",
             principal.foreign_id
+        )));
+    }
+    if let Some(native) = NativeWorkflow::for_principal_name(workflow_name)
+        && NativeWorkflow::from_name(workflow_name).is_none()
+    {
+        let principal = derive_workflow_principal(workflow_name);
+        return Err(WorkflowRuntimeError::BadRequest(format!(
+            "workflow {workflow_name:?} resolves to principal {:?}, which is reserved for native workflow {:?}",
+            principal.foreign_id,
+            native.name()
         )));
     }
     Ok(())
@@ -4595,7 +4689,7 @@ mod tests {
 
     #[test]
     fn direct_ingestion_rejects_reserved_workflow_name_after_slugging() {
-        let error = reject_reserved_workflow_name(" HOST! ").unwrap_err();
+        let error = validate_workflow_name_for_run(" HOST! ").unwrap_err();
         assert!(
             error
                 .to_string()
@@ -4604,7 +4698,61 @@ mod tests {
     }
 
     #[test]
-    fn discovery_rejects_colliding_workflow_principal_slugs() {
+    fn native_workflow_names_are_allowed_but_slug_variants_are_rejected() {
+        for native in NativeWorkflow::ALL {
+            validate_workflow_name_for_run(native.name()).unwrap();
+
+            let variant = native.name().replace('_', " ").to_uppercase();
+            let error = validate_workflow_name_for_run(&variant).unwrap_err();
+            let message = error.to_string();
+            assert!(message.contains(&derive_workflow_principal(native.name()).foreign_id));
+            assert!(message.contains(&format!("native workflow {:?}", native.name())));
+        }
+    }
+
+    #[test]
+    fn removed_workflow_reaper_always_knows_native_workflows() {
+        let known = known_workflow_names(&BTreeSet::from(["daily_report".to_owned()]));
+
+        assert!(known.contains("daily_report"));
+        for native in NativeWorkflow::ALL {
+            assert!(known.contains(native.name()));
+        }
+    }
+
+    #[test]
+    fn discovery_ignores_python_workflows_with_native_principal_identities() {
+        let payload: PythonWorkflowDiscoveryPayload = serde_json::from_value(json!({
+            "workflows": [
+                {
+                    "workflow_name": "agent_turn",
+                    "source_path": "workflows/native_exact.py",
+                    "schedule": {"schedule_id": "native_exact", "cron": "*/5 * * * *"},
+                    "principal": true,
+                },
+                {
+                    "workflow_name": "Agent Turn",
+                    "source_path": "workflows/native_slug.py",
+                },
+                {
+                    "workflow_name": "daily_report",
+                    "source_path": "workflows/daily_report.py",
+                },
+            ],
+        }))
+        .unwrap();
+
+        let metadata = metadata_from_discovery_payload(payload).unwrap();
+        assert_eq!(
+            metadata.workflow_names,
+            BTreeSet::from(["daily_report".to_owned()])
+        );
+        assert!(metadata.schedules.is_empty());
+        assert!(metadata.principals.is_empty());
+    }
+
+    #[test]
+    fn discovery_ignores_every_workflow_with_a_colliding_principal_slug() {
         let payload: PythonWorkflowDiscoveryPayload = serde_json::from_value(json!({
             "workflows": [
                 {
@@ -4615,15 +4763,30 @@ mod tests {
                     "workflow_name": "daily_report",
                     "source_path": "workflows/daily_report_snake.py",
                 },
+                {
+                    "workflow_name": "weekly_report",
+                    "source_path": "workflows/weekly_report.py",
+                    "schedule": {"schedule_id": "weekly_report", "cron": "*/5 * * * *"},
+                    "principal": true,
+                },
             ],
         }))
         .unwrap();
 
-        let error = metadata_from_discovery_payload(payload).unwrap_err();
-        let message = error.to_string();
-        assert!(message.contains("\"Daily Report\""));
-        assert!(message.contains("\"daily_report\""));
-        assert!(message.contains("\"workflow-daily-report\""));
+        let metadata = metadata_from_discovery_payload(payload).unwrap();
+        assert_eq!(
+            metadata.workflow_names,
+            BTreeSet::from(["weekly_report".to_owned()])
+        );
+        assert_eq!(metadata.schedules.len(), 1);
+        assert_eq!(
+            metadata.schedules[0].get("workflow_name"),
+            Some(&json!("weekly_report"))
+        );
+        assert_eq!(
+            metadata.principals,
+            BTreeSet::from(["weekly_report".to_owned()])
+        );
     }
 
     #[test]

--- a/services/api-rs/rfcs/0003-python-workflow-host.md
+++ b/services/api-rs/rfcs/0003-python-workflow-host.md
@@ -269,6 +269,10 @@ Rules:
 
 - honor explicit `thread_key`
 - otherwise derive `wf:<task_id>:agent:<step-or-message>`
+- bind automatically derived threads to the stable
+  `workflow-<slugged-workflow-name>` principal while keeping their session
+  state isolated per task
+- keep explicit thread keys on the normal session-derived principal path
 - honor explicit `message_id`
 - otherwise derive a deterministic message id from task id and call site
 - pass through `metadata`, `delivery`, `harness`, `persona`, and prompt override


### PR DESCRIPTION
Automatic workflow agent turns now bind their run-specific sessions to the stable workflow principal instead of creating one principal per run. Native and Python paths derive that identity from the workflow name. Python workflows that collide with workflow-host or a built-in native workflow identity are ignored during discovery, and non-native spellings of native identities are rejected before queueing. Every member of a duplicate Python principal-slug group is ignored without failing startup or reconciliation. api-rs only creates or reconciles workflow principals; Console applies configured default roles on initial creation and preserves later operator revocations. Workflow-host opt-in and agent turns share the same identity, and additional tool permissions remain operator-managed.