### PR TITLE
feat(githubbot): emit durable workflow events from CI and review webhooks

### DIFF
--- a/contrib/chart/Chart.yaml
+++ b/contrib/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: centaur
 description: Helm chart for the trusted Centaur control plane
 type: application
-version: 0.1.108
+version: 0.1.109
 appVersion: "0.1.0"
 dependencies:
   - name: connect

--- a/contrib/chart/templates/githubbot.yaml
+++ b/contrib/chart/templates/githubbot.yaml
@@ -98,8 +98,7 @@ spec:
               value: {{ .Values.githubbot.autoMerge | quote }}
             - name: GITHUBBOT_MERGE_METHOD
               value: {{ .Values.githubbot.mergeMethod | quote }}
-            # Durable-workflow event emission (ci-completed / codex-review ->
-            # POST /api/workflows/events on api-rs).
+            # Durable workflow-event emission (ci-completed / codex-review) to api-rs.
             - name: GITHUBBOT_WORKFLOW_EVENTS
               value: {{ .Values.githubbot.workflowEvents | quote }}
 {{- if .Values.githubbot.workflowReviewBots }}

--- a/contrib/chart/templates/githubbot.yaml
+++ b/contrib/chart/templates/githubbot.yaml
@@ -98,6 +98,14 @@ spec:
               value: {{ .Values.githubbot.autoMerge | quote }}
             - name: GITHUBBOT_MERGE_METHOD
               value: {{ .Values.githubbot.mergeMethod | quote }}
+            # Durable-workflow event emission (ci-completed / codex-review ->
+            # POST /api/workflows/events on api-rs).
+            - name: GITHUBBOT_WORKFLOW_EVENTS
+              value: {{ .Values.githubbot.workflowEvents | quote }}
+{{- if .Values.githubbot.workflowReviewBots }}
+            - name: GITHUBBOT_WORKFLOW_REVIEW_BOTS
+              value: {{ .Values.githubbot.workflowReviewBots | quote }}
+{{- end }}
 {{- if .Values.githubbot.escalationHandle }}
             - name: GITHUBBOT_ESCALATION_HANDLE
               value: {{ .Values.githubbot.escalationHandle | quote }}

--- a/contrib/chart/templates/githubbot.yaml
+++ b/contrib/chart/templates/githubbot.yaml
@@ -98,7 +98,7 @@ spec:
               value: {{ .Values.githubbot.autoMerge | quote }}
             - name: GITHUBBOT_MERGE_METHOD
               value: {{ .Values.githubbot.mergeMethod | quote }}
-            # Durable workflow-event emission (ci-completed / codex-review) to api-rs.
+            # Durable workflow-event emission (ci-completed / review-submitted) to api-rs.
             - name: GITHUBBOT_WORKFLOW_EVENTS
               value: {{ .Values.githubbot.workflowEvents | quote }}
 {{- if .Values.githubbot.workflowReviewBots }}

--- a/contrib/chart/values.yaml
+++ b/contrib/chart/values.yaml
@@ -554,6 +554,15 @@ githubbot:
   # / draft status.
   autoMerge: true
   mergeMethod: squash
+  # Durable-workflow event emission: when true, lifecycle webhooks also POST
+  # ci-completed / codex-review events to api-rs (/api/workflows/events) so
+  # durable workflows can wait on CI/review for ANY PR (not just bot-owned
+  # ones), keyed by head sha. The api-rs URL and service token are already
+  # wired; this only flips the behavior on.
+  workflowEvents: false
+  # Comma-separated reviewer logins whose submitted reviews emit codex-review
+  # events. Empty = the bot's default (chatgpt-codex-connector).
+  workflowReviewBots: ""
   # Fallback @handle (no leading @) the bot tags when it gives up; empty = none.
   escalationHandle: ""
   # Optional review / issue-work methodology overrides. When set, the chart writes

--- a/contrib/chart/values.yaml
+++ b/contrib/chart/values.yaml
@@ -555,13 +555,13 @@ githubbot:
   autoMerge: true
   mergeMethod: squash
   # Durable-workflow event emission: when true, lifecycle webhooks also POST
-  # ci-completed / codex-review events to api-rs (/api/workflows/events) so
+  # ci-completed / review-submitted events to api-rs (/api/workflows/events) so
   # durable workflows can wait on CI/review for ANY PR (not just bot-owned
   # ones), keyed by head sha. The api-rs URL and service token are already
   # wired; this only flips the behavior on.
   workflowEvents: false
-  # Comma-separated reviewer logins whose submitted reviews emit codex-review
-  # events. Empty = the bot's default (chatgpt-codex-connector).
+  # Comma-separated reviewer logins whose submitted reviews emit
+  # review-submitted events. Empty = the bot's default (chatgpt-codex-connector).
   workflowReviewBots: ""
   # Fallback @handle (no leading @) the bot tags when it gives up; empty = none.
   escalationHandle: ""

--- a/services/api-rs/crates/absurd-sdk/src/lib.rs
+++ b/services/api-rs/crates/absurd-sdk/src/lib.rs
@@ -2440,4 +2440,109 @@ mod tests {
         drop(worker);
         Ok(())
     }
+
+    #[tokio::test]
+    async fn integration_await_event_wait_emit_wake_timeout_when_database_url_is_set() -> Result<()>
+    {
+        let Some(pool) = optional_test_pool().await? else {
+            return Ok(());
+        };
+
+        let queue = unique_queue("rust_await_event");
+        let app = Client::from_pool_with_options(
+            pool,
+            ClientOptions {
+                queue_name: queue.clone(),
+                ..ClientOptions::default()
+            },
+        )?;
+        app.create_queue(None, Default::default()).await?;
+
+        // Emit BEFORE any waiter exists: the durable event row must resolve a
+        // later wait immediately (the runner can start waiting after CI finished).
+        app.emit_event("validation:early", json!({"conclusion": "success"}), None)
+            .await?;
+
+        app.register_task("waiter", |_params: Value, ctx| async move {
+            // Early emit resolves without sleeping.
+            let early = ctx
+                .await_event::<Value>("validation:early", AwaitEventOptions::default())
+                .await?;
+            // Live wait -> emit -> wake; a second await of the same event must
+            // return the checkpointed payload without another emit.
+            let got = ctx
+                .await_event::<Value>("validation:wake", AwaitEventOptions::default())
+                .await?;
+            let got_again = ctx
+                .await_event::<Value>("validation:wake", AwaitEventOptions::default())
+                .await?;
+            Ok(json!({"early": early, "got": got, "got_again": got_again}))
+        })?;
+
+        app.register_task("impatient", |_params: Value, ctx| async move {
+            // No emit inside the window: the timeout must surface as an error
+            // (the Python host raises it; the runner falls back to a poll).
+            let outcome = ctx
+                .await_event::<Value>(
+                    "validation:never",
+                    AwaitEventOptions {
+                        step_name: None,
+                        timeout: Some(Duration::from_millis(500)),
+                    },
+                )
+                .await;
+            Ok(match outcome {
+                Err(err) => json!({"error": err.to_string()}),
+                Ok(value) => json!({"error": Value::Null, "value": value}),
+            })
+        })?;
+
+        let spawned = app.spawn("waiter", json!({}), Default::default()).await?;
+        let timed = app
+            .spawn("impatient", json!({}), Default::default())
+            .await?;
+
+        let worker = app.start_worker(WorkerOptions {
+            worker_id: Some("rust-await-event-worker".to_string()),
+            concurrency: 2,
+            poll_interval: Duration::from_millis(25),
+            fatal_on_lease_timeout: false,
+            ..WorkerOptions::default()
+        });
+
+        // Let the worker reach the second wait, then emit.
+        tokio::time::sleep(Duration::from_millis(400)).await;
+        app.emit_event("validation:wake", json!({"review_id": 7}), None)
+            .await?;
+
+        let snapshot = app
+            .await_task_result(&spawned.task_id, None, Some(Duration::from_secs(10)))
+            .await?;
+        assert_eq!(
+            snapshot.result::<Value>()?,
+            Some(json!({
+                "early": {"conclusion": "success"},
+                "got": {"review_id": 7},
+                "got_again": {"review_id": 7},
+            }))
+        );
+
+        let timed_snapshot = app
+            .await_task_result(&timed.task_id, None, Some(Duration::from_secs(10)))
+            .await?;
+        let timed_error = timed_snapshot
+            .result::<Value>()?
+            .and_then(|v| v.get("error").cloned())
+            .and_then(|v| v.as_str().map(str::to_owned));
+        assert!(
+            timed_error
+                .as_deref()
+                .unwrap_or("")
+                .contains("timed out waiting for event"),
+            "expected timeout error, got {timed_snapshot:?}"
+        );
+
+        drop(worker);
+        Ok(())
+    }
 }

--- a/services/githubbot/README.md
+++ b/services/githubbot/README.md
@@ -155,7 +155,7 @@ requests**, **Pull request reviews**, **Check runs**, **Check suites**, and **Wo
 | `GITHUBBOT_MERGE_METHOD` | — | `merge` / `squash` / `rebase`. Default `squash`. |
 | `GITHUBBOT_HOLD_LABEL` | — | Label that pauses auto-merge. Default `do-not-merge`. |
 | `GITHUBBOT_CI_FIX_MAX_ATTEMPTS` | — | Consecutive CI-fix attempts before escalating. Default 3. |
-| `GITHUBBOT_WORKFLOW_EVENTS` | — | Emit durable workflow events to api-rs (`POST /api/workflows/events`) from lifecycle webhooks, before owned-PR gating: `ci-completed` (correlation `<owner>/<repo>:<head_sha>`) when a check run/suite/workflow run completes or a legacy status resolves, and `codex-review` (correlation `<owner>/<repo>:pr-<n>:<head_sha>`) when a configured reviewer bot submits. Default `false`. |
+| `GITHUBBOT_WORKFLOW_EVENTS` | — | Emit durable workflow events to api-rs (`POST /api/workflows/events`) from lifecycle webhooks, before owned-PR gating: `ci-completed` (correlation `<owner>/<repo>:<head_sha>`, payload `{failed, failing}`) once every check for the sha has settled — events are immutable per correlation, so a single check's completion never fires it — and `codex-review` (correlation `<owner>/<repo>:pr-<n>:<head_sha>`, payload `{review_id, state}`) when a configured reviewer bot submits. Default `false`. |
 | `GITHUBBOT_WORKFLOW_REVIEW_BOTS` | — | Comma-separated reviewer logins whose submitted reviews emit `codex-review`. Default `chatgpt-codex-connector`. |
 | `GITHUBBOT_DELETE_BRANCH_ON_MERGE` | — | Delete head branch after merge. Default `true`. |
 | `GITHUBBOT_ESCALATION_HANDLE` | — | Fallback @handle (no leading @) tagged when the bot gives up. |

--- a/services/githubbot/README.md
+++ b/services/githubbot/README.md
@@ -155,8 +155,8 @@ requests**, **Pull request reviews**, **Check runs**, **Check suites**, and **Wo
 | `GITHUBBOT_MERGE_METHOD` | — | `merge` / `squash` / `rebase`. Default `squash`. |
 | `GITHUBBOT_HOLD_LABEL` | — | Label that pauses auto-merge. Default `do-not-merge`. |
 | `GITHUBBOT_CI_FIX_MAX_ATTEMPTS` | — | Consecutive CI-fix attempts before escalating. Default 3. |
-| `GITHUBBOT_WORKFLOW_EVENTS` | — | Emit durable workflow events to api-rs (`POST /api/workflows/events`) from lifecycle webhooks, before owned-PR gating. `ci-completed`: correlation `<owner>/<repo>:<head_sha>`, payload `{failed, failing}`, fires only once every check for the sha settles (events are immutable per correlation). `codex-review`: correlation `<owner>/<repo>:pr-<n>:<head_sha>`, payload `{review_id, state}`, fires when a configured reviewer bot submits. Default `false`. |
-| `GITHUBBOT_WORKFLOW_REVIEW_BOTS` | — | Comma-separated reviewer logins whose submitted reviews emit `codex-review`. Default `chatgpt-codex-connector`. |
+| `GITHUBBOT_WORKFLOW_EVENTS` | — | Emit durable workflow events to api-rs (`POST /api/workflows/events`) from lifecycle webhooks, before owned-PR gating. `ci-completed`: correlation `<owner>/<repo>:<head_sha>`, payload `{failed, failing}`, fires only once every check for the sha settles (events are immutable per correlation). `review-submitted`: correlation `<owner>/<repo>:pr-<n>:<head_sha>`, payload `{review_id, state}`, fires when a configured reviewer bot submits. Default `false`. |
+| `GITHUBBOT_WORKFLOW_REVIEW_BOTS` | — | Comma-separated reviewer logins whose submitted reviews emit `review-submitted`. Default `chatgpt-codex-connector`. |
 | `GITHUBBOT_DELETE_BRANCH_ON_MERGE` | — | Delete head branch after merge. Default `true`. |
 | `GITHUBBOT_ESCALATION_HANDLE` | — | Fallback @handle (no leading @) tagged when the bot gives up. |
 | `SESSION_IDLE_TIMEOUT_MS` / `SESSION_MAX_DURATION_MS` | — | Forwarded to api-rs executes. |

--- a/services/githubbot/README.md
+++ b/services/githubbot/README.md
@@ -155,7 +155,7 @@ requests**, **Pull request reviews**, **Check runs**, **Check suites**, and **Wo
 | `GITHUBBOT_MERGE_METHOD` | — | `merge` / `squash` / `rebase`. Default `squash`. |
 | `GITHUBBOT_HOLD_LABEL` | — | Label that pauses auto-merge. Default `do-not-merge`. |
 | `GITHUBBOT_CI_FIX_MAX_ATTEMPTS` | — | Consecutive CI-fix attempts before escalating. Default 3. |
-| `GITHUBBOT_WORKFLOW_EVENTS` | — | Emit durable workflow events to api-rs (`POST /api/workflows/events`) from lifecycle webhooks, before owned-PR gating: `ci-completed` (correlation `<owner>/<repo>:<head_sha>`, payload `{failed, failing}`) once every check for the sha has settled — events are immutable per correlation, so a single check's completion never fires it — and `codex-review` (correlation `<owner>/<repo>:pr-<n>:<head_sha>`, payload `{review_id, state}`) when a configured reviewer bot submits. Default `false`. |
+| `GITHUBBOT_WORKFLOW_EVENTS` | — | Emit durable workflow events to api-rs (`POST /api/workflows/events`) from lifecycle webhooks, before owned-PR gating. `ci-completed`: correlation `<owner>/<repo>:<head_sha>`, payload `{failed, failing}`, fires only once every check for the sha settles (events are immutable per correlation). `codex-review`: correlation `<owner>/<repo>:pr-<n>:<head_sha>`, payload `{review_id, state}`, fires when a configured reviewer bot submits. Default `false`. |
 | `GITHUBBOT_WORKFLOW_REVIEW_BOTS` | — | Comma-separated reviewer logins whose submitted reviews emit `codex-review`. Default `chatgpt-codex-connector`. |
 | `GITHUBBOT_DELETE_BRANCH_ON_MERGE` | — | Delete head branch after merge. Default `true`. |
 | `GITHUBBOT_ESCALATION_HANDLE` | — | Fallback @handle (no leading @) tagged when the bot gives up. |

--- a/services/githubbot/README.md
+++ b/services/githubbot/README.md
@@ -155,6 +155,8 @@ requests**, **Pull request reviews**, **Check runs**, **Check suites**, and **Wo
 | `GITHUBBOT_MERGE_METHOD` | — | `merge` / `squash` / `rebase`. Default `squash`. |
 | `GITHUBBOT_HOLD_LABEL` | — | Label that pauses auto-merge. Default `do-not-merge`. |
 | `GITHUBBOT_CI_FIX_MAX_ATTEMPTS` | — | Consecutive CI-fix attempts before escalating. Default 3. |
+| `GITHUBBOT_WORKFLOW_EVENTS` | — | Emit durable workflow events to api-rs (`POST /api/workflows/events`) from lifecycle webhooks, before owned-PR gating: `ci-completed` (correlation `<owner>/<repo>:<head_sha>`) when a check run/suite/workflow run completes or a legacy status resolves, and `codex-review` (correlation `<owner>/<repo>:pr-<n>:<head_sha>`) when a configured reviewer bot submits. Default `false`. |
+| `GITHUBBOT_WORKFLOW_REVIEW_BOTS` | — | Comma-separated reviewer logins whose submitted reviews emit `codex-review`. Default `chatgpt-codex-connector`. |
 | `GITHUBBOT_DELETE_BRANCH_ON_MERGE` | — | Delete head branch after merge. Default `true`. |
 | `GITHUBBOT_ESCALATION_HANDLE` | — | Fallback @handle (no leading @) tagged when the bot gives up. |
 | `SESSION_IDLE_TIMEOUT_MS` / `SESSION_MAX_DURATION_MS` | — | Forwarded to api-rs executes. |

--- a/services/githubbot/src/pr-manager.ts
+++ b/services/githubbot/src/pr-manager.ts
@@ -1,12 +1,14 @@
 import type { GitHubAdapter } from "@chat-adapter/github";
 import type { StateAdapter } from "chat";
 import { backgroundWaitUntil } from "./context";
+import { emitWorkflowEvent } from "./session-api";
 import { runTurnStream } from "./turn";
 import type {
   ForwardSessionInput,
   GithubbotApiMessage,
   GithubbotOptions,
   GithubbotTrace,
+  JsonObject,
 } from "./types";
 import { errorMessage, noopLogger, nowMs, stringValue, traceLog } from "./utils";
 
@@ -35,6 +37,13 @@ export type PrManagerContext = {
 const STATE_TTL_MS = 90 * 24 * 60 * 60 * 1000;
 const CLAIM_TTL_MS = 7 * 24 * 60 * 60 * 1000;
 const DEFAULT_CI_FIX_MAX_ATTEMPTS = 3;
+
+// Durable-workflow event contract (consumed by workflow waiters via
+// ctx.wait_for_event). Correlation ids key on repo + head sha so a stale event
+// for an old push can never wake a waiter that has already moved on.
+export const WORKFLOW_EVENT_CI_COMPLETED = "ci-completed";
+export const WORKFLOW_EVENT_CODEX_REVIEW = "codex-review";
+const DEFAULT_WORKFLOW_REVIEW_BOTS = ["chatgpt-codex-connector"];
 
 // CI conclusions that count as a hard, fixable failure (neutral/skipped/success
 // and the in-progress states are not failures).
@@ -375,6 +384,11 @@ export async function handleReviewEvent(
   const reviewState = stringValue(reviewNode.state)?.toLowerCase();
 
   const pr = await fetchPr(ctx, repo.owner, repo.repo, number);
+  // Workflow-event emission sits before the owned-PR gate: durable workflows
+  // wait on reviews for PRs the bot does not own.
+  if (pr) {
+    await maybeEmitCodexReview(ctx, repo, number, pr.headSha, reviewer, reviewState, reviewId);
+  }
   if (!pr || !owns(ctx, pr)) return;
   // Never act on the bot's own review (it shouldn't review its own PRs anyway).
   if (reviewer && reviewer.toLowerCase() === ctx.userName.toLowerCase()) return;
@@ -409,6 +423,9 @@ export async function handleCiEvent(
   if (!repo) return;
   const target = ciTarget(eventType, payload);
   if (!target) return;
+  // Workflow-event emission sits before any owned-PR gating (processCi owns()
+  // below): durable workflows wait on CI for PRs the bot does not own.
+  await maybeEmitCiCompleted(ctx, eventType, repo, payload, target.headSha);
   const prNumbers =
     target.prNumbers.length > 0
       ? target.prNumbers
@@ -416,6 +433,79 @@ export async function handleCiEvent(
   await Promise.all(
     prNumbers.map((number) => processCi(ctx, repo.owner, repo.repo, number, target.headSha)),
   );
+}
+
+/**
+ * Emit `ci-completed` for workflow waiters when a CI signal for a head sha
+ * resolves (a check run/suite/workflow run completes, or a legacy status goes
+ * terminal). The payload can't see *required* checks, so waiters still verify
+ * with one live read on wake — this event is the wake-up, not the verdict.
+ */
+async function maybeEmitCiCompleted(
+  ctx: PrManagerContext,
+  eventType: string,
+  repo: { owner: string; repo: string },
+  payload: JsonRecord,
+  headSha: string,
+): Promise<void> {
+  if (ctx.options.workflowEvents !== true) return;
+  const detail = ciCompletionDetail(eventType, payload);
+  if (!detail) return;
+  await emitWorkflowEvent(ctx.options, {
+    eventType: WORKFLOW_EVENT_CI_COMPLETED,
+    correlationId: `${repo.owner}/${repo.repo}:${headSha}`,
+    payload: detail,
+  });
+}
+
+function ciCompletionDetail(eventType: string, payload: JsonRecord): JsonObject | null {
+  if (eventType === "status") {
+    const state = stringValue(payload.state);
+    if (!state || state === "pending") return null;
+    return {
+      conclusion: state,
+      name: stringValue(payload.context) ?? null,
+      html_url: stringValue(payload.target_url) ?? null,
+    };
+  }
+  if (stringValue(payload.action) !== "completed") return null;
+  const node =
+    eventType === "check_run"
+      ? payload.check_run
+      : eventType === "check_suite"
+        ? payload.check_suite
+        : payload.workflow_run;
+  if (!isRecord(node)) return null;
+  return {
+    conclusion: stringValue(node.conclusion) ?? null,
+    name: stringValue(node.name) ?? null,
+    html_url: stringValue(node.html_url) ?? null,
+  };
+}
+
+/**
+ * Emit `codex-review` when a configured reviewer bot submits a review on any
+ * PR (owned or not), keyed by head sha so a stale review on an old push never
+ * wakes a round that already pushed fixes.
+ */
+async function maybeEmitCodexReview(
+  ctx: PrManagerContext,
+  repo: { owner: string; repo: string },
+  number: number,
+  headSha: string,
+  reviewer: string | undefined,
+  reviewState: string | undefined,
+  reviewId: number,
+): Promise<void> {
+  if (ctx.options.workflowEvents !== true || !reviewer) return;
+  const bots = ctx.options.workflowReviewBots ?? DEFAULT_WORKFLOW_REVIEW_BOTS;
+  const target = reviewer.toLowerCase();
+  if (!bots.some((login) => login.toLowerCase() === target)) return;
+  await emitWorkflowEvent(ctx.options, {
+    eventType: WORKFLOW_EVENT_CODEX_REVIEW,
+    correlationId: `${repo.owner}/${repo.repo}:pr-${number}:${headSha}`,
+    payload: { review_id: reviewId, state: reviewState ?? null },
+  });
 }
 
 async function processCi(

--- a/services/githubbot/src/pr-manager.ts
+++ b/services/githubbot/src/pr-manager.ts
@@ -39,10 +39,25 @@ const DEFAULT_CI_FIX_MAX_ATTEMPTS = 3;
 
 // Durable-workflow event contract (consumed by workflow waiters via
 // ctx.wait_for_event). Correlation ids key on repo + head sha so a stale event
-// for an old push can never wake a waiter that has already moved on.
+// for an old push can never wake a waiter that has already moved on, and are
+// lowercased so case drift between a PR URL slug and repository.full_name can
+// never miss a waiter.
 export const WORKFLOW_EVENT_CI_COMPLETED = "ci-completed";
 export const WORKFLOW_EVENT_CODEX_REVIEW = "codex-review";
 const DEFAULT_WORKFLOW_REVIEW_BOTS = ["chatgpt-codex-connector"];
+
+function ciCorrelationId(owner: string, repo: string, headSha: string): string {
+  return `${owner}/${repo}:${headSha}`.toLowerCase();
+}
+
+function reviewCorrelationId(
+  owner: string,
+  repo: string,
+  number: number,
+  headSha: string,
+): string {
+  return `${owner}/${repo}:pr-${number}:${headSha}`.toLowerCase();
+}
 
 // CI conclusions that count as a hard, fixable failure (neutral/skipped/success
 // and the in-progress states are not failures).
@@ -423,14 +438,17 @@ export async function handleCiEvent(
   const target = ciTarget(eventType, payload);
   if (!target) return;
   // Workflow-event emission sits before any owned-PR gating (processCi owns()
-  // below): durable workflows wait on CI for PRs the bot does not own.
-  await maybeEmitCiCompleted(ctx, eventType, repo, payload, target.headSha);
+  // below): durable workflows wait on CI for PRs the bot does not own. The
+  // settled evaluation is shared so an owned PR isn't evaluated twice.
+  const evaluation = await maybeEmitCiCompleted(ctx, eventType, repo, payload, target.headSha);
   const prNumbers =
     target.prNumbers.length > 0
       ? target.prNumbers
       : await fetchPrNumbersForCommit(ctx, repo.owner, repo.repo, target.headSha);
   await Promise.all(
-    prNumbers.map((number) => processCi(ctx, repo.owner, repo.repo, number, target.headSha)),
+    prNumbers.map((number) =>
+      processCi(ctx, repo.owner, repo.repo, number, target.headSha, false, evaluation),
+    ),
   );
 }
 
@@ -441,7 +459,8 @@ export async function handleCiEvent(
  * event row while the rest of the suite is still running and strand waiters
  * on a premature wake. The aggregate payload can't see *required* checks, so
  * waiters still verify with one live read on wake — the event is the wake-up,
- * not the verdict.
+ * not the verdict. Returns the settled evaluation for the owned-PR path to
+ * reuse, or null when it wasn't computed.
  */
 async function maybeEmitCiCompleted(
   ctx: PrManagerContext,
@@ -449,16 +468,17 @@ async function maybeEmitCiCompleted(
   repo: { owner: string; repo: string },
   payload: JsonRecord,
   headSha: string,
-): Promise<void> {
-  if (ctx.options.workflowEvents !== true) return;
-  if (!ciCompletionSignaled(eventType, payload)) return;
+): Promise<CiEvaluation | null> {
+  if (ctx.options.workflowEvents !== true) return null;
+  if (!ciCompletionSignaled(eventType, payload)) return null;
   const evaluation = await fetchCiEvaluation(ctx, repo.owner, repo.repo, headSha);
-  if (!evaluation.settled) return;
+  if (!evaluation.settled) return null;
   await emitWorkflowEvent(ctx.options, {
     eventType: WORKFLOW_EVENT_CI_COMPLETED,
-    correlationId: `${repo.owner}/${repo.repo}:${headSha}`,
+    correlationId: ciCorrelationId(repo.owner, repo.repo, headSha),
     payload: { failed: evaluation.failed, failing: evaluation.failingNames },
   });
+  return evaluation;
 }
 
 /**
@@ -494,7 +514,7 @@ async function maybeEmitCodexReview(
   if (!bots.some((login) => login.toLowerCase() === target)) return;
   await emitWorkflowEvent(ctx.options, {
     eventType: WORKFLOW_EVENT_CODEX_REVIEW,
-    correlationId: `${repo.owner}/${repo.repo}:pr-${number}:${headSha}`,
+    correlationId: reviewCorrelationId(repo.owner, repo.repo, number, headSha),
     payload: { review_id: reviewId, state: reviewState ?? null },
   });
 }
@@ -506,13 +526,15 @@ async function processCi(
   number: number,
   headSha: string,
   force = false,
+  knownEvaluation?: CiEvaluation | null,
 ): Promise<void> {
   const pr = await fetchPr(ctx, owner, repo, number);
   if (!pr || !owns(ctx, pr)) return;
   // Ignore CI for a SHA that's already been superseded by a newer push.
   if (pr.headSha !== headSha) return;
 
-  const evaluation = await fetchCiEvaluation(ctx, owner, repo, headSha);
+  const evaluation =
+    knownEvaluation ?? (await fetchCiEvaluation(ctx, owner, repo, headSha));
   if (!evaluation.settled) return; // wait until *all* checks are done.
   // Act once per fully-settled SHA (the last-arriving check event wins).
   if (

--- a/services/githubbot/src/pr-manager.ts
+++ b/services/githubbot/src/pr-manager.ts
@@ -43,7 +43,7 @@ const DEFAULT_CI_FIX_MAX_ATTEMPTS = 3;
 // lowercased so case drift between a PR URL slug and repository.full_name can
 // never miss a waiter.
 export const WORKFLOW_EVENT_CI_COMPLETED = "ci-completed";
-export const WORKFLOW_EVENT_CODEX_REVIEW = "codex-review";
+export const WORKFLOW_EVENT_REVIEW_SUBMITTED = "review-submitted";
 const DEFAULT_WORKFLOW_REVIEW_BOTS = ["chatgpt-codex-connector"];
 
 function ciCorrelationId(owner: string, repo: string, headSha: string): string {
@@ -401,7 +401,7 @@ export async function handleReviewEvent(
   // Workflow-event emission sits before the owned-PR gate: durable workflows
   // wait on reviews for PRs the bot does not own.
   if (pr) {
-    await maybeEmitCodexReview(ctx, repo, number, pr.headSha, reviewer, reviewState, reviewId);
+    await maybeEmitReviewSubmitted(ctx, repo, number, pr.headSha, reviewer, reviewState, reviewId);
   }
   if (!pr || !owns(ctx, pr)) return;
   // Never act on the bot's own review (it shouldn't review its own PRs anyway).
@@ -495,11 +495,11 @@ function ciCompletionSignaled(eventType: string, payload: JsonRecord): boolean {
 }
 
 /**
- * Emit `codex-review` when a configured reviewer bot submits a review on any
- * PR (owned or not), keyed by head sha so a stale review on an old push never
- * wakes a round that already pushed fixes.
+ * Emit `review-submitted` when a configured reviewer bot submits a review on
+ * any PR (owned or not), keyed by head sha so a stale review on an old push
+ * never wakes a round that already pushed fixes.
  */
-async function maybeEmitCodexReview(
+async function maybeEmitReviewSubmitted(
   ctx: PrManagerContext,
   repo: { owner: string; repo: string },
   number: number,
@@ -513,7 +513,7 @@ async function maybeEmitCodexReview(
   const target = reviewer.toLowerCase();
   if (!bots.some((login) => login.toLowerCase() === target)) return;
   await emitWorkflowEvent(ctx.options, {
-    eventType: WORKFLOW_EVENT_CODEX_REVIEW,
+    eventType: WORKFLOW_EVENT_REVIEW_SUBMITTED,
     correlationId: reviewCorrelationId(repo.owner, repo.repo, number, headSha),
     payload: { review_id: reviewId, state: reviewState ?? null },
   });

--- a/services/githubbot/src/pr-manager.ts
+++ b/services/githubbot/src/pr-manager.ts
@@ -8,7 +8,6 @@ import type {
   GithubbotApiMessage,
   GithubbotOptions,
   GithubbotTrace,
-  JsonObject,
 } from "./types";
 import { errorMessage, noopLogger, nowMs, stringValue, traceLog } from "./utils";
 
@@ -436,10 +435,13 @@ export async function handleCiEvent(
 }
 
 /**
- * Emit `ci-completed` for workflow waiters when a CI signal for a head sha
- * resolves (a check run/suite/workflow run completes, or a legacy status goes
- * terminal). The payload can't see *required* checks, so waiters still verify
- * with one live read on wake — this event is the wake-up, not the verdict.
+ * Emit `ci-completed` for workflow waiters once every check for a head sha has
+ * settled. Durable events are immutable — first write wins per correlation —
+ * so this must never fire on a single check's completion: that would lock the
+ * event row while the rest of the suite is still running and strand waiters
+ * on a premature wake. The aggregate payload can't see *required* checks, so
+ * waiters still verify with one live read on wake — the event is the wake-up,
+ * not the verdict.
  */
 async function maybeEmitCiCompleted(
   ctx: PrManagerContext,
@@ -449,38 +451,27 @@ async function maybeEmitCiCompleted(
   headSha: string,
 ): Promise<void> {
   if (ctx.options.workflowEvents !== true) return;
-  const detail = ciCompletionDetail(eventType, payload);
-  if (!detail) return;
+  if (!ciCompletionSignaled(eventType, payload)) return;
+  const evaluation = await fetchCiEvaluation(ctx, repo.owner, repo.repo, headSha);
+  if (!evaluation.settled) return;
   await emitWorkflowEvent(ctx.options, {
     eventType: WORKFLOW_EVENT_CI_COMPLETED,
     correlationId: `${repo.owner}/${repo.repo}:${headSha}`,
-    payload: detail,
+    payload: { failed: evaluation.failed, failing: evaluation.failingNames },
   });
 }
 
-function ciCompletionDetail(eventType: string, payload: JsonRecord): JsonObject | null {
+/**
+ * Cheap pre-filter before spending two GitHub API reads on the settled
+ * evaluation: only an event signaling something finished (a completed
+ * run/suite, or a terminal legacy status) can flip the aggregate to settled.
+ */
+function ciCompletionSignaled(eventType: string, payload: JsonRecord): boolean {
   if (eventType === "status") {
     const state = stringValue(payload.state);
-    if (!state || state === "pending") return null;
-    return {
-      conclusion: state,
-      name: stringValue(payload.context) ?? null,
-      html_url: stringValue(payload.target_url) ?? null,
-    };
+    return Boolean(state) && state !== "pending";
   }
-  if (stringValue(payload.action) !== "completed") return null;
-  const node =
-    eventType === "check_run"
-      ? payload.check_run
-      : eventType === "check_suite"
-        ? payload.check_suite
-        : payload.workflow_run;
-  if (!isRecord(node)) return null;
-  return {
-    conclusion: stringValue(node.conclusion) ?? null,
-    name: stringValue(node.name) ?? null,
-    html_url: stringValue(node.html_url) ?? null,
-  };
+  return stringValue(payload.action) === "completed";
 }
 
 /**

--- a/services/githubbot/src/server.ts
+++ b/services/githubbot/src/server.ts
@@ -116,6 +116,8 @@ const options: GithubbotOptions = {
   autoMerge: boolEnv("GITHUBBOT_AUTO_MERGE", true),
   botUserId: optionalEnv("GITHUBBOT_USER_ID"),
   ciFixMaxAttempts: optionalNumberEnv("GITHUBBOT_CI_FIX_MAX_ATTEMPTS"),
+  workflowEvents: boolEnv("GITHUBBOT_WORKFLOW_EVENTS", false),
+  workflowReviewBots: listEnv("GITHUBBOT_WORKFLOW_REVIEW_BOTS"),
   deleteBranchOnMerge: boolEnv("GITHUBBOT_DELETE_BRANCH_ON_MERGE", true),
   escalationHandle: optionalEnv("GITHUBBOT_ESCALATION_HANDLE"),
   holdLabel: optionalEnv("GITHUBBOT_HOLD_LABEL"),

--- a/services/githubbot/src/session-api.ts
+++ b/services/githubbot/src/session-api.ts
@@ -16,6 +16,7 @@ import type {
 } from "./types";
 import {
   elapsedMs,
+  errorMessage,
   isJsonObject,
   noopLogger,
   nowMs,
@@ -591,6 +592,55 @@ async function streamSessionNotifications(
   await ensureApiOk(response, "stream events", options);
   if (!response.body) return toAsyncIterable([]);
   return parseSessionEventStream(response.body, onEventId);
+}
+
+export type EmitWorkflowEventInput = {
+  eventType: string;
+  correlationId: string;
+  payload: JsonObject;
+};
+
+/**
+ * Fire a durable workflow event into api-rs (`POST /api/workflows/events`),
+ * which resolves any `ctx.wait_for_event` waiters keyed on the same
+ * (event_type, correlation_id). Best-effort by contract — it never throws: a
+ * failed emission must not fail the webhook handler that produced it, and
+ * waiters fall back to their timeout path on a missed event.
+ */
+export async function emitWorkflowEvent(
+  options: GithubbotOptions,
+  input: EmitWorkflowEventInput,
+): Promise<void> {
+  const url = new URL(
+    "/api/workflows/events",
+    ensureTrailingSlash(options.apiUrl),
+  ).toString();
+  try {
+    const fetchFn = options.fetch ?? fetch;
+    const response = await fetchFn(url, {
+      method: "POST",
+      headers: apiHeaders(options),
+      body: JSON.stringify({
+        event_type: input.eventType,
+        correlation_id: input.correlationId,
+        payload: input.payload,
+      }),
+    });
+    if (!response.ok) {
+      (options.logger ?? noopLogger).warn("githubbot_workflow_event_emit_failed", {
+        correlation_id: input.correlationId,
+        event_type: input.eventType,
+        status: response.status,
+        status_text: response.statusText,
+      });
+    }
+  } catch (error) {
+    (options.logger ?? noopLogger).warn("githubbot_workflow_event_emit_failed", {
+      correlation_id: input.correlationId,
+      error: errorMessage(error),
+      event_type: input.eventType,
+    });
+  }
 }
 
 function apiSessionUrl(

--- a/services/githubbot/src/session-api.ts
+++ b/services/githubbot/src/session-api.ts
@@ -601,11 +601,10 @@ export type EmitWorkflowEventInput = {
 };
 
 /**
- * Fire a durable workflow event into api-rs (`POST /api/workflows/events`),
- * which resolves any `ctx.wait_for_event` waiters keyed on the same
- * (event_type, correlation_id). Best-effort by contract — it never throws: a
- * failed emission must not fail the webhook handler that produced it, and
- * waiters fall back to their timeout path on a missed event.
+ * Emit a durable workflow event (`POST /api/workflows/events`), resolving any
+ * `ctx.wait_for_event` waiters keyed on the same (event_type, correlation_id).
+ * Best-effort by contract — never throws: a failed emission must not fail the
+ * webhook handler, and waiters fall back to their timeout path on a miss.
  */
 export async function emitWorkflowEvent(
   options: GithubbotOptions,

--- a/services/githubbot/src/types.ts
+++ b/services/githubbot/src/types.ts
@@ -149,13 +149,13 @@ export type GithubbotOptions = {
    * lifecycle webhooks, before any owned-PR gating: `ci-completed` once every
    * check for a head sha has settled (durable events are immutable per
    * correlation, so a single check's completion must never fire it), and
-   * `codex-review` when a configured reviewer bot submits a review.
+   * `review-submitted` when a configured reviewer bot submits a review.
    * Correlation ids key on repo + head sha so durable workflows can wait for
    * exactly the push they care about. Default false.
    */
   workflowEvents?: boolean;
   /**
-   * Reviewer logins whose submitted reviews emit `codex-review` workflow
+   * Reviewer logins whose submitted reviews emit `review-submitted` workflow
    * events (case-insensitive). Default ["chatgpt-codex-connector"].
    */
   workflowReviewBots?: string[];

--- a/services/githubbot/src/types.ts
+++ b/services/githubbot/src/types.ts
@@ -146,9 +146,10 @@ export type GithubbotOptions = {
   ciFixMaxAttempts?: number;
   /**
    * Emit durable workflow events (`POST /api/workflows/events` on api-rs) from
-   * lifecycle webhooks, before any owned-PR gating: `ci-completed` when a
-   * check_run/check_suite/workflow_run completes or a legacy status resolves,
-   * and `codex-review` when a configured reviewer bot submits a review.
+   * lifecycle webhooks, before any owned-PR gating: `ci-completed` once every
+   * check for a head sha has settled (durable events are immutable per
+   * correlation, so a single check's completion must never fire it), and
+   * `codex-review` when a configured reviewer bot submits a review.
    * Correlation ids key on repo + head sha so durable workflows can wait for
    * exactly the push they care about. Default false.
    */

--- a/services/githubbot/src/types.ts
+++ b/services/githubbot/src/types.ts
@@ -144,6 +144,20 @@ export type GithubbotOptions = {
   autoMerge?: boolean;
   /** Max consecutive CI-fix attempts on an owned PR before escalating. Default 3. */
   ciFixMaxAttempts?: number;
+  /**
+   * Emit durable workflow events (`POST /api/workflows/events` on api-rs) from
+   * lifecycle webhooks, before any owned-PR gating: `ci-completed` when a
+   * check_run/check_suite/workflow_run completes or a legacy status resolves,
+   * and `codex-review` when a configured reviewer bot submits a review.
+   * Correlation ids key on repo + head sha so durable workflows can wait for
+   * exactly the push they care about. Default false.
+   */
+  workflowEvents?: boolean;
+  /**
+   * Reviewer logins whose submitted reviews emit `codex-review` workflow
+   * events (case-insensitive). Default ["chatgpt-codex-connector"].
+   */
+  workflowReviewBots?: string[];
   /** Delete the head branch after the bot merges an owned PR. Default true. */
   deleteBranchOnMerge?: boolean;
   /** Fallback @handle to tag when the bot gives up and escalates. */

--- a/services/githubbot/test/pr-manager.test.ts
+++ b/services/githubbot/test/pr-manager.test.ts
@@ -417,14 +417,25 @@ describe("workflow event emission", () => {
   // merge/turn mocks are needed.
   function emitCtx(
     emits: EmitCall[],
-    options?: { workflowEvents?: boolean; workflowReviewBots?: string[] },
+    options?: {
+      checkRuns?: { status: string; conclusion: string | null; name: string }[];
+      statuses?: { state: string; context: string }[];
+      workflowEvents?: boolean;
+      workflowReviewBots?: string[];
+    },
   ): PrManagerContext {
     return {
       octokit: {
         rest: {
-          checks: { listForRef: async () => ({ data: { check_runs: [] } }) },
+          checks: {
+            listForRef: async () => ({
+              data: { check_runs: options?.checkRuns ?? [] },
+            }),
+          },
           repos: {
-            getCombinedStatusForRef: async () => ({ data: { statuses: [] } }),
+            getCombinedStatusForRef: async () => ({
+              data: { statuses: options?.statuses ?? [] },
+            }),
             listPullRequestsAssociatedWithCommit: async () => ({ data: [] }),
           },
           pulls: {
@@ -473,18 +484,14 @@ describe("workflow event emission", () => {
     expect(emit.body).toEqual({
       event_type: "ci-completed",
       correlation_id: "base/repo:abc123",
-      payload: {
-        conclusion: "success",
-        name: "build",
-        html_url: "https://example.test/checks/1",
-      },
+      payload: { failed: false, failing: [] },
     });
   });
 
   test("emits ci-completed for a terminal legacy status", async () => {
     const emits: EmitCall[] = [];
     await handleCiEvent(
-      emitCtx(emits),
+      emitCtx(emits, { statuses: [{ state: "failure", context: "deploy" }] }),
       "status",
       JSON.stringify({
         repository: { full_name: "base/repo" },
@@ -498,12 +505,23 @@ describe("workflow event emission", () => {
     expect(emits[0]!.body).toEqual({
       event_type: "ci-completed",
       correlation_id: "base/repo:abc123",
-      payload: {
-        conclusion: "failure",
-        name: "deploy",
-        html_url: "https://example.test/deploy/1",
-      },
+      payload: { failed: true, failing: ["deploy"] },
     });
+  });
+
+  test("does not emit ci-completed while any check is still running", async () => {
+    const emits: EmitCall[] = [];
+    await handleCiEvent(
+      emitCtx(emits, {
+        checkRuns: [
+          { name: "build", status: "completed", conclusion: "success" },
+          { name: "test", status: "in_progress", conclusion: null },
+        ],
+      }),
+      "check_run",
+      completedCheckRun,
+    );
+    expect(emits.length).toBe(0);
   });
 
   test("does not emit for an in-flight check run or a pending status", async () => {

--- a/services/githubbot/test/pr-manager.test.ts
+++ b/services/githubbot/test/pr-manager.test.ts
@@ -573,7 +573,7 @@ describe("workflow event emission", () => {
     expect(emits.length).toBe(0);
   });
 
-  test("emits codex-review keyed by PR and head sha for a configured reviewer bot", async () => {
+  test("emits review-submitted keyed by PR and head sha for a configured reviewer bot", async () => {
     const emits: EmitCall[] = [];
     await handleReviewEvent(
       emitCtx(emits),
@@ -590,13 +590,13 @@ describe("workflow event emission", () => {
     );
     expect(emits.length).toBe(1);
     expect(emits[0]!.body).toEqual({
-      event_type: "codex-review",
+      event_type: "review-submitted",
       correlation_id: "base/repo:pr-7:abc123",
       payload: { review_id: 123, state: "commented" },
     });
   });
 
-  test("does not emit codex-review for other reviewers", async () => {
+  test("does not emit review-submitted for other reviewers", async () => {
     const emits: EmitCall[] = [];
     await handleReviewEvent(
       emitCtx(emits),
@@ -612,7 +612,7 @@ describe("workflow event emission", () => {
 
   test("honors a configured reviewer-bot list over the default", async () => {
     const emits: EmitCall[] = [];
-    const codexReview = (id: number, login: string) =>
+    const submittedReview = (id: number, login: string) =>
       JSON.stringify({
         action: "submitted",
         repository: { full_name: "base/repo" },
@@ -620,11 +620,11 @@ describe("workflow event emission", () => {
         review: { id, state: "commented", user: { login } },
       });
     const ctx = emitCtx(emits, { workflowReviewBots: ["acme-review-bot"] });
-    await handleReviewEvent(ctx, codexReview(125, "chatgpt-codex-connector"));
-    await handleReviewEvent(ctx, codexReview(126, "acme-review-bot"));
+    await handleReviewEvent(ctx, submittedReview(125, "chatgpt-codex-connector"));
+    await handleReviewEvent(ctx, submittedReview(126, "acme-review-bot"));
     expect(emits.length).toBe(1);
     expect(emits[0]!.body).toMatchObject({
-      event_type: "codex-review",
+      event_type: "review-submitted",
       correlation_id: "base/repo:pr-7:abc123",
     });
   });

--- a/services/githubbot/test/pr-manager.test.ts
+++ b/services/githubbot/test/pr-manager.test.ts
@@ -405,3 +405,175 @@ describe("CI fix counter and escalation", () => {
     });
   });
 });
+
+describe("workflow event emission", () => {
+  type EmitCall = {
+    url: string;
+    body: { event_type?: string; correlation_id?: string; payload?: unknown };
+  };
+
+  // The PR is deliberately NOT bot-owned (no assignees): workflow events must
+  // emit before the owned-PR gate, and the management path then no-ops, so no
+  // merge/turn mocks are needed.
+  function emitCtx(
+    emits: EmitCall[],
+    options?: { workflowEvents?: boolean; workflowReviewBots?: string[] },
+  ): PrManagerContext {
+    return {
+      octokit: {
+        rest: {
+          checks: { listForRef: async () => ({ data: { check_runs: [] } }) },
+          repos: {
+            getCombinedStatusForRef: async () => ({ data: { statuses: [] } }),
+            listPullRequestsAssociatedWithCommit: async () => ({ data: [] }),
+          },
+          pulls: {
+            get: async () => ({
+              data: prPayload({ assignees: [], headRepoFullName: "base/repo" }),
+            }),
+          },
+        },
+      },
+      options: {
+        apiUrl: "http://localhost",
+        logger: quietLogger,
+        workflowEvents: options?.workflowEvents ?? true,
+        workflowReviewBots: options?.workflowReviewBots,
+        fetch: (url: RequestInfo | URL, init?: RequestInit) => {
+          emits.push({
+            url: String(url),
+            body: JSON.parse(String(init?.body ?? "{}")),
+          });
+          return Promise.resolve(new Response('{"ok":true}', { status: 200 }));
+        },
+      },
+      state: makeState(),
+      userName: "centaur-bot",
+    } as unknown as PrManagerContext;
+  }
+
+  const completedCheckRun = JSON.stringify({
+    action: "completed",
+    repository: { full_name: "base/repo" },
+    check_run: {
+      head_sha: "abc123",
+      name: "build",
+      conclusion: "success",
+      html_url: "https://example.test/checks/1",
+      pull_requests: [{ number: 7 }],
+    },
+  });
+
+  test("emits ci-completed for a completed check run before ownership gating", async () => {
+    const emits: EmitCall[] = [];
+    await handleCiEvent(emitCtx(emits), "check_run", completedCheckRun);
+    expect(emits.length).toBe(1);
+    const emit = emits[0]!;
+    expect(emit.url).toBe("http://localhost/api/workflows/events");
+    expect(emit.body).toEqual({
+      event_type: "ci-completed",
+      correlation_id: "base/repo:abc123",
+      payload: {
+        conclusion: "success",
+        name: "build",
+        html_url: "https://example.test/checks/1",
+      },
+    });
+  });
+
+  test("emits ci-completed for a terminal legacy status", async () => {
+    const emits: EmitCall[] = [];
+    await handleCiEvent(
+      emitCtx(emits),
+      "status",
+      JSON.stringify({
+        repository: { full_name: "base/repo" },
+        sha: "abc123",
+        state: "failure",
+        context: "deploy",
+        target_url: "https://example.test/deploy/1",
+      }),
+    );
+    expect(emits.length).toBe(1);
+    expect(emits[0]!.body).toEqual({
+      event_type: "ci-completed",
+      correlation_id: "base/repo:abc123",
+      payload: {
+        conclusion: "failure",
+        name: "deploy",
+        html_url: "https://example.test/deploy/1",
+      },
+    });
+  });
+
+  test("does not emit for an in-flight check run or a pending status", async () => {
+    const emits: EmitCall[] = [];
+    const ctx = emitCtx(emits);
+    await handleCiEvent(
+      ctx,
+      "check_run",
+      JSON.stringify({
+        action: "created",
+        repository: { full_name: "base/repo" },
+        check_run: { head_sha: "abc123", pull_requests: [] },
+      }),
+    );
+    await handleCiEvent(
+      ctx,
+      "status",
+      JSON.stringify({
+        repository: { full_name: "base/repo" },
+        sha: "abc123",
+        state: "pending",
+      }),
+    );
+    expect(emits.length).toBe(0);
+  });
+
+  test("does not emit when workflowEvents is off", async () => {
+    const emits: EmitCall[] = [];
+    await handleCiEvent(
+      emitCtx(emits, { workflowEvents: false }),
+      "check_run",
+      completedCheckRun,
+    );
+    expect(emits.length).toBe(0);
+  });
+
+  test("emits codex-review keyed by PR and head sha for a configured reviewer bot", async () => {
+    const emits: EmitCall[] = [];
+    await handleReviewEvent(
+      emitCtx(emits),
+      JSON.stringify({
+        action: "submitted",
+        repository: { full_name: "base/repo" },
+        pull_request: { number: 7 },
+        review: {
+          id: 123,
+          state: "commented",
+          user: { login: "chatgpt-codex-connector" },
+        },
+      }),
+    );
+    expect(emits.length).toBe(1);
+    expect(emits[0]!.body).toEqual({
+      event_type: "codex-review",
+      correlation_id: "base/repo:pr-7:abc123",
+      payload: { review_id: 123, state: "commented" },
+    });
+  });
+
+  test("does not emit codex-review for other reviewers", async () => {
+    const emits: EmitCall[] = [];
+    await handleReviewEvent(
+      emitCtx(emits),
+      JSON.stringify({
+        action: "submitted",
+        repository: { full_name: "base/repo" },
+        pull_request: { number: 7 },
+        review: { id: 124, state: "approved", user: { login: "human-reviewer" } },
+      }),
+    );
+    expect(emits.length).toBe(0);
+  });
+});

--- a/services/githubbot/test/pr-manager.test.ts
+++ b/services/githubbot/test/pr-manager.test.ts
@@ -488,6 +488,21 @@ describe("workflow event emission", () => {
     });
   });
 
+  test("lowercases correlation ids against repository full_name case drift", async () => {
+    const emits: EmitCall[] = [];
+    await handleCiEvent(
+      emitCtx(emits),
+      "check_run",
+      JSON.stringify({
+        action: "completed",
+        repository: { full_name: "Base/Repo" },
+        check_run: { head_sha: "ABC123", pull_requests: [{ number: 7 }] },
+      }),
+    );
+    expect(emits.length).toBe(1);
+    expect(emits[0]!.body.correlation_id).toBe("base/repo:abc123");
+  });
+
   test("emits ci-completed for a terminal legacy status", async () => {
     const emits: EmitCall[] = [];
     await handleCiEvent(
@@ -593,5 +608,24 @@ describe("workflow event emission", () => {
       }),
     );
     expect(emits.length).toBe(0);
+  });
+
+  test("honors a configured reviewer-bot list over the default", async () => {
+    const emits: EmitCall[] = [];
+    const codexReview = (id: number, login: string) =>
+      JSON.stringify({
+        action: "submitted",
+        repository: { full_name: "base/repo" },
+        pull_request: { number: 7 },
+        review: { id, state: "commented", user: { login } },
+      });
+    const ctx = emitCtx(emits, { workflowReviewBots: ["acme-review-bot"] });
+    await handleReviewEvent(ctx, codexReview(125, "chatgpt-codex-connector"));
+    await handleReviewEvent(ctx, codexReview(126, "acme-review-bot"));
+    expect(emits.length).toBe(1);
+    expect(emits[0]!.body).toMatchObject({
+      event_type: "codex-review",
+      correlation_id: "base/repo:pr-7:abc123",
+    });
   });
 });


### PR DESCRIPTION
## Summary

Durable workflows can `ctx.wait_for_event(...)` (the Python host + Rust bridge + `POST /api/workflows/events` emission route all shipped), but nothing produces lifecycle events today — waiters still have to poll. This makes githubbot the producer:

- **`ci-completed`** — emitted once **every check for a head sha has settled** (aggregate `evaluateCi` over `listForRef` + combined status, the same gate the owned-PR path trusts; the webhook's completed/terminal action is only a cheap pre-filter). Correlation: `<owner>/<repo>:<head_sha>`. Payload `{failed, failing}`.
- **`review-submitted`** — emitted when a configured reviewer bot (default `chatgpt-codex-connector`, override via `GITHUBBOT_WORKFLOW_REVIEW_BOTS`) submits a review. Correlation: `<owner>/<repo>:pr-<n>:<head_sha>`, with the head sha from `fetchPr` (the webhook payload doesn't carry it). Payload `{review_id, state}`.

Both correlation ids are **lowercased** so case drift between a PR URL slug and `repository.full_name` can never miss a waiter (waiters lowercase their side too).

Two engine semantics shape the design:

- **Durable events are immutable — first write wins per correlation** (`absurd.emit_event` only applies the `NULL → payload` transition). So `ci-completed` must never fire on a single check's completion: that would lock the event row while the rest of the suite is still running, and waiters could never receive the real one. The settled aggregate is the only safe emission point.
- Keying both on **head sha** means a stale event for an old push can never wake a waiter that already moved on.

Placement is deliberate:

- Emission sits **before the owned-PR gate** in `handleCiEvent` / `handleReviewEvent` — durable workflow waiters are not bot-owned PRs, so gating on ownership would silently drop their wake-ups.
- The settled evaluation is computed once and shared with the owned-PR path (`processCi`), so an owned PR doesn't pay a second `listForRef` + combined-status round-trip per CI event.
- The aggregate payload can't see *required* checks, so the event is the wake-up, not the verdict — waiters still verify with one live read.
- Emission is best-effort and never fails the webhook handler; a missed event degenerates to the waiter's timeout path.
- Off by default (`githubbot.workflowEvents` / `GITHUBBOT_WORKFLOW_EVENTS`); api-rs URL and service token are already wired for the session API.

Also closes a coverage gap the design validation for this found: `absurd-sdk`'s `await_event` / `emit_event` had no database-backed test. The new test exercises early-emit-resolves-later-wait, wait→emit→wake with payload, checkpointed re-await, and timeout-as-error against a disposable Postgres (`ABSURD_TEST_DATABASE_URL`).

## Validation

- `pnpm --filter githubbot run check:types` ✓, `pnpm --filter githubbot test` — 86 pass (77 baseline + 9 new emission tests) ✓
- `helm lint contrib/chart` ✓ (chart version bumped)
- `ABSURD_TEST_DATABASE_URL=… cargo test -p absurd-sdk` — 8/8 incl. the new DB test ✓; `cargo fmt --check` + `cargo clippy -p absurd-sdk --all-targets -- -D warnings` ✓
