### PR TITLE
feat(githubbot): produce durable workflow events from CI and review webhooks

### DIFF
--- a/contrib/chart/Chart.yaml
+++ b/contrib/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: centaur
 description: Helm chart for the trusted Centaur control plane
 type: application
-version: 0.1.108
+version: 0.1.109
 appVersion: "0.1.0"
 dependencies:
   - name: connect

--- a/contrib/chart/templates/githubbot.yaml
+++ b/contrib/chart/templates/githubbot.yaml
@@ -98,6 +98,9 @@ spec:
               value: {{ .Values.githubbot.autoMerge | quote }}
             - name: GITHUBBOT_MERGE_METHOD
               value: {{ .Values.githubbot.mergeMethod | quote }}
+            # Durable workflow-event emission (ci-completed / review-submitted) to api-rs.
+            - name: GITHUBBOT_WORKFLOW_EVENTS
+              value: {{ .Values.githubbot.workflowEvents | quote }}
 {{- if .Values.githubbot.escalationHandle }}
             - name: GITHUBBOT_ESCALATION_HANDLE
               value: {{ .Values.githubbot.escalationHandle | quote }}

--- a/contrib/chart/values.yaml
+++ b/contrib/chart/values.yaml
@@ -554,6 +554,12 @@ githubbot:
   # / draft status.
   autoMerge: true
   mergeMethod: squash
+  # Durable-workflow event emission: when true, lifecycle webhooks also POST
+  # ci-completed / review-submitted events to api-rs (/api/workflows/events) so
+  # durable workflows can wait on CI/review for ANY PR (not just bot-owned
+  # ones), keyed by head sha. The api-rs URL and service token are already
+  # wired; this only flips the behavior on.
+  workflowEvents: false
   # Fallback @handle (no leading @) the bot tags when it gives up; empty = none.
   escalationHandle: ""
   # Optional review / issue-work methodology overrides. When set, the chart writes

--- a/services/api-rs/crates/absurd-sdk/src/lib.rs
+++ b/services/api-rs/crates/absurd-sdk/src/lib.rs
@@ -2440,4 +2440,109 @@ mod tests {
         drop(worker);
         Ok(())
     }
+
+    #[tokio::test]
+    async fn integration_await_event_wait_emit_wake_timeout_when_database_url_is_set() -> Result<()>
+    {
+        let Some(pool) = optional_test_pool().await? else {
+            return Ok(());
+        };
+
+        let queue = unique_queue("rust_await_event");
+        let app = Client::from_pool_with_options(
+            pool,
+            ClientOptions {
+                queue_name: queue.clone(),
+                ..ClientOptions::default()
+            },
+        )?;
+        app.create_queue(None, Default::default()).await?;
+
+        // Emit BEFORE any waiter exists: the durable event row must resolve a
+        // later wait immediately (the runner can start waiting after CI finished).
+        app.emit_event("validation:early", json!({"conclusion": "success"}), None)
+            .await?;
+
+        app.register_task("waiter", |_params: Value, ctx| async move {
+            // Early emit resolves without sleeping.
+            let early = ctx
+                .await_event::<Value>("validation:early", AwaitEventOptions::default())
+                .await?;
+            // Live wait -> emit -> wake; a second await of the same event must
+            // return the checkpointed payload without another emit.
+            let got = ctx
+                .await_event::<Value>("validation:wake", AwaitEventOptions::default())
+                .await?;
+            let got_again = ctx
+                .await_event::<Value>("validation:wake", AwaitEventOptions::default())
+                .await?;
+            Ok(json!({"early": early, "got": got, "got_again": got_again}))
+        })?;
+
+        app.register_task("impatient", |_params: Value, ctx| async move {
+            // No emit inside the window: the timeout must surface as an error
+            // (the Python host raises it; the runner falls back to a poll).
+            let outcome = ctx
+                .await_event::<Value>(
+                    "validation:never",
+                    AwaitEventOptions {
+                        step_name: None,
+                        timeout: Some(Duration::from_millis(500)),
+                    },
+                )
+                .await;
+            Ok(match outcome {
+                Err(err) => json!({"error": err.to_string()}),
+                Ok(value) => json!({"error": Value::Null, "value": value}),
+            })
+        })?;
+
+        let spawned = app.spawn("waiter", json!({}), Default::default()).await?;
+        let timed = app
+            .spawn("impatient", json!({}), Default::default())
+            .await?;
+
+        let worker = app.start_worker(WorkerOptions {
+            worker_id: Some("rust-await-event-worker".to_string()),
+            concurrency: 2,
+            poll_interval: Duration::from_millis(25),
+            fatal_on_lease_timeout: false,
+            ..WorkerOptions::default()
+        });
+
+        // Let the worker reach the second wait, then emit.
+        tokio::time::sleep(Duration::from_millis(400)).await;
+        app.emit_event("validation:wake", json!({"review_id": 7}), None)
+            .await?;
+
+        let snapshot = app
+            .await_task_result(&spawned.task_id, None, Some(Duration::from_secs(10)))
+            .await?;
+        assert_eq!(
+            snapshot.result::<Value>()?,
+            Some(json!({
+                "early": {"conclusion": "success"},
+                "got": {"review_id": 7},
+                "got_again": {"review_id": 7},
+            }))
+        );
+
+        let timed_snapshot = app
+            .await_task_result(&timed.task_id, None, Some(Duration::from_secs(10)))
+            .await?;
+        let timed_error = timed_snapshot
+            .result::<Value>()?
+            .and_then(|v| v.get("error").cloned())
+            .and_then(|v| v.as_str().map(str::to_owned));
+        assert!(
+            timed_error
+                .as_deref()
+                .unwrap_or("")
+                .contains("timed out waiting for event"),
+            "expected timeout error, got {timed_snapshot:?}"
+        );
+
+        drop(worker);
+        Ok(())
+    }
 }

--- a/services/githubbot/README.md
+++ b/services/githubbot/README.md
@@ -155,6 +155,7 @@ requests**, **Pull request reviews**, **Check runs**, **Check suites**, and **Wo
 | `GITHUBBOT_MERGE_METHOD` | — | `merge` / `squash` / `rebase`. Default `squash`. |
 | `GITHUBBOT_HOLD_LABEL` | — | Label that pauses auto-merge. Default `do-not-merge`. |
 | `GITHUBBOT_CI_FIX_MAX_ATTEMPTS` | — | Consecutive CI-fix attempts before escalating. Default 3. |
+| `GITHUBBOT_WORKFLOW_EVENTS` | — | Emit durable workflow events to api-rs (`POST /api/workflows/events`) from lifecycle webhooks, before owned-PR gating. `ci-completed`: correlation `<owner>/<repo>:<head_sha>`, payload `{failed, failing}`, fires only once every check for the sha settles (events are immutable per correlation). `review-submitted`: correlation `<owner>/<repo>:pr-<n>:<head_sha>:<reviewer>`, payload `{review_id, state}`, fires on every submitted review — waiters key on the reviewer login they care about. Default `false`. |
 | `GITHUBBOT_DELETE_BRANCH_ON_MERGE` | — | Delete head branch after merge. Default `true`. |
 | `GITHUBBOT_ESCALATION_HANDLE` | — | Fallback @handle (no leading @) tagged when the bot gives up. |
 | `SESSION_IDLE_TIMEOUT_MS` / `SESSION_MAX_DURATION_MS` | — | Forwarded to api-rs executes. |

--- a/services/githubbot/src/pr-manager.ts
+++ b/services/githubbot/src/pr-manager.ts
@@ -2,6 +2,12 @@ import type { GitHubAdapter } from "@chat-adapter/github";
 import type { StateAdapter } from "chat";
 import { backgroundWaitUntil } from "./context";
 import { runTurnStream } from "./turn";
+import {
+  fetchCiEvaluation,
+  maybeEmitCiCompleted,
+  maybeEmitReviewSubmitted,
+  type CiEvaluation,
+} from "./workflow-events";
 import type {
   ForwardSessionInput,
   GithubbotApiMessage,
@@ -36,59 +42,9 @@ const STATE_TTL_MS = 90 * 24 * 60 * 60 * 1000;
 const CLAIM_TTL_MS = 7 * 24 * 60 * 60 * 1000;
 const DEFAULT_CI_FIX_MAX_ATTEMPTS = 3;
 
-// CI conclusions that count as a hard, fixable failure (neutral/skipped/success
-// and the in-progress states are not failures).
-const FAILED_CONCLUSIONS = new Set([
-  "action_required",
-  "cancelled",
-  "failure",
-  "stale",
-  "timed_out",
-]);
-
 // ---------------------------------------------------------------------------
 // Pure decision helpers (unit-tested without GitHub).
 // ---------------------------------------------------------------------------
-
-export type CiCheck = { status: string; conclusion: string | null; name: string };
-export type CiStatus = { state: string; context: string };
-
-export type CiEvaluation = {
-  settled: boolean;
-  failed: boolean;
-  failingNames: string[];
-};
-
-/**
- * Decide whether all CI for a SHA is finished, and whether it's red. "Settled"
- * means no check run is still queued/in-progress and no legacy commit status is
- * pending — the point the user wants us to wait for before acting.
- */
-export function evaluateCi(
-  checks: CiCheck[],
-  statuses: CiStatus[],
-): CiEvaluation {
-  const anyCheckPending = checks.some((c) => c.status !== "completed");
-  const anyStatusPending = statuses.some((s) => s.state === "pending");
-  const failingChecks = checks.filter(
-    (c) =>
-      c.status === "completed" &&
-      c.conclusion !== null &&
-      FAILED_CONCLUSIONS.has(c.conclusion),
-  );
-  const failingStatuses = statuses.filter(
-    (s) => s.state === "failure" || s.state === "error",
-  );
-  const failingNames = [
-    ...failingChecks.map((c) => c.name),
-    ...failingStatuses.map((s) => s.context),
-  ];
-  return {
-    settled: !anyCheckPending && !anyStatusPending,
-    failed: failingNames.length > 0,
-    failingNames,
-  };
-}
 
 /**
  * A PR is bot-owned when the bot is one of its assignees. Ownership is purely an
@@ -375,6 +331,11 @@ export async function handleReviewEvent(
   const reviewState = stringValue(reviewNode.state)?.toLowerCase();
 
   const pr = await fetchPr(ctx, repo.owner, repo.repo, number);
+  // Workflow-event emission sits before the owned-PR gate: durable workflows
+  // wait on reviews for PRs the bot does not own.
+  if (pr) {
+    await maybeEmitReviewSubmitted(ctx, repo, number, pr.headSha, reviewer, reviewState, reviewId);
+  }
   if (!pr || !owns(ctx, pr)) return;
   // Never act on the bot's own review (it shouldn't review its own PRs anyway).
   if (reviewer && reviewer.toLowerCase() === ctx.userName.toLowerCase()) return;
@@ -409,12 +370,18 @@ export async function handleCiEvent(
   if (!repo) return;
   const target = ciTarget(eventType, payload);
   if (!target) return;
+  // Workflow-event emission sits before any owned-PR gating (processCi owns()
+  // below): durable workflows wait on CI for PRs the bot does not own. The
+  // settled evaluation is shared so an owned PR isn't evaluated twice.
+  const evaluation = await maybeEmitCiCompleted(ctx, eventType, repo, payload, target.headSha);
   const prNumbers =
     target.prNumbers.length > 0
       ? target.prNumbers
       : await fetchPrNumbersForCommit(ctx, repo.owner, repo.repo, target.headSha);
   await Promise.all(
-    prNumbers.map((number) => processCi(ctx, repo.owner, repo.repo, number, target.headSha)),
+    prNumbers.map((number) =>
+      processCi(ctx, repo.owner, repo.repo, number, target.headSha, false, evaluation),
+    ),
   );
 }
 
@@ -425,14 +392,16 @@ async function processCi(
   number: number,
   headSha: string,
   force = false,
+  knownEvaluation?: CiEvaluation | null,
 ): Promise<void> {
   const pr = await fetchPr(ctx, owner, repo, number);
   if (!pr || !owns(ctx, pr)) return;
   // Ignore CI for a SHA that's already been superseded by a newer push.
   if (pr.headSha !== headSha) return;
 
-  const evaluation = await fetchCiEvaluation(ctx, owner, repo, headSha);
-  if (!evaluation.settled) return; // wait until *all* checks are done.
+  const evaluation =
+    knownEvaluation ?? (await fetchCiEvaluation(ctx, owner, repo, headSha));
+  if (!evaluation?.settled) return; // wait until *all* checks are done (and readable).
   // Act once per fully-settled SHA (the last-arriving check event wins).
   if (
     !(await claim(
@@ -762,42 +731,6 @@ function managementMessage(
 // ---------------------------------------------------------------------------
 // GitHub API reads.
 // ---------------------------------------------------------------------------
-
-async function fetchCiEvaluation(
-  ctx: PrManagerContext,
-  owner: string,
-  repo: string,
-  sha: string,
-): Promise<CiEvaluation> {
-  const checks: CiCheck[] = [];
-  const statuses: CiStatus[] = [];
-  try {
-    const { data } = await ctx.octokit.rest.checks.listForRef({
-      owner,
-      repo,
-      ref: sha,
-      per_page: 100,
-    });
-    for (const run of data.check_runs) {
-      checks.push({ status: run.status, conclusion: run.conclusion, name: run.name });
-    }
-  } catch (error) {
-    logger(ctx).debug("githubbot_checks_list_failed", { error: errorMessage(error) });
-  }
-  try {
-    const { data } = await ctx.octokit.rest.repos.getCombinedStatusForRef({
-      owner,
-      repo,
-      ref: sha,
-    });
-    for (const s of data.statuses) {
-      statuses.push({ state: s.state, context: s.context });
-    }
-  } catch (error) {
-    logger(ctx).debug("githubbot_status_fetch_failed", { error: errorMessage(error) });
-  }
-  return evaluateCi(checks, statuses);
-}
 
 async function commitAuthor(
   ctx: PrManagerContext,

--- a/services/githubbot/src/server.ts
+++ b/services/githubbot/src/server.ts
@@ -116,6 +116,7 @@ const options: GithubbotOptions = {
   autoMerge: boolEnv("GITHUBBOT_AUTO_MERGE", true),
   botUserId: optionalEnv("GITHUBBOT_USER_ID"),
   ciFixMaxAttempts: optionalNumberEnv("GITHUBBOT_CI_FIX_MAX_ATTEMPTS"),
+  workflowEvents: boolEnv("GITHUBBOT_WORKFLOW_EVENTS", false),
   deleteBranchOnMerge: boolEnv("GITHUBBOT_DELETE_BRANCH_ON_MERGE", true),
   escalationHandle: optionalEnv("GITHUBBOT_ESCALATION_HANDLE"),
   holdLabel: optionalEnv("GITHUBBOT_HOLD_LABEL"),

--- a/services/githubbot/src/session-api.ts
+++ b/services/githubbot/src/session-api.ts
@@ -16,6 +16,7 @@ import type {
 } from "./types";
 import {
   elapsedMs,
+  errorMessage,
   isJsonObject,
   noopLogger,
   nowMs,
@@ -591,6 +592,54 @@ async function streamSessionNotifications(
   await ensureApiOk(response, "stream events", options);
   if (!response.body) return toAsyncIterable([]);
   return parseSessionEventStream(response.body, onEventId);
+}
+
+export type EmitWorkflowEventInput = {
+  eventType: string;
+  correlationId: string;
+  payload: JsonObject;
+};
+
+/**
+ * Emit a durable workflow event (`POST /api/workflows/events`), resolving any
+ * `ctx.wait_for_event` waiters keyed on the same (event_type, correlation_id).
+ * Best-effort by contract — never throws: a failed emission must not fail the
+ * webhook handler, and waiters fall back to their timeout path on a miss.
+ */
+export async function emitWorkflowEvent(
+  options: GithubbotOptions,
+  input: EmitWorkflowEventInput,
+): Promise<void> {
+  const url = new URL(
+    "/api/workflows/events",
+    ensureTrailingSlash(options.apiUrl),
+  ).toString();
+  try {
+    const fetchFn = options.fetch ?? fetch;
+    const response = await fetchFn(url, {
+      method: "POST",
+      headers: apiHeaders(options),
+      body: JSON.stringify({
+        event_type: input.eventType,
+        correlation_id: input.correlationId,
+        payload: input.payload,
+      }),
+    });
+    if (!response.ok) {
+      (options.logger ?? noopLogger).warn("githubbot_workflow_event_emit_failed", {
+        correlation_id: input.correlationId,
+        event_type: input.eventType,
+        status: response.status,
+        status_text: response.statusText,
+      });
+    }
+  } catch (error) {
+    (options.logger ?? noopLogger).warn("githubbot_workflow_event_emit_failed", {
+      correlation_id: input.correlationId,
+      error: errorMessage(error),
+      event_type: input.eventType,
+    });
+  }
 }
 
 function apiSessionUrl(

--- a/services/githubbot/src/types.ts
+++ b/services/githubbot/src/types.ts
@@ -144,6 +144,24 @@ export type GithubbotOptions = {
   autoMerge?: boolean;
   /** Max consecutive CI-fix attempts on an owned PR before escalating. Default 3. */
   ciFixMaxAttempts?: number;
+  /**
+   * Delay (ms) before re-reading a settled-green check rollup to confirm it
+   * isn't a registration race (push → first no-op checks complete → the
+   * rollup reads SUCCESS before the real suite registers). Default 15000;
+   * tests set 0.
+   */
+  ciSettleConfirmMs?: number;
+  /**
+   * Emit durable workflow events (`POST /api/workflows/events` on api-rs) from
+   * lifecycle webhooks, before any owned-PR gating: `ci-completed` once every
+   * check for a head sha has settled (durable events are immutable per
+   * correlation, so a single check's completion must never fire it), and
+   * `review-submitted` on every submitted review. Correlation ids key on
+   * repo + head sha (+ reviewer login for reviews) so durable workflows can
+   * wait for exactly the push — and reviewer — they care about. Default
+   * false.
+   */
+  workflowEvents?: boolean;
   /** Delete the head branch after the bot merges an owned PR. Default true. */
   deleteBranchOnMerge?: boolean;
   /** Fallback @handle to tag when the bot gives up and escalates. */

--- a/services/githubbot/src/workflow-events.ts
+++ b/services/githubbot/src/workflow-events.ts
@@ -1,0 +1,319 @@
+import type { GitHubAdapter } from "@chat-adapter/github";
+import { emitWorkflowEvent } from "./session-api";
+import type { GithubbotOptions } from "./types";
+import { errorMessage, noopLogger, stringValue } from "./utils";
+
+/**
+ * GitHub → durable-workflow-event producer.
+ *
+ * Lifecycle webhooks (check_run / check_suite / workflow_run / status /
+ * pull_request_review) are translated into curated durable events on api-rs
+ * (`POST /api/workflows/events`) that workflows suspend on via
+ * `ctx.wait_for_event`. This module is deliberately independent of the
+ * owned-PR manager in pr-manager.ts: it runs before any ownership gating,
+ * because workflow waiters are not bot-owned PRs. The manager reuses this
+ * module's settled-CI evaluation for its own gate so an owned PR is never
+ * evaluated twice for the same webhook.
+ *
+ * Two curation rules, both forced by the engine — durable events are
+ * immutable per (event_type, correlation_id); first write wins:
+ *
+ * 1. An event must be SEMANTICALLY COMPLETE when emitted. There is no
+ *    re-emit, so firing early (one check completing while the rest of the
+ *    suite runs) locks the correlation with a premature payload forever.
+ *    `ci-completed` therefore fires only once every check for the sha has
+ *    settled.
+ * 2. Anything a waiter would filter on must be part of the correlation.
+ *    await_event matches on the correlation alone and the first write wins,
+ *    so a property that distinguishes signals (WHO reviewed) must be a
+ *    correlation segment — otherwise one occurrence consumes the key and the
+ *    occurrence the waiter wanted can never land. Waiters therefore key on
+ *    exactly the discriminator they care about (e.g. one reviewer's login).
+ *
+ * Correlations are computable from data a waiter already has — the repo
+ * slug, the head sha, the PR number, the author's login — and are
+ * lowercased so case drift between a PR URL slug and repository.full_name
+ * can never miss:
+ *
+ *   commit-scoped: <owner>/<repo>:<head_sha>
+ *   PR-scoped:     <owner>/<repo>:pr-<n>:<head_sha>:<actor>
+ *
+ * <actor> is the author's login verbatim from the webhook (lowercased) —
+ * GitHub App reviewers carry their canonical `[bot]`-suffixed login
+ * (`chatgpt-codex-connector[bot]`), so waiter configs must name the exact
+ * login. New events should follow both rules and this convention.
+ */
+
+type Octokit = GitHubAdapter["octokit"];
+
+export type WorkflowEventProducerContext = {
+  octokit: Octokit;
+  options: GithubbotOptions;
+};
+
+type JsonRecord = Record<string, unknown>;
+
+// The event-type contract waiters key on.
+export const WORKFLOW_EVENT_CI_COMPLETED = "ci-completed";
+export const WORKFLOW_EVENT_REVIEW_SUBMITTED = "review-submitted";
+
+function ciCorrelationId(owner: string, repo: string, headSha: string): string {
+  return `${owner}/${repo}:${headSha}`.toLowerCase();
+}
+
+function reviewCorrelationId(
+  owner: string,
+  repo: string,
+  number: number,
+  headSha: string,
+  reviewer: string,
+): string {
+  return `${owner}/${repo}:pr-${number}:${headSha}:${reviewer}`.toLowerCase();
+}
+
+// ---------------------------------------------------------------------------
+// Settled-CI evaluation (shared with the owned-PR manager).
+// ---------------------------------------------------------------------------
+
+// CI conclusions that count as a hard, fixable failure (neutral/skipped/success
+// and the in-progress states are not failures).
+const FAILED_CONCLUSIONS = new Set([
+  "action_required",
+  "cancelled",
+  "failure",
+  "stale",
+  "timed_out",
+]);
+
+export type CiCheck = { status: string; conclusion: string | null; name: string };
+export type CiStatus = { state: string; context: string };
+
+export type CiEvaluation = {
+  settled: boolean;
+  failed: boolean;
+  failingNames: string[];
+};
+
+/**
+ * Decide whether all CI for a SHA is finished, and whether it's red. "Settled"
+ * means no check run is still queued/in-progress and no legacy commit status is
+ * pending — the point a waiter wants to wake at before acting.
+ */
+export function evaluateCi(
+  checks: CiCheck[],
+  statuses: CiStatus[],
+): CiEvaluation {
+  const anyCheckPending = checks.some((c) => c.status !== "completed");
+  const anyStatusPending = statuses.some((s) => s.state === "pending");
+  const failingChecks = checks.filter(
+    (c) =>
+      c.status === "completed" &&
+      c.conclusion !== null &&
+      FAILED_CONCLUSIONS.has(c.conclusion),
+  );
+  const failingStatuses = statuses.filter(
+    (s) => s.state === "failure" || s.state === "error",
+  );
+  const failingNames = [
+    ...failingChecks.map((c) => c.name),
+    ...failingStatuses.map((s) => s.context),
+  ];
+  return {
+    settled: !anyCheckPending && !anyStatusPending,
+    failed: failingNames.length > 0,
+    failingNames,
+  };
+}
+
+// The settled gate reads GitHub's own check rollup, not the per-check REST
+// lists: one authoritative aggregate (the same rollup `gh pr checks` uses),
+// including EXPECTED — a required check that hasn't reported yet, which no
+// list merge can see. The REST check-runs list is also unreadable by
+// fine-grained PATs (403), while the rollup state is not.
+const CI_ROLLUP_QUERY = `query($owner: String!, $repo: String!, $sha: GitObjectID!) {
+  repository(owner: $owner, name: $repo) {
+    object(oid: $sha) {
+      ... on Commit {
+        statusCheckRollup {
+          state
+          contexts(first: 100) {
+            nodes {
+              __typename
+              ... on CheckRun { name status conclusion }
+              ... on StatusContext { context state }
+            }
+          }
+        }
+      }
+    }
+  }
+}`;
+
+type CiRollupContext = {
+  __typename: string;
+  name?: string;
+  status?: string;
+  conclusion?: string | null;
+  context?: string;
+  state?: string;
+};
+
+type CiRollup = {
+  state: string;
+  contexts?: { nodes?: (CiRollupContext | null)[] | null } | null;
+};
+
+type CiRollupResponse = {
+  repository?: { object?: { statusCheckRollup?: CiRollup | null } | null } | null;
+};
+
+/**
+ * Read the aggregate CI state for a sha. Returns null when the rollup can't
+ * be read: an unreadable rollup is UNKNOWN, never "settled" — emitting or
+ * acting on an empty evaluation would manufacture a green signal out of thin
+ * air (a commit with genuinely no checks has no rollup either, and emits
+ * nothing because no CI webhook ever fires for it).
+ *
+ * Per-context detail is best-effort: fine-grained PATs get FORBIDDEN on the
+ * context nodes (they arrive null with a partial-data error we salvage the
+ * state from), so `failingNames` is empty under a PAT and full under GitHub
+ * App auth. Callers needing names should re-read with their own credentials.
+ */
+export async function fetchCiEvaluation(
+  ctx: WorkflowEventProducerContext,
+  owner: string,
+  repo: string,
+  sha: string,
+): Promise<CiEvaluation | null> {
+  const logger = ctx.options.logger ?? noopLogger;
+  let rollup: CiRollup | null | undefined;
+  try {
+    const result = await ctx.octokit.graphql<CiRollupResponse>(CI_ROLLUP_QUERY, {
+      owner,
+      repo,
+      sha,
+    });
+    rollup = result.repository?.object?.statusCheckRollup;
+  } catch (error) {
+    // octokit throws on ANY GraphQL errors, including the partial-data
+    // FORBIDDEN on context nodes — salvage the rollup state when it came back.
+    const partial = (error as { data?: CiRollupResponse }).data;
+    rollup = partial?.repository?.object?.statusCheckRollup;
+    if (!rollup) {
+      logger.warn("githubbot_ci_rollup_failed", { error: errorMessage(error) });
+      return null;
+    }
+  }
+  if (!rollup) return null;
+  if (rollup.state === "PENDING" || rollup.state === "EXPECTED") {
+    return { settled: false, failed: false, failingNames: [] };
+  }
+  const checks: CiCheck[] = [];
+  const statuses: CiStatus[] = [];
+  for (const node of rollup.contexts?.nodes ?? []) {
+    if (!node) continue;
+    if (node.__typename === "CheckRun" && node.name && node.status) {
+      checks.push({
+        status: node.status.toLowerCase(),
+        conclusion: node.conclusion?.toLowerCase() ?? null,
+        name: node.name,
+      });
+    } else if (node.__typename === "StatusContext" && node.context && node.state) {
+      statuses.push({ state: node.state.toLowerCase(), context: node.context });
+    }
+  }
+  const detail = evaluateCi(checks, statuses);
+  return {
+    settled: true,
+    failed:
+      rollup.state === "FAILURE" || rollup.state === "ERROR" || detail.failed,
+    failingNames: detail.failingNames,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Emission.
+// ---------------------------------------------------------------------------
+
+// How long to wait before re-reading a settled-green rollup: a push can read
+// SUCCESS for a few seconds between the first no-op checks completing and the
+// real suite registering (observed live: SUCCESS at T+1s, PENDING at T+7s),
+// and an emission on that false green locks the immutable event row while the
+// suite is still running. A red rollup needs no confirm — a completed failure
+// is already complete.
+const DEFAULT_CI_SETTLE_CONFIRM_MS = 15_000;
+
+/**
+ * Emit `ci-completed` for workflow waiters once every check for a head sha has
+ * settled — per rule 1 above, a single check's completion must never fire it,
+ * and a green rollup is confirmed with a delayed second read against the
+ * registration race. The aggregate payload can't see *required* checks, so
+ * waiters still verify with one live read on wake: the event is the wake-up,
+ * not the verdict. Returns the settled evaluation for the owned-PR path to
+ * reuse, or null when it wasn't computed.
+ */
+export async function maybeEmitCiCompleted(
+  ctx: WorkflowEventProducerContext,
+  eventType: string,
+  repo: { owner: string; repo: string },
+  payload: JsonRecord,
+  headSha: string,
+): Promise<CiEvaluation | null> {
+  if (ctx.options.workflowEvents !== true) return null;
+  if (!ciCompletionSignaled(eventType, payload)) return null;
+  const evaluation = await fetchCiEvaluation(ctx, repo.owner, repo.repo, headSha);
+  if (!evaluation?.settled) return null;
+  if (!evaluation.failed) {
+    await sleep(ctx.options.ciSettleConfirmMs ?? DEFAULT_CI_SETTLE_CONFIRM_MS);
+    const confirmed = await fetchCiEvaluation(ctx, repo.owner, repo.repo, headSha);
+    if (!confirmed?.settled || confirmed.failed) return null;
+  }
+  await emitWorkflowEvent(ctx.options, {
+    eventType: WORKFLOW_EVENT_CI_COMPLETED,
+    correlationId: ciCorrelationId(repo.owner, repo.repo, headSha),
+    payload: { failed: evaluation.failed, failing: evaluation.failingNames },
+  });
+  return evaluation;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Cheap pre-filter before spending two GitHub API reads on the settled
+ * evaluation: only an event signaling something finished (a completed
+ * run/suite, or a terminal legacy status) can flip the aggregate to settled.
+ */
+function ciCompletionSignaled(eventType: string, payload: JsonRecord): boolean {
+  if (eventType === "status") {
+    const state = stringValue(payload.state);
+    return Boolean(state) && state !== "pending";
+  }
+  return stringValue(payload.action) === "completed";
+}
+
+/**
+ * Emit `review-submitted` for every submitted review on any PR (owned or
+ * not), keyed by head sha AND reviewer login: reviews from different authors
+ * get independent rows, so a waiter keys on the author it cares about and a
+ * review from anyone else can never consume its correlation. One row per
+ * (PR, sha, author) — a second review by the same author on the same sha
+ * collapses, which is the complete signal: "author reviewed this head".
+ */
+export async function maybeEmitReviewSubmitted(
+  ctx: WorkflowEventProducerContext,
+  repo: { owner: string; repo: string },
+  number: number,
+  headSha: string,
+  reviewer: string | undefined,
+  reviewState: string | undefined,
+  reviewId: number,
+): Promise<void> {
+  if (ctx.options.workflowEvents !== true || !reviewer) return;
+  await emitWorkflowEvent(ctx.options, {
+    eventType: WORKFLOW_EVENT_REVIEW_SUBMITTED,
+    correlationId: reviewCorrelationId(repo.owner, repo.repo, number, headSha, reviewer),
+    payload: { review_id: reviewId, state: reviewState ?? null },
+  });
+}

--- a/services/githubbot/test/pr-manager.test.ts
+++ b/services/githubbot/test/pr-manager.test.ts
@@ -1,13 +1,12 @@
 import { describe, expect, test } from "bun:test";
 import {
   decideMerge,
-  evaluateCi,
   handleCiEvent,
   handleReviewEvent,
   isOwnedPr,
-  type CiCheck,
   type PrManagerContext,
 } from "../src/pr-manager";
+import { evaluateCi, type CiCheck } from "../src/workflow-events";
 
 function makeState() {
   const values = new Map<string, unknown>();
@@ -214,10 +213,14 @@ describe("PR management webhooks", () => {
     let mergeCalls = 0;
     const ctx = {
       octokit: {
-        rest: {
-          checks: {
-            listForRef: async () => ({ data: { check_runs: [] } }),
+        graphql: async () => ({
+          repository: {
+            object: {
+              statusCheckRollup: { state: "SUCCESS", contexts: { nodes: [] } },
+            },
           },
+        }),
+        rest: {
           pulls: {
             get: async () => ({
               data: prPayload({
@@ -231,9 +234,6 @@ describe("PR management webhooks", () => {
             },
           },
           repos: {
-            getCombinedStatusForRef: async () => ({
-              data: { statuses: [{ state: "success", context: "legacy-ci" }] },
-            }),
             listPullRequestsAssociatedWithCommit: async (input: {
               commit_sha: string;
             }) => {
@@ -340,18 +340,27 @@ describe("CI fix counter and escalation", () => {
   ): PrManagerContext {
     return {
       octokit: {
-        rest: {
-          checks: {
-            listForRef: async () => ({
-              data: {
-                check_runs: [
-                  { name: "build", status: "completed", conclusion: "failure" },
-                ],
+        graphql: async () => ({
+          repository: {
+            object: {
+              statusCheckRollup: {
+                state: "FAILURE",
+                contexts: {
+                  nodes: [
+                    {
+                      __typename: "CheckRun",
+                      name: "build",
+                      status: "COMPLETED",
+                      conclusion: "FAILURE",
+                    },
+                  ],
+                },
               },
-            }),
+            },
           },
+        }),
+        rest: {
           repos: {
-            getCombinedStatusForRef: async () => ({ data: { statuses: [] } }),
             getCommit: async () => ({
               data: { author: { login: "centaur-bot" } },
             }),
@@ -403,5 +412,250 @@ describe("CI fix counter and escalation", () => {
     expect(await state.get("centaur-githubbot:pr:base/repo#7")).toMatchObject({
       consecutiveCiFixes: 3,
     });
+  });
+});
+
+describe("workflow event emission", () => {
+  type EmitCall = {
+    url: string;
+    body: { event_type?: string; correlation_id?: string; payload?: unknown };
+  };
+
+  // The PR is deliberately NOT bot-owned (no assignees): workflow events must
+  // emit before the owned-PR gate, and the management path then no-ops, so no
+  // merge/turn mocks are needed.
+  type RollupStub = {
+    state?: string;
+    contexts?: Record<string, unknown>[];
+    fail?: boolean;
+  };
+
+  function emitCtx(
+    emits: EmitCall[],
+    options?: {
+      rollupSequence?: RollupStub[];
+      workflowEvents?: boolean;
+    },
+  ): PrManagerContext {
+    const sequence = [...(options?.rollupSequence ?? [{ state: "SUCCESS" }])];
+    return {
+      octokit: {
+        graphql: async () => {
+          const next = sequence.length > 1 ? sequence.shift()! : sequence[0]!;
+          if (next.fail) throw new Error("403 Forbidden");
+          return {
+            repository: {
+              object: {
+                statusCheckRollup: {
+                  state: next.state ?? "SUCCESS",
+                  contexts: { nodes: next.contexts ?? [] },
+                },
+              },
+            },
+          };
+        },
+        rest: {
+          repos: {
+            listPullRequestsAssociatedWithCommit: async () => ({ data: [] }),
+          },
+          pulls: {
+            get: async () => ({
+              data: prPayload({ assignees: [], headRepoFullName: "base/repo" }),
+            }),
+          },
+        },
+      },
+      options: {
+        apiUrl: "http://localhost",
+        ciSettleConfirmMs: 0,
+        logger: quietLogger,
+        workflowEvents: options?.workflowEvents ?? true,
+        fetch: (url: RequestInfo | URL, init?: RequestInit) => {
+          emits.push({
+            url: String(url),
+            body: JSON.parse(String(init?.body ?? "{}")),
+          });
+          return Promise.resolve(new Response('{"ok":true}', { status: 200 }));
+        },
+      },
+      state: makeState(),
+      userName: "centaur-bot",
+    } as unknown as PrManagerContext;
+  }
+
+  const completedCheckRun = JSON.stringify({
+    action: "completed",
+    repository: { full_name: "base/repo" },
+    check_run: {
+      head_sha: "abc123",
+      name: "build",
+      conclusion: "success",
+      html_url: "https://example.test/checks/1",
+      pull_requests: [{ number: 7 }],
+    },
+  });
+
+  test("emits ci-completed for a completed check run before ownership gating", async () => {
+    const emits: EmitCall[] = [];
+    await handleCiEvent(emitCtx(emits), "check_run", completedCheckRun);
+    expect(emits.length).toBe(1);
+    const emit = emits[0]!;
+    expect(emit.url).toBe("http://localhost/api/workflows/events");
+    expect(emit.body).toEqual({
+      event_type: "ci-completed",
+      correlation_id: "base/repo:abc123",
+      payload: { failed: false, failing: [] },
+    });
+  });
+
+  test("lowercases correlation ids against repository full_name case drift", async () => {
+    const emits: EmitCall[] = [];
+    await handleCiEvent(
+      emitCtx(emits),
+      "check_run",
+      JSON.stringify({
+        action: "completed",
+        repository: { full_name: "Base/Repo" },
+        check_run: { head_sha: "ABC123", pull_requests: [{ number: 7 }] },
+      }),
+    );
+    expect(emits.length).toBe(1);
+    expect(emits[0]!.body.correlation_id).toBe("base/repo:abc123");
+  });
+
+  test("emits ci-completed for a terminal legacy status", async () => {
+    const emits: EmitCall[] = [];
+    await handleCiEvent(
+      emitCtx(emits, {
+        rollupSequence: [
+          {
+            state: "FAILURE",
+            contexts: [
+              { __typename: "StatusContext", context: "deploy", state: "FAILURE" },
+            ],
+          },
+        ],
+      }),
+      "status",
+      JSON.stringify({
+        repository: { full_name: "base/repo" },
+        sha: "abc123",
+        state: "failure",
+        context: "deploy",
+        target_url: "https://example.test/deploy/1",
+      }),
+    );
+    expect(emits.length).toBe(1);
+    expect(emits[0]!.body).toEqual({
+      event_type: "ci-completed",
+      correlation_id: "base/repo:abc123",
+      payload: { failed: true, failing: ["deploy"] },
+    });
+  });
+
+  test("does not emit ci-completed while any check is still running", async () => {
+    const emits: EmitCall[] = [];
+    await handleCiEvent(
+      emitCtx(emits, { rollupSequence: [{ state: "PENDING" }] }),
+      "check_run",
+      completedCheckRun,
+    );
+    expect(emits.length).toBe(0);
+  });
+
+  test("does not emit on a momentary green — the registration race", async () => {
+    // Push lands, no-op checks complete first, the rollup reads SUCCESS for a
+    // few seconds before the real suite registers. The confirm re-read must
+    // catch it flipping PENDING and suppress the emission.
+    const emits: EmitCall[] = [];
+    await handleCiEvent(
+      emitCtx(emits, { rollupSequence: [{ state: "SUCCESS" }, { state: "PENDING" }] }),
+      "check_run",
+      completedCheckRun,
+    );
+    expect(emits.length).toBe(0);
+  });
+
+  test("does not emit ci-completed when the rollup is unreadable", async () => {
+    // A failed read is UNKNOWN, not settled — emitting would manufacture a
+    // green signal out of thin air (e.g. a token missing checks:read).
+    const emits: EmitCall[] = [];
+    await handleCiEvent(emitCtx(emits, { rollupSequence: [{ fail: true }] }), "check_run", completedCheckRun);
+    expect(emits.length).toBe(0);
+  });
+
+  test("does not emit for an in-flight check run or a pending status", async () => {
+    const emits: EmitCall[] = [];
+    const ctx = emitCtx(emits);
+    await handleCiEvent(
+      ctx,
+      "check_run",
+      JSON.stringify({
+        action: "created",
+        repository: { full_name: "base/repo" },
+        check_run: { head_sha: "abc123", pull_requests: [] },
+      }),
+    );
+    await handleCiEvent(
+      ctx,
+      "status",
+      JSON.stringify({
+        repository: { full_name: "base/repo" },
+        sha: "abc123",
+        state: "pending",
+      }),
+    );
+    expect(emits.length).toBe(0);
+  });
+
+  test("does not emit when workflowEvents is off", async () => {
+    const emits: EmitCall[] = [];
+    await handleCiEvent(
+      emitCtx(emits, { workflowEvents: false }),
+      "check_run",
+      completedCheckRun,
+    );
+    expect(emits.length).toBe(0);
+  });
+
+  test("emits review-submitted keyed by PR, head sha, and reviewer", async () => {
+    const emits: EmitCall[] = [];
+    await handleReviewEvent(
+      emitCtx(emits),
+      JSON.stringify({
+        action: "submitted",
+        repository: { full_name: "base/repo" },
+        pull_request: { number: 7 },
+        review: {
+          id: 123,
+          state: "commented",
+          user: { login: "chatgpt-codex-connector" },
+        },
+      }),
+    );
+    expect(emits.length).toBe(1);
+    expect(emits[0]!.body).toEqual({
+      event_type: "review-submitted",
+      correlation_id: "base/repo:pr-7:abc123:chatgpt-codex-connector",
+      payload: { review_id: 123, state: "commented" },
+    });
+  });
+
+  test("reviews from different authors get independent rows, never collapsing", async () => {
+    const emits: EmitCall[] = [];
+    const submittedReview = (id: number, login: string) =>
+      JSON.stringify({
+        action: "submitted",
+        repository: { full_name: "base/repo" },
+        pull_request: { number: 7 },
+        review: { id, state: "commented", user: { login } },
+      });
+    const ctx = emitCtx(emits);
+    await handleReviewEvent(ctx, submittedReview(125, "human-reviewer"));
+    await handleReviewEvent(ctx, submittedReview(126, "chatgpt-codex-connector"));
+    expect(emits.map((e) => e.body.correlation_id)).toEqual([
+      "base/repo:pr-7:abc123:human-reviewer",
+      "base/repo:pr-7:abc123:chatgpt-codex-connector",
+    ]);
   });
 });


### PR DESCRIPTION
## Summary

githubbot can produce durable workflow events from lifecycle webhooks, gated by
`githubbot.workflowEvents` (off by default) — new `workflow-events.ts` producer
module, deliberately separate from the owned-PR manager:

- `ci-completed` (`<owner>/<repo>:<head_sha>`, `{failed, failing}`) fires once
  every check for the sha has settled, read from the GraphQL `statusCheckRollup`
  (fine-grained PATs can't read the REST check-runs list — 403, ungrantable —
  so the aggregate moves to the same source `gh pr checks` uses; an unreadable
  rollup is unknown, never settled).
- `review-submitted` (`<owner>/<repo>:pr-<n>:<head_sha>:<reviewer>`,
  `{review_id, state}`) fires on every submitted review; author-scoped
  correlations never collapse across reviewers.

Durable events are immutable per correlation (first write wins), so emission is
settled-gated and anything a waiter filters on belongs in the correlation — the
full contract is in the module header. Also adds the first DB-backed absurd-sdk
`await_event`/`emit_event` test.

## Validation

- `pnpm --filter githubbot run check:types` + tests (85 pass, 8 new)
- `helm lint contrib/chart`
- `cargo test -p absurd-sdk` 8/8 vs live Postgres; fmt + clippy `-D warnings`
