### PR TITLE
feat: add default role assignments

### DIFF
--- a/services/api-rs/crates/centaur-api-server/src/args.rs
+++ b/services/api-rs/crates/centaur-api-server/src/args.rs
@@ -688,30 +688,23 @@ impl SandboxArgs {
             return Ok(None);
         };
         let namespace = self.iron_control.namespace.clone();
-        let role_ids = if self.iron_control_sync_infra_secrets {
+        if self.iron_control_sync_infra_secrets {
             let policy = self.iron_proxy.source_policy();
             let roles = self.iron_proxy.roles_to_register()?;
-            let mut role_ids = Vec::with_capacity(roles.len());
             for (spec, fragment) in &roles {
-                role_ids.push(
-                    register_role_with_retry(&client, &namespace, spec, fragment, &policy).await?,
-                );
+                register_role_with_retry(&client, &namespace, spec, fragment, &policy).await?;
             }
-            role_ids
         } else {
             let spec = RoleSpec::infra();
-            vec![
-                client
-                    .upsert_role(&IdentityInput {
-                        namespace: namespace.clone(),
-                        foreign_id: spec.foreign_id,
-                        name: spec.name,
-                        labels: BTreeMap::from([("managed-by".to_owned(), "centaur".to_owned())]),
-                    })
-                    .await?
-                    .id,
-            ]
-        };
+            client
+                .upsert_role(&IdentityInput {
+                    namespace: namespace.clone(),
+                    foreign_id: spec.foreign_id,
+                    name: spec.name,
+                    labels: BTreeMap::from([("managed-by".to_owned(), "centaur".to_owned())]),
+                })
+                .await?;
+        }
         let bootstrap = client
             .upsert_principal(&IdentityInput {
                 namespace: namespace.clone(),
@@ -734,11 +727,8 @@ impl SandboxArgs {
                 ]),
             })
             .await?;
-        for role_id in &role_ids {
-            client.assign_role(&workflow_host.id, role_id).await?;
-        }
         Ok(Some(IronControlRuntime {
-            registrar: SessionRegistrar::new(client.clone(), namespace.clone(), role_ids),
+            registrar: SessionRegistrar::new(client.clone(), namespace.clone()),
             warm_pool_bootstrap_principal: bootstrap.id,
             workflow_host_principal: workflow_host.id,
             workflow_principal_registrar: WorkflowPrincipalRegistrar::new(client, namespace),

--- a/services/api-rs/crates/centaur-iron-control/src/session.rs
+++ b/services/api-rs/crates/centaur-iron-control/src/session.rs
@@ -1,11 +1,11 @@
 //! Per-session principal registration.
 //!
 //! Roles are registered once at startup (see [`crate::register_role`]); a
-//! [`SessionRegistrar`] carries the resulting role OIDs and, when a session
-//! starts, upserts the session's principal. Brand-new principals receive the
-//! default roles once; existing principals keep their current assignments so
-//! operator revocations in console or ``centaur-perms`` remain sticky. The
-//! principal is derived from the thread key (see [`crate::derive_principal`]).
+//! When a session starts, [`SessionRegistrar`] upserts the session's principal.
+//! Iron-control owns default role assignment for brand-new principals, while
+//! existing principals keep their current assignments so operator revocations
+//! in console or ``centaur-perms`` remain sticky. The principal is derived from
+//! the thread key (see [`crate::derive_principal`]).
 
 use serde_json::Value;
 use std::collections::BTreeMap;
@@ -56,21 +56,13 @@ impl<'a> SessionPrincipalMetadata<'a> {
 pub struct SessionRegistrar {
     client: IronControlClient,
     namespace: String,
-    assign_role_ids: Vec<String>,
 }
 
 impl SessionRegistrar {
-    /// ``assign_role_ids`` are the iron-control role OIDs (from
-    /// [`crate::register_role`]) to assign to every session's principal.
-    pub fn new(
-        client: IronControlClient,
-        namespace: impl Into<String>,
-        assign_role_ids: Vec<String>,
-    ) -> Self {
+    pub fn new(client: IronControlClient, namespace: impl Into<String>) -> Self {
         Self {
             client,
             namespace: namespace.into(),
-            assign_role_ids,
         }
     }
 
@@ -79,10 +71,8 @@ impl SessionRegistrar {
     /// the OID) so callers can bind the session's egress proxy to the same
     /// identity.
     ///
-    /// Default roles are assigned only when the principal does not already
-    /// exist. Re-registering an existing channel/user still refreshes identity
-    /// metadata, but it must not restore roles that an operator manually
-    /// removed.
+    /// Re-registering an existing channel/user refreshes identity metadata but
+    /// leaves its role assignments to iron-control.
     pub async fn register_session(
         &self,
         thread_key: &str,
@@ -122,15 +112,6 @@ impl SessionRegistrar {
             self.client
                 .upsert_slack_channel_permission(&record.id, &permission)
                 .await?;
-        }
-        if !exists {
-            for role_id in &self.assign_role_ids {
-                match self.client.assign_role(&record.id, role_id).await {
-                    Ok(()) => {}
-                    Err(error) if is_status(&error, 409) || is_status(&error, 422) => {}
-                    Err(error) => return Err(error),
-                }
-            }
         }
         Ok(record)
     }
@@ -284,13 +265,10 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn register_session_seeds_roles_for_new_principal() {
+    async fn register_session_leaves_default_roles_to_iron_control() {
         let (base_url, requests, server) = spawn_iron_control_stub(false).await;
-        let registrar = SessionRegistrar::new(
-            IronControlClient::new(base_url, "test-key"),
-            "default",
-            vec!["role_infra".to_owned()],
-        );
+        let registrar =
+            SessionRegistrar::new(IronControlClient::new(base_url, "test-key"), "default");
         let metadata = json!({
             "slack_user_id": "U123",
             "slack_team_id": "T123",
@@ -314,18 +292,20 @@ mod tests {
                 &"POST /api/v1/principals/prn_channel/slack_channel_permissions".to_owned()
             )
         );
-        assert!(requests.contains(&"POST /api/v1/principals/prn_channel/roles".to_owned()));
+        assert!(
+            !requests
+                .iter()
+                .any(|request| request == "POST /api/v1/principals/prn_channel/roles"),
+            "iron-control assigns configured default roles during principal creation"
+        );
         server.abort();
     }
 
     #[tokio::test]
     async fn register_session_does_not_restore_roles_for_existing_principal() {
         let (base_url, requests, server) = spawn_iron_control_stub(true).await;
-        let registrar = SessionRegistrar::new(
-            IronControlClient::new(base_url, "test-key"),
-            "default",
-            vec!["role_infra".to_owned()],
-        );
+        let registrar =
+            SessionRegistrar::new(IronControlClient::new(base_url, "test-key"), "default");
         let metadata = json!({
             "slack_user_id": "U123",
             "slack_team_id": "T123",
@@ -362,11 +342,8 @@ mod tests {
     #[tokio::test]
     async fn register_session_upserts_slack_dm_permission_for_new_user_principal() {
         let (base_url, requests, server) = spawn_iron_control_stub(false).await;
-        let registrar = SessionRegistrar::new(
-            IronControlClient::new(base_url, "test-key"),
-            "default",
-            vec![],
-        );
+        let registrar =
+            SessionRegistrar::new(IronControlClient::new(base_url, "test-key"), "default");
         let metadata = json!({
             "slack_user_id": "U123",
             "slack_team_id": "T123",
@@ -390,11 +367,8 @@ mod tests {
     #[tokio::test]
     async fn register_session_upserts_slack_dm_permission_for_existing_user_principal() {
         let (base_url, requests, server) = spawn_iron_control_stub(true).await;
-        let registrar = SessionRegistrar::new(
-            IronControlClient::new(base_url, "test-key"),
-            "default",
-            vec!["role_infra".to_owned()],
-        );
+        let registrar =
+            SessionRegistrar::new(IronControlClient::new(base_url, "test-key"), "default");
         let metadata = json!({
             "slack_user_id": "U123",
             "slack_team_id": "T123",

--- a/services/api-rs/crates/centaur-session-runtime/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-runtime/src/lib.rs
@@ -1214,7 +1214,7 @@ impl SessionRuntime {
     }
 
     /// Attach an iron-control registrar so each new session upserts its
-    /// principal and assigns it the configured roles.
+    /// principal. Iron-control applies configured default roles on creation.
     pub fn with_iron_control(mut self, registrar: SessionRegistrar) -> Self {
         self.iron_control = Some(registrar);
         self

--- a/services/console/app/controllers/console/system_settings_controller.rb
+++ b/services/console/app/controllers/console/system_settings_controller.rb
@@ -9,17 +9,22 @@ module Console
     end
 
     def update
-      if @system_setting.update(system_setting_params)
-        redirect_to edit_console_system_settings_path, notice: "System settings updated."
-      else
-        render :edit, status: :unprocessable_entity
+      @system_setting.assign_attributes(system_setting_params)
+      return render :edit, status: :unprocessable_entity unless @system_setting.valid?
+
+      ActiveRecord::Base.transaction do
+        @system_setting.save!
+        Role.replace_default_assignments!(selected_default_role_ids)
       end
+
+      redirect_to edit_console_system_settings_path, notice: "System settings updated."
     end
 
     private
 
     def set_system_setting
       @system_setting = SystemSetting.current
+      @roles = Role.order(:namespace, :name, :foreign_id, :id)
     end
 
     def system_setting_params
@@ -28,6 +33,12 @@ module Console
         :default_sandbox_observability_enabled,
         :default_sandbox_api_server_enabled
       )
+    end
+
+    def selected_default_role_ids
+      @selected_default_role_ids ||= Array(params.dig(:system_setting, :default_role_ids)).filter_map do |value|
+        Integer(value, exception: false)
+      end.uniq
     end
   end
 end

--- a/services/console/app/controllers/console/system_settings_controller.rb
+++ b/services/console/app/controllers/console/system_settings_controller.rb
@@ -14,7 +14,7 @@ module Console
 
       ActiveRecord::Base.transaction do
         @system_setting.save!
-        Role.replace_default_assignments!(selected_default_role_ids)
+        Role.replace_default_assignments!(selected_default_role_ids) if params[:system_setting]&.key?(:default_role_ids)
       end
 
       redirect_to edit_console_system_settings_path, notice: "System settings updated."

--- a/services/console/app/models/principal.rb
+++ b/services/console/app/models/principal.rb
@@ -22,6 +22,7 @@ class Principal < ApplicationRecord
   include SlackChannelPermissionOwner
 
   after_commit :auto_grant_matching_oauth_credentials, on: %i[create update]
+  after_create :assign_default_roles, if: :roles_blank_for_defaulting?
   before_validation :apply_sandbox_repo_cache_label
   before_validation :promote_identity_labels_to_fields
   before_validation :strip_identity_labels
@@ -223,6 +224,19 @@ class Principal < ApplicationRecord
   end
 
   private
+
+  def roles_blank_for_defaulting?
+    association(:roles).target.empty? && !roles.exists?
+  end
+
+  def assign_default_roles
+    role_ids = Role.where(namespace: namespace, assign_by_default: true).ids
+    return if role_ids.empty?
+
+    # These assignments are part of the principal's initial state, so there is
+    # no prior sync config to invalidate.
+    PrincipalRole.insert_all!(role_ids.map { |role_id| { principal_id: id, role_id: role_id } })
+  end
 
   def auto_grant_matching_oauth_credentials
     PrincipalCredentialReconciliation.new.apply_for_principal(self)

--- a/services/console/app/models/role.rb
+++ b/services/console/app/models/role.rb
@@ -21,6 +21,32 @@ class Role < ApplicationRecord
             format: { with: URL_SAFE_FORMAT, message: URL_SAFE_MESSAGE }, allow_nil: true
   validate :labels_is_a_hash
 
+  def self.ensure_default_infra!(created_by:)
+    role = find_or_initialize_by(namespace: "default", foreign_id: "infra")
+    if role.new_record?
+      role.assign_attributes(
+        name: "Infra",
+        labels: { "managed-by" => "centaur" },
+        assign_by_default: true,
+        created_by: created_by
+      )
+      role.save!
+    elsif !role.assign_by_default?
+      role.update!(assign_by_default: true)
+    end
+    role
+  end
+
+  def self.replace_default_assignments!(role_ids)
+    transaction do
+      now = Time.current
+      where(assign_by_default: true).where.not(id: role_ids)
+        .update_all(assign_by_default: false, updated_at: now)
+      where(id: role_ids, assign_by_default: false)
+        .update_all(assign_by_default: true, updated_at: now)
+    end
+  end
+
   private
 
   def labels_is_a_hash

--- a/services/console/app/views/console/system_settings/edit.html.erb
+++ b/services/console/app/views/console/system_settings/edit.html.erb
@@ -57,6 +57,42 @@
     </div>
   </section>
 
+  <section class="form-section">
+    <h2 class="form-section-heading">Default Roles</h2>
+    <p class="mb-4 text-sm text-zinc-500">
+      New principals with no preassigned roles receive the selected roles from their namespace. Existing principals are unchanged.
+    </p>
+
+    <%= hidden_field_tag "system_setting[default_role_ids][]", "" %>
+    <% if @roles.any? %>
+      <div class="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+        <% @roles.group_by(&:namespace).each do |namespace, roles| %>
+          <fieldset class="rounded border border-ink-700 bg-ink-850/60 p-4">
+            <legend class="px-1 text-xs font-semibold uppercase tracking-wide text-zinc-400"><%= namespace %></legend>
+            <div class="space-y-3">
+              <% roles.each do |role| %>
+                <% role_label = role.name.presence || role.foreign_id.presence || role.oid %>
+                <label class="flex items-start gap-3">
+                  <%= check_box_tag "system_setting[default_role_ids][]",
+                                    role.id,
+                                    role.assign_by_default?,
+                                    id: "system_setting_default_role_ids_#{role.id}",
+                                    class: checkbox_class %>
+                  <span>
+                    <span class="block text-sm font-medium text-zinc-100"><%= role_label %></span>
+                    <span class="block text-xs text-zinc-500"><%= role.foreign_id.presence || role.oid %></span>
+                  </span>
+                </label>
+              <% end %>
+            </div>
+          </fieldset>
+        <% end %>
+      </div>
+    <% else %>
+      <p class="text-sm text-zinc-500">Create a role before configuring default role assignments.</p>
+    <% end %>
+  </section>
+
   <div class="flex items-center gap-3">
     <%= form.submit "Save settings", class: "btn-primary" %>
     <a href="<%= console_principals_path %>" class="btn-secondary">Cancel</a>

--- a/services/console/db/migrate/20260802022347_add_default_to_roles.rb
+++ b/services/console/db/migrate/20260802022347_add_default_to_roles.rb
@@ -1,0 +1,26 @@
+class AddDefaultToRoles < ActiveRecord::Migration[8.1]
+  def up
+    add_column :roles, :assign_by_default, :boolean, null: false, default: false
+
+    execute <<~SQL
+      INSERT INTO roles (namespace, foreign_id, name, labels, assign_by_default, created_by_id, created_at, updated_at)
+      SELECT
+        'default',
+        'infra',
+        'Infra',
+        '{"managed-by":"centaur"}'::jsonb,
+        TRUE,
+        users.id,
+        CURRENT_TIMESTAMP,
+        CURRENT_TIMESTAMP
+      FROM users
+      ORDER BY users.id
+      LIMIT 1
+      ON CONFLICT (namespace, foreign_id) DO UPDATE SET assign_by_default = TRUE
+    SQL
+  end
+
+  def down
+    remove_column :roles, :assign_by_default
+  end
+end

--- a/services/console/db/schema.rb
+++ b/services/console/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_31_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_02_022347) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -367,6 +367,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_31_120000) do
   end
 
   create_table "roles", force: :cascade do |t|
+    t.boolean "assign_by_default", default: false, null: false
     t.datetime "created_at", null: false
     t.bigint "created_by_id", null: false
     t.string "foreign_id"

--- a/services/console/docs/API.md
+++ b/services/console/docs/API.md
@@ -1180,6 +1180,12 @@ Slack OAuth apps should use normal Slack API scopes such as `channels:history`, 
 
 A principal is an identity (an application, service, or proxy owner) that can be granted secrets.
 
+When a principal is created with no preassigned roles, the console assigns the
+system default roles configured for that principal's namespace. Defaults apply
+only during initial creation. Updating an existing roleless principal does not
+restore roles that an operator removed. The default configuration assigns the
+system-managed `default/infra` role.
+
 ### Attributes
 
 | Field        | In requests | Notes |

--- a/services/console/lib/iron/bootstrap.rb
+++ b/services/console/lib/iron/bootstrap.rb
@@ -26,6 +26,7 @@ module Iron
         # The initial operator predates any approver, so it is created active and
         # admin -- it is the account that approves everyone else.
         user = User.create!(email: email, password: password, status: "active", admin: true)
+        Role.ensure_default_infra!(created_by: user)
 
         api_key = ApiKey.new(user: user, name: "bootstrap")
         unless supplied_token.empty?

--- a/services/console/test/controllers/api/v1/principals_controller_test.rb
+++ b/services/console/test/controllers/api/v1/principals_controller_test.rb
@@ -142,6 +142,18 @@ module Api
         assert_equal false, data["sandbox_api_server_enabled"]
       end
 
+      test "POST applies configured default roles from the principal namespace" do
+        roles(:acme_infra).update!(assign_by_default: true)
+        roles(:globex_infra).update!(assign_by_default: true)
+        body = { data: { namespace: "acme", foreign_id: "U-default-roles" } }
+
+        post api_v1_principals_url, params: body.to_json, headers: auth_headers
+        assert_response :created
+
+        principal = Principal.find_by!(namespace: "acme", foreign_id: "U-default-roles")
+        assert_equal [ roles(:acme_infra) ], principal.roles
+      end
+
       test "POST keeps explicit sandbox capabilities over system defaults" do
         system_settings(:default).update!(
           default_sandbox_repo_cache: "none",
@@ -821,6 +833,18 @@ module Api
         end
         assert_response :ok
         assert_equal "Renamed channel", principal.reload.name
+      end
+
+      test "PUT by foreign_id does not apply defaults to an existing roleless principal" do
+        principal = principals(:acme_user_bob)
+        principal.principal_roles.destroy_all
+        roles(:acme_infra).update!(assign_by_default: true)
+        body = { data: { namespace: "acme", name: "Still roleless" } }
+
+        put api_v1_principal_url(id: principal.foreign_id), params: body.to_json, headers: auth_headers
+
+        assert_response :ok
+        assert_empty principal.reload.roles
       end
 
       test "GET index rejects requests without an Authorization header" do

--- a/services/console/test/controllers/console/principals_controller_test.rb
+++ b/services/console/test/controllers/console/principals_controller_test.rb
@@ -37,6 +37,8 @@ module Console
         default_sandbox_observability_enabled: false,
         default_sandbox_api_server_enabled: false
       )
+      roles(:acme_infra).update!(assign_by_default: true)
+      roles(:globex_infra).update!(assign_by_default: true)
 
       assert_difference -> { Principal.count }, 1 do
         post console_create_principal_url,
@@ -64,6 +66,7 @@ module Console
       assert_equal "public", principal.sandbox_repo_cache
       assert_equal false, principal.sandbox_observability_enabled
       assert_equal false, principal.sandbox_api_server_enabled
+      assert_equal [ roles(:acme_infra) ], principal.roles
       assert_equal @operator, principal.created_by
     end
 

--- a/services/console/test/controllers/console/system_settings_controller_test.rb
+++ b/services/console/test/controllers/console/system_settings_controller_test.rb
@@ -27,9 +27,10 @@ module Console
       assert_select "select[name='system_setting[default_sandbox_repo_cache]']"
       assert_select "input[name='system_setting[default_sandbox_observability_enabled]']"
       assert_select "input[name='system_setting[default_sandbox_api_server_enabled]']"
+      assert_select "input[name='system_setting[default_role_ids][]'][value=?]", roles(:acme_infra).id.to_s
     end
 
-    test "admin updates default sandbox capabilities" do
+    test "admin updates principal defaults" do
       sign_in users(:acme_admin)
 
       patch console_system_settings_url,
@@ -37,7 +38,8 @@ module Console
               system_setting: {
                 default_sandbox_repo_cache: "public",
                 default_sandbox_observability_enabled: "0",
-                default_sandbox_api_server_enabled: "0"
+                default_sandbox_api_server_enabled: "0",
+                default_role_ids: [ roles(:acme_infra).id, roles(:globex_infra).id ]
               }
             }
 
@@ -47,6 +49,20 @@ module Console
       assert_equal "public", settings.default_sandbox_repo_cache
       assert_equal false, settings.default_sandbox_observability_enabled
       assert_equal false, settings.default_sandbox_api_server_enabled
+      assert_predicate roles(:acme_infra).reload, :assign_by_default?
+      assert_predicate roles(:globex_infra).reload, :assign_by_default?
+      assert_not roles(:default_infra).reload.assign_by_default?
+    end
+
+    test "admin can clear all default roles" do
+      sign_in users(:acme_admin)
+      roles(:acme_infra).update!(assign_by_default: true)
+
+      patch console_system_settings_url,
+            params: { system_setting: { default_role_ids: [ "" ] } }
+
+      assert_redirected_to edit_console_system_settings_path
+      assert_empty Role.where(assign_by_default: true)
     end
   end
 end

--- a/services/console/test/controllers/console/system_settings_controller_test.rb
+++ b/services/console/test/controllers/console/system_settings_controller_test.rb
@@ -64,5 +64,17 @@ module Console
       assert_redirected_to edit_console_system_settings_path
       assert_empty Role.where(assign_by_default: true)
     end
+
+    test "updating sandbox defaults without role params preserves default roles" do
+      sign_in users(:acme_admin)
+      role = roles(:acme_infra)
+      role.update!(assign_by_default: true)
+
+      patch console_system_settings_url,
+            params: { system_setting: { default_sandbox_repo_cache: "public" } }
+
+      assert_redirected_to edit_console_system_settings_path
+      assert_predicate role.reload, :assign_by_default?
+    end
   end
 end

--- a/services/console/test/fixtures/roles.yml
+++ b/services/console/test/fixtures/roles.yml
@@ -1,3 +1,12 @@
+default_infra:
+  namespace: default
+  foreign_id: infra
+  name: Infra
+  labels:
+    managed-by: centaur
+  assign_by_default: true
+  created_by: acme_admin
+
 acme_infra:
   namespace: acme
   foreign_id: infra

--- a/services/console/test/lib/iron/bootstrap_test.rb
+++ b/services/console/test/lib/iron/bootstrap_test.rb
@@ -65,12 +65,16 @@ class Iron::BootstrapTest < ActiveSupport::TestCase
     end
   end
 
-  test "creates user and api key when env vars supplied and DB empty" do
+  test "creates user, default infra role, and api key when env vars supplied and DB empty" do
     set_env(email: "boot@example.com", password: "password123456", api_key: VALID_TOKEN)
     Iron::Bootstrap.run!
     user = User.find_by!(email: "boot@example.com")
+    role = Role.find_by!(namespace: "default", foreign_id: "infra")
+
     assert_equal user, user.authenticate("password123456")
     assert_equal user, ApiKey.find_by_token(VALID_TOKEN).user
+    assert_equal user, role.created_by
+    assert_predicate role, :assign_by_default?
     assert user.active?, "the bootstrap operator must be active"
     assert user.admin?, "the bootstrap operator must be an admin"
   end

--- a/services/console/test/models/principal_test.rb
+++ b/services/console/test/models/principal_test.rb
@@ -195,6 +195,37 @@ class PrincipalTest < ActiveSupport::TestCase
     assert_predicate principal, :sandbox_api_server_enabled
   end
 
+  test "new principals with no roles receive configured defaults from their namespace" do
+    Role.update_all(assign_by_default: false)
+    [ roles(:acme_infra), roles(:acme_admin_role), roles(:globex_infra) ].each do |role|
+      role.update!(assign_by_default: true)
+    end
+
+    principal = Principal.create!(default_attrs(namespace: "acme", foreign_id: "U-default-roles"))
+
+    assert_equal [ roles(:acme_infra), roles(:acme_admin_role) ].sort_by(&:id), principal.roles.order(:id)
+  end
+
+  test "preassigned roles suppress configured defaults" do
+    roles(:acme_infra).update!(assign_by_default: true)
+    principal = Principal.new(default_attrs(namespace: "acme", foreign_id: "U-explicit-role"))
+    principal.roles = [ roles(:acme_admin_role) ]
+
+    principal.save!
+
+    assert_equal [ roles(:acme_admin_role) ], principal.reload.roles
+  end
+
+  test "configured defaults are not applied to existing roleless principals" do
+    principal = principals(:acme_user_bob)
+    principal.principal_roles.destroy_all
+    roles(:acme_infra).update!(assign_by_default: true)
+
+    principal.update!(name: "Still roleless")
+
+    assert_empty principal.reload.roles
+  end
+
   test "default sandbox repo-cache overwrites explicit label assignment" do
     principal = Principal.new(default_attrs(namespace: "acme", foreign_id: "C-explicit-repo-cache-label"))
 

--- a/services/console/test/models/role_test.rb
+++ b/services/console/test/models/role_test.rb
@@ -14,6 +14,52 @@ class RoleTest < ActiveSupport::TestCase
     assert Role.new(valid_attrs).valid?
   end
 
+  test "requires a creator for operator-managed roles" do
+    role = Role.new(valid_attrs(created_by: nil))
+
+    assert_not role.valid?
+    assert_includes role.errors[:created_by], "must exist"
+  end
+
+  test "the system-managed infra role is the initial default" do
+    assert_predicate roles(:default_infra), :assign_by_default?
+  end
+
+  test "ensure_default_infra creates the role when missing" do
+    roles(:default_infra).destroy!
+    owner = users(:acme_admin)
+
+    role = Role.ensure_default_infra!(created_by: owner)
+
+    assert_equal "default", role.namespace
+    assert_equal "infra", role.foreign_id
+    assert_equal "Infra", role.name
+    assert_equal({ "managed-by" => "centaur" }, role.labels)
+    assert_predicate role, :assign_by_default?
+    assert_equal owner, role.created_by
+  end
+
+  test "ensure_default_infra preserves an existing role and marks it default" do
+    role = roles(:default_infra)
+    role.update!(name: "Custom Infra", assign_by_default: false)
+
+    result = Role.ensure_default_infra!(created_by: users(:globex_admin))
+
+    assert_equal role, result
+    assert_equal "Custom Infra", result.name
+    assert_equal users(:acme_admin), result.created_by
+    assert_predicate result, :assign_by_default?
+  end
+
+  test "replace_default_assignments updates the selected roles" do
+    selected = roles(:acme_infra)
+
+    Role.replace_default_assignments!([ selected.id ])
+
+    assert_predicate selected.reload, :assign_by_default?
+    assert_not roles(:default_infra).reload.assign_by_default?
+  end
+
   test "requires namespace" do
     role = Role.new(valid_attrs(namespace: nil))
     assert_not role.valid?

--- a/services/console/test/models/system_setting_test.rb
+++ b/services/console/test/models/system_setting_test.rb
@@ -6,7 +6,7 @@ class SystemSettingTest < ActiveSupport::TestCase
   end
 
   test "defaults enable all sandbox capabilities" do
-    SystemSetting.delete_all
+    SystemSetting.destroy_all
 
     settings = SystemSetting.current
 


### PR DESCRIPTION
Adds configurable default-role assignments in console settings and applies matching namespace roles when a roleless principal is first created. Creates the default infra role during upgrades or initial bootstrap, and removes principal role-assignment logic from the Rust API while preserving role registration. Existing principal assignments remain unchanged.