### PR TITLE
feat(console): promote console user identity fields

### DIFF
--- a/services/console/app/controllers/api/base_controller.rb
+++ b/services/console/app/controllers/api/base_controller.rb
@@ -115,7 +115,7 @@ module Api
     DEFAULT_PAGE_LIMIT = 50
     MAX_PAGE_LIMIT = 200
 
-    def paginated_label_search(scope, promoted_label_fields: {})
+    def paginated_label_search(scope, promoted_label_fields: {}, promoted_label_decoder: nil)
       namespace = params.require(:namespace)
 
       labels = label_filter_params
@@ -126,11 +126,17 @@ module Api
 
         table = scope.connection.quote_table_name(scope.table_name)
         field = scope.connection.quote_column_name(column)
-        filtered = filtered.where(
-          "#{table}.#{field} = ? OR #{table}.labels @> ?",
-          value.to_s,
-          { label => value }.to_json
-        )
+        stored_value = promoted_label_decoder ? promoted_label_decoder.call(label, value) : value.to_s
+        label_filter = { label => value }.to_json
+        filtered = if stored_value.nil?
+          filtered.where("#{table}.labels @> ?", label_filter)
+        else
+          filtered.where(
+            "#{table}.#{field} = ? OR #{table}.labels @> ?",
+            stored_value,
+            label_filter
+          )
+        end
       end
       filtered = filtered.where("labels @> ?", labels.to_json) if labels.any?
 

--- a/services/console/app/controllers/api/base_controller.rb
+++ b/services/console/app/controllers/api/base_controller.rb
@@ -115,14 +115,22 @@ module Api
     DEFAULT_PAGE_LIMIT = 50
     MAX_PAGE_LIMIT = 200
 
-    def paginated_label_search(scope, promoted_label_columns: [])
+    def paginated_label_search(scope, promoted_label_fields: {})
       namespace = params.require(:namespace)
 
       labels = label_filter_params
       filtered = scope.where(namespace: namespace)
-      promoted_label_columns.each do |column|
-        value = labels.delete(column)
-        filtered = filtered.where(column => value.to_s) if value.present?
+      promoted_label_fields.each do |label, column|
+        value = labels.delete(label)
+        next if value.blank?
+
+        table = scope.connection.quote_table_name(scope.table_name)
+        field = scope.connection.quote_column_name(column)
+        filtered = filtered.where(
+          "#{table}.#{field} = ? OR #{table}.labels @> ?",
+          value.to_s,
+          { label => value }.to_json
+        )
       end
       filtered = filtered.where("labels @> ?", labels.to_json) if labels.any?
 

--- a/services/console/app/controllers/api/base_controller.rb
+++ b/services/console/app/controllers/api/base_controller.rb
@@ -115,30 +115,18 @@ module Api
     DEFAULT_PAGE_LIMIT = 50
     MAX_PAGE_LIMIT = 200
 
-    def paginated_label_search(scope, promoted_label_fields: {}, promoted_label_decoder: nil)
+    def paginated_label_search(scope, label_filter: nil)
       namespace = params.require(:namespace)
 
       labels = label_filter_params
       filtered = scope.where(namespace: namespace)
-      promoted_label_fields.each do |label, column|
-        value = labels.delete(label)
-        next if value.blank?
-
-        table = scope.connection.quote_table_name(scope.table_name)
-        field = scope.connection.quote_column_name(column)
-        stored_value = promoted_label_decoder ? promoted_label_decoder.call(label, value) : value.to_s
-        label_filter = { label => value }.to_json
-        filtered = if stored_value.nil?
-          filtered.where("#{table}.labels @> ?", label_filter)
-        else
-          filtered.where(
-            "#{table}.#{field} = ? OR #{table}.labels @> ?",
-            stored_value,
-            label_filter
-          )
-        end
+      filtered = if label_filter
+        label_filter.call(filtered, labels)
+      elsif labels.any?
+        filtered.where("labels @> ?", labels.to_json)
+      else
+        filtered
       end
-      filtered = filtered.where("labels @> ?", labels.to_json) if labels.any?
 
       limit = pagination_limit
       page = pagination_page

--- a/services/console/app/controllers/api/v1/principals_controller.rb
+++ b/services/console/app/controllers/api/v1/principals_controller.rb
@@ -6,8 +6,7 @@ module Api
       def index
         records, meta = paginated_label_search(
           Principal.includes(:console_user, :slack_channel_permissions, roles: :slack_channel_permissions),
-          promoted_label_fields: Principal::PROMOTED_LABEL_FIELDS,
-          promoted_label_decoder: Principal.method(:promoted_label_filter_value)
+          label_filter: PrincipalIdentityLabels.method(:apply_filters)
         )
         render json: { data: records.map { |p| record_payload(p) }, meta: meta }
       end

--- a/services/console/app/controllers/api/v1/principals_controller.rb
+++ b/services/console/app/controllers/api/v1/principals_controller.rb
@@ -5,8 +5,9 @@ module Api
 
       def index
         records, meta = paginated_label_search(
-          Principal.includes(:slack_channel_permissions, roles: :slack_channel_permissions),
-          promoted_label_fields: Principal::PROMOTED_LABEL_FIELDS
+          Principal.includes(:console_user, :slack_channel_permissions, roles: :slack_channel_permissions),
+          promoted_label_fields: Principal::PROMOTED_LABEL_FIELDS,
+          promoted_label_decoder: Principal.method(:promoted_label_filter_value)
         )
         render json: { data: records.map { |p| record_payload(p) }, meta: meta }
       end

--- a/services/console/app/controllers/api/v1/principals_controller.rb
+++ b/services/console/app/controllers/api/v1/principals_controller.rb
@@ -6,7 +6,7 @@ module Api
       def index
         records, meta = paginated_label_search(
           Principal.includes(:slack_channel_permissions, roles: :slack_channel_permissions),
-          promoted_label_columns: Principal::PROMOTED_LABEL_FIELDS
+          promoted_label_fields: Principal::PROMOTED_LABEL_FIELDS
         )
         render json: { data: records.map { |p| record_payload(p) }, meta: meta }
       end

--- a/services/console/app/controllers/console_controller.rb
+++ b/services/console/app/controllers/console_controller.rb
@@ -21,7 +21,7 @@ class ConsoleController < ApplicationController
   }.freeze
 
   def principals
-    @principals = Principal.order(created_at: :asc, id: :asc)
+    @principals = Principal.includes(:console_user).order(created_at: :asc, id: :asc)
   end
 
   def principal

--- a/services/console/app/controllers/mcp/oauth_controller.rb
+++ b/services/console/app/controllers/mcp/oauth_controller.rb
@@ -453,7 +453,7 @@ module Mcp
         principal.created_by ||= current_user
         principal.name = current_user.name.presence || current_user.email
         principal.kind = "console_user"
-        principal.console_user_id = current_user.oid
+        principal.console_user_id = current_user.id
         principal.console_user_email = current_user.email
         principal.assign_attributes(slack_identity_fields_for(current_user))
         principal.labels = principal.labels.merge(

--- a/services/console/app/controllers/mcp/oauth_controller.rb
+++ b/services/console/app/controllers/mcp/oauth_controller.rb
@@ -453,11 +453,11 @@ module Mcp
         principal.created_by ||= current_user
         principal.name = current_user.name.presence || current_user.email
         principal.kind = "console_user"
+        principal.console_user_id = current_user.oid
+        principal.console_user_email = current_user.email
         principal.assign_attributes(slack_identity_fields_for(current_user))
         principal.labels = principal.labels.merge(
-          "managed-by" => "centaur",
-          "console-user-id" => current_user.oid,
-          "email" => current_user.email
+          "managed-by" => "centaur"
         )
         principal.save!
         assign_user_mcp_role(principal) if newly_created

--- a/services/console/app/models/pg_dsn_secret.rb
+++ b/services/console/app/models/pg_dsn_secret.rb
@@ -103,9 +103,8 @@ class PgDsnSecret < ApplicationRecord
 
     label = ref["principal_label"] || ref[:principal_label]
     if label.present?
-      promoted_field = Principal.promoted_label_fields_for(principal&.kind)[label.to_s]
-      if promoted_field
-        return principal&.promoted_label_value(label).to_s
+      if PrincipalIdentityLabels.promoted?(principal, label)
+        return PrincipalIdentityLabels.value(principal, label).to_s
       end
 
       return principal&.labels&.fetch(label.to_s, "").to_s

--- a/services/console/app/models/pg_dsn_secret.rb
+++ b/services/console/app/models/pg_dsn_secret.rb
@@ -103,8 +103,9 @@ class PgDsnSecret < ApplicationRecord
 
     label = ref["principal_label"] || ref[:principal_label]
     if label.present?
-      if Principal::PROMOTED_LABEL_FIELDS.include?(label.to_s)
-        return principal&.public_send(label).to_s
+      promoted_field = Principal.promoted_label_fields_for(principal&.kind)[label.to_s]
+      if promoted_field
+        return principal&.public_send(promoted_field).to_s
       end
 
       return principal&.labels&.fetch(label.to_s, "").to_s

--- a/services/console/app/models/pg_dsn_secret.rb
+++ b/services/console/app/models/pg_dsn_secret.rb
@@ -105,7 +105,7 @@ class PgDsnSecret < ApplicationRecord
     if label.present?
       promoted_field = Principal.promoted_label_fields_for(principal&.kind)[label.to_s]
       if promoted_field
-        return principal&.public_send(promoted_field).to_s
+        return principal&.promoted_label_value(label).to_s
       end
 
       return principal&.labels&.fetch(label.to_s, "").to_s

--- a/services/console/app/models/principal.rb
+++ b/services/console/app/models/principal.rb
@@ -65,7 +65,6 @@ class Principal < ApplicationRecord
                             allow_nil: true, if: :will_save_change_to_slack_team_id?
   validates :slack_email, format: { with: URI::MailTo::EMAIL_REGEXP, message: "is not a valid email address" },
                           allow_nil: true, if: :will_save_change_to_slack_email?
-  validates :console_user_id, presence: true, if: -> { kind == "console_user" }
   validates :console_user_email, format: { with: URI::MailTo::EMAIL_REGEXP, message: "is not a valid email address" },
                                  allow_nil: true, if: :will_save_change_to_console_user_email?
 

--- a/services/console/app/models/principal.rb
+++ b/services/console/app/models/principal.rb
@@ -37,10 +37,19 @@ class Principal < ApplicationRecord
     unknown user console_user workflow slack_channel slack_dm discord_channel linear_issue
     teams_user teams_conversation
   ].freeze
-  PROMOTED_LABEL_FIELDS = %w[kind slack_user_id slack_channel_id slack_team_id slack_email].freeze
+  PROMOTED_LABEL_FIELDS = {
+    "kind" => "kind",
+    "slack_user_id" => "slack_user_id",
+    "slack_channel_id" => "slack_channel_id",
+    "slack_team_id" => "slack_team_id",
+    "slack_email" => "slack_email",
+    "console-user-id" => "console_user_id",
+    "email" => "console_user_email"
+  }.freeze
   SLACK_USER_ID_FORMAT = /\A(?:[UW][A-Z0-9]{8,}|USLACK)\z/
   SLACK_CHANNEL_ID_FORMAT = /\A[CDG][A-Z0-9]{8,}\z/
   SLACK_TEAM_ID_FORMAT = /\A[TE][A-Z0-9]{8,}\z/
+  CONSOLE_USER_ID_FORMAT = /\Ausr_[A-Za-z0-9]{8,}\z/
 
   validates :namespace, presence: true, format: { with: URL_SAFE_FORMAT, message: URL_SAFE_MESSAGE }
   validates :foreign_id, uniqueness: { scope: :namespace, allow_nil: true },
@@ -56,6 +65,11 @@ class Principal < ApplicationRecord
                             allow_nil: true, if: :will_save_change_to_slack_team_id?
   validates :slack_email, format: { with: URI::MailTo::EMAIL_REGEXP, message: "is not a valid email address" },
                           allow_nil: true, if: :will_save_change_to_slack_email?
+  validates :console_user_id,
+            format: { with: CONSOLE_USER_ID_FORMAT, message: "is not a valid console user ID" },
+            allow_nil: true, if: :will_save_change_to_console_user_id?
+  validates :console_user_email, format: { with: URI::MailTo::EMAIL_REGEXP, message: "is not a valid email address" },
+                                 allow_nil: true, if: :will_save_change_to_console_user_email?
 
   # Stand-in for an inline secret value in redacted config: operator inspection
   # reports that a control_plane source carries a value without revealing it.
@@ -124,8 +138,8 @@ class Principal < ApplicationRecord
   end
 
   def labels_with_sandbox_capabilities
-    compatibility_labels = PROMOTED_LABEL_FIELDS.to_h do |field|
-      [ field, public_send(field) ]
+    compatibility_labels = self.class.promoted_label_fields_for(kind).to_h do |label, field|
+      [ label, public_send(field) ]
     end.compact
 
     labels.to_h.merge(
@@ -208,6 +222,12 @@ class Principal < ApplicationRecord
     scopes.compact.reduce(none) { |combined, scope| combined.or(scope) }
   end
 
+  def self.promoted_label_fields_for(kind)
+    return PROMOTED_LABEL_FIELDS if kind == "console_user"
+
+    PROMOTED_LABEL_FIELDS.reject { |_label, field| field.start_with?("console_user_") }
+  end
+
   # Deep-walk a config payload and blank out the inline value of every
   # control_plane source, leaving the rest of the structure intact.
   def self.redact_live_secrets(value)
@@ -252,16 +272,23 @@ class Principal < ApplicationRecord
   def promote_identity_labels_to_fields
     return unless will_save_change_to_labels?
 
-    PROMOTED_LABEL_FIELDS.each do |field|
-      next if will_save_change_to_attribute?(field) || !labels.to_h.key?(field)
+    promote_identity_label("kind", "kind")
+    self.class.promoted_label_fields_for(kind).each do |label, field|
+      next if field == "kind"
 
-      value = labels.to_h[field]
-      self[field] = field == "kind" ? value : value.presence
+      promote_identity_label(label, field)
     end
   end
 
   def strip_identity_labels
-    self[:labels] = labels.to_h.except(*PROMOTED_LABEL_FIELDS)
+    self[:labels] = labels.to_h.except(*self.class.promoted_label_fields_for(kind).keys)
+  end
+
+  def promote_identity_label(label, field)
+    return if will_save_change_to_attribute?(field) || !labels.to_h.key?(label)
+
+    value = labels.to_h[label]
+    self[field] = field == "kind" ? value : value.presence
   end
 
   def supplied_key?(attributes, key)
@@ -356,7 +383,8 @@ class Principal < ApplicationRecord
   end
 
   def sync_config_fields_changed?
-    ([ "name", "labels", "sandbox_api_server_enabled" ] + PROMOTED_LABEL_FIELDS).any? do |field|
+    identity_fields = PROMOTED_LABEL_FIELDS.values
+    ([ "name", "labels", "sandbox_api_server_enabled" ] + identity_fields).any? do |field|
       previous_changes.key?(field)
     end
   end

--- a/services/console/app/models/principal.rb
+++ b/services/console/app/models/principal.rb
@@ -18,6 +18,7 @@ class Principal < ApplicationRecord
   has_many :mcp_oauth_authorization_codes, dependent: :destroy
   has_many :mcp_oauth_refresh_tokens, dependent: :destroy
   belongs_to :created_by, class_name: "User"
+  belongs_to :console_user, class_name: "User", optional: true
 
   include SlackChannelPermissionOwner
 
@@ -49,7 +50,6 @@ class Principal < ApplicationRecord
   SLACK_USER_ID_FORMAT = /\A(?:[UW][A-Z0-9]{8,}|USLACK)\z/
   SLACK_CHANNEL_ID_FORMAT = /\A[CDG][A-Z0-9]{8,}\z/
   SLACK_TEAM_ID_FORMAT = /\A[TE][A-Z0-9]{8,}\z/
-  CONSOLE_USER_ID_FORMAT = /\Ausr_[A-Za-z0-9]{8,}\z/
 
   validates :namespace, presence: true, format: { with: URL_SAFE_FORMAT, message: URL_SAFE_MESSAGE }
   validates :foreign_id, uniqueness: { scope: :namespace, allow_nil: true },
@@ -65,9 +65,7 @@ class Principal < ApplicationRecord
                             allow_nil: true, if: :will_save_change_to_slack_team_id?
   validates :slack_email, format: { with: URI::MailTo::EMAIL_REGEXP, message: "is not a valid email address" },
                           allow_nil: true, if: :will_save_change_to_slack_email?
-  validates :console_user_id,
-            format: { with: CONSOLE_USER_ID_FORMAT, message: "is not a valid console user ID" },
-            allow_nil: true, if: :will_save_change_to_console_user_id?
+  validates :console_user_id, presence: true, if: -> { kind == "console_user" }
   validates :console_user_email, format: { with: URI::MailTo::EMAIL_REGEXP, message: "is not a valid email address" },
                                  allow_nil: true, if: :will_save_change_to_console_user_email?
 
@@ -138,8 +136,8 @@ class Principal < ApplicationRecord
   end
 
   def labels_with_sandbox_capabilities
-    compatibility_labels = self.class.promoted_label_fields_for(kind).to_h do |label, field|
-      [ label, public_send(field) ]
+    compatibility_labels = self.class.promoted_label_fields_for(kind).to_h do |label, _field|
+      [ label, promoted_label_value(label) ]
     end.compact
 
     labels.to_h.merge(
@@ -228,6 +226,20 @@ class Principal < ApplicationRecord
     PROMOTED_LABEL_FIELDS.reject { |_label, field| field.start_with?("console_user_") }
   end
 
+  def self.promoted_label_filter_value(label, value)
+    return User.decode_oid(value) if label.to_s == "console-user-id"
+
+    value.to_s
+  end
+
+  def promoted_label_value(label)
+    field = self.class.promoted_label_fields_for(kind)[label.to_s]
+    return unless field
+    return console_user&.oid if field == "console_user_id"
+
+    public_send(field)
+  end
+
   # Deep-walk a config payload and blank out the inline value of every
   # control_plane source, leaving the rest of the structure intact.
   def self.redact_live_secrets(value)
@@ -288,7 +300,13 @@ class Principal < ApplicationRecord
     return if will_save_change_to_attribute?(field) || !labels.to_h.key?(label)
 
     value = labels.to_h[label]
-    self[field] = field == "kind" ? value : value.presence
+    self[field] = if field == "kind"
+      value
+    elsif field == "console_user_id"
+      User.find_by_oid(value)&.id
+    else
+      value.presence
+    end
   end
 
   def supplied_key?(attributes, key)

--- a/services/console/app/models/principal.rb
+++ b/services/console/app/models/principal.rb
@@ -38,15 +38,6 @@ class Principal < ApplicationRecord
     unknown user console_user workflow slack_channel slack_dm discord_channel linear_issue
     teams_user teams_conversation
   ].freeze
-  PROMOTED_LABEL_FIELDS = {
-    "kind" => "kind",
-    "slack_user_id" => "slack_user_id",
-    "slack_channel_id" => "slack_channel_id",
-    "slack_team_id" => "slack_team_id",
-    "slack_email" => "slack_email",
-    "console-user-id" => "console_user_id",
-    "email" => "console_user_email"
-  }.freeze
   SLACK_USER_ID_FORMAT = /\A(?:[UW][A-Z0-9]{8,}|USLACK)\z/
   SLACK_CHANNEL_ID_FORMAT = /\A[CDG][A-Z0-9]{8,}\z/
   SLACK_TEAM_ID_FORMAT = /\A[TE][A-Z0-9]{8,}\z/
@@ -135,12 +126,8 @@ class Principal < ApplicationRecord
   end
 
   def labels_with_sandbox_capabilities
-    compatibility_labels = self.class.promoted_label_fields_for(kind).to_h do |label, _field|
-      [ label, promoted_label_value(label) ]
-    end.compact
-
     labels.to_h.merge(
-      compatibility_labels,
+      PrincipalIdentityLabels.serialize(self),
       SANDBOX_REPO_CACHE_LABEL => sandbox_repo_cache
     )
   end
@@ -219,26 +206,6 @@ class Principal < ApplicationRecord
     scopes.compact.reduce(none) { |combined, scope| combined.or(scope) }
   end
 
-  def self.promoted_label_fields_for(kind)
-    return PROMOTED_LABEL_FIELDS if kind == "console_user"
-
-    PROMOTED_LABEL_FIELDS.reject { |_label, field| field.start_with?("console_user_") }
-  end
-
-  def self.promoted_label_filter_value(label, value)
-    return User.decode_oid(value) if label.to_s == "console-user-id"
-
-    value.to_s
-  end
-
-  def promoted_label_value(label)
-    field = self.class.promoted_label_fields_for(kind)[label.to_s]
-    return unless field
-    return console_user&.oid if field == "console_user_id"
-
-    public_send(field)
-  end
-
   # Deep-walk a config payload and blank out the inline value of every
   # control_plane source, leaving the rest of the structure intact.
   def self.redact_live_secrets(value)
@@ -281,31 +248,11 @@ class Principal < ApplicationRecord
   # compatibility release. Promote only fields that were not assigned directly.
   # Reserved identity labels are stripped below so columns remain authoritative.
   def promote_identity_labels_to_fields
-    return unless will_save_change_to_labels?
-
-    promote_identity_label("kind", "kind")
-    self.class.promoted_label_fields_for(kind).each do |label, field|
-      next if field == "kind"
-
-      promote_identity_label(label, field)
-    end
+    PrincipalIdentityLabels.assign(self)
   end
 
   def strip_identity_labels
-    self[:labels] = labels.to_h.except(*self.class.promoted_label_fields_for(kind).keys)
-  end
-
-  def promote_identity_label(label, field)
-    return if will_save_change_to_attribute?(field) || !labels.to_h.key?(label)
-
-    value = labels.to_h[label]
-    self[field] = if field == "kind"
-      value
-    elsif field == "console_user_id"
-      User.find_by_oid(value)&.id
-    else
-      value.presence
-    end
+    PrincipalIdentityLabels.strip(self)
   end
 
   def supplied_key?(attributes, key)
@@ -400,7 +347,7 @@ class Principal < ApplicationRecord
   end
 
   def sync_config_fields_changed?
-    identity_fields = PROMOTED_LABEL_FIELDS.values
+    identity_fields = PrincipalIdentityLabels.columns
     ([ "name", "labels", "sandbox_api_server_enabled" ] + identity_fields).any? do |field|
       previous_changes.key?(field)
     end

--- a/services/console/app/services/principal_credential_reconciliation.rb
+++ b/services/console/app/services/principal_credential_reconciliation.rb
@@ -33,7 +33,6 @@ class PrincipalCredentialReconciliation
   # provider-subject labels, which would widen the trust boundary beyond the
   # authenticated user.
   CONSOLE_USER_KIND = "console_user"
-  CONSOLE_USER_ID_LABEL = "console-user-id"
   SLACK_PROVIDER = Oauth::Providers::Slack::KEY
   GOOGLE_PROVIDER = Oauth::Providers::Google::KEY
   EMAIL_LABELS = %w[email google_email].freeze
@@ -338,7 +337,7 @@ class PrincipalCredentialReconciliation
   # Unverified emails are excluded: an unverified address must not adopt
   # someone else's credentials.
   def console_user_emails(principal)
-    user_oid = principal.labels&.[](CONSOLE_USER_ID_LABEL)
+    user_oid = principal.console_user_id
     return [] if user_oid.blank?
 
     @console_user_emails ||= {}

--- a/services/console/app/services/principal_credential_reconciliation.rb
+++ b/services/console/app/services/principal_credential_reconciliation.rb
@@ -331,24 +331,24 @@ class PrincipalCredentialReconciliation
       .uniq
   end
 
-  # Console-user principals carry the console user's oid, so every verified
+  # Console-user principals reference the console user's database row, so every verified
   # identity email of that user participates in matching -- a credential
   # registered under a secondary verified email still reaches the principal.
   # Unverified emails are excluded: an unverified address must not adopt
   # someone else's credentials.
   def console_user_emails(principal)
-    user_oid = principal.console_user_id
-    return [] if user_oid.blank?
+    user_id = principal.console_user_id
+    return [] if user_id.blank?
 
     @console_user_emails ||= {}
-    @console_user_emails.fetch(user_oid) do
-      user = User.find_by_oid(user_oid)
+    @console_user_emails.fetch(user_id) do
+      user = User.find_by(id: user_id)
       emails = if user
         [ user.email ] + user.user_identities.where(email_verified: true).pluck(:email)
       else
         []
       end
-      @console_user_emails[user_oid] = emails
+      @console_user_emails[user_id] = emails
     end
   end
 

--- a/services/console/app/services/principal_identity_labels.rb
+++ b/services/console/app/services/principal_identity_labels.rb
@@ -1,0 +1,106 @@
+class PrincipalIdentityLabels
+  FIELDS = {
+    "kind" => { column: "kind" }.freeze,
+    "slack_user_id" => { column: "slack_user_id" }.freeze,
+    "slack_channel_id" => { column: "slack_channel_id" }.freeze,
+    "slack_team_id" => { column: "slack_team_id" }.freeze,
+    "slack_email" => { column: "slack_email" }.freeze,
+    "console-user-id" => { column: "console_user_id", kind: "console_user" }.freeze,
+    "email" => { column: "console_user_email", kind: "console_user" }.freeze
+  }.freeze
+
+  class << self
+    def columns
+      FIELDS.values.map { |field| field.fetch(:column) }.uniq
+    end
+
+    def labels_for(kind)
+      fields_for(kind).keys
+    end
+
+    def serialize(principal)
+      fields_for(principal.kind).keys.to_h do |label|
+        [ label, value(principal, label) ]
+      end.compact
+    end
+
+    def assign(principal)
+      return unless principal.will_save_change_to_labels?
+
+      assign_label(principal, "kind")
+      fields_for(principal.kind).each_key do |label|
+        assign_label(principal, label) unless label == "kind"
+      end
+    end
+
+    def strip(principal)
+      principal[:labels] = principal.labels.to_h.except(*labels_for(principal.kind))
+    end
+
+    def promoted?(principal, label)
+      fields_for(principal&.kind).key?(label.to_s)
+    end
+
+    def value(principal, label)
+      return unless principal
+
+      field = fields_for(principal.kind)[label.to_s]
+      return unless field
+      return principal.console_user&.oid if field.fetch(:column) == "console_user_id"
+
+      principal.public_send(field.fetch(:column))
+    end
+
+    def apply_filters(scope, labels)
+      remaining = labels.dup
+      filtered = FIELDS.reduce(scope) do |relation, (label, field)|
+        value = remaining.delete(label)
+        next relation if value.blank?
+
+        table = scope.connection.quote_table_name(scope.table_name)
+        column = scope.connection.quote_column_name(field.fetch(:column))
+        stored_value = decode_filter_value(label, value)
+        label_filter = { label => value }.to_json
+        relation.where(filter_sql(table, column, stored_value), *filter_values(stored_value, label_filter))
+      end
+
+      remaining.any? ? filtered.where("labels @> ?", remaining.to_json) : filtered
+    end
+
+    private
+
+    def fields_for(kind)
+      FIELDS.select { |_label, field| field[:kind].nil? || field[:kind] == kind }
+    end
+
+    def assign_label(principal, label)
+      field = FIELDS.fetch(label).fetch(:column)
+      return if principal.will_save_change_to_attribute?(field) || !principal.labels.to_h.key?(label)
+
+      principal[field] = decode_assignment_value(label, principal.labels.to_h[label])
+    end
+
+    def decode_assignment_value(label, value)
+      return value if label == "kind"
+      return User.find_by_oid(value)&.id if label == "console-user-id"
+
+      value.presence
+    end
+
+    def decode_filter_value(label, value)
+      return User.decode_oid(value) if label == "console-user-id"
+
+      value.to_s
+    end
+
+    def filter_sql(table, column, stored_value)
+      return "#{table}.labels @> ?" if stored_value.nil?
+
+      "#{table}.#{column} = ? OR #{table}.labels @> ?"
+    end
+
+    def filter_values(stored_value, label_filter)
+      stored_value.nil? ? [ label_filter ] : [ stored_value, label_filter ]
+    end
+  end
+end

--- a/services/console/db/migrate/20260802170149_add_console_user_identity_fields_to_principals.rb
+++ b/services/console/db/migrate/20260802170149_add_console_user_identity_fields_to_principals.rb
@@ -1,6 +1,4 @@
 class AddConsoleUserIdentityFieldsToPrincipals < ActiveRecord::Migration[8.1]
-  CONSOLE_USER_ID_CHECK = "chk_principals_console_user_id".freeze
-
   class BackfillPrincipal < ActiveRecord::Base
     self.table_name = "principals"
   end
@@ -24,14 +22,6 @@ class AddConsoleUserIdentityFieldsToPrincipals < ActiveRecord::Migration[8.1]
       labels = principal.labels.to_h
       [ principal, labels, console_user_id_from_oid(labels["console-user-id"]) ]
     end
-    stale_principal_ids = backfills.filter_map do |principal, _labels, console_user_id|
-      principal.id unless console_user_id
-    end
-    if stale_principal_ids.any?
-      raise ActiveRecord::MigrationError,
-            "console-user principals reference missing users: #{stale_principal_ids.join(", ")}"
-    end
-
     backfills.each do |principal, labels, console_user_id|
       principal.update_columns(
         console_user_id: console_user_id,
@@ -41,13 +31,9 @@ class AddConsoleUserIdentityFieldsToPrincipals < ActiveRecord::Migration[8.1]
     end
 
     add_foreign_key :principals, :users, column: :console_user_id
-    add_check_constraint :principals,
-                         "kind <> 'console_user' OR console_user_id IS NOT NULL",
-                         name: CONSOLE_USER_ID_CHECK
   end
 
   def down
-    remove_check_constraint :principals, name: CONSOLE_USER_ID_CHECK, if_exists: true
     remove_foreign_key :principals, column: :console_user_id, if_exists: true
 
     BackfillPrincipal.reset_column_information

--- a/services/console/db/migrate/20260802170149_add_console_user_identity_fields_to_principals.rb
+++ b/services/console/db/migrate/20260802170149_add_console_user_identity_fields_to_principals.rb
@@ -1,40 +1,81 @@
 class AddConsoleUserIdentityFieldsToPrincipals < ActiveRecord::Migration[8.1]
-  CONSOLE_USER_ID_SQL = "labels ->> 'console-user-id'".freeze
-  CONSOLE_USER_EMAIL_SQL = "labels ->> 'email'".freeze
-  ORDINARY_LABELS_SQL = "labels - 'console-user-id' - 'email'".freeze
-  RESTORED_LABELS_SQL = <<~SQL.squish.freeze
-    labels || jsonb_strip_nulls(jsonb_build_object(
-      'console-user-id', console_user_id,
-      'email', console_user_email
-    ))
-  SQL
+  CONSOLE_USER_ID_CHECK = "chk_principals_console_user_id".freeze
+
+  class BackfillPrincipal < ActiveRecord::Base
+    self.table_name = "principals"
+  end
+
+  class BackfillUser < ActiveRecord::Base
+    self.table_name = "users"
+
+    include OpaqueId
+    oid_prefix "usr"
+  end
 
   def up
-    add_column :principals, :console_user_id, :string
+    add_column :principals, :console_user_id, :bigint
     add_column :principals, :console_user_email, :string
 
     add_index :principals, [ :namespace, :console_user_id ]
     add_index :principals, [ :namespace, :console_user_email ]
 
-    execute <<~SQL.squish
-      UPDATE principals
-      SET console_user_id = #{CONSOLE_USER_ID_SQL},
-          console_user_email = #{CONSOLE_USER_EMAIL_SQL},
-          labels = #{ORDINARY_LABELS_SQL}
-      WHERE kind = 'console_user'
-    SQL
+    BackfillPrincipal.reset_column_information
+    backfills = BackfillPrincipal.where(kind: "console_user").map do |principal|
+      labels = principal.labels.to_h
+      [ principal, labels, console_user_id_from_oid(labels["console-user-id"]) ]
+    end
+    stale_principal_ids = backfills.filter_map do |principal, _labels, console_user_id|
+      principal.id unless console_user_id
+    end
+    if stale_principal_ids.any?
+      raise ActiveRecord::MigrationError,
+            "console-user principals reference missing users: #{stale_principal_ids.join(", ")}"
+    end
+
+    backfills.each do |principal, labels, console_user_id|
+      principal.update_columns(
+        console_user_id: console_user_id,
+        console_user_email: labels["email"],
+        labels: ordinary_labels(labels)
+      )
+    end
+
+    add_foreign_key :principals, :users, column: :console_user_id
+    add_check_constraint :principals,
+                         "kind <> 'console_user' OR console_user_id IS NOT NULL",
+                         name: CONSOLE_USER_ID_CHECK
   end
 
   def down
-    execute <<~SQL.squish
-      UPDATE principals
-      SET labels = #{RESTORED_LABELS_SQL}
-      WHERE kind = 'console_user'
-    SQL
+    remove_check_constraint :principals, name: CONSOLE_USER_ID_CHECK, if_exists: true
+    remove_foreign_key :principals, column: :console_user_id, if_exists: true
+
+    BackfillPrincipal.reset_column_information
+    BackfillPrincipal.where(kind: "console_user").find_each do |principal|
+      labels = principal.labels.to_h
+      console_user_oid = console_user_oid_from_id(principal.console_user_id)
+      labels["console-user-id"] = console_user_oid if console_user_oid
+      labels["email"] = principal.console_user_email unless principal.console_user_email.nil?
+      principal.update_columns(labels: labels)
+    end
 
     remove_index :principals, [ :namespace, :console_user_email ], if_exists: true
     remove_index :principals, [ :namespace, :console_user_id ], if_exists: true
     remove_column :principals, :console_user_email, if_exists: true
     remove_column :principals, :console_user_id, if_exists: true
+  end
+
+  private
+
+  def console_user_id_from_oid(oid)
+    BackfillUser.find_by_oid(oid)&.id
+  end
+
+  def console_user_oid_from_id(id)
+    BackfillUser.find_by(id: id)&.oid
+  end
+
+  def ordinary_labels(labels)
+    labels.except("console-user-id", "email")
   end
 end

--- a/services/console/db/migrate/20260802170149_add_console_user_identity_fields_to_principals.rb
+++ b/services/console/db/migrate/20260802170149_add_console_user_identity_fields_to_principals.rb
@@ -1,0 +1,40 @@
+class AddConsoleUserIdentityFieldsToPrincipals < ActiveRecord::Migration[8.1]
+  CONSOLE_USER_ID_SQL = "labels ->> 'console-user-id'".freeze
+  CONSOLE_USER_EMAIL_SQL = "labels ->> 'email'".freeze
+  ORDINARY_LABELS_SQL = "labels - 'console-user-id' - 'email'".freeze
+  RESTORED_LABELS_SQL = <<~SQL.squish.freeze
+    labels || jsonb_strip_nulls(jsonb_build_object(
+      'console-user-id', console_user_id,
+      'email', console_user_email
+    ))
+  SQL
+
+  def up
+    add_column :principals, :console_user_id, :string
+    add_column :principals, :console_user_email, :string
+
+    add_index :principals, [ :namespace, :console_user_id ]
+    add_index :principals, [ :namespace, :console_user_email ]
+
+    execute <<~SQL.squish
+      UPDATE principals
+      SET console_user_id = #{CONSOLE_USER_ID_SQL},
+          console_user_email = #{CONSOLE_USER_EMAIL_SQL},
+          labels = #{ORDINARY_LABELS_SQL}
+      WHERE kind = 'console_user'
+    SQL
+  end
+
+  def down
+    execute <<~SQL.squish
+      UPDATE principals
+      SET labels = #{RESTORED_LABELS_SQL}
+      WHERE kind = 'console_user'
+    SQL
+
+    remove_index :principals, [ :namespace, :console_user_email ], if_exists: true
+    remove_index :principals, [ :namespace, :console_user_id ], if_exists: true
+    remove_column :principals, :console_user_email, if_exists: true
+    remove_column :principals, :console_user_id, if_exists: true
+  end
+end

--- a/services/console/db/schema.rb
+++ b/services/console/db/schema.rb
@@ -332,7 +332,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_02_170149) do
     t.index ["namespace", "slack_email"], name: "index_principals_on_namespace_and_slack_email"
     t.index ["namespace", "slack_team_id"], name: "index_principals_on_namespace_and_slack_team_id"
     t.index ["namespace", "slack_user_id"], name: "index_principals_on_namespace_and_slack_user_id"
-    t.check_constraint "kind::text <> 'console_user'::text OR console_user_id IS NOT NULL", name: "chk_principals_console_user_id"
   end
 
   create_table "proxies", force: :cascade do |t|

--- a/services/console/db/schema.rb
+++ b/services/console/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_02_022347) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_02_170149) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -304,6 +304,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_02_022347) do
   end
 
   create_table "principals", force: :cascade do |t|
+    t.string "console_user_email"
+    t.string "console_user_id"
     t.datetime "created_at", null: false
     t.bigint "created_by_id", null: false
     t.string "foreign_id"
@@ -322,6 +324,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_02_022347) do
     t.datetime "updated_at", null: false
     t.index ["created_by_id"], name: "index_principals_on_created_by_id"
     t.index ["labels"], name: "index_principals_on_labels", using: :gin
+    t.index ["namespace", "console_user_email"], name: "index_principals_on_namespace_and_console_user_email"
+    t.index ["namespace", "console_user_id"], name: "index_principals_on_namespace_and_console_user_id"
     t.index ["namespace", "foreign_id"], name: "index_principals_on_namespace_and_foreign_id", unique: true
     t.index ["namespace", "kind"], name: "index_principals_on_namespace_and_kind"
     t.index ["namespace", "slack_channel_id"], name: "index_principals_on_namespace_and_slack_channel_id"

--- a/services/console/db/schema.rb
+++ b/services/console/db/schema.rb
@@ -305,7 +305,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_02_170149) do
 
   create_table "principals", force: :cascade do |t|
     t.string "console_user_email"
-    t.string "console_user_id"
+    t.bigint "console_user_id"
     t.datetime "created_at", null: false
     t.bigint "created_by_id", null: false
     t.string "foreign_id"
@@ -332,6 +332,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_02_170149) do
     t.index ["namespace", "slack_email"], name: "index_principals_on_namespace_and_slack_email"
     t.index ["namespace", "slack_team_id"], name: "index_principals_on_namespace_and_slack_team_id"
     t.index ["namespace", "slack_user_id"], name: "index_principals_on_namespace_and_slack_user_id"
+    t.check_constraint "kind::text <> 'console_user'::text OR console_user_id IS NOT NULL", name: "chk_principals_console_user_id"
   end
 
   create_table "proxies", force: :cascade do |t|
@@ -520,6 +521,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_02_170149) do
   add_foreign_key "principal_roles", "principals"
   add_foreign_key "principal_roles", "roles"
   add_foreign_key "principal_sync_config_snapshots", "principals"
+  add_foreign_key "principals", "users", column: "console_user_id"
   add_foreign_key "principals", "users", column: "created_by_id"
   add_foreign_key "proxies", "principals", on_delete: :nullify
   add_foreign_key "request_rules", "aws_auth_secrets"

--- a/services/console/docs/API.md
+++ b/services/console/docs/API.md
@@ -1193,7 +1193,7 @@ system-managed `default/infra` role.
 | `namespace`  | optional    | Defaults to `"default"`. Immutable. |
 | `foreign_id` | optional    | Unique per namespace. Immutable. |
 | `name`       | optional    | |
-| `labels`     | optional    | Identity values remain represented here in this API version. Reserved keys are `kind`, `slack_user_id`, `slack_channel_id`, `slack_team_id`, and `slack_email`. |
+| `labels`     | optional    | Identity values remain represented here in this API version. Reserved keys are `kind`, `slack_user_id`, `slack_channel_id`, `slack_team_id`, and `slack_email`. For `console_user` principals, `console-user-id` and `email` are also reserved. |
 | `slack_channel_permissions` | optional | Direct permissions owned by the principal. Full replacement when present on create or update. |
 | `effective_slack_channel_permissions` | response only | Direct permissions merged with permissions inherited from assigned roles. |
 

--- a/services/console/test/controllers/api/v1/principals_controller_test.rb
+++ b/services/console/test/controllers/api/v1/principals_controller_test.rb
@@ -41,7 +41,7 @@ module Api
         assert_equal principal.oid, data["id"]
         assert_equal "acme", data["namespace"]
         assert_equal "C0123456789", data["foreign_id"]
-        Principal::PROMOTED_LABEL_FIELDS.each_value { |field| assert_not data.key?(field) }
+        PrincipalIdentityLabels.columns.each { |field| assert_not data.key?(field) }
         assert_equal(
           {
             "kind" => "slack_channel",
@@ -313,7 +313,7 @@ module Api
         principal = Principal.find_by!(namespace: "acme", foreign_id: "mixed-identity")
         assert_equal "user", principal.kind
         assert_nil principal.slack_email
-        Principal::PROMOTED_LABEL_FIELDS.each_value do |field|
+        PrincipalIdentityLabels.columns.each do |field|
           assert_not json_body.fetch("data").key?(field)
         end
       end
@@ -546,7 +546,7 @@ module Api
         assert_equal "TACME", principal.slack_team_id
         assert_equal "pending", principal.slack_email
         assert_equal "identity-platform", principal.labels["team"]
-        assert_empty principal.labels.slice(*Principal::PROMOTED_LABEL_FIELDS.keys)
+        assert_empty principal.labels.slice(*PrincipalIdentityLabels.labels_for(principal.kind))
       end
 
       test "POST leaves omitted flags unchanged on an existing permission" do

--- a/services/console/test/controllers/api/v1/principals_controller_test.rb
+++ b/services/console/test/controllers/api/v1/principals_controller_test.rb
@@ -41,7 +41,7 @@ module Api
         assert_equal principal.oid, data["id"]
         assert_equal "acme", data["namespace"]
         assert_equal "C0123456789", data["foreign_id"]
-        Principal::PROMOTED_LABEL_FIELDS.each { |field| assert_not data.key?(field) }
+        Principal::PROMOTED_LABEL_FIELDS.each_value { |field| assert_not data.key?(field) }
         assert_equal(
           {
             "kind" => "slack_channel",
@@ -313,7 +313,9 @@ module Api
         principal = Principal.find_by!(namespace: "acme", foreign_id: "mixed-identity")
         assert_equal "user", principal.kind
         assert_nil principal.slack_email
-        Principal::PROMOTED_LABEL_FIELDS.each { |field| assert_not json_body.fetch("data").key?(field) }
+        Principal::PROMOTED_LABEL_FIELDS.each_value do |field|
+          assert_not json_body.fetch("data").key?(field)
+        end
       end
 
       test "PUT updates labels" do
@@ -544,7 +546,7 @@ module Api
         assert_equal "TACME", principal.slack_team_id
         assert_equal "pending", principal.slack_email
         assert_equal "identity-platform", principal.labels["team"]
-        assert_empty principal.labels.slice(*Principal::PROMOTED_LABEL_FIELDS)
+        assert_empty principal.labels.slice(*Principal::PROMOTED_LABEL_FIELDS.keys)
       end
 
       test "POST leaves omitted flags unchanged on an existing permission" do
@@ -896,6 +898,52 @@ module Api
         assert_response :ok
 
         assert_equal [ "C0123456789" ], json_body.fetch("data").map { |p| p["foreign_id"] }
+      end
+
+      test "GET index filters console user compatibility labels through columns" do
+        user = users(:acme_admin)
+        Principal.create!(
+          namespace: "acme",
+          foreign_id: "console-user-admin",
+          kind: "console_user",
+          console_user_id: user.oid,
+          console_user_email: user.email,
+          created_by: user
+        )
+
+        get api_v1_principals_url,
+            params: {
+              namespace: "acme",
+              labels: {
+                kind: "console_user",
+                "console-user-id" => user.oid,
+                email: user.email
+              }
+            },
+            headers: auth_headers
+        assert_response :ok
+
+        data = json_body.fetch("data")
+        assert_equal [ "console-user-admin" ], data.map { |p| p["foreign_id"] }
+        assert_equal user.oid, data.first.dig("labels", "console-user-id")
+        assert_equal user.email, data.first.dig("labels", "email")
+      end
+
+      test "GET index still filters ordinary email labels" do
+        Principal.create!(
+          namespace: "acme",
+          foreign_id: "ordinary-email-principal",
+          kind: "user",
+          labels: { "email" => "ordinary@example.com" },
+          created_by: users(:acme_admin)
+        )
+
+        get api_v1_principals_url,
+            params: { namespace: "acme", labels: { email: "ordinary@example.com" } },
+            headers: auth_headers
+        assert_response :ok
+
+        assert_equal [ "ordinary-email-principal" ], json_body.fetch("data").map { |p| p["foreign_id"] }
       end
 
       test "GET index filters by sandbox repo-cache label" do

--- a/services/console/test/controllers/api/v1/principals_controller_test.rb
+++ b/services/console/test/controllers/api/v1/principals_controller_test.rb
@@ -906,7 +906,7 @@ module Api
           namespace: "acme",
           foreign_id: "console-user-admin",
           kind: "console_user",
-          console_user_id: user.oid,
+          console_user_id: user.id,
           console_user_email: user.email,
           created_by: user
         )

--- a/services/console/test/controllers/mcp/oauth_controller_test.rb
+++ b/services/console/test/controllers/mcp/oauth_controller_test.rb
@@ -156,6 +156,10 @@ module Mcp
       assert_equal @operator, stored_code.user
       assert_equal "http://localhost:3000/mcp", stored_code.resource
       assert_match(/\Aprn_/, stored_code.principal.oid)
+      assert_equal "console_user", stored_code.principal.kind
+      assert_equal @operator.oid, stored_code.principal.console_user_id
+      assert_equal @operator.email, stored_code.principal.console_user_email
+      assert_empty stored_code.principal.labels.slice("console-user-id", "email")
 
       exchange_authorization_code(client, code)
 

--- a/services/console/test/controllers/mcp/oauth_controller_test.rb
+++ b/services/console/test/controllers/mcp/oauth_controller_test.rb
@@ -157,7 +157,7 @@ module Mcp
       assert_equal "http://localhost:3000/mcp", stored_code.resource
       assert_match(/\Aprn_/, stored_code.principal.oid)
       assert_equal "console_user", stored_code.principal.kind
-      assert_equal @operator.oid, stored_code.principal.console_user_id
+      assert_equal @operator.id, stored_code.principal.console_user_id
       assert_equal @operator.email, stored_code.principal.console_user_email
       assert_empty stored_code.principal.labels.slice("console-user-id", "email")
 

--- a/services/console/test/migrations/add_console_user_identity_fields_to_principals_test.rb
+++ b/services/console/test/migrations/add_console_user_identity_fields_to_principals_test.rb
@@ -2,44 +2,32 @@ require "test_helper"
 require Rails.root.join("db/migrate/20260802170149_add_console_user_identity_fields_to_principals")
 
 class AddConsoleUserIdentityFieldsToPrincipalsTest < ActiveSupport::TestCase
-  test "preserves console user identity values exactly regardless of format" do
+  test "decodes existing console user oids and rejects stale references" do
+    user = users(:acme_admin)
+    stale_oid = User.new(id: User.maximum(:id) + 1_000).oid
+    migration = AddConsoleUserIdentityFieldsToPrincipals.new
+
+    assert_equal user.id, migration.send(:console_user_id_from_oid, user.oid)
+    assert_nil migration.send(:console_user_id_from_oid, stale_oid)
+    assert_nil migration.send(:console_user_id_from_oid, "not-an-oid")
+  end
+
+  test "removes migrated identity values from labels" do
     labels = {
-      "console-user-id" => " stale-user-id ",
-      "email" => " pending ",
+      "console-user-id" => "usr_12345678",
+      "email" => "ada@example.com",
       "managed-by" => "centaur"
     }
-    row = connection.select_one(<<~SQL.squish)
-      SELECT
-        #{AddConsoleUserIdentityFieldsToPrincipals::CONSOLE_USER_ID_SQL} AS console_user_id,
-        #{AddConsoleUserIdentityFieldsToPrincipals::CONSOLE_USER_EMAIL_SQL} AS console_user_email,
-        #{AddConsoleUserIdentityFieldsToPrincipals::ORDINARY_LABELS_SQL} AS labels
-      FROM (VALUES (#{connection.quote(labels.to_json)}::jsonb)) AS principals(labels)
-    SQL
+    migration = AddConsoleUserIdentityFieldsToPrincipals.new
 
-    assert_equal " stale-user-id ", row.fetch("console_user_id")
-    assert_equal " pending ", row.fetch("console_user_email")
-    assert_equal({ "managed-by" => "centaur" }, JSON.parse(row.fetch("labels")))
+    assert_equal({ "managed-by" => "centaur" }, migration.send(:ordinary_labels, labels))
   end
 
-  test "restores console user identity columns to labels for rollback" do
-    labels = { "managed-by" => "centaur", "nullable" => nil }
-    restored = connection.select_value(<<~SQL.squish)
-      SELECT #{AddConsoleUserIdentityFieldsToPrincipals::RESTORED_LABELS_SQL}
-      FROM (VALUES (
-        #{connection.quote(labels.to_json)}::jsonb,
-        'usr_12345678', 'ada@example.com'
-      )) AS principals(labels, console_user_id, console_user_email)
-    SQL
+  test "encodes console user ids back to oids for rollback" do
+    user = users(:acme_admin)
+    migration = AddConsoleUserIdentityFieldsToPrincipals.new
 
-    assert_equal(
-      labels.merge("console-user-id" => "usr_12345678", "email" => "ada@example.com"),
-      JSON.parse(restored)
-    )
-  end
-
-  private
-
-  def connection
-    ActiveRecord::Base.connection
+    assert_equal user.oid, migration.send(:console_user_oid_from_id, user.id)
+    assert_nil migration.send(:console_user_oid_from_id, User.maximum(:id) + 1_000)
   end
 end

--- a/services/console/test/migrations/add_console_user_identity_fields_to_principals_test.rb
+++ b/services/console/test/migrations/add_console_user_identity_fields_to_principals_test.rb
@@ -1,0 +1,45 @@
+require "test_helper"
+require Rails.root.join("db/migrate/20260802170149_add_console_user_identity_fields_to_principals")
+
+class AddConsoleUserIdentityFieldsToPrincipalsTest < ActiveSupport::TestCase
+  test "preserves console user identity values exactly regardless of format" do
+    labels = {
+      "console-user-id" => " stale-user-id ",
+      "email" => " pending ",
+      "managed-by" => "centaur"
+    }
+    row = connection.select_one(<<~SQL.squish)
+      SELECT
+        #{AddConsoleUserIdentityFieldsToPrincipals::CONSOLE_USER_ID_SQL} AS console_user_id,
+        #{AddConsoleUserIdentityFieldsToPrincipals::CONSOLE_USER_EMAIL_SQL} AS console_user_email,
+        #{AddConsoleUserIdentityFieldsToPrincipals::ORDINARY_LABELS_SQL} AS labels
+      FROM (VALUES (#{connection.quote(labels.to_json)}::jsonb)) AS principals(labels)
+    SQL
+
+    assert_equal " stale-user-id ", row.fetch("console_user_id")
+    assert_equal " pending ", row.fetch("console_user_email")
+    assert_equal({ "managed-by" => "centaur" }, JSON.parse(row.fetch("labels")))
+  end
+
+  test "restores console user identity columns to labels for rollback" do
+    labels = { "managed-by" => "centaur", "nullable" => nil }
+    restored = connection.select_value(<<~SQL.squish)
+      SELECT #{AddConsoleUserIdentityFieldsToPrincipals::RESTORED_LABELS_SQL}
+      FROM (VALUES (
+        #{connection.quote(labels.to_json)}::jsonb,
+        'usr_12345678', 'ada@example.com'
+      )) AS principals(labels, console_user_id, console_user_email)
+    SQL
+
+    assert_equal(
+      labels.merge("console-user-id" => "usr_12345678", "email" => "ada@example.com"),
+      JSON.parse(restored)
+    )
+  end
+
+  private
+
+  def connection
+    ActiveRecord::Base.connection
+  end
+end

--- a/services/console/test/migrations/add_console_user_identity_fields_to_principals_test.rb
+++ b/services/console/test/migrations/add_console_user_identity_fields_to_principals_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 require Rails.root.join("db/migrate/20260802170149_add_console_user_identity_fields_to_principals")
 
 class AddConsoleUserIdentityFieldsToPrincipalsTest < ActiveSupport::TestCase
-  test "decodes existing console user oids and rejects stale references" do
+  test "decodes existing console user oids and maps stale references to nil" do
     user = users(:acme_admin)
     stale_oid = User.new(id: User.maximum(:id) + 1_000).oid
     migration = AddConsoleUserIdentityFieldsToPrincipals.new

--- a/services/console/test/models/pg_dsn_secret_test.rb
+++ b/services/console/test/models/pg_dsn_secret_test.rb
@@ -167,6 +167,29 @@ class PgDsnSecretTest < ActiveSupport::TestCase
     )
   end
 
+  test "to_proxy_dsn resolves console user compatibility labels from columns" do
+    user = users(:acme_admin)
+    principal = Principal.create!(
+      namespace: "acme",
+      kind: "console_user",
+      console_user_id: user.oid,
+      console_user_email: user.email,
+      created_by: user
+    )
+    secret = with_dsn(PgDsnSecret.new(base_attrs(settings: [
+      { "name" => "app.user_id", "value_from" => { "principal_label" => "console-user-id" } },
+      { "name" => "app.email", "value_from" => { "principal_label" => "email" } }
+    ])))
+
+    assert_equal(
+      [
+        { "name" => "app.user_id", "value" => user.oid },
+        { "name" => "app.email", "value" => user.email }
+      ],
+      secret.to_proxy_dsn(principal: principal)["settings"]
+    )
+  end
+
   test "to_proxy_dsn resolves Slack history channel ids from permission rows" do
     principal = principals(:acme_channel)
     SlackChannelPermission.create!(

--- a/services/console/test/models/pg_dsn_secret_test.rb
+++ b/services/console/test/models/pg_dsn_secret_test.rb
@@ -172,7 +172,7 @@ class PgDsnSecretTest < ActiveSupport::TestCase
     principal = Principal.create!(
       namespace: "acme",
       kind: "console_user",
-      console_user_id: user.oid,
+      console_user_id: user.id,
       console_user_email: user.email,
       created_by: user
     )

--- a/services/console/test/models/principal_test.rb
+++ b/services/console/test/models/principal_test.rb
@@ -73,13 +73,13 @@ class PrincipalTest < ActiveSupport::TestCase
     user = users(:acme_admin)
     principal = Principal.create!(default_attrs(
       kind: "console_user",
-      console_user_id: user.oid,
+      console_user_id: user.id,
       console_user_email: user.email,
       labels: { "managed-by" => "centaur" }
     ))
 
     principal.reload
-    assert_equal user.oid, principal.console_user_id
+    assert_equal user.id, principal.console_user_id
     assert_equal user.email, principal.console_user_email
     assert_empty principal.labels.slice("console-user-id", "email")
     assert_equal user.oid, principal.labels_with_sandbox_capabilities["console-user-id"]
@@ -99,7 +99,7 @@ class PrincipalTest < ActiveSupport::TestCase
       labels: { "kind" => "user", "email" => user.email }
     ))
 
-    assert_equal user.oid, console_user.reload.console_user_id
+    assert_equal user.id, console_user.reload.console_user_id
     assert_equal user.email, console_user.console_user_email
     assert_empty console_user.labels.slice("console-user-id", "email")
     assert_nil ordinary_user.reload.console_user_id
@@ -133,7 +133,9 @@ class PrincipalTest < ActiveSupport::TestCase
 
   test "kind accepts only known values" do
     Principal::KINDS.each do |kind|
-      assert Principal.new(default_attrs(kind: kind)).valid?, "expected #{kind.inspect} to be valid"
+      attrs = { kind: kind }
+      attrs[:console_user_id] = users(:acme_admin).id if kind == "console_user"
+      assert Principal.new(default_attrs(attrs)).valid?, "expected #{kind.inspect} to be valid"
     end
 
     %w[service future_platform].each do |kind|
@@ -171,23 +173,23 @@ class PrincipalTest < ActiveSupport::TestCase
     end
   end
 
-  test "console user identity fields must use canonical formats" do
+  test "console user principals require a console user id and valid email" do
     user = users(:acme_admin)
     principal = Principal.new(default_attrs(
       kind: "console_user",
-      console_user_id: user.oid,
+      console_user_id: user.id,
       console_user_email: user.email
     ))
     assert principal.valid?
 
-    {
-      console_user_id: "not-a-user-id",
-      console_user_email: "not-an-email"
-    }.each do |field, value|
-      principal = Principal.new(default_attrs(kind: "console_user", field => value))
-      assert_not principal.valid?
-      assert_predicate principal.errors[field], :any?
-    end
+    principal.console_user_id = nil
+    assert_not principal.valid?
+    assert_predicate principal.errors[:console_user_id], :any?
+
+    principal.console_user_id = user.id
+    principal.console_user_email = "not-an-email"
+    assert_not principal.valid?
+    assert_predicate principal.errors[:console_user_email], :any?
   end
 
   test "unchanged malformed migrated Slack identities do not block unrelated saves" do

--- a/services/console/test/models/principal_test.rb
+++ b/services/console/test/models/principal_test.rb
@@ -66,7 +66,45 @@ class PrincipalTest < ActiveSupport::TestCase
     assert_equal "U0123456789", principal.slack_user_id
     assert_equal "T0123456789", principal.slack_team_id
     assert_equal "ada@example.com", principal.slack_email
-    assert_empty principal.labels.slice(*Principal::PROMOTED_LABEL_FIELDS)
+    assert_empty principal.labels.slice(*Principal::PROMOTED_LABEL_FIELDS.keys)
+  end
+
+  test "console user identity is stored only in columns and synthesized for compatibility" do
+    user = users(:acme_admin)
+    principal = Principal.create!(default_attrs(
+      kind: "console_user",
+      console_user_id: user.oid,
+      console_user_email: user.email,
+      labels: { "managed-by" => "centaur" }
+    ))
+
+    principal.reload
+    assert_equal user.oid, principal.console_user_id
+    assert_equal user.email, principal.console_user_email
+    assert_empty principal.labels.slice("console-user-id", "email")
+    assert_equal user.oid, principal.labels_with_sandbox_capabilities["console-user-id"]
+    assert_equal user.email, principal.labels_with_sandbox_capabilities["email"]
+  end
+
+  test "legacy console user identity labels are promoted only for console users" do
+    user = users(:acme_admin)
+    console_user = Principal.create!(default_attrs(
+      labels: {
+        "kind" => "console_user",
+        "console-user-id" => user.oid,
+        "email" => user.email
+      }
+    ))
+    ordinary_user = Principal.create!(default_attrs(
+      labels: { "kind" => "user", "email" => user.email }
+    ))
+
+    assert_equal user.oid, console_user.reload.console_user_id
+    assert_equal user.email, console_user.console_user_email
+    assert_empty console_user.labels.slice("console-user-id", "email")
+    assert_nil ordinary_user.reload.console_user_id
+    assert_nil ordinary_user.console_user_email
+    assert_equal user.email, ordinary_user.labels["email"]
   end
 
   test "blank legacy Slack identity labels clear columns" do
@@ -128,6 +166,25 @@ class PrincipalTest < ActiveSupport::TestCase
       slack_email: "not-an-email"
     }.each do |field, value|
       principal = Principal.new(default_attrs(field => value))
+      assert_not principal.valid?
+      assert_predicate principal.errors[field], :any?
+    end
+  end
+
+  test "console user identity fields must use canonical formats" do
+    user = users(:acme_admin)
+    principal = Principal.new(default_attrs(
+      kind: "console_user",
+      console_user_id: user.oid,
+      console_user_email: user.email
+    ))
+    assert principal.valid?
+
+    {
+      console_user_id: "not-a-user-id",
+      console_user_email: "not-an-email"
+    }.each do |field, value|
+      principal = Principal.new(default_attrs(kind: "console_user", field => value))
       assert_not principal.valid?
       assert_predicate principal.errors[field], :any?
     end

--- a/services/console/test/models/principal_test.rb
+++ b/services/console/test/models/principal_test.rb
@@ -66,7 +66,7 @@ class PrincipalTest < ActiveSupport::TestCase
     assert_equal "U0123456789", principal.slack_user_id
     assert_equal "T0123456789", principal.slack_team_id
     assert_equal "ada@example.com", principal.slack_email
-    assert_empty principal.labels.slice(*Principal::PROMOTED_LABEL_FIELDS.keys)
+    assert_empty principal.labels.slice(*PrincipalIdentityLabels.labels_for(principal.kind))
   end
 
   test "console user identity is stored only in columns and synthesized for compatibility" do

--- a/services/console/test/models/principal_test.rb
+++ b/services/console/test/models/principal_test.rb
@@ -133,9 +133,7 @@ class PrincipalTest < ActiveSupport::TestCase
 
   test "kind accepts only known values" do
     Principal::KINDS.each do |kind|
-      attrs = { kind: kind }
-      attrs[:console_user_id] = users(:acme_admin).id if kind == "console_user"
-      assert Principal.new(default_attrs(attrs)).valid?, "expected #{kind.inspect} to be valid"
+      assert Principal.new(default_attrs(kind: kind)).valid?, "expected #{kind.inspect} to be valid"
     end
 
     %w[service future_platform].each do |kind|
@@ -173,7 +171,7 @@ class PrincipalTest < ActiveSupport::TestCase
     end
   end
 
-  test "console user principals require a console user id and valid email" do
+  test "console user principals permit missing user references but require valid email" do
     user = users(:acme_admin)
     principal = Principal.new(default_attrs(
       kind: "console_user",
@@ -183,10 +181,8 @@ class PrincipalTest < ActiveSupport::TestCase
     assert principal.valid?
 
     principal.console_user_id = nil
-    assert_not principal.valid?
-    assert_predicate principal.errors[:console_user_id], :any?
+    assert principal.valid?
 
-    principal.console_user_id = user.id
     principal.console_user_email = "not-an-email"
     assert_not principal.valid?
     assert_predicate principal.errors[:console_user_email], :any?

--- a/services/console/test/services/principal_credential_reconciliation_test.rb
+++ b/services/console/test/services/principal_credential_reconciliation_test.rb
@@ -481,7 +481,7 @@ class PrincipalCredentialReconciliationTest < ActiveSupport::TestCase
       foreign_id: foreign_id,
       name: user.name.presence || user.email,
       kind: "console_user",
-      console_user_id: user.oid,
+      console_user_id: user.id,
       console_user_email: email || user.email,
       labels: {
         "managed-by" => "centaur"

--- a/services/console/test/services/principal_credential_reconciliation_test.rb
+++ b/services/console/test/services/principal_credential_reconciliation_test.rb
@@ -393,7 +393,7 @@ class PrincipalCredentialReconciliationTest < ActiveSupport::TestCase
     refute principal.grants.exists?(static_secret: secret)
   end
 
-  test "console user principal ignores a spoofed email label" do
+  test "console user principal ignores a spoofed cached email" do
     credential = create_credential(oauth_apps(:acme_slack), "slack-sub-carol", "carol@acme.example")
     secret = wrap(credential)
 
@@ -473,18 +473,18 @@ class PrincipalCredentialReconciliationTest < ActiveSupport::TestCase
   private
 
   # Mirrors the principal shape minted by Mcp::OauthController#principal_for_current_user.
-  # The email/extra_labels overrides simulate tampered or stale labels, which
-  # matching must ignore for console-user principals.
+  # The email/extra_labels overrides simulate tampered or stale cached identity,
+  # which matching must ignore for console-user principals.
   def create_console_user_principal(user, foreign_id:, email: nil, extra_labels: {})
     Principal.create!(
       namespace: "acme",
       foreign_id: foreign_id,
       name: user.name.presence || user.email,
+      kind: "console_user",
+      console_user_id: user.oid,
+      console_user_email: email || user.email,
       labels: {
-        "managed-by" => "centaur",
-        "kind" => "console_user",
-        "console-user-id" => user.oid,
-        "email" => email || user.email
+        "managed-by" => "centaur"
       }.merge(extra_labels),
       created_by: user
     )


### PR DESCRIPTION
Moves console-user principal IDs and email addresses from persisted labels into dedicated columns. Existing user OIDs are decoded to nullable database IDs with foreign-key protection for valid references, while compatibility labels remain synthesized for API consumers. Centralizes principal identity label projection, assignment, filtering, and OID conversion in one service.