### PR TITLE
feat(console): match OAuth credentials through the owner's Slack SSO identity

### DIFF
--- a/services/console/app/controllers/mcp/oauth_controller.rb
+++ b/services/console/app/controllers/mcp/oauth_controller.rb
@@ -489,17 +489,10 @@ module Mcp
     # Slack identity. Refuse an ambiguous account rather than guessing which
     # workspace should determine company-context RLS.
     def slack_identity_fields_for(user)
-      identities = user.user_identities.where(provider: UserIdentity::SLACK_PROVIDER).order(:id)
-      identities = identities.filter_map do |identity|
-        next if identity.subject.blank? || identity.team_id.blank?
-
-        [ identity.subject, identity.team_id ]
-      end.uniq
-      return {} unless identities.one?
-
-      slack_user_id, slack_team_id = identities.first
-      return {} unless Principal::SLACK_USER_ID_FORMAT.match?(slack_user_id)
-      return {} unless Principal::SLACK_TEAM_ID_FORMAT.match?(slack_team_id)
+      slack_user_id, slack_team_id = UserIdentity.unambiguous_slack_identity(
+        user.user_identities.slack.order(:id)
+      )
+      return {} unless slack_user_id
 
       { "slack_user_id" => slack_user_id, "slack_team_id" => slack_team_id }
     end

--- a/services/console/app/models/user_identity.rb
+++ b/services/console/app/models/user_identity.rb
@@ -10,9 +10,59 @@ class UserIdentity < ApplicationRecord
   PROVIDERS = %w[google slack].freeze
   SLACK_PROVIDER = "slack".freeze
 
+  scope :slack, -> { where(provider: SLACK_PROVIDER) }
+
+  # A Slack identity that arrives (or gains its team) after the user already
+  # consented to OAuth credentials is the one ordering the Principal/
+  # BrokerCredential/StaticSecret hooks cannot observe; re-run reconciliation
+  # over the owner's credentials so the grant still materializes. The update
+  # trigger is scoped to the fields that participate in matching, so the email
+  # re-cache on every returning SSO login does not re-run reconciliation.
+  after_commit :reconcile_owner_oauth_credentials,
+               on: %i[create update],
+               if: -> {
+                 slack? && (previously_new_record? || saved_change_to_subject? ||
+                   saved_change_to_team_id? || saved_change_to_user_id?)
+               }
+
   normalizes :email, with: ->(e) { e.to_s.strip.downcase.presence }
   normalizes :team_id, with: ->(id) { id.to_s.strip.presence }
 
   validates :provider, presence: true, inclusion: { in: PROVIDERS }
   validates :subject, presence: true, uniqueness: { scope: :provider }
+
+  def slack? = provider == SLACK_PROVIDER
+
+  # The single native Slack identity in ``identities``, as ``[subject,
+  # team_id]``, or nil. Slack's OIDC id_token is the authenticated source of
+  # these values; an ambiguous account (several distinct pairs) is refused
+  # rather than guessed at, and the chosen pair must be well-formed Slack ids.
+  def self.unambiguous_slack_identity(identities)
+    pairs = identities.filter_map do |identity|
+      next if identity.subject.blank? || identity.team_id.blank?
+
+      [ identity.subject, identity.team_id ]
+    end.uniq
+    return nil unless pairs.one?
+
+    subject, team_id = pairs.first
+    return nil unless Principal::SLACK_USER_ID_FORMAT.match?(subject)
+    return nil unless Principal::SLACK_TEAM_ID_FORMAT.match?(team_id)
+
+    pairs.first
+  end
+
+  private
+
+  # Never let reconciliation abort the surrounding write: this hook runs inside
+  # the SSO login's commit path, and a failure here must not break sign-in.
+  def reconcile_owner_oauth_credentials
+    reconciliation = PrincipalCredentialReconciliation.new
+    BrokerCredential.joins(:oauth_app).where(created_by_id: user_id)
+      .select(:id).find_each do |credential|
+      reconciliation.apply_for_credential(credential)
+    end
+  rescue StandardError => e
+    Rails.logger.warn("user_identity_credential_reconciliation_failed error=#{e.class}")
+  end
 end

--- a/services/console/app/services/principal_credential_reconciliation.rb
+++ b/services/console/app/services/principal_credential_reconciliation.rb
@@ -1,6 +1,8 @@
 # Finds OAuth-flow credentials (Slack/Google/GitHub/...) that appear to belong
 # to the same human as an existing user principal, then automatically grants
-# their wrapper static secrets to that principal.
+# their wrapper static secrets to that principal. Matching precedence per
+# provider: the principal's provider-native identity, else the union of
+# matches through the credential owner's Slack SSO identity and email.
 class PrincipalCredentialReconciliation
   Entry = Struct.new(
     :principal,
@@ -39,7 +41,8 @@ class PrincipalCredentialReconciliation
   # Ordinary principal labels carrying a provider-native identity. Slack uses
   # first-class columns instead. When a principal has a native identity, it
   # takes precedence over email matching for that provider's credentials.
-  # Providers without an entry (for example github) match by email only.
+  # Providers without an entry (for example github) match through the
+  # credential owner's Slack SSO identity or by email.
   PROVIDER_SUBJECT_LABELS = {
     GOOGLE_PROVIDER => %w[google_subject]
   }.freeze
@@ -150,6 +153,7 @@ class PrincipalCredentialReconciliation
         provider: provider,
         subject_index: indexes[provider][:subjects],
         email_index: indexes[provider][:emails],
+        owner_index: indexes[provider][:owners],
         emails: emails
       )
       acc[provider] = matched if matched.any?
@@ -177,7 +181,12 @@ class PrincipalCredentialReconciliation
   def credential_indexes
     providers.index_with do |provider|
       credentials = provider_credentials(provider)
-      { subjects: index_by_subject(credentials), emails: index_by_email(credentials) }
+      prime_owner_slack_identities(credentials)
+      {
+        subjects: index_by_subject(credentials),
+        emails: index_by_email(credentials),
+        owners: index_by_owner_identity(credentials)
+      }
     end
   end
 
@@ -218,11 +227,19 @@ class PrincipalCredentialReconciliation
     end
   end
 
-  def provider_credentials_for(principal, provider:, subject_index:, email_index:, emails:)
+  def index_by_owner_identity(credentials)
+    credentials.each_with_object(Hash.new { |hash, key| hash[key] = [] }) do |credential, acc|
+      identity = owner_slack_identity_for(credential)
+      acc[identity] << credential if identity
+    end
+  end
+
+  def provider_credentials_for(principal, provider:, subject_index:, email_index:, owner_index:, emails:)
     native = credentials_for_subject_labels(principal, provider, subject_index)
     return native if native.any?
 
-    credentials_for_emails(principal, emails, email_index, provider)
+    (credentials_for_owner_identity(principal, provider, owner_index) +
+      credentials_for_emails(principal, emails, email_index, provider)).uniq
   end
 
   def credentials_for_subject_labels(principal, provider, subject_index)
@@ -242,6 +259,14 @@ class PrincipalCredentialReconciliation
       .uniq
   end
 
+  def credentials_for_owner_identity(principal, provider, owner_index)
+    identity = principal_slack_identity(principal)
+    return [] unless identity
+
+    (owner_index[identity] || [])
+      .select { |credential| credential_matches_principal?(principal, credential, provider) }
+  end
+
   def credential_matches_principal?(principal, credential, provider = nil)
     provider ||= credential.oauth_app&.provider
     return false unless supported_provider?(credential)
@@ -255,8 +280,62 @@ class PrincipalCredentialReconciliation
     if subjects.any?
       subjects.include?(normalize_key(credential.provider_subject))
     else
-      principal_emails(principal).include?(normalize_email(credential.provider_email))
+      owner_identity_matches_principal?(principal, credential) ||
+        principal_emails(principal).include?(normalize_email(credential.provider_email))
     end
+  end
+
+  # A credential also matches through the console user who consented to it:
+  # when that user's single Slack SSO identity
+  # (UserIdentity.unambiguous_slack_identity) equals the principal's Slack
+  # identity. This is what lets providers whose credentials carry no usable
+  # identity (github: provider_email is the usually-empty public profile
+  # email) reconcile without manual grants. The owner side is authenticated --
+  # created_by is set server-side at consent, the identity comes from Slack's
+  # OIDC id_token -- while the principal's slack_user_id/slack_team_id carry
+  # the same operator-write trust as the email labels the email fallback uses.
+  def owner_identity_matches_principal?(principal, credential)
+    identity = principal_slack_identity(principal)
+    return false unless identity
+
+    owner_slack_identity_for(credential) == identity
+  end
+
+  def principal_slack_identity(principal)
+    return nil if console_user_principal?(principal)
+
+    subject = normalize_key(principal.slack_user_id)
+    team = normalize_key(principal.slack_team_id)
+    [ subject, team ] if subject && team
+  end
+
+  def owner_slack_identity_for(credential)
+    user_id = credential.created_by_id
+    return nil if user_id.blank?
+
+    owner_slack_identities.fetch(user_id) do
+      owner_slack_identities[user_id] = unambiguous_slack_identity(
+        UserIdentity.slack.where(user_id: user_id)
+      )
+    end
+  end
+
+  def prime_owner_slack_identities(credentials)
+    missing = credentials.filter_map(&:created_by_id).uniq - owner_slack_identities.keys
+    return if missing.empty?
+
+    identities_by_user = UserIdentity.slack.where(user_id: missing).group_by(&:user_id)
+    missing.each do |user_id|
+      owner_slack_identities[user_id] = unambiguous_slack_identity(identities_by_user[user_id] || [])
+    end
+  end
+
+  def unambiguous_slack_identity(identities)
+    UserIdentity.unambiguous_slack_identity(identities)&.map { |value| normalize_key(value) }
+  end
+
+  def owner_slack_identities
+    @owner_slack_identities ||= {}
   end
 
   def subject_label_keys(provider)

--- a/services/console/test/services/principal_credential_reconciliation_test.rb
+++ b/services/console/test/services/principal_credential_reconciliation_test.rb
@@ -644,6 +644,7 @@ class PrincipalCredentialReconciliationTest < ActiveSupport::TestCase
     credential = BrokerCredential.create!(
       namespace: "acme",
       provider_subject: "manual-sub",
+      client_id: "manual-client-id",
       token_endpoint: "https://example.com/token",
       refresh_token: "refresh-manual",
       access_token: "access-manual",

--- a/services/console/test/services/principal_credential_reconciliation_test.rb
+++ b/services/console/test/services/principal_credential_reconciliation_test.rb
@@ -470,6 +470,223 @@ class PrincipalCredentialReconciliationTest < ActiveSupport::TestCase
     assert principal.grants.exists?(static_secret: secret)
   end
 
+  test "grants a GitHub credential to the owner's Slack user principal via SSO identity" do
+    user = users(:member_user)
+    user.user_identities.create!(provider: "slack", subject: "U0123456789", team_id: "T0123456789")
+    principal = create_slack_user_principal(
+      foreign_id: "slack-user-t0123456789-u0123456789",
+      slack_user_id: "U0123456789",
+      slack_team_id: "T0123456789"
+    )
+    credential = create_credential(oauth_apps(:acme_github), "gh-12345", nil, created_by: user)
+
+    secret = nil
+    assert_difference -> { principal.grants.count }, 1 do
+      secret = wrap(credential)
+    end
+    assert principal.grants.exists?(static_secret: secret)
+  end
+
+  test "grants an existing GitHub credential when the Slack user principal appears" do
+    user = users(:member_user)
+    user.user_identities.create!(provider: "slack", subject: "U0223456789", team_id: "T0223456789")
+    credential = create_credential(oauth_apps(:acme_github), "gh-22345", nil, created_by: user)
+    secret = wrap(credential)
+
+    principal = create_slack_user_principal(
+      foreign_id: "slack-user-t0223456789-u0223456789",
+      slack_user_id: "U0223456789",
+      slack_team_id: "T0223456789"
+    )
+
+    assert principal.grants.exists?(static_secret: secret)
+    entry = PrincipalCredentialReconciliation.new.entries.find do |candidate|
+      candidate.principal == principal
+    end
+    assert_equal [ credential ], entry.credentials_for("github")
+  end
+
+  test "grants owner credentials when the Slack SSO identity arrives last" do
+    user = users(:member_user)
+    principal = create_slack_user_principal(
+      foreign_id: "slack-user-t0323456789-u0323456789",
+      slack_user_id: "U0323456789",
+      slack_team_id: "T0323456789"
+    )
+    credential = create_credential(oauth_apps(:acme_github), "gh-32345", nil, created_by: user)
+    secret = wrap(credential)
+    refute principal.grants.exists?(static_secret: secret)
+
+    assert_difference -> { principal.grants.count }, 1 do
+      user.user_identities.create!(provider: "slack", subject: "U0323456789", team_id: "T0323456789")
+    end
+    assert principal.grants.exists?(static_secret: secret)
+  end
+
+  test "does not match through an ambiguous owner Slack identity" do
+    user = users(:member_user)
+    user.user_identities.create!(provider: "slack", subject: "U0423456789", team_id: "T0423456789")
+    user.user_identities.create!(provider: "slack", subject: "U0523456789", team_id: "T0523456789")
+    principal = create_slack_user_principal(
+      foreign_id: "slack-user-t0423456789-u0423456789",
+      slack_user_id: "U0423456789",
+      slack_team_id: "T0423456789"
+    )
+    credential = create_credential(oauth_apps(:acme_github), "gh-42345", nil, created_by: user)
+    secret = wrap(credential)
+
+    refute principal.grants.exists?(static_secret: secret)
+  end
+
+  test "does not match through an owner Slack identity missing its team" do
+    user = users(:member_user)
+    user.user_identities.create!(provider: "slack", subject: "U0623456789")
+    principal = create_slack_user_principal(
+      foreign_id: "slack-user-u0623456789",
+      slack_user_id: "U0623456789",
+      slack_team_id: "T0623456789"
+    )
+    credential = create_credential(oauth_apps(:acme_github), "gh-52345", nil, created_by: user)
+    secret = wrap(credential)
+
+    refute principal.grants.exists?(static_secret: secret)
+  end
+
+  test "requires the owner identity team to match the principal" do
+    user = users(:member_user)
+    user.user_identities.create!(provider: "slack", subject: "U0723456789", team_id: "T0723456789")
+    principal = create_slack_user_principal(
+      foreign_id: "slack-user-t9923456789-u0723456789",
+      slack_user_id: "U0723456789",
+      slack_team_id: "T9923456789"
+    )
+    credential = create_credential(oauth_apps(:acme_github), "gh-62345", nil, created_by: user)
+    secret = wrap(credential)
+
+    refute principal.grants.exists?(static_secret: secret)
+  end
+
+  test "does not match owner identities across namespaces" do
+    user = users(:member_user)
+    user.user_identities.create!(provider: "slack", subject: "U0823456789", team_id: "T0823456789")
+    principal = create_slack_user_principal(
+      namespace: "globex",
+      foreign_id: "globex-slack-user-t0823456789-u0823456789",
+      slack_user_id: "U0823456789",
+      slack_team_id: "T0823456789",
+      created_by: users(:globex_admin)
+    )
+    credential = create_credential(oauth_apps(:acme_github), "gh-72345", nil, created_by: user)
+    secret = wrap(credential)
+
+    refute principal.grants.exists?(static_secret: secret)
+  end
+
+  test "native provider subject still outranks the owner identity" do
+    user = users(:member_user)
+    user.user_identities.create!(provider: "slack", subject: "U0923456789", team_id: "T0923456789")
+    principal = create_slack_user_principal(
+      foreign_id: "slack-user-t0923456789-u0923456789",
+      slack_user_id: "U0923456789",
+      slack_team_id: "T0923456789"
+    )
+    principal.update!(labels: principal.labels.merge("google_subject" => "google-sub-elsewhere"))
+    credential = create_credential(oauth_apps(:acme_google), "google-sub-owner", nil, created_by: user)
+    secret = wrap(credential)
+
+    refute principal.grants.exists?(static_secret: secret)
+  end
+
+  test "console user principals do not match through the owner identity" do
+    user = users(:member_user)
+    user.user_identities.create!(provider: "slack", subject: "U1023456789", team_id: "T1023456789")
+    credential = create_credential(oauth_apps(:acme_github), "gh-82345", nil, created_by: user)
+    secret = wrap(credential)
+
+    principal = create_console_user_principal(user, foreign_id: "console-user-owner-identity")
+
+    refute principal.grants.exists?(static_secret: secret)
+  end
+
+  test "requires the owner identity subject to match the principal" do
+    user = users(:member_user)
+    user.user_identities.create!(provider: "slack", subject: "U1123456780", team_id: "T1123456780")
+    principal = create_slack_user_principal(
+      foreign_id: "slack-user-t1123456780-u9923456780",
+      slack_user_id: "U9923456780",
+      slack_team_id: "T1123456780"
+    )
+    credential = create_credential(oauth_apps(:acme_github), "gh-92345", nil, created_by: user)
+    secret = wrap(credential)
+
+    refute principal.grants.exists?(static_secret: secret)
+  end
+
+  test "a credential without an owner does not match through the owner identity" do
+    principal = create_slack_user_principal(
+      foreign_id: "slack-user-t1223456780-u1223456780",
+      slack_user_id: "U1223456780",
+      slack_team_id: "T1223456780"
+    )
+    credential = create_credential(oauth_apps(:acme_github), "gh-a2345", nil)
+    secret = wrap(credential)
+
+    refute principal.grants.exists?(static_secret: secret)
+  end
+
+  test "identity creation ignores credentials without an oauth app" do
+    user = users(:member_user)
+    principal = create_slack_user_principal(
+      foreign_id: "slack-user-t1423456780-u1423456780",
+      slack_user_id: "U1423456780",
+      slack_team_id: "T1423456780"
+    )
+    credential = BrokerCredential.create!(
+      namespace: "acme",
+      provider_subject: "manual-sub",
+      token_endpoint: "https://example.com/token",
+      refresh_token: "refresh-manual",
+      access_token: "access-manual",
+      expires_at: 1.hour.from_now,
+      last_refresh: Time.current,
+      external_user_key: "user-manual",
+      created_by: user
+    )
+    secret = wrap(credential)
+
+    assert_no_difference -> { Grant.count } do
+      user.user_identities.create!(provider: "slack", subject: "U1423456780", team_id: "T1423456780")
+    end
+    refute principal.grants.exists?(static_secret: secret)
+  end
+
+  test "identity creation for other providers does not run reconciliation" do
+    user = users(:member_user)
+    principal = create_slack_user_principal(
+      foreign_id: "slack-user-t1523456780-u1523456780",
+      slack_user_id: "U1523456780",
+      slack_team_id: "T1523456780"
+    )
+    credential = create_credential(oauth_apps(:acme_github), "gh-c2345", nil, created_by: user)
+    secret = wrap(credential)
+
+    assert_no_difference -> { Grant.count } do
+      user.user_identities.create!(provider: "google", subject: "google-sub-noop")
+    end
+    refute principal.grants.exists?(static_secret: secret)
+  end
+
+  test "identity creation survives reconciliation failures" do
+    user = users(:member_user)
+    boom = proc { raise "boom" }
+
+    PrincipalCredentialReconciliation.stub(:new, boom) do
+      assert_difference -> { user.user_identities.count }, 1 do
+        user.user_identities.create!(provider: "slack", subject: "U1623456780", team_id: "T1623456780")
+      end
+    end
+  end
+
   private
 
   # Mirrors the principal shape minted by Mcp::OauthController#principal_for_current_user.
@@ -507,7 +724,7 @@ class PrincipalCredentialReconciliationTest < ActiveSupport::TestCase
     )
   end
 
-  def create_credential(app, subject, email)
+  def create_credential(app, subject, email, created_by: nil)
     BrokerCredential.create!(
       namespace: app.credential_namespace,
       oauth_app: app,
@@ -518,7 +735,8 @@ class PrincipalCredentialReconciliationTest < ActiveSupport::TestCase
       access_token: "access-#{subject}",
       expires_at: 1.hour.from_now,
       last_refresh: Time.current,
-      external_user_key: "user-#{subject}"
+      external_user_key: "user-#{subject}",
+      created_by: created_by
     )
   end
 


### PR DESCRIPTION
Step 1 of 4 towards RFC 0005 (#1256).

Today a user connects GitHub in the console and nothing happens: the credential is not granted to them, so an admin has to do it by hand. The automatic path only matches on the GitHub profile email, which is usually empty.

This PR matches the credential to its owner through their Slack SSO identity instead, and grants it to that user's principal automatically. It also re-runs the match when the Slack login happens after the GitHub connection.

Result: per-user credentials work in DMs with no admin steps. Useful on its own.