### PR TITLE
fix: use first-class principal identity fields

### DIFF
--- a/services/api-rs/crates/centaur-api-server/src/args.rs
+++ b/services/api-rs/crates/centaur-api-server/src/args.rs
@@ -16,8 +16,8 @@ use centaur_api_server::{
     discover_tool_proxy_fragment,
 };
 use centaur_iron_control::{
-    IdentityInput, IronControlClient, IronControlError, RegisterError, RoleSpec, SessionRegistrar,
-    register_role,
+    IdentityInput, IronControlClient, IronControlError, PrincipalInput, RegisterError, RoleSpec,
+    SessionRegistrar, register_role,
 };
 use centaur_iron_proxy::{
     ProxyFragment, SourceKind, SourcePolicy, bedrock_enabled, harness_auth_fragment, infra_fragment,
@@ -706,7 +706,7 @@ impl SandboxArgs {
                 .await?;
         }
         let bootstrap = client
-            .upsert_principal(&IdentityInput {
+            .upsert_principal(&PrincipalInput {
                 namespace: namespace.clone(),
                 foreign_id: "warm-pool-bootstrap".to_owned(),
                 name: "Warm pool bootstrap".to_owned(),
@@ -714,10 +714,15 @@ impl SandboxArgs {
                     ("managed-by".to_owned(), "centaur".to_owned()),
                     ("purpose".to_owned(), "warm-pool-bootstrap".to_owned()),
                 ]),
+                kind: None,
+                slack_user_id: None,
+                slack_channel_id: None,
+                slack_team_id: None,
+                slack_email: None,
             })
             .await?;
         let workflow_host = client
-            .upsert_principal(&IdentityInput {
+            .upsert_principal(&PrincipalInput {
                 namespace: namespace.clone(),
                 foreign_id: "workflow-host".to_owned(),
                 name: "Workflow host".to_owned(),
@@ -725,6 +730,11 @@ impl SandboxArgs {
                     ("managed-by".to_owned(), "centaur".to_owned()),
                     ("purpose".to_owned(), "workflow-host".to_owned()),
                 ]),
+                kind: None,
+                slack_user_id: None,
+                slack_channel_id: None,
+                slack_team_id: None,
+                slack_email: None,
             })
             .await?;
         Ok(Some(IronControlRuntime {

--- a/services/api-rs/crates/centaur-iron-control/src/client.rs
+++ b/services/api-rs/crates/centaur-iron-control/src/client.rs
@@ -15,8 +15,9 @@ use crate::error::{IronControlError, Result};
 use crate::models::{
     AwsAuthSecretInput, BrokerCredentialInput, BrokerCredentialRecord, DataEnvelope,
     EffectiveConfig, GcpAuthSecretInput, GcpIdTokenSecretInput, Grant, GrantSecret, Grantee,
-    HmacSecretInput, IdentityInput, OAuthTokenSecretInput, PgDsnSecretInput, Principal, Proxy,
-    ProxyInput, Role, SecretRecord, SlackChannelPermissionInput, StaticSecretInput,
+    HmacSecretInput, IdentityInput, OAuthTokenSecretInput, PgDsnSecretInput, Principal,
+    PrincipalInput, Proxy, ProxyInput, Role, SecretRecord, SlackChannelPermissionInput,
+    StaticSecretInput,
 };
 
 const API_PREFIX: &str = "/api/v1";
@@ -52,7 +53,7 @@ impl IronControlClient {
     // ----- principals & roles ---------------------------------------------
 
     /// Upsert a principal by ``foreign_id`` (create if absent, update if not).
-    pub async fn upsert_principal(&self, input: &IdentityInput) -> Result<Principal> {
+    pub async fn upsert_principal(&self, input: &PrincipalInput) -> Result<Principal> {
         self.write(
             Method::PUT,
             &upsert_path("principals", &input.foreign_id),

--- a/services/api-rs/crates/centaur-iron-control/src/lib.rs
+++ b/services/api-rs/crates/centaur-iron-control/src/lib.rs
@@ -21,8 +21,8 @@ pub use models::{
     EffectivePgDsn, EffectiveReplace, EffectiveSecret, GCP_ID_TOKEN_ALLOWED_HEADERS,
     GcpAuthSecretInput, GcpIdTokenSecretInput, Grant, GrantSecret, Grantee, HmacSecretHeader,
     HmacSecretInput, IdentityInput, InjectConfig, OAuthTokenSecretInput, PgDsnSecretInput,
-    PgDsnSettingInput, PgDsnSettingValueFromInput, Principal, Proxy, ProxyInput, ReplaceConfig,
-    RequestRule, Role, SECRET_TYPES, SecretRecord, SecretSource, StaticSecretInput,
+    PgDsnSettingInput, PgDsnSettingValueFromInput, Principal, PrincipalInput, Proxy, ProxyInput,
+    ReplaceConfig, RequestRule, Role, SECRET_TYPES, SecretRecord, SecretSource, StaticSecretInput,
     normalize_gcp_id_token_header,
 };
 pub use principal::{PrincipalRef, derive_principal};

--- a/services/api-rs/crates/centaur-iron-control/src/models.rs
+++ b/services/api-rs/crates/centaur-iron-control/src/models.rs
@@ -455,8 +455,7 @@ pub struct BrokerCredentialRecord {
 // Principals and roles
 // ---------------------------------------------------------------------------
 
-/// Request body for ``POST``/``PUT /api/v1/principals`` and ``/roles`` — both
-/// take the same ``namespace``/``foreign_id``/``name``/``labels`` shape.
+/// Request body for ``POST``/``PUT /api/v1/roles``.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize)]
 pub struct IdentityInput {
     pub namespace: String,
@@ -464,6 +463,29 @@ pub struct IdentityInput {
     pub name: String,
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub labels: BTreeMap<String, String>,
+}
+
+/// Request body for ``POST``/``PUT /api/v1/principals``.
+///
+/// Principal identity is stored in first-class iron-control fields. Labels are
+/// reserved for extensible metadata and must not carry copies of these values.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+pub struct PrincipalInput {
+    pub namespace: String,
+    pub foreign_id: String,
+    pub name: String,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub labels: BTreeMap<String, String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub kind: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub slack_user_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub slack_channel_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub slack_team_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub slack_email: Option<String>,
 }
 
 /// A principal as returned by iron-control. Unknown fields are ignored, so this

--- a/services/api-rs/crates/centaur-iron-control/src/principal.rs
+++ b/services/api-rs/crates/centaur-iron-control/src/principal.rs
@@ -22,7 +22,7 @@ use std::collections::BTreeMap;
 use base64::Engine;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 
-use crate::models::IdentityInput;
+use crate::models::PrincipalInput;
 use crate::util::{managed_labels, slugify};
 
 const KIND_LABEL: &str = "kind";
@@ -44,13 +44,18 @@ pub struct PrincipalRef {
 impl PrincipalRef {
     /// Build the upsert body for this principal in ``namespace``, tagging it as
     /// Centaur-managed.
-    pub fn to_identity_input(&self, namespace: &str) -> IdentityInput {
+    pub fn to_principal_input(&self, namespace: &str) -> PrincipalInput {
         let mut labels = managed_labels();
         labels.extend(self.labels.clone());
-        IdentityInput {
+        PrincipalInput {
             namespace: namespace.to_owned(),
             foreign_id: self.foreign_id.clone(),
             name: self.name.clone(),
+            kind: labels.remove(KIND_LABEL),
+            slack_user_id: labels.remove("slack_user_id"),
+            slack_channel_id: labels.remove("slack_channel_id"),
+            slack_team_id: labels.remove("slack_team_id"),
+            slack_email: labels.remove("slack_email"),
             labels,
         }
     }
@@ -615,21 +620,23 @@ mod tests {
     }
 
     #[test]
-    fn identity_input_carries_namespace_and_managed_label() {
-        let input = derive_principal("chat:C1:ts", None, None).to_identity_input("default");
+    fn principal_input_uses_first_class_slack_identity_fields() {
+        let input = derive_principal("chat:C1:ts", None, None).to_principal_input("default");
         assert_eq!(input.namespace, "default");
         assert_eq!(input.foreign_id, "slack-channel-c1");
         assert_eq!(
             input.labels.get("managed-by").map(String::as_str),
             Some("centaur")
         );
-        assert_eq!(
-            input.labels.get("slack_channel_id").map(String::as_str),
-            Some("C1")
-        );
-        assert_eq!(
-            input.labels.get("kind").map(String::as_str),
-            Some("slack_channel")
-        );
+        assert_eq!(input.slack_channel_id.as_deref(), Some("C1"));
+        assert_eq!(input.kind.as_deref(), Some("slack_channel"));
+        assert_eq!(input.labels.len(), 1);
+
+        let payload = serde_json::to_value(&input).unwrap();
+        assert_eq!(payload["kind"], "slack_channel");
+        assert_eq!(payload["slack_channel_id"], "C1");
+        assert_eq!(payload["labels"]["managed-by"], "centaur");
+        assert!(payload["labels"].get("kind").is_none());
+        assert!(payload["labels"].get("slack_channel_id").is_none());
     }
 }

--- a/services/api-rs/crates/centaur-iron-control/src/session.rs
+++ b/services/api-rs/crates/centaur-iron-control/src/session.rs
@@ -85,8 +85,8 @@ impl SessionRegistrar {
             metadata.slack_team_id,
             metadata.conversation_name,
         );
-        let mut input = principal.to_identity_input(&self.namespace);
-        apply_slack_dm_email_label(thread_key, metadata.slack_user_email, &mut input.labels);
+        let mut input = principal.to_principal_input(&self.namespace);
+        apply_slack_dm_email(thread_key, metadata.slack_user_email, &mut input);
         let existing = match self
             .client
             .get_principal(&self.namespace, &input.foreign_id)
@@ -99,10 +99,15 @@ impl SessionRegistrar {
         let exists = existing.is_some();
         if let Some(existing) = existing {
             let mut labels = existing.labels;
+            strip_compatibility_identity_labels(&mut labels);
             labels.extend(input.labels);
             input.labels = labels;
         }
-        let slack_permission = slack_permission_for_thread(thread_key, &input.labels);
+        let slack_permission = slack_permission_for_thread(
+            thread_key,
+            input.slack_channel_id.as_deref(),
+            input.slack_user_id.as_deref(),
+        );
         let should_upsert_slack_permission = !exists
             || slack_permission
                 .as_ref()
@@ -123,25 +128,24 @@ impl SessionRegistrar {
 
 fn slack_permission_for_thread(
     thread_key: &str,
-    labels: &BTreeMap<String, String>,
+    slack_channel_id: Option<&str>,
+    slack_user_id: Option<&str>,
 ) -> Option<SlackChannelPermissionInput> {
-    if let Some(channel_id) = labels.get("slack_channel_id") {
+    if let Some(channel_id) = slack_channel_id {
         let channel_id = channel_id.trim();
         return (!is_direct_message(Some(channel_id)))
             .then(|| slack_permission(channel_id.to_owned()));
     }
 
-    if !labels.contains_key("slack_user_id") {
-        return None;
-    }
+    slack_user_id?;
     let conversation_id = slack_conversation_id(thread_key)?;
     is_direct_message(Some(conversation_id)).then(|| slack_permission(conversation_id.to_owned()))
 }
 
-fn apply_slack_dm_email_label(
+fn apply_slack_dm_email(
     thread_key: &str,
     slack_user_email: Option<&str>,
-    labels: &mut BTreeMap<String, String>,
+    input: &mut crate::models::PrincipalInput,
 ) {
     let Some(email) = slack_user_email
         .map(str::trim)
@@ -152,8 +156,20 @@ fn apply_slack_dm_email_label(
     let Some(conversation_id) = slack_conversation_id(thread_key) else {
         return;
     };
-    if is_direct_message(Some(conversation_id)) && labels.contains_key("slack_user_id") {
-        labels.insert("slack_email".to_owned(), email.to_owned());
+    if is_direct_message(Some(conversation_id)) && input.slack_user_id.is_some() {
+        input.slack_email = Some(email.to_owned());
+    }
+}
+
+fn strip_compatibility_identity_labels(labels: &mut BTreeMap<String, String>) {
+    for label in [
+        "kind",
+        "slack_user_id",
+        "slack_channel_id",
+        "slack_team_id",
+        "slack_email",
+    ] {
+        labels.remove(label);
     }
 }
 
@@ -174,6 +190,7 @@ fn is_status(err: &IronControlError, code: u16) -> bool {
 mod tests {
     use std::sync::{Arc, Mutex};
 
+    use crate::derive_principal;
     use serde_json::json;
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
@@ -241,27 +258,24 @@ mod tests {
     }
 
     #[test]
-    fn slack_dm_email_label_applies_only_to_dm_user_principals() {
-        let mut dm_labels = BTreeMap::new();
-        dm_labels.insert("slack_user_id".to_owned(), "U123".to_owned());
-        apply_slack_dm_email_label(
+    fn slack_dm_email_applies_only_to_dm_user_principals() {
+        let mut dm_input = derive_principal("slack:T123:D123:ts", Some("U123"), None)
+            .to_principal_input("default");
+        apply_slack_dm_email(
             "slack:T123:D123:1773364194.179929",
             Some(" ada@example.com "),
-            &mut dm_labels,
+            &mut dm_input,
         );
-        assert_eq!(
-            dm_labels.get("slack_email").map(String::as_str),
-            Some("ada@example.com")
-        );
+        assert_eq!(dm_input.slack_email.as_deref(), Some("ada@example.com"));
 
-        let mut channel_labels = BTreeMap::new();
-        channel_labels.insert("slack_channel_id".to_owned(), "C123".to_owned());
-        apply_slack_dm_email_label(
+        let mut channel_input = derive_principal("slack:T123:C123:ts", Some("U123"), None)
+            .to_principal_input("default");
+        apply_slack_dm_email(
             "slack:T123:C123:1773364194.179929",
             Some("ada@example.com"),
-            &mut channel_labels,
+            &mut channel_input,
         );
-        assert_eq!(channel_labels.get("slack_email"), None);
+        assert_eq!(channel_input.slack_email, None);
     }
 
     #[tokio::test]
@@ -397,10 +411,31 @@ mod tests {
 
     #[test]
     fn slack_permission_for_thread_skips_dm_channel_fallback_without_user() {
-        let mut labels = BTreeMap::new();
-        labels.insert("slack_channel_id".to_owned(), "D123".to_owned());
+        assert_eq!(
+            slack_permission_for_thread("slack:D123:ts", Some("D123"), None),
+            None
+        );
+    }
 
-        assert_eq!(slack_permission_for_thread("slack:D123:ts", &labels), None);
+    #[test]
+    fn compatibility_identity_labels_are_not_merged_back_into_writes() {
+        let mut labels = BTreeMap::from([
+            ("kind".to_owned(), "slack_dm".to_owned()),
+            ("slack_user_id".to_owned(), "U0123456789".to_owned()),
+            ("slack_team_id".to_owned(), "T0123456789".to_owned()),
+            ("managed-by".to_owned(), "centaur".to_owned()),
+            ("team".to_owned(), "platform".to_owned()),
+        ]);
+
+        strip_compatibility_identity_labels(&mut labels);
+
+        assert_eq!(
+            labels,
+            BTreeMap::from([
+                ("managed-by".to_owned(), "centaur".to_owned()),
+                ("team".to_owned(), "platform".to_owned()),
+            ])
+        );
     }
 
     async fn spawn_iron_control_stub(

--- a/services/api-rs/crates/centaur-perms/src/main.rs
+++ b/services/api-rs/crates/centaur-perms/src/main.rs
@@ -11,7 +11,8 @@ use std::path::PathBuf;
 
 use centaur_iron_control::{
     BrokerCredentialInput, Grant, GrantSecret, Grantee, IdentityInput, IronControlClient,
-    IronControlError, Role, RoleSpec, SECRET_TYPES, grant_inputs_to_role, managed_labels,
+    IronControlError, PrincipalInput, Role, RoleSpec, SECRET_TYPES, grant_inputs_to_role,
+    managed_labels,
 };
 use centaur_iron_proxy::SourcePolicy;
 use clap::{Args, Parser, Subcommand, ValueEnum};
@@ -1026,7 +1027,7 @@ fn parse_kv(raw: &str, flag: &str) -> Result<(String, String)> {
 /// Ensure the principal exists, returning its OID. Looks it up first so an
 /// existing principal (e.g. one a session created) is never clobbered; creates
 /// it only when absent.
-async fn ensure_principal(client: &IronControlClient, identity: &IdentityInput) -> Result<String> {
+async fn ensure_principal(client: &IronControlClient, identity: &PrincipalInput) -> Result<String> {
     match client
         .get_principal(&identity.namespace, &identity.foreign_id)
         .await

--- a/services/api-rs/crates/centaur-perms/src/principal.rs
+++ b/services/api-rs/crates/centaur-perms/src/principal.rs
@@ -2,7 +2,7 @@
 
 use std::collections::BTreeMap;
 
-use centaur_iron_control::{IdentityInput, derive_principal};
+use centaur_iron_control::{PrincipalInput, derive_principal};
 
 /// Turn a `--principal` value (plus optional `--slack-user`) into the identity
 /// to upsert/look up.
@@ -16,17 +16,22 @@ pub fn resolve_principal(
     principal: &str,
     slack_user: Option<&str>,
     namespace: &str,
-) -> IdentityInput {
+) -> PrincipalInput {
     if principal.contains(':') {
         // The CLI has no resolved conversation name; the synthetic display name
         // is fine for operator-driven lookups.
-        derive_principal(principal, slack_user, None).to_identity_input(namespace)
+        derive_principal(principal, slack_user, None).to_principal_input(namespace)
     } else {
-        IdentityInput {
+        PrincipalInput {
             namespace: namespace.to_owned(),
             foreign_id: principal.to_owned(),
             name: principal.to_owned(),
             labels: BTreeMap::from([("managed-by".to_owned(), "centaur".to_owned())]),
+            kind: None,
+            slack_user_id: None,
+            slack_channel_id: None,
+            slack_team_id: None,
+            slack_email: None,
         }
     }
 }

--- a/services/api-rs/crates/centaur-workflows/src/lib.rs
+++ b/services/api-rs/crates/centaur-workflows/src/lib.rs
@@ -11,7 +11,7 @@ use absurd::{
     AwaitEventOptions, Client, ClientOptions, CreateQueueOptions, RetryKind, RetryStrategy,
     SpawnOptions, StepHandle, TaskContext, TaskRegistrationOptions, Worker, WorkerOptions,
 };
-use centaur_iron_control::{IdentityInput, IronControlClient, IronControlError, slugify};
+use centaur_iron_control::{IronControlClient, IronControlError, PrincipalInput, slugify};
 use centaur_sandbox_core::SandboxSpec;
 use centaur_session_core::{HarnessType, MessageRole, SessionMessageInput, ThreadKey};
 use centaur_session_runtime::{
@@ -312,11 +312,16 @@ impl WorkflowPrincipalRegistrar {
             let foreign_id = canonical_workflow_principal_foreign_id(workflow_name);
             let record = self
                 .client
-                .upsert_principal(&IdentityInput {
+                .upsert_principal(&PrincipalInput {
                     namespace: self.namespace.clone(),
                     foreign_id,
                     name: format!("Workflow {workflow_name}"),
                     labels: workflow_principal_labels(workflow_name),
+                    kind: Some("workflow".to_owned()),
+                    slack_user_id: None,
+                    slack_channel_id: None,
+                    slack_team_id: None,
+                    slack_email: None,
                 })
                 .await?;
             registered.insert(workflow_name.clone(), record.id);
@@ -331,7 +336,6 @@ fn canonical_workflow_principal_foreign_id(workflow_name: &str) -> String {
 
 fn workflow_principal_labels(workflow_name: &str) -> BTreeMap<String, String> {
     BTreeMap::from([
-        ("kind".to_owned(), "workflow".to_owned()),
         ("managed-by".to_owned(), "centaur".to_owned()),
         ("workflow_name".to_owned(), workflow_name.to_owned()),
     ])
@@ -4521,10 +4525,10 @@ mod tests {
     }
 
     #[test]
-    fn workflow_principal_labels_identify_workflow_kind() {
+    fn workflow_principal_labels_keep_extensible_metadata_only() {
         let labels = workflow_principal_labels("nightly_report");
 
-        assert_eq!(labels.get("kind").map(String::as_str), Some("workflow"));
+        assert!(!labels.contains_key("kind"));
         assert!(!labels.contains_key("purpose"));
         assert_eq!(
             labels.get("workflow_name").map(String::as_str),

--- a/services/console/app/controllers/api/v1/principals_controller.rb
+++ b/services/console/app/controllers/api/v1/principals_controller.rb
@@ -30,6 +30,7 @@ module Api
         principal = Principal.new(namespace: upsert_namespace, foreign_id: data_params[:foreign_id],
                                   created_by: current_user)
         ActiveRecord::Base.transaction do
+          validate_identity_consistency!(principal)
           principal.assign_attributes(principal_params)
           principal.apply_default_sandbox_capabilities!(principal_params)
           principal.save!
@@ -47,6 +48,7 @@ module Api
         principal = resolve_for_upsert(Principal)
         was_new = principal.new_record?
         ActiveRecord::Base.transaction do
+          validate_identity_consistency!(principal)
           principal.assign_attributes(principal_params)
           principal.apply_default_sandbox_capabilities!(principal_params) if was_new
           principal.save!
@@ -100,11 +102,23 @@ module Api
       def principal_params
         data_params.permit(
           :name,
+          :kind,
+          :slack_user_id,
+          :slack_channel_id,
+          :slack_team_id,
+          :slack_email,
+          :console_user_id,
+          :console_user_email,
           :sandbox_repo_cache,
           :sandbox_observability_enabled,
           :sandbox_api_server_enabled,
           labels: {}
         )
+      end
+
+      def validate_identity_consistency!(principal)
+        PrincipalIdentityLabels.validate_request_consistency(principal, data_params)
+        raise ActiveRecord::RecordInvalid.new(principal) if principal.errors.any?
       end
 
       def slack_channel_permission_owner

--- a/services/console/app/models/principal.rb
+++ b/services/console/app/models/principal.rb
@@ -25,6 +25,7 @@ class Principal < ApplicationRecord
   after_commit :auto_grant_matching_oauth_credentials, on: %i[create update]
   after_create :assign_default_roles, if: :roles_blank_for_defaulting?
   before_validation :apply_sandbox_repo_cache_label
+  before_validation :validate_identity_label_consistency
   before_validation :promote_identity_labels_to_fields
   before_validation :strip_identity_labels
   before_commit :bump_own_sync_config_cache_version, on: :update, if: :sync_config_fields_changed?
@@ -244,9 +245,14 @@ class Principal < ApplicationRecord
     self[:labels] = labels.to_h.merge(SANDBOX_REPO_CACHE_LABEL => sandbox_repo_cache)
   end
 
-  # API writers still send principal identity through labels during the
-  # compatibility release. Promote only fields that were not assigned directly.
-  # Reserved identity labels are stripped below so columns remain authoritative.
+  def validate_identity_label_consistency
+    PrincipalIdentityLabels.validate_consistency(self)
+  end
+
+  # Legacy API writers may still send principal identity through labels during
+  # the compatibility release. Promote only fields that were not assigned
+  # directly. Reserved identity labels are stripped below so columns remain
+  # authoritative.
   def promote_identity_labels_to_fields
     PrincipalIdentityLabels.assign(self)
   end

--- a/services/console/app/services/principal_identity_labels.rb
+++ b/services/console/app/services/principal_identity_labels.rb
@@ -33,6 +33,41 @@ class PrincipalIdentityLabels
       end
     end
 
+    def validate_consistency(principal)
+      labels = principal.labels.to_h
+      kind = effective_kind(principal, labels)
+
+      fields_for(kind).each do |label, field|
+        column = field.fetch(:column)
+        next unless labels.key?(label) && principal.will_save_change_to_attribute?(column)
+
+        add_conflict_error(principal, column, label) unless principal.public_send(column) == decode_assignment_value(label, labels[label])
+      end
+    end
+
+    def validate_request_consistency(principal, attributes)
+      attributes = attributes.to_unsafe_h if attributes.respond_to?(:to_unsafe_h)
+      attributes = attributes.to_h.stringify_keys
+      raw_labels = attributes.fetch("labels", {})
+      labels = raw_labels.respond_to?(:to_h) ? raw_labels.to_h.stringify_keys : {}
+      kind = if attributes.key?("kind")
+        attributes["kind"]
+      elsif labels.key?("kind")
+        labels["kind"]
+      else
+        principal.kind
+      end
+
+      fields_for(kind).each do |label, field|
+        column = field.fetch(:column)
+        next unless attributes.key?(column) && labels.key?(label)
+
+        direct_value = principal.class.type_for_attribute(column).cast(attributes[column])
+        label_value = decode_assignment_value(label, labels[label])
+        add_conflict_error(principal, column, label) unless direct_value == label_value
+      end
+    end
+
     def strip(principal)
       principal[:labels] = principal.labels.to_h.except(*labels_for(principal.kind))
     end
@@ -68,6 +103,16 @@ class PrincipalIdentityLabels
     end
 
     private
+
+    def effective_kind(principal, labels)
+      return principal.kind if principal.will_save_change_to_kind? || !labels.key?("kind")
+
+      decode_assignment_value("kind", labels["kind"])
+    end
+
+    def add_conflict_error(principal, column, label)
+      principal.errors.add(column, "does not agree with labels.#{label}")
+    end
 
     def fields_for(kind)
       FIELDS.select { |_label, field| field[:kind].nil? || field[:kind] == kind }

--- a/services/console/docs/API.md
+++ b/services/console/docs/API.md
@@ -1193,13 +1193,20 @@ system-managed `default/infra` role.
 | `namespace`  | optional    | Defaults to `"default"`. Immutable. |
 | `foreign_id` | optional    | Unique per namespace. Immutable. |
 | `name`       | optional    | |
-| `labels`     | optional    | Identity values remain represented here in this API version. Reserved keys are `kind`, `slack_user_id`, `slack_channel_id`, `slack_team_id`, and `slack_email`. For `console_user` principals, `console-user-id` and `email` are also reserved. |
+| `kind`       | optional    | Defaults to `unknown`. See the known values below. |
+| `slack_user_id` | optional | First-class Slack user identity. |
+| `slack_channel_id` | optional | First-class Slack conversation identity. |
+| `slack_team_id` | optional | First-class Slack team or enterprise scope. |
+| `slack_email` | optional | First-class Slack email identity. |
+| `console_user_id` | optional | Database ID of the associated console user for a `console_user` principal. |
+| `console_user_email` | optional | Email identity for a `console_user` principal. |
+| `labels`     | optional    | Extensible metadata. Compatibility identity labels are still accepted and synthesized in responses during the transition. |
 | `slack_channel_permissions` | optional | Direct permissions owned by the principal. Full replacement when present on create or update. |
 | `effective_slack_channel_permissions` | response only | Direct permissions merged with permissions inherited from assigned roles. |
 
 Known kinds are `unknown`, `user`, `console_user`, `workflow`,
 `slack_channel`, `slack_dm`, `discord_channel`, `linear_issue`, `teams_user`,
-and `teams_conversation`. Use one of these values for the `kind` label.
+and `teams_conversation`. Use one of these values for the `kind` field.
 
 ### Operations
 
@@ -1236,15 +1243,17 @@ Returns `201`:
 | `GET`  | `/api/v1/principals/lookup/:namespace/:foreign_id/effective_config` | [Effective config](#effective-config) by namespace + foreign id. `404` if missing. |
 | `GET`  | `/api/v1/principals/:principal_id/grants` | [List the grants](#list-by-grantee) granted directly to the principal. |
 | `POST` | `/api/v1/principals/:id/slack_channel_permissions` | Idempotently create or update one direct Slack channel permission. Omitted flags default to enabled on create and remain unchanged on update. |
-| `PUT`/`PATCH` | `/api/v1/principals/:id` | [Upsert](#upsert-put--patch) by OID or `foreign_id`. `name`, `labels`, and direct `slack_channel_permissions` are mutable on an existing record; `namespace` and `foreign_id` apply only when creating. |
+| `PUT`/`PATCH` | `/api/v1/principals/:id` | [Upsert](#upsert-put--patch) by OID or `foreign_id`. `name`, first-class identity fields, `labels`, and direct `slack_channel_permissions` are mutable on an existing record. `namespace` and `foreign_id` apply only when creating. |
 
-The reserved identity labels are backed by authoritative principal columns but
-remain labels in this API version. They are synthesized in responses, accepted
-in writes, and translated to column filters. Sending a null, empty, or
-whitespace-only Slack identity label clears that value. A null or blank `kind`
-is rejected, as are unknown kind values and new or changed malformed nonblank
-Slack identities. Unchanged legacy values remain round-trip safe during the
-compatibility release.
+The first-class identity fields are authoritative. For compatibility, responses
+still synthesize `kind`, `slack_user_id`, `slack_channel_id`, `slack_team_id`,
+and `slack_email` in `labels`. A `console_user` response also synthesizes
+`console-user-id` and `email`. Writes may send the compatibility labels, but if
+a request sends both forms, their values must agree or the API returns `422`.
+Sending a null, empty, or whitespace-only Slack identity label clears that
+value. A null or blank `kind` is rejected, as are unknown kind values and new
+or changed malformed nonblank Slack identities. Unchanged legacy values remain
+round-trip safe during the compatibility release.
 
 See [Role assignments](#role-assignments) for attaching roles to a principal.
 

--- a/services/console/test/controllers/api/v1/principals_controller_test.rb
+++ b/services/console/test/controllers/api/v1/principals_controller_test.rb
@@ -297,25 +297,141 @@ module Api
         assert_response :bad_request
       end
 
-      test "POST accepts identity only through labels" do
+      test "POST creates a Slack principal from first-class identity fields" do
         post api_v1_principals_url,
              params: {
                data: {
                  namespace: "acme",
-                 foreign_id: "mixed-identity",
+                 foreign_id: "direct-slack-identity",
+                 kind: "slack_dm",
+                 slack_user_id: "U0123456789",
+                 slack_team_id: "T0123456789",
                  slack_email: "ada@example.com",
-                 labels: { "kind" => "user" }
+                 labels: { "managed-by" => "centaur" }
                }
              }.to_json,
              headers: auth_headers
 
         assert_response :created
-        principal = Principal.find_by!(namespace: "acme", foreign_id: "mixed-identity")
-        assert_equal "user", principal.kind
-        assert_nil principal.slack_email
+        principal = Principal.find_by!(namespace: "acme", foreign_id: "direct-slack-identity")
+        assert_equal "slack_dm", principal.kind
+        assert_equal "U0123456789", principal.slack_user_id
+        assert_equal "T0123456789", principal.slack_team_id
+        assert_equal "ada@example.com", principal.slack_email
+        assert_equal "centaur", principal.labels["managed-by"]
         PrincipalIdentityLabels.columns.each do |field|
           assert_not json_body.fetch("data").key?(field)
         end
+      end
+
+      test "POST accepts matching first-class fields and compatibility labels" do
+        user = users(:acme_admin)
+
+        post api_v1_principals_url,
+             params: {
+               data: {
+                 namespace: "acme",
+                 foreign_id: "matching-console-user-identity",
+                 kind: "console_user",
+                 console_user_id: user.id,
+                 console_user_email: user.email,
+                 labels: {
+                   "kind" => "console_user",
+                   "console-user-id" => user.oid,
+                   "email" => user.email,
+                   "managed-by" => "centaur"
+                 }
+               }
+             }.to_json,
+             headers: auth_headers
+
+        assert_response :created
+        principal = Principal.find_by!(namespace: "acme", foreign_id: "matching-console-user-identity")
+        assert_equal user.id, principal.console_user_id
+        assert_equal user.email, principal.console_user_email
+        assert_equal "centaur", principal.labels["managed-by"]
+        assert_empty principal.labels.slice("kind", "console-user-id", "email")
+      end
+
+      test "POST returns 422 when first-class Slack fields disagree with compatibility labels" do
+        assert_no_difference -> { Principal.count } do
+          post api_v1_principals_url,
+               params: {
+                 data: {
+                   namespace: "acme",
+                   foreign_id: "conflicting-slack-identity",
+                   kind: "slack_dm",
+                   slack_user_id: "U0123456789",
+                   slack_channel_id: "D0123456789",
+                   slack_team_id: "T0123456789",
+                   slack_email: "ada@example.com",
+                   labels: {
+                     "kind" => "slack_channel",
+                     "slack_user_id" => "U9876543210",
+                     "slack_channel_id" => "D9876543210",
+                     "slack_team_id" => "T9876543210",
+                     "slack_email" => "grace@example.com"
+                   }
+                 }
+               }.to_json,
+               headers: auth_headers
+        end
+
+        assert_response :unprocessable_content
+        details = json_body.dig("error", "details")
+        %w[kind slack_user_id slack_channel_id slack_team_id slack_email].each do |field|
+          assert_includes details.fetch(field), "does not agree with labels.#{field}"
+        end
+      end
+
+      test "POST returns 422 when first-class console user fields disagree with compatibility labels" do
+        user = users(:acme_admin)
+        other_user = users(:globex_admin)
+
+        assert_no_difference -> { Principal.count } do
+          post api_v1_principals_url,
+               params: {
+                 data: {
+                   namespace: "acme",
+                   foreign_id: "conflicting-console-user-identity",
+                   kind: "console_user",
+                   console_user_id: user.id,
+                   console_user_email: user.email,
+                   labels: {
+                     "kind" => "console_user",
+                     "console-user-id" => other_user.oid,
+                     "email" => other_user.email
+                   }
+                 }
+               }.to_json,
+               headers: auth_headers
+        end
+
+        assert_response :unprocessable_content
+        details = json_body.dig("error", "details")
+        assert_includes details.fetch("console_user_id"), "does not agree with labels.console-user-id"
+        assert_includes details.fetch("console_user_email"), "does not agree with labels.email"
+      end
+
+      test "PUT returns 422 when an unchanged first-class field disagrees with a label" do
+        principal = principals(:acme_user_alice)
+
+        put api_v1_principal_url(id: principal.oid),
+            params: {
+              data: {
+                kind: principal.kind,
+                slack_user_id: principal.slack_user_id,
+                labels: {
+                  "kind" => principal.kind,
+                  "slack_user_id" => "U9876543210"
+                }
+              }
+            }.to_json,
+            headers: auth_headers
+
+        assert_response :unprocessable_content
+        assert_includes json_body.dig("error", "details", "slack_user_id"),
+                        "does not agree with labels.slack_user_id"
       end
 
       test "PUT updates labels" do

--- a/services/console/test/models/principal_test.rb
+++ b/services/console/test/models/principal_test.rb
@@ -69,6 +69,21 @@ class PrincipalTest < ActiveSupport::TestCase
     assert_empty principal.labels.slice(*PrincipalIdentityLabels.labels_for(principal.kind))
   end
 
+  test "first-class identity fields must agree with compatibility labels" do
+    principal = Principal.new(default_attrs(
+      kind: "slack_dm",
+      slack_user_id: "U0123456789",
+      labels: {
+        "kind" => "slack_channel",
+        "slack_user_id" => "U9876543210"
+      }
+    ))
+
+    assert_not principal.valid?
+    assert_includes principal.errors[:kind], "does not agree with labels.kind"
+    assert_includes principal.errors[:slack_user_id], "does not agree with labels.slack_user_id"
+  end
+
   test "console user identity is stored only in columns and synthesized for compatibility" do
     user = users(:acme_admin)
     principal = Principal.create!(default_attrs(


### PR DESCRIPTION
Send Rust-created Slack and workflow principal identities through first-class fields instead of compatibility labels, while preserving extensible labels during upserts. Accept the first-class Slack and console-user fields in Rails, keep labels-only compatibility, and return 422 when both representations are supplied with different values. Updates the principal API documentation and adds focused coverage for matching, conflicting, and labels-only inputs.