### PR TITLE
fix(slack): keep reactions when serializing messages

### DIFF
--- a/tools/productivity/slack/client.py
+++ b/tools/productivity/slack/client.py
@@ -495,6 +495,12 @@ class SlackClient:
             "reply_count": msg.get("reply_count", 0),
             "reply_users": msg.get("reply_users", []),
             "latest_reply": msg.get("latest_reply"),
+            # Rides along on the history/replies payload under channels:history,
+            # so no extra OAuth scope (feedback.py already reads it off the raw
+            # responses). Slack caps the per-reaction `users` array, so `count`
+            # can exceed `len(users)`; a caller needing the complete reactor
+            # list still wants reactions.get and its reactions:read scope.
+            "reactions": msg.get("reactions", []),
             "type": msg.get("type", "message"),
             "subtype": msg.get("subtype"),
             "parent_user_id": msg.get("parent_user_id"),

--- a/tools/productivity/slack/tests/test_client.py
+++ b/tools/productivity/slack/tests/test_client.py
@@ -342,6 +342,44 @@ def test_get_channel_history_page_paginates_with_date_window() -> None:
     assert result["messages"][1]["text"] == "hi @alice"
 
 
+def test_get_channel_history_page_preserves_reactions() -> None:
+    """Reactions ride along on the history payload; the serializer must keep them.
+
+    In channels where people answer by reacting rather than replying, the
+    reaction list is the signal and reply_count is close to noise. Dropping
+    reactions during serialization left callers with no way to tell the
+    difference between "nobody responded" and "everybody responded with an
+    emoji".
+    """
+    client, fake_web_client = _make_client()
+    client._get_user_cache = lambda: {"U1": "alice", "U2": "bob"}  # type: ignore[method-assign]
+    fake_web_client.history_pages = [
+        {
+            "messages": [
+                {
+                    "user": "U1",
+                    "text": "ship it?",
+                    "ts": "200.000000",
+                    "reactions": [
+                        {"name": "white_check_mark", "users": ["U1", "U2"], "count": 2},
+                    ],
+                },
+                {"user": "U2", "text": "no reactions here", "ts": "190.000000"},
+            ],
+            "response_metadata": {"next_cursor": ""},
+        },
+    ]
+
+    result = client.get_channel_history_page("paradigm-pulse", limit=2)
+
+    assert result["messages"][0]["reactions"] == [
+        {"name": "white_check_mark", "users": ["U1", "U2"], "count": 2},
+    ]
+    # A message with no reactions gets an empty list, matching how reply_users
+    # defaults, so callers can index without a guard.
+    assert result["messages"][1]["reactions"] == []
+
+
 def test_get_channel_history_page_surfaces_structured_auth_failure() -> None:
     client, fake_web_client = _make_client()
     client._get_user_cache = lambda: {}  # type: ignore[method-assign]


### PR DESCRIPTION
`_serialize_message` builds a fixed dict from the Slack payload and drops
everything it doesn't name, including the `reactions` array. Every read path
funnels through it (`get_channel_history_page`, `get_thread_replies_page`,
and the search fallback fetch), so nothing downstream of the serialized shape
can see reaction signal.

That's a blind spot wherever people answer by reacting rather than replying.
A message with 12 check-marks and no replies serializes to `reply_count: 0`,
which reads as "nobody responded" when the opposite is true. An agent working
off that shape either reports the reply count as a roster or has to say it
can't answer.

## No new OAuth scope

`reactions:read` gates the `reactions.*` methods. The `reactions` array on a
`conversations.history` payload rides along with `channels:history`, which
this tool already requires, and `feedback.py:372` has been reading it off the
raw responses this way for its thumbsup/thumbsdown signal.

Straightforward to check if you want to: an app granted `channels:history`
and not `reactions:read` still receives `reactions` on
`conversations.history`.

## Consistent across both read paths

The API server proxy (`slack_proxy.rs`) returns an untyped
`serde_json::Value` rather than a typed message struct, so it doesn't strip
unknown fields. Reactions survive the proxy, and the proxy and direct fetches
return the same shape.

## Relation to #1189

#1189 asked for `reaction_added` to wake the agent, which needs the
`reactions:read` scope plus ingress work in slackbotv2, and it noted that
reaction feedback currently has to be polled through
`conversations.history` + `conversations.replies`.

This is the cheaper read-side half of that problem. It makes reactions
visible to anything already reading history, with no new scope and no
platform change. It does not provide the real-time wake #1189 wanted, and it
doesn't remove `feedback.py`'s polling. It does mean a poller no longer has
to bypass the serializer to see the reactions it came for.

## Caveats

Defaults to `[]` like the neighbouring `reply_users`, so callers can index
without a guard, and messages without reactions cost one empty list.

Slack caps the per-reaction `users` array, so `count` can exceed
`len(users)`. Anyone needing a complete reactor list on a heavily reacted
message still wants `reactions.get` and the `reactions:read` scope it
requires. The comment at the call site says so, since a caller that treats a
truncated list as the full roster is confidently wrong in exactly the way the
missing field was.

## Validation

`test_get_channel_history_page_preserves_reactions` covers a message with
reactions and one without. It fails on `main` with `KeyError: 'reactions'`
and passes with the change. Full slack suite: 80 passed.

Also exercised end to end through the CLI
(`slack channel-direct <id> --limit 1 --oldest <ts> --latest <ts> --inclusive
--json`) against live Slack. The serialized message came back carrying its
`reactions` array with reactor and count intact, on a message that also had
`reply_count: 3`, so reaction and thread metadata coexist.

Not run: a local Kubernetes stack deploy. No cluster-level behavior changes
here, and the proxy path is covered by reading `slack_proxy.rs` above, but
flagging it since `AGENTS.md` asks for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
