### PR TITLE
feat(slackbotv2): decouple response metadata from Console

### DIFF
--- a/contrib/chart/templates/slackbotv2.yaml
+++ b/contrib/chart/templates/slackbotv2.yaml
@@ -79,6 +79,8 @@ spec:
               value: {{ .Values.apiRs.activitySummary.enabled | quote }}
             - name: SLACKBOTV2_AUTO_JOIN_CREATED_CHANNELS
               value: {{ .Values.slackbotv2.autoJoinCreatedChannels | quote }}
+            - name: SLACKBOTV2_RESPONSE_METADATA_ENABLED
+              value: {{ .Values.slackbotv2.responseMetadataEnabled | quote }}
             - name: SLACKBOTV2_MESSAGE_OVERRIDES_STRATEGY
               value: {{ .Values.slackbotv2.messageOverridesStrategy.mode | quote }}
             - name: SLACKBOTV2_MESSAGE_OVERRIDES_MODEL

--- a/contrib/chart/values.schema.json
+++ b/contrib/chart/values.schema.json
@@ -358,6 +358,7 @@
       "type": "object",
       "properties": {
         "mcpPublicUrl": { "type": "string" },
+        "responseMetadataEnabled": { "type": "boolean" },
         "metrics": {
           "type": "object",
           "properties": {

--- a/contrib/chart/values.yaml
+++ b/contrib/chart/values.yaml
@@ -475,6 +475,9 @@ slackbotv2:
   # Join newly-created public channels after subscribed channel_created events.
   # Requires the Slack app to grant channels:read and channels:join.
   autoJoinCreatedChannels: false
+  # Append model, harness, reasoning effort, and service tier to every live
+  # streamed Slack assistant response. Independent of the optional Console link below.
+  responseMetadataEnabled: false
   # Public/local MCP endpoint shown in MCP SSO setup messages. The default
   # assumes users connect through `kubectl port-forward ... 3000:8080`.
   mcpPublicUrl: "http://localhost:3000"

--- a/services/slackbotv2/src/console-session-link.ts
+++ b/services/slackbotv2/src/console-session-link.ts
@@ -59,6 +59,7 @@ const CODEX_REASONING_EFFORTS_BY_MODEL: Record<string, ReadonlySet<string>> = {
 const CODEX_CONFIG = codexConfig as {
   model?: unknown
   model_reasoning_effort?: unknown
+  service_tier?: unknown
 }
 
 // Default model each harness runs when no --model/--opus/... override is set,
@@ -88,6 +89,10 @@ const BAKED_DEFAULT_REASONING: Record<string, string | undefined> = {
     typeof CODEX_CONFIG.model_reasoning_effort === 'string'
       ? CODEX_CONFIG.model_reasoning_effort
       : undefined
+}
+
+const BAKED_DEFAULT_SERVICE_TIERS: Record<string, string | undefined> = {
+  codex: typeof CODEX_CONFIG.service_tier === 'string' ? CODEX_CONFIG.service_tier : undefined
 }
 
 /** Slack mrkdwn requires `&`, `<`, `>` to be escaped in free text. */
@@ -139,6 +144,15 @@ export function defaultReasoningForHarness(
   if (!harnessType) return undefined
   const key = harnessType.trim().toLowerCase()
   return configured?.[key]?.trim().toLowerCase() || BAKED_DEFAULT_REASONING[key]
+}
+
+/** Returns the baked service tier for a harness that consumes Codex config.toml. */
+export function defaultServiceTierForHarness(
+  harnessType: string | null | undefined
+): string | undefined {
+  if (!harnessType) return undefined
+  const key = harnessType.trim().toLowerCase()
+  return BAKED_DEFAULT_SERVICE_TIERS[key]
 }
 
 /** Resolves the effort the selected harness actually runs for this turn. */
@@ -206,28 +220,35 @@ export type SlackContextBlock = {
 }
 
 /**
- * Builds the "Open chat in Console · {MODEL} · {Harness} · {Effort}"
- * context block, or
- * undefined when no Console base URL is configured (a bare "Open chat in
- * Console" with no link is pointless, so the whole block is skipped). The
- * model id is uppercased for display.
+ * Builds a Slack context block containing the optional Console link and
+ * response metadata. Metadata can be enabled independently of the Console URL;
+ * the existing Console-link behavior continues to include it automatically.
  */
-export function buildConsoleSessionContextBlock(params: {
+export function buildSlackResponseContextBlock(params: {
   consoleBaseUrl: string | null | undefined
   threadKey: string
   harnessType?: string | null
+  metadataEnabled?: boolean
   model?: string | null
   reasoning?: string | null
+  serviceTier?: string | null
 }): SlackContextBlock | undefined {
   const url = consoleSessionUrl(params.consoleBaseUrl, params.threadKey)
-  if (!url) return undefined
-  const segments = [`<${url}|Open chat in Console>`]
-  const model = params.model?.trim()
-  if (model) segments.push(escapeSlackMrkdwn(model.toUpperCase()))
-  const harness = harnessDisplayName(params.harnessType)
-  if (harness) segments.push(escapeSlackMrkdwn(harness))
-  const reasoning = reasoningDisplayName(params.reasoning)
-  if (reasoning) segments.push(escapeSlackMrkdwn(reasoning))
+  const includeMetadata = params.metadataEnabled === true || Boolean(url)
+  if (!url && !includeMetadata) return undefined
+  const segments: string[] = []
+  if (url) segments.push(`<${url}|Open chat in Console>`)
+  if (includeMetadata) {
+    const model = params.model?.trim()
+    if (model) segments.push(escapeSlackMrkdwn(model.toUpperCase()))
+    const harness = harnessDisplayName(params.harnessType)
+    if (harness) segments.push(escapeSlackMrkdwn(harness))
+    const reasoning = reasoningDisplayName(params.reasoning)
+    if (reasoning) segments.push(escapeSlackMrkdwn(reasoning))
+    const serviceTier = params.serviceTier?.trim()
+    if (serviceTier) segments.push(escapeSlackMrkdwn(titleCase(serviceTier)))
+  }
+  if (segments.length === 0) return undefined
   // Middot (U+00B7) with a space on each side, matching the bot's other
   // context lines.
   return {

--- a/services/slackbotv2/src/index.ts
+++ b/services/slackbotv2/src/index.ts
@@ -53,8 +53,9 @@ import {
   withSlackApiTimeout
 } from './session-api'
 import {
-  buildConsoleSessionContextBlock,
+  buildSlackResponseContextBlock,
   defaultModelForHarness,
+  defaultServiceTierForHarness,
   effectiveReasoningForHarness,
   reasoningForModel,
   type SlackContextBlock
@@ -1120,13 +1121,18 @@ async function syncThreadMessageToSession(
     resolvedReasoning,
     input.options.harnessDefaultReasoning
   )
-  let consoleSessionBlock = isFirstAssistantMessage
-    ? buildConsoleSessionContextBlock({
-        consoleBaseUrl: input.options.consolePublicUrl,
+  const responseMetadataEnabled = input.options.responseMetadataEnabled === true
+  let responseContextBlock = isFirstAssistantMessage || responseMetadataEnabled
+    ? buildSlackResponseContextBlock({
+        consoleBaseUrl: isFirstAssistantMessage ? input.options.consolePublicUrl : undefined,
         threadKey: thread.id,
         harnessType: effectiveHarnessType,
+        metadataEnabled: responseMetadataEnabled,
         model: effectiveModel,
-        reasoning: effectiveReasoning
+        reasoning: effectiveReasoning,
+        serviceTier: resolvedProvider
+          ? undefined
+          : defaultServiceTierForHarness(effectiveHarnessType)
       })
     : undefined
   if (overrides.harnessType || overrides.model || overrides.provider || overrides.reasoning) {
@@ -1343,13 +1349,15 @@ async function syncThreadMessageToSession(
         )
         forwardInput.metadataModel = model
         forwardInput.reasoning = requestedReasoning
-        if (isFirstAssistantMessage) {
-          consoleSessionBlock = buildConsoleSessionContextBlock({
-            consoleBaseUrl: input.options.consolePublicUrl,
+        if (isFirstAssistantMessage || responseMetadataEnabled) {
+          responseContextBlock = buildSlackResponseContextBlock({
+            consoleBaseUrl: isFirstAssistantMessage ? input.options.consolePublicUrl : undefined,
             threadKey: thread.id,
             harnessType,
+            metadataEnabled: responseMetadataEnabled,
             model,
-            reasoning
+            reasoning,
+            serviceTier: resolvedProvider ? undefined : defaultServiceTierForHarness(harnessType)
           })
         }
         traceLog(input.options, 'slackbotv2_session_harness_resolved', trace, {
@@ -1371,7 +1379,7 @@ async function syncThreadMessageToSession(
       renderLease,
       assistantStatusVisible,
       trace,
-      consoleSessionBlock
+      responseContextBlock
     )
     traceLog(input.options, 'slackbotv2_forward_complete', trace, {
       last_event_id: lastEventId
@@ -1440,7 +1448,7 @@ function scheduleExecutionRender(
   renderLease: { release: (() => Promise<void>) | null },
   assistantStatusVisible: boolean,
   trace?: SlackbotV2Trace,
-  consoleSessionBlock?: SlackContextBlock
+  responseContextBlock?: SlackContextBlock
 ): void {
   const promise = (async () => {
     slackbotMetrics.activeLiveRenders.inc()
@@ -1455,7 +1463,7 @@ function scheduleExecutionRender(
           getLastEventId,
           assistantStatusVisible,
           trace,
-          consoleSessionBlock
+          responseContextBlock
         )
         if (result === 'complete') return
         const delayMs = renderRetryDelayMs(attempt)
@@ -1499,7 +1507,7 @@ async function renderExecutionAttempt(
   getLastEventId: () => number,
   assistantStatusVisible: boolean,
   trace?: SlackbotV2Trace,
-  consoleSessionBlock?: SlackContextBlock
+  responseContextBlock?: SlackContextBlock
 ): Promise<'complete' | 'retry'> {
   const renderStartedAtMs = nowMs()
   let outcome = 'failure'
@@ -1514,7 +1522,7 @@ async function renderExecutionAttempt(
       options,
       trace,
       assistantStatusVisible,
-      consoleSessionBlock
+      responseContextBlock
     )
     rendered = true
     outcome = 'complete'
@@ -2328,7 +2336,7 @@ async function renderExecutionStream(
   options: SlackbotV2Options,
   trace?: SlackbotV2Trace,
   assistantStatusVisible = false,
-  consoleSessionBlock?: SlackContextBlock
+  responseContextBlock?: SlackContextBlock
 ): Promise<{ diverged: boolean; messageId?: string }> {
   const promptText = slackMessagePromptText(message)
   if (isPlainTextOnlyRequest(promptText)) {
@@ -2378,9 +2386,9 @@ async function renderExecutionStream(
       recipientUserId: message.author.userId,
       ...(taskDisplayMode === 'none' ? {} : { taskDisplayMode }),
       // stopBlocks are appended to the end of the finalized Slack message via
-      // chat.stopStream. Present only for the first assistant message so the
-      // Console link renders once per thread.
-      ...(consoleSessionBlock ? { stopBlocks: [consoleSessionBlock] } : {})
+      // chat.stopStream. The Console link is only included on the first assistant
+      // message; optional response metadata may be appended on every live response.
+      ...(responseContextBlock ? { stopBlocks: [responseContextBlock] } : {})
     })
     return { diverged: capture.diverged, messageId: sent?.id }
   } finally {

--- a/services/slackbotv2/src/server.ts
+++ b/services/slackbotv2/src/server.ts
@@ -46,6 +46,7 @@ const options: SlackbotV2Options = {
     consoleLogger.warn('slackbotv2 SLACKBOTV2_CHANNEL_DEFAULTS', { reason })
   ),
   consolePublicUrl: optionalEnv('CENTAUR_CONSOLE_PUBLIC_URL'),
+  responseMetadataEnabled: booleanEnv('SLACKBOTV2_RESPONSE_METADATA_ENABLED', false),
   defaultHarnessType: optionalEnv('SLACKBOTV2_DEFAULT_HARNESS'),
   // Same env vars deployers use to override the sandbox harness model
   // (sandbox.extraEnv); the chart mirrors them here so displayed defaults
@@ -98,6 +99,7 @@ console.log(
     message_overrides_strategy: messageOverridesStrategyMode,
     message_overrides_strategy_enabled:
       messageOverridesStrategyMode !== 'llm' || Boolean(messageOverridesStrategyApiKey),
+    response_metadata_enabled: options.responseMetadataEnabled,
     port: server.port,
     api_url: apiUrl
   })

--- a/services/slackbotv2/src/types.ts
+++ b/services/slackbotv2/src/types.ts
@@ -142,10 +142,12 @@ export type SlackbotV2Options = {
   /**
    * Public origin of the Console UI (same value the Console itself uses,
    * `CENTAUR_CONSOLE_PUBLIC_URL`). When set, the first assistant message in a
-   * Slack thread gets an "Open chat in Console" context link. Unset skips
-   * the block entirely.
+   * Slack thread gets an "Open chat in Console" context link. Unset skips the
+   * link; response metadata may still render when independently enabled.
    */
   consolePublicUrl?: string
+  /** Append model, harness, reasoning, and service-tier metadata to every live response. */
+  responseMetadataEnabled?: boolean
   /**
    * Per-channel default harness/model/provider/reasoning, keyed by Slack
    * conversation id (SLACKBOTV2_CHANNEL_DEFAULTS). See channel-defaults.ts.

--- a/services/slackbotv2/test/chat-sdk-emulate.test.ts
+++ b/services/slackbotv2/test/chat-sdk-emulate.test.ts
@@ -927,6 +927,71 @@ describe('slackbotv2', () => {
     expect(consoleBlockTexts(slackApi.calls)).toHaveLength(0)
   })
 
+  it('appends response metadata to every assistant message without a Console URL', async () => {
+    const sharedState = createMemoryState()
+    await sharedState.connect()
+    bot = createTestBot({ responseMetadataEnabled: true, state: sharedState })
+
+    const metadataBlockTexts = (calls: StreamCall[]): string[] =>
+      calls
+        .filter(call => call.method === 'chat.stopStream')
+        .flatMap(call => (Array.isArray(call.body.blocks) ? (call.body.blocks as unknown[]) : []))
+        .map(block => JSON.stringify(block))
+        .filter(text => text.includes('GPT-5.6-SOL'))
+
+    const parent = await postUserMessage('Response metadata thread context.')
+    const firstMention = await postUserMessage(`<@${BOT_USER_ID}> start`, parent.ts)
+    const firstWaits: Promise<unknown>[] = []
+    const firstResponse = await bot.app.request(
+      '/api/webhooks/slack',
+      signedSlackEvent({
+        event_id: 'Ev-slackbotv2-response-metadata-first',
+        event: {
+          type: 'app_mention',
+          user: USER_ID,
+          channel: CHANNEL_ID,
+          team: TEAM_ID,
+          ts: firstMention.ts,
+          thread_ts: parent.ts,
+          text: `<@${BOT_USER_ID}> start`
+        }
+      }),
+      {},
+      waitUntilContext(firstWaits)
+    )
+    expect(firstResponse.status).toBe(200)
+    await Promise.all(firstWaits)
+    expect(metadataBlockTexts(slackApi.calls)).toHaveLength(1)
+    expect(metadataBlockTexts(slackApi.calls)[0]).toContain('Codex')
+    expect(metadataBlockTexts(slackApi.calls)[0]).toContain('Low')
+    expect(metadataBlockTexts(slackApi.calls)[0]).toContain('Fast')
+    expect(metadataBlockTexts(slackApi.calls)[0]).not.toContain('Open chat in Console')
+
+    slackApi.reset()
+    const secondMention = await postUserMessage(`<@${BOT_USER_ID}> continue`, parent.ts)
+    const secondWaits: Promise<unknown>[] = []
+    const secondResponse = await bot.app.request(
+      '/api/webhooks/slack',
+      signedSlackEvent({
+        event_id: 'Ev-slackbotv2-response-metadata-second',
+        event: {
+          type: 'app_mention',
+          user: USER_ID,
+          channel: CHANNEL_ID,
+          team: TEAM_ID,
+          ts: secondMention.ts,
+          thread_ts: parent.ts,
+          text: `<@${BOT_USER_ID}> continue`
+        }
+      }),
+      {},
+      waitUntilContext(secondWaits)
+    )
+    expect(secondResponse.status).toBe(200)
+    await Promise.all(secondWaits)
+    expect(metadataBlockTexts(slackApi.calls)).toHaveLength(1)
+  })
+
   it('shows the API-assigned harness in Slack and retains execution metadata', async () => {
     const sharedState = createMemoryState()
     await sharedState.connect()

--- a/services/slackbotv2/test/console-session-link.test.ts
+++ b/services/slackbotv2/test/console-session-link.test.ts
@@ -1,9 +1,10 @@
 import { describe, expect, test } from 'bun:test'
 import {
-  buildConsoleSessionContextBlock,
+  buildSlackResponseContextBlock,
   consoleSessionUrl,
   defaultModelForHarness,
   defaultReasoningForHarness,
+  defaultServiceTierForHarness,
   effectiveReasoningForHarness,
   harnessDisplayName,
   reasoningForModel
@@ -152,6 +153,17 @@ describe('defaultReasoningForHarness', () => {
   })
 })
 
+describe('defaultServiceTierForHarness', () => {
+  const bakedServiceTier = (codexConfig as { service_tier: string }).service_tier
+
+  test('reports the baked Codex service tier only for the Codex harness', () => {
+    expect(bakedServiceTier).toBe('fast')
+    expect(defaultServiceTierForHarness('codex')).toBe(bakedServiceTier)
+    expect(defaultServiceTierForHarness('nanocodex')).toBeUndefined()
+    expect(defaultServiceTierForHarness('claudecode')).toBeUndefined()
+  })
+})
+
 describe('consoleSessionUrl', () => {
   test('builds the /console/threads URL with an encoded thread key', () => {
     expect(consoleSessionUrl('https://console.centaur.dev', 'slack:C123:1700000000.000100')).toBe(
@@ -172,9 +184,9 @@ describe('consoleSessionUrl', () => {
   })
 })
 
-describe('buildConsoleSessionContextBlock', () => {
+describe('buildSlackResponseContextBlock', () => {
   test('builds a context block with uppercased model then harness, middot separated', () => {
-    const block = buildConsoleSessionContextBlock({
+    const block = buildSlackResponseContextBlock({
       consoleBaseUrl: 'https://console.centaur.dev',
       threadKey: 'slack:C123:1700000000.000100',
       harnessType: 'codex',
@@ -194,7 +206,7 @@ describe('buildConsoleSessionContextBlock', () => {
   })
 
   test('omits the model segment when no model is provided', () => {
-    const block = buildConsoleSessionContextBlock({
+    const block = buildSlackResponseContextBlock({
       consoleBaseUrl: 'https://console.centaur.dev',
       threadKey: 'slack:C1:1',
       harnessType: 'claudecode'
@@ -205,7 +217,7 @@ describe('buildConsoleSessionContextBlock', () => {
   })
 
   test('shows the resolved Nanocodex harness', () => {
-    const block = buildConsoleSessionContextBlock({
+    const block = buildSlackResponseContextBlock({
       consoleBaseUrl: 'https://console.centaur.dev',
       threadKey: 'slack:C1:1',
       harnessType: 'nanocodex',
@@ -220,12 +232,26 @@ describe('buildConsoleSessionContextBlock', () => {
 
   test('skips the block entirely when no console base URL is set', () => {
     expect(
-      buildConsoleSessionContextBlock({
+      buildSlackResponseContextBlock({
         consoleBaseUrl: undefined,
         threadKey: 'slack:C1:1',
         harnessType: 'codex',
         model: 'gpt-5.2'
       })
     ).toBeUndefined()
+  })
+
+  test('builds metadata without a Console URL when independently enabled', () => {
+    const block = buildSlackResponseContextBlock({
+      consoleBaseUrl: undefined,
+      threadKey: 'slack:C1:1',
+      harnessType: 'codex',
+      metadataEnabled: true,
+      model: 'gpt-5.6-sol',
+      reasoning: 'low',
+      serviceTier: 'fast'
+    })
+
+    expect(block?.elements[0]?.text).toBe('GPT-5.6-SOL · Codex · Low · Fast')
   })
 })


### PR DESCRIPTION
## Summary

- add `slackbotv2.responseMetadataEnabled`, independent of `CENTAUR_CONSOLE_PUBLIC_URL`
- append model, harness, reasoning effort, and service tier metadata to every live streamed Slack response when enabled
- preserve the existing first-message Console link behavior
- report Codex's configured service tier only when it is authoritative; omit it for alternate providers and Nanocodex

## Why

The Slack response footer was coupled to the optional public Console URL, so self-hosted installations without a Console URL could not show model or reasoning metadata at all. Service tier was also missing.

## Validation

- `pnpm --filter slackbotv2 run check:types`
- `pnpm --filter slackbotv2 test` (227 passed, 1 skipped)
- signed emulated Slack webhook coverage for first and subsequent responses without a Console URL
- Bun production bundle
- Helm dependency build, lint, and template render with `slackbotv2.responseMetadataEnabled=true`
- `git diff --check` and chart schema/YAML parsing