### PR TITLE
feat(api-rs): bind the requesting user's principal per turn

### DIFF
--- a/services/api-rs/crates/centaur-api-server/src/lib.rs
+++ b/services/api-rs/crates/centaur-api-server/src/lib.rs
@@ -60,6 +60,15 @@ mod tests {
             Ok(test_principal("prn_test"))
         }
 
+        async fn register_requester(
+            &self,
+            _thread_key: &str,
+            _metadata: Option<&Value>,
+        ) -> Result<Option<centaur_iron_control::Principal>, centaur_iron_control::IronControlError>
+        {
+            Ok(None)
+        }
+
         async fn get_principal(
             &self,
             principal: &str,

--- a/services/api-rs/crates/centaur-iron-control/src/client.rs
+++ b/services/api-rs/crates/centaur-iron-control/src/client.rs
@@ -400,17 +400,21 @@ impl IronControlClient {
 
     // ----- proxies ---------------------------------------------------------
 
-    /// Register a proxy owned by ``principal_id``. The returned [`Proxy::token`]
-    /// is the plaintext ``iprx_`` bearer and is only available here.
+    /// Register a proxy owned by ``principal_id``, optionally bound to the
+    /// requesting user's principal for the current turn. The returned
+    /// [`Proxy::token`] is the plaintext ``iprx_`` bearer and is only
+    /// available here.
     pub async fn create_proxy(
         &self,
         name: impl Into<String>,
         principal_id: impl Into<String>,
+        requester_principal_id: Option<String>,
         labels: std::collections::BTreeMap<String, String>,
     ) -> Result<Proxy> {
         let input = ProxyInput {
             name: name.into(),
             principal_id: principal_id.into(),
+            requester_principal_id,
             labels,
         };
         self.write(Method::POST, &collection_path("proxies"), &input)
@@ -421,15 +425,17 @@ impl IronControlClient {
     /// unchanged; the proxy picks up the new principal's grants on its next
     /// `/proxy/sync` (the config hash changes). This is how a warm-pool proxy,
     /// booted under a bootstrap principal, is bound to a session's principal at
-    /// checkout without a restart or token swap.
+    /// checkout without a restart or token swap. The requester principal is
+    /// re-bound (or cleared) on every assignment.
     pub async fn assign_proxy_principal(
         &self,
         id: &str,
         principal_id: &str,
+        requester_principal_id: Option<&str>,
         labels: &std::collections::BTreeMap<String, String>,
     ) -> Result<Proxy> {
         let path = format!("{API_PREFIX}/proxies/{}", urlencoding::encode(id));
-        let body = proxy_assignment_payload(principal_id, labels);
+        let body = proxy_assignment_payload(principal_id, requester_principal_id, labels);
         self.write(Method::PATCH, &path, &body).await
     }
 
@@ -488,12 +494,22 @@ impl IronControlClient {
 
 fn proxy_assignment_payload(
     principal_id: &str,
+    requester_principal_id: Option<&str>,
     labels: &std::collections::BTreeMap<String, String>,
 ) -> Value {
-    let mut body = serde_json::Map::from_iter([(
-        "principal_id".to_owned(),
-        Value::String(principal_id.to_owned()),
-    )]);
+    // The requester key is always sent: the console treats an omitted key as
+    // "leave unchanged", so only an explicit null clears a previous requester
+    // binding on a turn with no requester.
+    let mut body = serde_json::Map::from_iter([
+        (
+            "principal_id".to_owned(),
+            Value::String(principal_id.to_owned()),
+        ),
+        (
+            "requester_principal_id".to_owned(),
+            requester_principal_id.map_or(Value::Null, |id| Value::String(id.to_owned())),
+        ),
+    ]);
     if !labels.is_empty() {
         body.insert("labels".to_owned(), json!(labels));
     }
@@ -813,6 +829,7 @@ mod tests {
         let input = ProxyInput {
             name: "edge".to_owned(),
             principal_id: "prn_1".to_owned(),
+            requester_principal_id: None,
             labels: std::collections::BTreeMap::from([(
                 "centaur.slack_user_id".to_owned(),
                 "U1".to_owned(),
@@ -824,16 +841,38 @@ mod tests {
             json!({
                 "name": "edge",
                 "principal_id": "prn_1",
+                "requester_principal_id": null,
                 "labels": { "centaur.slack_user_id": "U1" }
             })
         );
     }
 
     #[test]
-    fn proxy_assignment_payload_omits_empty_labels() {
+    fn proxy_input_serializes_requester() {
+        let input = ProxyInput {
+            name: "edge".to_owned(),
+            principal_id: "prn_1".to_owned(),
+            requester_principal_id: Some("prn_req".to_owned()),
+            labels: std::collections::BTreeMap::new(),
+        };
+
         assert_eq!(
-            proxy_assignment_payload("prn_1", &std::collections::BTreeMap::new()),
-            json!({ "principal_id": "prn_1" })
+            serde_json::to_value(input).unwrap(),
+            json!({
+                "name": "edge",
+                "principal_id": "prn_1",
+                "requester_principal_id": "prn_req"
+            })
+        );
+    }
+
+    // The requester key stays present and null: the console leaves a binding
+    // unchanged when the key is absent, so only an explicit null clears it.
+    #[test]
+    fn proxy_assignment_payload_omits_empty_labels_and_nulls_absent_requester() {
+        assert_eq!(
+            proxy_assignment_payload("prn_1", None, &std::collections::BTreeMap::new()),
+            json!({ "principal_id": "prn_1", "requester_principal_id": null })
         );
     }
 
@@ -845,11 +884,20 @@ mod tests {
         )]);
 
         assert_eq!(
-            proxy_assignment_payload("prn_1", &labels),
+            proxy_assignment_payload("prn_1", None, &labels),
             json!({
                 "principal_id": "prn_1",
+                "requester_principal_id": null,
                 "labels": { "centaur.slack_user_id": "U1" }
             })
+        );
+    }
+
+    #[test]
+    fn proxy_assignment_payload_includes_requester_oid() {
+        assert_eq!(
+            proxy_assignment_payload("prn_1", Some("prn_req"), &std::collections::BTreeMap::new()),
+            json!({ "principal_id": "prn_1", "requester_principal_id": "prn_req" })
         );
     }
 }

--- a/services/api-rs/crates/centaur-iron-control/src/lib.rs
+++ b/services/api-rs/crates/centaur-iron-control/src/lib.rs
@@ -25,7 +25,7 @@ pub use models::{
     ReplaceConfig, RequestRule, Role, SECRET_TYPES, SecretRecord, SecretSource, StaticSecretInput,
     normalize_gcp_id_token_header,
 };
-pub use principal::{PrincipalRef, derive_principal};
+pub use principal::{PrincipalRef, derive_principal, derive_slack_requester_principal};
 pub use registry::{
     GCP_AUTH_DEFAULT_SCOPE, RegisterError, RoleSpec, SecretInput, TranslateError,
     gcp_auth_scopes_or_default, grant_inputs_to_role, register_role, secret_inputs_from_fragment,

--- a/services/api-rs/crates/centaur-iron-control/src/models.rs
+++ b/services/api-rs/crates/centaur-iron-control/src/models.rs
@@ -693,6 +693,9 @@ impl Grant {
 pub struct ProxyInput {
     pub name: String,
     pub principal_id: String,
+    /// Always serialized (``null`` when absent) so create and assign share one
+    /// wire shape; the console treats an omitted key as "leave unchanged".
+    pub requester_principal_id: Option<String>,
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub labels: BTreeMap<String, String>,
 }

--- a/services/api-rs/crates/centaur-iron-control/src/principal.rs
+++ b/services/api-rs/crates/centaur-iron-control/src/principal.rs
@@ -198,15 +198,7 @@ pub fn derive_principal_with_slack_team(
     if is_direct_message(conversation_id)
         && let Some(user) = actor_user_id.map(str::trim).filter(|user| !user.is_empty())
     {
-        labels.insert(KIND_LABEL.to_owned(), SLACK_DM_KIND.to_owned());
-        labels.insert("slack_user_id".to_owned(), user.to_owned());
-        return PrincipalRef {
-            foreign_id: format!("slack-user-{scope}{}", slugify(user)),
-            name: display_name
-                .map(|name| format!("Slack DM @{name}"))
-                .unwrap_or_else(|| format!("Slack User {user}{team_suffix}")),
-            labels,
-        };
+        return slack_user_principal(user, team_id, display_name);
     }
 
     if let Some(conversation_id) = conversation_id {
@@ -231,6 +223,64 @@ pub fn derive_principal_with_slack_team(
         name: display_name
             .map(ToOwned::to_owned)
             .unwrap_or_else(|| thread_key.to_owned()),
+        labels,
+    }
+}
+
+/// Resolve the requesting user's principal for a Slack channel thread. This is
+/// the same per-user principal a 1:1 DM with that user resolves to, so a user
+/// first seen in a channel and later in a DM (or vice versa) maps to one
+/// identity. Returns `None` for DM threads (the conversation principal already
+/// is the user's) and for non-Slack thread keys, which have no Slack requester.
+pub fn derive_slack_requester_principal(
+    thread_key: &str,
+    slack_user_id: &str,
+    slack_team_id: Option<&str>,
+    display_name: Option<&str>,
+) -> Option<PrincipalRef> {
+    let (thread_team_id, conversation_id) = parse_slack_segments(thread_key);
+    let conversation_id = conversation_id?;
+    if is_direct_message(Some(conversation_id)) {
+        return None;
+    }
+    let user = slack_user_id.trim();
+    if user.is_empty() {
+        return None;
+    }
+    let metadata_team_id = slack_team_id.map(str::trim).filter(|team| !team.is_empty());
+    Some(slack_user_principal(
+        user,
+        thread_team_id.or(metadata_team_id),
+        display_name.map(str::trim).filter(|name| !name.is_empty()),
+    ))
+}
+
+/// The per-user Slack principal shared by the DM branch of
+/// [`derive_principal_with_slack_team`] and
+/// [`derive_slack_requester_principal`], so the two can never mint diverging
+/// foreign ids or labels for the same user.
+fn slack_user_principal(
+    user: &str,
+    team_id: Option<&str>,
+    display_name: Option<&str>,
+) -> PrincipalRef {
+    let mut labels = BTreeMap::new();
+    if let Some(team) = team_id {
+        labels.insert("slack_team_id".to_owned(), team.to_owned());
+    }
+    labels.insert(KIND_LABEL.to_owned(), SLACK_DM_KIND.to_owned());
+    labels.insert("slack_user_id".to_owned(), user.to_owned());
+    let scope = team_id
+        .map(|team| format!("{}-", slugify(team)))
+        .unwrap_or_default();
+    let team_suffix = team_id
+        .map(|team| format!(" (team {team})"))
+        .unwrap_or_default();
+    PrincipalRef {
+        foreign_id: format!("slack-user-{scope}{}", slugify(user)),
+        name: display_name
+            .map(|name| format!("Slack DM @{name}"))
+            .unwrap_or_else(|| format!("Slack User {user}{team_suffix}")),
         labels,
     }
 }
@@ -615,6 +665,112 @@ mod tests {
             principal.labels.get("kind").map(String::as_str),
             Some("teams_user")
         );
+    }
+
+    #[test]
+    fn requester_channel_thread_keys_on_the_user() {
+        let principal = derive_slack_requester_principal(
+            "slack:T123:C456:1780000000.0001",
+            "U07ABC",
+            Some("T123"),
+            Some("Ada Lovelace"),
+        )
+        .unwrap();
+        assert_eq!(principal.foreign_id, "slack-user-t123-u07abc");
+        assert_eq!(principal.name, "Slack DM @Ada Lovelace");
+        assert_eq!(
+            principal.labels.get("kind").map(String::as_str),
+            Some("slack_dm")
+        );
+        assert_eq!(
+            principal.labels.get("slack_user_id").map(String::as_str),
+            Some("U07ABC")
+        );
+        assert_eq!(
+            principal.labels.get("slack_team_id").map(String::as_str),
+            Some("T123")
+        );
+    }
+
+    #[test]
+    fn requester_matches_the_dm_principal_for_the_same_user() {
+        let requester = derive_slack_requester_principal(
+            "slack:T123:C456:1780000000.0001",
+            "U07ABC",
+            Some("T123"),
+            None,
+        )
+        .unwrap();
+        let dm = derive_principal("slack:T123:D9:ts", Some("U07ABC"), None);
+        assert_eq!(requester.foreign_id, dm.foreign_id);
+        assert_eq!(requester.labels, dm.labels);
+    }
+
+    #[test]
+    fn requester_dm_thread_resolves_none() {
+        assert_eq!(
+            derive_slack_requester_principal("slack:T123:D9:ts", "U07ABC", Some("T123"), None),
+            None
+        );
+    }
+
+    #[test]
+    fn requester_non_slack_threads_resolve_none() {
+        for thread_key in [
+            "discord:111:222:333",
+            "linear:issue-1:s:sess-a",
+            "teams:abc:def",
+            "mcp:prn_x",
+            "api",
+        ] {
+            assert_eq!(
+                derive_slack_requester_principal(thread_key, "U07ABC", Some("T123"), None),
+                None,
+                "expected no requester for {thread_key}"
+            );
+        }
+    }
+
+    #[test]
+    fn requester_without_thread_team_uses_metadata_team() {
+        let principal =
+            derive_slack_requester_principal("chat:C123:ts", "U1", Some("T9"), None).unwrap();
+        assert_eq!(principal.foreign_id, "slack-user-t9-u1");
+        assert_eq!(
+            principal.labels.get("slack_team_id").map(String::as_str),
+            Some("T9")
+        );
+    }
+
+    #[test]
+    fn requester_thread_key_team_wins_over_metadata_team() {
+        let principal = derive_slack_requester_principal(
+            "slack:T_FROM_KEY:C456:ts",
+            "U1",
+            Some("T_FROM_METADATA"),
+            None,
+        )
+        .unwrap();
+        assert_eq!(principal.foreign_id, "slack-user-t-from-key-u1");
+        assert_eq!(
+            principal.labels.get("slack_team_id").map(String::as_str),
+            Some("T_FROM_KEY")
+        );
+    }
+
+    #[test]
+    fn requester_blank_user_resolves_none() {
+        assert_eq!(
+            derive_slack_requester_principal("slack:T123:C456:ts", "  ", Some("T123"), None),
+            None
+        );
+    }
+
+    #[test]
+    fn requester_synthetic_name_without_display_name() {
+        let principal =
+            derive_slack_requester_principal("slack:T123:C456:ts", "U07ABC", None, None).unwrap();
+        assert_eq!(principal.name, "Slack User U07ABC (team T123)");
     }
 
     #[test]

--- a/services/api-rs/crates/centaur-iron-control/src/principal.rs
+++ b/services/api-rs/crates/centaur-iron-control/src/principal.rs
@@ -250,7 +250,7 @@ pub fn derive_slack_requester_principal(
     let metadata_team_id = slack_team_id.map(str::trim).filter(|team| !team.is_empty());
     Some(slack_user_principal(
         user,
-        thread_team_id.or(metadata_team_id),
+        metadata_team_id.or(thread_team_id),
         display_name.map(str::trim).filter(|name| !name.is_empty()),
     ))
 }
@@ -743,7 +743,7 @@ mod tests {
     }
 
     #[test]
-    fn requester_thread_key_team_wins_over_metadata_team() {
+    fn requester_metadata_team_wins_over_thread_key_team() {
         let principal = derive_slack_requester_principal(
             "slack:T_FROM_KEY:C456:ts",
             "U1",
@@ -751,10 +751,10 @@ mod tests {
             None,
         )
         .unwrap();
-        assert_eq!(principal.foreign_id, "slack-user-t-from-key-u1");
+        assert_eq!(principal.foreign_id, "slack-user-t-from-metadata-u1");
         assert_eq!(
             principal.labels.get("slack_team_id").map(String::as_str),
-            Some("T_FROM_KEY")
+            Some("T_FROM_METADATA")
         );
     }
 

--- a/services/api-rs/crates/centaur-iron-control/src/principal.rs
+++ b/services/api-rs/crates/centaur-iron-control/src/principal.rs
@@ -228,29 +228,37 @@ pub fn derive_principal_with_slack_team(
 }
 
 /// Resolve the requesting user's principal for a Slack channel thread. This is
-/// the same per-user principal a 1:1 DM with that user resolves to, so a user
-/// first seen in a channel and later in a DM (or vice versa) maps to one
-/// identity. Returns `None` for DM threads (the conversation principal already
-/// is the user's) and for non-Slack thread keys, which have no Slack requester.
+/// the same per-user principal a 1:1 DM with that user resolves to (both key on
+/// the user's own workspace), so a user first seen in a channel and later in a
+/// DM (or vice versa) maps to one identity. Returns `None` for DM threads (the
+/// conversation principal already is the user's) and for non-Slack thread keys,
+/// which have no Slack requester.
+///
+/// ``slack_team_id`` must be a workspace the user is proven to belong to —
+/// callers pass the home-team-gate-validated metadata team. The thread key's
+/// team segment is deliberately never used: it names where the conversation
+/// lives, not where the user belongs, and Slack user ids are only unique
+/// within a workspace, so keying a user on the thread's team could mint (or
+/// collide with) an identity in a workspace the user is not a member of.
 pub fn derive_slack_requester_principal(
     thread_key: &str,
     slack_user_id: &str,
-    slack_team_id: Option<&str>,
+    slack_team_id: &str,
     display_name: Option<&str>,
 ) -> Option<PrincipalRef> {
-    let (thread_team_id, conversation_id) = parse_slack_segments(thread_key);
+    let (_, conversation_id) = parse_slack_segments(thread_key);
     let conversation_id = conversation_id?;
     if is_direct_message(Some(conversation_id)) {
         return None;
     }
     let user = slack_user_id.trim();
-    if user.is_empty() {
+    let team = slack_team_id.trim();
+    if user.is_empty() || team.is_empty() {
         return None;
     }
-    let metadata_team_id = slack_team_id.map(str::trim).filter(|team| !team.is_empty());
     Some(slack_user_principal(
         user,
-        metadata_team_id.or(thread_team_id),
+        Some(team),
         display_name.map(str::trim).filter(|name| !name.is_empty()),
     ))
 }
@@ -258,7 +266,9 @@ pub fn derive_slack_requester_principal(
 /// The per-user Slack principal shared by the DM branch of
 /// [`derive_principal_with_slack_team`] and
 /// [`derive_slack_requester_principal`], so the two can never mint diverging
-/// foreign ids or labels for the same user.
+/// foreign ids or labels for the same user. ``team_id`` must be a workspace
+/// the user is proven to belong to, never one inferred from where the message
+/// happened to land.
 fn slack_user_principal(
     user: &str,
     team_id: Option<&str>,
@@ -672,7 +682,7 @@ mod tests {
         let principal = derive_slack_requester_principal(
             "slack:T123:C456:1780000000.0001",
             "U07ABC",
-            Some("T123"),
+            "T123",
             Some("Ada Lovelace"),
         )
         .unwrap();
@@ -697,7 +707,7 @@ mod tests {
         let requester = derive_slack_requester_principal(
             "slack:T123:C456:1780000000.0001",
             "U07ABC",
-            Some("T123"),
+            "T123",
             None,
         )
         .unwrap();
@@ -709,7 +719,7 @@ mod tests {
     #[test]
     fn requester_dm_thread_resolves_none() {
         assert_eq!(
-            derive_slack_requester_principal("slack:T123:D9:ts", "U07ABC", Some("T123"), None),
+            derive_slack_requester_principal("slack:T123:D9:ts", "U07ABC", "T123", None),
             None
         );
     }
@@ -724,7 +734,7 @@ mod tests {
             "api",
         ] {
             assert_eq!(
-                derive_slack_requester_principal(thread_key, "U07ABC", Some("T123"), None),
+                derive_slack_requester_principal(thread_key, "U07ABC", "T123", None),
                 None,
                 "expected no requester for {thread_key}"
             );
@@ -732,9 +742,8 @@ mod tests {
     }
 
     #[test]
-    fn requester_without_thread_team_uses_metadata_team() {
-        let principal =
-            derive_slack_requester_principal("chat:C123:ts", "U1", Some("T9"), None).unwrap();
+    fn requester_teamless_thread_key_uses_verified_team() {
+        let principal = derive_slack_requester_principal("chat:C123:ts", "U1", "T9", None).unwrap();
         assert_eq!(principal.foreign_id, "slack-user-t9-u1");
         assert_eq!(
             principal.labels.get("slack_team_id").map(String::as_str),
@@ -743,11 +752,11 @@ mod tests {
     }
 
     #[test]
-    fn requester_metadata_team_wins_over_thread_key_team() {
+    fn requester_ignores_the_thread_key_team() {
         let principal = derive_slack_requester_principal(
             "slack:T_FROM_KEY:C456:ts",
             "U1",
-            Some("T_FROM_METADATA"),
+            "T_FROM_METADATA",
             None,
         )
         .unwrap();
@@ -758,10 +767,20 @@ mod tests {
         );
     }
 
+    // The thread key's team must never substitute for a missing verified team:
+    // it names where the conversation lives, not where the user belongs.
+    #[test]
+    fn requester_blank_team_resolves_none() {
+        assert_eq!(
+            derive_slack_requester_principal("slack:T123:C456:ts", "U07ABC", "  ", None),
+            None
+        );
+    }
+
     #[test]
     fn requester_blank_user_resolves_none() {
         assert_eq!(
-            derive_slack_requester_principal("slack:T123:C456:ts", "  ", Some("T123"), None),
+            derive_slack_requester_principal("slack:T123:C456:ts", "  ", "T123", None),
             None
         );
     }
@@ -769,7 +788,7 @@ mod tests {
     #[test]
     fn requester_synthetic_name_without_display_name() {
         let principal =
-            derive_slack_requester_principal("slack:T123:C456:ts", "U07ABC", None, None).unwrap();
+            derive_slack_requester_principal("slack:T123:C456:ts", "U07ABC", "T123", None).unwrap();
         assert_eq!(principal.name, "Slack User U07ABC (team T123)");
     }
 

--- a/services/api-rs/crates/centaur-iron-control/src/session.rs
+++ b/services/api-rs/crates/centaur-iron-control/src/session.rs
@@ -12,9 +12,10 @@ use std::collections::BTreeMap;
 
 use crate::IronControlClient;
 use crate::error::{IronControlError, Result};
-use crate::models::{Principal, SlackChannelPermissionInput};
+use crate::models::{Principal, PrincipalInput, SlackChannelPermissionInput};
 use crate::principal::{
-    derive_principal_with_slack_team, is_direct_message, slack_conversation_id,
+    derive_principal_with_slack_team, derive_slack_requester_principal, is_direct_message,
+    slack_conversation_id,
 };
 
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -83,18 +84,7 @@ impl SessionRegistrar {
         );
         let mut input = principal.to_principal_input();
         apply_slack_dm_email(thread_key, metadata.slack_user_email, &mut input);
-        let existing = match self.client.get_principal(&input.foreign_id).await {
-            Ok(existing) => Some(existing),
-            Err(error) if is_status(&error, 404) => None,
-            Err(error) => return Err(error),
-        };
-        let exists = existing.is_some();
-        if let Some(existing) = existing {
-            let mut labels = existing.labels;
-            strip_compatibility_identity_labels(&mut labels);
-            labels.extend(input.labels);
-            input.labels = labels;
-        }
+        let exists = self.merge_existing_labels(&mut input).await?;
         let slack_permission = slack_permission_for_thread(
             thread_key,
             input.slack_channel_id.as_deref(),
@@ -113,8 +103,65 @@ impl SessionRegistrar {
         Ok(record)
     }
 
+    /// Upsert the principal of the human requesting a Slack channel turn,
+    /// derived from the execute metadata (``slack_user_id`` and friends).
+    /// Returns ``Ok(None)`` for DM threads (the conversation principal already
+    /// is the user's), for non-Slack threads, and when the metadata carries no
+    /// ``slack_user_id``.
+    ///
+    /// Unlike [`Self::register_session`], this never writes Slack channel
+    /// permissions: the requester principal only scopes proxy credentials, and
+    /// the conversation principal already owns the thread's Slack permission.
+    /// Roles are left to iron-control's default assignment, as for sessions.
+    pub async fn register_requester(
+        &self,
+        thread_key: &str,
+        metadata: Option<&Value>,
+    ) -> Result<Option<Principal>> {
+        let Some(metadata) = metadata else {
+            return Ok(None);
+        };
+        let Some(slack_user_id) = metadata.get("slack_user_id").and_then(Value::as_str) else {
+            return Ok(None);
+        };
+        let Some(principal) = derive_slack_requester_principal(
+            thread_key,
+            slack_user_id,
+            metadata.get("slack_team_id").and_then(Value::as_str),
+            metadata.get("slack_display_name").and_then(Value::as_str),
+        ) else {
+            return Ok(None);
+        };
+        let mut input = principal.to_principal_input();
+        set_slack_email(
+            &mut input,
+            metadata.get("slack_user_email").and_then(Value::as_str),
+        );
+        self.merge_existing_labels(&mut input).await?;
+        Ok(Some(self.client.upsert_principal(&input).await?))
+    }
+
     pub async fn get_principal(&self, principal: &str) -> Result<Principal> {
         self.client.get_principal(principal).await
+    }
+
+    /// Fold an existing principal's labels under the freshly derived ones so
+    /// labels an operator or the console added survive re-registration.
+    /// Returns whether the principal already existed.
+    async fn merge_existing_labels(&self, input: &mut PrincipalInput) -> Result<bool> {
+        let existing = match self.client.get_principal(&input.foreign_id).await {
+            Ok(existing) => Some(existing),
+            Err(error) if is_status(&error, 404) => None,
+            Err(error) => return Err(error),
+        };
+        let Some(existing) = existing else {
+            return Ok(false);
+        };
+        let mut labels = existing.labels;
+        strip_compatibility_identity_labels(&mut labels);
+        labels.extend(std::mem::take(&mut input.labels));
+        input.labels = labels;
+        Ok(true)
     }
 }
 
@@ -137,18 +184,27 @@ fn slack_permission_for_thread(
 fn apply_slack_dm_email(
     thread_key: &str,
     slack_user_email: Option<&str>,
-    input: &mut crate::models::PrincipalInput,
+    input: &mut PrincipalInput,
 ) {
+    let Some(conversation_id) = slack_conversation_id(thread_key) else {
+        return;
+    };
+    if is_direct_message(Some(conversation_id)) {
+        set_slack_email(input, slack_user_email);
+    }
+}
+
+/// Stamp ``slack_email`` on a user principal, skipping blank emails. Shared by
+/// the DM session path and the channel requester path so a user carries the
+/// same identity either way.
+fn set_slack_email(input: &mut PrincipalInput, slack_user_email: Option<&str>) {
     let Some(email) = slack_user_email
         .map(str::trim)
         .filter(|email| !email.is_empty())
     else {
         return;
     };
-    let Some(conversation_id) = slack_conversation_id(thread_key) else {
-        return;
-    };
-    if is_direct_message(Some(conversation_id)) && input.slack_user_id.is_some() {
+    if input.slack_user_id.is_some() {
         input.slack_email = Some(email.to_owned());
     }
 }
@@ -390,6 +446,153 @@ mod tests {
                 .any(|request| request == "POST /api/v1/principals/prn_user/roles"),
             "existing DM principals must not have manually removed roles restored"
         );
+        server.abort();
+    }
+
+    #[test]
+    fn slack_email_applies_only_to_user_principals_with_non_blank_email() {
+        let mut user_input =
+            derive_principal("slack:T123:D123:ts", Some("U123"), None).to_principal_input();
+        set_slack_email(&mut user_input, Some(" ada@example.com "));
+        assert_eq!(user_input.slack_email.as_deref(), Some("ada@example.com"));
+
+        let mut blank_input =
+            derive_principal("slack:T123:D123:ts", Some("U123"), None).to_principal_input();
+        set_slack_email(&mut blank_input, Some("   "));
+        assert_eq!(blank_input.slack_email, None);
+
+        let mut channel_input =
+            derive_principal("slack:T123:C123:ts", None, None).to_principal_input();
+        set_slack_email(&mut channel_input, Some("ada@example.com"));
+        assert_eq!(channel_input.slack_email, None);
+    }
+
+    #[tokio::test]
+    async fn register_requester_upserts_user_principal_without_roles_or_permissions() {
+        let (base_url, requests, server) = spawn_iron_control_stub(false).await;
+        let registrar = SessionRegistrar::new(IronControlClient::new(base_url, "test-key"));
+        let metadata = json!({
+            "slack_user_id": "U123",
+            "slack_team_id": "T123",
+            "slack_display_name": "Ada Lovelace",
+            "slack_user_email": "ada@example.com"
+        });
+
+        let principal = registrar
+            .register_requester("slack:T123:C123:1773364194.179929", Some(&metadata))
+            .await
+            .unwrap()
+            .expect("channel requester resolves to a principal");
+        assert_eq!(principal.id, "prn_user");
+
+        let requests = requests.lock().unwrap();
+        assert!(
+            requests.contains(&"GET /api/v1/principals/lookup/slack-user-t123-u123".to_owned())
+        );
+        assert!(requests.contains(&"PUT /api/v1/principals/slack-user-t123-u123".to_owned()));
+        assert!(
+            !requests
+                .iter()
+                .any(|request| request.ends_with("/slack_channel_permissions")),
+            "requester upserts must not write Slack channel permissions"
+        );
+        assert!(
+            !requests
+                .iter()
+                .any(|request| request == "POST /api/v1/principals/prn_user/roles"),
+            "iron-control owns default role assignment"
+        );
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn register_requester_merges_labels_for_existing_principal() {
+        let (base_url, requests, server) = spawn_iron_control_stub(true).await;
+        let registrar = SessionRegistrar::new(IronControlClient::new(base_url, "test-key"));
+        let metadata = json!({
+            "slack_user_id": "U123",
+            "slack_team_id": "T123"
+        });
+
+        let principal = registrar
+            .register_requester("slack:T123:C123:1773364194.179929", Some(&metadata))
+            .await
+            .unwrap()
+            .expect("channel requester resolves to a principal");
+        assert_eq!(principal.id, "prn_user");
+
+        let requests = requests.lock().unwrap();
+        assert!(requests.contains(&"PUT /api/v1/principals/slack-user-t123-u123".to_owned()));
+        assert!(
+            !requests
+                .iter()
+                .any(|request| request.ends_with("/slack_channel_permissions")),
+            "existing requester principals must not have Slack permissions reset"
+        );
+        assert!(
+            !requests
+                .iter()
+                .any(|request| request == "POST /api/v1/principals/prn_user/roles"),
+            "existing requester principals must not have removed roles restored"
+        );
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn register_requester_returns_none_for_dm_thread() {
+        let (base_url, requests, server) = spawn_iron_control_stub(false).await;
+        let registrar = SessionRegistrar::new(IronControlClient::new(base_url, "test-key"));
+        let metadata = json!({
+            "slack_user_id": "U123",
+            "slack_team_id": "T123"
+        });
+
+        let principal = registrar
+            .register_requester("slack:T123:D123:1773364194.179929", Some(&metadata))
+            .await
+            .unwrap();
+
+        assert_eq!(principal, None);
+        assert!(requests.lock().unwrap().is_empty());
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn register_requester_returns_none_without_slack_user_id() {
+        let (base_url, requests, server) = spawn_iron_control_stub(false).await;
+        let registrar = SessionRegistrar::new(IronControlClient::new(base_url, "test-key"));
+        let metadata = json!({
+            "aad_object_id": "aad-user-1",
+            "user_id": "teams-user-1",
+            "slack_team_id": "T123"
+        });
+
+        let principal = registrar
+            .register_requester("slack:T123:C123:1773364194.179929", Some(&metadata))
+            .await
+            .unwrap();
+
+        assert_eq!(principal, None);
+        assert!(requests.lock().unwrap().is_empty());
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn register_requester_returns_none_for_non_slack_thread() {
+        let (base_url, requests, server) = spawn_iron_control_stub(false).await;
+        let registrar = SessionRegistrar::new(IronControlClient::new(base_url, "test-key"));
+        let metadata = json!({
+            "slack_user_id": "U123",
+            "slack_team_id": "T123"
+        });
+
+        let principal = registrar
+            .register_requester("linear:issue-1", Some(&metadata))
+            .await
+            .unwrap();
+
+        assert_eq!(principal, None);
+        assert!(requests.lock().unwrap().is_empty());
         server.abort();
     }
 

--- a/services/api-rs/crates/centaur-iron-control/src/session.rs
+++ b/services/api-rs/crates/centaur-iron-control/src/session.rs
@@ -106,8 +106,10 @@ impl SessionRegistrar {
     /// Upsert the principal of the human requesting a Slack channel turn,
     /// derived from the execute metadata (``slack_user_id`` and friends).
     /// Returns ``Ok(None)`` for DM threads (the conversation principal already
-    /// is the user's), for non-Slack threads, and when the metadata carries no
-    /// ``slack_user_id``.
+    /// is the user's), for non-Slack threads, when the metadata carries no
+    /// ``slack_user_id``, and when the requester is not proven to belong to the
+    /// Slack app's home team. This prevents Slack Connect users from supplying
+    /// requester credentials to a shared channel turn.
     ///
     /// Unlike [`Self::register_session`], this never writes Slack channel
     /// permissions: the requester principal only scopes proxy credentials, and
@@ -121,13 +123,16 @@ impl SessionRegistrar {
         let Some(metadata) = metadata else {
             return Ok(None);
         };
+        let Some(slack_team_id) = eligible_slack_requester_team(metadata) else {
+            return Ok(None);
+        };
         let Some(slack_user_id) = metadata.get("slack_user_id").and_then(Value::as_str) else {
             return Ok(None);
         };
         let Some(principal) = derive_slack_requester_principal(
             thread_key,
             slack_user_id,
-            metadata.get("slack_team_id").and_then(Value::as_str),
+            Some(slack_team_id),
             metadata.get("slack_display_name").and_then(Value::as_str),
         ) else {
             return Ok(None);
@@ -163,6 +168,20 @@ impl SessionRegistrar {
         input.labels = labels;
         Ok(true)
     }
+}
+
+fn eligible_slack_requester_team(metadata: &Value) -> Option<&str> {
+    let requester_team = metadata
+        .get("slack_team_id")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|team| !team.is_empty())?;
+    let home_team = metadata
+        .get("slack_home_team_id")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|team| !team.is_empty())?;
+    (requester_team == home_team).then_some(requester_team)
 }
 
 fn slack_permission_for_thread(
@@ -474,6 +493,7 @@ mod tests {
         let metadata = json!({
             "slack_user_id": "U123",
             "slack_team_id": "T123",
+            "slack_home_team_id": "T123",
             "slack_display_name": "Ada Lovelace",
             "slack_user_email": "ada@example.com"
         });
@@ -511,7 +531,8 @@ mod tests {
         let registrar = SessionRegistrar::new(IronControlClient::new(base_url, "test-key"));
         let metadata = json!({
             "slack_user_id": "U123",
-            "slack_team_id": "T123"
+            "slack_team_id": "T123",
+            "slack_home_team_id": "T123"
         });
 
         let principal = registrar
@@ -544,7 +565,8 @@ mod tests {
         let registrar = SessionRegistrar::new(IronControlClient::new(base_url, "test-key"));
         let metadata = json!({
             "slack_user_id": "U123",
-            "slack_team_id": "T123"
+            "slack_team_id": "T123",
+            "slack_home_team_id": "T123"
         });
 
         let principal = registrar
@@ -564,7 +586,8 @@ mod tests {
         let metadata = json!({
             "aad_object_id": "aad-user-1",
             "user_id": "teams-user-1",
-            "slack_team_id": "T123"
+            "slack_team_id": "T123",
+            "slack_home_team_id": "T123"
         });
 
         let principal = registrar
@@ -583,7 +606,8 @@ mod tests {
         let registrar = SessionRegistrar::new(IronControlClient::new(base_url, "test-key"));
         let metadata = json!({
             "slack_user_id": "U123",
-            "slack_team_id": "T123"
+            "slack_team_id": "T123",
+            "slack_home_team_id": "T123"
         });
 
         let principal = registrar
@@ -594,6 +618,66 @@ mod tests {
         assert_eq!(principal, None);
         assert!(requests.lock().unwrap().is_empty());
         server.abort();
+    }
+
+    #[tokio::test]
+    async fn register_requester_returns_none_for_external_slack_team() {
+        let (base_url, requests, server) = spawn_iron_control_stub(false).await;
+        let registrar = SessionRegistrar::new(IronControlClient::new(base_url, "test-key"));
+        let metadata = json!({
+            "slack_user_id": "U123",
+            "slack_team_id": "T_EXTERNAL",
+            "slack_home_team_id": "T_HOME"
+        });
+
+        let principal = registrar
+            .register_requester("slack:T_HOME:C123:1773364194.179929", Some(&metadata))
+            .await
+            .unwrap();
+
+        assert_eq!(principal, None);
+        assert!(requests.lock().unwrap().is_empty());
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn register_requester_returns_none_without_home_team() {
+        let (base_url, requests, server) = spawn_iron_control_stub(false).await;
+        let registrar = SessionRegistrar::new(IronControlClient::new(base_url, "test-key"));
+        let metadata = json!({
+            "slack_user_id": "U123",
+            "slack_team_id": "T123"
+        });
+
+        let principal = registrar
+            .register_requester("slack:T123:C123:1773364194.179929", Some(&metadata))
+            .await
+            .unwrap();
+
+        assert_eq!(principal, None);
+        assert!(requests.lock().unwrap().is_empty());
+        server.abort();
+    }
+
+    #[test]
+    fn requester_team_eligibility_requires_matching_non_blank_teams() {
+        for metadata in [
+            json!({"slack_home_team_id": "T123"}),
+            json!({"slack_team_id": "T123"}),
+            json!({"slack_team_id": "", "slack_home_team_id": "T123"}),
+            json!({"slack_team_id": "T123", "slack_home_team_id": "   "}),
+            json!({"slack_team_id": "T_EXTERNAL", "slack_home_team_id": "T_HOME"}),
+        ] {
+            assert_eq!(eligible_slack_requester_team(&metadata), None);
+        }
+
+        assert_eq!(
+            eligible_slack_requester_team(&json!({
+                "slack_team_id": " T123 ",
+                "slack_home_team_id": "T123"
+            })),
+            Some("T123")
+        );
     }
 
     #[test]

--- a/services/api-rs/crates/centaur-iron-control/src/session.rs
+++ b/services/api-rs/crates/centaur-iron-control/src/session.rs
@@ -132,7 +132,7 @@ impl SessionRegistrar {
         let Some(principal) = derive_slack_requester_principal(
             thread_key,
             slack_user_id,
-            Some(slack_team_id),
+            slack_team_id,
             metadata.get("slack_display_name").and_then(Value::as_str),
         ) else {
             return Ok(None);

--- a/services/api-rs/crates/centaur-sandbox-agent-k8s/src/iron_proxy.rs
+++ b/services/api-rs/crates/centaur-sandbox-agent-k8s/src/iron_proxy.rs
@@ -133,6 +133,9 @@ pub(crate) struct ResolvedIronProxy {
     console_url: String,
     // iron-control principal OID this sandbox's proxy binds to.
     principal_id: String,
+    // Requesting user's principal OID bound to the proxy for the current turn,
+    // when the turn has one.
+    requester_principal_id: Option<String>,
     // Labels applied to the iron-control proxy row and used by proxy-specific
     // config rendering in the control plane.
     labels: BTreeMap<String, String>,
@@ -217,6 +220,7 @@ impl AgentSandboxBackend {
         Ok(Some(self.resolved_iron_proxy_for_principal(
             id,
             principal_id,
+            spec.iron_control_requester_principal.clone(),
             labels,
             ResolvedIronProxyRuntime {
                 pg,
@@ -283,15 +287,19 @@ impl AgentSandboxBackend {
             .get(id.as_str())
             .await
             .map_err(|err| map_kube_error("get sandbox for resume", err))?;
-        let principal_id = sandbox
-            .metadata
-            .annotations
-            .as_ref()
+        let annotations = sandbox.metadata.annotations.as_ref();
+        let principal_id = annotations
             .and_then(|annotations| annotations.get(crate::IRON_CONTROL_PRINCIPAL_ANNOTATION))
             .cloned();
         let Some(principal_id) = principal_id else {
             return Ok(None);
         };
+        // Carry the last turn's requester across the pause so the recreated
+        // proxy row does not silently drop it before the post-resume ensure
+        // call re-asserts the current turn's binding.
+        let requester_principal_id = annotations
+            .and_then(|annotations| annotations.get(crate::IRON_CONTROL_REQUESTER_ANNOTATION))
+            .cloned();
         let pg = self.resolved_pg_for_recreation(Some(&sandbox));
         let replace_placeholders = self.effective_replace_placeholders(&principal_id).await?;
         let observability_enabled = resolve_resume_capability(
@@ -311,6 +319,7 @@ impl AgentSandboxBackend {
         Ok(Some(self.resolved_iron_proxy_for_principal(
             id,
             principal_id,
+            requester_principal_id,
             BTreeMap::new(),
             ResolvedIronProxyRuntime {
                 pg,
@@ -325,6 +334,7 @@ impl AgentSandboxBackend {
         &self,
         id: &SandboxId,
         principal_id: String,
+        requester_principal_id: Option<String>,
         labels: BTreeMap<String, String>,
         runtime: ResolvedIronProxyRuntime,
     ) -> ResolvedIronProxy {
@@ -334,6 +344,7 @@ impl AgentSandboxBackend {
             proxy_port: PROXY_TUNNEL_PORT,
             console_url: self.config.iron_control.control_url.clone(),
             principal_id,
+            requester_principal_id,
             labels,
             pg: runtime.pg,
             replace_placeholders: runtime.replace_placeholders,
@@ -414,7 +425,12 @@ impl AgentSandboxBackend {
         let iron_control = &self.config.iron_control;
         let proxy = iron_control
             .client
-            .create_proxy(id.as_str(), &resolved.principal_id, resolved.labels.clone())
+            .create_proxy(
+                id.as_str(),
+                &resolved.principal_id,
+                resolved.requester_principal_id.clone(),
+                resolved.labels.clone(),
+            )
             .await
             .map_err(|err| SandboxError::backend_source("iron-control create proxy", err))?;
         let token = proxy
@@ -526,6 +542,7 @@ impl AgentSandboxBackend {
         &self,
         id: &SandboxId,
         principal_id: &str,
+        requester_principal_id: Option<&str>,
         labels: &BTreeMap<String, String>,
     ) -> SandboxResult<()> {
         let iron_control = &self.config.iron_control;
@@ -537,8 +554,13 @@ impl AgentSandboxBackend {
                 "iron-proxy resources are missing or not running; recreating before assignment"
             );
             proxy_id = Some(
-                self.recreate_iron_proxy_resources_for_principal(id, principal_id, labels)
-                    .await?,
+                self.recreate_iron_proxy_resources_for_principal(
+                    id,
+                    principal_id,
+                    requester_principal_id,
+                    labels,
+                )
+                .await?,
             );
         }
         let proxy_id = proxy_id.ok_or_else(|| {
@@ -549,14 +571,14 @@ impl AgentSandboxBackend {
         })?;
         let proxy = iron_control
             .client
-            .assign_proxy_principal(&proxy_id, principal_id, labels)
+            .assign_proxy_principal(&proxy_id, principal_id, requester_principal_id, labels)
             .await
             .map_err(|err| SandboxError::backend_source("iron-control assign proxy", err))?;
         self.proxy_ids
             .lock()
             .await
             .insert(id.as_str().to_owned(), proxy.id);
-        self.patch_iron_control_principal_annotation(id, principal_id)
+        self.patch_iron_control_principal_annotation(id, principal_id, requester_principal_id)
             .await?;
         self.wait_for_proxy_principal_applied(id, principal_id, proxy.config_hash.as_deref())
             .await;
@@ -567,6 +589,7 @@ impl AgentSandboxBackend {
         &self,
         id: &SandboxId,
         principal_id: &str,
+        requester_principal_id: Option<&str>,
         labels: &BTreeMap<String, String>,
     ) -> SandboxResult<()> {
         if self.config.iron_proxy.is_none() {
@@ -581,21 +604,23 @@ impl AgentSandboxBackend {
                 .get(id.as_str())
                 .await
                 .map_err(|err| map_kube_error("get sandbox for proxy principal check", err))?;
-            let assigned_principal = sandbox
-                .metadata
-                .annotations
-                .as_ref()
-                .and_then(|annotations| annotations.get(crate::IRON_CONTROL_PRINCIPAL_ANNOTATION));
-            if assigned_principal.map(String::as_str) == Some(principal_id) && labels.is_empty() {
+            if proxy_binding_matches(
+                sandbox.metadata.annotations.as_ref(),
+                principal_id,
+                requester_principal_id,
+                labels,
+            ) {
                 return Ok(());
             }
 
             let iron_control = &self.config.iron_control;
             let proxy = iron_control
                 .client
-                .assign_proxy_principal(&proxy_id, principal_id, labels)
+                .assign_proxy_principal(&proxy_id, principal_id, requester_principal_id, labels)
                 .await
                 .map_err(|err| SandboxError::backend_source("iron-control assign proxy", err))?;
+            self.patch_iron_control_principal_annotation(id, principal_id, requester_principal_id)
+                .await?;
             self.wait_for_proxy_principal_applied(id, principal_id, proxy.config_hash.as_deref())
                 .await;
             return Ok(());
@@ -606,9 +631,14 @@ impl AgentSandboxBackend {
             principal_id,
             "iron-proxy resources are missing or not running; recreating before reuse"
         );
-        self.recreate_iron_proxy_resources_for_principal(id, principal_id, labels)
-            .await?;
-        self.patch_iron_control_principal_annotation(id, principal_id)
+        self.recreate_iron_proxy_resources_for_principal(
+            id,
+            principal_id,
+            requester_principal_id,
+            labels,
+        )
+        .await?;
+        self.patch_iron_control_principal_annotation(id, principal_id, requester_principal_id)
             .await?;
         Ok(())
     }
@@ -617,6 +647,7 @@ impl AgentSandboxBackend {
         &self,
         id: &SandboxId,
         principal_id: &str,
+        requester_principal_id: Option<&str>,
         labels: &BTreeMap<String, String>,
     ) -> SandboxResult<String> {
         if self.config.iron_proxy.is_none() {
@@ -672,6 +703,7 @@ impl AgentSandboxBackend {
         let resolved = self.resolved_iron_proxy_for_principal(
             id,
             principal_id,
+            requester_principal_id.map(ToOwned::to_owned),
             labels.clone(),
             ResolvedIronProxyRuntime {
                 pg,
@@ -958,11 +990,16 @@ impl AgentSandboxBackend {
         &self,
         id: &SandboxId,
         principal_id: &str,
+        requester_principal_id: Option<&str>,
     ) -> SandboxResult<()> {
+        // A merge-patch null removes the requester annotation, so "no
+        // requester" and "absent annotation" stay indistinguishable for the
+        // binding comparison.
         let patch = Patch::Merge(json!({
             "metadata": {
                 "annotations": {
                     crate::IRON_CONTROL_PRINCIPAL_ANNOTATION: principal_id,
+                    crate::IRON_CONTROL_REQUESTER_ANNOTATION: requester_principal_id,
                 },
             },
         }));
@@ -2105,6 +2142,26 @@ fn iron_proxy_labels(
     labels
 }
 
+/// Whether a sandbox's annotations already record the requested proxy binding,
+/// so the ensure path can skip a redundant reassignment. An absent requester
+/// annotation means "no requester" and compares equal to `None`, keeping
+/// label-less sessions (tool-host, non-Slack) on the skip path. Any label
+/// refresh always reassigns, mirroring the pre-requester behavior.
+fn proxy_binding_matches(
+    annotations: Option<&BTreeMap<String, String>>,
+    principal_id: &str,
+    requester_principal_id: Option<&str>,
+    labels: &BTreeMap<String, String>,
+) -> bool {
+    let assigned_principal = annotations
+        .and_then(|annotations| annotations.get(crate::IRON_CONTROL_PRINCIPAL_ANNOTATION));
+    let assigned_requester = annotations
+        .and_then(|annotations| annotations.get(crate::IRON_CONTROL_REQUESTER_ANNOTATION));
+    assigned_principal.map(String::as_str) == Some(principal_id)
+        && assigned_requester.map(String::as_str) == requester_principal_id
+        && labels.is_empty()
+}
+
 fn unique_suffix() -> String {
     let millis = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
@@ -2124,6 +2181,7 @@ mod tests {
             proxy_port: 8080,
             console_url: "http://console:3000".to_owned(),
             principal_id: "principal".to_owned(),
+            requester_principal_id: None,
             labels: BTreeMap::new(),
             pg: None,
             replace_placeholders: BTreeMap::new(),
@@ -2142,6 +2200,84 @@ mod tests {
             api_server_enabled,
             ..resolved()
         }
+    }
+
+    fn binding_annotations(
+        principal: Option<&str>,
+        requester: Option<&str>,
+    ) -> BTreeMap<String, String> {
+        let mut annotations = BTreeMap::new();
+        if let Some(principal) = principal {
+            annotations.insert(
+                crate::IRON_CONTROL_PRINCIPAL_ANNOTATION.to_owned(),
+                principal.to_owned(),
+            );
+        }
+        if let Some(requester) = requester {
+            annotations.insert(
+                crate::IRON_CONTROL_REQUESTER_ANNOTATION.to_owned(),
+                requester.to_owned(),
+            );
+        }
+        annotations
+    }
+
+    #[test]
+    fn proxy_binding_matches_compares_principal_requester_and_labels() {
+        let no_labels = BTreeMap::new();
+        let labels = BTreeMap::from([("centaur.slack_channel_id".to_owned(), "C1".to_owned())]);
+
+        let both = binding_annotations(Some("prn_conv"), Some("prn_req"));
+        assert!(proxy_binding_matches(
+            Some(&both),
+            "prn_conv",
+            Some("prn_req"),
+            &no_labels
+        ));
+
+        let no_requester = binding_annotations(Some("prn_conv"), None);
+        assert!(proxy_binding_matches(
+            Some(&no_requester),
+            "prn_conv",
+            None,
+            &no_labels
+        ));
+
+        // A requester swap, a requester-to-none clear, and a none-to-requester
+        // bind must all fall through to reassignment.
+        assert!(!proxy_binding_matches(
+            Some(&both),
+            "prn_conv",
+            Some("prn_other"),
+            &no_labels
+        ));
+        assert!(!proxy_binding_matches(
+            Some(&both),
+            "prn_conv",
+            None,
+            &no_labels
+        ));
+        assert!(!proxy_binding_matches(
+            Some(&no_requester),
+            "prn_conv",
+            Some("prn_req"),
+            &no_labels
+        ));
+
+        // Principal mismatch and non-empty labels always reassign.
+        assert!(!proxy_binding_matches(
+            Some(&both),
+            "prn_else",
+            Some("prn_req"),
+            &no_labels
+        ));
+        assert!(!proxy_binding_matches(
+            Some(&both),
+            "prn_conv",
+            Some("prn_req"),
+            &labels
+        ));
+        assert!(!proxy_binding_matches(None, "prn_conv", None, &no_labels));
     }
 
     fn control_target() -> ControlPlaneEgressTarget {

--- a/services/api-rs/crates/centaur-sandbox-agent-k8s/src/lib.rs
+++ b/services/api-rs/crates/centaur-sandbox-agent-k8s/src/lib.rs
@@ -45,6 +45,10 @@ const MANAGED_BY_VALUE: &str = "api-rs";
 // so resume (which has only the sandbox id) can rebind without the spec or any
 // in-memory state. Survives pause and api-rs restarts.
 const IRON_CONTROL_PRINCIPAL_ANNOTATION: &str = "centaur.ai/iron-control-principal";
+// Requesting user's principal OID bound to the proxy for the current turn.
+// Absent when the turn has no requester, so an annotation-vs-binding
+// comparison treats "absent" and "no requester" as equal.
+const IRON_CONTROL_REQUESTER_ANNOTATION: &str = "centaur.ai/iron-control-requester-principal";
 // RFC 3339 instant stamped when the sandbox is paused for idleness and cleared
 // on resume. This keeps suspended status observable across api-rs restarts.
 const PAUSED_AT_ANNOTATION: &str = "centaur.ai/paused-at";
@@ -468,18 +472,21 @@ impl SandboxBackend for AgentSandboxBackend {
         &self,
         id: &SandboxId,
         principal_id: &str,
+        requester_principal_id: Option<&str>,
         labels: &BTreeMap<String, String>,
     ) -> SandboxResult<()> {
-        self.assign_proxy_principal(id, principal_id, labels).await
+        self.assign_proxy_principal(id, principal_id, requester_principal_id, labels)
+            .await
     }
 
     async fn ensure_iron_control_proxy_resources(
         &self,
         id: &SandboxId,
         principal_id: &str,
+        requester_principal_id: Option<&str>,
         labels: &BTreeMap<String, String>,
     ) -> SandboxResult<()> {
-        self.ensure_proxy_resources_for_principal(id, principal_id, labels)
+        self.ensure_proxy_resources_for_principal(id, principal_id, requester_principal_id, labels)
             .await
     }
 
@@ -862,6 +869,12 @@ fn build_agent_sandbox(
             principal.clone(),
         );
     }
+    if let Some(requester) = &spec.iron_control_requester_principal {
+        annotations.insert(
+            IRON_CONTROL_REQUESTER_ANNOTATION.to_owned(),
+            requester.clone(),
+        );
+    }
 
     let crd_spec = serde_json::from_value(agent_spec)
         .map_err(|err| SandboxError::InvalidSpec(format!("invalid Agent Sandbox spec: {err}")))?;
@@ -1152,6 +1165,36 @@ mod tests {
         assert!(pod_spec.node_selector.is_none());
         assert!(pod_spec.tolerations.is_none());
         assert!(pod_spec.runtime_class_name.is_none());
+    }
+
+    #[test]
+    fn stamps_requester_annotation_only_when_spec_carries_one() {
+        let config = AgentSandboxConfig::new("centaur", test_iron_control_settings());
+
+        let mut spec = SandboxSpec::new("centaur-agent:latest").iron_control_principal("prn_conv");
+        spec.iron_control_requester_principal = Some("prn_req".to_owned());
+        let sandbox = build_agent_sandbox(&SandboxId::new("asbx-test"), &spec, &config).unwrap();
+        let annotations = sandbox.metadata.annotations.as_ref().unwrap();
+        assert_eq!(
+            annotations
+                .get(IRON_CONTROL_PRINCIPAL_ANNOTATION)
+                .map(String::as_str),
+            Some("prn_conv")
+        );
+        assert_eq!(
+            annotations
+                .get(IRON_CONTROL_REQUESTER_ANNOTATION)
+                .map(String::as_str),
+            Some("prn_req")
+        );
+
+        let spec = SandboxSpec::new("centaur-agent:latest").iron_control_principal("prn_conv");
+        let sandbox = build_agent_sandbox(&SandboxId::new("asbx-test"), &spec, &config).unwrap();
+        assert!(
+            sandbox.metadata.annotations.as_ref().is_none_or(
+                |annotations| !annotations.contains_key(IRON_CONTROL_REQUESTER_ANNOTATION)
+            )
+        );
     }
 
     #[test]

--- a/services/api-rs/crates/centaur-sandbox-core/src/backend.rs
+++ b/services/api-rs/crates/centaur-sandbox-core/src/backend.rs
@@ -55,11 +55,13 @@ pub trait SandboxBackend: Send + Sync {
     async fn stop(&self, id: &SandboxId) -> SandboxResult<()>;
 
     /// Rebind a running sandbox's managed iron-proxy to a different
-    /// iron-control principal.
+    /// iron-control principal, together with the requesting user's principal
+    /// for the current turn (`None` clears a previous requester binding).
     async fn assign_iron_control_proxy_principal(
         &self,
         _id: &SandboxId,
         _principal_id: &str,
+        _requester_principal_id: Option<&str>,
         _labels: &BTreeMap<String, String>,
     ) -> SandboxResult<()> {
         Err(crate::SandboxError::Unsupported {
@@ -69,12 +71,13 @@ pub trait SandboxBackend: Send + Sync {
     }
 
     /// Ensure a running sandbox's managed iron-proxy resources are present and
-    /// usable for the supplied iron-control principal without otherwise
-    /// changing the sandbox lifecycle.
+    /// usable for the supplied iron-control principal and requester without
+    /// otherwise changing the sandbox lifecycle.
     async fn ensure_iron_control_proxy_resources(
         &self,
         _id: &SandboxId,
         _principal_id: &str,
+        _requester_principal_id: Option<&str>,
         _labels: &BTreeMap<String, String>,
     ) -> SandboxResult<()> {
         Ok(())

--- a/services/api-rs/crates/centaur-sandbox-core/src/spec.rs
+++ b/services/api-rs/crates/centaur-sandbox-core/src/spec.rs
@@ -69,6 +69,11 @@ pub struct SandboxSpec {
     /// proxy for the sandbox instead of rendering a static proxy config.
     #[serde(default)]
     pub iron_control_principal: Option<String>,
+    /// iron-control principal OID of the human requesting the turn that
+    /// creates this sandbox, bound to the proxy alongside
+    /// [`Self::iron_control_principal`].
+    #[serde(default)]
+    pub iron_control_requester_principal: Option<String>,
     /// Labels applied to the iron-control proxy registered for this sandbox.
     /// These are distinct from Kubernetes labels and are used by iron-control
     /// when rendering proxy-specific config.
@@ -90,6 +95,7 @@ impl SandboxSpec {
             mounts: Vec::new(),
             resources: None,
             iron_control_principal: None,
+            iron_control_requester_principal: None,
             iron_control_proxy_labels: std::collections::BTreeMap::new(),
             capabilities: SandboxCapabilities::default_enabled(),
         }

--- a/services/api-rs/crates/centaur-sandbox-manager/src/manager.rs
+++ b/services/api-rs/crates/centaur-sandbox-manager/src/manager.rs
@@ -243,10 +243,11 @@ where
         &self,
         id: &SandboxId,
         principal_id: &str,
+        requester_principal_id: Option<&str>,
         labels: &BTreeMap<String, String>,
     ) -> SandboxResult<()> {
         self.backend
-            .assign_iron_control_proxy_principal(id, principal_id, labels)
+            .assign_iron_control_proxy_principal(id, principal_id, requester_principal_id, labels)
             .await
     }
 
@@ -254,10 +255,11 @@ where
         &self,
         id: &SandboxId,
         principal_id: &str,
+        requester_principal_id: Option<&str>,
         labels: &BTreeMap<String, String>,
     ) -> SandboxResult<()> {
         self.backend
-            .ensure_iron_control_proxy_resources(id, principal_id, labels)
+            .ensure_iron_control_proxy_resources(id, principal_id, requester_principal_id, labels)
             .await
     }
 

--- a/services/api-rs/crates/centaur-sandbox-manager/src/warm_pool.rs
+++ b/services/api-rs/crates/centaur-sandbox-manager/src/warm_pool.rs
@@ -65,6 +65,7 @@ impl WarmPoolManager {
         &self,
         thread_key: &str,
         iron_control_principal: Option<&str>,
+        requester_principal_id: Option<&str>,
         proxy_labels: &BTreeMap<String, String>,
     ) -> Result<Option<String>, WarmPoolError> {
         loop {
@@ -86,7 +87,12 @@ impl WarmPoolManager {
                     if let Some(principal_id) = iron_control_principal
                         && let Err(error) = self
                             .manager
-                            .assign_iron_control_proxy_principal(&id, principal_id, proxy_labels)
+                            .assign_iron_control_proxy_principal(
+                                &id,
+                                principal_id,
+                                requester_principal_id,
+                                proxy_labels,
+                            )
                             .await
                     {
                         let error_message = error.to_string();
@@ -252,8 +258,14 @@ mod tests {
 
     use super::*;
 
+    /// Replenishment prunes ready and stale warm rows database-wide, so
+    /// concurrently running tests would fail each other's sandboxes.
+    /// Serialize the database-backed tests in this module.
+    static TEST_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
     #[tokio::test]
     async fn replenisher_prunes_missing_ready_rows_before_counting() {
+        let _serial = TEST_LOCK.lock().await;
         let Some(store) = test_store().await else {
             return;
         };
@@ -311,9 +323,11 @@ mod tests {
                 .expect("count ready warm sandboxes"),
             1
         );
+        let claim_thread = format!("test:prune-claim-{suffix}");
+        insert_session_row(&store, &claim_thread).await;
         assert_eq!(
             store
-                .claim_ready_warm_sandbox(&workload_key, "test-thread")
+                .claim_ready_warm_sandbox(&workload_key, &claim_thread)
                 .await
                 .expect("claim ready warm sandbox"),
             Some(fresh_sandbox)
@@ -329,6 +343,7 @@ mod tests {
 
     #[tokio::test]
     async fn replenisher_prunes_stale_evicting_rows() {
+        let _serial = TEST_LOCK.lock().await;
         let Some(store) = test_store().await else {
             return;
         };
@@ -385,6 +400,73 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn claim_passes_requester_to_proxy_assignment() {
+        let _serial = TEST_LOCK.lock().await;
+        let Some(store) = test_store().await else {
+            return;
+        };
+        let suffix = unique_suffix();
+        let workload_key = format!("test-claim-requester-{suffix}");
+        let first_sandbox = format!("claim-first-{suffix}");
+        let second_sandbox = format!("claim-second-{suffix}");
+        let first_thread = format!("test:claim-req-a-{suffix}");
+        let second_thread = format!("test:claim-req-b-{suffix}");
+        for thread_key in [&first_thread, &second_thread] {
+            insert_session_row(&store, thread_key).await;
+        }
+
+        let backend = Arc::new(TestBackend::new(format!("fresh-{suffix}")));
+        let pool = WarmPoolManager::new(
+            Arc::new(SandboxManager::new(backend.clone())),
+            store.clone(),
+            Arc::new(|| SandboxSpec::new("image")),
+            workload_key.clone(),
+            WarmPoolConfig {
+                target_size: 0,
+                replenish_interval: Duration::from_secs(60),
+                bootstrap_iron_control_principal: "prn_test_bootstrap".to_owned(),
+                max_running_sandboxes: None,
+            },
+        );
+        let labels = BTreeMap::from([("centaur.slack_channel_id".to_owned(), "C1".to_owned())]);
+
+        store
+            .insert_ready_warm_sandbox(&first_sandbox, &workload_key)
+            .await
+            .expect("insert first warm sandbox");
+        backend.set_status(&first_sandbox, SandboxStatus::Running);
+        let claimed = pool
+            .claim(&first_thread, Some("prn_conv"), Some("prn_req"), &labels)
+            .await
+            .expect("claim first warm sandbox");
+        assert_eq!(claimed, Some(first_sandbox.clone()));
+
+        store
+            .insert_ready_warm_sandbox(&second_sandbox, &workload_key)
+            .await
+            .expect("insert second warm sandbox");
+        backend.set_status(&second_sandbox, SandboxStatus::Running);
+        let claimed = pool
+            .claim(&second_thread, Some("prn_conv"), None, &labels)
+            .await
+            .expect("claim second warm sandbox");
+        assert_eq!(claimed, Some(second_sandbox.clone()));
+
+        assert_eq!(
+            backend.assigned(),
+            vec![
+                (
+                    first_sandbox,
+                    "prn_conv".to_owned(),
+                    Some("prn_req".to_owned()),
+                    labels.clone()
+                ),
+                (second_sandbox, "prn_conv".to_owned(), None, labels),
+            ]
+        );
+    }
+
     async fn test_store() -> Option<PgSessionStore> {
         let Ok(url) = std::env::var("SESSION_RUNTIME_TEST_DATABASE_URL") else {
             eprintln!("skipping: SESSION_RUNTIME_TEST_DATABASE_URL not set");
@@ -397,6 +479,19 @@ mod tests {
         Some(store)
     }
 
+    /// Claimed warm rows reference `sessions.thread_key`, so a claim test must
+    /// create the session row first.
+    async fn insert_session_row(store: &PgSessionStore, thread_key: &str) {
+        sqlx::query(
+            "insert into sessions (thread_key, harness_type, status) \
+             values ($1, 'codex', 'idle') on conflict (thread_key) do nothing",
+        )
+        .bind(thread_key)
+        .execute(store.pool())
+        .await
+        .expect("insert session row");
+    }
+
     fn unique_suffix() -> String {
         SystemTime::now()
             .duration_since(UNIX_EPOCH)
@@ -405,10 +500,13 @@ mod tests {
             .to_string()
     }
 
+    type RecordedAssignment = (String, String, Option<String>, BTreeMap<String, String>);
+
     struct TestBackend {
         create_id: String,
         statuses: Mutex<BTreeMap<String, SandboxStatus>>,
         created: Mutex<Vec<String>>,
+        assigned: Mutex<Vec<RecordedAssignment>>,
     }
 
     impl TestBackend {
@@ -417,11 +515,16 @@ mod tests {
                 create_id,
                 statuses: Mutex::new(BTreeMap::new()),
                 created: Mutex::new(Vec::new()),
+                assigned: Mutex::new(Vec::new()),
             }
         }
 
         fn created(&self) -> Vec<String> {
             self.created.lock().unwrap().clone()
+        }
+
+        fn assigned(&self) -> Vec<RecordedAssignment> {
+            self.assigned.lock().unwrap().clone()
         }
 
         fn set_status(&self, sandbox_id: &str, status: SandboxStatus) {
@@ -489,6 +592,22 @@ mod tests {
                 .lock()
                 .unwrap()
                 .insert(id.as_str().to_owned(), SandboxStatus::Stopped);
+            Ok(())
+        }
+
+        async fn assign_iron_control_proxy_principal(
+            &self,
+            id: &SandboxId,
+            principal_id: &str,
+            requester_principal_id: Option<&str>,
+            labels: &BTreeMap<String, String>,
+        ) -> SandboxResult<()> {
+            self.assigned.lock().unwrap().push((
+                id.as_str().to_owned(),
+                principal_id.to_owned(),
+                requester_principal_id.map(ToOwned::to_owned),
+                labels.clone(),
+            ));
             Ok(())
         }
 

--- a/services/api-rs/crates/centaur-session-runtime/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-runtime/src/lib.rs
@@ -9520,7 +9520,11 @@ mod adoption_tests {
         let first = execute_with_metadata(
             &runtime,
             &thread_key,
-            json!({"slack_user_id": "U1", "slack_team_id": "T123"}),
+            json!({
+                "slack_user_id": "U1",
+                "slack_team_id": "T123",
+                "slack_home_team_id": "T123"
+            }),
         )
         .await;
         store
@@ -9543,7 +9547,11 @@ mod adoption_tests {
         let second = execute_with_metadata(
             &runtime,
             &thread_key,
-            json!({"slack_user_id": "U2", "slack_team_id": "T123"}),
+            json!({
+                "slack_user_id": "U2",
+                "slack_team_id": "T123",
+                "slack_home_team_id": "T123"
+            }),
         )
         .await;
         store
@@ -9562,6 +9570,64 @@ mod adoption_tests {
                     ("centaur.slack_team_id".to_owned(), "T123".to_owned()),
                 ])
             )]
+        );
+        server.abort();
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn slack_connect_channel_execute_binds_no_requester() {
+        let Some(store) = test_store().await else {
+            return;
+        };
+        let _serial = TEST_LOCK.lock().await;
+        let (base_url, requests, server) = spawn_execute_iron_control_stub().await;
+        let thread_key =
+            ThreadKey::parse(format!("slack:T_HOME:C123:{}", uuid::Uuid::new_v4())).unwrap();
+
+        let backend = Arc::new(MockBackend::new(SandboxStatus::Running, Vec::new()));
+        let (io, _stdout, _stdin) = mock_io();
+        backend.push_io(io).await;
+        let runtime =
+            runtime_with_registrar(&store, backend.clone(), requester_test_registrar(base_url));
+
+        runtime
+            .create_or_get_session(
+                &thread_key,
+                &HarnessType::Codex,
+                None,
+                Some(json!({
+                    "slack_team_id": "T_HOME",
+                    "slack_channel_id": "C123"
+                })),
+                HarnessConflictPolicy::Reject,
+            )
+            .await
+            .expect("create session");
+
+        let execution = execute_with_metadata(
+            &runtime,
+            &thread_key,
+            json!({
+                "slack_user_id": "U_EXTERNAL",
+                "slack_team_id": "T_EXTERNAL",
+                "slack_home_team_id": "T_HOME"
+            }),
+        )
+        .await;
+        store
+            .complete_execution(&execution.execution_id)
+            .await
+            .expect("complete execution");
+
+        let spec = backend.created_specs().pop().expect("created cold spec");
+        assert_eq!(spec.iron_control_requester_principal, None);
+        assert!(
+            !requests
+                .lock()
+                .unwrap()
+                .iter()
+                .any(|request| request.contains("slack-user")),
+            "Slack Connect executes must not upsert a requester principal"
         );
         server.abort();
     }

--- a/services/api-rs/crates/centaur-session-runtime/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-runtime/src/lib.rs
@@ -103,6 +103,12 @@ pub trait SessionPrincipalRegistrar: Send + Sync {
         metadata: Option<&Value>,
     ) -> Result<Principal, IronControlError>;
 
+    async fn register_requester(
+        &self,
+        thread_key: &str,
+        metadata: Option<&Value>,
+    ) -> Result<Option<Principal>, IronControlError>;
+
     async fn get_principal(&self, principal: &str) -> Result<Principal, IronControlError>;
 }
 
@@ -114,6 +120,14 @@ impl SessionPrincipalRegistrar for SessionRegistrar {
         metadata: Option<&Value>,
     ) -> Result<Principal, IronControlError> {
         SessionRegistrar::register_session(self, thread_key, metadata).await
+    }
+
+    async fn register_requester(
+        &self,
+        thread_key: &str,
+        metadata: Option<&Value>,
+    ) -> Result<Option<Principal>, IronControlError> {
+        SessionRegistrar::register_requester(self, thread_key, metadata).await
     }
 
     async fn get_principal(&self, principal: &str) -> Result<Principal, IronControlError> {
@@ -789,6 +803,7 @@ struct EnsureSessionSandboxRequest<'a> {
     existing_sandbox_id: Option<&'a str>,
     existing_sandbox_capabilities: Option<&'a SessionSandboxCapabilities>,
     iron_control_principal: Option<&'a str>,
+    requester_principal: Option<&'a str>,
     proxy_labels: &'a BTreeMap<String, String>,
     desired_capabilities: &'a SessionSandboxCapabilities,
     execution_id: &'a str,
@@ -1857,6 +1872,7 @@ impl SessionRuntime {
             let harness_label = session.harness_type.to_string();
             validate_input_lines(&input_lines)?;
             let (idle_timeout, max_duration) = duration_options(idle_timeout_ms, max_duration_ms)?;
+            let requester_metadata = metadata.clone();
 
             let execution = self
                 .store
@@ -1944,6 +1960,9 @@ impl SessionRuntime {
                     }),
                 )
                 .await?;
+            let requester_principal_id = self
+                .resolve_requester_principal(thread_key, requester_metadata.as_ref())
+                .await;
             let desired_capabilities = self
                 .resolve_sandbox_capabilities(session.iron_control_principal.as_deref())
                 .await?;
@@ -1956,6 +1975,7 @@ impl SessionRuntime {
                     existing_sandbox_id: session.sandbox_id.as_deref(),
                     existing_sandbox_capabilities: session.sandbox_capabilities.as_ref(),
                     iron_control_principal: session.iron_control_principal.as_deref(),
+                    requester_principal: requester_principal_id.as_deref(),
                     proxy_labels: &session.proxy_labels,
                     desired_capabilities: &desired_capabilities,
                     execution_id: &execution.execution_id,
@@ -2346,6 +2366,7 @@ impl SessionRuntime {
             existing_sandbox_id,
             existing_sandbox_capabilities,
             iron_control_principal,
+            requester_principal,
             proxy_labels,
             desired_capabilities,
             execution_id,
@@ -2420,6 +2441,7 @@ impl SessionRuntime {
                                     .ensure_iron_control_proxy_resources(
                                         &id,
                                         principal_id,
+                                        requester_principal,
                                         proxy_labels,
                                     )
                                     .await?;
@@ -2475,6 +2497,7 @@ impl SessionRuntime {
                                             .ensure_iron_control_proxy_resources(
                                                 &id,
                                                 principal_id,
+                                                requester_principal,
                                                 proxy_labels,
                                             )
                                             .await?;
@@ -2599,7 +2622,12 @@ impl SessionRuntime {
                 })
             {
                 match warm_pool
-                    .claim(thread_key.as_str(), iron_control_principal, proxy_labels)
+                    .claim(
+                        thread_key.as_str(),
+                        iron_control_principal,
+                        requester_principal,
+                        proxy_labels,
+                    )
                     .await
                 {
                     Ok(Some(sandbox_id)) => {
@@ -2623,6 +2651,7 @@ impl SessionRuntime {
                                     "sandbox_id": sandbox_id.as_str(),
                                     "workload_key": warm_pool.workload_key(),
                                     "iron_control_principal": iron_control_principal,
+                                    "requester_principal": requester_principal,
                                     "sandbox_capabilities": desired_capabilities,
                                 }),
                             )
@@ -2667,6 +2696,7 @@ impl SessionRuntime {
             );
             if let Some(principal) = iron_control_principal {
                 spec.iron_control_principal = Some(principal.to_owned());
+                spec.iron_control_requester_principal = requester_principal.map(ToOwned::to_owned);
                 spec.iron_control_proxy_labels = proxy_labels.clone();
             }
             apply_sandbox_boot_mode(&mut spec, &boot_mode);
@@ -2727,6 +2757,34 @@ impl SessionRuntime {
             );
         }
         result
+    }
+
+    /// Resolve and upsert the principal of the human requesting this turn from
+    /// the execute metadata. `None` for DM and non-Slack threads (the
+    /// registrar decides) and on registrar failure: a broken requester lookup
+    /// must degrade to today's requester-less turn, never fail the execution.
+    async fn resolve_requester_principal(
+        &self,
+        thread_key: &ThreadKey,
+        metadata: Option<&Value>,
+    ) -> Option<String> {
+        match self
+            .iron_control
+            .register_requester(thread_key.as_str(), metadata)
+            .await
+        {
+            Ok(principal) => principal.map(|principal| principal.id),
+            Err(error) => {
+                warn!(
+                    component = COMPONENT_SESSION_RUNTIME,
+                    event = "session_requester_registration_failed",
+                    thread_key = %thread_key,
+                    %error,
+                    "failed to register requester principal; proceeding without a requester"
+                );
+                None
+            }
+        }
     }
 
     async fn resolve_sandbox_capabilities(
@@ -8428,6 +8486,14 @@ mod adoption_tests {
             Ok(test_principal("prn_test"))
         }
 
+        async fn register_requester(
+            &self,
+            _thread_key: &str,
+            _metadata: Option<&Value>,
+        ) -> Result<Option<Principal>, IronControlError> {
+            Ok(None)
+        }
+
         async fn get_principal(&self, principal: &str) -> Result<Principal, IronControlError> {
             Ok(test_principal(principal))
         }
@@ -8444,7 +8510,7 @@ mod adoption_tests {
         }
     }
 
-    type ProxyEnsure = (String, String, BTreeMap<String, String>);
+    type ProxyEnsure = (String, String, Option<String>, BTreeMap<String, String>);
 
     struct MockBackend {
         ios: Mutex<VecDeque<SandboxIo>>,
@@ -8599,11 +8665,13 @@ mod adoption_tests {
             &self,
             id: &SandboxId,
             principal_id: &str,
+            requester_principal_id: Option<&str>,
             labels: &BTreeMap<String, String>,
         ) -> SandboxResult<()> {
             self.proxy_ensures.lock().unwrap().push((
                 id.as_str().to_owned(),
                 principal_id.to_owned(),
+                requester_principal_id.map(ToOwned::to_owned),
                 labels.clone(),
             ));
             Ok(())
@@ -9083,6 +9151,7 @@ mod adoption_tests {
                 existing_sandbox_id: session.sandbox_id.as_deref(),
                 existing_sandbox_capabilities: session.sandbox_capabilities.as_ref(),
                 iron_control_principal: None,
+                requester_principal: None,
                 proxy_labels: &BTreeMap::new(),
                 desired_capabilities: &restricted_capabilities(),
                 execution_id: &execution_id,
@@ -9174,6 +9243,7 @@ mod adoption_tests {
                 existing_sandbox_id: None,
                 existing_sandbox_capabilities: None,
                 iron_control_principal: None,
+                requester_principal: None,
                 proxy_labels: &BTreeMap::new(),
                 desired_capabilities: &restricted_capabilities(),
                 execution_id: &execution_id,
@@ -9237,6 +9307,7 @@ mod adoption_tests {
                 existing_sandbox_id: Some("sbx-existing"),
                 existing_sandbox_capabilities: None,
                 iron_control_principal: Some("principal-existing"),
+                requester_principal: None,
                 proxy_labels: &proxy_labels,
                 desired_capabilities: &SessionSandboxCapabilities::default_enabled(),
                 execution_id: &execution_id,
@@ -9250,9 +9321,435 @@ mod adoption_tests {
             vec![(
                 "sbx-existing".to_owned(),
                 "principal-existing".to_owned(),
+                None,
                 proxy_labels
             )]
         );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn existing_sandbox_ensure_swaps_and_clears_requester() {
+        let Some(store) = test_store().await else {
+            return;
+        };
+        let _serial = TEST_LOCK.lock().await;
+        let thread_key =
+            ThreadKey::parse(format!("test:requester-swap-{}", uuid::Uuid::new_v4())).unwrap();
+        store
+            .create_or_get_session(
+                &thread_key,
+                &HarnessType::Codex,
+                None,
+                json!({}),
+                Default::default(),
+            )
+            .await
+            .expect("create session");
+        let execution_id = store
+            .create_execution(&thread_key, None, json!({}))
+            .await
+            .expect("create execution")
+            .execution
+            .execution_id;
+
+        let backend = Arc::new(MockBackend::new(SandboxStatus::Running, Vec::new()));
+        let runtime = runtime_with(&store, backend.clone());
+        let proxy_labels = BTreeMap::new();
+        for requester in [Some("prn_a"), Some("prn_b"), None] {
+            runtime
+                .ensure_session_sandbox(EnsureSessionSandboxRequest {
+                    thread_key: &thread_key,
+                    harness_type: &HarnessType::Codex,
+                    persona_id: None,
+                    existing_sandbox_id: Some("sbx-existing"),
+                    existing_sandbox_capabilities: None,
+                    iron_control_principal: Some("prn_conv"),
+                    requester_principal: requester,
+                    proxy_labels: &proxy_labels,
+                    desired_capabilities: &SessionSandboxCapabilities::default_enabled(),
+                    execution_id: &execution_id,
+                })
+                .await
+                .expect("reuse existing sandbox");
+        }
+
+        assert_eq!(
+            backend.proxy_ensures(),
+            vec![
+                (
+                    "sbx-existing".to_owned(),
+                    "prn_conv".to_owned(),
+                    Some("prn_a".to_owned()),
+                    BTreeMap::new()
+                ),
+                (
+                    "sbx-existing".to_owned(),
+                    "prn_conv".to_owned(),
+                    Some("prn_b".to_owned()),
+                    BTreeMap::new()
+                ),
+                (
+                    "sbx-existing".to_owned(),
+                    "prn_conv".to_owned(),
+                    None,
+                    BTreeMap::new()
+                ),
+            ]
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn cold_create_carries_requester_on_spec() {
+        let Some(store) = test_store().await else {
+            return;
+        };
+        let _serial = TEST_LOCK.lock().await;
+        let thread_key =
+            ThreadKey::parse(format!("test:requester-cold-{}", uuid::Uuid::new_v4())).unwrap();
+        store
+            .create_or_get_session(
+                &thread_key,
+                &HarnessType::Codex,
+                None,
+                json!({}),
+                Default::default(),
+            )
+            .await
+            .expect("create session");
+        let execution_id = store
+            .create_execution(&thread_key, None, json!({}))
+            .await
+            .expect("create execution")
+            .execution
+            .execution_id;
+
+        let backend = Arc::new(MockBackend::new(SandboxStatus::Running, Vec::new()));
+        let runtime = runtime_with(&store, backend.clone());
+        runtime
+            .ensure_session_sandbox(EnsureSessionSandboxRequest {
+                thread_key: &thread_key,
+                harness_type: &HarnessType::Codex,
+                persona_id: None,
+                existing_sandbox_id: None,
+                existing_sandbox_capabilities: None,
+                iron_control_principal: Some("prn_conv"),
+                requester_principal: Some("prn_req"),
+                proxy_labels: &BTreeMap::new(),
+                desired_capabilities: &SessionSandboxCapabilities::default_enabled(),
+                execution_id: &execution_id,
+            })
+            .await
+            .expect("cold create sandbox");
+
+        let spec = backend.created_specs().pop().expect("created cold spec");
+        assert_eq!(spec.iron_control_principal.as_deref(), Some("prn_conv"));
+        assert_eq!(
+            spec.iron_control_requester_principal.as_deref(),
+            Some("prn_req")
+        );
+    }
+
+    fn requester_test_registrar(base_url: String) -> SessionRegistrar {
+        SessionRegistrar::new(centaur_iron_control::IronControlClient::new(
+            base_url, "test-key",
+        ))
+    }
+
+    fn runtime_with_registrar(
+        store: &PgSessionStore,
+        backend: Arc<MockBackend>,
+        registrar: SessionRegistrar,
+    ) -> SessionRuntime {
+        SessionRuntime::new(
+            store.clone(),
+            SandboxRuntime::backend(backend, SandboxSpec::new("mock")),
+            registrar,
+        )
+    }
+
+    async fn execute_with_metadata(
+        runtime: &SessionRuntime,
+        thread_key: &ThreadKey,
+        metadata: Value,
+    ) -> SessionExecution {
+        runtime
+            .execute_session(
+                thread_key,
+                ExecuteSessionInput {
+                    idempotency_key: None,
+                    metadata: Some(metadata),
+                    input_lines: vec![
+                        r#"{"type":"user","message":{"role":"user","content":[{"type":"text","text":"hi"}]}}"#
+                            .to_owned(),
+                    ],
+                    idle_timeout_ms: None,
+                    max_duration_ms: None,
+                },
+            )
+            .await
+            .expect("execute session")
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn channel_execute_binds_requester_and_second_user_swaps_it() {
+        let Some(store) = test_store().await else {
+            return;
+        };
+        let _serial = TEST_LOCK.lock().await;
+        let (base_url, _requests, server) = spawn_execute_iron_control_stub().await;
+        let thread_key =
+            ThreadKey::parse(format!("slack:T123:C123:{}", uuid::Uuid::new_v4())).unwrap();
+
+        let backend = Arc::new(MockBackend::new(SandboxStatus::Running, Vec::new()));
+        let (io, _stdout, _stdin) = mock_io();
+        backend.push_io(io).await;
+        let runtime =
+            runtime_with_registrar(&store, backend.clone(), requester_test_registrar(base_url));
+
+        runtime
+            .create_or_get_session(
+                &thread_key,
+                &HarnessType::Codex,
+                None,
+                Some(json!({"slack_team_id": "T123", "slack_channel_id": "C123"})),
+                HarnessConflictPolicy::Reject,
+            )
+            .await
+            .expect("create session");
+
+        let first = execute_with_metadata(
+            &runtime,
+            &thread_key,
+            json!({"slack_user_id": "U1", "slack_team_id": "T123"}),
+        )
+        .await;
+        store
+            .complete_execution(&first.execution_id)
+            .await
+            .expect("complete first execution");
+
+        // The thread's first turn binds the requester at sandbox creation.
+        let spec = backend.created_specs().pop().expect("created cold spec");
+        assert_eq!(
+            spec.iron_control_principal.as_deref(),
+            Some("prn_slack-channel-t123-c123")
+        );
+        assert_eq!(
+            spec.iron_control_requester_principal.as_deref(),
+            Some("prn_slack-user-t123-u1")
+        );
+
+        // A second turn by a different user swaps the requester on re-assign.
+        let second = execute_with_metadata(
+            &runtime,
+            &thread_key,
+            json!({"slack_user_id": "U2", "slack_team_id": "T123"}),
+        )
+        .await;
+        store
+            .complete_execution(&second.execution_id)
+            .await
+            .expect("complete second execution");
+
+        assert_eq!(
+            backend.proxy_ensures(),
+            vec![(
+                "mock-sbx".to_owned(),
+                "prn_slack-channel-t123-c123".to_owned(),
+                Some("prn_slack-user-t123-u2".to_owned()),
+                BTreeMap::from([
+                    ("centaur.slack_channel_id".to_owned(), "C123".to_owned()),
+                    ("centaur.slack_team_id".to_owned(), "T123".to_owned()),
+                ])
+            )]
+        );
+        server.abort();
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn dm_execute_binds_no_requester() {
+        let Some(store) = test_store().await else {
+            return;
+        };
+        let _serial = TEST_LOCK.lock().await;
+        let (base_url, requests, server) = spawn_execute_iron_control_stub().await;
+        let thread_key =
+            ThreadKey::parse(format!("slack:T123:D123:{}", uuid::Uuid::new_v4())).unwrap();
+
+        let backend = Arc::new(MockBackend::new(SandboxStatus::Running, Vec::new()));
+        let (io, _stdout, _stdin) = mock_io();
+        backend.push_io(io).await;
+        let runtime =
+            runtime_with_registrar(&store, backend.clone(), requester_test_registrar(base_url));
+
+        runtime
+            .create_or_get_session(
+                &thread_key,
+                &HarnessType::Codex,
+                None,
+                Some(json!({"slack_user_id": "U123", "slack_team_id": "T123"})),
+                HarnessConflictPolicy::Reject,
+            )
+            .await
+            .expect("create session");
+
+        let execution = execute_with_metadata(
+            &runtime,
+            &thread_key,
+            json!({"slack_user_id": "U123", "slack_team_id": "T123"}),
+        )
+        .await;
+        store
+            .complete_execution(&execution.execution_id)
+            .await
+            .expect("complete execution");
+
+        // In a DM the conversation principal already is the user's principal;
+        // the execute must not bind (or upsert) a separate requester.
+        let spec = backend.created_specs().pop().expect("created cold spec");
+        assert_eq!(
+            spec.iron_control_principal.as_deref(),
+            Some("prn_slack-user-t123-u123")
+        );
+        assert_eq!(spec.iron_control_requester_principal, None);
+        let user_upserts = requests
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|request| *request == "PUT /api/v1/principals/slack-user-t123-u123")
+            .count();
+        assert_eq!(user_upserts, 1, "only session create upserts the user");
+        server.abort();
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn non_slack_execute_binds_no_requester() {
+        let Some(store) = test_store().await else {
+            return;
+        };
+        let _serial = TEST_LOCK.lock().await;
+        let (base_url, requests, server) = spawn_execute_iron_control_stub().await;
+        let thread_key = ThreadKey::parse(format!(
+            "linear:issue-{}:s:sess-1",
+            uuid::Uuid::new_v4().simple()
+        ))
+        .unwrap();
+
+        let backend = Arc::new(MockBackend::new(SandboxStatus::Running, Vec::new()));
+        let (io, _stdout, _stdin) = mock_io();
+        backend.push_io(io).await;
+        let runtime =
+            runtime_with_registrar(&store, backend.clone(), requester_test_registrar(base_url));
+
+        runtime
+            .create_or_get_session(
+                &thread_key,
+                &HarnessType::Codex,
+                None,
+                None,
+                HarnessConflictPolicy::Reject,
+            )
+            .await
+            .expect("create session");
+
+        let execution = execute_with_metadata(
+            &runtime,
+            &thread_key,
+            json!({"slack_user_id": "U1", "slack_team_id": "T123"}),
+        )
+        .await;
+        store
+            .complete_execution(&execution.execution_id)
+            .await
+            .expect("complete execution");
+
+        let spec = backend.created_specs().pop().expect("created cold spec");
+        assert_eq!(spec.iron_control_requester_principal, None);
+        assert!(
+            !requests
+                .lock()
+                .unwrap()
+                .iter()
+                .any(|request| request.contains("slack-user")),
+            "non-Slack executes must not upsert a Slack requester principal"
+        );
+        server.abort();
+    }
+
+    /// Minimal raw-TCP iron-control stub for execute-level requester tests:
+    /// principal lookups 404 (every upsert is a create), upserts return an OID
+    /// derived from the foreign id (``prn_<foreign_id>``) so assertions can
+    /// name the expected binding, and OID lookups echo the principal back.
+    async fn spawn_execute_iron_control_stub() -> (
+        String,
+        Arc<std::sync::Mutex<Vec<String>>>,
+        tokio::task::JoinHandle<()>,
+    ) {
+        use tokio::io::AsyncReadExt;
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let base_url = format!("http://{}", listener.local_addr().unwrap());
+        let requests = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let seen = requests.clone();
+        let handle = tokio::spawn(async move {
+            loop {
+                let Ok((mut stream, _)) = listener.accept().await else {
+                    return;
+                };
+                let mut request = Vec::new();
+                let mut buf = [0u8; 1024];
+                while !request.windows(4).any(|window| window == b"\r\n\r\n") {
+                    match stream.read(&mut buf).await {
+                        Ok(0) | Err(_) => break,
+                        Ok(read) => request.extend_from_slice(&buf[..read]),
+                    }
+                }
+                let request = String::from_utf8_lossy(&request);
+                let first_line = request.lines().next().unwrap_or_default();
+                let mut parts = first_line.split_whitespace();
+                let method = parts.next().unwrap_or_default();
+                let path = parts.next().unwrap_or_default();
+                seen.lock().unwrap().push(format!("{method} {path}"));
+                let (status_line, body) = execute_iron_control_stub_response(method, path);
+                let response = format!(
+                    "HTTP/1.1 {status_line}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                    body.len(),
+                );
+                let _ = stream.write_all(response.as_bytes()).await;
+                let _ = stream.shutdown().await;
+            }
+        });
+        (base_url, requests, handle)
+    }
+
+    fn execute_iron_control_stub_response(method: &str, path: &str) -> (&'static str, String) {
+        fn principal_body(id: &str, foreign_id: &str) -> String {
+            format!(
+                r#"{{"data":{{"id":"{id}","namespace":"default","foreign_id":"{foreign_id}","name":"stub","labels":{{}}}}}}"#
+            )
+        }
+        match method {
+            "GET" if path.starts_with("/api/v1/principals/lookup/") => {
+                ("404 Not Found", r#"{"error":"not found"}"#.to_owned())
+            }
+            "GET" if path.starts_with("/api/v1/principals/prn_") => {
+                let id = path.rsplit('/').next().unwrap_or_default();
+                ("200 OK", principal_body(id, "stub"))
+            }
+            "PUT" if path.starts_with("/api/v1/principals/") => {
+                let foreign_id = path.rsplit('/').next().unwrap_or_default();
+                (
+                    "200 OK",
+                    principal_body(&format!("prn_{foreign_id}"), foreign_id),
+                )
+            }
+            "POST" if path.ends_with("/slack_channel_permissions") => {
+                ("200 OK", r#"{"data":{"ok":true}}"#.to_owned())
+            }
+            _ => (
+                "500 Internal Server Error",
+                r#"{"error":"unexpected"}"#.to_owned(),
+            ),
+        }
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -9618,6 +10115,7 @@ mod adoption_tests {
                 existing_sandbox_id: Some("sbx-old"),
                 existing_sandbox_capabilities: None,
                 iron_control_principal: None,
+                requester_principal: None,
                 proxy_labels: &BTreeMap::new(),
                 desired_capabilities: &SessionSandboxCapabilities::default_enabled(),
                 execution_id: &execution_id,


### PR DESCRIPTION
Step 4 of 4 towards RFC 0005 (#1256). Builds on #1258 and #1269, so their commits show here until they merge; review the last commits. Requester eligibility also depends on `slack_home_team_id` from #1360.

On every execute, api-rs now resolves who is asking and binds that user principal to the sandbox proxy for that turn, next to the unchanged conversation principal. The console (#1269) then serves the union.

Only Slack channel turns from users in the app home workspace bind a requester. api-rs requires nonblank, matching `slack_team_id` and `slack_home_team_id`, so Slack Connect users and ambiguous requests retain channel credentials only. In a DM the conversation principal already is the user, and other surfaces have no requester.

The binding is sent on every assignment, null included, so a turn with no requester clears the previous one. If the lookup fails the turn runs with no requester rather than failing. A user gets the same principal whether first seen in a DM or channel.