### PR TITLE
feat: add daily user experience scan workflow

### DIFF
--- a/contrib/chart/templates/apirs.yaml
+++ b/contrib/chart/templates/apirs.yaml
@@ -98,8 +98,28 @@
   (dict "name" "COMPANY_CONTEXT_DOCUMENTS_MAX_WINDOW_SECONDS" "value" (dig "companyContextDocuments" "maxWindowSeconds" 21600 $apiRsEtl))
   (dict "name" "COMPANY_CONTEXT_DOCUMENTS_BATCH_SIZE" "value" (dig "companyContextDocuments" "batchSize" 50 $apiRsEtl))
 -}}
+{{- $apiRsUserExperience := .Values.apiRs.userExperienceDigest | default dict -}}
+{{- $apiRsUserExperienceEnv := list
+  (dict "name" "USER_EXPERIENCE_DIGEST_ENABLED" "value" (dig "enabled" false $apiRsUserExperience))
+  (dict "name" "USER_EXPERIENCE_DIGEST_CRON" "value" (dig "cron" "0 8 * * *" $apiRsUserExperience))
+  (dict "name" "USER_EXPERIENCE_DIGEST_TIMEZONE" "value" (dig "timezone" "America/Los_Angeles" $apiRsUserExperience))
+  (dict "name" "USER_EXPERIENCE_DIGEST_MODEL" "value" (dig "model" "gpt-5.4-nano" $apiRsUserExperience))
+  (dict "name" "USER_EXPERIENCE_DIGEST_CLASSIFIER_VERSION" "value" (dig "classifierVersion" "v1" $apiRsUserExperience))
+  (dict "name" "USER_EXPERIENCE_DIGEST_OPENAI_BASE_URL" "value" (dig "openaiBaseUrl" "https://api.openai.com/v1" $apiRsUserExperience))
+  (dict "name" "USER_EXPERIENCE_DIGEST_SLACK_CHANNEL" "value" (dig "slackChannel" "" $apiRsUserExperience))
+  (dict "name" "USER_EXPERIENCE_DIGEST_IDLE_MINUTES" "value" (dig "idleMinutes" 60 $apiRsUserExperience))
+  (dict "name" "USER_EXPERIENCE_DIGEST_BATCH_SIZE" "value" (dig "batchSize" 100 $apiRsUserExperience))
+  (dict "name" "USER_EXPERIENCE_DIGEST_MAX_MESSAGES" "value" (dig "maxMessages" 40 $apiRsUserExperience))
+  (dict "name" "USER_EXPERIENCE_DIGEST_MAX_ATTEMPTS" "value" (dig "maxAttempts" 3 $apiRsUserExperience))
+  (dict "name" "USER_EXPERIENCE_DIGEST_MAX_OUTPUT_TOKENS" "value" (dig "maxOutputTokens" 500 $apiRsUserExperience))
+  (dict "name" "USER_EXPERIENCE_DIGEST_TIMEOUT_SECONDS" "value" (dig "timeoutSeconds" 20 $apiRsUserExperience))
+  (dict "name" "USER_EXPERIENCE_DIGEST_CONCURRENCY" "value" (dig "concurrency" 5 $apiRsUserExperience))
+  (dict "name" "USER_EXPERIENCE_DIGEST_LEASE_MINUTES" "value" (dig "leaseMinutes" 30 $apiRsUserExperience))
+  (dict "name" "USER_EXPERIENCE_DIGEST_INCLUDE_DIRECT_MESSAGES" "value" (dig "includeDirectMessages" false $apiRsUserExperience))
+-}}
+{{- $apiRsWorkflowEnv := concat $apiRsEtlEnv $apiRsUserExperienceEnv -}}
 {{- $apiRsEtlPassthroughNames := list -}}
-{{- range $env := $apiRsEtlEnv -}}
+{{- range $env := $apiRsWorkflowEnv -}}
 {{- $apiRsEtlPassthroughNames = append $apiRsEtlPassthroughNames $env.name -}}
 {{- end -}}
 {{- with (get .Values.apiRs.extraEnv "SESSION_SANDBOX_PASSTHROUGH_ENV") -}}
@@ -263,14 +283,14 @@ spec:
             - name: WORKFLOW_ALLOWED_NAMES
               value: {{ .Values.apiRs.workflowAllowedNames | quote }}
 {{- end }}
-{{- range $env := $apiRsEtlEnv }}
+{{- range $env := $apiRsWorkflowEnv }}
 {{- if not (hasKey $.Values.apiRs.extraEnv $env.name) }}
             - name: {{ $env.name }}
               value: {{ $env.value | toString | quote }}
 {{- end }}
 {{- end }}
-            # Forward the chart-rendered ETL workflow config into workflow-host
-            # sandboxes. Operators should set apiRs.etl.* values, not maintain
+            # Forward chart-rendered scheduled-workflow config into workflow-host
+            # sandboxes. Operators should use the chart values rather than maintain
             # SESSION_SANDBOX_PASSTHROUGH_ENV by hand.
             - name: SESSION_SANDBOX_PASSTHROUGH_ENV
               value: {{ join "," $apiRsEtlPassthroughNames | quote }}

--- a/contrib/chart/values.yaml
+++ b/contrib/chart/values.yaml
@@ -418,6 +418,8 @@ apiRs:
       batchSize: 50
   # Classify idle conversation snapshots and optionally post a private daily
   # Slack digest. Results and retry state are stored in user_experience_scans.
+  # Existing snapshots are baselined by the migration and are not classified
+  # until their thread receives a new message.
   userExperienceDigest:
     enabled: false
     cron: "0 8 * * *"

--- a/contrib/chart/values.yaml
+++ b/contrib/chart/values.yaml
@@ -417,9 +417,10 @@ apiRs:
       maxWindowSeconds: 21600
       batchSize: 50
   # Classify idle conversation snapshots and optionally post a private daily
-  # Slack digest. Results and retry state are stored in user_experience_scans.
-  # Existing snapshots are baselined by the migration and are not classified
-  # until their thread receives a new message.
+  # Slack digest. Only Slack threads with a persisted bot mention are eligible.
+  # Results and retry state are stored in user_experience_scans. Existing
+  # snapshots are baselined by the migration and are not classified until the
+  # bot is mentioned again in their thread.
   userExperienceDigest:
     enabled: false
     cron: "0 8 * * *"

--- a/contrib/chart/values.yaml
+++ b/contrib/chart/values.yaml
@@ -418,9 +418,9 @@ apiRs:
       batchSize: 50
   # Classify idle conversation snapshots and optionally post a private daily
   # Slack digest. Only Slack threads with a persisted bot mention are eligible.
-  # Results and retry state are stored in user_experience_scans. Existing
-  # snapshots are baselined by the migration and are not classified until the
-  # bot is mentioned again in their thread.
+  # Results and retry state are stored in user_experience_scans. Every thread
+  # that exists when the migration runs is permanently excluded; only threads
+  # created afterward can be classified.
   userExperienceDigest:
     enabled: false
     cron: "0 8 * * *"

--- a/contrib/chart/values.yaml
+++ b/contrib/chart/values.yaml
@@ -378,9 +378,9 @@ apiRs:
   workflowHostSandbox: true
   workflowEnableMode: all
   workflowAllowedNames: ""
-  # Scheduled ETL workflow configuration. The chart renders these into api-rs
-  # env so workflow discovery sees the right schedules, then derives the
-  # workflow-host passthrough list from the same non-secret config.
+  # Scheduled workflow configuration. The chart renders these into api-rs env
+  # so workflow discovery sees the right schedules, then derives the workflow-
+  # host passthrough list from the same non-secret config.
   etl:
     slack:
       enabled: false
@@ -416,6 +416,25 @@ apiRs:
       intervalSeconds: 14400
       maxWindowSeconds: 21600
       batchSize: 50
+  # Classify idle conversation snapshots and optionally post a private daily
+  # Slack digest. Results and retry state are stored in user_experience_scans.
+  userExperienceDigest:
+    enabled: false
+    cron: "0 8 * * *"
+    timezone: America/Los_Angeles
+    model: gpt-5.4-nano
+    classifierVersion: v1
+    openaiBaseUrl: https://api.openai.com/v1
+    slackChannel: ""
+    idleMinutes: 60
+    batchSize: 100
+    maxMessages: 40
+    maxAttempts: 3
+    maxOutputTokens: 500
+    timeoutSeconds: 20
+    concurrency: 5
+    leaseMinutes: 30
+    includeDirectMessages: false
   # Reaper: stop sandboxes older than the max lifetime, regardless of whether
   # they are running or suspended. 0 disables the sweep. Interval must be >= 1.
   sandboxMaxLifetimeSecs: 259200 # 3 days

--- a/docs/pages/reference/configuration.mdx
+++ b/docs/pages/reference/configuration.mdx
@@ -260,6 +260,10 @@ Linear ETL workflows:
 
 User experience digest workflow:
 
+The migration records existing thread snapshots as baselines, so classification
+is forward-looking from rollout. Historical threads are not classified unless
+they receive a new message after the baseline is established.
+
 | Env var | Set from | Controls |
 | --- | --- | --- |
 | `USER_EXPERIENCE_DIGEST_ENABLED`, `USER_EXPERIENCE_DIGEST_CRON`, `USER_EXPERIENCE_DIGEST_TIMEZONE` | `apiRs.userExperienceDigest.enabled`, `.cron`, `.timezone`. | Enables and schedules the daily classifier. |

--- a/docs/pages/reference/configuration.mdx
+++ b/docs/pages/reference/configuration.mdx
@@ -260,9 +260,10 @@ Linear ETL workflows:
 
 User experience digest workflow:
 
-The migration records existing thread snapshots as baselines, so classification
-is forward-looking from rollout. Historical threads are not classified unless
-they receive a new message after the baseline is established.
+The migration records existing Slack thread snapshots as baselines, so
+classification is forward-looking from rollout. Only threads containing a
+persisted bot mention are eligible. Historical threads are not classified
+unless they receive a new mentioned message after the baseline is established.
 
 | Env var | Set from | Controls |
 | --- | --- | --- |

--- a/docs/pages/reference/configuration.mdx
+++ b/docs/pages/reference/configuration.mdx
@@ -260,10 +260,10 @@ Linear ETL workflows:
 
 User experience digest workflow:
 
-The migration records existing Slack thread snapshots as baselines, so
-classification is forward-looking from rollout. Only threads containing a
-persisted bot mention are eligible. Historical threads are not classified
-unless they receive a new mentioned message after the baseline is established.
+The migration permanently baselines every existing Slack thread, so
+classification is forward-looking from rollout. Only threads created after the
+migration and containing a persisted bot mention are eligible; new messages in
+pre-existing threads do not make those threads eligible.
 
 | Env var | Set from | Controls |
 | --- | --- | --- |

--- a/docs/pages/reference/configuration.mdx
+++ b/docs/pages/reference/configuration.mdx
@@ -87,7 +87,7 @@ Optional required-by-mode variables:
 | `apiRs.metrics.annotations` | Helm value. | Additional scrape annotations for Prometheus-compatible collectors. |
 | `apiRs.activitySummary.*` | Helm values, default disabled. | Enables API-RS to summarize live session activity into durable `session.activity_summary` events. |
 | `SLACK_BOT_TOKEN` | Explicit `secretKeyRef` from `secretManager.existingSecretName`. | Slack Web API access for api-rs Slack proxy and workflow Slack helpers. |
-| `OPENAI_API_KEY` | Secret mounted into api-rs, or `apiRs.extraEnv` for local/dev overrides. | OpenAI credential for activity summaries; the feature stays disabled when no key is present. |
+| `OPENAI_API_KEY` | Secret mounted into api-rs or brokered into workflow sandboxes; `apiRs.extraEnv` may override it for local development. | OpenAI credential for activity summaries and the user-experience classifier; model-backed features stay disabled or fail closed when no key is present. |
 | `SESSION_ACTIVITY_SUMMARY_MODEL` | `apiRs.activitySummary.model`, default `gpt-5.4-nano`. | Model used for the short live activity sentence. |
 
 Sandbox lifecycle:
@@ -257,6 +257,17 @@ Linear ETL workflows:
 | --- | --- | --- |
 | `LINEAR_ETL_ENABLED` | `apiRs.etl.linear.enabled`. | Enables Linear project/issue/comment sync. |
 | `LINEAR_SYNC_INTERVAL_SECONDS` | `apiRs.etl.linear.syncIntervalSeconds`. | Linear sync schedule interval. |
+
+User experience digest workflow:
+
+| Env var | Set from | Controls |
+| --- | --- | --- |
+| `USER_EXPERIENCE_DIGEST_ENABLED`, `USER_EXPERIENCE_DIGEST_CRON`, `USER_EXPERIENCE_DIGEST_TIMEZONE` | `apiRs.userExperienceDigest.enabled`, `.cron`, `.timezone`. | Enables and schedules the daily classifier. |
+| `USER_EXPERIENCE_DIGEST_MODEL`, `USER_EXPERIENCE_DIGEST_CLASSIFIER_VERSION`, `USER_EXPERIENCE_DIGEST_OPENAI_BASE_URL` | `apiRs.userExperienceDigest.model`, `.classifierVersion`, `.openaiBaseUrl`. | Model attribution, classifier identity, and Responses API endpoint. |
+| `USER_EXPERIENCE_DIGEST_SLACK_CHANNEL` | `apiRs.userExperienceDigest.slackChannel`. | Private Slack channel for the daily summary; an empty value stores results without posting. |
+| `USER_EXPERIENCE_DIGEST_IDLE_MINUTES`, `USER_EXPERIENCE_DIGEST_BATCH_SIZE`, `USER_EXPERIENCE_DIGEST_MAX_MESSAGES` | `apiRs.userExperienceDigest.idleMinutes`, `.batchSize`, `.maxMessages`. | Thread quiet period, per-run scan limit, and transcript window. |
+| `USER_EXPERIENCE_DIGEST_MAX_ATTEMPTS`, `USER_EXPERIENCE_DIGEST_LEASE_MINUTES`, `USER_EXPERIENCE_DIGEST_CONCURRENCY` | `apiRs.userExperienceDigest.maxAttempts`, `.leaseMinutes`, `.concurrency`. | Durable retry/reclaim behavior and request concurrency. |
+| `USER_EXPERIENCE_DIGEST_INCLUDE_DIRECT_MESSAGES` | `apiRs.userExperienceDigest.includeDirectMessages`. | Includes Slack DMs in classification. Disabled by default to avoid moving private conversation summaries into reports. |
 
 ## Observability and Retention
 

--- a/services/api-rs/crates/centaur-session-sqlx/migrations/0050_user_experience_scans.sql
+++ b/services/api-rs/crates/centaur-session-sqlx/migrations/0050_user_experience_scans.sql
@@ -8,13 +8,8 @@ create table if not exists user_experience_scans (
     classifier_version text not null,
     model text not null,
     status text not null default 'pending',
-    problem_detected boolean,
-    experience text,
-    severity text,
-    user_emotion text,
-    agent_contribution text,
+    label text,
     confidence double precision,
-    failure_modes text[] not null default '{}',
     evidence_message_ids text[] not null default '{}',
     summary text,
     result jsonb not null default '{}'::jsonb,
@@ -32,35 +27,19 @@ create table if not exists user_experience_scans (
         unique (thread_key, last_message_id, classifier_version, model),
     constraint user_experience_scans_status_check
         check (status in ('pending', 'running', 'completed', 'failed', 'superseded')),
-    constraint user_experience_scans_experience_check
-        check (experience is null or experience in ('good', 'mixed', 'bad', 'unknown')),
-    constraint user_experience_scans_severity_check
-        check (severity is null or severity in ('none', 'low', 'medium', 'high', 'critical')),
-    constraint user_experience_scans_user_emotion_check
-        check (user_emotion is null or user_emotion in ('neutral', 'disappointed', 'frustrated', 'angry', 'unknown')),
-    constraint user_experience_scans_agent_contribution_check
-        check (agent_contribution is null or agent_contribution in ('none', 'possible', 'likely', 'unknown')),
+    constraint user_experience_scans_label_check
+        check (label is null or label in ('good', 'mixed', 'bad', 'unknown')),
     constraint user_experience_scans_confidence_check
         check (confidence is null or (confidence >= 0 and confidence <= 1)),
     constraint user_experience_scans_completed_result_check
         check (
             status <> 'completed'
             or (
-                problem_detected is not null
-                and experience is not null
-                and severity is not null
-                and user_emotion is not null
-                and agent_contribution is not null
+                label is not null
                 and confidence is not null
                 and summary is not null
                 and completed_at is not null
             )
-        ),
-    constraint user_experience_scans_problem_severity_check
-        check (
-            problem_detected is null
-            or (problem_detected and severity in ('low', 'medium', 'high', 'critical'))
-            or (not problem_detected and severity = 'none')
         ),
     constraint user_experience_scans_attempt_count_check
         check (attempt_count >= 0),
@@ -87,8 +66,8 @@ create index if not exists user_experience_scans_running_lease_idx
     where status = 'running';
 
 create index if not exists user_experience_scans_problem_completed_idx
-    on user_experience_scans (completed_at desc, severity)
-    where status = 'completed' and problem_detected = true;
+    on user_experience_scans (completed_at desc, label)
+    where status = 'completed' and label in ('mixed', 'bad');
 
 create index if not exists user_experience_scans_thread_created_idx
     on user_experience_scans (thread_key, created_at desc);

--- a/services/api-rs/crates/centaur-session-sqlx/migrations/0050_user_experience_scans.sql
+++ b/services/api-rs/crates/centaur-session-sqlx/migrations/0050_user_experience_scans.sql
@@ -1,0 +1,94 @@
+create table if not exists user_experience_scans (
+    scan_id text primary key,
+    thread_key text not null references sessions(thread_key) on delete cascade,
+    -- Keep the snapshot identifier even if message-level retention later prunes
+    -- the source row. Deleting the parent session still removes its scans.
+    last_message_id text not null,
+    last_message_created_at timestamptz not null,
+    classifier_version text not null,
+    model text not null,
+    status text not null default 'pending',
+    problem_detected boolean,
+    experience text,
+    severity text,
+    user_emotion text,
+    agent_contribution text,
+    confidence double precision,
+    failure_modes text[] not null default '{}',
+    evidence_message_ids text[] not null default '{}',
+    summary text,
+    result jsonb not null default '{}'::jsonb,
+    attempt_count integer not null default 0,
+    last_error text not null default '',
+    workflow_run_id text,
+    eligible_after timestamptz not null,
+    review_status text not null default 'unreviewed',
+    reviewed_by text,
+    reviewed_at timestamptz,
+    created_at timestamptz not null default now(),
+    updated_at timestamptz not null default now(),
+    completed_at timestamptz,
+    constraint user_experience_scans_snapshot_unique
+        unique (thread_key, last_message_id, classifier_version, model),
+    constraint user_experience_scans_status_check
+        check (status in ('pending', 'running', 'completed', 'failed', 'superseded')),
+    constraint user_experience_scans_experience_check
+        check (experience is null or experience in ('good', 'mixed', 'bad', 'unknown')),
+    constraint user_experience_scans_severity_check
+        check (severity is null or severity in ('none', 'low', 'medium', 'high', 'critical')),
+    constraint user_experience_scans_user_emotion_check
+        check (user_emotion is null or user_emotion in ('neutral', 'disappointed', 'frustrated', 'angry', 'unknown')),
+    constraint user_experience_scans_agent_contribution_check
+        check (agent_contribution is null or agent_contribution in ('none', 'possible', 'likely', 'unknown')),
+    constraint user_experience_scans_confidence_check
+        check (confidence is null or (confidence >= 0 and confidence <= 1)),
+    constraint user_experience_scans_completed_result_check
+        check (
+            status <> 'completed'
+            or (
+                problem_detected is not null
+                and experience is not null
+                and severity is not null
+                and user_emotion is not null
+                and agent_contribution is not null
+                and confidence is not null
+                and summary is not null
+                and completed_at is not null
+            )
+        ),
+    constraint user_experience_scans_problem_severity_check
+        check (
+            problem_detected is null
+            or (problem_detected and severity in ('low', 'medium', 'high', 'critical'))
+            or (not problem_detected and severity = 'none')
+        ),
+    constraint user_experience_scans_attempt_count_check
+        check (attempt_count >= 0),
+    constraint user_experience_scans_review_status_check
+        check (review_status in ('unreviewed', 'confirmed', 'false_positive', 'resolved')),
+    constraint user_experience_scans_classifier_version_len
+        check (octet_length(classifier_version) between 1 and 128),
+    constraint user_experience_scans_scan_id_len
+        check (octet_length(scan_id) between 1 and 128),
+    constraint user_experience_scans_model_len
+        check (octet_length(model) between 1 and 128),
+    constraint user_experience_scans_summary_len
+        check (summary is null or octet_length(summary) <= 4000),
+    constraint user_experience_scans_error_len
+        check (octet_length(last_error) <= 4000)
+);
+
+create index if not exists user_experience_scans_claim_idx
+    on user_experience_scans (status, eligible_after, created_at)
+    where status in ('pending', 'failed');
+
+create index if not exists user_experience_scans_running_lease_idx
+    on user_experience_scans (updated_at)
+    where status = 'running';
+
+create index if not exists user_experience_scans_problem_completed_idx
+    on user_experience_scans (completed_at desc, severity)
+    where status = 'completed' and problem_detected = true;
+
+create index if not exists user_experience_scans_thread_created_idx
+    on user_experience_scans (thread_key, created_at desc);

--- a/services/api-rs/crates/centaur-session-sqlx/migrations/0050_user_experience_scans.sql
+++ b/services/api-rs/crates/centaur-session-sqlx/migrations/0050_user_experience_scans.sql
@@ -57,9 +57,9 @@ create table if not exists user_experience_scans (
         check (octet_length(last_error) <= 4000)
 );
 
--- Establish a durable rollout baseline in the same table as scan results. These
--- rows prevent the first scheduled run from classifying retained history. A
--- thread becomes eligible only after its latest message changes.
+-- Establish a durable rollout boundary in the same table as scan results. A
+-- baseline row permanently excludes each Slack thread that exists when this
+-- migration runs; only threads created afterward can be classified.
 insert into user_experience_scans (
     scan_id,
     thread_key,
@@ -88,16 +88,6 @@ join lateral (
     limit 1
 ) latest on true
 where coalesce(s.metadata ->> 'platform', '') = 'slack'
-  and exists (
-      select 1
-      from session_messages user_message
-      where user_message.thread_key = s.thread_key
-        and user_message.role = 'user'
-        and user_message.metadata @> '{
-            "platform": "slack",
-            "is_mention": true
-        }'::jsonb
-  )
 on conflict do nothing;
 
 create index if not exists user_experience_scans_claim_idx

--- a/services/api-rs/crates/centaur-session-sqlx/migrations/0050_user_experience_scans.sql
+++ b/services/api-rs/crates/centaur-session-sqlx/migrations/0050_user_experience_scans.sql
@@ -87,14 +87,16 @@ join lateral (
     order by m.created_at desc, m.message_id desc
     limit 1
 ) latest on true
-where coalesce(s.metadata ->> 'platform', '') in (
-    'slack', 'discord', 'linear', 'github', 'msteams'
-)
+where coalesce(s.metadata ->> 'platform', '') = 'slack'
   and exists (
       select 1
       from session_messages user_message
       where user_message.thread_key = s.thread_key
         and user_message.role = 'user'
+        and user_message.metadata @> '{
+            "platform": "slack",
+            "is_mention": true
+        }'::jsonb
   )
 on conflict do nothing;
 

--- a/services/api-rs/crates/centaur-session-sqlx/migrations/0050_user_experience_scans.sql
+++ b/services/api-rs/crates/centaur-session-sqlx/migrations/0050_user_experience_scans.sql
@@ -26,7 +26,7 @@ create table if not exists user_experience_scans (
     constraint user_experience_scans_snapshot_unique
         unique (thread_key, last_message_id, classifier_version, model),
     constraint user_experience_scans_status_check
-        check (status in ('pending', 'running', 'completed', 'failed', 'superseded')),
+        check (status in ('baseline', 'pending', 'running', 'completed', 'failed', 'superseded')),
     constraint user_experience_scans_label_check
         check (label is null or label in ('good', 'mixed', 'bad', 'unknown')),
     constraint user_experience_scans_confidence_check
@@ -56,6 +56,47 @@ create table if not exists user_experience_scans (
     constraint user_experience_scans_error_len
         check (octet_length(last_error) <= 4000)
 );
+
+-- Establish a durable rollout baseline in the same table as scan results. These
+-- rows prevent the first scheduled run from classifying retained history. A
+-- thread becomes eligible only after its latest message changes.
+insert into user_experience_scans (
+    scan_id,
+    thread_key,
+    last_message_id,
+    last_message_created_at,
+    classifier_version,
+    model,
+    status,
+    eligible_after
+)
+select
+    'uxs_baseline_' || md5(s.thread_key || chr(31) || latest.message_id),
+    s.thread_key,
+    latest.message_id,
+    latest.created_at,
+    'baseline',
+    'baseline',
+    'baseline',
+    latest.created_at
+from sessions s
+join lateral (
+    select m.message_id, m.created_at
+    from session_messages m
+    where m.thread_key = s.thread_key
+    order by m.created_at desc, m.message_id desc
+    limit 1
+) latest on true
+where coalesce(s.metadata ->> 'platform', '') in (
+    'slack', 'discord', 'linear', 'github', 'msteams'
+)
+  and exists (
+      select 1
+      from session_messages user_message
+      where user_message.thread_key = s.thread_key
+        and user_message.role = 'user'
+  )
+on conflict do nothing;
 
 create index if not exists user_experience_scans_claim_idx
     on user_experience_scans (status, eligible_after, created_at)

--- a/workflows/tests/test_user_experience_digest.py
+++ b/workflows/tests/test_user_experience_digest.py
@@ -40,13 +40,8 @@ digest = _load_module()
 
 def _result(**overrides):
     value = {
-        "problem_detected": True,
-        "experience": "bad",
-        "severity": "high",
-        "user_emotion": "frustrated",
-        "agent_contribution": "likely",
+        "label": "bad",
         "confidence": 0.92,
-        "failure_modes": ["repeated_failure"],
         "evidence_message_ids": ["message-1"],
         "summary": "The agent repeated an unsuccessful answer after a correction.",
     }
@@ -81,15 +76,15 @@ def test_validate_result_rejects_evidence_outside_transcript():
         raise AssertionError("expected invalid evidence to be rejected")
 
 
-def test_validate_result_requires_none_severity_for_non_problem():
-    value = _result(problem_detected=False, experience="good")
+def test_validate_result_rejects_unknown_label():
+    value = _result(label="frustrated")
 
     try:
         digest._validate_result(value, {"message-1"})
     except ValueError as error:
-        assert "severity none" in str(error)
+        assert "invalid label" in str(error)
     else:
-        raise AssertionError("expected inconsistent severity to be rejected")
+        raise AssertionError("expected invalid label to be rejected")
 
 
 def test_classify_uses_strict_schema_and_store_false():
@@ -121,11 +116,17 @@ def test_classify_uses_strict_schema_and_store_false():
 
     result = asyncio.run(run())
 
-    assert result["problem_detected"] is True
+    assert result["label"] == "bad"
     assert requests[0]["store"] is False
     assert requests[0]["model"] == "small-model"
     assert requests[0]["text"]["format"]["strict"] is True
     assert requests[0]["text"]["format"]["schema"] == digest.CLASSIFIER_SCHEMA
+    assert set(digest.CLASSIFIER_SCHEMA["properties"]) == {
+        "label",
+        "confidence",
+        "evidence_message_ids",
+        "summary",
+    }
 
 
 def test_claim_reclaims_expired_running_rows():
@@ -214,19 +215,15 @@ def test_format_digest_lists_problem_threads_without_raw_evidence():
         {
             "thread_key": "slack:T1:C123:123.456",
             "status": "completed",
-            "problem_detected": True,
-            "severity": "high",
+            "label": "bad",
             "confidence": 0.9,
-            "failure_modes": ["wrong_answer"],
             "summary": "The response remained incorrect after a correction.",
         },
         {
             "thread_key": "linear:ISSUE-1",
             "status": "completed",
-            "problem_detected": False,
-            "severity": "none",
+            "label": "good",
             "confidence": 0.8,
-            "failure_modes": [],
             "summary": "No problem detected.",
         },
     ]
@@ -235,7 +232,7 @@ def test_format_digest_lists_problem_threads_without_raw_evidence():
 
     assert "problems *1*" in report
     assert "https://slack.com/archives/C123/p123456" in report
-    assert "wrong_answer" in report
+    assert "*BAD*" in report
     assert "No problem detected" not in report
 
 
@@ -263,10 +260,8 @@ def test_handler_discovers_classifies_and_posts_report(monkeypatch):
             {
                 "thread_key": scan.thread_key,
                 "status": "completed",
-                "problem_detected": True,
-                "severity": "high",
+                "label": "bad",
                 "confidence": 0.9,
-                "failure_modes": ["wrong_answer"],
                 "summary": "The answer was wrong.",
             }
         ]

--- a/workflows/tests/test_user_experience_digest.py
+++ b/workflows/tests/test_user_experience_digest.py
@@ -205,6 +205,9 @@ def test_discovery_uses_scan_rows_as_snapshot_checkpoints():
     assert inserted == 1
     assert "user_experience_scans existing" in pool.fetch_query
     assert "existing.status = 'baseline'" in pool.fetch_query
+    assert pool.fetch_query.index(
+        "existing.status = 'baseline'"
+    ) < pool.fetch_query.index("existing.last_message_id = latest.message_id")
     assert "metadata ->> 'platform'" in pool.fetch_query
     assert '"is_mention": true' in pool.fetch_query
     assert "'discord'" not in pool.fetch_query

--- a/workflows/tests/test_user_experience_digest.py
+++ b/workflows/tests/test_user_experience_digest.py
@@ -1,0 +1,329 @@
+from __future__ import annotations
+
+import asyncio
+import datetime as dt
+import importlib
+import json
+import os
+import sys
+import types
+from pathlib import Path
+
+import httpx
+
+
+def _load_module():
+    repo_root = Path(__file__).resolve().parents[2]
+    if str(repo_root) not in sys.path:
+        sys.path.insert(0, str(repo_root))
+    api_module = sys.modules.get("api") or types.ModuleType("api")
+    runtime_control = types.ModuleType("api.runtime_control")
+    runtime_control.decode_jsonb = lambda value, default: (
+        json.loads(value)
+        if isinstance(value, str)
+        else value
+        if value is not None
+        else default
+    )
+    workflow_engine = types.ModuleType("api.workflow_engine")
+    workflow_engine.WorkflowContext = object
+    api_module.runtime_control = runtime_control
+    api_module.workflow_engine = workflow_engine
+    sys.modules.setdefault("api", api_module)
+    sys.modules["api.runtime_control"] = runtime_control
+    sys.modules["api.workflow_engine"] = workflow_engine
+    return importlib.import_module("workflows.user_experience_digest")
+
+
+digest = _load_module()
+
+
+def _result(**overrides):
+    value = {
+        "problem_detected": True,
+        "experience": "bad",
+        "severity": "high",
+        "user_emotion": "frustrated",
+        "agent_contribution": "likely",
+        "confidence": 0.92,
+        "failure_modes": ["repeated_failure"],
+        "evidence_message_ids": ["message-1"],
+        "summary": "The agent repeated an unsuccessful answer after a correction.",
+    }
+    value.update(overrides)
+    return value
+
+
+def test_message_text_keeps_safe_text_and_attachment_name_only():
+    text = digest._message_text(
+        [
+            {"type": "text", "text": "Please inspect this"},
+            {
+                "type": "attachment",
+                "name": "trace.txt",
+                "dataBase64": "secret-payload",
+            },
+        ]
+    )
+
+    assert text == "Please inspect this\n[attachment: trace.txt]"
+    assert "secret-payload" not in text
+
+
+def test_validate_result_rejects_evidence_outside_transcript():
+    value = _result(evidence_message_ids=["invented-message"])
+
+    try:
+        digest._validate_result(value, {"message-1"})
+    except ValueError as error:
+        assert "evidence_message_ids" in str(error)
+    else:
+        raise AssertionError("expected invalid evidence to be rejected")
+
+
+def test_validate_result_requires_none_severity_for_non_problem():
+    value = _result(problem_detected=False, experience="good")
+
+    try:
+        digest._validate_result(value, {"message-1"})
+    except ValueError as error:
+        assert "severity none" in str(error)
+    else:
+        raise AssertionError("expected inconsistent severity to be rejected")
+
+
+def test_classify_uses_strict_schema_and_store_false():
+    requests: list[dict] = []
+
+    def handle(request: httpx.Request) -> httpx.Response:
+        requests.append(json.loads(request.content))
+        return httpx.Response(200, json={"output_text": json.dumps(_result())})
+
+    async def run():
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handle)) as client:
+            return await digest._classify(
+                client,
+                base_url="https://api.openai.test/v1",
+                api_key="placeholder",
+                model="small-model",
+                max_output_tokens=500,
+                thread_key="slack:C123:123.456",
+                transcript=[
+                    {
+                        "message_id": "message-1",
+                        "role": "user",
+                        "created_at": "2026-08-04T12:00:00+00:00",
+                        "text": "This still does not work.",
+                    }
+                ],
+                execution_summary={"recent_executions": []},
+            )
+
+    result = asyncio.run(run())
+
+    assert result["problem_detected"] is True
+    assert requests[0]["store"] is False
+    assert requests[0]["model"] == "small-model"
+    assert requests[0]["text"]["format"]["strict"] is True
+    assert requests[0]["text"]["format"]["schema"] == digest.CLASSIFIER_SCHEMA
+
+
+def test_claim_reclaims_expired_running_rows():
+    class FakePool:
+        def __init__(self):
+            self.execute_calls = []
+            self.query = ""
+            self.args = ()
+
+        async def execute(self, query, *args):
+            self.execute_calls.append((query, args))
+            return "UPDATE 0"
+
+        async def fetch(self, query, *args):
+            self.query = query
+            self.args = args
+            return []
+
+    pool = FakePool()
+    asyncio.run(
+        digest._claim_scans(
+            pool,
+            classifier_version="v1",
+            model="small-model",
+            limit=25,
+            max_attempts=3,
+            lease_minutes=30,
+            run_id="run-1",
+        )
+    )
+
+    assert "status = 'running'" in pool.query
+    assert "updated_at <= NOW()" in pool.query
+    assert pool.args == (3, "v1", "small-model", 25, 30, "run-1")
+    assert "maximum attempts" in pool.execute_calls[0][0]
+    assert pool.execute_calls[0][1] == (3, 30, "run-1")
+
+
+def test_discovery_uses_scan_rows_as_snapshot_checkpoints():
+    class FakePool:
+        def __init__(self):
+            self.fetch_query = ""
+            self.fetch_args = ()
+            self.execute_calls = []
+
+        async def fetch(self, query, *args):
+            self.fetch_query = query
+            self.fetch_args = args
+            return [
+                {
+                    "thread_key": "slack:C123:123.456",
+                    "last_message_id": "message-1",
+                    "last_message_created_at": dt.datetime(
+                        2026, 8, 4, 12, tzinfo=dt.UTC
+                    ),
+                }
+            ]
+
+        async def execute(self, query, *args):
+            self.execute_calls.append((query, args))
+            return "INSERT 0 1"
+
+    pool = FakePool()
+    inserted = asyncio.run(
+        digest._discover_candidates(
+            pool,
+            idle_minutes=60,
+            include_direct_messages=False,
+            classifier_version="v1",
+            model="small-model",
+            limit=100,
+            run_id="run-1",
+        )
+    )
+
+    assert inserted == 1
+    assert "user_experience_scans existing" in pool.fetch_query
+    assert "metadata ->> 'platform'" in pool.fetch_query
+    assert "D[^:]*:" in pool.fetch_query
+    assert pool.fetch_args == (60, False, "v1", "small-model", 100)
+    assert "ON CONFLICT (thread_key, last_message_id" in pool.execute_calls[0][0]
+
+
+def test_format_digest_lists_problem_threads_without_raw_evidence():
+    rows = [
+        {
+            "thread_key": "slack:T1:C123:123.456",
+            "status": "completed",
+            "problem_detected": True,
+            "severity": "high",
+            "confidence": 0.9,
+            "failure_modes": ["wrong_answer"],
+            "summary": "The response remained incorrect after a correction.",
+        },
+        {
+            "thread_key": "linear:ISSUE-1",
+            "status": "completed",
+            "problem_detected": False,
+            "severity": "none",
+            "confidence": 0.8,
+            "failure_modes": [],
+            "summary": "No problem detected.",
+        },
+    ]
+
+    report = digest._format_digest(rows, "small-model")
+
+    assert "problems *1*" in report
+    assert "https://slack.com/archives/C123/p123456" in report
+    assert "wrong_answer" in report
+    assert "No problem detected" not in report
+
+
+def test_handler_discovers_classifies_and_posts_report(monkeypatch):
+    scan = digest.Scan(
+        scan_id="scan-1",
+        thread_key="slack:C123:123.456",
+        last_message_id="message-1",
+        last_message_created_at=dt.datetime(2026, 8, 4, 12, tzinfo=dt.UTC),
+        model="small-model",
+        classifier_version="v1",
+    )
+
+    async def discover(*_args, **_kwargs):
+        return 1
+
+    async def claim(*_args, **_kwargs):
+        return [scan]
+
+    async def process(*_args, **_kwargs):
+        return {"completed": 1, "failed": 0, "superseded": 0}
+
+    async def results(*_args, **_kwargs):
+        return [
+            {
+                "thread_key": scan.thread_key,
+                "status": "completed",
+                "problem_detected": True,
+                "severity": "high",
+                "confidence": 0.9,
+                "failure_modes": ["wrong_answer"],
+                "summary": "The answer was wrong.",
+            }
+        ]
+
+    monkeypatch.setattr(digest, "_discover_candidates", discover)
+    monkeypatch.setattr(digest, "_claim_scans", claim)
+    monkeypatch.setattr(digest, "_process_scans", process)
+    monkeypatch.setattr(digest, "_load_run_results", results)
+    monkeypatch.setattr(
+        digest,
+        "_config",
+        lambda: {
+            "base_url": "https://api.openai.test/v1",
+            "model": "small-model",
+            "classifier_version": "v1",
+            "batch_size": 10,
+            "idle_minutes": 60,
+            "max_messages": 40,
+            "max_attempts": 3,
+            "max_output_tokens": 500,
+            "timeout_seconds": 20,
+            "concurrency": 2,
+            "lease_minutes": 30,
+            "include_direct_messages": False,
+            "slack_channel": "C-REPORT",
+        },
+    )
+    monkeypatch.setenv("OPENAI_API_KEY", "placeholder")
+
+    class FakeContext:
+        run_id = "run-1"
+        _pool = object()
+
+        def __init__(self):
+            self.posts = []
+            self.logs = []
+
+        async def step(self, _name, fn):
+            return await fn()
+
+        async def post_to_slack(self, channel, text, **kwargs):
+            self.posts.append((channel, text, kwargs))
+            return {"sent": True}
+
+        def log(self, event, **fields):
+            self.logs.append((event, fields))
+
+    context = FakeContext()
+    output = asyncio.run(digest.handler(digest.Input(), context))
+
+    assert output["discovered"] == 1
+    assert output["completed"] == 1
+    assert context.posts[0][0] == "C-REPORT"
+    assert "problems *1*" in context.posts[0][1]
+    assert context.posts[0][2]["client_msg_id"].startswith("user-experience-digest:")
+    assert context.logs[0][0] == "user_experience_digest_completed"
+
+
+def teardown_module():
+    os.environ.pop("OPENAI_API_KEY", None)

--- a/workflows/tests/test_user_experience_digest.py
+++ b/workflows/tests/test_user_experience_digest.py
@@ -206,6 +206,8 @@ def test_discovery_uses_scan_rows_as_snapshot_checkpoints():
     assert "user_experience_scans existing" in pool.fetch_query
     assert "existing.status = 'baseline'" in pool.fetch_query
     assert "metadata ->> 'platform'" in pool.fetch_query
+    assert '"is_mention": true' in pool.fetch_query
+    assert "'discord'" not in pool.fetch_query
     assert "D[^:]*:" in pool.fetch_query
     assert pool.fetch_args == (60, False, "v1", "small-model", 100)
     assert "ON CONFLICT (thread_key, last_message_id" in pool.execute_calls[0][0]

--- a/workflows/tests/test_user_experience_digest.py
+++ b/workflows/tests/test_user_experience_digest.py
@@ -204,6 +204,7 @@ def test_discovery_uses_scan_rows_as_snapshot_checkpoints():
 
     assert inserted == 1
     assert "user_experience_scans existing" in pool.fetch_query
+    assert "existing.status = 'baseline'" in pool.fetch_query
     assert "metadata ->> 'platform'" in pool.fetch_query
     assert "D[^:]*:" in pool.fetch_query
     assert pool.fetch_args == (60, False, "v1", "small-model", 100)

--- a/workflows/user_experience_digest.py
+++ b/workflows/user_experience_digest.py
@@ -189,13 +189,15 @@ async def _discover_candidates(
             LIMIT 1
         ) latest ON TRUE
         WHERE latest.created_at <= NOW() - ($1::bigint * INTERVAL '1 minute')
-          AND COALESCE(s.metadata ->> 'platform', '') IN (
-              'slack', 'discord', 'linear', 'github', 'msteams'
-          )
+          AND COALESCE(s.metadata ->> 'platform', '') = 'slack'
           AND EXISTS (
               SELECT 1 FROM session_messages user_message
               WHERE user_message.thread_key = s.thread_key
                 AND user_message.role = 'user'
+                AND user_message.metadata @> '{
+                    "platform": "slack",
+                    "is_mention": true
+                }'::jsonb
           )
           AND NOT EXISTS (
               SELECT 1 FROM session_executions active

--- a/workflows/user_experience_digest.py
+++ b/workflows/user_experience_digest.py
@@ -207,8 +207,13 @@ async def _discover_candidates(
               SELECT 1 FROM user_experience_scans existing
               WHERE existing.thread_key = s.thread_key
                 AND existing.last_message_id = latest.message_id
-                AND existing.classifier_version = $3
-                AND existing.model = $4
+                AND (
+                    existing.status = 'baseline'
+                    OR (
+                        existing.classifier_version = $3
+                        AND existing.model = $4
+                    )
+                )
           )
         ORDER BY latest.created_at, latest.message_id
         LIMIT $5

--- a/workflows/user_experience_digest.py
+++ b/workflows/user_experience_digest.py
@@ -39,39 +39,14 @@ SLACK_THREAD_KEY_RE = re.compile(
     r"^slack:(?:(?P<team>[^:]+):)?(?P<channel>[CDG][^:]*):(?P<thread_ts>[^:]+)$"
 )
 
-EXPERIENCES = {"good", "mixed", "bad", "unknown"}
-SEVERITIES = {"none", "low", "medium", "high", "critical"}
-USER_EMOTIONS = {"neutral", "disappointed", "frustrated", "angry", "unknown"}
-AGENT_CONTRIBUTIONS = {"none", "possible", "likely", "unknown"}
-FAILURE_MODES = {
-    "wrong_answer",
-    "ignored_instruction",
-    "repeated_failure",
-    "tool_failure",
-    "no_response",
-    "slow_response",
-    "poor_tone",
-    "other",
-}
+LABELS = {"good", "mixed", "bad", "unknown"}
 
 CLASSIFIER_SCHEMA: dict[str, Any] = {
     "type": "object",
     "additionalProperties": False,
     "properties": {
-        "problem_detected": {"type": "boolean"},
-        "experience": {"type": "string", "enum": sorted(EXPERIENCES)},
-        "severity": {"type": "string", "enum": sorted(SEVERITIES)},
-        "user_emotion": {"type": "string", "enum": sorted(USER_EMOTIONS)},
-        "agent_contribution": {
-            "type": "string",
-            "enum": sorted(AGENT_CONTRIBUTIONS),
-        },
+        "label": {"type": "string", "enum": sorted(LABELS)},
         "confidence": {"type": "number", "minimum": 0, "maximum": 1},
-        "failure_modes": {
-            "type": "array",
-            "items": {"type": "string", "enum": sorted(FAILURE_MODES)},
-            "uniqueItems": True,
-        },
         "evidence_message_ids": {
             "type": "array",
             "items": {"type": "string"},
@@ -81,27 +56,27 @@ CLASSIFIER_SCHEMA: dict[str, Any] = {
         "summary": {"type": "string", "maxLength": 1000},
     },
     "required": [
-        "problem_detected",
-        "experience",
-        "severity",
-        "user_emotion",
-        "agent_contribution",
+        "label",
         "confidence",
-        "failure_modes",
         "evidence_message_ids",
         "summary",
     ],
 }
 
-SYSTEM_PROMPT = """You classify whether a user had a poor experience with an AI agent.
-Judge the quality of the interaction, not merely negative emotion about an external
-problem. Treat repeated corrections, ignored instructions, wrong answers, failed
-tools, timeouts, missing responses, and unhelpful tone as evidence. Operational
-failure may establish a problem even without an explicit complaint. Do not call an
-interaction bad solely because the user describes an upsetting situation. Use
-unknown when the transcript is insufficient. Cite only provided message IDs, keep
-the summary factual and under two sentences, and do not quote secrets or personal
-data."""
+SYSTEM_PROMPT = """Classify the user's experience with an AI agent using one label:
+- good: no material agent-caused problem is evident.
+- mixed: the agent caused meaningful friction, but the interaction retained value
+  or substantially recovered.
+- bad: a clear, significant agent-caused or agent-amplified failure was unresolved.
+- unknown: the transcript is insufficient to judge.
+
+Judge the interaction, not merely negative emotion about an external problem.
+Repeated corrections, ignored instructions, wrong answers, failed tools, timeouts,
+missing responses, and unhelpful tone are evidence. Operational failure may make an
+experience mixed or bad without an explicit complaint. Do not use mixed or bad
+solely because the user describes an upsetting situation. Cite only provided
+message IDs, keep the summary factual and under two sentences, and do not quote
+secrets or personal data."""
 
 
 def _positive_int(value: int | str | None, default: int) -> int:
@@ -514,26 +489,13 @@ async def _classify(
 
 
 def _validate_result(result: dict[str, Any], message_ids: set[str]) -> dict[str, Any]:
-    if not isinstance(result.get("problem_detected"), bool):
-        raise TypeError("problem_detected must be a boolean")
-    if result.get("experience") not in EXPERIENCES:
-        raise ValueError("invalid experience")
-    if result.get("severity") not in SEVERITIES:
-        raise ValueError("invalid severity")
-    if result.get("user_emotion") not in USER_EMOTIONS:
-        raise ValueError("invalid user_emotion")
-    if result.get("agent_contribution") not in AGENT_CONTRIBUTIONS:
-        raise ValueError("invalid agent_contribution")
+    if result.get("label") not in LABELS:
+        raise ValueError("invalid label")
     confidence = result.get("confidence")
     if isinstance(confidence, bool) or not isinstance(confidence, (int, float)):
         raise TypeError("confidence must be numeric")
     if not 0 <= float(confidence) <= 1:
         raise ValueError("confidence must be between zero and one")
-    failure_modes = result.get("failure_modes")
-    if not isinstance(failure_modes, list) or any(
-        mode not in FAILURE_MODES for mode in failure_modes
-    ):
-        raise ValueError("invalid failure_modes")
     evidence = result.get("evidence_message_ids")
     if not isinstance(evidence, list) or any(
         item not in message_ids for item in evidence
@@ -542,17 +504,6 @@ def _validate_result(result: dict[str, Any], message_ids: set[str]) -> dict[str,
     summary = result.get("summary")
     if not isinstance(summary, str) or len(summary) > 1000:
         raise ValueError("summary must be a string of at most 1000 characters")
-    if not result["problem_detected"] and result["severity"] != "none":
-        raise ValueError("non-problem results must use severity none")
-    if result["problem_detected"] and result["severity"] == "none":
-        raise ValueError("problem results must use a non-none severity")
-    if result["problem_detected"] and result["experience"] not in {"mixed", "bad"}:
-        raise ValueError("problem results must use mixed or bad experience")
-    if not result["problem_detected"] and result["experience"] not in {
-        "good",
-        "unknown",
-    }:
-        raise ValueError("non-problem results must use good or unknown experience")
     return result
 
 
@@ -561,29 +512,19 @@ async def _complete_scan(pool: Any, scan_id: str, result: dict[str, Any]) -> Non
         """
         UPDATE user_experience_scans
         SET status = 'completed',
-            problem_detected = $2,
-            experience = $3,
-            severity = $4,
-            user_emotion = $5,
-            agent_contribution = $6,
-            confidence = $7,
-            failure_modes = $8,
-            evidence_message_ids = $9,
-            summary = $10,
-            result = $11::jsonb,
+            label = $2,
+            confidence = $3,
+            evidence_message_ids = $4,
+            summary = $5,
+            result = $6::jsonb,
             last_error = '',
             completed_at = NOW(),
             updated_at = NOW()
         WHERE scan_id = $1 AND status = 'running'
         """,
         scan_id,
-        result["problem_detected"],
-        result["experience"],
-        result["severity"],
-        result["user_emotion"],
-        result["agent_contribution"],
+        result["label"],
         float(result["confidence"]),
-        list(dict.fromkeys(result["failure_modes"])),
         list(dict.fromkeys(result["evidence_message_ids"])),
         result["summary"],
         json.dumps(result, separators=(",", ":")),
@@ -667,8 +608,8 @@ async def _process_scans(
 async def _load_run_results(pool: Any, run_id: str) -> list[dict[str, Any]]:
     rows = await pool.fetch(
         """
-        SELECT thread_key, status, problem_detected, severity, confidence,
-               failure_modes, summary, model, created_at, completed_at
+        SELECT thread_key, status, label, confidence, summary, model, created_at,
+               completed_at
         FROM user_experience_scans
         WHERE workflow_run_id = $1
         ORDER BY completed_at NULLS LAST, created_at
@@ -689,7 +630,7 @@ def _thread_reference(thread_key: str) -> str:
 
 def _format_digest(rows: list[dict[str, Any]], model: str) -> str:
     completed = [row for row in rows if row["status"] == "completed"]
-    problems = [row for row in completed if row["problem_detected"]]
+    problems = [row for row in completed if row["label"] in {"mixed", "bad"}]
     failed = sum(row["status"] == "failed" for row in rows)
     superseded = sum(row["status"] == "superseded" for row in rows)
     today = dt.datetime.now(dt.timezone.utc).date().isoformat()
@@ -708,28 +649,26 @@ def _format_digest(rows: list[dict[str, Any]], model: str) -> str:
         else:
             lines.append("No eligible thread snapshots were available in this run.")
         return "\n\n".join(lines)
-    severity_order = {"critical": 0, "high": 1, "medium": 2, "low": 3, "none": 4}
     problems.sort(
         key=lambda row: (
-            severity_order.get(str(row["severity"]), 5),
+            0 if row["label"] == "bad" else 1,
             -float(row["confidence"] or 0),
         )
     )
-    counts = {
-        severity: sum(row["severity"] == severity for row in problems)
-        for severity in ("critical", "high", "medium", "low")
-    }
     lines.append(
-        "Severity: "
-        + " · ".join(f"{name} *{count}*" for name, count in counts.items() if count)
+        "Labels: "
+        + " · ".join(
+            f"{label} *{sum(row['label'] == label for row in problems)}*"
+            for label in ("bad", "mixed")
+            if any(row["label"] == label for row in problems)
+        )
     )
     lines.append("*Highest-priority threads*")
     for row in problems[:10]:
-        modes = ", ".join(row["failure_modes"] or []) or "uncategorized"
         summary = str(row["summary"] or "No summary supplied").replace("\n", " ")
         lines.append(
-            f"• *{str(row['severity']).upper()}* {_thread_reference(str(row['thread_key']))} "
-            f"— {summary} _({modes})_"
+            f"• *{str(row['label']).upper()}* {_thread_reference(str(row['thread_key']))} "
+            f"— {summary}"
         )
     if len(problems) > 10:
         lines.append(f"…and {len(problems) - 10} more problematic threads.")

--- a/workflows/user_experience_digest.py
+++ b/workflows/user_experience_digest.py
@@ -1,0 +1,803 @@
+"""Classify completed conversation snapshots and post a daily experience digest.
+
+Each ``user_experience_scans`` row is both a durable work item and the result for
+one exact thread snapshot. A new final message or classifier/model version creates
+a new row, so scheduled runs do not need a separate global watermark.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import datetime as dt
+import json
+import os
+import re
+import uuid
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+from api.runtime_control import decode_jsonb
+from api.workflow_engine import WorkflowContext
+
+if TYPE_CHECKING:
+    import httpx
+
+WORKFLOW_NAME = "user_experience_digest"
+
+DEFAULT_MODEL = "gpt-5.4-nano"
+DEFAULT_CLASSIFIER_VERSION = "v1"
+DEFAULT_BATCH_SIZE = 100
+DEFAULT_IDLE_MINUTES = 60
+DEFAULT_MAX_MESSAGES = 40
+DEFAULT_MAX_ATTEMPTS = 3
+DEFAULT_MAX_OUTPUT_TOKENS = 500
+DEFAULT_TIMEOUT_SECONDS = 20
+DEFAULT_CONCURRENCY = 5
+DEFAULT_LEASE_MINUTES = 30
+FALSE_ENV_VALUES = {"0", "false", "no", "off"}
+SLACK_THREAD_KEY_RE = re.compile(
+    r"^slack:(?:(?P<team>[^:]+):)?(?P<channel>[CDG][^:]*):(?P<thread_ts>[^:]+)$"
+)
+
+EXPERIENCES = {"good", "mixed", "bad", "unknown"}
+SEVERITIES = {"none", "low", "medium", "high", "critical"}
+USER_EMOTIONS = {"neutral", "disappointed", "frustrated", "angry", "unknown"}
+AGENT_CONTRIBUTIONS = {"none", "possible", "likely", "unknown"}
+FAILURE_MODES = {
+    "wrong_answer",
+    "ignored_instruction",
+    "repeated_failure",
+    "tool_failure",
+    "no_response",
+    "slow_response",
+    "poor_tone",
+    "other",
+}
+
+CLASSIFIER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "additionalProperties": False,
+    "properties": {
+        "problem_detected": {"type": "boolean"},
+        "experience": {"type": "string", "enum": sorted(EXPERIENCES)},
+        "severity": {"type": "string", "enum": sorted(SEVERITIES)},
+        "user_emotion": {"type": "string", "enum": sorted(USER_EMOTIONS)},
+        "agent_contribution": {
+            "type": "string",
+            "enum": sorted(AGENT_CONTRIBUTIONS),
+        },
+        "confidence": {"type": "number", "minimum": 0, "maximum": 1},
+        "failure_modes": {
+            "type": "array",
+            "items": {"type": "string", "enum": sorted(FAILURE_MODES)},
+            "uniqueItems": True,
+        },
+        "evidence_message_ids": {
+            "type": "array",
+            "items": {"type": "string"},
+            "maxItems": 5,
+            "uniqueItems": True,
+        },
+        "summary": {"type": "string", "maxLength": 1000},
+    },
+    "required": [
+        "problem_detected",
+        "experience",
+        "severity",
+        "user_emotion",
+        "agent_contribution",
+        "confidence",
+        "failure_modes",
+        "evidence_message_ids",
+        "summary",
+    ],
+}
+
+SYSTEM_PROMPT = """You classify whether a user had a poor experience with an AI agent.
+Judge the quality of the interaction, not merely negative emotion about an external
+problem. Treat repeated corrections, ignored instructions, wrong answers, failed
+tools, timeouts, missing responses, and unhelpful tone as evidence. Operational
+failure may establish a problem even without an explicit complaint. Do not call an
+interaction bad solely because the user describes an upsetting situation. Use
+unknown when the transcript is insufficient. Cite only provided message IDs, keep
+the summary factual and under two sentences, and do not quote secrets or personal
+data."""
+
+
+def _positive_int(value: int | str | None, default: int) -> int:
+    try:
+        parsed = int(value) if value is not None else default
+    except (TypeError, ValueError):
+        return default
+    return parsed if parsed > 0 else default
+
+
+def _env_flag(name: str, default: bool = False) -> bool:
+    value = os.getenv(name)
+    if value is None:
+        return default
+    return value.strip().lower() not in FALSE_ENV_VALUES
+
+
+SCHEDULE = {
+    "schedule_id": WORKFLOW_NAME,
+    "cron": os.getenv("USER_EXPERIENCE_DIGEST_CRON", "0 8 * * *"),
+    "timezone": os.getenv("USER_EXPERIENCE_DIGEST_TIMEZONE", "America/Los_Angeles"),
+    "enabled": _env_flag("USER_EXPERIENCE_DIGEST_ENABLED"),
+    "no_delivery": True,
+}
+
+
+@dataclass
+class Input:
+    limit: int | None = None
+    slack_channel: str | None = None
+    post_report: bool = True
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class Scan:
+    scan_id: str
+    thread_key: str
+    last_message_id: str
+    last_message_created_at: dt.datetime
+    model: str
+    classifier_version: str
+
+
+def _config() -> dict[str, Any]:
+    return {
+        "base_url": os.getenv(
+            "USER_EXPERIENCE_DIGEST_OPENAI_BASE_URL", "https://api.openai.com/v1"
+        ).rstrip("/"),
+        "model": os.getenv("USER_EXPERIENCE_DIGEST_MODEL", DEFAULT_MODEL).strip()
+        or DEFAULT_MODEL,
+        "classifier_version": os.getenv(
+            "USER_EXPERIENCE_DIGEST_CLASSIFIER_VERSION", DEFAULT_CLASSIFIER_VERSION
+        ).strip()
+        or DEFAULT_CLASSIFIER_VERSION,
+        "batch_size": _positive_int(
+            os.getenv("USER_EXPERIENCE_DIGEST_BATCH_SIZE"), DEFAULT_BATCH_SIZE
+        ),
+        "idle_minutes": _positive_int(
+            os.getenv("USER_EXPERIENCE_DIGEST_IDLE_MINUTES"), DEFAULT_IDLE_MINUTES
+        ),
+        "max_messages": _positive_int(
+            os.getenv("USER_EXPERIENCE_DIGEST_MAX_MESSAGES"), DEFAULT_MAX_MESSAGES
+        ),
+        "max_attempts": _positive_int(
+            os.getenv("USER_EXPERIENCE_DIGEST_MAX_ATTEMPTS"), DEFAULT_MAX_ATTEMPTS
+        ),
+        "max_output_tokens": _positive_int(
+            os.getenv("USER_EXPERIENCE_DIGEST_MAX_OUTPUT_TOKENS"),
+            DEFAULT_MAX_OUTPUT_TOKENS,
+        ),
+        "timeout_seconds": _positive_int(
+            os.getenv("USER_EXPERIENCE_DIGEST_TIMEOUT_SECONDS"),
+            DEFAULT_TIMEOUT_SECONDS,
+        ),
+        "concurrency": _positive_int(
+            os.getenv("USER_EXPERIENCE_DIGEST_CONCURRENCY"), DEFAULT_CONCURRENCY
+        ),
+        "lease_minutes": _positive_int(
+            os.getenv("USER_EXPERIENCE_DIGEST_LEASE_MINUTES"), DEFAULT_LEASE_MINUTES
+        ),
+        "include_direct_messages": _env_flag(
+            "USER_EXPERIENCE_DIGEST_INCLUDE_DIRECT_MESSAGES"
+        ),
+        "slack_channel": os.getenv("USER_EXPERIENCE_DIGEST_SLACK_CHANNEL", "").strip(),
+    }
+
+
+async def _discover_candidates(
+    pool: Any,
+    *,
+    idle_minutes: int,
+    include_direct_messages: bool,
+    classifier_version: str,
+    model: str,
+    limit: int,
+    run_id: str,
+) -> int:
+    rows = await pool.fetch(
+        """
+        SELECT s.thread_key,
+               latest.message_id AS last_message_id,
+               latest.created_at AS last_message_created_at
+        FROM sessions s
+        JOIN LATERAL (
+            SELECT m.message_id, m.created_at
+            FROM session_messages m
+            WHERE m.thread_key = s.thread_key
+            ORDER BY m.created_at DESC, m.message_id DESC
+            LIMIT 1
+        ) latest ON TRUE
+        WHERE latest.created_at <= NOW() - ($1::bigint * INTERVAL '1 minute')
+          AND COALESCE(s.metadata ->> 'platform', '') IN (
+              'slack', 'discord', 'linear', 'github', 'msteams'
+          )
+          AND EXISTS (
+              SELECT 1 FROM session_messages user_message
+              WHERE user_message.thread_key = s.thread_key
+                AND user_message.role = 'user'
+          )
+          AND NOT EXISTS (
+              SELECT 1 FROM session_executions active
+              WHERE active.thread_key = s.thread_key
+                AND active.status IN ('queued', 'running')
+          )
+          AND ($2::boolean OR s.thread_key !~ '^slack:([^:]+:)?D[^:]*:')
+          AND NOT EXISTS (
+              SELECT 1 FROM user_experience_scans existing
+              WHERE existing.thread_key = s.thread_key
+                AND existing.last_message_id = latest.message_id
+                AND existing.classifier_version = $3
+                AND existing.model = $4
+          )
+        ORDER BY latest.created_at, latest.message_id
+        LIMIT $5
+        """,
+        idle_minutes,
+        include_direct_messages,
+        classifier_version,
+        model,
+        limit,
+    )
+    inserted = 0
+    for row in rows:
+        status = await pool.execute(
+            """
+            INSERT INTO user_experience_scans (
+                scan_id, thread_key, last_message_id, last_message_created_at,
+                classifier_version, model, status, workflow_run_id, eligible_after
+            )
+            VALUES ($1, $2, $3, $4, $5, $6, 'pending', $7,
+                    $4 + ($8::bigint * INTERVAL '1 minute'))
+            ON CONFLICT (thread_key, last_message_id, classifier_version, model)
+            DO NOTHING
+            """,
+            f"uxs_{uuid.uuid4().hex}",
+            str(row["thread_key"]),
+            str(row["last_message_id"]),
+            row["last_message_created_at"],
+            classifier_version,
+            model,
+            run_id,
+            idle_minutes,
+        )
+        inserted += int(status.endswith(" 1"))
+    return inserted
+
+
+async def _claim_scans(
+    pool: Any,
+    *,
+    classifier_version: str,
+    model: str,
+    limit: int,
+    max_attempts: int,
+    lease_minutes: int,
+    run_id: str,
+) -> list[Scan]:
+    await pool.execute(
+        """
+        UPDATE user_experience_scans
+        SET status = 'failed',
+            last_error = 'classification lease expired after maximum attempts',
+            workflow_run_id = $3,
+            updated_at = NOW()
+        WHERE status = 'running'
+          AND updated_at <= NOW() - ($2::bigint * INTERVAL '1 minute')
+          AND attempt_count >= $1
+        """,
+        max_attempts,
+        lease_minutes,
+        run_id,
+    )
+    rows = await pool.fetch(
+        """
+        WITH claimable AS (
+            SELECT scan_id
+            FROM user_experience_scans
+            WHERE (
+                    (status IN ('pending', 'failed') AND eligible_after <= NOW())
+                    OR (status = 'running'
+                        AND updated_at <= NOW() - ($5::bigint * INTERVAL '1 minute'))
+                  )
+              AND attempt_count < $1
+              AND classifier_version = $2
+              AND model = $3
+            ORDER BY eligible_after, created_at
+            FOR UPDATE SKIP LOCKED
+            LIMIT $4
+        )
+        UPDATE user_experience_scans scans
+        SET status = 'running',
+            attempt_count = scans.attempt_count + 1,
+            last_error = '',
+            workflow_run_id = $6,
+            updated_at = NOW()
+        FROM claimable
+        WHERE scans.scan_id = claimable.scan_id
+        RETURNING scans.scan_id, scans.thread_key, scans.last_message_id,
+                  scans.last_message_created_at, scans.model,
+                  scans.classifier_version
+        """,
+        max_attempts,
+        classifier_version,
+        model,
+        limit,
+        lease_minutes,
+        run_id,
+    )
+    return [Scan(**dict(row)) for row in rows]
+
+
+async def _snapshot_is_current(pool: Any, scan: Scan) -> bool:
+    row = await pool.fetchrow(
+        """
+        SELECT latest.message_id,
+               EXISTS (
+                   SELECT 1 FROM session_executions active
+                   WHERE active.thread_key = $1
+                     AND active.status IN ('queued', 'running')
+               ) AS has_active_execution
+        FROM LATERAL (
+            SELECT message_id
+            FROM session_messages
+            WHERE thread_key = $1
+            ORDER BY created_at DESC, message_id DESC
+            LIMIT 1
+        ) latest
+        """,
+        scan.thread_key,
+    )
+    return bool(
+        row
+        and str(row["message_id"]) == scan.last_message_id
+        and not row["has_active_execution"]
+    )
+
+
+async def _mark_superseded(pool: Any, scan_id: str) -> None:
+    await pool.execute(
+        """
+        UPDATE user_experience_scans
+        SET status = 'superseded', updated_at = NOW()
+        WHERE scan_id = $1 AND status = 'running'
+        """,
+        scan_id,
+    )
+
+
+def _message_text(parts: Any) -> str:
+    decoded = decode_jsonb(parts, [])
+    if not isinstance(decoded, list):
+        return ""
+    texts: list[str] = []
+    for part in decoded:
+        if not isinstance(part, dict):
+            continue
+        if part.get("type") == "text" and isinstance(part.get("text"), str):
+            text = part["text"].strip()
+            if text:
+                texts.append(text)
+        elif part.get("type") == "attachment":
+            name = part.get("name") or part.get("filename")
+            if isinstance(name, str) and name.strip():
+                texts.append(f"[attachment: {name.strip()}]")
+    return "\n".join(texts)[:4000]
+
+
+async def _load_transcript(
+    pool: Any, scan: Scan, max_messages: int
+) -> list[dict[str, str]]:
+    rows = await pool.fetch(
+        """
+        SELECT message_id, role, parts, created_at
+        FROM session_messages
+        WHERE thread_key = $1
+          AND (created_at, message_id) <= ($2, $3)
+        ORDER BY created_at DESC, message_id DESC
+        LIMIT $4
+        """,
+        scan.thread_key,
+        scan.last_message_created_at,
+        scan.last_message_id,
+        max_messages,
+    )
+    transcript = [
+        {
+            "message_id": str(row["message_id"]),
+            "role": str(row["role"]),
+            "created_at": row["created_at"].isoformat(),
+            "text": _message_text(row["parts"]),
+        }
+        for row in reversed(rows)
+    ]
+    return [message for message in transcript if message["text"]]
+
+
+async def _execution_summary(pool: Any, thread_key: str) -> dict[str, Any]:
+    rows = await pool.fetch(
+        """
+        SELECT status, started_at, completed_at, error IS NOT NULL AS has_error
+        FROM session_executions
+        WHERE thread_key = $1
+        ORDER BY created_at DESC
+        LIMIT 5
+        """,
+        thread_key,
+    )
+    return {
+        "recent_executions": [
+            {
+                "status": str(row["status"]),
+                "has_error": bool(row["has_error"]),
+                "duration_seconds": (
+                    max((row["completed_at"] - row["started_at"]).total_seconds(), 0)
+                    if row["started_at"] and row["completed_at"]
+                    else None
+                ),
+            }
+            for row in rows
+        ]
+    }
+
+
+def _response_output_text(value: Any) -> str:
+    if isinstance(value, dict) and isinstance(value.get("output_text"), str):
+        return value["output_text"]
+    parts: list[str] = []
+    if not isinstance(value, dict) or not isinstance(value.get("output"), list):
+        return ""
+    for item in value["output"]:
+        if not isinstance(item, dict) or not isinstance(item.get("content"), list):
+            continue
+        for content in item["content"]:
+            if isinstance(content, dict) and isinstance(content.get("text"), str):
+                parts.append(content["text"])
+    return " ".join(parts)
+
+
+async def _classify(
+    client: httpx.AsyncClient,
+    *,
+    base_url: str,
+    api_key: str,
+    model: str,
+    max_output_tokens: int,
+    thread_key: str,
+    transcript: list[dict[str, str]],
+    execution_summary: dict[str, Any],
+) -> dict[str, Any]:
+    response = await client.post(
+        f"{base_url}/responses",
+        headers={"authorization": f"Bearer {api_key}"},
+        json={
+            "model": model,
+            "instructions": SYSTEM_PROMPT,
+            "input": json.dumps(
+                {
+                    "thread_key": thread_key,
+                    "transcript": transcript,
+                    **execution_summary,
+                },
+                separators=(",", ":"),
+            ),
+            "max_output_tokens": max_output_tokens,
+            "reasoning": {"effort": "none"},
+            "store": False,
+            "text": {
+                "format": {
+                    "type": "json_schema",
+                    "name": "user_experience_scan",
+                    "strict": True,
+                    "schema": CLASSIFIER_SCHEMA,
+                }
+            },
+        },
+    )
+    if not response.is_success:
+        raise RuntimeError(f"OpenAI Responses API returned HTTP {response.status_code}")
+    value = response.json()
+    if isinstance(value, dict) and value.get("incomplete_details"):
+        raise RuntimeError("OpenAI Responses API returned an incomplete response")
+    output = _response_output_text(value)
+    if not output:
+        raise RuntimeError("OpenAI Responses API returned no output text")
+    parsed = json.loads(output)
+    if not isinstance(parsed, dict):
+        raise TypeError("classifier output must be a JSON object")
+    return parsed
+
+
+def _validate_result(result: dict[str, Any], message_ids: set[str]) -> dict[str, Any]:
+    if not isinstance(result.get("problem_detected"), bool):
+        raise TypeError("problem_detected must be a boolean")
+    if result.get("experience") not in EXPERIENCES:
+        raise ValueError("invalid experience")
+    if result.get("severity") not in SEVERITIES:
+        raise ValueError("invalid severity")
+    if result.get("user_emotion") not in USER_EMOTIONS:
+        raise ValueError("invalid user_emotion")
+    if result.get("agent_contribution") not in AGENT_CONTRIBUTIONS:
+        raise ValueError("invalid agent_contribution")
+    confidence = result.get("confidence")
+    if isinstance(confidence, bool) or not isinstance(confidence, (int, float)):
+        raise TypeError("confidence must be numeric")
+    if not 0 <= float(confidence) <= 1:
+        raise ValueError("confidence must be between zero and one")
+    failure_modes = result.get("failure_modes")
+    if not isinstance(failure_modes, list) or any(
+        mode not in FAILURE_MODES for mode in failure_modes
+    ):
+        raise ValueError("invalid failure_modes")
+    evidence = result.get("evidence_message_ids")
+    if not isinstance(evidence, list) or any(
+        item not in message_ids for item in evidence
+    ):
+        raise ValueError("evidence_message_ids must reference the supplied transcript")
+    summary = result.get("summary")
+    if not isinstance(summary, str) or len(summary) > 1000:
+        raise ValueError("summary must be a string of at most 1000 characters")
+    if not result["problem_detected"] and result["severity"] != "none":
+        raise ValueError("non-problem results must use severity none")
+    if result["problem_detected"] and result["severity"] == "none":
+        raise ValueError("problem results must use a non-none severity")
+    if result["problem_detected"] and result["experience"] not in {"mixed", "bad"}:
+        raise ValueError("problem results must use mixed or bad experience")
+    if not result["problem_detected"] and result["experience"] not in {
+        "good",
+        "unknown",
+    }:
+        raise ValueError("non-problem results must use good or unknown experience")
+    return result
+
+
+async def _complete_scan(pool: Any, scan_id: str, result: dict[str, Any]) -> None:
+    await pool.execute(
+        """
+        UPDATE user_experience_scans
+        SET status = 'completed',
+            problem_detected = $2,
+            experience = $3,
+            severity = $4,
+            user_emotion = $5,
+            agent_contribution = $6,
+            confidence = $7,
+            failure_modes = $8,
+            evidence_message_ids = $9,
+            summary = $10,
+            result = $11::jsonb,
+            last_error = '',
+            completed_at = NOW(),
+            updated_at = NOW()
+        WHERE scan_id = $1 AND status = 'running'
+        """,
+        scan_id,
+        result["problem_detected"],
+        result["experience"],
+        result["severity"],
+        result["user_emotion"],
+        result["agent_contribution"],
+        float(result["confidence"]),
+        list(dict.fromkeys(result["failure_modes"])),
+        list(dict.fromkeys(result["evidence_message_ids"])),
+        result["summary"],
+        json.dumps(result, separators=(",", ":")),
+    )
+
+
+def _safe_error(error: Exception) -> str:
+    return f"{type(error).__name__}: {error}".replace("\n", " ")[:1000]
+
+
+async def _fail_scan(pool: Any, scan_id: str, error: Exception) -> None:
+    await pool.execute(
+        """
+        UPDATE user_experience_scans
+        SET status = 'failed', last_error = $2, updated_at = NOW()
+        WHERE scan_id = $1 AND status = 'running'
+        """,
+        scan_id,
+        _safe_error(error),
+    )
+
+
+async def _process_scan(
+    pool: Any,
+    client: httpx.AsyncClient,
+    scan: Scan,
+    config: dict[str, Any],
+    api_key: str,
+) -> str:
+    try:
+        if not await _snapshot_is_current(pool, scan):
+            await _mark_superseded(pool, scan.scan_id)
+            return "superseded"
+        transcript = await _load_transcript(pool, scan, config["max_messages"])
+        execution_summary = await _execution_summary(pool, scan.thread_key)
+        result = await _classify(
+            client,
+            base_url=config["base_url"],
+            api_key=api_key,
+            model=scan.model,
+            max_output_tokens=config["max_output_tokens"],
+            thread_key=scan.thread_key,
+            transcript=transcript,
+            execution_summary=execution_summary,
+        )
+        validated = _validate_result(
+            result, {message["message_id"] for message in transcript}
+        )
+        await _complete_scan(pool, scan.scan_id, validated)
+        return "completed"
+    # A single malformed transcript, database race, or provider failure must not
+    # prevent the remaining claimed scans from reaching a terminal state.
+    except Exception as error:  # noqa: BLE001
+        await _fail_scan(pool, scan.scan_id, error)
+        return "failed"
+
+
+async def _process_scans(
+    pool: Any,
+    scans: list[Scan],
+    config: dict[str, Any],
+    api_key: str,
+) -> dict[str, int]:
+    import httpx
+
+    counts = {"completed": 0, "failed": 0, "superseded": 0}
+    semaphore = asyncio.Semaphore(config["concurrency"])
+    async with httpx.AsyncClient(
+        timeout=config["timeout_seconds"], trust_env=True
+    ) as client:
+
+        async def run(scan: Scan) -> str:
+            async with semaphore:
+                return await _process_scan(pool, client, scan, config, api_key)
+
+        for status in await asyncio.gather(*(run(scan) for scan in scans)):
+            counts[status] += 1
+    return counts
+
+
+async def _load_run_results(pool: Any, run_id: str) -> list[dict[str, Any]]:
+    rows = await pool.fetch(
+        """
+        SELECT thread_key, status, problem_detected, severity, confidence,
+               failure_modes, summary, model, created_at, completed_at
+        FROM user_experience_scans
+        WHERE workflow_run_id = $1
+        ORDER BY completed_at NULLS LAST, created_at
+        """,
+        run_id,
+    )
+    return [dict(row) for row in rows]
+
+
+def _thread_reference(thread_key: str) -> str:
+    match = SLACK_THREAD_KEY_RE.match(thread_key)
+    if not match:
+        return f"`{thread_key}`"
+    channel = match.group("channel")
+    thread_ts = match.group("thread_ts").replace(".", "")
+    return f"<https://slack.com/archives/{channel}/p{thread_ts}|thread>"
+
+
+def _format_digest(rows: list[dict[str, Any]], model: str) -> str:
+    completed = [row for row in rows if row["status"] == "completed"]
+    problems = [row for row in completed if row["problem_detected"]]
+    failed = sum(row["status"] == "failed" for row in rows)
+    superseded = sum(row["status"] == "superseded" for row in rows)
+    today = dt.datetime.now(dt.timezone.utc).date().isoformat()
+    lines = [
+        f"*Daily user experience scan — {today}*",
+        (
+            f"Scanned *{len(completed)}* thread snapshots with `{model}` · "
+            f"problems *{len(problems)}* · failed *{failed}* · superseded *{superseded}*"
+        ),
+    ]
+    if not problems:
+        if completed:
+            lines.append("No problematic experiences were detected in this run.")
+        elif failed:
+            lines.append("No classifications completed; inspect the failed scan rows.")
+        else:
+            lines.append("No eligible thread snapshots were available in this run.")
+        return "\n\n".join(lines)
+    severity_order = {"critical": 0, "high": 1, "medium": 2, "low": 3, "none": 4}
+    problems.sort(
+        key=lambda row: (
+            severity_order.get(str(row["severity"]), 5),
+            -float(row["confidence"] or 0),
+        )
+    )
+    counts = {
+        severity: sum(row["severity"] == severity for row in problems)
+        for severity in ("critical", "high", "medium", "low")
+    }
+    lines.append(
+        "Severity: "
+        + " · ".join(f"{name} *{count}*" for name, count in counts.items() if count)
+    )
+    lines.append("*Highest-priority threads*")
+    for row in problems[:10]:
+        modes = ", ".join(row["failure_modes"] or []) or "uncategorized"
+        summary = str(row["summary"] or "No summary supplied").replace("\n", " ")
+        lines.append(
+            f"• *{str(row['severity']).upper()}* {_thread_reference(str(row['thread_key']))} "
+            f"— {summary} _({modes})_"
+        )
+    if len(problems) > 10:
+        lines.append(f"…and {len(problems) - 10} more problematic threads.")
+    return "\n".join(lines)
+
+
+async def handler(inp: Input, ctx: WorkflowContext) -> dict[str, Any]:
+    if ctx._pool is None:
+        raise RuntimeError("user experience digest requires DATABASE_URL")
+    config = _config()
+    limit = _positive_int(inp.limit, config["batch_size"])
+    discovered = await ctx.step(
+        "discover_thread_snapshots",
+        lambda: _discover_candidates(
+            ctx._pool,
+            idle_minutes=config["idle_minutes"],
+            include_direct_messages=config["include_direct_messages"],
+            classifier_version=config["classifier_version"],
+            model=config["model"],
+            limit=limit,
+            run_id=ctx.run_id,
+        ),
+    )
+    scans = await _claim_scans(
+        ctx._pool,
+        classifier_version=config["classifier_version"],
+        model=config["model"],
+        limit=limit,
+        max_attempts=config["max_attempts"],
+        lease_minutes=config["lease_minutes"],
+        run_id=ctx.run_id,
+    )
+    if scans:
+        api_key = os.getenv("OPENAI_API_KEY", "").strip()
+        if not api_key:
+            error = RuntimeError("OPENAI_API_KEY is not configured")
+            for scan in scans:
+                await _fail_scan(ctx._pool, scan.scan_id, error)
+            counts = {"completed": 0, "failed": len(scans), "superseded": 0}
+        else:
+            counts = await _process_scans(ctx._pool, scans, config, api_key)
+    else:
+        counts = {"completed": 0, "failed": 0, "superseded": 0}
+    rows = await _load_run_results(ctx._pool, ctx.run_id)
+    channel = (inp.slack_channel or config["slack_channel"]).strip()
+    if inp.post_report and channel:
+        digest_date = dt.datetime.now(dt.timezone.utc).date().isoformat()
+        slack = await ctx.post_to_slack(
+            channel,
+            _format_digest(rows, config["model"]),
+            client_msg_id=(
+                f"user-experience-digest:{digest_date}:"
+                f"{config['classifier_version']}:{config['model']}"
+            ),
+        )
+    else:
+        slack = {"sent": False, "reason": "report_disabled_or_no_channel"}
+    ctx.log(
+        "user_experience_digest_completed",
+        discovered=discovered,
+        claimed=len(scans),
+        **counts,
+    )
+    return {
+        "discovered": discovered,
+        "claimed": len(scans),
+        **counts,
+        "model": config["model"],
+        "classifier_version": config["classifier_version"],
+        "slack": slack,
+    }

--- a/workflows/user_experience_digest.py
+++ b/workflows/user_experience_digest.py
@@ -208,11 +208,11 @@ async def _discover_candidates(
           AND NOT EXISTS (
               SELECT 1 FROM user_experience_scans existing
               WHERE existing.thread_key = s.thread_key
-                AND existing.last_message_id = latest.message_id
                 AND (
                     existing.status = 'baseline'
                     OR (
-                        existing.classifier_version = $3
+                        existing.last_message_id = latest.message_id
+                        AND existing.classifier_version = $3
                         AND existing.model = $4
                     )
                 )


### PR DESCRIPTION
## Summary

- add `user_experience_scans` as the durable work queue, snapshot checkpoint, and classifier result store
- add a daily scheduled workflow that classifies idle chat threads with strict structured output and posts a private Slack digest
- record all scanned snapshots, including the exact model, classifier version, creation/completion timestamps, problem labels, evidence IDs, and review state
- add lease recovery, bounded retries, superseded-snapshot detection, and deterministic Slack delivery IDs
- add Helm configuration and operator documentation; the feature and direct-message scanning are disabled by default

## Why

We need an auditable daily signal for poor user experiences without relying only on explicit feedback or a fragile global watermark. A scan row uniquely identifies the thread's final message plus classifier/model version, so new activity creates a new snapshot while retries remain durable and independent.

## Validation

- `uvx ruff check workflows/user_experience_digest.py workflows/tests/test_user_experience_digest.py`
- `uvx ruff format --check workflows/user_experience_digest.py workflows/tests/test_user_experience_digest.py`
- `uv run --project services/workflow-python --with pytest pytest workflows/tests/test_user_experience_digest.py -q` (8 passed)
- `cargo fmt --all --check`
- `cargo test -p centaur-session-sqlx`
- `cargo test -p centaur-workflows`
- `helm lint contrib/chart`
- rendered Helm values with the digest enabled and verified all workflow-host environment passthrough
- verified workflow discovery with the system Python runtime and the daily cron enabled
- `git diff --check`

## Validation limitations

- workspace-wide Clippy is blocked by the local Rust 1.94.0 toolchain; `aws-smithy-types@1.6.1` requires Rust 1.94.1
- the broader `workflows/tests` suite has five existing failures because `workflows/granola_sync.py` is absent on current `main`; the new focused suite passes
- a live local deployment was unavailable because the configured local Kubernetes endpoint was not running; database-backed migration execution also lacked a local Postgres server
