### PR TITLE
fix(docsend): allow Postmark verification links

### DIFF
--- a/tools/research/docsend/client.py
+++ b/tools/research/docsend/client.py
@@ -30,6 +30,7 @@ BROWSERBASE_PROXY_COUNTRY = os.environ.get("BROWSERBASE_PROXY_COUNTRY", "")  # n
 BROWSERBASE_DEFAULT_SESSION_TIMEOUT_SECONDS = 600
 BROWSERBASE_MAX_SESSION_TIMEOUT_SECONDS = 1800
 BROWSERBASE_DOWNLOAD_TIMEOUT_SECONDS = 120
+POSTMARK_TRACKING_HOST = "track.pstmrk.it"
 MAX_DOWNLOAD_BYTES = 100 * 1024 * 1024
 CDP_MAX_MESSAGE_BYTES = 256 * 1024 * 1024
 LOGGER = logging.getLogger(__name__)
@@ -186,10 +187,17 @@ def _decode_session_url(value: str) -> str:
 
 
 def _normalize_verification_url(url: str) -> str:
-    normalized = _normalize_docsend_url(url)
+    normalized = url.strip().rstrip("/")
     parsed = urlparse(normalized)
-    if parsed.scheme != "https" or parsed.username or parsed.password:
-        raise ValueError("Verification URL must be an HTTPS DocSend URL")
+    hostname = (parsed.hostname or "").lower()
+    is_docsend = hostname == "docsend.com" or hostname.endswith(".docsend.com")
+    if (
+        parsed.scheme != "https"
+        or parsed.username
+        or parsed.password
+        or not (is_docsend or hostname == POSTMARK_TRACKING_HOST)
+    ):
+        raise ValueError("Verification URL must be an HTTPS DocSend or Postmark URL")
     return normalized
 
 

--- a/tools/research/docsend/pyproject.toml
+++ b/tools/research/docsend/pyproject.toml
@@ -28,4 +28,5 @@ packages = ["."]
 
 [tool.centaur]
 module = "client.py"
+hosts = ["track.pstmrk.it"]
 secrets = [{type = "http", name = "BROWSERBASE_API_KEY", mode = "inject", inject_header = "X-BB-API-Key", hosts = ["api.browserbase.com"]}]

--- a/tools/research/docsend/test_client.py
+++ b/tools/research/docsend/test_client.py
@@ -1,0 +1,38 @@
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+_CLIENT_SPEC = importlib.util.spec_from_file_location(
+    "docsend_client_under_test", Path(__file__).with_name("client.py")
+)
+assert _CLIENT_SPEC is not None and _CLIENT_SPEC.loader is not None
+_CLIENT = importlib.util.module_from_spec(_CLIENT_SPEC)
+_CLIENT_SPEC.loader.exec_module(_CLIENT)
+_normalize_verification_url = _CLIENT._normalize_verification_url
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://docsend.com/presentation_users/token",
+        "https://paradigm.docsend.com/presentation_users/token",
+        "https://track.pstmrk.it/3s/docsend.com%2Fpresentation_users%2Ftoken/abc",
+    ],
+)
+def test_normalize_verification_url_allows_supported_hosts(url: str) -> None:
+    assert _normalize_verification_url(url) == url
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://track.pstmrk.it/3s/docsend.com%2Fpresentation_users%2Ftoken/abc",
+        "https://pstmrk.it/3s/docsend.com%2Fpresentation_users%2Ftoken/abc",
+        "https://track.pstmrk.it.evil.example/3s/docsend.com",
+        "https://example.com/presentation_users/token",
+    ],
+)
+def test_normalize_verification_url_rejects_unsupported_urls(url: str) -> None:
+    with pytest.raises(ValueError, match="HTTPS DocSend or Postmark URL"):
+        _normalize_verification_url(url)


### PR DESCRIPTION
Allow DocSend email-verification flows to follow Postmark tracking links while retaining strict HTTPS host validation.

Adds focused allow/reject coverage for DocSend and Postmark verification URLs.

Test: `uv run --no-project ... pytest tools/research/docsend/test_client.py` (7 passed)

Prompted by: mslipper