### PR TITLE
fix(websearch): enable Parallel REST/deep_research under iron-proxy

### DIFF
--- a/tools/research/websearch/README.md
+++ b/tools/research/websearch/README.md
@@ -27,10 +27,10 @@ That's the minimum — works with zero credentials via the free MCP. Add a `PARA
 
 ## Secrets
 
-Set in root `.env` (preferred) or `tools/research/websearch/.env`.
+Set in root `.env` (preferred) or `tools/research/websearch/.env` for local CLI use.
 
-- `PARALLEL_API_KEY` — optional. Get one at <https://platform.parallel.ai>. Unlocks the paid Search REST path (with source filters) and enables `deep_research` via the Task API.
-- `ANTHROPIC_API_KEY` — optional. Enables the Claude-backed synthesis pipeline on `search(synthesize=True)`.
+- `PARALLEL_API_KEY` — optional. Get one at <https://platform.parallel.ai>. Unlocks the paid Search REST path (with source filters) and enables `deep_research` via the Task API. In Centaur sandboxes this is a **replace**-mode secret (`Authorization`): grant it (e.g. `centaur-perms roles grant infra --tool websearch --secret-name PARALLEL_API_KEY`) so agents see the `PARALLEL_API_KEY=PARALLEL_API_KEY` placeholder and iron-proxy swaps the real value.
+- `ANTHROPIC_API_KEY` — optional. Enables the Claude-backed synthesis pipeline on `search(synthesize=True)` (inject-mode toward `api.anthropic.com`).
 
 Non-secret config (synthesis model, default Task processor, REST/MCP base URLs) is configured via `WebSearchClient(...)` constructor kwargs at instantiation time. Defaults: `synthesis_model="claude-opus-4-6"`, `parallel_deep_research_processor="ultra-fast"`, `parallel_api_base_url="https://api.parallel.ai"`, `parallel_mcp_url="https://search.parallel.ai/mcp"`.
 

--- a/tools/research/websearch/README.md
+++ b/tools/research/websearch/README.md
@@ -29,7 +29,7 @@ That's the minimum — works with zero credentials via the free MCP. Add a `PARA
 
 Set in root `.env` (preferred) or `tools/research/websearch/.env` for local CLI use.
 
-- `PARALLEL_API_KEY` — optional. Get one at <https://platform.parallel.ai>. Unlocks the paid Search REST path (with source filters) and enables `deep_research` via the Task API. In Centaur sandboxes this is a **replace**-mode secret (`Authorization`): grant it (e.g. `centaur-perms roles grant infra --tool websearch --secret-name PARALLEL_API_KEY`) so agents see the `PARALLEL_API_KEY=PARALLEL_API_KEY` placeholder and iron-proxy swaps the real value.
+- `PARALLEL_API_KEY` — optional. Get one at <https://platform.parallel.ai>. Unlocks the paid Search REST path (with source filters) and enables `deep_research` via the Task API. In Centaur sandboxes this is a **replace**-mode secret (`x-api-key` for the parallel-web SDK, plus `Authorization` for Bearer paths): grant it (e.g. `centaur-perms roles grant infra --tool websearch --secret-name PARALLEL_API_KEY`) so agents see the `PARALLEL_API_KEY=PARALLEL_API_KEY` placeholder and iron-proxy swaps the real value.
 - `ANTHROPIC_API_KEY` — optional. Enables the Claude-backed synthesis pipeline on `search(synthesize=True)` (inject-mode toward `api.anthropic.com`).
 
 Non-secret config (synthesis model, default Task processor, REST/MCP base URLs) is configured via `WebSearchClient(...)` constructor kwargs at instantiation time. Defaults: `synthesis_model="claude-opus-4-6"`, `parallel_deep_research_processor="ultra-fast"`, `parallel_api_base_url="https://api.parallel.ai"`, `parallel_mcp_url="https://search.parallel.ai/mcp"`.

--- a/tools/research/websearch/client.py
+++ b/tools/research/websearch/client.py
@@ -17,6 +17,7 @@ returns raw Parallel results and records the skipped synthesis in
 from __future__ import annotations
 
 import json
+import os
 import re
 import warnings
 from collections.abc import Callable
@@ -48,14 +49,21 @@ def _is_configured(key: str) -> bool:
     - Server / tool-runtime: ToolManager populates ``ctx.secrets[key]``
       only for secrets it actually resolved, so dict membership is the
       authoritative signal.
-    - CLI / direct-invoke: no ToolContext is bound; fall through to
-      ``secret(key)`` and treat the value-equals-key stub case as
-      "not configured" (the firewall has nothing to swap into).
+    - CLI / direct-invoke: sandbox shims leave ``ToolContext.secrets`` empty.
+      Replace-mode secrets appear as env ``KEY=KEY`` (placeholder); that is
+      configured — iron-proxy swaps the real value on allowlisted hosts.
+      Treat non-empty env presence as configured. Only when the key is
+      absent from the environment do we fall through to StubBackend's
+      value-equals-key "not configured" rule (laptop / bare CLI without a
+      real ``.env`` value).
     """
     try:
         ctx = get_tool_context()
         return bool(ctx.secrets.get(key))
     except LookupError:
+        env_val = os.environ.get(key)
+        if env_val is not None and env_val != "":
+            return True
         try:
             val = secret(key)
         except KeyError:

--- a/tools/research/websearch/pyproject.toml
+++ b/tools/research/websearch/pyproject.toml
@@ -33,8 +33,13 @@ module = "client.py"
 # PARALLEL_API_KEY to use the paid REST path and unlock `deep_research`.
 # Set ANTHROPIC_API_KEY to enable the Claude-backed synthesis pipeline on
 # top of search results (reviewer → writer → citation repair).
+# PARALLEL uses replace (not inject): sandboxes get PARALLEL_API_KEY=PARALLEL_API_KEY
+# and iron-proxy swaps the real value into Authorization on Parallel hosts. Inject
+# never sets sandbox env, so the CLI `_is_configured()` check never enabled REST /
+# deep_research even when the key was present on the proxy. ANTHROPIC synthesis
+# stays inject (optional; only needed when calling Anthropic directly).
 optional_secrets = [
-    {type = "http", name = "PARALLEL_API_KEY", mode = "inject", inject_header = "Authorization", inject_formatter = "Bearer {{ .Value }}", hosts = ["api.parallel.ai", "search.parallel.ai"]},
+    {type = "http", name = "PARALLEL_API_KEY", mode = "replace", match_headers = ["Authorization"], hosts = ["api.parallel.ai", "search.parallel.ai"]},
     {type = "http", name = "ANTHROPIC_API_KEY", mode = "inject", inject_header = "x-api-key", hosts = ["api.anthropic.com"]},
 ]
 hosts = ["api.parallel.ai", "search.parallel.ai"]

--- a/tools/research/websearch/pyproject.toml
+++ b/tools/research/websearch/pyproject.toml
@@ -39,7 +39,7 @@ module = "client.py"
 # deep_research even when the key was present on the proxy. ANTHROPIC synthesis
 # stays inject (optional; only needed when calling Anthropic directly).
 optional_secrets = [
-    {type = "http", name = "PARALLEL_API_KEY", mode = "replace", match_headers = ["Authorization"], hosts = ["api.parallel.ai", "search.parallel.ai"]},
+    {type = "http", name = "PARALLEL_API_KEY", mode = "replace", match_headers = ["Authorization", "x-api-key"], hosts = ["api.parallel.ai", "search.parallel.ai"]},
     {type = "http", name = "ANTHROPIC_API_KEY", mode = "inject", inject_header = "x-api-key", hosts = ["api.anthropic.com"]},
 ]
 hosts = ["api.parallel.ai", "search.parallel.ai"]

--- a/tools/research/websearch/pyproject.toml
+++ b/tools/research/websearch/pyproject.toml
@@ -34,10 +34,11 @@ module = "client.py"
 # Set ANTHROPIC_API_KEY to enable the Claude-backed synthesis pipeline on
 # top of search results (reviewer → writer → citation repair).
 # PARALLEL uses replace (not inject): sandboxes get PARALLEL_API_KEY=PARALLEL_API_KEY
-# and iron-proxy swaps the real value into Authorization on Parallel hosts. Inject
-# never sets sandbox env, so the CLI `_is_configured()` check never enabled REST /
-# deep_research even when the key was present on the proxy. ANTHROPIC synthesis
-# stays inject (optional; only needed when calling Anthropic directly).
+# and iron-proxy swaps the real value into x-api-key (parallel-web SDK) and
+# Authorization (Bearer) on Parallel hosts. Inject never sets sandbox env, so the
+# CLI `_is_configured()` check never enabled REST / deep_research even when the
+# key was present on the proxy. ANTHROPIC synthesis stays inject (optional; only
+# needed when calling Anthropic directly).
 optional_secrets = [
     {type = "http", name = "PARALLEL_API_KEY", mode = "replace", match_headers = ["Authorization", "x-api-key"], hosts = ["api.parallel.ai", "search.parallel.ai"]},
     {type = "http", name = "ANTHROPIC_API_KEY", mode = "inject", inject_header = "x-api-key", hosts = ["api.anthropic.com"]},


### PR DESCRIPTION
## Summary
- Switch `PARALLEL_API_KEY` from **inject** to **replace** (`Authorization` on `api.parallel.ai` / `search.parallel.ai`) so sandboxes get the `PARALLEL_API_KEY=PARALLEL_API_KEY` placeholder and iron-proxy swaps the real value.
- Fix `_is_configured` for CLI/shim invokes: Centaur tool shims leave `ToolContext.secrets` empty; treat non-empty env presence as configured (replace placeholders are `KEY=KEY`). StubBackend’s value-equals-key fallback still means “not configured” when the env var is absent.

## Why
With inject-mode, the real key can sit on iron-proxy while `websearch deep-research` still errors with “PARALLEL_API_KEY is not available” and `search` stays on free `parallel:mcp`. Replace-mode matches how harness API keys (OPENAI/ANTHROPIC) already work.

## Test plan
- [x]  Test with local overlay