### PR TITLE
docs: document overlay dependency on repoCache

### DIFF
--- a/contrib/chart/templates/apirs.yaml
+++ b/contrib/chart/templates/apirs.yaml
@@ -43,6 +43,16 @@
 {{- end -}}
 {{- $toolsUseRepoCache := and .Values.repoCache.enabled (gt (len $toolSources) 0) -}}
 {{- $useOverlayRepoCache := and .Values.repoCache.enabled (gt (len $overlaySources) 0) -}}
+{{- /*
+Every overlay discovery path is served by the repo-cache mount. With the cache
+disabled the chart renders no mount for api-rs and no repos mount for sandboxes,
+so overlay tools, workflows, and skills vanish from discovery and the workflow
+host resolves WORKFLOW_DIRS against a path that does not exist. Reject the
+combination here instead of letting it fail at runtime.
+*/ -}}
+{{- if and (not .Values.repoCache.enabled) .Values.overlays.sources }}
+{{- fail "overlays.sources requires repoCache.enabled=true: overlay tools, workflows, and skills are served from the repo-cache mount, which is not rendered when repoCache.enabled=false" }}
+{{- end }}
 {{- $toolDirs := list "/app/tools" -}}
 {{- $workflowDirs := "/app/workflows" -}}
 {{- if $toolsUseRepoCache -}}

--- a/docs/pages/extend/overlay.mdx
+++ b/docs/pages/extend/overlay.mdx
@@ -100,6 +100,16 @@ is missing from API discovery, inspect `/var/lib/centaur/repos/...` in the API
 container. If a skill or workflow-host import is missing, inspect
 `/home/agent/github/...` in the sandbox.
 
+Both mounts are served by repo-cache, so overlays require `repoCache.enabled:
+true` (the default). With `repoCache.enabled: false` the chart renders neither
+mount: api-rs falls back to the image's own `/app/tools` and `/app/workflows`,
+sandboxes lose `CENTAUR_SKILL_DIRS` and the `/home/agent/github` repos mount,
+and the workflow host resolves `WORKFLOW_DIRS` against a path that does not
+exist. Overlay tools, workflows, and skills silently disappear from discovery.
+The chart rejects that combination when `overlays.sources` is set, so the
+failure surfaces at `helm install` rather than as a missing-file error at
+runtime.
+
 ## Discovery paths
 
 The chart renders API discovery paths from the ordered overlay list:


### PR DESCRIPTION
## Problem

Setting `repoCache.enabled: false` looked like an independent toggle, but it silently removes the mounts every overlay depends on. We hit this as first-time operators: api-rs came up wrong and the eventual "No such file or directory" gave no hint that the repo cache was the cause. We recovered by putting `repoCache.enabled: true` back.

The dependency is real in both directions:

- `contrib/chart/templates/apirs.yaml` gates `$useOverlayRepoCache` on `repoCache.enabled`, so with the cache off api-rs gets no `repo-cache` volume mount and `TOOL_DIRS`/`WORKFLOW_DIRS` fall back to the image's `/app/tools` and `/app/workflows`.
- `CENTAUR_SKILL_DIRS`, `KUBERNETES_WORKFLOW_DIRS`, and `KUBERNETES_SANDBOX_REPOS_PATH` are all gated the same way, so sandboxes lose the `/home/agent/github` repos mount. `agent_k8s_workflow_dirs()` in `services/api-rs/crates/centaur-api-server/src/args.rs` then defaults `WORKFLOW_DIRS` to `/home/agent/github/<repo>/workflows` — a path that is no longer mounted.

Nothing in the docs mentions this, and nothing in the chart objects.

## Change

- `docs/pages/extend/overlay.mdx`: state in the mount-paths section that both mounts are served by repo-cache and spell out what `repoCache.enabled: false` actually drops.
- `contrib/chart/templates/apirs.yaml`: `fail` when `overlays.sources` is set while `repoCache.enabled` is false, so the error arrives at `helm install` naming the cause instead of as a missing-file error at runtime.

The guard is deliberately scoped to an explicit `overlays.sources`. The `toolServer.*` compatibility path is left alone, because `KUBERNETES_TOOLS_REPO_CACHE_PATH` is documented as optional there ("When present, sandboxes and api-rs copy tools from `<path>/<repo>/<subdir>` instead of fetching GitHub directly"), so cache-less tool delivery stays a supported mode.

## Verification

```
helm template t contrib/chart                                    # renders
helm template t contrib/chart --set repoCache.enabled=false      # renders (no overlays.sources)
helm template t contrib/chart --set repoCache.enabled=false \
  --set 'overlays.sources[0].repo=your-org/overlay'
# Error: execution error at (centaur/templates/apirs.yaml:54:4): overlays.sources
# requires repoCache.enabled=true: overlay tools, workflows, and skills are served
# from the repo-cache mount, which is not rendered when repoCache.enabled=false
```

Reported from a first-time production deployment; happy to adjust the guard's scope if cache-less overlays are meant to be supported.