### PR TITLE
fix(slackbot): shorten reasoning effort flag

### DIFF
--- a/contrib/chart/values.yaml
+++ b/contrib/chart/values.yaml
@@ -502,7 +502,7 @@ slackbotv2:
   #     C0TRIAGE: { reasoning: low }
   channelDefaults: {}
   # Message overrides strategy for Slack message text. "flags" keeps the legacy
-  # deterministic --model/--claude/-rsn strategy. "llm" asks a small model for
+  # deterministic --model/--claude/-r strategy. "llm" asks a small model for
   # normalized overrides, allowing natural language requests such as
   # "use max effort and the sol model". In llm mode,
   # set OPENAI_API_KEY in the shared secret or provide

--- a/crates/harness-server/src/codex.rs
+++ b/crates/harness-server/src/codex.rs
@@ -346,7 +346,7 @@ fn run_codex_user_turn<W: Write>(
         params["model"] = Value::String(model);
     }
     // Per-turn reasoning effort (codex `turn/start.effort`), parsed from the
-    // `-rsn` message flag. Values match codex's ReasoningEffort enum
+    // `-r` message flag. Values match codex's ReasoningEffort enum
     // (none|minimal|low|medium|high|xhigh|max); validation happens upstream.
     if let Some(reasoning) = reasoning {
         params["effort"] = Value::String(reasoning);

--- a/docs/pages/extend/workflows-v2.mdx
+++ b/docs/pages/extend/workflows-v2.mdx
@@ -151,7 +151,7 @@ principal while workflow-host sandboxing is disabled.
 
 `ctx.agent_turn(...)` accepts optional `model`, `provider`, and `reasoning`
 kwargs. They ride the turn exactly like the Slack `--model` / `--bedrock` /
-`-rsn` flags: `model` selects the model within the harness, `reasoning` sets the
+`-r` flags: `model` selects the model within the harness, `reasoning` sets the
 codex reasoning effort (`none`/`minimal`/`low`/`medium`/`high`/`xhigh`/`max`),
 and `provider` selects the codex model provider. `provider` and `reasoning` only
 affect the codex harness; claude and amp ignore them. `reasoning` also accepts

--- a/docs/public/md/extend/workflows-v2.md
+++ b/docs/public/md/extend/workflows-v2.md
@@ -124,7 +124,7 @@ session runtime.
 
 `ctx.agent_turn(...)` accepts optional `model`, `provider`, and `reasoning`
 kwargs. They ride the turn exactly like the Slack `--model` / `--bedrock` /
-`-rsn` flags: `model` selects the model within the harness, `reasoning` sets the
+`-r` flags: `model` selects the model within the harness, `reasoning` sets the
 codex reasoning effort (`none`/`minimal`/`low`/`medium`/`high`/`xhigh`/`max`),
 and `provider` selects the codex model provider. `provider` and `reasoning` only
 affect the codex harness; claude and amp ignore them. `reasoning` also accepts

--- a/services/api-rs/crates/centaur-workflows/src/lib.rs
+++ b/services/api-rs/crates/centaur-workflows/src/lib.rs
@@ -3613,7 +3613,7 @@ async fn run_python_agent_turn(
         .map(ToOwned::to_owned)
         .unwrap_or_else(|| format!("absurd-workflow-agent-turn:{client_message_id}"));
     // Optional per-turn harness knobs, mirroring the slackbot's `--model` /
-    // `--bedrock` / `-rsn` flags. `reasoning` accepts `reasoning_effort` and
+    // `--bedrock` / `-r` flags. `reasoning` accepts `reasoning_effort` and
     // `effort` aliases so Python callers can use whichever reads best.
     let model = first_str_arg(&args, &["model"]);
     let provider = first_str_arg(&args, &["provider"]);
@@ -3932,7 +3932,7 @@ struct AgentTurnRequest {
     max_duration_ms: u64,
     // Optional per-turn model / provider / reasoning-effort overrides. When set
     // they ride the execute input line exactly like the slackbot's per-turn
-    // `--model` / `--bedrock` / `-rsn` flags do (see slackbotv2's
+    // `--model` / `--bedrock` / `-r` flags do (see slackbotv2's
     // `toCodexInputLineWithStaged`), so the harness applies them to this turn;
     // when `None` the deployment/baked harness default stands. `provider` and
     // `reasoning` only affect the codex harness (claude/amp ignore them).

--- a/services/sandbox/SYSTEM_PROMPT.md
+++ b/services/sandbox/SYSTEM_PROMPT.md
@@ -38,7 +38,7 @@
 |Model selector: `--model <model-id-or-alias>` or `--model=<model-id-or-alias>`.
 |Claude shortcuts: `--fable`, `--opus`, `--sonnet`, and `--haiku`; these imply the Claude Code harness. The same aliases also work as `--model fable`, `--model opus`, `--model sonnet`, or `--model haiku`.
 |Good examples to show: `--claude --model=fable fix this`, `--codex --model=gpt-5.2 investigate this`, `--amp --model fast review this`, or `--opus implement the change`.
-|Slack-specific extras: `--meta` selects Codex with the Meta provider, `--bedrock` selects Codex with the Bedrock provider, and `-rsn <effort>` sets Codex reasoning effort for that turn.
+|Slack-specific extras: `--meta` selects Codex with the Meta provider, `--bedrock` selects Codex with the Bedrock provider, and `-r <effort>` sets Codex reasoning effort for that turn.
 |If changing the harness on an existing thread, mention that the thread may restart on the requested harness and re-read the thread context.
 
 [Research and Grounding]

--- a/services/sandbox/test_system_prompt.py
+++ b/services/sandbox/test_system_prompt.py
@@ -39,7 +39,7 @@ class SystemPromptTest(unittest.TestCase):
         self.assertIn("`--codex --model=gpt-5.2 investigate this`", prompt)
         self.assertIn("`--meta` selects Codex with the Meta provider", prompt)
         self.assertIn("`--bedrock` selects Codex with the Bedrock provider", prompt)
-        self.assertIn("`-rsn <effort>` sets Codex reasoning effort", prompt)
+        self.assertIn("`-r <effort>` sets Codex reasoning effort", prompt)
 
     def test_personal_oauth_app_connection_guidance_is_present(self) -> None:
         prompt = SYSTEM_PROMPT.read_text()

--- a/services/slackbotv2/src/overrides.ts
+++ b/services/slackbotv2/src/overrides.ts
@@ -5,7 +5,7 @@
  *   --bedrock                                    codex via the AWS Bedrock provider
  *   --meta                                       codex via Meta AI direct
  *   --model <name> (or --model=<name>)           pick the model within that harness
- *   -rsn <effort> (or -rsn=<effort>)             per-turn reasoning effort (codex/nanocodex)
+ *   -r <effort> (or -r=<effort>)                 per-turn reasoning effort (codex/nanocodex)
  *   --fable | --opus | --sonnet | --haiku        model shortcuts (imply claude-code)
  *
  * Flags are stripped from the text before it reaches the agent. The harness
@@ -116,10 +116,10 @@ const MODEL_FLAG_PATTERN = new RegExp(
   'i'
 )
 
-// Single dash by design: a short per-turn knob (`-rsn high`), so it can't reuse
+// Single dash by design: a short per-turn knob (`-r high`), so it can't reuse
 // the `--`-prefixed flagPattern() helper. Value-capturing like --model.
 const REASONING_FLAG_PATTERN = new RegExp(
-  String.raw`(?:^|\s)-rsn${MODEL_VALUE_SEPARATOR}([A-Za-z-]+)${FLAG_VALUE_BOUNDARY}`,
+  String.raw`(?:^|\s)-r${MODEL_VALUE_SEPARATOR}([A-Za-z-]+)${FLAG_VALUE_BOUNDARY}`,
   'i'
 )
 

--- a/services/slackbotv2/src/types.ts
+++ b/services/slackbotv2/src/types.ts
@@ -292,7 +292,7 @@ export type ForwardSessionInput = {
   metadataModel?: string
   /** Effective model provider selected by sticky thread flags (--bedrock); codex only. */
   provider?: string
-  /** Per-turn reasoning effort parsed from the `-rsn` flag (Codex/Nanocodex). */
+  /** Per-turn reasoning effort parsed from the `-r` flag (Codex/Nanocodex). */
   reasoning?: string
   onEventId(eventId: number): void
   openStream: boolean

--- a/services/slackbotv2/test/chat-sdk-emulate.test.ts
+++ b/services/slackbotv2/test/chat-sdk-emulate.test.ts
@@ -1264,7 +1264,7 @@ describe('slackbotv2', () => {
 
     const parent = await postUserMessage('Channel default override thread context.')
     const mention = await postUserMessage(
-      `<@${BOT_USER_ID}> --codex --model gpt-5.4 -rsn low go`,
+      `<@${BOT_USER_ID}> --codex --model gpt-5.4 -r low go`,
       parent.ts
     )
     const waits: Promise<unknown>[] = []
@@ -1279,7 +1279,7 @@ describe('slackbotv2', () => {
           team: TEAM_ID,
           ts: mention.ts,
           thread_ts: parent.ts,
-          text: `<@${BOT_USER_ID}> --codex --model gpt-5.4 -rsn low go`
+          text: `<@${BOT_USER_ID}> --codex --model gpt-5.4 -r low go`
         }
       }),
       {},
@@ -1288,7 +1288,7 @@ describe('slackbotv2', () => {
     expect(response.status).toBe(200)
     await Promise.all(waits)
 
-    // Explicit --codex/--model/-rsn beat every field of the channel default.
+    // Explicit --codex/--model/-r beat every field of the channel default.
     expect(codexApi.creates.map(create => create.body.harness_type)).toEqual(['codex'])
     expect(codexApi.executes).toHaveLength(1)
     const inputLine = JSON.parse(codexApi.executes[0]!.body.input_lines.at(-1)!) as Record<

--- a/services/slackbotv2/test/overrides.test.ts
+++ b/services/slackbotv2/test/overrides.test.ts
@@ -166,34 +166,34 @@ describe('extractMessageOverrides', () => {
     })
   })
 
-  test('parses -rsn with space or equals', () => {
-    expect(extractMessageOverrides('-rsn high fix it')).toEqual({
+  test('parses -r with space or equals', () => {
+    expect(extractMessageOverrides('-r high fix it')).toEqual({
       cleanedText: 'fix it',
       harnessType: undefined,
       model: undefined,
       reasoning: 'high'
     })
-    expect(extractMessageOverrides('-rsn=medium fix it').reasoning).toBe('medium')
+    expect(extractMessageOverrides('-r=medium fix it').reasoning).toBe('medium')
   })
 
-  test('-rsn is case-insensitive and normalizes the effort value', () => {
-    expect(extractMessageOverrides('-rsn HIGH fix it').reasoning).toBe('high')
-    expect(extractMessageOverrides('-rsn Medium fix it').reasoning).toBe('medium')
+  test('-r is case-insensitive and normalizes the effort value', () => {
+    expect(extractMessageOverrides('-r HIGH fix it').reasoning).toBe('high')
+    expect(extractMessageOverrides('-r Medium fix it').reasoning).toBe('medium')
   })
 
-  test('-rsn accepts short aliases', () => {
-    expect(extractMessageOverrides('-rsn min fix it').reasoning).toBe('minimal')
-    expect(extractMessageOverrides('-rsn med fix it').reasoning).toBe('medium')
-    expect(extractMessageOverrides('-rsn hi fix it').reasoning).toBe('high')
-    expect(extractMessageOverrides('-rsn xhi fix it').reasoning).toBe('xhigh')
+  test('-r accepts short aliases', () => {
+    expect(extractMessageOverrides('-r min fix it').reasoning).toBe('minimal')
+    expect(extractMessageOverrides('-r med fix it').reasoning).toBe('medium')
+    expect(extractMessageOverrides('-r hi fix it').reasoning).toBe('high')
+    expect(extractMessageOverrides('-r xhi fix it').reasoning).toBe('xhigh')
   })
 
-  test('-rsn accepts the GPT-5.6 max effort', () => {
-    expect(extractMessageOverrides('-rsn max fix it').reasoning).toBe('max')
+  test('-r accepts the GPT-5.6 max effort', () => {
+    expect(extractMessageOverrides('-r max fix it').reasoning).toBe('max')
   })
 
-  test('-rsn combines with a harness flag', () => {
-    expect(extractMessageOverrides('-rsn high --codex audit this')).toEqual({
+  test('-r combines with a harness flag', () => {
+    expect(extractMessageOverrides('-r high --codex audit this')).toEqual({
       cleanedText: 'audit this',
       harnessType: 'codex',
       model: undefined,
@@ -201,18 +201,27 @@ describe('extractMessageOverrides', () => {
     })
   })
 
-  test('-rsn with an unknown effort value is left untouched', () => {
-    expect(extractMessageOverrides('-rsn turbo fix it')).toEqual({
-      cleanedText: '-rsn turbo fix it',
+  test('-r with an unknown effort value is left untouched', () => {
+    expect(extractMessageOverrides('-r turbo fix it')).toEqual({
+      cleanedText: '-r turbo fix it',
       harnessType: undefined,
       model: undefined,
       reasoning: undefined
     })
   })
 
-  test('-rsn without a value is left untouched', () => {
-    expect(extractMessageOverrides('what does -rsn do?')).toEqual({
-      cleanedText: 'what does -rsn do?',
+  test('-r without a value is left untouched', () => {
+    expect(extractMessageOverrides('what does -r do?')).toEqual({
+      cleanedText: 'what does -r do?',
+      harnessType: undefined,
+      model: undefined,
+      reasoning: undefined
+    })
+  })
+
+  test('does not accept the old -rsn spelling', () => {
+    expect(extractMessageOverrides('-rsn high fix it')).toEqual({
+      cleanedText: '-rsn high fix it',
       harnessType: undefined,
       model: undefined,
       reasoning: undefined
@@ -247,7 +256,7 @@ describe('extractMessageOverrides', () => {
   })
 
   test('--meta combines with a reasoning override', () => {
-    expect(extractMessageOverrides('--meta -rsn high fix it')).toEqual({
+    expect(extractMessageOverrides('--meta -r high fix it')).toEqual({
       cleanedText: 'fix it',
       harnessType: 'codex',
       model: undefined,


### PR DESCRIPTION
Summary:
- Rename the Slack per-turn reasoning flag from `-rsn` to `-r`.
- Update parser coverage, prompts, docs, and related comments.
- Explicitly reject the old spelling.

Tests:
- `bun test test/overrides.test.ts`
- `bun test test/chat-sdk-emulate.test.ts`
- `pnpm --filter slackbotv2 run check:types`
- `uv run python -m unittest services/sandbox/test_system_prompt.py`

Prompted by: @Rjected