### PR TITLE
fix: preserve GitHub Git authentication scheme

### DIFF
--- a/services/console/app/controllers/api/v1/static_secrets_controller.rb
+++ b/services/console/app/controllers/api/v1/static_secrets_controller.rb
@@ -66,6 +66,10 @@ module Api
           ref, attrs, :name, :description, :kind,
           labels: {}, inject_config: {}, replace_config: {}
         )
+        # Older clients do not know about kind. Preserve it on update when the
+        # field is absent, while creates still receive the database default and
+        # an explicitly supplied kind still replaces the existing value.
+        ss_attrs[:kind] = ref.kind if ref.persisted? && !attrs.key?(:kind)
 
         source_attrs = if attrs.key?(:source) && attrs[:source].present?
           attrs.require(:source).permit(:source_type, :secret, config: {})

--- a/services/console/app/controllers/api/v1/static_secrets_controller.rb
+++ b/services/console/app/controllers/api/v1/static_secrets_controller.rb
@@ -63,7 +63,7 @@ module Api
 
       def assign_and_save!(ref, attrs)
         ss_attrs = permit_document(
-          ref, attrs, :name, :description,
+          ref, attrs, :name, :description, :kind,
           labels: {}, inject_config: {}, replace_config: {}
         )
 
@@ -74,9 +74,22 @@ module Api
         source = source_attrs ? SecretSource.new(source_attrs.to_h) : nil
         rules = build_rules(attrs)
 
+        # Resolve profile defaults before the replacement guard so a repeated
+        # write compares the effective persisted document, not the abbreviated
+        # client request.
+        candidate = ref.dup
+        candidate.assign_attributes(ss_attrs)
+        rules = candidate.apply_kind_defaults(rules: rules)
+        ss_attrs = ss_attrs.merge(
+          kind: candidate.kind,
+          inject_config: candidate.inject_config,
+          replace_config: candidate.replace_config
+        )
+
         StaticSecret.transaction do
           with_sync_config_replacement_guard(ref, ss_attrs, source: source, rules: rules) do
             ref.assign_attributes(ss_attrs)
+            ref.kind_rules_for_validation = rules
             ref.save!
 
             ref.source&.destroy!
@@ -103,6 +116,7 @@ module Api
           foreign_id: ref.foreign_id,
           name: ref.name,
           description: ref.description,
+          kind: ref.kind,
           labels: ref.labels,
           inject_config: ref.inject_config,
           replace_config: ref.replace_config,

--- a/services/console/app/controllers/console/static_secrets_controller.rb
+++ b/services/console/app/controllers/console/static_secrets_controller.rb
@@ -17,6 +17,7 @@ module Console
     def assign_form(secret)
       assign_identity(secret)
       st = params.fetch(:static, ActionController::Parameters.new)
+      secret.kind = st[:kind].presence || CredentialProfiles::Registry::CUSTOM_KIND
       if st[:mode] == "replace"
         secret.inject_config = nil
         secret.replace_config = replace_config(st)
@@ -26,6 +27,7 @@ module Console
       end
       secret.source = build_source
       assign_rules(secret)
+      secret.rules = secret.apply_kind_defaults(rules: secret.rules)
     end
 
     def inject_config(st)

--- a/services/console/app/controllers/oauth/flows_controller.rb
+++ b/services/console/app/controllers/oauth/flows_controller.rb
@@ -249,11 +249,10 @@ module Oauth
     # Wraps a minted credential in a grantable static secret, so an operator can
     # grant the integration's token to a principal straight from the console (a
     # broker credential is not grantable on its own). Most providers inject the
-    # live access token as `Authorization: Bearer <token>`. Providers whose hosts
-    # support multiple authentication schemes can override that configuration;
-    # GitHub preserves API Bearer/token and Git HTTP Basic headers by replacing a
-    # placeholder instead. The token stays fresh because the source resolves the
-    # credential live at sync time.
+    # live access token as `Authorization: Bearer <token>`. A provider can select
+    # a credential profile when its clients need a different proxy contract. The
+    # token stays fresh because the source resolves the credential live at sync
+    # time.
     #
     # Created once per credential (keyed on the broker_credential association, which
     # a unique index enforces) and left untouched on re-consent, so any operator
@@ -267,13 +266,25 @@ module Oauth
 
       secret.namespace = credential.namespace
       secret.name = "#{credential.name} token"
-      secret.assign_attributes(wrapping_secret_config)
+      secret.kind = wrapping_secret_kind
+      secret.assign_attributes(wrapping_secret_config) if secret.kind == CredentialProfiles::Registry::CUSTOM_KIND
       secret.source = SecretSource.new(source_type: "token_broker", config: { "credential_id" => credential.oid })
-      secret.rules = Array(@provider.api_hosts).each_with_index.map do |host, position|
-        RequestRule.new(host: host, http_methods: [], paths: [], position: position)
+      rules = if secret.kind == CredentialProfiles::Registry::CUSTOM_KIND
+        Array(@provider.api_hosts).each_with_index.map do |host, position|
+          RequestRule.new(host: host, http_methods: [], paths: [], position: position)
+        end
+      else
+        []
       end
+      secret.rules = secret.apply_kind_defaults(rules: rules)
       secret.save!
       secret
+    end
+
+    def wrapping_secret_kind
+      return @provider.wrapping_secret_kind if @provider.respond_to?(:wrapping_secret_kind)
+
+      CredentialProfiles::Registry::CUSTOM_KIND
     end
 
     def wrapping_secret_config

--- a/services/console/app/controllers/oauth/flows_controller.rb
+++ b/services/console/app/controllers/oauth/flows_controller.rb
@@ -248,10 +248,12 @@ module Oauth
 
     # Wraps a minted credential in a grantable static secret, so an operator can
     # grant the integration's token to a principal straight from the console (a
-    # broker credential is not grantable on its own). The secret injects the live
-    # access token as `Authorization: Bearer <token>` through a token_broker source
-    # pointing at the credential, scoped to the provider's API hosts. The token
-    # stays fresh because the source resolves the credential live at sync time.
+    # broker credential is not grantable on its own). Most providers inject the
+    # live access token as `Authorization: Bearer <token>`. Providers whose hosts
+    # support multiple authentication schemes can override that configuration;
+    # GitHub preserves API Bearer/token and Git HTTP Basic headers by replacing a
+    # placeholder instead. The token stays fresh because the source resolves the
+    # credential live at sync time.
     #
     # Created once per credential (keyed on the broker_credential association, which
     # a unique index enforces) and left untouched on re-consent, so any operator
@@ -265,13 +267,19 @@ module Oauth
 
       secret.namespace = credential.namespace
       secret.name = "#{credential.name} token"
-      secret.inject_config = { "header" => "Authorization", "formatter" => "Bearer {{ .Value }}" }
+      secret.assign_attributes(wrapping_secret_config)
       secret.source = SecretSource.new(source_type: "token_broker", config: { "credential_id" => credential.oid })
       secret.rules = Array(@provider.api_hosts).each_with_index.map do |host, position|
         RequestRule.new(host: host, http_methods: [], paths: [], position: position)
       end
       secret.save!
       secret
+    end
+
+    def wrapping_secret_config
+      return @provider.wrapping_secret_config if @provider.respond_to?(:wrapping_secret_config)
+
+      { inject_config: { "header" => "Authorization", "formatter" => "Bearer {{ .Value }}" } }
     end
 
     def read_and_clear_flow_cookie

--- a/services/console/app/models/request_rule.rb
+++ b/services/console/app/models/request_rule.rb
@@ -41,6 +41,7 @@ class RequestRule < ApplicationRecord
   validate :http_methods_are_valid
   validate :paths_are_valid
   validate :at_most_one_owner
+  validate :github_authorization_preserves_client_scheme
 
   private
 
@@ -52,6 +53,19 @@ class RequestRule < ApplicationRecord
     set = OWNER_ASSOCIATIONS.count { |assoc| send(assoc).present? }
     return if set <= 1
     errors.add(:base, "must belong to at most one of #{OWNER_ASSOCIATIONS.join(", ")}")
+  end
+
+  def github_authorization_preserves_client_scheme
+    return unless host.to_s.casecmp?("github.com")
+
+    inject = static_secret&.inject_config
+    return unless inject.is_a?(Hash) && inject["header"].to_s.casecmp?("Authorization")
+    return unless inject["formatter"] == "Bearer {{ .Value }}"
+
+    errors.add(
+      :base,
+      "github.com Bearer credentials must replace a placeholder so Git can preserve HTTP Basic authentication"
+    )
   end
 
   def host_xor_cidr

--- a/services/console/app/models/request_rule.rb
+++ b/services/console/app/models/request_rule.rb
@@ -41,7 +41,6 @@ class RequestRule < ApplicationRecord
   validate :http_methods_are_valid
   validate :paths_are_valid
   validate :at_most_one_owner
-  validate :github_authorization_preserves_client_scheme
 
   private
 
@@ -53,19 +52,6 @@ class RequestRule < ApplicationRecord
     set = OWNER_ASSOCIATIONS.count { |assoc| send(assoc).present? }
     return if set <= 1
     errors.add(:base, "must belong to at most one of #{OWNER_ASSOCIATIONS.join(", ")}")
-  end
-
-  def github_authorization_preserves_client_scheme
-    return unless host.to_s.casecmp?("github.com")
-
-    inject = static_secret&.inject_config
-    return unless inject.is_a?(Hash) && inject["header"].to_s.casecmp?("Authorization")
-    return unless inject["formatter"] == "Bearer {{ .Value }}"
-
-    errors.add(
-      :base,
-      "github.com Bearer credentials must replace a placeholder so Git can preserve HTTP Basic authentication"
-    )
   end
 
   def host_xor_cidr

--- a/services/console/app/models/static_secret.rb
+++ b/services/console/app/models/static_secret.rb
@@ -48,6 +48,16 @@ class StaticSecret < ApplicationRecord
   # proxy resolves at sync; this association is the console-level link.
   belongs_to :broker_credential, optional: true
 
+  def apply_kind_defaults(rules: self.rules)
+    CredentialProfiles::Registry.apply_defaults(self, rules: rules)
+  end
+
+  attr_writer :kind_rules_for_validation
+
+  def validate_kind_rules(rules: self.rules)
+    CredentialProfiles::Registry.validate_rules(self, rules: rules)
+  end
+
   after_commit :auto_grant_wrapped_oauth_credential,
                on: %i[create update],
                if: :broker_credential_id?
@@ -86,12 +96,15 @@ class StaticSecret < ApplicationRecord
   end
 
   validates :namespace, presence: true, format: { with: URL_SAFE_FORMAT, message: URL_SAFE_MESSAGE }
+  validates :kind, presence: true, inclusion: { in: CredentialProfiles::Registry.kinds }
   validates :foreign_id, uniqueness: { scope: :namespace, allow_nil: true },
             format: { with: URL_SAFE_FORMAT, message: URL_SAFE_MESSAGE }, allow_nil: true
   validate :labels_is_a_hash
   validate :exactly_one_of_inject_or_replace
   validate :inject_config_matches_schema
   validate :replace_config_matches_schema
+  validate :kind_config_matches_profile
+  validate :kind_rules_match_profile
 
   private
 
@@ -118,6 +131,14 @@ class StaticSecret < ApplicationRecord
 
   def replace_config_matches_schema
     validate_against_schema(:replace_config, replace_config, REPLACE_CONFIG_SCHEMA)
+  end
+
+  def kind_config_matches_profile
+    CredentialProfiles::Registry.validate_config(self)
+  end
+
+  def kind_rules_match_profile
+    validate_kind_rules(rules: @kind_rules_for_validation || rules)
   end
 
   def validate_against_schema(attr, value, schema)

--- a/services/console/app/services/credential_profiles/github_token.rb
+++ b/services/console/app/services/credential_profiles/github_token.rb
@@ -1,0 +1,57 @@
+module CredentialProfiles
+  # GitHub API clients authenticate with Bearer/token while Git-over-HTTPS uses
+  # HTTP Basic. Replacing a placeholder preserves the scheme selected by each
+  # client and confines the credential to GitHub's API and Git hosts.
+  module GithubToken
+    KIND = "github_token"
+    REPLACE_CONFIG = {
+      "proxy_value" => "GITHUB_TOKEN",
+      "match_headers" => [ "Authorization" ],
+      "require" => false
+    }.freeze
+    RULE_ATTRIBUTES = [
+      { host: "api.github.com", http_methods: [], paths: [], position: 0 },
+      { host: "github.com", http_methods: [], paths: [], position: 1 }
+    ].freeze
+
+    module_function
+
+    def apply_defaults(secret, rules:)
+      if secret.inject_config.blank? && canonical_replace_config?(secret.replace_config)
+        secret.replace_config = REPLACE_CONFIG.deep_dup
+      end
+      rules.presence || RULE_ATTRIBUTES.map { |attributes| RequestRule.new(attributes) }
+    end
+
+    def validate_config(secret)
+      return if secret.inject_config.blank? && secret.replace_config == REPLACE_CONFIG
+
+      secret.errors.add(
+        :base,
+        "github_token credentials must use the canonical Authorization placeholder replacement"
+      )
+    end
+
+    def validate_rules(secret, rules:)
+      actual = Array(rules).map do |rule|
+        {
+          host: rule.host,
+          cidr: rule.cidr,
+          http_methods: rule.http_methods,
+          paths: rule.paths,
+          position: rule.position
+        }.compact
+      end
+      return if actual == RULE_ATTRIBUTES
+
+      secret.errors.add(
+        :rules,
+        "github_token credentials must target only api.github.com and github.com"
+      )
+    end
+
+    def canonical_replace_config?(config)
+      config.blank? || config == REPLACE_CONFIG || config == REPLACE_CONFIG.except("require")
+    end
+  end
+end

--- a/services/console/app/services/credential_profiles/registry.rb
+++ b/services/console/app/services/credential_profiles/registry.rb
@@ -1,0 +1,31 @@
+module CredentialProfiles
+  # Maps a persisted StaticSecret kind to the implementation that owns its
+  # canonical proxy configuration and request rules. "custom" deliberately has
+  # no profile: operators continue to configure those secrets directly.
+  module Registry
+    CUSTOM_KIND = "custom"
+    PROFILES = {
+      GithubToken::KIND => GithubToken
+    }.freeze
+    KINDS = [ CUSTOM_KIND, *PROFILES.keys ].freeze
+
+    module_function
+
+    def kinds
+      KINDS
+    end
+
+    def apply_defaults(secret, rules:)
+      profile = PROFILES[secret.kind]
+      profile ? profile.apply_defaults(secret, rules: rules) : rules
+    end
+
+    def validate_config(secret)
+      PROFILES[secret.kind]&.validate_config(secret)
+    end
+
+    def validate_rules(secret, rules:)
+      PROFILES[secret.kind]&.validate_rules(secret, rules: rules)
+    end
+  end
+end

--- a/services/console/app/views/console/base_secrets/_form_static.html.erb
+++ b/services/console/app/views/console/base_secrets/_form_static.html.erb
@@ -7,6 +7,14 @@
   <div class="space-y-6">
     <%= render "identity_fields", secret: secret %>
 
+    <section class="form-section">
+      <h2 class="form-section-heading">Credential profile</h2>
+      <%= select_tag "static[kind]",
+                     options_for_select([ [ "Custom", "custom" ], [ "GitHub token", "github_token" ] ], secret.kind),
+                     class: "form-input" %>
+      <p class="form-hint">Profiles apply and validate the proxy configuration and request rules for known credential types.</p>
+    </section>
+
     <section data-controller="toggle" class="form-section">
       <h2 class="form-section-heading">Injection</h2>
       <% inject_errors = secret.errors[:base] + secret.errors[:inject_config] + secret.errors[:replace_config] %>

--- a/services/console/app/views/console/secret.html.erb
+++ b/services/console/app/views/console/secret.html.erb
@@ -148,6 +148,7 @@
   end
   case @secret
   when StaticSecret
+    rows << [ "Credential profile", @secret.kind ]
     rows << [ "Mode", @secret.replace_config.present? ? "replace" : "inject" ]
   when GcpAuthSecret
     rows << [ "Subject", @secret.subject ] if @secret.subject.present?

--- a/services/console/db/migrate/20260806190000_replace_github_bearer_injection.rb
+++ b/services/console/db/migrate/20260806190000_replace_github_bearer_injection.rb
@@ -1,0 +1,45 @@
+class ReplaceGithubBearerInjection < ActiveRecord::Migration[8.1]
+  def up
+    execute <<~SQL.squish
+      WITH updated_secrets AS (
+        UPDATE static_secrets
+        SET inject_config = NULL,
+            replace_config = jsonb_build_object(
+              'proxy_value', 'GITHUB_TOKEN',
+              'match_headers', jsonb_build_array('Authorization'),
+              'require', FALSE
+            ),
+            updated_at = CURRENT_TIMESTAMP
+        WHERE lower(COALESCE(inject_config->>'header', '')) = 'authorization'
+          AND inject_config->>'formatter' = 'Bearer {{ .Value }}'
+          AND EXISTS (
+            SELECT 1
+            FROM request_rules
+            WHERE request_rules.static_secret_id = static_secrets.id
+              AND lower(request_rules.host) = 'github.com'
+          )
+        RETURNING id
+      ), affected_principals AS (
+        SELECT grants.principal_id AS id
+        FROM grants
+        INNER JOIN updated_secrets ON updated_secrets.id = grants.static_secret_id
+        WHERE grants.principal_id IS NOT NULL
+        UNION
+        SELECT principal_roles.principal_id AS id
+        FROM grants
+        INNER JOIN updated_secrets ON updated_secrets.id = grants.static_secret_id
+        INNER JOIN principal_roles ON principal_roles.role_id = grants.role_id
+        WHERE grants.role_id IS NOT NULL
+      )
+      UPDATE principals
+      SET sync_config_cache_version = sync_config_cache_version + 1,
+          updated_at = CURRENT_TIMESTAMP
+      WHERE principals.id IN (SELECT id FROM affected_principals)
+    SQL
+  end
+
+  def down
+    # One-way credential repair. Operators can edit these secrets after rollout,
+    # so rollback must not restore a stale Bearer configuration over later work.
+  end
+end

--- a/services/console/db/migrate/20260806190100_add_kind_to_static_secrets.rb
+++ b/services/console/db/migrate/20260806190100_add_kind_to_static_secrets.rb
@@ -1,0 +1,5 @@
+class AddKindToStaticSecrets < ActiveRecord::Migration[8.1]
+  def change
+    add_column :static_secrets, :kind, :string, default: "custom", null: false
+  end
+end

--- a/services/console/db/migrate/20260806190200_backfill_github_token_kind.rb
+++ b/services/console/db/migrate/20260806190200_backfill_github_token_kind.rb
@@ -1,0 +1,54 @@
+class BackfillGithubTokenKind < ActiveRecord::Migration[8.1]
+  def up
+    execute <<~SQL.squish
+      UPDATE static_secrets
+        SET kind = 'github_token',
+            inject_config = NULL,
+            replace_config = jsonb_build_object(
+              'proxy_value', 'GITHUB_TOKEN',
+              'match_headers', jsonb_build_array('Authorization'),
+              'require', FALSE
+            ),
+            updated_at = CURRENT_TIMESTAMP
+        WHERE kind = 'custom'
+          AND (
+            (
+              lower(COALESCE(inject_config->>'header', '')) = 'authorization'
+              AND inject_config->>'formatter' = 'Bearer {{ .Value }}'
+            )
+            OR replace_config = jsonb_build_object(
+              'proxy_value', 'GITHUB_TOKEN',
+              'match_headers', jsonb_build_array('Authorization'),
+              'require', FALSE
+            )
+          )
+          AND EXISTS (
+            SELECT 1 FROM request_rules
+            WHERE request_rules.static_secret_id = static_secrets.id
+              AND request_rules.host = 'api.github.com'
+              AND request_rules.cidr IS NULL
+              AND request_rules.http_methods = '[]'::jsonb
+              AND request_rules.paths = '[]'::jsonb
+              AND request_rules.position = 0
+          )
+          AND EXISTS (
+            SELECT 1 FROM request_rules
+            WHERE request_rules.static_secret_id = static_secrets.id
+              AND request_rules.host = 'github.com'
+              AND request_rules.cidr IS NULL
+              AND request_rules.http_methods = '[]'::jsonb
+              AND request_rules.paths = '[]'::jsonb
+              AND request_rules.position = 1
+          )
+          AND 2 = (
+            SELECT COUNT(*) FROM request_rules
+            WHERE request_rules.static_secret_id = static_secrets.id
+          )
+    SQL
+  end
+
+  def down
+    # One-way classification of the credential repaired by the preceding
+    # migration. The schema migration removes kind on a full rollback.
+  end
+end

--- a/services/console/db/schema.rb
+++ b/services/console/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_02_170149) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_06_190000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 

--- a/services/console/db/schema.rb
+++ b/services/console/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_06_190000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_06_190200) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -434,6 +434,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_06_190000) do
     t.string "description"
     t.string "foreign_id"
     t.jsonb "inject_config"
+    t.string "kind", default: "custom", null: false
     t.jsonb "labels", default: {}, null: false
     t.string "name"
     t.string "namespace", default: "default", null: false

--- a/services/console/lib/oauth/providers/github.rb
+++ b/services/console/lib/oauth/providers/github.rb
@@ -13,31 +13,18 @@ module Oauth
       TOKEN_ENDPOINT = "https://github.com/login/oauth/access_token"
       USER_ENDPOINT = "https://api.github.com/user"
       IDENTITY_SCOPES = [].freeze
-      API_HOSTS = %w[api.github.com github.com].freeze
 
       def key = KEY
       def display_name = "GitHub"
       def authorization_endpoint = AUTHORIZATION_ENDPOINT
       def token_endpoint = TOKEN_ENDPOINT
       def identity_scopes = IDENTITY_SCOPES
-      def api_hosts = API_HOSTS
       def authorization_scope_param = "scope"
       def scope_separator = " "
       def extra_authorization_params = {}
       def refreshable? = false
 
-      # GitHub API clients send token/Bearer authorization while Git-over-HTTPS
-      # sends HTTP Basic. Replace only the placeholder value so each client keeps
-      # the authentication scheme its endpoint expects.
-      def wrapping_secret_config
-        {
-          replace_config: {
-            "proxy_value" => "GITHUB_TOKEN",
-            "match_headers" => [ "Authorization" ],
-            "require" => false
-          }
-        }
-      end
+      def wrapping_secret_kind = CredentialProfiles::GithubToken::KIND
 
       def parse_granted_scopes(scope)
         scope.to_s.split(/[,\s]+/).reject(&:blank?)

--- a/services/console/lib/oauth/providers/github.rb
+++ b/services/console/lib/oauth/providers/github.rb
@@ -26,6 +26,19 @@ module Oauth
       def extra_authorization_params = {}
       def refreshable? = false
 
+      # GitHub API clients send token/Bearer authorization while Git-over-HTTPS
+      # sends HTTP Basic. Replace only the placeholder value so each client keeps
+      # the authentication scheme its endpoint expects.
+      def wrapping_secret_config
+        {
+          replace_config: {
+            "proxy_value" => "GITHUB_TOKEN",
+            "match_headers" => [ "Authorization" ],
+            "require" => false
+          }
+        }
+      end
+
       def parse_granted_scopes(scope)
         scope.to_s.split(/[,\s]+/).reject(&:blank?)
       end

--- a/services/console/test/controllers/api/v1/static_secrets_controller_test.rb
+++ b/services/console/test/controllers/api/v1/static_secrets_controller_test.rb
@@ -374,7 +374,7 @@ module Api
         assert_equal version, principal.reload.sync_config_cache_version
       end
 
-      test "PUT resolves an abbreviated unchanged profile before the no-op check" do
+      test "PUT preserves an omitted kind and resolves the profile before the no-op check" do
         ref = StaticSecret.create!(
           namespace: "acme",
           name: "GitHub token",
@@ -394,7 +394,6 @@ module Api
           data: {
             namespace: ref.namespace,
             name: ref.name,
-            kind: "github_token",
             source: { source_type: "control_plane", secret: "same-secret" }
           }
         }
@@ -403,9 +402,39 @@ module Api
         assert_response :ok
 
         ref.reload
+        assert_equal "github_token", ref.kind
         assert_equal source.id, ref.source.id
         assert_equal rule_ids, ref.rules.pluck(:id)
         assert_equal version, principal.reload.sync_config_cache_version
+      end
+
+      test "PUT replaces an existing profile kind when custom is explicit" do
+        ref = StaticSecret.create!(
+          namespace: "acme",
+          name: "GitHub token",
+          kind: "github_token",
+          replace_config: CredentialProfiles::GithubToken::REPLACE_CONFIG,
+          created_by: users(:acme_admin),
+          rules: CredentialProfiles::GithubToken::RULE_ATTRIBUTES.map { |attrs| RequestRule.new(attrs) }
+        )
+
+        body = {
+          data: {
+            namespace: ref.namespace,
+            name: ref.name,
+            kind: "custom",
+            inject_config: { "header" => "X-Token" },
+            rules: [ { host: "example.com" } ]
+          }
+        }
+
+        put api_v1_static_secret_url(id: ref.oid), params: body.to_json, headers: auth_headers
+        assert_response :ok
+
+        ref.reload
+        assert_equal "custom", ref.kind
+        assert_equal({ "header" => "X-Token" }, ref.inject_config)
+        assert_equal [ "example.com" ], ref.rules.map(&:host)
       end
 
       test "PUT does not retain omitted source fields" do

--- a/services/console/test/controllers/api/v1/static_secrets_controller_test.rb
+++ b/services/console/test/controllers/api/v1/static_secrets_controller_test.rb
@@ -45,6 +45,7 @@ module Api
         assert_equal ref.oid, data["id"]
         assert_equal ref.namespace, data["namespace"]
         assert_equal ref.name, data["name"]
+        assert_equal "custom", data["kind"]
         assert_equal({ "header" => "Authorization", "formatter" => "Bearer {{ .Value }}" },
                      data["inject_config"])
         assert_equal "env", data.dig("source", "source_type")
@@ -55,6 +56,50 @@ module Api
         assert_equal "api.github.com", rule["host"]
         assert_equal %w[GET POST], rule["http_methods"]
         assert_nil rule["id"], "rule should not expose its own id"
+      end
+
+      test "POST resolves a github_token profile into explicit configuration and rules" do
+        body = {
+          data: {
+            namespace: "acme",
+            name: "GitHub token",
+            kind: "github_token",
+            source: { source_type: "env", config: { "var" => "GITHUB_TOKEN" } }
+          }
+        }
+
+        assert_difference -> { StaticSecret.count } => 1,
+                          -> { RequestRule.count } => 2 do
+          post api_v1_static_secrets_url, params: body.to_json, headers: auth_headers
+        end
+        assert_response :created
+
+        data = json_body.fetch("data")
+        assert_equal "github_token", data["kind"]
+        assert_nil data["inject_config"]
+        assert_equal CredentialProfiles::GithubToken::REPLACE_CONFIG, data["replace_config"]
+        assert_equal %w[api.github.com github.com], data["rules"].map { |rule| rule["host"] }
+      end
+
+      test "POST rejects configuration that conflicts with the selected profile" do
+        body = {
+          data: {
+            namespace: "acme",
+            name: "misconfigured GitHub token",
+            kind: "github_token",
+            inject_config: { "header" => "Authorization", "formatter" => "Bearer {{ .Value }}" },
+            rules: [ { host: "github.com" } ]
+          }
+        }
+
+        assert_no_difference [ "StaticSecret.count", "RequestRule.count" ] do
+          post api_v1_static_secrets_url, params: body.to_json, headers: auth_headers
+        end
+        assert_response :unprocessable_content
+        assert_includes json_body.dig("error", "details", "base"),
+                        "github_token credentials must use the canonical Authorization placeholder replacement"
+        assert_includes json_body.dig("error", "details", "rules"),
+                        "github_token credentials must target only api.github.com and github.com"
       end
 
       test "GET returns 404 for an unknown oid" do
@@ -326,6 +371,40 @@ module Api
         ref.reload
         assert_equal source.id, ref.source.id
         assert_equal [ rule.id ], ref.rules.pluck(:id)
+        assert_equal version, principal.reload.sync_config_cache_version
+      end
+
+      test "PUT resolves an abbreviated unchanged profile before the no-op check" do
+        ref = StaticSecret.create!(
+          namespace: "acme",
+          name: "GitHub token",
+          kind: "github_token",
+          replace_config: CredentialProfiles::GithubToken::REPLACE_CONFIG,
+          created_by: users(:acme_admin),
+          rules: CredentialProfiles::GithubToken::RULE_ATTRIBUTES.map { |attrs| RequestRule.new(attrs) }
+        )
+        source = SecretSource.create!(source_type: "control_plane", secret: "same-secret",
+                                      static_secret: ref)
+        rule_ids = ref.rules.pluck(:id)
+        principal = principals(:acme_channel)
+        Grant.create!(principal: principal, static_secret: ref, created_by: users(:acme_admin))
+        version = principal.reload.sync_config_cache_version
+
+        body = {
+          data: {
+            namespace: ref.namespace,
+            name: ref.name,
+            kind: "github_token",
+            source: { source_type: "control_plane", secret: "same-secret" }
+          }
+        }
+
+        put api_v1_static_secret_url(id: ref.oid), params: body.to_json, headers: auth_headers
+        assert_response :ok
+
+        ref.reload
+        assert_equal source.id, ref.source.id
+        assert_equal rule_ids, ref.rules.pluck(:id)
         assert_equal version, principal.reload.sync_config_cache_version
       end
 

--- a/services/console/test/controllers/console/secrets_controller_test.rb
+++ b/services/console/test/controllers/console/secrets_controller_test.rb
@@ -80,6 +80,49 @@ module Console
       assert_response :unprocessable_entity
     end
 
+    test "POST create resolves the GitHub token profile" do
+      assert_difference -> { StaticSecret.count } => 1,
+                        -> { RequestRule.count } => 2 do
+        post console_static_secrets_url, params: {
+          secret: { namespace: "acme", name: "GitHub token", foreign_id: "github-token" },
+          static: { kind: "github_token", mode: "inject" },
+          source: { source_type: "env", reference: "GITHUB_TOKEN" }
+        }
+      end
+
+      secret = StaticSecret.find_by!(namespace: "acme", foreign_id: "github-token")
+      assert_equal "github_token", secret.kind
+      assert_nil secret.inject_config
+      assert_equal CredentialProfiles::GithubToken::REPLACE_CONFIG, secret.replace_config
+      assert_equal %w[api.github.com github.com], secret.rules.map(&:host)
+    end
+
+    test "PATCH preserves a GitHub token profile through the form representation" do
+      secret = StaticSecret.create!(
+        namespace: "acme",
+        name: "GitHub token",
+        kind: "github_token",
+        replace_config: CredentialProfiles::GithubToken::REPLACE_CONFIG,
+        rules: CredentialProfiles::GithubToken::RULE_ATTRIBUTES.map { |attrs| RequestRule.new(attrs) }
+      )
+
+      patch console_static_secret_url(secret.oid), params: {
+        secret: { namespace: "acme", name: "renamed GitHub token" },
+        static: {
+          kind: "github_token", mode: "replace", proxy_value: "GITHUB_TOKEN",
+          match_headers: "Authorization"
+        },
+        rules: {
+          "0" => { host: "api.github.com" },
+          "1" => { host: "github.com" }
+        }
+      }
+
+      assert_redirected_to console_secret_path("static", secret.oid)
+      assert_equal "renamed GitHub token", secret.reload.name
+      assert_equal CredentialProfiles::GithubToken::REPLACE_CONFIG, secret.replace_config
+    end
+
     test "POST create with an invalid nested rule is rejected without writing" do
       assert_no_difference [ "StaticSecret.count", "RequestRule.count" ] do
         post console_static_secrets_url, params: {

--- a/services/console/test/controllers/oauth/flows_controller_test.rb
+++ b/services/console/test/controllers/oauth/flows_controller_test.rb
@@ -434,6 +434,15 @@ module Oauth
       assert_nil cred.next_attempt_at
       assert_equal [ "api.github.com", "github.com" ], cred.static_secret.rules.map(&:host)
       assert_equal "GitHub – Pending GitHub account token", cred.static_secret.name
+      assert_nil cred.static_secret.inject_config
+      assert_equal(
+        {
+          "proxy_value" => "GITHUB_TOKEN",
+          "match_headers" => [ "Authorization" ],
+          "require" => false
+        },
+        cred.static_secret.replace_config
+      )
       refute_includes BrokerCredential.refreshable, cred
     end
 

--- a/services/console/test/controllers/oauth/flows_controller_test.rb
+++ b/services/console/test/controllers/oauth/flows_controller_test.rb
@@ -434,6 +434,7 @@ module Oauth
       assert_nil cred.next_attempt_at
       assert_equal [ "api.github.com", "github.com" ], cred.static_secret.rules.map(&:host)
       assert_equal "GitHub – Pending GitHub account token", cred.static_secret.name
+      assert_equal "github_token", cred.static_secret.kind
       assert_nil cred.static_secret.inject_config
       assert_equal(
         {

--- a/services/console/test/lib/oauth/providers/github_test.rb
+++ b/services/console/test/lib/oauth/providers/github_test.rb
@@ -37,6 +37,17 @@ module Oauth
         assert_equal "https://github.com/login/oauth/authorize", strategy.authorization_endpoint
         assert_equal "https://github.com/login/oauth/access_token", strategy.token_endpoint
         assert_equal [], strategy.identity_scopes
+        assert_equal %w[api.github.com github.com], strategy.api_hosts
+        assert_equal(
+          {
+            replace_config: {
+              "proxy_value" => "GITHUB_TOKEN",
+              "match_headers" => [ "Authorization" ],
+              "require" => false
+            }
+          },
+          strategy.wrapping_secret_config
+        )
         assert_equal "scope", strategy.authorization_scope_param
         assert_equal " ", strategy.scope_separator
         refute strategy.refreshable?

--- a/services/console/test/lib/oauth/providers/github_test.rb
+++ b/services/console/test/lib/oauth/providers/github_test.rb
@@ -37,17 +37,7 @@ module Oauth
         assert_equal "https://github.com/login/oauth/authorize", strategy.authorization_endpoint
         assert_equal "https://github.com/login/oauth/access_token", strategy.token_endpoint
         assert_equal [], strategy.identity_scopes
-        assert_equal %w[api.github.com github.com], strategy.api_hosts
-        assert_equal(
-          {
-            replace_config: {
-              "proxy_value" => "GITHUB_TOKEN",
-              "match_headers" => [ "Authorization" ],
-              "require" => false
-            }
-          },
-          strategy.wrapping_secret_config
-        )
+        assert_equal "github_token", strategy.wrapping_secret_kind
         assert_equal "scope", strategy.authorization_scope_param
         assert_equal " ", strategy.scope_separator
         refute strategy.refreshable?

--- a/services/console/test/migrations/backfill_github_token_kind_test.rb
+++ b/services/console/test/migrations/backfill_github_token_kind_test.rb
@@ -1,0 +1,73 @@
+require "test_helper"
+require Rails.root.join("db/migrate/20260806190200_backfill_github_token_kind")
+
+class BackfillGithubTokenKindTest < ActiveSupport::TestCase
+  def create_github_secret!(name:, inject_config: nil, replace_config: nil)
+    secret = StaticSecret.create!(
+      namespace: "acme",
+      name: name,
+      inject_config: inject_config,
+      replace_config: replace_config,
+      created_by: users(:acme_admin)
+    )
+    RequestRule.create!(host: "api.github.com", position: 0, static_secret: secret)
+    RequestRule.create!(host: "github.com", position: 1, static_secret: secret)
+    secret
+  end
+
+  test "backfills canonical GitHub Bearer credentials" do
+    secret = create_github_secret!(
+      name: "legacy GitHub token",
+      inject_config: { "header" => "Authorization", "formatter" => "Bearer {{ .Value }}" }
+    )
+    BackfillGithubTokenKind.new.up
+
+    secret.reload
+    assert_equal "github_token", secret.kind
+    assert_nil secret.inject_config
+    assert_equal CredentialProfiles::GithubToken::REPLACE_CONFIG, secret.replace_config
+  end
+
+  test "marks an already repaired canonical GitHub credential with its kind" do
+    secret = create_github_secret!(
+      name: "repaired GitHub token",
+      replace_config: CredentialProfiles::GithubToken::REPLACE_CONFIG
+    )
+
+    BackfillGithubTokenKind.new.up
+
+    assert_equal "github_token", secret.reload.kind
+    assert_equal CredentialProfiles::GithubToken::REPLACE_CONFIG, secret.replace_config
+  end
+
+  test "leaves API-only, custom-format, and expanded GitHub credentials custom" do
+    api_only = StaticSecret.create!(
+      namespace: "acme",
+      name: "API token",
+      inject_config: { "header" => "Authorization", "formatter" => "Bearer {{ .Value }}" },
+      created_by: users(:acme_admin)
+    )
+    RequestRule.create!(host: "api.github.com", static_secret: api_only)
+
+    custom = StaticSecret.create!(
+      namespace: "acme",
+      name: "custom GitHub header",
+      inject_config: { "header" => "Authorization", "formatter" => "token {{ .Value }}" },
+      created_by: users(:acme_admin)
+    )
+    RequestRule.create!(host: "api.github.com", position: 0, static_secret: custom)
+    RequestRule.create!(host: "github.com", position: 1, static_secret: custom)
+
+    expanded = create_github_secret!(
+      name: "expanded GitHub token",
+      inject_config: { "header" => "Authorization", "formatter" => "Bearer {{ .Value }}" }
+    )
+    RequestRule.create!(host: "uploads.github.com", position: 2, static_secret: expanded)
+
+    BackfillGithubTokenKind.new.up
+
+    assert_equal "custom", api_only.reload.kind
+    assert_equal "custom", custom.reload.kind
+    assert_equal "custom", expanded.reload.kind
+  end
+end

--- a/services/console/test/migrations/replace_github_bearer_injection_test.rb
+++ b/services/console/test/migrations/replace_github_bearer_injection_test.rb
@@ -1,0 +1,57 @@
+require "test_helper"
+require Rails.root.join("db/migrate/20260806190000_replace_github_bearer_injection")
+
+class ReplaceGithubBearerInjectionTest < ActiveSupport::TestCase
+  test "converts GitHub host Bearer injection and invalidates granted principal snapshots" do
+    secret = StaticSecret.create!(
+      namespace: "acme",
+      name: "legacy GitHub token",
+      inject_config: { "header" => "Authorization", "formatter" => "Bearer {{ .Value }}" },
+      created_by: users(:acme_admin)
+    )
+    rule = RequestRule.create!(host: "github.invalid", static_secret: secret)
+    rule.update_column(:host, "github.com")
+    principal = principals(:acme_channel)
+    Grant.create!(principal: principal, static_secret: secret, created_by: users(:acme_admin))
+    previous_version = principal.reload.sync_config_cache_version
+
+    ReplaceGithubBearerInjection.new.up
+
+    secret.reload
+    assert_nil secret.inject_config
+    assert_equal(
+      {
+        "proxy_value" => "GITHUB_TOKEN",
+        "match_headers" => [ "Authorization" ],
+        "require" => false
+      },
+      secret.replace_config
+    )
+    assert_equal previous_version + 1, principal.reload.sync_config_cache_version
+  end
+
+  test "leaves API-only and non-Bearer GitHub credentials unchanged" do
+    api_only = StaticSecret.create!(
+      namespace: "acme",
+      name: "API token",
+      inject_config: { "header" => "Authorization", "formatter" => "Bearer {{ .Value }}" },
+      created_by: users(:acme_admin)
+    )
+    RequestRule.create!(host: "api.github.com", static_secret: api_only)
+    custom = StaticSecret.create!(
+      namespace: "acme",
+      name: "custom GitHub header",
+      inject_config: { "header" => "Authorization", "formatter" => "token {{ .Value }}" },
+      created_by: users(:acme_admin)
+    )
+    rule = RequestRule.create!(host: "github.invalid", static_secret: custom)
+    rule.update_column(:host, "github.com")
+
+    ReplaceGithubBearerInjection.new.up
+
+    assert api_only.reload.inject_config.present?
+    assert_nil api_only.replace_config
+    assert custom.reload.inject_config.present?
+    assert_nil custom.replace_config
+  end
+end

--- a/services/console/test/migrations/replace_github_bearer_injection_test.rb
+++ b/services/console/test/migrations/replace_github_bearer_injection_test.rb
@@ -9,8 +9,7 @@ class ReplaceGithubBearerInjectionTest < ActiveSupport::TestCase
       inject_config: { "header" => "Authorization", "formatter" => "Bearer {{ .Value }}" },
       created_by: users(:acme_admin)
     )
-    rule = RequestRule.create!(host: "github.invalid", static_secret: secret)
-    rule.update_column(:host, "github.com")
+    RequestRule.create!(host: "github.com", static_secret: secret)
     principal = principals(:acme_channel)
     Grant.create!(principal: principal, static_secret: secret, created_by: users(:acme_admin))
     previous_version = principal.reload.sync_config_cache_version
@@ -19,14 +18,7 @@ class ReplaceGithubBearerInjectionTest < ActiveSupport::TestCase
 
     secret.reload
     assert_nil secret.inject_config
-    assert_equal(
-      {
-        "proxy_value" => "GITHUB_TOKEN",
-        "match_headers" => [ "Authorization" ],
-        "require" => false
-      },
-      secret.replace_config
-    )
+    assert_equal CredentialProfiles::GithubToken::REPLACE_CONFIG, secret.replace_config
     assert_equal previous_version + 1, principal.reload.sync_config_cache_version
   end
 
@@ -44,8 +36,7 @@ class ReplaceGithubBearerInjectionTest < ActiveSupport::TestCase
       inject_config: { "header" => "Authorization", "formatter" => "token {{ .Value }}" },
       created_by: users(:acme_admin)
     )
-    rule = RequestRule.create!(host: "github.invalid", static_secret: custom)
-    rule.update_column(:host, "github.com")
+    RequestRule.create!(host: "github.com", static_secret: custom)
 
     ReplaceGithubBearerInjection.new.up
 

--- a/services/console/test/models/request_rule_test.rb
+++ b/services/console/test/models/request_rule_test.rb
@@ -123,4 +123,36 @@ class RequestRuleTest < ActiveSupport::TestCase
     assert_not r.valid?
     assert_includes r.errors[:base], "must belong to at most one of static_secret, gcp_auth_secret, gcp_id_token_secret, aws_auth_secret, oauth_token_secret, hmac_secret"
   end
+
+  test "rejects Bearer injection for github.com" do
+    r = new_rule(host: "github.com", static_secret: static_secrets(:github_token_inject))
+
+    assert_not r.valid?
+    assert_includes(
+      r.errors[:base],
+      "github.com Bearer credentials must replace a placeholder so Git can preserve HTTP Basic authentication"
+    )
+  end
+
+  test "accepts Authorization placeholder replacement for github.com" do
+    r = new_rule(host: "github.com", static_secret: static_secrets(:db_password_replace))
+
+    assert r.valid?, r.errors.full_messages.inspect
+  end
+
+  test "allows API-only GitHub Bearer injection" do
+    r = new_rule(host: "api.github.com", static_secret: static_secrets(:github_token_inject))
+
+    assert r.valid?, r.errors.full_messages.inspect
+  end
+
+  test "does not reinterpret custom github.com Authorization formats" do
+    secret = StaticSecret.new(
+      namespace: "acme",
+      inject_config: { "header" => "Authorization", "formatter" => "Basic {{ .Value }}" }
+    )
+    r = new_rule(host: "github.com", static_secret: secret)
+
+    assert r.valid?, r.errors.full_messages.inspect
+  end
 end

--- a/services/console/test/models/request_rule_test.rb
+++ b/services/console/test/models/request_rule_test.rb
@@ -123,36 +123,4 @@ class RequestRuleTest < ActiveSupport::TestCase
     assert_not r.valid?
     assert_includes r.errors[:base], "must belong to at most one of static_secret, gcp_auth_secret, gcp_id_token_secret, aws_auth_secret, oauth_token_secret, hmac_secret"
   end
-
-  test "rejects Bearer injection for github.com" do
-    r = new_rule(host: "github.com", static_secret: static_secrets(:github_token_inject))
-
-    assert_not r.valid?
-    assert_includes(
-      r.errors[:base],
-      "github.com Bearer credentials must replace a placeholder so Git can preserve HTTP Basic authentication"
-    )
-  end
-
-  test "accepts Authorization placeholder replacement for github.com" do
-    r = new_rule(host: "github.com", static_secret: static_secrets(:db_password_replace))
-
-    assert r.valid?, r.errors.full_messages.inspect
-  end
-
-  test "allows API-only GitHub Bearer injection" do
-    r = new_rule(host: "api.github.com", static_secret: static_secrets(:github_token_inject))
-
-    assert r.valid?, r.errors.full_messages.inspect
-  end
-
-  test "does not reinterpret custom github.com Authorization formats" do
-    secret = StaticSecret.new(
-      namespace: "acme",
-      inject_config: { "header" => "Authorization", "formatter" => "Basic {{ .Value }}" }
-    )
-    r = new_rule(host: "github.com", static_secret: secret)
-
-    assert r.valid?, r.errors.full_messages.inspect
-  end
 end

--- a/services/console/test/models/static_secret_test.rb
+++ b/services/console/test/models/static_secret_test.rb
@@ -28,6 +28,17 @@ class StaticSecretTest < ActiveSupport::TestCase
     assert StaticSecret.new(valid_replace_attrs).valid?
   end
 
+  test "kind defaults to custom" do
+    assert_equal "custom", StaticSecret.new.kind
+  end
+
+  test "rejects an unknown credential kind" do
+    ref = StaticSecret.new(valid_inject_attrs(kind: "githubish"))
+
+    assert_not ref.valid?
+    assert_includes ref.errors[:kind], "is not included in the list"
+  end
+
   test "rejects a foreign_id that starts with the opaque id prefix" do
     ref = StaticSecret.new(valid_inject_attrs(foreign_id: "ssr_abc123"))
     assert_not ref.valid?

--- a/services/console/test/services/credential_profiles/github_token_test.rb
+++ b/services/console/test/services/credential_profiles/github_token_test.rb
@@ -1,0 +1,58 @@
+require "test_helper"
+
+module CredentialProfiles
+  class GithubTokenTest < ActiveSupport::TestCase
+    test "applies canonical configuration and explicit request rules" do
+      secret = StaticSecret.new(namespace: "acme", kind: "github_token")
+
+      rules = secret.apply_kind_defaults(rules: [])
+      secret.rules = rules
+
+      assert_nil secret.inject_config
+      assert_equal GithubToken::REPLACE_CONFIG, secret.replace_config
+      assert_equal GithubToken::RULE_ATTRIBUTES, rules.map { |rule|
+        rule.attributes.symbolize_keys.slice(:host, :http_methods, :paths, :position)
+      }
+      assert secret.valid?, secret.errors.full_messages.inspect
+    end
+
+    test "does not overwrite conflicting caller configuration or rules" do
+      secret = StaticSecret.new(
+        namespace: "acme",
+        kind: "github_token",
+        inject_config: { "header" => "Authorization", "formatter" => "Bearer {{ .Value }}" }
+      )
+      supplied_rules = [ RequestRule.new(host: "example.com") ]
+
+      rules = secret.apply_kind_defaults(rules: supplied_rules)
+      secret.rules = rules
+
+      assert_same supplied_rules, rules
+      assert_not secret.valid?
+      assert_includes secret.errors[:base],
+                      "github_token credentials must use the canonical Authorization placeholder replacement"
+      assert_includes secret.errors[:rules],
+                      "github_token credentials must target only api.github.com and github.com"
+    end
+
+    test "normalizes an omitted false require flag" do
+      secret = StaticSecret.new(
+        namespace: "acme",
+        kind: "github_token",
+        replace_config: GithubToken::REPLACE_CONFIG.except("require")
+      )
+
+      secret.apply_kind_defaults(rules: [])
+
+      assert_equal GithubToken::REPLACE_CONFIG, secret.replace_config
+    end
+
+    test "custom secrets are not changed by the registry" do
+      secret = StaticSecret.new(namespace: "acme", inject_config: { "header" => "X-Api-Key" })
+      rules = [ RequestRule.new(host: "example.com") ]
+
+      assert_same rules, secret.apply_kind_defaults(rules: rules)
+      assert_equal({ "header" => "X-Api-Key" }, secret.inject_config)
+    end
+  end
+end

--- a/services/sandbox/entrypoint.sh
+++ b/services/sandbox/entrypoint.sh
@@ -465,17 +465,18 @@ if [ -n "${CENTAUR_TOOLS_URL:-}" ]; then
     done
 fi
 
-# Signal readiness
-touch "$HOME_DIR/.ready"
-
-# ── Background: slow auth tasks ─────────────────────────────────────────────
-{
-    if [ -n "${GITHUB_TOKEN:-}" ]; then
-        git config --global credential.helper store
-        printf 'https://oauth2:%s@github.com\n' "$GITHUB_TOKEN" > "$HOME_DIR/.git-credentials"
-        echo "${GITHUB_TOKEN}" | gh auth login --with-token 2>/dev/null || true
-        gh auth setup-git 2>/dev/null || true
+# Git and gh both read the placeholder token from the environment. Install gh's
+# credential helper before signalling readiness so Git can present that
+# placeholder as the HTTP Basic password for iron-proxy to replace. setup-git is
+# local-only; unlike `gh auth login`, it does not verify or persist the token.
+if [ -n "${GITHUB_TOKEN:-}" ]; then
+    if ! gh auth setup-git >/dev/null 2>&1; then
+        echo "failed to configure the GitHub credential helper" >&2
+        exit 1
     fi
-} &
+fi
+
+# Signal readiness only after every client-side credential helper is installed.
+touch "$HOME_DIR/.ready"
 
 exec "$@"


### PR DESCRIPTION
## Summary

- add a persisted `StaticSecret.kind` discriminator with backward-compatible `custom` behavior
- define a reusable credential-profile registry; `github_token` owns the canonical Authorization placeholder replacement and explicit rules for `api.github.com` and `github.com`
- have GitHub OAuth wrappers select `github_token` instead of embedding GitHub-specific proxy behavior in the provider or `RequestRule`
- preserve an existing profile kind when older API clients omit the new field during updates
- migrate legacy/repaired GitHub credentials to the new kind conservatively
- finish Git credential-helper setup before sandbox readiness

## Root cause

GitHub API requests accept Bearer tokens, while Git-over-HTTPS sends HTTP Basic credentials. The previous managed static secret injected `Authorization: Bearer ...` for both hosts, overwriting Git's Basic header and causing 401s even for public repositories.

## Design

`kind` is the persisted selector. Implementations live under `app/services/credential_profiles/`, and the resolved proxy configuration and request rules remain ordinary database rows so they stay visible in the console and in sync snapshots. `custom` secrets are unchanged.

The shared `infra` transform remains absent, so GitHub credentials stay governed by per-principal grants.

## Validation

- full console suite: 1,405 runs, 5,484 assertions, 0 failures, 34 skips
- RuboCop: 340 files, no offenses
- Brakeman: 0 warnings
- sandbox unit suite: 34 tests, all passing
- `shellcheck services/sandbox/entrypoint.sh`
- migration-chain and profile-specific API/UI/OAuth regression tests
