### PR TITLE
fix(codex): disable subagents via agents.enabled=false

### DIFF
--- a/harness/codex/config.toml
+++ b/harness/codex/config.toml
@@ -19,6 +19,10 @@ enable_fanout = false
 runtime_metrics = true
 
 [agents]
+# Codex 0.144+: features.multi_agent{,_v2}=false is not enough — model catalog
+# multi_agent_version (e.g. gpt-5.6-sol → v2) still enables spawn_agent while
+# agents.enabled defaults to true. This is the hard kill switch.
+enabled = false
 max_depth = 2
 job_max_runtime_seconds = 1800
 

--- a/services/sandbox/entrypoint.sh
+++ b/services/sandbox/entrypoint.sh
@@ -194,6 +194,32 @@ else:
         rewritten.append(f"{name} = false")
     lines = lines[: features_start + 1] + rewritten + lines[features_end:]
 
+# Codex 0.144+: features.multi_agent{,_v2}=false alone does not disable
+# collaboration tools when the model catalog advertises multi_agent_version
+# (e.g. gpt-5.6-sol → v2) and agents.enabled defaults to true. Force the hard
+# kill switch here; CODEX_CONFIG_OVERLAY can still re-enable after this.
+agents_start = next((i for i, line in enumerate(lines) if line.strip() == "[agents]"), None)
+if agents_start is None:
+    lines.extend(["", "[agents]", "enabled = false"])
+else:
+    agents_end = next(
+        (i for i in range(agents_start + 1, len(lines)) if lines[i].lstrip().startswith("[")),
+        len(lines),
+    )
+    seen_enabled = False
+    rewritten = []
+    for line in lines[agents_start + 1 : agents_end]:
+        stripped = line.strip()
+        name = stripped.split("=", 1)[0].strip() if "=" in stripped else None
+        if name == "enabled":
+            rewritten.append("enabled = false")
+            seen_enabled = True
+        else:
+            rewritten.append(line)
+    if not seen_enabled:
+        rewritten.insert(0, "enabled = false")
+    lines = lines[: agents_start + 1] + rewritten + lines[agents_end:]
+
 # Optional deploy-time override of the codex reasoning effort. Lets a deployment
 # (e.g. an org overlay via sandbox.extraEnv) set the default without forking the
 # baked-in config.toml. Named after codex's own config key (model_reasoning_effort)


### PR DESCRIPTION
## Summary
- Set `[agents] enabled = false` in the baked Codex harness config and force the same key in the sandbox entrypoint (alongside the existing `features.multi_agent{,_v2}=false` rewrite).
- **Codex 0.144+:** clearing the multi-agent feature flags is insufficient. When `agents.enabled` stays at its default (`true`) and the model catalog advertises `multi_agent_version` (e.g. `gpt-5.6-sol` → `v2`), collaboration tools remain available in `explicitRequestOnly` mode, so skills can still call `spawn_agent`.
- **Impact:** a parent turn that spawned a collab review subagent was closed when the **child** emitted `turn/completed` (`completion_reason: turn_completed`, result text from the child). The parent continued afterward (`git push` / `gh pr create`), but those tool calls and the final answer never made it into Centaur `session_events` / the console UI — so the turn looked finished with no push tool call even though GitHub was updated.

`CODEX_CONFIG_OVERLAY` can still re-enable after the entrypoint force if a deployment wants subagents back.

Fixes #1287

Made with [Cursor](https://cursor.com)