### PR TITLE
feat(attio): add file uploads

### DIFF
--- a/tools/business/attio/cli.py
+++ b/tools/business/attio/cli.py
@@ -617,6 +617,26 @@ def add_note(
     console.print(f"[cyan]ID:[/] {note_id}")
 
 
+@app.command("upload-file")
+def upload_file(
+    object_slug: str = typer.Argument(..., help="Object slug (e.g., 'people', 'companies')"),
+    record_id: str = typer.Argument(..., help="Record ID to attach the file to"),
+    file_path: str = typer.Argument(..., help="Path to the local file (maximum 50 MB)"),
+    parent_folder_id: str = typer.Option(None, "--parent-folder", help="Optional folder ID"),
+):
+    """Upload a file, including a PDF, to an Attio record."""
+    client = _get_client()
+    uploaded = client.upload_file(
+        object_slug,
+        record_id,
+        file_path,
+        parent_folder_id=parent_folder_id,
+    )
+    file_id = uploaded.get("id", {}).get("file_id", "")
+    console.print(f"[green]✓ Uploaded {uploaded.get('name', file_path)}[/]")
+    console.print(f"[cyan]ID:[/] {file_id}")
+
+
 @app.command()
 def tasks(
     object_slug: str = typer.Option(None, "--object", "-o", help="Filter by linked object"),

--- a/tools/business/attio/client.py
+++ b/tools/business/attio/client.py
@@ -1,5 +1,7 @@
 """Attio API client."""
 
+import mimetypes
+from pathlib import Path
 from typing import Any
 
 import httpx
@@ -28,7 +30,6 @@ class AttioClient:
             base_url="https://api.attio.com/v2",
             headers={
                 "Authorization": f"Bearer {api_key}",
-                "Content-Type": "application/json",
             },
             timeout=30.0,
         )
@@ -234,6 +235,36 @@ class AttioClient:
             params={"parent_object": parent_object, "parent_record_id": parent_record_id},
         )
         return data.get("data", [])
+
+    def upload_file(
+        self,
+        object_slug: str,
+        record_id: str,
+        file_path: str,
+        parent_folder_id: str | None = None,
+    ) -> dict:
+        """Upload a local file to an Attio record's native file storage."""
+        path = Path(file_path)
+        if not path.is_file():
+            raise ValueError(f"File does not exist or is not a regular file: {file_path}")
+
+        max_size = 50 * 1024 * 1024
+        if path.stat().st_size > max_size:
+            raise ValueError("Attio files must be 50 MB or smaller")
+
+        form = {"object": object_slug, "record_id": record_id}
+        if parent_folder_id:
+            form["parent_folder_id"] = parent_folder_id
+
+        content_type = mimetypes.guess_type(path.name)[0] or "application/octet-stream"
+        with path.open("rb") as file_handle:
+            data = self._request(
+                "POST",
+                "/files/upload",
+                data=form,
+                files={"file": (path.name, file_handle, content_type)},
+            )
+        return data.get("data", {})
 
     def list_threads(
         self,

--- a/tools/business/attio/pyproject.toml
+++ b/tools/business/attio/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "attio"
-description = "Attio CRM — objects, records, lists, notes, tasks"
+description = "Attio CRM — objects, records, lists, notes, files, tasks"
 version = "0.1.0"
 requires-python = ">=3.11"
 dependencies = [

--- a/tools/business/attio/test_client.py
+++ b/tools/business/attio/test_client.py
@@ -1,0 +1,49 @@
+from pathlib import Path
+
+import httpx
+import pytest
+from client import AttioClient
+
+
+def test_upload_file_sends_multipart_pdf(tmp_path: Path) -> None:
+    pdf = tmp_path / "brief.pdf"
+    pdf.write_bytes(b"%PDF-1.7\nexample")
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/v2/files/upload"
+        assert request.headers["authorization"] == "Bearer test-key"
+        assert request.headers["content-type"].startswith("multipart/form-data; boundary=")
+        body = request.read()
+        assert b'name="object"' in body
+        assert b"companies" in body
+        assert b'name="record_id"' in body
+        assert b"bf071e1f-6035-429d-b874-d83ea64ea13b" in body
+        assert b'filename="brief.pdf"' in body
+        assert b"Content-Type: application/pdf" in body
+        assert b"%PDF-1.7" in body
+        return httpx.Response(
+            201,
+            json={"data": {"id": {"file_id": "file-123"}, "name": "brief.pdf"}},
+        )
+
+    client = AttioClient(api_key="test-key")
+    client._client = httpx.Client(
+        base_url="https://api.attio.com/v2",
+        headers={"Authorization": "Bearer test-key"},
+        transport=httpx.MockTransport(handler),
+    )
+
+    result = client.upload_file(
+        "companies",
+        "bf071e1f-6035-429d-b874-d83ea64ea13b",
+        str(pdf),
+    )
+
+    assert result == {"id": {"file_id": "file-123"}, "name": "brief.pdf"}
+
+
+def test_upload_file_rejects_missing_path(tmp_path: Path) -> None:
+    client = AttioClient(api_key="test-key")
+
+    with pytest.raises(ValueError, match="does not exist"):
+        client.upload_file("companies", "record-id", str(tmp_path / "missing.pdf"))


### PR DESCRIPTION
## Summary

- add multipart file uploads to Attio records, including PDFs
- remove the global JSON content type so httpx can set multipart boundaries
- validate local paths and Attio's 50 MB file limit
- expose `attio upload-file` and cover the request shape with tests

## Validation

- `ruff check tools/business/attio`
- `pytest -q tools/business/attio/test_client.py` (2 passed)
- built the wheel and verified `attio --help` exposes `upload-file`

Prompted by: @snario