### PR TITLE
chore(sandbox): bump Claude Code 2.1.154 -> 2.1.223

### DIFF
--- a/services/sandbox/Dockerfile
+++ b/services/sandbox/Dockerfile
@@ -88,7 +88,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 RUN useradd -m -s /bin/bash -u 1001 agent \
     && echo "agent ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers.d/agent
 
-ARG CLAUDE_CODE_VERSION=2.1.154
+ARG CLAUDE_CODE_VERSION=2.1.223
 ARG CODEX_VERSION=0.144.0
 ARG PI_CODING_AGENT_VERSION=0.67.2
 ARG NUSHELL_VERSION=0.112.2


### PR DESCRIPTION
## Summary

Bumps the sandbox image's pinned Claude Code CLI from `2.1.154` (set in #272 for Opus 4.8 rendering) to the current npm latest `2.1.223` — the pin is roughly two months of releases behind.

## Verification

- `2.1.223` installs and launches cleanly (`npm install @anthropic-ai/claude-code@2.1.223` → `claude --version` → `2.1.223 (Claude Code)`).
- The image build already self-verifies the pin (`claude --version | grep -F "${CLAUDE_CODE_VERSION}"`), so a bad publish fails the build rather than shipping.
- Only reference to the version in the tree is this Dockerfile ARG.

Given the earlier stream-json/harness interaction incident (#903/#918/#921), you may want to run whatever harness-server validation you use for CLI bumps before merging — happy to help test on our deployment (we run the published images and validated per-turn `--model` overrides end-to-end on the current image today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)