### PR TITLE
feat: add hybrid company context search

### DIFF
--- a/contrib/chart/Chart.yaml
+++ b/contrib/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: centaur
 description: Helm chart for the trusted Centaur control plane
 type: application
-version: 0.1.112
+version: 0.1.113
 appVersion: "0.1.0"
 dependencies:
   - name: connect

--- a/contrib/chart/templates/apirs.yaml
+++ b/contrib/chart/templates/apirs.yaml
@@ -70,6 +70,8 @@
 {{- $apiRsMetricsAnnotations = mergeOverwrite $apiRsMetricsAnnotations (.Values.apiRs.metrics.annotations | default dict) -}}
 {{- end -}}
 {{- $apiRsEtl := .Values.apiRs.etl | default dict -}}
+{{- $companyContextEmbeddingsEnabled := dig "companyContextEmbeddings" "enabled" false $apiRsEtl -}}
+{{- $companyContextEmbeddingsModel := dig "companyContextEmbeddings" "model" "text-embedding-3-small" $apiRsEtl -}}
 {{- $apiRsEtlEnv := list
   (dict "name" "SLACK_ETL_ENABLED" "value" (dig "slack" "enabled" false $apiRsEtl))
   (dict "name" "SLACK_SYNC_INTERVAL_SECONDS" "value" (dig "slack" "syncIntervalSeconds" 3600 $apiRsEtl))
@@ -97,10 +99,10 @@
   (dict "name" "COMPANY_CONTEXT_DOCUMENTS_INTERVAL_SECONDS" "value" (dig "companyContextDocuments" "intervalSeconds" 14400 $apiRsEtl))
   (dict "name" "COMPANY_CONTEXT_DOCUMENTS_MAX_WINDOW_SECONDS" "value" (dig "companyContextDocuments" "maxWindowSeconds" 21600 $apiRsEtl))
   (dict "name" "COMPANY_CONTEXT_DOCUMENTS_BATCH_SIZE" "value" (dig "companyContextDocuments" "batchSize" 50 $apiRsEtl))
-  (dict "name" "COMPANY_CONTEXT_EMBEDDINGS_ENABLED" "value" (dig "companyContextEmbeddings" "enabled" false $apiRsEtl))
+  (dict "name" "COMPANY_CONTEXT_EMBEDDINGS_ENABLED" "value" $companyContextEmbeddingsEnabled)
   (dict "name" "COMPANY_CONTEXT_EMBEDDINGS_INTERVAL_SECONDS" "value" (dig "companyContextEmbeddings" "intervalSeconds" 300 $apiRsEtl))
   (dict "name" "COMPANY_CONTEXT_EMBEDDINGS_BATCH_SIZE" "value" (dig "companyContextEmbeddings" "batchSize" 250 $apiRsEtl))
-  (dict "name" "COMPANY_CONTEXT_EMBEDDINGS_MODEL" "value" (dig "companyContextEmbeddings" "model" "text-embedding-3-small" $apiRsEtl))
+  (dict "name" "COMPANY_CONTEXT_EMBEDDINGS_MODEL" "value" $companyContextEmbeddingsModel)
 -}}
 {{- $apiRsEtlPassthroughNames := list -}}
 {{- range $env := $apiRsEtlEnv -}}
@@ -396,6 +398,12 @@ spec:
 {{- end }}
 {{- if and .Values.repoCache.enabled (gt (len $publicSkillDirs) 0) }}
 {{- $sandboxEnvList = append $sandboxEnvList (dict "name" "CENTAUR_PUBLIC_SKILL_DIRS" "value" (join ":" $publicSkillDirs)) }}
+{{- end }}
+{{- if not (hasKey .Values.sandbox.extraEnv "COMPANY_CONTEXT_EMBEDDINGS_ENABLED") }}
+{{- $sandboxEnvList = append $sandboxEnvList (dict "name" "COMPANY_CONTEXT_EMBEDDINGS_ENABLED" "value" ($companyContextEmbeddingsEnabled | toString)) }}
+{{- end }}
+{{- if not (hasKey .Values.sandbox.extraEnv "COMPANY_CONTEXT_EMBEDDINGS_MODEL") }}
+{{- $sandboxEnvList = append $sandboxEnvList (dict "name" "COMPANY_CONTEXT_EMBEDDINGS_MODEL" "value" $companyContextEmbeddingsModel) }}
 {{- end }}
 {{- range $k, $v := .Values.sandbox.extraEnv }}
 {{- $sandboxEnvList = append $sandboxEnvList (dict "name" $k "value" ($v | toString)) }}

--- a/contrib/chart/values.schema.json
+++ b/contrib/chart/values.schema.json
@@ -334,6 +334,15 @@
                 "maxWindowSeconds": { "type": "integer" },
                 "batchSize": { "type": "integer", "minimum": 1 }
               }
+            },
+            "companyContextEmbeddings": {
+              "type": "object",
+              "properties": {
+                "enabled": { "type": "boolean" },
+                "intervalSeconds": { "type": "integer", "minimum": 1 },
+                "batchSize": { "type": "integer", "minimum": 1 },
+                "model": { "type": "string", "minLength": 1 }
+              }
             }
           }
         },

--- a/contrib/chart/values.yaml
+++ b/contrib/chart/values.yaml
@@ -417,9 +417,11 @@ apiRs:
       maxWindowSeconds: 21600
       batchSize: 50
     companyContextEmbeddings:
+      # Enables the embedding workflow and hybrid search in agent sandboxes.
       enabled: false
       intervalSeconds: 300
       batchSize: 250
+      # Shared by the embedding workflow and company-context searches in agent sandboxes.
       model: text-embedding-3-small
   # Reaper: stop sandboxes older than the max lifetime, regardless of whether
   # they are running or suspended. 0 disables the sweep. Interval must be >= 1.

--- a/services/api-rs/crates/centaur-session-sqlx/experimental-migrations/company-context-embeddings/0001_create_company_context_document_embeddings.sql
+++ b/services/api-rs/crates/centaur-session-sqlx/experimental-migrations/company-context-embeddings/0001_create_company_context_document_embeddings.sql
@@ -41,6 +41,14 @@ create table if not exists company_context_document_embeddings (
     )
 );
 
+-- Keep the embedding writer available while this is applied to an existing
+-- experiment table. PostgreSQL requires concurrent index builds to run outside
+-- an explicit transaction.
+create index concurrently if not exists company_context_document_embeddings_embedding_hnsw_idx
+    on company_context_document_embeddings
+    using hnsw (embedding vector_cosine_ops)
+    where embedding is not null and not embedding_failed;
+
 do $$
 begin
     if not exists (

--- a/tools/productivity/company_context/cli.py
+++ b/tools/productivity/company_context/cli.py
@@ -129,6 +129,11 @@ def search(
     occurred_before: str | None = typer.Option(
         None, "--before", help="Only results before this time."
     ),
+    hybrid: bool = typer.Option(
+        True,
+        "--hybrid/--no-hybrid",
+        help="Fuse keyword and vector results when embeddings are enabled.",
+    ),
     json_output: bool = typer.Option(False, "--json", help="Output raw JSON."),
 ) -> None:
     """Search indexed company context, including Google Docs and Granola notes."""
@@ -139,6 +144,7 @@ def search(
         source_type=source_type,
         occurred_after=occurred_after,
         occurred_before=occurred_before,
+        hybrid=hybrid,
     )
     _require_ok(result)
     if json_output:

--- a/tools/productivity/company_context/client.py
+++ b/tools/productivity/company_context/client.py
@@ -20,6 +20,13 @@ from centaur_sdk.tool_sdk import secret
 
 DEFAULT_SEARCH_LIMIT = 10
 MAX_SEARCH_LIMIT = 50
+MIN_HYBRID_CANDIDATE_LIMIT = 30
+RRF_K = 60
+DEFAULT_EMBEDDINGS_MODEL = "text-embedding-3-small"
+EMBEDDINGS_DIMENSIONS = 1_536
+OPENAI_API_KEY_ENV = "OPENAI_API_KEY"
+COMPANY_CONTEXT_EMBEDDINGS_ENABLED_ENV = "COMPANY_CONTEXT_EMBEDDINGS_ENABLED"
+COMPANY_CONTEXT_EMBEDDINGS_MODEL_ENV = "COMPANY_CONTEXT_EMBEDDINGS_MODEL"
 DEFAULT_QUERY_LIMIT = 100
 MAX_QUERY_LIMIT = 1_000
 DEFAULT_QUERY_TIMEOUT_SECONDS = 10
@@ -552,11 +559,61 @@ def _company_context_filters_for_source(
     return source, source_type
 
 
+def _hybrid_candidate_limit(limit: int) -> int:
+    """Retrieve enough candidates for rank fusion without exceeding tool bounds."""
+    return min(MAX_SEARCH_LIMIT, max(limit, MIN_HYBRID_CANDIDATE_LIMIT))
+
+
+def _reciprocal_rank_fusion(
+    keyword_results: list[dict[str, Any]],
+    vector_results: list[dict[str, Any]],
+    *,
+    limit: int,
+) -> list[dict[str, Any]]:
+    """Fuse lexical and semantic ranks with equal-weight reciprocal rank fusion."""
+    fused: dict[str, dict[str, Any]] = {}
+
+    for lane, results in (("keyword", keyword_results), ("vector", vector_results)):
+        for rank, result in enumerate(results, start=1):
+            document_id = str(result.get("document_id") or "")
+            if not document_id:
+                continue
+            item = fused.setdefault(document_id, dict(result))
+            item["fusion_score"] = float(item.get("fusion_score") or 0.0) + 1.0 / (RRF_K + rank)
+            item[f"{lane}_rank"] = rank
+            if lane == "keyword":
+                item["keyword_score"] = float(result.get("score") or 0.0)
+            else:
+                item["vector_similarity"] = float(result.get("vector_similarity") or 0.0)
+
+    for item in fused.values():
+        lanes = [lane for lane in ("keyword", "vector") if f"{lane}_rank" in item]
+        item["lane"] = "hybrid" if len(lanes) == 2 else lanes[0]
+        item["matched_lanes"] = lanes
+        item["score"] = float(item["fusion_score"])
+
+    return sorted(
+        fused.values(),
+        key=lambda item: (
+            float(item.get("fusion_score") or 0.0),
+            str(item.get("source_updated_at") or ""),
+            str(item.get("document_id") or ""),
+        ),
+        reverse=True,
+    )[:limit]
+
+
 class CompanyContextClient:
     """Query the shared company context document table."""
 
-    def __init__(self, database_url: str | None = None) -> None:
+    def __init__(
+        self,
+        database_url: str | None = None,
+        *,
+        embeddings_client: Any | None = None,
+    ) -> None:
         self._database_url = (database_url or _scoped_database_url()).strip()
+        self._embeddings_client = embeddings_client
 
     def _require_database_url(self) -> str:
         if not self._database_url:
@@ -567,6 +624,38 @@ class CompanyContextClient:
         return await asyncpg.connect(
             _database_url_with_name(self._require_database_url(), _postgres_database_name()),
             command_timeout=30,
+        )
+
+    async def _query_embedding_async(self, query: str) -> str:
+        client = self._embeddings_client
+        if client is None:
+            api_key = secret(OPENAI_API_KEY_ENV, default="").strip()
+            if not api_key:
+                raise RuntimeError(f"{OPENAI_API_KEY_ENV} is not configured")
+            from openai import AsyncOpenAI
+
+            client = AsyncOpenAI(api_key=api_key)
+            self._embeddings_client = client
+
+        response = await client.embeddings.create(
+            model=self._embeddings_model(),
+            input=query,
+            dimensions=EMBEDDINGS_DIMENSIONS,
+            encoding_format="float",
+        )
+        data = list(response.data or [])
+        if not data or not data[0].embedding:
+            raise RuntimeError("OpenAI returned no query embedding")
+        return json.dumps(data[0].embedding, separators=(",", ":"))
+
+    @staticmethod
+    def _embeddings_model() -> str:
+        return (
+            os.getenv(  # noqa: TID251 - non-secret model configuration
+                COMPANY_CONTEXT_EMBEDDINGS_MODEL_ENV,
+                DEFAULT_EMBEDDINGS_MODEL,
+            ).strip()
+            or DEFAULT_EMBEDDINGS_MODEL
         )
 
     async def _query_async(
@@ -641,6 +730,7 @@ class CompanyContextClient:
         *,
         query: str,
         limit: int,
+        hybrid: bool,
         source: str | None,
         source_type: str | None,
         occurred_after: datetime | None,
@@ -648,6 +738,10 @@ class CompanyContextClient:
     ) -> dict[str, Any]:
         conn = await self._connect()
         try:
+            embeddings_available = hybrid and _env_flag_enabled(
+                COMPANY_CONTEXT_EMBEDDINGS_ENABLED_ENV, default=False
+            )
+            candidate_limit = _hybrid_candidate_limit(limit) if embeddings_available else limit
             terms = _search_terms(query)
             search_terms = [query, *terms]
             results = []
@@ -703,7 +797,7 @@ class CompanyContextClient:
                 company_source_type,
                 occurred_after,
                 occurred_before,
-                limit,
+                candidate_limit,
             )
             for row in rows:
                 result = _document_summary(row)
@@ -722,7 +816,7 @@ class CompanyContextClient:
                         conn,
                         search_terms=search_terms,
                         term_count=len(terms),
-                        limit=limit,
+                        limit=candidate_limit,
                         modified_after=occurred_after,
                         modified_before=occurred_before,
                     )
@@ -745,7 +839,7 @@ class CompanyContextClient:
                         conn,
                         search_terms=search_terms,
                         term_count=len(terms),
-                        limit=limit,
+                        limit=candidate_limit,
                         occurred_after=occurred_after,
                         occurred_before=occurred_before,
                     )
@@ -769,7 +863,36 @@ class CompanyContextClient:
                 ),
                 reverse=True,
             )
-            results = results[:limit]
+            keyword_results = results[:candidate_limit]
+            vector_results: list[dict[str, Any]] = []
+            if embeddings_available:
+                try:
+                    query_embedding = await self._query_embedding_async(query)
+                    vector_results = await self._search_vectors_async(
+                        conn,
+                        query=query,
+                        query_embedding=query_embedding,
+                        limit=candidate_limit,
+                        source=source,
+                        source_type=source_type,
+                        occurred_after=occurred_after,
+                        occurred_before=occurred_before,
+                    )
+                except Exception:
+                    # Embedding generation and the experimental vector schema are
+                    # both optional. Any incompatibility falls back to lexical.
+                    vector_results = []
+
+            if vector_results:
+                results = _reciprocal_rank_fusion(
+                    keyword_results,
+                    vector_results,
+                    limit=limit,
+                )
+                search_mode = "hybrid"
+            else:
+                results = keyword_results[:limit]
+                search_mode = "keyword"
 
             _emit_company_context_lookup_metrics(
                 status="ok",
@@ -787,8 +910,10 @@ class CompanyContextClient:
                 "source_type": source_type,
                 "occurred_after": _isoformat(occurred_after),
                 "occurred_before": _isoformat(occurred_before),
+                "search_mode": search_mode,
                 "count": len(results),
                 "indexed_count": len(results),
+                "vector_count": len(vector_results),
                 "results": results,
             }
             if google_docs_error:
@@ -893,6 +1018,197 @@ class CompanyContextClient:
             occurred_before,
             limit,
         )
+
+    async def _search_vectors_async(
+        self,
+        conn: asyncpg.Connection,
+        *,
+        query: str,
+        query_embedding: str,
+        limit: int,
+        source: str | None,
+        source_type: str | None,
+        occurred_after: datetime | None,
+        occurred_before: datetime | None,
+    ) -> list[dict[str, Any]]:
+        results: list[dict[str, Any]] = []
+        company_source, company_source_type = _company_context_filters_for_source(
+            source,
+            source_type,
+        )
+        rows = await conn.fetch(
+            """
+            SELECT
+                d.document_id,
+                d.source,
+                d.source_type,
+                d.source_document_id,
+                d.source_chunk_id,
+                d.parent_document_id,
+                d.title,
+                d.url,
+                d.author_name,
+                d.access_scope,
+                d.body,
+                d.occurred_at,
+                d.source_updated_at,
+                d.metadata,
+                1 - (e.embedding <=> $1::vector) AS vector_similarity
+            FROM company_context_document_embeddings e
+            JOIN company_context_documents d
+              ON d.document_id = e.company_context_document_id
+            WHERE e.embedding IS NOT NULL
+              AND NOT e.embedding_failed
+              AND e.model = $2
+              AND ($3::text IS NULL OR d.source = $3)
+              AND ($4::text IS NULL OR d.source_type = $4)
+              AND ($5::timestamptz IS NULL OR d.occurred_at >= $5)
+              AND ($6::timestamptz IS NULL OR d.occurred_at < $6)
+            ORDER BY e.embedding <=> $1::vector,
+                     d.source_updated_at DESC NULLS LAST,
+                     d.document_id ASC
+            LIMIT $7
+            """,
+            query_embedding,
+            self._embeddings_model(),
+            company_source,
+            company_source_type,
+            occurred_after,
+            occurred_before,
+            limit,
+        )
+        for row in rows:
+            result = _document_summary(row)
+            result["vector_similarity"] = float(_row_value(row, "vector_similarity", 0.0) or 0.0)
+            result["score"] = result["vector_similarity"]
+            result["preview"] = _body_preview(
+                str(_row_value(row, "body", "") or ""),
+                query=query,
+            )
+            result["lane"] = "vector"
+            result["result_type"] = str(result["source_type"] or "indexed_document")
+            results.append(result)
+
+        if _include_google_docs_source(source, source_type):
+            try:
+                google_rows = await conn.fetch(
+                    """
+                    SELECT
+                        d.document_id,
+                        d.file_id,
+                        d.chunk_id,
+                        d.title,
+                        d.body,
+                        d.url,
+                        d.provider_author_id,
+                        d.provider_author_name,
+                        d.mime_type,
+                        d.drive_id,
+                        d.source_created_at,
+                        d.source_modified_at,
+                        d.metadata,
+                        1 - (e.embedding <=> $1::vector) AS vector_similarity
+                    FROM company_context_document_embeddings e
+                    JOIN google_docs_context_documents d
+                      ON d.document_id = e.google_docs_context_document_id
+                    WHERE e.embedding IS NOT NULL
+                      AND NOT e.embedding_failed
+                      AND e.model = $2
+                      AND ($3::timestamptz IS NULL OR d.source_modified_at >= $3)
+                      AND ($4::timestamptz IS NULL OR d.source_modified_at < $4)
+                    ORDER BY e.embedding <=> $1::vector,
+                             d.source_modified_at DESC NULLS LAST,
+                             d.document_id ASC
+                    LIMIT $5
+                    """,
+                    query_embedding,
+                    self._embeddings_model(),
+                    occurred_after,
+                    occurred_before,
+                    limit,
+                )
+                for row in google_rows:
+                    result = _google_doc_summary(row)
+                    result["vector_similarity"] = float(
+                        _row_value(row, "vector_similarity", 0.0) or 0.0
+                    )
+                    result["score"] = result["vector_similarity"]
+                    result["preview"] = _body_preview(
+                        str(_row_value(row, "body", "") or ""),
+                        query=query,
+                    )
+                    result["lane"] = "vector"
+                    result["result_type"] = GOOGLE_DOCS_SOURCE_TYPE
+                    results.append(result)
+            except Exception:
+                # Optional projections may lag the embedding experiment schema.
+                pass
+
+        if _include_granola_source(source, source_type):
+            try:
+                granola_rows = await conn.fetch(
+                    """
+                    SELECT
+                        d.document_id,
+                        d.note_id,
+                        d.title,
+                        d.body,
+                        d.url,
+                        d.owner_id,
+                        d.owner_email,
+                        d.owner_name,
+                        d.access_emails,
+                        d.attendee_labels,
+                        d.occurred_at,
+                        d.source_updated_at,
+                        d.metadata,
+                        1 - (e.embedding <=> $1::vector) AS vector_similarity
+                    FROM company_context_document_embeddings e
+                    JOIN granola_context_documents d
+                      ON d.document_id = e.granola_context_document_id
+                    WHERE e.embedding IS NOT NULL
+                      AND NOT e.embedding_failed
+                      AND e.model = $2
+                      AND ($3::timestamptz IS NULL OR d.occurred_at >= $3)
+                      AND ($4::timestamptz IS NULL OR d.occurred_at < $4)
+                    ORDER BY e.embedding <=> $1::vector,
+                             d.occurred_at DESC NULLS LAST,
+                             d.source_updated_at DESC NULLS LAST,
+                             d.document_id ASC
+                    LIMIT $5
+                    """,
+                    query_embedding,
+                    self._embeddings_model(),
+                    occurred_after,
+                    occurred_before,
+                    limit,
+                )
+                for row in granola_rows:
+                    result = _granola_doc_summary(row)
+                    result["vector_similarity"] = float(
+                        _row_value(row, "vector_similarity", 0.0) or 0.0
+                    )
+                    result["score"] = result["vector_similarity"]
+                    result["preview"] = _body_preview(
+                        str(_row_value(row, "body", "") or ""),
+                        query=query,
+                    )
+                    result["lane"] = "vector"
+                    result["result_type"] = GRANOLA_SOURCE_TYPE
+                    results.append(result)
+            except Exception:
+                # Optional projections may lag the embedding experiment schema.
+                pass
+
+        results.sort(
+            key=lambda item: (
+                float(item.get("vector_similarity") or 0.0),
+                str(item.get("source_updated_at") or ""),
+                str(item.get("document_id") or ""),
+            ),
+            reverse=True,
+        )
+        return results[:limit]
 
     async def _latest_date_for_connection(
         self,
@@ -1139,6 +1455,7 @@ class CompanyContextClient:
         source_type: str | None = None,
         occurred_after: str | datetime | None = None,
         occurred_before: str | datetime | None = None,
+        hybrid: bool = True,
     ) -> dict:
         """Search indexed company context documents and return candidate document ids."""
         normalized_query = query.strip()
@@ -1161,6 +1478,7 @@ class CompanyContextClient:
                 self._search_async(
                     query=normalized_query,
                     limit=_clamp(limit, minimum=1, maximum=MAX_SEARCH_LIMIT),
+                    hybrid=hybrid,
                     source=normalized_source,
                     source_type=normalized_source_type,
                     occurred_after=parsed_occurred_after,

--- a/tools/productivity/company_context/pyproject.toml
+++ b/tools/productivity/company_context/pyproject.toml
@@ -5,6 +5,7 @@ version = "0.1.0"
 requires-python = ">=3.11"
 dependencies = [
     "asyncpg>=0.30.0",
+    "openai>=2.53.0",
     "python-dotenv>=1.0.0",
     "rich>=13.0.0",
     "typer>=0.12.0",

--- a/tools/productivity/company_context/tests/test_cli.py
+++ b/tools/productivity/company_context/tests/test_cli.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+sys.path.insert(0, str(Path(__file__).resolve().parents[4]))
+
+from company_context import cli
+
+
+def test_search_no_hybrid_flag_forces_keyword_mode(monkeypatch):
+    calls = []
+
+    class FakeClient:
+        def search(self, **kwargs):
+            calls.append(kwargs)
+            return {"status": "ok", "results": [], "search_mode": "keyword"}
+
+    monkeypatch.setattr(cli, "CompanyContextClient", FakeClient)
+
+    result = CliRunner().invoke(
+        cli.app,
+        ["search", "roadmap", "--no-hybrid", "--json"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert calls == [
+        {
+            "query": "roadmap",
+            "limit": 10,
+            "source": None,
+            "source_type": None,
+            "occurred_after": None,
+            "occurred_before": None,
+            "hybrid": False,
+        }
+    ]

--- a/tools/productivity/company_context/tests/test_client.py
+++ b/tools/productivity/company_context/tests/test_client.py
@@ -4,6 +4,7 @@ import datetime as dt
 import re
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -24,16 +25,13 @@ class _FakeConnection:
         fetch_rows=None,
         row=None,
         fetchrow_rows=None,
-        val=None,
     ) -> None:
         self.rows = rows or []
         self.fetch_rows = list(fetch_rows or [])
         self.row = row
         self.fetchrow_rows = list(fetchrow_rows or [])
-        self.val = val
         self.fetch_calls = []
         self.fetchrow_calls = []
-        self.fetchval_calls = []
         self.execute_calls = []
         self.cursor_calls = []
         self.transaction_calls = []
@@ -42,7 +40,10 @@ class _FakeConnection:
     async def fetch(self, query, *args):
         self.fetch_calls.append((query, args))
         if self.fetch_rows:
-            return self.fetch_rows.pop(0)
+            result = self.fetch_rows.pop(0)
+            if isinstance(result, BaseException):
+                raise result
+            return result
         return self.rows
 
     async def fetchrow(self, query, *args):
@@ -50,10 +51,6 @@ class _FakeConnection:
         if self.fetchrow_rows:
             return self.fetchrow_rows.pop(0)
         return self.row
-
-    async def fetchval(self, query, *args):
-        self.fetchval_calls.append((query, args))
-        return self.val
 
     async def execute(self, query, *args):
         self.execute_calls.append((query, args))
@@ -92,9 +89,28 @@ class _FakeCursor:
             raise StopAsyncIteration from exc
 
 
+class _FakeEmbeddingsAPI:
+    def __init__(self, embedding=None, error: Exception | None = None) -> None:
+        self.embedding = embedding or [0.1, 0.2, 0.3]
+        self.error = error
+        self.calls = []
+
+    async def create(self, **kwargs):
+        self.calls.append(kwargs)
+        if self.error:
+            raise self.error
+        return SimpleNamespace(data=[SimpleNamespace(embedding=self.embedding)])
+
+
+class _FakeOpenAIClient:
+    def __init__(self, embedding=None, error: Exception | None = None) -> None:
+        self.embeddings = _FakeEmbeddingsAPI(embedding=embedding, error=error)
+
+
 @pytest.fixture(autouse=True)
 def _disable_lookup_metric_push(monkeypatch):
     monkeypatch.setenv("COMPANY_CONTEXT_LOOKUP_METRICS_ENABLED", "0")
+    monkeypatch.setenv("COMPANY_CONTEXT_EMBEDDINGS_ENABLED", "false")
 
 
 @pytest.mark.parametrize("query", ["", "   "])
@@ -322,6 +338,250 @@ def test_search_queries_bm25_and_returns_compact_results(monkeypatch):
         5,
     )
     assert fake.closed is True
+
+
+def test_search_skips_embeddings_when_experiment_is_disabled(monkeypatch):
+    fake = _FakeConnection(
+        rows=[
+            {
+                "document_id": "slack:thread:keyword",
+                "source": "slack",
+                "source_type": "slack_thread",
+                "title": "Keyword result",
+                "score": 2.0,
+            }
+        ],
+    )
+    embeddings_client = _FakeOpenAIClient()
+
+    async def fake_connect(*args, **kwargs):
+        return fake
+
+    monkeypatch.setattr(company_context_client.asyncpg, "connect", fake_connect)
+    monkeypatch.setenv("COMPANY_CONTEXT_EMBEDDINGS_ENABLED", "false")
+
+    result = CompanyContextClient(
+        "postgresql://example",
+        embeddings_client=embeddings_client,
+    ).search("keyword query", source="slack", limit=5)
+
+    assert result["status"] == "ok"
+    assert result["search_mode"] == "keyword"
+    assert result["vector_count"] == 0
+    assert [item["document_id"] for item in result["results"]] == ["slack:thread:keyword"]
+    assert embeddings_client.embeddings.calls == []
+    assert fake.fetch_calls[0][1][-1] == 5
+
+
+def test_search_hybrid_override_forces_keyword_search(monkeypatch):
+    fake = _FakeConnection(
+        rows=[
+            {
+                "document_id": "slack:thread:keyword",
+                "source": "slack",
+                "source_type": "slack_thread",
+                "title": "Keyword result",
+                "score": 2.0,
+            }
+        ],
+    )
+    embeddings_client = _FakeOpenAIClient()
+
+    async def fake_connect(*args, **kwargs):
+        return fake
+
+    monkeypatch.setattr(company_context_client.asyncpg, "connect", fake_connect)
+    monkeypatch.setenv("COMPANY_CONTEXT_EMBEDDINGS_ENABLED", "true")
+
+    result = CompanyContextClient(
+        "postgresql://example",
+        embeddings_client=embeddings_client,
+    ).search("keyword query", source="slack", limit=5, hybrid=False)
+
+    assert result["status"] == "ok"
+    assert result["search_mode"] == "keyword"
+    assert embeddings_client.embeddings.calls == []
+    assert fake.fetch_calls[0][1][-1] == 5
+
+
+def test_search_tolerates_empty_vector_results(monkeypatch):
+    fake = _FakeConnection(
+        fetch_rows=[
+            [
+                {
+                    "document_id": "slack:thread:keyword",
+                    "source": "slack",
+                    "source_type": "slack_thread",
+                    "title": "Keyword result",
+                    "score": 2.0,
+                }
+            ],
+            [],
+        ],
+    )
+    embeddings_client = _FakeOpenAIClient()
+
+    async def fake_connect(*args, **kwargs):
+        return fake
+
+    monkeypatch.setattr(company_context_client.asyncpg, "connect", fake_connect)
+    monkeypatch.setenv("COMPANY_CONTEXT_EMBEDDINGS_ENABLED", "true")
+    monkeypatch.setenv("COMPANY_CONTEXT_EMBEDDINGS_MODEL", "text-embedding-3-large")
+
+    result = CompanyContextClient(
+        "postgresql://example",
+        embeddings_client=embeddings_client,
+    ).search("semantic query", source="slack", limit=5)
+
+    assert result["status"] == "ok"
+    assert result["search_mode"] == "keyword"
+    assert result["vector_count"] == 0
+    assert result["results"][0]["lane"] == "indexed"
+    assert embeddings_client.embeddings.calls == [
+        {
+            "model": "text-embedding-3-large",
+            "input": "semantic query",
+            "dimensions": 1536,
+            "encoding_format": "float",
+        }
+    ]
+    assert fake.fetch_calls[0][1][-1] == 30
+    assert fake.fetch_calls[1][1][1] == "text-embedding-3-large"
+    assert fake.fetch_calls[1][1][-1] == 30
+
+
+def test_search_falls_back_when_query_embedding_fails(monkeypatch):
+    fake = _FakeConnection(
+        rows=[
+            {
+                "document_id": "slack:thread:keyword",
+                "source": "slack",
+                "source_type": "slack_thread",
+                "title": "Keyword result",
+                "score": 2.0,
+            }
+        ],
+    )
+    embeddings_client = _FakeOpenAIClient(error=RuntimeError("embedding unavailable"))
+
+    async def fake_connect(*args, **kwargs):
+        return fake
+
+    monkeypatch.setattr(company_context_client.asyncpg, "connect", fake_connect)
+    monkeypatch.setenv("COMPANY_CONTEXT_EMBEDDINGS_ENABLED", "true")
+
+    result = CompanyContextClient(
+        "postgresql://example",
+        embeddings_client=embeddings_client,
+    ).search("semantic query", source="slack", limit=5)
+
+    assert result["status"] == "ok"
+    assert result["search_mode"] == "keyword"
+    assert [item["document_id"] for item in result["results"]] == ["slack:thread:keyword"]
+    assert len(fake.fetch_calls) == 1
+
+
+def test_search_falls_back_when_vector_query_is_incompatible(monkeypatch):
+    fake = _FakeConnection(
+        fetch_rows=[
+            [
+                {
+                    "document_id": "slack:thread:keyword",
+                    "source": "slack",
+                    "source_type": "slack_thread",
+                    "title": "Keyword result",
+                    "score": 2.0,
+                }
+            ],
+            RuntimeError("vector operator is unavailable"),
+        ],
+    )
+    embeddings_client = _FakeOpenAIClient()
+
+    async def fake_connect(*args, **kwargs):
+        return fake
+
+    monkeypatch.setattr(company_context_client.asyncpg, "connect", fake_connect)
+    monkeypatch.setenv("COMPANY_CONTEXT_EMBEDDINGS_ENABLED", "true")
+
+    result = CompanyContextClient(
+        "postgresql://example",
+        embeddings_client=embeddings_client,
+    ).search("semantic query", source="slack", limit=5)
+
+    assert result["status"] == "ok"
+    assert result["search_mode"] == "keyword"
+    assert [item["document_id"] for item in result["results"]] == ["slack:thread:keyword"]
+    assert len(fake.fetch_calls) == 2
+
+
+def test_search_uses_equal_weight_reciprocal_rank_fusion(monkeypatch):
+    fake = _FakeConnection(
+        fetch_rows=[
+            [
+                {
+                    "document_id": "slack:thread:keyword-only",
+                    "source": "slack",
+                    "source_type": "slack_thread",
+                    "title": "Keyword only",
+                    "score": 10.0,
+                },
+                {
+                    "document_id": "slack:thread:both",
+                    "source": "slack",
+                    "source_type": "slack_thread",
+                    "title": "Both lanes",
+                    "score": 5.0,
+                },
+            ],
+            [
+                {
+                    "document_id": "slack:thread:both",
+                    "source": "slack",
+                    "source_type": "slack_thread",
+                    "title": "Both lanes",
+                    "vector_similarity": 0.91,
+                },
+                {
+                    "document_id": "slack:thread:vector-only",
+                    "source": "slack",
+                    "source_type": "slack_thread",
+                    "title": "Vector only",
+                    "vector_similarity": 0.89,
+                },
+            ],
+        ],
+    )
+    embeddings_client = _FakeOpenAIClient()
+
+    async def fake_connect(*args, **kwargs):
+        return fake
+
+    monkeypatch.setattr(company_context_client.asyncpg, "connect", fake_connect)
+    monkeypatch.setenv("COMPANY_CONTEXT_EMBEDDINGS_ENABLED", "true")
+
+    result = CompanyContextClient(
+        "postgresql://example",
+        embeddings_client=embeddings_client,
+    ).search("hybrid query", source="slack", limit=3)
+
+    assert result["status"] == "ok"
+    assert result["search_mode"] == "hybrid"
+    assert result["vector_count"] == 2
+    assert [item["document_id"] for item in result["results"]] == [
+        "slack:thread:both",
+        "slack:thread:keyword-only",
+        "slack:thread:vector-only",
+    ]
+    both, keyword_only, vector_only = result["results"]
+    assert both["lane"] == "hybrid"
+    assert both["matched_lanes"] == ["keyword", "vector"]
+    assert both["keyword_rank"] == 2
+    assert both["vector_rank"] == 1
+    assert both["keyword_score"] == 5.0
+    assert both["vector_similarity"] == 0.91
+    assert keyword_only["lane"] == "keyword"
+    assert vector_only["lane"] == "vector"
 
 
 def test_search_emits_grouped_lookup_metrics(monkeypatch):


### PR DESCRIPTION
Adds opt-in hybrid company-context retrieval using OpenAI query embeddings and equal-weight reciprocal rank fusion, with lexical fallback and a per-query CLI override. Wires the embedding enablement and model settings into agent sandboxes, adds an HNSW index for the experimental embeddings table, and bumps the Helm chart version. Includes focused coverage for disabled and empty vector paths, embedding and query failures, fusion behavior, and the CLI override.