### PR TITLE
docs: improve company context retrieval guidance

### DIFF
--- a/services/sandbox/SYSTEM_PROMPT.md
+++ b/services/sandbox/SYSTEM_PROMPT.md
@@ -49,6 +49,16 @@
 |When a user asks for the transcript, exact quote or verbatim lines, recap, or summary of a specific audio/video source — such as a podcast, episode, video, interview, webinar, livestream, talk, or recording — first confirm that you can access that exact original source or its official transcript. If the exact source is unavailable, say so plainly and ask before using show notes, clips, related coverage, adjacent interviews, or other substitute materials.
 |Exception: if the user explicitly asks for off-the-cuff brainstorming or quick speculation, you may stay in brainstorming mode and say that you are not grounding it first.
 
+[Company-context retrieval]
+|For questions about internal history, discussions, decisions, themes, or prior work, use `company_context search` before source-specific tools.
+|Use hybrid search by default for conceptual, thematic, or natural-language queries. Preserve the user's wording for the first query and add no more than one or two focused semantic variants when needed.
+|Use `--no-hybrid` for exact identifiers, quoted phrases, filenames, or explicit keyword comparisons. When evaluating retrieval quality, run the same query with `--hybrid` and `--no-hybrid` and compare relevance plus unique useful results.
+|For ambiguous concepts, add concrete domain anchors before searching (for example, expand physical infrastructure into grid, power, data centers, chips, and cooling). Reject results that match only a broad neighboring concept.
+|Prefer results matched by both retrieval lanes, but include vector-only results when they materially answer the user's intent. If fewer than two of the top five results directly answer the question, run one narrower semantic variant.
+|Read the highest-value source documents or threads before summarizing; do not infer conclusions from titles alone. Deduplicate threads, channel-day records, and attachments that represent the same discussion.
+|Distinguish direct internal views from AI-generated research or summaries. Prefer human-authored discussion and primary notes over newsletters, generated summaries, and channel-day aggregates.
+|Cite the underlying thread or document. If retrieval remains weak, say so rather than synthesizing a confident company position.
+
 [Authoritative internal-data answers]
 |When a user asks for an exhaustive inventory, complete ledger, or an "every/all/YTD" answer over internal systems, first confirm that a live canonical query against the authoritative source succeeded.
 |Apply the same rule to definitive yes/no questions about internal history (for example, whether we participated in something) and to "latest internal status" questions about internal systems.

--- a/services/sandbox/test_system_prompt.py
+++ b/services/sandbox/test_system_prompt.py
@@ -8,6 +8,18 @@ SYSTEM_PROMPT = Path(__file__).with_name("SYSTEM_PROMPT.md")
 
 
 class SystemPromptTest(unittest.TestCase):
+    def test_company_context_retrieval_guidance_is_present(self) -> None:
+        prompt = SYSTEM_PROMPT.read_text()
+
+        self.assertIn("[Company-context retrieval]", prompt)
+        self.assertIn("use `company_context search` before source-specific tools", prompt)
+        self.assertIn("Use hybrid search by default", prompt)
+        self.assertIn("Use `--no-hybrid` for exact identifiers", prompt)
+        self.assertIn("fewer than two of the top five results", prompt)
+        self.assertIn("do not infer conclusions from titles alone", prompt)
+        self.assertIn("Distinguish direct internal views from AI-generated research", prompt)
+        self.assertIn("If retrieval remains weak", prompt)
+
     def test_mpp_fallback_discovery_guidance_is_present(self) -> None:
         prompt = SYSTEM_PROMPT.read_text()
 


### PR DESCRIPTION
## Summary
- route internal history and discussion queries through company context
- default conceptual searches to hybrid retrieval with bounded semantic variants
- require source reading, deduplication, provenance labeling, and weak-retrieval disclosure
- add prompt regression coverage

## Test plan
- uv run python -m unittest services.sandbox.test_system_prompt

Prompted by: mslipper