### PR TITLE
fix(sandbox): apply configured runtime class

### DIFF
--- a/contrib/chart/Chart.yaml
+++ b/contrib/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: centaur
 description: Helm chart for the trusted Centaur control plane
 type: application
-version: 0.1.113
+version: 0.1.114
 appVersion: "0.1.0"
 dependencies:
   - name: connect

--- a/contrib/chart/templates/apirs.yaml
+++ b/contrib/chart/templates/apirs.yaml
@@ -332,6 +332,10 @@ spec:
               value: {{ printf "%s:%s" .Values.sandbox.image.repository .Values.sandbox.image.tag | quote }}
             - name: SESSION_SANDBOX_IMAGE_PULL_POLICY
               value: {{ .Values.sandbox.image.pullPolicy | quote }}
+{{- with .Values.sandbox.runtimeClassName }}
+            - name: SESSION_SANDBOX_RUNTIME_CLASS_NAME
+              value: {{ . | quote }}
+{{- end }}
 {{- if .Values.global.imagePullSecrets }}
             - name: SESSION_SANDBOX_IMAGE_PULL_SECRETS
               value: "{{- range $index, $secret := .Values.global.imagePullSecrets }}{{- if $index }},{{ end -}}{{ $secret.name }}{{- end }}"

--- a/contrib/chart/values.yaml
+++ b/contrib/chart/values.yaml
@@ -240,6 +240,8 @@ sandbox:
     repository: centaur-agent
     tag: latest
     pullPolicy: Always
+  # Optional Kubernetes RuntimeClass applied to every dynamic sandbox pod
+  # created by api-rs (for example, "gvisor" on a sandbox-enabled GKE pool).
   runtimeClassName: ""
   reposPath: ""
   # How the in-sandbox harness authenticates upstream. Single source of truth:

--- a/docs/pages/deploying-in-production.mdx
+++ b/docs/pages/deploying-in-production.mdx
@@ -270,6 +270,29 @@ sandbox:
   runtimeClassName: gvisor
 ```
 
+:::warning[RuntimeClass changes require recreating sandboxes]
+`runtimeClassName` is copied into the pod template only when api-rs creates a
+new `Sandbox` resource. Existing running, paused, and warm sandboxes keep their
+old pod template and can resume under the previous runtime.
+
+When enabling or changing the runtime class, schedule a maintenance window and
+drain active executions first. Complete the Helm upgrade, wait for the new
+api-rs deployment, then delete the existing api-rs-managed Sandbox resources so
+sessions and the warm pool recreate them with the new runtime:
+
+```bash
+kubectl rollout status -n centaur-system deploy/centaur-centaur-api-rs
+kubectl get sandboxes.agents.x-k8s.io -n centaur-system \
+  -l centaur.ai/managed-by=api-rs
+kubectl delete sandboxes.agents.x-k8s.io -n centaur-system \
+  -l centaur.ai/managed-by=api-rs --wait=true
+```
+
+The delete command interrupts any execution that was not drained. The Sandbox
+resources use `centaur.ai/managed-by=api-rs`; child pods may also carry
+controller-specific management labels.
+:::
+
 The Kubernetes sandbox backend is the active runtime backend; there is no chart
 switch named `api.sandboxBackend`.
 

--- a/docs/pages/reference/configuration.mdx
+++ b/docs/pages/reference/configuration.mdx
@@ -181,7 +181,8 @@ Kubernetes backend:
 | --- | --- | --- |
 | `KUBERNETES_NAMESPACE`, `POD_NAMESPACE`, `KUBERNETES_KUBECONFIG` | Chart namespace, downward API, or `api.extraEnv`. | Kubernetes client namespace/config. |
 | `KUBERNETES_AGENT_IMAGE_PULL_POLICY`, `KUBERNETES_SANDBOX_IMAGE_PULL_SECRETS` | `sandbox.image.pullPolicy`, `global.imagePullSecrets`. | Sandbox image pull behavior. |
-| `KUBERNETES_SANDBOX_RUNTIME_CLASS_NAME`, `KUBERNETES_SANDBOX_SERVICE_ACCOUNT_NAME` | `sandbox.runtimeClassName`, `api.extraEnv`. | Pod runtime class and service account. |
+| `SESSION_SANDBOX_RUNTIME_CLASS_NAME` (preferred), `KUBERNETES_SANDBOX_RUNTIME_CLASS_NAME` (legacy) | `sandbox.runtimeClassName` or `apiRs.extraEnv`. | Runtime class for newly created Sandbox pod templates. The preferred name wins when both are set. |
+| `KUBERNETES_SANDBOX_SERVICE_ACCOUNT_NAME` | `api.extraEnv`. | Sandbox pod service account. |
 | `KUBERNETES_SANDBOX_CPU_LIMIT`, `KUBERNETES_SANDBOX_MEMORY_LIMIT`, `KUBERNETES_SANDBOX_CPU_REQUEST`, `KUBERNETES_SANDBOX_MEMORY_REQUEST` | `sandbox.resources.*`. | Sandbox pod resources. |
 | `KUBERNETES_SANDBOX_READY_TIMEOUT_S`, `KUBERNETES_ATTACH_LOG_TAIL_LINES` | `api.extraEnv`. | Sandbox readiness and attach diagnostics. |
 | `SESSION_SANDBOX_RUNNING_LIMIT`, `SESSION_SANDBOX_HOT_IDLE_GRACE_SECS` | `apiRs.sandboxRunningLimit`, `apiRs.sandboxHotIdleGraceSecs`. | Capacity admission for running-like sandboxes; discards ready warm sandboxes first, then pauses least-recently-active idle sessions outside the grace window. |

--- a/docs/public/md/deploying-in-production.md
+++ b/docs/public/md/deploying-in-production.md
@@ -264,6 +264,29 @@ sandbox:
   runtimeClassName: gvisor
 ```
 
+:::warning[RuntimeClass changes require recreating sandboxes]
+`runtimeClassName` is copied into the pod template only when api-rs creates a
+new `Sandbox` resource. Existing running, paused, and warm sandboxes keep their
+old pod template and can resume under the previous runtime.
+
+When enabling or changing the runtime class, schedule a maintenance window and
+drain active executions first. Complete the Helm upgrade, wait for the new
+api-rs deployment, then delete the existing api-rs-managed Sandbox resources so
+sessions and the warm pool recreate them with the new runtime:
+
+```bash
+kubectl rollout status -n centaur-system deploy/centaur-centaur-api-rs
+kubectl get sandboxes.agents.x-k8s.io -n centaur-system \
+  -l centaur.ai/managed-by=api-rs
+kubectl delete sandboxes.agents.x-k8s.io -n centaur-system \
+  -l centaur.ai/managed-by=api-rs --wait=true
+```
+
+The delete command interrupts any execution that was not drained. The Sandbox
+resources use `centaur.ai/managed-by=api-rs`; child pods may also carry
+controller-specific management labels.
+:::
+
 The Kubernetes sandbox backend is the active runtime backend; there is no chart
 switch named `api.sandboxBackend`.
 

--- a/docs/public/md/reference/configuration.md
+++ b/docs/public/md/reference/configuration.md
@@ -179,7 +179,8 @@ Kubernetes backend:
 | --- | --- | --- |
 | `KUBERNETES_NAMESPACE`, `POD_NAMESPACE`, `KUBERNETES_KUBECONFIG` | Chart namespace, downward API, or `api.extraEnv`. | Kubernetes client namespace/config. |
 | `KUBERNETES_AGENT_IMAGE_PULL_POLICY`, `KUBERNETES_SANDBOX_IMAGE_PULL_SECRETS` | `sandbox.image.pullPolicy`, `global.imagePullSecrets`. | Sandbox image pull behavior. |
-| `KUBERNETES_SANDBOX_RUNTIME_CLASS_NAME`, `KUBERNETES_SANDBOX_SERVICE_ACCOUNT_NAME` | `sandbox.runtimeClassName`, `api.extraEnv`. | Pod runtime class and service account. |
+| `SESSION_SANDBOX_RUNTIME_CLASS_NAME` (preferred), `KUBERNETES_SANDBOX_RUNTIME_CLASS_NAME` (legacy) | `sandbox.runtimeClassName` or `apiRs.extraEnv`. | Runtime class for newly created Sandbox pod templates. The preferred name wins when both are set. |
+| `KUBERNETES_SANDBOX_SERVICE_ACCOUNT_NAME` | `api.extraEnv`. | Sandbox pod service account. |
 | `KUBERNETES_SANDBOX_CPU_LIMIT`, `KUBERNETES_SANDBOX_MEMORY_LIMIT`, `KUBERNETES_SANDBOX_CPU_REQUEST`, `KUBERNETES_SANDBOX_MEMORY_REQUEST` | `sandbox.resources.*`. | Sandbox pod resources. |
 | `KUBERNETES_SANDBOX_READY_TIMEOUT_S`, `KUBERNETES_ATTACH_LOG_TAIL_LINES` | `api.extraEnv`. | Sandbox readiness and attach diagnostics. |
 | `SESSION_SANDBOX_CLEANUP_INTERVAL_SECS`, `SESSION_SANDBOX_IDLE_CLEANUP_BACKSTOP_SECS` | `apiRs.sandboxCleanupIntervalSecs`, `apiRs.sandboxIdleCleanupBackstopSecs`. | DB-aware cleanup of unreferenced sandboxes and restart recovery for idle pauses. Persisted `idle_timeout_ms` is honored after restart; the backstop is the fallback for older execution rows without that metadata. |

--- a/services/api-rs/crates/centaur-api-server/src/args.rs
+++ b/services/api-rs/crates/centaur-api-server/src/args.rs
@@ -563,6 +563,12 @@ struct SandboxArgs {
     )]
     runtime_class_name: Option<String>,
     #[arg(
+        long = "kubernetes-sandbox-runtime-class-name",
+        env = "KUBERNETES_SANDBOX_RUNTIME_CLASS_NAME",
+        hide = true
+    )]
+    legacy_runtime_class_name: Option<String>,
+    #[arg(
         long = "session-sandbox-ready-timeout-secs",
         alias = "kubernetes-sandbox-ready-timeout-s",
         env = "SESSION_SANDBOX_READY_TIMEOUT_SECS",
@@ -1380,7 +1386,10 @@ impl TryFrom<&SandboxArgs> for AgentSandboxConfig {
             .filter(|secret| !secret.is_empty())
             .map(str::to_owned)
             .collect();
-        config.runtime_class_name = clean_optional_value(args.runtime_class_name.as_deref());
+        // Prefer the session-scoped name while preserving the documented legacy
+        // Kubernetes environment variable for existing deployments.
+        config.runtime_class_name = clean_optional_value(args.runtime_class_name.as_deref())
+            .or_else(|| clean_optional_value(args.legacy_runtime_class_name.as_deref()));
         config.ready_timeout = Duration::from_secs(args.ready_timeout_secs);
         let mut proxy = args.iron_proxy.to_config()?;
         let mut fragments = vec![args.iron_proxy.infra_fragment()?];
@@ -2292,9 +2301,12 @@ mod tests {
     }
 
     #[test]
-    fn runtime_class_name_is_read_from_environment() {
+    fn legacy_runtime_class_name_is_read_from_environment() {
         let _lock = ENV_LOCK.lock().unwrap();
-        let _env = EnvGuard::set(&[("SESSION_SANDBOX_RUNTIME_CLASS_NAME", "gvisor")]);
+        let _env = EnvGuard::set(&[
+            ("SESSION_SANDBOX_RUNTIME_CLASS_NAME", ""),
+            ("KUBERNETES_SANDBOX_RUNTIME_CLASS_NAME", "gvisor"),
+        ]);
         let args = Args::try_parse_from([
             "centaur-api-server",
             "--database-url",
@@ -2311,13 +2323,38 @@ mod tests {
     }
 
     #[test]
-    fn empty_runtime_class_name_is_omitted() {
+    fn preferred_runtime_class_name_takes_precedence_over_legacy_environment() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _env = EnvGuard::set(&[
+            ("SESSION_SANDBOX_RUNTIME_CLASS_NAME", "kata"),
+            ("KUBERNETES_SANDBOX_RUNTIME_CLASS_NAME", "gvisor"),
+        ]);
         let args = Args::try_parse_from([
             "centaur-api-server",
             "--database-url",
             "postgres://postgres:postgres@localhost/centaur",
-            "--session-sandbox-runtime-class-name",
-            "  ",
+            "--iron-control-url",
+            "http://console.local",
+            "--iron-control-api-key",
+            "iak_test",
+        ])
+        .unwrap();
+
+        let config = AgentSandboxConfig::try_from(&args.sandbox).unwrap();
+        assert_eq!(config.runtime_class_name.as_deref(), Some("kata"));
+    }
+
+    #[test]
+    fn empty_runtime_class_names_are_omitted() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _env = EnvGuard::set(&[
+            ("SESSION_SANDBOX_RUNTIME_CLASS_NAME", ""),
+            ("KUBERNETES_SANDBOX_RUNTIME_CLASS_NAME", "  "),
+        ]);
+        let args = Args::try_parse_from([
+            "centaur-api-server",
+            "--database-url",
+            "postgres://postgres:postgres@localhost/centaur",
             "--iron-control-url",
             "http://console.local",
             "--iron-control-api-key",

--- a/services/api-rs/crates/centaur-api-server/src/args.rs
+++ b/services/api-rs/crates/centaur-api-server/src/args.rs
@@ -558,6 +558,11 @@ struct SandboxArgs {
     )]
     image_pull_secrets: Vec<String>,
     #[arg(
+        long = "session-sandbox-runtime-class-name",
+        env = "SESSION_SANDBOX_RUNTIME_CLASS_NAME"
+    )]
+    runtime_class_name: Option<String>,
+    #[arg(
         long = "session-sandbox-ready-timeout-secs",
         alias = "kubernetes-sandbox-ready-timeout-s",
         env = "SESSION_SANDBOX_READY_TIMEOUT_SECS",
@@ -1375,6 +1380,7 @@ impl TryFrom<&SandboxArgs> for AgentSandboxConfig {
             .filter(|secret| !secret.is_empty())
             .map(str::to_owned)
             .collect();
+        config.runtime_class_name = clean_optional_value(args.runtime_class_name.as_deref());
         config.ready_timeout = Duration::from_secs(args.ready_timeout_secs);
         let mut proxy = args.iron_proxy.to_config()?;
         let mut fragments = vec![args.iron_proxy.infra_fragment()?];
@@ -2116,6 +2122,8 @@ mod tests {
             "centaur-test",
             "--session-sandbox-image",
             "centaur-agent:test",
+            "--session-sandbox-runtime-class-name",
+            "gvisor",
             "--session-sandbox-ready-timeout-secs",
             "17",
             "--session-sandbox-k8s-context",
@@ -2126,6 +2134,7 @@ mod tests {
         assert_eq!(args.sandbox.backend, SandboxBackendKind::AgentK8s);
         assert_eq!(args.sandbox.workload, SandboxWorkloadKind::CodexAppServer);
         assert_eq!(args.sandbox.k8s_namespace, "centaur-test");
+        assert_eq!(args.sandbox.runtime_class_name.as_deref(), Some("gvisor"));
         assert_eq!(args.sandbox.ready_timeout_secs, 17);
         assert_eq!(args.sandbox.k8s_context.as_deref(), Some("kind-test"));
     }
@@ -2259,6 +2268,8 @@ mod tests {
             "IfNotPresent",
             "--session-sandbox-image-pull-secrets",
             "github-access-token-read-packages, extra-secret ",
+            "--session-sandbox-runtime-class-name",
+            " gvisor ",
             "--session-sandbox-ready-timeout-secs",
             "42",
             "--iron-control-url",
@@ -2275,8 +2286,47 @@ mod tests {
             config.image_pull_secrets,
             vec!["github-access-token-read-packages", "extra-secret"]
         );
+        assert_eq!(config.runtime_class_name.as_deref(), Some("gvisor"));
         assert_eq!(config.ready_timeout, Duration::from_secs(42));
         assert!(config.iron_proxy.is_some());
+    }
+
+    #[test]
+    fn runtime_class_name_is_read_from_environment() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _env = EnvGuard::set(&[("SESSION_SANDBOX_RUNTIME_CLASS_NAME", "gvisor")]);
+        let args = Args::try_parse_from([
+            "centaur-api-server",
+            "--database-url",
+            "postgres://postgres:postgres@localhost/centaur",
+            "--iron-control-url",
+            "http://console.local",
+            "--iron-control-api-key",
+            "iak_test",
+        ])
+        .unwrap();
+
+        let config = AgentSandboxConfig::try_from(&args.sandbox).unwrap();
+        assert_eq!(config.runtime_class_name.as_deref(), Some("gvisor"));
+    }
+
+    #[test]
+    fn empty_runtime_class_name_is_omitted() {
+        let args = Args::try_parse_from([
+            "centaur-api-server",
+            "--database-url",
+            "postgres://postgres:postgres@localhost/centaur",
+            "--session-sandbox-runtime-class-name",
+            "  ",
+            "--iron-control-url",
+            "http://console.local",
+            "--iron-control-api-key",
+            "iak_test",
+        ])
+        .unwrap();
+
+        let config = AgentSandboxConfig::try_from(&args.sandbox).unwrap();
+        assert_eq!(config.runtime_class_name, None);
     }
 
     #[test]

--- a/services/api-rs/crates/centaur-sandbox-agent-k8s/src/lib.rs
+++ b/services/api-rs/crates/centaur-sandbox-agent-k8s/src/lib.rs
@@ -59,6 +59,7 @@ pub struct AgentSandboxConfig {
     pub annotations: BTreeMap<String, String>,
     pub image_pull_policy: Option<String>,
     pub image_pull_secrets: Vec<String>,
+    pub runtime_class_name: Option<String>,
     pub state_volume: Option<StateVolumeConfig>,
     pub iron_proxy: Option<IronProxyConfig>,
     pub iron_control: Option<IronControlSettings>,
@@ -106,6 +107,7 @@ impl AgentSandboxConfig {
             annotations: BTreeMap::new(),
             image_pull_policy: None,
             image_pull_secrets: Vec::new(),
+            runtime_class_name: None,
             state_volume: None,
             iron_proxy: None,
             iron_control: None,
@@ -113,6 +115,11 @@ impl AgentSandboxConfig {
             otlp_egress: None,
             ready_timeout: Duration::from_secs(60),
         }
+    }
+
+    pub fn runtime_class_name(mut self, runtime_class_name: impl Into<String>) -> Self {
+        self.runtime_class_name = Some(runtime_class_name.into());
+        self
     }
 
     pub fn state_volume(mut self, state_volume: StateVolumeConfig) -> Self {
@@ -702,6 +709,11 @@ fn build_agent_sandbox(
     }
     insert_optional(
         &mut pod_spec,
+        "runtimeClassName",
+        config.runtime_class_name.clone(),
+    );
+    insert_optional(
+        &mut pod_spec,
         "initContainers",
         (!init_containers.is_empty()).then_some(init_containers),
     );
@@ -914,10 +926,24 @@ mod tests {
             sandbox.spec.pod_template.spec.enable_service_links,
             Some(false)
         );
+        assert_eq!(sandbox.spec.pod_template.spec.runtime_class_name, None);
         assert_eq!(container.image.as_deref(), Some("centaur-agent:latest"));
         assert_eq!(container.stdin, Some(true));
         assert_eq!(container.volume_mounts.as_ref().unwrap().len(), 2);
         assert!(container.resources.as_ref().unwrap().limits.is_some());
+    }
+
+    #[test]
+    fn applies_configured_runtime_class_to_sandbox_pod_template() {
+        let spec = SandboxSpec::new("centaur-agent:latest");
+        let config = AgentSandboxConfig::new("centaur").runtime_class_name("gvisor");
+
+        let sandbox = build_agent_sandbox(&SandboxId::new("asbx-test"), &spec, &config).unwrap();
+
+        assert_eq!(
+            sandbox.spec.pod_template.spec.runtime_class_name.as_deref(),
+            Some("gvisor")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- pass `sandbox.runtimeClassName` from Helm into api-rs
- add a `SESSION_SANDBOX_RUNTIME_CLASS_NAME` CLI/env setting
- apply the configured RuntimeClass to every generated Agent Sandbox pod template
- keep the field omitted when unset or blank

## Why

The chart currently exposes `sandbox.runtimeClassName`, but the value is not wired into api-rs and generated sandbox pods therefore run with the default runtime. On GKE this silently bypasses the intended `gvisor` isolation boundary even when the node pool supports GKE Sandbox.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p centaur-sandbox-agent-k8s applies_configured_runtime_class_to_sandbox_pod_template`
- `cargo test -p centaur-api-server runtime_class_name`
- `cargo test -p centaur-api-server args::tests::parses_session_sandbox_flags`
- `cargo test -p centaur-api-server args::tests::agent_k8s_config_converts_from_sandbox_args`
- `helm lint contrib/chart`
- `helm template centaur contrib/chart --namespace centaur --set sandbox.runtimeClassName=gvisor` renders `SESSION_SANDBOX_RUNTIME_CLASS_NAME=gvisor`
