### PR TITLE
ci: run console CI for merge groups

### DIFF
--- a/.github/workflows/console-ci.yml
+++ b/.github/workflows/console-ci.yml
@@ -2,6 +2,7 @@ name: Console CI
 
 on:
   pull_request:
+  merge_group:
   push:
     branches: [ main ]
 


### PR DESCRIPTION
Run the Console CI workflow for merge queue commits so the required Console CI success check is produced before queued pull requests merge.