### PR TITLE
fix(websearch): use injected Parallel auth

### DIFF
--- a/tools/research/websearch/_parallel.py
+++ b/tools/research/websearch/_parallel.py
@@ -132,10 +132,9 @@ class ParallelBackend:
         # per backend instance so callers who omit it still get continuity
         # within a process.
         self._default_session_id = f"centaur-websearch-{uuid.uuid4().hex}"
-        # Set once a REST search fails auth — i.e. the configured "key" was an
-        # un-swapped placeholder (centaur replace-mode secret that iron-proxy
-        # had nothing to resolve). Subsequent searches skip REST and use the
-        # anonymous MCP path (see the fallback in `search`).
+        # Set once a REST search fails auth — i.e. iron-proxy did not inject a
+        # granted key or the configured key was invalid. Subsequent searches
+        # skip REST and use the anonymous MCP path (see `search`).
         self._rest_auth_failed = False
 
     @property
@@ -144,7 +143,7 @@ class ParallelBackend:
 
     @property
     def search_mode(self) -> str:
-        return "api" if self._api_key else "mcp"
+        return "api" if self._api_key and not self._rest_auth_failed else "mcp"
 
     def _sdk_client(self, *, timeout_seconds: float) -> AsyncParallel:
         if not self._api_key:
@@ -205,9 +204,9 @@ class ParallelBackend:
                 )
                 backend_label = "parallel:api"
             except AuthenticationError:
-                # The configured key was an un-swapped placeholder (centaur
-                # replace-mode secret with no real value in the vault). Fall
-                # back to the anonymous MCP path and skip REST from now on.
+                # No granted inject secret (or an invalid configured value)
+                # left the SDK placeholder in x-api-key. Fall back to the
+                # anonymous MCP path and skip REST from now on.
                 self._rest_auth_failed = True
                 use_rest = False
                 partial_failures.append(
@@ -344,25 +343,28 @@ class ParallelBackend:
 
         started = time.perf_counter()
         progress(f"creating task ({effective_processor}, timeout={int(effective_timeout)}s)")
-        client = self._sdk_client(timeout_seconds=effective_timeout)
         # Use auto schema (Parallel's default for pro/ultra processors), which
         # returns a structured JSON report with per-field basis grounding. The
         # canonical Deep Research example in the docs uses this — text mode
         # gives looser, less reliably-cited output.
-        async with client:
-            task = await client.task_run.create(
-                input=normalized,
-                processor=effective_processor,
-                enable_events=True,
-            )
-            run_id = task.run_id
-            progress(f"queued {run_id}")
+        try:
+            client = self._sdk_client(timeout_seconds=effective_timeout)
+            async with client:
+                task = await client.task_run.create(
+                    input=normalized,
+                    processor=effective_processor,
+                    enable_events=True,
+                )
+                run_id = task.run_id
+                progress(f"queued {run_id}")
 
-            await _stream_progress(client, run_id, progress)
+                await _stream_progress(client, run_id, progress)
 
-            result = await _await_task_result(
-                client, run_id=run_id, deadline=started + effective_timeout
-            )
+                result = await _await_task_result(
+                    client, run_id=run_id, deadline=started + effective_timeout
+                )
+        except AuthenticationError as exc:
+            raise RuntimeError("deep_research requires a valid, granted PARALLEL_API_KEY.") from exc
 
         sources, answer_markdown = _normalize_task_result(result, max_report_chars=max_report_chars)
         if not answer_markdown:
@@ -556,10 +558,9 @@ class ParallelBackend:
         }
         if session_id:
             headers["Mcp-Session-Id"] = session_id
-        # Only attach a Bearer token when we hold a key that actually
-        # authenticates. If REST already failed auth (placeholder/un-swapped
-        # replacer), the MCP fallback must stay anonymous — sending the bogus
-        # token would get the free endpoint to 401 as well.
+        # Only attach a Bearer token when REST has not rejected the candidate
+        # credential. After a failed inject attempt, the MCP fallback must stay
+        # anonymous or the placeholder would make the free endpoint return 401.
         if self._api_key and not self._rest_auth_failed:
             headers["Authorization"] = f"Bearer {self._api_key}"
         return headers

--- a/tools/research/websearch/client.py
+++ b/tools/research/websearch/client.py
@@ -76,17 +76,11 @@ class WebSearchClient:
         synthesis_model: str | None = None,
         max_retries: int = 3,
     ) -> None:
-        # PARALLEL_API_KEY / ANTHROPIC_API_KEY: read via secret() so the
-        # firewall (StubBackend → mitmproxy) can swap in real values for
-        # outbound headers. _is_configured() is the routing signal — it
-        # checks ctx.secrets membership rather than relying on secret()'s
-        # stub-as-placeholder fallback.
-        self._has_parallel_key = parallel_api_key is not None or _is_configured("PARALLEL_API_KEY")
+        # Always pass the StubBackend placeholder so the SDK sends x-api-key.
+        # Search falls back to anonymous MCP if injected authentication fails.
+        self._parallel_api_key = parallel_api_key or secret("PARALLEL_API_KEY", "PARALLEL_API_KEY")
         self._has_anthropic_key = anthropic_api_key is not None or _is_configured(
             "ANTHROPIC_API_KEY"
-        )
-        self._parallel_api_key = parallel_api_key or (
-            secret("PARALLEL_API_KEY") if self._has_parallel_key else None
         )
         self._anthropic_api_key = anthropic_api_key or (
             secret("ANTHROPIC_API_KEY") if self._has_anthropic_key else None
@@ -101,7 +95,7 @@ class WebSearchClient:
         self._max_retries = max_retries
         self._progress_callback: Callable[[str], None] | None = None
         self._backend = ParallelBackend(
-            api_key=self._parallel_api_key if self._has_parallel_key else None,
+            api_key=self._parallel_api_key,
             api_base_url=self._api_base_url,
             mcp_url=self._mcp_url,
             deep_research_processor=self._deep_research_processor,

--- a/tools/research/websearch/pyproject.toml
+++ b/tools/research/websearch/pyproject.toml
@@ -34,7 +34,7 @@ module = "client.py"
 # Set ANTHROPIC_API_KEY to enable the Claude-backed synthesis pipeline on
 # top of search results (reviewer → writer → citation repair).
 optional_secrets = [
-    {type = "http", name = "PARALLEL_API_KEY", mode = "inject", inject_header = "Authorization", inject_formatter = "Bearer {{ .Value }}", hosts = ["api.parallel.ai", "search.parallel.ai"]},
+    {type = "http", name = "PARALLEL_API_KEY", mode = "inject", inject_header = "x-api-key", hosts = ["api.parallel.ai"]},
     {type = "http", name = "ANTHROPIC_API_KEY", mode = "inject", inject_header = "x-api-key", hosts = ["api.anthropic.com"]},
 ]
 hosts = ["api.parallel.ai", "search.parallel.ai"]

--- a/tools/research/websearch/test_client.py
+++ b/tools/research/websearch/test_client.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import asyncio
+import tomllib
+from pathlib import Path
+
+import pytest
+from centaur_tool_websearch import _parallel
+from centaur_tool_websearch.client import WebSearchClient
+
+from centaur_sdk.backends import StubBackend, configure
+
+
+def test_client_uses_stub_to_enable_proxy_injection() -> None:
+    configure(StubBackend())
+
+    client = WebSearchClient()
+
+    assert client._parallel_api_key == "PARALLEL_API_KEY"
+    assert client.has_api_key is True
+
+
+def test_parallel_secret_is_injected_into_sdk_header() -> None:
+    manifest = tomllib.loads(Path(__file__).with_name("pyproject.toml").read_text())
+    secrets = manifest["tool"]["centaur"]["optional_secrets"]
+    parallel = next(secret for secret in secrets if secret["name"] == "PARALLEL_API_KEY")
+
+    assert parallel == {
+        "type": "http",
+        "name": "PARALLEL_API_KEY",
+        "mode": "inject",
+        "inject_header": "x-api-key",
+        "hosts": ["api.parallel.ai"],
+    }
+
+
+def test_search_attempts_rest_with_inject_stub(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def search_rest(**_kwargs):
+        return [], "api-request", []
+
+    async def reject_mcp(**_kwargs):
+        raise AssertionError("MCP should not be used when injected auth succeeds")
+
+    configure(StubBackend())
+    client = WebSearchClient()
+    monkeypatch.setattr(client._backend, "_search_api", search_rest)
+    monkeypatch.setattr(client._backend, "_search_mcp", reject_mcp)
+
+    result = asyncio.run(client.search("injected", synthesize=False))
+
+    assert result["meta"]["backend"] == "parallel:api"
+
+
+def test_search_falls_back_to_anonymous_mcp_when_injected_auth_is_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FakeAuthenticationError(Exception):
+        pass
+
+    async def reject_rest(**_kwargs):
+        raise FakeAuthenticationError
+
+    async def search_mcp(**_kwargs):
+        return [], "mcp-request", []
+
+    configure(StubBackend())
+    client = WebSearchClient()
+    monkeypatch.setattr(_parallel, "AuthenticationError", FakeAuthenticationError)
+    monkeypatch.setattr(client._backend, "_search_api", reject_rest)
+    monkeypatch.setattr(client._backend, "_search_mcp", search_mcp)
+
+    result = asyncio.run(client.search("fallback", synthesize=False))
+
+    assert result["meta"]["backend"] == "parallel:mcp"
+    assert client.search_mode == "mcp"
+    assert client._backend._mcp_headers(None).get("Authorization") is None
+
+
+def test_deep_research_reports_missing_injected_auth(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FakeAuthenticationError(Exception):
+        pass
+
+    def reject_client(**_kwargs):
+        raise FakeAuthenticationError
+
+    configure(StubBackend())
+    client = WebSearchClient()
+    monkeypatch.setattr(_parallel, "AuthenticationError", FakeAuthenticationError)
+    monkeypatch.setattr(client._backend, "_sdk_client", reject_client)
+
+    with pytest.raises(
+        RuntimeError,
+        match="deep_research requires a valid, granted PARALLEL_API_KEY",
+    ):
+        asyncio.run(client.deep_research("question"))


### PR DESCRIPTION
Before, websearch decided whether Parallel REST was available from `ToolContext` or the environment before making a request. Sandbox shims left `ToolContext.secrets` empty, so the client skipped REST and rejected deep research even when iron-proxy had an inject grant; the replace-mode approach in #1279 addressed that with an environment placeholder, which does not work for already-running warm-pool sandboxes.

After, `PARALLEL_API_KEY` remains inject-mode and targets the `x-api-key` header used by `parallel-web`. The client attempts REST with the StubBackend placeholder: successful injection uses REST, while an authentication failure marks REST unavailable and retries search through anonymous MCP without forwarding the placeholder. Deep research has no MCP equivalent, so authentication failures return a clear configuration error. Cold and warm-pool sandboxes now follow the same path.