### PR TITLE
fix: skip stale broker refresh jobs

### DIFF
--- a/services/console/app/jobs/broker/poll_refresh_job.rb
+++ b/services/console/app/jobs/broker/poll_refresh_job.rb
@@ -5,9 +5,10 @@ module Broker
   # next one (unlike a self-rescheduling job, which orphans a credential forever
   # if its enqueue is ever lost).
   #
-  # FOR UPDATE SKIP LOCKED skips credentials whose refresh is already in flight
-  # (locked by a RefreshCredentialJob), so we don't enqueue redundant work for
-  # them.
+  # FOR UPDATE SKIP LOCKED skips credentials whose refresh is actively holding
+  # its row lock. A credential can still be enqueued by multiple poll ticks
+  # while the first job waits in the queue; BrokerCredential#refresh! re-checks
+  # next_attempt_at under that same row lock so those stale jobs are no-ops.
   class PollRefreshJob < ApplicationJob
     queue_as :default
 

--- a/services/console/app/jobs/broker/refresh_credential_job.rb
+++ b/services/console/app/jobs/broker/refresh_credential_job.rb
@@ -1,8 +1,8 @@
 module Broker
   # Refreshes one BrokerCredential. limits_concurrency serializes runs per
-  # credential at the queue layer so duplicate enqueues (e.g. two poll ticks)
-  # don't pile up; BrokerCredential#refresh! takes a row lock as the real
-  # single-writer guarantee.
+  # credential at the queue layer. Duplicate enqueues (e.g. two poll ticks) may
+  # wait behind one another; BrokerCredential#refresh! takes a row lock as the
+  # real single-writer guarantee and skips jobs made stale by an earlier refresh.
   #
   # #refresh! never raises for an IdP or config failure -- it records the outcome
   # (backoff schedule or dead state) in the row -- so this job does not rely on

--- a/services/console/app/models/broker_credential.rb
+++ b/services/console/app/models/broker_credential.rb
@@ -150,6 +150,11 @@ class BrokerCredential < ApplicationRecord
   def refresh!(now: Time.current)
     with_lock do
       return if dead?
+      # Poll ticks can enqueue the same credential more than once while an
+      # earlier refresh job is still waiting. Re-check the schedule after
+      # taking the row lock so jobs queued before a successful refresh become
+      # no-ops instead of rotating the newly issued token again.
+      return if next_attempt_at.present? && next_attempt_at > now
 
       outcome = perform_refresh
       if outcome.dead_reason

--- a/services/console/test/jobs/broker/jobs_test.rb
+++ b/services/console/test/jobs/broker/jobs_test.rb
@@ -60,15 +60,6 @@ module Broker
       assert_equal "missing_initial_refresh_token", bc.dead_reason
     end
 
-    test "RefreshCredentialJob skips a credential that is no longer due" do
-      bc = make_credential(refresh_token: nil)
-      bc.update_columns(next_attempt_at: 1.hour.from_now)
-
-      Broker::RefreshCredentialJob.perform_now(bc.id)
-
-      refute bc.reload.dead?
-    end
-
     test "RefreshCredentialJob is a no-op for a missing credential" do
       assert_nothing_raised { Broker::RefreshCredentialJob.perform_now(-1) }
     end

--- a/services/console/test/jobs/broker/jobs_test.rb
+++ b/services/console/test/jobs/broker/jobs_test.rb
@@ -60,6 +60,15 @@ module Broker
       assert_equal "missing_initial_refresh_token", bc.dead_reason
     end
 
+    test "RefreshCredentialJob skips a credential that is no longer due" do
+      bc = make_credential(refresh_token: nil)
+      bc.update_columns(next_attempt_at: 1.hour.from_now)
+
+      Broker::RefreshCredentialJob.perform_now(bc.id)
+
+      refute bc.reload.dead?
+    end
+
     test "RefreshCredentialJob is a no-op for a missing credential" do
       assert_nothing_raised { Broker::RefreshCredentialJob.perform_now(-1) }
     end

--- a/services/console/test/models/broker_credential_test.rb
+++ b/services/console/test/models/broker_credential_test.rb
@@ -244,6 +244,24 @@ class BrokerCredentialTest < ActiveSupport::TestCase
     assert bc.next_attempt_at > now
   end
 
+  test "refresh skips a queued attempt made stale by a successful refresh" do
+    now = Time.current
+    client = Minitest::Mock.new
+    expect_refresh(client, returns: result(access_token: "AT-1", refresh_token: "RT-2", expires_in: 3600))
+    bc = create_credential
+    bc.update!(next_attempt_at: now)
+    bc.refresh_client = client
+
+    bc.refresh!(now: now)
+    bc.refresh!(now: now + 1.minute)
+
+    client.verify
+    bc.reload
+    assert_equal "AT-1", bc.access_token
+    assert_equal "RT-2", bc.refresh_token
+    assert_operator bc.next_attempt_at, :>, now + 1.minute
+  end
+
   test "refresh carries the previous refresh_token forward when the IdP omits it" do
     client = Minitest::Mock.new
     expect_refresh(client, returns: result(refresh_token: nil, expires_in: nil))


### PR DESCRIPTION
Re-checks a broker credential's refresh schedule after acquiring its row lock, so duplicate jobs queued by repeated poll ticks do not rotate a newly refreshed token again. Updates the queueing comments to describe the actual serialization behavior and adds model/job regression coverage for stale queued attempts.