### PR TITLE
fix(console): handle empty Granola syncs

### DIFF
--- a/services/console/app/services/granola/sync_credential.rb
+++ b/services/console/app/services/granola/sync_credential.rb
@@ -94,6 +94,8 @@ module Granola
         )
       ).first(self.class.max_notes)
 
+      return [] if meetings.empty?
+
       details = parse_meetings(
         mcp_tool("get_meetings", "meeting_ids" => meetings.map { |meeting| meeting.fetch("id") })
       ).index_by { |meeting| meeting.fetch("id") }

--- a/services/console/test/services/granola/sync_credential_test.rb
+++ b/services/console/test/services/granola/sync_credential_test.rb
@@ -115,6 +115,31 @@ module Granola
       assert_includes failed[:run][:error_text], "rate limited"
     end
 
+    test "records a successful sync when there are no new meetings" do
+      checkpoint_time = "2026-07-08T12:00:00Z"
+      api_client = FakeApiClient.new(
+        checkpoint: { "watermark_time" => checkpoint_time }
+      )
+      mcp_http = lambda do |tool:, **|
+        case tool
+        when "get_account_info"
+          { email: "owner@example.com" }.to_json
+        when "list_meetings"
+          ""
+        else
+          flunk "unexpected Granola MCP tool #{tool}"
+        end
+      end
+
+      SyncCredential.new(credential, api_client: api_client, mcp_http: mcp_http).call
+
+      batch = api_client.batches.fetch(0)
+      assert_equal "completed", batch[:run][:status]
+      assert_equal 0, batch[:run][:notes_seen]
+      assert_empty batch[:notes]
+      assert_equal checkpoint_time, batch[:checkpoint][:watermark_time]
+    end
+
     test "includes MCP tool error content in the raised error" do
       sync = SyncCredential.new(credential, api_client: FakeApiClient.new)
       sync.instance_variable_set(:@mcp_initialized, true)


### PR DESCRIPTION
## Summary
- treat an empty Granola `list_meetings` response as a successful zero-note sync
- skip the invalid `get_meetings(meeting_ids: [])` call
- preserve the existing checkpoint and add regression coverage

## Testing
- `git diff --check`
- Rails test not run locally: Ruby is unavailable and the sandbox has no Docker daemon; CI will run the focused coverage

Prompted by: mslipper