### PR TITLE
fix(attio): harden CRM mutations and pagination

### DIFF
--- a/tools/business/attio/cli.py
+++ b/tools/business/attio/cli.py
@@ -294,6 +294,20 @@ def update(
 
 
 @app.command()
+def replace(
+    object_slug: str = typer.Argument(..., help="Object slug"),
+    record_id: str = typer.Argument(..., help="Record ID"),
+    values_json: str = typer.Argument(..., help="Values to replace as JSON"),
+):
+    """Replace supplied attribute values, including multi-value relationships."""
+    client = _get_client()
+    values = json.loads(values_json)
+    client.replace_record_values(object_slug, record_id, values)
+
+    console.print(f"[green]✓ Replaced values on {object_slug} record {record_id[:8]}...[/]")
+
+
+@app.command()
 def delete(
     object_slug: str = typer.Argument(..., help="Object slug"),
     record_id: str = typer.Argument(..., help="Record ID"),

--- a/tools/business/attio/cli.py
+++ b/tools/business/attio/cli.py
@@ -208,12 +208,17 @@ def records(
     limit: int = typer.Option(25, "--limit", "-n", help="Max results"),
     filter_json: str = typer.Option(None, "--filter", "-f", help="Filter as JSON"),
     json_output: bool = typer.Option(False, "--json", "-j", help="Output as JSON"),
+    all_results: bool = typer.Option(False, "--all", help="Fetch all result pages"),
 ):
     """Query records for any object."""
     client = _get_client()
 
     filter_obj = json.loads(filter_json) if filter_json else None
-    records_list = client.query_records(object_slug, filter_obj=filter_obj, limit=limit)
+    records_list = (
+        client.query_all_records(object_slug, filter_obj=filter_obj, page_size=limit)
+        if all_results
+        else client.query_records(object_slug, filter_obj=filter_obj, limit=limit)
+    )
 
     if json_output:
         print(json.dumps(records_list, indent=2, ensure_ascii=False), file=sys.stdout)
@@ -280,15 +285,20 @@ def update(
     object_slug: str = typer.Argument(..., help="Object slug"),
     record_id: str = typer.Argument(..., help="Record ID"),
     values_json: str = typer.Argument(..., help="Values to update as JSON"),
+    json_output: bool = typer.Option(False, "--json", "-j", help="Output canonical response"),
 ):
-    """Update an existing record.
+    """Update a record, appending rather than replacing multiselect values.
 
     Examples:
         attio update people abc123 '{"email_addresses": [{"email_address": "new@email.com"}]}'
     """
     client = _get_client()
     values = json.loads(values_json)
-    client.update_record(object_slug, record_id, values)
+    record = client.update_record(object_slug, record_id, values)
+
+    if json_output:
+        print(json.dumps(record, indent=2, ensure_ascii=False), file=sys.stdout)
+        raise typer.Exit()
 
     console.print(f"[green]✓ Updated {object_slug} record {record_id[:8]}...[/]")
 
@@ -298,11 +308,16 @@ def replace(
     object_slug: str = typer.Argument(..., help="Object slug"),
     record_id: str = typer.Argument(..., help="Record ID"),
     values_json: str = typer.Argument(..., help="Values to replace as JSON"),
+    json_output: bool = typer.Option(False, "--json", "-j", help="Output canonical response"),
 ):
     """Replace supplied attribute values, including multi-value relationships."""
     client = _get_client()
     values = json.loads(values_json)
-    client.replace_record_values(object_slug, record_id, values)
+    record = client.replace_record_values(object_slug, record_id, values)
+
+    if json_output:
+        print(json.dumps(record, indent=2, ensure_ascii=False), file=sys.stdout)
+        raise typer.Exit()
 
     console.print(f"[green]✓ Replaced values on {object_slug} record {record_id[:8]}...[/]")
 
@@ -404,10 +419,15 @@ def notes(
     object_slug: str = typer.Argument(..., help="Parent object slug"),
     record_id: str = typer.Argument(..., help="Parent record ID"),
     json_output: bool = typer.Option(False, "--json", "-j", help="Output as JSON"),
+    all_results: bool = typer.Option(False, "--all", help="Fetch all result pages"),
 ):
     """List notes for a record."""
     client = _get_client()
-    notes_list = client.list_notes(object_slug, record_id)
+    notes_list = (
+        client.list_all_notes(object_slug, record_id)
+        if all_results
+        else client.list_notes(object_slug, record_id)
+    )
 
     if json_output:
         print(json.dumps(notes_list, indent=2, ensure_ascii=False), file=sys.stdout)

--- a/tools/business/attio/client.py
+++ b/tools/business/attio/client.py
@@ -2,6 +2,8 @@
 
 import mimetypes
 import time
+from datetime import UTC, datetime
+from email.utils import parsedate_to_datetime
 from pathlib import Path
 from typing import Any
 
@@ -44,11 +46,7 @@ class AttioClient:
             if response.status_code != 429 or attempt == self.max_rate_limit_retries:
                 break
             retry_after = response.headers.get("Retry-After", "1")
-            try:
-                delay = min(max(float(retry_after), 0.0), 5.0)
-            except ValueError:
-                delay = 1.0
-            time.sleep(delay)
+            time.sleep(self._retry_delay(retry_after))
         if response.status_code >= 400:
             try:
                 error = response.json()
@@ -57,6 +55,20 @@ class AttioClient:
                 msg = response.text
             raise RuntimeError(f"Attio API error ({response.status_code}): {msg}")
         return response.json()
+
+    def _retry_delay(self, retry_after: str, now: datetime | None = None) -> float:
+        """Parse Retry-After as delta seconds or an HTTP date, bounded to one minute."""
+        try:
+            delay = float(retry_after)
+        except ValueError:
+            try:
+                retry_at = parsedate_to_datetime(retry_after)
+                if retry_at.tzinfo is None:
+                    retry_at = retry_at.replace(tzinfo=UTC)
+                delay = (retry_at - (now or datetime.now(UTC))).total_seconds()
+            except (TypeError, ValueError, OverflowError):
+                delay = 1.0
+        return min(max(delay, 0.0), 60.0)
 
     def _clean_params(self, params: dict[str, Any]) -> dict[str, Any]:
         """Remove unset values and encode list query params the way Attio expects."""

--- a/tools/business/attio/client.py
+++ b/tools/business/attio/client.py
@@ -172,6 +172,12 @@ class AttioClient:
         data = self._request("PATCH", f"/objects/{object_slug}/records/{record_id}", json=body)
         return data.get("data", {})
 
+    def replace_record_values(self, object_slug: str, record_id: str, values: dict) -> dict:
+        """Replace the supplied record attribute values instead of appending them."""
+        body = {"data": {"values": values}}
+        data = self._request("PUT", f"/objects/{object_slug}/records/{record_id}", json=body)
+        return data.get("data", {})
+
     def delete_record(self, object_slug: str, record_id: str) -> bool:
         """Delete a record."""
         self._request("DELETE", f"/objects/{object_slug}/records/{record_id}")

--- a/tools/business/attio/client.py
+++ b/tools/business/attio/client.py
@@ -1,6 +1,7 @@
 """Attio API client."""
 
 import mimetypes
+import time
 from pathlib import Path
 from typing import Any
 
@@ -12,9 +13,10 @@ from centaur_sdk import secret
 class AttioClient:
     """Authenticated Attio CRM API client."""
 
-    def __init__(self, api_key: str | None = None):
+    def __init__(self, api_key: str | None = None, max_rate_limit_retries: int = 2):
         self._api_key_override = api_key
         self._client: httpx.Client | None = None
+        self.max_rate_limit_retries = max_rate_limit_retries
 
     def _http(self) -> httpx.Client:
         """Return the cached HTTP client, building it after secrets are injected."""
@@ -37,7 +39,16 @@ class AttioClient:
 
     def _request(self, method: str, path: str, **kwargs) -> dict[str, Any]:
         """Make authenticated request to Attio API."""
-        response = self._http().request(method, path, **kwargs)
+        for attempt in range(self.max_rate_limit_retries + 1):
+            response = self._http().request(method, path, **kwargs)
+            if response.status_code != 429 or attempt == self.max_rate_limit_retries:
+                break
+            retry_after = response.headers.get("Retry-After", "1")
+            try:
+                delay = min(max(float(retry_after), 0.0), 5.0)
+            except ValueError:
+                delay = 1.0
+            time.sleep(delay)
         if response.status_code >= 400:
             try:
                 error = response.json()
@@ -140,6 +151,31 @@ class AttioClient:
         data = self._request("POST", f"/objects/{object_slug}/records/query", json=body)
         return data.get("data", [])
 
+    def query_all_records(
+        self,
+        object_slug: str,
+        filter_obj: dict | None = None,
+        sorts: list[dict] | None = None,
+        page_size: int = 500,
+    ) -> list[dict]:
+        """Query every matching record using Attio's limit/offset pagination."""
+        if not 1 <= page_size <= 500:
+            raise ValueError("page_size must be between 1 and 500")
+        records: list[dict] = []
+        offset = 0
+        while True:
+            page = self.query_records(
+                object_slug,
+                filter_obj=filter_obj,
+                sorts=sorts,
+                limit=page_size,
+                offset=offset,
+            )
+            records.extend(page)
+            if len(page) < page_size:
+                return records
+            offset += page_size
+
     def get_record(self, object_slug: str, record_id: str) -> dict:
         """Get a specific record by ID."""
         data = self._request("GET", f"/objects/{object_slug}/records/{record_id}")
@@ -163,20 +199,30 @@ class AttioClient:
         return data.get("data", {})
 
     def update_record(self, object_slug: str, record_id: str, values: dict) -> dict:
-        """Update an existing record.
+        """Update a record, appending rather than replacing multiselect values.
 
         values format is the same as create_record — attribute slugs mapping to
         lists of typed value objects.
         """
         body = {"data": {"values": values}}
         data = self._request("PATCH", f"/objects/{object_slug}/records/{record_id}", json=body)
-        return data.get("data", {})
+        return self._validated_record_response(data, record_id)
 
     def replace_record_values(self, object_slug: str, record_id: str, values: dict) -> dict:
         """Replace the supplied record attribute values instead of appending them."""
         body = {"data": {"values": values}}
         data = self._request("PUT", f"/objects/{object_slug}/records/{record_id}", json=body)
-        return data.get("data", {})
+        return self._validated_record_response(data, record_id)
+
+    def _validated_record_response(self, response: dict[str, Any], record_id: str) -> dict:
+        """Require Attio to return the record that was mutated."""
+        record = response.get("data", {})
+        returned_id = record.get("id", {}).get("record_id")
+        if returned_id != record_id:
+            raise RuntimeError(
+                f"Attio mutation response did not confirm record {record_id}; got {returned_id!r}"
+            )
+        return record
 
     def delete_record(self, object_slug: str, record_id: str) -> bool:
         """Delete a record."""
@@ -223,9 +269,7 @@ class AttioClient:
         data = self._request("POST", f"/lists/{list_id}/entries/query", json=body)
         return data.get("data", [])
 
-    def create_entry(
-        self, list_id: str, parent_record_id: str, values: dict | None = None
-    ) -> dict:
+    def create_entry(self, list_id: str, parent_record_id: str, values: dict | None = None) -> dict:
         """Create a new entry in a list."""
         body: dict[str, Any] = {"data": {"parent_record_id": parent_record_id}}
         if values:
@@ -233,14 +277,45 @@ class AttioClient:
         data = self._request("POST", f"/lists/{list_id}/entries", json=body)
         return data.get("data", {})
 
-    def list_notes(self, parent_object: str, parent_record_id: str) -> list[dict]:
+    def list_notes(
+        self,
+        parent_object: str,
+        parent_record_id: str,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> list[dict]:
         """List notes for a record."""
         data = self._request(
             "GET",
             "/notes",
-            params={"parent_object": parent_object, "parent_record_id": parent_record_id},
+            params={
+                "parent_object": parent_object,
+                "parent_record_id": parent_record_id,
+                "limit": limit,
+                "offset": offset,
+            },
         )
         return data.get("data", [])
+
+    def list_all_notes(
+        self, parent_object: str, parent_record_id: str, page_size: int = 50
+    ) -> list[dict]:
+        """List every note for a record using Attio's limit/offset pagination."""
+        if not 1 <= page_size <= 50:
+            raise ValueError("page_size must be between 1 and 50")
+        notes: list[dict] = []
+        offset = 0
+        while True:
+            page = self.list_notes(
+                parent_object,
+                parent_record_id,
+                limit=page_size,
+                offset=offset,
+            )
+            notes.extend(page)
+            if len(page) < page_size:
+                return notes
+            offset += page_size
 
     def upload_file(
         self,

--- a/tools/business/attio/test_client.py
+++ b/tools/business/attio/test_client.py
@@ -1,4 +1,5 @@
 import json
+from datetime import UTC, datetime
 from pathlib import Path
 from unittest.mock import patch
 
@@ -151,3 +152,10 @@ def test_rate_limit_response_retries_then_succeeds() -> None:
 
     assert attempts == 2
     sleep.assert_called_once_with(0.0)
+
+
+def test_retry_after_http_date_is_parsed() -> None:
+    client = AttioClient(api_key="test-key")
+    now = datetime(2026, 8, 8, 12, 0, tzinfo=UTC)
+
+    assert client._retry_delay("Sat, 08 Aug 2026 12:00:05 GMT", now=now) == 5.0

--- a/tools/business/attio/test_client.py
+++ b/tools/business/attio/test_client.py
@@ -1,4 +1,6 @@
+import json
 from pathlib import Path
+from unittest.mock import patch
 
 import httpx
 import pytest
@@ -66,3 +68,86 @@ def test_replace_record_values_uses_put() -> None:
     result = client.replace_record_values("deals", "deal-123", {"dependencies_4": []})
 
     assert result == {"id": {"record_id": "deal-123"}}
+
+
+def test_update_record_rejects_unconfirmed_response() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"data": {"id": {"record_id": "wrong-record"}}})
+
+    client = AttioClient(api_key="test-key")
+    client._client = httpx.Client(
+        base_url="https://api.attio.com/v2",
+        headers={"Authorization": "Bearer test-key"},
+        transport=httpx.MockTransport(handler),
+    )
+
+    with pytest.raises(RuntimeError, match="did not confirm record deal-123"):
+        client.update_record("deals", "deal-123", {"name": "Example"})
+
+
+def test_query_all_records_paginates_to_short_page() -> None:
+    offsets: list[int] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.read())
+        offsets.append(body["offset"])
+        count = 2 if body["offset"] == 0 else 1
+        return httpx.Response(200, json={"data": [{"page": body["offset"]}] * count})
+
+    client = AttioClient(api_key="test-key")
+    client._client = httpx.Client(
+        base_url="https://api.attio.com/v2",
+        headers={"Authorization": "Bearer test-key"},
+        transport=httpx.MockTransport(handler),
+    )
+
+    result = client.query_all_records("deals", page_size=2)
+
+    assert offsets == [0, 2]
+    assert len(result) == 3
+
+
+def test_list_all_notes_paginates_to_short_page() -> None:
+    offsets: list[int] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        offset = int(request.url.params["offset"])
+        offsets.append(offset)
+        count = 2 if offset == 0 else 0
+        return httpx.Response(200, json={"data": [{"page": offset}] * count})
+
+    client = AttioClient(api_key="test-key")
+    client._client = httpx.Client(
+        base_url="https://api.attio.com/v2",
+        headers={"Authorization": "Bearer test-key"},
+        transport=httpx.MockTransport(handler),
+    )
+
+    result = client.list_all_notes("deals", "deal-123", page_size=2)
+
+    assert offsets == [0, 2]
+    assert len(result) == 2
+
+
+def test_rate_limit_response_retries_then_succeeds() -> None:
+    attempts = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            return httpx.Response(429, headers={"Retry-After": "0"}, json={"message": "wait"})
+        return httpx.Response(200, json={"data": []})
+
+    client = AttioClient(api_key="test-key")
+    client._client = httpx.Client(
+        base_url="https://api.attio.com/v2",
+        headers={"Authorization": "Bearer test-key"},
+        transport=httpx.MockTransport(handler),
+    )
+
+    with patch("client.time.sleep") as sleep:
+        assert client.list_objects() == []
+
+    assert attempts == 2
+    sleep.assert_called_once_with(0.0)

--- a/tools/business/attio/test_client.py
+++ b/tools/business/attio/test_client.py
@@ -47,3 +47,22 @@ def test_upload_file_rejects_missing_path(tmp_path: Path) -> None:
 
     with pytest.raises(ValueError, match="does not exist"):
         client.upload_file("companies", "record-id", str(tmp_path / "missing.pdf"))
+
+
+def test_replace_record_values_uses_put() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.method == "PUT"
+        assert request.url.path == "/v2/objects/deals/records/deal-123"
+        assert request.read() == b'{"data":{"values":{"dependencies_4":[]}}}'
+        return httpx.Response(200, json={"data": {"id": {"record_id": "deal-123"}}})
+
+    client = AttioClient(api_key="test-key")
+    client._client = httpx.Client(
+        base_url="https://api.attio.com/v2",
+        headers={"Authorization": "Bearer test-key"},
+        transport=httpx.MockTransport(handler),
+    )
+
+    result = client.replace_record_values("deals", "deal-123", {"dependencies_4": []})
+
+    assert result == {"id": {"record_id": "deal-123"}}


### PR DESCRIPTION
## Summary
- make PATCH append semantics explicit and add PUT replacement for relationship removal
- require mutation responses to confirm the expected record ID
- add complete record and note pagination paths for integration workflows
- retry bounded Attio 429 responses using `Retry-After`
- expose canonical mutation responses through CLI JSON output
- retain native file upload support and coverage

## Validation
- 8 Attio client tests pass
- Ruff check and format pass
- package source distribution and wheel build successfully
- live `attio health` succeeds against the Tempo workspace

Prompted by: @snario