### PR TITLE
feat: support explicit workflow principals

### DIFF
--- a/docs/pages/extend/workflows-v2.mdx
+++ b/docs/pages/extend/workflows-v2.mdx
@@ -132,8 +132,8 @@ WORKFLOW_PRINCIPAL = True
 ```
 
 The API derives and registers the `workflow-nightly-report` principal in the
-Centaur Console and runs that workflow's host sandbox under it. Grant only the
-roles or secrets that workflow needs:
+Centaur Console and runs that workflow's host sandbox and agent turns under it.
+Grant only the roles or secrets that workflow needs:
 
 ```bash
 cargo run -p centaur-perms -- \
@@ -141,22 +141,43 @@ cargo run -p centaur-perms -- \
   --tool slack
 ```
 
-The principal id is always `workflow-` plus the slugged `WORKFLOW_NAME`.
-Workflow code cannot choose another principal id, display name, or labels.
-`WORKFLOW_PRINCIPAL = True` requires `apiRs.workflowHostSandbox=true`, which
-renders `WORKFLOW_HOST_SANDBOX=true`; startup fails if a workflow declares a
-principal while workflow-host sandboxing is disabled.
+Set `WORKFLOW_PRINCIPAL` to an existing principal foreign id or `prn_...` id to
+reuse that principal instead:
+
+```python
+WORKFLOW_PRINCIPAL = "shared-automation"
+```
+
+Centaur resolves string references without creating or updating the principal.
+Startup fails if the principal does not exist. `WORKFLOW_PRINCIPAL = True`
+still derives `workflow-` plus the slugged `WORKFLOW_NAME`. Any declared
+workflow principal requires `apiRs.workflowHostSandbox=true`, which renders
+`WORKFLOW_HOST_SANDBOX=true`.
+
+Agent turns inherit `WORKFLOW_PRINCIPAL`. A turn can select another existing
+principal for its session with `principal`:
+
+```python
+await ctx.agent_turn(
+    "Publish the approved report.",
+    principal="report-publisher",
+)
+```
+
+An explicit `thread_key` cannot be reused with a different principal. Centaur
+rejects the turn instead of changing the identity of an existing session.
 
 #### Pick the model and reasoning effort
 
 `ctx.agent_turn(...)` accepts optional `model`, `provider`, and `reasoning`
-kwargs. They ride the turn exactly like the Slack `--model` / `--bedrock` /
+kwargs. It also accepts `principal` as described above. Model kwargs ride the
+turn exactly like the Slack `--model` / `--bedrock` /
 `-rsn` flags: `model` selects the model within the harness, `reasoning` sets the
 codex reasoning effort (`none`/`minimal`/`low`/`medium`/`high`/`xhigh`/`max`),
 and `provider` selects the codex model provider. `provider` and `reasoning` only
 affect the codex harness; claude and amp ignore them. `reasoning` also accepts
 the `reasoning_effort` and `effort` aliases. When a kwarg is omitted the
-deployment/baked harness default stands — dispatched turns are no longer pinned
+deployment/baked harness default stands. Dispatched turns are no longer pinned
 to the deployment default.
 
 To set a default for **every** turn in a workflow, declare a module-level

--- a/docs/pages/extend/workflows-v2.mdx
+++ b/docs/pages/extend/workflows-v2.mdx
@@ -141,21 +141,21 @@ cargo run -p centaur-perms -- \
   --tool slack
 ```
 
-Set `WORKFLOW_PRINCIPAL` to an existing principal foreign id or `prn_...` id to
-reuse that principal instead:
+Set `WORKFLOW_PRINCIPAL` to an existing principal foreign id to reuse that
+principal instead:
 
 ```python
 WORKFLOW_PRINCIPAL = "shared-automation"
 ```
 
 Centaur resolves string references without creating or updating the principal.
-Startup fails if the principal does not exist. `WORKFLOW_PRINCIPAL = True`
-still derives `workflow-` plus the slugged `WORKFLOW_NAME`. Any declared
-workflow principal requires `apiRs.workflowHostSandbox=true`, which renders
-`WORKFLOW_HOST_SANDBOX=true`.
+Principal OIDs such as `prn_...` are not accepted. Startup fails if the foreign
+id does not exist. `WORKFLOW_PRINCIPAL = True` still derives `workflow-` plus
+the slugged `WORKFLOW_NAME`. Any declared workflow principal requires
+`apiRs.workflowHostSandbox=true`, which renders `WORKFLOW_HOST_SANDBOX=true`.
 
 Agent turns inherit `WORKFLOW_PRINCIPAL`. A turn can select another existing
-principal for its session with `principal`:
+principal by foreign id for its session with `principal`:
 
 ```python
 await ctx.agent_turn(

--- a/docs/pages/extend/workflows-v2.mdx
+++ b/docs/pages/extend/workflows-v2.mdx
@@ -141,21 +141,21 @@ cargo run -p centaur-perms -- \
   --tool slack
 ```
 
-Set `WORKFLOW_PRINCIPAL` to an existing principal foreign id to reuse that
-principal instead:
+Set `WORKFLOW_PRINCIPAL` to an existing principal foreign id or `prn_...` id to
+reuse that principal instead:
 
 ```python
 WORKFLOW_PRINCIPAL = "shared-automation"
 ```
 
 Centaur resolves string references without creating or updating the principal.
-Principal OIDs such as `prn_...` are not accepted. Startup fails if the foreign
-id does not exist. `WORKFLOW_PRINCIPAL = True` still derives `workflow-` plus
-the slugged `WORKFLOW_NAME`. Any declared workflow principal requires
-`apiRs.workflowHostSandbox=true`, which renders `WORKFLOW_HOST_SANDBOX=true`.
+Startup fails if the principal does not exist. `WORKFLOW_PRINCIPAL = True`
+still derives `workflow-` plus the slugged `WORKFLOW_NAME`. Any declared
+workflow principal requires `apiRs.workflowHostSandbox=true`, which renders
+`WORKFLOW_HOST_SANDBOX=true`.
 
 Agent turns inherit `WORKFLOW_PRINCIPAL`. A turn can select another existing
-principal by foreign id for its session with `principal`:
+principal for its session with `principal`:
 
 ```python
 await ctx.agent_turn(

--- a/docs/pages/extend/workflows-v2.mdx
+++ b/docs/pages/extend/workflows-v2.mdx
@@ -141,21 +141,21 @@ cargo run -p centaur-perms -- \
   --tool slack
 ```
 
-Set `WORKFLOW_PRINCIPAL` to an existing principal foreign id or `prn_...` id to
-reuse that principal instead:
+Set `WORKFLOW_PRINCIPAL` to a principal foreign id to use a specific identity:
 
 ```python
 WORKFLOW_PRINCIPAL = "shared-automation"
 ```
 
-Centaur resolves string references without creating or updating the principal.
-Startup fails if the principal does not exist. `WORKFLOW_PRINCIPAL = True`
-still derives `workflow-` plus the slugged `WORKFLOW_NAME`. Any declared
-workflow principal requires `apiRs.workflowHostSandbox=true`, which renders
+Principal OIDs such as `prn_...` are not accepted in Python workflows. Centaur
+uses an existing principal with that foreign id without updating it, or creates
+the principal when it does not exist. `WORKFLOW_PRINCIPAL = True` still derives
+`workflow-` plus the slugged `WORKFLOW_NAME`. Any declared workflow principal
+requires `apiRs.workflowHostSandbox=true`, which renders
 `WORKFLOW_HOST_SANDBOX=true`.
 
-Agent turns inherit `WORKFLOW_PRINCIPAL`. A turn can select another existing
-principal for its session with `principal`:
+Agent turns inherit `WORKFLOW_PRINCIPAL`. A turn can select or create another
+principal by foreign id for its session with `principal`:
 
 ```python
 await ctx.agent_turn(

--- a/docs/pages/extend/workflows.mdx
+++ b/docs/pages/extend/workflows.mdx
@@ -69,13 +69,14 @@ directly with `ctx.call_tool(...)` and should have its own credential boundary.
 The API derives and registers the `workflow-nightly-report` principal from
 `WORKFLOW_NAME` and runs that workflow-host sandbox and its agent turns under
 it. Set `WORKFLOW_PRINCIPAL = "shared-automation"` to use an existing principal
-foreign id or `prn_...` id instead. String references are resolved without
-creating or updating the principal. Grant the required tool roles or secrets
-to the selected principal. Any declared workflow principal requires
+foreign id instead. Principal OIDs such as `prn_...` are rejected. String
+references are resolved without creating or updating the principal. Grant the
+required tool roles or secrets to the selected principal. Any declared
+workflow principal requires
 `apiRs.workflowHostSandbox=true`, which renders `WORKFLOW_HOST_SANDBOX=true`.
 
-Agent turns inherit the workflow principal by default. Pass
-`principal="report-publisher"` to `ctx.agent_turn(...)` to use a different
+Agent turns inherit the workflow principal by default. Pass a foreign id such
+as `principal="report-publisher"` to `ctx.agent_turn(...)` to use a different
 existing principal for that session. Centaur rejects an explicit `thread_key`
 that is already bound to a different principal.
 

--- a/docs/pages/extend/workflows.mdx
+++ b/docs/pages/extend/workflows.mdx
@@ -67,12 +67,17 @@ async def handler(inp: Input, ctx: WorkflowContext) -> dict[str, Any]:
 `WORKFLOW_PRINCIPAL` is optional. Use it when the workflow host calls tools
 directly with `ctx.call_tool(...)` and should have its own credential boundary.
 The API derives and registers the `workflow-nightly-report` principal from
-`WORKFLOW_NAME` and runs that workflow-host sandbox under it. Workflow code
-cannot choose another principal id, display name, or labels. Grant the required
-tool roles or secrets to the derived principal. `WORKFLOW_PRINCIPAL = True`
-requires `apiRs.workflowHostSandbox=true`, which renders
-`WORKFLOW_HOST_SANDBOX=true`; startup fails if workflow-host sandboxing is
-disabled.
+`WORKFLOW_NAME` and runs that workflow-host sandbox and its agent turns under
+it. Set `WORKFLOW_PRINCIPAL = "shared-automation"` to use an existing principal
+foreign id or `prn_...` id instead. String references are resolved without
+creating or updating the principal. Grant the required tool roles or secrets
+to the selected principal. Any declared workflow principal requires
+`apiRs.workflowHostSandbox=true`, which renders `WORKFLOW_HOST_SANDBOX=true`.
+
+Agent turns inherit the workflow principal by default. Pass
+`principal="report-publisher"` to `ctx.agent_turn(...)` to use a different
+existing principal for that session. Centaur rejects an explicit `thread_key`
+that is already bound to a different principal.
 
 ## Durable primitives
 

--- a/docs/pages/extend/workflows.mdx
+++ b/docs/pages/extend/workflows.mdx
@@ -68,15 +68,16 @@ async def handler(inp: Input, ctx: WorkflowContext) -> dict[str, Any]:
 directly with `ctx.call_tool(...)` and should have its own credential boundary.
 The API derives and registers the `workflow-nightly-report` principal from
 `WORKFLOW_NAME` and runs that workflow-host sandbox and its agent turns under
-it. Set `WORKFLOW_PRINCIPAL = "shared-automation"` to use an existing principal
-foreign id or `prn_...` id instead. String references are resolved without
-creating or updating the principal. Grant the required tool roles or secrets
+it. Set `WORKFLOW_PRINCIPAL = "shared-automation"` to use a specific principal
+foreign id instead. Principal OIDs such as `prn_...` are rejected in Python
+workflows. Centaur uses an existing principal without updating it, or creates
+the principal when it does not exist. Grant the required tool roles or secrets
 to the selected principal. Any declared workflow principal requires
 `apiRs.workflowHostSandbox=true`, which renders `WORKFLOW_HOST_SANDBOX=true`.
 
-Agent turns inherit the workflow principal by default. Pass
-`principal="report-publisher"` to `ctx.agent_turn(...)` to use a different
-existing principal for that session. Centaur rejects an explicit `thread_key`
+Agent turns inherit the workflow principal by default. Pass a foreign id such
+as `principal="report-publisher"` to `ctx.agent_turn(...)` to select or create a
+different principal for that session. Centaur rejects an explicit `thread_key`
 that is already bound to a different principal.
 
 ## Durable primitives

--- a/docs/pages/extend/workflows.mdx
+++ b/docs/pages/extend/workflows.mdx
@@ -69,14 +69,13 @@ directly with `ctx.call_tool(...)` and should have its own credential boundary.
 The API derives and registers the `workflow-nightly-report` principal from
 `WORKFLOW_NAME` and runs that workflow-host sandbox and its agent turns under
 it. Set `WORKFLOW_PRINCIPAL = "shared-automation"` to use an existing principal
-foreign id instead. Principal OIDs such as `prn_...` are rejected. String
-references are resolved without creating or updating the principal. Grant the
-required tool roles or secrets to the selected principal. Any declared
-workflow principal requires
+foreign id or `prn_...` id instead. String references are resolved without
+creating or updating the principal. Grant the required tool roles or secrets
+to the selected principal. Any declared workflow principal requires
 `apiRs.workflowHostSandbox=true`, which renders `WORKFLOW_HOST_SANDBOX=true`.
 
-Agent turns inherit the workflow principal by default. Pass a foreign id such
-as `principal="report-publisher"` to `ctx.agent_turn(...)` to use a different
+Agent turns inherit the workflow principal by default. Pass
+`principal="report-publisher"` to `ctx.agent_turn(...)` to use a different
 existing principal for that session. Centaur rejects an explicit `thread_key`
 that is already bound to a different principal.
 

--- a/docs/pages/secrets/advanced-permissioning.mdx
+++ b/docs/pages/secrets/advanced-permissioning.mdx
@@ -68,6 +68,8 @@ The stable principal ids follow these rules:
 Values are lowercased and converted to URL-safe slugs. Brackets in the Slack
 rows mark an optional team scope, not literal characters. Display names can
 change when a channel is renamed, but the foreign id remains stable.
+Workflows and agent turns that explicitly select an existing principal reuse
+that principal's foreign id.
 
 :::warning[Channel Grants Are Shared]
 Granting a Slack, Discord, or Teams channel principal gives the permission to
@@ -336,9 +338,11 @@ credential. Grant that wrapper secret to a user, channel, or role like any
 other secret. See [OAuth Apps](/secrets/oauth-apps) for registration and
 consent.
 
-Workflows opt into isolated permissions with `WORKFLOW_PRINCIPAL = True`.
-Centaur derives `workflow-<workflow-name>` and does not let workflow code choose
-another identity. Grant the workflow only the roles or secrets it needs. See
+Workflows opt into isolated permissions with `WORKFLOW_PRINCIPAL = True`, which
+derives `workflow-<workflow-name>`, or select an existing identity with
+`WORKFLOW_PRINCIPAL = "foreign-id-or-prn-id"`. Agent turns inherit that
+principal and can select another existing identity with the `principal` kwarg.
+Grant each workflow and agent turn only the roles or secrets it needs. See
 [Creating Workflows](/extend/workflows#define-a-workflow).
 
 ## Operational Checklist

--- a/docs/pages/secrets/advanced-permissioning.mdx
+++ b/docs/pages/secrets/advanced-permissioning.mdx
@@ -340,9 +340,8 @@ consent.
 
 Workflows opt into isolated permissions with `WORKFLOW_PRINCIPAL = True`, which
 derives `workflow-<workflow-name>`, or select an existing identity with
-`WORKFLOW_PRINCIPAL = "principal-foreign-id"`. Principal OIDs are not accepted.
-Agent turns inherit that principal and can select another existing identity by
-foreign id with the `principal` kwarg.
+`WORKFLOW_PRINCIPAL = "foreign-id-or-prn-id"`. Agent turns inherit that
+principal and can select another existing identity with the `principal` kwarg.
 Grant each workflow and agent turn only the roles or secrets it needs. See
 [Creating Workflows](/extend/workflows#define-a-workflow).
 

--- a/docs/pages/secrets/advanced-permissioning.mdx
+++ b/docs/pages/secrets/advanced-permissioning.mdx
@@ -340,8 +340,9 @@ consent.
 
 Workflows opt into isolated permissions with `WORKFLOW_PRINCIPAL = True`, which
 derives `workflow-<workflow-name>`, or select an existing identity with
-`WORKFLOW_PRINCIPAL = "foreign-id-or-prn-id"`. Agent turns inherit that
-principal and can select another existing identity with the `principal` kwarg.
+`WORKFLOW_PRINCIPAL = "principal-foreign-id"`. Principal OIDs are not accepted.
+Agent turns inherit that principal and can select another existing identity by
+foreign id with the `principal` kwarg.
 Grant each workflow and agent turn only the roles or secrets it needs. See
 [Creating Workflows](/extend/workflows#define-a-workflow).
 

--- a/docs/pages/secrets/advanced-permissioning.mdx
+++ b/docs/pages/secrets/advanced-permissioning.mdx
@@ -339,9 +339,11 @@ other secret. See [OAuth Apps](/secrets/oauth-apps) for registration and
 consent.
 
 Workflows opt into isolated permissions with `WORKFLOW_PRINCIPAL = True`, which
-derives `workflow-<workflow-name>`, or select an existing identity with
-`WORKFLOW_PRINCIPAL = "foreign-id-or-prn-id"`. Agent turns inherit that
-principal and can select another existing identity with the `principal` kwarg.
+derives `workflow-<workflow-name>`, or select an identity with
+`WORKFLOW_PRINCIPAL = "principal-foreign-id"`. Python workflows reject principal
+OIDs. Missing foreign ids create new principals. Agent turns inherit the
+workflow principal and can select or create another identity by foreign id with
+the `principal` kwarg.
 Grant each workflow and agent turn only the roles or secrets it needs. See
 [Creating Workflows](/extend/workflows#define-a-workflow).
 

--- a/services/api-rs/crates/centaur-iron-control/src/client.rs
+++ b/services/api-rs/crates/centaur-iron-control/src/client.rs
@@ -62,6 +62,20 @@ impl IronControlClient {
         .await
     }
 
+    /// Resolve a principal by ``foreign_id``, creating it from ``input`` when
+    /// no matching principal exists. Existing principals are returned without
+    /// updating their metadata.
+    pub async fn get_or_create_principal(&self, input: &PrincipalInput) -> Result<Principal> {
+        match self
+            .get_principal(&input.namespace, &input.foreign_id)
+            .await
+        {
+            Ok(principal) => Ok(principal),
+            Err(IronControlError::Status { status: 404, .. }) => self.upsert_principal(input).await,
+            Err(error) => Err(error),
+        }
+    }
+
     /// Upsert a role by ``foreign_id``.
     pub async fn upsert_role(&self, input: &IdentityInput) -> Result<Role> {
         self.write(Method::PUT, &upsert_path("roles", &input.foreign_id), input)

--- a/services/api-rs/crates/centaur-iron-control/src/session.rs
+++ b/services/api-rs/crates/centaur-iron-control/src/session.rs
@@ -78,15 +78,7 @@ impl SessionRegistrar {
         thread_key: &str,
         metadata: Option<&Value>,
     ) -> Result<Principal> {
-        let metadata = SessionPrincipalMetadata::from_session_metadata(metadata);
-        let principal = derive_principal_with_slack_team(
-            thread_key,
-            metadata.actor_user_id,
-            metadata.slack_team_id,
-            metadata.conversation_name,
-        );
-        let mut input = principal.to_principal_input(&self.namespace);
-        apply_slack_dm_email(thread_key, metadata.slack_user_email, &mut input);
+        let mut input = self.principal_input_for_session(thread_key, metadata);
         let existing = match self
             .client
             .get_principal(&self.namespace, &input.foreign_id)
@@ -119,6 +111,30 @@ impl SessionRegistrar {
                 .await?;
         }
         Ok(record)
+    }
+
+    /// Return the stable foreign id that `register_session` would use without
+    /// reading or mutating Iron Control.
+    pub fn foreign_id_for_session(&self, thread_key: &str, metadata: Option<&Value>) -> String {
+        self.principal_input_for_session(thread_key, metadata)
+            .foreign_id
+    }
+
+    fn principal_input_for_session(
+        &self,
+        thread_key: &str,
+        metadata: Option<&Value>,
+    ) -> crate::models::PrincipalInput {
+        let metadata = SessionPrincipalMetadata::from_session_metadata(metadata);
+        let principal = derive_principal_with_slack_team(
+            thread_key,
+            metadata.actor_user_id,
+            metadata.slack_team_id,
+            metadata.conversation_name,
+        );
+        let mut input = principal.to_principal_input(&self.namespace);
+        apply_slack_dm_email(thread_key, metadata.slack_user_email, &mut input);
+        input
     }
 
     pub async fn get_principal(&self, principal: &str) -> Result<Principal> {

--- a/services/api-rs/crates/centaur-iron-control/src/session.rs
+++ b/services/api-rs/crates/centaur-iron-control/src/session.rs
@@ -12,7 +12,7 @@ use std::collections::BTreeMap;
 
 use crate::IronControlClient;
 use crate::error::{IronControlError, Result};
-use crate::models::{Principal, SlackChannelPermissionInput};
+use crate::models::{Principal, PrincipalInput, SlackChannelPermissionInput};
 use crate::principal::{
     derive_principal_with_slack_team, is_direct_message, slack_conversation_id,
 };
@@ -139,6 +139,30 @@ impl SessionRegistrar {
 
     pub async fn get_principal(&self, principal: &str) -> Result<Principal> {
         self.client.get_principal(&self.namespace, principal).await
+    }
+
+    /// Resolve a basic principal by foreign id and create it when missing.
+    /// Existing principal metadata is left unchanged.
+    pub async fn resolve_or_create_principal(
+        &self,
+        foreign_id: &str,
+        name: &str,
+        labels: BTreeMap<String, String>,
+        kind: Option<&str>,
+    ) -> Result<Principal> {
+        self.client
+            .get_or_create_principal(&PrincipalInput {
+                namespace: self.namespace.clone(),
+                foreign_id: foreign_id.to_owned(),
+                name: name.to_owned(),
+                labels,
+                kind: kind.map(ToOwned::to_owned),
+                slack_user_id: None,
+                slack_channel_id: None,
+                slack_team_id: None,
+                slack_email: None,
+            })
+            .await
     }
 }
 
@@ -425,6 +449,34 @@ mod tests {
         server.abort();
     }
 
+    #[tokio::test]
+    async fn resolve_or_create_principal_only_creates_when_missing() {
+        for principal_exists in [true, false] {
+            let (base_url, requests, server) = spawn_iron_control_stub(principal_exists).await;
+            let registrar =
+                SessionRegistrar::new(IronControlClient::new(base_url, "test-key"), "default");
+
+            let principal = registrar
+                .resolve_or_create_principal(
+                    "report-publisher",
+                    "Workflow nightly_report",
+                    BTreeMap::new(),
+                    Some("workflow"),
+                )
+                .await
+                .unwrap();
+
+            assert_eq!(principal.id, "prn_report");
+            let mut expected =
+                vec!["GET /api/v1/principals/lookup/default/report-publisher".to_owned()];
+            if !principal_exists {
+                expected.push("PUT /api/v1/principals/report-publisher".to_owned());
+            }
+            assert_eq!(*requests.lock().unwrap(), expected);
+            server.abort();
+        }
+    }
+
     #[test]
     fn slack_permission_for_thread_skips_dm_channel_fallback_without_user() {
         assert_eq!(
@@ -492,8 +544,14 @@ mod tests {
                     {
                         ("200 OK", user_principal_body())
                     }
+                    ("GET", "/api/v1/principals/lookup/default/report-publisher")
+                        if principal_exists =>
+                    {
+                        ("200 OK", workflow_principal_body())
+                    }
                     ("GET", "/api/v1/principals/lookup/default/slack-channel-t123-c123")
-                    | ("GET", "/api/v1/principals/lookup/default/slack-user-t123-u123") => {
+                    | ("GET", "/api/v1/principals/lookup/default/slack-user-t123-u123")
+                    | ("GET", "/api/v1/principals/lookup/default/report-publisher") => {
                         ("404 Not Found", r#"{"error":"not found"}"#.to_owned())
                     }
                     ("PUT", "/api/v1/principals/slack-channel-t123-c123") => {
@@ -501,6 +559,9 @@ mod tests {
                     }
                     ("PUT", "/api/v1/principals/slack-user-t123-u123") => {
                         ("200 OK", user_principal_body())
+                    }
+                    ("PUT", "/api/v1/principals/report-publisher") => {
+                        ("200 OK", workflow_principal_body())
                     }
                     (
                         "POST",
@@ -532,5 +593,9 @@ mod tests {
 
     fn user_principal_body() -> String {
         r#"{"data":{"id":"prn_user","namespace":"default","foreign_id":"slack-user-t123-u123","name":"Slack DM @Ada Lovelace","labels":{}}}"#.to_owned()
+    }
+
+    fn workflow_principal_body() -> String {
+        r#"{"data":{"id":"prn_report","namespace":"default","foreign_id":"report-publisher","name":"Workflow nightly_report","labels":{}}}"#.to_owned()
     }
 }

--- a/services/api-rs/crates/centaur-session-runtime/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-runtime/src/lib.rs
@@ -104,6 +104,16 @@ pub trait SessionPrincipalRegistrar: Send + Sync {
     ) -> Result<Principal, IronControlError>;
 
     async fn get_principal(&self, principal: &str) -> Result<Principal, IronControlError>;
+
+    fn foreign_id_for_session(&self, thread_key: &str, metadata: Option<&Value>) -> String;
+
+    async fn resolve_or_create_principal(
+        &self,
+        foreign_id: &str,
+        name: &str,
+        labels: BTreeMap<String, String>,
+        kind: Option<&str>,
+    ) -> Result<Principal, IronControlError>;
 }
 
 #[async_trait::async_trait]
@@ -118,6 +128,20 @@ impl SessionPrincipalRegistrar for SessionRegistrar {
 
     async fn get_principal(&self, principal: &str) -> Result<Principal, IronControlError> {
         SessionRegistrar::get_principal(self, principal).await
+    }
+
+    fn foreign_id_for_session(&self, thread_key: &str, metadata: Option<&Value>) -> String {
+        SessionRegistrar::foreign_id_for_session(self, thread_key, metadata)
+    }
+
+    async fn resolve_or_create_principal(
+        &self,
+        foreign_id: &str,
+        name: &str,
+        labels: BTreeMap<String, String>,
+        kind: Option<&str>,
+    ) -> Result<Principal, IronControlError> {
+        SessionRegistrar::resolve_or_create_principal(self, foreign_id, name, labels, kind).await
     }
 }
 
@@ -1376,6 +1400,22 @@ impl SessionRuntime {
         .await
     }
 
+    /// Resolve an Iron Control principal by foreign id, creating it when it is
+    /// missing, and return its canonical OID.
+    pub async fn resolve_or_create_principal(
+        &self,
+        foreign_id: &str,
+        name: &str,
+        labels: BTreeMap<String, String>,
+        kind: Option<&str>,
+    ) -> Result<String, SessionRuntimeError> {
+        Ok(self
+            .iron_control
+            .resolve_or_create_principal(foreign_id, name, labels, kind)
+            .await?
+            .id)
+    }
+
     /// Create or load a session and optionally bind it to an existing Iron
     /// Control principal instead of deriving one from the thread key.
     pub async fn create_or_get_session_with_principal(
@@ -1427,7 +1467,10 @@ impl SessionRuntime {
                 )?;
                 principal
             } else if let Some(existing_principal_id) = existing_principal_id.as_deref() {
-                let existing_principal = self.iron_control.get_principal(existing_principal_id).await?;
+                let existing_principal = self
+                    .iron_control
+                    .get_principal(existing_principal_id)
+                    .await?;
                 let expected_foreign_id = self
                     .iron_control
                     .foreign_id_for_session(thread_key.as_str(), Some(&session_metadata));
@@ -8510,6 +8553,20 @@ mod adoption_tests {
         async fn get_principal(&self, principal: &str) -> Result<Principal, IronControlError> {
             Ok(test_principal(principal))
         }
+
+        fn foreign_id_for_session(&self, _thread_key: &str, _metadata: Option<&Value>) -> String {
+            "test".to_owned()
+        }
+
+        async fn resolve_or_create_principal(
+            &self,
+            _foreign_id: &str,
+            _name: &str,
+            _labels: BTreeMap<String, String>,
+            _kind: Option<&str>,
+        ) -> Result<Principal, IronControlError> {
+            Ok(test_principal("prn_test"))
+        }
     }
 
     fn test_principal(id: &str) -> Principal {
@@ -8926,14 +8983,14 @@ mod adoption_tests {
         };
         let _serial = TEST_LOCK.lock().await;
         let (base_url, requests, server) = spawn_principal_stub().await;
-        let runtime = runtime_with(
-            &store,
-            Arc::new(MockBackend::new(SandboxStatus::Running, Vec::new())),
-        )
-        .with_iron_control(SessionRegistrar::new(
-            IronControlClient::new(base_url, "test-key"),
-            "default",
-        ));
+        let runtime = SessionRuntime::new(
+            store.clone(),
+            SandboxRuntime::backend(
+                Arc::new(MockBackend::new(SandboxStatus::Running, Vec::new())),
+                SandboxSpec::new("mock"),
+            ),
+            SessionRegistrar::new(IronControlClient::new(base_url, "test-key"), "default"),
+        );
         let thread_key = ThreadKey::parse(format!(
             "wf:{}:agent:principal-test",
             uuid::Uuid::new_v4().simple()
@@ -8988,42 +9045,6 @@ mod adoption_tests {
             "a rejected rebind must not mutate Iron Control"
         );
         server.abort();
-    }
-
-    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn explicit_principal_requires_iron_control() {
-        let Some(store) = test_store().await else {
-            return;
-        };
-        let _serial = TEST_LOCK.lock().await;
-        let runtime = runtime_with(
-            &store,
-            Arc::new(MockBackend::new(SandboxStatus::Running, Vec::new())),
-        );
-        let thread_key = ThreadKey::parse(format!(
-            "wf:{}:agent:principal-test",
-            uuid::Uuid::new_v4().simple()
-        ))
-        .unwrap();
-
-        let error = runtime
-            .create_or_get_session_with_principal(
-                &thread_key,
-                &HarnessType::Codex,
-                None,
-                Some(json!({"source": "absurd_workflow"})),
-                HarnessConflictPolicy::Reject,
-                Some("report-publisher"),
-            )
-            .await
-            .expect_err("explicit principal must require Iron Control");
-
-        assert!(matches!(error, SessionRuntimeError::BadRequest(_)));
-        assert!(error.to_string().contains("requires Iron Control"));
-        assert!(matches!(
-            store.get_session(&thread_key).await,
-            Err(SessionStoreError::NotFound { .. })
-        ));
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/services/api-rs/crates/centaur-session-runtime/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-runtime/src/lib.rs
@@ -1377,7 +1377,8 @@ impl SessionRuntime {
     }
 
     /// Create or load a session and optionally bind it to an existing Iron
-    /// Control principal instead of deriving one from the thread key.
+    /// Control principal foreign id instead of deriving one from the thread
+    /// key. Principal OIDs are not accepted.
     pub async fn create_or_get_session_with_principal(
         &self,
         thread_key: &ThreadKey,
@@ -1387,6 +1388,9 @@ impl SessionRuntime {
         on_harness_conflict: HarnessConflictPolicy,
         iron_control_principal: Option<&str>,
     ) -> Result<CreateOrGetSessionOutcome, SessionRuntimeError> {
+        let iron_control_principal = iron_control_principal
+            .map(validate_explicit_principal_foreign_id)
+            .transpose()?;
         let span = info_span!(
             "centaur.api_rs.session.create_or_get",
             component = COMPONENT_SESSION_RUNTIME,
@@ -5628,6 +5632,21 @@ fn ensure_session_principal_matches(
     Ok(())
 }
 
+fn validate_explicit_principal_foreign_id(principal: &str) -> Result<&str, SessionRuntimeError> {
+    let principal = principal.trim();
+    if principal.is_empty() {
+        return Err(SessionRuntimeError::BadRequest(
+            "explicit session principal must be a non-empty foreign id".to_owned(),
+        ));
+    }
+    if principal.starts_with("prn_") {
+        return Err(SessionRuntimeError::BadRequest(
+            "explicit session principal must use a foreign id, not a prn_ id".to_owned(),
+        ));
+    }
+    Ok(principal)
+}
+
 fn session_principal_conflict_error(thread_key: &ThreadKey) -> SessionRuntimeError {
     SessionRuntimeError::BadRequest(format!(
         "session {thread_key} is already bound to a different Iron Control principal"
@@ -6933,6 +6952,16 @@ mod tests {
     use centaur_session_core::SessionStatus;
     use serde_json::json;
     use time::OffsetDateTime;
+
+    #[test]
+    fn explicit_session_principal_accepts_only_foreign_ids() {
+        assert_eq!(
+            validate_explicit_principal_foreign_id(" report-publisher ").unwrap(),
+            "report-publisher"
+        );
+        assert!(validate_explicit_principal_foreign_id("").is_err());
+        assert!(validate_explicit_principal_foreign_id("prn_123").is_err());
+    }
 
     #[test]
     fn sandbox_repo_cache_label_controls_access() {

--- a/services/api-rs/crates/centaur-session-runtime/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-runtime/src/lib.rs
@@ -1377,8 +1377,7 @@ impl SessionRuntime {
     }
 
     /// Create or load a session and optionally bind it to an existing Iron
-    /// Control principal foreign id instead of deriving one from the thread
-    /// key. Principal OIDs are not accepted.
+    /// Control principal instead of deriving one from the thread key.
     pub async fn create_or_get_session_with_principal(
         &self,
         thread_key: &ThreadKey,
@@ -1388,9 +1387,6 @@ impl SessionRuntime {
         on_harness_conflict: HarnessConflictPolicy,
         iron_control_principal: Option<&str>,
     ) -> Result<CreateOrGetSessionOutcome, SessionRuntimeError> {
-        let iron_control_principal = iron_control_principal
-            .map(validate_explicit_principal_foreign_id)
-            .transpose()?;
         let span = info_span!(
             "centaur.api_rs.session.create_or_get",
             component = COMPONENT_SESSION_RUNTIME,
@@ -5632,21 +5628,6 @@ fn ensure_session_principal_matches(
     Ok(())
 }
 
-fn validate_explicit_principal_foreign_id(principal: &str) -> Result<&str, SessionRuntimeError> {
-    let principal = principal.trim();
-    if principal.is_empty() {
-        return Err(SessionRuntimeError::BadRequest(
-            "explicit session principal must be a non-empty foreign id".to_owned(),
-        ));
-    }
-    if principal.starts_with("prn_") {
-        return Err(SessionRuntimeError::BadRequest(
-            "explicit session principal must use a foreign id, not a prn_ id".to_owned(),
-        ));
-    }
-    Ok(principal)
-}
-
 fn session_principal_conflict_error(thread_key: &ThreadKey) -> SessionRuntimeError {
     SessionRuntimeError::BadRequest(format!(
         "session {thread_key} is already bound to a different Iron Control principal"
@@ -6952,16 +6933,6 @@ mod tests {
     use centaur_session_core::SessionStatus;
     use serde_json::json;
     use time::OffsetDateTime;
-
-    #[test]
-    fn explicit_session_principal_accepts_only_foreign_ids() {
-        assert_eq!(
-            validate_explicit_principal_foreign_id(" report-publisher ").unwrap(),
-            "report-publisher"
-        );
-        assert!(validate_explicit_principal_foreign_id("").is_err());
-        assert!(validate_explicit_principal_foreign_id("prn_123").is_err());
-    }
 
     #[test]
     fn sandbox_repo_cache_label_controls_access() {

--- a/services/api-rs/crates/centaur-session-runtime/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-runtime/src/lib.rs
@@ -1413,8 +1413,37 @@ impl SessionRuntime {
             let mut harness_switched = false;
             let mut session_metadata = default_metadata(metadata);
             let proxy_labels = proxy_labels_from_session_metadata(thread_key, &session_metadata);
+            let existing_principal_id = match self.store.get_session(thread_key).await {
+                Ok(session) => session.iron_control_principal,
+                Err(SessionStoreError::NotFound { .. }) => None,
+                Err(error) => return Err(error.into()),
+            };
             let registered_principal = if let Some(principal) = iron_control_principal {
-                self.iron_control.get_principal(principal).await?
+                let principal = self.iron_control.get_principal(principal).await?;
+                ensure_session_principal_matches(
+                    thread_key,
+                    existing_principal_id.as_deref(),
+                    &principal.id,
+                )?;
+                principal
+            } else if let Some(existing_principal_id) = existing_principal_id.as_deref() {
+                let existing_principal = self.iron_control.get_principal(existing_principal_id).await?;
+                let expected_foreign_id = self
+                    .iron_control
+                    .foreign_id_for_session(thread_key.as_str(), Some(&session_metadata));
+                if existing_principal.foreign_id.as_deref() != Some(expected_foreign_id.as_str()) {
+                    return Err(session_principal_conflict_error(thread_key));
+                }
+                let principal = self
+                    .iron_control
+                    .register_session(thread_key.as_str(), Some(&session_metadata))
+                    .await?;
+                ensure_session_principal_matches(
+                    thread_key,
+                    Some(existing_principal_id),
+                    &principal.id,
+                )?;
+                principal
             } else {
                 self.iron_control
                     .register_session(thread_key.as_str(), Some(&session_metadata))
@@ -1462,13 +1491,12 @@ impl SessionRuntime {
                 }
                 Err(error) => return Err(error.into()),
             };
-            if iron_control_principal.is_some()
-                && let Some(existing) = session.iron_control_principal.as_deref()
-                && existing != registered_principal.id
-            {
-                return Err(SessionRuntimeError::BadRequest(format!(
-                    "session {thread_key} is already bound to a different Iron Control principal"
-                )));
+            if let Some(existing) = session.iron_control_principal.as_deref() {
+                ensure_session_principal_matches(
+                    thread_key,
+                    Some(existing),
+                    &registered_principal.id,
+                )?;
             }
             if let Some(context) = self.resolve_stored_persona(
                 session.persona_id.as_deref(),
@@ -5589,6 +5617,23 @@ fn sandbox_capabilities_from_principal(
     }
 }
 
+fn ensure_session_principal_matches(
+    thread_key: &ThreadKey,
+    existing_principal: Option<&str>,
+    requested_principal: &str,
+) -> Result<(), SessionRuntimeError> {
+    if existing_principal.is_some_and(|existing| existing != requested_principal) {
+        return Err(session_principal_conflict_error(thread_key));
+    }
+    Ok(())
+}
+
+fn session_principal_conflict_error(thread_key: &ThreadKey) -> SessionRuntimeError {
+    SessionRuntimeError::BadRequest(format!(
+        "session {thread_key} is already bound to a different Iron Control principal"
+    ))
+}
+
 fn apply_sandbox_capabilities(spec: &mut SandboxSpec, capabilities: &SessionSandboxCapabilities) {
     spec.capabilities = BackendSandboxCapabilities {
         repo_cache: match capabilities.repo_cache {
@@ -8438,8 +8483,9 @@ mod adoption_tests {
         sync::atomic::{AtomicBool, AtomicUsize, Ordering},
     };
 
+    use centaur_iron_control::{IronControlClient, SessionRegistrar};
     use centaur_sandbox_core::{ObservedSandbox, SandboxHandle, SandboxIo, SandboxResult};
-    use tokio::io::{AsyncWriteExt, DuplexStream};
+    use tokio::io::{AsyncReadExt, AsyncWriteExt, DuplexStream};
 
     use super::*;
 
@@ -8820,6 +8866,164 @@ mod adoption_tests {
             SandboxRuntime::backend(backend, SandboxSpec::new("mock")),
             TestSessionPrincipalRegistrar,
         )
+    }
+
+    async fn spawn_principal_stub() -> (
+        String,
+        Arc<std::sync::Mutex<Vec<String>>>,
+        tokio::task::JoinHandle<()>,
+    ) {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let base_url = format!("http://{}", listener.local_addr().unwrap());
+        let requests = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let seen = requests.clone();
+        let handle = tokio::spawn(async move {
+            loop {
+                let Ok((mut stream, _)) = listener.accept().await else {
+                    return;
+                };
+                let mut request = Vec::new();
+                let mut buf = [0u8; 1024];
+                while !request.windows(4).any(|window| window == b"\r\n\r\n") {
+                    match stream.read(&mut buf).await {
+                        Ok(0) | Err(_) => break,
+                        Ok(read) => request.extend_from_slice(&buf[..read]),
+                    }
+                }
+                let request = String::from_utf8_lossy(&request);
+                let first_line = request.lines().next().unwrap_or_default();
+                let mut parts = first_line.split_whitespace();
+                let method = parts.next().unwrap_or_default();
+                let path = parts.next().unwrap_or_default();
+                seen.lock().unwrap().push(format!("{method} {path}"));
+
+                let (status_line, body) = match (method, path) {
+                    (
+                        "GET",
+                        "/api/v1/principals/lookup/default/report-publisher"
+                        | "/api/v1/principals/prn_explicit",
+                    ) => (
+                        "200 OK",
+                        r#"{"data":{"id":"prn_explicit","namespace":"default","foreign_id":"report-publisher","name":"Report Publisher","labels":{}}}"#,
+                    ),
+                    _ => ("500 Internal Server Error", r#"{"error":"unexpected"}"#),
+                };
+                let response = format!(
+                    "HTTP/1.1 {status_line}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                    body.len(),
+                );
+                let _ = stream.write_all(response.as_bytes()).await;
+                let _ = stream.shutdown().await;
+            }
+        });
+        (base_url, requests, handle)
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn explicit_principal_cannot_be_rebound_when_later_create_omits_it() {
+        let Some(store) = test_store().await else {
+            return;
+        };
+        let _serial = TEST_LOCK.lock().await;
+        let (base_url, requests, server) = spawn_principal_stub().await;
+        let runtime = runtime_with(
+            &store,
+            Arc::new(MockBackend::new(SandboxStatus::Running, Vec::new())),
+        )
+        .with_iron_control(SessionRegistrar::new(
+            IronControlClient::new(base_url, "test-key"),
+            "default",
+        ));
+        let thread_key = ThreadKey::parse(format!(
+            "wf:{}:agent:principal-test",
+            uuid::Uuid::new_v4().simple()
+        ))
+        .unwrap();
+
+        runtime
+            .create_or_get_session_with_principal(
+                &thread_key,
+                &HarnessType::Codex,
+                None,
+                Some(json!({"source": "absurd_workflow"})),
+                HarnessConflictPolicy::Reject,
+                Some("report-publisher"),
+            )
+            .await
+            .expect("bind explicit principal");
+
+        let error = runtime
+            .create_or_get_session_with_principal(
+                &thread_key,
+                &HarnessType::Codex,
+                None,
+                Some(json!({"source": "absurd_workflow"})),
+                HarnessConflictPolicy::Reject,
+                None,
+            )
+            .await
+            .expect_err("omitting the principal must not rebind the session");
+
+        assert!(matches!(error, SessionRuntimeError::BadRequest(_)));
+        assert!(
+            error
+                .to_string()
+                .contains("different Iron Control principal")
+        );
+        assert_eq!(
+            store
+                .get_session(&thread_key)
+                .await
+                .expect("get session")
+                .iron_control_principal
+                .as_deref(),
+            Some("prn_explicit")
+        );
+        assert!(
+            requests
+                .lock()
+                .unwrap()
+                .iter()
+                .all(|request| request.starts_with("GET ")),
+            "a rejected rebind must not mutate Iron Control"
+        );
+        server.abort();
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn explicit_principal_requires_iron_control() {
+        let Some(store) = test_store().await else {
+            return;
+        };
+        let _serial = TEST_LOCK.lock().await;
+        let runtime = runtime_with(
+            &store,
+            Arc::new(MockBackend::new(SandboxStatus::Running, Vec::new())),
+        );
+        let thread_key = ThreadKey::parse(format!(
+            "wf:{}:agent:principal-test",
+            uuid::Uuid::new_v4().simple()
+        ))
+        .unwrap();
+
+        let error = runtime
+            .create_or_get_session_with_principal(
+                &thread_key,
+                &HarnessType::Codex,
+                None,
+                Some(json!({"source": "absurd_workflow"})),
+                HarnessConflictPolicy::Reject,
+                Some("report-publisher"),
+            )
+            .await
+            .expect_err("explicit principal must require Iron Control");
+
+        assert!(matches!(error, SessionRuntimeError::BadRequest(_)));
+        assert!(error.to_string().contains("requires Iron Control"));
+        assert!(matches!(
+            store.get_session(&thread_key).await,
+            Err(SessionStoreError::NotFound { .. })
+        ));
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/services/api-rs/crates/centaur-session-runtime/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-runtime/src/lib.rs
@@ -1365,6 +1365,28 @@ impl SessionRuntime {
         metadata: Option<Value>,
         on_harness_conflict: HarnessConflictPolicy,
     ) -> Result<CreateOrGetSessionOutcome, SessionRuntimeError> {
+        self.create_or_get_session_with_principal(
+            thread_key,
+            harness_type,
+            persona_id,
+            metadata,
+            on_harness_conflict,
+            None,
+        )
+        .await
+    }
+
+    /// Create or load a session and optionally bind it to an existing Iron
+    /// Control principal instead of deriving one from the thread key.
+    pub async fn create_or_get_session_with_principal(
+        &self,
+        thread_key: &ThreadKey,
+        harness_type: &HarnessType,
+        persona_id: Option<&str>,
+        metadata: Option<Value>,
+        on_harness_conflict: HarnessConflictPolicy,
+        iron_control_principal: Option<&str>,
+    ) -> Result<CreateOrGetSessionOutcome, SessionRuntimeError> {
         let span = info_span!(
             "centaur.api_rs.session.create_or_get",
             component = COMPONENT_SESSION_RUNTIME,
@@ -1391,10 +1413,13 @@ impl SessionRuntime {
             let mut harness_switched = false;
             let mut session_metadata = default_metadata(metadata);
             let proxy_labels = proxy_labels_from_session_metadata(thread_key, &session_metadata);
-            let registered_principal = self
-                .iron_control
-                .register_session(thread_key.as_str(), Some(&session_metadata))
-                .await?;
+            let registered_principal = if let Some(principal) = iron_control_principal {
+                self.iron_control.get_principal(principal).await?
+            } else {
+                self.iron_control
+                    .register_session(thread_key.as_str(), Some(&session_metadata))
+                    .await?
+            };
             let desired_capabilities = sandbox_capabilities_from_principal(&registered_principal);
             let persona_resolution =
                 self.resolve_persona_for_create(persona_id, &desired_capabilities)?;
@@ -1437,6 +1462,14 @@ impl SessionRuntime {
                 }
                 Err(error) => return Err(error.into()),
             };
+            if iron_control_principal.is_some()
+                && let Some(existing) = session.iron_control_principal.as_deref()
+                && existing != registered_principal.id
+            {
+                return Err(SessionRuntimeError::BadRequest(format!(
+                    "session {thread_key} is already bound to a different Iron Control principal"
+                )));
+            }
             if let Some(context) = self.resolve_stored_persona(
                 session.persona_id.as_deref(),
                 harness_type,

--- a/services/api-rs/crates/centaur-workflows/src/lib.rs
+++ b/services/api-rs/crates/centaur-workflows/src/lib.rs
@@ -221,13 +221,7 @@ pub struct WorkflowHostSandboxRuntime {
 #[derive(Clone, Default)]
 struct WorkflowPrincipalAssignments {
     required: BTreeMap<String, WorkflowPrincipalDeclaration>,
-    registered: BTreeMap<String, RegisteredWorkflowPrincipal>,
-}
-
-#[derive(Clone)]
-struct RegisteredWorkflowPrincipal {
-    id: String,
-    foreign_id: String,
+    registered: BTreeMap<String, String>,
 }
 
 impl WorkflowPrincipalAssignments {
@@ -236,7 +230,7 @@ impl WorkflowPrincipalAssignments {
         workflow_name: &str,
     ) -> Result<Option<String>, WorkflowRuntimeError> {
         if let Some(principal) = self.registered.get(workflow_name) {
-            return Ok(Some(principal.foreign_id.clone()));
+            return Ok(Some(principal.clone()));
         }
         if self.required.contains_key(workflow_name) {
             return Err(WorkflowRuntimeError::Internal(format!(
@@ -258,7 +252,7 @@ impl WorkflowHostSandboxRuntime {
 
     fn update_workflow_principals(
         &self,
-        registered: BTreeMap<String, RegisteredWorkflowPrincipal>,
+        registered: BTreeMap<String, String>,
         required: BTreeMap<String, WorkflowPrincipalDeclaration>,
     ) {
         let mut current = self
@@ -276,21 +270,15 @@ impl WorkflowHostSandboxRuntime {
         workflow_name: &str,
     ) -> Result<(SandboxSpec, Option<String>), WorkflowRuntimeError> {
         let mut spec = self.spec.clone();
-        let (principal, principal_id) = {
+        let principal = {
             let assignments = self
                 .workflow_principals
                 .read()
                 .unwrap_or_else(|poisoned| poisoned.into_inner());
-            (
-                assignments.principal_for_workflow(workflow_name)?,
-                assignments
-                    .registered
-                    .get(workflow_name)
-                    .map(|registered| registered.id.clone()),
-            )
+            assignments.principal_for_workflow(workflow_name)?
         };
-        if let Some(principal_id) = principal_id {
-            spec.iron_control_principal = Some(principal_id);
+        if let Some(principal) = principal.as_ref() {
+            spec.iron_control_principal = Some(principal.clone());
         }
         Ok((spec, principal))
     }
@@ -313,17 +301,16 @@ impl WorkflowPrincipalRegistrar {
     async fn resolve_workflow_principals(
         &self,
         principals: &BTreeMap<String, WorkflowPrincipalDeclaration>,
-    ) -> Result<BTreeMap<String, RegisteredWorkflowPrincipal>, WorkflowRuntimeError> {
+    ) -> Result<BTreeMap<String, String>, WorkflowRuntimeError> {
         let mut registered = BTreeMap::new();
         for (workflow_name, declaration) in principals {
-            let (record, foreign_id) = match declaration {
+            let record = match declaration {
                 WorkflowPrincipalDeclaration::Derived => {
                     let foreign_id = canonical_workflow_principal_foreign_id(workflow_name);
-                    let record = self
-                        .client
+                    self.client
                         .upsert_principal(&PrincipalInput {
                             namespace: self.namespace.clone(),
-                            foreign_id: foreign_id.clone(),
+                            foreign_id,
                             name: format!("Workflow {workflow_name}"),
                             labels: workflow_principal_labels(workflow_name),
                             kind: Some("workflow".to_owned()),
@@ -332,24 +319,15 @@ impl WorkflowPrincipalRegistrar {
                             slack_team_id: None,
                             slack_email: None,
                         })
-                        .await?;
-                    (record, foreign_id)
+                        .await?
                 }
                 WorkflowPrincipalDeclaration::Existing(principal) => {
-                    let record = self
-                        .client
+                    self.client
                         .get_principal(&self.namespace, principal)
-                        .await?;
-                    (record, principal.clone())
+                        .await?
                 }
             };
-            registered.insert(
-                workflow_name.clone(),
-                RegisteredWorkflowPrincipal {
-                    id: record.id,
-                    foreign_id,
-                },
-            );
+            registered.insert(workflow_name.clone(), record.id);
         }
         Ok(registered)
     }
@@ -1715,11 +1693,15 @@ impl PythonWorkflowPrincipal {
             Self::Enabled(true) => Ok(Some(WorkflowPrincipalDeclaration::Derived)),
             Self::Enabled(false) => Ok(None),
             Self::Existing(principal) => {
-                let principal = validate_principal_foreign_id(
-                    &principal,
-                    &format!("workflow {workflow_name} WORKFLOW_PRINCIPAL"),
-                )?;
-                Ok(Some(WorkflowPrincipalDeclaration::Existing(principal)))
+                let principal = principal.trim();
+                if principal.is_empty() {
+                    return Err(WorkflowRuntimeError::BadRequest(format!(
+                        "workflow {workflow_name} declares an empty WORKFLOW_PRINCIPAL"
+                    )));
+                }
+                Ok(Some(WorkflowPrincipalDeclaration::Existing(
+                    principal.to_owned(),
+                )))
             }
         }
     }
@@ -3728,32 +3710,19 @@ fn explicit_agent_principal(args: &Value) -> Result<Option<String>, WorkflowRunt
         if value.is_null() {
             continue;
         }
-        let principal = value.as_str().ok_or_else(|| {
+        let principal = value.as_str().map(str::trim).ok_or_else(|| {
             WorkflowRuntimeError::BadRequest(
-                "ctx.agent_turn principal must be a principal foreign id".to_owned(),
+                "ctx.agent_turn principal must be a non-empty string".to_owned(),
             )
         })?;
-        return validate_principal_foreign_id(principal, "ctx.agent_turn principal").map(Some);
+        if principal.is_empty() {
+            return Err(WorkflowRuntimeError::BadRequest(
+                "ctx.agent_turn principal must be a non-empty string".to_owned(),
+            ));
+        }
+        return Ok(Some(principal.to_owned()));
     }
     Ok(None)
-}
-
-fn validate_principal_foreign_id(
-    principal: &str,
-    field: &str,
-) -> Result<String, WorkflowRuntimeError> {
-    let principal = principal.trim();
-    if principal.is_empty() {
-        return Err(WorkflowRuntimeError::BadRequest(format!(
-            "{field} must be a non-empty principal foreign id"
-        )));
-    }
-    if principal.starts_with("prn_") {
-        return Err(WorkflowRuntimeError::BadRequest(format!(
-            "{field} must use a principal foreign id, not a prn_ id"
-        )));
-    }
-    Ok(principal.to_owned())
 }
 
 fn agent_principal(
@@ -4655,23 +4624,6 @@ mod tests {
     }
 
     #[test]
-    fn discovery_metadata_rejects_a_principal_oid() {
-        let payload: PythonWorkflowDiscoveryPayload = serde_json::from_value(json!({
-            "workflows": [{
-                "workflow_name": "nightly_report",
-                "source_path": "workflows/nightly_report.py",
-                "principal": "prn_123",
-            }],
-        }))
-        .unwrap();
-
-        let error = metadata_from_discovery_payload(payload).unwrap_err();
-
-        assert!(matches!(error, WorkflowRuntimeError::BadRequest(_)));
-        assert!(error.to_string().contains("foreign id, not a prn_ id"));
-    }
-
-    #[test]
     fn agent_turn_inherits_or_overrides_the_workflow_principal() {
         assert_eq!(
             agent_principal(&json!({}), Some("workflow-default")).unwrap(),
@@ -4690,7 +4642,6 @@ mod tests {
             Some("agent-specific".to_owned())
         );
         assert!(agent_principal(&json!({"principal": "  "}), None).is_err());
-        assert!(agent_principal(&json!({"principal": "prn_123"}), None).is_err());
     }
 
     #[test]
@@ -4734,30 +4685,6 @@ mod tests {
         assert!(matches!(error, WorkflowRuntimeError::Internal(_)));
         assert!(error.to_string().contains("nightly_report"));
         assert!(error.to_string().contains("WORKFLOW_PRINCIPAL"));
-    }
-
-    #[test]
-    fn registered_workflow_principal_exposes_its_foreign_id_to_agent_turns() {
-        let assignments = WorkflowPrincipalAssignments {
-            required: BTreeMap::from([(
-                "nightly_report".to_owned(),
-                WorkflowPrincipalDeclaration::Existing("shared-automation".to_owned()),
-            )]),
-            registered: BTreeMap::from([(
-                "nightly_report".to_owned(),
-                RegisteredWorkflowPrincipal {
-                    id: "prn_123".to_owned(),
-                    foreign_id: "shared-automation".to_owned(),
-                },
-            )]),
-        };
-
-        assert_eq!(
-            assignments
-                .principal_for_workflow("nightly_report")
-                .expect("registered principal should resolve"),
-            Some("shared-automation".to_owned())
-        );
     }
 
     #[test]

--- a/services/api-rs/crates/centaur-workflows/src/lib.rs
+++ b/services/api-rs/crates/centaur-workflows/src/lib.rs
@@ -11,7 +11,9 @@ use absurd::{
     AwaitEventOptions, Client, ClientOptions, CreateQueueOptions, RetryKind, RetryStrategy,
     SpawnOptions, StepHandle, TaskContext, TaskRegistrationOptions, Worker, WorkerOptions,
 };
-use centaur_iron_control::{IronControlClient, IronControlError, PrincipalInput, slugify};
+use centaur_iron_control::{
+    IronControlClient, IronControlError, Principal, PrincipalInput, slugify,
+};
 use centaur_sandbox_core::SandboxSpec;
 use centaur_session_core::{HarnessType, MessageRole, SessionMessageInput, ThreadKey};
 use centaur_session_runtime::{
@@ -321,15 +323,39 @@ impl WorkflowPrincipalRegistrar {
                         })
                         .await?
                 }
-                WorkflowPrincipalDeclaration::Existing(principal) => {
-                    self.client
-                        .get_principal(&self.namespace, principal)
+                WorkflowPrincipalDeclaration::ForeignId(principal) => {
+                    self.resolve_or_create_principal(workflow_name, principal)
                         .await?
                 }
             };
             registered.insert(workflow_name.clone(), record.id);
         }
         Ok(registered)
+    }
+
+    async fn resolve_or_create_principal(
+        &self,
+        workflow_name: &str,
+        foreign_id: &str,
+    ) -> Result<Principal, WorkflowRuntimeError> {
+        match self.client.get_principal(&self.namespace, foreign_id).await {
+            Ok(principal) => Ok(principal),
+            Err(IronControlError::Status { status: 404, .. }) => Ok(self
+                .client
+                .upsert_principal(&PrincipalInput {
+                    namespace: self.namespace.clone(),
+                    foreign_id: foreign_id.to_owned(),
+                    name: format!("Workflow {workflow_name}"),
+                    labels: workflow_principal_labels(workflow_name),
+                    kind: Some("workflow".to_owned()),
+                    slack_user_id: None,
+                    slack_channel_id: None,
+                    slack_team_id: None,
+                    slack_email: None,
+                })
+                .await?),
+            Err(error) => Err(error.into()),
+        }
     }
 }
 
@@ -625,10 +651,12 @@ impl WorkflowRuntime {
         let task_session_runtime = session_runtime.clone();
         let task_workflow_host_sandbox = workflow_host_sandbox.clone();
         let task_workflow_clients = workflow_clients.clone();
+        let task_workflow_principal_registrar = workflow_principal_registrar.clone();
         client.register_task(WORKFLOW_TASK, move |input: WorkflowTaskInput, ctx| {
             let session_runtime = task_session_runtime.clone();
             let workflow_host_sandbox = task_workflow_host_sandbox.clone();
             let workflow_clients = task_workflow_clients.clone();
+            let workflow_principal_registrar = task_workflow_principal_registrar.clone();
             async move {
                 run_centaur_workflow(
                     input,
@@ -636,6 +664,7 @@ impl WorkflowRuntime {
                     session_runtime,
                     workflow_host_sandbox,
                     workflow_clients,
+                    workflow_principal_registrar,
                 )
                 .await
             }
@@ -643,10 +672,12 @@ impl WorkflowRuntime {
         let slack_live_session_runtime = session_runtime.clone();
         let slack_live_workflow_host_sandbox = workflow_host_sandbox.clone();
         let slack_live_workflow_clients = workflow_clients.clone();
+        let slack_live_workflow_principal_registrar = workflow_principal_registrar.clone();
         slack_live_client.register_task(WORKFLOW_TASK, move |input: WorkflowTaskInput, ctx| {
             let session_runtime = slack_live_session_runtime.clone();
             let workflow_host_sandbox = slack_live_workflow_host_sandbox.clone();
             let workflow_clients = slack_live_workflow_clients.clone();
+            let workflow_principal_registrar = slack_live_workflow_principal_registrar.clone();
             async move {
                 run_centaur_workflow(
                     input,
@@ -654,6 +685,7 @@ impl WorkflowRuntime {
                     session_runtime,
                     workflow_host_sandbox,
                     workflow_clients,
+                    workflow_principal_registrar,
                 )
                 .await
             }
@@ -661,10 +693,12 @@ impl WorkflowRuntime {
         let etl_session_runtime = session_runtime.clone();
         let etl_workflow_host_sandbox = workflow_host_sandbox.clone();
         let etl_workflow_clients = workflow_clients.clone();
+        let etl_workflow_principal_registrar = workflow_principal_registrar.clone();
         etl_client.register_task(WORKFLOW_TASK, move |input: WorkflowTaskInput, ctx| {
             let session_runtime = etl_session_runtime.clone();
             let workflow_host_sandbox = etl_workflow_host_sandbox.clone();
             let workflow_clients = etl_workflow_clients.clone();
+            let workflow_principal_registrar = etl_workflow_principal_registrar.clone();
             async move {
                 run_centaur_workflow(
                     input,
@@ -672,6 +706,7 @@ impl WorkflowRuntime {
                     session_runtime,
                     workflow_host_sandbox,
                     workflow_clients,
+                    workflow_principal_registrar,
                 )
                 .await
             }
@@ -679,12 +714,15 @@ impl WorkflowRuntime {
         let etl_backfill_session_runtime = session_runtime.clone();
         let etl_backfill_workflow_host_sandbox = workflow_host_sandbox.clone();
         let etl_backfill_workflow_clients = workflow_clients.clone();
+        let etl_backfill_workflow_principal_registrar = workflow_principal_registrar.clone();
         etl_backfill_client.register_task(
             WORKFLOW_TASK,
             move |input: WorkflowTaskInput, ctx| {
                 let session_runtime = etl_backfill_session_runtime.clone();
                 let workflow_host_sandbox = etl_backfill_workflow_host_sandbox.clone();
                 let workflow_clients = etl_backfill_workflow_clients.clone();
+                let workflow_principal_registrar =
+                    etl_backfill_workflow_principal_registrar.clone();
                 async move {
                     run_centaur_workflow(
                         input,
@@ -692,6 +730,7 @@ impl WorkflowRuntime {
                         session_runtime,
                         workflow_host_sandbox,
                         workflow_clients,
+                        workflow_principal_registrar,
                     )
                     .await
                 }
@@ -1681,7 +1720,7 @@ enum PythonWorkflowPrincipal {
 #[derive(Clone, Debug, Eq, PartialEq)]
 enum WorkflowPrincipalDeclaration {
     Derived,
-    Existing(String),
+    ForeignId(String),
 }
 
 impl PythonWorkflowPrincipal {
@@ -1693,15 +1732,11 @@ impl PythonWorkflowPrincipal {
             Self::Enabled(true) => Ok(Some(WorkflowPrincipalDeclaration::Derived)),
             Self::Enabled(false) => Ok(None),
             Self::Existing(principal) => {
-                let principal = principal.trim();
-                if principal.is_empty() {
-                    return Err(WorkflowRuntimeError::BadRequest(format!(
-                        "workflow {workflow_name} declares an empty WORKFLOW_PRINCIPAL"
-                    )));
-                }
-                Ok(Some(WorkflowPrincipalDeclaration::Existing(
-                    principal.to_owned(),
-                )))
+                let principal = validate_python_principal_foreign_id(
+                    &principal,
+                    &format!("workflow {workflow_name} WORKFLOW_PRINCIPAL"),
+                )?;
+                Ok(Some(WorkflowPrincipalDeclaration::ForeignId(principal)))
             }
         }
     }
@@ -2613,6 +2648,7 @@ async fn run_centaur_workflow(
     session_runtime: SessionRuntime,
     workflow_host_sandbox: Option<WorkflowHostSandboxRuntime>,
     workflow_clients: WorkflowQueueClients,
+    workflow_principal_registrar: Option<WorkflowPrincipalRegistrar>,
 ) -> absurd::Result<WorkflowResult> {
     let mut cleanup_guard =
         WorkflowSandboxCleanupGuard::new(session_runtime.clone(), ctx.run_id().to_owned());
@@ -2622,6 +2658,7 @@ async fn run_centaur_workflow(
         session_runtime,
         workflow_host_sandbox,
         workflow_clients,
+        workflow_principal_registrar,
     )
     .await;
     if let Some(reason) = workflow_cleanup_reason(&result) {
@@ -2647,6 +2684,7 @@ async fn run_centaur_workflow_inner(
     session_runtime: SessionRuntime,
     workflow_host_sandbox: Option<WorkflowHostSandboxRuntime>,
     workflow_clients: WorkflowQueueClients,
+    workflow_principal_registrar: Option<WorkflowPrincipalRegistrar>,
 ) -> absurd::Result<WorkflowResult> {
     let _heartbeat_guard = start_workflow_task_heartbeat(ctx.clone())
         .await
@@ -2809,6 +2847,7 @@ async fn run_centaur_workflow_inner(
                 session_runtime,
                 workflow_host_sandbox,
                 workflow_clients,
+                workflow_principal_registrar,
             )
             .await
             .map_err(absurd_error)?;
@@ -2887,6 +2926,7 @@ async fn run_python_workflow_host(
     session_runtime: SessionRuntime,
     workflow_host_sandbox: Option<WorkflowHostSandboxRuntime>,
     workflow_clients: WorkflowQueueClients,
+    workflow_principal_registrar: Option<WorkflowPrincipalRegistrar>,
 ) -> Result<Value, WorkflowRuntimeError> {
     if let Some(sandbox) = workflow_host_sandbox {
         return run_python_workflow_host_in_sandbox(
@@ -2895,10 +2935,18 @@ async fn run_python_workflow_host(
             session_runtime,
             sandbox,
             workflow_clients,
+            workflow_principal_registrar,
         )
         .await;
     }
-    run_python_workflow_host_local(input, ctx, session_runtime, workflow_clients).await
+    run_python_workflow_host_local(
+        input,
+        ctx,
+        session_runtime,
+        workflow_clients,
+        workflow_principal_registrar,
+    )
+    .await
 }
 
 async fn start_workflow_task_heartbeat(
@@ -2921,11 +2969,13 @@ async fn run_python_workflow_host_local(
     ctx: TaskContext,
     session_runtime: SessionRuntime,
     workflow_clients: WorkflowQueueClients,
+    workflow_principal_registrar: Option<WorkflowPrincipalRegistrar>,
 ) -> Result<Value, WorkflowRuntimeError> {
     let workflow_context = PythonWorkflowHostContext {
         session_runtime,
         workflow_clients,
         principal: None,
+        principal_registrar: workflow_principal_registrar,
     };
     let host_path = python_workflow_host_path();
     let mut command = Command::new(
@@ -3055,6 +3105,7 @@ async fn run_python_workflow_host_in_sandbox(
     session_runtime: SessionRuntime,
     sandbox: WorkflowHostSandboxRuntime,
     workflow_clients: WorkflowQueueClients,
+    workflow_principal_registrar: Option<WorkflowPrincipalRegistrar>,
 ) -> Result<Value, WorkflowRuntimeError> {
     let (mut spec, workflow_principal) = sandbox.spec_for_workflow(&input.workflow_name)?;
     spec = spec
@@ -3087,6 +3138,7 @@ async fn run_python_workflow_host_in_sandbox(
             session_runtime,
             workflow_clients,
             principal: workflow_principal,
+            principal_registrar: workflow_principal_registrar,
         },
         &mut stdin,
         io.stdout,
@@ -3108,6 +3160,7 @@ struct PythonWorkflowHostContext {
     session_runtime: SessionRuntime,
     workflow_clients: WorkflowQueueClients,
     principal: Option<String>,
+    principal_registrar: Option<WorkflowPrincipalRegistrar>,
 }
 
 async fn run_python_workflow_host_protocol<W, R>(
@@ -3411,6 +3464,7 @@ async fn handle_python_context_request(
                 args,
                 &request_id,
                 workflow_context.principal.as_deref(),
+                workflow_context.principal_registrar.as_ref(),
             )
             .await
             {
@@ -3571,6 +3625,7 @@ async fn run_python_agent_turn(
     args: Value,
     request_id: &str,
     workflow_principal: Option<&str>,
+    workflow_principal_registrar: Option<&WorkflowPrincipalRegistrar>,
 ) -> Result<Value, WorkflowRuntimeError> {
     let text = args
         .get("text")
@@ -3662,7 +3717,13 @@ async fn run_python_agent_turn(
     let model = first_str_arg(&args, &["model"]);
     let provider = first_str_arg(&args, &["provider"]);
     let reasoning = first_str_arg(&args, &["reasoning", "reasoning_effort", "effort"]);
-    let agent_principal = agent_principal(&args, workflow_principal)?;
+    let agent_principal = resolve_python_agent_principal(
+        &args,
+        workflow_principal,
+        workflow_principal_registrar,
+        &input.workflow_name,
+    )
+    .await?;
     // Record the model on the execution like the slackbot does, so Console
     // readers can show what a workflow-dispatched turn ran on.
     if let Some(model) = model.as_deref() {
@@ -3693,6 +3754,29 @@ async fn run_python_agent_turn(
     serde_json::to_value(result).map_err(WorkflowRuntimeError::from)
 }
 
+async fn resolve_python_agent_principal(
+    args: &Value,
+    workflow_principal: Option<&str>,
+    workflow_principal_registrar: Option<&WorkflowPrincipalRegistrar>,
+    workflow_name: &str,
+) -> Result<Option<String>, WorkflowRuntimeError> {
+    Ok(
+        match (
+            explicit_agent_principal(args)?,
+            workflow_principal_registrar,
+        ) {
+            (Some(foreign_id), Some(registrar)) => Some(
+                registrar
+                    .resolve_or_create_principal(workflow_name, &foreign_id)
+                    .await?
+                    .id,
+            ),
+            (Some(foreign_id), None) => Some(foreign_id),
+            (None, _) => workflow_principal.map(ToOwned::to_owned),
+        },
+    )
+}
+
 /// Returns the first arg key that holds a non-empty (trimmed) string, owned.
 fn first_str_arg(args: &Value, keys: &[&str]) -> Option<String> {
     keys.iter()
@@ -3710,26 +3794,33 @@ fn explicit_agent_principal(args: &Value) -> Result<Option<String>, WorkflowRunt
         if value.is_null() {
             continue;
         }
-        let principal = value.as_str().map(str::trim).ok_or_else(|| {
+        let principal = value.as_str().ok_or_else(|| {
             WorkflowRuntimeError::BadRequest(
-                "ctx.agent_turn principal must be a non-empty string".to_owned(),
+                "ctx.agent_turn principal must be a principal foreign id".to_owned(),
             )
         })?;
-        if principal.is_empty() {
-            return Err(WorkflowRuntimeError::BadRequest(
-                "ctx.agent_turn principal must be a non-empty string".to_owned(),
-            ));
-        }
-        return Ok(Some(principal.to_owned()));
+        return validate_python_principal_foreign_id(principal, "ctx.agent_turn principal")
+            .map(Some);
     }
     Ok(None)
 }
 
-fn agent_principal(
-    args: &Value,
-    workflow_principal: Option<&str>,
-) -> Result<Option<String>, WorkflowRuntimeError> {
-    Ok(explicit_agent_principal(args)?.or_else(|| workflow_principal.map(ToOwned::to_owned)))
+fn validate_python_principal_foreign_id(
+    principal: &str,
+    field: &str,
+) -> Result<String, WorkflowRuntimeError> {
+    let principal = principal.trim();
+    if principal.is_empty() {
+        return Err(WorkflowRuntimeError::BadRequest(format!(
+            "{field} must be a non-empty principal foreign id"
+        )));
+    }
+    if principal.starts_with("prn_") {
+        return Err(WorkflowRuntimeError::BadRequest(format!(
+            "{field} must use a principal foreign id, not a prn_ id"
+        )));
+    }
+    Ok(principal.to_owned())
 }
 
 fn parse_agent_harness(args: &Value) -> Result<Option<HarnessType>, WorkflowRuntimeError> {
@@ -4247,6 +4338,8 @@ pub enum WorkflowRuntimeError {
 mod tests {
     use super::*;
     use chrono::TimeZone;
+    use std::sync::{Arc, Mutex};
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
     #[test]
     fn python_event_names_are_collision_free() {
@@ -4617,31 +4710,57 @@ mod tests {
 
         assert_eq!(
             metadata.principals.get("nightly_report"),
-            Some(&WorkflowPrincipalDeclaration::Existing(
+            Some(&WorkflowPrincipalDeclaration::ForeignId(
                 "shared-automation".to_owned()
             ))
         );
     }
 
     #[test]
-    fn agent_turn_inherits_or_overrides_the_workflow_principal() {
+    fn discovery_metadata_rejects_a_principal_oid() {
+        let payload: PythonWorkflowDiscoveryPayload = serde_json::from_value(json!({
+            "workflows": [{
+                "workflow_name": "nightly_report",
+                "source_path": "workflows/nightly_report.py",
+                "principal": "prn_123",
+            }],
+        }))
+        .unwrap();
+
+        let error = metadata_from_discovery_payload(payload).unwrap_err();
+
+        assert!(matches!(error, WorkflowRuntimeError::BadRequest(_)));
+        assert!(error.to_string().contains("foreign id, not a prn_ id"));
+    }
+
+    #[test]
+    fn agent_turn_accepts_only_explicit_foreign_ids() {
+        assert_eq!(explicit_agent_principal(&json!({})).unwrap(), None);
         assert_eq!(
-            agent_principal(&json!({}), Some("workflow-default")).unwrap(),
-            Some("workflow-default".to_owned())
+            explicit_agent_principal(&json!({"principal": null})).unwrap(),
+            None
         );
         assert_eq!(
-            agent_principal(&json!({"principal": null}), Some("workflow-default")).unwrap(),
-            Some("workflow-default".to_owned())
-        );
-        assert_eq!(
-            agent_principal(
-                &json!({"principal": "agent-specific"}),
-                Some("workflow-default")
-            )
-            .unwrap(),
+            explicit_agent_principal(&json!({"principal": "agent-specific"})).unwrap(),
             Some("agent-specific".to_owned())
         );
-        assert!(agent_principal(&json!({"principal": "  "}), None).is_err());
+        assert!(explicit_agent_principal(&json!({"principal": "  "})).is_err());
+        assert!(explicit_agent_principal(&json!({"principal": "prn_123"})).is_err());
+    }
+
+    #[tokio::test]
+    async fn agent_turn_without_override_inherits_resolved_workflow_principal() {
+        assert_eq!(
+            resolve_python_agent_principal(
+                &json!({"principal": null}),
+                Some("prn_workflow"),
+                None,
+                "nightly_report",
+            )
+            .await
+            .unwrap(),
+            Some("prn_workflow".to_owned())
+        );
     }
 
     #[test]
@@ -4666,6 +4785,152 @@ mod tests {
             labels.get("workflow_name").map(String::as_str),
             Some("nightly_report")
         );
+    }
+
+    #[tokio::test]
+    async fn workflow_principal_foreign_id_resolves_existing_principal_to_oid() {
+        let (base_url, requests, server) = spawn_workflow_principal_stub(true).await;
+        let registrar = WorkflowPrincipalRegistrar::new(
+            IronControlClient::new(base_url, "test-key"),
+            "default",
+        );
+
+        let resolved = registrar
+            .resolve_workflow_principals(&BTreeMap::from([(
+                "nightly_report".to_owned(),
+                WorkflowPrincipalDeclaration::ForeignId("report-publisher".to_owned()),
+            )]))
+            .await
+            .unwrap();
+
+        assert_eq!(
+            resolved.get("nightly_report").map(String::as_str),
+            Some("prn_report")
+        );
+        assert_eq!(
+            requests.lock().unwrap().as_slice(),
+            ["GET /api/v1/principals/lookup/default/report-publisher"]
+        );
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn workflow_principal_foreign_id_creates_missing_principal_and_returns_oid() {
+        let (base_url, requests, server) = spawn_workflow_principal_stub(false).await;
+        let registrar = WorkflowPrincipalRegistrar::new(
+            IronControlClient::new(base_url, "test-key"),
+            "default",
+        );
+
+        let resolved = registrar
+            .resolve_workflow_principals(&BTreeMap::from([(
+                "nightly_report".to_owned(),
+                WorkflowPrincipalDeclaration::ForeignId("report-publisher".to_owned()),
+            )]))
+            .await
+            .unwrap();
+
+        assert_eq!(
+            resolved.get("nightly_report").map(String::as_str),
+            Some("prn_report")
+        );
+        assert_eq!(
+            requests.lock().unwrap().as_slice(),
+            [
+                "GET /api/v1/principals/lookup/default/report-publisher",
+                "PUT /api/v1/principals/report-publisher",
+            ]
+        );
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn agent_turn_foreign_id_creates_missing_principal_and_returns_oid() {
+        let (base_url, requests, server) = spawn_workflow_principal_stub(false).await;
+        let registrar = WorkflowPrincipalRegistrar::new(
+            IronControlClient::new(base_url, "test-key"),
+            "default",
+        );
+
+        let resolved = resolve_python_agent_principal(
+            &json!({"principal": "report-publisher"}),
+            Some("prn_workflow"),
+            Some(&registrar),
+            "nightly_report",
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(resolved.as_deref(), Some("prn_report"));
+        assert_eq!(
+            requests.lock().unwrap().as_slice(),
+            [
+                "GET /api/v1/principals/lookup/default/report-publisher",
+                "PUT /api/v1/principals/report-publisher",
+            ]
+        );
+        server.abort();
+    }
+
+    async fn spawn_workflow_principal_stub(
+        principal_exists: bool,
+    ) -> (String, Arc<Mutex<Vec<String>>>, tokio::task::JoinHandle<()>) {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let base_url = format!("http://{}", listener.local_addr().unwrap());
+        let requests = Arc::new(Mutex::new(Vec::new()));
+        let seen = requests.clone();
+        let handle = tokio::spawn(async move {
+            loop {
+                let Ok((mut stream, _)) = listener.accept().await else {
+                    return;
+                };
+                let mut request = Vec::new();
+                let mut buffer = [0_u8; 1024];
+                while !request.windows(4).any(|window| window == b"\r\n\r\n") {
+                    match stream.read(&mut buffer).await {
+                        Ok(0) | Err(_) => break,
+                        Ok(read) => request.extend_from_slice(&buffer[..read]),
+                    }
+                }
+                let request = String::from_utf8_lossy(&request);
+                let request_line = request.lines().next().unwrap_or_default();
+                seen.lock().unwrap().push(
+                    request_line
+                        .split_whitespace()
+                        .take(2)
+                        .collect::<Vec<_>>()
+                        .join(" "),
+                );
+
+                let (status, body) = if request_line
+                    .starts_with("GET /api/v1/principals/lookup/default/report-publisher ")
+                {
+                    if principal_exists {
+                        ("200 OK", workflow_principal_body())
+                    } else {
+                        ("404 Not Found", r#"{"error":"not found"}"#.to_owned())
+                    }
+                } else if request_line.starts_with("PUT /api/v1/principals/report-publisher ") {
+                    ("200 OK", workflow_principal_body())
+                } else {
+                    (
+                        "500 Internal Server Error",
+                        r#"{"error":"unexpected"}"#.to_owned(),
+                    )
+                };
+                let response = format!(
+                    "HTTP/1.1 {status}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                    body.len(),
+                );
+                let _ = stream.write_all(response.as_bytes()).await;
+                let _ = stream.shutdown().await;
+            }
+        });
+        (base_url, requests, handle)
+    }
+
+    fn workflow_principal_body() -> String {
+        r#"{"data":{"id":"prn_report","namespace":"default","foreign_id":"report-publisher","name":"Report Publisher","labels":{}}}"#.to_owned()
     }
 
     #[test]

--- a/services/api-rs/crates/centaur-workflows/src/lib.rs
+++ b/services/api-rs/crates/centaur-workflows/src/lib.rs
@@ -3703,20 +3703,26 @@ fn first_str_arg(args: &Value, keys: &[&str]) -> Option<String> {
 }
 
 fn explicit_agent_principal(args: &Value) -> Result<Option<String>, WorkflowRuntimeError> {
-    let Some(value) = args.get("principal").or_else(|| args.get("principal_id")) else {
-        return Ok(None);
-    };
-    let principal = value.as_str().map(str::trim).ok_or_else(|| {
-        WorkflowRuntimeError::BadRequest(
-            "ctx.agent_turn principal must be a non-empty string".to_owned(),
-        )
-    })?;
-    if principal.is_empty() {
-        return Err(WorkflowRuntimeError::BadRequest(
-            "ctx.agent_turn principal must be a non-empty string".to_owned(),
-        ));
+    for key in ["principal", "principal_id"] {
+        let Some(value) = args.get(key) else {
+            continue;
+        };
+        if value.is_null() {
+            continue;
+        }
+        let principal = value.as_str().map(str::trim).ok_or_else(|| {
+            WorkflowRuntimeError::BadRequest(
+                "ctx.agent_turn principal must be a non-empty string".to_owned(),
+            )
+        })?;
+        if principal.is_empty() {
+            return Err(WorkflowRuntimeError::BadRequest(
+                "ctx.agent_turn principal must be a non-empty string".to_owned(),
+            ));
+        }
+        return Ok(Some(principal.to_owned()));
     }
-    Ok(Some(principal.to_owned()))
+    Ok(None)
 }
 
 fn agent_principal(
@@ -4621,6 +4627,10 @@ mod tests {
     fn agent_turn_inherits_or_overrides_the_workflow_principal() {
         assert_eq!(
             agent_principal(&json!({}), Some("workflow-default")).unwrap(),
+            Some("workflow-default".to_owned())
+        );
+        assert_eq!(
+            agent_principal(&json!({"principal": null}), Some("workflow-default")).unwrap(),
             Some("workflow-default".to_owned())
         );
         assert_eq!(

--- a/services/api-rs/crates/centaur-workflows/src/lib.rs
+++ b/services/api-rs/crates/centaur-workflows/src/lib.rs
@@ -221,7 +221,13 @@ pub struct WorkflowHostSandboxRuntime {
 #[derive(Clone, Default)]
 struct WorkflowPrincipalAssignments {
     required: BTreeMap<String, WorkflowPrincipalDeclaration>,
-    registered: BTreeMap<String, String>,
+    registered: BTreeMap<String, RegisteredWorkflowPrincipal>,
+}
+
+#[derive(Clone)]
+struct RegisteredWorkflowPrincipal {
+    id: String,
+    foreign_id: String,
 }
 
 impl WorkflowPrincipalAssignments {
@@ -230,7 +236,7 @@ impl WorkflowPrincipalAssignments {
         workflow_name: &str,
     ) -> Result<Option<String>, WorkflowRuntimeError> {
         if let Some(principal) = self.registered.get(workflow_name) {
-            return Ok(Some(principal.clone()));
+            return Ok(Some(principal.foreign_id.clone()));
         }
         if self.required.contains_key(workflow_name) {
             return Err(WorkflowRuntimeError::Internal(format!(
@@ -252,7 +258,7 @@ impl WorkflowHostSandboxRuntime {
 
     fn update_workflow_principals(
         &self,
-        registered: BTreeMap<String, String>,
+        registered: BTreeMap<String, RegisteredWorkflowPrincipal>,
         required: BTreeMap<String, WorkflowPrincipalDeclaration>,
     ) {
         let mut current = self
@@ -270,15 +276,21 @@ impl WorkflowHostSandboxRuntime {
         workflow_name: &str,
     ) -> Result<(SandboxSpec, Option<String>), WorkflowRuntimeError> {
         let mut spec = self.spec.clone();
-        let principal = {
+        let (principal, principal_id) = {
             let assignments = self
                 .workflow_principals
                 .read()
                 .unwrap_or_else(|poisoned| poisoned.into_inner());
-            assignments.principal_for_workflow(workflow_name)?
+            (
+                assignments.principal_for_workflow(workflow_name)?,
+                assignments
+                    .registered
+                    .get(workflow_name)
+                    .map(|registered| registered.id.clone()),
+            )
         };
-        if let Some(principal) = principal.as_ref() {
-            spec.iron_control_principal = Some(principal.clone());
+        if let Some(principal_id) = principal_id {
+            spec.iron_control_principal = Some(principal_id);
         }
         Ok((spec, principal))
     }
@@ -301,16 +313,17 @@ impl WorkflowPrincipalRegistrar {
     async fn resolve_workflow_principals(
         &self,
         principals: &BTreeMap<String, WorkflowPrincipalDeclaration>,
-    ) -> Result<BTreeMap<String, String>, WorkflowRuntimeError> {
+    ) -> Result<BTreeMap<String, RegisteredWorkflowPrincipal>, WorkflowRuntimeError> {
         let mut registered = BTreeMap::new();
         for (workflow_name, declaration) in principals {
-            let record = match declaration {
+            let (record, foreign_id) = match declaration {
                 WorkflowPrincipalDeclaration::Derived => {
                     let foreign_id = canonical_workflow_principal_foreign_id(workflow_name);
-                    self.client
+                    let record = self
+                        .client
                         .upsert_principal(&PrincipalInput {
                             namespace: self.namespace.clone(),
-                            foreign_id,
+                            foreign_id: foreign_id.clone(),
                             name: format!("Workflow {workflow_name}"),
                             labels: workflow_principal_labels(workflow_name),
                             kind: Some("workflow".to_owned()),
@@ -319,15 +332,24 @@ impl WorkflowPrincipalRegistrar {
                             slack_team_id: None,
                             slack_email: None,
                         })
-                        .await?
+                        .await?;
+                    (record, foreign_id)
                 }
                 WorkflowPrincipalDeclaration::Existing(principal) => {
-                    self.client
+                    let record = self
+                        .client
                         .get_principal(&self.namespace, principal)
-                        .await?
+                        .await?;
+                    (record, principal.clone())
                 }
             };
-            registered.insert(workflow_name.clone(), record.id);
+            registered.insert(
+                workflow_name.clone(),
+                RegisteredWorkflowPrincipal {
+                    id: record.id,
+                    foreign_id,
+                },
+            );
         }
         Ok(registered)
     }
@@ -1693,15 +1715,11 @@ impl PythonWorkflowPrincipal {
             Self::Enabled(true) => Ok(Some(WorkflowPrincipalDeclaration::Derived)),
             Self::Enabled(false) => Ok(None),
             Self::Existing(principal) => {
-                let principal = principal.trim();
-                if principal.is_empty() {
-                    return Err(WorkflowRuntimeError::BadRequest(format!(
-                        "workflow {workflow_name} declares an empty WORKFLOW_PRINCIPAL"
-                    )));
-                }
-                Ok(Some(WorkflowPrincipalDeclaration::Existing(
-                    principal.to_owned(),
-                )))
+                let principal = validate_principal_foreign_id(
+                    &principal,
+                    &format!("workflow {workflow_name} WORKFLOW_PRINCIPAL"),
+                )?;
+                Ok(Some(WorkflowPrincipalDeclaration::Existing(principal)))
             }
         }
     }
@@ -3710,19 +3728,32 @@ fn explicit_agent_principal(args: &Value) -> Result<Option<String>, WorkflowRunt
         if value.is_null() {
             continue;
         }
-        let principal = value.as_str().map(str::trim).ok_or_else(|| {
+        let principal = value.as_str().ok_or_else(|| {
             WorkflowRuntimeError::BadRequest(
-                "ctx.agent_turn principal must be a non-empty string".to_owned(),
+                "ctx.agent_turn principal must be a principal foreign id".to_owned(),
             )
         })?;
-        if principal.is_empty() {
-            return Err(WorkflowRuntimeError::BadRequest(
-                "ctx.agent_turn principal must be a non-empty string".to_owned(),
-            ));
-        }
-        return Ok(Some(principal.to_owned()));
+        return validate_principal_foreign_id(principal, "ctx.agent_turn principal").map(Some);
     }
     Ok(None)
+}
+
+fn validate_principal_foreign_id(
+    principal: &str,
+    field: &str,
+) -> Result<String, WorkflowRuntimeError> {
+    let principal = principal.trim();
+    if principal.is_empty() {
+        return Err(WorkflowRuntimeError::BadRequest(format!(
+            "{field} must be a non-empty principal foreign id"
+        )));
+    }
+    if principal.starts_with("prn_") {
+        return Err(WorkflowRuntimeError::BadRequest(format!(
+            "{field} must use a principal foreign id, not a prn_ id"
+        )));
+    }
+    Ok(principal.to_owned())
 }
 
 fn agent_principal(
@@ -4624,6 +4655,23 @@ mod tests {
     }
 
     #[test]
+    fn discovery_metadata_rejects_a_principal_oid() {
+        let payload: PythonWorkflowDiscoveryPayload = serde_json::from_value(json!({
+            "workflows": [{
+                "workflow_name": "nightly_report",
+                "source_path": "workflows/nightly_report.py",
+                "principal": "prn_123",
+            }],
+        }))
+        .unwrap();
+
+        let error = metadata_from_discovery_payload(payload).unwrap_err();
+
+        assert!(matches!(error, WorkflowRuntimeError::BadRequest(_)));
+        assert!(error.to_string().contains("foreign id, not a prn_ id"));
+    }
+
+    #[test]
     fn agent_turn_inherits_or_overrides_the_workflow_principal() {
         assert_eq!(
             agent_principal(&json!({}), Some("workflow-default")).unwrap(),
@@ -4642,6 +4690,7 @@ mod tests {
             Some("agent-specific".to_owned())
         );
         assert!(agent_principal(&json!({"principal": "  "}), None).is_err());
+        assert!(agent_principal(&json!({"principal": "prn_123"}), None).is_err());
     }
 
     #[test]
@@ -4685,6 +4734,30 @@ mod tests {
         assert!(matches!(error, WorkflowRuntimeError::Internal(_)));
         assert!(error.to_string().contains("nightly_report"));
         assert!(error.to_string().contains("WORKFLOW_PRINCIPAL"));
+    }
+
+    #[test]
+    fn registered_workflow_principal_exposes_its_foreign_id_to_agent_turns() {
+        let assignments = WorkflowPrincipalAssignments {
+            required: BTreeMap::from([(
+                "nightly_report".to_owned(),
+                WorkflowPrincipalDeclaration::Existing("shared-automation".to_owned()),
+            )]),
+            registered: BTreeMap::from([(
+                "nightly_report".to_owned(),
+                RegisteredWorkflowPrincipal {
+                    id: "prn_123".to_owned(),
+                    foreign_id: "shared-automation".to_owned(),
+                },
+            )]),
+        };
+
+        assert_eq!(
+            assignments
+                .principal_for_workflow("nightly_report")
+                .expect("registered principal should resolve"),
+            Some("shared-automation".to_owned())
+        );
     }
 
     #[test]

--- a/services/api-rs/crates/centaur-workflows/src/lib.rs
+++ b/services/api-rs/crates/centaur-workflows/src/lib.rs
@@ -190,7 +190,7 @@ impl WorkflowEnablement {
         });
         metadata
             .principals
-            .retain(|workflow_name| self.is_enabled(workflow_name));
+            .retain(|workflow_name, _| self.is_enabled(workflow_name));
     }
 }
 
@@ -220,7 +220,7 @@ pub struct WorkflowHostSandboxRuntime {
 
 #[derive(Clone, Default)]
 struct WorkflowPrincipalAssignments {
-    required: BTreeSet<String>,
+    required: BTreeMap<String, WorkflowPrincipalDeclaration>,
     registered: BTreeMap<String, String>,
 }
 
@@ -232,7 +232,7 @@ impl WorkflowPrincipalAssignments {
         if let Some(principal) = self.registered.get(workflow_name) {
             return Ok(Some(principal.clone()));
         }
-        if self.required.contains(workflow_name) {
+        if self.required.contains_key(workflow_name) {
             return Err(WorkflowRuntimeError::Internal(format!(
                 "workflow {workflow_name} declares WORKFLOW_PRINCIPAL but no scoped principal is registered"
             )));
@@ -253,7 +253,7 @@ impl WorkflowHostSandboxRuntime {
     fn update_workflow_principals(
         &self,
         registered: BTreeMap<String, String>,
-        required: BTreeSet<String>,
+        required: BTreeMap<String, WorkflowPrincipalDeclaration>,
     ) {
         let mut current = self
             .workflow_principals
@@ -265,7 +265,10 @@ impl WorkflowHostSandboxRuntime {
         };
     }
 
-    fn spec_for_workflow(&self, workflow_name: &str) -> Result<SandboxSpec, WorkflowRuntimeError> {
+    fn spec_for_workflow(
+        &self,
+        workflow_name: &str,
+    ) -> Result<(SandboxSpec, Option<String>), WorkflowRuntimeError> {
         let mut spec = self.spec.clone();
         let principal = {
             let assignments = self
@@ -274,10 +277,10 @@ impl WorkflowHostSandboxRuntime {
                 .unwrap_or_else(|poisoned| poisoned.into_inner());
             assignments.principal_for_workflow(workflow_name)?
         };
-        if let Some(principal) = principal {
-            spec.iron_control_principal = Some(principal);
+        if let Some(principal) = principal.as_ref() {
+            spec.iron_control_principal = Some(principal.clone());
         }
-        Ok(spec)
+        Ok((spec, principal))
     }
 }
 
@@ -295,27 +298,35 @@ impl WorkflowPrincipalRegistrar {
         }
     }
 
-    async fn register_workflow_principals(
+    async fn resolve_workflow_principals(
         &self,
-        principals: &BTreeSet<String>,
+        principals: &BTreeMap<String, WorkflowPrincipalDeclaration>,
     ) -> Result<BTreeMap<String, String>, WorkflowRuntimeError> {
         let mut registered = BTreeMap::new();
-        for workflow_name in principals {
-            let foreign_id = canonical_workflow_principal_foreign_id(workflow_name);
-            let record = self
-                .client
-                .upsert_principal(&PrincipalInput {
-                    namespace: self.namespace.clone(),
-                    foreign_id,
-                    name: format!("Workflow {workflow_name}"),
-                    labels: workflow_principal_labels(workflow_name),
-                    kind: Some("workflow".to_owned()),
-                    slack_user_id: None,
-                    slack_channel_id: None,
-                    slack_team_id: None,
-                    slack_email: None,
-                })
-                .await?;
+        for (workflow_name, declaration) in principals {
+            let record = match declaration {
+                WorkflowPrincipalDeclaration::Derived => {
+                    let foreign_id = canonical_workflow_principal_foreign_id(workflow_name);
+                    self.client
+                        .upsert_principal(&PrincipalInput {
+                            namespace: self.namespace.clone(),
+                            foreign_id,
+                            name: format!("Workflow {workflow_name}"),
+                            labels: workflow_principal_labels(workflow_name),
+                            kind: Some("workflow".to_owned()),
+                            slack_user_id: None,
+                            slack_channel_id: None,
+                            slack_team_id: None,
+                            slack_email: None,
+                        })
+                        .await?
+                }
+                WorkflowPrincipalDeclaration::Existing(principal) => {
+                    self.client
+                        .get_principal(&self.namespace, principal)
+                        .await?
+                }
+            };
             registered.insert(workflow_name.clone(), record.id);
         }
         Ok(registered)
@@ -1657,7 +1668,43 @@ struct PythonWorkflowDiscovery {
     #[serde(default)]
     schedule: Option<Value>,
     #[serde(default)]
-    principal: Option<bool>,
+    principal: Option<PythonWorkflowPrincipal>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum PythonWorkflowPrincipal {
+    Enabled(bool),
+    Existing(String),
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+enum WorkflowPrincipalDeclaration {
+    Derived,
+    Existing(String),
+}
+
+impl PythonWorkflowPrincipal {
+    fn into_declaration(
+        self,
+        workflow_name: &str,
+    ) -> Result<Option<WorkflowPrincipalDeclaration>, WorkflowRuntimeError> {
+        match self {
+            Self::Enabled(true) => Ok(Some(WorkflowPrincipalDeclaration::Derived)),
+            Self::Enabled(false) => Ok(None),
+            Self::Existing(principal) => {
+                let principal = principal.trim();
+                if principal.is_empty() {
+                    return Err(WorkflowRuntimeError::BadRequest(format!(
+                        "workflow {workflow_name} declares an empty WORKFLOW_PRINCIPAL"
+                    )));
+                }
+                Ok(Some(WorkflowPrincipalDeclaration::Existing(
+                    principal.to_owned(),
+                )))
+            }
+        }
+    }
 }
 
 #[derive(Debug, Deserialize)]
@@ -1670,17 +1717,16 @@ struct PythonWorkflowMetadata {
     webhooks: Vec<RegisteredWorkflowWebhook>,
     schedules: Vec<Value>,
     workflow_names: BTreeSet<String>,
-    principals: BTreeSet<String>,
+    principals: BTreeMap<String, WorkflowPrincipalDeclaration>,
 }
 
 fn metadata_from_discovery_payload(
     payload: PythonWorkflowDiscoveryPayload,
-) -> PythonWorkflowMetadata {
+) -> Result<PythonWorkflowMetadata, WorkflowRuntimeError> {
     let mut metadata = PythonWorkflowMetadata::default();
     for workflow in payload.workflows {
-        metadata
-            .workflow_names
-            .insert(workflow.workflow_name.clone());
+        let workflow_name = workflow.workflow_name.clone();
+        metadata.workflow_names.insert(workflow_name.clone());
         metadata.webhooks.extend(workflow.webhooks);
         if let Some(mut schedule) = workflow.schedule {
             if let Some(object) = schedule.as_object_mut() {
@@ -1693,11 +1739,13 @@ fn metadata_from_discovery_payload(
             }
             metadata.schedules.push(schedule);
         }
-        if workflow.principal.unwrap_or(false) {
-            metadata.principals.insert(workflow.workflow_name);
+        if let Some(principal) = workflow.principal
+            && let Some(declaration) = principal.into_declaration(&workflow_name)?
+        {
+            metadata.principals.insert(workflow_name, declaration);
         }
     }
-    metadata
+    Ok(metadata)
 }
 
 async fn prepare_workflow_host_sandbox(
@@ -1710,7 +1758,7 @@ async fn prepare_workflow_host_sandbox(
         if !discovery.principals.is_empty() {
             let workflow_names = discovery
                 .principals
-                .iter()
+                .keys()
                 .cloned()
                 .collect::<Vec<_>>()
                 .join(", ");
@@ -1737,8 +1785,8 @@ async fn reconcile_workflow_principals(
     enablement: &WorkflowEnablement,
 ) -> Result<(), WorkflowRuntimeError> {
     let mut principals = discovery.principals.clone();
-    principals.retain(|workflow_name| enablement.is_enabled(workflow_name));
-    let registered = match registrar.register_workflow_principals(&principals).await {
+    principals.retain(|workflow_name, _| enablement.is_enabled(workflow_name));
+    let registered = match registrar.resolve_workflow_principals(&principals).await {
         Ok(registered) => registered,
         Err(error) => {
             sandbox.update_workflow_principals(BTreeMap::new(), principals);
@@ -1804,7 +1852,7 @@ async fn discover_python_workflow_metadata() -> Result<PythonWorkflowMetadata, W
             Some("workflow.discovery") => {
                 let _ = child.wait().await;
                 let payload: PythonWorkflowDiscoveryPayload = serde_json::from_value(message)?;
-                let mut metadata = metadata_from_discovery_payload(payload);
+                let mut metadata = metadata_from_discovery_payload(payload)?;
                 WorkflowEnablement::from_env()?.filter_metadata(&mut metadata);
                 return Ok(metadata);
             }
@@ -2692,6 +2740,7 @@ async fn run_centaur_workflow_inner(
                                     "absurd-workflow-agent-turn:{client_message_id}"
                                 ),
                                 workflow_owned_thread: true,
+                                principal: None,
                                 idle_timeout_ms,
                                 max_duration_ms,
                                 model: None,
@@ -2873,6 +2922,11 @@ async fn run_python_workflow_host_local(
     session_runtime: SessionRuntime,
     workflow_clients: WorkflowQueueClients,
 ) -> Result<Value, WorkflowRuntimeError> {
+    let workflow_context = PythonWorkflowHostContext {
+        session_runtime,
+        workflow_clients,
+        principal: None,
+    };
     let host_path = python_workflow_host_path();
     let mut command = Command::new(
         env::var(PYTHON_HOST_INTERPRETER_ENV).unwrap_or_else(|_| "python3".to_owned()),
@@ -2966,23 +3020,18 @@ async fn run_python_workflow_host_local(
                 record_python_workflow_metric(&message);
             }
             Some(message_type) if message_type.starts_with("ctx.") => {
-                let response = match handle_python_context_request(
-                    &message,
-                    &ctx,
-                    &session_runtime,
-                    &input,
-                    &workflow_clients,
-                )
-                .await
-                {
-                    Ok(response) => response,
-                    Err(error) => {
-                        drop(stdin);
-                        let _ = child.start_kill();
-                        let _ = child.wait().await;
-                        return Err(error);
-                    }
-                };
+                let response =
+                    match handle_python_context_request(&message, &ctx, &input, &workflow_context)
+                        .await
+                    {
+                        Ok(response) => response,
+                        Err(error) => {
+                            drop(stdin);
+                            let _ = child.start_kill();
+                            let _ = child.wait().await;
+                            return Err(error);
+                        }
+                    };
                 write_host_message(&mut stdin, &response).await?;
             }
             other => {
@@ -3007,7 +3056,7 @@ async fn run_python_workflow_host_in_sandbox(
     sandbox: WorkflowHostSandboxRuntime,
     workflow_clients: WorkflowQueueClients,
 ) -> Result<Value, WorkflowRuntimeError> {
-    let mut spec = sandbox.spec_for_workflow(&input.workflow_name)?;
+    let (mut spec, workflow_principal) = sandbox.spec_for_workflow(&input.workflow_name)?;
     spec = spec
         .env("WORKFLOW_RUN_ID", ctx.run_id())
         .env("WORKFLOW_TASK_ID", ctx.task_id())
@@ -3034,8 +3083,11 @@ async fn run_python_workflow_host_in_sandbox(
     let result = run_python_workflow_host_protocol(
         input,
         ctx,
-        session_runtime,
-        workflow_clients,
+        PythonWorkflowHostContext {
+            session_runtime,
+            workflow_clients,
+            principal: workflow_principal,
+        },
         &mut stdin,
         io.stdout,
         stderr_task,
@@ -3052,11 +3104,16 @@ fn sandbox_spec_has_env(spec: &SandboxSpec, name: &str) -> bool {
     spec.env.iter().any(|entry| entry.name == name)
 }
 
+struct PythonWorkflowHostContext {
+    session_runtime: SessionRuntime,
+    workflow_clients: WorkflowQueueClients,
+    principal: Option<String>,
+}
+
 async fn run_python_workflow_host_protocol<W, R>(
     input: WorkflowTaskInput,
     ctx: TaskContext,
-    session_runtime: SessionRuntime,
-    workflow_clients: WorkflowQueueClients,
+    workflow_context: PythonWorkflowHostContext,
     stdin: &mut W,
     stdout: R,
     stderr_task: JoinHandle<String>,
@@ -3116,14 +3173,9 @@ where
                 record_python_workflow_metric(&message);
             }
             Some(message_type) if message_type.starts_with("ctx.") => {
-                let response = handle_python_context_request(
-                    &message,
-                    &ctx,
-                    &session_runtime,
-                    &input,
-                    &workflow_clients,
-                )
-                .await?;
+                let response =
+                    handle_python_context_request(&message, &ctx, &input, &workflow_context)
+                        .await?;
                 write_host_message(stdin, &response).await?;
             }
             other => {
@@ -3251,9 +3303,8 @@ fn is_valid_prometheus_name(value: &str) -> bool {
 async fn handle_python_context_request(
     message: &Value,
     ctx: &TaskContext,
-    session_runtime: &SessionRuntime,
     input: &WorkflowTaskInput,
-    workflow_clients: &WorkflowQueueClients,
+    workflow_context: &PythonWorkflowHostContext,
 ) -> Result<Value, WorkflowRuntimeError> {
     let request_id = message
         .get("request_id")
@@ -3353,15 +3404,24 @@ async fn handle_python_context_request(
         }
         Some("ctx.agent_turn") => {
             let args = message.get("args").cloned().unwrap_or_else(|| json!({}));
-            match run_python_agent_turn(session_runtime.clone(), ctx, input, args, &request_id)
-                .await
+            match run_python_agent_turn(
+                workflow_context.session_runtime.clone(),
+                ctx,
+                input,
+                args,
+                &request_id,
+                workflow_context.principal.as_deref(),
+            )
+            .await
             {
                 Ok(value) => Ok(value),
                 Err(error) => Err(error.to_string()),
             }
         }
         Some("ctx.workflow.start") => {
-            match start_python_child_workflow(message, input, workflow_clients).await {
+            match start_python_child_workflow(message, input, &workflow_context.workflow_clients)
+                .await
+            {
                 Ok(value) => Ok(value),
                 Err(error) => Err(error.to_string()),
             }
@@ -3510,6 +3570,7 @@ async fn run_python_agent_turn(
     input: &WorkflowTaskInput,
     args: Value,
     request_id: &str,
+    workflow_principal: Option<&str>,
 ) -> Result<Value, WorkflowRuntimeError> {
     let text = args
         .get("text")
@@ -3601,6 +3662,7 @@ async fn run_python_agent_turn(
     let model = first_str_arg(&args, &["model"]);
     let provider = first_str_arg(&args, &["provider"]);
     let reasoning = first_str_arg(&args, &["reasoning", "reasoning_effort", "effort"]);
+    let agent_principal = agent_principal(&args, workflow_principal)?;
     // Record the model on the execution like the slackbot does, so Console
     // readers can show what a workflow-dispatched turn ran on.
     if let Some(model) = model.as_deref() {
@@ -3619,6 +3681,7 @@ async fn run_python_agent_turn(
             execution_metadata,
             execution_idempotency_key,
             workflow_owned_thread,
+            principal: agent_principal,
             idle_timeout_ms,
             max_duration_ms,
             model,
@@ -3637,6 +3700,30 @@ fn first_str_arg(args: &Value, keys: &[&str]) -> Option<String> {
         .map(str::trim)
         .find(|value| !value.is_empty())
         .map(ToOwned::to_owned)
+}
+
+fn explicit_agent_principal(args: &Value) -> Result<Option<String>, WorkflowRuntimeError> {
+    let Some(value) = args.get("principal").or_else(|| args.get("principal_id")) else {
+        return Ok(None);
+    };
+    let principal = value.as_str().map(str::trim).ok_or_else(|| {
+        WorkflowRuntimeError::BadRequest(
+            "ctx.agent_turn principal must be a non-empty string".to_owned(),
+        )
+    })?;
+    if principal.is_empty() {
+        return Err(WorkflowRuntimeError::BadRequest(
+            "ctx.agent_turn principal must be a non-empty string".to_owned(),
+        ));
+    }
+    Ok(Some(principal.to_owned()))
+}
+
+fn agent_principal(
+    args: &Value,
+    workflow_principal: Option<&str>,
+) -> Result<Option<String>, WorkflowRuntimeError> {
+    Ok(explicit_agent_principal(args)?.or_else(|| workflow_principal.map(ToOwned::to_owned)))
 }
 
 fn parse_agent_harness(args: &Value) -> Result<Option<HarnessType>, WorkflowRuntimeError> {
@@ -3911,6 +3998,7 @@ struct AgentTurnRequest {
     execution_metadata: Value,
     execution_idempotency_key: String,
     workflow_owned_thread: bool,
+    principal: Option<String>,
     idle_timeout_ms: u64,
     max_duration_ms: u64,
     // Optional per-turn model / provider / reasoning-effort overrides. When set
@@ -3966,6 +4054,7 @@ async fn run_agent_session_turn(
         execution_metadata,
         execution_idempotency_key,
         workflow_owned_thread,
+        principal,
         idle_timeout_ms,
         max_duration_ms,
         model,
@@ -3978,12 +4067,13 @@ async fn run_agent_session_turn(
         object_insert(&mut session_metadata, "workflow_owned_thread", json!(true));
     }
     session_runtime
-        .create_or_get_session(
+        .create_or_get_session_with_principal(
             &thread_key,
             &harness_type,
             persona_id.as_deref(),
             Some(session_metadata),
             HarnessConflictPolicy::Reject,
+            principal.as_deref(),
         )
         .await?;
     session_runtime
@@ -4487,7 +4577,7 @@ mod tests {
             ],
         }))
         .unwrap();
-        let metadata = metadata_from_discovery_payload(payload);
+        let metadata = metadata_from_discovery_payload(payload).unwrap();
         assert_eq!(
             metadata.workflow_names,
             BTreeSet::from([
@@ -4500,7 +4590,48 @@ mod tests {
             metadata.schedules[0].get("workflow_name"),
             Some(&json!("scheduled_workflow"))
         );
-        assert!(metadata.principals.contains("scheduled_workflow"));
+        assert_eq!(
+            metadata.principals.get("scheduled_workflow"),
+            Some(&WorkflowPrincipalDeclaration::Derived)
+        );
+    }
+
+    #[test]
+    fn discovery_metadata_accepts_an_existing_workflow_principal() {
+        let payload: PythonWorkflowDiscoveryPayload = serde_json::from_value(json!({
+            "workflows": [{
+                "workflow_name": "nightly_report",
+                "source_path": "workflows/nightly_report.py",
+                "principal": "shared-automation",
+            }],
+        }))
+        .unwrap();
+
+        let metadata = metadata_from_discovery_payload(payload).unwrap();
+
+        assert_eq!(
+            metadata.principals.get("nightly_report"),
+            Some(&WorkflowPrincipalDeclaration::Existing(
+                "shared-automation".to_owned()
+            ))
+        );
+    }
+
+    #[test]
+    fn agent_turn_inherits_or_overrides_the_workflow_principal() {
+        assert_eq!(
+            agent_principal(&json!({}), Some("workflow-default")).unwrap(),
+            Some("workflow-default".to_owned())
+        );
+        assert_eq!(
+            agent_principal(
+                &json!({"principal": "agent-specific"}),
+                Some("workflow-default")
+            )
+            .unwrap(),
+            Some("agent-specific".to_owned())
+        );
+        assert!(agent_principal(&json!({"principal": "  "}), None).is_err());
     }
 
     #[test]
@@ -4530,7 +4661,10 @@ mod tests {
     #[test]
     fn required_workflow_principal_fails_closed_when_unregistered() {
         let assignments = WorkflowPrincipalAssignments {
-            required: BTreeSet::from(["nightly_report".to_owned()]),
+            required: BTreeMap::from([(
+                "nightly_report".to_owned(),
+                WorkflowPrincipalDeclaration::Derived,
+            )]),
             registered: BTreeMap::new(),
         };
 
@@ -4558,7 +4692,10 @@ mod tests {
     #[tokio::test]
     async fn workflow_principal_requires_workflow_host_sandbox() {
         let discovery = PythonWorkflowMetadata {
-            principals: BTreeSet::from(["nightly_report".to_owned()]),
+            principals: BTreeMap::from([(
+                "nightly_report".to_owned(),
+                WorkflowPrincipalDeclaration::Derived,
+            )]),
             workflow_names: BTreeSet::from(["nightly_report".to_owned()]),
             ..PythonWorkflowMetadata::default()
         };
@@ -4625,7 +4762,7 @@ mod tests {
         }))
         .unwrap();
 
-        let metadata = metadata_from_discovery_payload(payload);
+        let metadata = metadata_from_discovery_payload(payload).unwrap();
         let filter = metadata.webhooks[0].spec.filter.as_ref().unwrap();
         let all = filter.all.as_ref().unwrap();
         assert_eq!(all.len(), 2);
@@ -4755,7 +4892,7 @@ mod tests {
             ],
         }))
         .unwrap();
-        let mut metadata = metadata_from_discovery_payload(payload);
+        let mut metadata = metadata_from_discovery_payload(payload).unwrap();
         WorkflowEnablement::allowlist("allowed_workflow").filter_metadata(&mut metadata);
 
         assert_eq!(
@@ -4770,7 +4907,7 @@ mod tests {
         assert_eq!(metadata.webhooks.len(), 1);
         assert_eq!(metadata.webhooks[0].workflow_name, "allowed_workflow");
         assert_eq!(
-            metadata.principals.iter().cloned().collect::<Vec<_>>(),
+            metadata.principals.keys().cloned().collect::<Vec<_>>(),
             vec!["allowed_workflow".to_owned()]
         );
     }

--- a/services/api-rs/crates/centaur-workflows/src/lib.rs
+++ b/services/api-rs/crates/centaur-workflows/src/lib.rs
@@ -11,9 +11,7 @@ use absurd::{
     AwaitEventOptions, Client, ClientOptions, CreateQueueOptions, RetryKind, RetryStrategy,
     SpawnOptions, StepHandle, TaskContext, TaskRegistrationOptions, Worker, WorkerOptions,
 };
-use centaur_iron_control::{
-    IronControlClient, IronControlError, Principal, PrincipalInput, slugify,
-};
+use centaur_iron_control::{IronControlClient, IronControlError, PrincipalInput, slugify};
 use centaur_sandbox_core::SandboxSpec;
 use centaur_session_core::{HarnessType, MessageRole, SessionMessageInput, ThreadKey};
 use centaur_session_runtime::{
@@ -310,52 +308,26 @@ impl WorkflowPrincipalRegistrar {
                 WorkflowPrincipalDeclaration::Derived => {
                     let foreign_id = canonical_workflow_principal_foreign_id(workflow_name);
                     self.client
-                        .upsert_principal(&PrincipalInput {
-                            namespace: self.namespace.clone(),
-                            foreign_id,
-                            name: format!("Workflow {workflow_name}"),
-                            labels: workflow_principal_labels(workflow_name),
-                            kind: Some("workflow".to_owned()),
-                            slack_user_id: None,
-                            slack_channel_id: None,
-                            slack_team_id: None,
-                            slack_email: None,
-                        })
+                        .upsert_principal(&workflow_principal_input(
+                            &self.namespace,
+                            workflow_name,
+                            &foreign_id,
+                        ))
                         .await?
                 }
                 WorkflowPrincipalDeclaration::ForeignId(principal) => {
-                    self.resolve_or_create_principal(workflow_name, principal)
+                    self.client
+                        .get_or_create_principal(&workflow_principal_input(
+                            &self.namespace,
+                            workflow_name,
+                            principal,
+                        ))
                         .await?
                 }
             };
             registered.insert(workflow_name.clone(), record.id);
         }
         Ok(registered)
-    }
-
-    async fn resolve_or_create_principal(
-        &self,
-        workflow_name: &str,
-        foreign_id: &str,
-    ) -> Result<Principal, WorkflowRuntimeError> {
-        match self.client.get_principal(&self.namespace, foreign_id).await {
-            Ok(principal) => Ok(principal),
-            Err(IronControlError::Status { status: 404, .. }) => Ok(self
-                .client
-                .upsert_principal(&PrincipalInput {
-                    namespace: self.namespace.clone(),
-                    foreign_id: foreign_id.to_owned(),
-                    name: format!("Workflow {workflow_name}"),
-                    labels: workflow_principal_labels(workflow_name),
-                    kind: Some("workflow".to_owned()),
-                    slack_user_id: None,
-                    slack_channel_id: None,
-                    slack_team_id: None,
-                    slack_email: None,
-                })
-                .await?),
-            Err(error) => Err(error.into()),
-        }
     }
 }
 
@@ -368,6 +340,24 @@ fn workflow_principal_labels(workflow_name: &str) -> BTreeMap<String, String> {
         ("managed-by".to_owned(), "centaur".to_owned()),
         ("workflow_name".to_owned(), workflow_name.to_owned()),
     ])
+}
+
+fn workflow_principal_input(
+    namespace: &str,
+    workflow_name: &str,
+    foreign_id: &str,
+) -> PrincipalInput {
+    PrincipalInput {
+        namespace: namespace.to_owned(),
+        foreign_id: foreign_id.to_owned(),
+        name: format!("Workflow {workflow_name}"),
+        labels: workflow_principal_labels(workflow_name),
+        kind: Some("workflow".to_owned()),
+        slack_user_id: None,
+        slack_channel_id: None,
+        slack_team_id: None,
+        slack_email: None,
+    }
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -651,12 +641,10 @@ impl WorkflowRuntime {
         let task_session_runtime = session_runtime.clone();
         let task_workflow_host_sandbox = workflow_host_sandbox.clone();
         let task_workflow_clients = workflow_clients.clone();
-        let task_workflow_principal_registrar = workflow_principal_registrar.clone();
         client.register_task(WORKFLOW_TASK, move |input: WorkflowTaskInput, ctx| {
             let session_runtime = task_session_runtime.clone();
             let workflow_host_sandbox = task_workflow_host_sandbox.clone();
             let workflow_clients = task_workflow_clients.clone();
-            let workflow_principal_registrar = task_workflow_principal_registrar.clone();
             async move {
                 run_centaur_workflow(
                     input,
@@ -664,7 +652,6 @@ impl WorkflowRuntime {
                     session_runtime,
                     workflow_host_sandbox,
                     workflow_clients,
-                    workflow_principal_registrar,
                 )
                 .await
             }
@@ -672,12 +659,10 @@ impl WorkflowRuntime {
         let slack_live_session_runtime = session_runtime.clone();
         let slack_live_workflow_host_sandbox = workflow_host_sandbox.clone();
         let slack_live_workflow_clients = workflow_clients.clone();
-        let slack_live_workflow_principal_registrar = workflow_principal_registrar.clone();
         slack_live_client.register_task(WORKFLOW_TASK, move |input: WorkflowTaskInput, ctx| {
             let session_runtime = slack_live_session_runtime.clone();
             let workflow_host_sandbox = slack_live_workflow_host_sandbox.clone();
             let workflow_clients = slack_live_workflow_clients.clone();
-            let workflow_principal_registrar = slack_live_workflow_principal_registrar.clone();
             async move {
                 run_centaur_workflow(
                     input,
@@ -685,7 +670,6 @@ impl WorkflowRuntime {
                     session_runtime,
                     workflow_host_sandbox,
                     workflow_clients,
-                    workflow_principal_registrar,
                 )
                 .await
             }
@@ -693,12 +677,10 @@ impl WorkflowRuntime {
         let etl_session_runtime = session_runtime.clone();
         let etl_workflow_host_sandbox = workflow_host_sandbox.clone();
         let etl_workflow_clients = workflow_clients.clone();
-        let etl_workflow_principal_registrar = workflow_principal_registrar.clone();
         etl_client.register_task(WORKFLOW_TASK, move |input: WorkflowTaskInput, ctx| {
             let session_runtime = etl_session_runtime.clone();
             let workflow_host_sandbox = etl_workflow_host_sandbox.clone();
             let workflow_clients = etl_workflow_clients.clone();
-            let workflow_principal_registrar = etl_workflow_principal_registrar.clone();
             async move {
                 run_centaur_workflow(
                     input,
@@ -706,7 +688,6 @@ impl WorkflowRuntime {
                     session_runtime,
                     workflow_host_sandbox,
                     workflow_clients,
-                    workflow_principal_registrar,
                 )
                 .await
             }
@@ -714,15 +695,12 @@ impl WorkflowRuntime {
         let etl_backfill_session_runtime = session_runtime.clone();
         let etl_backfill_workflow_host_sandbox = workflow_host_sandbox.clone();
         let etl_backfill_workflow_clients = workflow_clients.clone();
-        let etl_backfill_workflow_principal_registrar = workflow_principal_registrar.clone();
         etl_backfill_client.register_task(
             WORKFLOW_TASK,
             move |input: WorkflowTaskInput, ctx| {
                 let session_runtime = etl_backfill_session_runtime.clone();
                 let workflow_host_sandbox = etl_backfill_workflow_host_sandbox.clone();
                 let workflow_clients = etl_backfill_workflow_clients.clone();
-                let workflow_principal_registrar =
-                    etl_backfill_workflow_principal_registrar.clone();
                 async move {
                     run_centaur_workflow(
                         input,
@@ -730,7 +708,6 @@ impl WorkflowRuntime {
                         session_runtime,
                         workflow_host_sandbox,
                         workflow_clients,
-                        workflow_principal_registrar,
                     )
                     .await
                 }
@@ -1714,7 +1691,7 @@ struct PythonWorkflowDiscovery {
 #[serde(untagged)]
 enum PythonWorkflowPrincipal {
     Enabled(bool),
-    Existing(String),
+    ForeignId(String),
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -1731,7 +1708,7 @@ impl PythonWorkflowPrincipal {
         match self {
             Self::Enabled(true) => Ok(Some(WorkflowPrincipalDeclaration::Derived)),
             Self::Enabled(false) => Ok(None),
-            Self::Existing(principal) => {
+            Self::ForeignId(principal) => {
                 let principal = validate_python_principal_foreign_id(
                     &principal,
                     &format!("workflow {workflow_name} WORKFLOW_PRINCIPAL"),
@@ -2648,7 +2625,6 @@ async fn run_centaur_workflow(
     session_runtime: SessionRuntime,
     workflow_host_sandbox: Option<WorkflowHostSandboxRuntime>,
     workflow_clients: WorkflowQueueClients,
-    workflow_principal_registrar: Option<WorkflowPrincipalRegistrar>,
 ) -> absurd::Result<WorkflowResult> {
     let mut cleanup_guard =
         WorkflowSandboxCleanupGuard::new(session_runtime.clone(), ctx.run_id().to_owned());
@@ -2658,7 +2634,6 @@ async fn run_centaur_workflow(
         session_runtime,
         workflow_host_sandbox,
         workflow_clients,
-        workflow_principal_registrar,
     )
     .await;
     if let Some(reason) = workflow_cleanup_reason(&result) {
@@ -2684,7 +2659,6 @@ async fn run_centaur_workflow_inner(
     session_runtime: SessionRuntime,
     workflow_host_sandbox: Option<WorkflowHostSandboxRuntime>,
     workflow_clients: WorkflowQueueClients,
-    workflow_principal_registrar: Option<WorkflowPrincipalRegistrar>,
 ) -> absurd::Result<WorkflowResult> {
     let _heartbeat_guard = start_workflow_task_heartbeat(ctx.clone())
         .await
@@ -2847,7 +2821,6 @@ async fn run_centaur_workflow_inner(
                 session_runtime,
                 workflow_host_sandbox,
                 workflow_clients,
-                workflow_principal_registrar,
             )
             .await
             .map_err(absurd_error)?;
@@ -2926,7 +2899,6 @@ async fn run_python_workflow_host(
     session_runtime: SessionRuntime,
     workflow_host_sandbox: Option<WorkflowHostSandboxRuntime>,
     workflow_clients: WorkflowQueueClients,
-    workflow_principal_registrar: Option<WorkflowPrincipalRegistrar>,
 ) -> Result<Value, WorkflowRuntimeError> {
     if let Some(sandbox) = workflow_host_sandbox {
         return run_python_workflow_host_in_sandbox(
@@ -2935,18 +2907,10 @@ async fn run_python_workflow_host(
             session_runtime,
             sandbox,
             workflow_clients,
-            workflow_principal_registrar,
         )
         .await;
     }
-    run_python_workflow_host_local(
-        input,
-        ctx,
-        session_runtime,
-        workflow_clients,
-        workflow_principal_registrar,
-    )
-    .await
+    run_python_workflow_host_local(input, ctx, session_runtime, workflow_clients).await
 }
 
 async fn start_workflow_task_heartbeat(
@@ -2969,13 +2933,11 @@ async fn run_python_workflow_host_local(
     ctx: TaskContext,
     session_runtime: SessionRuntime,
     workflow_clients: WorkflowQueueClients,
-    workflow_principal_registrar: Option<WorkflowPrincipalRegistrar>,
 ) -> Result<Value, WorkflowRuntimeError> {
     let workflow_context = PythonWorkflowHostContext {
         session_runtime,
         workflow_clients,
         principal: None,
-        principal_registrar: workflow_principal_registrar,
     };
     let host_path = python_workflow_host_path();
     let mut command = Command::new(
@@ -3105,7 +3067,6 @@ async fn run_python_workflow_host_in_sandbox(
     session_runtime: SessionRuntime,
     sandbox: WorkflowHostSandboxRuntime,
     workflow_clients: WorkflowQueueClients,
-    workflow_principal_registrar: Option<WorkflowPrincipalRegistrar>,
 ) -> Result<Value, WorkflowRuntimeError> {
     let (mut spec, workflow_principal) = sandbox.spec_for_workflow(&input.workflow_name)?;
     spec = spec
@@ -3138,7 +3099,6 @@ async fn run_python_workflow_host_in_sandbox(
             session_runtime,
             workflow_clients,
             principal: workflow_principal,
-            principal_registrar: workflow_principal_registrar,
         },
         &mut stdin,
         io.stdout,
@@ -3160,7 +3120,6 @@ struct PythonWorkflowHostContext {
     session_runtime: SessionRuntime,
     workflow_clients: WorkflowQueueClients,
     principal: Option<String>,
-    principal_registrar: Option<WorkflowPrincipalRegistrar>,
 }
 
 async fn run_python_workflow_host_protocol<W, R>(
@@ -3464,7 +3423,6 @@ async fn handle_python_context_request(
                 args,
                 &request_id,
                 workflow_context.principal.as_deref(),
-                workflow_context.principal_registrar.as_ref(),
             )
             .await
             {
@@ -3625,7 +3583,6 @@ async fn run_python_agent_turn(
     args: Value,
     request_id: &str,
     workflow_principal: Option<&str>,
-    workflow_principal_registrar: Option<&WorkflowPrincipalRegistrar>,
 ) -> Result<Value, WorkflowRuntimeError> {
     let text = args
         .get("text")
@@ -3717,13 +3674,20 @@ async fn run_python_agent_turn(
     let model = first_str_arg(&args, &["model"]);
     let provider = first_str_arg(&args, &["provider"]);
     let reasoning = first_str_arg(&args, &["reasoning", "reasoning_effort", "effort"]);
-    let agent_principal = resolve_python_agent_principal(
-        &args,
-        workflow_principal,
-        workflow_principal_registrar,
-        &input.workflow_name,
-    )
-    .await?;
+    let agent_principal = if let Some(foreign_id) = explicit_agent_principal(&args)? {
+        Some(
+            session_runtime
+                .resolve_or_create_principal(
+                    &foreign_id,
+                    &format!("Workflow {}", input.workflow_name),
+                    workflow_principal_labels(&input.workflow_name),
+                    Some("workflow"),
+                )
+                .await?,
+        )
+    } else {
+        workflow_principal.map(ToOwned::to_owned)
+    };
     // Record the model on the execution like the slackbot does, so Console
     // readers can show what a workflow-dispatched turn ran on.
     if let Some(model) = model.as_deref() {
@@ -3752,29 +3716,6 @@ async fn run_python_agent_turn(
     )
     .await?;
     serde_json::to_value(result).map_err(WorkflowRuntimeError::from)
-}
-
-async fn resolve_python_agent_principal(
-    args: &Value,
-    workflow_principal: Option<&str>,
-    workflow_principal_registrar: Option<&WorkflowPrincipalRegistrar>,
-    workflow_name: &str,
-) -> Result<Option<String>, WorkflowRuntimeError> {
-    Ok(
-        match (
-            explicit_agent_principal(args)?,
-            workflow_principal_registrar,
-        ) {
-            (Some(foreign_id), Some(registrar)) => Some(
-                registrar
-                    .resolve_or_create_principal(workflow_name, &foreign_id)
-                    .await?
-                    .id,
-            ),
-            (Some(foreign_id), None) => Some(foreign_id),
-            (None, _) => workflow_principal.map(ToOwned::to_owned),
-        },
-    )
 }
 
 /// Returns the first arg key that holds a non-empty (trimmed) string, owned.
@@ -4338,8 +4279,6 @@ pub enum WorkflowRuntimeError {
 mod tests {
     use super::*;
     use chrono::TimeZone;
-    use std::sync::{Arc, Mutex};
-    use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
     #[test]
     fn python_event_names_are_collision_free() {
@@ -4696,7 +4635,7 @@ mod tests {
     }
 
     #[test]
-    fn discovery_metadata_accepts_an_existing_workflow_principal() {
+    fn discovery_metadata_accepts_a_workflow_principal_foreign_id() {
         let payload: PythonWorkflowDiscoveryPayload = serde_json::from_value(json!({
             "workflows": [{
                 "workflow_name": "nightly_report",
@@ -4748,21 +4687,6 @@ mod tests {
         assert!(explicit_agent_principal(&json!({"principal": "prn_123"})).is_err());
     }
 
-    #[tokio::test]
-    async fn agent_turn_without_override_inherits_resolved_workflow_principal() {
-        assert_eq!(
-            resolve_python_agent_principal(
-                &json!({"principal": null}),
-                Some("prn_workflow"),
-                None,
-                "nightly_report",
-            )
-            .await
-            .unwrap(),
-            Some("prn_workflow".to_owned())
-        );
-    }
-
     #[test]
     fn workflow_principal_foreign_id_is_derived_from_workflow_name() {
         assert_eq!(
@@ -4785,152 +4709,6 @@ mod tests {
             labels.get("workflow_name").map(String::as_str),
             Some("nightly_report")
         );
-    }
-
-    #[tokio::test]
-    async fn workflow_principal_foreign_id_resolves_existing_principal_to_oid() {
-        let (base_url, requests, server) = spawn_workflow_principal_stub(true).await;
-        let registrar = WorkflowPrincipalRegistrar::new(
-            IronControlClient::new(base_url, "test-key"),
-            "default",
-        );
-
-        let resolved = registrar
-            .resolve_workflow_principals(&BTreeMap::from([(
-                "nightly_report".to_owned(),
-                WorkflowPrincipalDeclaration::ForeignId("report-publisher".to_owned()),
-            )]))
-            .await
-            .unwrap();
-
-        assert_eq!(
-            resolved.get("nightly_report").map(String::as_str),
-            Some("prn_report")
-        );
-        assert_eq!(
-            requests.lock().unwrap().as_slice(),
-            ["GET /api/v1/principals/lookup/default/report-publisher"]
-        );
-        server.abort();
-    }
-
-    #[tokio::test]
-    async fn workflow_principal_foreign_id_creates_missing_principal_and_returns_oid() {
-        let (base_url, requests, server) = spawn_workflow_principal_stub(false).await;
-        let registrar = WorkflowPrincipalRegistrar::new(
-            IronControlClient::new(base_url, "test-key"),
-            "default",
-        );
-
-        let resolved = registrar
-            .resolve_workflow_principals(&BTreeMap::from([(
-                "nightly_report".to_owned(),
-                WorkflowPrincipalDeclaration::ForeignId("report-publisher".to_owned()),
-            )]))
-            .await
-            .unwrap();
-
-        assert_eq!(
-            resolved.get("nightly_report").map(String::as_str),
-            Some("prn_report")
-        );
-        assert_eq!(
-            requests.lock().unwrap().as_slice(),
-            [
-                "GET /api/v1/principals/lookup/default/report-publisher",
-                "PUT /api/v1/principals/report-publisher",
-            ]
-        );
-        server.abort();
-    }
-
-    #[tokio::test]
-    async fn agent_turn_foreign_id_creates_missing_principal_and_returns_oid() {
-        let (base_url, requests, server) = spawn_workflow_principal_stub(false).await;
-        let registrar = WorkflowPrincipalRegistrar::new(
-            IronControlClient::new(base_url, "test-key"),
-            "default",
-        );
-
-        let resolved = resolve_python_agent_principal(
-            &json!({"principal": "report-publisher"}),
-            Some("prn_workflow"),
-            Some(&registrar),
-            "nightly_report",
-        )
-        .await
-        .unwrap();
-
-        assert_eq!(resolved.as_deref(), Some("prn_report"));
-        assert_eq!(
-            requests.lock().unwrap().as_slice(),
-            [
-                "GET /api/v1/principals/lookup/default/report-publisher",
-                "PUT /api/v1/principals/report-publisher",
-            ]
-        );
-        server.abort();
-    }
-
-    async fn spawn_workflow_principal_stub(
-        principal_exists: bool,
-    ) -> (String, Arc<Mutex<Vec<String>>>, tokio::task::JoinHandle<()>) {
-        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let base_url = format!("http://{}", listener.local_addr().unwrap());
-        let requests = Arc::new(Mutex::new(Vec::new()));
-        let seen = requests.clone();
-        let handle = tokio::spawn(async move {
-            loop {
-                let Ok((mut stream, _)) = listener.accept().await else {
-                    return;
-                };
-                let mut request = Vec::new();
-                let mut buffer = [0_u8; 1024];
-                while !request.windows(4).any(|window| window == b"\r\n\r\n") {
-                    match stream.read(&mut buffer).await {
-                        Ok(0) | Err(_) => break,
-                        Ok(read) => request.extend_from_slice(&buffer[..read]),
-                    }
-                }
-                let request = String::from_utf8_lossy(&request);
-                let request_line = request.lines().next().unwrap_or_default();
-                seen.lock().unwrap().push(
-                    request_line
-                        .split_whitespace()
-                        .take(2)
-                        .collect::<Vec<_>>()
-                        .join(" "),
-                );
-
-                let (status, body) = if request_line
-                    .starts_with("GET /api/v1/principals/lookup/default/report-publisher ")
-                {
-                    if principal_exists {
-                        ("200 OK", workflow_principal_body())
-                    } else {
-                        ("404 Not Found", r#"{"error":"not found"}"#.to_owned())
-                    }
-                } else if request_line.starts_with("PUT /api/v1/principals/report-publisher ") {
-                    ("200 OK", workflow_principal_body())
-                } else {
-                    (
-                        "500 Internal Server Error",
-                        r#"{"error":"unexpected"}"#.to_owned(),
-                    )
-                };
-                let response = format!(
-                    "HTTP/1.1 {status}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
-                    body.len(),
-                );
-                let _ = stream.write_all(response.as_bytes()).await;
-                let _ = stream.shutdown().await;
-            }
-        });
-        (base_url, requests, handle)
-    }
-
-    fn workflow_principal_body() -> String {
-        r#"{"data":{"id":"prn_report","namespace":"default","foreign_id":"report-publisher","name":"Report Publisher","labels":{}}}"#.to_owned()
     }
 
     #[test]

--- a/services/workflow-python/api/workflow_engine.py
+++ b/services/workflow-python/api/workflow_engine.py
@@ -126,7 +126,6 @@ class WorkflowContext:
         args = {**self._agent_defaults, **kwargs}
         if text is not None:
             args.setdefault("text", text)
-        normalize_agent_principal(args)
         return await self._rpc.request({"type": "ctx.agent_turn", "args": args})
 
     async def run_agent(self, *args: Any, text: str | None = None, **kwargs: Any) -> Any:
@@ -174,19 +173,3 @@ def duration_seconds(value: dt.timedelta | int | float) -> float:
     if isinstance(value, dt.timedelta):
         return max(value.total_seconds(), 0.0)
     return max(float(value), 0.0)
-
-
-def normalize_agent_principal(args: dict[str, Any]) -> None:
-    for key in ("principal", "principal_id"):
-        if key not in args or args[key] is None:
-            continue
-        principal = args[key]
-        if not isinstance(principal, str) or not principal.strip():
-            raise ValueError("ctx.agent_turn principal must be a non-empty foreign id")
-        principal = principal.strip()
-        if principal.startswith("prn_"):
-            raise ValueError(
-                "ctx.agent_turn principal must use a foreign id, not a prn_ id"
-            )
-        args[key] = principal
-        return

--- a/services/workflow-python/api/workflow_engine.py
+++ b/services/workflow-python/api/workflow_engine.py
@@ -126,6 +126,7 @@ class WorkflowContext:
         args = {**self._agent_defaults, **kwargs}
         if text is not None:
             args.setdefault("text", text)
+        normalize_agent_principal(args)
         return await self._rpc.request({"type": "ctx.agent_turn", "args": args})
 
     async def run_agent(self, *args: Any, text: str | None = None, **kwargs: Any) -> Any:
@@ -173,3 +174,19 @@ def duration_seconds(value: dt.timedelta | int | float) -> float:
     if isinstance(value, dt.timedelta):
         return max(value.total_seconds(), 0.0)
     return max(float(value), 0.0)
+
+
+def normalize_agent_principal(args: dict[str, Any]) -> None:
+    for key in ("principal", "principal_id"):
+        if key not in args or args[key] is None:
+            continue
+        principal = args[key]
+        if not isinstance(principal, str) or not principal.strip():
+            raise ValueError("ctx.agent_turn principal must be a non-empty foreign id")
+        principal = principal.strip()
+        if principal.startswith("prn_"):
+            raise ValueError(
+                "ctx.agent_turn principal must use a foreign id, not a prn_ id"
+            )
+        args[key] = principal
+        return

--- a/services/workflow-python/tests/test_workflow_host.py
+++ b/services/workflow-python/tests/test_workflow_host.py
@@ -313,6 +313,18 @@ class WorkflowHostTests(unittest.TestCase):
             },
         )
 
+    def test_agent_turn_rejects_principal_oid(self) -> None:
+        host = load_workflow_host()
+        ctx = host.WorkflowContext(
+            RequestRpc(),
+            run_id="run-123",
+            task_id="task-456",
+            workflow_name="sample",
+        )
+
+        with self.assertRaisesRegex(ValueError, "foreign id, not a prn_ id"):
+            asyncio.run(ctx.agent_turn("do the thing", principal="prn_123"))
+
     def test_start_workflow_enqueues_durable_child_with_idempotency_key(self) -> None:
         host = load_workflow_host()
         rpc = RequestRpc()
@@ -542,6 +554,28 @@ class WorkflowHostTests(unittest.TestCase):
                 return_value={"principal_workflow": workflow},
             ),
             self.assertRaisesRegex(ValueError, "empty WORKFLOW_PRINCIPAL"),
+        ):
+            host.discovery_payload()
+
+    def test_workflow_principal_oid_fails_discovery(self) -> None:
+        host = load_workflow_host()
+        workflow = host.RegisteredWorkflow(
+            workflow_name="principal_workflow",
+            source_path="workflows/principal_workflow.py",
+            handler=lambda inp, ctx: None,
+            input_cls=None,
+            webhooks=None,
+            schedule=None,
+            principal="prn_123",
+        )
+
+        with (
+            patch.object(
+                host,
+                "discover_workflows",
+                return_value={"principal_workflow": workflow},
+            ),
+            self.assertRaisesRegex(ValueError, "foreign id, not a prn_ id"),
         ):
             host.discovery_payload()
 

--- a/services/workflow-python/tests/test_workflow_host.py
+++ b/services/workflow-python/tests/test_workflow_host.py
@@ -545,6 +545,28 @@ class WorkflowHostTests(unittest.TestCase):
         ):
             host.discovery_payload()
 
+    def test_principal_oid_fails_discovery(self) -> None:
+        host = load_workflow_host()
+        workflow = host.RegisteredWorkflow(
+            workflow_name="principal_workflow",
+            source_path="workflows/principal_workflow.py",
+            handler=lambda inp, ctx: None,
+            input_cls=None,
+            webhooks=None,
+            schedule=None,
+            principal="prn_123",
+        )
+
+        with (
+            patch.object(
+                host,
+                "discover_workflows",
+                return_value={"principal_workflow": workflow},
+            ),
+            self.assertRaisesRegex(ValueError, "foreign id, not a prn_ id"),
+        ):
+            host.discovery_payload()
+
     def test_workflow_name_from_source_reads_string_constant(self) -> None:
         host = load_workflow_host()
         with tempfile.TemporaryDirectory() as tmp:

--- a/services/workflow-python/tests/test_workflow_host.py
+++ b/services/workflow-python/tests/test_workflow_host.py
@@ -313,18 +313,6 @@ class WorkflowHostTests(unittest.TestCase):
             },
         )
 
-    def test_agent_turn_rejects_principal_oid(self) -> None:
-        host = load_workflow_host()
-        ctx = host.WorkflowContext(
-            RequestRpc(),
-            run_id="run-123",
-            task_id="task-456",
-            workflow_name="sample",
-        )
-
-        with self.assertRaisesRegex(ValueError, "foreign id, not a prn_ id"):
-            asyncio.run(ctx.agent_turn("do the thing", principal="prn_123"))
-
     def test_start_workflow_enqueues_durable_child_with_idempotency_key(self) -> None:
         host = load_workflow_host()
         rpc = RequestRpc()

--- a/services/workflow-python/tests/test_workflow_host.py
+++ b/services/workflow-python/tests/test_workflow_host.py
@@ -545,28 +545,6 @@ class WorkflowHostTests(unittest.TestCase):
         ):
             host.discovery_payload()
 
-    def test_principal_oid_fails_discovery(self) -> None:
-        host = load_workflow_host()
-        workflow = host.RegisteredWorkflow(
-            workflow_name="principal_workflow",
-            source_path="workflows/principal_workflow.py",
-            handler=lambda inp, ctx: None,
-            input_cls=None,
-            webhooks=None,
-            schedule=None,
-            principal="prn_123",
-        )
-
-        with (
-            patch.object(
-                host,
-                "discover_workflows",
-                return_value={"principal_workflow": workflow},
-            ),
-            self.assertRaisesRegex(ValueError, "foreign id, not a prn_ id"),
-        ):
-            host.discovery_payload()
-
     def test_workflow_name_from_source_reads_string_constant(self) -> None:
         host = load_workflow_host()
         with tempfile.TemporaryDirectory() as tmp:

--- a/services/workflow-python/tests/test_workflow_host.py
+++ b/services/workflow-python/tests/test_workflow_host.py
@@ -288,14 +288,29 @@ class WorkflowHostTests(unittest.TestCase):
             run_id="run-123",
             task_id="task-456",
             workflow_name="sample",
-            agent_defaults={"model": "claude-opus-4-8", "reasoning": "high"},
+            agent_defaults={
+                "model": "claude-opus-4-8",
+                "reasoning": "high",
+                "principal": "workflow-default",
+            },
         )
 
-        result = asyncio.run(ctx.agent_turn("cheap step", reasoning="low"))
+        result = asyncio.run(
+            ctx.agent_turn(
+                "cheap step",
+                reasoning="low",
+                principal="agent-specific",
+            )
+        )
 
         self.assertEqual(
             result,
-            {"model": "claude-opus-4-8", "reasoning": "low", "text": "cheap step"},
+            {
+                "model": "claude-opus-4-8",
+                "reasoning": "low",
+                "principal": "agent-specific",
+                "text": "cheap step",
+            },
         )
 
     def test_start_workflow_enqueues_durable_child_with_idempotency_key(self) -> None:
@@ -492,6 +507,21 @@ class WorkflowHostTests(unittest.TestCase):
 
         assert registered is not None
         self.assertEqual(host.normalize_principal(registered), True)
+
+    def test_load_workflow_file_reads_specific_workflow_principal(self) -> None:
+        host = load_workflow_host()
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "principal_workflow.py"
+            path.write_text(
+                "WORKFLOW_NAME = 'principal_workflow'\n"
+                "WORKFLOW_PRINCIPAL = '  shared-automation  '\n"
+                "def handler(inp, ctx):\n"
+                "    return None\n"
+            )
+            registered = host.load_workflow_file(path)
+
+        assert registered is not None
+        self.assertEqual(host.normalize_principal(registered), "shared-automation")
 
     def test_workflow_name_from_source_reads_string_constant(self) -> None:
         host = load_workflow_host()

--- a/services/workflow-python/tests/test_workflow_host.py
+++ b/services/workflow-python/tests/test_workflow_host.py
@@ -523,6 +523,28 @@ class WorkflowHostTests(unittest.TestCase):
         assert registered is not None
         self.assertEqual(host.normalize_principal(registered), "shared-automation")
 
+    def test_empty_workflow_principal_fails_discovery(self) -> None:
+        host = load_workflow_host()
+        workflow = host.RegisteredWorkflow(
+            workflow_name="principal_workflow",
+            source_path="workflows/principal_workflow.py",
+            handler=lambda inp, ctx: None,
+            input_cls=None,
+            webhooks=None,
+            schedule=None,
+            principal="   ",
+        )
+
+        with (
+            patch.object(
+                host,
+                "discover_workflows",
+                return_value={"principal_workflow": workflow},
+            ),
+            self.assertRaisesRegex(ValueError, "empty WORKFLOW_PRINCIPAL"),
+        ):
+            host.discovery_payload()
+
     def test_workflow_name_from_source_reads_string_constant(self) -> None:
         host = load_workflow_host()
         with tempfile.TemporaryDirectory() as tmp:

--- a/services/workflow-python/workflow_host.py
+++ b/services/workflow-python/workflow_host.py
@@ -356,9 +356,13 @@ def normalize_schedule(workflow: RegisteredWorkflow) -> dict[str, Any] | None:
     return schedule
 
 
-def normalize_principal(workflow: RegisteredWorkflow) -> bool | None:
+def normalize_principal(workflow: RegisteredWorkflow) -> bool | str | None:
     raw = workflow.principal
-    return raw if isinstance(raw, bool) and raw else None
+    if isinstance(raw, bool):
+        return raw or None
+    if isinstance(raw, str) and raw.strip():
+        return raw.strip()
+    return None
 
 
 async def run_workflow(message: dict[str, Any], rpc: RpcClient) -> dict[str, Any]:

--- a/services/workflow-python/workflow_host.py
+++ b/services/workflow-python/workflow_host.py
@@ -366,11 +366,6 @@ def normalize_principal(workflow: RegisteredWorkflow) -> bool | str | None:
             raise ValueError(
                 f"workflow {workflow.workflow_name!r} declares an empty WORKFLOW_PRINCIPAL"
             )
-        if principal.startswith("prn_"):
-            raise ValueError(
-                f"workflow {workflow.workflow_name!r} WORKFLOW_PRINCIPAL must use "
-                "a principal foreign id, not a prn_ id"
-            )
         return principal
     return None
 

--- a/services/workflow-python/workflow_host.py
+++ b/services/workflow-python/workflow_host.py
@@ -360,8 +360,13 @@ def normalize_principal(workflow: RegisteredWorkflow) -> bool | str | None:
     raw = workflow.principal
     if isinstance(raw, bool):
         return raw or None
-    if isinstance(raw, str) and raw.strip():
-        return raw.strip()
+    if isinstance(raw, str):
+        principal = raw.strip()
+        if not principal:
+            raise ValueError(
+                f"workflow {workflow.workflow_name!r} declares an empty WORKFLOW_PRINCIPAL"
+            )
+        return principal
     return None
 
 

--- a/services/workflow-python/workflow_host.py
+++ b/services/workflow-python/workflow_host.py
@@ -366,6 +366,11 @@ def normalize_principal(workflow: RegisteredWorkflow) -> bool | str | None:
             raise ValueError(
                 f"workflow {workflow.workflow_name!r} declares an empty WORKFLOW_PRINCIPAL"
             )
+        if principal.startswith("prn_"):
+            raise ValueError(
+                f"workflow {workflow.workflow_name!r} WORKFLOW_PRINCIPAL must use "
+                "a principal foreign id, not a prn_ id"
+            )
         return principal
     return None
 


### PR DESCRIPTION
Adds workflow-scoped Iron Control principals through WORKFLOW_PRINCIPAL and lets agent turns inherit or override them using foreign IDs. Missing foreign IDs are created and resolved to canonical OIDs, while existing session bindings reject identity changes. Includes Python and Rust validation, documentation, and regression coverage for principal resolution and session conflicts.