### PR TITLE
fix(granola): handle MCP meeting attributes and batches

### DIFF
--- a/services/console/Gemfile
+++ b/services/console/Gemfile
@@ -12,6 +12,8 @@ gem "pg", "~> 1.5"
 gem "sqids", "~> 0.2"
 # JSON Schema validation for jsonb config columns
 gem "json_schemer", "~> 2.3"
+# Parse Granola MCP meeting XML
+gem "nokogiri", "~> 1.19"
 # Use the Puma web server [https://github.com/puma/puma]
 gem "puma", ">= 5.0"
 # Use JavaScript with ESM import maps [https://github.com/rails/importmap-rails]

--- a/services/console/Gemfile.lock
+++ b/services/console/Gemfile.lock
@@ -402,6 +402,7 @@ DEPENDENCIES
   jwt (~> 3.1)
   lograge
   minitest-mock (~> 5.27)
+  nokogiri (~> 1.19)
   pg (~> 1.5)
   propshaft
   puma (>= 5.0)

--- a/services/console/app/services/granola/sync_credential.rb
+++ b/services/console/app/services/granola/sync_credential.rb
@@ -243,23 +243,11 @@ module Granola
     end
 
     def participant_list(text)
-      remaining = text.to_s
-      participants = []
-
-      loop do
-        email_start = remaining.index("<")
-        break unless email_start
-
-        email_end = remaining.index(">", email_start + 1)
-        break unless email_end
-
-        name = remaining[...email_start].strip.delete_prefix(",").strip
-        email = remaining[(email_start + 1)...email_end].strip.downcase
-        participants << { "name" => name, "email" => email } if name.present? && email.present?
-        remaining = remaining[(email_end + 1)..]
+      Nokogiri::HTML5.fragment(text.to_s).css("*").filter_map do |email_node|
+        name = email_node.previous_sibling&.text.to_s.strip.delete_prefix(",").strip
+        email = email_node.name.downcase
+        { "name" => name, "email" => email } if name.present? && email.present?
       end
-
-      participants
     end
 
     def parse_mcp_date(value)

--- a/services/console/app/services/granola/sync_credential.rb
+++ b/services/console/app/services/granola/sync_credential.rb
@@ -10,11 +10,6 @@ module Granola
   class SyncCredential
     MCP_URL = "https://mcp.granola.ai/mcp"
     DEFAULT_INITIAL_LOOKBACK_DAYS = 365
-    # The MCP service currently advertises an average limit of about 100
-    # requests/minute. One run issues a list call, a batched detail call, and
-    # at most one transcript call per note, so fifty keeps a normal run well
-    # inside that envelope.
-    DEFAULT_MAX_NOTES = 50
     WATERMARK_OVERLAP_SECONDS = 5 * 60
 
     PARTICIPANT_RE = /(?<name>[^,<]+?)\s*<(?<email>[^>]+)>/
@@ -36,10 +31,6 @@ module Granola
 
       def initial_lookback_days
         positive_int(ConsoleEnv["GRANOLA_SYNC_INITIAL_LOOKBACK_DAYS"], DEFAULT_INITIAL_LOOKBACK_DAYS)
-      end
-
-      def max_notes
-        positive_int(ConsoleEnv["GRANOLA_SYNC_MAX_NOTES"], DEFAULT_MAX_NOTES)
       end
 
       def positive_int(value, default)
@@ -88,7 +79,7 @@ module Granola
         "custom_end" => Time.current.utc.to_date.iso8601
       )
       document = parse_meeting_document(response)
-      meetings = parse_meetings(document).first(self.class.max_notes)
+      meetings = parse_meetings(document)
       reported_count = document.at_xpath("//meetings_data")&.[]("count").to_i
       if meetings.empty? && reported_count.positive?
         raise GranolaApiError, "Granola MCP reported meetings that could not be parsed"

--- a/services/console/app/services/granola/sync_credential.rb
+++ b/services/console/app/services/granola/sync_credential.rb
@@ -1,6 +1,6 @@
-require "cgi"
 require "date"
 require "json"
+require "nokogiri"
 require "time"
 
 module Granola
@@ -17,9 +17,6 @@ module Granola
     DEFAULT_MAX_NOTES = 50
     WATERMARK_OVERLAP_SECONDS = 5 * 60
 
-    MEETING_RE = /<meeting\s+id="(?<id>[^"]+)"\s+title="(?<title>[^"]*)"\s+date="(?<date>[^"]*)">(?<body>.*?)<\/meeting>/m
-    PARTICIPANTS_RE = /<known_participants>(?<participants>.*?)<\/known_participants>/m
-    SUMMARY_RE = /<summary>(?<summary>.*?)<\/summary>/m
     PARTICIPANT_RE = /(?<name>[^,<]+?)\s*<(?<email>[^>]+)>/
     MCP_DATE_RE = /\A(?<date>\w+ \d+, \d+ \d+:\d+ [AP]M) GMT(?<offset>[+-]\d+)?\z/
 
@@ -85,20 +82,26 @@ module Granola
     end
 
     def sync_notes(checkpoint)
-      meetings = parse_meetings(
-        mcp_tool(
-          "list_meetings",
-          "time_range" => "custom",
-          "custom_start" => range_start(checkpoint),
-          "custom_end" => Time.current.utc.to_date.iso8601
-        )
-      ).first(self.class.max_notes)
+      response = mcp_tool(
+        "list_meetings",
+        "time_range" => "custom",
+        "custom_start" => range_start(checkpoint),
+        "custom_end" => Time.current.utc.to_date.iso8601
+      )
+      document = parse_meeting_document(response)
+      meetings = parse_meetings(document).first(self.class.max_notes)
+      reported_count = document.at_xpath("//meetings_data")&.[]("count").to_i
+      if meetings.empty? && reported_count.positive?
+        raise GranolaApiError, "Granola MCP reported meetings that could not be parsed"
+      end
 
       return [] if meetings.empty?
 
-      details = parse_meetings(
-        mcp_tool("get_meetings", "meeting_ids" => meetings.map { |meeting| meeting.fetch("id") })
-      ).index_by { |meeting| meeting.fetch("id") }
+      details = meetings.each_slice(10).flat_map do |batch|
+        parse_meetings(
+          mcp_tool("get_meetings", "meeting_ids" => batch.map { |meeting| meeting.fetch("id") })
+        )
+      end.index_by { |meeting| meeting.fetch("id") }
 
       meetings.filter_map do |meeting|
         detailed = details.fetch(meeting.fetch("id"), meeting)
@@ -216,28 +219,35 @@ module Granola
     end
 
     def parse_meetings(text)
-      text.to_s.scan(MEETING_RE).filter_map do |id, title, date, body|
-        participants = participant_list(body)
+      document = text.is_a?(Nokogiri::XML::Node) ? text : parse_meeting_document(text)
+      document.xpath("//meeting").filter_map do |meeting|
+        next unless meeting.values_at("id", "title", "date").all?(&:present?)
+
+        participants = participant_list(meeting.at_xpath("./known_participants")&.text)
         owner = participants.find { |participant| participant["name"].include?("(note creator)") } || participants.first || {}
         owner = owner.merge(
           "name" => owner.fetch("name", "").sub("(note creator)", "").split(" from ", 2).first.strip
         ) unless owner.empty?
-        summary_match = body.match(SUMMARY_RE)
         {
-          "id" => CGI.unescapeHTML(id),
-          "title" => CGI.unescapeHTML(title),
-          "date" => CGI.unescapeHTML(date),
+          "id" => meeting["id"],
+          "title" => meeting["title"],
+          "date" => meeting["date"],
           "owner" => owner,
           "attendees" => participants,
-          "summary_markdown" => CGI.unescapeHTML(summary_match&.[](:summary).to_s.strip)
+          "summary_markdown" => meeting.at_xpath("./summary")&.text.to_s.strip
         }
       end
     end
 
-    def participant_list(body)
-      participants = CGI.unescapeHTML(body.match(PARTICIPANTS_RE)&.[](:participants).to_s)
-      participants.scan(PARTICIPANT_RE).map do |name, email|
-        { "name" => CGI.unescapeHTML(name).strip, "email" => email.strip.downcase }
+    def parse_meeting_document(text)
+      Nokogiri::XML("<granola_response>#{text}</granola_response>") { |config| config.strict.nonet }
+    rescue Nokogiri::XML::SyntaxError => error
+      raise GranolaApiError, "Granola MCP returned malformed meeting XML: #{error.message}"
+    end
+
+    def participant_list(text)
+      text.to_s.scan(PARTICIPANT_RE).map do |name, email|
+        { "name" => name.strip, "email" => email.strip.downcase }
       end
     end
 

--- a/services/console/app/services/granola/sync_credential.rb
+++ b/services/console/app/services/granola/sync_credential.rb
@@ -17,6 +17,8 @@ module Granola
     DEFAULT_MAX_NOTES = 50
     WATERMARK_OVERLAP_SECONDS = 5 * 60
 
+    PARTICIPANT_RE = /(?<name>[^,<]+?)\s*<(?<email>[^>]+)>/
+
     GranolaApiError = Class.new(StandardError)
 
     class << self
@@ -243,10 +245,8 @@ module Granola
     end
 
     def participant_list(text)
-      Nokogiri::HTML5.fragment(text.to_s).css("*").filter_map do |email_node|
-        name = email_node.previous_sibling&.text.to_s.strip.delete_prefix(",").strip
-        email = email_node.name.downcase
-        { "name" => name, "email" => email } if name.present? && email.present?
+      text.to_s.scan(PARTICIPANT_RE).map do |name, email|
+        { "name" => name.strip, "email" => email.strip.downcase }
       end
     end
 

--- a/services/console/app/services/granola/sync_credential.rb
+++ b/services/console/app/services/granola/sync_credential.rb
@@ -17,9 +17,6 @@ module Granola
     DEFAULT_MAX_NOTES = 50
     WATERMARK_OVERLAP_SECONDS = 5 * 60
 
-    PARTICIPANT_RE = /(?<name>[^,<]+?)\s*<(?<email>[^>]+)>/
-    MCP_DATE_RE = /\A(?<date>\w+ \d+, \d+ \d+:\d+ [AP]M) GMT(?<offset>[+-]\d+)?\z/
-
     GranolaApiError = Class.new(StandardError)
 
     class << self
@@ -221,7 +218,7 @@ module Granola
     def parse_meetings(text)
       document = text.is_a?(Nokogiri::XML::Node) ? text : parse_meeting_document(text)
       document.xpath("//meeting").filter_map do |meeting|
-        next unless meeting.values_at("id", "title", "date").all?(&:present?)
+        next unless %w[id title date].all? { |attribute| meeting[attribute].present? }
 
         participants = participant_list(meeting.at_xpath("./known_participants")&.text)
         owner = participants.find { |participant| participant["name"].include?("(note creator)") } || participants.first || {}
@@ -246,18 +243,35 @@ module Granola
     end
 
     def participant_list(text)
-      text.to_s.scan(PARTICIPANT_RE).map do |name, email|
-        { "name" => name.strip, "email" => email.strip.downcase }
+      remaining = text.to_s
+      participants = []
+
+      loop do
+        email_start = remaining.index("<")
+        break unless email_start
+
+        email_end = remaining.index(">", email_start + 1)
+        break unless email_end
+
+        name = remaining[...email_start].strip.delete_prefix(",").strip
+        email = remaining[(email_start + 1)...email_end].strip.downcase
+        participants << { "name" => name, "email" => email } if name.present? && email.present?
+        remaining = remaining[(email_end + 1)..]
       end
+
+      participants
     end
 
     def parse_mcp_date(value)
-      match = value.to_s.match(MCP_DATE_RE)
-      return nil unless match
+      date, separator, offset_text = value.to_s.rpartition(" GMT")
+      return nil if separator.empty?
 
-      offset = format("%+03d00", (match[:offset].presence || "+0").to_i)
-      Time.strptime("#{match[:date]} #{offset}", "%b %d, %Y %I:%M %p %z").iso8601
-    rescue ArgumentError
+      offset_hours = Integer(offset_text.presence || "0", 10)
+      return nil unless (-23..23).cover?(offset_hours)
+
+      offset = format("%+03d00", offset_hours)
+      Time.strptime("#{date} #{offset}", "%b %d, %Y %I:%M %p %z").iso8601
+    rescue ArgumentError, TypeError
       nil
     end
 

--- a/services/console/app/services/granola/sync_credential.rb
+++ b/services/console/app/services/granola/sync_credential.rb
@@ -80,7 +80,7 @@ module Granola
       )
       document = parse_meeting_document(response)
       meetings = parse_meetings(document)
-      reported_count = document.at_xpath("//meetings_data")&.[]("count").to_i
+      reported_count = document.at_xpath(".//meetings_data")&.[]("count").to_i
       if meetings.empty? && reported_count.positive?
         raise GranolaApiError, "Granola MCP reported meetings that could not be parsed"
       end
@@ -210,7 +210,7 @@ module Granola
 
     def parse_meetings(text)
       document = text.is_a?(Nokogiri::XML::Node) ? text : parse_meeting_document(text)
-      document.xpath("//meeting").filter_map do |meeting|
+      document.xpath(".//meeting").filter_map do |meeting|
         next unless %w[id title date].all? { |attribute| meeting[attribute].present? }
 
         participants = participant_list(meeting.at_xpath("./known_participants")&.text)
@@ -230,7 +230,7 @@ module Granola
     end
 
     def parse_meeting_document(text)
-      Nokogiri::XML("<granola_response>#{text}</granola_response>") { |config| config.strict.nonet }
+      Nokogiri::XML::DocumentFragment.parse(text.to_s) { |config| config.strict.nonet }
     rescue Nokogiri::XML::SyntaxError => error
       raise GranolaApiError, "Granola MCP returned malformed meeting XML: #{error.message}"
     end

--- a/services/console/test/services/granola/sync_credential_test.rb
+++ b/services/console/test/services/granola/sync_credential_test.rb
@@ -161,9 +161,9 @@ module Granola
       assert_nil api_client.batches.fetch(0)[:checkpoint][:watermark_time]
     end
 
-    test "fetches meeting details in batches of ten" do
+    test "fetches all meeting details in batches of ten" do
       api_client = FakeApiClient.new
-      meetings = 11.times.map { |index| meeting_xml(id: "meeting-#{index}") }
+      meetings = 51.times.map { |index| meeting_xml(id: "meeting-#{index}") }
       detail_batches = []
       mcp_http = lambda do |tool:, arguments: {}, **|
         case tool
@@ -184,8 +184,8 @@ module Granola
 
       SyncCredential.new(credential, api_client: api_client, mcp_http: mcp_http).call
 
-      assert_equal [ 10, 1 ], detail_batches.map(&:length)
-      assert_equal 11, api_client.batches.fetch(0)[:notes].length
+      assert_equal [ 10, 10, 10, 10, 10, 1 ], detail_batches.map(&:length)
+      assert_equal 51, api_client.batches.fetch(0)[:notes].length
     end
 
     test "includes MCP tool error content in the raised error" do

--- a/services/console/test/services/granola/sync_credential_test.rb
+++ b/services/console/test/services/granola/sync_credential_test.rb
@@ -140,6 +140,54 @@ module Granola
       assert_equal checkpoint_time, batch[:checkpoint][:watermark_time]
     end
 
+    test "does not advance the checkpoint when reported meetings cannot be parsed" do
+      api_client = FakeApiClient.new
+      mcp_http = lambda do |tool:, **|
+        case tool
+        when "get_account_info"
+          { email: "owner@example.com" }.to_json
+        when "list_meetings"
+          '<meetings_data count="1"><meeting></meeting></meetings_data>'
+        else
+          flunk "unexpected Granola MCP tool #{tool}"
+        end
+      end
+
+      error = assert_raises(SyncCredential::GranolaApiError) do
+        SyncCredential.new(credential, api_client: api_client, mcp_http: mcp_http).call
+      end
+
+      assert_equal "Granola MCP reported meetings that could not be parsed", error.message
+      assert_nil api_client.batches.fetch(0)[:checkpoint][:watermark_time]
+    end
+
+    test "fetches meeting details in batches of ten" do
+      api_client = FakeApiClient.new
+      meetings = 11.times.map { |index| meeting_xml(id: "meeting-#{index}") }
+      detail_batches = []
+      mcp_http = lambda do |tool:, arguments: {}, **|
+        case tool
+        when "get_account_info"
+          { email: "owner@example.com" }.to_json
+        when "list_meetings"
+          meetings.join
+        when "get_meetings"
+          detail_batches << arguments.fetch("meeting_ids")
+          indexes = arguments.fetch("meeting_ids").map { |id| id.delete_prefix("meeting-").to_i }
+          meetings.values_at(*indexes).join
+        when "get_meeting_transcript"
+          ""
+        else
+          flunk "unexpected Granola MCP tool #{tool}"
+        end
+      end
+
+      SyncCredential.new(credential, api_client: api_client, mcp_http: mcp_http).call
+
+      assert_equal [ 10, 1 ], detail_batches.map(&:length)
+      assert_equal 11, api_client.batches.fetch(0)[:notes].length
+    end
+
     test "includes MCP tool error content in the raised error" do
       sync = SyncCredential.new(credential, api_client: FakeApiClient.new)
       sync.instance_variable_set(:@mcp_initialized, true)
@@ -175,9 +223,9 @@ module Granola
 
     private
 
-    def meeting_xml
+    def meeting_xml(id: "meeting-1")
       <<~XML
-        <meeting id="meeting-1" title="Planning" date="Jul 8, 2026 5:30 PM GMT+2">
+        <meeting id="#{id}" title="Planning" date="Jul 8, 2026 5:30 PM GMT+2" captured_by_me="true" listed_as_participant="true" is_workspace_visible="false">
           <known_participants>Ada (note creator) from Acme &lt;ada@example.com&gt;
           Bob &lt;bob@example.com&gt;</known_participants>
           <summary>Ship the Granola sync.</summary>

--- a/tools/productivity/granola/client.py
+++ b/tools/productivity/granola/client.py
@@ -13,6 +13,7 @@ GRANOLA_BACKEND=mcp|rest.
 """
 
 import json
+import re
 from datetime import datetime, timedelta, timezone
 from typing import Any
 from xml.etree import ElementTree
@@ -127,6 +128,9 @@ class GranolaClient:
         return [n for n in all_notes if query_lower in (n.get("title") or "").lower()][:limit]
 
 
+_PARTICIPANT_RE = re.compile(r"(?P<name>[^,<]+?)\s*<(?P<email>[^>]+)>")
+
+
 def _parse_meeting_date(raw: str) -> str:
     """Convert MCP dates like 'Jul 8, 2026 5:30 PM GMT+2' to ISO, best effort."""
     date_text, separator, offset_text = raw.rpartition(" GMT")
@@ -143,19 +147,14 @@ def _parse_meeting_date(raw: str) -> str:
 
 
 def _parse_participants(text: str) -> list[dict[str, str]]:
-    """Parse Granola's display-name/email participant text using its delimiters."""
-    attendees = []
-    remaining = text
-    while "<" in remaining:
-        name_text, _, email_text = remaining.partition("<")
-        email, separator, remaining = email_text.partition(">")
-        if not separator:
-            break
-        name = name_text.strip().removeprefix(",").strip()
-        email = email.strip().lower()
-        if name and email:
-            attendees.append({"name": name, "email": email})
-    return attendees
+    """Parse Granola's display-name/email participant text."""
+    return [
+        {
+            "name": participant.group("name").strip(),
+            "email": participant.group("email").strip().lower(),
+        }
+        for participant in _PARTICIPANT_RE.finditer(text)
+    ]
 
 
 def _parse_meetings(text: str) -> list[dict[str, Any]]:

--- a/tools/productivity/granola/client.py
+++ b/tools/productivity/granola/client.py
@@ -16,6 +16,7 @@ import json
 import re
 from datetime import datetime
 from typing import Any
+from xml.etree import ElementTree
 
 import httpx
 from centaur_sdk import secret
@@ -127,14 +128,6 @@ class GranolaClient:
         return [n for n in all_notes if query_lower in (n.get("title") or "").lower()][:limit]
 
 
-# Matches one <meeting ...>...</meeting> block in MCP meetings_data output.
-_MEETING_RE = re.compile(
-    r'<meeting id="(?P<id>[^"]+)" title="(?P<title>[^"]*)" date="(?P<date>[^"]*)">'
-    r"(?P<body>.*?)</meeting>",
-    re.DOTALL,
-)
-_PARTICIPANTS_RE = re.compile(r"<known_participants>(.*?)</known_participants>", re.DOTALL)
-_SUMMARY_RE = re.compile(r"<summary>(.*?)</summary>", re.DOTALL)
 # "Zygimantas (note creator) from Tempo <z@tempo.xyz>" -> name + email
 _PARTICIPANT_RE = re.compile(r"(?P<name>[^,<]+?)\s*<(?P<email>[^>]+)>")
 
@@ -154,13 +147,19 @@ def _parse_meeting_date(raw: str) -> str:
 
 def _parse_meetings(text: str) -> list[dict[str, Any]]:
     """Parse MCP meetings_data text into REST-shaped note dicts."""
+    try:
+        root = ElementTree.fromstring(f"<granola_response>{text}</granola_response>")
+    except ElementTree.ParseError as error:
+        raise RuntimeError("Granola MCP returned malformed meeting XML") from error
+
     notes = []
-    for m in _MEETING_RE.finditer(text):
-        body = m.group("body")
+    for meeting in root.findall(".//meeting"):
+        if not all(meeting.get(name) for name in ("id", "title", "date")):
+            continue
         attendees = []
-        pm = _PARTICIPANTS_RE.search(body)
-        if pm:
-            for p in _PARTICIPANT_RE.finditer(pm.group(1)):
+        participants = meeting.findtext("known_participants", default="")
+        if participants:
+            for p in _PARTICIPANT_RE.finditer(participants):
                 attendees.append({"name": p.group("name").strip(), "email": p.group("email")})
         owner = next(
             (a for a in attendees if "(note creator)" in a["name"]),
@@ -168,15 +167,15 @@ def _parse_meetings(text: str) -> list[dict[str, Any]]:
         )
         if owner:
             owner = {**owner, "name": owner["name"].replace("(note creator)", "").split(" from ")[0].strip()}
-        sm = _SUMMARY_RE.search(body)
+        summary = meeting.findtext("summary")
         notes.append(
             {
-                "id": m.group("id"),
-                "title": m.group("title"),
-                "created_at": _parse_meeting_date(m.group("date")),
+                "id": meeting.get("id"),
+                "title": meeting.get("title"),
+                "created_at": _parse_meeting_date(meeting.get("date", "")),
                 "owner": owner,
                 "attendees": attendees,
-                "summary_markdown": sm.group(1).strip() if sm else None,
+                "summary_markdown": summary.strip() if summary else None,
             }
         )
     return notes

--- a/tools/productivity/granola/client.py
+++ b/tools/productivity/granola/client.py
@@ -13,8 +13,7 @@ GRANOLA_BACKEND=mcp|rest.
 """
 
 import json
-import re
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 from typing import Any
 from xml.etree import ElementTree
 
@@ -128,21 +127,35 @@ class GranolaClient:
         return [n for n in all_notes if query_lower in (n.get("title") or "").lower()][:limit]
 
 
-# "Zygimantas (note creator) from Tempo <z@tempo.xyz>" -> name + email
-_PARTICIPANT_RE = re.compile(r"(?P<name>[^,<]+?)\s*<(?P<email>[^>]+)>")
-
-
 def _parse_meeting_date(raw: str) -> str:
     """Convert MCP dates like 'Jul 8, 2026 5:30 PM GMT+2' to ISO, best effort."""
-    m = re.match(r"(\w+ \d+, \d+ \d+:\d+ [AP]M) GMT(?P<off>[+-]\d+)?", raw)
-    if not m:
+    date_text, separator, offset_text = raw.rpartition(" GMT")
+    if not separator:
         return raw
     try:
-        dt = datetime.strptime(m.group(1), "%b %d, %Y %I:%M %p")
-        off = m.group("off")
-        return dt.isoformat() + (f"{int(off):+03d}:00" if off else "")
+        offset_hours = int(offset_text or "0")
+        if not -23 <= offset_hours <= 23:
+            return raw
+        dt = datetime.strptime(date_text, "%b %d, %Y %I:%M %p")
+        return dt.replace(tzinfo=timezone(timedelta(hours=offset_hours))).isoformat()
     except ValueError:
         return raw
+
+
+def _parse_participants(text: str) -> list[dict[str, str]]:
+    """Parse Granola's display-name/email participant text using its delimiters."""
+    attendees = []
+    remaining = text
+    while "<" in remaining:
+        name_text, _, email_text = remaining.partition("<")
+        email, separator, remaining = email_text.partition(">")
+        if not separator:
+            break
+        name = name_text.strip().removeprefix(",").strip()
+        email = email.strip().lower()
+        if name and email:
+            attendees.append({"name": name, "email": email})
+    return attendees
 
 
 def _parse_meetings(text: str) -> list[dict[str, Any]]:
@@ -156,11 +169,8 @@ def _parse_meetings(text: str) -> list[dict[str, Any]]:
     for meeting in root.findall(".//meeting"):
         if not all(meeting.get(name) for name in ("id", "title", "date")):
             continue
-        attendees = []
         participants = meeting.findtext("known_participants", default="")
-        if participants:
-            for p in _PARTICIPANT_RE.finditer(participants):
-                attendees.append({"name": p.group("name").strip(), "email": p.group("email")})
+        attendees = _parse_participants(participants)
         owner = next(
             (a for a in attendees if "(note creator)" in a["name"]),
             attendees[0] if attendees else {},

--- a/tools/productivity/granola/test_client.py
+++ b/tools/productivity/granola/test_client.py
@@ -1,4 +1,4 @@
-from client import _parse_meetings
+from client import _parse_meeting_date, _parse_meetings, _parse_participants
 
 
 def test_parse_meetings_accepts_extra_attributes_and_decodes_entities():
@@ -23,3 +23,20 @@ def test_parse_meetings_accepts_extra_attributes_and_decodes_entities():
         "daniel@example.com",
     ]
     assert notes[0]["summary_markdown"] == "Discuss A & B."
+
+
+def test_parse_participants_uses_structural_delimiters():
+    participants = _parse_participants(
+        "Matt (note creator) from Acme <MATT@example.com>, Daniel <daniel@example.com>"
+    )
+
+    assert participants == [
+        {"name": "Matt (note creator) from Acme", "email": "matt@example.com"},
+        {"name": "Daniel", "email": "daniel@example.com"},
+    ]
+
+
+def test_parse_meeting_date_uses_gmt_suffix():
+    assert _parse_meeting_date("Jul 8, 2026 5:30 PM GMT+2") == "2026-07-08T17:30:00+02:00"
+    assert _parse_meeting_date("Jul 8, 2026 5:30 PM GMT") == "2026-07-08T17:30:00+00:00"
+    assert _parse_meeting_date("Jul 8, 2026 5:30 PM CST") == "Jul 8, 2026 5:30 PM CST"

--- a/tools/productivity/granola/test_client.py
+++ b/tools/productivity/granola/test_client.py
@@ -1,0 +1,25 @@
+from client import _parse_meetings
+
+
+def test_parse_meetings_accepts_extra_attributes_and_decodes_entities():
+    text = """
+    <meetings_data count="1">
+      <meeting id="meeting-1" title="Matt &lt;&gt; Daniel" date="Aug 5, 2026 5:00 PM CST"
+               captured_by_me="true" listed_as_participant="true">
+        <known_participants>Matt (note creator) from Acme &lt;matt@example.com&gt;, Daniel &lt;daniel@example.com&gt;</known_participants>
+        <summary>Discuss A &amp; B.</summary>
+      </meeting>
+    </meetings_data>
+    """
+
+    notes = _parse_meetings(text)
+
+    assert len(notes) == 1
+    assert notes[0]["id"] == "meeting-1"
+    assert notes[0]["title"] == "Matt <> Daniel"
+    assert notes[0]["owner"] == {"name": "Matt", "email": "matt@example.com"}
+    assert [attendee["email"] for attendee in notes[0]["attendees"]] == [
+        "matt@example.com",
+        "daniel@example.com",
+    ]
+    assert notes[0]["summary_markdown"] == "Discuss A & B."


### PR DESCRIPTION
Parses Granola MCP meeting payloads with XML parsers so reordered or additional attributes and escaped content are handled correctly; regular expressions are limited to the plain-text participant list. Processes every meeting returned by Granola, batching detail requests at the 10-ID API limit, and fails closed when a response reports meetings that cannot be parsed.