### PR TITLE
fix(api-rs): name the sandbox failure cause in stdout-pump terminal errors

### DIFF
--- a/services/api-rs/crates/centaur-sandbox-agent-k8s/src/lib.rs
+++ b/services/api-rs/crates/centaur-sandbox-agent-k8s/src/lib.rs
@@ -15,7 +15,9 @@ use centaur_sandbox_core::{
     MountKind, ObservedSandbox, SandboxBackend, SandboxError, SandboxHandle, SandboxId, SandboxIo,
     SandboxResult, SandboxSpec, SandboxStatus,
 };
-use k8s_openapi::api::core::v1::{PersistentVolumeClaim, Pod};
+use k8s_openapi::api::core::v1::{
+    ContainerStateTerminated, ContainerStatus, PersistentVolumeClaim, Pod,
+};
 use kube::api::{
     AttachParams, DeleteParams, ListParams, LogParams, Patch, PatchParams, PostParams,
 };
@@ -245,6 +247,10 @@ impl AgentSandboxBackend {
         let pod = self.get_pod(id).await?;
         let status = sandbox_status_from_pod(replicas, pod.as_ref());
         Ok(ObservedSandbox::new(id.clone(), BACKEND_NAME, status)
+            .with_reason(pod_diagnostic_reason(
+                pod.as_ref(),
+                &self.config.container_name,
+            ))
             .with_created_at(sandbox_creation_time(sandbox))
             .with_suspended_since(sandbox_paused_at(sandbox)))
     }
@@ -662,6 +668,129 @@ fn pod_ready(pod: &Pod) -> bool {
         })
 }
 
+/// Best-effort diagnostic for a sandbox that cannot serve I/O, surfaced as
+/// `ObservedSandbox.reason` so failure paths (reattach, reconciliation) can
+/// name the real cause — OOM-kill, eviction, image pull failure — instead of
+/// the opaque portable status. A healthy running pod carries no reason.
+fn pod_diagnostic_reason(pod: Option<&Pod>, container_name: &str) -> Option<String> {
+    let Some(pod) = pod else {
+        // The Sandbox CR exists but its backing pod does not: external
+        // deletion (janitor, node pressure, manual reap) before the
+        // controller recreates it.
+        return Some("backing pod not found".to_owned());
+    };
+    let mut details: Vec<String> = Vec::new();
+    if pod.metadata.deletion_timestamp.is_some() {
+        details.push("pod deletion in progress".to_owned());
+    }
+    let status = pod.status.as_ref();
+    let phase = status
+        .and_then(|status| status.phase.as_deref())
+        .unwrap_or("unknown")
+        .to_ascii_lowercase();
+    match phase.as_str() {
+        "failed" | "succeeded" => {
+            let mut detail = format!("pod {phase}");
+            if let Some(reason) = status.and_then(|status| status.reason.as_deref()) {
+                detail = format!("{detail} (reason {reason})");
+            }
+            details.push(detail);
+        }
+        "pending" => details.push("pod pending".to_owned()),
+        "running" if !pod_ready(pod) => details.push("pod running but not ready".to_owned()),
+        _ => {}
+    }
+    if let Some(detail) = container_diagnostic_detail(pod, container_name) {
+        details.push(detail);
+    }
+    if details.is_empty() {
+        None
+    } else {
+        Some(details.join("; "))
+    }
+}
+
+/// Diagnostic for the most relevant container in the pod. The agent container
+/// wins over init/sidecar containers; containers that completed cleanly
+/// (finished init containers) are not diagnostics.
+fn container_diagnostic_detail(pod: &Pod, container_name: &str) -> Option<String> {
+    let status = pod.status.as_ref()?;
+    let statuses = status
+        .container_statuses
+        .iter()
+        .chain(status.init_container_statuses.iter())
+        .flatten();
+    let mut fallback = None;
+    for container in statuses {
+        let detail = container_state_detail(container, container.name == container_name);
+        if container.name == container_name && detail.is_some() {
+            return detail;
+        }
+        fallback = fallback.or(detail);
+    }
+    fallback
+}
+
+fn container_state_detail(container: &ContainerStatus, is_agent: bool) -> Option<String> {
+    let name = container.name.as_str();
+    if let Some(terminated) = container
+        .state
+        .as_ref()
+        .and_then(|state| state.terminated.as_ref())
+    {
+        // A cleanly completed non-agent container (e.g. a finished init
+        // container) is normal, not a diagnostic.
+        if !is_agent && terminated.exit_code == 0 {
+            return None;
+        }
+        return Some(terminated_detail(name, false, terminated));
+    }
+    if let Some(waiting) = container
+        .state
+        .as_ref()
+        .and_then(|state| state.waiting.as_ref())
+        && let Some(reason) = waiting.reason.as_deref()
+    {
+        return Some(format!("container \"{name}\" waiting (reason {reason})"));
+    }
+    // With restartPolicy Never a dead container stays in `state.terminated`;
+    // `last_state.terminated` only fills after a restart, but covers pod
+    // templates that restart in place.
+    if let Some(terminated) = container
+        .last_state
+        .as_ref()
+        .and_then(|state| state.terminated.as_ref())
+    {
+        if !is_agent && terminated.exit_code == 0 {
+            return None;
+        }
+        return Some(terminated_detail(name, true, terminated));
+    }
+    None
+}
+
+fn terminated_detail(name: &str, restarted: bool, terminated: &ContainerStateTerminated) -> String {
+    let exit_code = terminated.exit_code;
+    match (terminated.reason.as_deref(), restarted) {
+        (Some("OOMKilled"), false) => {
+            format!("container \"{name}\" OOM-killed (exit code {exit_code})")
+        }
+        (Some("OOMKilled"), true) => {
+            format!("container \"{name}\" previously OOM-killed (exit code {exit_code})")
+        }
+        (Some(reason), false) => {
+            format!("container \"{name}\" terminated (reason {reason}, exit code {exit_code})")
+        }
+        (Some(reason), true) => {
+            format!(
+                "container \"{name}\" previously terminated (reason {reason}, exit code {exit_code})"
+            )
+        }
+        (None, false) => format!("container \"{name}\" exited (exit code {exit_code})"),
+        (None, true) => format!("container \"{name}\" previously exited (exit code {exit_code})"),
+    }
+}
+
 fn build_agent_sandbox(
     id: &SandboxId,
     spec: &SandboxSpec,
@@ -988,7 +1117,9 @@ mod tests {
     use centaur_sandbox_core::{
         RepoCacheAccess, ResourceRequirements, SandboxCapabilities, SandboxSpec,
     };
-    use k8s_openapi::api::core::v1::{PodCondition, PodStatus};
+    use k8s_openapi::api::core::v1::{
+        ContainerState, ContainerStateRunning, ContainerStateWaiting, PodCondition, PodStatus,
+    };
     use k8s_openapi::apimachinery::pkg::util::intstr::IntOrString;
 
     use super::*;
@@ -1494,6 +1625,195 @@ mod tests {
             state_pvc_name(&SandboxId::new("asbx-test")),
             "state-asbx-test"
         );
+    }
+
+    #[test]
+    fn pod_diagnostic_reason_names_oom_kill() {
+        // The restartPolicy Never shape: the OOM-killed container stays in
+        // `state.terminated` while the pod phase settles to Failed.
+        let failed_pod = pod_with_container_state(
+            "Failed",
+            false,
+            agent_container_state(ContainerState {
+                terminated: Some(ContainerStateTerminated {
+                    exit_code: 137,
+                    reason: Some("OOMKilled".to_owned()),
+                    ..ContainerStateTerminated::default()
+                }),
+                ..ContainerState::default()
+            }),
+        );
+        assert_eq!(
+            pod_diagnostic_reason(Some(&failed_pod), "agent"),
+            Some("pod failed; container \"agent\" OOM-killed (exit code 137)".to_owned())
+        );
+
+        // Mid-transition the phase can still be Running; the container state
+        // must still name the OOM-kill.
+        let stale_running_pod = pod_with_container_state(
+            "Running",
+            false,
+            agent_container_state(ContainerState {
+                terminated: Some(ContainerStateTerminated {
+                    exit_code: 137,
+                    reason: Some("OOMKilled".to_owned()),
+                    ..ContainerStateTerminated::default()
+                }),
+                ..ContainerState::default()
+            }),
+        );
+        assert_eq!(
+            pod_diagnostic_reason(Some(&stale_running_pod), "agent"),
+            Some(
+                "pod running but not ready; container \"agent\" OOM-killed (exit code 137)"
+                    .to_owned()
+            )
+        );
+    }
+
+    #[test]
+    fn pod_diagnostic_reason_names_eviction_and_deletion() {
+        let mut evicted_pod = pod_with_phase_and_ready("Failed", false);
+        evicted_pod.status.as_mut().unwrap().reason = Some("Evicted".to_owned());
+        assert_eq!(
+            pod_diagnostic_reason(Some(&evicted_pod), "agent"),
+            Some("pod failed (reason Evicted)".to_owned())
+        );
+
+        let mut deleting_pod = pod_with_phase_and_ready("Running", true);
+        deleting_pod.metadata.deletion_timestamp = Some(
+            k8s_openapi::apimachinery::pkg::apis::meta::v1::Time(jiff::Timestamp::now()),
+        );
+        assert_eq!(
+            pod_diagnostic_reason(Some(&deleting_pod), "agent"),
+            Some("pod deletion in progress".to_owned())
+        );
+
+        assert_eq!(
+            pod_diagnostic_reason(None, "agent"),
+            Some("backing pod not found".to_owned())
+        );
+    }
+
+    #[test]
+    fn pod_diagnostic_reason_prefers_agent_container_and_skips_healthy_pods() {
+        // A waiting agent container names the wait reason (image pull,
+        // crash loop) even when a sidecar also has a diagnostic.
+        let pod = pod_with_container_state(
+            "Pending",
+            false,
+            vec![
+                ContainerStatus {
+                    name: "agent".to_owned(),
+                    state: Some(ContainerState {
+                        waiting: Some(ContainerStateWaiting {
+                            reason: Some("ImagePullBackOff".to_owned()),
+                            ..ContainerStateWaiting::default()
+                        }),
+                        ..ContainerState::default()
+                    }),
+                    ..ContainerStatus::default()
+                },
+                ContainerStatus {
+                    name: "tools-bootstrap".to_owned(),
+                    state: Some(ContainerState {
+                        terminated: Some(ContainerStateTerminated {
+                            exit_code: 1,
+                            reason: Some("Error".to_owned()),
+                            ..ContainerStateTerminated::default()
+                        }),
+                        ..ContainerState::default()
+                    }),
+                    ..ContainerStatus::default()
+                },
+            ],
+        );
+        assert_eq!(
+            pod_diagnostic_reason(Some(&pod), "agent"),
+            Some("pod pending; container \"agent\" waiting (reason ImagePullBackOff)".to_owned())
+        );
+
+        // A healthy running pod with a cleanly completed init container has
+        // no diagnostic.
+        let healthy = pod_with_container_state(
+            "Running",
+            true,
+            vec![
+                ContainerStatus {
+                    name: "agent".to_owned(),
+                    state: Some(ContainerState {
+                        running: Some(ContainerStateRunning::default()),
+                        ..ContainerState::default()
+                    }),
+                    ..ContainerStatus::default()
+                },
+                ContainerStatus {
+                    name: "tools-bootstrap".to_owned(),
+                    state: Some(ContainerState {
+                        terminated: Some(ContainerStateTerminated {
+                            exit_code: 0,
+                            reason: Some("Completed".to_owned()),
+                            ..ContainerStateTerminated::default()
+                        }),
+                        ..ContainerState::default()
+                    }),
+                    ..ContainerStatus::default()
+                },
+            ],
+        );
+        assert_eq!(pod_diagnostic_reason(Some(&healthy), "agent"), None);
+    }
+
+    #[test]
+    fn pod_diagnostic_reason_reads_last_terminated_state_after_restart() {
+        // restartPolicy Never keeps a dead container in `state.terminated`;
+        // a template that restarts in place reports the kill through
+        // `last_state.terminated` instead.
+        let pod = pod_with_container_state(
+            "Running",
+            false,
+            vec![ContainerStatus {
+                name: "agent".to_owned(),
+                state: Some(ContainerState {
+                    running: Some(ContainerStateRunning::default()),
+                    ..ContainerState::default()
+                }),
+                last_state: Some(ContainerState {
+                    terminated: Some(ContainerStateTerminated {
+                        exit_code: 137,
+                        reason: Some("OOMKilled".to_owned()),
+                        ..ContainerStateTerminated::default()
+                    }),
+                    ..ContainerState::default()
+                }),
+                ..ContainerStatus::default()
+            }],
+        );
+        assert_eq!(
+            pod_diagnostic_reason(Some(&pod), "agent"),
+            Some(
+                "pod running but not ready; container \"agent\" previously OOM-killed (exit code 137)"
+                    .to_owned()
+            )
+        );
+    }
+
+    fn agent_container_state(state: ContainerState) -> Vec<ContainerStatus> {
+        vec![ContainerStatus {
+            name: "agent".to_owned(),
+            state: Some(state),
+            ..ContainerStatus::default()
+        }]
+    }
+
+    fn pod_with_container_state(
+        phase: &str,
+        ready: bool,
+        container_statuses: Vec<ContainerStatus>,
+    ) -> Pod {
+        let mut pod = pod_with_phase_and_ready(phase, ready);
+        pod.status.as_mut().unwrap().container_statuses = Some(container_statuses);
+        pod
     }
 
     fn pod_with_phase_and_ready(phase: &str, ready: bool) -> Pod {

--- a/services/api-rs/crates/centaur-sandbox-core/src/lifecycle.rs
+++ b/services/api-rs/crates/centaur-sandbox-core/src/lifecycle.rs
@@ -123,6 +123,11 @@ impl ObservedSandbox {
         }
     }
 
+    pub fn with_reason(mut self, reason: Option<String>) -> Self {
+        self.reason = reason;
+        self
+    }
+
     pub fn with_created_at(mut self, created_at: Option<SystemTime>) -> Self {
         self.created_at = created_at;
         self

--- a/services/api-rs/crates/centaur-session-runtime/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-runtime/src/lib.rs
@@ -13,7 +13,7 @@ use std::{
 
 use centaur_iron_control::{IronControlError, Principal, SessionRegistrar};
 use centaur_sandbox_core::{
-    Mount, RepoCacheAccess, ResourceRequirements, SandboxBackend,
+    Mount, ObservedSandbox, RepoCacheAccess, ResourceRequirements, SandboxBackend,
     SandboxCapabilities as BackendSandboxCapabilities, SandboxError, SandboxId, SandboxIoGuard,
     SandboxRead, SandboxSpec, SandboxStatus, SandboxWrite,
 };
@@ -4128,8 +4128,12 @@ async fn reattach_session_pipe(
     }
 
     let id = SandboxId::new(sandbox_id);
-    match ctx.manager.status(&id).await {
-        Ok(status) if status.can_open_io() => match ctx.manager.open_io(&id).await {
+    // Observe rather than bare status: the observation carries the
+    // backend-owned diagnostic reason (OOM-kill, eviction, pod deletion),
+    // which is the difference between an actionable terminal error and an
+    // opaque "no longer accepts io" for a sandbox that died mid-execution.
+    match ctx.manager.observe(&id).await {
+        Ok(observed) if observed.status.can_open_io() => match ctx.manager.open_io(&id).await {
             Ok(io) => {
                 let parts = io.into_parts();
                 let new_pipe = session_pipe_from_stdin(parts.stdin);
@@ -4146,13 +4150,25 @@ async fn reattach_session_pipe(
                 ReattachOutcome::Retryable(format!("sandbox stdout reattach failed: {error}"))
             }
         },
-        Ok(status) => {
-            ReattachOutcome::Dead(format!("sandbox no longer accepts io (status {status:?})"))
-        }
+        Ok(observed) => ReattachOutcome::Dead(detached_sandbox_detail(&observed)),
         Err(SandboxError::NotFound(_)) => {
             ReattachOutcome::Dead("sandbox no longer exists".to_owned())
         }
         Err(error) => ReattachOutcome::Retryable(format!("sandbox status check failed: {error}")),
+    }
+}
+
+/// Terminal detail for a sandbox that will not serve I/O again, appending the
+/// backend-owned diagnostic (OOM-kill, eviction, pod deletion) when the
+/// backend observed one.
+fn detached_sandbox_detail(observed: &ObservedSandbox) -> String {
+    let detail = format!(
+        "sandbox no longer accepts io (status {:?})",
+        observed.status
+    );
+    match observed.reason.as_deref().map(str::trim) {
+        Some(reason) if !reason.is_empty() => format!("{detail}: {reason}"),
+        _ => detail,
     }
 }
 
@@ -7427,6 +7443,30 @@ mod tests {
     }
 
     #[test]
+    fn detached_sandbox_detail_appends_backend_diagnostic_reason() {
+        let observed = ObservedSandbox::new("sbx-1", "mock", SandboxStatus::Stopped).with_reason(
+            Some("container \"agent\" OOM-killed (exit code 137)".to_owned()),
+        );
+        assert_eq!(
+            detached_sandbox_detail(&observed),
+            "sandbox no longer accepts io (status Stopped): container \"agent\" OOM-killed (exit code 137)"
+        );
+
+        let without_reason = ObservedSandbox::new("sbx-1", "mock", SandboxStatus::Created);
+        assert_eq!(
+            detached_sandbox_detail(&without_reason),
+            "sandbox no longer accepts io (status Created)"
+        );
+
+        let blank_reason = ObservedSandbox::new("sbx-1", "mock", SandboxStatus::Created)
+            .with_reason(Some("  ".to_owned()));
+        assert_eq!(
+            detached_sandbox_detail(&blank_reason),
+            "sandbox no longer accepts io (status Created)"
+        );
+    }
+
+    #[test]
     fn execution_metadata_preserves_idle_and_max_duration() {
         let metadata =
             execution_metadata(Some(json!({"source": "test"})), Some(2_000), Some(5_000));
@@ -8453,6 +8493,7 @@ mod adoption_tests {
         open_count: AtomicUsize,
         status: std::sync::Mutex<SandboxStatus>,
         observed_statuses: std::sync::Mutex<BTreeMap<String, SandboxStatus>>,
+        observed_reasons: std::sync::Mutex<BTreeMap<String, String>>,
         create_id: String,
         created_specs: std::sync::Mutex<Vec<SandboxSpec>>,
         resume_fails: AtomicBool,
@@ -8469,6 +8510,7 @@ mod adoption_tests {
                 open_count: AtomicUsize::new(0),
                 status: std::sync::Mutex::new(status),
                 observed_statuses: std::sync::Mutex::new(BTreeMap::new()),
+                observed_reasons: std::sync::Mutex::new(BTreeMap::new()),
                 create_id: "mock-sbx".to_owned(),
                 created_specs: std::sync::Mutex::new(Vec::new()),
                 resume_fails: AtomicBool::new(false),
@@ -8499,6 +8541,13 @@ mod adoption_tests {
                 .lock()
                 .unwrap()
                 .insert(sandbox_id.to_owned(), status);
+        }
+
+        fn set_observed_reason(&self, sandbox_id: &str, reason: &str) {
+            self.observed_reasons
+                .lock()
+                .unwrap()
+                .insert(sandbox_id.to_owned(), reason.to_owned());
         }
 
         fn status_of(&self, sandbox_id: &str) -> Option<SandboxStatus> {
@@ -8574,7 +8623,13 @@ mod adoption_tests {
 
         async fn observe(&self, id: &SandboxId) -> SandboxResult<ObservedSandbox> {
             let status = self.status(id).await?;
-            Ok(ObservedSandbox::new(id.clone(), "mock", status))
+            let reason = self
+                .observed_reasons
+                .lock()
+                .unwrap()
+                .get(id.as_str())
+                .cloned();
+            Ok(ObservedSandbox::new(id.clone(), "mock", status).with_reason(reason))
         }
 
         async fn list_observed(&self) -> SandboxResult<Vec<ObservedSandbox>> {
@@ -8738,6 +8793,27 @@ mod adoption_tests {
         .await
         .expect("expire stdout lease");
         assert_eq!(result.rows_affected(), 1, "expected to expire one lease");
+    }
+
+    /// Gives the test runtime the stdout-owner lease the execute path would
+    /// have claimed for a live execution; output and terminal updates are
+    /// fenced on that ownership.
+    async fn claim_runtime_stdout_owner(
+        store: &PgSessionStore,
+        execution_id: &str,
+        runtime: &SessionRuntime,
+    ) {
+        assert!(
+            store
+                .claim_stdout_owner(
+                    execution_id,
+                    &runtime.stdout_owner_id,
+                    Duration::from_secs(60),
+                )
+                .await
+                .expect("claim stdout owner"),
+            "expected to claim stdout ownership"
+        );
     }
 
     async fn wait_for_event(store: &PgSessionStore, thread_key: &ThreadKey, event_type: &str) {
@@ -9673,13 +9749,15 @@ mod adoption_tests {
         let _serial = TEST_LOCK.lock().await;
         let thread_key =
             ThreadKey::parse(format!("test:eof-recorded-{}", uuid::Uuid::new_v4())).unwrap();
-        orphaned_execution(&store, &thread_key, Some("sbx-recorded"), true).await;
+        let execution_id =
+            orphaned_execution(&store, &thread_key, Some("sbx-recorded"), true).await;
 
         let backend = Arc::new(MockBackend::new(SandboxStatus::Running, Vec::new()));
         let (io, stdout, _stdin) = mock_io();
         backend.push_io(io).await;
 
         let runtime = runtime_with(&store, backend.clone());
+        claim_runtime_stdout_owner(&store, &execution_id, &runtime).await;
         runtime
             .ensure_session_pipe(&thread_key, "sbx-recorded")
             .await
@@ -9723,7 +9801,8 @@ mod adoption_tests {
         let _serial = TEST_LOCK.lock().await;
         let thread_key =
             ThreadKey::parse(format!("test:eof-reattach-{}", uuid::Uuid::new_v4())).unwrap();
-        orphaned_execution(&store, &thread_key, Some("sbx-reattach"), true).await;
+        let execution_id =
+            orphaned_execution(&store, &thread_key, Some("sbx-reattach"), true).await;
 
         let backend = Arc::new(MockBackend::new(SandboxStatus::Running, Vec::new()));
         let (first_io, mut first_stdout, _first_stdin) = mock_io();
@@ -9732,6 +9811,7 @@ mod adoption_tests {
         backend.push_io(second_io).await;
 
         let runtime = runtime_with(&store, backend.clone());
+        claim_runtime_stdout_owner(&store, &execution_id, &runtime).await;
         runtime
             .ensure_session_pipe(&thread_key, "sbx-reattach")
             .await
@@ -9844,13 +9924,14 @@ mod adoption_tests {
         let _serial = TEST_LOCK.lock().await;
         let thread_key =
             ThreadKey::parse(format!("test:eof-gone-{}", uuid::Uuid::new_v4())).unwrap();
-        orphaned_execution(&store, &thread_key, Some("sbx-gone"), true).await;
+        let execution_id = orphaned_execution(&store, &thread_key, Some("sbx-gone"), true).await;
 
         let backend = Arc::new(MockBackend::new(SandboxStatus::Running, Vec::new()));
         let (io, stdout, _stdin) = mock_io();
         backend.push_io(io).await;
 
         let runtime = runtime_with(&store, backend.clone());
+        claim_runtime_stdout_owner(&store, &execution_id, &runtime).await;
         runtime
             .ensure_session_pipe(&thread_key, "sbx-gone")
             .await
@@ -9877,6 +9958,50 @@ mod adoption_tests {
             !all.iter()
                 .any(|event| event.event_type == "session.stdout_pump_reattached"),
             "gone sandbox should not reattach"
+        );
+        assert_eq!(backend.opens(), 1);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn stdout_eof_failure_names_backend_diagnostic_reason() {
+        let Some(store) = test_store().await else {
+            return;
+        };
+        let _serial = TEST_LOCK.lock().await;
+        let thread_key =
+            ThreadKey::parse(format!("test:eof-oom-{}", uuid::Uuid::new_v4())).unwrap();
+        let execution_id = orphaned_execution(&store, &thread_key, Some("sbx-oom"), true).await;
+
+        let backend = Arc::new(MockBackend::new(SandboxStatus::Running, Vec::new()));
+        let (io, stdout, _stdin) = mock_io();
+        backend.push_io(io).await;
+
+        let runtime = runtime_with(&store, backend.clone());
+        claim_runtime_stdout_owner(&store, &execution_id, &runtime).await;
+        runtime
+            .ensure_session_pipe(&thread_key, "sbx-oom")
+            .await
+            .expect("open initial pipe");
+        // The agent-k8s backend surfaces an OOM-kill this way while the pod
+        // phase settles from Running to Failed.
+        backend.set_status(SandboxStatus::Stopped);
+        backend.set_observed_reason("sbx-oom", "container \"agent\" OOM-killed (exit code 137)");
+        drop(stdout);
+
+        wait_for_event(&store, &thread_key, "session.execution_failed").await;
+        let all = events(&store, &thread_key).await;
+        let failed = all
+            .iter()
+            .find(|event| event.event_type == "session.execution_failed")
+            .expect("failed event");
+        let error = failed.payload["error"].as_str().unwrap_or_default();
+        assert!(
+            error.contains("sandbox no longer accepts io (status Stopped)"),
+            "expected sandbox status detail: {error}"
+        );
+        assert!(
+            error.contains("container \"agent\" OOM-killed (exit code 137)"),
+            "expected the backend diagnostic reason in the failure: {error}"
         );
         assert_eq!(backend.opens(), 1);
     }


### PR DESCRIPTION
## Summary

When a sandbox's stdout stream closes mid-execution, the pump's reattach path classifies the execution as dead with `sandbox no longer accepts io (status X)` — a message that carries no hint of the actual cause. Every investigation starts from scratch in the logs.

This populates the (previously never-populated, RFC 0001-sanctioned) `ObservedSandbox.reason` field in the agent-k8s backend with a pod diagnostic — missing pod, deletion in progress, pod phase/reason (e.g. `Evicted`), and per-container terminated/waiting reasons — and appends it to the pump's terminal error. The failure now reads:

```
sandbox stdout closed before terminal output; sandbox no longer accepts io (status Stopped): container "agent" OOM-killed (exit code 137)
```

Backends that report no reason produce byte-identical messages to before; the contract change is one additive `ObservedSandbox::with_reason` builder.

Notes:

- The agent container is preferred over init/sidecar containers for the diagnostic; healthy pods report no reason. `last_state.terminated` is also read so the diagnostic survives if the pod template ever gains in-place restarts.
- Also fixes (test-only) three pre-existing `stdout_eof_*` DB-backed tests that fail on `main` since the stdout-ownership fencing landed — they never claimed the lease. They currently silently skip in CI because `SESSION_RUNTIME_TEST_DATABASE_URL` is unset; with a database provided they now pass.

## Validation

- `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p centaur-session-runtime` (104 passed, with `SESSION_RUNTIME_TEST_DATABASE_URL` against a disposable Postgres) including a new DB-backed regression test that drives the EOF→Dead path and asserts the recorded error names the backend diagnostic
- `cargo test -p centaur-sandbox-agent-k8s` (61 passed) with new unit tests for OOM/eviction/deletion/missing-pod diagnostics
- `cargo test -p centaur-sandbox-core -p centaur-sandbox-local -p centaur-sandbox-manager` (17 passed)

Generated with [Devin](https://devin.ai)
