### PR TITLE
docs: tie the ACME example's 1Password keys to a secret source

### DIFF
--- a/docs/pages/extend/acme-example.mdx
+++ b/docs/pages/extend/acme-example.mdx
@@ -173,6 +173,10 @@ kubectl create secret generic centaur-infra-env \
   --from-literal=SLACKBOT_API_KEY=...
 ```
 
+`OP_SERVICE_ACCOUNT_TOKEN` and `OP_VAULT` apply to the chart's default
+`ironProxy.secretSource: onepassword`. Use `OP_CONNECT_TOKEN` and `OP_VAULT`
+for `onepassword-connect`, and omit all three for `env`.
+
 Model and tool credentials such as `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`,
 `AMP_API_KEY`, and `GITHUB_TOKEN` should be configured through Centaur's
 credential source. Sandboxes should receive placeholders; iron-proxy injects the


### PR DESCRIPTION
The example's create-secret command lists OP_SERVICE_ACCOUNT_TOKEN and OP_VAULT without saying which ironProxy.secretSource they belong to. They match the chart default, but a reader running secretSource: env copies two keys that have no effect and no way to tell from the example.

Name the source each key belongs to, using the same pairings as the infra secret table in the production guide.