### PR TITLE
docs: document what ctx.agent_turn returns

### DIFF
--- a/docs/pages/extend/workflows-v2.mdx
+++ b/docs/pages/extend/workflows-v2.mdx
@@ -121,6 +121,19 @@ The workflow host sandbox is separate from the agent sandbox. The workflow
 handler coordinates the run; the agent turn runs through the normal Centaur
 session runtime.
 
+`ctx.agent_turn(...)` resolves to the execution record, not to the answer. Read
+`result_text` for the agent's final text:
+
+```python
+{
+    "thread_key": "wf:<task-id>:agent:<workflow-name>",
+    "execution_id": "...",
+    "status": "completed",
+    "output_lines": [...],
+    "result_text": "the agent's final text",
+}
+```
+
 #### Declare Workflow-Host Permissions
 
 When a workflow calls tools directly from the workflow host with


### PR DESCRIPTION
ctx.agent_turn resolves to the whole execution record — thread_key, execution_id, status, output_lines, result_text — but the workflows page only ever shows the call, never the shape, so reading the agent's answer means discovering result_text by inspection.

Print the payload next to the agent turn example and name the field that carries the final text.