### PR TITLE
docs: note that the DATABASE_URL password must be URL-encoded

### DIFF
--- a/docs/pages/deploying-in-production.mdx
+++ b/docs/pages/deploying-in-production.mdx
@@ -59,7 +59,7 @@ Minimum keys:
 
 | Secret | Required for | Notes |
 |--------|--------------|-------|
-| `DATABASE_URL` | API | Postgres connection string. |
+| `DATABASE_URL` | API | Postgres connection string. Make sure the password is URL-encoded. |
 | `POSTGRES_PASSWORD` | Bundled Postgres | Password used when the chart manages Postgres. |
 | `IRON_MANAGEMENT_API_KEY` | [iron-proxy](https://docs.iron.sh) management API | Generate with `openssl rand -hex 32`. |
 | `SANDBOX_SIGNING_KEY` | Sandbox API tokens | Generate with `openssl rand -hex 32`; keeps sandbox tokens valid across API restarts. |

--- a/docs/pages/secrets/environment.mdx
+++ b/docs/pages/secrets/environment.mdx
@@ -41,6 +41,8 @@ kubectl create secret generic centaur-infra-env \
   --from-literal=WAREHOUSE_API_KEY='...'
 ```
 
+Make sure the password in `DATABASE_URL` is URL-encoded.
+
 For local development, `just bootstrap-secrets` creates the local Kubernetes
 Secret from your shell environment.
 


### PR DESCRIPTION
The infra secret's DATABASE_URL is supplied by the operator; the chart never composes it, and bootstrap-k8s-secrets.sh only covers the bundled Postgres with a generated hex password. Anyone hand-creating the Secret owns the encoding.

A reserved character in the password ends the URL's authority section early, so the parser reads the wrong span as the port and reports InvalidPort, naming a component the operator never wrote. State the requirement on the secret key reference and next to the create-secret example that carries a DATABASE_URL placeholder.