### PR TITLE
docs: note that a session keeps the harness it was created with

### DIFF
--- a/docs/pages/deploying-in-production.mdx
+++ b/docs/pages/deploying-in-production.mdx
@@ -106,6 +106,11 @@ Store one secret per enabled harness credential:
 | Claude Code | `claude-code` | `--claude` | `ANTHROPIC_API_KEY` | `api.anthropic.com` |
 | pi-mono | `pi-mono` | `--pi` | `ANTHROPIC_API_KEY` | `api.anthropic.com` |
 
+`sandbox.harnessEngine` and the selectors above apply when a session is created.
+A session records its harness and keeps it for the life of the thread, so
+changing the chart value does not move existing threads onto another harness.
+Start a new thread to pick one up.
+
 In normal sandbox mode, containers receive placeholder values such as
 `OPENAI_API_KEY=OPENAI_API_KEY`. [iron-proxy](https://docs.iron.sh) swaps the
 placeholder for the real key on outbound requests, only on the hosts and


### PR DESCRIPTION
sessions.harness_type is written when the session is created, and a later request for a different harness raises HarnessConflict and falls back to the session's existing harness. So sandbox.harnessEngine only affects new sessions.

The reference tables say this for SLACKBOTV2_DEFAULT_HARNESS and TEAMS_DEFAULT_HARNESS_TYPE, but not where operators actually choose a harness. State it next to the harness table.