### PR TITLE
refactor: migrate pg dsn identity selectors

### DIFF
--- a/services/api-rs/crates/centaur-api-server/src/tool_discovery.rs
+++ b/services/api-rs/crates/centaur-api-server/src/tool_discovery.rs
@@ -1635,8 +1635,8 @@ mod tests {
                     name: "centaur.slack_channel_id".to_owned(),
                     value: None,
                     value_from: Some(PgDsnSettingValueFrom {
-                        principal_label: Some("slack_channel_id".to_owned()),
-                        principal_field: None,
+                        principal_label: None,
+                        principal_field: Some("slack_channel_id".to_owned()),
                         proxy_label: None,
                     }),
                 },

--- a/services/api-rs/crates/centaur-iron-control/src/registry.rs
+++ b/services/api-rs/crates/centaur-iron-control/src/registry.rs
@@ -1121,7 +1121,7 @@ postgres:
     settings:
       - name: centaur.slack_channel_id
         value_from:
-          principal_label: slack_channel_id
+          principal_field: slack_channel_id
       - name: centaur.slack_user_id
         value_from:
           proxy_label: centaur.slack_user_id
@@ -1144,7 +1144,7 @@ postgres:
             input.settings[0]
                 .value_from
                 .as_ref()
-                .and_then(|value_from| value_from.principal_label.as_deref()),
+                .and_then(|value_from| value_from.principal_field.as_deref()),
             Some("slack_channel_id")
         );
         assert_eq!(input.settings[1].name, "centaur.slack_user_id");

--- a/services/api-rs/crates/centaur-perms/src/tests.rs
+++ b/services/api-rs/crates/centaur-perms/src/tests.rs
@@ -372,7 +372,7 @@ fn aws_auth_requires_hosts() {
 #[test]
 fn parses_pg_dsn_secret() {
     let parsed = tools::parse_secret(
-        &entry(r#"{ type = "pg_dsn", name = "RESHIFT_DSN", database = "pmadmin", secret_ref = "RESHIFT_DSN", role = "centaur_slack_reader", settings = [{ name = "centaur.slack_channel_id", value_from = { principal_label = "slack_channel_id" } }, { name = "centaur.slack_user_id", value_from = { proxy_label = "centaur.slack_user_id" } }] }"#),
+        &entry(r#"{ type = "pg_dsn", name = "RESHIFT_DSN", database = "pmadmin", secret_ref = "RESHIFT_DSN", role = "centaur_slack_reader", settings = [{ name = "centaur.slack_channel_id", value_from = { principal_field = "slack_channel_id" } }, { name = "centaur.slack_user_id", value_from = { proxy_label = "centaur.slack_user_id" } }] }"#),
         &[],
     )
     .unwrap();
@@ -389,7 +389,7 @@ fn parses_pg_dsn_secret() {
         pg.settings[0]
             .value_from
             .as_ref()
-            .and_then(|value_from| value_from.principal_label.as_deref()),
+            .and_then(|value_from| value_from.principal_field.as_deref()),
         Some("slack_channel_id")
     );
     assert_eq!(pg.settings[1].name, "centaur.slack_user_id");
@@ -563,7 +563,7 @@ fn translates_oauth_with_json_key_fields() {
 fn translates_pg_dsn_to_input_with_roundtrip_foreign_id() {
     let secrets = vec![
         tools::parse_secret(
-            &entry(r#"{ type = "pg_dsn", name = "RESHIFT_DSN", database = "pmadmin", secret_ref = "RESHIFT_DSN", role = "centaur_slack_reader", settings = [{ name = "centaur.slack_channel_id", value_from = { principal_label = "slack_channel_id" } }, { name = "centaur.slack_user_id", value_from = { proxy_label = "centaur.slack_user_id" } }] }"#),
+            &entry(r#"{ type = "pg_dsn", name = "RESHIFT_DSN", database = "pmadmin", secret_ref = "RESHIFT_DSN", role = "centaur_slack_reader", settings = [{ name = "centaur.slack_channel_id", value_from = { principal_field = "slack_channel_id" } }, { name = "centaur.slack_user_id", value_from = { proxy_label = "centaur.slack_user_id" } }] }"#),
             &[],
         )
         .unwrap(),
@@ -584,7 +584,7 @@ fn translates_pg_dsn_to_input_with_roundtrip_foreign_id() {
         input.settings[0]
             .value_from
             .as_ref()
-            .and_then(|value_from| value_from.principal_label.as_deref()),
+            .and_then(|value_from| value_from.principal_field.as_deref()),
         Some("slack_channel_id")
     );
     assert_eq!(

--- a/services/console/app/models/pg_dsn_secret.rb
+++ b/services/console/app/models/pg_dsn_secret.rb
@@ -30,7 +30,8 @@ class PgDsnSecret < ApplicationRecord
   # A setting's `value_from` reference takes exactly one of these keys.
   VALUE_FROM_KEYS = %w[principal_label principal_field proxy_label].freeze
   # Principal attributes a `principal_field` reference may name. `id` resolves
-  # to the opaque oid rather than the database primary key.
+  # to the principal oid and `console_user_id` to the associated user oid; raw
+  # database primary keys are never exposed as setting values.
   PRINCIPAL_FIELDS = %w[
     id namespace foreign_id name kind slack_user_id slack_channel_id slack_team_id slack_email
     console_user_id console_user_email slack_history_channel_ids
@@ -159,7 +160,7 @@ class PgDsnSecret < ApplicationRecord
     when "slack_channel_id" then principal.slack_channel_id.to_s
     when "slack_team_id" then principal.slack_team_id.to_s
     when "slack_email" then principal.slack_email.to_s
-    when "console_user_id" then principal.console_user_id.to_s
+    when "console_user_id" then principal.console_user&.oid.to_s
     when "console_user_email" then principal.console_user_email.to_s
     when "slack_history_channel_ids" then JSON.generate(principal.slack_history_channel_ids)
     else "" # Invalid persisted or unsaved settings fail closed.

--- a/services/console/app/models/pg_dsn_secret.rb
+++ b/services/console/app/models/pg_dsn_secret.rb
@@ -79,7 +79,8 @@ class PgDsnSecret < ApplicationRecord
   def proxy_settings(principal: nil, proxy: nil)
     Array(settings).filter_map do |s|
       next unless s.is_a?(Hash)
-      name = s["name"].presence || s[:name].presence
+
+      name = s.with_indifferent_access[:name].presence
       next if name.blank?
       { "name" => name, "value" => setting_value(s, principal, proxy) }
     end
@@ -89,10 +90,10 @@ class PgDsnSecret < ApplicationRecord
     Array(settings).any? do |setting|
       next false unless setting.is_a?(Hash)
 
-      ref = setting["value_from"] || setting[:value_from]
+      ref = setting.with_indifferent_access[:value_from]
       next false unless ref.is_a?(Hash)
 
-      (ref["proxy_label"] || ref[:proxy_label]).present?
+      ref[:proxy_label].present?
     end
   end
 
@@ -113,22 +114,16 @@ class PgDsnSecret < ApplicationRecord
     normalized = settings.map do |setting|
       next setting unless setting.is_a?(Hash)
 
-      value_from = setting["value_from"] || setting[:value_from]
+      indifferent_setting = setting.with_indifferent_access
+      value_from = indifferent_setting[:value_from]
       next setting unless value_from.is_a?(Hash)
 
-      label = value_from["principal_label"] || value_from[:principal_label]
-      field = IDENTITY_PRINCIPAL_LABEL_FIELDS[label.to_s]
+      field = IDENTITY_PRINCIPAL_LABEL_FIELDS[value_from[:principal_label].to_s]
       next setting unless field
 
-      normalized_value_from = value_from.dup
-      normalized_value_from.delete("principal_label")
-      normalized_value_from.delete(:principal_label)
-      normalized_value_from["principal_field"] = field
-
-      normalized_setting = setting.dup
-      normalized_setting.delete(:value_from)
-      normalized_setting["value_from"] = normalized_value_from
-      normalized_setting
+      indifferent_setting.except(:value_from).merge(
+        value_from: value_from.except(:principal_label).merge(principal_field: field)
+      ).to_h
     end
     self.settings = normalized unless normalized == settings
   end
@@ -142,10 +137,11 @@ class PgDsnSecret < ApplicationRecord
   # resolve to "" when no principal/proxy is given or the label is absent, so
   # RLS-style policies fail closed rather than seeing a literal placeholder.
   def setting_value(setting, principal, proxy)
-    ref = setting["value_from"] || setting[:value_from]
-    return (setting["value"] || setting[:value]).to_s unless ref.is_a?(Hash)
+    setting = setting.with_indifferent_access
+    ref = setting[:value_from]
+    return setting[:value].to_s unless ref.is_a?(Hash)
 
-    label = ref["principal_label"] || ref[:principal_label]
+    label = ref[:principal_label]
     if label.present?
       if PrincipalIdentityLabels.promoted?(principal, label)
         return PrincipalIdentityLabels.value(principal, label).to_s
@@ -154,12 +150,12 @@ class PgDsnSecret < ApplicationRecord
       return principal&.labels&.fetch(label.to_s, "").to_s
     end
 
-    proxy_label = ref["proxy_label"] || ref[:proxy_label]
+    proxy_label = ref[:proxy_label]
     return proxy&.labels&.fetch(proxy_label.to_s, "").to_s if proxy_label.present?
 
     return "" unless principal
 
-    case (ref["principal_field"] || ref[:principal_field]).to_s
+    case ref[:principal_field].to_s
     when "id" then principal.oid
     when "namespace" then principal.namespace.to_s
     when "foreign_id" then principal.foreign_id.to_s
@@ -195,7 +191,8 @@ class PgDsnSecret < ApplicationRecord
   def setting_error(setting, seen)
     return "must be an object" unless setting.is_a?(Hash)
 
-    name = (setting["name"] || setting[:name]).to_s
+    setting = setting.with_indifferent_access
+    name = setting[:name].to_s
     return "name is required" if name.blank?
     return "invalid setting name #{name.inspect}" unless name.match?(GUC_NAME_FORMAT)
 
@@ -211,9 +208,10 @@ class PgDsnSecret < ApplicationRecord
   # structured shape: a typo'd field is an error here, not an empty string the
   # proxy quietly pins at sync time.
   def value_from_error(setting)
-    ref = setting["value_from"] || setting[:value_from]
+    setting = setting.with_indifferent_access
+    ref = setting[:value_from]
     return nil if ref.nil?
-    return "value and value_from are mutually exclusive" unless (setting["value"] || setting[:value]).nil?
+    return "value and value_from are mutually exclusive" unless setting[:value].nil?
     return "value_from must be an object" unless ref.is_a?(Hash)
 
     keys = ref.keys.map(&:to_s)
@@ -221,10 +219,10 @@ class PgDsnSecret < ApplicationRecord
       return "value_from must have exactly one of #{VALUE_FROM_KEYS.join(" or ")}"
     end
 
-    label = ref["principal_label"] || ref[:principal_label]
-    field = ref["principal_field"] || ref[:principal_field]
+    label = ref[:principal_label]
+    field = ref[:principal_field]
     return "principal_label can't be blank" if keys.first == "principal_label" && label.to_s.blank?
-    proxy_label = ref["proxy_label"] || ref[:proxy_label]
+    proxy_label = ref[:proxy_label]
     return "proxy_label can't be blank" if keys.first == "proxy_label" && proxy_label.to_s.blank?
     if keys.first == "principal_field" && !PRINCIPAL_FIELDS.include?(field.to_s)
       return "unknown principal_field #{field.to_s.inspect} (one of: #{PRINCIPAL_FIELDS.join(", ")})"

--- a/services/console/app/models/pg_dsn_secret.rb
+++ b/services/console/app/models/pg_dsn_secret.rb
@@ -36,9 +36,18 @@ class PgDsnSecret < ApplicationRecord
     id namespace foreign_id name kind slack_user_id slack_channel_id slack_team_id slack_email
     console_user_id console_user_email slack_history_channel_ids
   ].freeze
-  IDENTITY_PRINCIPAL_FIELDS = %w[
-    kind slack_user_id slack_channel_id slack_team_id slack_email
-  ].freeze
+  # Legacy `principal_label` selectors that canonicalize to a first-class
+  # `principal_field` on save. The `email` label stays on the compatibility
+  # shim: unlike these names, it is plausible as a custom label on principals
+  # of other kinds, where a rewrite would change what it resolves to.
+  IDENTITY_PRINCIPAL_LABEL_FIELDS = {
+    "kind" => "kind",
+    "slack_user_id" => "slack_user_id",
+    "slack_channel_id" => "slack_channel_id",
+    "slack_team_id" => "slack_team_id",
+    "slack_email" => "slack_email",
+    "console-user-id" => "console_user_id"
+  }.freeze
 
   has_one :dsn_source, class_name: "SecretSource", dependent: :destroy
   has_many :grants, dependent: :destroy
@@ -108,13 +117,13 @@ class PgDsnSecret < ApplicationRecord
       next setting unless value_from.is_a?(Hash)
 
       label = value_from["principal_label"] || value_from[:principal_label]
-      label = label.to_s
-      next setting unless IDENTITY_PRINCIPAL_FIELDS.include?(label)
+      field = IDENTITY_PRINCIPAL_LABEL_FIELDS[label.to_s]
+      next setting unless field
 
       normalized_value_from = value_from.dup
       normalized_value_from.delete("principal_label")
       normalized_value_from.delete(:principal_label)
-      normalized_value_from["principal_field"] = label
+      normalized_value_from["principal_field"] = field
 
       normalized_setting = setting.dup
       normalized_setting.delete(:value_from)

--- a/services/console/app/models/pg_dsn_secret.rb
+++ b/services/console/app/models/pg_dsn_secret.rb
@@ -123,8 +123,15 @@ class PgDsnSecret < ApplicationRecord
     when "namespace" then principal.namespace.to_s
     when "foreign_id" then principal.foreign_id.to_s
     when "name" then principal.name.to_s
+    when "kind" then principal.kind.to_s
+    when "slack_user_id" then principal.slack_user_id.to_s
+    when "slack_channel_id" then principal.slack_channel_id.to_s
+    when "slack_team_id" then principal.slack_team_id.to_s
+    when "slack_email" then principal.slack_email.to_s
+    when "console_user_id" then principal.console_user_id.to_s
+    when "console_user_email" then principal.console_user_email.to_s
     when "slack_history_channel_ids" then JSON.generate(principal.slack_history_channel_ids)
-    else principal.public_send(ref["principal_field"] || ref[:principal_field]).to_s
+    else "" # Invalid persisted or unsaved settings fail closed.
     end
   end
 

--- a/services/console/app/models/pg_dsn_secret.rb
+++ b/services/console/app/models/pg_dsn_secret.rb
@@ -35,10 +35,15 @@ class PgDsnSecret < ApplicationRecord
     id namespace foreign_id name kind slack_user_id slack_channel_id slack_team_id slack_email
     console_user_id console_user_email slack_history_channel_ids
   ].freeze
+  IDENTITY_PRINCIPAL_FIELDS = %w[
+    kind slack_user_id slack_channel_id slack_team_id slack_email
+  ].freeze
 
   has_one :dsn_source, class_name: "SecretSource", dependent: :destroy
   has_many :grants, dependent: :destroy
   belongs_to :created_by, class_name: "User"
+
+  before_validation :normalize_identity_principal_label_settings
 
   # One entry in the proxy's synced `postgres` list, keyed for routing by
   # `database`. The opaque id is carried too so the proxy can refer back to the
@@ -91,6 +96,32 @@ class PgDsnSecret < ApplicationRecord
   validate :database_matches_inline_dsn
 
   private
+
+  def normalize_identity_principal_label_settings
+    return unless settings.is_a?(Array)
+
+    normalized = settings.map do |setting|
+      next setting unless setting.is_a?(Hash)
+
+      value_from = setting["value_from"] || setting[:value_from]
+      next setting unless value_from.is_a?(Hash)
+
+      label = value_from["principal_label"] || value_from[:principal_label]
+      label = label.to_s
+      next setting unless IDENTITY_PRINCIPAL_FIELDS.include?(label)
+
+      normalized_value_from = value_from.dup
+      normalized_value_from.delete("principal_label")
+      normalized_value_from.delete(:principal_label)
+      normalized_value_from["principal_field"] = label
+
+      normalized_setting = setting.dup
+      normalized_setting.delete(:value_from)
+      normalized_setting["value_from"] = normalized_value_from
+      normalized_setting
+    end
+    self.settings = normalized unless normalized == settings
+  end
 
   def labels_is_a_hash
     errors.add(:labels, "must be a hash") unless labels.is_a?(Hash)

--- a/services/console/app/models/pg_dsn_secret.rb
+++ b/services/console/app/models/pg_dsn_secret.rb
@@ -29,9 +29,12 @@ class PgDsnSecret < ApplicationRecord
 
   # A setting's `value_from` reference takes exactly one of these keys.
   VALUE_FROM_KEYS = %w[principal_label principal_field proxy_label].freeze
-  # Principal attributes a `principal_field` reference may name, matching how
-  # the API serializes principals (`id` is the opaque oid).
-  PRINCIPAL_FIELDS = %w[id namespace foreign_id name slack_history_channel_ids].freeze
+  # Principal attributes a `principal_field` reference may name. `id` resolves
+  # to the opaque oid rather than the database primary key.
+  PRINCIPAL_FIELDS = %w[
+    id namespace foreign_id name kind slack_user_id slack_channel_id slack_team_id slack_email
+    console_user_id console_user_email slack_history_channel_ids
+  ].freeze
 
   has_one :dsn_source, class_name: "SecretSource", dependent: :destroy
   has_many :grants, dependent: :destroy
@@ -121,7 +124,7 @@ class PgDsnSecret < ApplicationRecord
     when "foreign_id" then principal.foreign_id.to_s
     when "name" then principal.name.to_s
     when "slack_history_channel_ids" then JSON.generate(principal.slack_history_channel_ids)
-    else "" # unreachable for saved records; settings_are_valid rejects others
+    else principal.public_send(ref["principal_field"] || ref[:principal_field]).to_s
     end
   end
 

--- a/services/console/db/migrate/20260810120000_migrate_pg_dsn_identity_labels_to_principal_fields.rb
+++ b/services/console/db/migrate/20260810120000_migrate_pg_dsn_identity_labels_to_principal_fields.rb
@@ -1,0 +1,42 @@
+class MigratePgDsnIdentityLabelsToPrincipalFields < ActiveRecord::Migration[8.1]
+  IDENTITY_FIELDS = %w[
+    kind slack_user_id slack_channel_id slack_team_id slack_email
+  ].freeze
+
+  class MigrationPgDsnSecret < ActiveRecord::Base
+    self.table_name = "pg_dsn_secrets"
+  end
+
+  def up
+    rewrite_settings(from: "principal_label", to: "principal_field")
+  end
+
+  def down
+    rewrite_settings(from: "principal_field", to: "principal_label")
+  end
+
+  private
+
+  def rewrite_settings(from:, to:)
+    MigrationPgDsnSecret.find_each do |secret|
+      rewritten = rewrite_secret_settings(secret.settings, from:, to:)
+      next if rewritten == secret.settings
+
+      secret.update_columns(settings: rewritten, updated_at: Time.current)
+    end
+  end
+
+  def rewrite_secret_settings(settings, from:, to:)
+    Array(settings).map do |setting|
+      next setting unless setting.is_a?(Hash)
+
+      value_from = setting["value_from"]
+      next setting unless value_from.is_a?(Hash)
+
+      field = value_from[from]
+      next setting unless IDENTITY_FIELDS.include?(field)
+
+      setting.merge("value_from" => value_from.except(from).merge(to => field))
+    end
+  end
+end

--- a/services/console/db/migrate/20260810120000_migrate_pg_dsn_identity_labels_to_principal_fields.rb
+++ b/services/console/db/migrate/20260810120000_migrate_pg_dsn_identity_labels_to_principal_fields.rb
@@ -1,42 +1,50 @@
 class MigratePgDsnIdentityLabelsToPrincipalFields < ActiveRecord::Migration[8.1]
-  IDENTITY_FIELDS = %w[
-    kind slack_user_id slack_channel_id slack_team_id slack_email
-  ].freeze
+  # Legacy identity label => first-class principal field. The `email` label is
+  # deliberately not migrated: it is plausible as a custom label on principals
+  # of other kinds, where a rewrite would change what it resolves to.
+  LABEL_FIELDS = {
+    "kind" => "kind",
+    "slack_user_id" => "slack_user_id",
+    "slack_channel_id" => "slack_channel_id",
+    "slack_team_id" => "slack_team_id",
+    "slack_email" => "slack_email",
+    "console-user-id" => "console_user_id"
+  }.freeze
 
   class MigrationPgDsnSecret < ActiveRecord::Base
     self.table_name = "pg_dsn_secrets"
   end
 
   def up
-    rewrite_settings(from: "principal_label", to: "principal_field")
+    rewrite_settings(from: "principal_label", to: "principal_field", mapping: LABEL_FIELDS)
   end
 
   def down
-    rewrite_settings(from: "principal_field", to: "principal_label")
+    rewrite_settings(from: "principal_field", to: "principal_label", mapping: LABEL_FIELDS.invert)
   end
 
   private
 
-  def rewrite_settings(from:, to:)
+  def rewrite_settings(from:, to:, mapping:)
     MigrationPgDsnSecret.find_each do |secret|
-      rewritten = rewrite_secret_settings(secret.settings, from:, to:)
+      rewritten = rewrite_secret_settings(secret.settings, from:, to:, mapping:)
       next if rewritten == secret.settings
 
       secret.update_columns(settings: rewritten, updated_at: Time.current)
     end
   end
 
-  def rewrite_secret_settings(settings, from:, to:)
+  def rewrite_secret_settings(settings, from:, to:, mapping:)
     Array(settings).map do |setting|
       next setting unless setting.is_a?(Hash)
 
       value_from = setting["value_from"]
       next setting unless value_from.is_a?(Hash)
 
-      field = value_from[from]
-      next setting unless IDENTITY_FIELDS.include?(field)
+      mapped = mapping[value_from[from]]
+      next setting unless mapped
 
-      setting.merge("value_from" => value_from.except(from).merge(to => field))
+      setting.merge("value_from" => value_from.except(from).merge(to => mapped))
     end
   end
 end

--- a/services/console/db/migrate/20260810120000_migrate_pg_dsn_identity_labels_to_principal_fields.rb
+++ b/services/console/db/migrate/20260810120000_migrate_pg_dsn_identity_labels_to_principal_fields.rb
@@ -35,16 +35,16 @@ class MigratePgDsnIdentityLabelsToPrincipalFields < ActiveRecord::Migration[8.1]
   end
 
   def rewrite_secret_settings(settings, from:, to:, mapping:)
-    Array(settings).map do |setting|
-      next setting unless setting.is_a?(Hash)
+    Array(settings).map { |setting| rewrite_setting(setting, from:, to:, mapping:) }
+  end
 
-      value_from = setting["value_from"]
-      next setting unless value_from.is_a?(Hash)
+  def rewrite_setting(setting, from:, to:, mapping:)
+    return setting unless setting.is_a?(Hash) && setting["value_from"].is_a?(Hash)
 
-      mapped = mapping[value_from[from]]
-      next setting unless mapped
+    value_from = setting.fetch("value_from")
+    mapped = mapping[value_from[from]]
+    return setting unless mapped
 
-      setting.merge("value_from" => value_from.except(from).merge(to => mapped))
-    end
+    setting.merge("value_from" => value_from.except(from).merge(to => mapped))
   end
 end

--- a/services/console/db/schema.rb
+++ b/services/console/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_07_091441) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_10_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 

--- a/services/console/test/controllers/api/v1/pg_dsn_secrets_controller_test.rb
+++ b/services/console/test/controllers/api/v1/pg_dsn_secrets_controller_test.rb
@@ -222,6 +222,32 @@ module Api
         )
       end
 
+      test "POST canonicalizes legacy identity labels without changing custom labels" do
+        body = {
+          data: {
+            namespace: "acme",
+            foreign_id: "legacy-value-from-pg",
+            database: "legacy-value-from-db",
+            settings: [
+              { name: "centaur.slack_channel_id", value_from: { principal_label: "slack_channel_id" } },
+              { name: "app.tenant", value_from: { principal_label: "tenant" } }
+            ],
+            dsn: { source_type: "env", config: { var: "LEGACY_VALUE_FROM_DSN" } }
+          }
+        }
+
+        post api_v1_pg_dsn_secrets_url, params: body.to_json, headers: auth_headers
+        assert_response :created
+
+        assert_equal(
+          [
+            { "name" => "centaur.slack_channel_id", "value_from" => { "principal_field" => "slack_channel_id" } },
+            { "name" => "app.tenant", "value_from" => { "principal_label" => "tenant" } }
+          ],
+          json_body.dig("data", "settings")
+        )
+      end
+
       test "POST with an invalid value_from is rejected" do
         body = {
           data: {

--- a/services/console/test/controllers/api/v1/pg_dsn_secrets_controller_test.rb
+++ b/services/console/test/controllers/api/v1/pg_dsn_secrets_controller_test.rb
@@ -203,7 +203,7 @@ module Api
             foreign_id: "value-from-pg",
             database: "value-from-db",
             settings: [
-              { name: "centaur.slack_channel_id", value_from: { principal_label: "slack_channel_id" } },
+              { name: "centaur.slack_channel_id", value_from: { principal_field: "slack_channel_id" } },
               { name: "centaur.principal", value_from: { principal_field: "foreign_id" } }
             ],
             dsn: { source_type: "env", config: { var: "VALUE_FROM_DSN" } }
@@ -215,7 +215,7 @@ module Api
 
         assert_equal(
           [
-            { "name" => "centaur.slack_channel_id", "value_from" => { "principal_label" => "slack_channel_id" } },
+            { "name" => "centaur.slack_channel_id", "value_from" => { "principal_field" => "slack_channel_id" } },
             { "name" => "centaur.principal", "value_from" => { "principal_field" => "foreign_id" } }
           ],
           json_body.dig("data", "settings")

--- a/services/console/test/controllers/api/v1/proxy_sync_controller_test.rb
+++ b/services/console/test/controllers/api/v1/proxy_sync_controller_test.rb
@@ -323,12 +323,12 @@ class ProxySyncControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "postgres entries resolve value_from settings against the proxy principal" do
-    @proxy.principal.update!(labels: { "slack_channel_id" => "C0123456789" })
+    @proxy.principal.update!(slack_channel_id: "C0123456789")
     pg = pg_dsn_secrets(:acme_analytics_pg)
     pg.update!(settings: [
       {
         "name" => "centaur.slack_channel_id",
-        "value_from" => { "principal_label" => "slack_channel_id" }
+        "value_from" => { "principal_field" => "slack_channel_id" }
       }
     ])
 

--- a/services/console/test/controllers/console/secrets_controller_test.rb
+++ b/services/console/test/controllers/console/secrets_controller_test.rb
@@ -246,7 +246,7 @@ module Console
       post console_pg_dsn_secrets_url, params: {
         secret: { namespace: "acme", foreign_id: "ui-value-from", database: "valuefromdb" },
         settings: {
-          "0" => { name: "centaur.slack_channel_id", kind: "principal_label", value: "slack_channel_id" },
+          "0" => { name: "centaur.slack_channel_id", kind: "principal_field", value: "slack_channel_id" },
           "1" => { name: "centaur.principal", kind: "principal_field", value: "foreign_id" },
           "2" => { name: "app.tenant", kind: "literal", value: "centaur" }
         },
@@ -256,7 +256,7 @@ module Console
       assert_redirected_to console_secret_path("pg_dsn", secret.oid)
       assert_equal(
         [
-          { "name" => "centaur.slack_channel_id", "value_from" => { "principal_label" => "slack_channel_id" } },
+          { "name" => "centaur.slack_channel_id", "value_from" => { "principal_field" => "slack_channel_id" } },
           { "name" => "centaur.principal", "value_from" => { "principal_field" => "foreign_id" } },
           { "name" => "app.tenant", "value" => "centaur" }
         ],

--- a/services/console/test/migrations/migrate_pg_dsn_identity_labels_to_principal_fields_test.rb
+++ b/services/console/test/migrations/migrate_pg_dsn_identity_labels_to_principal_fields_test.rb
@@ -10,6 +10,8 @@ class MigratePgDsnIdentityLabelsToPrincipalFieldsTest < ActiveSupport::TestCase
       { "name" => "app.channel_id", "value_from" => { "principal_label" => "slack_channel_id" } },
       { "name" => "app.team_id", "value_from" => { "principal_label" => "slack_team_id" } },
       { "name" => "app.email", "value_from" => { "principal_label" => "slack_email" } },
+      { "name" => "app.console_user_id", "value_from" => { "principal_label" => "console-user-id" } },
+      { "name" => "app.console_email", "value_from" => { "principal_label" => "email" } },
       { "name" => "app.tenant", "value_from" => { "principal_label" => "tenant" } },
       { "name" => "app.literal", "value" => "preserved" }
     ])
@@ -22,6 +24,8 @@ class MigratePgDsnIdentityLabelsToPrincipalFieldsTest < ActiveSupport::TestCase
       { "name" => "app.channel_id", "value_from" => { "principal_field" => "slack_channel_id" } },
       { "name" => "app.team_id", "value_from" => { "principal_field" => "slack_team_id" } },
       { "name" => "app.email", "value_from" => { "principal_field" => "slack_email" } },
+      { "name" => "app.console_user_id", "value_from" => { "principal_field" => "console_user_id" } },
+      { "name" => "app.console_email", "value_from" => { "principal_label" => "email" } },
       { "name" => "app.tenant", "value_from" => { "principal_label" => "tenant" } },
       { "name" => "app.literal", "value" => "preserved" }
     ], secret.reload.settings
@@ -31,6 +35,7 @@ class MigratePgDsnIdentityLabelsToPrincipalFieldsTest < ActiveSupport::TestCase
     secret = pg_dsn_secrets(:acme_analytics_pg)
     secret.update_columns(settings: [
       { "name" => "app.channel_id", "value_from" => { "principal_field" => "slack_channel_id" } },
+      { "name" => "app.console_user_id", "value_from" => { "principal_field" => "console_user_id" } },
       { "name" => "app.principal", "value_from" => { "principal_field" => "foreign_id" } }
     ])
 
@@ -38,6 +43,7 @@ class MigratePgDsnIdentityLabelsToPrincipalFieldsTest < ActiveSupport::TestCase
 
     assert_equal [
       { "name" => "app.channel_id", "value_from" => { "principal_label" => "slack_channel_id" } },
+      { "name" => "app.console_user_id", "value_from" => { "principal_label" => "console-user-id" } },
       { "name" => "app.principal", "value_from" => { "principal_field" => "foreign_id" } }
     ], secret.reload.settings
   end

--- a/services/console/test/migrations/migrate_pg_dsn_identity_labels_to_principal_fields_test.rb
+++ b/services/console/test/migrations/migrate_pg_dsn_identity_labels_to_principal_fields_test.rb
@@ -1,0 +1,44 @@
+require "test_helper"
+require Rails.root.join("db/migrate/20260810120000_migrate_pg_dsn_identity_labels_to_principal_fields")
+
+class MigratePgDsnIdentityLabelsToPrincipalFieldsTest < ActiveSupport::TestCase
+  test "rewrites persisted identity label selectors as fields" do
+    secret = pg_dsn_secrets(:acme_analytics_pg)
+    secret.update_columns(settings: [
+      { "name" => "app.kind", "value_from" => { "principal_label" => "kind" } },
+      { "name" => "app.user_id", "value_from" => { "principal_label" => "slack_user_id" } },
+      { "name" => "app.channel_id", "value_from" => { "principal_label" => "slack_channel_id" } },
+      { "name" => "app.team_id", "value_from" => { "principal_label" => "slack_team_id" } },
+      { "name" => "app.email", "value_from" => { "principal_label" => "slack_email" } },
+      { "name" => "app.tenant", "value_from" => { "principal_label" => "tenant" } },
+      { "name" => "app.literal", "value" => "preserved" }
+    ])
+
+    MigratePgDsnIdentityLabelsToPrincipalFields.new.up
+
+    assert_equal [
+      { "name" => "app.kind", "value_from" => { "principal_field" => "kind" } },
+      { "name" => "app.user_id", "value_from" => { "principal_field" => "slack_user_id" } },
+      { "name" => "app.channel_id", "value_from" => { "principal_field" => "slack_channel_id" } },
+      { "name" => "app.team_id", "value_from" => { "principal_field" => "slack_team_id" } },
+      { "name" => "app.email", "value_from" => { "principal_field" => "slack_email" } },
+      { "name" => "app.tenant", "value_from" => { "principal_label" => "tenant" } },
+      { "name" => "app.literal", "value" => "preserved" }
+    ], secret.reload.settings
+  end
+
+  test "down restores identity field selectors as labels" do
+    secret = pg_dsn_secrets(:acme_analytics_pg)
+    secret.update_columns(settings: [
+      { "name" => "app.channel_id", "value_from" => { "principal_field" => "slack_channel_id" } },
+      { "name" => "app.principal", "value_from" => { "principal_field" => "foreign_id" } }
+    ])
+
+    MigratePgDsnIdentityLabelsToPrincipalFields.new.down
+
+    assert_equal [
+      { "name" => "app.channel_id", "value_from" => { "principal_label" => "slack_channel_id" } },
+      { "name" => "app.principal", "value_from" => { "principal_field" => "foreign_id" } }
+    ], secret.reload.settings
+  end
+end

--- a/services/console/test/models/pg_dsn_secret_test.rb
+++ b/services/console/test/models/pg_dsn_secret_test.rb
@@ -126,6 +126,20 @@ class PgDsnSecretTest < ActiveSupport::TestCase
     )
   end
 
+  test "identity principal labels are normalized to fields before persistence" do
+    secret = with_dsn(PgDsnSecret.new(base_attrs(settings: [
+      { "name" => "app.user_id", "value_from" => { "principal_label" => "slack_user_id" } },
+      { "name" => "app.tenant", "value_from" => { "principal_label" => "tenant" } }
+    ])))
+
+    secret.save!
+
+    assert_equal [
+      { "name" => "app.user_id", "value_from" => { "principal_field" => "slack_user_id" } },
+      { "name" => "app.tenant", "value_from" => { "principal_label" => "tenant" } }
+    ], secret.reload.settings
+  end
+
   test "to_proxy_dsn resolves value_from principal labels and fields" do
     principal = principals(:acme_channel)
     principal.update!(

--- a/services/console/test/models/pg_dsn_secret_test.rb
+++ b/services/console/test/models/pg_dsn_secret_test.rb
@@ -190,6 +190,58 @@ class PgDsnSecretTest < ActiveSupport::TestCase
     )
   end
 
+  test "to_proxy_dsn resolves first-class identity fields while compatibility labels remain supported" do
+    principal = principals(:acme_channel)
+    principal.update!(
+      slack_user_id: "U0123456789",
+      slack_team_id: "T0123456789",
+      slack_email: "ada@example.com"
+    )
+    secret = with_dsn(PgDsnSecret.new(base_attrs(settings: [
+      { "name" => "app.kind", "value_from" => { "principal_field" => "kind" } },
+      { "name" => "app.user_id", "value_from" => { "principal_field" => "slack_user_id" } },
+      { "name" => "app.channel_id", "value_from" => { "principal_field" => "slack_channel_id" } },
+      { "name" => "app.team_id", "value_from" => { "principal_field" => "slack_team_id" } },
+      { "name" => "app.email", "value_from" => { "principal_field" => "slack_email" } }
+    ])))
+
+    assert secret.valid?
+    assert_equal(
+      [
+        { "name" => "app.kind", "value" => "slack_channel" },
+        { "name" => "app.user_id", "value" => "U0123456789" },
+        { "name" => "app.channel_id", "value" => "C0123456789" },
+        { "name" => "app.team_id", "value" => "T0123456789" },
+        { "name" => "app.email", "value" => "ada@example.com" }
+      ],
+      secret.to_proxy_dsn(principal: principal)["settings"]
+    )
+  end
+
+  test "to_proxy_dsn resolves first-class console user fields" do
+    user = users(:acme_admin)
+    principal = Principal.create!(
+      namespace: "acme",
+      kind: "console_user",
+      console_user_id: user.id,
+      console_user_email: user.email,
+      created_by: user
+    )
+    secret = with_dsn(PgDsnSecret.new(base_attrs(settings: [
+      { "name" => "app.user_id", "value_from" => { "principal_field" => "console_user_id" } },
+      { "name" => "app.email", "value_from" => { "principal_field" => "console_user_email" } }
+    ])))
+
+    assert secret.valid?
+    assert_equal(
+      [
+        { "name" => "app.user_id", "value" => user.id.to_s },
+        { "name" => "app.email", "value" => user.email }
+      ],
+      secret.to_proxy_dsn(principal: principal)["settings"]
+    )
+  end
+
   test "to_proxy_dsn resolves Slack history channel ids from permission rows" do
     principal = principals(:acme_channel)
     SlackChannelPermission.create!(
@@ -330,7 +382,7 @@ class PgDsnSecretTest < ActiveSupport::TestCase
     ])))
     assert_not secret.valid?
     assert_includes secret.errors[:settings],
-      %([0] unknown principal_field "labels" (one of: id, namespace, foreign_id, name, slack_history_channel_ids))
+      %([0] unknown principal_field "labels" (one of: #{PgDsnSecret::PRINCIPAL_FIELDS.join(", ")}))
   end
 
   test "settings with a valid empty value are accepted and stringified" do

--- a/services/console/test/models/pg_dsn_secret_test.rb
+++ b/services/console/test/models/pg_dsn_secret_test.rb
@@ -128,7 +128,7 @@ class PgDsnSecretTest < ActiveSupport::TestCase
 
   test "identity principal labels are normalized to fields before persistence" do
     secret = with_dsn(PgDsnSecret.new(base_attrs(settings: [
-      { "name" => "app.user_id", "value_from" => { "principal_label" => "slack_user_id" } },
+      { name: "app.user_id", value_from: { principal_label: "slack_user_id" } },
       { "name" => "app.console_user_id", "value_from" => { "principal_label" => "console-user-id" } },
       { "name" => "app.console_email", "value_from" => { "principal_label" => "email" } },
       { "name" => "app.tenant", "value_from" => { "principal_label" => "tenant" } }

--- a/services/console/test/models/pg_dsn_secret_test.rb
+++ b/services/console/test/models/pg_dsn_secret_test.rb
@@ -129,6 +129,8 @@ class PgDsnSecretTest < ActiveSupport::TestCase
   test "identity principal labels are normalized to fields before persistence" do
     secret = with_dsn(PgDsnSecret.new(base_attrs(settings: [
       { "name" => "app.user_id", "value_from" => { "principal_label" => "slack_user_id" } },
+      { "name" => "app.console_user_id", "value_from" => { "principal_label" => "console-user-id" } },
+      { "name" => "app.console_email", "value_from" => { "principal_label" => "email" } },
       { "name" => "app.tenant", "value_from" => { "principal_label" => "tenant" } }
     ])))
 
@@ -136,6 +138,8 @@ class PgDsnSecretTest < ActiveSupport::TestCase
 
     assert_equal [
       { "name" => "app.user_id", "value_from" => { "principal_field" => "slack_user_id" } },
+      { "name" => "app.console_user_id", "value_from" => { "principal_field" => "console_user_id" } },
+      { "name" => "app.console_email", "value_from" => { "principal_label" => "email" } },
       { "name" => "app.tenant", "value_from" => { "principal_label" => "tenant" } }
     ], secret.reload.settings
   end

--- a/services/console/test/models/pg_dsn_secret_test.rb
+++ b/services/console/test/models/pg_dsn_secret_test.rb
@@ -385,6 +385,16 @@ class PgDsnSecretTest < ActiveSupport::TestCase
       %([0] unknown principal_field "labels" (one of: #{PgDsnSecret::PRINCIPAL_FIELDS.join(", ")}))
   end
 
+  test "an unknown principal_field cannot invoke a principal method while rendering" do
+    principal = principals(:acme_channel)
+    secret = with_dsn(PgDsnSecret.new(base_attrs(settings: [
+      { "name" => "app.tenant", "value_from" => { "principal_field" => "destroy" } }
+    ])))
+
+    assert_equal "", secret.to_proxy_dsn(principal: principal).dig("settings", 0, "value")
+    assert Principal.exists?(principal.id)
+  end
+
   test "settings with a valid empty value are accepted and stringified" do
     secret = with_dsn(PgDsnSecret.new(base_attrs(settings: [ { "name" => "app.tenant", "value" => "" } ])))
     assert secret.valid?

--- a/services/console/test/models/pg_dsn_secret_test.rb
+++ b/services/console/test/models/pg_dsn_secret_test.rb
@@ -249,7 +249,7 @@ class PgDsnSecretTest < ActiveSupport::TestCase
     assert secret.valid?
     assert_equal(
       [
-        { "name" => "app.user_id", "value" => user.id.to_s },
+        { "name" => "app.user_id", "value" => user.oid },
         { "name" => "app.email", "value" => user.email }
       ],
       secret.to_proxy_dsn(principal: principal)["settings"]

--- a/services/console/test/models/principal_sync_config_snapshot_test.rb
+++ b/services/console/test/models/principal_sync_config_snapshot_test.rb
@@ -236,12 +236,12 @@ class PrincipalSyncConfigSnapshotTest < ActiveSupport::TestCase
 
   test "sync_postgres resolves value_from settings against the principal" do
     principal = principals(:globex_user)
-    principal.update!(labels: { "slack_channel_id" => "C9999999999" })
+    principal.update!(slack_channel_id: "C9999999999")
     pg = pg_dsn_secrets(:acme_analytics_pg)
     pg.update!(settings: [
       {
         "name" => "centaur.slack_channel_id",
-        "value_from" => { "principal_label" => "slack_channel_id" }
+        "value_from" => { "principal_field" => "slack_channel_id" }
       },
       { "name" => "centaur.principal", "value_from" => { "principal_field" => "foreign_id" } }
     ])

--- a/tools/productivity/company_context/pyproject.toml
+++ b/tools/productivity/company_context/pyproject.toml
@@ -34,7 +34,7 @@ database = "centaur"
 secret_ref = "CENTAUR_POSTGRES_DSN"
 role = "centaur_slack_reader"
 settings = [
-    { name = "centaur.slack_channel_id", value_from = { principal_label = "slack_channel_id" } },
-    { name = "centaur.slack_team_id", value_from = { principal_label = "slack_team_id" } },
-    { name = "centaur.slack_user_id", value_from = { principal_label = "slack_user_id" } },
+    { name = "centaur.slack_channel_id", value_from = { principal_field = "slack_channel_id" } },
+    { name = "centaur.slack_team_id", value_from = { principal_field = "slack_team_id" } },
+    { name = "centaur.slack_user_id", value_from = { principal_field = "slack_user_id" } },
 ]


### PR DESCRIPTION
Adds first-class principal-field resolution for PG DSN identity settings while retaining legacy label compatibility. Migrates stored kind and Slack identity selectors and updates company-context registration paths so new API pods stop writing legacy selectors. Custom principal labels remain supported.