### PR TITLE
feat(console): paginate principal detail sections

### DIFF
--- a/services/console/app/controllers/console_controller.rb
+++ b/services/console/app/controllers/console_controller.rb
@@ -11,6 +11,7 @@ class ConsoleController < ApplicationController
   before_action :require_admin
 
   PRINCIPALS_PER_PAGE = 50
+  PRINCIPAL_DETAIL_PER_PAGE = 50
 
   # Friendly labels for the source backend (and the gcp_auth credentials_provider
   # type). The secrets table shows only this -- the full reference lives on the
@@ -45,8 +46,8 @@ class ConsoleController < ApplicationController
     @principal = Principal.find_by_oid!(params[:id])
     load_slack_channel_permission_form(@principal)
     @inherited_slack_channel_permissions = @principal.inherited_slack_channel_permissions_payload
-    @roles = @principal.roles.order(:id)
-    @granted = {
+    load_principal_roles
+    effective_grant_relations = {
       "static" => @principal.granted_static_secrets,
       "gcp_auth" => @principal.granted_gcp_auth_secrets,
       "gcp_id_token" => @principal.granted_gcp_id_token_secrets,
@@ -55,22 +56,28 @@ class ConsoleController < ApplicationController
       "pg_dsn" => @principal.granted_pg_dsn_secrets,
       "hmac" => @principal.granted_hmac_secrets
     }
+    effective_page = PrincipalEffectiveGrantsPage.new(
+      principal: @principal,
+      relations: effective_grant_relations,
+      page: params[:effective_grants_page],
+      per_page: PRINCIPAL_DETAIL_PER_PAGE
+    ).call
+    @granted = effective_page.records_by_kind
+    @grant_sources = effective_page.sources_by_key
+    @effective_grants_page = effective_page.page
+    @effective_grants_total_pages = effective_page.total_pages
+    @effective_grants_total_count = effective_page.total_count
+
     # Direct grants (revocable here) -- distinct from @granted, which also folds in
     # grants inherited from roles.
-    @direct_grants = @principal.grants
+    direct_grants_scope = @principal.grants.order(:id)
+    @direct_grants_total_count = direct_grants_scope.count
+    @direct_grants_total_pages = total_pages(@direct_grants_total_count, PRINCIPAL_DETAIL_PER_PAGE)
+    @direct_grants_page = bounded_page(params[:direct_grants_page], @direct_grants_total_pages)
+    @direct_grants = direct_grants_scope
       .includes(Grant::GRANTABLE_ASSOCIATIONS)
-      .order(:id)
-    # How each effective secret is reached, for the Source column: keyed by
-    # [kind, secret_id], a list of { type: :direct } / { type: :role, role: } --
-    # a secret can be granted directly and/or through one or more roles.
-    @grant_sources = Hash.new { |h, k| h[k] = [] }
-    @principal.effective_grants.includes(:role).each do |grant|
-      assoc = Grant::GRANTABLE_ASSOCIATIONS.find { |a| grant.public_send("#{a}_id") }
-      next unless assoc
-      kind = assoc.to_s.delete_suffix("_secret")
-      @grant_sources[[ kind, grant.public_send("#{assoc}_id") ]] <<
-        (grant.role ? { type: :role, role: grant.role } : { type: :direct })
-    end
+      .limit(PRINCIPAL_DETAIL_PER_PAGE)
+      .offset((@direct_grants_page - 1) * PRINCIPAL_DETAIL_PER_PAGE)
     # Assignment options for the inline forms. Roles are namespace-scoped, so
     # only same-namespace roles are assignable from this principal. Secrets span
     # all namespaces; the namespace is shown as a label on each option.
@@ -81,11 +88,14 @@ class ConsoleController < ApplicationController
       .where(namespace: @principal.namespace)
       .where.not(id: @principal.role_ids)
       .order(:id)
-    granted_ids = Hash.new { |h, k| h[k] = [] }
-    @direct_grants.each do |grant|
-      assoc = Grant::GRANTABLE_ASSOCIATIONS.find { |a| grant.public_send("#{a}_id") }
-      next unless assoc
-      granted_ids[assoc.to_s.delete_suffix("_secret")] << grant.public_send("#{assoc}_id")
+    granted_ids = Hash.new { |hash, key| hash[key] = [] }
+    @principal.grants.pluck(*Grant::GRANTABLE_ASSOCIATIONS.map { |assoc| "#{assoc}_id" }).each do |ids|
+      ids.each_with_index do |id, index|
+        next unless id
+
+        kind = Grant::GRANTABLE_ASSOCIATIONS.fetch(index).to_s.delete_suffix("_secret")
+        granted_ids[kind] << id
+      end
     end
     @assignable_secrets = SECRET_KINDS.each_with_object({}) do |(kind, cfg), acc|
       acc[kind] = cfg[:model].where.not(id: granted_ids[kind]).order(:namespace, :id)
@@ -210,6 +220,25 @@ class ConsoleController < ApplicationController
   end
 
   private
+
+  def load_principal_roles
+    scope = @principal.roles.order(:id)
+    @roles_total_count = scope.count
+    @roles_total_pages = total_pages(@roles_total_count, PRINCIPAL_DETAIL_PER_PAGE)
+    @roles_page = bounded_page(params[:roles_page], @roles_total_pages)
+    @roles = scope
+      .limit(PRINCIPAL_DETAIL_PER_PAGE)
+      .offset((@roles_page - 1) * PRINCIPAL_DETAIL_PER_PAGE)
+  end
+
+  def total_pages(total_count, per_page)
+    [ (total_count.to_f / per_page).ceil, 1 ].max
+  end
+
+  def bounded_page(value, total_pages)
+    page = Integer(value.to_s, 10, exception: false) || 1
+    [ [ page, 1 ].max, total_pages ].min
+  end
 
   def page_param
     page = Integer(params[:page].to_s, 10, exception: false) || 1

--- a/services/console/app/services/principal_effective_grants_page.rb
+++ b/services/console/app/services/principal_effective_grants_page.rb
@@ -38,16 +38,11 @@ class PrincipalEffectiveGrantsPage
 
   def effective_secret_counts
     kinds = relations.keys
-    unique_ids = kinds.to_h { |kind| [ kind, {} ] }
     columns = kinds.map { |kind| GRANT_COLUMN_BY_KIND.fetch(kind) }
+    aggregates = columns.map { |column| Grant.arel_table[column].count(true) }
+    counts = principal.effective_grants.pick(*aggregates)
 
-    principal.effective_grants.pluck(*columns).each do |ids|
-      ids.each_with_index do |id, index|
-        unique_ids.fetch(kinds.fetch(index))[id] = true if id
-      end
-    end
-
-    unique_ids.transform_values(&:size)
+    kinds.zip(Array(counts)).to_h
   end
 
   def page_records(counts, offset:)

--- a/services/console/app/services/principal_effective_grants_page.rb
+++ b/services/console/app/services/principal_effective_grants_page.rb
@@ -1,0 +1,98 @@
+class PrincipalEffectiveGrantsPage
+  Result = Data.define(:records_by_kind, :sources_by_key, :page, :total_pages, :total_count)
+
+  def initialize(principal:, relations:, page:, per_page:)
+    @principal = principal
+    @relations = relations
+    @requested_page = page
+    @per_page = per_page
+  end
+
+  def call
+    counts = effective_secret_counts
+    total_count = counts.values.sum
+    total_pages = [ (total_count.to_f / per_page).ceil, 1 ].max
+    page = [ normalized_page, total_pages ].min
+    records_by_kind = page_records(counts, offset: (page - 1) * per_page)
+
+    Result.new(
+      records_by_kind: records_by_kind,
+      sources_by_key: sources_for(records_by_kind),
+      page: page,
+      total_pages: total_pages,
+      total_count: total_count
+    )
+  end
+
+  private
+
+  attr_reader :principal, :relations, :requested_page, :per_page
+
+  def normalized_page
+    page = Integer(requested_page.to_s, 10, exception: false) || 1
+    page < 1 ? 1 : page
+  end
+
+  def effective_secret_counts
+    kinds = relations.keys
+    unique_ids = kinds.to_h { |kind| [ kind, {} ] }
+    columns = kinds.map { |kind| "#{kind}_secret_id" }
+
+    principal.effective_grants.pluck(*columns).each do |ids|
+      ids.each_with_index do |id, index|
+        unique_ids.fetch(kinds.fetch(index))[id] = true if id
+      end
+    end
+
+    unique_ids.transform_values(&:size)
+  end
+
+  def page_records(counts, offset:)
+    remaining = per_page
+    records = relations.to_h { |kind, _relation| [ kind, [] ] }
+
+    relations.each do |kind, relation|
+      count = counts.fetch(kind)
+      if offset >= count
+        offset -= count
+        next
+      end
+
+      limit = [ remaining, count - offset ].min
+      records[kind] = relation.offset(offset).limit(limit).to_a
+      remaining -= limit
+      break if remaining.zero?
+
+      offset = 0
+    end
+
+    records
+  end
+
+  # How each displayed effective secret is reached, keyed by [kind, secret_id].
+  # A value contains { type: :direct } and/or { type: :role, role: } entries
+  # because the same secret can be granted directly and through several roles.
+  # Limit this attribution query to the current page rather than loading every
+  # effective grant merely to render one bounded table page.
+  def sources_for(records_by_kind)
+    selected = records_by_kind.filter_map do |kind, records|
+      ids = records.map(&:id)
+      [ kind, ids ] if ids.any?
+    end
+    return {} if selected.empty?
+
+    selected_scope = selected.reduce(Grant.none) do |scope, (kind, ids)|
+      scope.or(Grant.where("#{kind}_secret_id" => ids))
+    end
+    grants = principal.effective_grants.merge(selected_scope).includes(:role)
+
+    grants.each_with_object(Hash.new { |hash, key| hash[key] = [] }) do |grant, sources|
+      association = Grant::GRANTABLE_ASSOCIATIONS.find { |name| grant.public_send("#{name}_id") }
+      next unless association
+
+      kind = association.to_s.delete_suffix("_secret")
+      key = [ kind, grant.public_send("#{association}_id") ]
+      sources[key] << (grant.role ? { type: :role, role: grant.role } : { type: :direct })
+    end
+  end
+end

--- a/services/console/app/services/principal_effective_grants_page.rb
+++ b/services/console/app/services/principal_effective_grants_page.rb
@@ -1,5 +1,8 @@
 class PrincipalEffectiveGrantsPage
   Result = Data.define(:records_by_kind, :sources_by_key, :page, :total_pages, :total_count)
+  GRANT_COLUMN_BY_KIND = Grant::GRANTABLE_ASSOCIATIONS.to_h do |association|
+    [ association.to_s.delete_suffix("_secret"), :"#{association}_id" ]
+  end.freeze
 
   def initialize(principal:, relations:, page:, per_page:)
     @principal = principal
@@ -36,7 +39,7 @@ class PrincipalEffectiveGrantsPage
   def effective_secret_counts
     kinds = relations.keys
     unique_ids = kinds.to_h { |kind| [ kind, {} ] }
-    columns = kinds.map { |kind| "#{kind}_secret_id" }
+    columns = kinds.map { |kind| GRANT_COLUMN_BY_KIND.fetch(kind) }
 
     principal.effective_grants.pluck(*columns).each do |ids|
       ids.each_with_index do |id, index|
@@ -82,7 +85,7 @@ class PrincipalEffectiveGrantsPage
     return {} if selected.empty?
 
     selected_scope = selected.reduce(Grant.none) do |scope, (kind, ids)|
-      scope.or(Grant.where("#{kind}_secret_id" => ids))
+      scope.or(Grant.where(GRANT_COLUMN_BY_KIND.fetch(kind) => ids))
     end
     grants = principal.effective_grants.merge(selected_scope).includes(:role)
 

--- a/services/console/app/views/console/_pagination.html.erb
+++ b/services/console/app/views/console/_pagination.html.erb
@@ -1,6 +1,12 @@
-<%# Prev/next pager footer. Locals: page, total_pages, total_count, unit.
+<%# Prev/next pager footer. Locals: page, total_pages, total_count, unit,
+    optional page_param (defaults to "page") and anchor.
     Preserves the current query params (filters) while swapping the page. %>
-<% page_url = ->(n) { "#{request.path}?#{request.query_parameters.merge("page" => n).to_query}" } %>
+<% page_param = local_assigns.fetch(:page_param, "page").to_s %>
+<% anchor = local_assigns[:anchor].presence %>
+<% page_url = ->(n) do
+     query = request.query_parameters.merge(page_param => n).to_query
+     "#{request.path}?#{query}#{"##{anchor}" if anchor}"
+   end %>
 <div class="flex items-center justify-between gap-4 border-t border-ink-700 px-5 py-3 text-xs text-zinc-500">
   <div>
     <%= number_with_delimiter(total_count) %> <%= unit.pluralize(total_count) %>

--- a/services/console/app/views/console/principal.html.erb
+++ b/services/console/app/views/console/principal.html.erb
@@ -91,7 +91,7 @@
 </section>
 
 <!-- Roles -->
-<section class="mb-8">
+<section id="roles" class="mb-8">
   <div class="mb-4 flex flex-wrap items-end justify-between gap-3">
     <div>
       <h2 class="mb-1 text-xs font-semibold uppercase tracking-wider text-zinc-500">Roles</h2>
@@ -134,6 +134,13 @@
           <% end %>
         </tbody>
       </table>
+      <%= render "console/pagination",
+                 page: @roles_page,
+                 total_pages: @roles_total_pages,
+                 total_count: @roles_total_count,
+                 unit: "role",
+                 page_param: :roles_page,
+                 anchor: "roles" %>
     </div>
   <% else %>
     <div class="empty-state">No roles assigned.</div>
@@ -141,7 +148,7 @@
 </section>
 
 <!-- Direct grants -->
-<section class="mb-8">
+<section id="direct-grants" class="mb-8">
   <h2 class="mb-1 text-xs font-semibold uppercase tracking-wider text-zinc-500">Direct Grants</h2>
   <p class="mb-4 text-sm text-zinc-500">Secrets granted to this principal directly. Grants inherited from roles are managed on the role, not here.</p>
 
@@ -198,6 +205,13 @@
           <% end %>
         </tbody>
       </table>
+      <%= render "console/pagination",
+                 page: @direct_grants_page,
+                 total_pages: @direct_grants_total_pages,
+                 total_count: @direct_grants_total_count,
+                 unit: "direct grant",
+                 page_param: :direct_grants_page,
+                 anchor: "direct-grants" %>
     </div>
   <% else %>
     <div class="mb-4 rounded-xl border border-dashed border-ink-600 bg-ink-850/40 px-5 py-10 text-center text-zinc-600">
@@ -223,12 +237,11 @@
 </section>
 
 <!-- Effective grants -->
-<section>
+<section id="effective-grants">
   <h2 class="mb-1 text-xs font-semibold uppercase tracking-wider text-zinc-500">Effective Grants</h2>
   <p class="mb-4 text-sm text-zinc-500">Every secret this principal resolves to: the direct grants above plus grants inherited from its roles. Read-only.</p>
 
-  <% total = @granted.values.sum(&:size) %>
-  <% if total.zero? %>
+  <% if @effective_grants_total_count.zero? %>
     <div class="rounded-xl border border-dashed border-ink-600 bg-ink-850/40 px-5 py-10 text-center text-zinc-600">
       This principal has no effective grants.
     </div>
@@ -296,6 +309,13 @@
           <% end %>
         </tbody>
       </table>
+      <%= render "console/pagination",
+                 page: @effective_grants_page,
+                 total_pages: @effective_grants_total_pages,
+                 total_count: @effective_grants_total_count,
+                 unit: "effective grant",
+                 page_param: :effective_grants_page,
+                 anchor: "effective-grants" %>
     </div>
   <% end %>
 </section>

--- a/services/console/test/controllers/console_controller_test.rb
+++ b/services/console/test/controllers/console_controller_test.rb
@@ -395,6 +395,73 @@ class ConsoleControllerTest < ActionDispatch::IntegrationTest
     assert_select "a[href=?]", console_secret_path("static", static_secrets(:github_token_inject).oid)
   end
 
+  test "principal detail paginates roles, direct grants, and effective grants independently" do
+    principal = principals(:acme_channel)
+    now = Time.current
+    role_ids = Role.insert_all!((1..50).map do |number|
+      {
+        namespace: principal.namespace,
+        foreign_id: "detail-page-role-#{number}",
+        name: "Detail page role #{number}",
+        labels: {},
+        assign_by_default: false,
+        created_by_id: @operator.id,
+        created_at: now,
+        updated_at: now
+      }
+    end, returning: %w[id]).rows.flatten
+    PrincipalRole.insert_all!(role_ids.map do |role_id|
+      { principal_id: principal.id, role_id: role_id, created_at: now, updated_at: now }
+    end)
+
+    secret_ids = StaticSecret.insert_all!((1..50).map do |number|
+      {
+        namespace: principal.namespace,
+        foreign_id: "detail-page-secret-#{number}",
+        name: "Detail page secret #{number}",
+        kind: "custom",
+        labels: {},
+        inject_config: { "header" => "X-Detail-Page-#{number}" },
+        created_by_id: @operator.id,
+        created_at: now,
+        updated_at: now
+      }
+    end, returning: %w[id]).rows.flatten
+    Grant.insert_all!(secret_ids.map do |secret_id|
+      {
+        principal_id: principal.id,
+        static_secret_id: secret_id,
+        priority: Grant::DEFAULT_DIRECT_PRIORITY,
+        created_by_id: @operator.id,
+        created_at: now,
+        updated_at: now
+      }
+    end)
+
+    get console_principal_url(principal.oid), params: {
+      roles_page: 2,
+      direct_grants_page: 2,
+      effective_grants_page: 2
+    }
+
+    assert_response :ok
+    assert_select "section#roles" do
+      assert_select "tbody tr", count: 1
+      assert_select "a[href*='roles_page=1'][href$='#roles']", text: "Previous"
+      assert_select "div", text: /51 roles.*page 2 of 2/
+    end
+    assert_select "section#direct-grants" do
+      assert_select "tbody tr", count: 3
+      assert_select "a[href*='direct_grants_page=1'][href$='#direct-grants']", text: "Previous"
+      assert_select "div", text: /53 direct grants.*page 2 of 2/
+    end
+    assert_select "section#effective-grants" do
+      assert_select "tbody tr", count: 4
+      assert_select "a[href*='effective_grants_page=1'][href$='#effective-grants']", text: "Previous"
+      assert_select "div", text: /54 effective grants.*page 2 of 2/
+    end
+  end
+
   test "effective grants table sources each secret as direct or via a role" do
     principal = principals(:acme_channel) # direct grants + acme_prod_api_key via the acme_infra role
     get console_principal_url(principal.oid)


### PR DESCRIPTION
## Summary

- paginate assigned roles, direct grants, and effective grants independently on the principal detail page
- preserve each section's pagination state and return navigation to the relevant section anchor
- load effective-grant records and source attribution only for the current page

## Why

Principal detail pages rendered every assigned role and grant at once. On high-cardinality installations this produced large responses and unnecessary record loading even when an operator only needed the first page.

Each section now uses bounded 50-row offset pagination, following the existing Console list pagination pattern. Slack catalog behavior is intentionally unchanged and will be addressed separately.

## Validation

- `bundle exec rails test test/controllers/console_controller_test.rb test/controllers/console/workflows_controller_test.rb` (44 tests, 327 assertions)
- `bundle exec rubocop app/controllers/console_controller.rb app/services/principal_effective_grants_page.rb test/controllers/console_controller_test.rb`
- `git diff --check`
