### PR TITLE
fix(workflows): classify child start outcomes

### DIFF
--- a/services/api-rs/crates/centaur-workflows/src/lib.rs
+++ b/services/api-rs/crates/centaur-workflows/src/lib.rs
@@ -3361,10 +3361,13 @@ async fn handle_python_context_request(
             }
         }
         Some("ctx.workflow.start") => {
-            match start_python_child_workflow(message, input, workflow_clients).await {
-                Ok(value) => Ok(value),
-                Err(error) => Err(error.to_string()),
-            }
+            return Ok(handle_python_child_start_context_request(
+                &request_id,
+                message,
+                input,
+                workflow_clients,
+            )
+            .await);
         }
         Some("ctx.call_tool") => match call_python_workflow_tool(message).await {
             Ok(value) => Ok(value),
@@ -3378,27 +3381,86 @@ async fn handle_python_context_request(
         }
         other => Err(format!("unsupported context request type {other:?}")),
     };
-    Ok(match result {
+    Ok(python_context_response(&request_id, result, None))
+}
+
+async fn handle_python_child_start_context_request(
+    request_id: &str,
+    message: &Value,
+    input: &WorkflowTaskInput,
+    workflow_clients: &WorkflowQueueClients,
+) -> Value {
+    match start_python_child_workflow(message, input, workflow_clients).await {
+        Ok(value) => python_context_response(request_id, Ok(value), None),
+        Err(error) => {
+            python_context_response(request_id, Err(error.to_string()), Some(error.error_code()))
+        }
+    }
+}
+
+fn python_context_response(
+    request_id: &str,
+    result: Result<Value, String>,
+    error_code: Option<&str>,
+) -> Value {
+    match result {
         Ok(value) => json!({
             "type": "ctx.response",
             "request_id": request_id,
             "ok": true,
             "value": value,
         }),
-        Err(error) => json!({
-            "type": "ctx.response",
-            "request_id": request_id,
-            "ok": false,
-            "error": error,
-        }),
-    })
+        Err(error) => {
+            let mut response = json!({
+                "type": "ctx.response",
+                "request_id": request_id,
+                "ok": false,
+                "error": error,
+            });
+            if let Some(error_code) = error_code.filter(|code| !code.is_empty()) {
+                response["error_code"] = json!(error_code);
+            }
+            response
+        }
+    }
+}
+
+struct ChildWorkflowStartError {
+    error: WorkflowRuntimeError,
+    error_code: &'static str,
+}
+
+impl ChildWorkflowStartError {
+    fn rejected_before_spawn(error: WorkflowRuntimeError) -> Self {
+        Self {
+            error,
+            error_code: "workflow_start_rejected_before_spawn",
+        }
+    }
+
+    fn outcome_unknown(error: WorkflowRuntimeError) -> Self {
+        Self {
+            error,
+            error_code: "workflow_start_outcome_unknown",
+        }
+    }
+
+    fn error_code(&self) -> &'static str {
+        self.error_code
+    }
+}
+
+impl std::fmt::Display for ChildWorkflowStartError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.error.fmt(formatter)
+    }
 }
 
 async fn start_python_child_workflow(
     message: &Value,
     parent: &WorkflowTaskInput,
     workflow_clients: &WorkflowQueueClients,
-) -> Result<Value, WorkflowRuntimeError> {
+) -> Result<Value, ChildWorkflowStartError> {
     let workflow_name = message
         .get("workflow_name")
         .and_then(Value::as_str)
@@ -3408,12 +3470,17 @@ async fn start_python_child_workflow(
             WorkflowRuntimeError::BadRequest(
                 "ctx.workflow.start requires a non-empty workflow_name".to_owned(),
             )
-        })?;
-    WorkflowEnablement::from_env()?.ensure_enabled(workflow_name)?;
+        })
+        .map_err(ChildWorkflowStartError::rejected_before_spawn)?;
+    WorkflowEnablement::from_env()
+        .and_then(|enablement| enablement.ensure_enabled(workflow_name))
+        .map_err(ChildWorkflowStartError::rejected_before_spawn)?;
     let child_input = message.get("input").cloned().unwrap_or_else(|| json!({}));
     if !child_input.is_object() {
-        return Err(WorkflowRuntimeError::BadRequest(
-            "ctx.workflow.start input must be an object".to_owned(),
+        return Err(ChildWorkflowStartError::rejected_before_spawn(
+            WorkflowRuntimeError::BadRequest(
+                "ctx.workflow.start input must be an object".to_owned(),
+            ),
         ));
     }
     let idempotency_key = message
@@ -3441,7 +3508,8 @@ async fn start_python_child_workflow(
                 ..SpawnOptions::default()
             },
         )
-        .await?;
+        .await
+        .map_err(|error| ChildWorkflowStartError::outcome_unknown(error.into()))?;
     Ok(json!({
         "workflow_name": workflow_name,
         "task_id": spawn.task_id,
@@ -4151,6 +4219,93 @@ pub enum WorkflowRuntimeError {
 mod tests {
     use super::*;
     use chrono::TimeZone;
+    use sqlx::postgres::PgPoolOptions;
+
+    fn child_start_test_clients() -> WorkflowQueueClients {
+        let pool = PgPoolOptions::new()
+            .connect_lazy("postgres://localhost/absurd")
+            .expect("test URL should be valid without connecting");
+        let client = Client::from_pool(pool).expect("client should accept a lazy pool");
+        WorkflowQueueClients {
+            standard: client.clone(),
+            slack_live: client.clone(),
+            etl: client.clone(),
+            etl_backfill: client,
+        }
+    }
+
+    fn child_start_test_parent() -> WorkflowTaskInput {
+        WorkflowTaskInput {
+            workflow_name: "parent".to_owned(),
+            input: json!({}),
+            harness_type: HarnessType::Codex,
+        }
+    }
+
+    #[tokio::test]
+    async fn rejected_child_start_includes_rejected_before_spawn_code_in_context_response() {
+        let response = handle_python_child_start_context_request(
+            "child-start",
+            &json!({"type": "ctx.workflow.start", "request_id": "child-start"}),
+            &child_start_test_parent(),
+            &child_start_test_clients(),
+        )
+        .await;
+
+        assert_eq!(response["ok"], json!(false));
+        assert_eq!(
+            response["error"],
+            json!("ctx.workflow.start requires a non-empty workflow_name")
+        );
+        assert_eq!(
+            response["error_code"],
+            json!("workflow_start_rejected_before_spawn")
+        );
+    }
+
+    #[tokio::test]
+    async fn failed_child_spawn_includes_unknown_outcome_code_in_context_response() {
+        let response = handle_python_child_start_context_request(
+            "child-start",
+            &json!({
+                "type": "ctx.workflow.start",
+                "workflow_name": "child",
+                "input": {},
+            }),
+            &child_start_test_parent(),
+            &child_start_test_clients(),
+        )
+        .await;
+
+        assert_eq!(response["ok"], json!(false));
+        assert_eq!(
+            response["error_code"],
+            json!("workflow_start_outcome_unknown")
+        );
+    }
+
+    #[test]
+    fn non_start_context_failure_keeps_legacy_response_shape() {
+        let response =
+            python_context_response("agent-turn", Err("agent unavailable".to_owned()), None);
+
+        assert_eq!(response["ok"], json!(false));
+        assert_eq!(response["error"], json!("agent unavailable"));
+        assert!(response.get("error_code").is_none());
+    }
+
+    #[test]
+    fn successful_context_response_never_includes_an_error_code() {
+        let response = python_context_response(
+            "child-start",
+            Ok(json!({"created": true})),
+            Some("workflow_start_outcome_unknown"),
+        );
+
+        assert_eq!(response["ok"], json!(true));
+        assert_eq!(response["value"], json!({"created": true}));
+        assert!(response.get("error_code").is_none());
+    }
 
     #[test]
     fn python_event_names_are_collision_free() {

--- a/services/api-rs/crates/centaur-workflows/src/lib.rs
+++ b/services/api-rs/crates/centaur-workflows/src/lib.rs
@@ -3361,13 +3361,10 @@ async fn handle_python_context_request(
             }
         }
         Some("ctx.workflow.start") => {
-            return Ok(handle_python_child_start_context_request(
+            return Ok(python_child_start_context_response(
                 &request_id,
-                message,
-                input,
-                workflow_clients,
-            )
-            .await);
+                start_python_child_workflow(message, input, workflow_clients).await,
+            ));
         }
         Some("ctx.call_tool") => match call_python_workflow_tool(message).await {
             Ok(value) => Ok(value),
@@ -3384,13 +3381,11 @@ async fn handle_python_context_request(
     Ok(python_context_response(&request_id, result, None))
 }
 
-async fn handle_python_child_start_context_request(
+fn python_child_start_context_response(
     request_id: &str,
-    message: &Value,
-    input: &WorkflowTaskInput,
-    workflow_clients: &WorkflowQueueClients,
+    result: Result<Value, ChildWorkflowStartError>,
 ) -> Value {
-    match start_python_child_workflow(message, input, workflow_clients).await {
+    match result {
         Ok(value) => python_context_response(request_id, Ok(value), None),
         Err(error) => {
             python_context_response(request_id, Err(error.to_string()), Some(error.error_code()))
@@ -4219,38 +4214,17 @@ pub enum WorkflowRuntimeError {
 mod tests {
     use super::*;
     use chrono::TimeZone;
-    use sqlx::postgres::PgPoolOptions;
 
-    fn child_start_test_clients() -> WorkflowQueueClients {
-        let pool = PgPoolOptions::new()
-            .connect_lazy("postgres://localhost/absurd")
-            .expect("test URL should be valid without connecting");
-        let client = Client::from_pool(pool).expect("client should accept a lazy pool");
-        WorkflowQueueClients {
-            standard: client.clone(),
-            slack_live: client.clone(),
-            etl: client.clone(),
-            etl_backfill: client,
-        }
-    }
-
-    fn child_start_test_parent() -> WorkflowTaskInput {
-        WorkflowTaskInput {
-            workflow_name: "parent".to_owned(),
-            input: json!({}),
-            harness_type: HarnessType::Codex,
-        }
-    }
-
-    #[tokio::test]
-    async fn rejected_child_start_includes_rejected_before_spawn_code_in_context_response() {
-        let response = handle_python_child_start_context_request(
+    #[test]
+    fn rejected_child_start_includes_rejected_before_spawn_code_in_context_response() {
+        let response = python_child_start_context_response(
             "child-start",
-            &json!({"type": "ctx.workflow.start", "request_id": "child-start"}),
-            &child_start_test_parent(),
-            &child_start_test_clients(),
-        )
-        .await;
+            Err(ChildWorkflowStartError::rejected_before_spawn(
+                WorkflowRuntimeError::BadRequest(
+                    "ctx.workflow.start requires a non-empty workflow_name".to_owned(),
+                ),
+            )),
+        );
 
         assert_eq!(response["ok"], json!(false));
         assert_eq!(
@@ -4263,19 +4237,14 @@ mod tests {
         );
     }
 
-    #[tokio::test]
-    async fn failed_child_spawn_includes_unknown_outcome_code_in_context_response() {
-        let response = handle_python_child_start_context_request(
+    #[test]
+    fn failed_child_spawn_includes_unknown_outcome_code_in_context_response() {
+        let response = python_child_start_context_response(
             "child-start",
-            &json!({
-                "type": "ctx.workflow.start",
-                "workflow_name": "child",
-                "input": {},
-            }),
-            &child_start_test_parent(),
-            &child_start_test_clients(),
-        )
-        .await;
+            Err(ChildWorkflowStartError::outcome_unknown(
+                WorkflowRuntimeError::Internal("queue response timed out".to_owned()),
+            )),
+        );
 
         assert_eq!(response["ok"], json!(false));
         assert_eq!(
@@ -4296,11 +4265,8 @@ mod tests {
 
     #[test]
     fn successful_context_response_never_includes_an_error_code() {
-        let response = python_context_response(
-            "child-start",
-            Ok(json!({"created": true})),
-            Some("workflow_start_outcome_unknown"),
-        );
+        let response =
+            python_child_start_context_response("child-start", Ok(json!({"created": true})));
 
         assert_eq!(response["ok"], json!(true));
         assert_eq!(response["value"], json!({"created": true}));

--- a/services/workflow-python/api/workflow_engine.py
+++ b/services/workflow-python/api/workflow_engine.py
@@ -8,6 +8,12 @@ from typing import Any
 from api.app import WorkflowToolManager, WorkflowTools, bind_context_rpc, reset_context_rpc
 
 
+class ContextRpcError(RuntimeError):
+    def __init__(self, message: str, *, error_code: str) -> None:
+        super().__init__(message)
+        self.error_code = error_code
+
+
 @dataclasses.dataclass
 class Delivery:
     channel: str = ""

--- a/services/workflow-python/tests/test_workflow_host.py
+++ b/services/workflow-python/tests/test_workflow_host.py
@@ -692,6 +692,140 @@ class WorkflowHostTests(unittest.TestCase):
             assert proc.stderr is not None
             self.assertEqual(proc.stderr.read(), "")
 
+    def test_failed_context_response_exposes_rejected_before_spawn_code(self) -> None:
+        host = load_workflow_host()
+
+        async def resolve_failure() -> RuntimeError:
+            rpc = host.RpcClient()
+            future = asyncio.get_running_loop().create_future()
+            rpc._pending["child-start"] = future
+            rpc.resolve(
+                {
+                    "type": "ctx.response",
+                    "request_id": "child-start",
+                    "ok": False,
+                    "error": "workflow is disabled",
+                    "error_code": "workflow_start_rejected_before_spawn",
+                }
+            )
+            with self.assertRaises(RuntimeError) as raised:
+                await future
+            return raised.exception
+
+        error = asyncio.run(resolve_failure())
+
+        self.assertEqual(type(error).__name__, "ContextRpcError")
+        self.assertEqual(str(error), "workflow is disabled")
+        self.assertEqual(
+            getattr(error, "error_code", None),
+            "workflow_start_rejected_before_spawn",
+        )
+
+    def test_failed_context_response_exposes_unknown_start_outcome_code(self) -> None:
+        host = load_workflow_host()
+
+        async def resolve_failure() -> RuntimeError:
+            rpc = host.RpcClient()
+            future = asyncio.get_running_loop().create_future()
+            rpc._pending["child-start"] = future
+            rpc.resolve(
+                {
+                    "type": "ctx.response",
+                    "request_id": "child-start",
+                    "ok": False,
+                    "error": "queue response timed out",
+                    "error_code": "workflow_start_outcome_unknown",
+                }
+            )
+            with self.assertRaises(RuntimeError) as raised:
+                await future
+            return raised.exception
+
+        error = asyncio.run(resolve_failure())
+
+        self.assertEqual(type(error).__name__, "ContextRpcError")
+        self.assertEqual(str(error), "queue response timed out")
+        self.assertEqual(
+            getattr(error, "error_code", None),
+            "workflow_start_outcome_unknown",
+        )
+
+    def test_failed_context_response_exposes_any_nonempty_string_error_code(self) -> None:
+        host = load_workflow_host()
+
+        async def resolve_failure() -> RuntimeError:
+            rpc = host.RpcClient()
+            future = asyncio.get_running_loop().create_future()
+            rpc._pending["child-start"] = future
+            rpc.resolve(
+                {
+                    "type": "ctx.response",
+                    "request_id": "child-start",
+                    "ok": False,
+                    "error": "workflow is disabled",
+                    "error_code": " ",
+                }
+            )
+            with self.assertRaises(RuntimeError) as raised:
+                await future
+            return raised.exception
+
+        error = asyncio.run(resolve_failure())
+
+        self.assertEqual(type(error).__name__, "ContextRpcError")
+        self.assertEqual(str(error), "workflow is disabled")
+        self.assertEqual(getattr(error, "error_code", None), " ")
+
+    def test_failed_context_response_ignores_empty_or_non_string_error_codes(self) -> None:
+        host = load_workflow_host()
+
+        async def resolve_failure(error_code: object) -> RuntimeError:
+            rpc = host.RpcClient()
+            future = asyncio.get_running_loop().create_future()
+            rpc._pending["child-start"] = future
+            rpc.resolve(
+                {
+                    "type": "ctx.response",
+                    "request_id": "child-start",
+                    "ok": False,
+                    "error": "workflow is disabled",
+                    "error_code": error_code,
+                }
+            )
+            with self.assertRaises(RuntimeError) as raised:
+                await future
+            return raised.exception
+
+        for error_code in ("", 7, None, {}):
+            error = asyncio.run(resolve_failure(error_code))
+            self.assertIs(type(error), RuntimeError)
+            self.assertEqual(str(error), "workflow is disabled")
+            self.assertFalse(hasattr(error, "error_code"))
+
+    def test_failed_context_response_without_error_code_remains_runtime_error(self) -> None:
+        host = load_workflow_host()
+
+        async def resolve_failure() -> RuntimeError:
+            rpc = host.RpcClient()
+            future = asyncio.get_running_loop().create_future()
+            rpc._pending["child-start"] = future
+            rpc.resolve(
+                {
+                    "type": "ctx.response",
+                    "request_id": "child-start",
+                    "ok": False,
+                    "error": "workflow is disabled",
+                }
+            )
+            with self.assertRaises(RuntimeError) as raised:
+                await future
+            return raised.exception
+
+        error = asyncio.run(resolve_failure())
+
+        self.assertIs(type(error), RuntimeError)
+        self.assertEqual(str(error), "workflow is disabled")
+
     def test_workflow_host_finishes_active_workflow_after_stdin_eof(self) -> None:
         source = (
             "import asyncio\n"

--- a/services/workflow-python/tests/test_workflow_host.py
+++ b/services/workflow-python/tests/test_workflow_host.py
@@ -16,6 +16,9 @@ from pathlib import Path
 from unittest.mock import patch
 
 
+MISSING_ERROR_CODE = object()
+
+
 def load_workflow_host():
     module_path = Path(__file__).resolve().parents[1] / "workflow_host.py"
     sys.path.insert(0, str(module_path.parent))
@@ -136,6 +139,33 @@ class WorkflowHostTests(unittest.TestCase):
         for stream in (proc.stdin, proc.stdout, proc.stderr):
             if stream is not None and not stream.closed:
                 stream.close()
+
+    def failed_context_response_error(
+        self,
+        *,
+        message: str = "workflow is disabled",
+        error_code: object = MISSING_ERROR_CODE,
+    ) -> RuntimeError:
+        host = load_workflow_host()
+
+        async def resolve_failure() -> RuntimeError:
+            rpc = host.RpcClient()
+            future = asyncio.get_running_loop().create_future()
+            rpc._pending["child-start"] = future
+            response = {
+                "type": "ctx.response",
+                "request_id": "child-start",
+                "ok": False,
+                "error": message,
+            }
+            if error_code is not MISSING_ERROR_CODE:
+                response["error_code"] = error_code
+            rpc.resolve(response)
+            with self.assertRaises(RuntimeError) as raised:
+                await future
+            return raised.exception
+
+        return asyncio.run(resolve_failure())
 
     def test_workflow_api_modules_are_importable(self) -> None:
         load_workflow_host()
@@ -692,139 +722,30 @@ class WorkflowHostTests(unittest.TestCase):
             assert proc.stderr is not None
             self.assertEqual(proc.stderr.read(), "")
 
-    def test_failed_context_response_exposes_rejected_before_spawn_code(self) -> None:
-        host = load_workflow_host()
-
-        async def resolve_failure() -> RuntimeError:
-            rpc = host.RpcClient()
-            future = asyncio.get_running_loop().create_future()
-            rpc._pending["child-start"] = future
-            rpc.resolve(
-                {
-                    "type": "ctx.response",
-                    "request_id": "child-start",
-                    "ok": False,
-                    "error": "workflow is disabled",
-                    "error_code": "workflow_start_rejected_before_spawn",
-                }
-            )
-            with self.assertRaises(RuntimeError) as raised:
-                await future
-            return raised.exception
-
-        error = asyncio.run(resolve_failure())
-
-        self.assertEqual(type(error).__name__, "ContextRpcError")
-        self.assertEqual(str(error), "workflow is disabled")
-        self.assertEqual(
-            getattr(error, "error_code", None),
-            "workflow_start_rejected_before_spawn",
-        )
-
-    def test_failed_context_response_exposes_unknown_start_outcome_code(self) -> None:
-        host = load_workflow_host()
-
-        async def resolve_failure() -> RuntimeError:
-            rpc = host.RpcClient()
-            future = asyncio.get_running_loop().create_future()
-            rpc._pending["child-start"] = future
-            rpc.resolve(
-                {
-                    "type": "ctx.response",
-                    "request_id": "child-start",
-                    "ok": False,
-                    "error": "queue response timed out",
-                    "error_code": "workflow_start_outcome_unknown",
-                }
-            )
-            with self.assertRaises(RuntimeError) as raised:
-                await future
-            return raised.exception
-
-        error = asyncio.run(resolve_failure())
-
-        self.assertEqual(type(error).__name__, "ContextRpcError")
-        self.assertEqual(str(error), "queue response timed out")
-        self.assertEqual(
-            getattr(error, "error_code", None),
-            "workflow_start_outcome_unknown",
-        )
-
     def test_failed_context_response_exposes_any_nonempty_string_error_code(self) -> None:
-        host = load_workflow_host()
+        for error_code, message in (
+            ("workflow_start_rejected_before_spawn", "workflow is disabled"),
+            ("workflow_start_outcome_unknown", "queue response timed out"),
+            (" ", "workflow is disabled"),
+        ):
+            with self.subTest(error_code=error_code):
+                error = self.failed_context_response_error(
+                    error_code=error_code,
+                    message=message,
+                )
 
-        async def resolve_failure() -> RuntimeError:
-            rpc = host.RpcClient()
-            future = asyncio.get_running_loop().create_future()
-            rpc._pending["child-start"] = future
-            rpc.resolve(
-                {
-                    "type": "ctx.response",
-                    "request_id": "child-start",
-                    "ok": False,
-                    "error": "workflow is disabled",
-                    "error_code": " ",
-                }
-            )
-            with self.assertRaises(RuntimeError) as raised:
-                await future
-            return raised.exception
+                self.assertEqual(type(error).__name__, "ContextRpcError")
+                self.assertEqual(str(error), message)
+                self.assertEqual(getattr(error, "error_code", None), error_code)
 
-        error = asyncio.run(resolve_failure())
+    def test_failed_context_response_ignores_absent_or_invalid_error_codes(self) -> None:
+        for error_code in (MISSING_ERROR_CODE, "", 7, None, {}):
+            with self.subTest(error_code=error_code):
+                error = self.failed_context_response_error(error_code=error_code)
 
-        self.assertEqual(type(error).__name__, "ContextRpcError")
-        self.assertEqual(str(error), "workflow is disabled")
-        self.assertEqual(getattr(error, "error_code", None), " ")
-
-    def test_failed_context_response_ignores_empty_or_non_string_error_codes(self) -> None:
-        host = load_workflow_host()
-
-        async def resolve_failure(error_code: object) -> RuntimeError:
-            rpc = host.RpcClient()
-            future = asyncio.get_running_loop().create_future()
-            rpc._pending["child-start"] = future
-            rpc.resolve(
-                {
-                    "type": "ctx.response",
-                    "request_id": "child-start",
-                    "ok": False,
-                    "error": "workflow is disabled",
-                    "error_code": error_code,
-                }
-            )
-            with self.assertRaises(RuntimeError) as raised:
-                await future
-            return raised.exception
-
-        for error_code in ("", 7, None, {}):
-            error = asyncio.run(resolve_failure(error_code))
-            self.assertIs(type(error), RuntimeError)
-            self.assertEqual(str(error), "workflow is disabled")
-            self.assertFalse(hasattr(error, "error_code"))
-
-    def test_failed_context_response_without_error_code_remains_runtime_error(self) -> None:
-        host = load_workflow_host()
-
-        async def resolve_failure() -> RuntimeError:
-            rpc = host.RpcClient()
-            future = asyncio.get_running_loop().create_future()
-            rpc._pending["child-start"] = future
-            rpc.resolve(
-                {
-                    "type": "ctx.response",
-                    "request_id": "child-start",
-                    "ok": False,
-                    "error": "workflow is disabled",
-                }
-            )
-            with self.assertRaises(RuntimeError) as raised:
-                await future
-            return raised.exception
-
-        error = asyncio.run(resolve_failure())
-
-        self.assertIs(type(error), RuntimeError)
-        self.assertEqual(str(error), "workflow is disabled")
+                self.assertIs(type(error), RuntimeError)
+                self.assertEqual(str(error), "workflow is disabled")
+                self.assertFalse(hasattr(error, "error_code"))
 
     def test_workflow_host_finishes_active_workflow_after_stdin_eof(self) -> None:
         source = (

--- a/services/workflow-python/workflow_host.py
+++ b/services/workflow-python/workflow_host.py
@@ -22,7 +22,7 @@ from pathlib import Path
 from typing import Any
 
 from api import metrics
-from api.workflow_engine import WorkflowContext
+from api.workflow_engine import ContextRpcError, WorkflowContext
 
 DATABASE_CONNECT_ATTEMPTS = 5
 DATABASE_CONNECT_BACKOFF_SECONDS = 0.25
@@ -73,7 +73,12 @@ class RpcClient:
         if response.get("ok"):
             fut.set_result(response.get("value"))
         else:
-            fut.set_exception(RuntimeError(str(response.get("error") or "context RPC failed")))
+            message = str(response.get("error") or "context RPC failed")
+            error_code = response.get("error_code")
+            if isinstance(error_code, str) and error_code:
+                fut.set_exception(ContextRpcError(message, error_code=error_code))
+            else:
+                fut.set_exception(RuntimeError(message))
 
 
 @dataclasses.dataclass


### PR DESCRIPTION
## Summary

- classify child workflow start failures as either rejected before spawn or outcome unknown after a spawn attempt
- preserve stable error codes through the Python workflow host with a typed `ContextRpcError`
- keep legacy response shapes for every non-start context RPC failure

## Why

A returned `.spawn(...).await` error does not prove that the durable child was not created. Callers need a stable phase-aware signal so they can release pre-spawn reservations only when no spawn was attempted and treat post-attempt failures conservatively.

## Verification

- `cargo fmt --all --check`
- `cargo clippy -p centaur-workflows --all-targets -- -D warnings`
- `cargo test -p centaur-workflows` (39 passed)
- `uv run --project services/workflow-python python -m unittest discover -s services/workflow-python/tests -p 'test_*.py'` (30 passed)
- `uv run --project services/workflow-python --with pytest python -m pytest workflows/tests workflows/slack/tests` (65 passed)
- `cargo clippy --workspace --all-targets -- -D warnings` with disposable Postgres databases
- `cargo test --workspace --quiet` with database-backed Absurd and SQLx tests enabled
- `just build-one workflow-python`
- local Kind smoke: typed pre-spawn rejection, durable child completion, and idempotent parent retry
