### PR TITLE
docs: add external Slack channel guide

### DIFF
--- a/docs/pages/deploying-in-production.mdx
+++ b/docs/pages/deploying-in-production.mdx
@@ -277,6 +277,50 @@ The Slackbot accepts Slack events at `/api/webhooks/slack`. It also registers
 compatibility paths for `/api/slack/events`, `/api/slack/actions`,
 `/api/slack/options`, and `/api/slack/commands`.
 
+### Enable Centaur for External Slack Channels
+
+Treat Slack Connect channels as a separate trust boundary. Configure these
+controls before adding Centaur to an external channel:
+
+1. Allowlist each external workspace by its Slack team id. Messages and Block
+   Kit actions attributed to any other external workspace are ignored.
+
+   ```yaml
+   slackbotv2:
+     externalOrgAllowlist: "T01234567,T07654321"
+   ```
+
+2. In the Console, reduce the shared `infra` role to the minimum harness and
+   platform secrets every admitted principal needs. Remove tool grants from
+   this role. Then disable automatic infra-secret synchronization so a later
+   tool change cannot add them back:
+
+   ```yaml
+   apiRs:
+     syncInfraSecrets: false
+   ```
+
+   The equivalent environment variable is
+   `IRON_CONTROL_SYNC_INFRA_SECRETS=false`. With synchronization disabled,
+   manage changes to the `infra` role and its secrets explicitly in the
+   Console.
+
+3. Open **System Settings** and configure **Default Roles** for new principals.
+   Select the reduced `infra` role plus only the other roles that every new
+   external channel should inherit. We recommend putting tools approved for
+   broad use in a separate role such as `company-shared`, then adding that role
+   to the defaults only if all admitted external channels may use those tools.
+   Grant narrower tool roles to individual channel principals after reviewing
+   who can participate in each channel. As a conservative sandbox baseline,
+   set repo-cache access to `none` and disable observability and API server
+   access.
+
+Console defaults apply only when a principal is first created. If Centaur has
+already received a message from an external channel, open **Principals** and
+restrict that channel principal directly. Disabling synchronization does not
+remove existing secrets or grants, and changing default roles does not update
+existing principals.
+
 ## 6. Deploy With Helm
 
 The chart lives at `contrib/chart`. Select service images, [iron-proxy](https://docs.iron.sh) secret


### PR DESCRIPTION
Adds a production guide for enabling Centaur in Slack Connect channels. It covers external workspace allowlisting, minimizing and freezing the shared infra role, configuring Console default roles, and using a separate company-shared role for broadly approved tools.