### PR TITLE
docs: move external Slack guidance to permissioning

### DIFF
--- a/docs/pages/deploying-in-production.mdx
+++ b/docs/pages/deploying-in-production.mdx
@@ -277,49 +277,9 @@ The Slackbot accepts Slack events at `/api/webhooks/slack`. It also registers
 compatibility paths for `/api/slack/events`, `/api/slack/actions`,
 `/api/slack/options`, and `/api/slack/commands`.
 
-### Enable Centaur for External Slack Channels
-
-Treat Slack Connect channels as a separate trust boundary. Configure these
-controls before adding Centaur to an external channel:
-
-1. Allowlist each external workspace by its Slack team id. Messages and Block
-   Kit actions attributed to any other external workspace are ignored.
-
-   ```yaml
-   slackbotv2:
-     externalOrgAllowlist: "T01234567,T07654321"
-   ```
-
-2. In the Console, reduce the shared `infra` role to the minimum harness and
-   platform secrets every admitted principal needs. Remove tool grants from
-   this role. Then disable automatic infra-secret synchronization so a later
-   tool change cannot add them back:
-
-   ```yaml
-   apiRs:
-     syncInfraSecrets: false
-   ```
-
-   The equivalent environment variable is
-   `IRON_CONTROL_SYNC_INFRA_SECRETS=false`. With synchronization disabled,
-   manage changes to the `infra` role and its secrets explicitly in the
-   Console.
-
-3. Open **System Settings** and configure **Default Roles** for new principals.
-   Select the reduced `infra` role plus only the other roles that every new
-   external channel should inherit. We recommend putting tools approved for
-   broad use in a separate role such as `company-shared`, then adding that role
-   to the defaults only if all admitted external channels may use those tools.
-   Grant narrower tool roles to individual channel principals after reviewing
-   who can participate in each channel. As a conservative sandbox baseline,
-   set repo-cache access to `none` and disable observability and API server
-   access.
-
-Console defaults apply only when a principal is first created. If Centaur has
-already received a message from an external channel, open **Principals** and
-restrict that channel principal directly. Disabling synchronization does not
-remove existing secrets or grants, and changing default roles does not update
-existing principals.
+For Slack Connect channels, follow [Enable Centaur for External Slack
+Channels](/secrets/advanced-permissioning#enable-centaur-for-external-slack-channels)
+before adding Centaur to the channel.
 
 ## 6. Deploy With Helm
 

--- a/docs/pages/secrets/advanced-permissioning.mdx
+++ b/docs/pages/secrets/advanced-permissioning.mdx
@@ -237,37 +237,58 @@ when possible.
 Slack Connect channels can include participants from other workspaces. Configure
 these controls before adding Centaur to an external channel:
 
-1. Allowlist each external workspace by its Slack team id. Messages and Block
-   Kit actions attributed to any other external workspace are ignored.
+### Allow External Workspaces
 
-   ```yaml
-   slackbotv2:
-     externalOrgAllowlist: "T01234567,T07654321"
-   ```
+Allowlist each external workspace by its Slack team id. Messages and Block Kit
+actions attributed to any other external workspace are ignored.
 
-2. In the Console, reduce the shared `infra` role to the minimum harness and
-   platform secrets every admitted principal needs. Remove tool grants from
-   this role. Then disable automatic infra-secret synchronization so a later
-   tool change cannot add them back:
+```yaml
+slackbotv2:
+  externalOrgAllowlist: "T01234567,T07654321"
+```
 
-   ```yaml
-   apiRs:
-     syncInfraSecrets: false
-   ```
+### Allow Bots to Mention Centaur
 
-   The equivalent environment variable is
-   `IRON_CONTROL_SYNC_INFRA_SECRETS=false`. With synchronization disabled,
-   manage changes to the `infra` role and its secrets explicitly in the
-   Console.
+Centaur ignores bot-authored messages by default, including messages that
+mention Centaur. Add each bot that may trigger Centaur to
+`slackbotv2.triggerBotAllowlist`. For an exact Slack bot id from an event's
+`bot_id` field, prefix the `B...` id with `bot:`:
 
-3. Open **System Settings** and configure **Default Roles** for new principals.
-   Select the reduced `infra` role plus only the other roles that every new
-   external channel should inherit. Put tools approved for broad use in a
-   separate role such as `company-shared`, then add that role to the defaults
-   only if all admitted external channels may use those tools. Grant narrower
-   tool roles to individual channel principals after reviewing who can
-   participate in each channel. For a restrictive sandbox baseline, set
-   repo-cache access to `none` and disable observability and API server access.
+```yaml
+slackbotv2:
+  triggerBotAllowlist: "bot:B01234567,bot:B07654321"
+```
+
+Use bot ids that start with `B`, not Slack app ids that start with `A`. A bare
+`B...` value is not accepted. Bot member ids that start with `U` or `W` are
+also supported without a prefix.
+
+### Restrict the Shared Infra Role
+
+In the Console, reduce the shared `infra` role to the minimum harness and
+platform secrets every admitted principal needs. Remove tool grants from this
+role. Then disable automatic infra-secret synchronization so a later tool
+change cannot add them back:
+
+```yaml
+apiRs:
+  syncInfraSecrets: false
+```
+
+The equivalent environment variable is
+`IRON_CONTROL_SYNC_INFRA_SECRETS=false`. With synchronization disabled, manage
+changes to the `infra` role and its secrets explicitly in the Console.
+
+### Set Defaults for External Channels
+
+Open **System Settings** and configure **Default Roles** for new principals.
+Select the reduced `infra` role plus only the other roles that every new
+external channel should inherit. Put tools approved for broad use in a separate
+role such as `company-shared`, then add that role to the defaults only if all
+admitted external channels may use those tools. Grant narrower tool roles to
+individual channel principals after reviewing who can participate in each
+channel. For a restrictive sandbox baseline, set repo-cache access to `none`
+and disable observability and API server access.
 
 Console defaults apply only when a principal is first created. If Centaur has
 already received a message from an external channel, open **Principals** and

--- a/docs/pages/secrets/advanced-permissioning.mdx
+++ b/docs/pages/secrets/advanced-permissioning.mdx
@@ -232,6 +232,49 @@ cargo run -p centaur-perms -- \
 Prefer selecting an existing foreign id from the Console or `principals list`
 when possible.
 
+## Enable Centaur for External Slack Channels
+
+Slack Connect channels can include participants from other workspaces. Configure
+these controls before adding Centaur to an external channel:
+
+1. Allowlist each external workspace by its Slack team id. Messages and Block
+   Kit actions attributed to any other external workspace are ignored.
+
+   ```yaml
+   slackbotv2:
+     externalOrgAllowlist: "T01234567,T07654321"
+   ```
+
+2. In the Console, reduce the shared `infra` role to the minimum harness and
+   platform secrets every admitted principal needs. Remove tool grants from
+   this role. Then disable automatic infra-secret synchronization so a later
+   tool change cannot add them back:
+
+   ```yaml
+   apiRs:
+     syncInfraSecrets: false
+   ```
+
+   The equivalent environment variable is
+   `IRON_CONTROL_SYNC_INFRA_SECRETS=false`. With synchronization disabled,
+   manage changes to the `infra` role and its secrets explicitly in the
+   Console.
+
+3. Open **System Settings** and configure **Default Roles** for new principals.
+   Select the reduced `infra` role plus only the other roles that every new
+   external channel should inherit. Put tools approved for broad use in a
+   separate role such as `company-shared`, then add that role to the defaults
+   only if all admitted external channels may use those tools. Grant narrower
+   tool roles to individual channel principals after reviewing who can
+   participate in each channel. For a restrictive sandbox baseline, set
+   repo-cache access to `none` and disable observability and API server access.
+
+Console defaults apply only when a principal is first created. If Centaur has
+already received a message from an external channel, open **Principals** and
+restrict that channel principal directly. Disabling synchronization does not
+remove existing secrets or grants, and changing default roles does not update
+existing principals.
+
 ## Build Reusable Roles
 
 Create a custom role such as `tool-support` from **Roles** in the Console. Then

--- a/docs/pages/secrets/advanced-permissioning.mdx
+++ b/docs/pages/secrets/advanced-permissioning.mdx
@@ -235,7 +235,8 @@ when possible.
 ## Enable Centaur for External Slack Channels
 
 Slack Connect channels can include participants from other workspaces. Configure
-these controls before adding Centaur to an external channel:
+the workspace and permission controls before adding Centaur to an external
+channel.
 
 ### Allow External Workspaces
 
@@ -246,22 +247,6 @@ actions attributed to any other external workspace are ignored.
 slackbotv2:
   externalOrgAllowlist: "T01234567,T07654321"
 ```
-
-### Allow Bots to Mention Centaur
-
-Centaur ignores bot-authored messages by default, including messages that
-mention Centaur. Add each bot that may trigger Centaur to
-`slackbotv2.triggerBotAllowlist`. For an exact Slack bot id from an event's
-`bot_id` field, prefix the `B...` id with `bot:`:
-
-```yaml
-slackbotv2:
-  triggerBotAllowlist: "bot:B01234567,bot:B07654321"
-```
-
-Use bot ids that start with `B`, not Slack app ids that start with `A`. A bare
-`B...` value is not accepted. Bot member ids that start with `U` or `W` are
-also supported without a prefix.
 
 ### Restrict the Shared Infra Role
 
@@ -295,6 +280,25 @@ already received a message from an external channel, open **Principals** and
 restrict that channel principal directly. Disabling synchronization does not
 remove existing secrets or grants, and changing default roles does not update
 existing principals.
+
+### Optional: Allow Bots to Mention Centaur
+
+Human-authored mentions work without this setting. If another bot needs to
+trigger Centaur, add it to `slackbotv2.triggerBotAllowlist`. Centaur ignores
+bot-authored messages that are not on this list, including messages that
+mention Centaur.
+
+For an exact Slack bot id from an event's `bot_id` field, prefix the `B...` id
+with `bot:`:
+
+```yaml
+slackbotv2:
+  triggerBotAllowlist: "bot:B01234567,bot:B07654321"
+```
+
+Use bot ids that start with `B`, not Slack app ids that start with `A`. A bare
+`B...` value is not accepted. Bot member ids that start with `U` or `W` are
+also supported without a prefix.
 
 ## Build Reusable Roles
 


### PR DESCRIPTION
Moves the external Slack channel configuration guidance from the production deployment guide to Advanced Permissioning. Replaces abstract security phrasing with concrete Slack Connect controls and keeps a cross-link from the Slack setup section. Adds an optional final section explaining how to allow specific bots to mention Centaur.