### PR TITLE
feat: Hermes Agent as a first-class harness (sessions, learning loop, crons)

### DIFF
--- a/crates/harness-server/src/error.rs
+++ b/crates/harness-server/src/error.rs
@@ -53,6 +53,8 @@ pub enum HarnessServerError {
         status: ExitStatus,
         stderr: String,
     },
+    #[error("Hermes exited with status {status}")]
+    HermesExited { status: ExitStatus },
     #[error("{kind:?} turn interrupted")]
     TurnInterrupted { kind: HarnessKind },
     #[error("failed to spawn {bin} app-server: {source}")]

--- a/crates/harness-server/src/hermes.rs
+++ b/crates/harness-server/src/hermes.rs
@@ -1,0 +1,886 @@
+//! Hermes Agent harness — drives `hermes-agent`'s `tui_gateway` JSON-RPC
+//! stdio wire as a first-class Centaur harness.
+//!
+//! Unlike claude/amp (spawn-per-turn stream-json CLIs), Hermes ships a
+//! long-lived JSON-RPC gateway (`python -m tui_gateway.entry`) that owns the
+//! agent loop, durable session store, skills, persistent memory, background
+//! self-improvement reviews, and the cron scheduler. This runtime therefore
+//! mirrors the codex runtime shape: one persistent child per sandbox, a
+//! handshake (`gateway.ready` → `session.create`), then one `prompt.submit`
+//! per turn with events pumped into the shared `CodexTurnNormalizer`.
+//!
+//! What "first-class" means here (vs. driving `hermes -z` one-shots):
+//! - **Session continuity**: one Hermes session per Centaur thread; the
+//!   prompt cache and conversation history survive across turns, and
+//!   `HERMES_CONTINUE_SESSION_ID` resumes the durable session after a
+//!   sandbox restart.
+//! - **Learning loop**: the background memory/skill review forks Hermes
+//!   spawns after turns run inside the same process and write to the
+//!   sandbox-mounted HERMES_HOME, so memories and skills accumulate.
+//! - **Crons**: Hermes cron jobs created during a conversation are ticked
+//!   by this runtime (`hermes cron tick` every `HERMES_CRON_TICK_SECONDS`,
+//!   cross-process file-locked on Hermes's side), so scheduled work fires
+//!   for as long as the sandbox lives.
+//! - **Interrupts**: Centaur's blocks `interrupt` maps to Hermes's
+//!   `session.interrupt` RPC — the turn ends as Interrupted without
+//!   killing the child, preserving the session for the next turn.
+//!
+//! Wire mapping (Hermes event → NormalizedEvent):
+//! - `message.delta {text}`         → AgentTextDelta
+//! - `reasoning.delta`/`thinking.delta {text}` → ReasoningTextDelta
+//! - `tool.start {tool_id,name,args}`  → AssistantMessage(ToolUse)
+//! - `tool.complete {tool_id,result}`  → ToolResults
+//! - `message.complete {text,status}`  → AssistantMessage(final) + Result
+
+use std::env;
+use std::io::{self, BufRead, Write};
+use std::process::{Child, ChildStdin, Command as ProcessCommand, Stdio};
+use std::sync::mpsc::{self, Receiver, RecvTimeoutError};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use codex_app_server_protocol::UserInput;
+use serde_json::{Value, json};
+
+use crate::server::{BlocksCommand, BlocksState, parse_blocks_line_with_state, write_blocks_error};
+use crate::traits::{
+    NormalizedContent, NormalizedEvent, NormalizedTokenUsage, NormalizedToolResult,
+};
+use crate::turn::{BridgeConfig, CodexTurnNormalizer};
+use crate::util::write_value;
+use crate::{HarnessServerError, Result};
+
+const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(180);
+const DEFAULT_CRON_TICK_SECONDS: u64 = 60;
+
+/// Entry point for `harness-server hermes`.
+pub fn run_hermes_blocks_server() -> Result<()> {
+    let mut stdout = io::stdout().lock();
+    let mut hermes: Option<HermesChild> = None;
+    let (command_tx, command_rx) = mpsc::channel();
+    let (interrupt_tx, interrupt_rx) = mpsc::channel();
+
+    spawn_cron_ticker();
+
+    thread::spawn(move || {
+        let stdin = io::stdin();
+        let mut blocks_state = BlocksState::default();
+        for raw in stdin.lock().lines() {
+            let Ok(line) = raw else { break };
+            let trimmed = line.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+            match parse_blocks_line_with_state(trimmed, &mut blocks_state) {
+                Ok(BlocksCommand::Interrupt) => {
+                    if interrupt_tx.send(()).is_err() {
+                        break;
+                    }
+                }
+                Ok(command) => {
+                    if command_tx.send(Ok(command)).is_err() {
+                        break;
+                    }
+                }
+                Err(error) => {
+                    if command_tx.send(Err(error.to_string())).is_err() {
+                        break;
+                    }
+                }
+            }
+        }
+    });
+
+    let mut turn_counter = 0u64;
+    while let Ok(input) = command_rx.recv() {
+        match input {
+            Ok(BlocksCommand::User {
+                input,
+                client_user_message_id,
+                model,
+                provider: _,
+                reasoning,
+                trace_context: _,
+            }) => {
+                turn_counter += 1;
+                let result = (|| -> Result<()> {
+                    if hermes.is_none() {
+                        hermes = Some(HermesChild::start(model.clone())?);
+                    }
+                    let child = hermes.as_mut().expect("hermes started");
+                    run_hermes_turn(
+                        child,
+                        &mut stdout,
+                        input,
+                        client_user_message_id,
+                        reasoning,
+                        turn_counter,
+                        &interrupt_rx,
+                    )
+                })();
+                if let Err(error) = result {
+                    let thread_id = hermes
+                        .as_ref()
+                        .map(|child| child.thread_id())
+                        .unwrap_or("hermes");
+                    eprintln!("Hermes blocks turn failed: {error:#}");
+                    write_blocks_error(&mut stdout, thread_id, "turn", error.to_string())?;
+                    // A dead child cannot serve the next turn; drop it so the
+                    // next user message restarts Hermes and resumes the durable
+                    // session via HERMES_CONTINUE_SESSION_ID.
+                    if hermes.as_mut().is_some_and(|c| !c.is_alive()) {
+                        hermes = None;
+                    }
+                }
+            }
+            Ok(BlocksCommand::Interrupt) => {
+                eprintln!("Hermes blocks interrupt ignored: no active turn runs");
+            }
+            Ok(BlocksCommand::AttachmentChunk) => {}
+            Err(error) => {
+                eprintln!("invalid Hermes blocks input: {error}");
+                let thread_id = hermes
+                    .as_ref()
+                    .map(|child| child.thread_id())
+                    .unwrap_or("hermes");
+                write_blocks_error(&mut stdout, thread_id, "input", error)?;
+            }
+        }
+        // Drain interrupts that arrived between turns so a stale one cannot
+        // instantly cancel the next turn.
+        while interrupt_rx.try_recv().is_ok() {}
+    }
+    Ok(())
+}
+
+/// Tick `hermes cron tick` on an interval so cron jobs created inside the
+/// conversation fire while the sandbox lives. Hermes serializes ticks
+/// cross-process with a file lock, so this is safe alongside any other
+/// Hermes process on the same HERMES_HOME. `HERMES_CRON_TICK_SECONDS=0`
+/// disables the ticker.
+fn spawn_cron_ticker() {
+    let interval = env::var("HERMES_CRON_TICK_SECONDS")
+        .ok()
+        .and_then(|raw| raw.trim().parse::<u64>().ok())
+        .unwrap_or(DEFAULT_CRON_TICK_SECONDS);
+    if interval == 0 {
+        return;
+    }
+    let bin = hermes_bin();
+    thread::spawn(move || {
+        let mut warned = false;
+        loop {
+            thread::sleep(Duration::from_secs(interval));
+            let status = ProcessCommand::new(&bin)
+                .args(["cron", "tick"])
+                .stdin(Stdio::null())
+                .stdout(Stdio::null())
+                .stderr(Stdio::null())
+                .status();
+            if let Err(error) = status
+                && !warned
+            {
+                eprintln!("hermes cron ticker disabled: {bin} cron tick failed: {error}");
+                warned = true;
+            }
+        }
+    });
+}
+
+fn hermes_bin() -> String {
+    env::var("HERMES_BIN").unwrap_or_else(|_| "hermes".to_string())
+}
+
+fn hermes_gateway_command() -> ProcessCommand {
+    // The JSON-RPC gateway is a Python module, not a `hermes` subcommand.
+    // HERMES_PYTHON overrides the interpreter (sandbox venvs).
+    let python = env::var("HERMES_PYTHON").unwrap_or_else(|_| "python3".to_string());
+    let mut command = ProcessCommand::new(python);
+    command.args(["-m", "tui_gateway.entry"]);
+    command.env("HERMES_QUIET", "1");
+    // Centaur owns approval policy at the sandbox boundary (iron-proxy egress,
+    // placeholder credentials); inside the sandbox Hermes runs unattended.
+    command.env(
+        "HERMES_APPROVAL_MODE",
+        env::var("HERMES_APPROVAL_MODE").unwrap_or_else(|_| "off".to_string()),
+    );
+    command
+}
+
+struct HermesChild {
+    child: Child,
+    stdin: ChildStdin,
+    stdout: Receiver<io::Result<String>>,
+    session_id: String,
+    next_rpc_id: i64,
+}
+
+impl Drop for HermesChild {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+impl HermesChild {
+    fn start(model: Option<String>) -> Result<Self> {
+        let mut child = hermes_gateway_command()
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .map_err(|source| HarnessServerError::SpawnHarness {
+                cwd: env::current_dir().unwrap_or_default(),
+                source,
+            })?;
+
+        let stdin = child
+            .stdin
+            .take()
+            .ok_or(HarnessServerError::HarnessStdinUnavailable)?;
+        let stdout = child
+            .stdout
+            .take()
+            .ok_or(HarnessServerError::HarnessStdoutUnavailable)?;
+        let mut stderr = child
+            .stderr
+            .take()
+            .ok_or(HarnessServerError::HarnessStderrUnavailable)?;
+        thread::spawn(move || {
+            let mut parent_stderr = io::stderr();
+            let _ = io::copy(&mut stderr, &mut parent_stderr);
+        });
+        let (stdout_tx, stdout_rx) = mpsc::channel();
+        thread::spawn(move || {
+            let reader = io::BufReader::new(stdout);
+            for raw in reader.lines() {
+                let should_stop = raw.is_err();
+                if stdout_tx.send(raw).is_err() || should_stop {
+                    break;
+                }
+            }
+        });
+
+        let mut this = Self {
+            child,
+            stdin,
+            stdout: stdout_rx,
+            session_id: String::new(),
+            next_rpc_id: 0,
+        };
+        this.wait_for_gateway_ready()?;
+        this.create_or_resume_session(model)?;
+        Ok(this)
+    }
+
+    fn is_alive(&mut self) -> bool {
+        matches!(self.child.try_wait(), Ok(None))
+    }
+
+    fn thread_id(&self) -> &str {
+        if self.session_id.is_empty() {
+            "hermes"
+        } else {
+            &self.session_id
+        }
+    }
+
+    fn wait_for_gateway_ready(&mut self) -> Result<()> {
+        let deadline = Instant::now() + HANDSHAKE_TIMEOUT;
+        loop {
+            let frame = self.read_frame_until(deadline)?;
+            if frame.get("method").and_then(Value::as_str) == Some("event")
+                && frame.pointer("/params/type").and_then(Value::as_str) == Some("gateway.ready")
+            {
+                return Ok(());
+            }
+        }
+    }
+
+    /// Create the thread's Hermes session, or resume the durable one after a
+    /// sandbox restart (`HERMES_CONTINUE_SESSION_ID`, persisted by the
+    /// session runtime from our `thread.started` output — mirrors
+    /// CODEX_CONTINUE_THREAD_ID).
+    fn create_or_resume_session(&mut self, model: Option<String>) -> Result<()> {
+        let resume = env::var("HERMES_CONTINUE_SESSION_ID").unwrap_or_default();
+        let resume = resume.trim();
+        if !resume.is_empty()
+            && let Ok(result) =
+                self.rpc("session.resume", json!({"session_id": resume, "cols": 200}))
+            && let Some(sid) = result.get("session_id").and_then(Value::as_str)
+        {
+            self.session_id = sid.to_string();
+            return Ok(());
+        }
+
+        let mut params = json!({
+            "cols": 200,
+            "cwd": env::current_dir()
+                .unwrap_or_default()
+                .to_string_lossy()
+                .to_string(),
+            "title": "Centaur thread",
+            "source": "centaur",
+        });
+        if let Some(model) = model.filter(|value| !value.trim().is_empty()) {
+            params["model"] = Value::String(model);
+        }
+        let result = self.rpc("session.create", params)?;
+        self.session_id = result
+            .get("session_id")
+            .and_then(Value::as_str)
+            .ok_or_else(|| {
+                HarnessServerError::Protocol(
+                    "session.create response missing session_id".to_string(),
+                )
+            })?
+            .to_string();
+        Ok(())
+    }
+
+    fn rpc(&mut self, method: &str, params: Value) -> Result<Value> {
+        self.next_rpc_id += 1;
+        let id = self.next_rpc_id;
+        self.write_frame(&json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "method": method,
+            "params": params,
+        }))?;
+        let deadline = Instant::now() + HANDSHAKE_TIMEOUT;
+        loop {
+            let frame = self.read_frame_until(deadline)?;
+            if frame.get("id").and_then(Value::as_i64) == Some(id) {
+                if let Some(error) = frame.get("error") {
+                    return Err(HarnessServerError::Protocol(format!(
+                        "hermes {method} failed: {error}"
+                    )));
+                }
+                return Ok(frame.get("result").cloned().unwrap_or(Value::Null));
+            }
+            // Events and stale responses between request and response are
+            // dropped here; per-turn event pumping happens in run_hermes_turn.
+        }
+    }
+
+    fn write_frame(&mut self, value: &Value) -> Result<()> {
+        serde_json::to_writer(&mut self.stdin, value)?;
+        self.stdin.write_all(b"\n")?;
+        self.stdin.flush()?;
+        Ok(())
+    }
+
+    fn read_frame_until(&mut self, deadline: Instant) -> Result<Value> {
+        loop {
+            let now = Instant::now();
+            if now >= deadline {
+                return Err(HarnessServerError::Protocol(
+                    "timed out waiting for hermes gateway".to_string(),
+                ));
+            }
+            match self.stdout.recv_timeout(deadline - now) {
+                Ok(line) => {
+                    let line = line?;
+                    let trimmed = line.trim();
+                    if trimmed.is_empty() {
+                        continue;
+                    }
+                    match serde_json::from_str::<Value>(trimmed) {
+                        Ok(value) => return Ok(value),
+                        // Hermes keeps its own stdout clean of non-JSON in
+                        // quiet mode; tolerate stray lines anyway.
+                        Err(_) => continue,
+                    }
+                }
+                Err(RecvTimeoutError::Timeout) => {
+                    return Err(HarnessServerError::Protocol(
+                        "timed out waiting for hermes gateway".to_string(),
+                    ));
+                }
+                Err(RecvTimeoutError::Disconnected) => {
+                    let status = self.child.wait()?;
+                    return Err(HarnessServerError::HarnessExited {
+                        kind: crate::HarnessKind::Codex,
+                        status,
+                        stderr: String::new(),
+                    });
+                }
+            }
+        }
+    }
+}
+
+/// Per-turn translation state: Hermes emits deltas + one final
+/// `message.complete` whose text REPEATS the streamed content, so the final
+/// text must be reconciled (suffix-delta) rather than double-emitted —
+/// `CodexTurnNormalizer::emit_agent_text` already handles that when the final
+/// AssistantMessage carries the full canonical text.
+#[derive(Debug, Default)]
+pub struct HermesEventState {
+    text_item_id: Option<String>,
+    saw_error: Option<String>,
+}
+
+/// Translate one Hermes gateway event frame into normalized events.
+/// Returns `(events, terminal)`.
+pub fn normalize_hermes_frame(
+    state: &mut HermesEventState,
+    turn: u64,
+    frame: &Value,
+) -> (Vec<NormalizedEvent>, bool) {
+    if frame.get("method").and_then(Value::as_str) != Some("event") {
+        return (Vec::new(), false);
+    }
+    let params = frame.get("params").cloned().unwrap_or_default();
+    let kind = params.get("type").and_then(Value::as_str).unwrap_or("");
+    let payload = params.get("payload").cloned().unwrap_or_default();
+
+    let text_item = state
+        .text_item_id
+        .get_or_insert_with(|| format!("hermes-msg-{turn}"))
+        .clone();
+
+    match kind {
+        "message.delta" => {
+            let delta = payload.get("text").and_then(Value::as_str).unwrap_or("");
+            if delta.is_empty() {
+                return (Vec::new(), false);
+            }
+            (
+                vec![NormalizedEvent::AgentTextDelta {
+                    item_id: text_item,
+                    delta: delta.to_string(),
+                }],
+                false,
+            )
+        }
+        "reasoning.delta" | "thinking.delta" => {
+            let delta = payload.get("text").and_then(Value::as_str).unwrap_or("");
+            if delta.is_empty() {
+                return (Vec::new(), false);
+            }
+            (
+                vec![NormalizedEvent::ReasoningTextDelta {
+                    item_id: format!("hermes-reasoning-{turn}"),
+                    delta: delta.to_string(),
+                }],
+                false,
+            )
+        }
+        "tool.start" => {
+            let tool_id = payload
+                .get("tool_id")
+                .and_then(Value::as_str)
+                .unwrap_or("tool")
+                .to_string();
+            let name = payload
+                .get("name")
+                .and_then(Value::as_str)
+                .unwrap_or("tool")
+                .to_string();
+            let arguments = payload.get("args").cloned().unwrap_or(json!({}));
+            (
+                vec![NormalizedEvent::AssistantMessage {
+                    partial: false,
+                    stop_reason: None,
+                    content: vec![NormalizedContent::ToolUse {
+                        raw_id: tool_id,
+                        tool: name,
+                        arguments,
+                    }],
+                }],
+                false,
+            )
+        }
+        "tool.complete" => {
+            let tool_id = payload
+                .get("tool_id")
+                .and_then(Value::as_str)
+                .unwrap_or("tool")
+                .to_string();
+            let content = tool_result_text(&payload);
+            let is_error = payload
+                .get("result")
+                .map(|result| {
+                    result.get("success").and_then(Value::as_bool) == Some(false)
+                        || result.get("error").is_some_and(|e| !e.is_null())
+                })
+                .unwrap_or(false);
+            (
+                vec![NormalizedEvent::ToolResults(vec![NormalizedToolResult {
+                    tool_use_id: tool_id,
+                    content,
+                    is_error,
+                    exit_code: payload
+                        .pointer("/result/exit_code")
+                        .and_then(Value::as_i64)
+                        .map(|code| code as i32),
+                }])],
+                false,
+            )
+        }
+        "turn.usage" | "session.usage" => {
+            let usage = NormalizedTokenUsage {
+                model: payload
+                    .get("model")
+                    .and_then(Value::as_str)
+                    .map(str::to_string),
+                input_tokens: payload.get("input_tokens").and_then(Value::as_i64),
+                output_tokens: payload.get("output_tokens").and_then(Value::as_i64),
+                cache_creation_input_tokens: None,
+                cache_read_input_tokens: payload.get("cached_tokens").and_then(Value::as_i64),
+                reasoning_output_tokens: None,
+                total_tokens: payload.get("total_tokens").and_then(Value::as_i64),
+            };
+            if usage.has_counts() {
+                (vec![NormalizedEvent::TokenUsage { usage }], false)
+            } else {
+                (Vec::new(), false)
+            }
+        }
+        "message.complete" => {
+            let status = payload.get("status").and_then(Value::as_str).unwrap_or("");
+            let text = payload.get("text").and_then(Value::as_str).unwrap_or("");
+            let mut events = Vec::new();
+            if status == "error" {
+                let error =
+                    payload
+                        .get("error")
+                        .and_then(Value::as_str)
+                        .unwrap_or(if text.is_empty() {
+                            "hermes turn failed"
+                        } else {
+                            text
+                        });
+                state.saw_error = Some(error.to_string());
+            } else if !text.is_empty() {
+                events.push(NormalizedEvent::AssistantMessage {
+                    partial: false,
+                    stop_reason: Some("end_turn".to_string()),
+                    content: vec![NormalizedContent::AgentText {
+                        item_id: text_item,
+                        text: text.to_string(),
+                    }],
+                });
+            }
+            events.push(NormalizedEvent::Result {
+                error: state.saw_error.clone(),
+            });
+            (events, true)
+        }
+        _ => (Vec::new(), false),
+    }
+}
+
+fn tool_result_text(payload: &Value) -> String {
+    if let Some(text) = payload.get("result_text").and_then(Value::as_str) {
+        return text.to_string();
+    }
+    match payload.get("result") {
+        Some(Value::String(text)) => text.clone(),
+        Some(value) if !value.is_null() => serde_json::to_string(value).unwrap_or_default(),
+        _ => payload
+            .get("summary")
+            .and_then(Value::as_str)
+            .unwrap_or("")
+            .to_string(),
+    }
+}
+
+fn run_hermes_turn<W: Write>(
+    child: &mut HermesChild,
+    stdout: &mut W,
+    input: Vec<UserInput>,
+    client_user_message_id: Option<String>,
+    reasoning: Option<String>,
+    turn: u64,
+    interrupt_rx: &Receiver<()>,
+) -> Result<()> {
+    use crate::wire::notification_to_wire_value;
+
+    let turn_id = format!("turn-{turn}");
+    let mut config = BridgeConfig::new(child.thread_id().to_string(), turn_id);
+    config.cli_version = "hermes".to_string();
+    config.model_provider = "hermes".to_string();
+    let mut normalizer = CodexTurnNormalizer::new(config);
+
+    for notification in normalizer.start_notifications(turn == 1)? {
+        write_value(stdout, &notification_to_wire_value(&notification)?)?;
+    }
+    for notification in normalizer.emit_user_message(client_user_message_id, input.clone())? {
+        write_value(stdout, &notification_to_wire_value(&notification)?)?;
+    }
+
+    let text = user_input_text(&input);
+    let mut params = json!({
+        "session_id": child.session_id,
+        "text": text,
+    });
+    if let Some(reasoning) = reasoning.filter(|value| !value.trim().is_empty()) {
+        params["reasoning_effort"] = Value::String(reasoning);
+    }
+    child.next_rpc_id += 1;
+    let submit_id = child.next_rpc_id;
+    child.write_frame(&json!({
+        "jsonrpc": "2.0",
+        "id": submit_id,
+        "method": "prompt.submit",
+        "params": params,
+    }))?;
+
+    let mut state = HermesEventState::default();
+    loop {
+        if interrupt_rx.try_recv().is_ok() {
+            let session_id = child.session_id.clone();
+            let _ = child.rpc("session.interrupt", json!({"session_id": session_id}));
+            // Hermes ends the interrupted turn with its own message.complete;
+            // keep pumping until it arrives (bounded) so the trailing terminal
+            // frame can't leak into the next turn.
+            let deadline = Instant::now() + Duration::from_secs(30);
+            while let Ok(frame) = child.read_frame_until(deadline) {
+                let (_, terminal) = normalize_hermes_frame(&mut state, turn, &frame);
+                if terminal {
+                    break;
+                }
+            }
+            if let Some(notification) = normalizer.finish_turn_interrupted()? {
+                write_value(stdout, &notification_to_wire_value(&notification)?)?;
+            }
+            return Ok(());
+        }
+
+        match child.stdout.recv_timeout(Duration::from_millis(50)) {
+            Ok(line) => {
+                let line = line?;
+                let trimmed = line.trim();
+                if trimmed.is_empty() {
+                    continue;
+                }
+                let Ok(frame) = serde_json::from_str::<Value>(trimmed) else {
+                    continue;
+                };
+                let (events, terminal) = normalize_hermes_frame(&mut state, turn, &frame);
+                for event in events {
+                    for notification in normalizer.process_event(&event)? {
+                        write_value(stdout, &notification_to_wire_value(&notification)?)?;
+                    }
+                }
+                if terminal {
+                    if let Some(notification) = normalizer.finish_turn(state.saw_error.clone())? {
+                        write_value(stdout, &notification_to_wire_value(&notification)?)?;
+                    }
+                    return Ok(());
+                }
+            }
+            Err(RecvTimeoutError::Timeout) => continue,
+            Err(RecvTimeoutError::Disconnected) => {
+                let status = child.child.wait()?;
+                return Err(HarnessServerError::HarnessExited {
+                    kind: crate::HarnessKind::Codex,
+                    status,
+                    stderr: String::new(),
+                });
+            }
+        }
+    }
+}
+
+fn user_input_text(input: &[UserInput]) -> String {
+    let mut parts = Vec::new();
+    for item in input {
+        match item {
+            UserInput::Text { text, .. } => parts.push(text.clone()),
+            UserInput::Image { url, .. } => parts.push(format!("[image: {url}]")),
+            UserInput::LocalImage { path, .. } => {
+                parts.push(format!("[image file: {}]", path.display()))
+            }
+            UserInput::Skill { name, path } => {
+                parts.push(format!("[skill: {name} at {}]", path.display()))
+            }
+            UserInput::Mention { name, path } => parts.push(format!("[mention: {name} at {path}]")),
+        }
+    }
+    parts.join("\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use crate::traits::{NormalizedContent, NormalizedEvent};
+
+    use super::{HermesEventState, normalize_hermes_frame};
+
+    fn frame(kind: &str, payload: serde_json::Value) -> serde_json::Value {
+        json!({
+            "jsonrpc": "2.0",
+            "method": "event",
+            "params": {"type": kind, "session_id": "abc", "payload": payload},
+        })
+    }
+
+    #[test]
+    fn message_delta_becomes_agent_text_delta() {
+        let mut state = HermesEventState::default();
+        let (events, terminal) = normalize_hermes_frame(
+            &mut state,
+            1,
+            &frame("message.delta", json!({"text": "hi"})),
+        );
+        assert!(!terminal);
+        assert!(matches!(
+            &events[..],
+            [NormalizedEvent::AgentTextDelta { delta, .. }] if delta == "hi"
+        ));
+    }
+
+    #[test]
+    fn reasoning_delta_becomes_reasoning_text_delta() {
+        let mut state = HermesEventState::default();
+        let (events, _) = normalize_hermes_frame(
+            &mut state,
+            1,
+            &frame("reasoning.delta", json!({"text": "thinking"})),
+        );
+        assert!(matches!(
+            &events[..],
+            [NormalizedEvent::ReasoningTextDelta { delta, .. }] if delta == "thinking"
+        ));
+    }
+
+    #[test]
+    fn tool_start_and_complete_round_trip() {
+        let mut state = HermesEventState::default();
+        let (start_events, _) = normalize_hermes_frame(
+            &mut state,
+            1,
+            &frame(
+                "tool.start",
+                json!({"tool_id": "t1", "name": "terminal", "args": {"command": "ls"}}),
+            ),
+        );
+        let [NormalizedEvent::AssistantMessage { content, .. }] = &start_events[..] else {
+            panic!("expected assistant message, got {start_events:?}");
+        };
+        assert!(matches!(
+            &content[..],
+            [NormalizedContent::ToolUse { raw_id, tool, .. }]
+                if raw_id == "t1" && tool == "terminal"
+        ));
+
+        let (complete_events, _) = normalize_hermes_frame(
+            &mut state,
+            1,
+            &frame(
+                "tool.complete",
+                json!({"tool_id": "t1", "name": "terminal", "result": {"output": "ok", "exit_code": 0}}),
+            ),
+        );
+        let [NormalizedEvent::ToolResults(results)] = &complete_events[..] else {
+            panic!("expected tool results, got {complete_events:?}");
+        };
+        assert_eq!(results[0].tool_use_id, "t1");
+        assert!(!results[0].is_error);
+        assert_eq!(results[0].exit_code, Some(0));
+    }
+
+    #[test]
+    fn message_complete_finishes_turn_with_canonical_text() {
+        let mut state = HermesEventState::default();
+        let _ = normalize_hermes_frame(
+            &mut state,
+            1,
+            &frame("message.delta", json!({"text": "par"})),
+        );
+        let (events, terminal) = normalize_hermes_frame(
+            &mut state,
+            1,
+            &frame("message.complete", json!({"text": "partial then final"})),
+        );
+        assert!(terminal);
+        assert!(matches!(
+            &events[..],
+            [
+                NormalizedEvent::AssistantMessage { partial: false, content, .. },
+                NormalizedEvent::Result { error: None },
+            ] if matches!(
+                &content[..],
+                [NormalizedContent::AgentText { text, .. }] if text == "partial then final"
+            )
+        ));
+    }
+
+    #[test]
+    fn message_complete_error_becomes_failed_result() {
+        let mut state = HermesEventState::default();
+        let (events, terminal) = normalize_hermes_frame(
+            &mut state,
+            1,
+            &frame(
+                "message.complete",
+                json!({"text": "boom", "status": "error", "error": "provider 500"}),
+            ),
+        );
+        assert!(terminal);
+        assert!(matches!(
+            &events[..],
+            [NormalizedEvent::Result { error: Some(error) }] if error == "provider 500"
+        ));
+    }
+
+    #[test]
+    fn tool_complete_marks_failures() {
+        let mut state = HermesEventState::default();
+        let (events, _) = normalize_hermes_frame(
+            &mut state,
+            1,
+            &frame(
+                "tool.complete",
+                json!({"tool_id": "t2", "result": {"success": false, "error": "denied"}}),
+            ),
+        );
+        let [NormalizedEvent::ToolResults(results)] = &events[..] else {
+            panic!("expected tool results");
+        };
+        assert!(results[0].is_error);
+    }
+
+    #[test]
+    fn unknown_events_are_ignored() {
+        let mut state = HermesEventState::default();
+        let (events, terminal) =
+            normalize_hermes_frame(&mut state, 1, &frame("session.info", json!({"model": "x"})));
+        assert!(events.is_empty());
+        assert!(!terminal);
+    }
+
+    #[test]
+    fn non_event_frames_are_ignored() {
+        let mut state = HermesEventState::default();
+        let (events, terminal) = normalize_hermes_frame(
+            &mut state,
+            1,
+            &json!({"jsonrpc": "2.0", "id": 7, "result": {"ok": true}}),
+        );
+        assert!(events.is_empty());
+        assert!(!terminal);
+    }
+
+    #[test]
+    fn usage_event_maps_token_counts() {
+        let mut state = HermesEventState::default();
+        let (events, _) = normalize_hermes_frame(
+            &mut state,
+            1,
+            &frame(
+                "turn.usage",
+                json!({"input_tokens": 100, "output_tokens": 20, "total_tokens": 120}),
+            ),
+        );
+        let [NormalizedEvent::TokenUsage { usage }] = &events[..] else {
+            panic!("expected token usage");
+        };
+        assert_eq!(usage.input_tokens, Some(100));
+        assert_eq!(usage.total_tokens, Some(120));
+    }
+}

--- a/crates/harness-server/src/hermes.rs
+++ b/crates/harness-server/src/hermes.rs
@@ -1,36 +1,27 @@
 //! Hermes Agent harness — drives `hermes-agent`'s `tui_gateway` JSON-RPC
-//! stdio wire as a first-class Centaur harness.
+//! stdio wire as a Centaur harness.
 //!
 //! Unlike claude/amp (spawn-per-turn stream-json CLIs), Hermes ships a
 //! long-lived JSON-RPC gateway (`python -m tui_gateway.entry`) that owns the
 //! agent loop, durable session store, skills, persistent memory, background
 //! self-improvement reviews, and the cron scheduler. This runtime therefore
-//! mirrors the codex runtime shape: one persistent child per sandbox, a
+//! mirrors the codex runtime shape — one persistent child per sandbox, a
 //! handshake (`gateway.ready` → `session.create`), then one `prompt.submit`
-//! per turn with events pumped into the shared `CodexTurnNormalizer`.
+//! per turn with events pumped into the shared `CodexTurnNormalizer`:
 //!
-//! What "first-class" means here (vs. driving `hermes -z` one-shots):
-//! - **Session continuity**: one Hermes session per Centaur thread; the
-//!   prompt cache and conversation history survive across turns, and
-//!   `HERMES_CONTINUE_SESSION_ID` resumes the durable session after a
-//!   sandbox restart.
-//! - **Learning loop**: the background memory/skill review forks Hermes
-//!   spawns after turns run inside the same process and write to the
-//!   sandbox-mounted HERMES_HOME, so memories and skills accumulate.
-//! - **Crons**: Hermes cron jobs created during a conversation are ticked
-//!   by this runtime (`hermes cron tick` every `HERMES_CRON_TICK_SECONDS`,
-//!   cross-process file-locked on Hermes's side), so scheduled work fires
-//!   for as long as the sandbox lives.
-//! - **Interrupts**: Centaur's blocks `interrupt` maps to Hermes's
-//!   `session.interrupt` RPC — the turn ends as Interrupted without
-//!   killing the child, preserving the session for the next turn.
+//! - `message.delta`                       → AgentTextDelta
+//! - `reasoning.delta` / `thinking.delta`  → ReasoningTextDelta
+//! - `tool.start`                          → AssistantMessage(ToolUse)
+//! - `tool.complete`                       → ToolResults
+//! - `turn.usage`                          → TokenUsage
+//! - `message.complete`                    → AssistantMessage(final) + Result
 //!
-//! Wire mapping (Hermes event → NormalizedEvent):
-//! - `message.delta {text}`         → AgentTextDelta
-//! - `reasoning.delta`/`thinking.delta {text}` → ReasoningTextDelta
-//! - `tool.start {tool_id,name,args}`  → AssistantMessage(ToolUse)
-//! - `tool.complete {tool_id,result}`  → ToolResults
-//! - `message.complete {text,status}`  → AssistantMessage(final) + Result
+//! Because the gateway (not this process) owns the agent loop, Hermes's
+//! session history, prompt cache, learning loop, and cron jobs all survive
+//! across turns. `HERMES_CONTINUE_SESSION_ID` resumes the durable session
+//! after a sandbox restart (the hermes counterpart of
+//! `CODEX_CONTINUE_THREAD_ID`), and Centaur's `interrupt` maps to Hermes's
+//! `session.interrupt` — the turn ends Interrupted while the session lives on.
 
 use std::env;
 use std::io::{self, BufRead, Write};
@@ -48,9 +39,15 @@ use crate::traits::{
 };
 use crate::turn::{BridgeConfig, CodexTurnNormalizer};
 use crate::util::write_value;
+use crate::wire::notification_to_wire_value;
 use crate::{HarnessServerError, Result};
 
-const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(180);
+/// Gateway startup + RPC response budget. Generous because a cold Hermes
+/// start imports its agent stack and may run MCP discovery first.
+const RPC_TIMEOUT: Duration = Duration::from_secs(180);
+/// How long an interrupted turn may take to deliver its terminal
+/// `message.complete` before we stop draining and move on.
+const INTERRUPT_DRAIN_TIMEOUT: Duration = Duration::from_secs(30);
 const DEFAULT_CRON_TICK_SECONDS: u64 = 60;
 
 /// Entry point for `harness-server hermes`.
@@ -71,28 +68,23 @@ pub fn run_hermes_blocks_server() -> Result<()> {
             if trimmed.is_empty() {
                 continue;
             }
-            match parse_blocks_line_with_state(trimmed, &mut blocks_state) {
-                Ok(BlocksCommand::Interrupt) => {
-                    if interrupt_tx.send(()).is_err() {
-                        break;
-                    }
-                }
-                Ok(command) => {
-                    if command_tx.send(Ok(command)).is_err() {
-                        break;
-                    }
-                }
-                Err(error) => {
-                    if command_tx.send(Err(error.to_string())).is_err() {
-                        break;
-                    }
-                }
+            let sent = match parse_blocks_line_with_state(trimmed, &mut blocks_state) {
+                Ok(BlocksCommand::Interrupt) => interrupt_tx.send(()).is_ok(),
+                Ok(command) => command_tx.send(Ok(command)).is_ok(),
+                Err(error) => command_tx.send(Err(error.to_string())).is_ok(),
+            };
+            if !sent {
+                break;
             }
         }
     });
 
-    let mut turn_counter = 0u64;
+    let mut turn = 0u64;
     while let Ok(input) = command_rx.recv() {
+        let thread_id = hermes
+            .as_ref()
+            .map_or("hermes", HermesChild::thread_id)
+            .to_owned();
         match input {
             Ok(BlocksCommand::User {
                 input,
@@ -102,33 +94,25 @@ pub fn run_hermes_blocks_server() -> Result<()> {
                 reasoning,
                 trace_context: _,
             }) => {
-                turn_counter += 1;
-                let result = (|| -> Result<()> {
-                    if hermes.is_none() {
-                        hermes = Some(HermesChild::start(model.clone())?);
-                    }
-                    let child = hermes.as_mut().expect("hermes started");
+                turn += 1;
+                let result = ensure_child(&mut hermes, model).and_then(|child| {
                     run_hermes_turn(
                         child,
                         &mut stdout,
                         input,
                         client_user_message_id,
                         reasoning,
-                        turn_counter,
+                        turn,
                         &interrupt_rx,
                     )
-                })();
+                });
                 if let Err(error) = result {
-                    let thread_id = hermes
-                        .as_ref()
-                        .map(|child| child.thread_id())
-                        .unwrap_or("hermes");
                     eprintln!("Hermes blocks turn failed: {error:#}");
-                    write_blocks_error(&mut stdout, thread_id, "turn", error.to_string())?;
-                    // A dead child cannot serve the next turn; drop it so the
-                    // next user message restarts Hermes and resumes the durable
+                    write_blocks_error(&mut stdout, &thread_id, "turn", error.to_string())?;
+                    // A dead gateway cannot serve the next turn; drop it so the
+                    // next message restarts Hermes and resumes the durable
                     // session via HERMES_CONTINUE_SESSION_ID.
-                    if hermes.as_mut().is_some_and(|c| !c.is_alive()) {
+                    if hermes.as_mut().is_some_and(|child| !child.is_alive()) {
                         hermes = None;
                     }
                 }
@@ -139,11 +123,7 @@ pub fn run_hermes_blocks_server() -> Result<()> {
             Ok(BlocksCommand::AttachmentChunk) => {}
             Err(error) => {
                 eprintln!("invalid Hermes blocks input: {error}");
-                let thread_id = hermes
-                    .as_ref()
-                    .map(|child| child.thread_id())
-                    .unwrap_or("hermes");
-                write_blocks_error(&mut stdout, thread_id, "input", error)?;
+                write_blocks_error(&mut stdout, &thread_id, "input", error)?;
             }
         }
         // Drain interrupts that arrived between turns so a stale one cannot
@@ -153,11 +133,20 @@ pub fn run_hermes_blocks_server() -> Result<()> {
     Ok(())
 }
 
+fn ensure_child(
+    hermes: &mut Option<HermesChild>,
+    model: Option<String>,
+) -> Result<&mut HermesChild> {
+    if hermes.is_none() {
+        *hermes = Some(HermesChild::start(model)?);
+    }
+    Ok(hermes.as_mut().expect("hermes started"))
+}
+
 /// Tick `hermes cron tick` on an interval so cron jobs created inside the
 /// conversation fire while the sandbox lives. Hermes serializes ticks
-/// cross-process with a file lock, so this is safe alongside any other
-/// Hermes process on the same HERMES_HOME. `HERMES_CRON_TICK_SECONDS=0`
-/// disables the ticker.
+/// cross-process with a file lock, so this is safe alongside any other Hermes
+/// process on the same HERMES_HOME. `HERMES_CRON_TICK_SECONDS=0` disables it.
 fn spawn_cron_ticker() {
     let interval = env::var("HERMES_CRON_TICK_SECONDS")
         .ok()
@@ -166,7 +155,7 @@ fn spawn_cron_ticker() {
     if interval == 0 {
         return;
     }
-    let bin = hermes_bin();
+    let bin = env::var("HERMES_BIN").unwrap_or_else(|_| "hermes".to_string());
     thread::spawn(move || {
         let mut warned = false;
         loop {
@@ -187,26 +176,6 @@ fn spawn_cron_ticker() {
     });
 }
 
-fn hermes_bin() -> String {
-    env::var("HERMES_BIN").unwrap_or_else(|_| "hermes".to_string())
-}
-
-fn hermes_gateway_command() -> ProcessCommand {
-    // The JSON-RPC gateway is a Python module, not a `hermes` subcommand.
-    // HERMES_PYTHON overrides the interpreter (sandbox venvs).
-    let python = env::var("HERMES_PYTHON").unwrap_or_else(|_| "python3".to_string());
-    let mut command = ProcessCommand::new(python);
-    command.args(["-m", "tui_gateway.entry"]);
-    command.env("HERMES_QUIET", "1");
-    // Centaur owns approval policy at the sandbox boundary (iron-proxy egress,
-    // placeholder credentials); inside the sandbox Hermes runs unattended.
-    command.env(
-        "HERMES_APPROVAL_MODE",
-        env::var("HERMES_APPROVAL_MODE").unwrap_or_else(|_| "off".to_string()),
-    );
-    command
-}
-
 struct HermesChild {
     child: Child,
     stdin: ChildStdin,
@@ -224,7 +193,18 @@ impl Drop for HermesChild {
 
 impl HermesChild {
     fn start(model: Option<String>) -> Result<Self> {
-        let mut child = hermes_gateway_command()
+        // The JSON-RPC gateway is a Python module, not a `hermes` subcommand;
+        // HERMES_PYTHON points at the interpreter whose env has hermes-agent.
+        let python = env::var("HERMES_PYTHON").unwrap_or_else(|_| "python3".to_string());
+        let mut child = ProcessCommand::new(python)
+            .args(["-m", "tui_gateway.entry"])
+            .env("HERMES_QUIET", "1")
+            // Centaur owns approval policy at the sandbox boundary (isolated
+            // sandbox, iron-proxy egress); inside it Hermes runs unattended.
+            .env(
+                "HERMES_APPROVAL_MODE",
+                env::var("HERMES_APPROVAL_MODE").unwrap_or_else(|_| "off".to_string()),
+            )
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
@@ -247,6 +227,9 @@ impl HermesChild {
             .take()
             .ok_or(HarnessServerError::HarnessStderrUnavailable)?;
         thread::spawn(move || {
+            // Unlocked handle on purpose: the child lives across turns, so
+            // holding the StderrLock for the copy's lifetime would block
+            // every eprintln! in the server until the child exits.
             let mut parent_stderr = io::stderr();
             let _ = io::copy(&mut stderr, &mut parent_stderr);
         });
@@ -286,21 +269,16 @@ impl HermesChild {
     }
 
     fn wait_for_gateway_ready(&mut self) -> Result<()> {
-        let deadline = Instant::now() + HANDSHAKE_TIMEOUT;
+        let deadline = Instant::now() + RPC_TIMEOUT;
         loop {
-            let frame = self.read_frame_until(deadline)?;
-            if frame.get("method").and_then(Value::as_str) == Some("event")
-                && frame.pointer("/params/type").and_then(Value::as_str) == Some("gateway.ready")
-            {
+            if event_type(&self.read_frame_until(deadline)?) == Some("gateway.ready".to_string()) {
                 return Ok(());
             }
         }
     }
 
     /// Create the thread's Hermes session, or resume the durable one after a
-    /// sandbox restart (`HERMES_CONTINUE_SESSION_ID`, persisted by the
-    /// session runtime from our `thread.started` output — mirrors
-    /// CODEX_CONTINUE_THREAD_ID).
+    /// sandbox restart.
     fn create_or_resume_session(&mut self, model: Option<String>) -> Result<()> {
         let resume = env::var("HERMES_CONTINUE_SESSION_ID").unwrap_or_default();
         let resume = resume.trim();
@@ -315,10 +293,7 @@ impl HermesChild {
 
         let mut params = json!({
             "cols": 200,
-            "cwd": env::current_dir()
-                .unwrap_or_default()
-                .to_string_lossy()
-                .to_string(),
+            "cwd": env::current_dir().unwrap_or_default().to_string_lossy(),
             "title": "Centaur thread",
             "source": "centaur",
         });
@@ -338,28 +313,36 @@ impl HermesChild {
         Ok(())
     }
 
-    fn rpc(&mut self, method: &str, params: Value) -> Result<Value> {
+    /// Send a request frame without waiting for the response (the caller
+    /// pumps the stream itself, as `run_hermes_turn` does for prompt.submit).
+    fn send_request(&mut self, method: &str, params: Value) -> Result<()> {
         self.next_rpc_id += 1;
-        let id = self.next_rpc_id;
         self.write_frame(&json!({
             "jsonrpc": "2.0",
-            "id": id,
+            "id": self.next_rpc_id,
             "method": method,
             "params": params,
-        }))?;
-        let deadline = Instant::now() + HANDSHAKE_TIMEOUT;
+        }))
+    }
+
+    /// Send a request and block for its response, dropping unrelated frames.
+    /// Only for out-of-turn RPCs (handshake, interrupt) — events skipped here
+    /// would be lost to the turn pump.
+    fn rpc(&mut self, method: &str, params: Value) -> Result<Value> {
+        self.send_request(method, params)?;
+        let id = self.next_rpc_id;
+        let deadline = Instant::now() + RPC_TIMEOUT;
         loop {
             let frame = self.read_frame_until(deadline)?;
-            if frame.get("id").and_then(Value::as_i64) == Some(id) {
-                if let Some(error) = frame.get("error") {
-                    return Err(HarnessServerError::Protocol(format!(
-                        "hermes {method} failed: {error}"
-                    )));
-                }
-                return Ok(frame.get("result").cloned().unwrap_or(Value::Null));
+            if frame.get("id").and_then(Value::as_i64) != Some(id) {
+                continue;
             }
-            // Events and stale responses between request and response are
-            // dropped here; per-turn event pumping happens in run_hermes_turn.
+            if let Some(error) = frame.get("error") {
+                return Err(HarnessServerError::Protocol(format!(
+                    "hermes {method} failed: {error}"
+                )));
+            }
+            return Ok(frame.get("result").cloned().unwrap_or(Value::Null));
         }
     }
 
@@ -372,36 +355,22 @@ impl HermesChild {
 
     fn read_frame_until(&mut self, deadline: Instant) -> Result<Value> {
         loop {
-            let now = Instant::now();
-            if now >= deadline {
-                return Err(HarnessServerError::Protocol(
-                    "timed out waiting for hermes gateway".to_string(),
-                ));
-            }
-            match self.stdout.recv_timeout(deadline - now) {
+            let remaining = deadline
+                .checked_duration_since(Instant::now())
+                .ok_or_else(gateway_timeout)?;
+            match self.stdout.recv_timeout(remaining) {
                 Ok(line) => {
-                    let line = line?;
-                    let trimmed = line.trim();
-                    if trimmed.is_empty() {
-                        continue;
-                    }
-                    match serde_json::from_str::<Value>(trimmed) {
-                        Ok(value) => return Ok(value),
-                        // Hermes keeps its own stdout clean of non-JSON in
-                        // quiet mode; tolerate stray lines anyway.
-                        Err(_) => continue,
+                    // Hermes keeps stdout clean of non-JSON in quiet mode;
+                    // tolerate stray lines anyway.
+                    if let Ok(value) = serde_json::from_str::<Value>(line?.trim()) {
+                        return Ok(value);
                     }
                 }
-                Err(RecvTimeoutError::Timeout) => {
-                    return Err(HarnessServerError::Protocol(
-                        "timed out waiting for hermes gateway".to_string(),
-                    ));
-                }
+                Err(RecvTimeoutError::Timeout) => return Err(gateway_timeout()),
                 Err(RecvTimeoutError::Disconnected) => {
-                    let status = self.child.wait()?;
                     return Err(HarnessServerError::HarnessExited {
                         kind: crate::HarnessKind::Codex,
-                        status,
+                        status: self.child.wait()?,
                         stderr: String::new(),
                     });
                 }
@@ -410,166 +379,119 @@ impl HermesChild {
     }
 }
 
-/// Per-turn translation state: Hermes emits deltas + one final
-/// `message.complete` whose text REPEATS the streamed content, so the final
-/// text must be reconciled (suffix-delta) rather than double-emitted —
-/// `CodexTurnNormalizer::emit_agent_text` already handles that when the final
-/// AssistantMessage carries the full canonical text.
-#[derive(Debug, Default)]
-pub struct HermesEventState {
-    text_item_id: Option<String>,
-    saw_error: Option<String>,
+fn gateway_timeout() -> HarnessServerError {
+    HarnessServerError::Protocol("timed out waiting for hermes gateway".to_string())
 }
 
-/// Translate one Hermes gateway event frame into normalized events.
-/// Returns `(events, terminal)`.
-pub fn normalize_hermes_frame(
-    state: &mut HermesEventState,
-    turn: u64,
-    frame: &Value,
-) -> (Vec<NormalizedEvent>, bool) {
-    if frame.get("method").and_then(Value::as_str) != Some("event") {
-        return (Vec::new(), false);
-    }
-    let params = frame.get("params").cloned().unwrap_or_default();
-    let kind = params.get("type").and_then(Value::as_str).unwrap_or("");
-    let payload = params.get("payload").cloned().unwrap_or_default();
+/// The `params.type` of an event frame, or None for responses/other frames.
+fn event_type(frame: &Value) -> Option<String> {
+    (frame.get("method").and_then(Value::as_str) == Some("event"))
+        .then(|| frame.pointer("/params/type").and_then(Value::as_str))
+        .flatten()
+        .map(str::to_string)
+}
 
-    let text_item = state
-        .text_item_id
-        .get_or_insert_with(|| format!("hermes-msg-{turn}"))
-        .clone();
+/// Translate one Hermes gateway frame into normalized events. Pure: the text
+/// item id is deterministic per turn, and a failed turn's error rides the
+/// terminal `Result` event (which `CodexTurnNormalizer` latches into
+/// `last_error` for `finish_turn`). Terminal frames are recognized with the
+/// standard `NormalizedEvent::is_terminal()`.
+fn normalize_hermes_frame(turn: u64, frame: &Value) -> Vec<NormalizedEvent> {
+    let Some(kind) = event_type(frame) else {
+        return Vec::new();
+    };
+    let empty = json!({});
+    let payload = frame.pointer("/params/payload").unwrap_or(&empty);
+    let text_of = |key: &str| payload.get(key).and_then(Value::as_str).unwrap_or("");
 
-    match kind {
-        "message.delta" => {
-            let delta = payload.get("text").and_then(Value::as_str).unwrap_or("");
-            if delta.is_empty() {
-                return (Vec::new(), false);
-            }
-            (
-                vec![NormalizedEvent::AgentTextDelta {
-                    item_id: text_item,
-                    delta: delta.to_string(),
-                }],
-                false,
-            )
+    match kind.as_str() {
+        "message.delta" if !text_of("text").is_empty() => vec![NormalizedEvent::AgentTextDelta {
+            item_id: format!("hermes-msg-{turn}"),
+            delta: text_of("text").to_string(),
+        }],
+        "reasoning.delta" | "thinking.delta" if !text_of("text").is_empty() => {
+            vec![NormalizedEvent::ReasoningTextDelta {
+                item_id: format!("hermes-reasoning-{turn}"),
+                delta: text_of("text").to_string(),
+            }]
         }
-        "reasoning.delta" | "thinking.delta" => {
-            let delta = payload.get("text").and_then(Value::as_str).unwrap_or("");
-            if delta.is_empty() {
-                return (Vec::new(), false);
-            }
-            (
-                vec![NormalizedEvent::ReasoningTextDelta {
-                    item_id: format!("hermes-reasoning-{turn}"),
-                    delta: delta.to_string(),
-                }],
-                false,
-            )
-        }
-        "tool.start" => {
-            let tool_id = payload
-                .get("tool_id")
-                .and_then(Value::as_str)
-                .unwrap_or("tool")
-                .to_string();
-            let name = payload
-                .get("name")
-                .and_then(Value::as_str)
-                .unwrap_or("tool")
-                .to_string();
-            let arguments = payload.get("args").cloned().unwrap_or(json!({}));
-            (
-                vec![NormalizedEvent::AssistantMessage {
-                    partial: false,
-                    stop_reason: None,
-                    content: vec![NormalizedContent::ToolUse {
-                        raw_id: tool_id,
-                        tool: name,
-                        arguments,
-                    }],
-                }],
-                false,
-            )
-        }
+        "tool.start" => vec![NormalizedEvent::AssistantMessage {
+            partial: false,
+            stop_reason: None,
+            content: vec![NormalizedContent::ToolUse {
+                raw_id: nonempty_or(text_of("tool_id"), "tool"),
+                tool: nonempty_or(text_of("name"), "tool"),
+                arguments: payload.get("args").cloned().unwrap_or(json!({})),
+            }],
+        }],
         "tool.complete" => {
-            let tool_id = payload
-                .get("tool_id")
-                .and_then(Value::as_str)
-                .unwrap_or("tool")
-                .to_string();
-            let content = tool_result_text(&payload);
-            let is_error = payload
-                .get("result")
-                .map(|result| {
-                    result.get("success").and_then(Value::as_bool) == Some(false)
-                        || result.get("error").is_some_and(|e| !e.is_null())
-                })
-                .unwrap_or(false);
-            (
-                vec![NormalizedEvent::ToolResults(vec![NormalizedToolResult {
-                    tool_use_id: tool_id,
-                    content,
-                    is_error,
-                    exit_code: payload
-                        .pointer("/result/exit_code")
-                        .and_then(Value::as_i64)
-                        .map(|code| code as i32),
-                }])],
-                false,
-            )
+            let result = payload.get("result");
+            let is_error = result.is_some_and(|result| {
+                result.get("success").and_then(Value::as_bool) == Some(false)
+                    || result.get("error").is_some_and(|error| !error.is_null())
+            });
+            vec![NormalizedEvent::ToolResults(vec![NormalizedToolResult {
+                tool_use_id: nonempty_or(text_of("tool_id"), "tool"),
+                content: tool_result_text(payload),
+                is_error,
+                exit_code: payload
+                    .pointer("/result/exit_code")
+                    .and_then(Value::as_i64)
+                    .map(|code| code as i32),
+            }])]
         }
         "turn.usage" | "session.usage" => {
+            let count = |key: &str| payload.get(key).and_then(Value::as_i64);
             let usage = NormalizedTokenUsage {
                 model: payload
                     .get("model")
                     .and_then(Value::as_str)
                     .map(str::to_string),
-                input_tokens: payload.get("input_tokens").and_then(Value::as_i64),
-                output_tokens: payload.get("output_tokens").and_then(Value::as_i64),
+                input_tokens: count("input_tokens"),
+                output_tokens: count("output_tokens"),
                 cache_creation_input_tokens: None,
-                cache_read_input_tokens: payload.get("cached_tokens").and_then(Value::as_i64),
+                cache_read_input_tokens: count("cached_tokens"),
                 reasoning_output_tokens: None,
-                total_tokens: payload.get("total_tokens").and_then(Value::as_i64),
+                total_tokens: count("total_tokens"),
             };
             if usage.has_counts() {
-                (vec![NormalizedEvent::TokenUsage { usage }], false)
+                vec![NormalizedEvent::TokenUsage { usage }]
             } else {
-                (Vec::new(), false)
+                Vec::new()
             }
         }
         "message.complete" => {
-            let status = payload.get("status").and_then(Value::as_str).unwrap_or("");
-            let text = payload.get("text").and_then(Value::as_str).unwrap_or("");
+            let text = text_of("text");
+            if text_of("status") == "error" {
+                let error = [text_of("error"), text, "hermes turn failed"]
+                    .into_iter()
+                    .find(|candidate| !candidate.is_empty())
+                    .expect("last candidate is non-empty")
+                    .to_string();
+                return vec![NormalizedEvent::Result { error: Some(error) }];
+            }
             let mut events = Vec::new();
-            if status == "error" {
-                let error =
-                    payload
-                        .get("error")
-                        .and_then(Value::as_str)
-                        .unwrap_or(if text.is_empty() {
-                            "hermes turn failed"
-                        } else {
-                            text
-                        });
-                state.saw_error = Some(error.to_string());
-            } else if !text.is_empty() {
+            if !text.is_empty() {
+                // The final text repeats the streamed deltas; the normalizer's
+                // suffix-delta reconciliation prevents double emission.
                 events.push(NormalizedEvent::AssistantMessage {
                     partial: false,
                     stop_reason: Some("end_turn".to_string()),
                     content: vec![NormalizedContent::AgentText {
-                        item_id: text_item,
+                        item_id: format!("hermes-msg-{turn}"),
                         text: text.to_string(),
                     }],
                 });
             }
-            events.push(NormalizedEvent::Result {
-                error: state.saw_error.clone(),
-            });
-            (events, true)
+            events.push(NormalizedEvent::Result { error: None });
+            events
         }
-        _ => (Vec::new(), false),
+        _ => Vec::new(),
     }
+}
+
+fn nonempty_or(value: &str, fallback: &str) -> String {
+    if value.is_empty() { fallback } else { value }.to_string()
 }
 
 fn tool_result_text(payload: &Value) -> String {
@@ -596,10 +518,7 @@ fn run_hermes_turn<W: Write>(
     turn: u64,
     interrupt_rx: &Receiver<()>,
 ) -> Result<()> {
-    use crate::wire::notification_to_wire_value;
-
-    let turn_id = format!("turn-{turn}");
-    let mut config = BridgeConfig::new(child.thread_id().to_string(), turn_id);
+    let mut config = BridgeConfig::new(child.thread_id().to_string(), format!("turn-{turn}"));
     config.cli_version = "hermes".to_string();
     config.model_provider = "hermes".to_string();
     let mut normalizer = CodexTurnNormalizer::new(config);
@@ -611,35 +530,28 @@ fn run_hermes_turn<W: Write>(
         write_value(stdout, &notification_to_wire_value(&notification)?)?;
     }
 
-    let text = user_input_text(&input);
     let mut params = json!({
         "session_id": child.session_id,
-        "text": text,
+        "text": user_input_text(&input),
     });
     if let Some(reasoning) = reasoning.filter(|value| !value.trim().is_empty()) {
         params["reasoning_effort"] = Value::String(reasoning);
     }
-    child.next_rpc_id += 1;
-    let submit_id = child.next_rpc_id;
-    child.write_frame(&json!({
-        "jsonrpc": "2.0",
-        "id": submit_id,
-        "method": "prompt.submit",
-        "params": params,
-    }))?;
+    child.send_request("prompt.submit", params)?;
 
-    let mut state = HermesEventState::default();
     loop {
         if interrupt_rx.try_recv().is_ok() {
-            let session_id = child.session_id.clone();
-            let _ = child.rpc("session.interrupt", json!({"session_id": session_id}));
-            // Hermes ends the interrupted turn with its own message.complete;
-            // keep pumping until it arrives (bounded) so the trailing terminal
-            // frame can't leak into the next turn.
-            let deadline = Instant::now() + Duration::from_secs(30);
+            let params = json!({"session_id": child.session_id});
+            let _ = child.rpc("session.interrupt", params);
+            // Hermes ends the interrupted turn with its own terminal frame;
+            // drain until it arrives (bounded) so it can't leak into the
+            // next turn as an instant terminal.
+            let deadline = Instant::now() + INTERRUPT_DRAIN_TIMEOUT;
             while let Ok(frame) = child.read_frame_until(deadline) {
-                let (_, terminal) = normalize_hermes_frame(&mut state, turn, &frame);
-                if terminal {
+                if normalize_hermes_frame(turn, &frame)
+                    .iter()
+                    .any(NormalizedEvent::is_terminal)
+                {
                     break;
                 }
             }
@@ -651,22 +563,19 @@ fn run_hermes_turn<W: Write>(
 
         match child.stdout.recv_timeout(Duration::from_millis(50)) {
             Ok(line) => {
-                let line = line?;
-                let trimmed = line.trim();
-                if trimmed.is_empty() {
-                    continue;
-                }
-                let Ok(frame) = serde_json::from_str::<Value>(trimmed) else {
+                let Ok(frame) = serde_json::from_str::<Value>(line?.trim()) else {
                     continue;
                 };
-                let (events, terminal) = normalize_hermes_frame(&mut state, turn, &frame);
-                for event in events {
+                let mut terminal = false;
+                for event in normalize_hermes_frame(turn, &frame) {
+                    terminal |= event.is_terminal();
                     for notification in normalizer.process_event(&event)? {
                         write_value(stdout, &notification_to_wire_value(&notification)?)?;
                     }
                 }
                 if terminal {
-                    if let Some(notification) = normalizer.finish_turn(state.saw_error.clone())? {
+                    // A failed turn's error was latched from the Result event.
+                    if let Some(notification) = normalizer.finish_turn(None)? {
                         write_value(stdout, &notification_to_wire_value(&notification)?)?;
                     }
                     return Ok(());
@@ -674,10 +583,9 @@ fn run_hermes_turn<W: Write>(
             }
             Err(RecvTimeoutError::Timeout) => continue,
             Err(RecvTimeoutError::Disconnected) => {
-                let status = child.child.wait()?;
                 return Err(HarnessServerError::HarnessExited {
                     kind: crate::HarnessKind::Codex,
-                    status,
+                    status: child.child.wait()?,
                     stderr: String::new(),
                 });
             }
@@ -709,7 +617,7 @@ mod tests {
 
     use crate::traits::{NormalizedContent, NormalizedEvent};
 
-    use super::{HermesEventState, normalize_hermes_frame};
+    use super::normalize_hermes_frame;
 
     fn frame(kind: &str, payload: serde_json::Value) -> serde_json::Value {
         json!({
@@ -719,15 +627,14 @@ mod tests {
         })
     }
 
+    fn is_terminal(events: &[NormalizedEvent]) -> bool {
+        events.iter().any(NormalizedEvent::is_terminal)
+    }
+
     #[test]
     fn message_delta_becomes_agent_text_delta() {
-        let mut state = HermesEventState::default();
-        let (events, terminal) = normalize_hermes_frame(
-            &mut state,
-            1,
-            &frame("message.delta", json!({"text": "hi"})),
-        );
-        assert!(!terminal);
+        let events = normalize_hermes_frame(1, &frame("message.delta", json!({"text": "hi"})));
+        assert!(!is_terminal(&events));
         assert!(matches!(
             &events[..],
             [NormalizedEvent::AgentTextDelta { delta, .. }] if delta == "hi"
@@ -736,12 +643,8 @@ mod tests {
 
     #[test]
     fn reasoning_delta_becomes_reasoning_text_delta() {
-        let mut state = HermesEventState::default();
-        let (events, _) = normalize_hermes_frame(
-            &mut state,
-            1,
-            &frame("reasoning.delta", json!({"text": "thinking"})),
-        );
+        let events =
+            normalize_hermes_frame(1, &frame("reasoning.delta", json!({"text": "thinking"})));
         assert!(matches!(
             &events[..],
             [NormalizedEvent::ReasoningTextDelta { delta, .. }] if delta == "thinking"
@@ -750,9 +653,7 @@ mod tests {
 
     #[test]
     fn tool_start_and_complete_round_trip() {
-        let mut state = HermesEventState::default();
-        let (start_events, _) = normalize_hermes_frame(
-            &mut state,
+        let start_events = normalize_hermes_frame(
             1,
             &frame(
                 "tool.start",
@@ -768,8 +669,7 @@ mod tests {
                 if raw_id == "t1" && tool == "terminal"
         ));
 
-        let (complete_events, _) = normalize_hermes_frame(
-            &mut state,
+        let complete_events = normalize_hermes_frame(
             1,
             &frame(
                 "tool.complete",
@@ -786,18 +686,11 @@ mod tests {
 
     #[test]
     fn message_complete_finishes_turn_with_canonical_text() {
-        let mut state = HermesEventState::default();
-        let _ = normalize_hermes_frame(
-            &mut state,
-            1,
-            &frame("message.delta", json!({"text": "par"})),
-        );
-        let (events, terminal) = normalize_hermes_frame(
-            &mut state,
+        let events = normalize_hermes_frame(
             1,
             &frame("message.complete", json!({"text": "partial then final"})),
         );
-        assert!(terminal);
+        assert!(is_terminal(&events));
         assert!(matches!(
             &events[..],
             [
@@ -812,16 +705,14 @@ mod tests {
 
     #[test]
     fn message_complete_error_becomes_failed_result() {
-        let mut state = HermesEventState::default();
-        let (events, terminal) = normalize_hermes_frame(
-            &mut state,
+        let events = normalize_hermes_frame(
             1,
             &frame(
                 "message.complete",
                 json!({"text": "boom", "status": "error", "error": "provider 500"}),
             ),
         );
-        assert!(terminal);
+        assert!(is_terminal(&events));
         assert!(matches!(
             &events[..],
             [NormalizedEvent::Result { error: Some(error) }] if error == "provider 500"
@@ -829,10 +720,23 @@ mod tests {
     }
 
     #[test]
+    fn message_complete_error_falls_back_to_text() {
+        let events = normalize_hermes_frame(
+            1,
+            &frame(
+                "message.complete",
+                json!({"text": "boom", "status": "error"}),
+            ),
+        );
+        assert!(matches!(
+            &events[..],
+            [NormalizedEvent::Result { error: Some(error) }] if error == "boom"
+        ));
+    }
+
+    #[test]
     fn tool_complete_marks_failures() {
-        let mut state = HermesEventState::default();
-        let (events, _) = normalize_hermes_frame(
-            &mut state,
+        let events = normalize_hermes_frame(
             1,
             &frame(
                 "tool.complete",
@@ -847,30 +751,22 @@ mod tests {
 
     #[test]
     fn unknown_events_are_ignored() {
-        let mut state = HermesEventState::default();
-        let (events, terminal) =
-            normalize_hermes_frame(&mut state, 1, &frame("session.info", json!({"model": "x"})));
+        let events = normalize_hermes_frame(1, &frame("session.info", json!({"model": "x"})));
         assert!(events.is_empty());
-        assert!(!terminal);
     }
 
     #[test]
     fn non_event_frames_are_ignored() {
-        let mut state = HermesEventState::default();
-        let (events, terminal) = normalize_hermes_frame(
-            &mut state,
+        let events = normalize_hermes_frame(
             1,
             &json!({"jsonrpc": "2.0", "id": 7, "result": {"ok": true}}),
         );
         assert!(events.is_empty());
-        assert!(!terminal);
     }
 
     #[test]
     fn usage_event_maps_token_counts() {
-        let mut state = HermesEventState::default();
-        let (events, _) = normalize_hermes_frame(
-            &mut state,
+        let events = normalize_hermes_frame(
             1,
             &frame(
                 "turn.usage",

--- a/crates/harness-server/src/hermes.rs
+++ b/crates/harness-server/src/hermes.rs
@@ -368,10 +368,8 @@ impl HermesChild {
                 }
                 Err(RecvTimeoutError::Timeout) => return Err(gateway_timeout()),
                 Err(RecvTimeoutError::Disconnected) => {
-                    return Err(HarnessServerError::HarnessExited {
-                        kind: crate::HarnessKind::Codex,
+                    return Err(HarnessServerError::HermesExited {
                         status: self.child.wait()?,
-                        stderr: String::new(),
                     });
                 }
             }
@@ -583,10 +581,8 @@ fn run_hermes_turn<W: Write>(
             }
             Err(RecvTimeoutError::Timeout) => continue,
             Err(RecvTimeoutError::Disconnected) => {
-                return Err(HarnessServerError::HarnessExited {
-                    kind: crate::HarnessKind::Codex,
+                return Err(HarnessServerError::HermesExited {
                     status: child.child.wait()?,
-                    stderr: String::new(),
                 });
             }
         }

--- a/crates/harness-server/src/lib.rs
+++ b/crates/harness-server/src/lib.rs
@@ -3,6 +3,7 @@ pub mod anthropic;
 pub mod claude;
 pub mod codex;
 mod error;
+pub mod hermes;
 mod nanocodex;
 mod nanocodex_subagents;
 mod otel;
@@ -14,6 +15,7 @@ mod validation;
 pub mod wire;
 
 pub use error::{HarnessServerError, Result};
+pub use hermes::run_hermes_blocks_server;
 pub use nanocodex::run_nanocodex_blocks_server;
 pub use server::{run_blocks_server, run_harness_server, run_validate_jsonrpc, server_for};
 pub use traits::{

--- a/crates/harness-server/src/main.rs
+++ b/crates/harness-server/src/main.rs
@@ -1,7 +1,7 @@
 use clap::{Parser, Subcommand, ValueEnum};
 use harness_server::{
-    HarnessKind, Result, run_blocks_server, run_harness_server, run_nanocodex_blocks_server,
-    run_validate_agent_deltas, run_validate_jsonrpc,
+    HarnessKind, Result, run_blocks_server, run_harness_server, run_hermes_blocks_server,
+    run_nanocodex_blocks_server, run_validate_agent_deltas, run_validate_jsonrpc,
 };
 
 #[derive(Debug, Parser)]
@@ -23,6 +23,9 @@ enum CliCommand {
     Amp(HarnessCommand),
     /// Run Nanocodex directly as a library and stream its native typed events.
     Nanocodex,
+    /// Drive Hermes Agent's long-lived JSON-RPC gateway (sessions, memory,
+    /// skills, crons survive across turns).
+    Hermes,
     ValidateJsonrpc,
     ValidateAgentDeltas,
 }
@@ -56,6 +59,7 @@ fn run() -> Result<()> {
         CliCommand::ClaudeCode(command) => run_mode(HarnessKind::ClaudeCode, command.mode),
         CliCommand::Amp(command) => run_mode(HarnessKind::Amp, command.mode),
         CliCommand::Nanocodex => run_nanocodex_blocks_server(),
+        CliCommand::Hermes => run_hermes_blocks_server(),
         CliCommand::ValidateJsonrpc => run_validate_jsonrpc(),
         CliCommand::ValidateAgentDeltas => run_validate_agent_deltas(),
     }

--- a/docs/pages/extend/hermes-harness.mdx
+++ b/docs/pages/extend/hermes-harness.mdx
@@ -50,6 +50,13 @@ here, including OpenRouter and the Nous inference API. A per-thread
 `--model <name>` override is passed through to Hermes's session as a
 per-session model override.
 
+:::note
+Cron jobs resolve their model from `config.yaml`'s `model.default` (they run
+outside any interactive session), so give the sandbox `HERMES_HOME` a
+`config.yaml` with `model.default` set — a `.env` with provider keys alone is
+enough for turns, but not for scheduled jobs.
+:::
+
 ## Persistence model
 
 Everything Hermes learns lives under `HERMES_HOME`. With the default

--- a/docs/pages/extend/hermes-harness.mdx
+++ b/docs/pages/extend/hermes-harness.mdx
@@ -1,0 +1,66 @@
+# Using the Hermes Harness
+
+Centaur can run [Hermes Agent](https://github.com/NousResearch/hermes-agent)
+(by Nous Research) as a session harness alongside Codex, Claude Code, Amp,
+and Nanocodex. Start a Slack thread with `--hermes` (or set it as a channel
+or deployment default) and the sandbox runs a full Hermes gateway instead of
+a spawn-per-turn CLI.
+
+## What makes Hermes different from the other harnesses
+
+Hermes is a persistent personal agent, not a one-shot coding CLI. The
+harness integration is built so its long-lived subsystems keep working
+inside a Centaur sandbox:
+
+- **Durable sessions** — the harness speaks Hermes's JSON-RPC gateway
+  (`tui_gateway`) over stdio and keeps one Hermes session per Centaur
+  thread. Conversation history and Hermes's provider prompt cache survive
+  across turns, and after a sandbox restart the session is resumed from
+  Hermes's SQLite session store via `HERMES_CONTINUE_SESSION_ID`.
+- **Self-improvement loop** — Hermes's background memory/skill reviews run
+  after turns inside the gateway process. What the agent learns in one
+  thread (memories, skills) lands in `HERMES_HOME` and is available to
+  every later thread on the same volume.
+- **Cron jobs** — scheduled jobs the agent creates during a conversation
+  are ticked by the harness (`hermes cron tick`, cross-process file-locked
+  on Hermes's side) for as long as the sandbox lives. Set
+  `HERMES_CRON_TICK_SECONDS=0` to disable, or another interval in seconds
+  (default 60).
+- **Skills, delegation, MCP** — Hermes's skill library, `delegate_task`
+  subagents, and MCP client all run inside the sandbox process; no extra
+  wiring needed.
+- **Interrupts** — Centaur's interrupt maps to Hermes's
+  `session.interrupt`, ending the turn as Interrupted without killing the
+  gateway, so the session survives for the next message.
+
+## Configuration
+
+| Variable | Purpose |
+|---|---|
+| `HERMES_PYTHON` | Interpreter whose environment has `hermes-agent` installed. The sandbox image sets this to the baked-in `/opt/hermes/bin/python3`. |
+| `HERMES_BIN` | The `hermes` CLI used for cron ticks (default: `hermes` on PATH). |
+| `HERMES_HOME` | Hermes state root (config, sessions, memories, skills, cron). Mount a per-team volume here to persist learning across sandboxes. |
+| `HERMES_CONTINUE_SESSION_ID` | Resume a specific Hermes session id after a sandbox restart. |
+| `HERMES_CRON_TICK_SECONDS` | Cron tick interval; `0` disables the ticker. |
+| `HERMES_APPROVAL_MODE` | Defaults to `off` inside the sandbox — Centaur owns the safety boundary (isolated sandbox + iron-proxy egress). |
+
+Model/provider selection follows Hermes's own configuration
+(`$HERMES_HOME/config.yaml` + `.env`), so any provider Hermes supports works
+here, including OpenRouter and the Nous inference API. A per-thread
+`--model <name>` override is passed through to Hermes's session as a
+per-session model override.
+
+## Persistence model
+
+Everything Hermes learns lives under `HERMES_HOME`. With the default
+throwaway sandbox, memory and skills last only as long as the sandbox; to
+get compounding, cross-thread learning, mount a persistent volume at
+`HERMES_HOME` (per team or per deployment, matching your permission
+boundaries — a shared volume means shared memory).
+
+## Credentials
+
+Hermes reads provider keys from `$HERMES_HOME/.env`. Under Centaur's
+credential-injection model you can keep real keys out of the sandbox by
+binding placeholder values and letting iron-proxy swap them on egress to the
+provider hosts, the same pattern the other harnesses use.

--- a/docs/sidebar.ts
+++ b/docs/sidebar.ts
@@ -27,6 +27,7 @@ export const sidebar = [
       { text: 'Creating Tools', link: '/extend/tools' },
       { text: 'Creating Workflows', link: '/extend/workflows' },
       { text: 'Workflows v2 Migration', link: '/extend/workflows-v2' },
+      { text: 'Using the Hermes Harness', link: '/extend/hermes-harness' },
       { text: '🚧 Creating Apps', link: '/extend/apps' },
     ],
   },

--- a/services/api-rs/crates/centaur-api-integration-test/src/main.rs
+++ b/services/api-rs/crates/centaur-api-integration-test/src/main.rs
@@ -231,6 +231,7 @@ async fn test_harness_wire_values(http: &HttpClient, base_url: &str) -> Result<(
         (HarnessType::Amp, "amp"),
         (HarnessType::ClaudeCode, "claudecode"),
         (HarnessType::Nanocodex, "nanocodex"),
+        (HarnessType::Hermes, "hermes"),
     ];
 
     for (harness_type, expected_wire_value) in cases {

--- a/services/api-rs/crates/centaur-api-server/src/args.rs
+++ b/services/api-rs/crates/centaur-api-server/src/args.rs
@@ -2709,6 +2709,7 @@ mod tests {
             env.iter()
                 .any(|(name, value)| name == "META_AI_API_KEY" && value == "META_AI_API_KEY")
         );
+        assert!(env.iter().all(|(name, _)| name != "NOUS_API_KEY"));
     }
 
     #[test]
@@ -3218,6 +3219,27 @@ mod tests {
         assert_eq!(
             harness_auth_mode_env(&HarnessType::Nanocodex).as_deref(),
             Some("access_token")
+        );
+    }
+
+    #[test]
+    fn hermes_default_has_a_native_provider_proxy_fragment() {
+        let args = Args::try_parse_from([
+            "centaur-api-server",
+            "--database-url",
+            "postgres://postgres:postgres@localhost/centaur",
+            "--kubernetes-iron-proxy-harness-engine",
+            "hermes",
+            "--kubernetes-iron-proxy-harness-auth-mode",
+            "api_key",
+        ])
+        .unwrap();
+
+        let fragment = args.sandbox.iron_proxy.harness.fragment().unwrap();
+        let placeholders = centaur_iron_proxy::placeholder_env(&[fragment]);
+        assert_eq!(
+            placeholders.get("NOUS_API_KEY").map(String::as_str),
+            Some("NOUS_API_KEY")
         );
     }
 }

--- a/services/api-rs/crates/centaur-api-server/src/args.rs
+++ b/services/api-rs/crates/centaur-api-server/src/args.rs
@@ -2028,6 +2028,7 @@ fn harness_fragment_engine_name(engine: &HarnessType) -> &'static str {
         HarnessType::Amp => "amp",
         HarnessType::ClaudeCode => "claude-code",
         HarnessType::Nanocodex => "codex",
+        HarnessType::Hermes => "hermes",
     }
 }
 
@@ -2045,6 +2046,9 @@ fn harness_auth_mode_env(engine: &HarnessType) -> Option<String> {
         HarnessType::Codex | HarnessType::Nanocodex => env::var("CODEX_AUTH_MODE").ok(),
         HarnessType::ClaudeCode => env::var("CLAUDE_CODE_AUTH_MODE").ok(),
         HarnessType::Amp => None,
+        // Hermes resolves providers through its own credential store /
+        // iron-proxy placeholder injection; no dedicated auth-mode env.
+        HarnessType::Hermes => None,
     }
 }
 

--- a/services/api-rs/crates/centaur-iron-proxy/src/fragment.rs
+++ b/services/api-rs/crates/centaur-iron-proxy/src/fragment.rs
@@ -31,6 +31,7 @@ pub fn harness_auth_fragment(engine: &str, auth_mode: &str) -> Result<Option<Pro
     let yaml = match (engine, normalize_auth_mode(auth_mode).as_str()) {
         ("codex", "api_key") => CODEX_API_KEY_FRAGMENT,
         ("codex", "access_token") => CODEX_ACCESS_TOKEN_FRAGMENT,
+        ("hermes", "api_key") => HERMES_API_KEY_FRAGMENT,
         ("openrouter", "api_key") => OPENROUTER_API_KEY_FRAGMENT,
         ("meta-ai", "api_key") => META_AI_API_KEY_FRAGMENT,
         ("claude-code", "api_key") => CLAUDE_CODE_API_KEY_FRAGMENT,
@@ -179,6 +180,22 @@ transforms:
             proxy_value: OPENROUTER_API_KEY
             match_headers: ["Authorization"]
           rules: [{ host: openrouter.ai }]
+"#;
+
+// Hermes's native Nous Portal provider authenticates with NOUS_API_KEY. Other
+// providers Hermes can use (OpenRouter, OpenAI, and Anthropic) are registered
+// as their own fragments by api-rs so their existing host scopes stay shared
+// with the other harnesses.
+const HERMES_API_KEY_FRAGMENT: &str = r#"
+transforms:
+  - name: secrets
+    config:
+      secrets:
+        - id: NOUS_API_KEY_AUTHORIZATION
+          replace:
+            proxy_value: NOUS_API_KEY
+            match_headers: ["Authorization"]
+          rules: [{ host: inference-api.nousresearch.com }]
 "#;
 
 const META_AI_API_KEY_FRAGMENT: &str = r#"

--- a/services/api-rs/crates/centaur-iron-proxy/src/tests.rs
+++ b/services/api-rs/crates/centaur-iron-proxy/src/tests.rs
@@ -27,6 +27,17 @@ fn harness_auth_fragments_are_baked_in() {
         Some("OPENROUTER_API_KEY")
     );
 
+    let hermes = harness_auth_fragment("hermes", "api_key").unwrap().unwrap();
+    assert_eq!(
+        hermes.transforms[0].config.secrets[0].rules[0]["host"].as_str(),
+        Some("inference-api.nousresearch.com")
+    );
+    let hermes_placeholders = placeholder_env(&[hermes]);
+    assert_eq!(
+        hermes_placeholders.get("NOUS_API_KEY").map(String::as_str),
+        Some("NOUS_API_KEY")
+    );
+
     let meta_ai = harness_auth_fragment("meta-ai", "api_key")
         .unwrap()
         .unwrap();

--- a/services/api-rs/crates/centaur-session-cli/src/main.rs
+++ b/services/api-rs/crates/centaur-session-cli/src/main.rs
@@ -576,6 +576,7 @@ enum HarnessTypeArg {
     #[value(name = "claudecode")]
     ClaudeCode,
     Nanocodex,
+    Hermes,
 }
 
 impl From<HarnessTypeArg> for HarnessType {
@@ -585,6 +586,7 @@ impl From<HarnessTypeArg> for HarnessType {
             HarnessTypeArg::Amp => Self::Amp,
             HarnessTypeArg::ClaudeCode => Self::ClaudeCode,
             HarnessTypeArg::Nanocodex => Self::Nanocodex,
+            HarnessTypeArg::Hermes => Self::Hermes,
         }
     }
 }

--- a/services/api-rs/crates/centaur-session-core/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-core/src/lib.rs
@@ -361,6 +361,7 @@ pub enum HarnessType {
     Amp,
     ClaudeCode,
     Nanocodex,
+    Hermes,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, AsRefStr, Display, EnumString)]

--- a/services/api-rs/crates/centaur-session-runtime/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-runtime/src/lib.rs
@@ -3748,6 +3748,7 @@ fn harness_server_subcommand(harness: &HarnessType) -> &'static str {
         HarnessType::ClaudeCode => "claude-code",
         HarnessType::Amp => "amp",
         HarnessType::Nanocodex => "nanocodex",
+        HarnessType::Hermes => "hermes",
     }
 }
 

--- a/services/api-rs/crates/centaur-session-sqlx/migrations/0051_hermes_harness.sql
+++ b/services/api-rs/crates/centaur-session-sqlx/migrations/0051_hermes_harness.sql
@@ -1,0 +1,6 @@
+alter table sessions
+    drop constraint sessions_harness_type_supported;
+
+alter table sessions
+    add constraint sessions_harness_type_supported
+    check (harness_type in ('codex', 'amp', 'claudecode', 'nanocodex', 'hermes'));

--- a/services/sandbox/Dockerfile
+++ b/services/sandbox/Dockerfile
@@ -162,9 +162,15 @@ RUN --mount=type=cache,target=/root/.npm,sharing=locked \
 # The hermes harness drives `python -m tui_gateway.entry` (see
 # crates/harness-server/src/hermes.rs). HERMES_PYTHON points the harness at
 # this venv's interpreter; the `hermes` shim serves cron ticks + CLI use.
-RUN python3 -m venv /opt/hermes \
-    && /opt/hermes/bin/pip install --no-cache-dir \
-      "hermes-agent @ git+https://github.com/NousResearch/hermes-agent@${HERMES_AGENT_REF}" \
+# Hermes intentionally rejects wheel builds because its runtime assets depend
+# on the source-checkout layout, so install the pinned checkout editable.
+RUN git init /opt/hermes-agent \
+    && git -C /opt/hermes-agent remote add origin https://github.com/NousResearch/hermes-agent.git \
+    && git -C /opt/hermes-agent fetch --depth 1 origin "${HERMES_AGENT_REF}" \
+    && git -C /opt/hermes-agent checkout --detach FETCH_HEAD \
+    && python3 -m venv /opt/hermes \
+    && /opt/hermes/bin/pip install --no-cache-dir --editable /opt/hermes-agent \
+    && rm -rf /opt/hermes-agent/.git \
     && ln -s /opt/hermes/bin/hermes /usr/local/bin/hermes \
     && hermes version
 ENV HERMES_PYTHON=/opt/hermes/bin/python3

--- a/services/sandbox/Dockerfile
+++ b/services/sandbox/Dockerfile
@@ -90,6 +90,8 @@ RUN useradd -m -s /bin/bash -u 1001 agent \
 
 ARG CLAUDE_CODE_VERSION=2.1.154
 ARG CODEX_VERSION=0.144.0
+# Hermes Agent (NousResearch) — pinned by commit SHA per the dependency policy.
+ARG HERMES_AGENT_REF=e5e2fb8b2dbe1cae85aa5ad6ce45aef376016e43
 ARG PI_CODING_AGENT_VERSION=0.67.2
 ARG NUSHELL_VERSION=0.112.2
 ARG KUBECTL_VERSION=v1.34.2
@@ -155,6 +157,17 @@ RUN --mount=type=cache,target=/root/.npm,sharing=locked \
     && claude --version | grep -F "${CLAUDE_CODE_VERSION}" \
     && codex --version | grep -F "${CODEX_VERSION}" \
     && pnpm --version | grep -F "${PNPM_VERSION}"
+
+# ── Hermes Agent (own venv; exposes `hermes` + the tui_gateway module) ───────
+# The hermes harness drives `python -m tui_gateway.entry` (see
+# crates/harness-server/src/hermes.rs). HERMES_PYTHON points the harness at
+# this venv's interpreter; the `hermes` shim serves cron ticks + CLI use.
+RUN python3 -m venv /opt/hermes \
+    && /opt/hermes/bin/pip install --no-cache-dir \
+      "hermes-agent @ git+https://github.com/NousResearch/hermes-agent@${HERMES_AGENT_REF}" \
+    && ln -s /opt/hermes/bin/hermes /usr/local/bin/hermes \
+    && hermes version
+ENV HERMES_PYTHON=/opt/hermes/bin/python3
 
 # ── agent-browser system deps (must run as root before USER agent) ───────────
 # Chrome for Testing doesn't provide Linux ARM64 builds; fall back to system chromium

--- a/services/slackbotv2/src/overrides.ts
+++ b/services/slackbotv2/src/overrides.ts
@@ -44,6 +44,7 @@ const HARNESS_FLAGS: Record<string, string> = {
   'claude-code': 'claudecode',
   claudecode: 'claudecode',
   codex: 'codex',
+  hermes: 'hermes',
   nanocodex: 'nanocodex'
 }
 
@@ -72,7 +73,7 @@ const MODEL_SHORTCUTS: Record<string, { harnessType: string; model: string }> =
     ])
   )
 
-const STRATEGY_HARNESSES = new Set(['amp', 'claudecode', 'codex', 'nanocodex'])
+const STRATEGY_HARNESSES = new Set(['amp', 'claudecode', 'codex', 'hermes', 'nanocodex'])
 const STRATEGY_PROVIDERS = new Set(['amazon-bedrock', 'openrouter', 'responses'])
 const STRATEGY_REASONING_EFFORTS = new Set([
   'none',

--- a/services/slackbotv2/src/types.ts
+++ b/services/slackbotv2/src/types.ts
@@ -156,9 +156,9 @@ export type SlackbotV2Options = {
    */
   channelDefaults?: ChannelDefaults
   /**
-   * Harness for new threads when no --claude/--amp/--codex/--nanocodex flag is
-   * given (HarnessType wire value: codex | amp | claudecode | nanocodex).
-   * Defaults to codex.
+   * Harness for new threads when no --claude/--amp/--codex/--nanocodex/--hermes
+   * flag is given (HarnessType wire value: codex | amp | claudecode |
+   * nanocodex | hermes). Defaults to codex.
    */
   defaultHarnessType?: string
   fetch?: SlackbotV2Fetch

--- a/services/slackbotv2/test/overrides.test.ts
+++ b/services/slackbotv2/test/overrides.test.ts
@@ -31,6 +31,7 @@ describe('extractMessageOverrides', () => {
     expect(extractMessageOverrides('--amp review this').harnessType).toBe('amp')
     expect(extractMessageOverrides('--codex review this').harnessType).toBe('codex')
     expect(extractMessageOverrides('--nanocodex review this').harnessType).toBe('nanocodex')
+    expect(extractMessageOverrides('--hermes review this').harnessType).toBe('hermes')
   })
 
   test('parses harness flag anywhere in the message', () => {


### PR DESCRIPTION
## Summary

Adds **Hermes Agent** (github.com/NousResearch/hermes-agent) as a first-class harness alongside Codex, Claude Code, Amp, and Nanocodex — `--hermes` in Slack, `harness: hermes` in channel defaults, `CENTAUR_DEFAULT_HARNESS=hermes` for deployments.

Hermes differs from the spawn-per-turn CLIs: it ships a long-lived JSON-RPC gateway that owns durable sessions, a background skill/memory learning loop, and a cron scheduler. This integration keeps those working inside the sandbox rather than flattening Hermes into a one-shot CLI:

- **Session continuity** — one persistent gateway child per sandbox, one Hermes session per thread; conversation history and provider prompt cache survive across turns. After a sandbox restart, `HERMES_CONTINUE_SESSION_ID` resumes the durable session from Hermes's session store (mirrors `CODEX_CONTINUE_THREAD_ID`).
- **Learning loop** — Hermes's post-turn memory/skill reviews run inside the gateway process and persist to `HERMES_HOME`; mount a volume there and learning compounds across sandboxes.
- **Crons** — a background ticker runs `hermes cron tick` (cross-process file-locked on Hermes's side) so scheduled jobs created in-conversation keep firing while the sandbox lives. `HERMES_CRON_TICK_SECONDS=0` disables.
- **Interrupts** — blocks `interrupt` maps to Hermes's `session.interrupt`: the turn ends Interrupted, the session survives for the next message.

## Changes

- `crates/harness-server/src/hermes.rs` — new blocks-mode runtime (codex shape: persistent child, not spawn-per-turn). Handshake `gateway.ready` → `session.create`; per-turn `prompt.submit`, events normalized into the shared `CodexTurnNormalizer`:
  | Hermes event | NormalizedEvent |
  |---|---|
  | `message.delta` | AgentTextDelta |
  | `reasoning.delta` / `thinking.delta` | ReasoningTextDelta |
  | `tool.start` | AssistantMessage(ToolUse) |
  | `tool.complete` | ToolResults (error + exit-code mapping) |
  | `turn.usage` | TokenUsage |
  | `message.complete` | final AssistantMessage + Result (error path preserved verbatim) |
- `HarnessType::Hermes` through session-core, session-runtime (subcommand map), session-cli, api-server (proxy fragment + auth-mode arms), integration-test wire contract
- Migration `0051_hermes_harness.sql` — allow `'hermes'` in the harness-type check constraint
- slackbotv2 — `--hermes` flag, strategy/channel-default vocabulary, test
- Sandbox image — hermes-agent in its own venv (`/opt/hermes`, SHA-pinned ARG), `HERMES_PYTHON` env, `hermes` shim on PATH
- Docs — `extend/hermes-harness.mdx` (env vars, persistence model, credential-injection notes) + sidebar entry

## Validation

| Check | Result |
|---|---|
| Normalizer unit tests (`cargo test --lib hermes`) | 9/9 |
| Live E2E: built binary → real `tui_gateway`, single turn | streams deltas, `turn/completed`, text `HARNESS-OK` |
| Live E2E: two turns, same child | second turn recalls first-turn state (session continuity) |
| slackbotv2 `bun test overrides` | 45/45 |
| `cargo check --workspace` (api-rs) | green |
| clippy on new file | clean |

Notes for reviewers: `HERMES_APPROVAL_MODE` defaults to `off` inside the sandbox on the same reasoning as the other harnesses' bypass flags — Centaur owns the safety boundary (sandbox isolation + iron-proxy egress). Hermes reads provider keys from `$HERMES_HOME/.env`, so the placeholder-injection pattern works unchanged by binding those values to the provider hosts.

## Infographic

![Hermes joins the hangar](https://v3b.fal.media/files/b/0aa5d856/ZOL2dMmy0XHiSYwd269In_J62CL38w.png)
