### PR TITLE
fix(workflows): Linear searchIssues takes `term`, not `query`

### DIFF
--- a/workflows/linear/readonly.py
+++ b/workflows/linear/readonly.py
@@ -374,8 +374,8 @@ class LinearReadonlyClient(LinearGraphQLClient):
     def search_issues(self, query_str: str, limit: int = 25) -> list[dict[str, Any]]:
         """Search issues by text."""
         query = """
-        query SearchIssues($query: String!, $first: Int!, $after: String) {
-            searchIssues(query: $query, first: $first, after: $after) {
+        query SearchIssues($term: String!, $first: Int!, $after: String) {
+            searchIssues(term: $term, first: $first, after: $after) {
                 nodes {
                     id
                     identifier
@@ -393,7 +393,7 @@ class LinearReadonlyClient(LinearGraphQLClient):
         return self._connection_nodes(
             query,
             connection_path=("searchIssues",),
-            variables={"query": query_str},
+            variables={"term": query_str},
             limit=limit,
         )
 

--- a/workflows/tests/test_linear_readonly.py
+++ b/workflows/tests/test_linear_readonly.py
@@ -1,0 +1,41 @@
+"""Tests for the workflows-side Linear read-only GraphQL helpers.
+
+This mirrors tools/productivity/linear/test_readonly.py. The two clients are
+independent copies of the same code, and the `term:` fix landed in only one of
+them -- so the invariant is pinned on both sides now, or they drift again.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from workflows.linear.readonly import LinearReadonlyClient
+
+
+class RecordingReadonlyClient(LinearReadonlyClient):
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    def _query(self, query: str, variables: dict[str, Any] | None = None) -> dict[str, Any]:
+        self.calls.append({"query": query, "variables": variables})
+        return {
+            "searchIssues": {
+                "nodes": [{"identifier": "ENG-1", "title": "Search result"}],
+                "pageInfo": {"hasNextPage": False, "endCursor": None},
+            }
+        }
+
+
+def test_search_issues_uses_linear_term_argument():
+    # `searchIssues` names its search string `term` and requires it. `query` was
+    # the argument of `issueSearch`, the endpoint Linear deprecated in favour of
+    # this one; passing it here fails GraphQL validation, which Linear returns as
+    # an HTTP 400.
+    client = RecordingReadonlyClient()
+
+    result = client.search_issues("auth", limit=1)
+
+    assert result == [{"identifier": "ENG-1", "title": "Search result"}]
+    assert "searchIssues(term: $term" in client.calls[0]["query"]
+    assert "query:" not in client.calls[0]["query"]
+    assert client.calls[0]["variables"] == {"term": "auth", "first": 1, "after": None}


### PR DESCRIPTION
#832 fixed this argument in `tools/productivity/linear/readonly.py` and pinned it
with a regression test. There is a second, independent copy of the same client at
`workflows/linear/readonly.py` that was never touched — it still builds:

```graphql
query SearchIssues($query: String!, ...) { searchIssues(query: $query, ...) }
```

while the copy this repo tests builds `searchIssues(term: $term, ...)`. The two
disagree on the argument name, and only one of them is pinned.

This copy ships: `services/api-rs/Dockerfile` copies `workflows/` into the image,
`WORKFLOW_DIRS` points at it, and `LinearReadonlyClient` is exported from
`workflows/linear/__init__.py`. Nothing calls `search_issues` on this path today,
so it is latent rather than a live break — which is why it went unnoticed.

The test is a mirror of the one #832 added, asserting the same three things
against this client. The absence of a test here is the reason the fix did not
propagate; #1300 now runs `workflows/tests` in CI, so it is gated from here on.
Verified it fails against the unfixed client and passes against the fixed one.

**Scope is the argument name only.** The two copies still differ in their
selection sets — the tools copy also selects `project` and `projectMilestone` —
and this change leaves that alone rather than quietly widening the payload of a
query nobody calls yet.
