### PR TITLE
feat: add Hermes ACP harness adapter

### DIFF
--- a/contrib/chart/templates/slackbotv2.yaml
+++ b/contrib/chart/templates/slackbotv2.yaml
@@ -122,7 +122,7 @@ spec:
             - name: SLACKBOTV2_CHANNEL_DEFAULTS
               value: {{ .Values.slackbotv2.channelDefaults | toJson | quote }}
 {{- end }}
-{{- range $name := tuple "CLAUDE_MODEL" "CODEX_MODEL" "CODEX_MODEL_REASONING_EFFORT" }}
+{{- range $name := tuple "CLAUDE_MODEL" "CODEX_MODEL" "CODEX_MODEL_REASONING_EFFORT" "HERMES_MODEL" }}
 {{- if and (hasKey $.Values.sandbox.extraEnv $name) (not (hasKey $.Values.slackbotv2.extraEnv $name)) }}
             # Mirror the deployer's harness default override (sandbox.extraEnv)
             # so the Slack Console-link line names the model/reasoning policy

--- a/contrib/chart/values.yaml
+++ b/contrib/chart/values.yaml
@@ -270,7 +270,8 @@ sandbox:
   #                  subscription token (proxy injects the brokered credential).
   codexAuthMode: api_key
   claudeCodeAuthMode: api_key
-  # The deployment's default harness: codex | amp | claudecode. Decides what
+  # The deployment's default harness: codex | amp | claudecode | nanocodex |
+  # hermes. Decides what
   # warm sandboxes boot (SESSION_SANDBOX_HARNESS) and which harness auth
   # fragment is required at startup (the other harnesses' fragments are
   # registered too when available, so per-session --claude/--amp/--codex
@@ -278,7 +279,8 @@ sandbox:
   # their session's harness via container args; the sandbox image CMD only
   # matters for containers started outside api-rs.
   harnessEngine: codex
-  # Copied into every sandbox pod. CLAUDE_MODEL / CODEX_MODEL set here are also
+  # Copied into every sandbox pod. CLAUDE_MODEL / CODEX_MODEL / HERMES_MODEL
+  # set here are also
   # mirrored into slackbotv2 and the Console; CODEX_MODEL_REASONING_EFFORT is
   # mirrored into slackbotv2. This keeps Slack's model/thinking footer aligned
   # with the policy the sandbox actually runs.

--- a/crates/harness-server/src/hermes.rs
+++ b/crates/harness-server/src/hermes.rs
@@ -1,0 +1,1003 @@
+use std::env;
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process::Command as ProcessCommand;
+use std::sync::mpsc::RecvTimeoutError;
+use std::time::Duration;
+
+use base64::Engine;
+use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
+use codex_app_server_protocol::UserInput;
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+use sha2::{Digest, Sha256};
+use uuid::Uuid;
+
+use crate::{
+    HarnessKind, HarnessServer, HarnessServerError, NormalizedContent, NormalizedEvent,
+    NormalizedTokenUsage, NormalizedToolResult, Result, ThreadState, command_from_override,
+};
+
+const INITIALIZE_REQUEST_ID: &str = "centaur-hermes-initialize";
+const SESSION_REQUEST_ID: &str = "centaur-hermes-session";
+const MODE_REQUEST_ID: &str = "centaur-hermes-mode";
+const MODEL_REQUEST_ID: &str = "centaur-hermes-model";
+const PROMPT_REQUEST_ID: &str = "centaur-hermes-prompt";
+const STEER_REQUEST_ID_PREFIX: &str = "centaur-hermes-steer-";
+const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(30);
+
+#[derive(Debug, Default)]
+pub(crate) struct HermesHarness;
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(untagged)]
+pub(crate) enum AcpRequestId {
+    String(String),
+    Number(i64),
+}
+
+impl AcpRequestId {
+    fn is(&self, expected: &str) -> bool {
+        matches!(self, Self::String(value) if value == expected)
+    }
+
+    fn starts_with(&self, prefix: &str) -> bool {
+        matches!(self, Self::String(value) if value.starts_with(prefix))
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct AcpWireMessage {
+    #[serde(default)]
+    id: Option<AcpRequestId>,
+    #[serde(default)]
+    method: Option<String>,
+    #[serde(default)]
+    params: Option<Value>,
+    #[serde(default)]
+    result: Option<Value>,
+    #[serde(default)]
+    error: Option<AcpRpcError>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct AcpRpcError {
+    code: i64,
+    message: String,
+    #[serde(default)]
+    #[serde(rename = "data")]
+    _data: Option<Value>,
+}
+
+#[derive(Debug)]
+enum AcpResponse {
+    Success(Value),
+    Error(AcpRpcError),
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct AcpSessionNotification {
+    #[serde(rename = "sessionId")]
+    _session_id: String,
+    update: AcpSessionUpdate,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(tag = "sessionUpdate", rename_all = "snake_case")]
+enum AcpSessionUpdate {
+    AgentMessageChunk {
+        content: AcpContentBlock,
+    },
+    AgentThoughtChunk {
+        content: AcpContentBlock,
+    },
+    ToolCall {
+        #[serde(rename = "toolCallId")]
+        tool_call_id: String,
+        title: String,
+        #[serde(default)]
+        kind: Option<String>,
+        #[serde(default, rename = "rawInput")]
+        raw_input: Option<Value>,
+    },
+    ToolCallUpdate {
+        #[serde(rename = "toolCallId")]
+        tool_call_id: String,
+        #[serde(default)]
+        status: Option<String>,
+        #[serde(default)]
+        content: Option<Vec<AcpToolContent>>,
+        #[serde(default, rename = "rawOutput")]
+        raw_output: Option<Value>,
+    },
+    #[serde(other)]
+    Other,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+enum AcpContentBlock {
+    Text {
+        text: String,
+    },
+    #[serde(other)]
+    Other,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+enum AcpToolContent {
+    Content {
+        content: AcpContentBlock,
+    },
+    Diff {
+        path: String,
+        #[serde(default, rename = "oldText")]
+        old_text: Option<String>,
+        #[serde(rename = "newText")]
+        new_text: String,
+    },
+    Terminal {
+        #[serde(rename = "terminalId")]
+        terminal_id: String,
+    },
+    #[serde(other)]
+    Other,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct AcpPromptResponse {
+    stop_reason: String,
+    #[serde(default)]
+    usage: Option<AcpUsage>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct AcpUsage {
+    input_tokens: i64,
+    output_tokens: i64,
+    total_tokens: i64,
+    #[serde(default)]
+    thought_tokens: Option<i64>,
+    #[serde(default)]
+    cached_read_tokens: Option<i64>,
+    #[serde(default)]
+    cached_write_tokens: Option<i64>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct AcpPermissionRequest {
+    options: Vec<AcpPermissionOption>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct AcpPermissionOption {
+    option_id: String,
+    kind: String,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) enum HermesAcpEvent {
+    SessionUpdate(AcpSessionNotification),
+    PromptResponse(AcpPromptResponse),
+    ClientRequest {
+        id: AcpRequestId,
+        method: String,
+        params: Option<Value>,
+    },
+    RpcError {
+        request_id: Option<AcpRequestId>,
+        error: AcpRpcError,
+    },
+    Ignored,
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct HermesEventNormalizer {
+    message_index: usize,
+    message_text: String,
+    reasoning_text: String,
+}
+
+impl HermesEventNormalizer {
+    fn message_item_id(&self) -> String {
+        format!("hermes-message-{}", self.message_index)
+    }
+
+    fn reasoning_item_id(&self) -> String {
+        "hermes-reasoning".to_string()
+    }
+
+    fn finish_message(&mut self, stop_reason: &str, out: &mut Vec<NormalizedEvent>) {
+        if self.message_text.is_empty() {
+            return;
+        }
+        out.push(NormalizedEvent::AssistantMessage {
+            partial: false,
+            stop_reason: Some(stop_reason.to_string()),
+            content: vec![NormalizedContent::AgentText {
+                item_id: self.message_item_id(),
+                text: std::mem::take(&mut self.message_text),
+            }],
+        });
+        self.message_index += 1;
+    }
+
+    fn finish_reasoning(&mut self, out: &mut Vec<NormalizedEvent>) {
+        if self.reasoning_text.is_empty() {
+            return;
+        }
+        out.push(NormalizedEvent::AssistantMessage {
+            partial: false,
+            stop_reason: None,
+            content: vec![NormalizedContent::ReasoningText {
+                item_id: self.reasoning_item_id(),
+                text: std::mem::take(&mut self.reasoning_text),
+            }],
+        });
+    }
+
+    fn normalize(&mut self, event: HermesAcpEvent) -> Vec<NormalizedEvent> {
+        let mut out = Vec::new();
+        match event {
+            HermesAcpEvent::SessionUpdate(notification) => match notification.update {
+                AcpSessionUpdate::AgentMessageChunk {
+                    content: AcpContentBlock::Text { text },
+                } => {
+                    self.message_text.push_str(&text);
+                    out.push(NormalizedEvent::AgentTextDelta {
+                        item_id: self.message_item_id(),
+                        delta: text,
+                    });
+                }
+                AcpSessionUpdate::AgentThoughtChunk {
+                    content: AcpContentBlock::Text { text },
+                } => {
+                    self.reasoning_text.push_str(&text);
+                    out.push(NormalizedEvent::ReasoningTextDelta {
+                        item_id: self.reasoning_item_id(),
+                        delta: text,
+                    });
+                }
+                AcpSessionUpdate::ToolCall {
+                    tool_call_id,
+                    title,
+                    kind,
+                    raw_input,
+                } => {
+                    self.finish_message("tool_use", &mut out);
+                    let arguments = raw_input.unwrap_or_else(|| json!({}));
+                    let tool = tool_name(&title, kind.as_deref());
+                    out.push(NormalizedEvent::AssistantMessage {
+                        partial: false,
+                        stop_reason: Some("tool_use".to_string()),
+                        content: vec![NormalizedContent::ToolUse {
+                            raw_id: tool_call_id,
+                            tool,
+                            arguments,
+                        }],
+                    });
+                }
+                AcpSessionUpdate::ToolCallUpdate {
+                    tool_call_id,
+                    status,
+                    content,
+                    raw_output,
+                } if status
+                    .as_deref()
+                    .is_some_and(|status| matches!(status, "completed" | "failed")) =>
+                {
+                    out.push(NormalizedEvent::ToolResults(vec![NormalizedToolResult {
+                        tool_use_id: tool_call_id,
+                        content: tool_result_text(raw_output.as_ref(), content.as_deref()),
+                        is_error: status.as_deref() == Some("failed"),
+                        exit_code: tool_exit_code(raw_output.as_ref()),
+                    }]));
+                }
+                _ => {}
+            },
+            HermesAcpEvent::PromptResponse(response) => {
+                self.finish_message(&response.stop_reason, &mut out);
+                self.finish_reasoning(&mut out);
+                if let Some(usage) = response.usage {
+                    out.push(NormalizedEvent::TokenUsage {
+                        usage: NormalizedTokenUsage {
+                            model: None,
+                            input_tokens: Some(usage.input_tokens),
+                            output_tokens: Some(usage.output_tokens),
+                            cache_creation_input_tokens: usage.cached_write_tokens,
+                            cache_read_input_tokens: usage.cached_read_tokens,
+                            reasoning_output_tokens: usage.thought_tokens,
+                            total_tokens: Some(usage.total_tokens),
+                        },
+                    });
+                }
+                let error = (response.stop_reason == "refusal")
+                    .then(|| "Hermes refused the prompt".to_string());
+                out.push(NormalizedEvent::Result { error });
+            }
+            HermesAcpEvent::RpcError { request_id, error }
+                if request_id
+                    .as_ref()
+                    .is_some_and(|id| id.is(PROMPT_REQUEST_ID)) =>
+            {
+                out.push(NormalizedEvent::Error {
+                    message: format!("Hermes ACP error {}: {}", error.code, error.message),
+                });
+            }
+            HermesAcpEvent::RpcError { request_id, error }
+                if request_id
+                    .as_ref()
+                    .is_some_and(|id| id.starts_with(STEER_REQUEST_ID_PREFIX)) =>
+            {
+                // turn/steer is acknowledged after the request is written to Hermes. Keep a
+                // later native rejection non-terminal for the active turn, but make it visible
+                // instead of silently discarding the user's steer.
+                eprintln!(
+                    "Hermes ACP steer request was rejected ({}): {}",
+                    error.code, error.message
+                );
+            }
+            HermesAcpEvent::RpcError { .. } => {}
+            HermesAcpEvent::ClientRequest { .. } | HermesAcpEvent::Ignored => {}
+        }
+        out
+    }
+}
+
+impl HarnessServer for HermesHarness {
+    type Event = HermesAcpEvent;
+    type EventNormalizer = HermesEventNormalizer;
+
+    fn kind(&self) -> HarnessKind {
+        HarnessKind::Hermes
+    }
+
+    fn cli_version(&self) -> &'static str {
+        "hermes-acp"
+    }
+
+    fn default_model(&self) -> String {
+        env::var("HERMES_MODEL").unwrap_or_else(|_| "openrouter/auto".to_string())
+    }
+
+    fn default_model_provider(&self) -> &'static str {
+        "hermes"
+    }
+
+    fn command_for_turn(&self, _state: &ThreadState) -> ProcessCommand {
+        if let Some(command) = command_from_override("CENTAUR_HERMES_ACP_COMMAND") {
+            return command;
+        }
+        ProcessCommand::new(env::var("HERMES_ACP_BIN").unwrap_or_else(|_| "hermes-acp".to_string()))
+    }
+
+    fn initialize_process(&self, state: &mut ThreadState) -> Result<()> {
+        send_request(
+            state,
+            INITIALIZE_REQUEST_ID,
+            "initialize",
+            json!({
+                "protocolVersion": 1,
+                "clientCapabilities": {
+                    "fs": {"readTextFile": false, "writeTextFile": false},
+                    "terminal": false,
+                    "auth": {"terminal": false}
+                },
+                "clientInfo": {"name": "centaur-harness-server", "version": env!("CARGO_PKG_VERSION")}
+            }),
+        )?;
+        wait_for_response(state, INITIALIZE_REQUEST_ID)?;
+
+        let mapped = read_session_mapping(&state.id)?;
+        let candidate = mapped.or_else(|| {
+            state
+                .harness_session_id
+                .clone()
+                .filter(|session_id| session_id != &state.id)
+        });
+        let session_id = if let Some(session_id) = candidate {
+            send_request(
+                state,
+                SESSION_REQUEST_ID,
+                "session/load",
+                json!({"cwd": state.cwd, "sessionId": session_id, "mcpServers": []}),
+            )?;
+            match wait_for_rpc_response(state, SESSION_REQUEST_ID)? {
+                // ACP session/load has no required result fields. Hermes versions have returned
+                // both null and empty objects here, so any successful response means the native
+                // session was restored.
+                AcpResponse::Success(_) => session_id,
+                // A stale Centaur mapping is expected when Hermes' local session store is wiped
+                // or its storage format changes. Recover by replacing the missing native session.
+                AcpResponse::Error(error) => {
+                    eprintln!(
+                        "Hermes ACP could not load native session; creating a replacement ({}): {}",
+                        error.code, error.message
+                    );
+                    create_session(state)?
+                }
+            }
+        } else {
+            create_session(state)?
+        };
+        state.harness_session_id = Some(session_id.clone());
+        write_session_mapping(&state.id, &session_id)?;
+
+        send_request(
+            state,
+            MODE_REQUEST_ID,
+            "session/set_mode",
+            json!({"sessionId": session_id, "modeId": "dont_ask"}),
+        )?;
+        wait_for_response(state, MODE_REQUEST_ID)?;
+
+        if !state.model.trim().is_empty() {
+            send_request(
+                state,
+                MODEL_REQUEST_ID,
+                "session/set_model",
+                json!({"sessionId": session_id, "modelId": state.model}),
+            )?;
+            wait_for_response(state, MODEL_REQUEST_ID)?;
+        }
+        Ok(())
+    }
+
+    fn stdin_for_turn(&self, _input: &[UserInput]) -> Result<Vec<u8>> {
+        Err(HarnessServerError::Protocol(
+            "Hermes ACP prompts require initialized thread state".to_string(),
+        ))
+    }
+
+    fn stdin_for_state_turn(&self, state: &ThreadState, input: &[UserInput]) -> Result<Vec<u8>> {
+        prompt_request(state, input, PROMPT_REQUEST_ID, false)
+    }
+
+    fn stdin_for_state_steer(&self, state: &ThreadState, input: &[UserInput]) -> Result<Vec<u8>> {
+        let request_id = format!("{STEER_REQUEST_ID_PREFIX}{}", Uuid::new_v4().simple());
+        prompt_request(state, input, &request_id, true)
+    }
+
+    fn stdin_for_interrupt(&self, state: &ThreadState) -> Result<Option<Vec<u8>>> {
+        let session_id = state.harness_session_id.as_deref().ok_or_else(|| {
+            HarnessServerError::Protocol("Hermes ACP session is not initialized".to_string())
+        })?;
+        Ok(Some(json_line(&json!({
+            "jsonrpc": "2.0",
+            "method": "session/cancel",
+            "params": {"sessionId": session_id}
+        }))?))
+    }
+
+    fn wait_for_interrupt(&self, state: &mut ThreadState) -> Result<()> {
+        wait_for_response(state, PROMPT_REQUEST_ID).map(|_| ())
+    }
+
+    fn parse_stdout_line(&self, line: &str) -> Result<Self::Event> {
+        parse_acp_event(line)
+    }
+
+    fn response_for_event(&self, event: &Self::Event) -> Result<Option<Vec<u8>>> {
+        let HermesAcpEvent::ClientRequest { id, method, params } = event else {
+            return Ok(None);
+        };
+        if method == "session/request_permission" {
+            let result = permission_response_result(params.clone())?;
+            return Ok(Some(rpc_response_line(id, result)?));
+        }
+        Ok(Some(json_line(&json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "error": {"code": -32601, "message": format!("unsupported ACP client method: {method}")}
+        }))?))
+    }
+
+    fn normalize_events(
+        &self,
+        normalizer: &mut Self::EventNormalizer,
+        event: Self::Event,
+    ) -> Result<Vec<NormalizedEvent>> {
+        Ok(normalizer.normalize(event))
+    }
+}
+
+fn create_session(state: &mut ThreadState) -> Result<String> {
+    send_request(
+        state,
+        SESSION_REQUEST_ID,
+        "session/new",
+        json!({"cwd": state.cwd, "mcpServers": []}),
+    )?;
+    let result = wait_for_response(state, SESSION_REQUEST_ID)?;
+    result
+        .get("sessionId")
+        .and_then(Value::as_str)
+        .map(str::to_string)
+        .ok_or_else(|| {
+            HarnessServerError::Protocol("Hermes session/new omitted sessionId".to_string())
+        })
+}
+
+fn send_request(state: &mut ThreadState, id: &str, method: &str, params: Value) -> Result<()> {
+    let process = state
+        .process
+        .as_mut()
+        .ok_or(HarnessServerError::HarnessStdinUnavailable)?;
+    process.stdin.write_all(&json_line(&json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "method": method,
+        "params": params
+    }))?)?;
+    process.stdin.flush()?;
+    Ok(())
+}
+
+fn wait_for_response(state: &mut ThreadState, expected_id: &str) -> Result<Value> {
+    match wait_for_rpc_response(state, expected_id)? {
+        AcpResponse::Success(result) => Ok(result),
+        AcpResponse::Error(error) => Err(HarnessServerError::Protocol(format!(
+            "Hermes ACP error {}: {}",
+            error.code, error.message
+        ))),
+    }
+}
+
+fn wait_for_rpc_response(state: &mut ThreadState, expected_id: &str) -> Result<AcpResponse> {
+    let process = state
+        .process
+        .as_mut()
+        .ok_or(HarnessServerError::HarnessStdoutUnavailable)?;
+    loop {
+        let line = match process.stdout.recv_timeout(HANDSHAKE_TIMEOUT) {
+            Ok(line) => line?,
+            Err(RecvTimeoutError::Timeout) => {
+                return Err(HarnessServerError::Protocol(format!(
+                    "timed out waiting for Hermes ACP response `{expected_id}`"
+                )));
+            }
+            Err(RecvTimeoutError::Disconnected) => {
+                let status = process.child.wait()?;
+                return Err(HarnessServerError::HarnessExited {
+                    kind: HarnessKind::Hermes,
+                    status,
+                    stderr: String::new(),
+                });
+            }
+        };
+        let wire: AcpWireMessage = serde_json::from_str(line.trim())?;
+        if wire.id.as_ref().is_some_and(|id| id.is(expected_id)) {
+            if let Some(error) = wire.error {
+                return Ok(AcpResponse::Error(error));
+            }
+            return Ok(AcpResponse::Success(wire.result.unwrap_or(Value::Null)));
+        }
+        if wire.method.as_deref() == Some("session/request_permission")
+            && let Some(id) = wire.id
+        {
+            let result = permission_response_result(wire.params)?;
+            process.stdin.write_all(&rpc_response_line(&id, result)?)?;
+            process.stdin.flush()?;
+        }
+    }
+}
+
+fn permission_response_result(params: Option<Value>) -> Result<Value> {
+    let request: AcpPermissionRequest =
+        serde_json::from_value(params.unwrap_or_else(|| json!({})))?;
+    let selected = request
+        .options
+        .iter()
+        .find(|option| option.option_id == "allow_session")
+        .or_else(|| {
+            request
+                .options
+                .iter()
+                .find(|option| option.kind == "allow_always")
+        })
+        .or_else(|| {
+            request
+                .options
+                .iter()
+                .find(|option| option.kind == "allow_once")
+        });
+    Ok(selected.map_or_else(
+        || json!({"outcome": {"outcome": "cancelled"}}),
+        |option| json!({"outcome": {"outcome": "selected", "optionId": option.option_id}}),
+    ))
+}
+
+fn prompt_request(
+    state: &ThreadState,
+    input: &[UserInput],
+    request_id: &str,
+    steer: bool,
+) -> Result<Vec<u8>> {
+    let session_id = state.harness_session_id.as_deref().ok_or_else(|| {
+        HarnessServerError::Protocol("Hermes ACP session is not initialized".to_string())
+    })?;
+    let mut prompt = acp_prompt(input)?;
+    if steer {
+        let text = prompt
+            .iter()
+            .filter_map(|part| part.get("text").and_then(Value::as_str))
+            .collect::<Vec<_>>()
+            .join("\n");
+        prompt = vec![json!({"type": "text", "text": format!("/steer {text}")})];
+    }
+    json_line(&json!({
+        "jsonrpc": "2.0",
+        "id": request_id,
+        "method": "session/prompt",
+        "params": {"sessionId": session_id, "prompt": prompt}
+    }))
+}
+
+fn acp_prompt(input: &[UserInput]) -> Result<Vec<Value>> {
+    input
+        .iter()
+        .map(|item| match item {
+            UserInput::Text { text, .. } => Ok(json!({"type": "text", "text": text})),
+            UserInput::LocalImage { path, .. } => Ok(json!({
+                "type": "image",
+                "data": BASE64_STANDARD.encode(fs::read(path)?),
+                "mimeType": image_mime_type(path),
+            })),
+            UserInput::Image { url, .. } => {
+                Ok(json!({"type": "text", "text": format!("[image: {url}]")}))
+            }
+            UserInput::Skill { name, path } => Ok(json!({
+                "type": "text",
+                "text": format!("[skill: {name} at {}]", path.display()),
+            })),
+            UserInput::Mention { name, path } => Ok(json!({
+                "type": "text",
+                "text": format!("[mention: {name} at {path}]"),
+            })),
+        })
+        .collect()
+}
+
+fn image_mime_type(path: &Path) -> &'static str {
+    match path.extension().and_then(|extension| extension.to_str()) {
+        Some(extension) if extension.eq_ignore_ascii_case("png") => "image/png",
+        Some(extension) if extension.eq_ignore_ascii_case("webp") => "image/webp",
+        Some(extension) if extension.eq_ignore_ascii_case("gif") => "image/gif",
+        _ => "image/jpeg",
+    }
+}
+
+fn parse_acp_event(line: &str) -> Result<HermesAcpEvent> {
+    let wire: AcpWireMessage = serde_json::from_str(line)?;
+    if let (Some(method), Some(id)) = (wire.method.as_deref(), wire.id.clone()) {
+        return Ok(HermesAcpEvent::ClientRequest {
+            id,
+            method: method.to_string(),
+            params: wire.params,
+        });
+    }
+    if wire.method.as_deref() == Some("session/update") {
+        let notification = serde_json::from_value(wire.params.unwrap_or_else(|| json!({})))?;
+        return Ok(HermesAcpEvent::SessionUpdate(notification));
+    }
+    if let Some(error) = wire.error {
+        return Ok(HermesAcpEvent::RpcError {
+            request_id: wire.id,
+            error,
+        });
+    }
+    if wire.id.as_ref().is_some_and(|id| id.is(PROMPT_REQUEST_ID)) {
+        let response = serde_json::from_value(wire.result.unwrap_or_else(|| json!({})))?;
+        return Ok(HermesAcpEvent::PromptResponse(response));
+    }
+    Ok(HermesAcpEvent::Ignored)
+}
+
+fn tool_name(title: &str, kind: Option<&str>) -> String {
+    if kind == Some("execute") {
+        "shell_command".to_string()
+    } else if let Some(kind) = kind.filter(|kind| !kind.is_empty()) {
+        kind.to_string()
+    } else {
+        title.trim().to_string().if_empty("tool")
+    }
+}
+
+trait IfEmpty {
+    fn if_empty(self, fallback: &str) -> String;
+}
+
+impl IfEmpty for String {
+    fn if_empty(self, fallback: &str) -> String {
+        if self.is_empty() {
+            fallback.to_string()
+        } else {
+            self
+        }
+    }
+}
+
+fn tool_result_text(raw_output: Option<&Value>, content: Option<&[AcpToolContent]>) -> String {
+    if let Some(Value::String(text)) = raw_output {
+        return text.clone();
+    }
+    if let Some(value) = raw_output {
+        return serde_json::to_string(value).unwrap_or_else(|_| format!("{value:?}"));
+    }
+    content
+        .unwrap_or_default()
+        .iter()
+        .filter_map(|item| match item {
+            AcpToolContent::Content {
+                content: AcpContentBlock::Text { text },
+            } => Some(text.clone()),
+            AcpToolContent::Diff {
+                path,
+                old_text,
+                new_text,
+            } => Some(format!(
+                "diff {path}\n--- old\n{}\n+++ new\n{new_text}",
+                old_text.as_deref().unwrap_or("")
+            )),
+            AcpToolContent::Terminal { terminal_id } => Some(format!("terminal: {terminal_id}")),
+            _ => None,
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn tool_exit_code(raw_output: Option<&Value>) -> Option<i32> {
+    raw_output?
+        .get("exitCode")
+        .or_else(|| raw_output?.get("exit_code"))
+        .and_then(Value::as_i64)
+        .and_then(|code| i32::try_from(code).ok())
+}
+
+fn json_line(value: &Value) -> Result<Vec<u8>> {
+    let mut bytes = serde_json::to_vec(value)?;
+    bytes.push(b'\n');
+    Ok(bytes)
+}
+
+fn rpc_response_line(id: &AcpRequestId, result: Value) -> Result<Vec<u8>> {
+    json_line(&json!({"jsonrpc": "2.0", "id": id, "result": result}))
+}
+
+fn session_mapping_path(thread_id: &str) -> PathBuf {
+    let home = env::var_os("HERMES_HOME")
+        .map(PathBuf::from)
+        .or_else(|| env::var_os("HOME").map(|home| PathBuf::from(home).join(".hermes")))
+        .unwrap_or_else(|| PathBuf::from("/tmp/hermes"));
+    let digest = Sha256::digest(thread_id.as_bytes());
+    let filename = digest
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect::<String>();
+    home.join("centaur-acp-sessions").join(filename)
+}
+
+fn read_session_mapping(thread_id: &str) -> Result<Option<String>> {
+    let path = session_mapping_path(thread_id);
+    match fs::read_to_string(path) {
+        Ok(session_id) => Ok(Some(session_id.trim().to_string()).filter(|id| !id.is_empty())),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(error.into()),
+    }
+}
+
+fn write_session_mapping(thread_id: &str, session_id: &str) -> Result<()> {
+    let path = session_mapping_path(thread_id);
+    let parent = path.parent().ok_or_else(|| {
+        HarnessServerError::Protocol("Hermes session mapping path has no parent".to_string())
+    })?;
+    fs::create_dir_all(parent)?;
+    fs::write(path, format!("{session_id}\n"))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use codex_app_server_protocol::UserInput;
+    use serde_json::{Value, json};
+
+    use crate::{HarnessServer, NormalizedContent, NormalizedEvent, ThreadState};
+
+    use super::{
+        HermesAcpEvent, HermesEventNormalizer, HermesHarness, PROMPT_REQUEST_ID,
+        STEER_REQUEST_ID_PREFIX, parse_acp_event, permission_response_result,
+    };
+
+    fn state() -> ThreadState {
+        ThreadState {
+            id: "thread-1".to_string(),
+            cwd: PathBuf::from("/tmp/project"),
+            model: String::new(),
+            model_provider: "hermes".to_string(),
+            service_tier: None,
+            harness_session_id: Some("hermes-session-1".to_string()),
+            completed_turns: Vec::new(),
+            process: None,
+            thread_started_sent: false,
+        }
+    }
+
+    #[test]
+    fn turn_stdin_is_an_acp_prompt_for_the_native_session() {
+        let bytes = HermesHarness
+            .stdin_for_state_turn(
+                &state(),
+                &[UserInput::Text {
+                    text: "hello".to_string(),
+                    text_elements: Vec::new(),
+                }],
+            )
+            .unwrap();
+        let value: Value = serde_json::from_slice(&bytes).unwrap();
+
+        assert_eq!(value["id"], PROMPT_REQUEST_ID);
+        assert_eq!(value["method"], "session/prompt");
+        assert_eq!(value["params"]["sessionId"], "hermes-session-1");
+        assert_eq!(value["params"]["prompt"][0]["text"], "hello");
+    }
+
+    #[test]
+    fn steer_uses_hermes_active_turn_command() {
+        let first = HermesHarness
+            .stdin_for_state_steer(
+                &state(),
+                &[UserInput::Text {
+                    text: "use the other file".to_string(),
+                    text_elements: Vec::new(),
+                }],
+            )
+            .unwrap();
+        let second = HermesHarness
+            .stdin_for_state_steer(
+                &state(),
+                &[UserInput::Text {
+                    text: "use the other file".to_string(),
+                    text_elements: Vec::new(),
+                }],
+            )
+            .unwrap();
+        let first: Value = serde_json::from_slice(&first).unwrap();
+        let second: Value = serde_json::from_slice(&second).unwrap();
+
+        assert_eq!(
+            first["params"]["prompt"][0]["text"],
+            "/steer use the other file"
+        );
+        assert!(
+            first["id"]
+                .as_str()
+                .unwrap()
+                .starts_with(STEER_REQUEST_ID_PREFIX)
+        );
+        assert_ne!(first["id"], second["id"]);
+    }
+
+    #[test]
+    fn parses_and_normalizes_message_thought_tool_and_terminal_response() {
+        let mut normalizer = HermesEventNormalizer::default();
+        let message = parse_acp_event(
+            r#"{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"s1","update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"Checking."}}}}"#,
+        )
+        .unwrap();
+        let events = normalizer.normalize(message);
+        assert!(matches!(
+            events.as_slice(),
+            [NormalizedEvent::AgentTextDelta { delta, .. }] if delta == "Checking."
+        ));
+
+        let thought = parse_acp_event(
+            r#"{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"s1","update":{"sessionUpdate":"agent_thought_chunk","content":{"type":"text","text":"Need inspect."}}}}"#,
+        )
+        .unwrap();
+        assert!(matches!(
+            normalizer.normalize(thought).as_slice(),
+            [NormalizedEvent::ReasoningTextDelta { delta, .. }] if delta == "Need inspect."
+        ));
+
+        let tool = parse_acp_event(
+            r#"{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"s1","update":{"sessionUpdate":"tool_call","toolCallId":"tc1","title":"Run command","kind":"execute","rawInput":{"command":"pwd"}}}}"#,
+        )
+        .unwrap();
+        let events = normalizer.normalize(tool);
+        assert!(matches!(
+            &events[0],
+            NormalizedEvent::AssistantMessage { stop_reason: Some(reason), content, .. }
+                if reason == "tool_use"
+                    && matches!(content.as_slice(), [NormalizedContent::AgentText { text, .. }] if text == "Checking.")
+        ));
+        assert!(matches!(
+            &events[1],
+            NormalizedEvent::AssistantMessage { content, .. }
+                if matches!(content.as_slice(), [NormalizedContent::ToolUse { tool, arguments, .. }]
+                    if tool == "shell_command" && arguments["command"] == "pwd")
+        ));
+
+        let complete = parse_acp_event(
+            r#"{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"s1","update":{"sessionUpdate":"tool_call_update","toolCallId":"tc1","status":"completed","rawOutput":"/tmp/project"}}}"#,
+        )
+        .unwrap();
+        assert!(matches!(
+            normalizer.normalize(complete).as_slice(),
+            [NormalizedEvent::ToolResults(results)] if results[0].content == "/tmp/project"
+        ));
+
+        let response = parse_acp_event(
+            r#"{"jsonrpc":"2.0","id":"centaur-hermes-prompt","result":{"stopReason":"end_turn","usage":{"inputTokens":10,"outputTokens":4,"totalTokens":14}}}"#,
+        )
+        .unwrap();
+        let events = normalizer.normalize(response);
+        assert!(events.iter().any(|event| matches!(event, NormalizedEvent::TokenUsage { usage } if usage.total_tokens == Some(14))));
+        assert!(matches!(
+            events.last(),
+            Some(NormalizedEvent::Result { error: None })
+        ));
+    }
+
+    #[test]
+    fn permission_requests_are_approved_for_the_session() {
+        let event = parse_acp_event(
+            r#"{"jsonrpc":"2.0","id":7,"method":"session/request_permission","params":{"sessionId":"s1","toolCall":{"toolCallId":"p1"},"options":[{"optionId":"allow_once","kind":"allow_once","name":"Once"},{"optionId":"allow_session","kind":"allow_always","name":"Session"}]}}"#,
+        )
+        .unwrap();
+        let response = HermesHarness.response_for_event(&event).unwrap().unwrap();
+        let value: Value = serde_json::from_slice(&response).unwrap();
+
+        assert_eq!(value["id"], 7);
+        assert_eq!(value["result"]["outcome"]["outcome"], "selected");
+        assert_eq!(value["result"]["outcome"]["optionId"], "allow_session");
+    }
+
+    #[test]
+    fn permission_selection_falls_back_to_once_and_then_cancelled() {
+        let once = permission_response_result(Some(json!({
+            "options": [{"optionId": "once", "kind": "allow_once"}]
+        })))
+        .unwrap();
+        assert_eq!(once["outcome"]["optionId"], "once");
+
+        let cancelled = permission_response_result(Some(json!({"options": []}))).unwrap();
+        assert_eq!(cancelled["outcome"]["outcome"], "cancelled");
+    }
+
+    #[test]
+    fn ignores_steer_responses_as_non_terminal() {
+        let event = parse_acp_event(
+            &json!({"jsonrpc": "2.0", "id": "centaur-hermes-steer-123", "result": {"stopReason": "end_turn"}}).to_string(),
+        )
+        .unwrap();
+        assert!(matches!(event, HermesAcpEvent::Ignored));
+    }
+
+    #[test]
+    fn steer_rpc_errors_are_non_terminal() {
+        let event = parse_acp_event(
+            &json!({
+                "jsonrpc": "2.0",
+                "id": "centaur-hermes-steer-123",
+                "error": {"code": -32000, "message": "prompt already active"}
+            })
+            .to_string(),
+        )
+        .unwrap();
+        assert!(matches!(
+            &event,
+            HermesAcpEvent::RpcError { request_id: Some(id), .. }
+                if id.starts_with(STEER_REQUEST_ID_PREFIX)
+        ));
+        assert!(HermesEventNormalizer::default().normalize(event).is_empty());
+    }
+}

--- a/crates/harness-server/src/lib.rs
+++ b/crates/harness-server/src/lib.rs
@@ -3,6 +3,7 @@ pub mod anthropic;
 pub mod claude;
 pub mod codex;
 mod error;
+mod hermes;
 mod nanocodex;
 mod nanocodex_subagents;
 mod otel;

--- a/crates/harness-server/src/main.rs
+++ b/crates/harness-server/src/main.rs
@@ -21,6 +21,8 @@ enum CliCommand {
     #[command(alias = "claude")]
     ClaudeCode(HarnessCommand),
     Amp(HarnessCommand),
+    /// Run Hermes Agent through its native ACP stdio server.
+    Hermes(HarnessCommand),
     /// Run Nanocodex directly as a library and stream its native typed events.
     Nanocodex,
     ValidateJsonrpc,
@@ -55,6 +57,7 @@ fn run() -> Result<()> {
         CliCommand::Codex(command) => run_mode(HarnessKind::Codex, command.mode),
         CliCommand::ClaudeCode(command) => run_mode(HarnessKind::ClaudeCode, command.mode),
         CliCommand::Amp(command) => run_mode(HarnessKind::Amp, command.mode),
+        CliCommand::Hermes(command) => run_mode(HarnessKind::Hermes, command.mode),
         CliCommand::Nanocodex => run_nanocodex_blocks_server(),
         CliCommand::ValidateJsonrpc => run_validate_jsonrpc(),
         CliCommand::ValidateAgentDeltas => run_validate_agent_deltas(),

--- a/crates/harness-server/src/otel.rs
+++ b/crates/harness-server/src/otel.rs
@@ -849,6 +849,7 @@ fn harness_name(kind: HarnessKind) -> &'static str {
         HarnessKind::Codex => "codex",
         HarnessKind::ClaudeCode => "claude",
         HarnessKind::Amp => "amp",
+        HarnessKind::Hermes => "hermes",
     }
 }
 
@@ -860,6 +861,8 @@ fn gen_ai_system(kind: HarnessKind, model_provider: &str) -> &'static str {
         "openai"
     } else if provider.contains("amp") || matches!(kind, HarnessKind::Amp) {
         "amp"
+    } else if provider.contains("hermes") || matches!(kind, HarnessKind::Hermes) {
+        "hermes"
     } else {
         "unknown"
     }

--- a/crates/harness-server/src/server.rs
+++ b/crates/harness-server/src/server.rs
@@ -30,6 +30,7 @@ use uuid::Uuid;
 use crate::amp::AmpHarness;
 use crate::claude::ClaudeCodeHarness;
 use crate::codex::CodexHarnessServer;
+use crate::hermes::HermesHarness;
 use crate::otel::{self, HarnessUsageSpan, TraceContext};
 use crate::traits::{
     AppServerNormalizer, AppServerRuntime, HarnessChild, HarnessKind, HarnessServer,
@@ -45,6 +46,7 @@ pub fn server_for(kind: HarnessKind) -> Box<dyn AppServerRuntime> {
         HarnessKind::Codex => Box::new(CodexHarnessServer::codex()),
         HarnessKind::ClaudeCode => Box::new(AppServerNormalizer::new(ClaudeCodeHarness)),
         HarnessKind::Amp => Box::new(AppServerNormalizer::new(AmpHarness)),
+        HarnessKind::Hermes => Box::new(AppServerNormalizer::new(HermesHarness)),
     }
 }
 
@@ -57,6 +59,7 @@ pub fn run_blocks_server(kind: HarnessKind) -> Result<()> {
         HarnessKind::Codex => crate::codex::run_codex_blocks_server(CodexHarnessServer::codex()),
         HarnessKind::ClaudeCode => run_blocks_app_server(&ClaudeCodeHarness),
         HarnessKind::Amp => run_blocks_app_server(&AmpHarness),
+        HarnessKind::Hermes => run_blocks_app_server(&HermesHarness),
     }
 }
 
@@ -1086,13 +1089,13 @@ fn apply_resume_overrides(state: &mut ThreadState, params: &ThreadResumeParams) 
 
 fn handle_active_turn_request<H: HarnessServer, W: Write>(
     harness: &H,
-    process: &mut HarnessChild,
+    state: &mut ThreadState,
     normalizer: &mut CodexTurnNormalizer,
     request: ActiveTurnRequest,
     stdout: &mut W,
 ) -> Result<bool> {
     let ActiveTurnRequest::JsonRpc(request) = request else {
-        process.kill_and_wait()?;
+        interrupt_harness(harness, state)?;
         return Ok(true);
     };
 
@@ -1121,10 +1124,19 @@ fn handle_active_turn_request<H: HarnessServer, W: Write>(
                 )?;
                 return Ok(false);
             }
-            process
+            let steer = harness.stdin_for_state_steer(state, &params.input)?;
+            state
+                .process
+                .as_mut()
+                .ok_or(HarnessServerError::HarnessStdinUnavailable)?
                 .stdin
-                .write_all(&harness.stdin_for_steer(&params.input)?)?;
-            process.stdin.flush()?;
+                .write_all(&steer)?;
+            state
+                .process
+                .as_mut()
+                .ok_or(HarnessServerError::HarnessStdinUnavailable)?
+                .stdin
+                .flush()?;
             write_client_response(
                 stdout,
                 ClientResponse::TurnSteer {
@@ -1165,7 +1177,7 @@ fn handle_active_turn_request<H: HarnessServer, W: Write>(
                 )?;
                 return Ok(false);
             }
-            process.kill_and_wait()?;
+            interrupt_harness(harness, state)?;
             write_client_response(
                 stdout,
                 ClientResponse::TurnInterrupt {
@@ -1185,6 +1197,29 @@ fn handle_active_turn_request<H: HarnessServer, W: Write>(
             Ok(false)
         }
     }
+}
+
+fn interrupt_harness<H: HarnessServer>(harness: &H, state: &mut ThreadState) -> Result<()> {
+    if let Some(message) = harness.stdin_for_interrupt(state)? {
+        let process = state
+            .process
+            .as_mut()
+            .ok_or(HarnessServerError::HarnessStdinUnavailable)?;
+        process.stdin.write_all(&message)?;
+        process.stdin.flush()?;
+        if let Err(error) = harness.wait_for_interrupt(state) {
+            eprintln!(
+                "{:?} native cancellation did not settle; restarting the harness process: {error}",
+                harness.kind()
+            );
+            if let Some(mut process) = state.process.take() {
+                process.kill_and_wait()?;
+            }
+        }
+    } else if let Some(mut process) = state.process.take() {
+        process.kill_and_wait()?;
+    }
+    Ok(())
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -1220,7 +1255,6 @@ fn run_normalized_turn<H: HarnessServer, W: Write>(
         Ok(Some(turn)) => state.completed_turns.push(turn),
         Ok(None) => {}
         Err(HarnessServerError::TurnInterrupted { .. }) => {
-            state.process = None;
             finish_turn_interrupted(state, normalizer, stdout)?;
         }
         Err(error) => {
@@ -1283,6 +1317,7 @@ fn run_harness_turn<H: HarnessServer, W: Write>(
     let usage_span_input = usage_span_input_value(input);
     let mut usage_span_output = UsageSpanOutput::default();
     ensure_harness_process(harness, state)?;
+    let turn_stdin = harness.stdin_for_state_turn(state, input)?;
     {
         let process = state
             .process
@@ -1293,7 +1328,7 @@ fn run_harness_turn<H: HarnessServer, W: Write>(
         // late `result` (and trailing rate-limit noise) behind, which would
         // otherwise read as this turn's instant terminal.
         while process.stdout.try_recv().is_ok() {}
-        process.stdin.write_all(&harness.stdin_for_turn(input)?)?;
+        process.stdin.write_all(&turn_stdin)?;
         process.stdin.flush()?;
     }
 
@@ -1309,12 +1344,7 @@ fn run_harness_turn<H: HarnessServer, W: Write>(
     let mut latest_usage = None;
     loop {
         while let Ok(request) = request_rx.try_recv() {
-            let process = state
-                .process
-                .as_mut()
-                .ok_or(HarnessServerError::HarnessStdinUnavailable)?;
-            if handle_active_turn_request(harness, process, normalizer, request, stdout)? {
-                state.process = None;
+            if handle_active_turn_request(harness, state, normalizer, request, stdout)? {
                 return Err(HarnessServerError::TurnInterrupted {
                     kind: harness.kind(),
                 });
@@ -1341,6 +1371,14 @@ fn run_harness_turn<H: HarnessServer, W: Write>(
                     continue;
                 }
                 let event = harness.parse_stdout_line(trimmed)?;
+                if let Some(response) = harness.response_for_event(&event)? {
+                    let process = state
+                        .process
+                        .as_mut()
+                        .ok_or(HarnessServerError::HarnessStdinUnavailable)?;
+                    process.stdin.write_all(&response)?;
+                    process.stdin.flush()?;
+                }
                 let normalized_events = harness.normalize_events(&mut event_normalizer, event)?;
                 let mut terminal_stop = false;
                 for normalized in normalized_events {
@@ -1568,7 +1606,6 @@ fn ensure_harness_process<H: HarnessServer>(harness: &H, state: &mut ThreadState
             cwd: state.cwd.clone(),
             source,
         })?;
-
     let stdin = child
         .stdin
         .take()
@@ -1606,6 +1643,12 @@ fn ensure_harness_process<H: HarnessServer>(harness: &H, state: &mut ThreadState
         stdin,
         stdout: stdout_rx,
     });
+    if let Err(error) = harness.initialize_process(state) {
+        if let Some(mut process) = state.process.take() {
+            let _ = process.kill_and_wait();
+        }
+        return Err(error);
+    }
     Ok(())
 }
 

--- a/crates/harness-server/src/traits.rs
+++ b/crates/harness-server/src/traits.rs
@@ -15,6 +15,7 @@ pub enum HarnessKind {
     Codex,
     ClaudeCode,
     Amp,
+    Hermes,
 }
 
 pub struct ThreadState {
@@ -62,11 +63,39 @@ pub trait HarnessServer {
     fn default_model(&self) -> String;
     fn default_model_provider(&self) -> &'static str;
     fn command_for_turn(&self, state: &ThreadState) -> ProcessCommand;
+    /// Perform any native protocol handshake after the harness process starts.
+    /// Stream-JSON harnesses are ready immediately; protocol servers such as
+    /// ACP use this hook to initialize and create or restore their session.
+    fn initialize_process(&self, _state: &mut ThreadState) -> Result<()> {
+        Ok(())
+    }
     fn stdin_for_turn(&self, input: &[UserInput]) -> Result<Vec<u8>>;
+    fn stdin_for_state_turn(&self, _state: &ThreadState, input: &[UserInput]) -> Result<Vec<u8>> {
+        self.stdin_for_turn(input)
+    }
     fn stdin_for_steer(&self, input: &[UserInput]) -> Result<Vec<u8>> {
         self.stdin_for_turn(input)
     }
+    fn stdin_for_state_steer(&self, _state: &ThreadState, input: &[UserInput]) -> Result<Vec<u8>> {
+        self.stdin_for_steer(input)
+    }
+    /// Return a native cancellation message when the process can cancel a turn
+    /// without being killed. `None` retains the default kill-and-respawn path.
+    fn stdin_for_interrupt(&self, _state: &ThreadState) -> Result<Option<Vec<u8>>> {
+        Ok(None)
+    }
+    /// Finish any native cancellation handshake before the interrupted turn is
+    /// reported complete. This prevents a late native terminal response from
+    /// being mistaken for the following turn.
+    fn wait_for_interrupt(&self, _state: &mut ThreadState) -> Result<()> {
+        Ok(())
+    }
     fn parse_stdout_line(&self, line: &str) -> Result<Self::Event>;
+    /// Some harness protocols can issue client requests while a turn runs (for
+    /// example ACP permission requests). Return the response to write back.
+    fn response_for_event(&self, _event: &Self::Event) -> Result<Option<Vec<u8>>> {
+        Ok(None)
+    }
     fn normalize_events(
         &self,
         normalizer: &mut Self::EventNormalizer,

--- a/crates/harness-server/tests/app_server_stdio.rs
+++ b/crates/harness-server/tests/app_server_stdio.rs
@@ -10,6 +10,7 @@ use std::time::{Duration, Instant};
 use codex_app_server_protocol::{JSONRPCMessage, ServerNotification};
 use harness_server::is_known_untyped_server_notification;
 use serde_json::{Value, json};
+use sha2::{Digest, Sha256};
 use uuid::Uuid;
 
 const LONG_PROMPT: &str = "Write exactly 24 lines. Each line must be 'LONG_STREAM_DELTA_LINE_N: abcdefghijklmnopqrstuvwxyz 0123456789' where N is 01 through 24. Do not use markdown, bullets, tools, or extra text.";
@@ -19,6 +20,7 @@ enum Harness {
     ClaudeCode,
     Amp,
     Codex,
+    Hermes,
 }
 
 impl Harness {
@@ -27,6 +29,7 @@ impl Harness {
             Self::ClaudeCode => "claude-code",
             Self::Amp => "amp",
             Self::Codex => "codex",
+            Self::Hermes => "hermes",
         }
     }
 
@@ -35,6 +38,7 @@ impl Harness {
             Self::ClaudeCode => &["claude-code", "--mode", "jsonrpc"],
             Self::Amp => &["amp", "--mode", "jsonrpc"],
             Self::Codex => &["codex", "--mode", "jsonrpc"],
+            Self::Hermes => &["hermes", "--mode", "jsonrpc"],
         }
     }
 
@@ -43,6 +47,7 @@ impl Harness {
             Self::ClaudeCode => &["claude-code"],
             Self::Amp => &["amp"],
             Self::Codex => &["codex"],
+            Self::Hermes => &["hermes"],
         }
     }
 
@@ -51,6 +56,7 @@ impl Harness {
             Self::ClaudeCode => Some("CENTAUR_CLAUDE_APP_BRIDGE_COMMAND"),
             Self::Amp => Some("CENTAUR_AMP_APP_BRIDGE_COMMAND"),
             Self::Codex => None,
+            Self::Hermes => Some("CENTAUR_HERMES_ACP_COMMAND"),
         }
     }
 
@@ -79,8 +85,191 @@ impl Harness {
                 }
                 params
             }
+            Self::Hermes => json!({}),
         }
     }
+}
+
+#[test]
+fn fake_hermes_acp_streams_codex_v2_notifications() {
+    let fake_hermes_path = temp_path("fake-hermes-acp.sh");
+    std::fs::write(&fake_hermes_path, fake_hermes_acp_script())
+        .expect("write fake Hermes ACP server");
+    let mut permissions = std::fs::metadata(&fake_hermes_path)
+        .expect("fake Hermes ACP metadata")
+        .permissions();
+    permissions.set_mode(0o755);
+    std::fs::set_permissions(&fake_hermes_path, permissions).expect("chmod fake Hermes ACP server");
+    let hermes_home = temp_path("fake-hermes-home");
+    std::fs::create_dir_all(&hermes_home).unwrap();
+    let hermes_home = hermes_home.to_string_lossy().to_string();
+    let mut bridge = BridgeProcess::spawn_harness(
+        Harness::Hermes,
+        Some(fake_hermes_path.to_string_lossy().to_string()),
+        Some(("HERMES_HOME", hermes_home.as_str())),
+    );
+    let timeout = Duration::from_secs(10);
+    let thread_id = bridge.initialize_and_start_thread(Harness::Hermes, timeout);
+    let turn = bridge.run_turn(&thread_id, 3, "say hello", None, timeout);
+    bridge.finish_successfully();
+
+    assert_completed_turn(&turn);
+    assert_eq!(turn.text_from_deltas, "hello from Hermes");
+    assert_eq!(turn.reasoning_delta_count, 1);
+    assert_codex_v2_turn(&turn);
+
+    std::fs::remove_file(fake_hermes_path).expect("remove fake Hermes ACP server");
+    std::fs::remove_dir_all(hermes_home).expect("remove fake Hermes home");
+}
+
+#[test]
+fn fake_hermes_acp_supports_the_blocks_harness_interface() {
+    let fake_hermes_path = temp_path("fake-hermes-blocks-acp.sh");
+    std::fs::write(&fake_hermes_path, fake_hermes_acp_script())
+        .expect("write fake Hermes ACP server");
+    let mut permissions = std::fs::metadata(&fake_hermes_path)
+        .expect("fake Hermes ACP metadata")
+        .permissions();
+    permissions.set_mode(0o755);
+    std::fs::set_permissions(&fake_hermes_path, permissions).expect("chmod fake Hermes ACP server");
+    let hermes_home = temp_path("fake-hermes-blocks-home");
+    std::fs::create_dir_all(&hermes_home).expect("create fake Hermes home");
+    let hermes_home = hermes_home.to_string_lossy().to_string();
+    let mut bridge = BridgeProcess::spawn_harness_blocks(
+        Harness::Hermes,
+        Some(fake_hermes_path.to_string_lossy().to_string()),
+        Some(("HERMES_HOME", hermes_home.as_str())),
+    );
+    let turn = bridge.run_blocks_user_turn("say hello", Duration::from_secs(10));
+    bridge.finish_successfully();
+
+    assert_completed_turn(&turn);
+    assert_eq!(turn.text_from_deltas, "hello from Hermes");
+    assert_codex_v2_turn(&turn);
+
+    std::fs::remove_file(fake_hermes_path).expect("remove fake Hermes ACP server");
+    std::fs::remove_dir_all(hermes_home).expect("remove fake Hermes home");
+}
+
+#[test]
+fn fake_hermes_acp_cancel_settles_before_the_next_turn() {
+    let fake_hermes_path = temp_path("fake-hermes-cancel-acp.sh");
+    std::fs::write(&fake_hermes_path, fake_hermes_cancel_script())
+        .expect("write cancellable fake Hermes ACP server");
+    let mut permissions = std::fs::metadata(&fake_hermes_path)
+        .expect("fake Hermes ACP metadata")
+        .permissions();
+    permissions.set_mode(0o755);
+    std::fs::set_permissions(&fake_hermes_path, permissions).expect("chmod fake Hermes ACP server");
+    let hermes_home = temp_path("fake-hermes-cancel-home");
+    std::fs::create_dir_all(&hermes_home).expect("create fake Hermes home");
+    let hermes_home = hermes_home.to_string_lossy().to_string();
+    let mut bridge = BridgeProcess::spawn_harness(
+        Harness::Hermes,
+        Some(fake_hermes_path.to_string_lossy().to_string()),
+        Some(("HERMES_HOME", hermes_home.as_str())),
+    );
+    let timeout = Duration::from_secs(10);
+    let thread_id = bridge.initialize_and_start_thread(Harness::Hermes, timeout);
+
+    let interrupted =
+        bridge.run_interrupted_turn(&thread_id, 3, 4, "wait", Duration::from_secs(10));
+    assert_eq!(interrupted.terminal_status.as_deref(), Some("interrupted"));
+
+    let fresh = bridge.run_turn(&thread_id, 5, "continue", None, timeout);
+    bridge.finish_successfully();
+    assert_completed_turn(&fresh);
+    assert_eq!(fresh.text_from_deltas, "after cancel");
+
+    std::fs::remove_file(fake_hermes_path).expect("remove fake Hermes ACP server");
+    std::fs::remove_dir_all(hermes_home).expect("remove fake Hermes home");
+}
+
+#[test]
+fn fake_hermes_acp_recovers_when_a_mapped_session_is_missing() {
+    let fake_hermes_path = temp_path("fake-hermes-load-error-acp.sh");
+    write_executable(&fake_hermes_path, fake_hermes_load_error_script());
+    let hermes_home = temp_path("fake-hermes-load-error-home");
+    std::fs::create_dir_all(&hermes_home).expect("create fake Hermes home");
+    let hermes_home_string = hermes_home.to_string_lossy().to_string();
+    let mut bridge = BridgeProcess::spawn_harness(
+        Harness::Hermes,
+        Some(fake_hermes_path.to_string_lossy().to_string()),
+        Some(("HERMES_HOME", hermes_home_string.as_str())),
+    );
+    let timeout = Duration::from_secs(10);
+    let thread_id = bridge.initialize_and_start_thread(Harness::Hermes, timeout);
+    write_hermes_session_mapping(&hermes_home, &thread_id, "missing-native-session");
+
+    let turn = bridge.run_turn(&thread_id, 3, "recover", None, timeout);
+    bridge.finish_successfully();
+
+    assert_completed_turn(&turn);
+    assert_eq!(turn.text_from_deltas, "recovered session");
+    assert_eq!(
+        read_hermes_session_mapping(&hermes_home, &thread_id),
+        "replacement-session"
+    );
+
+    std::fs::remove_file(fake_hermes_path).expect("remove fake Hermes ACP server");
+    std::fs::remove_dir_all(hermes_home).expect("remove fake Hermes home");
+}
+
+#[test]
+fn fake_hermes_acp_accepts_an_empty_successful_load_response() {
+    let fake_hermes_path = temp_path("fake-hermes-empty-load-acp.sh");
+    write_executable(&fake_hermes_path, fake_hermes_empty_load_script());
+    let hermes_home = temp_path("fake-hermes-empty-load-home");
+    std::fs::create_dir_all(&hermes_home).expect("create fake Hermes home");
+    let hermes_home_string = hermes_home.to_string_lossy().to_string();
+    let mut bridge = BridgeProcess::spawn_harness(
+        Harness::Hermes,
+        Some(fake_hermes_path.to_string_lossy().to_string()),
+        Some(("HERMES_HOME", hermes_home_string.as_str())),
+    );
+    let timeout = Duration::from_secs(10);
+    let thread_id = bridge.initialize_and_start_thread(Harness::Hermes, timeout);
+    write_hermes_session_mapping(&hermes_home, &thread_id, "existing-native-session");
+
+    let turn = bridge.run_turn(&thread_id, 3, "continue", None, timeout);
+    bridge.finish_successfully();
+
+    assert_completed_turn(&turn);
+    assert_eq!(turn.text_from_deltas, "loaded existing session");
+    assert_eq!(
+        read_hermes_session_mapping(&hermes_home, &thread_id),
+        "existing-native-session"
+    );
+
+    std::fs::remove_file(fake_hermes_path).expect("remove fake Hermes ACP server");
+    std::fs::remove_dir_all(hermes_home).expect("remove fake Hermes home");
+}
+
+#[test]
+fn fake_hermes_acp_cancel_error_restarts_before_the_next_turn() {
+    let fake_hermes_path = temp_path("fake-hermes-cancel-error-acp.sh");
+    write_executable(&fake_hermes_path, fake_hermes_cancel_error_script());
+    let hermes_home = temp_path("fake-hermes-cancel-error-home");
+    std::fs::create_dir_all(&hermes_home).expect("create fake Hermes home");
+    let hermes_home_string = hermes_home.to_string_lossy().to_string();
+    let mut bridge = BridgeProcess::spawn_harness(
+        Harness::Hermes,
+        Some(fake_hermes_path.to_string_lossy().to_string()),
+        Some(("HERMES_HOME", hermes_home_string.as_str())),
+    );
+    let timeout = Duration::from_secs(10);
+    let thread_id = bridge.initialize_and_start_thread(Harness::Hermes, timeout);
+
+    let interrupted = bridge.run_interrupted_turn(&thread_id, 3, 4, "wait", timeout);
+    assert_eq!(interrupted.terminal_status.as_deref(), Some("interrupted"));
+
+    let fresh = bridge.run_turn(&thread_id, 5, "continue", None, timeout);
+    bridge.finish_successfully();
+    assert_completed_turn(&fresh);
+    assert_eq!(fresh.text_from_deltas, "after failed cancel");
+
+    std::fs::remove_file(fake_hermes_path).expect("remove fake Hermes ACP server");
+    std::fs::remove_dir_all(hermes_home).expect("remove fake Hermes home");
 }
 
 #[test]
@@ -1931,7 +2120,9 @@ fn run_native_anthropic(harness: Harness, prompt: &str, timeout: Duration) -> Na
             ]);
             command
         }
-        Harness::Codex => panic!("native anthropic runner does not support Codex"),
+        Harness::Codex | Harness::Hermes => {
+            panic!("native anthropic runner does not support this harness")
+        }
     };
     command
         .stdin(Stdio::piped())
@@ -2349,6 +2540,214 @@ fn temp_path(name: &str) -> PathBuf {
         std::process::id(),
         Uuid::new_v4().simple()
     ))
+}
+
+fn fake_hermes_acp_script() -> &'static str {
+    r#"#!/bin/sh
+while IFS= read -r line; do
+  case "$line" in
+    *'"method":"initialize"'*)
+      printf '%s\n' '{"jsonrpc":"2.0","id":"centaur-hermes-initialize","result":{"protocolVersion":1}}'
+      ;;
+    *'"method":"session/new"'*)
+      printf '%s\n' '{"jsonrpc":"2.0","id":"centaur-hermes-session","result":{"sessionId":"hermes-session","modes":{"currentModeId":"default","availableModes":[]}}}'
+      ;;
+    *'"method":"session/set_mode"'*)
+      printf '%s\n' '{"jsonrpc":"2.0","id":"centaur-hermes-mode","result":{}}'
+      ;;
+    *'"method":"session/set_model"'*)
+      printf '%s\n' '{"jsonrpc":"2.0","id":"centaur-hermes-model","result":{}}'
+      ;;
+    *'"method":"session/prompt"'*)
+      printf '%s\n' '{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"hermes-session","update":{"sessionUpdate":"agent_thought_chunk","content":{"type":"text","text":"thinking"}}}}'
+      printf '%s\n' '{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"hermes-session","update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"hello from Hermes"}}}}'
+      printf '%s\n' '{"jsonrpc":"2.0","id":"centaur-hermes-prompt","result":{"stopReason":"end_turn","usage":{"inputTokens":8,"outputTokens":3,"totalTokens":11}}}'
+      ;;
+    *)
+      printf '%s\n' "unexpected request: $line" >&2
+      exit 65
+      ;;
+  esac
+done
+"#
+}
+
+fn fake_hermes_cancel_script() -> &'static str {
+    r#"#!/bin/sh
+prompt_count=0
+while IFS= read -r line; do
+  case "$line" in
+    *'"method":"initialize"'*)
+      printf '%s\n' '{"jsonrpc":"2.0","id":"centaur-hermes-initialize","result":{"protocolVersion":1}}'
+      ;;
+    *'"method":"session/new"'*)
+      printf '%s\n' '{"jsonrpc":"2.0","id":"centaur-hermes-session","result":{"sessionId":"hermes-session","modes":{"currentModeId":"default","availableModes":[]}}}'
+      ;;
+    *'"method":"session/set_mode"'*)
+      printf '%s\n' '{"jsonrpc":"2.0","id":"centaur-hermes-mode","result":{}}'
+      ;;
+    *'"method":"session/set_model"'*)
+      printf '%s\n' '{"jsonrpc":"2.0","id":"centaur-hermes-model","result":{}}'
+      ;;
+    *'"method":"session/prompt"'*)
+      prompt_count=$((prompt_count + 1))
+      if [ "$prompt_count" -gt 1 ]; then
+        printf '%s\n' '{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"hermes-session","update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"after cancel"}}}}'
+        printf '%s\n' '{"jsonrpc":"2.0","id":"centaur-hermes-prompt","result":{"stopReason":"end_turn"}}'
+      fi
+      ;;
+    *'"method":"session/cancel"'*)
+      printf '%s\n' '{"jsonrpc":"2.0","id":"centaur-hermes-prompt","result":{"stopReason":"cancelled"}}'
+      ;;
+    *)
+      printf '%s\n' "unexpected request: $line" >&2
+      exit 65
+      ;;
+  esac
+done
+"#
+}
+
+fn fake_hermes_load_error_script() -> &'static str {
+    r#"#!/bin/sh
+while IFS= read -r line; do
+  case "$line" in
+    *'"method":"initialize"'*)
+      printf '%s\n' '{"jsonrpc":"2.0","id":"centaur-hermes-initialize","result":{"protocolVersion":1}}'
+      ;;
+    *'"method":"session/load"'*)
+      printf '%s\n' '{"jsonrpc":"2.0","id":"centaur-hermes-session","error":{"code":-32001,"message":"unknown session"}}'
+      ;;
+    *'"method":"session/new"'*)
+      printf '%s\n' '{"jsonrpc":"2.0","id":"centaur-hermes-session","result":{"sessionId":"replacement-session"}}'
+      ;;
+    *'"method":"session/set_mode"'*)
+      printf '%s\n' '{"jsonrpc":"2.0","id":"centaur-hermes-mode","result":{}}'
+      ;;
+    *'"method":"session/set_model"'*)
+      printf '%s\n' '{"jsonrpc":"2.0","id":"centaur-hermes-model","result":{}}'
+      ;;
+    *'"method":"session/prompt"'*)
+      printf '%s\n' '{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"replacement-session","update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"recovered session"}}}}'
+      printf '%s\n' '{"jsonrpc":"2.0","id":"centaur-hermes-prompt","result":{"stopReason":"end_turn"}}'
+      ;;
+    *)
+      printf '%s\n' "unexpected request: $line" >&2
+      exit 65
+      ;;
+  esac
+done
+"#
+}
+
+fn fake_hermes_empty_load_script() -> &'static str {
+    r#"#!/bin/sh
+while IFS= read -r line; do
+  case "$line" in
+    *'"method":"initialize"'*)
+      printf '%s\n' '{"jsonrpc":"2.0","id":"centaur-hermes-initialize","result":{"protocolVersion":1}}'
+      ;;
+    *'"method":"session/load"'*)
+      printf '%s\n' '{"jsonrpc":"2.0","id":"centaur-hermes-session","result":null}'
+      ;;
+    *'"method":"session/new"'*)
+      printf '%s\n' 'session/new must not follow a successful session/load' >&2
+      exit 65
+      ;;
+    *'"method":"session/set_mode"'*)
+      printf '%s\n' '{"jsonrpc":"2.0","id":"centaur-hermes-mode","result":{}}'
+      ;;
+    *'"method":"session/set_model"'*)
+      printf '%s\n' '{"jsonrpc":"2.0","id":"centaur-hermes-model","result":{}}'
+      ;;
+    *'"method":"session/prompt"'*)
+      printf '%s\n' '{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"existing-native-session","update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"loaded existing session"}}}}'
+      printf '%s\n' '{"jsonrpc":"2.0","id":"centaur-hermes-prompt","result":{"stopReason":"end_turn"}}'
+      ;;
+    *)
+      printf '%s\n' "unexpected request: $line" >&2
+      exit 65
+      ;;
+  esac
+done
+"#
+}
+
+fn fake_hermes_cancel_error_script() -> &'static str {
+    r#"#!/bin/sh
+marker="${HERMES_HOME}/cancel-error-restarted"
+if [ -f "$marker" ]; then
+  restarted=1
+else
+  restarted=0
+  : > "$marker"
+fi
+
+while IFS= read -r line; do
+  case "$line" in
+    *'"method":"initialize"'*)
+      printf '%s\n' '{"jsonrpc":"2.0","id":"centaur-hermes-initialize","result":{"protocolVersion":1}}'
+      ;;
+    *'"method":"session/new"'*)
+      printf '%s\n' '{"jsonrpc":"2.0","id":"centaur-hermes-session","result":{"sessionId":"hermes-session"}}'
+      ;;
+    *'"method":"session/load"'*)
+      printf '%s\n' '{"jsonrpc":"2.0","id":"centaur-hermes-session","result":{}}'
+      ;;
+    *'"method":"session/set_mode"'*)
+      printf '%s\n' '{"jsonrpc":"2.0","id":"centaur-hermes-mode","result":{}}'
+      ;;
+    *'"method":"session/set_model"'*)
+      printf '%s\n' '{"jsonrpc":"2.0","id":"centaur-hermes-model","result":{}}'
+      ;;
+    *'"method":"session/prompt"'*)
+      if [ "$restarted" -eq 1 ]; then
+        printf '%s\n' '{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"hermes-session","update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"after failed cancel"}}}}'
+        printf '%s\n' '{"jsonrpc":"2.0","id":"centaur-hermes-prompt","result":{"stopReason":"end_turn"}}'
+      fi
+      ;;
+    *'"method":"session/cancel"'*)
+      printf '%s\n' '{"jsonrpc":"2.0","id":"centaur-hermes-prompt","error":{"code":-32002,"message":"cancel did not settle"}}'
+      ;;
+    *)
+      printf '%s\n' "unexpected request: $line" >&2
+      exit 65
+      ;;
+  esac
+done
+"#
+}
+
+fn write_executable(path: &Path, contents: &str) {
+    std::fs::write(path, contents).expect("write executable fixture");
+    let mut permissions = std::fs::metadata(path)
+        .expect("executable fixture metadata")
+        .permissions();
+    permissions.set_mode(0o755);
+    std::fs::set_permissions(path, permissions).expect("chmod executable fixture");
+}
+
+fn hermes_session_mapping_path(home: &Path, thread_id: &str) -> PathBuf {
+    let digest = Sha256::digest(thread_id.as_bytes());
+    let filename = digest
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect::<String>();
+    home.join("centaur-acp-sessions").join(filename)
+}
+
+fn write_hermes_session_mapping(home: &Path, thread_id: &str, session_id: &str) {
+    let path = hermes_session_mapping_path(home, thread_id);
+    std::fs::create_dir_all(path.parent().expect("mapping parent"))
+        .expect("create Hermes mapping directory");
+    std::fs::write(path, format!("{session_id}\n")).expect("write Hermes mapping");
+}
+
+fn read_hermes_session_mapping(home: &Path, thread_id: &str) -> String {
+    std::fs::read_to_string(hermes_session_mapping_path(home, thread_id))
+        .expect("read Hermes mapping")
+        .trim()
+        .to_string()
 }
 
 fn shell_quote(path: &Path) -> String {

--- a/services/api-rs/crates/centaur-api-integration-test/src/main.rs
+++ b/services/api-rs/crates/centaur-api-integration-test/src/main.rs
@@ -231,6 +231,7 @@ async fn test_harness_wire_values(http: &HttpClient, base_url: &str) -> Result<(
         (HarnessType::Amp, "amp"),
         (HarnessType::ClaudeCode, "claudecode"),
         (HarnessType::Nanocodex, "nanocodex"),
+        (HarnessType::Hermes, "hermes"),
     ];
 
     for (harness_type, expected_wire_value) in cases {

--- a/services/api-rs/crates/centaur-api-server/src/args.rs
+++ b/services/api-rs/crates/centaur-api-server/src/args.rs
@@ -1972,7 +1972,9 @@ impl IronProxyHarnessArgs {
                 fragments.push(fragment);
             }
         }
-        if let Some(fragment) = harness_auth_fragment("openrouter", "api_key")? {
+        if harness_fragment_engine_name(&self.engine) != "openrouter"
+            && let Some(fragment) = harness_auth_fragment("openrouter", "api_key")?
+        {
             fragments.push(fragment);
         }
         if let Some(fragment) = harness_auth_fragment("meta-ai", "api_key")? {
@@ -2028,6 +2030,7 @@ fn harness_fragment_engine_name(engine: &HarnessType) -> &'static str {
         HarnessType::Amp => "amp",
         HarnessType::ClaudeCode => "claude-code",
         HarnessType::Nanocodex => "codex",
+        HarnessType::Hermes => "openrouter",
     }
 }
 
@@ -2045,6 +2048,7 @@ fn harness_auth_mode_env(engine: &HarnessType) -> Option<String> {
         HarnessType::Codex | HarnessType::Nanocodex => env::var("CODEX_AUTH_MODE").ok(),
         HarnessType::ClaudeCode => env::var("CLAUDE_CODE_AUTH_MODE").ok(),
         HarnessType::Amp => None,
+        HarnessType::Hermes => None,
     }
 }
 
@@ -3215,5 +3219,14 @@ mod tests {
             harness_auth_mode_env(&HarnessType::Nanocodex).as_deref(),
             Some("access_token")
         );
+    }
+
+    #[test]
+    fn hermes_uses_the_openrouter_proxy_fragment() {
+        assert_eq!(
+            harness_fragment_engine_name(&HarnessType::Hermes),
+            "openrouter"
+        );
+        assert_eq!(harness_auth_mode_env(&HarnessType::Hermes), None);
     }
 }

--- a/services/api-rs/crates/centaur-session-cli/src/main.rs
+++ b/services/api-rs/crates/centaur-session-cli/src/main.rs
@@ -576,6 +576,7 @@ enum HarnessTypeArg {
     #[value(name = "claudecode")]
     ClaudeCode,
     Nanocodex,
+    Hermes,
 }
 
 impl From<HarnessTypeArg> for HarnessType {
@@ -585,6 +586,7 @@ impl From<HarnessTypeArg> for HarnessType {
             HarnessTypeArg::Amp => Self::Amp,
             HarnessTypeArg::ClaudeCode => Self::ClaudeCode,
             HarnessTypeArg::Nanocodex => Self::Nanocodex,
+            HarnessTypeArg::Hermes => Self::Hermes,
         }
     }
 }

--- a/services/api-rs/crates/centaur-session-core/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-core/src/lib.rs
@@ -361,6 +361,7 @@ pub enum HarnessType {
     Amp,
     ClaudeCode,
     Nanocodex,
+    Hermes,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, AsRefStr, Display, EnumString)]
@@ -860,6 +861,10 @@ mod tests {
     fn harness_type_accepts_supported_values() {
         assert_eq!(HarnessType::from_str("codex").unwrap(), HarnessType::Codex);
         assert_eq!(HarnessType::from_str("amp").unwrap(), HarnessType::Amp);
+        assert_eq!(
+            HarnessType::from_str("hermes").unwrap(),
+            HarnessType::Hermes
+        );
         assert_eq!(
             HarnessType::from_str("nanocodex").unwrap(),
             HarnessType::Nanocodex

--- a/services/api-rs/crates/centaur-session-runtime/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-runtime/src/lib.rs
@@ -3748,6 +3748,7 @@ fn harness_server_subcommand(harness: &HarnessType) -> &'static str {
         HarnessType::ClaudeCode => "claude-code",
         HarnessType::Amp => "amp",
         HarnessType::Nanocodex => "nanocodex",
+        HarnessType::Hermes => "hermes",
     }
 }
 
@@ -7988,10 +7989,12 @@ mod tests {
         let codex_spec = workload.spec(&thread_key, &HarnessType::Codex, None);
         let claude_spec = workload.spec(&thread_key, &HarnessType::ClaudeCode, None);
         let amp_spec = workload.spec(&thread_key, &HarnessType::Amp, None);
+        let hermes_spec = workload.spec(&thread_key, &HarnessType::Hermes, None);
 
         assert_eq!(codex_spec.args, vec!["harness-server", "codex"]);
         assert_eq!(claude_spec.args, vec!["harness-server", "claude-code"]);
         assert_eq!(amp_spec.args, vec!["harness-server", "amp"]);
+        assert_eq!(hermes_spec.args, vec!["harness-server", "hermes"]);
         // The image entrypoint must be preserved: only CMD is overridden.
         assert_eq!(codex_spec.command, None);
     }

--- a/services/api-rs/crates/centaur-session-sqlx/migrations/0051_hermes_harness.sql
+++ b/services/api-rs/crates/centaur-session-sqlx/migrations/0051_hermes_harness.sql
@@ -1,0 +1,6 @@
+alter table sessions
+drop constraint sessions_harness_type_supported;
+
+alter table sessions
+add constraint sessions_harness_type_supported
+check (harness_type in ('codex', 'amp', 'claudecode', 'nanocodex', 'hermes'));

--- a/services/api-rs/crates/centaur-session-sqlx/migrations/0051_hermes_harness.sql
+++ b/services/api-rs/crates/centaur-session-sqlx/migrations/0051_hermes_harness.sql
@@ -1,6 +1,0 @@
-alter table sessions
-drop constraint sessions_harness_type_supported;
-
-alter table sessions
-add constraint sessions_harness_type_supported
-check (harness_type in ('codex', 'amp', 'claudecode', 'nanocodex', 'hermes'));

--- a/services/console/app/controllers/console/threads_controller.rb
+++ b/services/console/app/controllers/console/threads_controller.rb
@@ -73,7 +73,8 @@ class Console::ThreadsController < ApplicationController
   # the chart. Amp has no fixed default model, so it is intentionally absent.
   HARNESS_DEFAULT_MODEL_ENVS = {
     "claudecode" => "CLAUDE_MODEL",
-    "codex" => "CODEX_MODEL"
+    "codex" => "CODEX_MODEL",
+    "hermes" => "HERMES_MODEL"
   }.freeze
   # Harness config files carrying each harness's baked-in default model, used
   # when no env override is set. Resolved against CENTAUR_HARNESS_CONFIG_DIR
@@ -83,6 +84,9 @@ class Console::ThreadsController < ApplicationController
   HARNESS_CONFIG_FILES = {
     "claudecode" => "claude/settings.json",
     "codex" => "codex/config.toml"
+  }.freeze
+  HARNESS_FALLBACK_DEFAULT_MODELS = {
+    "hermes" => "openrouter/auto"
   }.freeze
 
   SlackThreadOwner = Struct.new(:user_id, :team_id, keyword_init: true)
@@ -118,6 +122,8 @@ class Console::ThreadsController < ApplicationController
                       efforts: CODEX_EFFORTS + [ %w[max Max] ]),
     ComposerAgent.new(value: "nanocodex", label: "Nanocodex (GPT-5.6 Sol)",
                       harness: "nanocodex", model: nil, efforts: []),
+    ComposerAgent.new(value: "hermes", label: "Hermes Agent",
+                      harness: "hermes", model: nil, efforts: []),
     ComposerAgent.new(value: "gpt-5.5", label: "GPT-5.5",
                       harness: "codex", model: "gpt-5.5",
                       efforts: CODEX_EFFORTS),
@@ -1473,6 +1479,7 @@ class Console::ThreadsController < ApplicationController
     when "claudecode" then "Claude Code"
     when "amp" then "Amp"
     when "nanocodex" then "Nanocodex"
+    when "hermes" then "Hermes Agent"
     else source_label(session.harness_type)
     end
   end
@@ -1501,7 +1508,8 @@ class Console::ThreadsController < ApplicationController
     env_name = HARNESS_DEFAULT_MODEL_ENVS[harness_type]
     return unless env_name
 
-    ENV[env_name].presence || self.class.baked_harness_default_model(harness_type)
+    ENV[env_name].presence || self.class.baked_harness_default_model(harness_type) ||
+      HARNESS_FALLBACK_DEFAULT_MODELS[harness_type]
   end
 
   # Cached per (config dir, harness): the files are immutable within a deploy,

--- a/services/console/app/helpers/application_helper.rb
+++ b/services/console/app/helpers/application_helper.rb
@@ -51,6 +51,7 @@ module ApplicationHelper
     when "claudecode" then "Claude Code"
     when "amp" then "Amp"
     when "nanocodex" then "Nanocodex"
+    when "hermes" then "Hermes Agent"
     when "" then nil
     else harness_type.to_s.tr("_-", " ").squish.split.map(&:capitalize).join(" ")
     end

--- a/services/console/test/controllers/console/threads_controller_test.rb
+++ b/services/console/test/controllers/console/threads_controller_test.rb
@@ -603,6 +603,8 @@ class Console::ThreadsControllerTest < ActionDispatch::IntegrationTest
     assert_equal "Codex", controller.send(:thread_harness_label, session)
     session.harness_type = "nanocodex"
     assert_equal "Nanocodex", controller.send(:thread_harness_label, session)
+    session.harness_type = "hermes"
+    assert_equal "Hermes Agent", controller.send(:thread_harness_label, session)
   end
 
   test "thread model label prefers the latest execution's recorded model override" do
@@ -675,6 +677,17 @@ class Console::ThreadsControllerTest < ActionDispatch::IntegrationTest
       :thread_model_label,
       TranscriptSession.new(metadata_hash: {}, harness_type: "amp")
     )
+  end
+
+  test "thread model label uses the Hermes OpenRouter default" do
+    controller = Console::ThreadsController.new
+
+    with_env("HERMES_MODEL" => nil) do
+      assert_equal "OPENROUTER/AUTO", controller.send(
+        :thread_model_label,
+        TranscriptSession.new(metadata_hash: {}, harness_type: "hermes")
+      )
+    end
   end
 
   test "visible thread scope matches Slack threads owned by the current user's Slack OAuth record" do

--- a/services/githubbot/src/overrides.ts
+++ b/services/githubbot/src/overrides.ts
@@ -26,6 +26,7 @@ const HARNESS_FLAGS: Record<string, string> = {
   claudecode: "claudecode",
   codex: "codex",
   nanocodex: "nanocodex",
+  hermes: "hermes",
 };
 
 // Claude model aliases, usable both as bare flags (--opus) and as --model

--- a/services/githubbot/test/overrides.test.ts
+++ b/services/githubbot/test/overrides.test.ts
@@ -31,6 +31,9 @@ describe("extractMessageOverrides", () => {
     expect(extractMessageOverrides("--nanocodex review this").harnessType).toBe(
       "nanocodex",
     );
+    expect(extractMessageOverrides("--hermes review this").harnessType).toBe(
+      "hermes",
+    );
   });
 
   test("parses harness flag anywhere in the message", () => {

--- a/services/linearbot/src/overrides.ts
+++ b/services/linearbot/src/overrides.ts
@@ -28,6 +28,7 @@ const HARNESS_FLAGS: Record<string, string> = {
   claudecode: "claudecode",
   codex: "codex",
   nanocodex: "nanocodex",
+  hermes: "hermes",
 };
 
 const PROVIDER_FLAGS: Record<string, { provider: string; harnessType: string }> = {

--- a/services/linearbot/test/overrides.test.ts
+++ b/services/linearbot/test/overrides.test.ts
@@ -31,6 +31,9 @@ describe("extractMessageOverrides", () => {
     expect(extractMessageOverrides("--nanocodex review this").harnessType).toBe(
       "nanocodex",
     );
+    expect(extractMessageOverrides("--hermes review this").harnessType).toBe(
+      "hermes",
+    );
   });
 
   test("parses harness flag anywhere in the message", () => {

--- a/services/sandbox/Dockerfile
+++ b/services/sandbox/Dockerfile
@@ -182,6 +182,7 @@ ENV PATH="/home/agent/.cargo/bin:/home/agent/.local/bin:/home/agent/.foundry/bin
 ARG FOUNDRY_VERSION=v1.7.0
 ARG AMP_CLI_VERSION=0.0.1774529752-g94f44d
 ARG MANIM_VERSION=0.20.1
+ARG HERMES_AGENT_VERSION=0.19.0
 ARG BUN_VERSION=bun-v1.3.13
 
 # ── Agent-scoped toolchains ─────────────────────────────────────────────────
@@ -205,6 +206,10 @@ RUN curl -fsSL https://bun.sh/install | bash -s "${BUN_VERSION}"
 RUN --mount=type=cache,target=/home/agent/.cache/uv,uid=1001,gid=1001,sharing=locked \
     uv tool install "manim==${MANIM_VERSION}" \
     && manim --version
+RUN --mount=type=cache,target=/home/agent/.cache/uv,uid=1001,gid=1001,sharing=locked \
+    uv tool install "hermes-agent[acp]==${HERMES_AGENT_VERSION}" \
+    && hermes-acp --version | grep -F "${HERMES_AGENT_VERSION}" \
+    && hermes-acp --check
 RUN curl -L https://foundry.paradigm.xyz | bash \
     && /home/agent/.foundry/bin/foundryup --install ${FOUNDRY_VERSION} \
     && for bin in forge cast anvil chisel; do \

--- a/services/slackbotv2/src/console-session-link.ts
+++ b/services/slackbotv2/src/console-session-link.ts
@@ -16,7 +16,8 @@ const HARNESS_DISPLAY_NAMES: Record<string, string> = {
   amp: 'Amp',
   claudecode: 'Claude Code',
   codex: 'Codex',
-  nanocodex: 'Nanocodex'
+  nanocodex: 'Nanocodex',
+  hermes: 'Hermes Agent'
 }
 
 const REASONING_DISPLAY_NAMES: Record<string, string> = {
@@ -69,12 +70,13 @@ const CODEX_CONFIG = codexConfig as {
 // Deployers who override the sandbox model via CLAUDE_MODEL / CODEX_MODEL
 // (sandbox.extraEnv) get the same values mirrored into slackbotv2 by the chart
 // and passed here through SlackbotV2Options.harnessDefaultModels, which takes
-// precedence. Amp has no fixed default model (deep/fast modes), so it is
-// intentionally absent.
+// precedence. Hermes defaults to OpenRouter's model router. Amp has no fixed
+// default model (deep/fast modes), so it is intentionally absent.
 const BAKED_DEFAULT_MODELS: Record<string, string | undefined> = {
   claudecode: typeof claudeSettings.model === 'string' ? claudeSettings.model : undefined,
   codex: typeof CODEX_CONFIG.model === 'string' ? CODEX_CONFIG.model : undefined,
-  nanocodex: typeof CODEX_CONFIG.model === 'string' ? CODEX_CONFIG.model : undefined
+  nanocodex: typeof CODEX_CONFIG.model === 'string' ? CODEX_CONFIG.model : undefined,
+  hermes: 'openrouter/auto'
 }
 
 // Nanocodex deliberately shares Codex's default reasoning policy. Its harness

--- a/services/slackbotv2/src/message-overrides-strategy.ts
+++ b/services/slackbotv2/src/message-overrides-strategy.ts
@@ -13,7 +13,7 @@ const SYSTEM_PROMPT = [
   'Decide whether the Slack message asks to use a specific AI harness, model, provider, or reasoning effort.',
   'Return only canonical override values from the schema.',
   'Use null for every field when the message does not ask to change model selection.',
-  'Allowed harness values: codex, claudecode, amp, nanocodex.',
+  'Allowed harness values: codex, claudecode, amp, nanocodex, hermes.',
   'Allowed provider values: responses, amazon-bedrock, openrouter.',
   'Allowed reasoning values: none, minimal, low, medium, high, xhigh, max.',
   'Treat inline flags such as "--claude", "--claude --model=fable", and "--fable" as model selection requests.',
@@ -55,7 +55,7 @@ const MESSAGE_OVERRIDES_SCHEMA = {
   additionalProperties: false,
   properties: {
     harness: {
-      enum: ['codex', 'claudecode', 'amp', 'nanocodex', null],
+      enum: ['codex', 'claudecode', 'amp', 'nanocodex', 'hermes', null],
       type: ['string', 'null']
     },
     model: {

--- a/services/slackbotv2/src/overrides.ts
+++ b/services/slackbotv2/src/overrides.ts
@@ -1,6 +1,6 @@
 /**
  * Inline message directives, restored from the v1 slackbot:
- *   --claude | --claude-code | --amp | --codex | --nanocodex
+ *   --claude | --claude-code | --amp | --codex | --nanocodex | --hermes
  *                                                  pick the harness for the thread
  *   --bedrock                                    codex via the AWS Bedrock provider
  *   --meta                                       codex via Meta AI direct
@@ -44,7 +44,8 @@ const HARNESS_FLAGS: Record<string, string> = {
   'claude-code': 'claudecode',
   claudecode: 'claudecode',
   codex: 'codex',
-  nanocodex: 'nanocodex'
+  nanocodex: 'nanocodex',
+  hermes: 'hermes'
 }
 
 // Provider flags select a model provider within the codex harness (and imply
@@ -72,7 +73,7 @@ const MODEL_SHORTCUTS: Record<string, { harnessType: string; model: string }> =
     ])
   )
 
-const STRATEGY_HARNESSES = new Set(['amp', 'claudecode', 'codex', 'nanocodex'])
+const STRATEGY_HARNESSES = new Set(['amp', 'claudecode', 'codex', 'nanocodex', 'hermes'])
 const STRATEGY_PROVIDERS = new Set(['amazon-bedrock', 'openrouter', 'responses'])
 const STRATEGY_REASONING_EFFORTS = new Set([
   'none',

--- a/services/slackbotv2/src/server.ts
+++ b/services/slackbotv2/src/server.ts
@@ -56,7 +56,8 @@ const options: SlackbotV2Options = {
     ...(optionalEnv('CLAUDE_MODEL') ? { claudecode: optionalEnv('CLAUDE_MODEL')! } : {}),
     ...(optionalEnv('CODEX_MODEL')
       ? { codex: optionalEnv('CODEX_MODEL')!, nanocodex: optionalEnv('CODEX_MODEL')! }
-      : {})
+      : {}),
+    ...(optionalEnv('HERMES_MODEL') ? { hermes: optionalEnv('HERMES_MODEL')! } : {})
   },
   harnessDefaultReasoning: optionalEnv('CODEX_MODEL_REASONING_EFFORT')
     ? {

--- a/services/slackbotv2/test/console-session-link.test.ts
+++ b/services/slackbotv2/test/console-session-link.test.ts
@@ -18,6 +18,7 @@ describe('harnessDisplayName', () => {
     expect(harnessDisplayName('nanocodex')).toBe('Nanocodex')
     expect(harnessDisplayName('claudecode')).toBe('Claude Code')
     expect(harnessDisplayName('amp')).toBe('Amp')
+    expect(harnessDisplayName('hermes')).toBe('Hermes Agent')
   })
 
   test('is case-insensitive and trims', () => {
@@ -107,6 +108,7 @@ describe('defaultModelForHarness', () => {
     expect(defaultModelForHarness('claudecode')).toBe(bakedClaudeModel)
     expect(defaultModelForHarness('codex')).toBe(bakedCodexModel)
     expect(defaultModelForHarness('nanocodex')).toBe(bakedCodexModel)
+    expect(defaultModelForHarness('hermes')).toBe('openrouter/auto')
   })
 
   test('prefers the deployment-configured model over the baked default', () => {

--- a/services/slackbotv2/test/overrides.test.ts
+++ b/services/slackbotv2/test/overrides.test.ts
@@ -31,6 +31,7 @@ describe('extractMessageOverrides', () => {
     expect(extractMessageOverrides('--amp review this').harnessType).toBe('amp')
     expect(extractMessageOverrides('--codex review this').harnessType).toBe('codex')
     expect(extractMessageOverrides('--nanocodex review this').harnessType).toBe('nanocodex')
+    expect(extractMessageOverrides('--hermes review this').harnessType).toBe('hermes')
   })
 
   test('parses harness flag anywhere in the message', () => {


### PR DESCRIPTION
Adds Hermes ACP as a first-class harness across the harness server, session runtime, bot overrides, console, sandbox image, and Helm configuration. The adapter normalizes Hermes ACP streams into the shared App Server interface and supports native session restoration, permissions, steering, cancellation, model selection, and token usage. It also hardens stale-session recovery and failed-cancellation process cleanup to keep subsequent turns healthy.

The database constraint migration is split into #1337 and should land first.