### PR TITLE
feat: allow Hermes session harness type

### DIFF
--- a/services/api-rs/crates/centaur-session-sqlx/migrations/0051_hermes_harness.sql
+++ b/services/api-rs/crates/centaur-session-sqlx/migrations/0051_hermes_harness.sql
@@ -1,0 +1,6 @@
+alter table sessions
+drop constraint sessions_harness_type_supported;
+
+alter table sessions
+add constraint sessions_harness_type_supported
+check (harness_type in ('codex', 'amp', 'claudecode', 'nanocodex', 'hermes'));


### PR DESCRIPTION
Extends the sessions harness-type constraint to allow Hermes. This lets the database migration land before the Hermes application support in #1336.