### PR TITLE
ci: verify console migrations match schema

### DIFF
--- a/.github/workflows/console-ci.yml
+++ b/.github/workflows/console-ci.yml
@@ -137,6 +137,17 @@ jobs:
           working-directory: services/console
           bundler-cache: true
 
+      - name: Verify migrations match the checked-in schema
+        env:
+          RAILS_ENV: test
+          IRON_CONTROL_DB_HOST: localhost
+          IRON_CONTROL_DB_PORT: 5432
+          IRON_CONTROL_DB_USERNAME: postgres
+          IRON_CONTROL_DB_PASSWORD: postgres
+        run: |
+          bin/rails db:create db:migrate
+          git diff --exit-code -- db/schema.rb
+
       - name: Run tests
         env:
           RAILS_ENV: test


### PR DESCRIPTION
Adds a console CI step that builds the test database from migrations and fails if applying them changes the checked-in db/schema.rb. This catches stale or non-reproducible schema dumps before merge.