### PR TITLE
fix(console): link Slack DM principals to users

### DIFF
--- a/services/console/app/models/broker_credential.rb
+++ b/services/console/app/models/broker_credential.rb
@@ -54,6 +54,8 @@ class BrokerCredential < ApplicationRecord
   # undeliverable. The operator must remove the references first.
   before_destroy :ensure_not_referenced
   after_commit :auto_grant_matching_principals, on: %i[create update], if: :oauth_app_id?
+  after_commit :auto_link_matching_slack_dm_principals,
+               on: %i[create update], if: :slack_identity_link_relevant_change?
   before_validation :default_preqin_token_endpoint
   before_commit :bump_referencing_principal_sync_config_versions, if: :sync_config_relevant_change?
 
@@ -179,6 +181,19 @@ class BrokerCredential < ApplicationRecord
 
   def auto_grant_matching_principals
     PrincipalCredentialReconciliation.new.apply_for_credential(self)
+  end
+
+  def auto_link_matching_slack_dm_principals
+    PrincipalConsoleUserReconciliation.new.apply_for_slack_credential(self)
+  rescue StandardError => e
+    Rails.logger.warn("principal_console_user_reconciliation_failed source=broker_credential error=#{e.class}")
+  end
+
+  def slack_identity_link_relevant_change?
+    return false unless oauth_app&.provider == Oauth::Providers::Slack::KEY
+
+    previously_new_record? ||
+      (previous_changes.keys & %w[oauth_app_id created_by_id provider_subject labels]).any?
   end
 
   def perform_refresh

--- a/services/console/app/models/principal.rb
+++ b/services/console/app/models/principal.rb
@@ -27,6 +27,7 @@ class Principal < ApplicationRecord
   before_validation :apply_sandbox_repo_cache_label
   before_validation :validate_identity_label_consistency
   before_validation :promote_identity_labels_to_fields
+  before_validation :link_console_user_from_slack_identity
   before_validation :strip_identity_labels
   before_commit :bump_own_sync_config_cache_version, on: :update, if: :sync_config_fields_changed?
 
@@ -255,6 +256,12 @@ class Principal < ApplicationRecord
   # authoritative.
   def promote_identity_labels_to_fields
     PrincipalIdentityLabels.assign(self)
+  end
+
+  def link_console_user_from_slack_identity
+    PrincipalConsoleUserReconciliation.new.assign_for_principal(self)
+  rescue StandardError => e
+    Rails.logger.warn("principal_console_user_reconciliation_failed source=principal error=#{e.class}")
   end
 
   def strip_identity_labels

--- a/services/console/app/models/user_identity.rb
+++ b/services/console/app/models/user_identity.rb
@@ -21,7 +21,7 @@ class UserIdentity < ApplicationRecord
   after_commit :reconcile_owner_oauth_credentials,
                on: %i[create update], if: :slack_identity_reconciliation_required?
   after_commit :link_slack_dm_principals,
-               on: %i[create update], if: :slack_identity_reconciliation_required?
+               on: %i[create update], if: :console_user_link_reconciliation_required?
 
   normalizes :email, with: ->(e) { e.to_s.strip.downcase.presence }
   normalizes :team_id, with: ->(id) { id.to_s.strip.presence }
@@ -53,12 +53,20 @@ class UserIdentity < ApplicationRecord
   private
 
   def slack_identity_reconciliation_required?
-    slack? && (previously_new_record? || saved_change_to_subject? ||
+    slack? && (previously_new_record? || saved_change_to_provider? || saved_change_to_subject? ||
       saved_change_to_team_id? || saved_change_to_user_id?)
   end
 
+  def console_user_link_reconciliation_required?
+    return true if slack_identity_reconciliation_required?
+
+    email_verified? && email.present? &&
+      (previously_new_record? || saved_change_to_email? ||
+        saved_change_to_email_verified? || saved_change_to_user_id?)
+  end
+
   def link_slack_dm_principals
-    PrincipalConsoleUserReconciliation.new.apply_for_slack_identity(self)
+    PrincipalConsoleUserReconciliation.new.apply_for_user_identity(self)
   rescue StandardError => e
     Rails.logger.warn("principal_console_user_reconciliation_failed source=user_identity error=#{e.class}")
   end

--- a/services/console/app/models/user_identity.rb
+++ b/services/console/app/models/user_identity.rb
@@ -19,11 +19,9 @@ class UserIdentity < ApplicationRecord
   # trigger is scoped to the fields that participate in matching, so the email
   # re-cache on every returning SSO login does not re-run reconciliation.
   after_commit :reconcile_owner_oauth_credentials,
-               on: %i[create update],
-               if: -> {
-                 slack? && (previously_new_record? || saved_change_to_subject? ||
-                   saved_change_to_team_id? || saved_change_to_user_id?)
-               }
+               on: %i[create update], if: :slack_identity_reconciliation_required?
+  after_commit :link_slack_dm_principals,
+               on: %i[create update], if: :slack_identity_reconciliation_required?
 
   normalizes :email, with: ->(e) { e.to_s.strip.downcase.presence }
   normalizes :team_id, with: ->(id) { id.to_s.strip.presence }
@@ -53,6 +51,17 @@ class UserIdentity < ApplicationRecord
   end
 
   private
+
+  def slack_identity_reconciliation_required?
+    slack? && (previously_new_record? || saved_change_to_subject? ||
+      saved_change_to_team_id? || saved_change_to_user_id?)
+  end
+
+  def link_slack_dm_principals
+    PrincipalConsoleUserReconciliation.new.apply_for_slack_identity(self)
+  rescue StandardError => e
+    Rails.logger.warn("principal_console_user_reconciliation_failed source=user_identity error=#{e.class}")
+  end
 
   # Never let reconciliation abort the surrounding write: this hook runs inside
   # the SSO login's commit path, and a failure here must not break sign-in.

--- a/services/console/app/services/principal_console_user_reconciliation.rb
+++ b/services/console/app/services/principal_console_user_reconciliation.rb
@@ -1,7 +1,7 @@
 # Links a Slack DM principal to the Console user who authenticated the same
-# workspace/user pair. The association is identity-sensitive because it grants
-# access to that user's private skills, so email and other mutable metadata never
-# participate. Existing links are sticky and are never overwritten here.
+# Slack workspace/user pair or whose IdP-verified email matches the email fetched
+# from that Slack user's profile. Existing links are sticky and are never
+# overwritten here.
 class PrincipalConsoleUserReconciliation
   SLACK_PROVIDER = Oauth::Providers::Slack::KEY
 
@@ -10,7 +10,8 @@ class PrincipalConsoleUserReconciliation
 
     user = unambiguous_user_for(
       slack_team_id: principal.slack_team_id,
-      slack_user_id: principal.slack_user_id
+      slack_user_id: principal.slack_user_id,
+      slack_email: principal.slack_email
     )
     return false unless user
 
@@ -26,20 +27,23 @@ class PrincipalConsoleUserReconciliation
     true
   end
 
-  def apply_for_slack_identity(identity)
-    return 0 unless identity.slack?
-
-    apply_for_identity(
-      slack_team_id: identity.team_id,
-      slack_user_id: identity.subject
-    )
+  def apply_for_user_identity(identity)
+    linked = 0
+    if identity.slack?
+      linked += apply_for_slack_identity(
+        slack_team_id: identity.team_id,
+        slack_user_id: identity.subject
+      )
+    end
+    linked += apply_for_verified_email(identity.email) if identity.email_verified?
+    linked
   end
 
   def apply_for_slack_credential(credential)
     return 0 unless credential.created_by_id.present?
     return 0 unless credential.oauth_app&.provider == SLACK_PROVIDER
 
-    apply_for_identity(
+    apply_for_slack_identity(
       slack_team_id: credential.labels.to_h["slack_team_id"],
       slack_user_id: credential.provider_subject
     )
@@ -47,10 +51,19 @@ class PrincipalConsoleUserReconciliation
 
   private
 
-  def apply_for_identity(slack_team_id:, slack_user_id:)
+  def apply_for_slack_identity(slack_team_id:, slack_user_id:)
     return 0 unless valid_identity?(slack_team_id:, slack_user_id:)
 
     matching_unlinked_principals(slack_team_id:, slack_user_id:).count do |principal|
+      apply_for_principal(principal)
+    end
+  end
+
+  def apply_for_verified_email(email)
+    email = normalize_email(email)
+    return 0 unless email
+
+    matching_unlinked_principals_by_email(email).count do |principal|
       apply_for_principal(principal)
     end
   end
@@ -78,9 +91,15 @@ class PrincipalConsoleUserReconciliation
     )
   end
 
-  def unambiguous_user_for(slack_team_id:, slack_user_id:)
+  def matching_unlinked_principals_by_email(email)
+    Principal.where(kind: "slack_dm", console_user_id: nil)
+      .where("lower(trim(slack_email)) = ?", email)
+  end
+
+  def unambiguous_user_for(slack_team_id:, slack_user_id:, slack_email:)
     user_ids = sso_user_ids(slack_team_id:, slack_user_id:) |
-      oauth_credential_user_ids(slack_team_id:, slack_user_id:)
+      oauth_credential_user_ids(slack_team_id:, slack_user_id:) |
+      verified_email_user_ids(slack_email)
     return unless user_ids.one?
 
     User.find_by(id: user_ids.first)
@@ -99,5 +118,16 @@ class PrincipalConsoleUserReconciliation
       .where.not(created_by_id: nil)
       .where("broker_credentials.labels ->> 'slack_team_id' = ?", slack_team_id)
       .pluck(:created_by_id)
+  end
+
+  def verified_email_user_ids(email)
+    email = normalize_email(email)
+    return [] unless email
+
+    UserIdentity.where(email_verified: true, email: email).pluck(:user_id)
+  end
+
+  def normalize_email(value)
+    value.to_s.strip.downcase.presence
   end
 end

--- a/services/console/app/services/principal_console_user_reconciliation.rb
+++ b/services/console/app/services/principal_console_user_reconciliation.rb
@@ -1,0 +1,103 @@
+# Links a Slack DM principal to the Console user who authenticated the same
+# workspace/user pair. The association is identity-sensitive because it grants
+# access to that user's private skills, so email and other mutable metadata never
+# participate. Existing links are sticky and are never overwritten here.
+class PrincipalConsoleUserReconciliation
+  SLACK_PROVIDER = Oauth::Providers::Slack::KEY
+
+  def assign_for_principal(principal)
+    return false unless linkable_principal?(principal)
+
+    user = unambiguous_user_for(
+      slack_team_id: principal.slack_team_id,
+      slack_user_id: principal.slack_user_id
+    )
+    return false unless user
+
+    principal.console_user = user
+    principal.console_user_email = user.email
+    true
+  end
+
+  def apply_for_principal(principal)
+    return false unless assign_for_principal(principal)
+
+    principal.save! if principal.persisted?
+    true
+  end
+
+  def apply_for_slack_identity(identity)
+    return 0 unless identity.slack?
+
+    apply_for_identity(
+      slack_team_id: identity.team_id,
+      slack_user_id: identity.subject
+    )
+  end
+
+  def apply_for_slack_credential(credential)
+    return 0 unless credential.created_by_id.present?
+    return 0 unless credential.oauth_app&.provider == SLACK_PROVIDER
+
+    apply_for_identity(
+      slack_team_id: credential.labels.to_h["slack_team_id"],
+      slack_user_id: credential.provider_subject
+    )
+  end
+
+  private
+
+  def apply_for_identity(slack_team_id:, slack_user_id:)
+    return 0 unless valid_identity?(slack_team_id:, slack_user_id:)
+
+    matching_unlinked_principals(slack_team_id:, slack_user_id:).count do |principal|
+      apply_for_principal(principal)
+    end
+  end
+
+  def linkable_principal?(principal)
+    principal.console_user_id.blank? &&
+      principal.kind == "slack_dm" &&
+      valid_identity?(
+        slack_team_id: principal.slack_team_id,
+        slack_user_id: principal.slack_user_id
+      )
+  end
+
+  def valid_identity?(slack_team_id:, slack_user_id:)
+    Principal::SLACK_TEAM_ID_FORMAT.match?(slack_team_id.to_s) &&
+      Principal::SLACK_USER_ID_FORMAT.match?(slack_user_id.to_s)
+  end
+
+  def matching_unlinked_principals(slack_team_id:, slack_user_id:)
+    Principal.where(
+      kind: "slack_dm",
+      console_user_id: nil,
+      slack_team_id: slack_team_id,
+      slack_user_id: slack_user_id
+    )
+  end
+
+  def unambiguous_user_for(slack_team_id:, slack_user_id:)
+    user_ids = sso_user_ids(slack_team_id:, slack_user_id:) |
+      oauth_credential_user_ids(slack_team_id:, slack_user_id:)
+    return unless user_ids.one?
+
+    User.find_by(id: user_ids.first)
+  end
+
+  def sso_user_ids(slack_team_id:, slack_user_id:)
+    UserIdentity.slack
+      .where(team_id: slack_team_id, subject: slack_user_id)
+      .pluck(:user_id)
+  end
+
+  def oauth_credential_user_ids(slack_team_id:, slack_user_id:)
+    BrokerCredential.joins(:oauth_app)
+      .where(oauth_apps: { provider: SLACK_PROVIDER })
+      .where(provider_subject: slack_user_id)
+      .where.not(created_by_id: nil)
+      .where("broker_credentials.labels ->> 'slack_team_id' = ?", slack_team_id)
+      .pluck(:created_by_id)
+  end
+end

--- a/services/console/db/migrate/20260811183627_backfill_slack_dm_console_users.rb
+++ b/services/console/db/migrate/20260811183627_backfill_slack_dm_console_users.rb
@@ -1,0 +1,51 @@
+class BackfillSlackDmConsoleUsers < ActiveRecord::Migration[8.1]
+  def up
+    execute <<~SQL.squish
+      WITH eligible_principals AS (
+        SELECT id, slack_team_id, slack_user_id
+        FROM principals
+        WHERE kind = 'slack_dm'
+          AND console_user_id IS NULL
+          AND slack_user_id ~ '^([UW][A-Z0-9]{8,}|USLACK)$'
+          AND slack_team_id ~ '^[TE][A-Z0-9]{8,}$'
+      ), candidates AS (
+        SELECT principals.id AS principal_id, user_identities.user_id
+        FROM eligible_principals principals
+        INNER JOIN user_identities
+          ON user_identities.provider = 'slack'
+         AND user_identities.subject = principals.slack_user_id
+         AND user_identities.team_id = principals.slack_team_id
+
+        UNION
+
+        SELECT principals.id AS principal_id, broker_credentials.created_by_id AS user_id
+        FROM eligible_principals principals
+        INNER JOIN broker_credentials
+          ON broker_credentials.provider_subject = principals.slack_user_id
+         AND broker_credentials.labels->>'slack_team_id' = principals.slack_team_id
+         AND broker_credentials.created_by_id IS NOT NULL
+        INNER JOIN oauth_apps
+          ON oauth_apps.id = broker_credentials.oauth_app_id
+         AND oauth_apps.provider = 'slack'
+      ), resolved AS (
+        SELECT principal_id, MIN(user_id) AS user_id
+        FROM candidates
+        GROUP BY principal_id
+        HAVING COUNT(DISTINCT user_id) = 1
+      )
+      UPDATE principals
+      SET console_user_id = resolved.user_id,
+          console_user_email = users.email,
+          updated_at = CURRENT_TIMESTAMP
+      FROM resolved
+      INNER JOIN users ON users.id = resolved.user_id
+      WHERE principals.id = resolved.principal_id
+        AND principals.console_user_id IS NULL
+    SQL
+  end
+
+  def down
+    # One-way identity backfill. A derived link may become operationally
+    # significant after deployment, so rollback must not remove it.
+  end
+end

--- a/services/console/db/migrate/20260811183627_backfill_slack_dm_console_users.rb
+++ b/services/console/db/migrate/20260811183627_backfill_slack_dm_console_users.rb
@@ -2,7 +2,7 @@ class BackfillSlackDmConsoleUsers < ActiveRecord::Migration[8.1]
   def up
     execute <<~SQL.squish
       WITH eligible_principals AS (
-        SELECT id, slack_team_id, slack_user_id
+        SELECT id, slack_team_id, slack_user_id, slack_email
         FROM principals
         WHERE kind = 'slack_dm'
           AND console_user_id IS NULL
@@ -15,6 +15,14 @@ class BackfillSlackDmConsoleUsers < ActiveRecord::Migration[8.1]
           ON user_identities.provider = 'slack'
          AND user_identities.subject = principals.slack_user_id
          AND user_identities.team_id = principals.slack_team_id
+
+        UNION
+
+        SELECT principals.id AS principal_id, user_identities.user_id
+        FROM eligible_principals principals
+        INNER JOIN user_identities
+          ON user_identities.email_verified = TRUE
+         AND lower(trim(user_identities.email)) = lower(trim(principals.slack_email))
 
         UNION
 

--- a/services/console/db/schema.rb
+++ b/services/console/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_10_194508) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_11_183627) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_search"

--- a/services/console/test/controllers/api/v1/sandbox_skills_controller_test.rb
+++ b/services/console/test/controllers/api/v1/sandbox_skills_controller_test.rb
@@ -3,9 +3,8 @@ require "test_helper"
 class Api::V1::SandboxSkillsControllerTest < ActionDispatch::IntegrationTest
   setup do
     users(:member_user).user_identities.create!(
-      provider: "slack",
-      subject: "U5123456789",
-      team_id: "T5123456789",
+      provider: "google",
+      subject: "google-member-skill-user",
       email: users(:member_user).email,
       email_verified: true
     )
@@ -16,6 +15,7 @@ class Api::V1::SandboxSkillsControllerTest < ActionDispatch::IntegrationTest
       kind: :slack_dm,
       slack_user_id: "U5123456789",
       slack_team_id: "T5123456789",
+      slack_email: users(:member_user).email,
       labels: {},
       created_by: users(:member_user)
     )
@@ -167,16 +167,16 @@ class Api::V1::SandboxSkillsControllerTest < ActionDispatch::IntegrationTest
       slack_team_id: "T5223456789"
     )
     users(:disabled_user).user_identities.create!(
-      provider: "slack",
-      subject: "U5323456789",
-      team_id: "T5323456789",
+      provider: "google",
+      subject: "google-disabled-skill-user",
       email: users(:disabled_user).email,
       email_verified: true
     )
     disabled_proxy = create_slack_dm_proxy(
       name: "disabled-slack-dm-proxy",
       slack_user_id: "U5323456789",
-      slack_team_id: "T5323456789"
+      slack_team_id: "T5323456789",
+      slack_email: users(:disabled_user).email
     )
     assert_equal users(:disabled_user), disabled_proxy.principal.console_user
 
@@ -241,7 +241,7 @@ class Api::V1::SandboxSkillsControllerTest < ActionDispatch::IntegrationTest
 
   private
 
-  def create_slack_dm_proxy(name:, slack_user_id:, slack_team_id:)
+  def create_slack_dm_proxy(name:, slack_user_id:, slack_team_id:, slack_email: nil)
     principal = Principal.create!(
       namespace: "sandbox-skill-test",
       foreign_id: "#{name}-principal",
@@ -249,6 +249,7 @@ class Api::V1::SandboxSkillsControllerTest < ActionDispatch::IntegrationTest
       kind: "slack_dm",
       slack_user_id: slack_user_id,
       slack_team_id: slack_team_id,
+      slack_email: slack_email,
       created_by: users(:acme_admin)
     )
     Proxy.create!(

--- a/services/console/test/controllers/api/v1/sandbox_skills_controller_test.rb
+++ b/services/console/test/controllers/api/v1/sandbox_skills_controller_test.rb
@@ -2,18 +2,26 @@ require "test_helper"
 
 class Api::V1::SandboxSkillsControllerTest < ActionDispatch::IntegrationTest
   setup do
+    users(:member_user).user_identities.create!(
+      provider: "slack",
+      subject: "U5123456789",
+      team_id: "T5123456789",
+      email: users(:member_user).email,
+      email_verified: true
+    )
     principal = Principal.create!(
       namespace: "sandbox-skill-test",
-      foreign_id: "console-user-member",
+      foreign_id: "slack-user-t5123456789-u5123456789",
       name: "Member User",
-      kind: :console_user,
-      console_user: users(:member_user),
-      console_user_email: users(:member_user).email,
+      kind: :slack_dm,
+      slack_user_id: "U5123456789",
+      slack_team_id: "T5123456789",
       labels: {},
       created_by: users(:member_user)
     )
-    @member_proxy = Proxy.create!(
-      name: "member-console-proxy",
+    assert_equal users(:member_user), principal.console_user
+    @slack_dm_proxy = Proxy.create!(
+      name: "member-slack-dm-proxy",
       principal: principal,
       bearer_token_hash: Digest::SHA256.hexdigest("iprx_#{'d' * 64}")
     )
@@ -21,7 +29,7 @@ class Api::V1::SandboxSkillsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "user principal sees its private skills and shared skills" do
-    with_token(@member_proxy) do |headers|
+    with_token(@slack_dm_proxy) do |headers|
       get "/api/v1/sandbox/skills", headers: headers
     end
     assert_response :ok
@@ -43,20 +51,20 @@ class Api::V1::SandboxSkillsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "search is principal scoped and read returns current content" do
-    with_token(@member_proxy) do |headers|
+    with_token(@slack_dm_proxy) do |headers|
       get "/api/v1/sandbox/skills/search", params: { q: "production incidents" }, headers: headers
     end
     assert_response :ok
     assert_equal skills(:member_private).oid, json_body.dig("data", 0, "id")
 
-    with_token(@member_proxy) do |headers|
+    with_token(@slack_dm_proxy) do |headers|
       get "/api/v1/sandbox/skills/#{skills(:member_private).oid}", headers: headers
     end
     assert_response :ok
     assert_equal skills(:member_private).skill_document, json_body.dig("data", "document")
     assert_equal "no-store", response.headers["Cache-Control"]
 
-    with_token(@member_proxy) do |headers|
+    with_token(@slack_dm_proxy) do |headers|
       get "/api/v1/sandbox/skills/#{skills(:member_private).name}", headers: headers
     end
     assert_response :ok
@@ -80,8 +88,8 @@ class Api::V1::SandboxSkillsControllerTest < ActionDispatch::IntegrationTest
     assert_response :ok
   end
 
-  test "console user principal authors through the sandbox namespace" do
-    with_token(@member_proxy) do |headers|
+  test "automatically linked Slack DM principal authors through the sandbox namespace" do
+    with_token(@slack_dm_proxy) do |headers|
       post "/api/v1/sandbox/skills",
            params: {
              data: {
@@ -98,7 +106,7 @@ class Api::V1::SandboxSkillsControllerTest < ActionDispatch::IntegrationTest
     assert_equal "shared", skill.visibility
     assert_not_nil skill.shared_at
 
-    with_token(@member_proxy) do |headers|
+    with_token(@slack_dm_proxy) do |headers|
       patch "/api/v1/sandbox/skills/#{skill.oid}",
             params: {
               data: {
@@ -115,19 +123,19 @@ class Api::V1::SandboxSkillsControllerTest < ActionDispatch::IntegrationTest
     assert_equal "Updated through the sandbox API.", skill.reload.description
     assert_includes skill.content, "Updated instructions."
 
-    with_token(@member_proxy) do |headers|
+    with_token(@slack_dm_proxy) do |headers|
       post "/api/v1/sandbox/skills/#{skill.oid}/share", headers: headers
     end
     assert_response :ok
     assert skill.reload.shared?
 
-    with_token(@member_proxy) do |headers|
+    with_token(@slack_dm_proxy) do |headers|
       post "/api/v1/sandbox/skills/#{skill.oid}/unshare", headers: headers
     end
     assert_response :ok
     assert_not skill.reload.shared?
 
-    with_token(@member_proxy) do |headers|
+    with_token(@slack_dm_proxy) do |headers|
       delete "/api/v1/sandbox/skills/#{skill.oid}", headers: headers
     end
     assert_response :no_content
@@ -152,13 +160,58 @@ class Api::V1::SandboxSkillsControllerTest < ActionDispatch::IntegrationTest
     assert_response :forbidden
   end
 
+  test "unmatched and disabled Slack DM principals remain shared-only" do
+    unmatched_proxy = create_slack_dm_proxy(
+      name: "unmatched-slack-dm-proxy",
+      slack_user_id: "U5223456789",
+      slack_team_id: "T5223456789"
+    )
+    users(:disabled_user).user_identities.create!(
+      provider: "slack",
+      subject: "U5323456789",
+      team_id: "T5323456789",
+      email: users(:disabled_user).email,
+      email_verified: true
+    )
+    disabled_proxy = create_slack_dm_proxy(
+      name: "disabled-slack-dm-proxy",
+      slack_user_id: "U5323456789",
+      slack_team_id: "T5323456789"
+    )
+    assert_equal users(:disabled_user), disabled_proxy.principal.console_user
+
+    [ unmatched_proxy, disabled_proxy ].each do |proxy|
+      with_token(proxy) do |headers|
+        get "/api/v1/sandbox/skills", headers: headers
+      end
+      assert_response :ok
+      assert_equal [ skills(:admin_shared).oid ], json_body.fetch("data").map { |skill| skill.fetch("id") }
+
+      assert_no_difference("Skill.count") do
+        with_token(proxy) do |headers|
+          post "/api/v1/sandbox/skills",
+               params: {
+                 data: {
+                   name: "forbidden-#{proxy.name}",
+                   description: "Must not be created.",
+                   instructions: "# Instructions"
+                 }
+               },
+               headers: headers,
+               as: :json
+        end
+      end
+      assert_response :forbidden
+    end
+  end
+
   test "duplicate-name create races return a validation response" do
     duplicate_race = lambda do |skill|
       raise ActiveRecord::RecordNotUnique, "duplicate skill name" if skill.name == "duplicate-skill"
     end
     Skill.set_callback(:validation, :after, duplicate_race)
 
-    with_token(@member_proxy) do |headers|
+    with_token(@slack_dm_proxy) do |headers|
       post "/api/v1/sandbox/skills",
            params: {
              data: {
@@ -179,14 +232,31 @@ class Api::V1::SandboxSkillsControllerTest < ActionDispatch::IntegrationTest
 
   test "rejects a token after its proxy principal changes" do
     with_env("CENTAUR_JWT_SIGNING_SECRET" => "test-secret") do
-      token = SandboxEntitlements::Jwt.encode_for_proxy(@member_proxy)
-      @member_proxy.update!(principal: principals(:acme_channel))
+      token = SandboxEntitlements::Jwt.encode_for_proxy(@slack_dm_proxy)
+      @slack_dm_proxy.update!(principal: principals(:acme_channel))
       get "/api/v1/sandbox/skills", headers: auth_headers(token)
     end
     assert_response :unauthorized
   end
 
   private
+
+  def create_slack_dm_proxy(name:, slack_user_id:, slack_team_id:)
+    principal = Principal.create!(
+      namespace: "sandbox-skill-test",
+      foreign_id: "#{name}-principal",
+      name: name,
+      kind: "slack_dm",
+      slack_user_id: slack_user_id,
+      slack_team_id: slack_team_id,
+      created_by: users(:acme_admin)
+    )
+    Proxy.create!(
+      name: name,
+      principal: principal,
+      bearer_token_hash: Digest::SHA256.hexdigest("iprx_#{name.ljust(64, '0').first(64)}")
+    )
+  end
 
   def with_token(proxy)
     with_env("CENTAUR_JWT_SIGNING_SECRET" => "test-secret") do

--- a/services/console/test/migrations/backfill_slack_dm_console_users_test.rb
+++ b/services/console/test/migrations/backfill_slack_dm_console_users_test.rb
@@ -13,36 +13,61 @@ class BackfillSlackDmConsoleUsersTest < ActiveSupport::TestCase
     oauth = create_principal("U4223456789", "T4223456789", namespace: "globex")
     create_credential(users(:member_user), oauth)
 
-    combined = create_principal("U4323456789", "T4323456789")
+    email = create_principal(
+      "U4323456789",
+      "T4323456789",
+      slack_email: "google-member@example.com"
+    )
+    create_google_identity(users(:member_user), "google-member@example.com")
+
+    combined = create_principal(
+      "U4423456789",
+      "T4423456789",
+      slack_email: "combined@example.com"
+    )
     create_identity(users(:member_user), combined)
     create_credential(users(:member_user), combined)
+    create_google_identity(users(:member_user), "combined@example.com")
 
-    ambiguous = create_principal("U4423456789", "T4423456789")
-    create_identity(users(:member_user), ambiguous)
+    ambiguous = create_principal(
+      "U4523456789",
+      "T4523456789",
+      slack_email: "ambiguous@example.com"
+    )
+    create_google_identity(users(:member_user), "ambiguous@example.com")
     create_credential(users(:acme_admin), ambiguous)
 
-    unmatched = create_principal("U4523456789", "T4523456789")
-
-    existing = create_principal(
+    unverified = create_principal(
       "U4623456789",
       "T4623456789",
+      slack_email: "unverified-migration@example.com"
+    )
+    create_google_identity(users(:member_user), "unverified-migration@example.com", email_verified: false)
+
+    unmatched = create_principal("U4723456789", "T4723456789")
+
+    existing = create_principal(
+      "U4823456789",
+      "T4823456789",
+      slack_email: "existing@example.com",
       console_user: users(:acme_admin)
     )
-    create_identity(users(:member_user), existing)
+    create_google_identity(users(:member_user), "existing@example.com")
 
     # Live callbacks repair these records as evidence is created. Clear only the
     # principals intended to simulate rows from before this migration existed.
-    [ sso, oauth, combined, ambiguous, unmatched ].each do |principal|
+    [ sso, oauth, email, combined, ambiguous, unverified, unmatched ].each do |principal|
       principal.update_columns(console_user_id: nil, console_user_email: nil)
     end
 
     BackfillSlackDmConsoleUsers.new.up
 
-    [ sso, oauth, combined ].each do |principal|
+    [ sso, oauth, email, combined ].each do |principal|
       assert_equal users(:member_user), principal.reload.console_user
       assert_equal users(:member_user).email, principal.console_user_email
     end
     assert_nil ambiguous.reload.console_user
+    assert_nil unverified.reload.console_user
     assert_nil unmatched.reload.console_user
     assert_equal users(:acme_admin), existing.reload.console_user
     assert_equal users(:acme_admin).email, existing.console_user_email
@@ -50,13 +75,20 @@ class BackfillSlackDmConsoleUsersTest < ActiveSupport::TestCase
 
   private
 
-  def create_principal(slack_user_id, slack_team_id, namespace: "acme", console_user: nil)
+  def create_principal(
+    slack_user_id,
+    slack_team_id,
+    namespace: "acme",
+    slack_email: nil,
+    console_user: nil
+  )
     Principal.create!(
       namespace: namespace,
       foreign_id: "migration-#{namespace}-#{slack_team_id}-#{slack_user_id}",
       kind: "slack_dm",
       slack_user_id: slack_user_id,
       slack_team_id: slack_team_id,
+      slack_email: slack_email,
       console_user: console_user,
       console_user_email: console_user&.email,
       created_by: users(:acme_admin)
@@ -87,6 +119,15 @@ class BackfillSlackDmConsoleUsersTest < ActiveSupport::TestCase
       last_refresh: Time.current,
       external_user_key: "user-#{principal.slack_user_id}",
       created_by: user
+    )
+  end
+
+  def create_google_identity(user, email, email_verified: true)
+    user.user_identities.create!(
+      provider: "google",
+      subject: "google-#{SecureRandom.hex(8)}",
+      email: email,
+      email_verified: email_verified
     )
   end
 end

--- a/services/console/test/migrations/backfill_slack_dm_console_users_test.rb
+++ b/services/console/test/migrations/backfill_slack_dm_console_users_test.rb
@@ -1,0 +1,92 @@
+require "test_helper"
+require Rails.root.join("db/migrate/20260811183627_backfill_slack_dm_console_users")
+
+class BackfillSlackDmConsoleUsersTest < ActiveSupport::TestCase
+  setup do
+    oauth_apps(:acme_slack).update!(client_secret: "slack-secret")
+  end
+
+  test "backfills only unambiguous Slack DM ownership evidence" do
+    sso = create_principal("U4123456789", "T4123456789")
+    create_identity(users(:member_user), sso)
+
+    oauth = create_principal("U4223456789", "T4223456789", namespace: "globex")
+    create_credential(users(:member_user), oauth)
+
+    combined = create_principal("U4323456789", "T4323456789")
+    create_identity(users(:member_user), combined)
+    create_credential(users(:member_user), combined)
+
+    ambiguous = create_principal("U4423456789", "T4423456789")
+    create_identity(users(:member_user), ambiguous)
+    create_credential(users(:acme_admin), ambiguous)
+
+    unmatched = create_principal("U4523456789", "T4523456789")
+
+    existing = create_principal(
+      "U4623456789",
+      "T4623456789",
+      console_user: users(:acme_admin)
+    )
+    create_identity(users(:member_user), existing)
+
+    # Live callbacks repair these records as evidence is created. Clear only the
+    # principals intended to simulate rows from before this migration existed.
+    [ sso, oauth, combined, ambiguous, unmatched ].each do |principal|
+      principal.update_columns(console_user_id: nil, console_user_email: nil)
+    end
+
+    BackfillSlackDmConsoleUsers.new.up
+
+    [ sso, oauth, combined ].each do |principal|
+      assert_equal users(:member_user), principal.reload.console_user
+      assert_equal users(:member_user).email, principal.console_user_email
+    end
+    assert_nil ambiguous.reload.console_user
+    assert_nil unmatched.reload.console_user
+    assert_equal users(:acme_admin), existing.reload.console_user
+    assert_equal users(:acme_admin).email, existing.console_user_email
+  end
+
+  private
+
+  def create_principal(slack_user_id, slack_team_id, namespace: "acme", console_user: nil)
+    Principal.create!(
+      namespace: namespace,
+      foreign_id: "migration-#{namespace}-#{slack_team_id}-#{slack_user_id}",
+      kind: "slack_dm",
+      slack_user_id: slack_user_id,
+      slack_team_id: slack_team_id,
+      console_user: console_user,
+      console_user_email: console_user&.email,
+      created_by: users(:acme_admin)
+    )
+  end
+
+  def create_identity(user, principal)
+    user.user_identities.create!(
+      provider: "slack",
+      subject: principal.slack_user_id,
+      team_id: principal.slack_team_id,
+      email: user.email,
+      email_verified: true
+    )
+  end
+
+  def create_credential(user, principal)
+    app = oauth_apps(:acme_slack)
+    BrokerCredential.create!(
+      namespace: app.credential_namespace,
+      oauth_app: app,
+      provider_subject: principal.slack_user_id,
+      labels: { "slack_team_id" => principal.slack_team_id },
+      token_endpoint: app.provider_strategy.token_endpoint,
+      refresh_token: "refresh-#{principal.slack_user_id}",
+      access_token: "access-#{principal.slack_user_id}",
+      expires_at: 1.hour.from_now,
+      last_refresh: Time.current,
+      external_user_key: "user-#{principal.slack_user_id}",
+      created_by: user
+    )
+  end
+end

--- a/services/console/test/services/principal_console_user_reconciliation_test.rb
+++ b/services/console/test/services/principal_console_user_reconciliation_test.rb
@@ -103,25 +103,23 @@ class PrincipalConsoleUserReconciliationTest < ActiveSupport::TestCase
     assert_equal user, principal.reload.console_user
   end
 
-  test "deduplicates SSO and OAuth evidence owned by the same user" do
+  test "deduplicates Slack and verified email evidence owned by the same user" do
     user = users(:member_user)
     create_slack_identity(user:, slack_user_id: "U2523456789", slack_team_id: "T2523456789")
     create_slack_credential(user:, slack_user_id: "U2523456789", slack_team_id: "T2523456789")
+    create_google_identity(user:, email: "same-user@example.com")
 
     principal = create_slack_dm_principal(
       slack_user_id: "U2523456789",
-      slack_team_id: "T2523456789"
+      slack_team_id: "T2523456789",
+      slack_email: "same-user@example.com"
     )
 
     assert_equal user, principal.console_user
   end
 
   test "does not link when authenticated sources resolve to different users" do
-    create_slack_identity(
-      user: users(:member_user),
-      slack_user_id: "U2623456789",
-      slack_team_id: "T2623456789"
-    )
+    create_google_identity(user: users(:member_user), email: "conflict@example.com")
     create_slack_credential(
       user: users(:acme_admin),
       slack_user_id: "U2623456789",
@@ -130,20 +128,66 @@ class PrincipalConsoleUserReconciliationTest < ActiveSupport::TestCase
 
     principal = create_slack_dm_principal(
       slack_user_id: "U2623456789",
-      slack_team_id: "T2623456789"
+      slack_team_id: "T2623456789",
+      slack_email: "conflict@example.com"
     )
 
     assert_nil principal.console_user
     assert_nil principal.console_user_email
   end
 
-  test "does not use Slack email as identity evidence" do
+  test "links through a Slack profile email matching a verified Google identity" do
     user = users(:member_user)
+    create_google_identity(user:, email: "Person@Example.com")
 
     principal = create_slack_dm_principal(
       slack_user_id: "U2723456789",
       slack_team_id: "T2723456789",
-      slack_email: user.email
+      slack_email: "PERSON@EXAMPLE.COM"
+    )
+
+    assert_equal user, principal.console_user
+    assert_equal user.email, principal.console_user_email
+  end
+
+  test "links an existing Slack DM when a verified Google identity arrives" do
+    user = users(:member_user)
+    principal = create_slack_dm_principal(
+      slack_user_id: "U3523456789",
+      slack_team_id: "T3523456789",
+      slack_email: "late-google@example.com"
+    )
+
+    assert_nil principal.console_user
+    create_google_identity(user:, email: "late-google@example.com")
+
+    assert_equal user, principal.reload.console_user
+  end
+
+  test "waits for an identity email to become verified" do
+    user = users(:member_user)
+    identity = create_google_identity(user:, email: "unverified@example.com", email_verified: false)
+
+    principal = create_slack_dm_principal(
+      slack_user_id: "U3623456789",
+      slack_team_id: "T3623456789",
+      slack_email: "unverified@example.com"
+    )
+
+    assert_nil principal.console_user
+    identity.update!(email_verified: true)
+
+    assert_equal user, principal.reload.console_user
+  end
+
+  test "does not link when a verified email belongs to multiple users" do
+    create_google_identity(user: users(:member_user), email: "shared@example.com")
+    create_google_identity(user: users(:acme_admin), email: "shared@example.com")
+
+    principal = create_slack_dm_principal(
+      slack_user_id: "U3723456789",
+      slack_team_id: "T3723456789",
+      slack_email: "shared@example.com"
     )
 
     assert_nil principal.console_user
@@ -197,16 +241,12 @@ class PrincipalConsoleUserReconciliationTest < ActiveSupport::TestCase
     assert_equal existing_user.email, principal.console_user_email
   end
 
-  test "source callback failures do not abort Slack identity or credential writes" do
+  test "source callback failures do not abort SSO identity or credential writes" do
     failure = proc { raise "boom" }
 
     PrincipalConsoleUserReconciliation.stub(:new, failure) do
       assert_difference("UserIdentity.count", 1) do
-        create_slack_identity(
-          user: users(:member_user),
-          slack_user_id: "U3123456789",
-          slack_team_id: "T3123456789"
-        )
+        create_google_identity(user: users(:member_user), email: "failure@example.com")
       end
 
       assert_difference("BrokerCredential.count", 1) do
@@ -228,6 +268,15 @@ class PrincipalConsoleUserReconciliationTest < ActiveSupport::TestCase
       team_id: slack_team_id,
       email: user.email,
       email_verified: true
+    )
+  end
+
+  def create_google_identity(user:, email:, email_verified: true)
+    user.user_identities.create!(
+      provider: "google",
+      subject: "google-#{SecureRandom.hex(8)}",
+      email: email,
+      email_verified: email_verified
     )
   end
 

--- a/services/console/test/services/principal_console_user_reconciliation_test.rb
+++ b/services/console/test/services/principal_console_user_reconciliation_test.rb
@@ -1,0 +1,271 @@
+require "test_helper"
+
+class PrincipalConsoleUserReconciliationTest < ActiveSupport::TestCase
+  setup do
+    oauth_apps(:acme_slack).update!(client_secret: "slack-secret")
+  end
+
+  test "links a new Slack DM principal through an existing Slack SSO identity" do
+    user = users(:member_user)
+    create_slack_identity(user:, slack_user_id: "U2123456789", slack_team_id: "T2123456789")
+
+    principal = create_slack_dm_principal(
+      slack_user_id: "U2123456789",
+      slack_team_id: "T2123456789"
+    )
+
+    assert_equal user, principal.console_user
+    assert_equal user.email, principal.console_user_email
+  end
+
+  test "links an existing Slack DM principal when its Slack SSO identity arrives" do
+    user = users(:member_user)
+    principal = create_slack_dm_principal(
+      slack_user_id: "U2223456789",
+      slack_team_id: "T2223456789"
+    )
+
+    assert_nil principal.console_user
+    create_slack_identity(user:, slack_user_id: "U2223456789", slack_team_id: "T2223456789")
+
+    assert_equal user, principal.reload.console_user
+    assert_equal user.email, principal.console_user_email
+  end
+
+  test "links when an existing Slack SSO identity gains its team" do
+    user = users(:member_user)
+    principal = create_slack_dm_principal(
+      slack_user_id: "U3323456789",
+      slack_team_id: "T3323456789"
+    )
+    identity = create_slack_identity(
+      user: user,
+      slack_user_id: "U3323456789",
+      slack_team_id: nil
+    )
+
+    assert_nil principal.reload.console_user
+    identity.update!(team_id: "T3323456789")
+
+    assert_equal user, principal.reload.console_user
+  end
+
+  test "links a new Slack DM principal through an existing owned Slack OAuth credential" do
+    user = users(:member_user)
+    create_slack_credential(
+      user:,
+      slack_user_id: "U2323456789",
+      slack_team_id: "T2323456789"
+    )
+
+    principal = create_slack_dm_principal(
+      slack_user_id: "U2323456789",
+      slack_team_id: "T2323456789",
+      namespace: "globex"
+    )
+
+    assert_equal user, principal.console_user
+    assert_equal user.email, principal.console_user_email
+  end
+
+  test "links an existing Slack DM principal when an owned Slack OAuth credential arrives" do
+    user = users(:member_user)
+    principal = create_slack_dm_principal(
+      slack_user_id: "U2423456789",
+      slack_team_id: "T2423456789"
+    )
+
+    assert_nil principal.console_user
+    create_slack_credential(
+      user:,
+      slack_user_id: "U2423456789",
+      slack_team_id: "T2423456789"
+    )
+
+    assert_equal user, principal.reload.console_user
+  end
+
+  test "links when an owned Slack OAuth credential gains its team" do
+    user = users(:member_user)
+    principal = create_slack_dm_principal(
+      slack_user_id: "U3423456789",
+      slack_team_id: "T3423456789"
+    )
+    credential = create_slack_credential(
+      user: user,
+      slack_user_id: "U3423456789",
+      slack_team_id: nil
+    )
+
+    assert_nil principal.reload.console_user
+    credential.update!(labels: { "slack_team_id" => "T3423456789" })
+
+    assert_equal user, principal.reload.console_user
+  end
+
+  test "deduplicates SSO and OAuth evidence owned by the same user" do
+    user = users(:member_user)
+    create_slack_identity(user:, slack_user_id: "U2523456789", slack_team_id: "T2523456789")
+    create_slack_credential(user:, slack_user_id: "U2523456789", slack_team_id: "T2523456789")
+
+    principal = create_slack_dm_principal(
+      slack_user_id: "U2523456789",
+      slack_team_id: "T2523456789"
+    )
+
+    assert_equal user, principal.console_user
+  end
+
+  test "does not link when authenticated sources resolve to different users" do
+    create_slack_identity(
+      user: users(:member_user),
+      slack_user_id: "U2623456789",
+      slack_team_id: "T2623456789"
+    )
+    create_slack_credential(
+      user: users(:acme_admin),
+      slack_user_id: "U2623456789",
+      slack_team_id: "T2623456789"
+    )
+
+    principal = create_slack_dm_principal(
+      slack_user_id: "U2623456789",
+      slack_team_id: "T2623456789"
+    )
+
+    assert_nil principal.console_user
+    assert_nil principal.console_user_email
+  end
+
+  test "does not use Slack email as identity evidence" do
+    user = users(:member_user)
+
+    principal = create_slack_dm_principal(
+      slack_user_id: "U2723456789",
+      slack_team_id: "T2723456789",
+      slack_email: user.email
+    )
+
+    assert_nil principal.console_user
+  end
+
+  test "ignores incomplete or malformed Slack identities" do
+    reconciliation = PrincipalConsoleUserReconciliation.new
+    principals = [
+      Principal.new(kind: "slack_dm", slack_user_id: "U2823456789"),
+      Principal.new(kind: "slack_dm", slack_team_id: "T2823456789"),
+      Principal.new(kind: "slack_dm", slack_user_id: "not-a-user", slack_team_id: "T2823456789")
+    ]
+
+    principals.each do |principal|
+      refute reconciliation.assign_for_principal(principal)
+      assert_nil principal.console_user
+    end
+  end
+
+  test "does not link non-DM principals" do
+    user = users(:member_user)
+    create_slack_identity(user:, slack_user_id: "U2923456789", slack_team_id: "T2923456789")
+
+    principal = Principal.create!(
+      namespace: "acme",
+      foreign_id: "ordinary-slack-user",
+      kind: "user",
+      slack_user_id: "U2923456789",
+      slack_team_id: "T2923456789",
+      created_by: users(:acme_admin)
+    )
+
+    assert_nil principal.console_user
+  end
+
+  test "preserves an existing link even when current evidence points elsewhere" do
+    existing_user = users(:acme_admin)
+    create_slack_identity(
+      user: users(:member_user),
+      slack_user_id: "U3023456789",
+      slack_team_id: "T3023456789"
+    )
+
+    principal = create_slack_dm_principal(
+      slack_user_id: "U3023456789",
+      slack_team_id: "T3023456789",
+      console_user: existing_user
+    )
+
+    assert_equal existing_user, principal.console_user
+    assert_equal existing_user.email, principal.console_user_email
+  end
+
+  test "source callback failures do not abort Slack identity or credential writes" do
+    failure = proc { raise "boom" }
+
+    PrincipalConsoleUserReconciliation.stub(:new, failure) do
+      assert_difference("UserIdentity.count", 1) do
+        create_slack_identity(
+          user: users(:member_user),
+          slack_user_id: "U3123456789",
+          slack_team_id: "T3123456789"
+        )
+      end
+
+      assert_difference("BrokerCredential.count", 1) do
+        create_slack_credential(
+          user: users(:member_user),
+          slack_user_id: "U3223456789",
+          slack_team_id: "T3223456789"
+        )
+      end
+    end
+  end
+
+  private
+
+  def create_slack_identity(user:, slack_user_id:, slack_team_id:)
+    user.user_identities.create!(
+      provider: "slack",
+      subject: slack_user_id,
+      team_id: slack_team_id,
+      email: user.email,
+      email_verified: true
+    )
+  end
+
+  def create_slack_credential(user:, slack_user_id:, slack_team_id:)
+    app = oauth_apps(:acme_slack)
+    BrokerCredential.create!(
+      namespace: app.credential_namespace,
+      oauth_app: app,
+      provider_subject: slack_user_id,
+      labels: slack_team_id ? { "slack_team_id" => slack_team_id } : {},
+      token_endpoint: app.provider_strategy.token_endpoint,
+      refresh_token: "refresh-#{slack_user_id}",
+      access_token: "access-#{slack_user_id}",
+      expires_at: 1.hour.from_now,
+      last_refresh: Time.current,
+      external_user_key: "user-#{slack_user_id}",
+      created_by: user
+    )
+  end
+
+  def create_slack_dm_principal(
+    slack_user_id:,
+    slack_team_id:,
+    namespace: "acme",
+    slack_email: nil,
+    console_user: nil
+  )
+    Principal.create!(
+      namespace: namespace,
+      foreign_id: "slack-user-#{namespace}-#{slack_team_id}-#{slack_user_id}",
+      name: "Slack DM #{slack_user_id}",
+      kind: "slack_dm",
+      slack_user_id: slack_user_id,
+      slack_team_id: slack_team_id,
+      slack_email: slack_email,
+      console_user: console_user,
+      console_user_email: console_user&.email,
+      created_by: users(:acme_admin)
+    )
+  end
+end


### PR DESCRIPTION
Automatically links Slack DM principals to Console users using exact Slack identity ownership or an authenticated Slack profile email matching an IdP-verified identity such as Google SSO. Reconciliation handles either record arrival order, preserves existing links, backfills unambiguous principals, and keeps conflicting, unverified, or unmatched principals shared-only.