### PR TITLE
feat: add Grid MCP tool

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -66,6 +66,8 @@ The open-source tool inventory lives in this `tools/` tree and changes over time
   with best-effort vlogs/vmetrics context without exposing message context.
 - `datadog`: query Datadog logs, metrics, monitors, hosts, and dashboards
   read-only with `DD_API_KEY` and `DD_APP_KEY`.
+- `grid`: discover and call Grid presentation tools over Streamable HTTP MCP;
+  authentication is injected by iron-proxy for `grid.tempo.xyz`.
 - `preqin`: query Preqin Operational API fund and fund-manager data, with
   redacted auth diagnostics for `PREQIN_*` credentials.
 

--- a/tools/productivity/grid/.env.example
+++ b/tools/productivity/grid/.env.example
@@ -1,0 +1,1 @@
+GRID_MCP_TOKEN=Bearer token for local Grid MCP development; production uses iron-proxy injection

--- a/tools/productivity/grid/cli.py
+++ b/tools/productivity/grid/cli.py
@@ -1,0 +1,65 @@
+"""CLI for Grid's MCP server."""
+
+import json
+from typing import Any
+
+import typer
+from dotenv import load_dotenv
+
+from .client import GridClient
+
+load_dotenv()
+
+app = typer.Typer(name="grid", help="Discover and call Grid presentation MCP tools")
+
+
+def _print(value: Any) -> None:
+    print(json.dumps(value, indent=2, ensure_ascii=False, default=str))
+
+
+@app.command("health")
+def health() -> None:
+    """Assert Grid MCP connectivity and authentication."""
+    client = GridClient()
+    try:
+        result = client.list_tools()
+        _print({"ok": True, "tool": "grid", "error": None, "details": result})
+    except Exception as exc:
+        _print({"ok": False, "tool": "grid", "error": str(exc), "details": {}})
+        raise typer.Exit(1) from exc
+    finally:
+        client.close()
+
+
+@app.command("tools")
+def list_tools() -> None:
+    """List tools advertised by Grid."""
+    client = GridClient()
+    try:
+        _print(client.list_tools())
+    finally:
+        client.close()
+
+
+@app.command("call")
+def call_tool(
+    name: str = typer.Argument(..., help="Grid MCP tool name"),
+    arguments: str = typer.Option("{}", "--arguments", "-a", help="Tool arguments as JSON"),
+) -> None:
+    """Call a Grid MCP tool."""
+    try:
+        parsed = json.loads(arguments)
+    except json.JSONDecodeError as exc:
+        raise typer.BadParameter(f"arguments must be valid JSON: {exc}") from exc
+    if not isinstance(parsed, dict):
+        raise typer.BadParameter("arguments must decode to a JSON object")
+
+    client = GridClient()
+    try:
+        _print(client.call_tool(name, parsed))
+    finally:
+        client.close()
+
+
+if __name__ == "__main__":
+    app()

--- a/tools/productivity/grid/client.py
+++ b/tools/productivity/grid/client.py
@@ -1,0 +1,104 @@
+"""Client for Grid's Streamable HTTP MCP server.
+
+In Centaur, iron-proxy injects the shared Grid Bearer token for
+``grid.tempo.xyz``. For local development only, set ``GRID_MCP_TOKEN``.
+"""
+
+import json
+from typing import Any
+
+import httpx
+
+from centaur_sdk import secret
+
+MCP_URL = "https://grid.tempo.xyz/api/mcp"
+MCP_PROTOCOL_VERSION = "2025-06-18"
+
+
+class GridClient:
+    """Thin JSON-RPC client for Grid's MCP server."""
+
+    def __init__(self, token: str | None = None, timeout: float = 120.0):
+        headers = {
+            "Accept": "application/json, text/event-stream",
+            "Content-Type": "application/json",
+        }
+        token = token or secret("GRID_MCP_TOKEN", "")
+        if token:
+            headers["Authorization"] = f"Bearer {token}"
+        self._http = httpx.Client(headers=headers, timeout=timeout)
+        self._rpc_id = 0
+        self._initialized = False
+
+    def close(self) -> None:
+        self._http.close()
+
+    def _decode_response(self, response: httpx.Response, rpc_id: int) -> dict[str, Any]:
+        response.raise_for_status()
+        if not response.content:
+            return {}
+
+        content_type = response.headers.get("content-type", "")
+        if content_type.startswith("text/event-stream"):
+            messages = []
+            for line in response.text.splitlines():
+                if line.startswith("data:"):
+                    messages.append(json.loads(line.removeprefix("data:").strip()))
+            message = next((item for item in reversed(messages) if item.get("id") == rpc_id), None)
+            if message is None:
+                raise RuntimeError("Grid MCP event stream contained no matching JSON-RPC response")
+        else:
+            message = response.json()
+
+        if "error" in message:
+            raise RuntimeError(f"Grid MCP error: {message['error']}")
+        return message.get("result", {})
+
+    def _request(self, method: str, params: dict[str, Any] | None = None) -> dict[str, Any]:
+        self._rpc_id += 1
+        rpc_id = self._rpc_id
+        response = self._http.post(
+            MCP_URL,
+            json={"jsonrpc": "2.0", "id": rpc_id, "method": method, "params": params or {}},
+        )
+        session_id = response.headers.get("Mcp-Session-Id")
+        if session_id:
+            self._http.headers["Mcp-Session-Id"] = session_id
+        return self._decode_response(response, rpc_id)
+
+    def _notify(self, method: str) -> None:
+        response = self._http.post(MCP_URL, json={"jsonrpc": "2.0", "method": method})
+        response.raise_for_status()
+
+    def _ensure_initialized(self) -> None:
+        if self._initialized:
+            return
+        result = self._request(
+            "initialize",
+            {
+                "protocolVersion": MCP_PROTOCOL_VERSION,
+                "capabilities": {},
+                "clientInfo": {"name": "centaur-grid", "version": "0.1.0"},
+            },
+        )
+        protocol_version = result.get("protocolVersion", MCP_PROTOCOL_VERSION)
+        self._http.headers["MCP-Protocol-Version"] = protocol_version
+        self._notify("notifications/initialized")
+        self._initialized = True
+
+    def list_tools(self) -> dict[str, Any]:
+        """List tools exposed by Grid's MCP server."""
+        self._ensure_initialized()
+        return self._request("tools/list")
+
+    def call_tool(self, name: str, arguments: dict[str, Any] | None = None) -> dict[str, Any]:
+        """Call a Grid MCP tool by name with its JSON-compatible arguments."""
+        self._ensure_initialized()
+        result = self._request("tools/call", {"name": name, "arguments": arguments or {}})
+        if result.get("isError"):
+            raise RuntimeError(f"Grid MCP tool {name} failed: {result}")
+        return result
+
+
+def _client() -> GridClient:
+    return GridClient()

--- a/tools/productivity/grid/pyproject.toml
+++ b/tools/productivity/grid/pyproject.toml
@@ -1,0 +1,30 @@
+[project]
+name = "grid"
+description = "Grid presentation MCP CLI for AI agents"
+version = "0.1.0"
+requires-python = ">=3.11"
+dependencies = [
+    "python-dotenv>=1.0.0",
+    "httpx>=0.27.0",
+    "typer>=0.12.0",
+]
+
+[project.scripts]
+grid = "centaur_tool_grid.cli:app"
+
+[tool.hatch.build.targets.wheel]
+packages = ["."]
+
+[tool.hatch.build.targets.wheel.sources]
+"." = "centaur_tool_grid"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.centaur]
+module = "client.py"
+# The Grid Bearer token is supplied by an iron-control grant. Keeping only the
+# host declaration here prevents credentials from being materialized in the
+# sandbox while allowing the proxy to inject them for Grid MCP requests.
+hosts = ["grid.tempo.xyz"]


### PR DESCRIPTION
## Summary

- add a `grid` CLI and agent-facing client for Grid's Streamable HTTP MCP server
- support MCP initialization, session IDs, protocol negotiation, tool discovery, and generic tool calls
- keep production credentials out of the sandbox by declaring `grid.tempo.xyz` for iron-proxy injection

## Testing

- `uvx ruff check tools/productivity/grid`
- `uvx ruff format --check tools/productivity/grid`
- `uv build tools/productivity/grid --out-dir /tmp/grid-dist-final`
- mocked initialize → initialized notification → tools/list protocol check
- live unauthenticated health check returns the expected HTTP 401

## Follow-up

The Grid token still needs to be stored in iron-control and granted to the intended principal before an authenticated end-to-end smoke test.

Prompted by: @tanishqsh
