### PR TITLE
perf(console): refresh Slack channel catalog asynchronously

### DIFF
--- a/services/console/app/controllers/concerns/console/slack_channel_permission_management.rb
+++ b/services/console/app/controllers/concerns/console/slack_channel_permission_management.rb
@@ -5,7 +5,7 @@ module Console
     private
 
     def load_slack_channel_permission_form(owner)
-      @slack_channel_catalog = SlackChannelCatalog.fetch
+      @slack_channel_catalog = SlackChannelCatalogProvider.fetch
       @slack_channel_names = @slack_channel_catalog.channels.to_h { |channel| [ channel.id, channel.name ] }
       @slack_channel_permissions = owner.slack_channel_permissions.ordered
       @slack_channel_options = @slack_channel_catalog.channels.map do |channel|

--- a/services/console/app/jobs/slack_channel_catalog_refresh_job.rb
+++ b/services/console/app/jobs/slack_channel_catalog_refresh_job.rb
@@ -1,0 +1,5 @@
+class SlackChannelCatalogRefreshJob < ApplicationJob
+  def perform(cache_key)
+    SlackChannelCatalogProvider.refresh(cache_key: cache_key)
+  end
+end

--- a/services/console/app/services/slack_channel_catalog.rb
+++ b/services/console/app/services/slack_channel_catalog.rb
@@ -1,4 +1,3 @@
-require "digest"
 require "json"
 
 class SlackChannelCatalog
@@ -11,53 +10,9 @@ class SlackChannelCatalog
 
   DEFAULT_API_URL = "https://slack.com/api".freeze
   DEFAULT_TYPES = "public_channel,private_channel".freeze
-  CACHE_TTL = 5.minutes
   OPEN_TIMEOUT_SECONDS = 2
   READ_TIMEOUT_SECONDS = 5
   WRITE_TIMEOUT_SECONDS = 2
-
-  def self.fetch
-    token = ENV["CENTAUR_CONSOLE_SLACK_BOT_TOKEN"].presence || ENV["SLACK_BOT_TOKEN"].presence
-    return Result.new(channels: [], error: "SLACK_BOT_TOKEN is not configured.", configured: false) if token.blank?
-
-    api_url = ENV["SLACK_API_URL"].presence || DEFAULT_API_URL
-    key = cache_key(token: token, api_url: api_url)
-    cached = Rails.cache.read(key)
-    return deserialize_result(cached) if cached
-
-    result = new(token: token, api_url: api_url).fetch
-    Rails.cache.write(key, serialize_result(result), expires_in: CACHE_TTL) if result.ok?
-    result
-  end
-
-  def self.cache_key(token:, api_url:)
-    token_digest = Digest::SHA256.hexdigest(token)
-    api_url_digest = Digest::SHA256.hexdigest(api_url)
-    "slack_channel_catalog/v1/#{api_url_digest}/#{token_digest}"
-  end
-
-  def self.serialize_result(result)
-    {
-      "channels" => result.channels.map do |channel|
-        { "id" => channel.id, "name" => channel.name, "private" => channel.private }
-      end,
-      "error" => result.error,
-      "configured" => result.configured
-    }
-  end
-
-  def self.deserialize_result(payload)
-    return payload if payload.is_a?(Result)
-
-    channels = Array(payload["channels"]).map do |channel|
-      Channel.new(
-        id: channel.fetch("id"),
-        name: channel.fetch("name"),
-        private: channel.fetch("private")
-      )
-    end
-    Result.new(channels: channels, error: payload["error"], configured: payload["configured"])
-  end
 
   def initialize(token:, api_url:, api: nil)
     @token = token

--- a/services/console/app/services/slack_channel_catalog_provider.rb
+++ b/services/console/app/services/slack_channel_catalog_provider.rb
@@ -1,0 +1,112 @@
+require "digest"
+
+class SlackChannelCatalogProvider
+  FRESH_TTL = 5.minutes
+  STALE_TTL = 24.hours
+  ERROR_TTL = 30.seconds
+  REFRESH_LOCK_TTL = 1.minute
+
+  class << self
+    def fetch
+      config = configuration
+      return unconfigured_result unless config
+
+      key = cache_key(**config)
+      payload = Rails.cache.read(key)
+      enqueue_refresh(key) unless fresh?(payload)
+
+      payload ? deserialize_result(payload) : loading_result
+    end
+
+    def refresh(cache_key:)
+      config = configuration
+      return unless config && cache_key == self.cache_key(**config)
+
+      cached = Rails.cache.read(cache_key)
+      result = SlackChannelCatalog.new(**config).fetch
+      if result.ok?
+        Rails.cache.write(cache_key, serialize_result(result), expires_in: STALE_TTL)
+      elsif cached.nil?
+        Rails.cache.write(cache_key, serialize_result(result), expires_in: ERROR_TTL)
+      end
+      result
+    ensure
+      Rails.cache.delete(refresh_lock_key(cache_key))
+    end
+
+    def cache_key(token:, api_url:)
+      token_digest = Digest::SHA256.hexdigest(token)
+      api_url_digest = Digest::SHA256.hexdigest(api_url)
+      "slack_channel_catalog/v2/#{api_url_digest}/#{token_digest}"
+    end
+
+    private
+
+    def configuration
+      token = ENV["CENTAUR_CONSOLE_SLACK_BOT_TOKEN"].presence || ENV["SLACK_BOT_TOKEN"].presence
+      return if token.blank?
+
+      { token: token, api_url: ENV["SLACK_API_URL"].presence || SlackChannelCatalog::DEFAULT_API_URL }
+    end
+
+    def enqueue_refresh(cache_key)
+      lock_key = refresh_lock_key(cache_key)
+      return unless Rails.cache.write(lock_key, true, expires_in: REFRESH_LOCK_TTL, unless_exist: true)
+
+      SlackChannelCatalogRefreshJob.perform_later(cache_key)
+    rescue StandardError => e
+      Rails.cache.delete(lock_key)
+      Rails.logger.warn("Could not enqueue Slack channel catalog refresh: #{e.class}: #{e.message}")
+    end
+
+    def fresh?(payload)
+      payload.is_a?(Hash) && payload["refreshed_at"].to_f > FRESH_TTL.ago.to_f
+    end
+
+    def refresh_lock_key(cache_key)
+      "#{cache_key}/refreshing"
+    end
+
+    def serialize_result(result)
+      {
+        "channels" => result.channels.map do |channel|
+          { "id" => channel.id, "name" => channel.name, "private" => channel.private }
+        end,
+        "error" => result.error,
+        "configured" => result.configured,
+        "refreshed_at" => Time.current.to_f
+      }
+    end
+
+    def deserialize_result(payload)
+      channels = Array(payload["channels"]).map do |channel|
+        SlackChannelCatalog::Channel.new(
+          id: channel.fetch("id"),
+          name: channel.fetch("name"),
+          private: channel.fetch("private")
+        )
+      end
+      SlackChannelCatalog::Result.new(
+        channels: channels,
+        error: payload["error"],
+        configured: payload["configured"]
+      )
+    end
+
+    def loading_result
+      SlackChannelCatalog::Result.new(
+        channels: [],
+        error: "Slack channel catalog is loading. Enter a channel ID or reload shortly.",
+        configured: true
+      )
+    end
+
+    def unconfigured_result
+      SlackChannelCatalog::Result.new(
+        channels: [],
+        error: "SLACK_BOT_TOKEN is not configured.",
+        configured: false
+      )
+    end
+  end
+end

--- a/services/console/test/controllers/console/roles_controller_test.rb
+++ b/services/console/test/controllers/console/roles_controller_test.rb
@@ -317,7 +317,7 @@ module Console
     private
 
     def with_slack_channel_catalog(catalog)
-      singleton = SlackChannelCatalog.singleton_class
+      singleton = SlackChannelCatalogProvider.singleton_class
       original = singleton.instance_method(:fetch)
       singleton.define_method(:fetch) { catalog }
       yield

--- a/services/console/test/controllers/console_controller_test.rb
+++ b/services/console/test/controllers/console_controller_test.rb
@@ -504,7 +504,7 @@ class ConsoleControllerTest < ActionDispatch::IntegrationTest
   private
 
   def with_slack_channel_catalog(catalog)
-    singleton = SlackChannelCatalog.singleton_class
+    singleton = SlackChannelCatalogProvider.singleton_class
     original = singleton.instance_method(:fetch)
     singleton.define_method(:fetch) { catalog }
     yield

--- a/services/console/test/jobs/slack_channel_catalog_refresh_job_test.rb
+++ b/services/console/test/jobs/slack_channel_catalog_refresh_job_test.rb
@@ -1,0 +1,15 @@
+require "test_helper"
+
+class SlackChannelCatalogRefreshJobTest < ActiveJob::TestCase
+  test "refreshes the requested cache entry through the provider" do
+    cache_key = "slack_channel_catalog/v2/api-digest/token-digest"
+    refreshed_key = nil
+    refresh = ->(cache_key:) { refreshed_key = cache_key }
+
+    SlackChannelCatalogProvider.stub(:refresh, refresh) do
+      SlackChannelCatalogRefreshJob.perform_now(cache_key)
+    end
+
+    assert_equal cache_key, refreshed_key
+  end
+end

--- a/services/console/test/services/slack_channel_catalog_provider_test.rb
+++ b/services/console/test/services/slack_channel_catalog_provider_test.rb
@@ -1,0 +1,170 @@
+require "test_helper"
+
+class SlackChannelCatalogProviderTest < ActiveJob::TestCase
+  TOKEN = "xoxb-test-token"
+  API_URL = "https://slack.test/api"
+
+  test "cache miss returns immediately and enqueues one refresh without exposing the token" do
+    cache = ActiveSupport::Cache::MemoryStore.new
+    key = SlackChannelCatalogProvider.cache_key(token: TOKEN, api_url: API_URL)
+
+    with_catalog_env do
+      Rails.stub(:cache, cache) do
+        SlackChannelCatalog.stub(:new, ->(**) { flunk("request path must not construct the Slack client") }) do
+          assert_enqueued_jobs 1, only: SlackChannelCatalogRefreshJob do
+            first = SlackChannelCatalogProvider.fetch
+            second = SlackChannelCatalogProvider.fetch
+
+            assert_empty first.channels
+            assert_match(/loading/, first.error)
+            assert_equal first, second
+          end
+          assert_enqueued_with(job: SlackChannelCatalogRefreshJob, args: [ key ])
+        end
+      end
+    end
+
+    refute_includes key, TOKEN
+  end
+
+  test "refresh caches a successful catalog for request-time reads" do
+    cache = ActiveSupport::Cache::MemoryStore.new
+    key = SlackChannelCatalogProvider.cache_key(token: TOKEN, api_url: API_URL)
+    result = catalog_result
+    catalog = Minitest::Mock.new
+    catalog.expect(:fetch, result)
+
+    with_catalog_env do
+      Rails.stub(:cache, cache) do
+        SlackChannelCatalog.stub(:new, ->(token:, api_url:) do
+          assert_equal TOKEN, token
+          assert_equal API_URL, api_url
+          catalog
+        end) do
+          SlackChannelCatalogProvider.refresh(cache_key: key)
+
+          assert_no_enqueued_jobs do
+            cached = SlackChannelCatalogProvider.fetch
+            assert_equal [ "C0123456789" ], cached.channels.map(&:id)
+          end
+        end
+      end
+    end
+
+    catalog.verify
+  end
+
+  test "stale catalog is returned while a refresh is enqueued" do
+    cache = ActiveSupport::Cache::MemoryStore.new
+    key = SlackChannelCatalogProvider.cache_key(token: TOKEN, api_url: API_URL)
+    catalog = Minitest::Mock.new
+    catalog.expect(:fetch, catalog_result)
+
+    with_catalog_env do
+      Rails.stub(:cache, cache) do
+        SlackChannelCatalog.stub(:new, ->(**) { catalog }) do
+          SlackChannelCatalogProvider.refresh(cache_key: key)
+        end
+
+        travel SlackChannelCatalogProvider::FRESH_TTL + 1.second do
+          assert_enqueued_with(job: SlackChannelCatalogRefreshJob, args: [ key ]) do
+            stale = SlackChannelCatalogProvider.fetch
+            assert_equal [ "C0123456789" ], stale.channels.map(&:id)
+          end
+        end
+      end
+    end
+
+    catalog.verify
+  end
+
+  test "failed refresh does not replace a successful catalog" do
+    cache = ActiveSupport::Cache::MemoryStore.new
+    key = SlackChannelCatalogProvider.cache_key(token: TOKEN, api_url: API_URL)
+    success_catalog = Minitest::Mock.new
+    success_catalog.expect(:fetch, catalog_result)
+    failed_catalog = Minitest::Mock.new
+    failed_catalog.expect(
+      :fetch,
+      SlackChannelCatalog::Result.new(channels: [], error: "Slack API request failed.", configured: true)
+    )
+
+    with_catalog_env do
+      Rails.stub(:cache, cache) do
+        SlackChannelCatalog.stub(:new, ->(**) { success_catalog }) do
+          SlackChannelCatalogProvider.refresh(cache_key: key)
+        end
+        SlackChannelCatalog.stub(:new, ->(**) { failed_catalog }) do
+          SlackChannelCatalogProvider.refresh(cache_key: key)
+        end
+
+        cached = SlackChannelCatalogProvider.fetch
+        assert_equal [ "C0123456789" ], cached.channels.map(&:id)
+        assert_nil cached.error
+      end
+    end
+
+    success_catalog.verify
+    failed_catalog.verify
+  end
+
+  test "failed cold refresh is briefly cached before another attempt" do
+    cache = ActiveSupport::Cache::MemoryStore.new
+    key = SlackChannelCatalogProvider.cache_key(token: TOKEN, api_url: API_URL)
+    failed_catalog = Minitest::Mock.new
+    failed_catalog.expect(
+      :fetch,
+      SlackChannelCatalog::Result.new(channels: [], error: "Slack API request failed.", configured: true)
+    )
+
+    with_catalog_env do
+      Rails.stub(:cache, cache) do
+        SlackChannelCatalog.stub(:new, ->(**) { failed_catalog }) do
+          SlackChannelCatalogProvider.refresh(cache_key: key)
+        end
+
+        assert_no_enqueued_jobs do
+          cached_error = SlackChannelCatalogProvider.fetch
+          assert_equal "Slack API request failed.", cached_error.error
+        end
+
+        travel SlackChannelCatalogProvider::ERROR_TTL + 1.second do
+          assert_enqueued_with(job: SlackChannelCatalogRefreshJob, args: [ key ]) do
+            assert_match(/loading/, SlackChannelCatalogProvider.fetch.error)
+          end
+        end
+      end
+    end
+
+    failed_catalog.verify
+  end
+
+  test "unconfigured provider does not enqueue a refresh" do
+    with_env("CENTAUR_CONSOLE_SLACK_BOT_TOKEN" => nil, "SLACK_BOT_TOKEN" => nil) do
+      assert_no_enqueued_jobs do
+        result = SlackChannelCatalogProvider.fetch
+        refute result.configured
+        assert_match(/not configured/, result.error)
+      end
+    end
+  end
+
+  private
+
+  def with_catalog_env(&)
+    with_env(
+      "CENTAUR_CONSOLE_SLACK_BOT_TOKEN" => TOKEN,
+      "SLACK_BOT_TOKEN" => nil,
+      "SLACK_API_URL" => API_URL,
+      &
+    )
+  end
+
+  def catalog_result
+    SlackChannelCatalog::Result.new(
+      channels: [ SlackChannelCatalog::Channel.new(id: "C0123456789", name: "general", private: false) ],
+      error: nil,
+      configured: true
+    )
+  end
+end

--- a/services/console/test/services/slack_channel_catalog_test.rb
+++ b/services/console/test/services/slack_channel_catalog_test.rb
@@ -1,58 +1,6 @@
 require "test_helper"
 
 class SlackChannelCatalogTest < ActiveSupport::TestCase
-  test "fetch caches slack channel catalog lookups" do
-    cache = ActiveSupport::Cache::MemoryStore.new
-    result = SlackChannelCatalog::Result.new(
-      channels: [ SlackChannelCatalog::Channel.new(id: "C0123456789", name: "general", private: false) ],
-      error: nil,
-      configured: true
-    )
-    catalog = Minitest::Mock.new
-    catalog.expect(:fetch, result)
-
-    with_env("CENTAUR_CONSOLE_SLACK_BOT_TOKEN" => "xoxb-test-token", "SLACK_API_URL" => "https://slack.test/api") do
-      Rails.stub(:cache, cache) do
-        SlackChannelCatalog.stub(:new, ->(token:, api_url:) { catalog }) do
-          first = SlackChannelCatalog.fetch
-          second = SlackChannelCatalog.fetch
-
-          assert_equal [ "C0123456789" ], first.channels.map(&:id)
-          assert_equal [ "C0123456789" ], second.channels.map(&:id)
-          catalog.verify
-        end
-      end
-    end
-  end
-
-  test "fetch does not cache slack channel catalog errors" do
-    cache = ActiveSupport::Cache::MemoryStore.new
-    error = SlackChannelCatalog::Result.new(channels: [], error: "Slack API request failed.", configured: true)
-    success = SlackChannelCatalog::Result.new(
-      channels: [ SlackChannelCatalog::Channel.new(id: "C0123456789", name: "general", private: false) ],
-      error: nil,
-      configured: true
-    )
-    catalog = Minitest::Mock.new
-    catalog.expect(:fetch, error)
-    catalog.expect(:fetch, success)
-
-    with_env("CENTAUR_CONSOLE_SLACK_BOT_TOKEN" => "xoxb-test-token", "SLACK_API_URL" => "https://slack.test/api") do
-      Rails.stub(:cache, cache) do
-        SlackChannelCatalog.stub(:new, ->(token:, api_url:) { catalog }) do
-          first = SlackChannelCatalog.fetch
-          second = SlackChannelCatalog.fetch
-          third = SlackChannelCatalog.fetch
-
-          assert_equal "Slack API request failed.", first.error
-          assert_nil second.error
-          assert_nil third.error
-          catalog.verify
-        end
-      end
-    end
-  end
-
   test "fetch configures short slack api timeouts" do
     api = Minitest::Mock.new
     api.expect(:get, HttpClient::Response.new(status: 200, body: { ok: true, channels: [] }.to_json),


### PR DESCRIPTION
## Summary

- separate the synchronous Slack API client from a request-facing cached catalog provider
- serve fresh or stale cached channel snapshots immediately and refresh them through a deduplicated background job
- render an ID-entry fallback on a cold cache instead of blocking the principal or role detail page on Slack
- keep Slack tokens out of job arguments and preserve successful cached data across refresh failures

## Why

Principal and role detail requests previously fetched the full Slack channel catalog synchronously whenever the five-minute cache expired. A cold production request spent roughly one second fetching 912 channels, so Slack latency and timeouts directly delayed the page shell.

This introduces stale-while-refresh behavior: successful snapshots are fresh for five minutes and may be served stale for up to 24 hours, while cold failures are cached for 30 seconds to avoid retrying Slack on every request. Rendering the complete cached catalog into the channel selector remains a separate follow-up.

## Validation

- `bundle exec rails test` — 1,427 runs, 5,579 assertions, 0 failures
- `bundle exec rubocop` — 349 files, no offenses
- `bundle exec brakeman --quiet --no-pager --exit-on-warn --exit-on-error` — 0 warnings
- focused provider and job tests — 7 runs, 33 assertions, 0 failures