### PR TITLE
fix(slackbotv2): clear rejected sticky model overrides

### DIFF
--- a/services/slackbotv2/src/index.ts
+++ b/services/slackbotv2/src/index.ts
@@ -1524,7 +1524,7 @@ async function renderExecutionAttempt(
   try {
     const streamResult = await renderExecutionStream(
       thread,
-      streamSessionAfterHandoff(options, input),
+      clearRejectedStickyModel(thread, input, streamSessionAfterHandoff(options, input), options),
       message,
       options,
       trace,
@@ -1664,6 +1664,47 @@ async function renderExecutionAttempt(
     })
     recordRenderAttempt('live', outcome, renderStartedAtMs)
   }
+}
+
+async function* clearRejectedStickyModel(
+  thread: Thread<SlackbotV2ThreadState>,
+  input: ForwardSessionInput,
+  stream: AsyncIterable<SlackbotV2RendererSource>,
+  options: SlackbotV2Options
+): AsyncIterable<SlackbotV2RendererSource> {
+  for await (const event of stream) {
+    if (input.model && isRejectedModelEvent(event)) {
+      const latest = (await thread.state) ?? {}
+      // A newer turn may already have replaced the sticky model while this
+      // stream was finishing. Clear only the value rejected by this execution.
+      if (latest.model === input.model) {
+        await thread.setState({ model: null })
+        traceLog(options, 'slackbotv2_rejected_sticky_model_cleared', input.trace, {
+          model: input.model
+        })
+      }
+    }
+    yield event
+  }
+}
+
+function isRejectedModelEvent(event: SlackbotV2RendererSource): boolean {
+  if (!event || typeof event !== 'object') return false
+  const eventKind = String(
+    'eventKind' in event ? event.eventKind : 'event' in event ? event.event : ''
+  )
+  if (eventKind !== 'session.execution_failed' && eventKind !== 'session.stream_error') {
+    return false
+  }
+  const detail = JSON.stringify('data' in event ? event.data : event).toLowerCase()
+  return (
+    detail.includes('model_not_found') ||
+    (/\bmodel\b/.test(detail) &&
+      (detail.includes('does not exist') ||
+        detail.includes('not supported') ||
+        detail.includes('unsupported model') ||
+        detail.includes('invalid model')))
+  )
 }
 
 /**

--- a/services/slackbotv2/test/chat-sdk-emulate.test.ts
+++ b/services/slackbotv2/test/chat-sdk-emulate.test.ts
@@ -730,6 +730,74 @@ describe('slackbotv2', () => {
     )
   })
 
+  it('clears a sticky model rejected by the harness and accepts a later override', async () => {
+    const sharedState = createMemoryState()
+    await sharedState.connect()
+    bot = createTestBot({ state: sharedState })
+    codexApi.autoRespond = false
+
+    const parent = await postUserMessage('Thread default context.')
+    const runTurn = async (eventId: string, text: string, terminalEvent: string, data: unknown) => {
+      const mention = await postUserMessage(`<@${BOT_USER_ID}> ${text}`, parent.ts)
+      const waits: Promise<unknown>[] = []
+      const response = await bot.app.request(
+        '/api/webhooks/slack',
+        signedSlackEvent({
+          event_id: eventId,
+          event: {
+            type: 'app_mention',
+            user: USER_ID,
+            channel: CHANNEL_ID,
+            team: TEAM_ID,
+            ts: mention.ts,
+            thread_ts: parent.ts,
+            text: `<@${BOT_USER_ID}> ${text}`
+          }
+        }),
+        {},
+        waitUntilContext(waits)
+      )
+      expect(response.status).toBe(200)
+      await waitFor(() => codexApi.eventRequests.length === codexApi.executes.length, 3000)
+      codexApi.emitSessionEvent(threadKey(parent.ts), terminalEvent, data)
+      await Promise.all(waits)
+    }
+
+    await runTurn('Ev-invalid-sticky-model', '--model 5.6-sol first', 'session.execution_failed', {
+      error: JSON.stringify({
+        type: 'invalid_request_error',
+        code: 'model_not_found',
+        message: "The requested model '5.6-sol' does not exist.",
+        param: 'model'
+      })
+    })
+    expect(
+      await sharedState.get<Record<string, unknown>>(`thread-state:${threadKey(parent.ts)}`)
+    ).toEqual(expect.objectContaining({ model: null }))
+
+    await runTurn(
+      'Ev-after-invalid-sticky-model',
+      'continue without flags',
+      'session.execution_completed',
+      { result_text: 'Recovered on the default model.' }
+    )
+    await runTurn(
+      'Ev-replace-invalid-sticky-model',
+      '--model gpt-5.4 use this model',
+      'session.execution_completed',
+      { result_text: 'Accepted the replacement model.' }
+    )
+
+    const models = codexApi.executes.map(execute => {
+      const input = JSON.parse(execute.body.input_lines.at(-1) ?? '{}') as Record<string, unknown>
+      return input.model
+    })
+    expect(models).toEqual(['5.6-sol', undefined, 'gpt-5.4'])
+    expect(
+      await sharedState.get<Record<string, unknown>>(`thread-state:${threadKey(parent.ts)}`)
+    ).toEqual(expect.objectContaining({ model: 'gpt-5.4' }))
+  })
+
   it('keeps a top-level harness flag pinned when the LLM strategy guesses another harness', async () => {
     const sharedState = createMemoryState()
     await sharedState.connect()


### PR DESCRIPTION
## Summary

- clear a sticky thread model when the harness rejects that same model
- preserve a newer concurrent model selection by comparing before clearing
- cover recovery to the default model and a later valid override

## Testing

- `pnpm --filter slackbotv2 run check:types`
- `pnpm --filter slackbotv2 test` (231 passed, 1 skipped)

Fixes #1325

Prompted by: @snario