### PR TITLE
fix: preserve Slack transcript ordering

### DIFF
--- a/services/console/app/controllers/console/threads_controller.rb
+++ b/services/console/app/controllers/console/threads_controller.rb
@@ -963,10 +963,12 @@ class Console::ThreadsController < ApplicationController
   # api-rs's activity-summary worker condenses harness output into short
   # first-person status lines persisted as session.activity_summary events,
   # each pointing at the output-line event that triggered it via
-  # source_event_id. A summary belongs to the latest trace item at or before
-  # its source line, so each disclosure's collapsed preview shows the newest
-  # status generated during that block; items no summary covers keep the
-  # raw-text fallback rendered by the transcript partial.
+  # source_event_id. A summary belongs to the latest trace item from the same
+  # execution at or before its source line, so each disclosure's collapsed
+  # preview shows the newest status generated during that block; items no
+  # summary covers keep the raw-text fallback rendered by the transcript
+  # partial. Legacy summaries without an execution id retain event-order
+  # matching for compatibility with imported fixtures.
   def apply_activity_summaries(items)
     anchored = items.select { |item| item[:event_id] }
     return items if anchored.empty?
@@ -977,7 +979,11 @@ class Console::ThreadsController < ApplicationController
       source_event_id = payload["source_event_id"]
       next if summary.blank? || source_event_id.nil?
 
-      item = anchored.reverse_each.find { |candidate| candidate[:event_id] <= source_event_id.to_i }
+      execution_id = event.execution_id.presence
+      item = anchored.reverse_each.find do |candidate|
+        candidate[:event_id] <= source_event_id.to_i &&
+          (execution_id.blank? || candidate[:execution_id].to_s == execution_id.to_s)
+      end
       item[:summary] = summary if item
     end
     items

--- a/services/console/test/controllers/console/threads_controller_test.rb
+++ b/services/console/test/controllers/console/threads_controller_test.rb
@@ -6,7 +6,13 @@ class Console::ThreadsControllerTest < ActionDispatch::IntegrationTest
   TranscriptSession = Struct.new(:metadata_hash, :harness_type, :title, keyword_init: true)
   ModelSession = Struct.new(:thread_key, :metadata_hash, :harness_type, keyword_init: true)
   ModelExecution = Struct.new(:metadata, keyword_init: true)
-  TranscriptEvent = Struct.new(:event_type, :payload_hash, :created_at, keyword_init: true)
+  TranscriptEvent = Struct.new(
+    :event_type,
+    :payload_hash,
+    :created_at,
+    :execution_id,
+    keyword_init: true
+  )
   SelectedSession = Struct.new(:thread_key, keyword_init: true)
 
   setup do
@@ -1591,6 +1597,32 @@ class Console::ThreadsControllerTest < ActionDispatch::IntegrationTest
     # summaries preceding every trace item are dropped.
     assert_equal "I'm writing the query", items[0][:summary]
     assert_nil items[1][:summary]
+  end
+
+  test "activity summaries do not attach to trace items from another execution" do
+    controller = Console::ThreadsController.new
+    items = [
+      { event_id: 10, execution_id: "exe-1", text: "first execution" },
+      { event_id: 20, execution_id: "exe-2", text: "second execution" }
+    ]
+    summaries = [
+      TranscriptEvent.new(
+        event_type: "session.activity_summary",
+        execution_id: "exe-2",
+        payload_hash: { "summary" => "I'm starting the second execution", "source_event_id" => 15 }
+      ),
+      TranscriptEvent.new(
+        event_type: "session.activity_summary",
+        execution_id: "exe-2",
+        payload_hash: { "summary" => "I'm working in the second execution", "source_event_id" => 21 }
+      )
+    ]
+    controller.define_singleton_method(:selected_activity_summaries) { summaries }
+
+    controller.send(:apply_activity_summaries, items)
+
+    assert_nil items[0][:summary]
+    assert_equal "I'm working in the second execution", items[1][:summary]
   end
 
   test "thinking extraction formats claude stream-json tool calls" do

--- a/services/slackbotv2/src/index.ts
+++ b/services/slackbotv2/src/index.ts
@@ -3117,7 +3117,7 @@ async function slackApiMessageFromSlack(
     author: {
       fullName: actorId,
       isBot,
-      isMe: Boolean(actorId && actorId === currentMessage.author.userId),
+      isMe: Boolean(actorId && options.botUserId && actorId === options.botUserId),
       userId: actorId,
       userName: actorId
     },

--- a/services/slackbotv2/src/server.ts
+++ b/services/slackbotv2/src/server.ts
@@ -1,5 +1,6 @@
 import { createSlackbotV2, type SlackbotV2Options } from './index'
 import { parseChannelDefaults } from './channel-defaults'
+import { resolveSlackBotUserId } from './slack-user'
 import {
   createFlagMessageOverridesStrategy,
   createOpenAiMessageOverridesStrategy
@@ -9,6 +10,14 @@ const port = numberEnv('PORT', 3002)
 const apiUrl = stringEnv('CENTAUR_API_URL', 'http://127.0.0.1:8080')
 const botToken = requiredEnv('SLACK_BOT_TOKEN')
 const signingSecret = requiredEnv('SLACK_SIGNING_SECRET')
+const slackApiUrl = optionalEnv('SLACK_API_URL')
+const slackApiTimeoutMs = optionalNumberEnv('SLACKBOTV2_SLACK_API_TIMEOUT_MS')
+const botUserId = await resolveSlackBotUserId({
+  botToken,
+  configuredBotUserId: optionalEnv('SLACK_BOT_USER_ID'),
+  slackApiUrl,
+  timeoutMs: slackApiTimeoutMs
+})
 const messageOverridesStrategyMode = messageOverridesStrategyModeEnv(
   'SLACKBOTV2_MESSAGE_OVERRIDES_STRATEGY'
 )
@@ -41,7 +50,7 @@ const options: SlackbotV2Options = {
   activitySummaryStatusEnabled: booleanEnv('SLACKBOTV2_ACTIVITY_SUMMARY_STATUS_ENABLED', false),
   autoJoinCreatedChannels: booleanEnv('SLACKBOTV2_AUTO_JOIN_CREATED_CHANNELS', false),
   botToken,
-  botUserId: optionalEnv('SLACK_BOT_USER_ID'),
+  botUserId,
   channelDefaults: parseChannelDefaults(optionalEnv('SLACKBOTV2_CHANNEL_DEFAULTS'), reason =>
     consoleLogger.warn('slackbotv2 SLACKBOTV2_CHANNEL_DEFAULTS', { reason })
   ),
@@ -76,8 +85,8 @@ const options: SlackbotV2Options = {
   ),
   sessionApiTimeoutMs: optionalNumberEnv('SLACKBOTV2_SESSION_API_TIMEOUT_MS'),
   signingSecret,
-  slackApiUrl: optionalEnv('SLACK_API_URL'),
-  slackApiTimeoutMs: optionalNumberEnv('SLACKBOTV2_SLACK_API_TIMEOUT_MS'),
+  slackApiUrl,
+  slackApiTimeoutMs,
   stateKeyPrefix: optionalEnv('SLACKBOTV2_STATE_KEY_PREFIX'),
   userName: stringEnv('SLACKBOTV2_USER_NAME', 'centaur'),
   logger: consoleLogger

--- a/services/slackbotv2/src/slack-user.ts
+++ b/services/slackbotv2/src/slack-user.ts
@@ -1,5 +1,15 @@
 import { isJsonObject, stringValue } from './utils'
 
+type ResolveSlackBotUserIdOptions = {
+  botToken: string
+  configuredBotUserId?: string
+  fetchFn?: typeof fetch
+  slackApiUrl?: string
+  timeoutMs?: number
+}
+
+const DEFAULT_SLACK_AUTH_TIMEOUT_MS = 5_000
+
 type MessageWithSlackUser = {
   author?: {
     userId?: unknown
@@ -22,4 +32,25 @@ export function rawSlackUserId(raw: unknown): string | undefined {
   const botProfile = raw.bot_profile
   if (isJsonObject(botProfile)) return stringValue(botProfile.user_id)
   return undefined
+}
+
+export async function resolveSlackBotUserId(
+  options: ResolveSlackBotUserIdOptions
+): Promise<string> {
+  const configuredBotUserId = options.configuredBotUserId?.trim()
+  if (configuredBotUserId) return configuredBotUserId
+
+  const url = new URL('auth.test', options.slackApiUrl ?? 'https://slack.com/api/')
+  const response = await (options.fetchFn ?? fetch)(url, {
+    method: 'POST',
+    headers: { authorization: `Bearer ${options.botToken}` },
+    signal: AbortSignal.timeout(options.timeoutMs ?? DEFAULT_SLACK_AUTH_TIMEOUT_MS)
+  })
+  const payload = await response.json()
+  const userId = isJsonObject(payload) ? stringValue(payload.user_id) : undefined
+  if (!response.ok || !isJsonObject(payload) || payload.ok !== true || !userId) {
+    const reason = isJsonObject(payload) ? stringValue(payload.error) : undefined
+    throw new Error(`Slack auth.test failed${reason ? `: ${reason}` : ''}`)
+  }
+  return userId
 }

--- a/services/slackbotv2/test/chat-sdk-emulate.test.ts
+++ b/services/slackbotv2/test/chat-sdk-emulate.test.ts
@@ -60,6 +60,7 @@ let slackApi: PatchedSlackApi
 let codexApi: MockSessionApi
 let slack: WebClient
 let slackB: WebClient
+let slackBot: WebClient
 let slackApiUrl: string
 let bot: SlackbotV2
 
@@ -105,6 +106,7 @@ beforeAll(async () => {
   slackApiUrl = `${slackApi.url}/api/`
   slack = new WebClient(USER_TOKEN, { slackApiUrl })
   slackB = new WebClient(USER_B_TOKEN, { slackApiUrl })
+  slackBot = new WebClient(BOT_TOKEN, { slackApiUrl })
 })
 
 beforeEach(() => {
@@ -2057,6 +2059,11 @@ describe('slackbotv2', () => {
     expect(rootResponse.status).toBe(200)
     await Promise.all(rootWaits)
 
+    await slackBot.chat.postMessage({
+      channel: CHANNEL_ID,
+      text: 'Prior assistant reply that must not be imported.',
+      thread_ts: rootMention.ts
+    })
     await postUserMessage('Important reply between mentions.', rootMention.ts)
     const replyMention = await postUserMessage(
       `<@${BOT_USER_ID}> now use the full thread`,
@@ -2091,6 +2098,10 @@ describe('slackbotv2', () => {
     expect(sessionMessageTexts(codexApi.appends[1]!.body.messages)).toEqual([
       'Important reply between mentions.',
       `@${BOT_USER_ID} now use the full thread`
+    ])
+    expect(codexApi.appends[1]!.body.messages.map(message => message.role)).toEqual([
+      'user',
+      'user'
     ])
     expect(codexApi.executes.map(execute => execute.body.idempotency_key)).toEqual([
       rootMention.ts,

--- a/services/slackbotv2/test/slack-user.test.ts
+++ b/services/slackbotv2/test/slack-user.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from 'bun:test'
-import { rawSlackUserId, slackUserIdForMessage } from '../src/slack-user'
+import {
+  rawSlackUserId,
+  resolveSlackBotUserId,
+  slackUserIdForMessage
+} from '../src/slack-user'
 
 describe('Slack user ID extraction', () => {
   test('prefers the Chat SDK author user ID', () => {
@@ -28,5 +32,46 @@ describe('Slack user ID extraction', () => {
   test('returns undefined when no Slack user ID is present', () => {
     expect(slackUserIdForMessage({ raw: { user: {} } })).toBeUndefined()
     expect(rawSlackUserId({ bot_profile: {} })).toBeUndefined()
+  })
+
+  test('uses the configured bot user ID without calling Slack', async () => {
+    let calls = 0
+    const userId = await resolveSlackBotUserId({
+      botToken: 'xoxb-test',
+      configuredBotUserId: 'UBOT',
+      fetchFn: async () => {
+        calls += 1
+        return Response.json({ ok: true, user_id: 'UOTHER' })
+      }
+    })
+
+    expect(userId).toBe('UBOT')
+    expect(calls).toBe(0)
+  })
+
+  test('resolves the bot user ID with auth.test when it is not configured', async () => {
+    let request: Request | undefined
+    const userId = await resolveSlackBotUserId({
+      botToken: 'xoxb-test',
+      slackApiUrl: 'https://slack.test/api/',
+      fetchFn: async (input, init) => {
+        request = new Request(input, init)
+        return Response.json({ ok: true, user_id: 'URESOLVED' })
+      }
+    })
+
+    expect(userId).toBe('URESOLVED')
+    expect(request?.url).toBe('https://slack.test/api/auth.test')
+    expect(request?.method).toBe('POST')
+    expect(request?.headers.get('authorization')).toBe('Bearer xoxb-test')
+  })
+
+  test('rejects an auth.test response without a bot user ID', async () => {
+    await expect(
+      resolveSlackBotUserId({
+        botToken: 'xoxb-test',
+        fetchFn: async () => Response.json({ ok: false, error: 'invalid_auth' })
+      })
+    ).rejects.toThrow('Slack auth.test failed: invalid_auth')
   })
 })


### PR DESCRIPTION
## Summary

- scope Console activity summaries to trace items from the same execution
- resolve the Slack bot user ID with `auth.test` when it is not explicitly configured
- classify fetched Slack history against the bot identity and exclude prior Centaur replies
- add regressions for cross-execution summaries, bot self-ingestion, message roles, and bot identity resolution

## Root cause

Console matched activity summaries only by event order. When a new execution emitted a summary before its first displayable trace item, that summary could label a command from the previous execution.

Separately, production did not configure `SLACK_BOT_USER_ID`. The self-message filter therefore admitted Centaur's own prior Slack replies, and the Slack history serializer compared authors against the current human requester instead of the bot identity. Those replies were persisted as new user turns and appeared twice in Console.

## Impact

Slack transcripts retain execution-local activity labels, prior assistant replies are not re-imported as user messages, and historical human messages remain user-authored.

## Validation

- `pnpm --filter slackbotv2 run check:types`
- `pnpm --filter slackbotv2 test` — 233 passed, 1 skipped
- `bin/rubocop app/controllers/console/threads_controller.rb test/controllers/console/threads_controller_test.rb`
- direct Rails regression for execution-scoped activity-summary matching
- `git diff --check`

The standard Rails controller test runner could not load locally because the available PostgreSQL installation does not provide the repository's `pg_search` extension; CI should run the committed regression against the normal Console test database.
