### PR TITLE
fix: omit external Slack user emails

### DIFF
--- a/services/slackbotv2/src/server.ts
+++ b/services/slackbotv2/src/server.ts
@@ -1,5 +1,6 @@
 import { createSlackbotV2, type SlackbotV2Options } from './index'
 import { parseChannelDefaults } from './channel-defaults'
+import { resolveSlackHomeTeamId } from './session-api'
 import { resolveSlackBotUserId } from './slack-user'
 import {
   createFlagMessageOverridesStrategy,
@@ -91,6 +92,7 @@ const options: SlackbotV2Options = {
   userName: stringEnv('SLACKBOTV2_USER_NAME', 'centaur'),
   logger: consoleLogger
 }
+options.slackHomeTeamId = await resolveSlackHomeTeamId(options)
 
 const { app } = createSlackbotV2(options)
 const server = Bun.serve({

--- a/services/slackbotv2/src/session-api.ts
+++ b/services/slackbotv2/src/session-api.ts
@@ -966,7 +966,12 @@ async function resolveRequesterIdentity(
     ?? stringValue(profile.real_name)
     ?? stringValue(profile.name)
     ?? identity.slackDisplayName
-  identity.slackEmail = stringValue(profile.email) ?? identity.slackEmail
+  if (
+    options.slackHomeTeamId
+    && stringValue(profile.team_id) === options.slackHomeTeamId
+  ) {
+    identity.slackEmail = stringValue(profile.email) ?? identity.slackEmail
+  }
   identity.slackUserName = stringValue(profile.name) ?? identity.slackUserName
 
   const github = extractGithubHandleFromSlackProfile(profile)
@@ -1144,6 +1149,13 @@ async function fetchSlackChannelName(
     name
   })
   return name
+}
+
+export async function resolveSlackHomeTeamId(
+  options: SlackbotV2Options
+): Promise<string | undefined> {
+  const payload = await slackApiGet(options, 'auth.test', {})
+  return stringValue(payload?.team_id)
 }
 
 async function slackApiGet(

--- a/services/slackbotv2/src/session-api.ts
+++ b/services/slackbotv2/src/session-api.ts
@@ -1153,9 +1153,13 @@ async function fetchSlackChannelName(
 
 export async function resolveSlackHomeTeamId(
   options: SlackbotV2Options
-): Promise<string | undefined> {
+): Promise<string> {
   const payload = await slackApiGet(options, 'auth.test', {})
-  return stringValue(payload?.team_id)
+  const teamId = stringValue(payload?.team_id)
+  if (!teamId) {
+    throw new Error('Slack auth.test failed to resolve the bot home team ID')
+  }
+  return teamId
 }
 
 async function slackApiGet(

--- a/services/slackbotv2/src/types.ts
+++ b/services/slackbotv2/src/types.ts
@@ -201,6 +201,8 @@ export type SlackbotV2Options = {
   sessionApiTimeoutMs?: number
   signingSecret: string
   slackApiUrl?: string
+  /** Bot workspace team ID resolved once from Slack's auth.test response. */
+  slackHomeTeamId?: string
   /** Deadline for optional Slack Web API metadata lookups. */
   slackApiTimeoutMs?: number
   state?: StateAdapter

--- a/services/slackbotv2/test/session-api.test.ts
+++ b/services/slackbotv2/test/session-api.test.ts
@@ -1004,7 +1004,7 @@ describe('session principal display name', () => {
     expect(requests.some(request => request.url.endsWith('/execute'))).toBe(true)
   })
 
-  test('DM sessions name the principal after the DM partner', async () => {
+  test('DM sessions include the email of a home-team partner', async () => {
     const { fetchFn, requests } = fakeApi()
     const dm = apiMessage('hi')
     dm.threadId = 'slack:D9:1700000000.000100'
@@ -1014,7 +1014,11 @@ describe('session principal display name', () => {
         if (url.includes('users.info')) {
           return Response.json({
             ok: true,
-            user: { profile: { display_name: 'Ada Lovelace', email: 'ada@example.com' } }
+            user: {
+              is_stranger: false,
+              profile: { display_name: 'Ada Lovelace', email: 'ada@example.com' },
+              team_id: 'T1'
+            }
           })
         }
         return Response.json({
@@ -1023,13 +1027,51 @@ describe('session principal display name', () => {
         })
       },
       async () => {
-        await forwardToSessionApi(slackOptions(fetchFn), forwardInput(dm))
+        await forwardToSessionApi(
+          { ...slackOptions(fetchFn), slackHomeTeamId: 'T1' },
+          forwardInput(dm)
+        )
       }
-	    )
-	    expect(createBody(requests).metadata?.slack_conversation_name).toBe('Ada Lovelace')
-	    expect(createBody(requests).metadata?.slack_channel_id).toBe('D9')
-	    expect(createBody(requests).metadata?.slack_team_id).toBe('T1')
+    )
+    expect(createBody(requests).metadata?.slack_conversation_name).toBe('Ada Lovelace')
+    expect(createBody(requests).metadata?.slack_channel_id).toBe('D9')
+    expect(createBody(requests).metadata?.slack_team_id).toBe('T1')
     expect(createBody(requests).metadata?.slack_user_email).toBe('ada@example.com')
+    expect(createBody(requests).metadata?.slack_user_id).toBe('U1')
+  })
+
+  test('DM sessions omit the email of an external-team partner', async () => {
+    const { fetchFn, requests } = fakeApi()
+    const dm = apiMessage('hi')
+    dm.threadId = 'slack:D9:1700000000.000100'
+    dm.raw = { channel: 'D9' }
+    await withSlackStub(
+      url => {
+        if (url.includes('users.info')) {
+          return Response.json({
+            ok: true,
+            user: {
+              is_stranger: true,
+              profile: { display_name: 'Grace Hopper', email: 'grace@example.com' },
+              team_id: 'T2'
+            }
+          })
+        }
+        return Response.json({
+          ok: true,
+          profile: { display_name: 'Grace Hopper' }
+        })
+      },
+      async () => {
+        await forwardToSessionApi(
+          { ...slackOptions(fetchFn), slackHomeTeamId: 'T1' },
+          forwardInput(dm)
+        )
+      }
+    )
+
+    expect(createBody(requests).metadata?.slack_conversation_name).toBe('Grace Hopper')
+    expect(createBody(requests).metadata?.slack_user_email).toBeUndefined()
     expect(createBody(requests).metadata?.slack_user_id).toBe('U1')
   })
 

--- a/services/slackbotv2/test/session-api.test.ts
+++ b/services/slackbotv2/test/session-api.test.ts
@@ -7,6 +7,7 @@ import {
   harnessRestartPreamble,
   interruptSessionExecution,
   openSessionEventStream,
+  resolveSlackHomeTeamId,
   serializeAttachment,
   serializeMessage
 } from '../src/session-api'
@@ -145,6 +146,50 @@ function textPartIncludes(part: JsonObject, text: string): boolean {
 function isJsonRecord(value: JsonValue | undefined): value is JsonObject {
   return Boolean(value && typeof value === 'object' && !Array.isArray(value))
 }
+
+describe('Slack home team resolution', () => {
+  test('resolves the home team ID from auth.test', async () => {
+    const realFetch = globalThis.fetch
+    let request: Request | undefined
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      request = new Request(input, init)
+      return Response.json({ ok: true, team_id: 'T_HOME' })
+    }) as typeof fetch
+    try {
+      const teamId = await resolveSlackHomeTeamId({
+        apiUrl: 'http://api.test',
+        botToken: 'xoxb-test',
+        signingSecret: 'secret',
+        slackApiUrl: 'https://slack.test/api/'
+      })
+
+      expect(teamId).toBe('T_HOME')
+      expect(request?.url).toBe('https://slack.test/api/auth.test')
+      expect(request?.method).toBe('GET')
+      expect(request?.headers.get('authorization')).toBe('Bearer xoxb-test')
+    } finally {
+      globalThis.fetch = realFetch
+    }
+  })
+
+  test('rejects startup when auth.test cannot resolve a home team ID', async () => {
+    const realFetch = globalThis.fetch
+    globalThis.fetch = (async (_input: RequestInfo | URL, _init?: RequestInit) =>
+      Response.json({ error: 'invalid_auth', ok: false }, { status: 401 })) as typeof fetch
+    try {
+      await expect(
+        resolveSlackHomeTeamId({
+          apiUrl: 'http://api.test',
+          botToken: 'xoxb-test',
+          signingSecret: 'secret',
+          slackApiUrl: 'https://slack.test/api/'
+        })
+      ).rejects.toThrow('Slack auth.test failed to resolve the bot home team ID')
+    } finally {
+      globalThis.fetch = realFetch
+    }
+  })
+})
 
 describe('session event streaming', () => {
   test('passes activity summary events through to the renderer source stream', async () => {


### PR DESCRIPTION
Caches the Slack bot's home team ID from auth.test and only forwards a requester's Slack email when their profile belongs to that team. SlackbotV2 now refuses startup when the home team cannot be resolved, avoiding silent loss of internal DM email linkage. Adds session API coverage for home-team and external-team authors plus successful and failed home-team discovery.