### PR TITLE
fix: sanitize Slack DM sync payloads

### DIFF
--- a/services/console/app/services/slack_dm/sync_credential.rb
+++ b/services/console/app/services/slack_dm/sync_credential.rb
@@ -75,7 +75,7 @@ module SlackDm
       batch[:run][:replies_fetched] = @replies_fetched
       batch[:run][:replies_upserted] = batch[:messages].count { |message| message[:parent_message_ts].present? }
       batch[:run][:finished] = true
-      @api_client.ingest_slack_dm_sync_batch(batch)
+      @api_client.ingest_slack_dm_sync_batch(sanitize_for_postgres(batch))
     end
 
     private
@@ -346,6 +346,21 @@ module SlackDm
     def slack_ts_sort_key(value)
       seconds, micros = value.to_s.split(".", 2)
       [ seconds.to_i, micros.to_s.ljust(6, "0")[0, 6].to_i ]
+    end
+
+    def sanitize_for_postgres(value)
+      case value
+      when Hash
+        value.to_h do |key, nested_value|
+          [ sanitize_for_postgres(key), sanitize_for_postgres(nested_value) ]
+        end
+      when Array
+        value.map { |nested_value| sanitize_for_postgres(nested_value) }
+      when String
+        value.delete("\u0000")
+      else
+        value
+      end
     end
 
     def slack_timeout = positive_env("SLACK_DM_SYNC_TIMEOUT_SECONDS", 20)

--- a/services/console/test/services/slack_dm/sync_credential_test.rb
+++ b/services/console/test/services/slack_dm/sync_credential_test.rb
@@ -90,7 +90,8 @@ module SlackDm
                 "is_im" => true,
                 "is_mpim" => false,
                 "user" => "U_OTHER",
-                "is_archived" => false
+                "is_archived" => false,
+                "purpose" => { "value" => "direct\u0000message" }
               }
             ],
             "response_metadata" => { "next_cursor" => "" }
@@ -112,14 +113,15 @@ module SlackDm
                 "ts" => "1700000000.000002",
                 "thread_ts" => "1700000000.000002",
                 "user" => "U_OTHER",
-                "text" => "hello",
+                "text" => "hel\u0000lo",
+                "blocks" => [ { "text" => { "text" => "hel\u0000lo" } } ],
                 "reply_count" => 1,
                 "reply_users" => [ "U_ME" ],
                 "latest_reply" => "1700000000.000003",
                 "files" => [
                   {
                     "id" => "F123",
-                    "name" => "note.txt",
+                    "name" => "no\u0000te.txt",
                     "title" => "Note",
                     "mimetype" => "text/plain",
                     "filetype" => "text",
@@ -171,8 +173,12 @@ module SlackDm
       assert_equal %w[U_OTHER U_ME], batch[:members].map { |member| member[:user_id] }
       assert_equal 2, batch[:messages].length
       assert_equal "hello", batch[:messages].first[:text]
+      assert_equal "hello", batch[:messages].first[:raw_payload].dig("blocks", 0, "text", "text")
+      assert_equal "directmessage", batch[:conversations].first[:raw_payload].dig("purpose", "value")
       assert_equal "1700000000.000002", batch[:messages].last[:parent_message_ts]
       assert_equal "F123", batch[:attachments].first[:slack_file_id]
+      assert_equal "note.txt", batch[:attachments].first[:name]
+      assert_equal "note.txt", batch[:attachments].first[:raw_payload]["name"]
       assert_equal "1700000000.000002", batch[:checkpoints].first[:watermark_ts]
     end
 


### PR DESCRIPTION
Remove NUL characters recursively from Slack DM sync batches before ingestion so PostgreSQL can store normalized fields and nested raw payloads. Adds regression coverage for NULs in conversation metadata, rich-text message content, and attachment data.