### PR TITLE
fix: require canonical Slack DM principals

### DIFF
--- a/docs/pages/secrets/advanced-permissioning.mdx
+++ b/docs/pages/secrets/advanced-permissioning.mdx
@@ -56,7 +56,7 @@ The stable principal ids follow these rules:
 
 | Context | Principal foreign id | Shared by |
 |---------|----------------------|-----------|
-| Slack direct message | `slack-user-[<team-id>-]<user-id>` | That Slack user |
+| Slack direct message | `slack-user-<team-id>-<user-id>` | That Slack user in that workspace |
 | Slack channel or group | `slack-channel-[<team-id>-]<channel-id>` | Everyone using Centaur in that channel |
 | Discord channel | `discord-channel-<guild-id>-<channel-id>` | Every thread in that channel |
 | Linear issue | `linear-issue-<issue-id>` | Every Centaur session on that issue |
@@ -65,9 +65,10 @@ The stable principal ids follow these rules:
 | Workflow with `WORKFLOW_PRINCIPAL = True` | `workflow-<workflow-name>` | Runs of that workflow |
 | Other session key | `thread-<session-key>` | That session key |
 
-Values are lowercased and converted to URL-safe slugs. Brackets in the Slack
-rows mark an optional team scope, not literal characters. Display names can
-change when a channel is renamed, but the foreign id remains stable.
+Values are lowercased and converted to URL-safe slugs. The team scope is
+required for Slack DMs and optional for Slack channel keys. Brackets mark an
+optional scope, not literal characters. Display names can change when a channel
+is renamed, but the foreign id remains stable.
 
 :::warning[Channel Grants Are Shared]
 Granting a Slack, Discord, or Teams channel principal gives the permission to
@@ -151,7 +152,7 @@ role, and assigns the role to the principal.
 ```bash
 cargo run -p centaur-perms -- \
   --tools-dir ../../tools \
-  principals grant slack-user-u123 \
+  principals grant slack-user-t123-u123 \
   --tool github
 ```
 
@@ -163,7 +164,7 @@ cargo run -p centaur-perms -- \
   --source-policy onepassword-connect \
   --op-vault Engineering \
   --tools-dir ../../tools \
-  principals grant slack-user-u123 \
+  principals grant slack-user-t123-u123 \
   --tool github
 ```
 
@@ -189,7 +190,7 @@ Grant a whole tool to one Slack user:
 
 ```bash
 cargo run -p centaur-perms -- \
-  principals grant slack-user-u123 \
+  principals grant slack-user-t123-u123 \
   --tool github
 ```
 
@@ -197,7 +198,7 @@ Grant an existing role:
 
 ```bash
 cargo run -p centaur-perms -- \
-  principals grant slack-user-u123 \
+  principals grant slack-user-t123-u123 \
   --role tool-github
 ```
 
@@ -205,7 +206,7 @@ Grant one existing secret directly by OID:
 
 ```bash
 cargo run -p centaur-perms -- \
-  principals grant slack-user-u123 \
+  principals grant slack-user-t123-u123 \
   --secret ssr_...
 ```
 
@@ -219,7 +220,8 @@ cargo run -p centaur-perms -- \
 ```
 
 The CLI also accepts a canonical thread key and derives its principal. For a
-Slack DM, include the acting user because the DM principal is user-scoped:
+Slack DM, include both the team in the thread key and the acting user because
+the DM principal is scoped to that user in that workspace:
 
 ```bash
 cargo run -p centaur-perms -- \
@@ -346,7 +348,7 @@ grants, and effective secret placeholders:
 
 ```bash
 cargo run -p centaur-perms -- principals list --managed --filter slack
-cargo run -p centaur-perms -- principals show slack-user-u123
+cargo run -p centaur-perms -- principals show slack-user-t123-u123
 ```
 
 Inspect the role and registered secrets:
@@ -375,7 +377,7 @@ Revoke a tool role from a principal:
 
 ```bash
 cargo run -p centaur-perms -- \
-  principals revoke slack-user-u123 \
+  principals revoke slack-user-t123-u123 \
   --tool github
 ```
 
@@ -383,11 +385,11 @@ Revoke one direct secret or a known grant:
 
 ```bash
 cargo run -p centaur-perms -- \
-  principals revoke slack-user-u123 \
+  principals revoke slack-user-t123-u123 \
   --secret ssr_...
 
 cargo run -p centaur-perms -- \
-  principals revoke slack-user-u123 \
+  principals revoke slack-user-t123-u123 \
   --grant-id grant_...
 ```
 

--- a/services/api-rs/crates/centaur-api-server/src/args.rs
+++ b/services/api-rs/crates/centaur-api-server/src/args.rs
@@ -1399,6 +1399,7 @@ async fn register_role_with_retry(
 fn should_retry_iron_control_register(error: &RegisterError) -> bool {
     match error {
         RegisterError::Translate(_) => false,
+        RegisterError::Control(IronControlError::PrincipalDerivation(_)) => false,
         RegisterError::Control(IronControlError::Transport { .. }) => true,
         RegisterError::Control(IronControlError::Decode { .. }) => false,
         RegisterError::Control(IronControlError::Status { status, .. }) => {

--- a/services/api-rs/crates/centaur-api-server/src/error.rs
+++ b/services/api-rs/crates/centaur-api-server/src/error.rs
@@ -67,6 +67,9 @@ impl IntoResponse for ApiError {
             Self::Runtime(SessionRuntimeError::Store(SessionStoreError::PersonaConflict {
                 ..
             })) => StatusCode::CONFLICT,
+            Self::Runtime(SessionRuntimeError::IronControl(
+                centaur_iron_control::IronControlError::PrincipalDerivation(_),
+            )) => StatusCode::BAD_REQUEST,
             Self::Workflow(WorkflowRuntimeError::BadRequest(_)) => StatusCode::BAD_REQUEST,
             Self::Workflow(WorkflowRuntimeError::Disabled(_)) => StatusCode::FORBIDDEN,
             Self::Workflow(WorkflowRuntimeError::NotFound(_)) => StatusCode::NOT_FOUND,
@@ -124,4 +127,20 @@ pub(crate) fn error_chain(error: &dyn std::error::Error) -> String {
         source = cause.source();
     }
     message
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use centaur_iron_control::{IronControlError, PrincipalDerivationError};
+
+    #[test]
+    fn principal_derivation_errors_are_bad_requests() {
+        let response = ApiError::Runtime(SessionRuntimeError::IronControl(
+            IronControlError::PrincipalDerivation(PrincipalDerivationError::MissingSlackTeamId),
+        ))
+        .into_response();
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
 }

--- a/services/api-rs/crates/centaur-iron-control/src/error.rs
+++ b/services/api-rs/crates/centaur-iron-control/src/error.rs
@@ -1,8 +1,14 @@
 use thiserror::Error;
 
+use crate::principal::PrincipalDerivationError;
+
 /// Errors returned by the iron-control admin client.
 #[derive(Debug, Error)]
 pub enum IronControlError {
+    /// A session did not carry enough identity metadata to derive its
+    /// canonical principal.
+    #[error(transparent)]
+    PrincipalDerivation(#[from] PrincipalDerivationError),
     /// The HTTP request could not be sent or the response could not be read.
     #[error("iron-control request to {path} failed: {source}")]
     Transport {

--- a/services/api-rs/crates/centaur-iron-control/src/lib.rs
+++ b/services/api-rs/crates/centaur-iron-control/src/lib.rs
@@ -25,7 +25,7 @@ pub use models::{
     ReplaceConfig, RequestRule, Role, SECRET_TYPES, SecretRecord, SecretSource, StaticSecretInput,
     normalize_gcp_id_token_header,
 };
-pub use principal::{PrincipalRef, derive_principal};
+pub use principal::{PrincipalDerivationError, PrincipalRef, derive_principal};
 pub use registry::{
     GCP_AUTH_DEFAULT_SCOPE, RegisterError, RoleSpec, SecretInput, TranslateError,
     gcp_auth_scopes_or_default, grant_inputs_to_role, register_role, secret_inputs_from_fragment,

--- a/services/api-rs/crates/centaur-iron-control/src/principal.rs
+++ b/services/api-rs/crates/centaur-iron-control/src/principal.rs
@@ -11,8 +11,10 @@
 //! identified by their Slack prefix rather than position, because the optional
 //! team id shifts everything after it (``T`` = team, ``C``/``G`` = channel,
 //! ``D`` = DM; a ``thread_ts`` is numeric). When a team id is present it is
-//! folded into the principal key so the same channel/user id in two workspaces
-//! never collides onto one principal.
+//! folded into a DM principal key so the same user id in two workspaces never
+//! collides onto one principal. Slack DMs require both a team id and acting user
+//! id; derivation fails rather than emitting a legacy teamless or
+//! conversation-keyed DM principal.
 //!
 //! [`derive_principal`] is pure so the mapping is unit-tested directly; callers
 //! upsert the returned [`PrincipalRef`] at session start.
@@ -21,6 +23,7 @@ use std::collections::BTreeMap;
 
 use base64::Engine;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use thiserror::Error;
 
 use crate::models::PrincipalInput;
 use crate::util::{managed_labels, slugify};
@@ -39,6 +42,16 @@ pub struct PrincipalRef {
     pub foreign_id: String,
     pub name: String,
     pub labels: BTreeMap<String, String>,
+}
+
+/// A chat thread does not contain enough identity information to derive its
+/// canonical principal.
+#[derive(Clone, Debug, Error, PartialEq, Eq)]
+pub enum PrincipalDerivationError {
+    #[error("Slack DM principal requires a Slack team ID")]
+    MissingSlackTeamId,
+    #[error("Slack DM principal requires an acting Slack user ID")]
+    MissingSlackUserId,
 }
 
 impl PrincipalRef {
@@ -62,11 +75,11 @@ impl PrincipalRef {
 /// Resolve the principal for a thread.
 ///
 /// ``actor_user_id`` is the acting user, when known (carried in session
-/// metadata). It is used to key 1:1 Slack DMs and Teams chats without a team;
-/// channel threads key on the channel/conversation so everyone in the channel
-/// shares one principal. When the thread key is not a recognizable chat
-/// conversation, the whole key is slugged so every thread still maps to a
-/// deterministic, distinct principal.
+/// metadata). It is used to key 1:1 Slack DMs and Teams chats without a team.
+/// Slack DMs additionally require a team id. Channel threads key on the
+/// channel/conversation so everyone in the channel shares one principal. When
+/// the thread key is not a recognizable chat conversation, the whole key is
+/// slugged so every thread still maps to a deterministic, distinct principal.
 ///
 /// ``conversation_name`` is the human-readable channel name (or DM partner's
 /// display name) the slackbot resolves and carries in session metadata. When
@@ -80,7 +93,7 @@ pub fn derive_principal(
     thread_key: &str,
     actor_user_id: Option<&str>,
     conversation_name: Option<&str>,
-) -> PrincipalRef {
+) -> Result<PrincipalRef, PrincipalDerivationError> {
     derive_principal_with_slack_team(thread_key, actor_user_id, None, conversation_name)
 }
 
@@ -91,7 +104,7 @@ pub fn derive_principal_with_slack_team(
     actor_user_id: Option<&str>,
     slack_team_id: Option<&str>,
     conversation_name: Option<&str>,
-) -> PrincipalRef {
+) -> Result<PrincipalRef, PrincipalDerivationError> {
     let display_name = conversation_name
         .map(str::trim)
         .filter(|name| !name.is_empty());
@@ -109,13 +122,13 @@ pub fn derive_principal_with_slack_team(
         if let Some(channel) = channel_id {
             labels.insert("discord_channel_id".to_owned(), channel.to_owned());
         }
-        return PrincipalRef {
+        return Ok(PrincipalRef {
             foreign_id: format!("discord-channel-{scope}{}", slugify(key_id)),
             name: display_name
                 .map(|name| format!("Discord Channel #{name}"))
                 .unwrap_or_else(|| format!("Discord Channel {key_id} (guild {guild_id})")),
             labels,
-        };
+        });
     }
 
     // Linear sessions key on the issue so every agent session on an issue shares
@@ -126,13 +139,13 @@ pub fn derive_principal_with_slack_team(
         let mut labels = BTreeMap::new();
         labels.insert(KIND_LABEL.to_owned(), LINEAR_ISSUE_KIND.to_owned());
         labels.insert("linear_issue_id".to_owned(), issue_id.to_owned());
-        return PrincipalRef {
+        return Ok(PrincipalRef {
             foreign_id: format!("linear-issue-{}", slugify(issue_id)),
             name: display_name
                 .map(|name| format!("Linear Issue #{name}"))
                 .unwrap_or_else(|| format!("Linear Issue {issue_id}")),
             labels,
-        };
+        });
     }
 
     if let Some((conversation_id, service_url, thread_id)) =
@@ -152,38 +165,54 @@ pub fn derive_principal_with_slack_team(
         {
             labels.insert(KIND_LABEL.to_owned(), TEAMS_USER_KIND.to_owned());
             labels.insert("teams_user_id".to_owned(), user.to_owned());
-            return PrincipalRef {
+            return Ok(PrincipalRef {
                 foreign_id: format!("teams-user-{}", slugify(user)),
                 name: display_name
                     .map(|name| format!("Teams User @{name}"))
                     .unwrap_or_else(|| format!("Teams User {user}")),
                 labels,
-            };
+            });
         }
         labels.insert(KIND_LABEL.to_owned(), TEAMS_CONVERSATION_KIND.to_owned());
-        return PrincipalRef {
+        return Ok(PrincipalRef {
             foreign_id: format!("teams-conversation-{}", slugify(&conversation_id)),
             name: display_name
                 .map(|name| format!("Teams Conversation {name}"))
                 .unwrap_or_else(|| format!("Teams Conversation {conversation_id}")),
             labels,
-        };
+        });
     }
 
     let (thread_team_id, conversation_id) = parse_slack_segments(thread_key);
     let metadata_team_id = slack_team_id.map(str::trim).filter(|team| !team.is_empty());
+    if is_direct_message(conversation_id) {
+        let team = thread_team_id
+            .or(metadata_team_id)
+            .ok_or(PrincipalDerivationError::MissingSlackTeamId)?;
+        let user = actor_user_id
+            .map(str::trim)
+            .filter(|user| !user.is_empty())
+            .ok_or(PrincipalDerivationError::MissingSlackUserId)?;
+        let labels = BTreeMap::from([
+            (KIND_LABEL.to_owned(), SLACK_DM_KIND.to_owned()),
+            ("slack_team_id".to_owned(), team.to_owned()),
+            ("slack_user_id".to_owned(), user.to_owned()),
+        ]);
+        return Ok(PrincipalRef {
+            foreign_id: format!("slack-user-{}-{}", slugify(team), slugify(user)),
+            name: display_name
+                .map(|name| format!("Slack DM @{name}"))
+                .unwrap_or_else(|| format!("Slack User {user} (team {team})")),
+            labels,
+        });
+    }
+
     // Channel principals must never be scoped by the message-derived metadata
     // team: in Slack Connect shared channels that team can identify an external
     // requester's workspace, which would fork a separate principal from the
-    // host channel's. A Slack channel id is globally unique, so an un-teamed
-    // scope is correct and collision-free. DM principals stay team-scoped so
-    // legacy DM keys that omit the team still resolve to the right per-user
-    // identity (see #882).
-    let team_id = if is_direct_message(conversation_id) {
-        thread_team_id.or(metadata_team_id)
-    } else {
-        thread_team_id
-    };
+    // host channel's. Thread-key team ids remain part of the established
+    // channel identity format.
+    let team_id = thread_team_id;
     let mut labels = BTreeMap::new();
     if let Some(team) = team_id {
         labels.insert("slack_team_id".to_owned(), team.to_owned());
@@ -195,44 +224,25 @@ pub fn derive_principal_with_slack_team(
         .map(|team| format!(" (team {team})"))
         .unwrap_or_default();
 
-    if is_direct_message(conversation_id)
-        && let Some(user) = actor_user_id.map(str::trim).filter(|user| !user.is_empty())
-    {
-        labels.insert(KIND_LABEL.to_owned(), SLACK_DM_KIND.to_owned());
-        labels.insert("slack_user_id".to_owned(), user.to_owned());
-        return PrincipalRef {
-            foreign_id: format!("slack-user-{scope}{}", slugify(user)),
-            name: display_name
-                .map(|name| format!("Slack DM @{name}"))
-                .unwrap_or_else(|| format!("Slack User {user}{team_suffix}")),
-            labels,
-        };
-    }
-
     if let Some(conversation_id) = conversation_id {
-        let principal_kind = if is_direct_message(Some(conversation_id)) {
-            SLACK_DM_KIND
-        } else {
-            SLACK_CHANNEL_KIND
-        };
-        labels.insert(KIND_LABEL.to_owned(), principal_kind.to_owned());
+        labels.insert(KIND_LABEL.to_owned(), SLACK_CHANNEL_KIND.to_owned());
         labels.insert("slack_channel_id".to_owned(), conversation_id.to_owned());
-        return PrincipalRef {
+        return Ok(PrincipalRef {
             foreign_id: format!("slack-channel-{scope}{}", slugify(conversation_id)),
             name: display_name
                 .map(|name| format!("Slack Channel #{name}"))
                 .unwrap_or_else(|| format!("Slack Channel {conversation_id}{team_suffix}")),
             labels,
-        };
+        });
     }
 
-    PrincipalRef {
+    Ok(PrincipalRef {
         foreign_id: format!("thread-{}", slugify(thread_key)),
         name: display_name
             .map(ToOwned::to_owned)
             .unwrap_or_else(|| thread_key.to_owned()),
         labels,
-    }
+    })
 }
 
 /// Identify the team and conversation segments by their Slack prefix, ignoring
@@ -321,11 +331,35 @@ pub(crate) fn is_direct_message(conversation_id: Option<&str>) -> bool {
 mod tests {
     use super::*;
 
+    fn derive_principal(
+        thread_key: &str,
+        actor_user_id: Option<&str>,
+        conversation_name: Option<&str>,
+    ) -> PrincipalRef {
+        super::derive_principal(thread_key, actor_user_id, conversation_name)
+            .expect("principal should be derivable")
+    }
+
+    fn derive_principal_with_slack_team(
+        thread_key: &str,
+        actor_user_id: Option<&str>,
+        slack_team_id: Option<&str>,
+        conversation_name: Option<&str>,
+    ) -> PrincipalRef {
+        super::derive_principal_with_slack_team(
+            thread_key,
+            actor_user_id,
+            slack_team_id,
+            conversation_name,
+        )
+        .expect("principal should be derivable")
+    }
+
     #[test]
     fn dm_with_user_keys_on_the_user() {
-        let principal = derive_principal("slack:D0420:1780000000.0001", Some("U07ABC"), None);
-        assert_eq!(principal.foreign_id, "slack-user-u07abc");
-        assert_eq!(principal.name, "Slack User U07ABC");
+        let principal = derive_principal("slack:T123:D0420:1780000000.0001", Some("U07ABC"), None);
+        assert_eq!(principal.foreign_id, "slack-user-t123-u07abc");
+        assert_eq!(principal.name, "Slack User U07ABC (team T123)");
         assert_eq!(
             principal.labels.get("slack_user_id").map(String::as_str),
             Some("U07ABC")
@@ -337,12 +371,18 @@ mod tests {
     }
 
     #[test]
-    fn dm_without_user_falls_back_to_the_conversation() {
-        let principal = derive_principal("slack:D0420:1780000000.0001", None, None);
-        assert_eq!(principal.foreign_id, "slack-channel-d0420");
+    fn dm_without_team_id_is_rejected() {
         assert_eq!(
-            principal.labels.get("kind").map(String::as_str),
-            Some("slack_dm")
+            super::derive_principal("slack:D0420:1780000000.0001", Some("U07ABC"), None),
+            Err(PrincipalDerivationError::MissingSlackTeamId)
+        );
+    }
+
+    #[test]
+    fn dm_without_user_id_is_rejected() {
+        assert_eq!(
+            super::derive_principal("slack:T123:D0420:1780000000.0001", None, None),
+            Err(PrincipalDerivationError::MissingSlackUserId)
         );
     }
 
@@ -390,7 +430,7 @@ mod tests {
     }
 
     #[test]
-    fn metadata_team_id_is_folded_into_legacy_dm_user_key() {
+    fn teamless_dm_thread_key_uses_metadata_team_id() {
         let principal = derive_principal_with_slack_team(
             "slack:D9:ts",
             Some("U07ABC"),
@@ -459,8 +499,9 @@ mod tests {
 
     #[test]
     fn conversation_name_overrides_the_dm_display_name() {
-        let principal = derive_principal("slack:D0420:ts", Some("U07ABC"), Some("Ada Lovelace"));
-        assert_eq!(principal.foreign_id, "slack-user-u07abc");
+        let principal =
+            derive_principal("slack:T123:D0420:ts", Some("U07ABC"), Some("Ada Lovelace"));
+        assert_eq!(principal.foreign_id, "slack-user-t123-u07abc");
         assert_eq!(principal.name, "Slack DM @Ada Lovelace");
     }
 

--- a/services/api-rs/crates/centaur-iron-control/src/session.rs
+++ b/services/api-rs/crates/centaur-iron-control/src/session.rs
@@ -80,7 +80,7 @@ impl SessionRegistrar {
             metadata.actor_user_id,
             metadata.slack_team_id,
             metadata.conversation_name,
-        );
+        )?;
         let mut input = principal.to_principal_input();
         apply_slack_dm_email(thread_key, metadata.slack_user_email, &mut input);
         let existing = match self.client.get_principal(&input.foreign_id).await {
@@ -182,7 +182,7 @@ fn is_status(err: &IronControlError, code: u16) -> bool {
 mod tests {
     use std::sync::{Arc, Mutex};
 
-    use crate::derive_principal;
+    use crate::{PrincipalDerivationError, derive_principal};
     use serde_json::json;
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
@@ -251,8 +251,9 @@ mod tests {
 
     #[test]
     fn slack_dm_email_applies_only_to_dm_user_principals() {
-        let mut dm_input =
-            derive_principal("slack:T123:D123:ts", Some("U123"), None).to_principal_input();
+        let mut dm_input = derive_principal("slack:T123:D123:ts", Some("U123"), None)
+            .expect("DM principal should be derivable")
+            .to_principal_input();
         apply_slack_dm_email(
             "slack:T123:D123:1773364194.179929",
             Some(" ada@example.com "),
@@ -260,14 +261,49 @@ mod tests {
         );
         assert_eq!(dm_input.slack_email.as_deref(), Some("ada@example.com"));
 
-        let mut channel_input =
-            derive_principal("slack:T123:C123:ts", Some("U123"), None).to_principal_input();
+        let mut channel_input = derive_principal("slack:T123:C123:ts", Some("U123"), None)
+            .expect("channel principal should be derivable")
+            .to_principal_input();
         apply_slack_dm_email(
             "slack:T123:C123:1773364194.179929",
             Some("ada@example.com"),
             &mut channel_input,
         );
         assert_eq!(channel_input.slack_email, None);
+    }
+
+    #[tokio::test]
+    async fn register_session_rejects_slack_dm_without_team_id() {
+        let registrar =
+            SessionRegistrar::new(IronControlClient::new("http://127.0.0.1:1", "test-key"));
+        let metadata = json!({ "slack_user_id": "U123" });
+
+        let error = registrar
+            .register_session("slack:D123:1773364194.179929", Some(&metadata))
+            .await
+            .unwrap_err();
+
+        assert!(matches!(
+            error,
+            IronControlError::PrincipalDerivation(PrincipalDerivationError::MissingSlackTeamId)
+        ));
+    }
+
+    #[tokio::test]
+    async fn register_session_rejects_slack_dm_without_user_id() {
+        let registrar =
+            SessionRegistrar::new(IronControlClient::new("http://127.0.0.1:1", "test-key"));
+        let metadata = json!({ "slack_team_id": "T123" });
+
+        let error = registrar
+            .register_session("slack:D123:1773364194.179929", Some(&metadata))
+            .await
+            .unwrap_err();
+
+        assert!(matches!(
+            error,
+            IronControlError::PrincipalDerivation(PrincipalDerivationError::MissingSlackUserId)
+        ));
     }
 
     #[tokio::test]

--- a/services/api-rs/crates/centaur-perms/src/main.rs
+++ b/services/api-rs/crates/centaur-perms/src/main.rs
@@ -372,7 +372,7 @@ async fn describe_grant(client: &IronControlClient, grant: &Grant) -> Option<Str
 }
 
 async fn principals_show(client: &IronControlClient, args: &PrincipalSelector) -> Result<()> {
-    let identity = principal::resolve_principal(&args.principal, args.slack_user.as_deref());
+    let identity = principal::resolve_principal(&args.principal, args.slack_user.as_deref())?;
     let principal = get_principal_or_fail(client, &identity.foreign_id).await?;
     println!(
         "principal: {} ({}) — {}",
@@ -441,7 +441,7 @@ async fn principals_grant(
         bail!("--grant-id is only valid for `principals revoke`");
     }
     let policy = build_source_policy(cli)?;
-    let identity = principal::resolve_principal(&args.principal, args.slack_user.as_deref());
+    let identity = principal::resolve_principal(&args.principal, args.slack_user.as_deref())?;
     let principal_id = ensure_principal(client, &identity).await?;
     println!("principal: {} ({principal_id})", identity.foreign_id);
 
@@ -492,7 +492,7 @@ async fn principals_revoke(client: &IronControlClient, args: &PrincipalGrantArgs
     {
         bail!("nothing to revoke: pass at least one --tool, --role, --secret, or --grant-id");
     }
-    let identity = principal::resolve_principal(&args.principal, args.slack_user.as_deref());
+    let identity = principal::resolve_principal(&args.principal, args.slack_user.as_deref())?;
     let principal = get_principal_or_fail(client, &identity.foreign_id).await?;
     println!("principal: {} ({})", identity.foreign_id, principal.id);
 

--- a/services/api-rs/crates/centaur-perms/src/principal.rs
+++ b/services/api-rs/crates/centaur-perms/src/principal.rs
@@ -2,7 +2,7 @@
 
 use std::collections::BTreeMap;
 
-use centaur_iron_control::{PrincipalInput, derive_principal};
+use centaur_iron_control::{PrincipalDerivationError, PrincipalInput, derive_principal};
 
 /// Turn a `--principal` value (plus optional `--slack-user`) into the identity
 /// to upsert/look up.
@@ -12,13 +12,16 @@ use centaur_iron_control::{PrincipalInput, derive_principal};
 /// what api-rs writes at session start. Any other value is used verbatim as a
 /// principal `foreign_id` (e.g. `slack-channel-t1-c9`), so an operator can name
 /// an already-registered principal directly.
-pub fn resolve_principal(principal: &str, slack_user: Option<&str>) -> PrincipalInput {
+pub fn resolve_principal(
+    principal: &str,
+    slack_user: Option<&str>,
+) -> Result<PrincipalInput, PrincipalDerivationError> {
     if principal.contains(':') {
         // The CLI has no resolved conversation name; the synthetic display name
         // is fine for operator-driven lookups.
-        derive_principal(principal, slack_user, None).to_principal_input()
+        Ok(derive_principal(principal, slack_user, None)?.to_principal_input())
     } else {
-        PrincipalInput {
+        Ok(PrincipalInput {
             foreign_id: principal.to_owned(),
             name: principal.to_owned(),
             labels: BTreeMap::from([("managed-by".to_owned(), "centaur".to_owned())]),
@@ -27,7 +30,7 @@ pub fn resolve_principal(principal: &str, slack_user: Option<&str>) -> Principal
             slack_channel_id: None,
             slack_team_id: None,
             slack_email: None,
-        }
+        })
     }
 }
 
@@ -37,14 +40,22 @@ mod tests {
 
     #[test]
     fn thread_key_is_derived() {
-        let id = resolve_principal("slack:T123:C456:1780000000.0001", Some("U1"));
+        let id = resolve_principal("slack:T123:C456:1780000000.0001", Some("U1")).unwrap();
         assert_eq!(id.foreign_id, "slack-channel-t123-c456");
     }
 
     #[test]
     fn dm_thread_key_keys_on_user() {
-        let id = resolve_principal("slack:D9:ts", Some("U07ABC"));
-        assert_eq!(id.foreign_id, "slack-user-u07abc");
+        let id = resolve_principal("slack:T123:D9:ts", Some("U07ABC")).unwrap();
+        assert_eq!(id.foreign_id, "slack-user-t123-u07abc");
+    }
+
+    #[test]
+    fn teamless_dm_thread_key_is_rejected() {
+        assert_eq!(
+            resolve_principal("slack:D9:ts", Some("U07ABC")),
+            Err(PrincipalDerivationError::MissingSlackTeamId)
+        );
     }
 
     #[test]
@@ -54,7 +65,8 @@ mod tests {
         let id = resolve_principal(
             &format!("teams:{conversation}:{service_url}"),
             Some("aad-user-1"),
-        );
+        )
+        .unwrap();
         assert_eq!(id.foreign_id, "teams-conversation-19-abc123-thread-tacv2");
     }
 
@@ -65,14 +77,15 @@ mod tests {
         let id = resolve_principal(
             &format!("teams:{conversation}:{service_url}"),
             Some("aad-user-1"),
-        );
+        )
+        .unwrap();
         assert_eq!(id.foreign_id, "teams-conversation-19-abc123-thread-tacv2");
     }
 
     #[test]
     fn raw_foreign_id_is_verbatim() {
-        let id = resolve_principal("slack-channel-t1-c9", None);
-        assert_eq!(id.foreign_id, "slack-channel-t1-c9");
-        assert_eq!(id.name, "slack-channel-t1-c9");
+        let id = resolve_principal("External-System-AbC123", None).unwrap();
+        assert_eq!(id.foreign_id, "External-System-AbC123");
+        assert_eq!(id.name, "External-System-AbC123");
     }
 }

--- a/services/console/Gemfile.lock
+++ b/services/console/Gemfile.lock
@@ -84,7 +84,7 @@ GEM
     bindex (0.8.1)
     bootsnap (1.24.6)
       msgpack (~> 1.2)
-    brakeman (8.0.5)
+    brakeman (8.0.6)
       racc
     builder (3.3.0)
     bundler-audit (0.9.3)

--- a/services/slackbotv2/src/session-api.ts
+++ b/services/slackbotv2/src/session-api.ts
@@ -909,7 +909,10 @@ function sessionRequesterMetadata(
   identity?: RequesterIdentity
 ): JsonObject {
   const slackUserId = identity?.slackUserId ?? messageRequesterUserId(message)
-  const slackTeamId = identity?.slackTeamId ?? messageSlackTeamId(message)
+  // A resolved identity's team is authoritative even when absent: it may have
+  // been deliberately dropped as unverified (see homeGatedTeamId), so it must
+  // not be resurrected from the raw message.
+  const slackTeamId = identity ? identity.slackTeamId : messageSlackTeamId(message)
   const slackChannelId = message ? slackConversationId(message) : undefined
   const slackUserName = identity?.slackUserName ?? message?.author.userName
   const slackDisplayName = identity?.slackDisplayName ?? message?.author.fullName
@@ -930,6 +933,20 @@ function messageSlackTeamId(message: SlackbotV2ApiMessage | undefined): string |
   return message.teamId || slackTeamId(message.raw) || rawSlackString(message.raw, 'team_id')
 }
 
+// Event-derived teams are trusted only when they name the bot's own workspace:
+// Slack does not document the Connect payloads' `team` as the sender's home
+// workspace, and the DM principal foreign id is keyed on this value. A foreign
+// team must come from the users.info override in resolveRequesterIdentity.
+// Without a resolved home team there is nothing to verify against, so the
+// event team passes through.
+function homeGatedTeamId(
+  teamId: string | undefined,
+  options: SlackbotV2Options
+): string | undefined {
+  if (!options.slackHomeTeamId) return teamId
+  return teamId === options.slackHomeTeamId ? teamId : undefined
+}
+
 function messageRequesterUserId(message: SlackbotV2ApiMessage | undefined): string | undefined {
   if (!message) return undefined
   const rawUserId = rawSlackUserId(message.raw)
@@ -945,7 +962,7 @@ async function resolveRequesterIdentity(
   const identity: RequesterIdentity = {
     slackDisplayName: stringValue(message.author.fullName),
     slackMention: slackUserId ? `<@${slackUserId}>` : undefined,
-    slackTeamId: messageSlackTeamId(message),
+    slackTeamId: homeGatedTeamId(messageSlackTeamId(message), options),
     slackUserId,
     slackUserName: stringValue(message.author.userName)
   }
@@ -967,6 +984,10 @@ async function resolveRequesterIdentity(
     ?? stringValue(profile.real_name)
     ?? stringValue(profile.name)
     ?? identity.slackDisplayName
+  // users.info `team_id` is the user's home workspace — authoritative over
+  // event-derived teams, which can name the delivery workspace for Slack
+  // Connect senders. The DM principal foreign id is keyed on this value.
+  identity.slackTeamId = stringValue(profile.team_id) ?? identity.slackTeamId
   if (
     options.slackHomeTeamId
     && stringValue(profile.team_id) === options.slackHomeTeamId
@@ -990,7 +1011,7 @@ function requesterIdentityCacheKey(
   message: SlackbotV2ApiMessage,
   slackUserId: string
 ): string | undefined {
-  const teamId = message.teamId || slackTeamId(message.raw) || rawSlackString(message.raw, 'team_id')
+  const teamId = messageSlackTeamId(message)
   return teamId ? `slack:${teamId}:${slackUserId}` : `slack:${slackUserId}`
 }
 
@@ -1025,7 +1046,9 @@ function mergeRequesterIdentity(
     slackDisplayName: cached.slackDisplayName ?? fallback.slackDisplayName,
     slackEmail: cached.slackEmail ?? fallback.slackEmail,
     slackMention: fallback.slackMention ?? cached.slackMention,
-    slackTeamId: fallback.slackTeamId ?? cached.slackTeamId,
+    // Cached identities carry the profile-verified team; the fallback's team
+    // is message-derived and home-gated (see homeGatedTeamId).
+    slackTeamId: cached.slackTeamId ?? fallback.slackTeamId,
     slackUserId: fallback.slackUserId ?? cached.slackUserId,
     slackUserName: cached.slackUserName ?? fallback.slackUserName
   }

--- a/services/slackbotv2/test/session-api.test.ts
+++ b/services/slackbotv2/test/session-api.test.ts
@@ -1158,6 +1158,74 @@ describe('session principal display name', () => {
     expect(createBody(requests).metadata?.slack_conversation_name).toBe('Grace Hopper')
     expect(createBody(requests).metadata?.slack_user_email).toBeUndefined()
     expect(createBody(requests).metadata?.slack_user_id).toBe('U1')
+    expect(createBody(requests).metadata?.slack_team_id).toBe('T2')
+  })
+
+  test('DM metadata falls back to the event team when the profile lookup fails', async () => {
+    const { fetchFn, requests } = fakeApi()
+    const dm = apiMessage('hi')
+    dm.threadId = 'slack:D9:1700000000.000100'
+    dm.raw = { channel: 'D9', team: 'THOST' }
+    dm.teamId = 'THOST'
+    await withSlackStub(
+      () => Response.json({ error: 'user_not_found', ok: false }),
+      async () => {
+        await forwardToSessionApi(
+          { ...slackOptions(fetchFn), slackHomeTeamId: 'THOST' },
+          forwardInput(dm)
+        )
+      }
+    )
+    expect(createBody(requests).metadata?.slack_team_id).toBe('THOST')
+  })
+
+  test('DM metadata drops an unverified foreign event team when the profile lookup fails', async () => {
+    const { fetchFn, requests } = fakeApi()
+    const dm = apiMessage('hi')
+    dm.threadId = 'slack:D9:1700000000.000100'
+    dm.raw = { channel: 'D9', team: 'TEXTERNAL' }
+    dm.teamId = 'TEXTERNAL'
+    await withSlackStub(
+      () => Response.json({ error: 'user_not_found', ok: false }),
+      async () => {
+        await forwardToSessionApi(
+          { ...slackOptions(fetchFn), slackHomeTeamId: 'THOST' },
+          forwardInput(dm)
+        )
+      }
+    )
+    expect(createBody(requests).metadata?.slack_team_id).toBeUndefined()
+    expect(createBody(requests).metadata?.slack_user_id).toBe('U1')
+  })
+
+  test('DM metadata prefers the users.info home team over the event team', async () => {
+    const { fetchFn, requests } = fakeApi()
+    const dm = apiMessage('hi')
+    dm.threadId = 'slack:D9:1700000000.000100'
+    dm.raw = { channel: 'D9', team: 'THOST' }
+    dm.teamId = 'THOST'
+    await withSlackStub(
+      url => {
+        if (url.includes('users.info')) {
+          return Response.json({
+            ok: true,
+            user: {
+              is_stranger: true,
+              profile: { display_name: 'Grace Hopper' },
+              team_id: 'TEXTERNAL'
+            }
+          })
+        }
+        return Response.json({ ok: true, profile: { display_name: 'Grace Hopper' } })
+      },
+      async () => {
+        await forwardToSessionApi(
+          { ...slackOptions(fetchFn), slackHomeTeamId: 'THOST' },
+          forwardInput(dm)
+        )
+      }
+    )
+    expect(createBody(requests).metadata?.slack_team_id).toBe('TEXTERNAL')
   })
 
   test('falls back to no name when the channel lookup fails', async () => {


### PR DESCRIPTION
Require Slack team and acting user IDs when deriving DM principals, eliminating legacy teamless and conversation-keyed outputs. Keep Console foreign IDs opaque and preserve verbatim operator-supplied IDs.

On the slackbot side, resolve the DM metadata's `slack_team_id` from the requester identity: the users.info `team_id` (the sender's home workspace) is authoritative, and event-derived teams are trusted only when they name the bot's own workspace. A Slack Connect DM whose profile lookup fails omits the team and fails registration closed rather than keying the principal on an unverified team.

Validated with the affected Rust test suites, clippy with warnings denied, and the slackbotv2 test suite.