### PR TITLE
feat: add console SQL exporter

### DIFF
--- a/contrib/chart/Chart.yaml
+++ b/contrib/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: centaur
 description: Helm chart for the trusted Centaur control plane
 type: application
-version: 0.1.115
+version: 0.1.116
 appVersion: "0.1.0"
 dependencies:
   - name: connect

--- a/contrib/chart/templates/console-sql-exporter-configmap.yaml
+++ b/contrib/chart/templates/console-sql-exporter-configmap.yaml
@@ -1,0 +1,100 @@
+{{- $console := include "centaur.consoleValues" . | fromYaml }}
+{{- if $console.sqlExporter.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "centaur.componentName" (dict "root" . "component" "console-sql-exporter") }}
+  labels:
+{{ include "centaur.componentLabels" (dict "root" . "component" "console-sql-exporter") | nindent 4 }}
+data:
+  sql_exporter.yml: |-
+    global:
+      scrape_timeout: {{ $console.sqlExporter.scrapeTimeout }}
+      scrape_timeout_offset: 500ms
+      min_interval: {{ $console.sqlExporter.minInterval }}
+      max_connections: 2
+      max_idle_connections: 2
+      max_connection_lifetime: 10m
+    target:
+      name: console_solid_queue
+      # SQLEXPORTER_TARGET_DSN overrides this placeholder at startup. Keeping
+      # the real credential out of the ConfigMap also keeps it out of rendered
+      # Helm output.
+      data_source_name: postgresql://invalid/invalid
+      collectors: [console_solid_queue]
+    collectors:
+      - collector_name: console_solid_queue
+        metrics:
+          - metric_name: centaur_console_queue_executions
+            type: gauge
+            help: Current Solid Queue execution count by queue and state.
+            key_labels: [queue, state]
+            values: [value]
+            query: |
+              WITH executions AS (
+                SELECT queue_name AS queue, 'ready'::text AS state
+                FROM solid_queue_ready_executions
+                UNION ALL
+                SELECT jobs.queue_name AS queue, 'claimed'::text AS state
+                FROM solid_queue_claimed_executions AS executions
+                JOIN solid_queue_jobs AS jobs ON jobs.id = executions.job_id
+                UNION ALL
+                SELECT queue_name AS queue, 'scheduled'::text AS state
+                FROM solid_queue_scheduled_executions
+                UNION ALL
+                SELECT queue_name AS queue, 'blocked'::text AS state
+                FROM solid_queue_blocked_executions
+                UNION ALL
+                SELECT jobs.queue_name AS queue, 'failed'::text AS state
+                FROM solid_queue_failed_executions AS executions
+                JOIN solid_queue_jobs AS jobs ON jobs.id = executions.job_id
+              )
+              SELECT queue, state, COUNT(*)::double precision AS value
+              FROM executions
+              GROUP BY queue, state
+          - metric_name: centaur_console_queue_oldest_ready_age_seconds
+            type: gauge
+            help: Age in seconds of the oldest execution ready to run in each queue.
+            key_labels: [queue]
+            values: [value]
+            query: |
+              SELECT
+                queue_name AS queue,
+                GREATEST(
+                  EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - MIN(created_at))),
+                  0
+                )::double precision AS value
+              FROM solid_queue_ready_executions
+              GROUP BY queue_name
+          - metric_name: centaur_console_queue_processes
+            type: gauge
+            help: Registered Solid Queue process count by process kind.
+            key_labels: [kind]
+            values: [value]
+            query: |
+              SELECT kind, COUNT(*)::double precision AS value
+              FROM solid_queue_processes
+              GROUP BY kind
+          - metric_name: centaur_console_queue_max_heartbeat_age_seconds
+            type: gauge
+            help: Maximum Solid Queue process heartbeat age in seconds by process kind.
+            key_labels: [kind]
+            values: [value]
+            query: |
+              SELECT
+                kind,
+                GREATEST(
+                  EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - MIN(last_heartbeat_at))),
+                  0
+                )::double precision AS value
+              FROM solid_queue_processes
+              GROUP BY kind
+          - metric_name: centaur_console_queue_paused
+            type: gauge
+            help: Whether a Solid Queue queue is paused. Present with value 1 only for paused queues.
+            key_labels: [queue]
+            static_value: 1
+            query: |
+              SELECT queue_name AS queue
+              FROM solid_queue_pauses
+{{- end }}

--- a/contrib/chart/templates/console-sql-exporter.yaml
+++ b/contrib/chart/templates/console-sql-exporter.yaml
@@ -1,0 +1,159 @@
+{{- $console := include "centaur.consoleValues" . | fromYaml }}
+{{- if $console.sqlExporter.enabled }}
+{{- $sqlExporter := $console.sqlExporter }}
+{{- $name := include "centaur.componentName" (dict "root" . "component" "console-sql-exporter") }}
+{{- $secretEnv := include "centaur.secretEnvName" . }}
+{{- $prefix := .Values.secretManager.envPrefix }}
+{{- $metricsAnnotations := dict }}
+{{- if $sqlExporter.metrics.scrapeAnnotations }}
+{{- $metricsAnnotations = dict "prometheus.io/scrape" "true" "prometheus.io/path" $sqlExporter.metrics.path "prometheus.io/port" (printf "%v" $sqlExporter.port) }}
+{{- $metricsAnnotations = mergeOverwrite $metricsAnnotations ($sqlExporter.metrics.annotations | default dict) }}
+{{- end }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $name }}
+{{- with $metricsAnnotations }}
+  annotations:
+{{ toYaml . | nindent 4 }}
+{{- end }}
+  labels:
+{{ include "centaur.componentLabels" (dict "root" . "component" "console-sql-exporter") | nindent 4 }}
+spec:
+  selector:
+{{ include "centaur.componentSelectorLabels" (dict "root" . "component" "console-sql-exporter") | nindent 4 }}
+  ports:
+    - name: metrics
+      port: {{ $sqlExporter.port }}
+      targetPort: metrics
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $name }}
+  labels:
+{{ include "centaur.componentLabels" (dict "root" . "component" "console-sql-exporter") | nindent 4 }}
+spec:
+  # Queue metrics describe one shared database. Keep one exporter replica so
+  # every series has one authoritative source.
+  replicas: 1
+  selector:
+    matchLabels:
+{{ include "centaur.componentSelectorLabels" (dict "root" . "component" "console-sql-exporter") | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/infra-secrets: {{ include "centaur.infraSecretsChecksum" . }}
+        checksum/config: {{ include (print $.Template.BasePath "/console-sql-exporter-configmap.yaml") . | sha256sum }}
+{{- with $metricsAnnotations }}
+{{ toYaml . | nindent 8 }}
+{{- end }}
+      labels:
+{{ include "centaur.componentSelectorLabels" (dict "root" . "component" "console-sql-exporter") | nindent 8 }}
+        centaur.ai/metrics: console-sql-exporter
+    spec:
+      automountServiceAccountToken: false
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: sql-exporter
+          image: {{ printf "%s:%s" $sqlExporter.image.repository $sqlExporter.image.tag | quote }}
+          imagePullPolicy: {{ $sqlExporter.image.pullPolicy }}
+          # SQL Exporter reads the complete, read-only queue DSN from the
+          # environment. The credential never appears in argv or the rendered
+          # ConfigMap.
+          args:
+            - --config.file=/etc/sql-exporter/sql_exporter.yml
+            - --web.listen-address=:{{ $sqlExporter.port }}
+            - --web.metrics-path={{ $sqlExporter.metrics.path }}
+          env:
+            - name: SQLEXPORTER_TARGET_DSN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secretEnv }}
+                  key: {{ printf "%s%s" $prefix $sqlExporter.databaseUrlSecretKey }}
+          ports:
+            - name: metrics
+              containerPort: {{ $sqlExporter.port }}
+          startupProbe:
+            tcpSocket:
+              port: metrics
+            failureThreshold: 30
+            periodSeconds: 2
+            timeoutSeconds: 1
+          readinessProbe:
+            tcpSocket:
+              port: metrics
+            failureThreshold: 3
+            periodSeconds: 10
+            timeoutSeconds: 1
+          livenessProbe:
+            tcpSocket:
+              port: metrics
+            failureThreshold: 3
+            periodSeconds: 10
+            timeoutSeconds: 1
+          securityContext:
+{{ toYaml .Values.containerSecurityContext | nindent 12 }}
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 65534
+            runAsGroup: 65534
+          resources:
+{{ toYaml $sqlExporter.resources | nindent 12 }}
+          volumeMounts:
+            - name: config
+              mountPath: /etc/sql-exporter
+              readOnly: true
+      volumes:
+        - name: config
+          configMap:
+            name: {{ $name }}
+{{- if .Values.networkPolicy.enabled }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ $name }}
+  labels:
+{{ include "centaur.componentLabels" (dict "root" . "component" "console-sql-exporter") | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+{{ include "centaur.componentSelectorLabels" (dict "root" . "component" "console-sql-exporter") | nindent 6 }}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        # Metrics collectors deployed in the Centaur namespace.
+        - podSelector: {}
+{{- range .Values.networkPolicy.metricsIngressSourceNamespaces }}
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ . | quote }}
+{{- end }}
+      ports:
+        - protocol: TCP
+          port: {{ $sqlExporter.port }}
+  egress:
+{{- if .Values.postgres.enabled }}
+    - to:
+        - podSelector:
+            matchLabels:
+{{ include "centaur.componentSelectorLabels" (dict "root" . "component" "postgres") | nindent 14 }}
+      ports:
+        - protocol: TCP
+          port: {{ $sqlExporter.databasePort }}
+{{- else }}
+    # The Console queue database is externally managed. Restrict egress to its
+    # configured Postgres port; the DSN still controls the destination host.
+    - ports:
+        - protocol: TCP
+          port: {{ $sqlExporter.databasePort }}
+{{- end }}
+    # DNS egress is provided by the namespace-wide allow-dns policy.
+{{- end }}
+{{- end }}

--- a/contrib/chart/templates/networkpolicy.yaml
+++ b/contrib/chart/templates/networkpolicy.yaml
@@ -93,6 +93,12 @@ spec:
         - podSelector:
             matchLabels:
 {{ include "centaur.componentSelectorLabels" (dict "root" . "component" "console-worker") | nindent 14 }}
+{{- if $console.sqlExporter.enabled }}
+        # The Console SQL Exporter reads queue state from the bundled Postgres.
+        - podSelector:
+            matchLabels:
+{{ include "centaur.componentSelectorLabels" (dict "root" . "component" "console-sql-exporter") | nindent 14 }}
+{{- end }}
         # iron-proxy pods forward the tool-server sidecar's pool to Postgres
         # (the sidecar reaches the core DB through the per-sandbox proxy, not
         # directly), so the proxy must be allowed to connect.

--- a/contrib/chart/values.schema.json
+++ b/contrib/chart/values.schema.json
@@ -52,6 +52,37 @@
             "resources": { "type": "object" }
           }
         },
+        "sqlExporter": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "image": {
+              "type": "object",
+              "properties": {
+                "repository": { "type": "string" },
+                "tag": { "type": "string" },
+                "pullPolicy": { "type": "string" }
+              }
+            },
+            "port": { "type": "integer", "minimum": 1, "maximum": 65535 },
+            "databaseUrlSecretKey": { "type": "string", "minLength": 1 },
+            "databasePort": { "type": "integer", "minimum": 1, "maximum": 65535 },
+            "minInterval": { "type": "string", "minLength": 1 },
+            "scrapeTimeout": { "type": "string", "minLength": 1 },
+            "metrics": {
+              "type": "object",
+              "properties": {
+                "scrapeAnnotations": { "type": "boolean" },
+                "path": { "type": "string" },
+                "annotations": {
+                  "type": "object",
+                  "additionalProperties": { "type": "string" }
+                }
+              }
+            },
+            "resources": { "type": "object" }
+          }
+        },
         "resources": { "type": "object" }
       }
     }
@@ -420,6 +451,10 @@
           "items": { "type": "string" }
         },
         "apiIngressSourceNamespaces": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "metricsIngressSourceNamespaces": {
           "type": "array",
           "items": { "type": "string" }
         },

--- a/contrib/chart/values.yaml
+++ b/contrib/chart/values.yaml
@@ -189,6 +189,34 @@ console:
   worker:
     replicaCount: 1
     resources: {}
+  # Prometheus SQL Exporter for Console database metrics, initially Solid Queue.
+  # This runs as one internal-only replica because every instance would report
+  # the same global database state. The exporter reads a dedicated, read-only DSN
+  # from secretManager.existingSecretName without writing the credential into
+  # its ConfigMap or command-line arguments.
+  sqlExporter:
+    # Enable after CONSOLE_SQLEXPORTER_DATABASE_URL has been added to the
+    # shared infra Secret and its PostgreSQL role has been granted SELECT on
+    # every table queried by a configured collector.
+    enabled: false
+    image:
+      repository: burningalchemist/sql_exporter
+      tag: 0.24.4
+      pullPolicy: IfNotPresent
+    port: 9399
+    # Key in secretManager.existingSecretName containing the complete database
+    # URL for a dedicated read-only PostgreSQL role.
+    databaseUrlSecretKey: CONSOLE_SQLEXPORTER_DATABASE_URL
+    # Used by NetworkPolicy when postgres.enabled=false and the queue database
+    # is externally managed.
+    databasePort: 5432
+    minInterval: 15s
+    scrapeTimeout: 5s
+    metrics:
+      scrapeAnnotations: true
+      path: /metrics
+      annotations: {}
+    resources: {}
 
 # Values for the upstream 1Password Connect subchart
 # (https://github.com/1Password/connect-helm-charts/tree/main/charts/connect).
@@ -695,6 +723,10 @@ networkPolicy:
   enabled: true
   ingressSourceNamespaces: []
   apiIngressSourceNamespaces: []
+  # Namespaces containing Prometheus-compatible collectors that may scrape
+  # internal metrics-only Services such as the Console queue SQL Exporter.
+  # Same-namespace collectors are always admitted.
+  metricsIngressSourceNamespaces: []
   ingressControllerNamespaces:
     - kube-system
   # Port the kubernetes.default ClusterIP forwards to for the API server. The

--- a/contrib/scripts/bootstrap-k8s-secrets.sh
+++ b/contrib/scripts/bootstrap-k8s-secrets.sh
@@ -78,6 +78,10 @@ Console bootstrap:
   IRON_CONTROL_DATABASE_URL    overrides the derived DSN (default points at the
                                bundled Postgres server with no database path, so
                                Rails resolves db names from its database.yml)
+  CONSOLE_SQLEXPORTER_DATABASE_URL
+                               database DSN for a separately
+                               provisioned read-only PostgreSQL role; copied
+                               into centaur-infra-env when set
   IRON_CONTROL_INITIAL_USER_EMAIL
                                initial admin email (default admin@centaur.local)
   The initial password, API key, the three ActiveRecord encryption keys, and
@@ -250,6 +254,10 @@ if secret_exists centaur-infra-env; then
     fi
     patch_data+=("\"IRON_CONTROL_DATABASE_URL\":\"$(printf '%s' "$ic_db_url" | base64 | tr -d '\n')\"")
   fi
+  if [[ -n "${CONSOLE_SQLEXPORTER_DATABASE_URL:-}" ]] && \
+     ! secret_key_present CONSOLE_SQLEXPORTER_DATABASE_URL; then
+    patch_data+=("\"CONSOLE_SQLEXPORTER_DATABASE_URL\":\"$(printf '%s' "$CONSOLE_SQLEXPORTER_DATABASE_URL" | base64 | tr -d '\n')\"")
+  fi
   if ! secret_key_present IRON_CONTROL_INITIAL_USER_EMAIL; then
     ic_email="${IRON_CONTROL_INITIAL_USER_EMAIL:-admin@centaur.local}"
     patch_data+=("\"IRON_CONTROL_INITIAL_USER_EMAIL\":\"$(printf '%s' "$ic_email" | base64 | tr -d '\n')\"")
@@ -334,6 +342,11 @@ else
     --from-literal=IRON_CONTROL_SECRET_KEY_BASE="$(rand_hex)$(rand_hex)"
     --from-literal=CENTAUR_JWT_SIGNING_SECRET="$(rand_hex)$(rand_hex)"
   )
+  if [[ -n "${CONSOLE_SQLEXPORTER_DATABASE_URL:-}" ]]; then
+    secret_args+=(
+      --from-literal=CONSOLE_SQLEXPORTER_DATABASE_URL="$CONSOLE_SQLEXPORTER_DATABASE_URL"
+    )
+  fi
   if [[ -n "${DISCORD_BOT_TOKEN:-}" ]]; then
     secret_args+=(
       --from-literal=DISCORD_BOT_TOKEN="$DISCORD_BOT_TOKEN"

--- a/docs/pages/reference/configuration.mdx
+++ b/docs/pages/reference/configuration.mdx
@@ -16,6 +16,7 @@ Use these as the main extension points:
 | `api.extraEnv` | API feature flags, worker tuning, retention, observability, and deployment-specific overrides. |
 | `apiRs.extraEnv` | Rust API feature flags, telemetry exporter settings, and deployment-specific overrides. |
 | `apiRs.metrics.*` | Prometheus/VictoriaMetrics scrape metadata for the Rust API `/metrics` endpoint. |
+| `console.sqlExporter.*` | SQL Exporter configuration and scrape metadata for Console database metrics. |
 | `slackbot.extraEnv` | Slackbot HTTP, Slack, feedback, and cross-org behavior. |
 | `sandbox.extraEnv` | Extra variables copied into every sandbox pod through `KUBERNETES_SANDBOX_EXTRA_ENV`. |
 | `overlays.sources` | Ordered repo-cache-backed overlay repos for tools, workflows, and skills; subdirs default to `tools`, `workflows`, and `.agents/skills`. |
@@ -51,6 +52,7 @@ Optional required-by-mode variables:
 | `LOCAL_DEV_API_KEY` | API env. | Static local admin/dev key bootstrapped into Postgres. |
 | `TEAMS_BOT_APP_ID`, `TEAMS_BOT_APP_PASSWORD`, `TEAMS_BOT_APP_TENANT_ID` | Local shell before `just bootstrap-secrets`; production Secret. | Required by Teamsbot when `teamsbot.enabled=true`. |
 | `TEAMSBOT_API_KEY` | `secretManager.existingSecretName`; local bootstrap generates it when Teams credentials are present and it is omitted. | Static API key used by Teamsbot. |
+| `CONSOLE_SQLEXPORTER_DATABASE_URL` | `secretManager.existingSecretName`; local bootstrap copies it from the shell when provided. | Database URL for a separately provisioned read-only PostgreSQL role. Required when `console.sqlExporter.enabled=true`. |
 
 ## Console and Permission Control Plane
 
@@ -70,6 +72,10 @@ for the operator workflow.
 | `console.publicUrl` | Helm value. | Public Console origin used for links and MCP authorization metadata. |
 | `console.passwordLoginEnabled` | Helm value, default `true`. | Enables the break-glass email and password login. Disable after SSO is configured for a public Console. |
 | `console.ssoEmailDomains` | Helm value. | Limits Google or Slack SSO admission by email domain. Empty accepts any IdP-authenticated email. |
+| `console.sqlExporter.enabled` | Helm value, default `false`. | Runs one internal SQL Exporter replica, initially configured with Solid Queue collectors. Enable it after the read-only database role and Secret key exist. |
+| `console.sqlExporter.metrics.*` | Helm values. | Configures the SQL Exporter metrics path and Prometheus-compatible scrape annotations. |
+| `console.sqlExporter.databaseUrlSecretKey` | Helm value, default `CONSOLE_SQLEXPORTER_DATABASE_URL`. | Selects the key in `secretManager.existingSecretName` containing the database URL for a dedicated read-only PostgreSQL role. |
+| `networkPolicy.metricsIngressSourceNamespaces` | Helm value. | Allows Prometheus-compatible collectors in the listed namespaces to scrape internal metrics Services. Collectors in the Centaur namespace are always allowed. |
 | `apiRs.syncInfraSecrets`, `IRON_CONTROL_SYNC_INFRA_SECRETS` | Helm value, default `true`. | Upserts the shared `infra` role and its harness/platform secrets. Set false only when another process owns that shared Console state. |
 | `IRON_CONTROL_URL`, `IRON_CONTROL_API_KEY`, `IRON_CONTROL_NAMESPACE` | Chart-rendered for api-rs; operator shell for `centaur-perms`. | Connects the runtime or CLI to the same Console namespace. |
 


### PR DESCRIPTION
Adds an opt-in SQL Exporter Deployment and Service for Console database metrics, initially covering Solid Queue depth, latency, process health, and pause state. The exporter reads a dedicated read-only database DSN from the existing infra Secret through CONSOLE_SQLEXPORTER_DATABASE_URL and exposes Prometheus-compatible scrape annotations for VictoriaMetrics collection. It also adds scoped NetworkPolicy configuration, local secret bootstrap support, and chart documentation.