### PR TITLE
fix(investigator): convert asyncpg records by column name

### DIFF
--- a/tools/infra/centaur_investigator/client.py
+++ b/tools/infra/centaur_investigator/client.py
@@ -81,7 +81,7 @@ def _serialize(value: Any) -> Any:
 def _record_to_dict(row: Any) -> dict[str, Any]:
     if isinstance(row, dict):
         return {key: _serialize(value) for key, value in row.items()}
-    return {key: _serialize(row[key]) for key in row}
+    return {key: _serialize(row[key]) for key in row.keys()}
 
 
 def _connection_role(connection: dict[str, Any]) -> str | None:

--- a/tools/infra/centaur_investigator/tests/test_client.py
+++ b/tools/infra/centaur_investigator/tests/test_client.py
@@ -12,9 +12,36 @@ import client as centaur_client
 from client import (
     CentaurInvestigatorClient,
     _database_url_with_name,
+    _record_to_dict,
     _postgres_database_name,
     parse_slack_reference,
 )
+
+
+class _FakeRecord:
+    """Match asyncpg.Record: iteration yields values while keys() yields column names."""
+
+    def __init__(self, **values) -> None:
+        self._values = values
+
+    def __iter__(self):
+        return iter(self._values.values())
+
+    def keys(self):
+        return self._values.keys()
+
+    def __getitem__(self, key):
+        return self._values[key]
+
+
+def test_record_to_dict_uses_asyncpg_record_column_names() -> None:
+    created_at = dt.datetime(2026, 8, 11, 12, 0, tzinfo=dt.UTC)
+    row = _FakeRecord(thread_key="slack:C123:123.456", created_at=created_at)
+
+    assert _record_to_dict(row) == {
+        "thread_key": "slack:C123:123.456",
+        "created_at": created_at.isoformat(),
+    }
 
 
 def test_database_url_with_name_appends_database_to_base_dsn() -> None:


### PR DESCRIPTION
## Summary

- iterate `asyncpg.Record.keys()` when converting query rows to dictionaries
- preserve existing serialization behavior for record values
- add a regression fixture matching `asyncpg.Record` iteration semantics

Fixes #1334.

## Testing

```text
uv run --no-project --with pytest --with asyncpg --with httpx --with typer --with rich --with python-dotenv pytest -q
9 passed
```