### PR TITLE
feat: expose Slack home team ID in session metadata

### DIFF
--- a/services/slackbotv2/src/session-api.ts
+++ b/services/slackbotv2/src/session-api.ts
@@ -833,6 +833,7 @@ async function postCreateSession(
       source: 'slackbotv2',
       platform: 'slack',
       thread_id: threadId,
+      ...slackHomeTeamMetadata(options),
       ...sessionRequesterMetadata(message, requesterIdentity),
       ...(conversationName ? { slack_conversation_name: conversationName } : {})
     },
@@ -1310,6 +1311,7 @@ async function executeSession(
     // it. Metadata only; the harness receives `model` via input_lines and only
     // when explicitly overridden.
     metadata: sessionMetadata(
+      options,
       message,
       {
         action: 'execute',
@@ -1329,6 +1331,7 @@ async function executeSession(
       requesterIdentity
     ),
     input_lines: toCodexInputLines(
+      options,
       message,
       threadId,
       model,
@@ -1458,7 +1461,7 @@ async function toSessionMessage(
     client_message_id: message.id,
     role: message.author.isMe ? 'assistant' : 'user',
     parts: sessionMessageParts(message, requesterIdentity),
-    metadata: sessionMetadata(message, {}, requesterIdentity)
+    metadata: sessionMetadata(options, message, {}, requesterIdentity)
   }
 }
 
@@ -1494,6 +1497,7 @@ function sessionAttachmentPart(attachment: SlackbotV2ApiAttachment): JsonObject 
 }
 
 function sessionMetadata(
+  options: SlackbotV2Options,
   message: SlackbotV2ApiMessage,
   extra: JsonObject = {},
   requesterIdentity?: RequesterIdentity
@@ -1508,9 +1512,15 @@ function sessionMetadata(
     user_id: message.author.userId,
     user_name: message.author.userName,
     ...sessionSlackTextMetadata(message),
+    ...slackHomeTeamMetadata(options),
     ...sessionRequesterMetadata(message, requesterIdentity),
     ...extra
   }
+}
+
+function slackHomeTeamMetadata(options: SlackbotV2Options): JsonObject {
+  const slackHomeTeamId = stringValue(options.slackHomeTeamId)
+  return slackHomeTeamId ? { slack_home_team_id: slackHomeTeamId } : {}
 }
 
 function sessionSlackTextMetadata(message: SlackbotV2ApiMessage): JsonObject {
@@ -1529,6 +1539,7 @@ function sessionSlackTextMetadata(message: SlackbotV2ApiMessage): JsonObject {
 }
 
 function toCodexInputLines(
+  options: SlackbotV2Options,
   message: SlackbotV2ApiMessage,
   threadId: string,
   model?: string,
@@ -1543,6 +1554,7 @@ function toCodexInputLines(
   for (const attachment of executableAttachments(message, contextMessages)) {
     if (!attachment.dataBase64) continue
     const inlineLine = toCodexInputLineWithStaged(
+      options,
       message,
       threadId,
       staged,
@@ -1565,6 +1577,7 @@ function toCodexInputLines(
   }
   lines.push(
     toCodexInputLineWithStaged(
+      options,
       message,
       threadId,
       staged,
@@ -1593,6 +1606,7 @@ function executableAttachments(
 }
 
 function toCodexInputLineWithStaged(
+  options: SlackbotV2Options,
   message: SlackbotV2ApiMessage,
   threadId: string,
   staged: Map<SlackbotV2ApiAttachment, string>,
@@ -1606,7 +1620,7 @@ function toCodexInputLineWithStaged(
   return JSON.stringify({
     type: 'user',
     thread_key: threadId,
-    trace_metadata: sessionMetadata(message, { action: 'execute' }, requesterIdentity),
+    trace_metadata: sessionMetadata(options, message, { action: 'execute' }, requesterIdentity),
     ...(model ? { model } : {}),
     ...(provider ? { provider } : {}),
     ...(reasoning ? { reasoning } : {}),

--- a/services/slackbotv2/test/session-api.test.ts
+++ b/services/slackbotv2/test/session-api.test.ts
@@ -191,6 +191,46 @@ describe('Slack home team resolution', () => {
   })
 })
 
+describe('Slack home team API metadata', () => {
+  test('exposes the home team ID throughout durable session requests', async () => {
+    const { fetchFn, requests } = fakeApi()
+
+    await forwardToSessionApi(
+      { ...options(fetchFn), slackHomeTeamId: 'T_HOME' },
+      forwardInput(apiMessage('hello'))
+    )
+
+    const create = requests.find(request => request.url.endsWith('.000100'))?.body as {
+      metadata?: JsonObject
+    }
+    const append = requests.find(request => request.url.endsWith('/messages'))?.body as {
+      messages?: Array<{ metadata?: JsonObject }>
+    }
+    const execute = executeBody(requests) as { metadata?: JsonObject }
+
+    expect(create.metadata?.slack_home_team_id).toBe('T_HOME')
+    expect(append.messages?.[0]?.metadata?.slack_home_team_id).toBe('T_HOME')
+    expect(execute.metadata?.slack_home_team_id).toBe('T_HOME')
+    expect(executeLine(requests).trace_metadata).toEqual(
+      expect.objectContaining({ slack_home_team_id: 'T_HOME' })
+    )
+  })
+
+  test('omits the home team ID when it is unavailable', async () => {
+    const { fetchFn, requests } = fakeApi()
+
+    await forwardToSessionApi(options(fetchFn), forwardInput(apiMessage('hello')))
+
+    const create = requests.find(request => request.url.endsWith('.000100'))?.body as {
+      metadata?: JsonObject
+    }
+    const execute = executeBody(requests) as { metadata?: JsonObject }
+
+    expect(create.metadata?.slack_home_team_id).toBeUndefined()
+    expect(execute.metadata?.slack_home_team_id).toBeUndefined()
+  })
+})
+
 describe('session event streaming', () => {
   test('passes activity summary events through to the renderer source stream', async () => {
     const encoded = new TextEncoder().encode(


### PR DESCRIPTION
Adds the Slack bot's resolved home workspace team ID as `slack_home_team_id` throughout durable session request metadata. Covers session creation, appended messages, execution metadata, and harness trace metadata with focused tests.