### PR TITLE
fix(granola): use replace-mode auth so the API key actually gets injected (#1243)

### DIFF
--- a/services/api-rs/crates/centaur-perms/src/tests.rs
+++ b/services/api-rs/crates/centaur-perms/src/tests.rs
@@ -473,6 +473,46 @@ fn translates_http_replace_to_static_input() {
 }
 
 #[test]
+fn granola_api_key_translates_to_authorization_replace_rule() {
+    // Regression for issue #1243: the granola REST client sets
+    // `Authorization: Bearer <placeholder>` itself, so GRANOLA_API_KEY must be a
+    // replace-mode secret whose placeholder iron-proxy swaps inside the header the
+    // client already sends — not inject-mode, which would add a second header and
+    // leave the placeholder in place (upstream 401). This asserts the exact
+    // declaration shipped in tools/productivity/granola/pyproject.toml.
+    let secrets = vec![
+        tools::parse_secret(
+            &entry(
+                r#"{type = "http", name = "GRANOLA_API_KEY", match_headers = ["Authorization"], hosts = ["public-api.granola.ai"]}"#,
+            ),
+            &[],
+        )
+        .unwrap(),
+    ];
+
+    // Parses as replace mode with the placeholder defaulting to the secret name —
+    // the same string the tool client emits as the Bearer token.
+    let ParsedSecret::Http(http) = &secrets[0] else {
+        panic!("expected http")
+    };
+    assert_eq!(http.mode, SecretMode::Replace);
+    assert_eq!(http.replacer, "GRANOLA_API_KEY");
+    assert_eq!(http.match_headers, vec!["Authorization".to_owned()]);
+
+    // Translates to a proxy rule that scans the Authorization header for that
+    // placeholder and swaps it — no inject config.
+    let out = translate::translate("tool-granola", &secrets, &SourcePolicy::env());
+    let SecretInput::Static(input) = &out.inputs[0] else {
+        panic!("expected static")
+    };
+    let replace = input.replace_config.as_ref().unwrap();
+    assert_eq!(replace.proxy_value, "GRANOLA_API_KEY");
+    assert_eq!(replace.match_headers, vec!["Authorization".to_owned()]);
+    assert!(input.inject_config.is_none());
+    assert_eq!(input.rules[0].host.as_deref(), Some("public-api.granola.ai"));
+}
+
+#[test]
 fn translates_gcp_auth_defaults_scopes_when_unset() {
     let secrets = vec![
         tools::parse_secret(

--- a/tools/productivity/granola/pyproject.toml
+++ b/tools/productivity/granola/pyproject.toml
@@ -28,6 +28,11 @@ module = "client.py"
 # MCP backend: the Bearer token for mcp.granola.ai is injected by the proxy
 # from the console OAuth consent flow grant, not declared here.
 hosts = ["mcp.granola.ai"]
+# REST backend: the client sets `Authorization: Bearer <placeholder>` itself, so
+# GRANOLA_API_KEY is a replace-mode secret matched on the Authorization header.
+# Inject mode would only *add* a header the client never sends; here iron-proxy
+# must swap the placeholder in the header the client already emits, or the
+# upstream sees the placeholder and 401s.
 secrets = [
-    {type = "http", name = "GRANOLA_API_KEY", mode = "inject", inject_header = "Authorization", inject_formatter = "Bearer {{ .Value }}", hosts = ["public-api.granola.ai"]},
+    {type = "http", name = "GRANOLA_API_KEY", match_headers = ["Authorization"], hosts = ["public-api.granola.ai"]},
 ]

--- a/tools/productivity/granola/test_client.py
+++ b/tools/productivity/granola/test_client.py
@@ -1,4 +1,14 @@
-from client import _parse_meeting_date, _parse_meetings, _parse_participants
+import tomllib
+from pathlib import Path
+
+from client import (
+    GranolaClient,
+    _parse_meeting_date,
+    _parse_meetings,
+    _parse_participants,
+)
+
+from centaur_sdk.backends import StubBackend, configure
 
 
 def test_parse_meetings_accepts_extra_attributes_and_decodes_entities():
@@ -40,3 +50,39 @@ def test_parse_meeting_date_uses_gmt_suffix():
     assert _parse_meeting_date("Jul 8, 2026 5:30 PM GMT+2") == "2026-07-08T17:30:00+02:00"
     assert _parse_meeting_date("Jul 8, 2026 5:30 PM GMT") == "2026-07-08T17:30:00+00:00"
     assert _parse_meeting_date("Jul 8, 2026 5:30 PM CST") == "Jul 8, 2026 5:30 PM CST"
+
+
+def test_granola_api_key_is_replace_mode_on_authorization():
+    """GRANOLA_API_KEY must be replace-mode matched on Authorization (issue #1243).
+
+    The REST client sets `Authorization: Bearer <placeholder>` itself, so the
+    proxy has to swap that placeholder in the header the client already sends.
+    Inject mode only *adds* a header the client never sends; against a header the
+    client already sets it leaves the placeholder in place and the upstream 401s.
+    """
+    manifest = tomllib.loads(Path(__file__).with_name("pyproject.toml").read_text())
+    secrets = manifest["tool"]["centaur"]["secrets"]
+    granola = next(s for s in secrets if s["name"] == "GRANOLA_API_KEY")
+
+    assert granola == {
+        "type": "http",
+        "name": "GRANOLA_API_KEY",
+        "match_headers": ["Authorization"],
+        "hosts": ["public-api.granola.ai"],
+    }
+    assert granola.get("mode") != "inject"
+
+
+def test_rest_client_emits_placeholder_in_matched_authorization_header():
+    """The client must place the secret placeholder in the header the proxy matches.
+
+    With the stub backend, `secret("GRANOLA_API_KEY")` resolves to the placeholder
+    string `GRANOLA_API_KEY`; the client must send it as the Bearer token so that
+    replace-mode injection has a placeholder to swap.
+    """
+    configure(StubBackend())
+    client = GranolaClient()
+    try:
+        assert client._client.headers["Authorization"] == "Bearer GRANOLA_API_KEY"
+    finally:
+        client.close()


### PR DESCRIPTION
## What

The granola REST tool always 401s against `public-api.granola.ai`, even with a valid workspace key. Fixes #1243.

## Why

The client sets its own `Authorization: Bearer <key>` header, where `<key>` comes from `secret("GRANOLA_API_KEY")`. But the secret was declared as `mode = "inject"` on that same header.

Inject mode is for adding a header the client does not send. When the client already sends the header, iron-proxy has nothing to swap, so the placeholder value goes upstream and Granola rejects it.

This is the only secret in the tree using inject on a header its own client also sets. The working ones (`SLACK_BOT_TOKEN`, `AFFINITY_API_KEY`) use replace mode on `Authorization`.

## The fix

Switch `GRANOLA_API_KEY` to replace mode:

```toml
# before
{type = "http", name = "GRANOLA_API_KEY", mode = "inject", inject_header = "Authorization", inject_formatter = "Bearer {{ .Value }}", hosts = ["public-api.granola.ai"]}

# after
{type = "http", name = "GRANOLA_API_KEY", match_headers = ["Authorization"], hosts = ["public-api.granola.ai"]}
```

With `mode` omitted the parser defaults to replace, and `replacer` defaults to the secret name. So iron-proxy scans the `Authorization` header for `GRANOLA_API_KEY` and swaps in the real value, which is exactly the placeholder the client puts there. This is now the same rule shape as the Slack tokens that work in production today.

## Tests

- `centaur-perms`: new `granola_api_key_translates_to_authorization_replace_rule` runs the real parser and translator on the shipped declaration and asserts it produces a replace rule on `Authorization` with no inject config. Full crate green (53 passed).
- granola tool: added a declaration regression test (fails on the old inject config) and a client test asserting it emits the placeholder in the matched header. Suite green (5 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)