### PR TITLE
fix: defer rate-limited Slack sync jobs

### DIFF
--- a/services/console/app/jobs/slack_dm/sync_credential_job.rb
+++ b/services/console/app/jobs/slack_dm/sync_credential_job.rb
@@ -1,6 +1,6 @@
 module SlackDm
   class SyncCredentialJob < ApplicationJob
-    MAX_RATE_LIMIT_EXECUTIONS = 5
+    MAX_RATE_LIMIT_EXECUTIONS = 2
 
     queue_as :default
 

--- a/services/console/app/jobs/slack_dm/sync_credential_job.rb
+++ b/services/console/app/jobs/slack_dm/sync_credential_job.rb
@@ -1,5 +1,7 @@
 module SlackDm
   class SyncCredentialJob < ApplicationJob
+    MAX_RATE_LIMIT_EXECUTIONS = 5
+
     queue_as :default
 
     limits_concurrency to: 1, key: ->(credential_id) { "slack_dm_sync_#{credential_id}" }
@@ -13,6 +15,16 @@ module SlackDm
       return unless SlackDm::SyncCredential.required_scopes_granted?(credential.scopes)
 
       SlackDm::SyncCredential.new(credential).call
+    rescue SlackDm::SyncCredential::RateLimitedError => e
+      if executions >= MAX_RATE_LIMIT_EXECUTIONS
+        Rails.logger.warn do
+          "Slack sync job dropped after repeated rate limits: " \
+            "credential_id=#{credential_id} executions=#{executions}"
+        end
+        return
+      end
+
+      retry_job wait: e.retry_after.seconds, error: e
     end
   end
 end

--- a/services/console/app/services/slack_dm/sync_credential.rb
+++ b/services/console/app/services/slack_dm/sync_credential.rb
@@ -14,6 +14,14 @@ module SlackDm
     CONVERSATIONS_REPLIES_ENDPOINT = "https://slack.com/api/conversations.replies"
 
     SlackApiError = Class.new(StandardError)
+    class RateLimitedError < SlackApiError
+      attr_reader :retry_after
+
+      def initialize(retry_after:)
+        @retry_after = retry_after
+        super("Slack API rate limited; retry after #{retry_after} seconds")
+      end
+    end
 
     class << self
       attr_accessor :slack_api_http
@@ -36,10 +44,11 @@ module SlackDm
       end
     end
 
-    def initialize(credential, api_client: CentaurApiClient.new, slack_api_http: nil)
+    def initialize(credential, api_client: CentaurApiClient.new, slack_api_http: nil, http_client: nil)
       @credential = credential
       @api_client = api_client
       @slack_api_http = slack_api_http || self.class.slack_api_http
+      @http_client = http_client
       @run_id = "sdms_#{SecureRandom.hex(16)}"
       @messages_fetched = 0
       @replies_fetched = 0
@@ -61,6 +70,7 @@ module SlackDm
         sync_history(conversation, home_team_id, checkpoints[conversation.fetch("id")], batch)
         batch[:run][:conversations_synced] += 1
       rescue StandardError => e
+        raise if e.is_a?(RateLimitedError)
         raise if Rails.env.test?
 
         batch[:run][:conversations_failed] += 1
@@ -322,12 +332,17 @@ module SlackDm
         )
       end
 
-      response = HttpClient.new(open_timeout: slack_timeout, read_timeout: slack_timeout).get(
+      http_client = @http_client || HttpClient.new(open_timeout: slack_timeout, read_timeout: slack_timeout)
+      response = http_client.get(
         endpoint,
         params: params,
         headers: { "Authorization" => "Bearer #{@credential.access_token}" }
       )
-      raise SlackApiError, "Slack API rate limited" if response.status == 429
+      if response.status == 429
+        retry_after = Float(response["retry-after"], exception: false)
+        retry_after = 1 unless retry_after&.positive?
+        raise RateLimitedError.new(retry_after: [ retry_after, rate_limit_max_wait ].min)
+      end
 
       parsed = response.json
       raise SlackApiError, "Slack API returned HTTP #{response.status}" unless response.success?
@@ -364,6 +379,7 @@ module SlackDm
     end
 
     def slack_timeout = positive_env("SLACK_DM_SYNC_TIMEOUT_SECONDS", 20)
+    def rate_limit_max_wait = positive_env("SLACK_DM_SYNC_RATE_LIMIT_MAX_WAIT_SECONDS", 5.minutes.to_i)
     def list_page_size = positive_env("SLACK_DM_SYNC_LIST_PAGE_SIZE", 200)
     def list_max_pages = positive_env("SLACK_DM_SYNC_LIST_MAX_PAGES", 10)
     def members_page_size = positive_env("SLACK_DM_SYNC_MEMBERS_PAGE_SIZE", 200)

--- a/services/console/test/jobs/slack_dm/jobs_test.rb
+++ b/services/console/test/jobs/slack_dm/jobs_test.rb
@@ -56,5 +56,42 @@ module SlackDm
     test "SyncCredentialJob is a no-op for missing credentials" do
       assert_nothing_raised { SlackDm::SyncCredentialJob.perform_now(-1) }
     end
+
+    test "SyncCredentialJob defers rate-limited work using Retry-After" do
+      credential = slack_credential(app: slack_app)
+      sync = rate_limited_sync(retry_after: 120)
+      now = Time.zone.parse("2026-08-12 12:00:00")
+
+      SlackDm::SyncCredential.stub(:new, ->(*) { sync }) do
+        travel_to(now) { SlackDm::SyncCredentialJob.perform_now(credential.id) }
+      end
+
+      retry_job = enqueued_jobs.sole
+      assert_equal SlackDm::SyncCredentialJob, retry_job[:job]
+      assert_equal [ credential.id ], retry_job[:args]
+      assert_in_delta now.to_f + 120, retry_job[:at], 0.001
+    end
+
+    test "SyncCredentialJob stops retrying rate limits at the execution cap" do
+      credential = slack_credential(app: slack_app)
+      job = SlackDm::SyncCredentialJob.new(credential.id)
+      job.executions = SlackDm::SyncCredentialJob::MAX_RATE_LIMIT_EXECUTIONS - 1
+
+      SlackDm::SyncCredential.stub(:new, ->(*) { rate_limited_sync(retry_after: 120) }) do
+        assert_no_enqueued_jobs { job.perform_now }
+      end
+
+      assert_equal SlackDm::SyncCredentialJob::MAX_RATE_LIMIT_EXECUTIONS, job.executions
+    end
+
+    private
+
+    def rate_limited_sync(retry_after:)
+      Object.new.tap do |sync|
+        sync.define_singleton_method(:call) do
+          raise SlackDm::SyncCredential::RateLimitedError.new(retry_after: retry_after)
+        end
+      end
+    end
   end
 end

--- a/services/console/test/jobs/slack_dm/jobs_test.rb
+++ b/services/console/test/jobs/slack_dm/jobs_test.rb
@@ -72,7 +72,7 @@ module SlackDm
       assert_in_delta now.to_f + 120, retry_job[:at], 0.001
     end
 
-    test "SyncCredentialJob stops retrying rate limits at the execution cap" do
+    test "SyncCredentialJob allows only one delayed rate-limit retry" do
       credential = slack_credential(app: slack_app)
       job = SlackDm::SyncCredentialJob.new(credential.id)
       job.executions = SlackDm::SyncCredentialJob::MAX_RATE_LIMIT_EXECUTIONS - 1

--- a/services/console/test/services/slack_dm/sync_credential_test.rb
+++ b/services/console/test/services/slack_dm/sync_credential_test.rb
@@ -24,6 +24,16 @@ module SlackDm
       end
     end
 
+    class FakeHttpClient
+      def initialize(response)
+        @response = response
+      end
+
+      def get(*)
+        @response
+      end
+    end
+
     def slack_app
       OauthApp.create!(
         provider: "slack",
@@ -279,6 +289,29 @@ module SlackDm
       assert_nil api_client.batch
     ensure
       previous.nil? ? ENV.delete(env_key) : ENV[env_key] = previous
+    end
+
+    test "429 responses expose Retry-After for deferred job execution" do
+      [
+        [ "120", 120 ],
+        [ "600", 5.minutes.to_i ],
+        [ "invalid", 1 ]
+      ].each do |header, expected|
+        response = HttpClient::Response.new(
+          status: 429,
+          body: "",
+          headers: { "retry-after" => header }
+        )
+
+        error = assert_raises(SlackDm::SyncCredential::RateLimitedError) do
+          SlackDm::SyncCredential.new(
+            credential,
+            http_client: FakeHttpClient.new(response)
+          ).call
+        end
+
+        assert_equal expected, error.retry_after
+      end
     end
   end
 end


### PR DESCRIPTION
Handles Slack HTTP 429 responses by parsing the Retry-After header, bounded at five minutes, and using an Active Job delayed retry instead of sleeping in a worker. Allows one delayed retry before falling back to the regular ten-minute poll, preventing long retry chains. Adds service and job behavior coverage.