### PR TITLE
fix(sandbox): seed brokered Codex auth for Hermes

### DIFF
--- a/services/sandbox/Dockerfile
+++ b/services/sandbox/Dockerfile
@@ -293,6 +293,7 @@ COPY --link --chmod=755 services/workflow-python/workflow_host.py /usr/local/bin
 COPY --link services/workflow-python/api/ /usr/local/bin/api/
 COPY --link --chmod=755 services/sandbox/git-branch.sh /usr/local/bin/git-branch
 COPY --link --chmod=755 services/sandbox/install_tool_shims.py /usr/local/bin/install-tool-shims
+COPY --link --chmod=755 services/sandbox/seed_hermes_codex_auth.py /usr/local/bin/seed-hermes-codex-auth
 COPY --link --chmod=755 services/sandbox/centaur_tool_host.py /usr/local/bin/centaur-tool-host
 COPY --link --chmod=755 services/sandbox/compose_system_prompt.py /usr/local/bin/compose-system-prompt
 COPY --link --chmod=755 services/sandbox/repo_cache_sync.py /usr/local/bin/repo-cache-sync

--- a/services/sandbox/entrypoint.sh
+++ b/services/sandbox/entrypoint.sh
@@ -128,6 +128,7 @@ mkdir -p "$HOME_DIR/.codex"
 if [ "$CODEX_AUTH_MODE" = "access_token" ] && [ -f /etc/centaur/codex-auth.default.json ]; then
     cp /etc/centaur/codex-auth.default.json "$HOME_DIR/.codex/auth.json"
     chmod 600 "$HOME_DIR/.codex/auth.json"
+    seed-hermes-codex-auth "$HOME_DIR/.codex/auth.json" "$HOME_DIR/.hermes/auth.json"
 elif [ ! -f "$HOME_DIR/.codex/auth.json" ] && [ -f /etc/centaur/codex-auth.default.json ]; then
     cp /etc/centaur/codex-auth.default.json "$HOME_DIR/.codex/auth.json"
     chmod 600 "$HOME_DIR/.codex/auth.json"

--- a/services/sandbox/seed_hermes_codex_auth.py
+++ b/services/sandbox/seed_hermes_codex_auth.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""Seed Hermes with Centaur's broker-only Codex credential placeholder."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+
+def seed(codex_auth_path: Path, hermes_auth_path: Path) -> None:
+    codex = json.loads(codex_auth_path.read_text(encoding="utf-8"))
+    tokens = codex.get("tokens")
+    if not isinstance(tokens, dict) or not all(tokens.get(key) for key in ("access_token", "refresh_token")):
+        raise ValueError("Codex auth must contain access_token and refresh_token placeholders")
+
+    try:
+        auth = json.loads(hermes_auth_path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        auth = {"version": 1, "providers": {}}
+    if not isinstance(auth, dict) or not isinstance(auth.setdefault("providers", {}), dict):
+        raise ValueError("Hermes auth must be a JSON object with a providers object")
+
+    auth["providers"]["openai-codex"] = {
+        "tokens": {
+            "access_token": tokens["access_token"],
+            "refresh_token": tokens["refresh_token"],
+        },
+        "last_refresh": codex.get("last_refresh"),
+        "auth_mode": "chatgpt",
+    }
+
+    hermes_auth_path.parent.mkdir(parents=True, exist_ok=True)
+    fd, temporary = tempfile.mkstemp(dir=hermes_auth_path.parent, prefix="auth.json.")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            json.dump(auth, handle, indent=2)
+            handle.write("\n")
+        os.chmod(temporary, 0o600)
+        os.replace(temporary, hermes_auth_path)
+    finally:
+        if os.path.exists(temporary):
+            os.unlink(temporary)
+
+
+if __name__ == "__main__":
+    seed(Path(sys.argv[1]), Path(sys.argv[2]))

--- a/services/sandbox/test_seed_hermes_codex_auth.py
+++ b/services/sandbox/test_seed_hermes_codex_auth.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import json
+import stat
+import tempfile
+import unittest
+from pathlib import Path
+
+from seed_hermes_codex_auth import seed
+
+
+class SeedHermesCodexAuthTest(unittest.TestCase):
+    def test_seeds_placeholder_and_preserves_other_providers(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            codex = root / "codex.json"
+            hermes = root / ".hermes" / "auth.json"
+            codex.write_text(json.dumps({
+                "tokens": {"access_token": "dummy-access", "refresh_token": "dummy-refresh"},
+                "last_refresh": "2025-01-01T00:00:00Z",
+            }))
+            hermes.parent.mkdir()
+            hermes.write_text(json.dumps({"version": 1, "providers": {"other": {"api_key": "placeholder"}}}))
+
+            seed(codex, hermes)
+
+            auth = json.loads(hermes.read_text())
+            self.assertEqual(auth["providers"]["other"]["api_key"], "placeholder")
+            self.assertEqual(auth["providers"]["openai-codex"]["tokens"], {
+                "access_token": "dummy-access",
+                "refresh_token": "dummy-refresh",
+            })
+            self.assertEqual(stat.S_IMODE(hermes.stat().st_mode), 0o600)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- seed Hermes’ `openai-codex` auth store when `CODEX_AUTH_MODE=access_token`
- copy only the existing Centaur dummy OAuth placeholders; real OAuth remains in iron-proxy’s `openai-codex` token broker
- preserve unrelated Hermes provider credentials and write the auth store atomically as mode `0600`

## Problem
The sandbox already installs an OAuth-shaped `~/.codex/auth.json` for brokered ChatGPT subscription auth. Hermes intentionally does not silently import Codex CLI credentials on first boot, so `--hermes` fails before making a request even though the proxy broker path is configured.

Centaur’s fixture is safe to seed explicitly because its access/refresh values are non-secret placeholders. Hermes emits the placeholder Bearer request and iron-proxy replaces it with the managed broker access token.

## Validation
- `uv run --python 3.11 python -m unittest discover -s services/sandbox -p 'test_*.py'` (36 passed)\n- `shellcheck services/sandbox/entrypoint.sh`\n- `uv run --python 3.11 ruff check services/sandbox/seed_hermes_codex_auth.py services/sandbox/test_seed_hermes_codex_auth.py`\n- pinned Hermes runtime resolves `openai-codex` / `codex_responses` from the generated placeholder auth store