### PR TITLE
fix: stabilize Slack DM sync ingestion

### DIFF
--- a/services/api-rs/crates/centaur-api-server/src/routes.rs
+++ b/services/api-rs/crates/centaur-api-server/src/routes.rs
@@ -2048,6 +2048,7 @@ async fn ingest_slack_dm_sync_batch(
     validate_slack_dm_sync_batch(&request)?;
     let pool = db_pool(&state)?;
     let mut tx = pool.begin().await?;
+    acquire_slack_dm_sync_locks(&mut tx, &request).await?;
 
     if let Some(run) = &request.run {
         upsert_slack_dm_sync_run(&mut tx, run).await?;
@@ -3138,6 +3139,60 @@ fn validate_slack_dm_sync_batch(request: &SlackDmSyncBatchRequest) -> Result<(),
     Ok(())
 }
 
+async fn acquire_slack_dm_sync_locks(
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    request: &SlackDmSyncBatchRequest,
+) -> Result<(), ApiError> {
+    // Credential-scoped job limits still allow two credentials to update the
+    // same shared conversation. Transaction-scoped locks serialize only
+    // overlapping conversations and release automatically on commit or
+    // rollback. BTreeSet ordering prevents multi-conversation batches from
+    // deadlocking while acquiring the locks.
+    for (home_team_id, conversation_id) in slack_dm_sync_conversation_keys(request) {
+        let lock_name = format!("centaur:slack-private-sync:{home_team_id}:{conversation_id}");
+        sqlx::query("SELECT pg_advisory_xact_lock(hashtextextended($1, 0))")
+            .bind(lock_name)
+            .execute(&mut **tx)
+            .await?;
+    }
+    Ok(())
+}
+
+fn slack_dm_sync_conversation_keys(request: &SlackDmSyncBatchRequest) -> BTreeSet<(&str, &str)> {
+    let mut conversation_keys = BTreeSet::new();
+    conversation_keys.extend(request.conversations.iter().map(|conversation| {
+        (
+            conversation.home_team_id.as_str(),
+            conversation.conversation_id.as_str(),
+        )
+    }));
+    conversation_keys.extend(request.members.iter().map(|member| {
+        (
+            member.home_team_id.as_str(),
+            member.conversation_id.as_str(),
+        )
+    }));
+    conversation_keys.extend(request.messages.iter().map(|message| {
+        (
+            message.home_team_id.as_str(),
+            message.conversation_id.as_str(),
+        )
+    }));
+    conversation_keys.extend(request.attachments.iter().map(|attachment| {
+        (
+            attachment.home_team_id.as_str(),
+            attachment.conversation_id.as_str(),
+        )
+    }));
+    conversation_keys.extend(request.checkpoints.iter().map(|checkpoint| {
+        (
+            checkpoint.home_team_id.as_str(),
+            checkpoint.conversation_id.as_str(),
+        )
+    }));
+    conversation_keys
+}
+
 #[cfg(test)]
 mod slack_user_sync_tests {
     use super::*;
@@ -3171,6 +3226,25 @@ mod slack_user_sync_tests {
         let error = validate_slack_dm_sync_batch(&request_with_conversation_type("public_channel"))
             .unwrap_err();
         assert!(matches!(error, ApiError::BadRequest(_)));
+    }
+
+    #[test]
+    fn collects_sync_conversation_locks_in_stable_order() {
+        let mut request = request_with_conversation_type("im");
+        request.conversations.push(SlackDmSyncConversationPayload {
+            home_team_id: "T123".to_owned(),
+            conversation_id: "D999".to_owned(),
+            conversation_type: "im".to_owned(),
+            is_archived: false,
+            is_ext_shared: false,
+            raw_payload: json!({}),
+        });
+
+        let conversation_keys = slack_dm_sync_conversation_keys(&request)
+            .into_iter()
+            .collect::<Vec<_>>();
+
+        assert_eq!(conversation_keys, vec![("T123", "D999"), ("T123", "G123")]);
     }
 }
 

--- a/services/console/app/services/centaur_api_client.rb
+++ b/services/console/app/services/centaur_api_client.rb
@@ -8,10 +8,11 @@ class CentaurApiClient
 
   attr_reader :base_url
 
-  def initialize(base_url: nil, api_key: nil, http: nil, timeout: DEFAULT_TIMEOUT_SECONDS)
+  def initialize(base_url: nil, api_key: nil, http: nil, timeout: DEFAULT_TIMEOUT_SECONDS,
+                 read_timeout: timeout)
     @base_url = (base_url.presence || ConsoleEnv["CENTAUR_API_URL"].presence || "http://localhost:8080").delete_suffix("/")
     @api_key = api_key.presence || ConsoleEnv["CENTAUR_API_KEY"].presence
-    @api = HttpClient.new(http: http, open_timeout: timeout, read_timeout: timeout)
+    @api = HttpClient.new(http: http, open_timeout: timeout, read_timeout: read_timeout)
   end
 
   def list_slack_archive_imports(limit: 100)

--- a/services/console/app/services/slack_dm/sync_credential.rb
+++ b/services/console/app/services/slack_dm/sync_credential.rb
@@ -12,6 +12,7 @@ module SlackDm
     CONVERSATIONS_MEMBERS_ENDPOINT = "https://slack.com/api/conversations.members"
     CONVERSATIONS_HISTORY_ENDPOINT = "https://slack.com/api/conversations.history"
     CONVERSATIONS_REPLIES_ENDPOINT = "https://slack.com/api/conversations.replies"
+    API_READ_TIMEOUT_SECONDS = 120
 
     SlackApiError = Class.new(StandardError)
     class RateLimitedError < SlackApiError
@@ -44,9 +45,9 @@ module SlackDm
       end
     end
 
-    def initialize(credential, api_client: CentaurApiClient.new, slack_api_http: nil, http_client: nil)
+    def initialize(credential, api_client: nil, slack_api_http: nil, http_client: nil)
       @credential = credential
-      @api_client = api_client
+      @api_client = api_client || CentaurApiClient.new(read_timeout: API_READ_TIMEOUT_SECONDS)
       @slack_api_http = slack_api_http || self.class.slack_api_http
       @http_client = http_client
       @run_id = "sdms_#{SecureRandom.hex(16)}"

--- a/services/console/test/services/centaur_api_client_test.rb
+++ b/services/console/test/services/centaur_api_client_test.rb
@@ -88,6 +88,22 @@ class CentaurApiClientTest < ActiveSupport::TestCase
     http.verify
   end
 
+  test "supports a longer read timeout for sync batches" do
+    http = Minitest::Mock.new
+    expect_request(http, status: 200, body: { ok: true }.to_json) do |request|
+      assert_equal 120, request[:timeout]
+    end
+    client = CentaurApiClient.new(
+      base_url: "http://api.internal:8080",
+      http: http,
+      read_timeout: 120
+    )
+
+    client.ingest_slack_dm_sync_batch(messages: [])
+
+    http.verify
+  end
+
   test "gets Google Docs sync checkpoint for a broker credential" do
     http = Minitest::Mock.new
     expect_request(http, status: 200, body: { checkpoint: nil }.to_json) do |request|

--- a/services/console/test/services/slack_dm/sync_credential_test.rb
+++ b/services/console/test/services/slack_dm/sync_credential_test.rb
@@ -59,6 +59,22 @@ module SlackDm
       )
     end
 
+    test "uses an extended API read timeout by default" do
+      api_client = Object.new
+      client_created = false
+      factory = lambda do |read_timeout:|
+        assert_equal SlackDm::SyncCredential::API_READ_TIMEOUT_SECONDS, read_timeout
+        client_created = true
+        api_client
+      end
+
+      CentaurApiClient.stub(:new, factory) do
+        SlackDm::SyncCredential.new(Object.new)
+      end
+
+      assert client_created
+    end
+
     test "oauth_app_slug defaults to slack and honors console env prefix" do
       env_key = "CENTAUR_CONSOLE_SLACK_DM_SYNC_OAUTH_APP_SLUG"
       legacy_env_key = "IRON_CONTROL_SLACK_DM_SYNC_OAUTH_APP_SLUG"


### PR DESCRIPTION
Serialize overlapping Slack DM sync batches with transaction-scoped advisory locks keyed by conversation, preventing concurrent credentials from deadlocking on shared conversations. Extend the console client's read timeout for DM batch ingestion so large transactions can finish without timing out.