### PR TITLE
feat: link Slack DM principals to console users

### DIFF
--- a/services/console/app/controllers/api/v1/principals_controller.rb
+++ b/services/console/app/controllers/api/v1/principals_controller.rb
@@ -27,6 +27,7 @@ module Api
         principal = Principal.new(foreign_id: data_params[:foreign_id], created_by: current_user)
         ActiveRecord::Base.transaction do
           principal.assign_attributes(principal_params)
+          principal.link_console_user_by_slack_email if data_params.key?(:slack_email)
           principal.apply_default_sandbox_capabilities!(principal_params)
           principal.save!
           replace_slack_channel_permissions!(principal) if data_params.key?(:slack_channel_permissions)
@@ -43,6 +44,7 @@ module Api
         was_new = principal.new_record?
         ActiveRecord::Base.transaction do
           principal.assign_attributes(principal_params)
+          principal.link_console_user_by_slack_email if data_params.key?(:slack_email)
           principal.apply_default_sandbox_capabilities!(principal_params) if was_new
           principal.save!
           replace_slack_channel_permissions!(principal) if data_params.key?(:slack_channel_permissions)

--- a/services/console/app/controllers/api/v1/principals_controller.rb
+++ b/services/console/app/controllers/api/v1/principals_controller.rb
@@ -101,7 +101,6 @@ module Api
           :slack_team_id,
           :slack_email,
           :console_user_id,
-          :console_user_email,
           :sandbox_repo_cache,
           :sandbox_observability_enabled,
           :sandbox_api_server_enabled,

--- a/services/console/app/controllers/mcp/oauth_controller.rb
+++ b/services/console/app/controllers/mcp/oauth_controller.rb
@@ -452,7 +452,6 @@ module Mcp
         principal.name = current_user.name.presence || current_user.email
         principal.kind = "console_user"
         principal.console_user_id = current_user.id
-        principal.console_user_email = current_user.email
         principal.assign_attributes(slack_identity_fields_for(current_user))
         principal.labels = principal.labels.merge(
           "managed-by" => "centaur"

--- a/services/console/app/models/pg_dsn_secret.rb
+++ b/services/console/app/models/pg_dsn_secret.rb
@@ -125,7 +125,7 @@ class PgDsnSecret < ApplicationRecord
     when "slack_team_id" then principal.slack_team_id.to_s
     when "slack_email" then principal.slack_email.to_s
     when "console_user_id" then principal.console_user&.oid.to_s
-    when "console_user_email" then principal.console_user_email.to_s
+    when "console_user_email" then principal.console_user&.email.to_s
     when "slack_history_channel_ids" then JSON.generate(principal.slack_history_channel_ids)
     else "" # Invalid persisted or unsaved settings fail closed.
     end

--- a/services/console/app/models/principal.rb
+++ b/services/console/app/models/principal.rb
@@ -53,8 +53,6 @@ class Principal < ApplicationRecord
                             allow_nil: true, if: :will_save_change_to_slack_team_id?
   validates :slack_email, format: { with: URI::MailTo::EMAIL_REGEXP, message: "is not a valid email address" },
                           allow_nil: true, if: :will_save_change_to_slack_email?
-  validates :console_user_email, format: { with: URI::MailTo::EMAIL_REGEXP, message: "is not a valid email address" },
-                                 allow_nil: true, if: :will_save_change_to_console_user_email?
 
   # Stand-in for an inline secret value in redacted config: operator inspection
   # reports that a control_plane source carries a value without revealing it.
@@ -155,7 +153,6 @@ class Principal < ApplicationRecord
     return unless user
 
     self.console_user = user
-    self.console_user_email = user.email
   end
 
   def labels_with_sandbox_capabilities
@@ -370,7 +367,7 @@ class Principal < ApplicationRecord
   def sync_config_fields_changed?
     %w[
       name labels sandbox_api_server_enabled kind slack_user_id slack_channel_id slack_team_id slack_email
-      console_user_id console_user_email
+      console_user_id
     ].any? do |field|
       previous_changes.key?(field)
     end

--- a/services/console/app/models/principal.rb
+++ b/services/console/app/models/principal.rb
@@ -145,14 +145,12 @@ class Principal < ApplicationRecord
   # bot's home workspace. Treat an explicitly supplied email as a trusted
   # bridge to the corresponding Console account. This is called from the API
   # upsert boundary rather than a model callback so an omitted email never
-  # activates a stale value already stored on the principal.
+  # activates a stale value already stored on the principal. A supplied email
+  # with no matching account clears any previous link.
   def link_console_user_by_slack_email
     return unless kind == "slack_dm" && slack_email.present?
 
-    user = User.find_by(email: slack_email.to_s.strip.downcase)
-    return unless user
-
-    self.console_user = user
+    self.console_user = User.find_by(email: slack_email.to_s.strip.downcase)
   end
 
   def labels_with_sandbox_capabilities

--- a/services/console/app/models/principal.rb
+++ b/services/console/app/models/principal.rb
@@ -143,6 +143,21 @@ class Principal < ApplicationRecord
     end
   end
 
+  # Slackbot only sends a DM partner's email when that user belongs to the
+  # bot's home workspace. Treat an explicitly supplied email as a trusted
+  # bridge to the corresponding Console account. This is called from the API
+  # upsert boundary rather than a model callback so an omitted email never
+  # activates a stale value already stored on the principal.
+  def link_console_user_by_slack_email
+    return unless kind == "slack_dm" && slack_email.present?
+
+    user = User.find_by(email: slack_email.to_s.strip.downcase)
+    return unless user
+
+    self.console_user = user
+    self.console_user_email = user.email
+  end
+
   def labels_with_sandbox_capabilities
     labels.to_h.merge(
       SANDBOX_REPO_CACHE_LABEL => sandbox_repo_cache

--- a/services/console/db/migrate/20260813181200_backfill_slack_dm_principal_console_users.rb
+++ b/services/console/db/migrate/20260813181200_backfill_slack_dm_principal_console_users.rb
@@ -3,7 +3,6 @@ class BackfillSlackDmPrincipalConsoleUsers < ActiveRecord::Migration[8.1]
     execute <<~SQL
       UPDATE principals
       SET console_user_id = users.id,
-          console_user_email = users.email,
           sync_config_cache_version = principals.sync_config_cache_version + 1,
           updated_at = CURRENT_TIMESTAMP
       FROM users

--- a/services/console/db/migrate/20260813181200_backfill_slack_dm_principal_console_users.rb
+++ b/services/console/db/migrate/20260813181200_backfill_slack_dm_principal_console_users.rb
@@ -1,0 +1,18 @@
+class BackfillSlackDmPrincipalConsoleUsers < ActiveRecord::Migration[8.1]
+  def up
+    execute <<~SQL
+      UPDATE principals
+      SET console_user_id = users.id,
+          console_user_email = users.email,
+          sync_config_cache_version = principals.sync_config_cache_version + 1,
+          updated_at = CURRENT_TIMESTAMP
+      FROM users
+      WHERE principals.kind = 'slack_dm'
+        AND principals.console_user_id IS NULL
+        AND NULLIF(BTRIM(principals.slack_email), '') IS NOT NULL
+        AND LOWER(BTRIM(principals.slack_email)) = LOWER(BTRIM(users.email))
+    SQL
+  end
+
+  def down; end
+end

--- a/services/console/db/migrate/20260813182623_remove_console_user_email_from_principals.rb
+++ b/services/console/db/migrate/20260813182623_remove_console_user_email_from_principals.rb
@@ -5,6 +5,12 @@ class RemoveConsoleUserEmailFromPrincipals < ActiveRecord::Migration[8.1]
 
   def down
     add_column :principals, :console_user_email, :string
+    execute <<~SQL
+      UPDATE principals
+      SET console_user_email = users.email
+      FROM users
+      WHERE principals.console_user_id = users.id
+    SQL
     add_index :principals, :console_user_email
   end
 end

--- a/services/console/db/migrate/20260813182623_remove_console_user_email_from_principals.rb
+++ b/services/console/db/migrate/20260813182623_remove_console_user_email_from_principals.rb
@@ -1,0 +1,10 @@
+class RemoveConsoleUserEmailFromPrincipals < ActiveRecord::Migration[8.1]
+  def up
+    remove_column :principals, :console_user_email, :string
+  end
+
+  def down
+    add_column :principals, :console_user_email, :string
+    add_index :principals, :console_user_email
+  end
+end

--- a/services/console/db/schema.rb
+++ b/services/console/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_12_042212) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_13_181200) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_search"

--- a/services/console/db/schema.rb
+++ b/services/console/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_13_181200) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_13_182623) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_search"
@@ -298,7 +298,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_13_181200) do
   end
 
   create_table "principals", force: :cascade do |t|
-    t.string "console_user_email"
     t.bigint "console_user_id"
     t.datetime "created_at", null: false
     t.bigint "created_by_id", null: false
@@ -315,7 +314,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_13_181200) do
     t.string "slack_user_id"
     t.bigint "sync_config_cache_version", default: 0, null: false
     t.datetime "updated_at", null: false
-    t.index ["console_user_email"], name: "index_principals_on_console_user_email"
     t.index ["console_user_id"], name: "index_principals_on_console_user_id"
     t.index ["created_by_id"], name: "index_principals_on_created_by_id"
     t.index ["foreign_id"], name: "index_principals_on_foreign_id", unique: true

--- a/services/console/docs/API.md
+++ b/services/console/docs/API.md
@@ -1174,8 +1174,8 @@ system-managed `infra` role.
 | `slack_channel_id` | optional | First-class Slack conversation identity. |
 | `slack_team_id` | optional | First-class Slack team or enterprise scope. |
 | `slack_email` | optional | First-class Slack email identity. |
-| `console_user_id` | optional | Database ID of the associated console user for a `console_user` principal. |
-| `console_user_email` | optional | Email identity for a `console_user` principal. |
+| `console_user_id` | optional | Database ID of the associated Console user. A `slack_dm` principal is linked automatically when an explicitly supplied `slack_email` matches a Console user's email. |
+| `console_user_email` | optional | Email identity of the associated Console user. |
 | `labels`     | optional    | Extensible metadata. Identity is read from the first-class fields, not from labels with matching names. |
 | `slack_channel_permissions` | optional | Direct permissions owned by the principal. Full replacement when present on create or update. |
 | `effective_slack_channel_permissions` | response only | Direct permissions merged with permissions inherited from assigned roles. |
@@ -1447,7 +1447,7 @@ Console stores and validates `name`, `description`, and Markdown `instructions` 
 
 ### Sandbox Operations
 
-These endpoints use the existing sandbox entitlement JWT injected by `iron-proxy`. Console-user principals can see their own private skills and every public skill. Other principal kinds can see public skills only. Mutations require an active Console user linked to the sandbox principal and can change only that user's skills.
+These endpoints use the existing sandbox entitlement JWT injected by `iron-proxy`. Principals linked to an active Console user can see that user's private skills and every public skill. Other principals can see public skills only. Mutations require an active Console user linked to the sandbox principal and can change only that user's skills.
 
 | Method | Path | Notes |
 | ------ | ---- | ----- |

--- a/services/console/docs/API.md
+++ b/services/console/docs/API.md
@@ -679,7 +679,7 @@ labels instead of storing a literal, by replacing `value` with `value_from`:
 | Key               | Resolves to |
 | ----------------- | ----------- |
 | `principal_label` | The named label on the assigned principal. A label the principal does not carry resolves to an empty string, so RLS-style policies fail closed. |
-| `principal_field` | One of the principal's fields: `id` (the opaque `prn_...` id), `foreign_id`, `name`, `kind`, `slack_user_id`, `slack_channel_id`, `slack_team_id`, `slack_email`, `console_user_id`, `console_user_email`, or `slack_history_channel_ids` (JSON array of Slack channel IDs with history permission). |
+| `principal_field` | One of the principal's fields: `id` (the opaque `prn_...` id), `foreign_id`, `name`, `kind`, `slack_user_id`, `slack_channel_id`, `slack_team_id`, `slack_email`, `console_user_id`, `console_user_email` (the associated Console user's current email), or `slack_history_channel_ids` (JSON array of Slack channel IDs with history permission). |
 | `proxy_label`     | The named label on the proxy. A label the proxy does not carry resolves to an empty string, so RLS-style policies fail closed. |
 
 A setting has either `value` or `value_from`, never both; unknown
@@ -1175,7 +1175,6 @@ system-managed `infra` role.
 | `slack_team_id` | optional | First-class Slack team or enterprise scope. |
 | `slack_email` | optional | First-class Slack email identity. |
 | `console_user_id` | optional | Database ID of the associated Console user. A `slack_dm` principal is linked automatically when an explicitly supplied `slack_email` matches a Console user's email. |
-| `console_user_email` | optional | Email identity of the associated Console user. |
 | `labels`     | optional    | Extensible metadata. Identity is read from the first-class fields, not from labels with matching names. |
 | `slack_channel_permissions` | optional | Direct permissions owned by the principal. Full replacement when present on create or update. |
 | `effective_slack_channel_permissions` | response only | Direct permissions merged with permissions inherited from assigned roles. |

--- a/services/console/test/controllers/api/v1/principals_controller_test.rb
+++ b/services/console/test/controllers/api/v1/principals_controller_test.rb
@@ -419,6 +419,26 @@ module Api
         assert_equal second_user, principal.reload.console_user
       end
 
+      test "PUT unlinks a Slack DM when its trusted email no longer matches a Console user" do
+        user = users(:member_user)
+        principal = Principal.create!(
+          foreign_id: "formerly-linked-slack-dm",
+          kind: "slack_dm",
+          slack_email: user.email,
+          console_user: user,
+          created_by: users(:acme_admin)
+        )
+
+        put api_v1_principal_url(id: principal.oid),
+            params: { data: { slack_email: "unmatched-new-email@example.com" } }.to_json,
+            headers: auth_headers
+
+        assert_response :ok
+        principal.reload
+        assert_equal "unmatched-new-email@example.com", principal.slack_email
+        assert_nil principal.console_user
+      end
+
       test "PUT does not link from a stored Slack email when the request omits it" do
         user = users(:member_user)
         principal = Principal.create!(

--- a/services/console/test/controllers/api/v1/principals_controller_test.rb
+++ b/services/console/test/controllers/api/v1/principals_controller_test.rb
@@ -354,6 +354,27 @@ module Api
         assert_equal user, principal.console_user
       end
 
+      test "POST leaves a Slack DM unlinked when no Console user has the supplied email" do
+        email = "missing-console-user@example.com"
+
+        post api_v1_principals_url,
+             params: {
+               data: {
+                 foreign_id: "unmatched-slack-dm",
+                 kind: "slack_dm",
+                 slack_user_id: "U1123456789",
+                 slack_team_id: "T1123456789",
+                 slack_email: email
+               }
+             }.to_json,
+             headers: auth_headers
+
+        assert_response :created
+        principal = Principal.find_by!(foreign_id: "unmatched-slack-dm")
+        assert_equal email, principal.slack_email
+        assert_nil principal.console_user
+      end
+
       test "PUT links an existing Slack DM when the trusted email is supplied again" do
         user = users(:member_user)
         principal = Principal.create!(
@@ -369,6 +390,33 @@ module Api
 
         assert_response :ok
         assert_equal user, principal.reload.console_user
+      end
+
+      test "PUT relinks a Slack DM when its trusted email changes to another Console user" do
+        first_user = users(:member_user)
+        second_user = users(:globex_admin)
+
+        post api_v1_principals_url,
+             params: {
+               data: {
+                 foreign_id: "relinked-slack-dm",
+                 kind: "slack_dm",
+                 slack_user_id: "U2123456789",
+                 slack_team_id: "T2123456789",
+                 slack_email: first_user.email
+               }
+             }.to_json,
+             headers: auth_headers
+        assert_response :created
+        principal = Principal.find_by!(foreign_id: "relinked-slack-dm")
+        assert_equal first_user, principal.console_user
+
+        put api_v1_principal_url(id: principal.oid),
+            params: { data: { slack_email: second_user.email } }.to_json,
+            headers: auth_headers
+
+        assert_response :ok
+        assert_equal second_user, principal.reload.console_user
       end
 
       test "PUT does not link from a stored Slack email when the request omits it" do

--- a/services/console/test/controllers/api/v1/principals_controller_test.rb
+++ b/services/console/test/controllers/api/v1/principals_controller_test.rb
@@ -41,7 +41,7 @@ module Api
         refute data.key?("namespace")
         assert_equal principal.oid, data["id"]
         assert_equal "C0123456789", data["foreign_id"]
-        %w[kind slack_user_id slack_channel_id slack_team_id slack_email console_user_id console_user_email].each do |field|
+        %w[kind slack_user_id slack_channel_id slack_team_id slack_email console_user_id].each do |field|
           assert_not data.key?(field)
         end
         assert_equal(
@@ -329,7 +329,7 @@ module Api
         assert_equal "T0123456789", principal.slack_team_id
         assert_equal "ada@example.com", principal.slack_email
         assert_equal "centaur", principal.labels["managed-by"]
-        %w[kind slack_user_id slack_channel_id slack_team_id slack_email console_user_id console_user_email].each do |field|
+        %w[kind slack_user_id slack_channel_id slack_team_id slack_email console_user_id].each do |field|
           assert_not json_body.fetch("data").key?(field)
         end
       end
@@ -352,7 +352,6 @@ module Api
         assert_response :created
         principal = Principal.find_by!(foreign_id: "linked-slack-dm")
         assert_equal user, principal.console_user
-        assert_equal user.email, principal.console_user_email
       end
 
       test "PUT links an existing Slack DM when the trusted email is supplied again" do
@@ -370,7 +369,6 @@ module Api
 
         assert_response :ok
         assert_equal user, principal.reload.console_user
-        assert_equal user.email, principal.console_user_email
       end
 
       test "PUT does not link from a stored Slack email when the request omits it" do
@@ -388,7 +386,6 @@ module Api
 
         assert_response :ok
         assert_nil principal.reload.console_user
-        assert_nil principal.console_user_email
       end
 
       test "POST does not link a non-DM principal by Slack email" do
@@ -407,7 +404,6 @@ module Api
         assert_response :created
         principal = Principal.find_by!(foreign_id: "channel-with-user-email")
         assert_nil principal.console_user
-        assert_nil principal.console_user_email
       end
 
       test "POST keeps identity-named labels separate from first-class fields" do
@@ -419,7 +415,6 @@ module Api
                  foreign_id: "matching-console-user-identity",
                  kind: "console_user",
                  console_user_id: user.id,
-                 console_user_email: user.email,
                  labels: {
                    "kind" => "custom",
                    "console-user-id" => "custom-user",
@@ -433,7 +428,6 @@ module Api
         assert_response :created
         principal = Principal.find_by!(foreign_id: "matching-console-user-identity")
         assert_equal user.id, principal.console_user_id
-        assert_equal user.email, principal.console_user_email
         assert_equal "centaur", principal.labels["managed-by"]
         assert_equal "custom", principal.labels["kind"]
         assert_equal "custom-user", principal.labels["console-user-id"]
@@ -1027,7 +1021,6 @@ module Api
           foreign_id: "console-user-admin",
           kind: "console_user",
           console_user_id: user.id,
-          console_user_email: user.email,
           labels: {
             "kind" => "custom",
             "console-user-id" => "custom-user",

--- a/services/console/test/controllers/api/v1/principals_controller_test.rb
+++ b/services/console/test/controllers/api/v1/principals_controller_test.rb
@@ -334,6 +334,82 @@ module Api
         end
       end
 
+      test "POST links a Slack DM principal to the Console user with the same email" do
+        user = users(:member_user)
+
+        post api_v1_principals_url,
+             params: {
+               data: {
+                 foreign_id: "linked-slack-dm",
+                 kind: "slack_dm",
+                 slack_user_id: "U0123456789",
+                 slack_team_id: "T0123456789",
+                 slack_email: user.email.upcase
+               }
+             }.to_json,
+             headers: auth_headers
+
+        assert_response :created
+        principal = Principal.find_by!(foreign_id: "linked-slack-dm")
+        assert_equal user, principal.console_user
+        assert_equal user.email, principal.console_user_email
+      end
+
+      test "PUT links an existing Slack DM when the trusted email is supplied again" do
+        user = users(:member_user)
+        principal = Principal.create!(
+          foreign_id: "existing-unlinked-slack-dm",
+          kind: "slack_dm",
+          slack_email: user.email,
+          created_by: users(:acme_admin)
+        )
+
+        put api_v1_principal_url(id: principal.oid),
+            params: { data: { slack_email: user.email } }.to_json,
+            headers: auth_headers
+
+        assert_response :ok
+        assert_equal user, principal.reload.console_user
+        assert_equal user.email, principal.console_user_email
+      end
+
+      test "PUT does not link from a stored Slack email when the request omits it" do
+        user = users(:member_user)
+        principal = Principal.create!(
+          foreign_id: "untrusted-stored-slack-email",
+          kind: "slack_dm",
+          slack_email: user.email,
+          created_by: users(:acme_admin)
+        )
+
+        put api_v1_principal_url(id: principal.oid),
+            params: { data: { name: "External Slack DM" } }.to_json,
+            headers: auth_headers
+
+        assert_response :ok
+        assert_nil principal.reload.console_user
+        assert_nil principal.console_user_email
+      end
+
+      test "POST does not link a non-DM principal by Slack email" do
+        user = users(:member_user)
+
+        post api_v1_principals_url,
+             params: {
+               data: {
+                 foreign_id: "channel-with-user-email",
+                 kind: "slack_channel",
+                 slack_email: user.email
+               }
+             }.to_json,
+             headers: auth_headers
+
+        assert_response :created
+        principal = Principal.find_by!(foreign_id: "channel-with-user-email")
+        assert_nil principal.console_user
+        assert_nil principal.console_user_email
+      end
+
       test "POST keeps identity-named labels separate from first-class fields" do
         user = users(:acme_admin)
 

--- a/services/console/test/controllers/api/v1/sandbox_skills_controller_test.rb
+++ b/services/console/test/controllers/api/v1/sandbox_skills_controller_test.rb
@@ -7,7 +7,6 @@ class Api::V1::SandboxSkillsControllerTest < ActionDispatch::IntegrationTest
       name: "Member User",
       kind: :console_user,
       console_user: users(:member_user),
-      console_user_email: users(:member_user).email,
       labels: {},
       created_by: users(:member_user)
     )

--- a/services/console/test/controllers/mcp/oauth_controller_test.rb
+++ b/services/console/test/controllers/mcp/oauth_controller_test.rb
@@ -158,7 +158,6 @@ module Mcp
       assert_match(/\Aprn_/, stored_code.principal.oid)
       assert_equal "console_user", stored_code.principal.kind
       assert_equal @operator.id, stored_code.principal.console_user_id
-      assert_equal @operator.email, stored_code.principal.console_user_email
       assert_empty stored_code.principal.labels.slice("console-user-id", "email")
 
       exchange_authorization_code(client, code)

--- a/services/console/test/migrations/backfill_slack_dm_principal_console_users_test.rb
+++ b/services/console/test/migrations/backfill_slack_dm_principal_console_users_test.rb
@@ -1,0 +1,50 @@
+require "test_helper"
+require Rails.root.join("db/migrate/20260813181200_backfill_slack_dm_principal_console_users")
+
+class BackfillSlackDmPrincipalConsoleUsersTest < ActiveSupport::TestCase
+  test "links only unlinked Slack DM principals with matching Console user emails" do
+    member = users(:member_user)
+    admin = users(:acme_admin)
+    matching = create_principal(
+      foreign_id: "backfill-matching-slack-dm",
+      kind: "slack_dm",
+      slack_email: member.email.upcase
+    )
+    matching.update_columns(slack_email: " #{member.email.upcase} ")
+    matching.reload
+    unmatched = create_principal(
+      foreign_id: "backfill-unmatched-slack-dm",
+      kind: "slack_dm",
+      slack_email: "unknown@example.com"
+    )
+    channel = create_principal(
+      foreign_id: "backfill-slack-channel",
+      kind: "slack_channel",
+      slack_email: member.email
+    )
+    already_linked = create_principal(
+      foreign_id: "backfill-already-linked-slack-dm",
+      kind: "slack_dm",
+      slack_email: member.email,
+      console_user: admin,
+      console_user_email: admin.email
+    )
+    previous_cache_version = matching.sync_config_cache_version
+
+    BackfillSlackDmPrincipalConsoleUsers.new.up
+
+    assert_equal member, matching.reload.console_user
+    assert_equal member.email, matching.console_user_email
+    assert_equal previous_cache_version + 1, matching.sync_config_cache_version
+    assert_nil unmatched.reload.console_user
+    assert_nil channel.reload.console_user
+    assert_equal admin, already_linked.reload.console_user
+    assert_equal admin.email, already_linked.console_user_email
+  end
+
+  private
+
+  def create_principal(attributes)
+    Principal.create!({ created_by: users(:acme_admin) }.merge(attributes))
+  end
+end

--- a/services/console/test/migrations/backfill_slack_dm_principal_console_users_test.rb
+++ b/services/console/test/migrations/backfill_slack_dm_principal_console_users_test.rb
@@ -26,20 +26,17 @@ class BackfillSlackDmPrincipalConsoleUsersTest < ActiveSupport::TestCase
       foreign_id: "backfill-already-linked-slack-dm",
       kind: "slack_dm",
       slack_email: member.email,
-      console_user: admin,
-      console_user_email: admin.email
+      console_user: admin
     )
     previous_cache_version = matching.sync_config_cache_version
 
     BackfillSlackDmPrincipalConsoleUsers.new.up
 
     assert_equal member, matching.reload.console_user
-    assert_equal member.email, matching.console_user_email
     assert_equal previous_cache_version + 1, matching.sync_config_cache_version
     assert_nil unmatched.reload.console_user
     assert_nil channel.reload.console_user
     assert_equal admin, already_linked.reload.console_user
-    assert_equal admin.email, already_linked.console_user_email
   end
 
   private

--- a/services/console/test/models/pg_dsn_secret_test.rb
+++ b/services/console/test/models/pg_dsn_secret_test.rb
@@ -164,7 +164,6 @@ class PgDsnSecretTest < ActiveSupport::TestCase
     principal = Principal.create!(
       kind: "console_user",
       console_user_id: user.id,
-      console_user_email: user.email,
       created_by: user
     )
     secret = with_dsn(PgDsnSecret.new(base_attrs(settings: [
@@ -178,6 +177,12 @@ class PgDsnSecretTest < ActiveSupport::TestCase
         { "name" => "app.email", "value" => user.email }
       ],
       secret.to_proxy_dsn(principal: principal)["settings"]
+    )
+
+    user.update!(email: "renamed-admin@acme.example")
+    assert_equal(
+      { "name" => "app.email", "value" => user.email },
+      secret.to_proxy_dsn(principal: principal.reload)["settings"].second
     )
   end
 
@@ -204,29 +209,6 @@ class PgDsnSecretTest < ActiveSupport::TestCase
         { "name" => "app.channel_id", "value" => "C0123456789" },
         { "name" => "app.team_id", "value" => "T0123456789" },
         { "name" => "app.email", "value" => "ada@example.com" }
-      ],
-      secret.to_proxy_dsn(principal: principal)["settings"]
-    )
-  end
-
-  test "to_proxy_dsn resolves first-class console user fields" do
-    user = users(:acme_admin)
-    principal = Principal.create!(
-      kind: "console_user",
-      console_user_id: user.id,
-      console_user_email: user.email,
-      created_by: user
-    )
-    secret = with_dsn(PgDsnSecret.new(base_attrs(settings: [
-      { "name" => "app.user_id", "value_from" => { "principal_field" => "console_user_id" } },
-      { "name" => "app.email", "value_from" => { "principal_field" => "console_user_email" } }
-    ])))
-
-    assert secret.valid?
-    assert_equal(
-      [
-        { "name" => "app.user_id", "value" => user.oid },
-        { "name" => "app.email", "value" => user.email }
       ],
       secret.to_proxy_dsn(principal: principal)["settings"]
     )

--- a/services/console/test/models/principal_test.rb
+++ b/services/console/test/models/principal_test.rb
@@ -67,18 +67,16 @@ class PrincipalTest < ActiveSupport::TestCase
     assert_equal "custom-user", principal.labels["slack_user_id"]
   end
 
-  test "console user identity is stored only in columns" do
+  test "console user identity is stored as an association" do
     user = users(:acme_admin)
     principal = Principal.create!(default_attrs(
       kind: "console_user",
       console_user_id: user.id,
-      console_user_email: user.email,
       labels: { "managed-by" => "centaur" }
     ))
 
     principal.reload
     assert_equal user.id, principal.console_user_id
-    assert_equal user.email, principal.console_user_email
     assert_empty principal.labels.slice("console-user-id", "email")
     assert_nil principal.labels_with_sandbox_capabilities["console-user-id"]
     assert_nil principal.labels_with_sandbox_capabilities["email"]
@@ -124,21 +122,16 @@ class PrincipalTest < ActiveSupport::TestCase
     end
   end
 
-  test "console user principals permit missing user references but require valid email" do
+  test "console user principals permit missing user references" do
     user = users(:acme_admin)
     principal = Principal.new(default_attrs(
       kind: "console_user",
-      console_user_id: user.id,
-      console_user_email: user.email
+      console_user_id: user.id
     ))
     assert principal.valid?
 
     principal.console_user_id = nil
     assert principal.valid?
-
-    principal.console_user_email = "not-an-email"
-    assert_not principal.valid?
-    assert_predicate principal.errors[:console_user_email], :any?
   end
 
   test "unchanged malformed migrated Slack identities do not block unrelated saves" do

--- a/services/console/test/services/principal_credential_reconciliation_test.rb
+++ b/services/console/test/services/principal_credential_reconciliation_test.rb
@@ -389,19 +389,6 @@ class PrincipalCredentialReconciliationTest < ActiveSupport::TestCase
     assert principal.grants.exists?(static_secret: secret)
   end
 
-  test "console user principal ignores a spoofed cached email" do
-    credential = create_credential(oauth_apps(:acme_slack), "slack-sub-carol", "carol@acme.example")
-    secret = wrap(credential)
-
-    principal = create_console_user_principal(
-      users(:member_user),
-      email: "carol@acme.example",
-      foreign_id: "console-user-spoofed-email"
-    )
-
-    refute principal.grants.exists?(static_secret: secret)
-  end
-
   test "console user principal ignores provider subject labels" do
     credential = create_credential(oauth_apps(:acme_google), "google-sub-carol", "carol@acme.example")
     secret = wrap(credential)
@@ -685,15 +672,14 @@ class PrincipalCredentialReconciliationTest < ActiveSupport::TestCase
   private
 
   # Mirrors the principal shape minted by Mcp::OauthController#principal_for_current_user.
-  # The email/extra_labels overrides simulate tampered or stale cached identity,
-  # which matching must ignore for console-user principals.
-  def create_console_user_principal(user, foreign_id:, email: nil, extra_labels: {})
+  # The label override simulates tampered cached identity, which matching must
+  # ignore for console-user principals.
+  def create_console_user_principal(user, foreign_id:, extra_labels: {})
     Principal.create!(
       foreign_id: foreign_id,
       name: user.name.presence || user.email,
       kind: "console_user",
       console_user_id: user.id,
-      console_user_email: email || user.email,
       labels: {
         "managed-by" => "centaur"
       }.merge(extra_labels),


### PR DESCRIPTION
Links Slack DM principals to matching Console users when a trusted Slack email is explicitly supplied, while preserving the omission boundary for external users. Backfills existing unlinked DM principals by normalized email and makes the foreign-keyed Console user association the sole source of truth; the compatible Postgres email setting now derives the user's current email. Includes controller, model, and migration regression coverage and updates the API documentation.