### PR TITLE
feat: support DocSend dealroom downloads

### DIFF
--- a/.agents/skills/docsend/SKILL.md
+++ b/.agents/skills/docsend/SKILL.md
@@ -101,7 +101,10 @@ Both commands return only one directory level. Read each folder's ID from the pr
 For bulk downloads, inspect the returned `items`, traverse any folders, and call
 `fetch` once for each item whose `type` is `file`. Fetch files sequentially so
 the agent can choose output paths and report an individual failure without
-losing the rest of the inventory:
+losing the rest of the inventory. Treat every fetch as independent: if one item
+does not return `status: ok`, record its path, status, and error, then move on to
+the next file. Do not stop the bulk download because one item failed. This is
+common for unsupported file types such as videos.
 
 ```bash
 docsend fetch '<session-id>' \
@@ -128,5 +131,6 @@ docsend close '<session-id>'
 - For `email_required`, ask for an email unless the user already supplied one.
 - For `passcode_required`, ask only for the document passcode.
 - Preserve session fields on verification and failure responses.
+- During a bulk download, continue to the next file after any per-item failure and summarize all skipped or failed items after attempting the full inventory.
 - Report statuses such as `blocked`, `expired`, `item_not_found`, `not_downloadable`, and `download_unavailable` exactly. Only recover pages that the authenticated DocSend viewer renders; do not bypass access controls.
 - Do not expose email addresses, passcodes, verification URLs, API keys, or downloaded file data in the final response.

--- a/.agents/skills/docsend/SKILL.md
+++ b/.agents/skills/docsend/SKILL.md
@@ -79,6 +79,9 @@ Start a `/view/s/` URL with `login`:
 docsend login '<docsend-space-url>' --email '<email>'
 ```
 
+For a larger bulk download, add `--session-timeout 1800` to the initial `login`
+command so the agent has time to traverse folders and fetch each document.
+
 After login or verification returns `deal_room_ready`, keep its `session_id` for every following command.
 
 List the Space root:
@@ -95,7 +98,10 @@ docsend open-folder '<session-id>' --folder-id '<folder-item-id>'
 
 Both commands return only one directory level. Read each folder's ID from the preceding JSON response and call `open-folder` again to traverse deeper.
 
-Download the selected file using its returned item ID:
+For bulk downloads, inspect the returned `items`, traverse any folders, and call
+`fetch` once for each item whose `type` is `file`. Fetch files sequentially so
+the agent can choose output paths and report an individual failure without
+losing the rest of the inventory:
 
 ```bash
 docsend fetch '<session-id>' \
@@ -103,7 +109,12 @@ docsend fetch '<session-id>' \
   --output '<output-path>'
 ```
 
-The downloaded filename may differ from the visible Space title. Fetch files sequentially, and do not pass folder or external URL item IDs to `fetch`.
+When the owner enabled downloads, `fetch` uses DocSend's regular download button
+and returns the original file with `download_method: original`. When the button
+is disabled, `fetch` opens the document viewer in the authenticated Space
+session and uses the standalone rendered-page recovery to return a PDF with
+`download_method: rendered_pdf`. The downloaded filename may differ from the
+visible Space title. Do not pass folder or external URL item IDs to `fetch`.
 
 Close the session when finished:
 
@@ -117,5 +128,5 @@ docsend close '<session-id>'
 - For `email_required`, ask for an email unless the user already supplied one.
 - For `passcode_required`, ask only for the document passcode.
 - Preserve session fields on verification and failure responses.
-- Report statuses such as `blocked`, `expired`, `item_not_found`, `not_downloadable`, and `download_unavailable` exactly. Do not bypass access or download controls.
+- Report statuses such as `blocked`, `expired`, `item_not_found`, `not_downloadable`, and `download_unavailable` exactly. Only recover pages that the authenticated DocSend viewer renders; do not bypass access controls.
 - Do not expose email addresses, passcodes, verification URLs, API keys, or downloaded file data in the final response.

--- a/tools/research/docsend/cli.py
+++ b/tools/research/docsend/cli.py
@@ -168,7 +168,7 @@ def fetch(
     ),
     output: str | None = typer.Option(None, "--output", "-o", help="Output file path"),
 ) -> None:
-    """Download one permitted item from a verified DocSend Space."""
+    """Download or recover one document from a verified DocSend Space."""
     _handle_result(
         get_client().fetch(session_id=session_id, item_id=item_id),
         output,

--- a/tools/research/docsend/client.py
+++ b/tools/research/docsend/client.py
@@ -14,7 +14,7 @@ from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager, suppress
 from functools import partial
 from io import BytesIO
-from urllib.parse import urlparse
+from urllib.parse import urljoin, urlparse
 
 import httpx
 from browserbase import APIStatusError, AsyncBrowserbase
@@ -508,7 +508,8 @@ class DocsendClient:
             item_id: Stable item ID returned by list_space() or open_folder().
 
         Returns:
-            Dict containing the original file as base64 when downloading is allowed.
+            Dict containing the original file as base64 when downloading is enabled,
+            or a recovered PDF when DocSend renders the document without a download button.
         """
         item = _decode_space_item_id(item_id)
         if item is None:
@@ -820,72 +821,14 @@ class DocsendClient:
                         items=items,
                     )
 
-                # 5. Get slide count
-                total = 0
-                for _ in range(3):
-                    total = await _slide_count(page)
-                    if total > 0:
-                        break
-                    await asyncio.sleep(2)
-                if total == 0:
-                    return _err("Could not determine page count")
-                LOGGER.info("DocSend document contains %d pages", total)
-
-                # 6. Navigate through ALL slides to force rendering
-                await _navigate_all_slides(page, total)
-
-                # 7. Try DOM extraction first (most reliable)
-                LOGGER.info("Extracting rendered slide image URLs")
-                image_urls = await _extract_dom_image_urls(page)
-
-                if len(image_urls) == total:
-                    LOGGER.info("Found %d rendered slide images", len(image_urls))
-                    good = await _download_images(image_urls)
-                else:
-                    # Fallback: /page_data/ API
-                    LOGGER.info(
-                        "Found %d/%d rendered slide images; using the DocSend page-data fallback",
-                        len(image_urls),
-                        total,
-                    )
-                    api_urls = await _fetch_slide_urls(page, total)
-                    valid = [u for u in api_urls if u]
-                    if len(valid) != total:
-                        return _err(
-                            f"Failed to recover all document pages ({len(valid)}/{total}).",
-                            page_count=total,
-                        )
-                    good = await _download_images(valid)
-
-                if len(good) != total:
-                    return _err(
-                        f"Failed to download all document pages ({len(good)}/{total}).",
-                        page_count=total,
-                    )
-
-                # 8. Assemble PDF
-                LOGGER.info("Assembling %d downloaded pages into a PDF", len(good))
-                buf = BytesIO()
-                good[0].save(
-                    buf,
-                    "PDF",
-                    save_all=True,
-                    append_images=good[1:] if len(good) > 1 else [],
-                )
-
                 slug_m = re.search(r"docsend\.com/view/(?:s/)?([a-zA-Z0-9]+)", url)
                 slug = slug_m.group(1) if slug_m else "document"
-
-                result = {
-                    "status": "ok",
-                    "filename": f"docsend_{slug}.pdf",
-                    "data": base64.b64encode(buf.getvalue()).decode(),
-                    "mime_type": "application/pdf",
-                    "page_count": total,
-                    "downloaded": len(good),
-                    "error": None,
-                }
-                LOGGER.info("DocSend download completed successfully")
+                result = await _recover_rendered_document(
+                    page,
+                    filename=f"docsend_{slug}.pdf",
+                )
+                if result["status"] == "ok":
+                    LOGGER.info("DocSend download completed successfully")
                 return result
 
         except Exception as e:
@@ -1184,12 +1127,15 @@ async def _extract_space_inventory(page, parent_path: str) -> tuple[str, list[di
         if is_folder:
             item_type = "folder"
             downloadable = None
+            download_method = None
         elif is_file:
             item_type = "file"
             downloadable = await download_button.count() == 1 and await download_button.is_enabled()
+            download_method = "original" if downloadable else "rendered_pdf"
         else:
             item_type = "url"
             downloadable = None
+            download_method = None
 
         path = f"{parent_path.rstrip('/')}/{name}" if parent_path else name
         items.append(
@@ -1198,6 +1144,7 @@ async def _extract_space_inventory(page, parent_path: str) -> tuple[str, list[di
                 path=path,
                 item_type=item_type,
                 downloadable=downloadable,
+                download_method=download_method,
             )
         )
 
@@ -1243,6 +1190,7 @@ def _make_space_item(
     path: str,
     item_type: str,
     downloadable: bool | None,
+    download_method: str | None = None,
 ) -> dict:
     identity = json.dumps(
         {"path": path, "type": item_type},
@@ -1258,6 +1206,7 @@ def _make_space_item(
         "path": path,
         "type": item_type,
         "downloadable": downloadable,
+        "download_method": download_method,
     }
 
 
@@ -1330,7 +1279,7 @@ async def _find_unique_space_row(page, name: str, *, folder: bool = False):
     return rows.first
 
 
-async def _click_space_file_download(page, item: dict) -> dict:
+async def _find_space_file_row(page, item: dict):
     parent_path, _, _ = item["path"].rpartition("/")
     try:
         if parent_path:
@@ -1338,14 +1287,22 @@ async def _click_space_file_download(page, item: dict) -> dict:
         else:
             await _navigate_space_root(page)
     except RuntimeError as exc:
-        return _err(str(exc), status="item_not_found")
+        return None, _err(str(exc), status="item_not_found")
 
     row = await _find_unique_space_row(page, item["name"])
     if row is None:
-        return _err(
+        return None, _err(
             f"Could not uniquely locate file {item['name']!r} in the DocSend Space.",
             status="item_not_found",
         )
+    return row, None
+
+
+async def _click_space_file_download(page, item: dict, row=None) -> dict:
+    if row is None:
+        row, error = await _find_space_file_row(page, item)
+        if error is not None:
+            return error
     download_button = row.locator('button[aria-label="Download file"]')
     if await download_button.count() != 1 or not await download_button.is_enabled():
         return _err(
@@ -1356,6 +1313,61 @@ async def _click_space_file_download(page, item: dict) -> dict:
     LOGGER.info("Clicking the download control once for deal-room item %s", item["id"])
     await download_button.click(timeout=SPACE_SELECTOR_TIMEOUT_MS)
     return {"status": "ok", "error": None}
+
+
+def _rendered_pdf_filename(name: str) -> str:
+    filename = name.rsplit("/", 1)[-1].replace("\x00", "").strip() or "docsend_document"
+    stem = re.sub(r"\.[A-Za-z0-9]{1,10}$", "", filename).strip() or "docsend_document"
+    return f"{stem}.pdf"
+
+
+async def _recover_space_document(page, item: dict, row) -> dict:
+    links = row.locator("a[href]")
+    if await links.count() < 1:
+        return _err(
+            "DocSend did not provide a viewer link for this item.",
+            status="download_unavailable",
+        )
+    href = await links.first.get_attribute("href")
+    if not href:
+        return _err(
+            "DocSend did not provide a viewer link for this item.",
+            status="download_unavailable",
+        )
+    try:
+        document_url = _normalize_docsend_url(urljoin(page.url, href))
+    except ValueError as exc:
+        return _err(str(exc), status="download_unavailable")
+
+    LOGGER.info("Recovering rendered pages for deal-room item %s", item["id"])
+    document_page = await page.context.new_page()
+    try:
+        try:
+            await document_page.goto(document_url, wait_until="networkidle", timeout=45000)
+        except Exception:
+            LOGGER.warning(
+                "Deal-room document navigation did not reach network idle; inspecting the page"
+            )
+        state = await _detect_state(document_page)
+        if state == "expired":
+            return _err("Document not found or expired", status="expired")
+        if state == "blocked":
+            return _err("Blocked by CloudFront/WAF", status="blocked")
+        if state != "ready" or await _has_verification_wall(document_page):
+            return _err(
+                "The deal-room session did not unlock this document viewer.",
+                status="download_unavailable",
+            )
+        await _dismiss_cookies(document_page)
+        result = await _recover_rendered_document(
+            document_page,
+            filename=_rendered_pdf_filename(item["name"]),
+        )
+        if result["status"] == "ok":
+            result["download_method"] = "rendered_pdf"
+        return result
+    finally:
+        await document_page.close()
 
 
 async def _fetch_space_item(
@@ -1370,12 +1382,24 @@ async def _fetch_space_item(
             f"{item['name']} is a {item['type']} and cannot be downloaded as a file.",
             status="not_downloadable",
         )
+    row, error = await _find_space_file_row(page, item)
+    if error is not None:
+        return error
+    download_button = row.locator('button[aria-label="Download file"]')
+    has_original_download = (
+        await download_button.count() == 1 and await download_button.is_enabled()
+    )
+    if not has_original_download:
+        result = await _recover_space_document(page, item, row)
+        result["item_id"] = item["id"]
+        return result
+
     existing_downloads = await _browserbase_download_records(api_key, session_id)
     existing_ids = {
         download["id"] for download in existing_downloads if isinstance(download.get("id"), str)
     }
     await _configure_browserbase_downloads(browser)
-    click_result = await _click_space_file_download(page, item)
+    click_result = await _click_space_file_download(page, item, row)
     if click_result["status"] != "ok":
         return click_result
     downloaded = await _wait_for_new_download(
@@ -1401,6 +1425,7 @@ async def _fetch_space_item(
         "filename": filename,
         "mime_type": mime_type,
         "size": len(content),
+        "download_method": "original",
         "data": base64.b64encode(content).decode(),
         "error": None,
     }
@@ -1409,6 +1434,65 @@ async def _fetch_space_item(
 # ---------------------------------------------------------------------------
 # Slide extraction
 # ---------------------------------------------------------------------------
+
+
+async def _recover_rendered_document(page, *, filename: str) -> dict:
+    """Recover a visible DocSend document from its rendered page images."""
+    total = 0
+    for _ in range(3):
+        total = await _slide_count(page)
+        if total > 0:
+            break
+        await asyncio.sleep(2)
+    if total == 0:
+        return _err("Could not determine page count")
+    LOGGER.info("DocSend document contains %d pages", total)
+
+    await _navigate_all_slides(page, total)
+
+    LOGGER.info("Extracting rendered slide image URLs")
+    image_urls = await _extract_dom_image_urls(page)
+    if len(image_urls) == total:
+        LOGGER.info("Found %d rendered slide images", len(image_urls))
+        images = await _download_images(image_urls)
+    else:
+        LOGGER.info(
+            "Found %d/%d rendered slide images; using the DocSend page-data fallback",
+            len(image_urls),
+            total,
+        )
+        api_urls = await _fetch_slide_urls(page, total)
+        valid_urls = [url for url in api_urls if url]
+        if len(valid_urls) != total:
+            return _err(
+                f"Failed to recover all document pages ({len(valid_urls)}/{total}).",
+                page_count=total,
+            )
+        images = await _download_images(valid_urls)
+
+    if len(images) != total:
+        return _err(
+            f"Failed to download all document pages ({len(images)}/{total}).",
+            page_count=total,
+        )
+
+    LOGGER.info("Assembling %d downloaded pages into a PDF", len(images))
+    buffer = BytesIO()
+    images[0].save(
+        buffer,
+        "PDF",
+        save_all=True,
+        append_images=images[1:] if len(images) > 1 else [],
+    )
+    return {
+        "status": "ok",
+        "filename": filename,
+        "data": base64.b64encode(buffer.getvalue()).decode(),
+        "mime_type": "application/pdf",
+        "page_count": total,
+        "downloaded": len(images),
+        "error": None,
+    }
 
 
 async def _slide_count(page) -> int:

--- a/tools/research/docsend/client.py
+++ b/tools/research/docsend/client.py
@@ -1560,7 +1560,7 @@ async def _capture_visible_pages(page, total: int) -> list[Image.Image]:
     images: list[Image.Image] = []
     for page_number in range(1, total + 1):
         try:
-            png = await page.screenshot(full_page=False)
+            png = await _capture_visible_page(page)
             source = Image.open(BytesIO(png))
             rgb = Image.new("RGB", source.size, (255, 255, 255))
             rgb.paste(source, mask=source.split()[3] if source.mode == "RGBA" else None)
@@ -1574,6 +1574,24 @@ async def _capture_visible_pages(page, total: int) -> list[Image.Image]:
             await asyncio.sleep(0.75)
     LOGGER.info("Captured %d/%d DocSend pages from the viewport", len(images), total)
     return images
+
+
+async def _capture_visible_page(page) -> bytes:
+    """Capture the document surface without DocSend's surrounding viewer chrome."""
+    await page.evaluate(
+        """() => {
+          const cookieFrame = document.querySelector('#ccpa-iframe');
+          if (cookieFrame) cookieFrame.style.visibility = 'hidden';
+        }"""
+    )
+    spreadsheet = page.locator(
+        'iframe#previews-iframe:visible, iframe[class*="spreadsheet-viewer"]:visible'
+    ).first
+    if await spreadsheet.count() > 0:
+        LOGGER.info("Capturing the visible DocSend spreadsheet frame")
+        return await spreadsheet.screenshot()
+    LOGGER.info("No document-only capture surface found; capturing the viewer viewport")
+    return await page.screenshot(full_page=False)
 
 
 async def _extract_dom_image_urls(page) -> list[str]:

--- a/tools/research/docsend/client.py
+++ b/tools/research/docsend/client.py
@@ -1438,50 +1438,54 @@ async def _fetch_space_item(
 
 async def _recover_rendered_document(page, *, filename: str) -> dict:
     """Recover a visible DocSend document from its rendered page images."""
-    total = 0
-    for _ in range(3):
-        total = await _slide_count(page)
-        if total > 0:
-            break
-        await asyncio.sleep(2)
-    if total == 0:
-        return _err("Could not determine page count")
-    LOGGER.info("DocSend document contains %d pages", total)
-
-    await _navigate_all_slides(page, total)
-
-    LOGGER.info("Extracting rendered slide image URLs")
-    image_urls = await _extract_dom_image_urls(page)
-    if len(image_urls) == total:
-        LOGGER.info("Found %d rendered slide images", len(image_urls))
-        images = await _download_images(image_urls)
+    images = await _capture_spreadsheet_sheets(page)
+    total = len(images)
+    if total:
+        LOGGER.info("Captured %d DocSend spreadsheet sheets", total)
     else:
-        LOGGER.info(
-            "Found %d/%d rendered slide images; using the DocSend page-data fallback",
-            len(image_urls),
-            total,
-        )
-        api_urls = await _fetch_slide_urls(page, total)
-        valid_urls = [url for url in api_urls if url]
-        if len(valid_urls) != total:
-            return _err(
-                f"Failed to recover all document pages ({len(valid_urls)}/{total}).",
-                page_count=total,
-            )
-        images = await _download_images(valid_urls)
+        for _ in range(3):
+            total = await _slide_count(page)
+            if total > 0:
+                break
+            await asyncio.sleep(2)
+        if total == 0:
+            return _err("Could not determine page count")
+        LOGGER.info("DocSend document contains %d pages", total)
 
-    if len(images) != total:
-        LOGGER.info(
-            "Downloaded %d/%d rendered slide images; using the viewport capture fallback",
-            len(images),
-            total,
-        )
-        images = await _capture_visible_pages(page, total)
-        if len(images) != total:
-            return _err(
-                f"Failed to recover all document pages ({len(images)}/{total}).",
-                page_count=total,
+        await _navigate_all_slides(page, total)
+
+        LOGGER.info("Extracting rendered slide image URLs")
+        image_urls = await _extract_dom_image_urls(page)
+        if len(image_urls) == total:
+            LOGGER.info("Found %d rendered slide images", len(image_urls))
+            images = await _download_images(image_urls)
+        else:
+            LOGGER.info(
+                "Found %d/%d rendered slide images; using the DocSend page-data fallback",
+                len(image_urls),
+                total,
             )
+            api_urls = await _fetch_slide_urls(page, total)
+            valid_urls = [url for url in api_urls if url]
+            if len(valid_urls) != total:
+                return _err(
+                    f"Failed to recover all document pages ({len(valid_urls)}/{total}).",
+                    page_count=total,
+                )
+            images = await _download_images(valid_urls)
+
+        if len(images) != total:
+            LOGGER.info(
+                "Downloaded %d/%d rendered slide images; using the viewport capture fallback",
+                len(images),
+                total,
+            )
+            images = await _capture_visible_pages(page, total)
+            if len(images) != total:
+                return _err(
+                    f"Failed to recover all document pages ({len(images)}/{total}).",
+                    page_count=total,
+                )
 
     LOGGER.info("Assembling %d downloaded pages into a PDF", len(images))
     buffer = BytesIO()
@@ -1561,11 +1565,7 @@ async def _capture_visible_pages(page, total: int) -> list[Image.Image]:
     for page_number in range(1, total + 1):
         try:
             png = await _capture_visible_page(page)
-            source = Image.open(BytesIO(png))
-            rgb = Image.new("RGB", source.size, (255, 255, 255))
-            rgb.paste(source, mask=source.split()[3] if source.mode == "RGBA" else None)
-            source.close()
-            images.append(rgb)
+            images.append(_rgb_image_from_png(png))
         except Exception as exc:
             LOGGER.warning("Failed to capture DocSend page %d: %s", page_number, exc)
             break
@@ -1576,14 +1576,46 @@ async def _capture_visible_pages(page, total: int) -> list[Image.Image]:
     return images
 
 
+async def _capture_spreadsheet_sheets(page) -> list[Image.Image]:
+    """Click and capture each sheet inside DocSend's spreadsheet preview iframe."""
+    await _hide_capture_overlays(page)
+    iframe = await page.query_selector("#previews-iframe")
+    if iframe is None:
+        return []
+    frame = await iframe.content_frame()
+    if frame is None:
+        return []
+
+    tabs = frame.locator("#tabstrip a.tabstrip-link")
+    sheets = frame.locator(".sheet-content")
+    tab_count = await tabs.count()
+    if tab_count == 0 or await sheets.count() != tab_count:
+        return []
+
+    images: list[Image.Image] = []
+    for index in range(tab_count):
+        tab = tabs.nth(index)
+        sheet = sheets.nth(index)
+        name = (await tab.inner_text()).strip() or f"Sheet {index + 1}"
+        LOGGER.info("Capturing DocSend spreadsheet tab %d/%d: %s", index + 1, tab_count, name)
+        await tab.click(force=True)
+        await frame.wait_for_timeout(500)
+        await sheet.wait_for(state="visible")
+        images.append(_rgb_image_from_png(await iframe.screenshot()))
+    return images
+
+
+def _rgb_image_from_png(png: bytes) -> Image.Image:
+    source = Image.open(BytesIO(png))
+    rgb = Image.new("RGB", source.size, (255, 255, 255))
+    rgb.paste(source, mask=source.split()[3] if source.mode == "RGBA" else None)
+    source.close()
+    return rgb
+
+
 async def _capture_visible_page(page) -> bytes:
     """Capture the document surface without DocSend's surrounding viewer chrome."""
-    await page.evaluate(
-        """() => {
-          const cookieFrame = document.querySelector('#ccpa-iframe');
-          if (cookieFrame) cookieFrame.style.visibility = 'hidden';
-        }"""
-    )
+    await _hide_capture_overlays(page)
     spreadsheet = page.locator(
         'iframe#previews-iframe:visible, iframe[class*="spreadsheet-viewer"]:visible'
     ).first
@@ -1592,6 +1624,16 @@ async def _capture_visible_page(page) -> bytes:
         return await spreadsheet.screenshot()
     LOGGER.info("No document-only capture surface found; capturing the viewer viewport")
     return await page.screenshot(full_page=False)
+
+
+async def _hide_capture_overlays(page) -> None:
+    """Hide DocSend overlays that obscure documents or intercept workbook clicks."""
+    await page.evaluate(
+        """() => {
+          const cookieFrame = document.querySelector('#ccpa-iframe');
+          if (cookieFrame) cookieFrame.style.visibility = 'hidden';
+        }"""
+    )
 
 
 async def _extract_dom_image_urls(page) -> list[str]:

--- a/tools/research/docsend/client.py
+++ b/tools/research/docsend/client.py
@@ -1471,10 +1471,17 @@ async def _recover_rendered_document(page, *, filename: str) -> dict:
         images = await _download_images(valid_urls)
 
     if len(images) != total:
-        return _err(
-            f"Failed to download all document pages ({len(images)}/{total}).",
-            page_count=total,
+        LOGGER.info(
+            "Downloaded %d/%d rendered slide images; using the viewport capture fallback",
+            len(images),
+            total,
         )
+        images = await _capture_visible_pages(page, total)
+        if len(images) != total:
+            return _err(
+                f"Failed to recover all document pages ({len(images)}/{total}).",
+                page_count=total,
+            )
 
     LOGGER.info("Assembling %d downloaded pages into a PDF", len(images))
     buffer = BytesIO()
@@ -1534,6 +1541,39 @@ async def _navigate_all_slides(page, total: int) -> None:
         if page_number == total or page_number % 10 == 0:
             LOGGER.info("Rendered page %d/%d", page_number, total)
     await asyncio.sleep(1)
+
+
+async def _capture_visible_pages(page, total: int) -> list[Image.Image]:
+    """Capture every page from the authenticated viewer when image URLs reject downloads.
+
+    Spreadsheet-style DocSend viewers can render pages successfully while their signed
+    image URLs return 403 outside the renderer. In that case, preserve exactly what the
+    authenticated browser can display by stepping through the viewer and capturing each
+    viewport as a PDF page.
+    """
+    LOGGER.info("Capturing all %d DocSend pages from the authenticated viewport", total)
+    for _ in range(total):
+        await page.keyboard.press("ArrowLeft")
+        await asyncio.sleep(0.1)
+    await asyncio.sleep(1)
+
+    images: list[Image.Image] = []
+    for page_number in range(1, total + 1):
+        try:
+            png = await page.screenshot(full_page=False)
+            source = Image.open(BytesIO(png))
+            rgb = Image.new("RGB", source.size, (255, 255, 255))
+            rgb.paste(source, mask=source.split()[3] if source.mode == "RGBA" else None)
+            source.close()
+            images.append(rgb)
+        except Exception as exc:
+            LOGGER.warning("Failed to capture DocSend page %d: %s", page_number, exc)
+            break
+        if page_number < total:
+            await page.keyboard.press("ArrowRight")
+            await asyncio.sleep(0.75)
+    LOGGER.info("Captured %d/%d DocSend pages from the viewport", len(images), total)
+    return images
 
 
 async def _extract_dom_image_urls(page) -> list[str]:

--- a/tools/research/docsend/test_client.py
+++ b/tools/research/docsend/test_client.py
@@ -93,6 +93,76 @@ def test_recover_rendered_document_builds_a_pdf_from_visible_pages(monkeypatch) 
     ]
 
 
+def test_recover_rendered_document_captures_viewports_when_images_are_forbidden(
+    monkeypatch,
+) -> None:
+    calls: list[tuple[str, object]] = []
+
+    class FakeImage:
+        def save(self, buffer, file_format, *, save_all, append_images) -> None:
+            calls.append(("save", (file_format, save_all, len(append_images))))
+            buffer.write(b"spreadsheet-pdf")
+
+    async def slide_count(page) -> int:
+        return 2
+
+    async def navigate(page, total: int) -> None:
+        calls.append(("navigate", total))
+
+    async def extract(page) -> list[str]:
+        return []
+
+    async def fetch(page, total: int) -> list[str]:
+        return ["https://example.test/1", "https://example.test/2"]
+
+    async def download(urls: list[str]) -> list[FakeImage]:
+        calls.append(("download", urls))
+        return []
+
+    async def capture(page, total: int) -> list[FakeImage]:
+        calls.append(("capture", total))
+        return [FakeImage(), FakeImage()]
+
+    monkeypatch.setattr(_CLIENT, "_slide_count", slide_count)
+    monkeypatch.setattr(_CLIENT, "_navigate_all_slides", navigate)
+    monkeypatch.setattr(_CLIENT, "_extract_dom_image_urls", extract)
+    monkeypatch.setattr(_CLIENT, "_fetch_slide_urls", fetch)
+    monkeypatch.setattr(_CLIENT, "_download_images", download)
+    monkeypatch.setattr(_CLIENT, "_capture_visible_pages", capture)
+
+    result = asyncio.run(_CLIENT._recover_rendered_document(object(), filename="Model.pdf"))
+
+    assert result["status"] == "ok"
+    assert result["page_count"] == 2
+    assert base64.b64decode(result["data"]) == b"spreadsheet-pdf"
+    assert calls == [
+        ("navigate", 2),
+        ("download", ["https://example.test/1", "https://example.test/2"]),
+        ("capture", 2),
+        ("save", ("PDF", True, 1)),
+    ]
+
+
+def test_navigate_all_slides_visits_each_page(monkeypatch) -> None:
+    keys: list[str] = []
+
+    class Keyboard:
+        async def press(self, key: str) -> None:
+            keys.append(key)
+
+    class Page:
+        keyboard = Keyboard()
+
+    async def no_sleep(seconds: float) -> None:
+        return None
+
+    monkeypatch.setattr(_CLIENT.asyncio, "sleep", no_sleep)
+
+    asyncio.run(_CLIENT._navigate_all_slides(Page(), 3))
+
+    assert keys == ["ArrowLeft", "ArrowLeft", "ArrowLeft", "ArrowRight", "ArrowRight"]
+
+
 def test_fetch_space_item_recovers_a_document_when_download_is_disabled(monkeypatch) -> None:
     class DisabledDownloadButton:
         async def count(self) -> int:

--- a/tools/research/docsend/test_client.py
+++ b/tools/research/docsend/test_client.py
@@ -163,6 +163,61 @@ def test_navigate_all_slides_visits_each_page(monkeypatch) -> None:
     assert keys == ["ArrowLeft", "ArrowLeft", "ArrowLeft", "ArrowRight", "ArrowRight"]
 
 
+def test_capture_visible_page_uses_spreadsheet_frame_without_viewer_chrome() -> None:
+    class SpreadsheetFrame:
+        @property
+        def first(self):
+            return self
+
+        async def count(self) -> int:
+            return 1
+
+        async def screenshot(self) -> bytes:
+            return b"spreadsheet-only"
+
+    class Page:
+        async def evaluate(self, script: str) -> None:
+            assert "#ccpa-iframe" in script
+
+        def locator(self, selector: str):
+            assert selector == (
+                'iframe#previews-iframe:visible, iframe[class*="spreadsheet-viewer"]:visible'
+            )
+            return SpreadsheetFrame()
+
+        async def screenshot(self, **kwargs) -> bytes:
+            raise AssertionError("the surrounding DocSend viewport must not be captured")
+
+    result = asyncio.run(_CLIENT._capture_visible_page(Page()))
+
+    assert result == b"spreadsheet-only"
+
+
+def test_capture_visible_page_falls_back_for_unknown_viewers() -> None:
+    class MissingFrame:
+        @property
+        def first(self):
+            return self
+
+        async def count(self) -> int:
+            return 0
+
+    class Page:
+        async def evaluate(self, script: str) -> None:
+            assert "#ccpa-iframe" in script
+
+        def locator(self, selector: str):
+            return MissingFrame()
+
+        async def screenshot(self, *, full_page: bool) -> bytes:
+            assert full_page is False
+            return b"viewer-viewport"
+
+    result = asyncio.run(_CLIENT._capture_visible_page(Page()))
+
+    assert result == b"viewer-viewport"
+
+
 def test_fetch_space_item_recovers_a_document_when_download_is_disabled(monkeypatch) -> None:
     class DisabledDownloadButton:
         async def count(self) -> int:

--- a/tools/research/docsend/test_client.py
+++ b/tools/research/docsend/test_client.py
@@ -1,3 +1,5 @@
+import asyncio
+import base64
 import importlib.util
 from pathlib import Path
 
@@ -10,6 +12,7 @@ assert _CLIENT_SPEC is not None and _CLIENT_SPEC.loader is not None
 _CLIENT = importlib.util.module_from_spec(_CLIENT_SPEC)
 _CLIENT_SPEC.loader.exec_module(_CLIENT)
 _normalize_verification_url = _CLIENT._normalize_verification_url
+_rendered_pdf_filename = _CLIENT._rendered_pdf_filename
 
 
 @pytest.mark.parametrize(
@@ -36,3 +39,246 @@ def test_normalize_verification_url_allows_supported_hosts(url: str) -> None:
 def test_normalize_verification_url_rejects_unsupported_urls(url: str) -> None:
     with pytest.raises(ValueError, match="HTTPS DocSend or Postmark URL"):
         _normalize_verification_url(url)
+
+
+@pytest.mark.parametrize(
+    ("name", "expected"),
+    [
+        ("Investor Deck.pptx", "Investor Deck.pdf"),
+        ("Quarterly Update", "Quarterly Update.pdf"),
+        ("archive.tar.gz", "archive.tar.pdf"),
+        ("\x00", "docsend_document.pdf"),
+    ],
+)
+def test_rendered_pdf_filename_replaces_the_source_extension(name: str, expected: str) -> None:
+    assert _rendered_pdf_filename(name) == expected
+
+
+def test_recover_rendered_document_builds_a_pdf_from_visible_pages(monkeypatch) -> None:
+    calls: list[tuple[str, object]] = []
+
+    class FakeImage:
+        def save(self, buffer, file_format, *, save_all, append_images) -> None:
+            calls.append(("save", (file_format, save_all, len(append_images))))
+            buffer.write(b"rendered-pdf")
+
+    async def slide_count(page) -> int:
+        return 2
+
+    async def navigate(page, total: int) -> None:
+        calls.append(("navigate", total))
+
+    async def extract(page) -> list[str]:
+        return ["https://example.test/1", "https://example.test/2"]
+
+    async def download(urls: list[str]) -> list[FakeImage]:
+        calls.append(("download", urls))
+        return [FakeImage(), FakeImage()]
+
+    monkeypatch.setattr(_CLIENT, "_slide_count", slide_count)
+    monkeypatch.setattr(_CLIENT, "_navigate_all_slides", navigate)
+    monkeypatch.setattr(_CLIENT, "_extract_dom_image_urls", extract)
+    monkeypatch.setattr(_CLIENT, "_download_images", download)
+
+    result = asyncio.run(_CLIENT._recover_rendered_document(object(), filename="Investor Deck.pdf"))
+
+    assert result["status"] == "ok"
+    assert result["filename"] == "Investor Deck.pdf"
+    assert result["page_count"] == 2
+    assert base64.b64decode(result["data"]) == b"rendered-pdf"
+    assert calls == [
+        ("navigate", 2),
+        ("download", ["https://example.test/1", "https://example.test/2"]),
+        ("save", ("PDF", True, 1)),
+    ]
+
+
+def test_fetch_space_item_recovers_a_document_when_download_is_disabled(monkeypatch) -> None:
+    class DisabledDownloadButton:
+        async def count(self) -> int:
+            return 0
+
+        async def is_enabled(self) -> bool:
+            raise AssertionError("a missing button must not be queried for enabled state")
+
+    class Row:
+        def locator(self, selector: str):
+            assert selector == 'button[aria-label="Download file"]'
+            return DisabledDownloadButton()
+
+    item = _CLIENT._make_space_item(
+        name="Investor Deck",
+        path="Investor Deck",
+        item_type="file",
+        downloadable=False,
+        download_method="rendered_pdf",
+    )
+
+    async def find_row(page, selected_item):
+        assert selected_item == item
+        return Row(), None
+
+    async def recover(page, selected_item, row):
+        assert selected_item == item
+        return {
+            "status": "ok",
+            "filename": "Investor Deck.pdf",
+            "download_method": "rendered_pdf",
+            "data": "cGRm",
+            "error": None,
+        }
+
+    async def unexpected_records(*args, **kwargs):
+        raise AssertionError("Browserbase downloads must not be queried for rendered recovery")
+
+    monkeypatch.setattr(_CLIENT, "_find_space_file_row", find_row)
+    monkeypatch.setattr(_CLIENT, "_recover_space_document", recover)
+    monkeypatch.setattr(_CLIENT, "_browserbase_download_records", unexpected_records)
+
+    result = asyncio.run(
+        _CLIENT._fetch_space_item(object(), object(), "api-key", "session-id", item)
+    )
+
+    assert result["status"] == "ok"
+    assert result["download_method"] == "rendered_pdf"
+    assert result["item_id"] == item["id"]
+
+
+def test_fetch_space_item_uses_original_download_when_enabled(monkeypatch) -> None:
+    calls: list[str] = []
+
+    class EnabledDownloadButton:
+        async def count(self) -> int:
+            return 1
+
+        async def is_enabled(self) -> bool:
+            return True
+
+    class Row:
+        def locator(self, selector: str):
+            assert selector == 'button[aria-label="Download file"]'
+            return EnabledDownloadButton()
+
+    item = _CLIENT._make_space_item(
+        name="Financials.xlsx",
+        path="Financials.xlsx",
+        item_type="file",
+        downloadable=True,
+        download_method="original",
+    )
+
+    async def find_row(page, selected_item):
+        return Row(), None
+
+    async def records(api_key: str, session_id: str) -> list[dict]:
+        calls.append("records")
+        return [{"id": "existing"}]
+
+    async def configure(browser) -> None:
+        calls.append("configure")
+
+    async def click(page, selected_item, row) -> dict:
+        calls.append("click")
+        return {"status": "ok", "error": None}
+
+    async def wait(api_key: str, session_id: str, existing_ids: set[str]):
+        calls.append("wait")
+        assert existing_ids == {"existing"}
+        return "Financials.xlsx", b"original-file"
+
+    async def unexpected_recovery(*args, **kwargs):
+        raise AssertionError("rendered recovery must not run when original download is enabled")
+
+    monkeypatch.setattr(_CLIENT, "_find_space_file_row", find_row)
+    monkeypatch.setattr(_CLIENT, "_browserbase_download_records", records)
+    monkeypatch.setattr(_CLIENT, "_configure_browserbase_downloads", configure)
+    monkeypatch.setattr(_CLIENT, "_click_space_file_download", click)
+    monkeypatch.setattr(_CLIENT, "_wait_for_new_download", wait)
+    monkeypatch.setattr(_CLIENT, "_recover_space_document", unexpected_recovery)
+
+    result = asyncio.run(
+        _CLIENT._fetch_space_item(object(), object(), "api-key", "session-id", item)
+    )
+
+    assert result["status"] == "ok"
+    assert result["filename"] == "Financials.xlsx"
+    assert result["download_method"] == "original"
+    assert base64.b64decode(result["data"]) == b"original-file"
+    assert calls == ["records", "configure", "click", "wait"]
+
+
+def test_recover_space_document_opens_viewer_in_authenticated_context(monkeypatch) -> None:
+    calls: list[object] = []
+
+    class Link:
+        @property
+        def first(self):
+            return self
+
+        async def count(self) -> int:
+            return 1
+
+        async def get_attribute(self, name: str) -> str:
+            assert name == "href"
+            return "/view/deck123/d/room-document"
+
+    class Row:
+        def locator(self, selector: str):
+            assert selector == "a[href]"
+            return Link()
+
+    class DocumentPage:
+        async def goto(self, url: str, **kwargs) -> None:
+            calls.append(("goto", url))
+
+        async def close(self) -> None:
+            calls.append("close")
+
+    document_page = DocumentPage()
+
+    class Context:
+        async def new_page(self):
+            calls.append("new_page")
+            return document_page
+
+    class SpacePage:
+        url = "https://docsend.com/view/s/space123"
+        context = Context()
+
+    item = _CLIENT._make_space_item(
+        name="Investor Deck",
+        path="Investor Deck",
+        item_type="file",
+        downloadable=False,
+        download_method="rendered_pdf",
+    )
+
+    async def detect_state(page) -> str:
+        return "ready"
+
+    async def has_verification_wall(page) -> bool:
+        return False
+
+    async def dismiss_cookies(page) -> None:
+        calls.append("dismiss")
+
+    async def recover(page, *, filename: str) -> dict:
+        calls.append(("recover", filename))
+        return {"status": "ok", "filename": filename, "data": "cGRm", "error": None}
+
+    monkeypatch.setattr(_CLIENT, "_detect_state", detect_state)
+    monkeypatch.setattr(_CLIENT, "_has_verification_wall", has_verification_wall)
+    monkeypatch.setattr(_CLIENT, "_dismiss_cookies", dismiss_cookies)
+    monkeypatch.setattr(_CLIENT, "_recover_rendered_document", recover)
+
+    result = asyncio.run(_CLIENT._recover_space_document(SpacePage(), item, Row()))
+
+    assert result["status"] == "ok"
+    assert result["download_method"] == "rendered_pdf"
+    assert calls == [
+        "new_page",
+        ("goto", "https://docsend.com/view/deck123/d/room-document"),
+        "dismiss",
+        ("recover", "Investor Deck.pdf"),
+        "close",
+    ]

--- a/tools/research/docsend/test_client.py
+++ b/tools/research/docsend/test_client.py
@@ -65,6 +65,9 @@ def test_recover_rendered_document_builds_a_pdf_from_visible_pages(monkeypatch) 
     async def slide_count(page) -> int:
         return 2
 
+    async def no_spreadsheet(page) -> list:
+        return []
+
     async def navigate(page, total: int) -> None:
         calls.append(("navigate", total))
 
@@ -76,6 +79,7 @@ def test_recover_rendered_document_builds_a_pdf_from_visible_pages(monkeypatch) 
         return [FakeImage(), FakeImage()]
 
     monkeypatch.setattr(_CLIENT, "_slide_count", slide_count)
+    monkeypatch.setattr(_CLIENT, "_capture_spreadsheet_sheets", no_spreadsheet)
     monkeypatch.setattr(_CLIENT, "_navigate_all_slides", navigate)
     monkeypatch.setattr(_CLIENT, "_extract_dom_image_urls", extract)
     monkeypatch.setattr(_CLIENT, "_download_images", download)
@@ -106,6 +110,9 @@ def test_recover_rendered_document_captures_viewports_when_images_are_forbidden(
     async def slide_count(page) -> int:
         return 2
 
+    async def no_spreadsheet(page) -> list:
+        return []
+
     async def navigate(page, total: int) -> None:
         calls.append(("navigate", total))
 
@@ -124,6 +131,7 @@ def test_recover_rendered_document_captures_viewports_when_images_are_forbidden(
         return [FakeImage(), FakeImage()]
 
     monkeypatch.setattr(_CLIENT, "_slide_count", slide_count)
+    monkeypatch.setattr(_CLIENT, "_capture_spreadsheet_sheets", no_spreadsheet)
     monkeypatch.setattr(_CLIENT, "_navigate_all_slides", navigate)
     monkeypatch.setattr(_CLIENT, "_extract_dom_image_urls", extract)
     monkeypatch.setattr(_CLIENT, "_fetch_slide_urls", fetch)
@@ -161,6 +169,81 @@ def test_navigate_all_slides_visits_each_page(monkeypatch) -> None:
     asyncio.run(_CLIENT._navigate_all_slides(Page(), 3))
 
     assert keys == ["ArrowLeft", "ArrowLeft", "ArrowLeft", "ArrowRight", "ArrowRight"]
+
+
+def test_capture_spreadsheet_sheets_clicks_and_captures_each_tab(monkeypatch) -> None:
+    calls: list[tuple] = []
+    state = {"selected": 0}
+
+    class Tab:
+        def __init__(self, index: int):
+            self.index = index
+
+        async def inner_text(self) -> str:
+            return ["Summary", "Spend Ranking"][self.index]
+
+        async def click(self, *, force: bool) -> None:
+            calls.append(("click", self.index, force))
+            state["selected"] = self.index
+
+    class Sheet:
+        def __init__(self, index: int):
+            self.index = index
+
+        async def wait_for(self, *, state: str) -> None:
+            calls.append(("wait", self.index, state))
+
+    class Collection:
+        def __init__(self, kind: str):
+            self.kind = kind
+
+        async def count(self) -> int:
+            return 2
+
+        def nth(self, index: int):
+            return Tab(index) if self.kind == "tabs" else Sheet(index)
+
+    class Frame:
+        def locator(self, selector: str):
+            if selector == "#tabstrip a.tabstrip-link":
+                return Collection("tabs")
+            assert selector == ".sheet-content"
+            return Collection("sheets")
+
+        async def wait_for_timeout(self, milliseconds: int) -> None:
+            calls.append(("timeout", milliseconds))
+
+    class Iframe:
+        async def content_frame(self):
+            return Frame()
+
+        async def screenshot(self) -> bytes:
+            calls.append(("screenshot", state["selected"]))
+            return f"sheet-{state['selected']}".encode()
+
+    class Page:
+        async def evaluate(self, script: str) -> None:
+            assert "#ccpa-iframe" in script
+
+        async def query_selector(self, selector: str):
+            assert selector == "#previews-iframe"
+            return Iframe()
+
+    monkeypatch.setattr(_CLIENT, "_rgb_image_from_png", lambda png: png.decode())
+
+    result = asyncio.run(_CLIENT._capture_spreadsheet_sheets(Page()))
+
+    assert result == ["sheet-0", "sheet-1"]
+    assert calls == [
+        ("click", 0, True),
+        ("timeout", 500),
+        ("wait", 0, "visible"),
+        ("screenshot", 0),
+        ("click", 1, True),
+        ("timeout", 500),
+        ("wait", 1, "visible"),
+        ("screenshot", 1),
+    ]
 
 
 def test_capture_visible_page_uses_spreadsheet_frame_without_viewer_chrome() -> None:


### PR DESCRIPTION
Adds agent-driven bulk downloading for DocSend dealrooms. Dealroom inventory identifies whether each document can use the original download or needs rendered-page PDF recovery, and fetch reuses the authenticated browser session for either path. Updates the DocSend skill and adds focused coverage for both download modes.