### PR TITLE
feat: support Standard Webhooks authentication

### DIFF
--- a/docs/pages/extend/workflows.mdx
+++ b/docs/pages/extend/workflows.mdx
@@ -275,8 +275,37 @@ that content type is listed in `allowed_content_types`.
 Webhook requests do not use Centaur API keys. The API verifies the provider
 signature before creating workflow state. `HmacAuth.github(...)` verifies
 `X-Hub-Signature-256`; a plain `HmacAuth(...)` can be used for other
-SHA-256 HMAC providers. During local development or for trusted internal
-routes, `auth="none"` is allowed.
+SHA-256 HMAC providers that sign the raw request body. During local development
+or for trusted internal routes, `auth="none"` is allowed.
+
+For providers that implement the [Standard Webhooks
+specification](https://www.standardwebhooks.com/), use the explicit
+`standard_webhooks` auth type:
+
+```python
+WEBHOOKS = [
+    {
+        "slug": "feed-ingest",
+        "provider": "feed-provider",
+        "auth": {
+            "type": "standard_webhooks",
+            "secret_ref": "FEED_WEBHOOK_SECRET",
+        },
+        "trigger_key": {"type": "header", "header": "webhook-id"},
+        "allowed_methods": ["POST"],
+        "allowed_content_types": ["application/json"],
+    }
+]
+```
+
+Set `FEED_WEBHOOK_SECRET` in the API deployment to the provider's signing
+secret (normally a `whsec_`-prefixed, base64-encoded value). Centaur requires
+the `webhook-id`, `webhook-timestamp`, and `webhook-signature` headers, verifies
+the `v1` signature over the exact raw body, supports space-separated signatures
+for key rotation, and rejects timestamps outside a five-minute window. Using
+`webhook-id` as the trigger key also gives retries the same durable workflow
+identity. Auth schemes are selected by `auth.type`; Centaur does not infer one
+from the headers.
 
 The workflow receives input in this shape:
 

--- a/docs/pages/reference/configuration.mdx
+++ b/docs/pages/reference/configuration.mdx
@@ -259,7 +259,7 @@ Sandbox entrypoint and wrappers:
 | `WORKFLOW_RECONCILE_INTERVAL_S`, `WORKFLOW_RESUSPEND_BACKOFF_S` | `api.extraEnv`. | Workflow claim/reclaim cadence. |
 | `WORKFLOW_SCHEDULE_TICK_INTERVAL_S`, `WORKFLOW_SCHEDULE_CATCHUP_LIMIT`, `WORKFLOW_SCHEDULE_MISFIRE_GRACE_S` | `api.extraEnv`. | Scheduled workflow timing and catch-up behavior. |
 | `MY_THREAD_KEY`, `<WORKFLOW_NAME>_THREAD_KEY`, `<WORKFLOW_NAME>_SLACK_CHANNEL` | Workflow-specific env. | Fallback thread/channel targets for workflow agent steps. |
-| `<WEBHOOK_SECRET_REF>` | API env or Secret named by a workflow `WebhookSpec`. | HMAC secret for public workflow webhooks, for example `GITHUB_WEBHOOK_SECRET`. |
+| `<WEBHOOK_SECRET_REF>` | API env or Secret named by a workflow `WebhookSpec`. | Signing secret or bearer token for public workflow webhooks, for example `GITHUB_WEBHOOK_SECRET` or a Standard Webhooks `whsec_...` value. |
 
 Slack ETL workflows:
 

--- a/services/api-rs/Cargo.lock
+++ b/services/api-rs/Cargo.lock
@@ -717,6 +717,12 @@ checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
 name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
@@ -904,6 +910,7 @@ dependencies = [
  "serde_yaml",
  "sha2 0.11.0",
  "sqlx",
+ "standardwebhooks",
  "subtle",
  "thiserror 2.0.19",
  "time",
@@ -2234,6 +2241,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hmac-sha256"
+version = "1.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec9d92d097f4749b64e8cc33d924d9f40a2d4eb91402b458014b781f5733d60f"
+
+[[package]]
 name = "home"
 version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3206,7 +3219,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4952,6 +4965,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "standardwebhooks"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "747264efdc09640f0a838c03b220810a0b89930cb50e3a30f19379d1a90284ac"
+dependencies = [
+ "base64 0.21.7",
+ "hmac-sha256",
+ "http 1.4.2",
+ "thiserror 2.0.19",
+ "time",
+]
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6037,7 +6063,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/services/api-rs/Cargo.toml
+++ b/services/api-rs/Cargo.toml
@@ -87,6 +87,7 @@ metrics-exporter-prometheus = { version = "0.18.3", default-features = false }
 sqlx = { version = "0.8.6", default-features = false, features = ["derive", "json", "macros", "migrate", "postgres", "runtime-tokio-rustls", "time"] }
 strum = { version = "0.28", features = ["derive"] }
 subtle = "2"
+standardwebhooks = "1.0.1"
 test-case = "3.3.1"
 thiserror = "2"
 time = { version = "0.3", features = ["serde", "serde-well-known"] }

--- a/services/api-rs/crates/centaur-api-server/Cargo.toml
+++ b/services/api-rs/crates/centaur-api-server/Cargo.toml
@@ -35,6 +35,7 @@ serde.workspace = true
 serde_json.workspace = true
 serde_yaml.workspace = true
 sha2.workspace = true
+standardwebhooks.workspace = true
 subtle.workspace = true
 sqlx.workspace = true
 thiserror.workspace = true

--- a/services/api-rs/crates/centaur-api-server/src/routes.rs
+++ b/services/api-rs/crates/centaur-api-server/src/routes.rs
@@ -215,6 +215,7 @@ const REDACTED_WEBHOOK_HEADERS: &[&str] = &[
     "x-hub-signature",
     "x-hub-signature-256",
     "x-slack-signature",
+    "webhook-signature",
     "stripe-signature",
 ];
 
@@ -3831,6 +3832,9 @@ fn verify_webhook_auth(
             headers,
             raw_body,
         ),
+        WorkflowWebhookAuth::StandardWebhooks { secret_ref } => {
+            verify_standard_webhook_signature(secret_ref, headers, raw_body)
+        }
         WorkflowWebhookAuth::Hmac {
             secret_ref,
             signature_header,
@@ -3846,6 +3850,33 @@ fn verify_webhook_auth(
             raw_body,
         ),
     }
+}
+
+fn verify_standard_webhook_signature(
+    secret_ref: &str,
+    headers: &HeaderMap,
+    raw_body: &[u8],
+) -> Result<(), ApiError> {
+    let secret = env::var(secret_ref).map_err(|_| {
+        ApiError::Internal(format!(
+            "webhook auth secret {secret_ref} is not configured"
+        ))
+    })?;
+    let secret = secret.trim();
+    let encoded_secret = secret.strip_prefix("whsec_").unwrap_or(secret);
+    if encoded_secret.is_empty() {
+        return Err(ApiError::Internal(format!(
+            "webhook auth secret {secret_ref} is not valid Standard Webhooks key material"
+        )));
+    }
+    let webhook = standardwebhooks::Webhook::new(secret).map_err(|_| {
+        ApiError::Internal(format!(
+            "webhook auth secret {secret_ref} is not valid Standard Webhooks key material"
+        ))
+    })?;
+    webhook
+        .verify(raw_body, headers)
+        .map_err(|_| ApiError::Unauthorized("invalid webhook signature".to_owned()))
 }
 
 fn verify_hmac_signature(
@@ -3899,6 +3930,7 @@ fn signature_header_name(auth: &WorkflowWebhookAuth) -> Option<&str> {
     match auth {
         WorkflowWebhookAuth::None | WorkflowWebhookAuth::Bearer { .. } => None,
         WorkflowWebhookAuth::Github { .. } => Some("X-Hub-Signature-256"),
+        WorkflowWebhookAuth::StandardWebhooks { .. } => Some("webhook-signature"),
         WorkflowWebhookAuth::Hmac {
             signature_header, ..
         } => Some(signature_header),
@@ -4265,6 +4297,35 @@ mod webhook_tests {
     }
 
     #[test]
+    fn redacts_standard_webhooks_signature_header() {
+        let mut headers = HeaderMap::new();
+        headers.insert("webhook-signature", "v1,c2lnbmF0dXJl".parse().unwrap());
+        headers.insert("webhook-id", "msg_test".parse().unwrap());
+        headers.insert("webhook-timestamp", "1700000000".parse().unwrap());
+        let spec = WorkflowWebhookSpec {
+            slug: "unit".to_owned(),
+            provider: None,
+            auth: WorkflowWebhookAuth::StandardWebhooks {
+                secret_ref: "TEST_WEBHOOK_SECRET".to_owned(),
+            },
+            trigger_key: None,
+            allowed_methods: vec!["POST".to_owned()],
+            allowed_content_types: vec!["application/json".to_owned()],
+            filter: None,
+        };
+
+        let safe = safe_webhook_headers(&headers, &spec);
+
+        assert_eq!(
+            safe,
+            json!({
+                "webhook-id": "msg_test",
+                "webhook-timestamp": "1700000000"
+            })
+        );
+    }
+
+    #[test]
     fn derives_header_trigger_key() {
         let mut headers = HeaderMap::new();
         headers.insert("x-test-delivery", "delivery-1".parse().unwrap());
@@ -4306,6 +4367,97 @@ mod webhook_tests {
             raw_body,
         )
         .unwrap();
+    }
+
+    fn standard_webhook_headers(
+        secret: &str,
+        message_id: &str,
+        timestamp: i64,
+        raw_body: &[u8],
+    ) -> HeaderMap {
+        let encoded_secret = secret.strip_prefix("whsec_").unwrap_or(secret);
+        let key = general_purpose::STANDARD.decode(encoded_secret).unwrap();
+        let mut signed_content = Vec::new();
+        signed_content.extend_from_slice(message_id.as_bytes());
+        signed_content.push(b'.');
+        signed_content.extend_from_slice(timestamp.to_string().as_bytes());
+        signed_content.push(b'.');
+        signed_content.extend_from_slice(raw_body);
+        let mut mac = Hmac::<Sha256>::new_from_slice(&key).unwrap();
+        mac.update(&signed_content);
+        let signature = general_purpose::STANDARD.encode(mac.finalize().into_bytes());
+
+        let mut headers = HeaderMap::new();
+        headers.insert("webhook-id", message_id.parse().unwrap());
+        headers.insert("webhook-timestamp", timestamp.to_string().parse().unwrap());
+        headers.insert(
+            "webhook-signature",
+            format!("v2,ignored v1,AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA= v1,{signature}")
+                .parse()
+                .unwrap(),
+        );
+        headers
+    }
+
+    #[test]
+    fn verifies_standard_webhooks_signature() {
+        let raw_body = br#"{"hello":"signed"}"#;
+        let secret_ref = "CENTRAUR_TEST_STANDARD_WEBHOOK_SECRET";
+        let secret = "whsec_MfKQ9r8GKYqrTwjUPD8ILPZIo2LaLaSw";
+        let timestamp = OffsetDateTime::now_utc().unix_timestamp();
+        unsafe {
+            env::set_var(secret_ref, secret);
+        }
+        let headers = standard_webhook_headers(secret, "msg_test", timestamp, raw_body);
+
+        verify_standard_webhook_signature(secret_ref, &headers, raw_body).unwrap();
+    }
+
+    #[test]
+    fn rejects_invalid_or_stale_standard_webhooks_signature() {
+        let raw_body = br#"{"hello":"signed"}"#;
+        let secret_ref = "CENTRAUR_TEST_STANDARD_WEBHOOK_SECRET_REJECT";
+        let secret = "whsec_MfKQ9r8GKYqrTwjUPD8ILPZIo2LaLaSw";
+        unsafe {
+            env::set_var(secret_ref, secret);
+        }
+
+        let timestamp = OffsetDateTime::now_utc().unix_timestamp();
+        let headers = standard_webhook_headers(secret, "msg_test", timestamp, raw_body);
+        let error =
+            verify_standard_webhook_signature(secret_ref, &headers, br#"{"hello":"tampered"}"#)
+                .unwrap_err();
+        assert!(matches!(error, ApiError::Unauthorized(_)));
+
+        let stale_headers = standard_webhook_headers(secret, "msg_test", timestamp - 301, raw_body);
+        let error =
+            verify_standard_webhook_signature(secret_ref, &stale_headers, raw_body).unwrap_err();
+        assert!(matches!(error, ApiError::Unauthorized(_)));
+    }
+
+    #[test]
+    fn malformed_or_empty_standard_webhooks_secret_is_internal_error() {
+        let secret_ref = "CENTRAUR_TEST_STANDARD_WEBHOOK_SECRET_INVALID";
+        unsafe {
+            env::set_var(secret_ref, "whsec_not-base64");
+        }
+        let headers = standard_webhook_headers(
+            "whsec_MfKQ9r8GKYqrTwjUPD8ILPZIo2LaLaSw",
+            "msg_test",
+            OffsetDateTime::now_utc().unix_timestamp(),
+            b"{}",
+        );
+
+        let error = verify_standard_webhook_signature(secret_ref, &headers, b"{}").unwrap_err();
+
+        assert!(matches!(error, ApiError::Internal(_)));
+
+        unsafe {
+            env::set_var(secret_ref, "whsec_");
+        }
+        let error = verify_standard_webhook_signature(secret_ref, &headers, b"{}").unwrap_err();
+
+        assert!(matches!(error, ApiError::Internal(_)));
     }
 
     fn webhook_filter(value: Value) -> WebhookFilter {

--- a/services/api-rs/crates/centaur-workflows/src/lib.rs
+++ b/services/api-rs/crates/centaur-workflows/src/lib.rs
@@ -435,6 +435,9 @@ pub enum WorkflowWebhookAuth {
     Github {
         secret_ref: String,
     },
+    StandardWebhooks {
+        secret_ref: String,
+    },
     Bearer {
         secret_ref: String,
     },
@@ -1250,7 +1253,9 @@ fn normalize_webhook(webhook: &mut RegisteredWorkflowWebhook) -> Result<(), Work
                 ));
             }
         }
-        WorkflowWebhookAuth::Github { secret_ref } | WorkflowWebhookAuth::Bearer { secret_ref } => {
+        WorkflowWebhookAuth::Github { secret_ref }
+        | WorkflowWebhookAuth::StandardWebhooks { secret_ref }
+        | WorkflowWebhookAuth::Bearer { secret_ref } => {
             if secret_ref.trim().is_empty() {
                 return Err(WorkflowRuntimeError::BadRequest(format!(
                     "workflow webhook {:?} auth requires secret_ref",
@@ -4626,6 +4631,52 @@ mod tests {
         assert_eq!(all.len(), 2);
         assert_eq!(all[0].source.as_deref(), Some("header"));
         assert_eq!(all[1].key.as_deref(), Some("repository.full_name"));
+    }
+
+    #[test]
+    fn discovery_metadata_preserves_standard_webhooks_auth() {
+        let payload: PythonWorkflowDiscoveryPayload = serde_json::from_value(json!({
+            "workflows": [
+                {
+                    "workflow_name": "feed_ingest",
+                    "source_path": "workflows/feed_ingest.py",
+                    "webhooks": [
+                        {
+                            "workflow_name": "feed_ingest",
+                            "source_path": "workflows/feed_ingest.py",
+                            "spec": {
+                                "slug": "feed-ingest",
+                                "auth": {
+                                    "type": "standard_webhooks",
+                                    "secret_ref": "FEED_WEBHOOK_SECRET"
+                                },
+                                "trigger_key": {
+                                    "type": "header",
+                                    "header": "webhook-id"
+                                }
+                            }
+                        }
+                    ]
+                }
+            ],
+        }))
+        .unwrap();
+
+        let metadata = metadata_from_discovery_payload(payload);
+        let registry =
+            build_webhook_registry(&metadata, &WorkflowEnablement::allowlist("feed_ingest"))
+                .unwrap();
+        let webhook = registry.get("feed-ingest").unwrap();
+
+        assert!(matches!(
+            &webhook.spec.auth,
+            WorkflowWebhookAuth::StandardWebhooks { secret_ref }
+                if secret_ref == "FEED_WEBHOOK_SECRET"
+        ));
+        assert!(matches!(
+            &webhook.spec.trigger_key,
+            Some(WorkflowWebhookTriggerKey::Header { header }) if header == "webhook-id"
+        ));
     }
 
     fn webhook_with_filter(filter: Value) -> RegisteredWorkflowWebhook {

--- a/services/api-rs/rfcs/0003-python-workflow-host.md
+++ b/services/api-rs/rfcs/0003-python-workflow-host.md
@@ -300,7 +300,7 @@ The route should:
 
 - look up the registered slug
 - enforce allowed methods and content types
-- verify HMAC, GitHub HMAC, or bearer auth
+- verify raw-body HMAC, GitHub HMAC, Standard Webhooks, or bearer auth
 - redact sensitive headers
 - parse JSON or form payloads
 - preserve the Python-compatible input envelope


### PR DESCRIPTION
## Why

Centaur's generic HMAC webhook auth signs only the raw request body. Providers using the Standard Webhooks specification instead sign `webhook-id.webhook-timestamp.raw_body`, encode the HMAC-SHA256 result as a `v1` base64 signature, and rely on the timestamp for replay protection.

Supporting that protocol explicitly lets Standard Webhooks providers integrate without an auth-translating proxy or an unauthenticated endpoint.

## How

- Add an explicit `auth.type = "standard_webhooks"` workflow contract with a `secret_ref`.
- Verify `webhook-id`, `webhook-timestamp`, and `webhook-signature` through the official `standardwebhooks` Rust crate before creating workflow state.
- Enforce the specification's five-minute timestamp tolerance and accept space-separated `v1` signatures for key rotation.
- Fail closed when the deployment secret is missing, malformed, or empty, and redact `webhook-signature` from the workflow envelope.
- Document configuration, auth selection, replay behavior, and using `webhook-id` as the durable trigger key.

Existing `none`, raw-body `hmac`, `github`, and `bearer` behavior is unchanged. Auth remains explicitly selected by the workflow declaration; there is no header-based autodetection.

## Verification

Automated checks:

- `cargo +1.94.1 test --workspace --locked`
- `cargo +1.94.1 clippy --workspace --all-targets --locked -- -D warnings`
- `cargo +1.94.1 fmt --all --check`
- `npm ci` in `docs/`
- `npm run build` in `docs/`

Release-image and deployment smoke test:

- Built the changed release image with `just build-one api-rs`.
- Created an isolated local Kind cluster with a dedicated kubeconfig, loaded the branch-built `centaur-api-rs:latest` image, and deployed the chart with `KUBECONFIG=<isolated-kind-kubeconfig> CENTAUR_EXTRA_VALUES=<minimal-local-values> just deploy`.
- Confirmed Postgres, Console, and api-rs reached `1/1 Running`, and `/readyz` returned `200`.
- Configured one allowlisted `standard_webhooks` probe and generated deliveries with the independent official Python `standardwebhooks` SDK v1.1.0.
- A valid current delivery returned `202`, `idempotent: false`, and created exactly one durable task keyed by `webhook:pr1380-standard-webhooks-probe:webhook-id:msg_pr1380_valid_001`.
- A correctly signed body that was changed in transit returned `401`; the durable task count remained one.
- A correctly signed delivery timestamped ten minutes in the past returned `401`; the durable task count remained one.
- Replaying the valid `webhook-id` returned `200`, `idempotent: true`, reused the same task, and left the durable task count at one.

The workspace's infrastructure-dependent sandbox E2E tests remain ignored by the standard test command, as expected. The local probe intentionally exercises the changed ingress/authentication/idempotency path; its synthetic workflow has no handler.
