### PR TITLE
feat: add skill authoring commands

### DIFF
--- a/docs/pages/extend/skills.mdx
+++ b/docs/pages/extend/skills.mdx
@@ -88,6 +88,25 @@ Builtin skills remain separate: the sandbox mounts them from the overlay and
 the agent's native skill loader discovers them directly. A skill never adds
 credentials or grants.
 
+## Author Skills From A Sandbox
+
+Console users can create shared skills and edit skills they own from a sandbox:
+
+```bash
+centaur-skills create deployment-checks \
+  --description "Check a deployment before declaring it healthy." \
+  --instructions-file instructions.md
+centaur-skills edit skl_example \
+  --description "Check and diagnose deployments." \
+  --instructions-file updated-instructions.md
+```
+
+Use `--instructions` instead of `--instructions-file` for a short inline
+Markdown body. `edit` accepts partial changes and targets skills by OID. Pass
+the current `lock_version` with `--lock-version` when an edit should fail if
+another writer changed the skill first. Newly created skills are public and
+edits to public skills are visible to agents immediately.
+
 ## Verify Builtin Skills
 
 Start an agent with the overlay loaded and ask it to inspect available skills.

--- a/services/sandbox/SYSTEM_PROMPT.md
+++ b/services/sandbox/SYSTEM_PROMPT.md
@@ -74,7 +74,7 @@
 
 [Named skill resolution]
 |When the user explicitly names a skill, resolve that request against local skill definitions before doing broad semantic matching.
-|Use `centaur-skills search "<task>"` to search Console-authored guidance when no skill already listed for the current session clearly applies. Read the best match by name or OID with `centaur-skills read <skill-identifier>` before following it.
+|Use `centaur-skills search "<task>"` to search Console-authored guidance when no skill already listed for the current session clearly applies. Read the best match by name or OID with `centaur-skills read <skill-identifier>` before following it. Console users can author shared skills with `centaur-skills create` and update their own skills by OID with `centaur-skills edit`.
 |The `centaur-skills` catalog contains only Console-authored skills. Builtin skills are loaded separately by the harness. Console applies private and public visibility rules for the current principal. Catalog results are instructions only and never expand the current principal's tool or credential grants.
 |Start with the skills listed for the current session, then check local skill definitions in `.agents/skills` and any mounted overlay skills when you need to confirm the exact name or an obvious alias from the skill title or description.
 |Prefer exact name matches first, then obvious aliases, and only then fall back to broader description-level matching. Do not choose a generic adjacent workflow while a more specific named skill remains plausible.
@@ -125,6 +125,8 @@
 |centaur-tools list              → list available deployment tool CLIs
 |centaur-skills search "task"    → discover relevant private and public Console skills
 |centaur-skills read <name-or-oid> → read a Console skill's complete current SKILL.md
+|centaur-skills create <name> --description "..." --instructions-file <path> → create a shared Console skill
+|centaur-skills edit <oid> --description "..." --instructions-file <path> → update an owned Console skill
 |<tool> --help                   → inspect commands/options for one tool
 |<tool> health                   → smoke test one tool's configured auth/connectivity path
 |websearch search "query"        → web research

--- a/tools/README.md
+++ b/tools/README.md
@@ -65,7 +65,7 @@ The open-source tool inventory lives in this `tools/` tree and changes over time
 - `centaur_investigator`: parse Centaur Slack thread references and enrich them
   with best-effort vlogs/vmetrics context without exposing message context.
 - `centaur-console`: inspect sandbox permissions and configured OAuth apps.
-- `centaur-skills`: discover and read private and public Console-authored skills.
+- `centaur-skills`: discover, read, create, and edit private and public Console-authored skills.
 - `datadog`: query Datadog logs, metrics, monitors, hosts, and dashboards
   read-only with `DD_API_KEY` and `DD_APP_KEY`.
 - `preqin`: query Preqin Operational API fund and fund-manager data, with

--- a/tools/infra/centaur-skills/cli.py
+++ b/tools/infra/centaur-skills/cli.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 
 import typer
 from dotenv import load_dotenv
@@ -11,7 +12,7 @@ load_dotenv()
 
 app = typer.Typer(
     name="centaur-skills",
-    help="Discover Console-authored skills available to this agent",
+    help="Discover and author Console skills available to this agent",
     no_args_is_help=True,
 )
 
@@ -57,6 +58,97 @@ def read(
 
     document = str(result.get("document") or "")
     print(document, end="" if document.endswith("\n") else "\n")
+
+
+@app.command("create")
+def create(
+    name: str = typer.Argument(..., help="Unique lowercase skill name"),
+    description: str = typer.Option(..., "--description", "-d", help="When to use the skill"),
+    instructions: str | None = typer.Option(
+        None,
+        "--instructions",
+        "-i",
+        help="Markdown instruction body",
+    ),
+    instructions_file: Path | None = typer.Option(  # noqa: B008
+        None,
+        "--instructions-file",
+        exists=True,
+        dir_okay=False,
+        readable=True,
+        help="Read the Markdown instruction body from this file",
+    ),
+) -> None:
+    """Create a shared Console-authored skill."""
+    resolved_instructions = _resolve_instructions(instructions, instructions_file, required=True)
+    assert resolved_instructions is not None
+    with get_client() as client:
+        result = client.create(name, description, resolved_instructions)
+    print(json.dumps({"data": result}, indent=2, default=str))
+
+
+@app.command("edit")
+def edit(
+    identifier: str = typer.Argument(..., help="OID of an owned skill"),
+    name: str | None = typer.Option(None, "--name", help="New lowercase skill name"),
+    description: str | None = typer.Option(
+        None,
+        "--description",
+        "-d",
+        help="New description",
+    ),
+    instructions: str | None = typer.Option(
+        None,
+        "--instructions",
+        "-i",
+        help="New Markdown instruction body",
+    ),
+    instructions_file: Path | None = typer.Option(  # noqa: B008
+        None,
+        "--instructions-file",
+        exists=True,
+        dir_okay=False,
+        readable=True,
+        help="Read the new Markdown instruction body from this file",
+    ),
+    lock_version: int | None = typer.Option(
+        None,
+        "--lock-version",
+        min=0,
+        help="Reject the edit if the skill has changed since this version",
+    ),
+) -> None:
+    """Edit fields on an owned Console-authored skill."""
+    resolved_instructions = _resolve_instructions(instructions, instructions_file, required=False)
+    if all(value is None for value in (name, description, resolved_instructions)):
+        raise typer.BadParameter("provide --name, --description, or instructions to edit")
+
+    with get_client() as client:
+        result = client.edit(
+            identifier,
+            name=name,
+            description=description,
+            instructions=resolved_instructions,
+            lock_version=lock_version,
+        )
+    print(json.dumps({"data": result}, indent=2, default=str))
+
+
+def _resolve_instructions(
+    instructions: str | None,
+    instructions_file: Path | None,
+    *,
+    required: bool,
+) -> str | None:
+    if instructions is not None and instructions_file is not None:
+        raise typer.BadParameter("use only one of --instructions or --instructions-file")
+    if instructions_file is not None:
+        return instructions_file.read_text(encoding="utf-8")
+    if instructions is not None:
+        return instructions
+    if required:
+        raise typer.BadParameter("provide --instructions or --instructions-file")
+    return None
 
 
 if __name__ == "__main__":

--- a/tools/infra/centaur-skills/client.py
+++ b/tools/infra/centaur-skills/client.py
@@ -12,7 +12,7 @@ SANDBOX_SKILLS_PATH = "/api/v1/sandbox/skills"
 
 
 class SkillsClient:
-    """Read Console skills visible to the current sandbox principal."""
+    """Read and author Console skills for the current sandbox principal."""
 
     def __init__(
         self,
@@ -30,7 +30,11 @@ class SkillsClient:
     @property
     def base_url(self) -> str:
         # Non-secret endpoint config. Sandboxes receive this from api-rs.
-        url = (self._url or os.getenv("CENTAUR_CONSOLE_URL", "http://centaur-console:3000")).strip().rstrip("/")  # noqa: TID251
+        url = (
+            (self._url or os.getenv("CENTAUR_CONSOLE_URL", "http://centaur-console:3000"))  # noqa: TID251
+            .strip()
+            .rstrip("/")
+        )
         if url and not url.startswith(("http://", "https://")):
             url = f"http://{url}"
         return url
@@ -82,13 +86,62 @@ class SkillsClient:
             raise RuntimeError("centaur-skills response did not include a data object")
         return result
 
+    def create(self, name: str, description: str, instructions: str) -> dict[str, Any]:
+        """Create a shared Console skill owned by the current Console user."""
+        result = self._request(
+            SANDBOX_SKILLS_PATH,
+            method="POST",
+            json={
+                "data": {
+                    "name": name,
+                    "description": description,
+                    "instructions": instructions,
+                }
+            },
+        )
+        if not isinstance(result, dict):
+            raise RuntimeError("centaur-skills response did not include a data object")
+        return result
+
+    def edit(
+        self,
+        identifier: str,
+        name: str | None = None,
+        description: str | None = None,
+        instructions: str | None = None,
+        lock_version: int | None = None,
+    ) -> dict[str, Any]:
+        """Edit an owned Console skill by OID."""
+        attributes: dict[str, str | int] = {}
+        if name is not None:
+            attributes["name"] = name
+        if description is not None:
+            attributes["description"] = description
+        if instructions is not None:
+            attributes["instructions"] = instructions
+        if not attributes:
+            raise ValueError("at least one skill field must be provided")
+        if lock_version is not None:
+            attributes["lock_version"] = lock_version
+
+        result = self._request(
+            f"{SANDBOX_SKILLS_PATH}/{quote(identifier, safe='')}",
+            method="PATCH",
+            json={"data": attributes},
+        )
+        if not isinstance(result, dict):
+            raise RuntimeError("centaur-skills response did not include a data object")
+        return result
+
     def _request(
         self,
         path: str,
+        method: str = "GET",
         params: dict[str, str | int] | None = None,
+        json: dict[str, Any] | None = None,
     ) -> dict[str, Any] | list[dict[str, Any]]:
-        response = self.client.get(path, params=params)
         try:
+            response = self.client.request(method, path, params=params, json=json)
             response.raise_for_status()
         except httpx.HTTPStatusError as exc:
             detail = _response_error_detail(exc.response)

--- a/tools/infra/centaur-skills/pyproject.toml
+++ b/tools/infra/centaur-skills/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "centaur-skills"
-description = "Discover and read Console-authored skills"
+description = "Discover, read, create, and edit Console-authored skills"
 version = "0.1.0"
 requires-python = ">=3.11"
 dependencies = [

--- a/tools/infra/centaur-skills/test_client.py
+++ b/tools/infra/centaur-skills/test_client.py
@@ -2,7 +2,7 @@ import json
 
 import httpx
 import pytest
-from cli import list_skills, read, search
+from cli import create, edit, list_skills, read, search
 from client import SANDBOX_SKILLS_PATH, SkillsClient
 
 
@@ -67,6 +67,75 @@ def test_read_uses_skill_name_or_oid_and_returns_document(identifier):
     assert result["document"].startswith("---\n")
 
 
+def test_create_posts_skill_fields_and_returns_author_payload():
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.method == "POST"
+        assert request.url.path == SANDBOX_SKILLS_PATH
+        assert json.loads(request.content) == {
+            "data": {
+                "name": "incident-triage",
+                "description": "Triage incidents.",
+                "instructions": "# Workflow\n\nInvestigate the alert.",
+            }
+        }
+        return json_response(
+            {
+                "data": {
+                    "id": "skl_123",
+                    "name": "incident-triage",
+                    "lock_version": 0,
+                }
+            },
+            status_code=201,
+        )
+
+    result = make_client(handler).create(
+        "incident-triage",
+        "Triage incidents.",
+        "# Workflow\n\nInvestigate the alert.",
+    )
+
+    assert result == {
+        "id": "skl_123",
+        "name": "incident-triage",
+        "lock_version": 0,
+    }
+
+
+def test_edit_patches_only_provided_fields_with_lock_version():
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.method == "PATCH"
+        assert request.url.path == f"{SANDBOX_SKILLS_PATH}/skl_123"
+        assert json.loads(request.content) == {
+            "data": {
+                "description": "Updated incident guidance.",
+                "lock_version": 2,
+            }
+        }
+        return json_response(
+            {
+                "data": {
+                    "id": "skl_123",
+                    "description": "Updated incident guidance.",
+                    "lock_version": 3,
+                }
+            }
+        )
+
+    result = make_client(handler).edit(
+        "skl_123",
+        description="Updated incident guidance.",
+        lock_version=2,
+    )
+
+    assert result["lock_version"] == 3
+
+
+def test_edit_requires_a_field():
+    with pytest.raises(ValueError, match="at least one skill field"):
+        make_client(lambda _request: json_response({})).edit("skl_123")
+
+
 def test_requests_wrap_http_errors_without_exposing_credentials():
     def handler(_request: httpx.Request) -> httpx.Response:
         return json_response({"error": {"message": "invalid sandbox token"}}, status_code=401)
@@ -123,3 +192,70 @@ def test_cli_read_outputs_raw_skill_markdown(monkeypatch, capsys):
     read("incident-response")
 
     assert capsys.readouterr().out == "# Incident Response\n"
+
+
+def test_cli_create_reads_instructions_file(monkeypatch, capsys, tmp_path):
+    instructions_file = tmp_path / "instructions.md"
+    instructions_file.write_text("# Workflow\n\nInvestigate the alert.\n")
+
+    class StubClient:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return None
+
+        def create(self, name, description, instructions):
+            assert name == "incident-triage"
+            assert description == "Triage incidents."
+            assert instructions == "# Workflow\n\nInvestigate the alert.\n"
+            return {"id": "skl_123", "name": name, "lock_version": 0}
+
+    monkeypatch.setattr("cli.get_client", StubClient)
+
+    create(
+        "incident-triage",
+        description="Triage incidents.",
+        instructions=None,
+        instructions_file=instructions_file,
+    )
+
+    assert json.loads(capsys.readouterr().out) == {
+        "data": {"id": "skl_123", "name": "incident-triage", "lock_version": 0}
+    }
+
+
+def test_cli_edit_sends_partial_fields(monkeypatch, capsys):
+    class StubClient:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return None
+
+        def edit(self, identifier, *, name, description, instructions, lock_version):
+            assert identifier == "skl_123"
+            assert name is None
+            assert description == "Updated guidance."
+            assert instructions is None
+            assert lock_version == 2
+            return {"id": identifier, "description": description, "lock_version": 3}
+
+    monkeypatch.setattr("cli.get_client", StubClient)
+
+    edit(
+        "skl_123",
+        name=None,
+        description="Updated guidance.",
+        instructions=None,
+        instructions_file=None,
+        lock_version=2,
+    )
+
+    assert json.loads(capsys.readouterr().out) == {
+        "data": {
+            "id": "skl_123",
+            "description": "Updated guidance.",
+            "lock_version": 3,
+        }
+    }


### PR DESCRIPTION
Adds create and partial edit support to the centaur-skills client and CLI, including inline or file-based instructions and optional optimistic locking. Updates sandbox guidance and skill documentation, with focused request and CLI coverage.