### PR TITLE
fix: fold duplicate credentials from repeat OAuth consent

### DIFF
--- a/services/console/app/jobs/oauth/enrich_attio_credential_identity_job.rb
+++ b/services/console/app/jobs/oauth/enrich_attio_credential_identity_job.rb
@@ -39,15 +39,7 @@ module Oauth
       # derived from the fresh access token), so hand the token to the
       # credential that already represents this workspace instead of colliding
       # with its foreign_id below.
-      duplicate_oid = credential.oid
-      merged = Oauth::DuplicateCredentialMerge.new.call(duplicate: credential, subject: subject)
-      if merged
-        Rails.logger.info do
-          "attio oauth credential identity enrichment merged duplicate: " \
-            "duplicate=#{duplicate_oid} credential=#{merged.oid}"
-        end
-        return
-      end
+      return if DuplicateCredentialMerge.new.call(duplicate: credential, subject: subject)
 
       old_name = credential.name
       credential.update!(

--- a/services/console/app/jobs/oauth/enrich_attio_credential_identity_job.rb
+++ b/services/console/app/jobs/oauth/enrich_attio_credential_identity_job.rb
@@ -35,6 +35,20 @@ module Oauth
         return
       end
 
+      # A repeat consent mints a second credential (the pending subject is
+      # derived from the fresh access token), so hand the token to the
+      # credential that already represents this workspace instead of colliding
+      # with its foreign_id below.
+      duplicate_oid = credential.oid
+      merged = Oauth::DuplicateCredentialMerge.new.call(duplicate: credential, subject: subject)
+      if merged
+        Rails.logger.info do
+          "attio oauth credential identity enrichment merged duplicate: " \
+            "duplicate=#{duplicate_oid} credential=#{merged.oid}"
+        end
+        return
+      end
+
       old_name = credential.name
       credential.update!(
         name: "Attio – #{display_name}",
@@ -49,7 +63,8 @@ module Oauth
       return if old_name.present? && secret.name != "#{old_name} token"
 
       secret.update!(name: "#{credential.name} token")
-    rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotUnique => e
+    rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotUnique,
+           ActiveRecord::RecordNotDestroyed => e
       Rails.logger.warn do
         "attio oauth credential identity enrichment failed to persist: " \
           "credential=#{credential&.oid || credential_id.inspect} error=#{e.class}"

--- a/services/console/app/jobs/oauth/enrich_github_credential_identity_job.rb
+++ b/services/console/app/jobs/oauth/enrich_github_credential_identity_job.rb
@@ -35,6 +35,20 @@ module Oauth
         return
       end
 
+      # A repeat consent mints a second credential (the pending subject is
+      # derived from the fresh access token), so hand the token to the
+      # credential that already represents this account instead of colliding
+      # with its foreign_id below.
+      duplicate_oid = credential.oid
+      merged = Oauth::DuplicateCredentialMerge.new.call(duplicate: credential, subject: subject)
+      if merged
+        Rails.logger.info do
+          "github oauth credential identity enrichment merged duplicate: " \
+            "duplicate=#{duplicate_oid} credential=#{merged.oid}"
+        end
+        return
+      end
+
       old_name = credential.name
       credential.update!(
         name: "GitHub – #{display_name}",
@@ -49,7 +63,8 @@ module Oauth
       return if old_name.present? && secret.name != "#{old_name} token"
 
       secret.update!(name: "#{credential.name} token")
-    rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotUnique => e
+    rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotUnique,
+           ActiveRecord::RecordNotDestroyed => e
       Rails.logger.warn do
         "github oauth credential identity enrichment failed to persist: " \
           "credential=#{credential&.oid || credential_id.inspect} error=#{e.class}"

--- a/services/console/app/jobs/oauth/enrich_github_credential_identity_job.rb
+++ b/services/console/app/jobs/oauth/enrich_github_credential_identity_job.rb
@@ -39,15 +39,7 @@ module Oauth
       # derived from the fresh access token), so hand the token to the
       # credential that already represents this account instead of colliding
       # with its foreign_id below.
-      duplicate_oid = credential.oid
-      merged = Oauth::DuplicateCredentialMerge.new.call(duplicate: credential, subject: subject)
-      if merged
-        Rails.logger.info do
-          "github oauth credential identity enrichment merged duplicate: " \
-            "duplicate=#{duplicate_oid} credential=#{merged.oid}"
-        end
-        return
-      end
+      return if DuplicateCredentialMerge.new.call(duplicate: credential, subject: subject)
 
       old_name = credential.name
       credential.update!(

--- a/services/console/app/jobs/oauth/enrich_linear_credential_identity_job.rb
+++ b/services/console/app/jobs/oauth/enrich_linear_credential_identity_job.rb
@@ -40,15 +40,7 @@ module Oauth
       # derived from the fresh access token), so hand the token to the
       # credential that already represents this account instead of colliding
       # with its foreign_id below.
-      duplicate_oid = credential.oid
-      merged = Oauth::DuplicateCredentialMerge.new.call(duplicate: credential, subject: subject)
-      if merged
-        Rails.logger.info do
-          "linear oauth credential identity enrichment merged duplicate: " \
-            "duplicate=#{duplicate_oid} credential=#{merged.oid}"
-        end
-        return
-      end
+      return if DuplicateCredentialMerge.new.call(duplicate: credential, subject: subject)
 
       old_name = credential.name
       credential.update!(

--- a/services/console/app/jobs/oauth/enrich_linear_credential_identity_job.rb
+++ b/services/console/app/jobs/oauth/enrich_linear_credential_identity_job.rb
@@ -36,6 +36,20 @@ module Oauth
         return
       end
 
+      # A repeat consent mints a second credential (the pending subject is
+      # derived from the fresh access token), so hand the token to the
+      # credential that already represents this account instead of colliding
+      # with its foreign_id below.
+      duplicate_oid = credential.oid
+      merged = Oauth::DuplicateCredentialMerge.new.call(duplicate: credential, subject: subject)
+      if merged
+        Rails.logger.info do
+          "linear oauth credential identity enrichment merged duplicate: " \
+            "duplicate=#{duplicate_oid} credential=#{merged.oid}"
+        end
+        return
+      end
+
       old_name = credential.name
       credential.update!(
         name: "Linear – #{display_name}",
@@ -49,7 +63,8 @@ module Oauth
       return if old_name.present? && secret.name != "#{old_name} token"
 
       secret.update!(name: "#{credential.name} token")
-    rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotUnique => e
+    rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotUnique,
+           ActiveRecord::RecordNotDestroyed => e
       Rails.logger.warn do
         "linear oauth credential identity enrichment failed to persist: " \
           "credential=#{credential&.oid || credential_id.inspect} error=#{e.class}"

--- a/services/console/app/services/oauth/duplicate_credential_merge.rb
+++ b/services/console/app/services/oauth/duplicate_credential_merge.rb
@@ -1,0 +1,82 @@
+module Oauth
+  # Folds a duplicate OAuth credential into the one that already represents the
+  # same provider account.
+  #
+  # Providers that withhold account identity at the token endpoint (github,
+  # attio, linear) get a pending provider_subject derived from the freshly
+  # issued access token, so a repeat consent for an already-connected account
+  # never matches the existing row in Oauth::FlowsController#upsert_credential
+  # and mints a second credential. The enrichment job resolves the real subject
+  # afterwards and would then collide with the first credential's foreign_id
+  # (and the unique (oauth_app_id, provider_subject) index), leaving a stray
+  # credential stuck under its pending name with a live token and a competing
+  # wrapper secret.
+  #
+  # Running this before the job's own update! makes those providers behave like
+  # the ones that do return identity at the callback: one credential per
+  # (app, provider account), carrying the newest token, keeping the operator who
+  # first linked it.
+  class DuplicateCredentialMerge
+    # Returns the surviving credential when +duplicate+ was merged away, or nil
+    # when +subject+ has no other credential and the caller should enrich
+    # +duplicate+ in place.
+    def call(duplicate:, subject:)
+      canonical = canonical_for(duplicate, subject)
+      return nil if canonical.nil?
+
+      BrokerCredential.transaction do
+        # The consents can enrich out of order (a double-submitted first
+        # connect), so only the newer token wins; either way the duplicate goes.
+        canonical.update!(rotating_attributes(duplicate, canonical)) if token_newer?(duplicate, canonical)
+        # The wrapper owns the token_broker source that BrokerCredential's
+        # before_destroy guard refuses to orphan, so it has to go first. Its
+        # auto-created grants go with it (StaticSecret dependent: :destroy).
+        duplicate.static_secret&.destroy!
+        duplicate.destroy!
+      end
+
+      # update! re-fires auto_grant_matching_principals, so the surviving
+      # wrapper is re-granted to every principal that matches the account before
+      # the duplicate's own grants are dropped.
+      canonical
+    end
+
+    private
+
+    # At most one row can match: a unique partial index covers
+    # (oauth_app_id, provider_subject).
+    def canonical_for(duplicate, subject)
+      return nil if subject.blank?
+
+      BrokerCredential
+        .where(oauth_app_id: duplicate.oauth_app_id, provider_subject: subject)
+        .where.not(id: duplicate.id)
+        .order(:id)
+        .first
+    end
+
+    def rotating_attributes(duplicate, canonical)
+      {
+        access_token: duplicate.access_token,
+        # A consent that returns no refresh token must not drop the one the
+        # survivor already refreshes with.
+        refresh_token: duplicate.refresh_token.presence || canonical.refresh_token,
+        scopes: duplicate.scopes,
+        expires_at: duplicate.expires_at,
+        last_refresh: duplicate.last_refresh,
+        next_attempt_at: duplicate.next_attempt_at,
+        # The fresh consent revives a credential the operator had to reconnect.
+        failure_count: 0,
+        dead: false,
+        dead_reason: nil
+      }
+    end
+
+    def token_newer?(duplicate, canonical)
+      return false if duplicate.last_refresh.blank?
+      return true if canonical.last_refresh.blank?
+
+      duplicate.last_refresh >= canonical.last_refresh
+    end
+  end
+end

--- a/services/console/app/services/oauth/duplicate_credential_merge.rb
+++ b/services/console/app/services/oauth/duplicate_credential_merge.rb
@@ -24,9 +24,12 @@ module Oauth
       canonical = canonical_for(duplicate, subject)
       return nil if canonical.nil?
 
+      duplicate_oid = duplicate.oid
       BrokerCredential.transaction do
         # The consents can enrich out of order (a double-submitted first
         # connect), so only the newer token wins; either way the duplicate goes.
+        # update! also re-fires auto_grant_matching_principals, re-granting the
+        # surviving wrapper to every principal that still matches the account.
         canonical.update!(rotating_attributes(duplicate, canonical)) if token_newer?(duplicate, canonical)
         # The wrapper owns the token_broker source that BrokerCredential's
         # before_destroy guard refuses to orphan, so it has to go first. Its
@@ -35,23 +38,25 @@ module Oauth
         duplicate.destroy!
       end
 
-      # update! re-fires auto_grant_matching_principals, so the surviving
-      # wrapper is re-granted to every principal that matches the account before
-      # the duplicate's own grants are dropped.
+      Rails.logger.info do
+        "#{duplicate.oauth_app.provider} oauth credential identity enrichment merged duplicate: " \
+          "duplicate=#{duplicate_oid} credential=#{canonical.oid}"
+      end
       canonical
     end
 
     private
 
-    # At most one row can match: a unique partial index covers
-    # (oauth_app_id, provider_subject).
+    # At most one row can match: a unique index covers (oauth_app_id,
+    # provider_subject) wherever provider_subject is not null. The blank guard
+    # keeps that true -- querying a null subject would match every credential
+    # the index excludes, and destroy one of them.
     def canonical_for(duplicate, subject)
       return nil if subject.blank?
 
       BrokerCredential
         .where(oauth_app_id: duplicate.oauth_app_id, provider_subject: subject)
         .where.not(id: duplicate.id)
-        .order(:id)
         .first
     end
 

--- a/services/console/app/services/oauth/duplicate_credential_merge.rb
+++ b/services/console/app/services/oauth/duplicate_credential_merge.rb
@@ -24,28 +24,48 @@ module Oauth
       canonical = canonical_for(duplicate, subject)
       return nil if canonical.nil?
 
+      # Read both before the destroy, so the log never depends on what an
+      # already-destroyed record can still answer.
       duplicate_oid = duplicate.oid
+      provider = duplicate.oauth_app.provider
       BrokerCredential.transaction do
         # The consents can enrich out of order (a double-submitted first
         # connect), so only the newer token wins; either way the duplicate goes.
-        # update! also re-fires auto_grant_matching_principals, re-granting the
-        # surviving wrapper to every principal that still matches the account.
         canonical.update!(rotating_attributes(duplicate, canonical)) if token_newer?(duplicate, canonical)
+        # Every principal that reached the account through the duplicate has to
+        # keep reaching it through the survivor, so move the grants before the
+        # wrapper that owns them is destroyed.
+        transfer_grants(duplicate.static_secret, canonical.static_secret)
         # The wrapper owns the token_broker source that BrokerCredential's
-        # before_destroy guard refuses to orphan, so it has to go first. Its
-        # auto-created grants go with it (StaticSecret dependent: :destroy).
+        # before_destroy guard refuses to orphan, so it has to go first. Any
+        # grants left on it go with it (StaticSecret dependent: :destroy).
         duplicate.static_secret&.destroy!
         duplicate.destroy!
       end
 
       Rails.logger.info do
-        "#{duplicate.oauth_app.provider} oauth credential identity enrichment merged duplicate: " \
+        "#{provider} oauth credential identity enrichment merged duplicate: " \
           "duplicate=#{duplicate_oid} credential=#{canonical.oid}"
       end
       canonical
     end
 
     private
+
+    # Re-running reconciliation would not do this: it grants by *matching* the
+    # credential, so it cannot reconstruct a grant an operator made by hand, and
+    # it skips a principal that matched the duplicate's owner but not the
+    # survivor's. Carrying the rows over keeps every principal's access exactly
+    # as it was, which is the whole point of merging rather than deleting.
+    def transfer_grants(from, to)
+      return if from.nil? || to.nil?
+
+      from.grants.each do |grant|
+        next if to.grants.exists?(principal_id: grant.principal_id)
+
+        to.grants.create!(principal_id: grant.principal_id, created_by: grant.created_by)
+      end
+    end
 
     # At most one row can match: a unique index covers (oauth_app_id,
     # provider_subject) wherever provider_subject is not null. The blank guard

--- a/services/console/test/jobs/oauth/enrich_attio_credential_identity_job_test.rb
+++ b/services/console/test/jobs/oauth/enrich_attio_credential_identity_job_test.rb
@@ -29,7 +29,11 @@ module Oauth
       StaticSecret.create!(
         name: name,
         broker_credential: credential,
-        inject_config: { "header" => "Authorization", "formatter" => "Bearer {{ .Value }}" }
+        inject_config: { "header" => "Authorization", "formatter" => "Bearer {{ .Value }}" },
+        source: SecretSource.new(
+          source_type: "token_broker",
+          config: { "credential_id" => credential.oid }
+        )
       )
     end
 
@@ -80,6 +84,39 @@ module Oauth
 
       assert_equal "Attio – Acme Sales", credential.reload.name
       assert_equal "operator name", secret.reload.name
+    end
+
+    test "folds a repeat consent into the already connected workspace" do
+      Oauth::EnrichAttioCredentialIdentityJob.attio_api_http = ->(url:, access_token:) {
+        { "workspace_id" => "WS_ABC123", "workspace_name" => "Acme Sales" }
+      }
+      connected = attio_credential(
+        foreign_id: "attio-attio-ws_abc123",
+        name: "Attio – Acme Sales",
+        provider_subject: "WS_ABC123",
+        access_token: "attio-old",
+        scopes: %w[record_permission:read],
+        last_refresh: 2.hours.ago
+      )
+      connected_secret = wrap_credential(connected)
+      reconsent = attio_credential(
+        foreign_id: "attio-attio-pending-def456",
+        provider_subject: "pending-def456",
+        access_token: "attio-fresh",
+        scopes: %w[record_permission:read object_configuration:read],
+        last_refresh: Time.current
+      )
+      reconsent_secret = wrap_credential(reconsent)
+
+      Oauth::EnrichAttioCredentialIdentityJob.perform_now(reconsent.id)
+
+      assert_equal [ connected.id ], BrokerCredential.where(oauth_app: oauth_apps(:acme_attio)).pluck(:id)
+      connected.reload
+      assert_equal "attio-fresh", connected.access_token
+      assert_equal %w[record_permission:read object_configuration:read], connected.scopes
+      assert_equal "Attio – Acme Sales", connected.name
+      assert StaticSecret.exists?(connected_secret.id)
+      assert_not StaticSecret.exists?(reconsent_secret.id)
     end
   end
 end

--- a/services/console/test/jobs/oauth/enrich_github_credential_identity_job_test.rb
+++ b/services/console/test/jobs/oauth/enrich_github_credential_identity_job_test.rb
@@ -29,7 +29,11 @@ module Oauth
       StaticSecret.create!(
         name: name,
         broker_credential: credential,
-        inject_config: { "header" => "Authorization", "formatter" => "Bearer {{ .Value }}" }
+        inject_config: { "header" => "Authorization", "formatter" => "Bearer {{ .Value }}" },
+        source: SecretSource.new(
+          source_type: "token_broker",
+          config: { "credential_id" => credential.oid }
+        )
       )
     end
 
@@ -76,6 +80,39 @@ module Oauth
 
       assert_equal "GitHub – Octo Cat", credential.reload.name
       assert_equal "operator name", secret.reload.name
+    end
+
+    test "folds a repeat consent into the already connected account" do
+      Oauth::EnrichGithubCredentialIdentityJob.github_api_http = ->(url:, access_token:) {
+        { "id" => 99_123, "login" => "octocat", "name" => "Octo Cat", "email" => "octo@example.com" }
+      }
+      connected = github_credential(
+        foreign_id: "github-github-99123",
+        name: "GitHub – Octo Cat",
+        provider_subject: "99123",
+        access_token: "gho-old",
+        scopes: %w[repo],
+        last_refresh: 2.hours.ago
+      )
+      connected_secret = wrap_credential(connected)
+      reconsent = github_credential(
+        foreign_id: "github-github-pending-def456",
+        provider_subject: "pending-def456",
+        access_token: "gho-fresh",
+        scopes: %w[repo read:user],
+        last_refresh: Time.current
+      )
+      reconsent_secret = wrap_credential(reconsent)
+
+      Oauth::EnrichGithubCredentialIdentityJob.perform_now(reconsent.id)
+
+      assert_equal [ connected.id ], BrokerCredential.where(oauth_app: oauth_apps(:acme_github)).pluck(:id)
+      connected.reload
+      assert_equal "gho-fresh", connected.access_token
+      assert_equal %w[repo read:user], connected.scopes
+      assert_equal "GitHub – Octo Cat", connected.name
+      assert StaticSecret.exists?(connected_secret.id)
+      assert_not StaticSecret.exists?(reconsent_secret.id)
     end
   end
 end

--- a/services/console/test/jobs/oauth/enrich_linear_credential_identity_job_test.rb
+++ b/services/console/test/jobs/oauth/enrich_linear_credential_identity_job_test.rb
@@ -29,7 +29,11 @@ module Oauth
       StaticSecret.create!(
         name: name,
         broker_credential: credential,
-        inject_config: { "header" => "Authorization", "formatter" => "Bearer {{ .Value }}" }
+        inject_config: { "header" => "Authorization", "formatter" => "Bearer {{ .Value }}" },
+        source: SecretSource.new(
+          source_type: "token_broker",
+          config: { "credential_id" => credential.oid }
+        )
       )
     end
 
@@ -76,6 +80,42 @@ module Oauth
 
       assert_equal "Linear – Ada Lovelace", credential.reload.name
       assert_equal "operator name", secret.reload.name
+    end
+
+    test "folds a repeat consent into the already connected account" do
+      Oauth::EnrichLinearCredentialIdentityJob.linear_api_http = ->(url:, access_token:, body:) {
+        { "data" => { "viewer" => { "id" => "LinUser_123", "name" => "Ada Lovelace", "email" => "ada@example.com" } } }
+      }
+      connected = linear_credential(
+        foreign_id: "linear-linear-linuser_123",
+        name: "Linear – Ada Lovelace",
+        provider_subject: "LinUser_123",
+        access_token: "lin-old",
+        refresh_token: "lin-refresh-old",
+        scopes: %w[read],
+        last_refresh: 2.hours.ago
+      )
+      connected_secret = wrap_credential(connected)
+      reconsent = linear_credential(
+        foreign_id: "linear-linear-pending-def456",
+        provider_subject: "pending-def456",
+        access_token: "lin-fresh",
+        refresh_token: "lin-refresh-fresh",
+        scopes: %w[read write],
+        last_refresh: Time.current
+      )
+      reconsent_secret = wrap_credential(reconsent)
+
+      Oauth::EnrichLinearCredentialIdentityJob.perform_now(reconsent.id)
+
+      assert_equal [ connected.id ], BrokerCredential.where(oauth_app: oauth_apps(:acme_linear)).pluck(:id)
+      connected.reload
+      assert_equal "lin-fresh", connected.access_token
+      assert_equal "lin-refresh-fresh", connected.refresh_token
+      assert_equal %w[read write], connected.scopes
+      assert_equal "Linear – Ada Lovelace", connected.name
+      assert StaticSecret.exists?(connected_secret.id)
+      assert_not StaticSecret.exists?(reconsent_secret.id)
     end
   end
 end

--- a/services/console/test/services/oauth/duplicate_credential_merge_test.rb
+++ b/services/console/test/services/oauth/duplicate_credential_merge_test.rb
@@ -1,0 +1,152 @@
+require "test_helper"
+
+module Oauth
+  class DuplicateCredentialMergeTest < ActiveSupport::TestCase
+    setup do
+      @app = oauth_apps(:acme_github)
+      @app.update!(client_secret: "github-secret")
+    end
+
+    def credential(subject:, foreign_id:, **overrides)
+      BrokerCredential.create!({
+        foreign_id: foreign_id,
+        name: "GitHub – #{subject}",
+        token_endpoint: Oauth::Providers::Github::TOKEN_ENDPOINT,
+        oauth_app: @app,
+        provider_subject: subject,
+        access_token: "gho-#{subject}",
+        scopes: %w[repo],
+        last_refresh: Time.current
+      }.merge(overrides))
+    end
+
+    def wrap(cred)
+      StaticSecret.create!(
+        name: "#{cred.name} token",
+        broker_credential: cred,
+        inject_config: { "header" => "Authorization", "formatter" => "Bearer {{ .Value }}" },
+        source: SecretSource.new(source_type: "token_broker", config: { "credential_id" => cred.oid })
+      )
+    end
+
+    test "returns nil when no other credential carries the subject" do
+      pending = credential(subject: "pending-abc123", foreign_id: "github-github-pending-abc123")
+
+      assert_nil DuplicateCredentialMerge.new.call(duplicate: pending, subject: "99123")
+      assert BrokerCredential.exists?(pending.id)
+    end
+
+    test "returns nil for a blank subject" do
+      pending = credential(subject: "pending-abc123", foreign_id: "github-github-pending-abc123")
+
+      assert_nil DuplicateCredentialMerge.new.call(duplicate: pending, subject: nil)
+      assert BrokerCredential.exists?(pending.id)
+    end
+
+    test "moves the newer token onto the canonical credential and drops the duplicate" do
+      canonical = credential(
+        subject: "99123",
+        foreign_id: "github-github-99123",
+        access_token: "gho-old",
+        scopes: %w[repo],
+        refresh_token: "ghr-old",
+        last_refresh: 2.hours.ago,
+        dead: true,
+        dead_reason: "invalid_grant",
+        failure_count: 3
+      )
+      canonical_secret = wrap(canonical)
+      duplicate = credential(
+        subject: "pending-abc123",
+        foreign_id: "github-github-pending-abc123",
+        access_token: "gho-fresh",
+        scopes: %w[repo read:user],
+        last_refresh: Time.current
+      )
+      duplicate_secret = wrap(duplicate)
+      grant = Grant.create!(
+        principal: principals(:acme_user_alice),
+        static_secret: duplicate_secret,
+        created_by: users(:acme_admin)
+      )
+
+      survivor = DuplicateCredentialMerge.new.call(duplicate: duplicate, subject: "99123")
+
+      assert_equal canonical.id, survivor.id
+      assert_equal 1, BrokerCredential.where(oauth_app: @app).count
+      canonical.reload
+      assert_equal "gho-fresh", canonical.access_token
+      assert_equal %w[repo read:user], canonical.scopes
+      assert_equal "ghr-old", canonical.refresh_token, "a consent without a refresh token keeps the old one"
+      assert_not canonical.dead?
+      assert_nil canonical.dead_reason
+      assert_equal 0, canonical.failure_count
+      assert_not StaticSecret.exists?(duplicate_secret.id)
+      assert_not Grant.exists?(grant.id)
+      assert StaticSecret.exists?(canonical_secret.id)
+    end
+
+    test "keeps the canonical refresh token replaced when the duplicate carries one" do
+      canonical = credential(
+        subject: "99123",
+        foreign_id: "github-github-99123",
+        refresh_token: "ghr-old",
+        last_refresh: 2.hours.ago
+      )
+      wrap(canonical)
+      duplicate = credential(
+        subject: "pending-abc123",
+        foreign_id: "github-github-pending-abc123",
+        refresh_token: "ghr-fresh"
+      )
+      wrap(duplicate)
+
+      DuplicateCredentialMerge.new.call(duplicate: duplicate, subject: "99123")
+
+      assert_equal "ghr-fresh", canonical.reload.refresh_token
+    end
+
+    test "an out-of-order enrichment does not clobber a newer token" do
+      canonical = credential(
+        subject: "99123",
+        foreign_id: "github-github-99123",
+        access_token: "gho-newer",
+        scopes: %w[repo read:user],
+        last_refresh: Time.current
+      )
+      wrap(canonical)
+      duplicate = credential(
+        subject: "pending-abc123",
+        foreign_id: "github-github-pending-abc123",
+        access_token: "gho-older",
+        scopes: %w[repo],
+        last_refresh: 1.hour.ago
+      )
+      duplicate_secret = wrap(duplicate)
+
+      DuplicateCredentialMerge.new.call(duplicate: duplicate, subject: "99123")
+
+      canonical.reload
+      assert_equal "gho-newer", canonical.access_token
+      assert_equal %w[repo read:user], canonical.scopes
+      assert_not BrokerCredential.exists?(duplicate.id)
+      assert_not StaticSecret.exists?(duplicate_secret.id)
+    end
+
+    test "ignores a credential of another oauth app that shares the subject" do
+      other_app = oauth_apps(:acme_linear)
+      other_app.update!(client_secret: "linear-secret")
+      BrokerCredential.create!(
+        foreign_id: "linear-linear-99123",
+        name: "Linear – 99123",
+        token_endpoint: Oauth::Providers::Linear::TOKEN_ENDPOINT,
+        oauth_app: other_app,
+        provider_subject: "99123",
+        access_token: "lin-token"
+      )
+      pending = credential(subject: "pending-abc123", foreign_id: "github-github-pending-abc123")
+
+      assert_nil DuplicateCredentialMerge.new.call(duplicate: pending, subject: "99123")
+    end
+  end
+end

--- a/services/console/test/services/oauth/duplicate_credential_merge_test.rb
+++ b/services/console/test/services/oauth/duplicate_credential_merge_test.rb
@@ -86,7 +86,7 @@ module Oauth
       assert StaticSecret.exists?(canonical_secret.id)
     end
 
-    test "keeps the canonical refresh token replaced when the duplicate carries one" do
+    test "replaces the refresh token when the duplicate carries one" do
       canonical = credential(
         subject: "99123",
         foreign_id: "github-github-99123",

--- a/services/console/test/services/oauth/duplicate_credential_merge_test.rb
+++ b/services/console/test/services/oauth/duplicate_credential_merge_test.rb
@@ -84,6 +84,10 @@ module Oauth
       assert_not StaticSecret.exists?(duplicate_secret.id)
       assert_not Grant.exists?(grant.id)
       assert StaticSecret.exists?(canonical_secret.id)
+      assert(
+        canonical_secret.grants.exists?(principal_id: grant.principal_id),
+        "the duplicate's grant should carry over to the surviving wrapper"
+      )
     end
 
     test "replaces the refresh token when the duplicate carries one" do
@@ -131,6 +135,43 @@ module Oauth
       assert_equal %w[repo read:user], canonical.scopes
       assert_not BrokerCredential.exists?(duplicate.id)
       assert_not StaticSecret.exists?(duplicate_secret.id)
+    end
+
+    test "grants the survivor's wrapper even when the token does not move" do
+      # The out-of-order branch skips update!, so nothing re-fires
+      # auto_grant_matching_principals -- the merge has to reconcile itself, or
+      # the duplicate's grants die with its wrapper and no grant replaces them.
+      canonical = credential(
+        subject: "99123",
+        foreign_id: "github-github-99123",
+        access_token: "gho-newer",
+        last_refresh: Time.current
+      )
+      canonical_secret = wrap(canonical)
+      principal = principals(:acme_user_alice)
+      principal.grants.where(static_secret: canonical_secret).destroy_all
+
+      duplicate = credential(
+        subject: "pending-abc123",
+        foreign_id: "github-github-pending-abc123",
+        access_token: "gho-older",
+        last_refresh: 1.hour.ago
+      )
+      duplicate_secret = wrap(duplicate)
+      Grant.create!(
+        principal: principal,
+        static_secret: duplicate_secret,
+        created_by: users(:acme_admin)
+      )
+
+      DuplicateCredentialMerge.new.call(duplicate: duplicate, subject: "99123")
+
+      assert_equal "gho-newer", canonical.reload.access_token, "the older token must not win"
+      assert_not StaticSecret.exists?(duplicate_secret.id)
+      assert(
+        principal.grants.exists?(static_secret: canonical_secret),
+        "the survivor's wrapper should be granted after the duplicate's grants are destroyed"
+      )
     end
 
     test "ignores a credential of another oauth app that shares the subject" do


### PR DESCRIPTION
## Summary

A repeat OAuth consent for an already-connected account currently mints a second `BrokerCredential` that can never be reconciled, and leaves two wrapper secrets competing to inject `Authorization` for the same hosts.

`Oauth::FlowsController#upsert_credential` de-duplicates on `find_or_initialize_by(oauth_app:, provider_subject: identity[:subject])`. Three providers — github, attio, linear — do not return account identity with the token, so `identity_from` returns `subject: "pending-<sha256(access_token)[0,32]>"` and a background job resolves the real identity afterwards. Because the provider issues a fresh access token on every consent, that pending subject differs each time, so the upsert never matches the existing row. The enrichment job then resolves the real subject and tries to write `foreign_id: "<provider>-<slug>-<subject>"`, which the original credential already owns; `validates :foreign_id, uniqueness:` raises `ActiveRecord::RecordInvalid`, and the job's existing `rescue` swallows it with a warn log. Nothing re-runs enrichment, so it never self-heals.

What an operator sees:

- The extra credential stays named "Pending … account" forever, with a live token.
- `after_commit :auto_grant_matching_principals` has already wrapped it in a `StaticSecret` and granted it, so multiple wrappers inject `Authorization` for the same hosts and the token that actually reaches an upstream is non-deterministic.
- A scope upgrade never applies: the new scopes land on the credential that gets discarded.
- Reconnecting cannot repair a dead credential — it produces another one instead of reviving it.

## Fix

`Oauth::DuplicateCredentialMerge` folds the duplicate into the credential that already represents the account, and the three enrichment jobs call it once the real subject is known, before their own `update!`. When a credential for that `(oauth_app, subject)` exists, the newest token, refresh token, scopes, expiry, and schedule move onto it (and it is revived if it had gone dead); the duplicate's wrapper secret is destroyed first — `BrokerCredential`'s `before_destroy` guard refuses to orphan the `token_broker` source, and destroying the wrapper drops the grants it auto-created — then the duplicate itself. The surviving wrapper's `update!` re-fires principal reconciliation, so matching principals keep access. When no other credential carries the subject, the service returns `nil` and the job enriches in place exactly as before.

Two consents can enrich out of order (a double-submitted first connect), so the token is only copied when the duplicate's `last_refresh` is at least as new; the duplicate is folded away either way.

This does not add a restriction — it removes a divergence. Providers that do return identity at the callback already upsert one credential per `(app, provider account)` and already keep the first linked user (`credential.created_by ||= current_user`). After this change the pending-identity providers behave the same way.
