### PR TITLE
feat: add collaborative skill editors

### DIFF
--- a/services/console/app/controllers/api/v1/sandbox/skills_controller.rb
+++ b/services/console/app/controllers/api/v1/sandbox/skills_controller.rb
@@ -31,7 +31,7 @@ module Api
         end
 
         def update
-          skill = owned_skill
+          skill = editable_skill
           skill.update!(skill_params)
           render json: { data: author_payload(skill) }
         end
@@ -82,6 +82,10 @@ module Api
 
         def owned_skill
           authoring_user.skills.active.find_by_oid!(params[:id])
+        end
+
+        def editable_skill
+          Skill.editable_by(authoring_user).find_by_oid!(params[:id])
         end
 
         def skill_params

--- a/services/console/app/controllers/api/v1/sandbox/skills_controller.rb
+++ b/services/console/app/controllers/api/v1/sandbox/skills_controller.rb
@@ -3,7 +3,7 @@ module Api
     module Sandbox
       class SkillsController < Api::SandboxBaseController
         MAX_LIMIT = 20
-        before_action :require_authoring_user!, only: %i[create update destroy share unshare]
+        before_action :require_authoring_user!, only: %i[create update destroy share unshare editors add_editor remove_editor]
 
         def index
           scope = visible_skills.order(updated_at: :desc, id: :asc).limit(limit)
@@ -53,6 +53,37 @@ module Api
           render json: { data: author_payload(skill) }
         end
 
+        def editors
+          render json: { data: editor_management_payload(editable_skill) }
+        end
+
+        def add_editor
+          skill = owned_skill
+          editor = resolve_editor!(User.active)
+
+          Skill.transaction do
+            assignment = skill.skill_editors.find_or_initialize_by(user: editor)
+            if assignment.new_record?
+              assignment.save!
+              skill.touch
+            end
+          end
+
+          render json: { data: editor_management_payload(skill) }
+        end
+
+        def remove_editor
+          skill = owned_skill
+          editor = resolve_editor!(skill.editors)
+
+          Skill.transaction do
+            skill.skill_editors.find_by!(user: editor).destroy!
+            skill.touch
+          end
+
+          render json: { data: editor_management_payload(skill) }
+        end
+
         private
 
         def require_authoring_user!
@@ -96,6 +127,30 @@ module Api
 
         def author_payload(skill)
           skill.catalog_payload(include_document: true).merge(lock_version: skill.lock_version)
+        end
+
+        def editor_management_payload(skill)
+          {
+            id: skill.oid,
+            editors: skill.editors.order(:email).map { |editor| editor_payload(editor) },
+            lock_version: skill.lock_version
+          }
+        end
+
+        def editor_payload(editor)
+          {
+            id: editor.oid,
+            email: editor.email,
+            name: editor.name,
+            status: editor.status
+          }
+        end
+
+        def resolve_editor!(scope)
+          reference = params.require(:data).require(:user).to_s.strip
+          return scope.find_by_oid!(reference) if reference.start_with?("usr_")
+
+          scope.find_by!(email: reference.downcase)
         end
 
         def limit

--- a/services/console/app/controllers/api/v1/sandbox/skills_controller.rb
+++ b/services/console/app/controllers/api/v1/sandbox/skills_controller.rb
@@ -3,7 +3,7 @@ module Api
     module Sandbox
       class SkillsController < Api::SandboxBaseController
         MAX_LIMIT = 20
-        before_action :require_authoring_user!, only: %i[create update destroy share unshare editors add_editor remove_editor]
+        before_action :require_authoring_user!, only: %i[create update destroy share unshare add_editor remove_editor]
 
         def index
           scope = visible_skills.order(updated_at: :desc, id: :asc).limit(limit)
@@ -54,7 +54,7 @@ module Api
         end
 
         def editors
-          render json: { data: editor_management_payload(editable_skill) }
+          render json: { data: editor_management_payload(visible_skill) }
         end
 
         def add_editor

--- a/services/console/app/controllers/console/skills_controller.rb
+++ b/services/console/app/controllers/console/skills_controller.rb
@@ -16,11 +16,15 @@ class Console::SkillsController < ApplicationController
 
   def new
     @skill = current_user.skills.new(content: "# Instructions")
+    prepare_editor_picker
   end
 
   def create
-    @skill = current_user.skills.new(skill_params)
-    if @skill.save
+    attributes = skill_params
+    editor_oids = attributes.delete(:editor_oids)
+    @skill = current_user.skills.new(attributes)
+    prepare_editor_picker(editor_oids)
+    if save_with_editors
       redirect_to console_skill_path(@skill.oid), notice: "Skill created."
     else
       render :new, status: :unprocessable_entity
@@ -28,12 +32,17 @@ class Console::SkillsController < ApplicationController
   end
 
   def edit
-    @skill = owned_skill
+    @skill = editable_skill
+    prepare_editor_picker
   end
 
   def update
-    @skill = owned_skill
-    if @skill.update(skill_params)
+    @skill = editable_skill
+    attributes = skill_params
+    editor_oids = attributes.delete(:editor_oids)
+    @skill.assign_attributes(attributes)
+    prepare_editor_picker(owner? ? editor_oids : nil)
+    if save_with_editors(manage_editors: owner?)
       redirect_to console_skill_path(@skill.oid), notice: "Skill saved."
     else
       render :edit, status: :unprocessable_entity
@@ -66,7 +75,7 @@ class Console::SkillsController < ApplicationController
     @tab = tab
     @query = params[:q].to_s.strip
     @skills = if @tab == "mine"
-      current_user.skills.active
+      Skill.editable_by(current_user).includes(:user)
     else
       Skill.active.shared.includes(:user)
     end
@@ -82,6 +91,10 @@ class Console::SkillsController < ApplicationController
     current_user.skills.active.find_by_oid!(params[:id])
   end
 
+  def editable_skill
+    Skill.editable_by(current_user).find_by_oid!(params[:id])
+  end
+
   def moderation_skill
     return owned_skill unless acting_admin?
 
@@ -89,6 +102,51 @@ class Console::SkillsController < ApplicationController
   end
 
   def skill_params
-    params.require(:skill).permit(:name, :description, :content, :lock_version)
+    params.require(:skill).permit(:name, :description, :content, :lock_version, editor_oids: [])
+  end
+
+  def owner?
+    @skill.user_id == current_user.id
+  end
+
+  def prepare_editor_picker(submitted_oids = nil)
+    @editor_candidates = User.active.where.not(id: @skill.user_id || current_user.id).order(:email)
+    @selected_editors = if submitted_oids.nil?
+      @skill.persisted? ? @skill.editors.active.order(:email).to_a : []
+    else
+      resolve_editor_users(submitted_oids)
+    end
+  end
+
+  def resolve_editor_users(oids)
+    submitted = Array(oids).compact_blank.uniq
+    ids = submitted.filter_map { |oid| User.decode_oid(oid) }
+    users_by_id = User.active.where(id: ids).index_by(&:id)
+    users = ids.filter_map { |id| users_by_id[id] }.reject { |user| user.id == @skill.user_id }
+
+    if ids.length != submitted.length || users.length != ids.length
+      @skill.errors.add(:editors, "include an unavailable user")
+      @editor_selection_invalid = true
+    end
+    users
+  end
+
+  def save_with_editors(manage_editors: true)
+    return false unless @skill.valid?
+    if @editor_selection_invalid
+      @skill.errors.add(:editors, "include an unavailable user")
+      return false
+    end
+
+    if manage_editors
+      selected_ids = @selected_editors.map(&:id)
+      @skill.updated_at = Time.current if @skill.editor_ids.sort != selected_ids.sort
+    end
+
+    Skill.transaction do
+      @skill.save!
+      @skill.editor_ids = @selected_editors.map(&:id) if manage_editors
+    end
+    true
   end
 end

--- a/services/console/app/javascript/controllers/user_typeahead_controller.js
+++ b/services/console/app/javascript/controllers/user_typeahead_controller.js
@@ -1,0 +1,131 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Multi-user picker with a filterable listbox. Selected users are submitted as
+// opaque IDs, while all filtering and chip management stays client-side.
+export default class extends Controller {
+  static targets = ["input", "listbox", "option", "selections", "empty"]
+
+  connect() {
+    this.syncOptions()
+  }
+
+  open() {
+    this.listboxTarget.hidden = false
+    this.inputTarget.setAttribute("aria-expanded", "true")
+    this.filter()
+  }
+
+  close(event) {
+    if (event && this.element.contains(event.target)) return
+
+    this.listboxTarget.hidden = true
+    this.inputTarget.setAttribute("aria-expanded", "false")
+    this.activeOption = null
+  }
+
+  filter() {
+    const query = this.inputTarget.value.trim().toLowerCase()
+    const selectedOids = this.selectedOids()
+
+    this.optionTargets.forEach((option) => {
+      const selected = selectedOids.has(option.dataset.userOid)
+      option.closest("li").hidden = selected || !option.dataset.searchText.includes(query)
+    })
+  }
+
+  select(event) {
+    event.preventDefault()
+    this.addOption(event.currentTarget)
+  }
+
+  remove(event) {
+    event.preventDefault()
+    event.currentTarget.closest("[data-user-typeahead-target='selection']").remove()
+    this.syncOptions()
+    this.inputTarget.focus()
+    this.open()
+  }
+
+  navigate(event) {
+    if (event.key === "Escape") {
+      this.close()
+      return
+    }
+
+    if (!["ArrowDown", "ArrowUp", "Enter"].includes(event.key)) return
+
+    const options = this.visibleOptions()
+    if (options.length === 0) return
+
+    event.preventDefault()
+    if (event.key === "Enter") {
+      this.addOption(this.activeOption || options[0])
+      return
+    }
+
+    const currentIndex = options.indexOf(this.activeOption)
+    const offset = event.key === "ArrowDown" ? 1 : -1
+    const nextIndex = currentIndex === -1
+      ? (offset === 1 ? 0 : options.length - 1)
+      : (currentIndex + offset + options.length) % options.length
+    this.focusOption(options[nextIndex])
+  }
+
+  addOption(option) {
+    if (this.selectedOids().has(option.dataset.userOid)) return
+
+    const row = document.createElement("div")
+    row.className = "flex items-center justify-between gap-3 rounded border border-ink-600 bg-ink-850 px-3 py-2"
+    row.dataset.userTypeaheadTarget = "selection"
+    row.dataset.userOid = option.dataset.userOid
+
+    const label = document.createElement("span")
+    label.className = "min-w-0 truncate text-sm text-zinc-300"
+    label.textContent = option.dataset.label
+
+    const hidden = document.createElement("input")
+    hidden.type = "hidden"
+    hidden.name = "skill[editor_oids][]"
+    hidden.value = option.dataset.userOid
+
+    const remove = document.createElement("button")
+    remove.type = "button"
+    remove.className = "shrink-0 text-xs text-zinc-500 transition-colors hover:text-red-400"
+    remove.dataset.action = "user-typeahead#remove"
+    remove.textContent = "Remove"
+
+    row.append(label, hidden, remove)
+    this.selectionsTarget.append(row)
+    this.inputTarget.value = ""
+    this.syncOptions()
+    this.inputTarget.focus()
+  }
+
+  syncOptions() {
+    this.filter()
+    this.emptyTarget.hidden = this.hasSelectionsTarget && this.selectionsTarget.children.length > 0
+  }
+
+  selectedOids() {
+    return new Set(
+      Array.from(
+        this.selectionsTarget.querySelectorAll("input[name='skill[editor_oids][]']"),
+        (input) => input.value
+      )
+    )
+  }
+
+  visibleOptions() {
+    return this.optionTargets.filter((option) => !option.closest("li").hidden)
+  }
+
+  focusOption(option) {
+    this.optionTargets.forEach((candidate) => {
+      candidate.setAttribute("aria-selected", "false")
+      candidate.classList.remove("bg-ink-700")
+    })
+    option.setAttribute("aria-selected", "true")
+    option.classList.add("bg-ink-700")
+    this.activeOption = option
+  }
+}

--- a/services/console/app/models/skill.rb
+++ b/services/console/app/models/skill.rb
@@ -9,15 +9,24 @@ class Skill < ApplicationRecord
   RESERVED_NAMES = %w[search].freeze
 
   belongs_to :user
+  has_many :skill_editors, dependent: :destroy
+  has_many :editors, through: :skill_editors, source: :user
 
   enum :visibility, { private: "private", shared: "shared" },
        default: :shared, validate: true, prefix: true
 
   scope :active, -> { where(archived_at: nil) }
   scope :shared, -> { where(visibility: "shared") }
+  scope :editable_by, lambda { |user|
+    return none unless user
+
+    active.where(user: user).or(
+      active.where(id: SkillEditor.where(user: user).select(:skill_id))
+    )
+  }
   scope :catalog_visible_to, lambda { |user|
     shared_scope = active.shared
-    user ? shared_scope.or(active.where(user: user)) : shared_scope
+    user ? shared_scope.or(editable_by(user)) : shared_scope
   }
 
   normalizes :name, :description, with: ->(value) { value.to_s.strip }
@@ -64,6 +73,10 @@ class Skill < ApplicationRecord
 
   def shared?
     visibility_shared?
+  end
+
+  def editable_by?(candidate)
+    candidate && (user_id == candidate.id || editors.exists?(candidate.id))
   end
 
   def unshare!

--- a/services/console/app/models/skill_editor.rb
+++ b/services/console/app/models/skill_editor.rb
@@ -1,0 +1,15 @@
+class SkillEditor < ApplicationRecord
+  belongs_to :skill
+  belongs_to :user
+
+  validates :user_id, uniqueness: { scope: :skill_id }
+  validate :editor_is_not_owner
+
+  private
+
+  def editor_is_not_owner
+    return unless skill && user_id == skill.user_id
+
+    errors.add(:user, "is already the skill owner")
+  end
+end

--- a/services/console/app/models/user.rb
+++ b/services/console/app/models/user.rb
@@ -12,6 +12,8 @@ class User < ApplicationRecord
   has_many :mcp_oauth_refresh_tokens, dependent: :destroy
   has_many :user_identities, dependent: :destroy
   has_many :skills, dependent: :destroy
+  has_many :skill_editor_assignments, class_name: "SkillEditor", dependent: :destroy
+  has_many :edited_skills, through: :skill_editor_assignments, source: :skill
   belongs_to :approved_by, class_name: "User", optional: true
 
   after_update :revoke_mcp_oauth_refresh_tokens_when_disabled,

--- a/services/console/app/views/console/skills/_editor_picker.html.erb
+++ b/services/console/app/views/console/skills/_editor_picker.html.erb
@@ -54,7 +54,7 @@
       <% end %>
     </div>
     <p class="mt-3 text-sm text-zinc-600" data-user-typeahead-target="empty" <%= "hidden" if @selected_editors.any? %>>No additional editors.</p>
-    <p class="mt-2 text-xs text-zinc-500">Editors can read and update this skill. Only you can manage editors, visibility, or archiving.</p>
+    <p class="mt-2 text-xs text-zinc-500">Editors can read and update this skill. Their names and emails are visible to anyone who can view the skill. Only you can manage editors, visibility, or archiving.</p>
   </div>
 <% else %>
   <div>

--- a/services/console/app/views/console/skills/_editor_picker.html.erb
+++ b/services/console/app/views/console/skills/_editor_picker.html.erb
@@ -1,0 +1,70 @@
+<% if skill.user_id == current_user.id %>
+  <div data-controller="user-typeahead"
+       data-action="click@window->user-typeahead#close">
+    <%= label_tag :skill_editor_search, "Editors", class: "mb-2 block text-sm font-medium text-zinc-200" %>
+    <%= hidden_field_tag "skill[editor_oids][]", "" %>
+    <div class="relative max-w-xl">
+      <%= text_field_tag :skill_editor_search,
+                         nil,
+                         placeholder: "Search console users by name or email",
+                         autocomplete: "off",
+                         role: "combobox",
+                         aria: { autocomplete: "list", expanded: "false", controls: "skill-editor-options" },
+                         class: "form-input",
+                         data: {
+                           user_typeahead_target: "input",
+                           action: "focus->user-typeahead#open input->user-typeahead#open keydown->user-typeahead#navigate"
+                         } %>
+      <ul id="skill-editor-options"
+          role="listbox"
+          hidden
+          data-user-typeahead-target="listbox"
+          class="absolute z-20 mt-1 max-h-60 w-full overflow-y-auto rounded-lg border border-ink-600 bg-ink-850 p-1 shadow-xl">
+        <% @editor_candidates.each do |user| %>
+          <% label = user.name.present? ? "#{user.name} (#{user.email})" : user.email %>
+          <li>
+            <button type="button"
+                    role="option"
+                    aria-selected="false"
+                    data-user-typeahead-target="option"
+                    data-user-oid="<%= user.oid %>"
+                    data-label="<%= label %>"
+                    data-search-text="<%= label.downcase %>"
+                    data-action="user-typeahead#select"
+                    class="w-full rounded px-3 py-2 text-left text-sm text-zinc-300 hover:bg-ink-700 focus:bg-ink-700 focus:outline-none">
+              <span class="block truncate"><%= label %></span>
+            </button>
+          </li>
+        <% end %>
+      </ul>
+    </div>
+
+    <div class="mt-3 space-y-2" data-user-typeahead-target="selections">
+      <% @selected_editors.each do |user| %>
+        <% label = user.name.present? ? "#{user.name} (#{user.email})" : user.email %>
+        <div class="flex items-center justify-between gap-3 rounded border border-ink-600 bg-ink-850 px-3 py-2"
+             data-user-typeahead-target="selection"
+             data-user-oid="<%= user.oid %>">
+          <span class="min-w-0 truncate text-sm text-zinc-300"><%= label %></span>
+          <%= hidden_field_tag "skill[editor_oids][]", user.oid %>
+          <button type="button"
+                  data-action="user-typeahead#remove"
+                  class="shrink-0 text-xs text-zinc-500 transition-colors hover:text-red-400">Remove</button>
+        </div>
+      <% end %>
+    </div>
+    <p class="mt-3 text-sm text-zinc-600" data-user-typeahead-target="empty" <%= "hidden" if @selected_editors.any? %>>No additional editors.</p>
+    <p class="mt-2 text-xs text-zinc-500">Editors can read and update this skill. Only you can manage editors, visibility, or archiving.</p>
+  </div>
+<% else %>
+  <div>
+    <h2 class="mb-2 text-sm font-medium text-zinc-200">Editors</h2>
+    <div class="space-y-2">
+      <% @selected_editors.each do |user| %>
+        <% label = user.name.present? ? "#{user.name} (#{user.email})" : user.email %>
+        <div class="rounded border border-ink-600 bg-ink-850 px-3 py-2 text-sm text-zinc-300"><%= label %></div>
+      <% end %>
+    </div>
+    <p class="mt-2 text-xs text-zinc-500">Only the skill owner can manage editors.</p>
+  </div>
+<% end %>

--- a/services/console/app/views/console/skills/_form.html.erb
+++ b/services/console/app/views/console/skills/_form.html.erb
@@ -33,6 +33,8 @@
     </div>
   </div>
 
+  <%= render "editor_picker", skill: skill %>
+
   <div>
     <%= form.label :content, "Instructions", class: "mb-2 block text-sm font-medium text-zinc-200" %>
     <%= form.text_area :content,

--- a/services/console/app/views/console/skills/show.html.erb
+++ b/services/console/app/views/console/skills/show.html.erb
@@ -1,9 +1,10 @@
 <% content_for :title, "#{@skill.name} · Centaur Console" %>
 <% owned = @skill.user_id == current_user.id %>
+<% editable = @skill.editable_by?(current_user) %>
 <% visibility_badge_class = @skill.shared? ? "resource-badge" : "role-pill" %>
 
 <nav class="mb-4" aria-label="Breadcrumb">
-  <%= link_to(owned ? mine_console_skills_path : console_skills_path,
+  <%= link_to(editable ? mine_console_skills_path : console_skills_path,
               class: "inline-flex items-center gap-1.5 text-sm text-zinc-500 hover:text-centaur-300") do %>
     <span aria-hidden="true">&larr;</span>
     <span>Back to Skills</span>
@@ -18,8 +19,10 @@
     </div>
 
     <div class="flex min-h-9 shrink-0 flex-wrap items-center gap-2">
-      <% if owned %>
+      <% if editable %>
         <%= link_to "Edit", edit_console_skill_path(@skill.oid), class: "inline-flex h-9 items-center rounded border border-ink-600 px-3 text-sm text-zinc-200 hover:border-ink-500" %>
+      <% end %>
+      <% if owned %>
         <%= button_to(@skill.shared? ? unshare_console_skill_path(@skill.oid) : share_console_skill_path(@skill.oid),
                       form: { class: "flex items-center" },
                       class: "inline-flex h-9 items-center gap-2 rounded border border-ink-600 px-3 text-xs hover:border-ink-500",
@@ -62,4 +65,15 @@
       <%= console_markdown(@skill.content) %>
     </article>
   </section>
+
+  <% if @skill.editors.active.any? %>
+    <section aria-labelledby="skill-editors-heading">
+      <h2 id="skill-editors-heading" class="mb-3 text-sm font-semibold text-zinc-100">Editors</h2>
+      <ul class="space-y-2 text-sm text-zinc-400">
+        <% @skill.editors.active.order(:email).each do |editor| %>
+          <li><%= editor.name.present? ? "#{editor.name} (#{editor.email})" : editor.email %></li>
+        <% end %>
+      </ul>
+    </section>
+  <% end %>
 </div>

--- a/services/console/config/routes.rb
+++ b/services/console/config/routes.rb
@@ -262,6 +262,9 @@ Rails.application.routes.draw do
           member do
             post :share
             post :unshare
+            get :editors
+            post :add_editor, path: "editors"
+            delete :remove_editor, path: "editors"
           end
         end
       end

--- a/services/console/db/migrate/20260813212224_create_skill_editors.rb
+++ b/services/console/db/migrate/20260813212224_create_skill_editors.rb
@@ -1,0 +1,12 @@
+class CreateSkillEditors < ActiveRecord::Migration[8.1]
+  def change
+    create_table :skill_editors do |t|
+      t.references :skill, null: false, foreign_key: { on_delete: :cascade }
+      t.references :user, null: false, foreign_key: { on_delete: :cascade }
+
+      t.timestamps
+    end
+
+    add_index :skill_editors, [ :skill_id, :user_id ], unique: true
+  end
+end

--- a/services/console/db/schema.rb
+++ b/services/console/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_13_182623) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_13_212224) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_search"
@@ -405,6 +405,16 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_13_182623) do
     t.index ["static_secret_id"], name: "index_secret_sources_on_static_secret_id", unique: true
   end
 
+  create_table "skill_editors", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.bigint "skill_id", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
+    t.index ["skill_id", "user_id"], name: "index_skill_editors_on_skill_id_and_user_id", unique: true
+    t.index ["skill_id"], name: "index_skill_editors_on_skill_id"
+    t.index ["user_id"], name: "index_skill_editors_on_user_id"
+  end
+
   create_table "skills", force: :cascade do |t|
     t.datetime "archived_at"
     t.text "content", null: false
@@ -547,6 +557,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_13_182623) do
   add_foreign_key "secret_sources", "oauth_token_secrets"
   add_foreign_key "secret_sources", "pg_dsn_secrets"
   add_foreign_key "secret_sources", "static_secrets"
+  add_foreign_key "skill_editors", "skills", on_delete: :cascade
+  add_foreign_key "skill_editors", "users", on_delete: :cascade
   add_foreign_key "skills", "users", on_delete: :cascade
   add_foreign_key "slack_channel_permissions", "principals"
   add_foreign_key "slack_channel_permissions", "roles"

--- a/services/console/docs/API.md
+++ b/services/console/docs/API.md
@@ -1446,7 +1446,7 @@ Console stores and validates `name`, `description`, and Markdown `instructions` 
 
 ### Sandbox Operations
 
-These endpoints use the existing sandbox entitlement JWT injected by `iron-proxy`. Principals linked to an active Console user can see that user's private skills and every public skill. Other principals can see public skills only. Mutations require an active Console user linked to the sandbox principal and can change only that user's skills.
+These endpoints use the existing sandbox entitlement JWT injected by `iron-proxy`. Principals linked to an active Console user can see that user's private skills, private skills they have been added to as an editor, and every public skill. Other principals can see public skills only. Mutations require an active Console user linked to the sandbox principal. Owners can perform every mutation on their skills, while editors can update skill content but cannot share, unshare, or archive the skill.
 
 | Method | Path | Notes |
 | ------ | ---- | ----- |
@@ -1454,7 +1454,7 @@ These endpoints use the existing sandbox entitlement JWT injected by `iron-proxy
 | `GET` | `/api/v1/sandbox/skills/search?q=...` | Full-text search visible skills. |
 | `GET` | `/api/v1/sandbox/skills/:id` | Read a visible skill by its exact name or `skl_...` OID. |
 | `POST` | `/api/v1/sandbox/skills` | Create a public skill from `data.name`, `data.description`, and `data.instructions`. |
-| `PUT`/`PATCH` | `/api/v1/sandbox/skills/:id` | Update an owned skill using those fields; optional `data.lock_version` detects concurrent edits. |
+| `PUT`/`PATCH` | `/api/v1/sandbox/skills/:id` | Update an owned or editable skill using those fields; optional `data.lock_version` detects concurrent edits. |
 | `DELETE` | `/api/v1/sandbox/skills/:id` | Archive an owned skill. |
 | `POST` | `/api/v1/sandbox/skills/:id/share` | Make an owned skill public. |
 | `POST` | `/api/v1/sandbox/skills/:id/unshare` | Make an owned skill private. |

--- a/services/console/docs/API.md
+++ b/services/console/docs/API.md
@@ -1458,8 +1458,11 @@ These endpoints use the existing sandbox entitlement JWT injected by `iron-proxy
 | `DELETE` | `/api/v1/sandbox/skills/:id` | Archive an owned skill. |
 | `POST` | `/api/v1/sandbox/skills/:id/share` | Make an owned skill public. |
 | `POST` | `/api/v1/sandbox/skills/:id/unshare` | Make an owned skill private. |
+| `GET` | `/api/v1/sandbox/skills/:id/editors` | List editors for an owned or editable skill OID. |
+| `POST` | `/api/v1/sandbox/skills/:id/editors` | Add an editor to an owned skill OID using an exact email or `usr_...` OID in `data.user`. |
+| `DELETE` | `/api/v1/sandbox/skills/:id/editors` | Remove an editor from an owned skill OID using an exact email or `usr_...` OID in `data.user`. |
 
-Catalog responses include the skill ID and a checksum over the generated document. Read responses set `Cache-Control: no-store`.
+Editor responses include each editor's OID, email, name, and account status, plus the skill's current `lock_version`. Adding an editor is idempotent. Catalog responses include the skill ID and a checksum over the generated document. Read responses set `Cache-Control: no-store`.
 
 ## Proxies
 

--- a/services/console/docs/API.md
+++ b/services/console/docs/API.md
@@ -1458,11 +1458,11 @@ These endpoints use the existing sandbox entitlement JWT injected by `iron-proxy
 | `DELETE` | `/api/v1/sandbox/skills/:id` | Archive an owned skill. |
 | `POST` | `/api/v1/sandbox/skills/:id/share` | Make an owned skill public. |
 | `POST` | `/api/v1/sandbox/skills/:id/unshare` | Make an owned skill private. |
-| `GET` | `/api/v1/sandbox/skills/:id/editors` | List editors for an owned or editable skill OID. |
+| `GET` | `/api/v1/sandbox/skills/:id/editors` | List editors for any visible skill by exact name or OID. |
 | `POST` | `/api/v1/sandbox/skills/:id/editors` | Add an editor to an owned skill OID using an exact email or `usr_...` OID in `data.user`. |
 | `DELETE` | `/api/v1/sandbox/skills/:id/editors` | Remove an editor from an owned skill OID using an exact email or `usr_...` OID in `data.user`. |
 
-Editor responses include each editor's OID, email, name, and account status, plus the skill's current `lock_version`. Adding an editor is idempotent. Catalog responses include the skill ID and a checksum over the generated document. Read responses set `Cache-Control: no-store`.
+Editor responses include each editor's OID, email, name, and account status, plus the skill's current `lock_version`. The editor list follows skill visibility: every principal that can read a shared skill can also read its editor list, while a private skill's list remains visible only to its owner and editors. Adding an editor is idempotent. Catalog responses include the skill ID and a checksum over the generated document. Read responses set `Cache-Control: no-store`.
 
 ## Proxies
 

--- a/services/console/test/controllers/api/v1/sandbox_skills_controller_test.rb
+++ b/services/console/test/controllers/api/v1/sandbox_skills_controller_test.rb
@@ -132,6 +132,38 @@ class Api::V1::SandboxSkillsControllerTest < ActionDispatch::IntegrationTest
     assert_not_nil skill.reload.archived_at
   end
 
+  test "editor principal reads and updates a private skill but cannot archive it" do
+    skill = skills(:other_private)
+    skill.editors << users(:member_user)
+
+    with_token(@member_proxy) do |headers|
+      get "/api/v1/sandbox/skills/#{skill.oid}", headers: headers
+    end
+    assert_response :ok
+
+    with_token(@member_proxy) do |headers|
+      patch "/api/v1/sandbox/skills/#{skill.oid}",
+            params: {
+              data: {
+                name: skill.name,
+                description: "Updated by a collaborator.",
+                instructions: skill.content,
+                lock_version: skill.lock_version
+              }
+            },
+            headers: headers,
+            as: :json
+    end
+    assert_response :ok
+    assert_equal "Updated by a collaborator.", skill.reload.description
+
+    with_token(@member_proxy) do |headers|
+      delete "/api/v1/sandbox/skills/#{skill.oid}", headers: headers
+    end
+    assert_response :not_found
+    assert_nil skill.reload.archived_at
+  end
+
   test "non-user principal cannot mutate skills" do
     assert_no_difference("Skill.count") do
       with_token(@channel_proxy) do |headers|

--- a/services/console/test/controllers/api/v1/sandbox_skills_controller_test.rb
+++ b/services/console/test/controllers/api/v1/sandbox_skills_controller_test.rb
@@ -164,6 +164,118 @@ class Api::V1::SandboxSkillsControllerTest < ActionDispatch::IntegrationTest
     assert_nil skill.reload.archived_at
   end
 
+  test "owner lists adds and removes editors by email or user OID" do
+    skill = skills(:member_private)
+    editor = users(:globex_admin)
+    initial_lock_version = skill.lock_version
+
+    with_token(@member_proxy) do |headers|
+      get "/api/v1/sandbox/skills/#{skill.oid}/editors", headers: headers
+    end
+    assert_response :ok
+    assert_equal [], json_body.dig("data", "editors")
+
+    assert_difference("SkillEditor.count", 1) do
+      with_token(@member_proxy) do |headers|
+        post "/api/v1/sandbox/skills/#{skill.oid}/editors",
+             params: { data: { user: editor.email.upcase } },
+             headers: headers,
+             as: :json
+      end
+    end
+    assert_response :ok
+    assert_equal editor.oid, json_body.dig("data", "editors", 0, "id")
+    assert_equal editor.email, json_body.dig("data", "editors", 0, "email")
+    assert_equal initial_lock_version + 1, json_body.dig("data", "lock_version")
+
+    assert_no_difference("SkillEditor.count") do
+      with_token(@member_proxy) do |headers|
+        post "/api/v1/sandbox/skills/#{skill.oid}/editors",
+             params: { data: { user: editor.oid } },
+             headers: headers,
+             as: :json
+      end
+    end
+    assert_response :ok
+    assert_equal initial_lock_version + 1, json_body.dig("data", "lock_version")
+
+    assert_difference("SkillEditor.count", -1) do
+      with_token(@member_proxy) do |headers|
+        delete "/api/v1/sandbox/skills/#{skill.oid}/editors",
+               params: { data: { user: editor.email } },
+               headers: headers,
+               as: :json
+      end
+    end
+    assert_response :ok
+    assert_equal [], json_body.dig("data", "editors")
+    assert_equal initial_lock_version + 2, json_body.dig("data", "lock_version")
+  end
+
+  test "editor can list membership but cannot manage editors" do
+    skill = skills(:other_private)
+    skill.editors << users(:member_user)
+
+    with_token(@member_proxy) do |headers|
+      get "/api/v1/sandbox/skills/#{skill.oid}/editors", headers: headers
+    end
+    assert_response :ok
+    assert_equal users(:member_user).oid, json_body.dig("data", "editors", 0, "id")
+
+    with_token(@member_proxy) do |headers|
+      post "/api/v1/sandbox/skills/#{skill.oid}/editors",
+           params: { data: { user: users(:globex_admin).oid } },
+           headers: headers,
+           as: :json
+    end
+    assert_response :not_found
+
+    with_token(@member_proxy) do |headers|
+      delete "/api/v1/sandbox/skills/#{skill.oid}/editors",
+             params: { data: { user: users(:member_user).oid } },
+             headers: headers,
+             as: :json
+    end
+    assert_response :not_found
+    assert_equal [ users(:member_user) ], skill.reload.editors.to_a
+  end
+
+  test "editor membership is not exposed to public viewers or shared principals" do
+    skill = skills(:admin_shared)
+    skill.editors << users(:globex_admin)
+
+    with_token(@member_proxy) do |headers|
+      get "/api/v1/sandbox/skills/#{skill.oid}/editors", headers: headers
+    end
+    assert_response :not_found
+
+    with_token(@channel_proxy) do |headers|
+      get "/api/v1/sandbox/skills/#{skill.oid}/editors", headers: headers
+    end
+    assert_response :forbidden
+  end
+
+  test "owner cannot add itself or a disabled user as an editor" do
+    skill = skills(:member_private)
+
+    with_token(@member_proxy) do |headers|
+      post "/api/v1/sandbox/skills/#{skill.oid}/editors",
+           params: { data: { user: users(:member_user).oid } },
+           headers: headers,
+           as: :json
+    end
+    assert_response :unprocessable_entity
+
+    with_token(@member_proxy) do |headers|
+      post "/api/v1/sandbox/skills/#{skill.oid}/editors",
+           params: { data: { user: users(:disabled_user).email } },
+           headers: headers,
+           as: :json
+    end
+    assert_response :not_found
+    assert_empty skill.reload.editors
+  end
+
   test "non-user principal cannot mutate skills" do
     assert_no_difference("Skill.count") do
       with_token(@channel_proxy) do |headers|

--- a/services/console/test/controllers/api/v1/sandbox_skills_controller_test.rb
+++ b/services/console/test/controllers/api/v1/sandbox_skills_controller_test.rb
@@ -240,8 +240,25 @@ class Api::V1::SandboxSkillsControllerTest < ActionDispatch::IntegrationTest
     assert_equal [ users(:member_user) ], skill.reload.editors.to_a
   end
 
-  test "editor membership is not exposed to public viewers or shared principals" do
+  test "shared skill editor membership is visible to user and shared principals" do
     skill = skills(:admin_shared)
+    skill.editors << users(:globex_admin)
+
+    with_token(@member_proxy) do |headers|
+      get "/api/v1/sandbox/skills/#{skill.oid}/editors", headers: headers
+    end
+    assert_response :ok
+    assert_equal users(:globex_admin).email, json_body.dig("data", "editors", 0, "email")
+
+    with_token(@channel_proxy) do |headers|
+      get "/api/v1/sandbox/skills/#{skill.oid}/editors", headers: headers
+    end
+    assert_response :ok
+    assert_equal users(:globex_admin).oid, json_body.dig("data", "editors", 0, "id")
+  end
+
+  test "private skill editor membership remains limited to users who can edit it" do
+    skill = skills(:other_private)
     skill.editors << users(:globex_admin)
 
     with_token(@member_proxy) do |headers|
@@ -252,7 +269,7 @@ class Api::V1::SandboxSkillsControllerTest < ActionDispatch::IntegrationTest
     with_token(@channel_proxy) do |headers|
       get "/api/v1/sandbox/skills/#{skill.oid}/editors", headers: headers
     end
-    assert_response :forbidden
+    assert_response :not_found
   end
 
   test "owner cannot add itself or a disabled user as an editor" do

--- a/services/console/test/controllers/console/skills_controller_test.rb
+++ b/services/console/test/controllers/console/skills_controller_test.rb
@@ -17,6 +17,18 @@ class Console::SkillsControllerTest < ActionDispatch::IntegrationTest
     assert_no_match skills(:other_private).name, response.body
   end
 
+  test "shows editor identities to viewers of a shared skill" do
+    skill = skills(:admin_shared)
+    editor = users(:globex_admin)
+    skill.editors << editor
+
+    get console_skill_url(skill.oid)
+
+    assert_response :ok
+    assert_select "#skill-editors-heading", text: "Editors"
+    assert_match editor.email, response.body
+  end
+
   test "shows owned and editable skills on the my skills tab" do
     skills(:other_private).editors << @user
     get mine_console_skills_url
@@ -72,6 +84,7 @@ class Console::SkillsControllerTest < ActionDispatch::IntegrationTest
     assert_select "textarea[name='skill[content]']"
     assert_select "input[role='combobox'][data-user-typeahead-target='input']"
     assert_select "input[name='skill[editor_oids][]']"
+    assert_match "Their names and emails are visible to anyone who can view the skill.", response.body
   end
 
   test "owner adds and removes editors" do

--- a/services/console/test/controllers/console/skills_controller_test.rb
+++ b/services/console/test/controllers/console/skills_controller_test.rb
@@ -17,14 +17,15 @@ class Console::SkillsControllerTest < ActionDispatch::IntegrationTest
     assert_no_match skills(:other_private).name, response.body
   end
 
-  test "shows only owned skills on the my skills tab" do
+  test "shows owned and editable skills on the my skills tab" do
+    skills(:other_private).editors << @user
     get mine_console_skills_url
 
     assert_response :ok
     assert_match "My Skills", response.body
     assert_match skills(:member_private).name, response.body
+    assert_match skills(:other_private).name, response.body
     assert_no_match skills(:admin_shared).name, response.body
-    assert_no_match skills(:other_private).name, response.body
   end
 
   test "creates edits and immediately shares a skill" do
@@ -33,13 +34,15 @@ class Console::SkillsControllerTest < ActionDispatch::IntegrationTest
         skill: {
           name: "release-helper",
           description: "Help with release readiness.",
-          content: "# Release\n\nFollow the release checklist."
+          content: "# Release\n\nFollow the release checklist.",
+          editor_oids: [ users(:globex_admin).oid ]
         }
       }
     end
     skill = @user.skills.find_by!(name: "release-helper")
     assert_redirected_to console_skill_path(skill.oid)
     assert_equal "# Release\n\nFollow the release checklist.", skill.content
+    assert_equal [ users(:globex_admin) ], skill.editors.to_a
     assert skill.shared?
     assert_not_nil skill.shared_at
 
@@ -67,6 +70,90 @@ class Console::SkillsControllerTest < ActionDispatch::IntegrationTest
     assert_select "input[name='skill[name]']"
     assert_select "input[name='skill[description]']"
     assert_select "textarea[name='skill[content]']"
+    assert_select "input[role='combobox'][data-user-typeahead-target='input']"
+    assert_select "input[name='skill[editor_oids][]']"
+  end
+
+  test "owner adds and removes editors" do
+    skill = skills(:member_private)
+    editor = users(:globex_admin)
+
+    assert_difference("SkillEditor.count", 1) do
+      patch console_skill_url(skill.oid), params: {
+        skill: {
+          name: skill.name,
+          description: skill.description,
+          content: skill.content,
+          lock_version: skill.lock_version,
+          editor_oids: [ editor.oid ]
+        }
+      }
+    end
+    assert_redirected_to console_skill_path(skill.oid)
+    assert_equal [ editor ], skill.reload.editors.to_a
+
+    get edit_console_skill_url(skill.oid)
+    assert_response :ok
+    assert_select "input[name='skill[editor_oids][]'][value='#{editor.oid}']"
+
+    assert_difference("SkillEditor.count", -1) do
+      patch console_skill_url(skill.oid), params: {
+        skill: {
+          name: skill.name,
+          description: skill.description,
+          content: skill.content,
+          lock_version: skill.lock_version,
+          editor_oids: [ "" ]
+        }
+      }
+    end
+    assert_empty skill.reload.editors
+  end
+
+  test "owner cannot add an unavailable editor" do
+    skill = skills(:member_private)
+
+    patch console_skill_url(skill.oid), params: {
+      skill: {
+        name: skill.name,
+        description: skill.description,
+        content: skill.content,
+        lock_version: skill.lock_version,
+        editor_oids: [ users(:disabled_user).oid ]
+      }
+    }
+
+    assert_response :unprocessable_entity
+    assert_match "Editors include an unavailable user", response.body
+    assert_empty skill.reload.editors
+  end
+
+  test "editor updates a private skill but cannot manage it" do
+    skill = skills(:other_private)
+    skill.editors << @user
+
+    get console_skill_url(skill.oid)
+    assert_response :ok
+    assert_select "nav[aria-label='Breadcrumb'] a[href='#{mine_console_skills_path}']", text: /Back to Skills/
+    assert_select "a[href='#{edit_console_skill_path(skill.oid)}']", text: "Edit"
+    assert_select "button[role='switch']", count: 0
+    assert_select "form[action='#{console_skill_path(skill.oid)}'] button", text: "Archive", count: 0
+
+    patch console_skill_url(skill.oid), params: {
+      skill: {
+        name: skill.name,
+        description: "Updated by an editor.",
+        content: skill.content,
+        lock_version: skill.lock_version,
+        editor_oids: [ users(:globex_admin).oid ]
+      }
+    }
+    assert_redirected_to console_skill_path(skill.oid)
+    assert_equal "Updated by an editor.", skill.reload.description
+    assert_equal [ @user ], skill.editors.to_a
+
+    delete console_skill_url(skill.oid)
+    assert_response :not_found
   end
 
   test "preserves separate fields when instructions are invalid" do

--- a/services/console/test/models/skill_test.rb
+++ b/services/console/test/models/skill_test.rb
@@ -85,6 +85,24 @@ class SkillTest < ActiveSupport::TestCase
     assert_not_includes results, skills(:other_private)
   end
 
+  test "editors can access private skills without becoming owners" do
+    skill = skills(:other_private)
+    editor = users(:member_user)
+    skill.editors << editor
+
+    assert_includes Skill.editable_by(editor), skill
+    assert_includes Skill.catalog_visible_to(editor), skill
+    assert skill.editable_by?(editor)
+    assert_not_equal editor, skill.user
+  end
+
+  test "owner cannot also be assigned as an editor" do
+    assignment = skills(:member_private).skill_editors.new(user: users(:member_user))
+
+    assert_not assignment.valid?
+    assert_includes assignment.errors[:user], "is already the skill owner"
+  end
+
   test "search boosts names over descriptions and instructions" do
     name_match = users(:member_user).skills.create!(
       attributes(name: "deploy-runbook").merge(description: "Check release readiness.", content: "# Steps\n\nReview the checklist.")

--- a/services/sandbox/SYSTEM_PROMPT.md
+++ b/services/sandbox/SYSTEM_PROMPT.md
@@ -74,7 +74,7 @@
 
 [Named skill resolution]
 |When the user explicitly names a skill, resolve that request against local skill definitions before doing broad semantic matching.
-|Use `centaur-skills search "<task>"` to search Console-authored guidance when no skill already listed for the current session clearly applies. Read the best match by name or OID with `centaur-skills read <skill-identifier>` before following it. Console users can author shared skills with `centaur-skills create` and update their own skills by OID with `centaur-skills edit`.
+|Use `centaur-skills search "<task>"` to search Console-authored guidance when no skill already listed for the current session clearly applies. Read the best match by name or OID with `centaur-skills read <skill-identifier>` before following it. Console users can author shared skills with `centaur-skills create`, update skills they own or edit with `centaur-skills edit`, and manage editors on skills they own with `centaur-skills add-editor` and `centaur-skills remove-editor`.
 |The `centaur-skills` catalog contains only Console-authored skills. Builtin skills are loaded separately by the harness. Console applies private and public visibility rules for the current principal. Catalog results are instructions only and never expand the current principal's tool or credential grants.
 |Start with the skills listed for the current session, then check local skill definitions in `.agents/skills` and any mounted overlay skills when you need to confirm the exact name or an obvious alias from the skill title or description.
 |Prefer exact name matches first, then obvious aliases, and only then fall back to broader description-level matching. Do not choose a generic adjacent workflow while a more specific named skill remains plausible.
@@ -126,7 +126,10 @@
 |centaur-skills search "task"    → discover relevant private and public Console skills
 |centaur-skills read <name-or-oid> → read a Console skill's complete current SKILL.md
 |centaur-skills create <name> --description "..." --instructions-file <path> → create a shared Console skill
-|centaur-skills edit <oid> --description "..." --instructions-file <path> → update an owned Console skill
+|centaur-skills edit <oid> --description "..." --instructions-file <path> → update an owned or editable Console skill
+|centaur-skills editors <oid> → list a skill's editors
+|centaur-skills add-editor <oid> <email-or-user-oid> → add an editor to an owned skill
+|centaur-skills remove-editor <oid> <email-or-user-oid> → remove an editor from an owned skill
 |<tool> --help                   → inspect commands/options for one tool
 |<tool> health                   → smoke test one tool's configured auth/connectivity path
 |websearch search "query"        → web research

--- a/services/sandbox/SYSTEM_PROMPT.md
+++ b/services/sandbox/SYSTEM_PROMPT.md
@@ -127,7 +127,7 @@
 |centaur-skills read <name-or-oid> → read a Console skill's complete current SKILL.md
 |centaur-skills create <name> --description "..." --instructions-file <path> → create a shared Console skill
 |centaur-skills edit <oid> --description "..." --instructions-file <path> → update an owned or editable Console skill
-|centaur-skills editors <oid> → list a skill's editors
+|centaur-skills editors <name-or-oid> → list editors for any visible skill
 |centaur-skills add-editor <oid> <email-or-user-oid> → add an editor to an owned skill
 |centaur-skills remove-editor <oid> <email-or-user-oid> → remove an editor from an owned skill
 |<tool> --help                   → inspect commands/options for one tool

--- a/tools/README.md
+++ b/tools/README.md
@@ -65,7 +65,7 @@ The open-source tool inventory lives in this `tools/` tree and changes over time
 - `centaur_investigator`: parse Centaur Slack thread references and enrich them
   with best-effort vlogs/vmetrics context without exposing message context.
 - `centaur-console`: inspect sandbox permissions and configured OAuth apps.
-- `centaur-skills`: discover, read, create, and edit private and public Console-authored skills.
+- `centaur-skills`: discover, author, and manage editors for private and public Console-authored skills.
 - `datadog`: query Datadog logs, metrics, monitors, hosts, and dashboards
   read-only with `DD_API_KEY` and `DD_APP_KEY`.
 - `preqin`: query Preqin Operational API fund and fund-manager data, with

--- a/tools/infra/centaur-skills/cli.py
+++ b/tools/infra/centaur-skills/cli.py
@@ -136,9 +136,9 @@ def edit(
 
 @app.command("editors")
 def editors(
-    identifier: str = typer.Argument(..., help="OID of an owned or editable skill"),
+    identifier: str = typer.Argument(..., help="Visible skill name or OID"),
 ) -> None:
-    """List editors for an owned or editable skill."""
+    """List editors for a visible skill."""
     with get_client() as client:
         result = client.list_editors(identifier)
     print(json.dumps({"data": result}, indent=2, default=str))

--- a/tools/infra/centaur-skills/cli.py
+++ b/tools/infra/centaur-skills/cli.py
@@ -12,7 +12,7 @@ load_dotenv()
 
 app = typer.Typer(
     name="centaur-skills",
-    help="Discover and author Console skills available to this agent",
+    help="Discover, author, and manage editors for Console skills available to this agent",
     no_args_is_help=True,
 )
 
@@ -89,7 +89,7 @@ def create(
 
 @app.command("edit")
 def edit(
-    identifier: str = typer.Argument(..., help="OID of an owned skill"),
+    identifier: str = typer.Argument(..., help="OID of an owned or editable skill"),
     name: str | None = typer.Option(None, "--name", help="New lowercase skill name"),
     description: str | None = typer.Option(
         None,
@@ -118,7 +118,7 @@ def edit(
         help="Reject the edit if the skill has changed since this version",
     ),
 ) -> None:
-    """Edit fields on an owned Console-authored skill."""
+    """Edit fields on an owned or editable Console-authored skill."""
     resolved_instructions = _resolve_instructions(instructions, instructions_file, required=False)
     if all(value is None for value in (name, description, resolved_instructions)):
         raise typer.BadParameter("provide --name, --description, or instructions to edit")
@@ -131,6 +131,38 @@ def edit(
             instructions=resolved_instructions,
             lock_version=lock_version,
         )
+    print(json.dumps({"data": result}, indent=2, default=str))
+
+
+@app.command("editors")
+def editors(
+    identifier: str = typer.Argument(..., help="OID of an owned or editable skill"),
+) -> None:
+    """List editors for an owned or editable skill."""
+    with get_client() as client:
+        result = client.list_editors(identifier)
+    print(json.dumps({"data": result}, indent=2, default=str))
+
+
+@app.command("add-editor")
+def add_editor(
+    identifier: str = typer.Argument(..., help="OID of an owned skill"),
+    user: str = typer.Argument(..., help="Exact Console user email or usr_ OID"),
+) -> None:
+    """Add an editor to an owned Console-authored skill."""
+    with get_client() as client:
+        result = client.add_editor(identifier, user)
+    print(json.dumps({"data": result}, indent=2, default=str))
+
+
+@app.command("remove-editor")
+def remove_editor(
+    identifier: str = typer.Argument(..., help="OID of an owned skill"),
+    user: str = typer.Argument(..., help="Exact Console user email or usr_ OID"),
+) -> None:
+    """Remove an editor from an owned Console-authored skill."""
+    with get_client() as client:
+        result = client.remove_editor(identifier, user)
     print(json.dumps({"data": result}, indent=2, default=str))
 
 

--- a/tools/infra/centaur-skills/client.py
+++ b/tools/infra/centaur-skills/client.py
@@ -134,7 +134,7 @@ class SkillsClient:
         return result
 
     def list_editors(self, identifier: str) -> dict[str, Any]:
-        """List editors for an owned or editable Console skill by OID."""
+        """List editors for a visible Console skill by exact name or OID."""
         result = self._request(
             f"{SANDBOX_SKILLS_PATH}/{quote(identifier, safe='')}/editors"
         )

--- a/tools/infra/centaur-skills/client.py
+++ b/tools/infra/centaur-skills/client.py
@@ -111,7 +111,7 @@ class SkillsClient:
         instructions: str | None = None,
         lock_version: int | None = None,
     ) -> dict[str, Any]:
-        """Edit an owned Console skill by OID."""
+        """Edit an owned or editable Console skill by OID."""
         attributes: dict[str, str | int] = {}
         if name is not None:
             attributes["name"] = name
@@ -128,6 +128,37 @@ class SkillsClient:
             f"{SANDBOX_SKILLS_PATH}/{quote(identifier, safe='')}",
             method="PATCH",
             json={"data": attributes},
+        )
+        if not isinstance(result, dict):
+            raise RuntimeError("centaur-skills response did not include a data object")
+        return result
+
+    def list_editors(self, identifier: str) -> dict[str, Any]:
+        """List editors for an owned or editable Console skill by OID."""
+        result = self._request(
+            f"{SANDBOX_SKILLS_PATH}/{quote(identifier, safe='')}/editors"
+        )
+        if not isinstance(result, dict):
+            raise RuntimeError("centaur-skills response did not include a data object")
+        return result
+
+    def add_editor(self, identifier: str, user: str) -> dict[str, Any]:
+        """Add an editor to an owned skill by exact email or Console user OID."""
+        return self._manage_editor(identifier, user, method="POST")
+
+    def remove_editor(self, identifier: str, user: str) -> dict[str, Any]:
+        """Remove an editor from an owned skill by exact email or Console user OID."""
+        return self._manage_editor(identifier, user, method="DELETE")
+
+    def _manage_editor(self, identifier: str, user: str, *, method: str) -> dict[str, Any]:
+        normalized_user = user.strip()
+        if not normalized_user:
+            raise ValueError("user email or OID must not be empty")
+
+        result = self._request(
+            f"{SANDBOX_SKILLS_PATH}/{quote(identifier, safe='')}/editors",
+            method=method,
+            json={"data": {"user": normalized_user}},
         )
         if not isinstance(result, dict):
             raise RuntimeError("centaur-skills response did not include a data object")

--- a/tools/infra/centaur-skills/pyproject.toml
+++ b/tools/infra/centaur-skills/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "centaur-skills"
-description = "Discover, read, create, and edit Console-authored skills"
+description = "Discover, author, and manage editors for Console-authored skills"
 version = "0.1.0"
 requires-python = ">=3.11"
 dependencies = [

--- a/tools/infra/centaur-skills/test_client.py
+++ b/tools/infra/centaur-skills/test_client.py
@@ -2,7 +2,7 @@ import json
 
 import httpx
 import pytest
-from cli import create, edit, list_skills, read, search
+from cli import add_editor, create, edit, editors, list_skills, read, remove_editor, search
 from client import SANDBOX_SKILLS_PATH, SkillsClient
 
 
@@ -136,6 +136,53 @@ def test_edit_requires_a_field():
         make_client(lambda _request: json_response({})).edit("skl_123")
 
 
+def test_list_add_and_remove_editors_use_editor_endpoint():
+    requests = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return json_response(
+            {
+                "data": {
+                    "id": "skl_123",
+                    "editors": [
+                        {
+                            "id": "usr_456",
+                            "email": "editor@example.com",
+                            "name": "Editor",
+                            "status": "active",
+                        }
+                    ],
+                    "lock_version": 3,
+                }
+            }
+        )
+
+    client = make_client(handler)
+    listed = client.list_editors("skl_123")
+    added = client.add_editor("skl_123", " editor@example.com ")
+    removed = client.remove_editor("skl_123", "usr_456")
+
+    assert listed["editors"][0]["id"] == "usr_456"
+    assert added["lock_version"] == 3
+    assert removed["id"] == "skl_123"
+    assert [request.method for request in requests] == ["GET", "POST", "DELETE"]
+    assert all(
+        request.url.path == f"{SANDBOX_SKILLS_PATH}/skl_123/editors"
+        for request in requests
+    )
+    assert json.loads(requests[1].content) == {"data": {"user": "editor@example.com"}}
+    assert json.loads(requests[2].content) == {"data": {"user": "usr_456"}}
+
+
+@pytest.mark.parametrize("method", ["add_editor", "remove_editor"])
+def test_editor_mutations_require_a_user(method):
+    client = make_client(lambda _request: json_response({}))
+
+    with pytest.raises(ValueError, match="must not be empty"):
+        getattr(client, method)("skl_123", " ")
+
+
 def test_requests_wrap_http_errors_without_exposing_credentials():
     def handler(_request: httpx.Request) -> httpx.Response:
         return json_response({"error": {"message": "invalid sandbox token"}}, status_code=401)
@@ -259,3 +306,37 @@ def test_cli_edit_sends_partial_fields(monkeypatch, capsys):
             "lock_version": 3,
         }
     }
+
+
+def test_cli_lists_adds_and_removes_editors(monkeypatch, capsys):
+    class StubClient:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return None
+
+        def list_editors(self, identifier):
+            assert identifier == "skl_123"
+            return {"id": identifier, "editors": [], "lock_version": 1}
+
+        def add_editor(self, identifier, user):
+            assert identifier == "skl_123"
+            assert user == "editor@example.com"
+            return {"id": identifier, "editors": [{"id": "usr_456"}], "lock_version": 2}
+
+        def remove_editor(self, identifier, user):
+            assert identifier == "skl_123"
+            assert user == "usr_456"
+            return {"id": identifier, "editors": [], "lock_version": 3}
+
+    monkeypatch.setattr("cli.get_client", StubClient)
+
+    editors("skl_123")
+    assert json.loads(capsys.readouterr().out)["data"]["editors"] == []
+
+    add_editor("skl_123", "editor@example.com")
+    assert json.loads(capsys.readouterr().out)["data"]["editors"] == [{"id": "usr_456"}]
+
+    remove_editor("skl_123", "usr_456")
+    assert json.loads(capsys.readouterr().out)["data"]["editors"] == []


### PR DESCRIPTION
Adds an owner-managed editor list to skills with a searchable Console user picker. Editors can read private skills and update them through the Console or sandbox API, while sharing, archiving, and membership management remain owner-only. Editor identities follow skill visibility, so anyone who can view a shared skill can also see its editors. The sandbox API and centaur-skills tool support listing, adding, and removing editors by exact email or opaque Console user ID. Includes the join-table migration, documentation updates, and authorization coverage.