### PR TITLE
chore: default Codex reasoning effort to medium

### DIFF
--- a/crates/harness-server/src/nanocodex.rs
+++ b/crates/harness-server/src/nanocodex.rs
@@ -348,13 +348,13 @@ fn configured_default_thinking() -> Thinking {
         .ok()
         .filter(|value| !value.trim().is_empty())
     else {
-        return Thinking::Low;
+        return Thinking::Medium;
     };
     match parse_thinking(&value) {
         Ok(thinking) => thinking,
         Err(error) => {
             eprintln!("ignoring invalid CODEX_MODEL_REASONING_EFFORT: {error}");
-            Thinking::Low
+            Thinking::Medium
         }
     }
 }
@@ -362,7 +362,7 @@ fn configured_default_thinking() -> Thinking {
 fn parse_thinking(value: &str) -> Result<Thinking> {
     let normalized = value.trim().to_ascii_lowercase();
     // Nanocodex does not expose a distinct `minimal` level. Low is the nearest
-    // supported Responses effort and is also Centaur's stock Codex default.
+    // supported Responses effort. Centaur's stock Codex default is medium.
     let normalized = if normalized == "minimal" {
         "low"
     } else {

--- a/harness/codex/config.toml
+++ b/harness/codex/config.toml
@@ -1,5 +1,5 @@
 model = "gpt-5.6-sol"
-model_reasoning_effort = "low"
+model_reasoning_effort = "medium"
 personality = "pragmatic"
 model_verbosity = "low"
 service_tier = "fast"

--- a/services/slackbotv2/test/console-session-link.test.ts
+++ b/services/slackbotv2/test/console-session-link.test.ts
@@ -134,7 +134,7 @@ describe('defaultReasoningForHarness', () => {
     .model_reasoning_effort
 
   test('shares the baked Codex reasoning default with Nanocodex', () => {
-    expect(bakedCodexReasoning).toBe('low')
+    expect(bakedCodexReasoning).toBe('medium')
     expect(defaultReasoningForHarness('codex')).toBe(bakedCodexReasoning)
     expect(defaultReasoningForHarness('nanocodex')).toBe(bakedCodexReasoning)
     expect(defaultReasoningForHarness('claudecode')).toBeUndefined()


### PR DESCRIPTION
## Summary

- change the baked Codex reasoning default from `low` to `medium`
- keep Nanocodex aligned with the Codex default
- update Slack metadata coverage for the new default

## Validation

- `cargo +nightly fmt --check`
- `cargo test nanocodex --lib`
- `bun test test/console-session-link.test.ts`

Prompted by: @akshaan