### PR TITLE
fix: prevent task phrasing from selecting amp

### DIFF
--- a/services/slackbotv2/src/message-overrides-strategy.ts
+++ b/services/slackbotv2/src/message-overrides-strategy.ts
@@ -23,8 +23,8 @@ const SYSTEM_PROMPT = [
   'Return reasoning even when the requested model is not Codex; validation will ignore reasoning that cannot apply.',
   'Map OpenAI model aliases to canonical IDs: sol -> gpt-5.6-sol, terra -> gpt-5.6-terra, luna -> gpt-5.6-luna, 5.5 -> gpt-5.5, 5.5 pro -> gpt-5.5-pro, 5.4 -> gpt-5.4, 5.4 pro -> gpt-5.4-pro, 5.4 mini -> gpt-5.4-mini, 5.4 nano -> gpt-5.4-nano.',
   'Map Claude model aliases to canonical IDs: fable -> claude-fable-5, opus -> claude-opus-4-8, opus 4.7 -> claude-opus-4-7, opus 5 -> claude-opus-5, opus 5 fast -> claude-opus-5-fast, sonnet -> claude-sonnet-4-6, sonnet 5 -> claude-sonnet-5, haiku -> claude-haiku-4-5.',
-  'Map Amp model aliases to canonical IDs: deep -> deep, fast -> fast. Select an Amp model only when the user explicitly names Amp or clearly asks for the deep or fast model/mode. Do not infer Amp from words about intelligence, thoroughness, speed, or task style.',
-  'Words containing or evoking model aliases are not model requests. For example, "use the gigabrain", "think deeply", "do a deep analysis", and "give me a fast answer" do not select Amp. Unless another explicit selector is present, "use the gigabrain" returns null for every field.',
+  'Map Amp model aliases to canonical IDs: deep -> deep, fast -> fast. Select an Amp model only when the user explicitly names Amp or clearly asks for the deep or fast model/mode. Requests such as "use the deep model" and "switch to fast mode" select the corresponding Amp model. Do not infer Amp from superlatives, coined terms, or casual requests to be more intelligent, thorough, or fast.',
+  'Words containing or merely evoking model aliases are not model requests. For example, "think deeply", "do a deep analysis", "use your strongest thinking", and "give me a fast answer" do not select Amp. Unless another explicit selector is present, return null for every field.',
   'For example, "use max effort and the sol model" should return model "gpt-5.6-sol" and reasoning "max".',
   'Do not treat ordinary discussion of model names as a selection request.'
 ].join('\n')

--- a/services/slackbotv2/src/message-overrides-strategy.ts
+++ b/services/slackbotv2/src/message-overrides-strategy.ts
@@ -23,7 +23,8 @@ const SYSTEM_PROMPT = [
   'Return reasoning even when the requested model is not Codex; validation will ignore reasoning that cannot apply.',
   'Map OpenAI model aliases to canonical IDs: sol -> gpt-5.6-sol, terra -> gpt-5.6-terra, luna -> gpt-5.6-luna, 5.5 -> gpt-5.5, 5.5 pro -> gpt-5.5-pro, 5.4 -> gpt-5.4, 5.4 pro -> gpt-5.4-pro, 5.4 mini -> gpt-5.4-mini, 5.4 nano -> gpt-5.4-nano.',
   'Map Claude model aliases to canonical IDs: fable -> claude-fable-5, opus -> claude-opus-4-8, opus 4.7 -> claude-opus-4-7, opus 5 -> claude-opus-5, opus 5 fast -> claude-opus-5-fast, sonnet -> claude-sonnet-4-6, sonnet 5 -> claude-sonnet-5, haiku -> claude-haiku-4-5.',
-  'Map Amp model aliases to canonical IDs: deep -> deep, fast -> fast.',
+  'Map Amp model aliases to canonical IDs: deep -> deep, fast -> fast. Select an Amp model only when the user explicitly names Amp or clearly asks for the deep or fast model/mode. Do not infer Amp from words about intelligence, thoroughness, speed, or task style.',
+  'Words containing or evoking model aliases are not model requests. For example, "use the gigabrain", "think deeply", "do a deep analysis", and "give me a fast answer" do not select Amp. Unless another explicit selector is present, "use the gigabrain" returns null for every field.',
   'For example, "use max effort and the sol model" should return model "gpt-5.6-sol" and reasoning "max".',
   'Do not treat ordinary discussion of model names as a selection request.'
 ].join('\n')


### PR DESCRIPTION
Tightens the Slack message override classifier prompt so coined superlatives and task-style phrasing do not imply the Amp harness. Explicit Amp, deep or fast model, reasoning, Codex, and model selections continue to classify normally. Live gpt-5.4-nano evaluations cover the reported request and nearby positive and negative controls.