### PR TITLE
fix: acknowledge session execution before sandbox startup

### DIFF
--- a/services/api-rs/crates/centaur-api-server/src/routes.rs
+++ b/services/api-rs/crates/centaur-api-server/src/routes.rs
@@ -953,7 +953,7 @@ async fn execute_session(
     let thread_key = ThreadKey::try_from(raw_thread_key)?;
     let execution = state
         .runtime()?
-        .execute_session(
+        .enqueue_session_execution(
             &thread_key,
             ExecuteSessionInput {
                 idempotency_key: request.idempotency_key,

--- a/services/api-rs/crates/centaur-session-runtime/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-runtime/src/lib.rs
@@ -1807,10 +1807,32 @@ impl SessionRuntime {
         thread_key: &ThreadKey,
         input: ExecuteSessionInput,
     ) -> Result<SessionExecution, SessionRuntimeError> {
+        self.execute_session_impl(thread_key, input, None).await
+    }
+
+    async fn drive_session_execution(
+        &self,
+        thread_key: &ThreadKey,
+        execution_id: &str,
+        input: ExecuteSessionInput,
+    ) -> Result<SessionExecution, SessionRuntimeError> {
+        self.execute_session_impl(thread_key, input, Some(execution_id))
+            .await
+    }
+
+    async fn execute_session_impl(
+        &self,
+        thread_key: &ThreadKey,
+        input: ExecuteSessionInput,
+        persisted_execution_id: Option<&str>,
+    ) -> Result<SessionExecution, SessionRuntimeError> {
         if self.shutting_down.load(Ordering::SeqCst) {
             return Err(SessionRuntimeError::ShuttingDown);
         }
-        let persisted_request = persisted_execute_request(&input)?;
+        let persisted_request = persisted_execution_id
+            .is_none()
+            .then(|| persisted_execute_request(&input))
+            .transpose()?;
         let ExecuteSessionInput {
             idempotency_key,
             metadata,
@@ -1854,36 +1876,47 @@ impl SessionRuntime {
             let (idle_timeout, max_duration) = duration_options(idle_timeout_ms, max_duration_ms)?;
             let requester_metadata = metadata.clone();
 
-            let execution = self
-                .store
-                .create_execution_with_request(
-                    thread_key,
-                    idempotency_key.as_deref(),
-                    execution_metadata(metadata, idle_timeout_ms, max_duration_ms),
-                    persisted_request,
-                )
-                .await?;
-            span.record(
-                "centaur.execution_id",
-                execution.execution.execution_id.as_str(),
-            );
-            span.record("execution_id", execution.execution.execution_id.as_str());
-            if !execution.created && execution.execution.status != ExecutionStatus::Queued {
-                info!(
-                    component = COMPONENT_SESSION_RUNTIME,
-                    event = "session_execute_idempotent_replay",
-                    thread_key = %thread_key,
-                    execution_id = %execution.execution.execution_id,
-                    status = %execution.execution.status,
-                    "returning existing execution"
+            let claim = if let Some(execution_id) = persisted_execution_id {
+                span.record("centaur.execution_id", execution_id);
+                span.record("execution_id", execution_id);
+                self.store.mark_execution_running(execution_id).await?
+            } else {
+                let execution = self
+                    .store
+                    .create_execution_with_request(
+                        thread_key,
+                        idempotency_key.as_deref(),
+                        execution_metadata(metadata, idle_timeout_ms, max_duration_ms),
+                        persisted_request.expect("new executions have a persisted request"),
+                    )
+                    .await?;
+                span.record(
+                    "centaur.execution_id",
+                    execution.execution.execution_id.as_str(),
                 );
-                return Ok(execution.execution);
-            }
-            let claim = self
-                .store
-                .mark_execution_running(&execution.execution.execution_id)
-                .await?;
+                span.record("execution_id", execution.execution.execution_id.as_str());
+                if !execution.created && execution.execution.status != ExecutionStatus::Queued {
+                    info!(
+                        component = COMPONENT_SESSION_RUNTIME,
+                        event = "session_execute_idempotent_replay",
+                        thread_key = %thread_key,
+                        execution_id = %execution.execution.execution_id,
+                        status = %execution.execution.status,
+                        "returning existing execution"
+                    );
+                    return Ok(execution.execution);
+                }
+                self.store
+                    .mark_execution_running(&execution.execution.execution_id)
+                    .await?
+            };
             let execution = claim.execution;
+            if execution.thread_key != *thread_key {
+                return Err(SessionRuntimeError::BadRequest(format!(
+                    "execution {} belongs to thread {}, not {}",
+                    execution.execution_id, execution.thread_key, thread_key
+                )));
+            }
             span.record("centaur.execution_id", execution.execution_id.as_str());
             span.record("execution_id", execution.execution_id.as_str());
             if !claim.claimed {
@@ -2082,24 +2115,11 @@ impl SessionRuntime {
                 self.load_persisted_execute_request(&execution.execution.execution_id)
                     .await?
             };
-            let runtime = self.clone();
-            let queued_thread_key = thread_key.clone();
-            let queued_execution_id = execution.execution.execution_id.clone();
-            tokio::spawn(async move {
-                if let Err(error) = runtime
-                    .execute_session(&queued_thread_key, persisted_input)
-                    .await
-                {
-                    warn!(
-                        component = COMPONENT_SESSION_RUNTIME,
-                        event = "session_execute_dispatch_failed",
-                        thread_key = %queued_thread_key,
-                        execution_id = queued_execution_id,
-                        %error,
-                        "failed to dispatch queued session execution"
-                    );
-                }
-            });
+            self.spawn_session_execution(
+                thread_key.clone(),
+                execution.execution.execution_id.clone(),
+                persisted_input,
+            );
         }
 
         info!(
@@ -2114,16 +2134,36 @@ impl SessionRuntime {
         Ok(execution.execution)
     }
 
+    fn spawn_session_execution(
+        &self,
+        thread_key: ThreadKey,
+        execution_id: String,
+        input: ExecuteSessionInput,
+    ) {
+        let runtime = self.clone();
+        tokio::spawn(async move {
+            if let Err(error) = runtime
+                .drive_session_execution(&thread_key, &execution_id, input)
+                .await
+            {
+                warn!(
+                    component = COMPONENT_SESSION_RUNTIME,
+                    event = "session_execute_dispatch_failed",
+                    thread_key = %thread_key,
+                    execution_id,
+                    %error,
+                    "failed to dispatch queued session execution"
+                );
+            }
+        });
+    }
+
     async fn load_persisted_execute_request(
         &self,
         execution_id: &str,
     ) -> Result<ExecuteSessionInput, SessionRuntimeError> {
         let request = self.store.execution_request(execution_id).await?;
-        serde_json::from_value(request).map_err(|error| {
-            SessionRuntimeError::BadRequest(format!(
-                "execution {execution_id} has an invalid persisted request: {error}"
-            ))
-        })
+        deserialize_persisted_execute_request(execution_id, request)
     }
 
     async fn record_execution_failure(
@@ -3106,10 +3146,11 @@ impl SessionRuntime {
         });
     }
 
-    /// One pass over all active executions. Queued requests can always be
-    /// claimed and replayed from durable input. `pre_sandbox_grace` only
-    /// protects a running row that has not finished sandbox assignment;
-    /// `None` is only correct when no re-scan will follow.
+    /// One pass over all active executions. Queued requests with persisted
+    /// input can be claimed and replayed immediately. `pre_sandbox_grace`
+    /// protects running rows awaiting sandbox assignment and legacy queued
+    /// rows that predate durable requests; `None` is only correct when no
+    /// re-scan will follow.
     async fn run_orphan_adoption_scan(
         &self,
         state: &mut OrphanAdoptionState,
@@ -3238,7 +3279,37 @@ impl SessionRuntime {
         if execution.status == ExecutionStatus::Queued {
             // mark_execution_running is an atomic claim, so a periodic scan
             // can safely race the accepting process without double delivery.
-            let input = match self.load_persisted_execute_request(execution_id).await {
+            let request = match self.store.execution_request(execution_id).await {
+                Ok(request) => request,
+                Err(error) => {
+                    self.fail_orphaned_execution(
+                        thread_key,
+                        execution_id,
+                        "",
+                        &format!("queued request could not be recovered: {error}"),
+                    )
+                    .await;
+                    return Ok(OrphanAdoption::Failed);
+                }
+            };
+            let request_is_empty = request.as_object().is_some_and(serde_json::Map::is_empty);
+            if request_is_empty {
+                let age = SystemTime::now()
+                    .duration_since(SystemTime::from(execution.created_at))
+                    .unwrap_or_default();
+                if pre_sandbox_grace.is_some_and(|grace| age < grace) {
+                    debug!(
+                        component = COMPONENT_SESSION_RUNTIME,
+                        event = "execution_adoption_skipped",
+                        thread_key = %thread_key,
+                        execution_id,
+                        age_ms = duration_millis_u64(age),
+                        "skipping young queued execution without a persisted request"
+                    );
+                    return Ok(OrphanAdoption::Skipped);
+                }
+            }
+            let input = match deserialize_persisted_execute_request(execution_id, request) {
                 Ok(input) => input,
                 Err(error) => {
                     self.fail_orphaned_execution(
@@ -3251,14 +3322,13 @@ impl SessionRuntime {
                     return Ok(OrphanAdoption::Failed);
                 }
             };
-            self.execute_session(thread_key, input).await?;
             info!(
                 component = COMPONENT_SESSION_RUNTIME,
                 event = "execution_adopted",
                 thread_key = %thread_key,
                 execution_id,
                 mode = "queued_request",
-                "dispatched queued execution from its persisted request"
+                "scheduling queued execution from its persisted request"
             );
             let _ = self
                 .store
@@ -3269,6 +3339,7 @@ impl SessionRuntime {
                     json!({ "mode": "queued_request" }),
                 )
                 .await;
+            self.spawn_session_execution(thread_key.clone(), execution.execution_id.clone(), input);
             return Ok(OrphanAdoption::Adopted);
         }
         let session = self.store.get_session(thread_key).await?;
@@ -6910,6 +6981,17 @@ fn persisted_execute_request(input: &ExecuteSessionInput) -> Result<Value, Sessi
     })
 }
 
+fn deserialize_persisted_execute_request(
+    execution_id: &str,
+    request: Value,
+) -> Result<ExecuteSessionInput, SessionRuntimeError> {
+    serde_json::from_value(request).map_err(|error| {
+        SessionRuntimeError::BadRequest(format!(
+            "execution {execution_id} has an invalid persisted request: {error}"
+        ))
+    })
+}
+
 fn idle_timeout_from_execution(execution: &SessionExecution) -> Option<Duration> {
     execution
         .metadata
@@ -8830,28 +8912,32 @@ mod adoption_tests {
                 .await
                 .expect("set sandbox id");
         }
-        let created = store
-            .create_execution_with_request(
-                thread_key,
-                None,
-                json!({}),
-                persisted_execute_request(&ExecuteSessionInput {
-                    idempotency_key: None,
-                    metadata: Some(json!({"source": "adoption-test"})),
-                    input_lines: vec![
-                        json!({
-                            "type": "user",
-                            "message": {"content": [{"type": "text", "text": "recover me"}]}
-                        })
-                        .to_string(),
-                    ],
-                    idle_timeout_ms: None,
-                    max_duration_ms: None,
-                })
-                .expect("serialize execution request"),
-            )
-            .await
-            .expect("create execution");
+        let created = if running {
+            store.create_execution(thread_key, None, json!({})).await
+        } else {
+            store
+                .create_execution_with_request(
+                    thread_key,
+                    None,
+                    json!({}),
+                    persisted_execute_request(&ExecuteSessionInput {
+                        idempotency_key: None,
+                        metadata: Some(json!({"source": "adoption-test"})),
+                        input_lines: vec![
+                            json!({
+                                "type": "user",
+                                "message": {"content": [{"type": "text", "text": "recover me"}]}
+                            })
+                            .to_string(),
+                        ],
+                        idle_timeout_ms: None,
+                        max_duration_ms: None,
+                    })
+                    .expect("serialize execution request"),
+                )
+                .await
+        }
+        .expect("create execution");
         let execution_id = created.execution.execution_id;
         if running {
             store
@@ -8969,7 +9055,7 @@ mod adoption_tests {
         backend.push_io(io).await;
         let runtime = runtime_with(&store, backend.clone());
         let input = ExecuteSessionInput {
-            idempotency_key: Some("slack-message-1".to_owned()),
+            idempotency_key: None,
             metadata: Some(json!({"source": "slackbotv2"})),
             input_lines: vec![
                 json!({
@@ -9009,6 +9095,23 @@ mod adoption_tests {
             .await
             .expect("write terminal output");
         wait_for_event(&store, &thread_key, "session.execution_completed").await;
+        let latest = store
+            .latest_execution_for_thread(&thread_key)
+            .await
+            .expect("load latest execution")
+            .expect("execution exists");
+        assert_eq!(latest.execution_id, execution.execution_id);
+        assert_eq!(latest.status, ExecutionStatus::Completed);
+        let completed = events(&store, &thread_key)
+            .await
+            .into_iter()
+            .filter(|event| event.event_type == "session.execution_completed")
+            .collect::<Vec<_>>();
+        assert_eq!(completed.len(), 1);
+        assert_eq!(
+            completed[0].execution_id.as_deref(),
+            Some(execution.execution_id.as_str())
+        );
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -10708,13 +10811,16 @@ mod adoption_tests {
         let _serial = TEST_LOCK.lock().await;
         let thread_key =
             ThreadKey::parse(format!("test:adopt-queued-{}", uuid::Uuid::new_v4())).unwrap();
-        orphaned_execution(&store, &thread_key, Some("sbx-mock"), false).await;
+        let execution_id = orphaned_execution(&store, &thread_key, None, false).await;
 
         let backend = Arc::new(MockBackend::new(SandboxStatus::Running, Vec::new()));
+        let create_gate = backend.hold_create();
         let (io, mut stdout, _stdin) = mock_io();
         backend.push_io(io).await;
         let runtime = runtime_with(&store, backend.clone());
-        runtime.adopt_orphaned_executions().await;
+        timeout(Duration::from_secs(1), runtime.adopt_orphaned_executions())
+            .await
+            .expect("adoption scan must not wait for sandbox creation");
 
         let all = events(&store, &thread_key).await;
         assert!(
@@ -10724,13 +10830,84 @@ mod adoption_tests {
             }),
             "expected queued request adoption event"
         );
-        assert_eq!(backend.opens(), 1);
+        timeout(Duration::from_secs(1), backend.create_started.notified())
+            .await
+            .expect("background recovery should start sandbox creation");
+        assert_eq!(backend.opens(), 0);
 
+        create_gate.notify_one();
         stdout
             .write_all(&completed_output_bytes("Recovered queued request."))
             .await
             .unwrap();
         wait_for_event(&store, &thread_key, "session.execution_completed").await;
+        let latest = store
+            .latest_execution_for_thread(&thread_key)
+            .await
+            .expect("load latest execution")
+            .expect("execution exists");
+        assert_eq!(latest.execution_id, execution_id);
+        assert_eq!(latest.status, ExecutionStatus::Completed);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn periodic_scan_graces_young_legacy_queued_execution_without_request() {
+        let Some(store) = test_store().await else {
+            return;
+        };
+        let _serial = TEST_LOCK.lock().await;
+        let thread_key =
+            ThreadKey::parse(format!("test:adopt-legacy-{}", uuid::Uuid::new_v4())).unwrap();
+        store
+            .create_or_get_session(
+                &thread_key,
+                &HarnessType::Codex,
+                None,
+                json!({}),
+                Default::default(),
+            )
+            .await
+            .expect("create session");
+        let execution_id = store
+            .create_execution(&thread_key, None, json!({}))
+            .await
+            .expect("create legacy execution")
+            .execution
+            .execution_id;
+
+        let backend = Arc::new(MockBackend::new(SandboxStatus::Running, Vec::new()));
+        let runtime = runtime_with(&store, backend);
+        runtime
+            .run_orphan_adoption_scan(
+                &mut OrphanAdoptionState::default(),
+                Some(PRE_SANDBOX_ORPHAN_GRACE),
+            )
+            .await;
+
+        let active = store
+            .active_execution_for_thread(&thread_key)
+            .await
+            .expect("load active execution")
+            .expect("legacy execution remains active");
+        assert_eq!(active.execution_id, execution_id);
+        assert_eq!(active.status, ExecutionStatus::Queued);
+        assert!(
+            events(&store, &thread_key)
+                .await
+                .iter()
+                .all(|event| event.event_type != "session.execution_failed"),
+            "young legacy execution must remain claimable by the old process"
+        );
+
+        let claim = store
+            .mark_execution_running(&execution_id)
+            .await
+            .expect("old process claims execution after grace");
+        assert!(claim.claimed);
+        store
+            .fail_execution(&execution_id, "test cleanup")
+            .await
+            .expect("terminalize legacy execution");
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/services/api-rs/crates/centaur-session-runtime/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-runtime/src/lib.rs
@@ -69,9 +69,9 @@ const STDOUT_OWNER_LEASE: Duration = Duration::from_secs(45);
 const STDOUT_OWNER_RENEW_INTERVAL: Duration = Duration::from_secs(10);
 const EXECUTION_HANDOFF_POLL_INTERVAL: Duration = Duration::from_millis(500);
 const EXECUTION_HANDOFF_DB_TIMEOUT: Duration = Duration::from_secs(5);
-/// A live execution can briefly have no sandbox while it moves from queued
-/// through warm-sandbox assignment. A periodic adoption scan must not fail a
-/// young row it observes in that window.
+/// A running execution can briefly have no sandbox while it moves through
+/// warm-sandbox assignment. A periodic adoption scan must not fail a young row
+/// it observes in that window.
 const PRE_SANDBOX_ORPHAN_GRACE: Duration = Duration::from_secs(120);
 const COMPONENT_SESSION_RUNTIME: &str = "session_runtime";
 const SANDBOX_REPOS_MOUNT_PATH: &str = "/home/agent/github";
@@ -356,7 +356,7 @@ pub struct WorkflowSandboxCleanupReport {
     pub failed: Vec<DrainFailure>,
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct ExecuteSessionInput {
     pub idempotency_key: Option<String>,
     pub metadata: Option<Value>,
@@ -1807,6 +1807,10 @@ impl SessionRuntime {
         thread_key: &ThreadKey,
         input: ExecuteSessionInput,
     ) -> Result<SessionExecution, SessionRuntimeError> {
+        if self.shutting_down.load(Ordering::SeqCst) {
+            return Err(SessionRuntimeError::ShuttingDown);
+        }
+        let persisted_request = persisted_execute_request(&input)?;
         let ExecuteSessionInput {
             idempotency_key,
             metadata,
@@ -1852,10 +1856,11 @@ impl SessionRuntime {
 
             let execution = self
                 .store
-                .create_execution(
+                .create_execution_with_request(
                     thread_key,
                     idempotency_key.as_deref(),
                     execution_metadata(metadata, idle_timeout_ms, max_duration_ms),
+                    persisted_request,
                 )
                 .await?;
             span.record(
@@ -2037,6 +2042,88 @@ impl SessionRuntime {
             );
         }
         result
+    }
+
+    /// Persist an execution request and return before sandbox provisioning or
+    /// stdin delivery. The queued row is the durable handoff boundary for HTTP
+    /// callers: a background driver handles the live attempt, while the
+    /// orphan-adoption scan replays a queued request after process restart.
+    pub async fn enqueue_session_execution(
+        &self,
+        thread_key: &ThreadKey,
+        input: ExecuteSessionInput,
+    ) -> Result<SessionExecution, SessionRuntimeError> {
+        if self.shutting_down.load(Ordering::SeqCst) {
+            return Err(SessionRuntimeError::ShuttingDown);
+        }
+        self.store.get_session(thread_key).await?;
+        validate_input_lines(&input.input_lines)?;
+        let _ = duration_options(input.idle_timeout_ms, input.max_duration_ms)?;
+
+        let request = persisted_execute_request(&input)?;
+        let execution = self
+            .store
+            .create_execution_with_request(
+                thread_key,
+                input.idempotency_key.as_deref(),
+                execution_metadata(
+                    input.metadata.clone(),
+                    input.idle_timeout_ms,
+                    input.max_duration_ms,
+                ),
+                request,
+            )
+            .await?;
+
+        if execution.execution.status == ExecutionStatus::Queued {
+            let persisted_input = if execution.created {
+                input
+            } else {
+                self.load_persisted_execute_request(&execution.execution.execution_id)
+                    .await?
+            };
+            let runtime = self.clone();
+            let queued_thread_key = thread_key.clone();
+            let queued_execution_id = execution.execution.execution_id.clone();
+            tokio::spawn(async move {
+                if let Err(error) = runtime
+                    .execute_session(&queued_thread_key, persisted_input)
+                    .await
+                {
+                    warn!(
+                        component = COMPONENT_SESSION_RUNTIME,
+                        event = "session_execute_dispatch_failed",
+                        thread_key = %queued_thread_key,
+                        execution_id = queued_execution_id,
+                        %error,
+                        "failed to dispatch queued session execution"
+                    );
+                }
+            });
+        }
+
+        info!(
+            component = COMPONENT_SESSION_RUNTIME,
+            event = "session_execute_enqueued",
+            thread_key = %thread_key,
+            execution_id = %execution.execution.execution_id,
+            status = %execution.execution.status,
+            created = execution.created,
+            "persisted session execution request"
+        );
+        Ok(execution.execution)
+    }
+
+    async fn load_persisted_execute_request(
+        &self,
+        execution_id: &str,
+    ) -> Result<ExecuteSessionInput, SessionRuntimeError> {
+        let request = self.store.execution_request(execution_id).await?;
+        serde_json::from_value(request).map_err(|error| {
+            SessionRuntimeError::BadRequest(format!(
+                "execution {execution_id} has an invalid persisted request: {error}"
+            ))
+        })
     }
 
     async fn record_execution_failure(
@@ -2994,9 +3081,6 @@ impl SessionRuntime {
     ///    and re-arm the remaining max-duration deadline.
     /// 3. The sandbox is gone: record the failure honestly.
     pub async fn adopt_orphaned_executions(&self) {
-        // A one-shot scan has no later tick to revisit skipped rows, so
-        // queued orphans are failed immediately regardless of age — the
-        // pre-rescan startup behavior.
         self.run_orphan_adoption_scan(&mut OrphanAdoptionState::default(), None)
             .await;
     }
@@ -3022,9 +3106,10 @@ impl SessionRuntime {
         });
     }
 
-    /// One pass over all active executions. `pre_sandbox_grace` is the
-    /// minimum age before a row awaiting sandbox assignment is treated as
-    /// orphaned; `None` is only correct when no re-scan will follow.
+    /// One pass over all active executions. Queued requests can always be
+    /// claimed and replayed from durable input. `pre_sandbox_grace` only
+    /// protects a running row that has not finished sandbox assignment;
+    /// `None` is only correct when no re-scan will follow.
     async fn run_orphan_adoption_scan(
         &self,
         state: &mut OrphanAdoptionState,
@@ -3151,35 +3236,40 @@ impl SessionRuntime {
         let thread_key = &execution.thread_key;
         let execution_id = execution.execution_id.as_str();
         if execution.status == ExecutionStatus::Queued {
-            // Input is only written after an execution is marked running, so
-            // a queued orphan never reached the harness: nothing can come.
-            // On a periodic scan, young queued rows are skipped instead of
-            // failed: they are most likely a live execute_session observed
-            // mid-transition, and a later tick revisits them.
-            if let Some(grace) = pre_sandbox_grace {
-                let age = SystemTime::now()
-                    .duration_since(SystemTime::from(execution.created_at))
-                    .unwrap_or_default();
-                if age < grace {
-                    debug!(
-                        component = COMPONENT_SESSION_RUNTIME,
-                        event = "execution_adoption_skipped",
-                        thread_key = %thread_key,
+            // mark_execution_running is an atomic claim, so a periodic scan
+            // can safely race the accepting process without double delivery.
+            let input = match self.load_persisted_execute_request(execution_id).await {
+                Ok(input) => input,
+                Err(error) => {
+                    self.fail_orphaned_execution(
+                        thread_key,
                         execution_id,
-                        age_ms = duration_millis_u64(age),
-                        "skipping young queued execution; a live execute may still claim it"
-                    );
-                    return Ok(OrphanAdoption::Skipped);
+                        "",
+                        &format!("queued request could not be recovered: {error}"),
+                    )
+                    .await;
+                    return Ok(OrphanAdoption::Failed);
                 }
-            }
-            self.fail_orphaned_execution(
-                thread_key,
+            };
+            self.execute_session(thread_key, input).await?;
+            info!(
+                component = COMPONENT_SESSION_RUNTIME,
+                event = "execution_adopted",
+                thread_key = %thread_key,
                 execution_id,
-                "",
-                "orphaned before input was sent",
-            )
-            .await;
-            return Ok(OrphanAdoption::Failed);
+                mode = "queued_request",
+                "dispatched queued execution from its persisted request"
+            );
+            let _ = self
+                .store
+                .append_event(
+                    thread_key,
+                    Some(execution_id),
+                    "session.execution_adopted",
+                    json!({ "mode": "queued_request" }),
+                )
+                .await;
+            return Ok(OrphanAdoption::Adopted);
         }
         let session = self.store.get_session(thread_key).await?;
         let Some(sandbox_id) = session.sandbox_id.as_deref() else {
@@ -6812,6 +6902,14 @@ fn execution_metadata(
     metadata
 }
 
+fn persisted_execute_request(input: &ExecuteSessionInput) -> Result<Value, SessionRuntimeError> {
+    serde_json::to_value(input).map_err(|error| {
+        SessionRuntimeError::BadRequest(format!(
+            "session execution request could not be persisted: {error}"
+        ))
+    })
+}
+
 fn idle_timeout_from_execution(execution: &SessionExecution) -> Option<Duration> {
     execution
         .metadata
@@ -8473,6 +8571,8 @@ mod adoption_tests {
         ios: Mutex<VecDeque<SandboxIo>>,
         recorded_output: std::sync::Mutex<Vec<String>>,
         open_count: AtomicUsize,
+        create_started: tokio::sync::Notify,
+        create_gate: std::sync::Mutex<Option<Arc<tokio::sync::Notify>>>,
         status: std::sync::Mutex<SandboxStatus>,
         observed_statuses: std::sync::Mutex<BTreeMap<String, SandboxStatus>>,
         create_id: String,
@@ -8489,6 +8589,8 @@ mod adoption_tests {
                 ios: Mutex::new(VecDeque::new()),
                 recorded_output: std::sync::Mutex::new(recorded_output),
                 open_count: AtomicUsize::new(0),
+                create_started: tokio::sync::Notify::new(),
+                create_gate: std::sync::Mutex::new(None),
                 status: std::sync::Mutex::new(status),
                 observed_statuses: std::sync::Mutex::new(BTreeMap::new()),
                 create_id: "mock-sbx".to_owned(),
@@ -8506,6 +8608,12 @@ mod adoption_tests {
 
         fn opens(&self) -> usize {
             self.open_count.load(Ordering::SeqCst)
+        }
+
+        fn hold_create(&self) -> Arc<tokio::sync::Notify> {
+            let gate = Arc::new(tokio::sync::Notify::new());
+            *self.create_gate.lock().unwrap() = Some(gate.clone());
+            gate
         }
 
         fn set_recorded_output(&self, recorded_output: Vec<String>) {
@@ -8563,6 +8671,11 @@ mod adoption_tests {
 
         async fn create(&self, spec: SandboxSpec) -> SandboxResult<SandboxHandle> {
             self.created_specs.lock().unwrap().push(spec);
+            self.create_started.notify_one();
+            let gate = self.create_gate.lock().unwrap().clone();
+            if let Some(gate) = gate {
+                gate.notified().await;
+            }
             self.set_observed_status(&self.create_id, SandboxStatus::Running);
             Ok(SandboxHandle::new(
                 SandboxId::new(self.create_id.clone()),
@@ -8718,7 +8831,25 @@ mod adoption_tests {
                 .expect("set sandbox id");
         }
         let created = store
-            .create_execution(thread_key, None, json!({}))
+            .create_execution_with_request(
+                thread_key,
+                None,
+                json!({}),
+                persisted_execute_request(&ExecuteSessionInput {
+                    idempotency_key: None,
+                    metadata: Some(json!({"source": "adoption-test"})),
+                    input_lines: vec![
+                        json!({
+                            "type": "user",
+                            "message": {"content": [{"type": "text", "text": "recover me"}]}
+                        })
+                        .to_string(),
+                    ],
+                    idle_timeout_ms: None,
+                    max_duration_ms: None,
+                })
+                .expect("serialize execution request"),
+            )
             .await
             .expect("create execution");
         let execution_id = created.execution.execution_id;
@@ -8731,8 +8862,8 @@ mod adoption_tests {
         execution_id
     }
 
-    /// Ages an execution row past `PRE_SANDBOX_ORPHAN_GRACE` so adoption treats it
-    /// as a genuine orphan instead of a young row racing a live execute.
+    /// Ages a running pre-sandbox row past `PRE_SANDBOX_ORPHAN_GRACE` so
+    /// adoption treats it as a genuine orphan instead of an assignment race.
     async fn backdate_execution(store: &PgSessionStore, execution_id: &str, seconds: f64) {
         let result = sqlx::query(
             "update session_executions \
@@ -8811,6 +8942,73 @@ mod adoption_tests {
             SandboxRuntime::backend(backend, SandboxSpec::new("mock")),
             TestSessionPrincipalRegistrar,
         )
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn enqueue_returns_after_durable_commit_without_waiting_for_sandbox() {
+        let Some(store) = test_store().await else {
+            return;
+        };
+        let _serial = TEST_LOCK.lock().await;
+        let thread_key =
+            ThreadKey::parse(format!("test:enqueue-{}", uuid::Uuid::new_v4())).unwrap();
+        store
+            .create_or_get_session(
+                &thread_key,
+                &HarnessType::Codex,
+                None,
+                json!({}),
+                Default::default(),
+            )
+            .await
+            .expect("create session");
+
+        let backend = Arc::new(MockBackend::new(SandboxStatus::Running, Vec::new()));
+        let create_gate = backend.hold_create();
+        let (io, mut stdout, _stdin) = mock_io();
+        backend.push_io(io).await;
+        let runtime = runtime_with(&store, backend.clone());
+        let input = ExecuteSessionInput {
+            idempotency_key: Some("slack-message-1".to_owned()),
+            metadata: Some(json!({"source": "slackbotv2"})),
+            input_lines: vec![
+                json!({
+                    "type": "user",
+                    "message": {"content": [{"type": "text", "text": "queue me"}]}
+                })
+                .to_string(),
+            ],
+            idle_timeout_ms: None,
+            max_duration_ms: None,
+        };
+
+        let execution = timeout(
+            Duration::from_secs(1),
+            runtime.enqueue_session_execution(&thread_key, input.clone()),
+        )
+        .await
+        .expect("enqueue must not wait for sandbox creation")
+        .expect("enqueue execution");
+        assert_eq!(execution.status, ExecutionStatus::Queued);
+        assert_eq!(
+            store
+                .execution_request(&execution.execution_id)
+                .await
+                .expect("load durable request"),
+            persisted_execute_request(&input).expect("serialize input")
+        );
+
+        timeout(Duration::from_secs(1), backend.create_started.notified())
+            .await
+            .expect("background driver should start sandbox creation");
+        assert!(backend.created_specs().len() == 1);
+
+        create_gate.notify_one();
+        stdout
+            .write_all(&completed_output_bytes("Processed from durable queue."))
+            .await
+            .expect("write terminal output");
+        wait_for_event(&store, &thread_key, "session.execution_completed").await;
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -10503,7 +10701,7 @@ mod adoption_tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn fails_queued_orphans_that_never_received_input() {
+    async fn dispatches_queued_orphans_from_durable_input() {
         let Some(store) = test_store().await else {
             return;
         };
@@ -10512,69 +10710,60 @@ mod adoption_tests {
             ThreadKey::parse(format!("test:adopt-queued-{}", uuid::Uuid::new_v4())).unwrap();
         orphaned_execution(&store, &thread_key, Some("sbx-mock"), false).await;
 
-        // The one-shot scan has no later tick to revisit skipped rows, so it
-        // fails queued orphans immediately regardless of age.
         let backend = Arc::new(MockBackend::new(SandboxStatus::Running, Vec::new()));
+        let (io, mut stdout, _stdin) = mock_io();
+        backend.push_io(io).await;
         let runtime = runtime_with(&store, backend.clone());
         runtime.adopt_orphaned_executions().await;
 
-        wait_for_event(&store, &thread_key, "session.execution_failed").await;
         let all = events(&store, &thread_key).await;
-        let failed = all
-            .iter()
-            .find(|event| event.event_type == "session.execution_failed")
-            .expect("failed event");
-        let error = failed.payload["error"].as_str().unwrap_or_default();
         assert!(
-            error.contains("orphaned before input was sent"),
-            "unexpected error: {error}"
+            all.iter().any(|event| {
+                event.event_type == "session.execution_adopted"
+                    && event.payload["mode"] == json!("queued_request")
+            }),
+            "expected queued request adoption event"
         );
-        assert_eq!(backend.opens(), 0);
+        assert_eq!(backend.opens(), 1);
+
+        stdout
+            .write_all(&completed_output_bytes("Recovered queued request."))
+            .await
+            .unwrap();
+        wait_for_event(&store, &thread_key, "session.execution_completed").await;
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn periodic_scan_skips_young_pre_sandbox_executions_until_grace_passes() {
+    async fn periodic_scan_dispatches_queued_but_graces_young_running_executions() {
         let Some(store) = test_store().await else {
             return;
         };
         let _serial = TEST_LOCK.lock().await;
         let thread_key =
             ThreadKey::parse(format!("test:adopt-young-{}", uuid::Uuid::new_v4())).unwrap();
-        let execution_id = orphaned_execution(&store, &thread_key, Some("sbx-mock"), false).await;
+        orphaned_execution(&store, &thread_key, Some("sbx-mock"), false).await;
 
         let backend = Arc::new(MockBackend::new(SandboxStatus::Running, Vec::new()));
+        let (io, mut stdout, _stdin) = mock_io();
+        backend.push_io(io).await;
         let runtime = runtime_with(&store, backend.clone());
         let mut state = OrphanAdoptionState::default();
         runtime
             .run_orphan_adoption_scan(&mut state, Some(PRE_SANDBOX_ORPHAN_GRACE))
             .await;
 
-        // A queued row younger than the grace window may belong to a live
-        // execute_session mid-transition; a periodic scan must leave it
-        // alone and revisit it later.
-        let all = events(&store, &thread_key).await;
         assert!(
-            all.iter()
-                .all(|event| event.event_type != "session.execution_failed"),
-            "young queued execution must not be failed"
+            events(&store, &thread_key).await.iter().any(|event| {
+                event.event_type == "session.execution_adopted"
+                    && event.payload["mode"] == json!("queued_request")
+            }),
+            "queued execution should be dispatched immediately"
         );
-        let active = store
-            .list_active_executions()
+        stdout
+            .write_all(&completed_output_bytes("Recovered on periodic scan."))
             .await
-            .expect("list active executions");
-        assert!(
-            active
-                .iter()
-                .any(|execution| execution.execution_id == execution_id),
-            "young queued execution must stay active"
-        );
-
-        // Once the row ages past the grace window, a later tick fails it.
-        backdate_execution(&store, &execution_id, 300.0).await;
-        runtime
-            .run_orphan_adoption_scan(&mut state, Some(PRE_SANDBOX_ORPHAN_GRACE))
-            .await;
-        wait_for_event(&store, &thread_key, "session.execution_failed").await;
+            .unwrap();
+        wait_for_event(&store, &thread_key, "session.execution_completed").await;
 
         // A newly running execution can still be waiting for its warm
         // sandbox assignment. It gets the same periodic grace, but is failed

--- a/services/api-rs/crates/centaur-session-runtime/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-runtime/src/lib.rs
@@ -28,8 +28,8 @@ use centaur_session_core::{
     SessionMessageInput, ThreadKey,
 };
 use centaur_session_sqlx::{
-    ClaimExecutionResult, PgSessionStore, SandboxCapacityCandidate, SessionEventListener,
-    SessionStoreError, default_metadata,
+    PgSessionStore, SandboxCapacityCandidate, SessionEventListener, SessionStoreError,
+    default_metadata,
 };
 use centaur_telemetry::{
     export_thread_trace_root_span, record_sandbox_warm_pool_claim,
@@ -151,14 +151,6 @@ pub struct SessionRuntime {
     session_title_rerun_requested: SessionTitleThreadSet,
     capacity: Option<Arc<SandboxCapacityController>>,
     stdout_owner_id: String,
-    /// Serializes stdout-owner claims with the shutdown fence. A driver either
-    /// commits its running state and owner before shutdown begins, or observes
-    /// the fence while its execution is still queued.
-    execution_claim_gate: Arc<Mutex<()>>,
-    /// Executions owned by this process whose stdin request has not yet been
-    /// accepted. Shutdown requeues these instead of handing them off as live
-    /// executions, because a successor must replay their durable requests.
-    pending_input_deliveries: Arc<DashMap<String, ThreadKey>>,
     /// Set once a shutdown handoff begins; fences new stdout-owner claims
     /// so an execution cannot start on a control plane that is about to
     /// exit and release its leases.
@@ -841,8 +833,6 @@ impl SessionRuntime {
             session_title_rerun_requested: Arc::new(DashSet::new()),
             capacity: None,
             stdout_owner_id: format!("api-rs-{}", uuid::Uuid::new_v4().simple()),
-            execution_claim_gate: Arc::new(Mutex::new(())),
-            pending_input_deliveries: Arc::new(DashMap::new()),
             shutting_down: Arc::new(AtomicBool::new(false)),
         }
     }
@@ -1215,7 +1205,6 @@ impl SessionRuntime {
     }
 
     async fn claim_stdout_owner(&self, execution_id: &str) -> Result<(), SessionRuntimeError> {
-        let _claim_guard = self.execution_claim_gate.lock().await;
         if self.shutting_down.load(Ordering::SeqCst) {
             return Err(SessionRuntimeError::ShuttingDown);
         }
@@ -1232,34 +1221,10 @@ impl SessionRuntime {
         Ok(())
     }
 
-    async fn claim_execution_for_dispatch(
-        &self,
-        execution_id: &str,
-    ) -> Result<ClaimExecutionResult, SessionRuntimeError> {
-        let _claim_guard = self.execution_claim_gate.lock().await;
-        if self.shutting_down.load(Ordering::SeqCst) {
-            return Err(SessionRuntimeError::ShuttingDown);
-        }
-        let claim = self
-            .store
-            .claim_execution_for_stdout(execution_id, &self.stdout_owner_id, STDOUT_OWNER_LEASE)
-            .await?;
-        if claim.claimed {
-            self.pending_input_deliveries
-                .insert(execution_id.to_owned(), claim.execution.thread_key.clone());
-            spawn_stdout_owner_renewer(self.context(), execution_id.to_owned());
-        }
-        Ok(claim)
-    }
-
     async fn claim_expired_stdout_owner(
         &self,
         execution_id: &str,
     ) -> Result<bool, SessionRuntimeError> {
-        let _claim_guard = self.execution_claim_gate.lock().await;
-        if self.shutting_down.load(Ordering::SeqCst) {
-            return Err(SessionRuntimeError::ShuttingDown);
-        }
         let claimed = self
             .store
             .claim_expired_stdout_owner(execution_id, &self.stdout_owner_id, STDOUT_OWNER_LEASE)
@@ -1914,7 +1879,7 @@ impl SessionRuntime {
             let claim = if let Some(execution_id) = persisted_execution_id {
                 span.record("centaur.execution_id", execution_id);
                 span.record("execution_id", execution_id);
-                self.claim_execution_for_dispatch(execution_id).await?
+                self.store.mark_execution_running(execution_id).await?
             } else {
                 let execution = self
                     .store
@@ -1941,7 +1906,8 @@ impl SessionRuntime {
                     );
                     return Ok(execution.execution);
                 }
-                self.claim_execution_for_dispatch(&execution.execution.execution_id)
+                self.store
+                    .mark_execution_running(&execution.execution.execution_id)
                     .await?
             };
             let execution = claim.execution;
@@ -1967,6 +1933,11 @@ impl SessionRuntime {
                     "execution was already claimed or terminal"
                 );
                 return Ok(execution);
+            }
+            if let Err(error) = self.claim_stdout_owner(&execution.execution_id).await {
+                self.handle_stdout_claim_failure(thread_key, &execution.execution_id, &error)
+                    .await;
+                return Err(error);
             }
             let execution_trace_span = info_span!(
                 "centaur.api_rs.session.execution",
@@ -2053,40 +2024,16 @@ impl SessionRuntime {
 
             let trace = SessionTraceContext::new(thread_key, Some(&execution_trace_span));
             let input_lines = input_lines_with_session_context(thread_key, &trace, &input_lines);
-            let write_result = {
-                // Serialize the final pre-delivery shutdown check with the
-                // shutdown fence. Once this block succeeds, handoff may safely
-                // treat the execution as live instead of replaying its request.
-                let _claim_guard = self.execution_claim_gate.lock().await;
-                let result = if self.shutting_down.load(Ordering::SeqCst) {
-                    Err(SessionRuntimeError::ShuttingDown)
-                } else {
-                    write_input_lines(
-                        &pipe,
-                        &input_lines,
-                        thread_key,
-                        &execution.execution_id,
-                        Some(&sandbox_id),
-                    )
-                    .instrument(execution_trace_span.clone())
-                    .await
-                };
-                if result.is_ok() {
-                    self.pending_input_deliveries
-                        .remove(&execution.execution_id);
-                }
-                result
-            };
-            if let Err(error) = write_result {
-                if matches!(error, SessionRuntimeError::ShuttingDown) {
-                    self.requeue_execution_before_input(
-                        thread_key,
-                        &execution.execution_id,
-                        "control_plane_shutdown",
-                    )
-                    .await;
-                    return Err(error);
-                }
+            if let Err(error) = write_input_lines(
+                &pipe,
+                &input_lines,
+                thread_key,
+                &execution.execution_id,
+                Some(&sandbox_id),
+            )
+            .instrument(execution_trace_span.clone())
+            .await
+            {
                 self.record_execution_failure(thread_key, &execution.execution_id, &error)
                     .await;
                 return Err(error);
@@ -2225,7 +2172,6 @@ impl SessionRuntime {
         execution_id: &str,
         error: &SessionRuntimeError,
     ) {
-        self.pending_input_deliveries.remove(execution_id);
         self.execution_spans.lock().await.remove(execution_id);
         let error_message = error.to_string();
         let execution = match self
@@ -2244,7 +2190,6 @@ impl SessionRuntime {
                     event = "session_execution_failure_not_recorded",
                     thread_key = %thread_key,
                     execution_id,
-                    stdout_owner_id = %self.stdout_owner_id,
                     original_error = %error_message,
                     "execution was terminal or stdout ownership changed before failure could be recorded"
                 );
@@ -2256,7 +2201,6 @@ impl SessionRuntime {
                     event = "session_execution_failure_record_failed",
                     thread_key = %thread_key,
                     execution_id,
-                    stdout_owner_id = %self.stdout_owner_id,
                     original_error = %error_message,
                     error = %record_error,
                     "failed to persist execution failure"
@@ -2287,67 +2231,44 @@ impl SessionRuntime {
         .await;
     }
 
-    async fn requeue_execution_before_input(
+    async fn handle_stdout_claim_failure(
         &self,
         thread_key: &ThreadKey,
         execution_id: &str,
-        reason: &str,
-    ) -> bool {
-        let execution = match self
-            .store
-            .requeue_execution_if_active_and_stdout_owner(execution_id, &self.stdout_owner_id)
-            .await
-        {
-            Ok(Some(execution)) => execution,
-            Ok(None) => {
-                warn!(
-                    component = COMPONENT_SESSION_RUNTIME,
-                    event = "session_execution_requeue_not_recorded",
-                    thread_key = %thread_key,
-                    execution_id,
-                    reason,
-                    "execution was terminal or stdout ownership changed before it could be requeued"
-                );
-                return false;
+        error: &SessionRuntimeError,
+    ) {
+        if matches!(error, SessionRuntimeError::ShuttingDown) {
+            match self
+                .store
+                .requeue_execution_if_running_without_stdout_owner(execution_id)
+                .await
+            {
+                Ok(Some(_)) => {
+                    info!(
+                        component = COMPONENT_SESSION_RUNTIME,
+                        event = "session_execution_requeued",
+                        thread_key = %thread_key,
+                        execution_id,
+                        reason = "control_plane_shutdown",
+                        "returned undelivered execution to the durable queue"
+                    );
+                    return;
+                }
+                Ok(None) => {}
+                Err(requeue_error) => {
+                    warn!(
+                        component = COMPONENT_SESSION_RUNTIME,
+                        event = "session_execution_requeue_failed",
+                        thread_key = %thread_key,
+                        execution_id,
+                        error = %requeue_error,
+                        "failed to return undelivered execution to the durable queue"
+                    );
+                }
             }
-            Err(error) => {
-                warn!(
-                    component = COMPONENT_SESSION_RUNTIME,
-                    event = "session_execution_requeue_failed",
-                    thread_key = %thread_key,
-                    execution_id,
-                    reason,
-                    %error,
-                    "failed to return undelivered execution to the durable queue"
-                );
-                return false;
-            }
-        };
-        self.pending_input_deliveries.remove(execution_id);
-        self.execution_spans.lock().await.remove(execution_id);
-        let _ = self
-            .store
-            .append_event(
-                thread_key,
-                Some(execution_id),
-                "session.execution_requeued",
-                json!({
-                    "execution_id": execution_id,
-                    "thread_key": thread_key.as_str(),
-                    "reason": reason,
-                }),
-            )
+        }
+        self.record_execution_failure(thread_key, execution_id, error)
             .await;
-        info!(
-            component = COMPONENT_SESSION_RUNTIME,
-            event = "session_execution_requeued",
-            thread_key = %thread_key,
-            execution_id,
-            status = %execution.status,
-            reason,
-            "returned undelivered execution to the durable queue"
-        );
-        true
     }
 
     async fn forward_messages_to_active_execution(
@@ -3650,17 +3571,10 @@ impl SessionRuntime {
         sandbox_id: &str,
         detail: &str,
     ) {
-        if let Err(error) = self.claim_stdout_owner(execution_id).await {
-            warn!(
-                component = COMPONENT_SESSION_RUNTIME,
-                event = "execution_adoption_failure_claim_failed",
-                thread_key = %thread_key,
-                execution_id,
-                %error,
-                "failed to claim orphaned execution before recording its failure"
-            );
-            return;
-        }
+        let _ = self
+            .store
+            .claim_stdout_owner(execution_id, &self.stdout_owner_id, STDOUT_OWNER_LEASE)
+            .await;
         let error = format!("execution orphaned by control plane restart; {detail}");
         if let Err(record_error) = record_terminal_output(
             &self.context(),
@@ -3694,10 +3608,7 @@ impl SessionRuntime {
         // Fence new stdout-owner claims first: an execution accepted after
         // this point would otherwise claim a lease that outlives the
         // process, stranding it until the lease TTL expires.
-        {
-            let _claim_guard = self.execution_claim_gate.lock().await;
-            self.shutting_down.store(true, Ordering::SeqCst);
-        }
+        self.shutting_down.store(true, Ordering::SeqCst);
         let deadline = Instant::now()
             .checked_add(timeout)
             .unwrap_or_else(|| Instant::now() + Duration::from_secs(3600));
@@ -3747,19 +3658,6 @@ impl SessionRuntime {
                 }
             }
             sleep(EXECUTION_HANDOFF_POLL_INTERVAL).await;
-        }
-        let pending_input_execution_ids = self
-            .pending_input_deliveries
-            .iter()
-            .map(|entry| (entry.key().clone(), entry.value().clone()))
-            .collect::<Vec<_>>();
-        for (execution_id, thread_key) in pending_input_execution_ids {
-            self.requeue_execution_before_input(
-                &thread_key,
-                &execution_id,
-                "control_plane_shutdown_timeout",
-            )
-            .await;
         }
         let released = tokio::time::timeout(
             EXECUTION_HANDOFF_DB_TIMEOUT,
@@ -9265,16 +9163,6 @@ mod adoption_tests {
             .expect("execution exists");
         assert_eq!(latest.execution_id, execution.execution_id);
         assert_eq!(latest.status, ExecutionStatus::Completed);
-        let completed = events(&store, &thread_key)
-            .await
-            .into_iter()
-            .filter(|event| event.event_type == "session.execution_completed")
-            .collect::<Vec<_>>();
-        assert_eq!(completed.len(), 1);
-        assert_eq!(
-            completed[0].execution_id.as_deref(),
-            Some(execution.execution_id.as_str())
-        );
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -11074,40 +10962,14 @@ mod adoption_tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn periodic_scan_dispatches_queued_but_graces_young_running_executions() {
+    async fn periodic_scan_graces_young_running_executions() {
         let Some(store) = test_store().await else {
             return;
         };
         let _serial = TEST_LOCK.lock().await;
-        let thread_key =
-            ThreadKey::parse(format!("test:adopt-young-{}", uuid::Uuid::new_v4())).unwrap();
-        orphaned_execution(&store, &thread_key, Some("sbx-mock"), false).await;
-
         let backend = Arc::new(MockBackend::new(SandboxStatus::Running, Vec::new()));
-        let (io, mut stdout, _stdin) = mock_io();
-        backend.push_io(io).await;
-        let runtime = runtime_with(&store, backend.clone());
+        let runtime = runtime_with(&store, backend);
         let mut state = OrphanAdoptionState::default();
-        runtime
-            .run_orphan_adoption_scan(&mut state, Some(PRE_SANDBOX_ORPHAN_GRACE))
-            .await;
-
-        assert!(
-            events(&store, &thread_key).await.iter().any(|event| {
-                event.event_type == "session.execution_adopted"
-                    && event.payload["mode"] == json!("queued_request")
-            }),
-            "queued execution should be dispatched immediately"
-        );
-        stdout
-            .write_all(&completed_output_bytes("Recovered on periodic scan."))
-            .await
-            .unwrap();
-        wait_for_event(&store, &thread_key, "session.execution_completed").await;
-
-        // A newly running execution can still be waiting for its warm
-        // sandbox assignment. It gets the same periodic grace, but is failed
-        // if it remains unassigned after the grace window.
         let running_thread =
             ThreadKey::parse(format!("test:adopt-young-running-{}", uuid::Uuid::new_v4())).unwrap();
         let running_execution = orphaned_execution(&store, &running_thread, None, true).await;
@@ -11394,122 +11256,40 @@ mod adoption_tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn shutdown_requeues_claimed_execution_before_input_delivery() {
-        let Some(store) = test_store().await else {
-            return;
-        };
-        let _serial = TEST_LOCK.lock().await;
-        let thread_key =
-            ThreadKey::parse(format!("test:handoff-pre-input-{}", uuid::Uuid::new_v4())).unwrap();
-        store
-            .create_or_get_session(
-                &thread_key,
-                &HarnessType::Codex,
-                None,
-                json!({}),
-                Default::default(),
-            )
-            .await
-            .expect("create session");
-
-        let backend = Arc::new(MockBackend::new(SandboxStatus::Running, Vec::new()));
-        let create_gate = backend.hold_create();
-        let (io, _stdout, _stdin) = mock_io();
-        backend.push_io(io).await;
-        let runtime = runtime_with(&store, backend.clone());
-        let execution = runtime
-            .enqueue_session_execution(
-                &thread_key,
-                ExecuteSessionInput {
-                    idempotency_key: None,
-                    metadata: Some(json!({"source": "shutdown-test"})),
-                    input_lines: vec![json!({"type": "user", "text": "replay me"}).to_string()],
-                    idle_timeout_ms: None,
-                    max_duration_ms: None,
-                },
-            )
-            .await
-            .expect("enqueue execution");
-        timeout(Duration::from_secs(1), backend.create_started.notified())
-            .await
-            .expect("driver should claim execution before sandbox create");
-
-        runtime.handoff_owned_executions(Duration::ZERO).await;
-
-        let ownership = store
-            .list_active_executions_with_ownership()
-            .await
-            .expect("load execution ownership")
-            .into_iter()
-            .find(|candidate| candidate.execution.execution_id == execution.execution_id)
-            .expect("execution remains recoverable");
-        assert_eq!(ownership.execution.status, ExecutionStatus::Queued);
-        assert!(ownership.execution.started_at.is_none());
-        assert!(ownership.stdout_owner_id.is_none());
-        assert!(!ownership.stdout_owner_lease_active);
-        assert!(
-            events(&store, &thread_key)
-                .await
-                .iter()
-                .any(|event| event.event_type == "session.execution_requeued"),
-            "shutdown must record that undelivered input was returned to the queue"
-        );
-
-        create_gate.notify_one();
-        store
-            .fail_execution_if_active(&execution.execution_id, "test cleanup")
-            .await
-            .expect("terminalize execution");
-    }
-
-    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn shutdown_fences_new_stdout_claims() {
         let Some(store) = test_store().await else {
             return;
         };
         let _serial = TEST_LOCK.lock().await;
-        let thread_key =
-            ThreadKey::parse(format!("test:handoff-fence-{}", uuid::Uuid::new_v4())).unwrap();
-        let execution_id = orphaned_execution(&store, &thread_key, Some("sbx-mock"), false).await;
         let backend = Arc::new(MockBackend::new(SandboxStatus::Running, Vec::new()));
         let runtime = runtime_with(&store, backend);
-        let input = runtime
-            .load_persisted_execute_request(&execution_id)
-            .await
-            .expect("load durable request");
 
         // Nothing owned: the handoff returns immediately but still flips
         // the shutdown fence.
         runtime.handoff_owned_executions(Duration::ZERO).await;
 
+        let thread_key =
+            ThreadKey::parse(format!("test:handoff-fence-{}", uuid::Uuid::new_v4())).unwrap();
+        let execution_id = orphaned_execution(&store, &thread_key, Some("sbx-mock"), true).await;
         let error = runtime
-            .drive_session_execution(&thread_key, &execution_id, input)
+            .claim_stdout_owner(&execution_id)
             .await
-            .expect_err("shutdown must fence the queued execution claim");
+            .expect_err("claims after shutdown must be rejected");
         assert!(
             matches!(error, SessionRuntimeError::ShuttingDown),
             "unexpected error: {error}"
         );
-
-        let ownership = store
-            .list_active_executions_with_ownership()
+        runtime
+            .handle_stdout_claim_failure(&thread_key, &execution_id, &error)
+            .await;
+        let execution = store
+            .latest_execution_for_thread(&thread_key)
             .await
-            .expect("load execution ownership")
-            .into_iter()
-            .find(|candidate| candidate.execution.execution_id == execution_id)
-            .expect("execution remains recoverable");
-        assert_eq!(ownership.execution.status, ExecutionStatus::Queued);
-        assert!(ownership.execution.started_at.is_none());
-        assert!(ownership.stdout_owner_id.is_none());
-        assert!(!ownership.stdout_owner_lease_active);
-        assert!(
-            events(&store, &thread_key)
-                .await
-                .iter()
-                .all(|event| event.event_type != "session.execution_failed"),
-            "shutdown handoff must leave the durable request for a successor"
-        );
-
+            .expect("load execution")
+            .expect("execution exists");
+        assert_eq!(execution.execution_id, execution_id);
+        assert_eq!(execution.status, ExecutionStatus::Queued);
+        assert!(execution.started_at.is_none());
         store
             .fail_execution_if_active(&execution_id, "test cleanup")
             .await

--- a/services/api-rs/crates/centaur-session-runtime/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-runtime/src/lib.rs
@@ -28,8 +28,8 @@ use centaur_session_core::{
     SessionMessageInput, ThreadKey,
 };
 use centaur_session_sqlx::{
-    PgSessionStore, SandboxCapacityCandidate, SessionEventListener, SessionStoreError,
-    default_metadata,
+    ClaimExecutionResult, PgSessionStore, SandboxCapacityCandidate, SessionEventListener,
+    SessionStoreError, default_metadata,
 };
 use centaur_telemetry::{
     export_thread_trace_root_span, record_sandbox_warm_pool_claim,
@@ -151,6 +151,14 @@ pub struct SessionRuntime {
     session_title_rerun_requested: SessionTitleThreadSet,
     capacity: Option<Arc<SandboxCapacityController>>,
     stdout_owner_id: String,
+    /// Serializes stdout-owner claims with the shutdown fence. A driver either
+    /// commits its running state and owner before shutdown begins, or observes
+    /// the fence while its execution is still queued.
+    execution_claim_gate: Arc<Mutex<()>>,
+    /// Executions owned by this process whose stdin request has not yet been
+    /// accepted. Shutdown requeues these instead of handing them off as live
+    /// executions, because a successor must replay their durable requests.
+    pending_input_deliveries: Arc<DashMap<String, ThreadKey>>,
     /// Set once a shutdown handoff begins; fences new stdout-owner claims
     /// so an execution cannot start on a control plane that is about to
     /// exit and release its leases.
@@ -833,6 +841,8 @@ impl SessionRuntime {
             session_title_rerun_requested: Arc::new(DashSet::new()),
             capacity: None,
             stdout_owner_id: format!("api-rs-{}", uuid::Uuid::new_v4().simple()),
+            execution_claim_gate: Arc::new(Mutex::new(())),
+            pending_input_deliveries: Arc::new(DashMap::new()),
             shutting_down: Arc::new(AtomicBool::new(false)),
         }
     }
@@ -1205,6 +1215,7 @@ impl SessionRuntime {
     }
 
     async fn claim_stdout_owner(&self, execution_id: &str) -> Result<(), SessionRuntimeError> {
+        let _claim_guard = self.execution_claim_gate.lock().await;
         if self.shutting_down.load(Ordering::SeqCst) {
             return Err(SessionRuntimeError::ShuttingDown);
         }
@@ -1221,10 +1232,34 @@ impl SessionRuntime {
         Ok(())
     }
 
+    async fn claim_execution_for_dispatch(
+        &self,
+        execution_id: &str,
+    ) -> Result<ClaimExecutionResult, SessionRuntimeError> {
+        let _claim_guard = self.execution_claim_gate.lock().await;
+        if self.shutting_down.load(Ordering::SeqCst) {
+            return Err(SessionRuntimeError::ShuttingDown);
+        }
+        let claim = self
+            .store
+            .claim_execution_for_stdout(execution_id, &self.stdout_owner_id, STDOUT_OWNER_LEASE)
+            .await?;
+        if claim.claimed {
+            self.pending_input_deliveries
+                .insert(execution_id.to_owned(), claim.execution.thread_key.clone());
+            spawn_stdout_owner_renewer(self.context(), execution_id.to_owned());
+        }
+        Ok(claim)
+    }
+
     async fn claim_expired_stdout_owner(
         &self,
         execution_id: &str,
     ) -> Result<bool, SessionRuntimeError> {
+        let _claim_guard = self.execution_claim_gate.lock().await;
+        if self.shutting_down.load(Ordering::SeqCst) {
+            return Err(SessionRuntimeError::ShuttingDown);
+        }
         let claimed = self
             .store
             .claim_expired_stdout_owner(execution_id, &self.stdout_owner_id, STDOUT_OWNER_LEASE)
@@ -1879,7 +1914,7 @@ impl SessionRuntime {
             let claim = if let Some(execution_id) = persisted_execution_id {
                 span.record("centaur.execution_id", execution_id);
                 span.record("execution_id", execution_id);
-                self.store.mark_execution_running(execution_id).await?
+                self.claim_execution_for_dispatch(execution_id).await?
             } else {
                 let execution = self
                     .store
@@ -1906,8 +1941,7 @@ impl SessionRuntime {
                     );
                     return Ok(execution.execution);
                 }
-                self.store
-                    .mark_execution_running(&execution.execution.execution_id)
+                self.claim_execution_for_dispatch(&execution.execution.execution_id)
                     .await?
             };
             let execution = claim.execution;
@@ -1933,11 +1967,6 @@ impl SessionRuntime {
                     "execution was already claimed or terminal"
                 );
                 return Ok(execution);
-            }
-            if let Err(error) = self.claim_stdout_owner(&execution.execution_id).await {
-                self.record_execution_failure(thread_key, &execution.execution_id, &error)
-                    .await;
-                return Err(error);
             }
             let execution_trace_span = info_span!(
                 "centaur.api_rs.session.execution",
@@ -2024,16 +2053,40 @@ impl SessionRuntime {
 
             let trace = SessionTraceContext::new(thread_key, Some(&execution_trace_span));
             let input_lines = input_lines_with_session_context(thread_key, &trace, &input_lines);
-            if let Err(error) = write_input_lines(
-                &pipe,
-                &input_lines,
-                thread_key,
-                &execution.execution_id,
-                Some(&sandbox_id),
-            )
-            .instrument(execution_trace_span.clone())
-            .await
-            {
+            let write_result = {
+                // Serialize the final pre-delivery shutdown check with the
+                // shutdown fence. Once this block succeeds, handoff may safely
+                // treat the execution as live instead of replaying its request.
+                let _claim_guard = self.execution_claim_gate.lock().await;
+                let result = if self.shutting_down.load(Ordering::SeqCst) {
+                    Err(SessionRuntimeError::ShuttingDown)
+                } else {
+                    write_input_lines(
+                        &pipe,
+                        &input_lines,
+                        thread_key,
+                        &execution.execution_id,
+                        Some(&sandbox_id),
+                    )
+                    .instrument(execution_trace_span.clone())
+                    .await
+                };
+                if result.is_ok() {
+                    self.pending_input_deliveries
+                        .remove(&execution.execution_id);
+                }
+                result
+            };
+            if let Err(error) = write_result {
+                if matches!(error, SessionRuntimeError::ShuttingDown) {
+                    self.requeue_execution_before_input(
+                        thread_key,
+                        &execution.execution_id,
+                        "control_plane_shutdown",
+                    )
+                    .await;
+                    return Err(error);
+                }
                 self.record_execution_failure(thread_key, &execution.execution_id, &error)
                     .await;
                 return Err(error);
@@ -2172,6 +2225,7 @@ impl SessionRuntime {
         execution_id: &str,
         error: &SessionRuntimeError,
     ) {
+        self.pending_input_deliveries.remove(execution_id);
         self.execution_spans.lock().await.remove(execution_id);
         let error_message = error.to_string();
         let execution = match self
@@ -2184,8 +2238,31 @@ impl SessionRuntime {
             .await
         {
             Ok(Some(execution)) => execution,
-            Ok(None) => return,
-            Err(_) => return,
+            Ok(None) => {
+                warn!(
+                    component = COMPONENT_SESSION_RUNTIME,
+                    event = "session_execution_failure_not_recorded",
+                    thread_key = %thread_key,
+                    execution_id,
+                    stdout_owner_id = %self.stdout_owner_id,
+                    original_error = %error_message,
+                    "execution was terminal or stdout ownership changed before failure could be recorded"
+                );
+                return;
+            }
+            Err(record_error) => {
+                warn!(
+                    component = COMPONENT_SESSION_RUNTIME,
+                    event = "session_execution_failure_record_failed",
+                    thread_key = %thread_key,
+                    execution_id,
+                    stdout_owner_id = %self.stdout_owner_id,
+                    original_error = %error_message,
+                    error = %record_error,
+                    "failed to persist execution failure"
+                );
+                return;
+            }
         };
         let _ = self
             .store
@@ -2208,6 +2285,69 @@ impl SessionRuntime {
             Some(runtime_error_failure_class(error)),
         )
         .await;
+    }
+
+    async fn requeue_execution_before_input(
+        &self,
+        thread_key: &ThreadKey,
+        execution_id: &str,
+        reason: &str,
+    ) -> bool {
+        let execution = match self
+            .store
+            .requeue_execution_if_active_and_stdout_owner(execution_id, &self.stdout_owner_id)
+            .await
+        {
+            Ok(Some(execution)) => execution,
+            Ok(None) => {
+                warn!(
+                    component = COMPONENT_SESSION_RUNTIME,
+                    event = "session_execution_requeue_not_recorded",
+                    thread_key = %thread_key,
+                    execution_id,
+                    reason,
+                    "execution was terminal or stdout ownership changed before it could be requeued"
+                );
+                return false;
+            }
+            Err(error) => {
+                warn!(
+                    component = COMPONENT_SESSION_RUNTIME,
+                    event = "session_execution_requeue_failed",
+                    thread_key = %thread_key,
+                    execution_id,
+                    reason,
+                    %error,
+                    "failed to return undelivered execution to the durable queue"
+                );
+                return false;
+            }
+        };
+        self.pending_input_deliveries.remove(execution_id);
+        self.execution_spans.lock().await.remove(execution_id);
+        let _ = self
+            .store
+            .append_event(
+                thread_key,
+                Some(execution_id),
+                "session.execution_requeued",
+                json!({
+                    "execution_id": execution_id,
+                    "thread_key": thread_key.as_str(),
+                    "reason": reason,
+                }),
+            )
+            .await;
+        info!(
+            component = COMPONENT_SESSION_RUNTIME,
+            event = "session_execution_requeued",
+            thread_key = %thread_key,
+            execution_id,
+            status = %execution.status,
+            reason,
+            "returned undelivered execution to the durable queue"
+        );
+        true
     }
 
     async fn forward_messages_to_active_execution(
@@ -3510,10 +3650,17 @@ impl SessionRuntime {
         sandbox_id: &str,
         detail: &str,
     ) {
-        let _ = self
-            .store
-            .claim_stdout_owner(execution_id, &self.stdout_owner_id, STDOUT_OWNER_LEASE)
-            .await;
+        if let Err(error) = self.claim_stdout_owner(execution_id).await {
+            warn!(
+                component = COMPONENT_SESSION_RUNTIME,
+                event = "execution_adoption_failure_claim_failed",
+                thread_key = %thread_key,
+                execution_id,
+                %error,
+                "failed to claim orphaned execution before recording its failure"
+            );
+            return;
+        }
         let error = format!("execution orphaned by control plane restart; {detail}");
         if let Err(record_error) = record_terminal_output(
             &self.context(),
@@ -3547,7 +3694,10 @@ impl SessionRuntime {
         // Fence new stdout-owner claims first: an execution accepted after
         // this point would otherwise claim a lease that outlives the
         // process, stranding it until the lease TTL expires.
-        self.shutting_down.store(true, Ordering::SeqCst);
+        {
+            let _claim_guard = self.execution_claim_gate.lock().await;
+            self.shutting_down.store(true, Ordering::SeqCst);
+        }
         let deadline = Instant::now()
             .checked_add(timeout)
             .unwrap_or_else(|| Instant::now() + Duration::from_secs(3600));
@@ -3597,6 +3747,19 @@ impl SessionRuntime {
                 }
             }
             sleep(EXECUTION_HANDOFF_POLL_INTERVAL).await;
+        }
+        let pending_input_execution_ids = self
+            .pending_input_deliveries
+            .iter()
+            .map(|entry| (entry.key().clone(), entry.value().clone()))
+            .collect::<Vec<_>>();
+        for (execution_id, thread_key) in pending_input_execution_ids {
+            self.requeue_execution_before_input(
+                &thread_key,
+                &execution_id,
+                "control_plane_shutdown_timeout",
+            )
+            .await;
         }
         let released = tokio::time::timeout(
             EXECUTION_HANDOFF_DB_TIMEOUT,
@@ -11231,29 +11394,122 @@ mod adoption_tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn shutdown_requeues_claimed_execution_before_input_delivery() {
+        let Some(store) = test_store().await else {
+            return;
+        };
+        let _serial = TEST_LOCK.lock().await;
+        let thread_key =
+            ThreadKey::parse(format!("test:handoff-pre-input-{}", uuid::Uuid::new_v4())).unwrap();
+        store
+            .create_or_get_session(
+                &thread_key,
+                &HarnessType::Codex,
+                None,
+                json!({}),
+                Default::default(),
+            )
+            .await
+            .expect("create session");
+
+        let backend = Arc::new(MockBackend::new(SandboxStatus::Running, Vec::new()));
+        let create_gate = backend.hold_create();
+        let (io, _stdout, _stdin) = mock_io();
+        backend.push_io(io).await;
+        let runtime = runtime_with(&store, backend.clone());
+        let execution = runtime
+            .enqueue_session_execution(
+                &thread_key,
+                ExecuteSessionInput {
+                    idempotency_key: None,
+                    metadata: Some(json!({"source": "shutdown-test"})),
+                    input_lines: vec![json!({"type": "user", "text": "replay me"}).to_string()],
+                    idle_timeout_ms: None,
+                    max_duration_ms: None,
+                },
+            )
+            .await
+            .expect("enqueue execution");
+        timeout(Duration::from_secs(1), backend.create_started.notified())
+            .await
+            .expect("driver should claim execution before sandbox create");
+
+        runtime.handoff_owned_executions(Duration::ZERO).await;
+
+        let ownership = store
+            .list_active_executions_with_ownership()
+            .await
+            .expect("load execution ownership")
+            .into_iter()
+            .find(|candidate| candidate.execution.execution_id == execution.execution_id)
+            .expect("execution remains recoverable");
+        assert_eq!(ownership.execution.status, ExecutionStatus::Queued);
+        assert!(ownership.execution.started_at.is_none());
+        assert!(ownership.stdout_owner_id.is_none());
+        assert!(!ownership.stdout_owner_lease_active);
+        assert!(
+            events(&store, &thread_key)
+                .await
+                .iter()
+                .any(|event| event.event_type == "session.execution_requeued"),
+            "shutdown must record that undelivered input was returned to the queue"
+        );
+
+        create_gate.notify_one();
+        store
+            .fail_execution_if_active(&execution.execution_id, "test cleanup")
+            .await
+            .expect("terminalize execution");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn shutdown_fences_new_stdout_claims() {
         let Some(store) = test_store().await else {
             return;
         };
         let _serial = TEST_LOCK.lock().await;
+        let thread_key =
+            ThreadKey::parse(format!("test:handoff-fence-{}", uuid::Uuid::new_v4())).unwrap();
+        let execution_id = orphaned_execution(&store, &thread_key, Some("sbx-mock"), false).await;
         let backend = Arc::new(MockBackend::new(SandboxStatus::Running, Vec::new()));
         let runtime = runtime_with(&store, backend);
+        let input = runtime
+            .load_persisted_execute_request(&execution_id)
+            .await
+            .expect("load durable request");
 
         // Nothing owned: the handoff returns immediately but still flips
         // the shutdown fence.
         runtime.handoff_owned_executions(Duration::ZERO).await;
 
-        let thread_key =
-            ThreadKey::parse(format!("test:handoff-fence-{}", uuid::Uuid::new_v4())).unwrap();
-        let execution_id = orphaned_execution(&store, &thread_key, Some("sbx-mock"), true).await;
         let error = runtime
-            .claim_stdout_owner(&execution_id)
+            .drive_session_execution(&thread_key, &execution_id, input)
             .await
-            .expect_err("claims after shutdown must be rejected");
+            .expect_err("shutdown must fence the queued execution claim");
         assert!(
             matches!(error, SessionRuntimeError::ShuttingDown),
             "unexpected error: {error}"
         );
+
+        let ownership = store
+            .list_active_executions_with_ownership()
+            .await
+            .expect("load execution ownership")
+            .into_iter()
+            .find(|candidate| candidate.execution.execution_id == execution_id)
+            .expect("execution remains recoverable");
+        assert_eq!(ownership.execution.status, ExecutionStatus::Queued);
+        assert!(ownership.execution.started_at.is_none());
+        assert!(ownership.stdout_owner_id.is_none());
+        assert!(!ownership.stdout_owner_lease_active);
+        assert!(
+            events(&store, &thread_key)
+                .await
+                .iter()
+                .all(|event| event.event_type != "session.execution_failed"),
+            "shutdown handoff must leave the durable request for a successor"
+        );
+
         store
             .fail_execution_if_active(&execution_id, "test cleanup")
             .await

--- a/services/api-rs/crates/centaur-session-sqlx/migrations/0052_session_execution_request.sql
+++ b/services/api-rs/crates/centaur-session-sqlx/migrations/0052_session_execution_request.sql
@@ -1,0 +1,2 @@
+alter table session_executions
+    add column if not exists request jsonb not null default '{}'::jsonb;

--- a/services/api-rs/crates/centaur-session-sqlx/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-sqlx/src/lib.rs
@@ -527,6 +527,127 @@ impl PgSessionStore {
         })
     }
 
+    /// Atomically transitions a queued execution to running and assigns its
+    /// stdout owner. Keeping both changes in one transaction prevents a
+    /// running execution from becoming visible without an owner during a
+    /// control-plane shutdown.
+    pub async fn claim_execution_for_stdout(
+        &self,
+        execution_id: &str,
+        owner_id: &str,
+        lease: Duration,
+    ) -> Result<ClaimExecutionResult, SessionStoreError> {
+        let lease_expires_at = stdout_lease_expires_at(lease);
+        let mut tx = self.pool.begin().await?;
+        let maybe_row = sqlx::query_as::<_, SessionExecutionRow>(
+            r#"
+            update session_executions
+            set status = $2,
+                started_at = coalesce(started_at, now()),
+                stdout_owner_id = $3,
+                stdout_owner_lease_expires_at = $4,
+                updated_at = now()
+            where execution_id = $1 and status = $5
+            returning execution_id, idempotency_key, thread_key, status, metadata, error, created_at, updated_at, started_at, completed_at
+            "#,
+        )
+        .bind(execution_id)
+        .bind(ExecutionStatus::Running.as_ref())
+        .bind(owner_id)
+        .bind(lease_expires_at)
+        .bind(ExecutionStatus::Queued.as_ref())
+        .fetch_optional(&mut *tx)
+        .await?;
+
+        let Some(row) = maybe_row else {
+            let row = sqlx::query_as::<_, SessionExecutionRow>(
+                r#"
+                select execution_id, idempotency_key, thread_key, status, metadata, error, created_at, updated_at, started_at, completed_at
+                from session_executions
+                where execution_id = $1
+                "#,
+            )
+            .bind(execution_id)
+            .fetch_one(&mut *tx)
+            .await?;
+            tx.commit().await?;
+            return Ok(ClaimExecutionResult {
+                execution: row.try_into()?,
+                claimed: false,
+            });
+        };
+
+        sqlx::query(
+            r#"
+            update sessions
+            set status = $2, updated_at = now()
+            where thread_key = $1
+            "#,
+        )
+        .bind(&row.thread_key)
+        .bind(SessionStatus::Executing.as_ref())
+        .execute(&mut *tx)
+        .await?;
+        tx.commit().await?;
+
+        Ok(ClaimExecutionResult {
+            execution: row.try_into()?,
+            claimed: true,
+        })
+    }
+
+    /// Returns a claimed execution to the durable queue before its input has
+    /// been delivered. The owner predicate prevents a stale control-plane
+    /// process from requeueing work after ownership has moved elsewhere.
+    pub async fn requeue_execution_if_active_and_stdout_owner(
+        &self,
+        execution_id: &str,
+        owner_id: &str,
+    ) -> Result<Option<SessionExecution>, SessionStoreError> {
+        let mut tx = self.pool.begin().await?;
+        let row = sqlx::query_as::<_, SessionExecutionRow>(
+            r#"
+            update session_executions
+            set status = $2,
+                error = null,
+                started_at = null,
+                completed_at = null,
+                stdout_owner_id = null,
+                stdout_owner_lease_expires_at = null,
+                updated_at = now()
+            where execution_id = $1
+              and status = $3
+              and stdout_owner_id = $4
+            returning execution_id, idempotency_key, thread_key, status, metadata, error, created_at, updated_at, started_at, completed_at
+            "#,
+        )
+        .bind(execution_id)
+        .bind(ExecutionStatus::Queued.as_ref())
+        .bind(ExecutionStatus::Running.as_ref())
+        .bind(owner_id)
+        .fetch_optional(&mut *tx)
+        .await?;
+
+        let Some(row) = row else {
+            tx.commit().await?;
+            return Ok(None);
+        };
+        sqlx::query(
+            r#"
+            update sessions
+            set status = $2, updated_at = now()
+            where thread_key = $1
+            "#,
+        )
+        .bind(&row.thread_key)
+        .bind(SessionStatus::Idle.as_ref())
+        .execute(&mut *tx)
+        .await?;
+        tx.commit().await?;
+
+        row.try_into().map(Some)
+    }
+
     pub async fn claim_stdout_owner(
         &self,
         execution_id: &str,
@@ -1943,7 +2064,7 @@ fn stdout_lease_expires_at(lease: Duration) -> OffsetDateTime {
 mod tests {
     use std::{collections::BTreeMap, time::Duration};
 
-    use centaur_session_core::{HarnessType, ThreadKey};
+    use centaur_session_core::{ExecutionStatus, HarnessType, SessionStatus, ThreadKey};
     use serde_json::json;
     use time::{Duration as TimeDuration, OffsetDateTime};
     use uuid::Uuid;
@@ -2136,6 +2257,91 @@ mod tests {
             .complete_execution(&first.execution.execution_id)
             .await
             .expect("complete execution");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn execution_claim_sets_running_status_and_stdout_owner_together() {
+        let Some(store) = test_store().await else {
+            return;
+        };
+        let thread_key =
+            ThreadKey::parse(format!("test:execution-claim-{}", Uuid::new_v4())).unwrap();
+        store
+            .create_or_get_session(
+                &thread_key,
+                &HarnessType::Codex,
+                None,
+                json!({}),
+                Default::default(),
+            )
+            .await
+            .expect("create session");
+        let execution_id = store
+            .create_execution(&thread_key, None, json!({}))
+            .await
+            .expect("create execution")
+            .execution
+            .execution_id;
+
+        let claim = store
+            .claim_execution_for_stdout(&execution_id, "claim-owner", Duration::from_secs(30))
+            .await
+            .expect("claim execution and stdout");
+        assert!(claim.claimed);
+        assert_eq!(claim.execution.status, ExecutionStatus::Running);
+
+        let ownership = store
+            .list_active_executions_with_ownership()
+            .await
+            .expect("load execution ownership")
+            .into_iter()
+            .find(|candidate| candidate.execution.execution_id == execution_id)
+            .expect("claimed execution remains active");
+        assert_eq!(ownership.stdout_owner_id.as_deref(), Some("claim-owner"));
+        assert!(ownership.stdout_owner_lease_active);
+        assert_eq!(
+            store
+                .get_session(&thread_key)
+                .await
+                .expect("load session")
+                .status,
+            SessionStatus::Executing
+        );
+
+        let replay = store
+            .claim_execution_for_stdout(&execution_id, "other-owner", Duration::from_secs(30))
+            .await
+            .expect("repeat claim");
+        assert!(!replay.claimed);
+        assert_eq!(replay.execution.status, ExecutionStatus::Running);
+        let requeued = store
+            .requeue_execution_if_active_and_stdout_owner(&execution_id, "claim-owner")
+            .await
+            .expect("requeue execution")
+            .expect("owner should requeue its active execution");
+        assert_eq!(requeued.status, ExecutionStatus::Queued);
+        assert!(requeued.started_at.is_none());
+        let ownership = store
+            .list_active_executions_with_ownership()
+            .await
+            .expect("load requeued execution ownership")
+            .into_iter()
+            .find(|candidate| candidate.execution.execution_id == execution_id)
+            .expect("requeued execution remains active");
+        assert!(ownership.stdout_owner_id.is_none());
+        assert!(!ownership.stdout_owner_lease_active);
+        assert_eq!(
+            store
+                .get_session(&thread_key)
+                .await
+                .expect("load requeued session")
+                .status,
+            SessionStatus::Idle
+        );
+        store
+            .fail_execution_if_active(&execution_id, "test cleanup")
+            .await
+            .expect("terminalize execution");
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/services/api-rs/crates/centaur-session-sqlx/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-sqlx/src/lib.rs
@@ -324,15 +324,31 @@ impl PgSessionStore {
         idempotency_key: Option<&str>,
         metadata: Value,
     ) -> Result<CreateExecutionResult, SessionStoreError> {
+        self.create_execution_with_request(thread_key, idempotency_key, metadata, empty_object())
+            .await
+    }
+
+    pub async fn create_execution_with_request(
+        &self,
+        thread_key: &ThreadKey,
+        idempotency_key: Option<&str>,
+        metadata: Value,
+        request: Value,
+    ) -> Result<CreateExecutionResult, SessionStoreError> {
         let execution_id = prefixed_id("exe");
         let row = sqlx::query_as::<_, CreateExecutionRow>(
             r#"
             insert into session_executions
-                (execution_id, thread_key, idempotency_key, status, metadata)
-            values ($1, $2, $3, $4, $5)
+                (execution_id, thread_key, idempotency_key, status, metadata, request)
+            values ($1, $2, $3, $4, $5, $6)
             on conflict (thread_key, idempotency_key)
                 where idempotency_key is not null
-            do update set idempotency_key = excluded.idempotency_key
+            do update set
+                idempotency_key = excluded.idempotency_key,
+                request = case
+                    when session_executions.request = '{}'::jsonb then excluded.request
+                    else session_executions.request
+                end
             returning
                 execution_id = $1 as created,
                 execution_id,
@@ -352,10 +368,27 @@ impl PgSessionStore {
         .bind(idempotency_key)
         .bind(ExecutionStatus::Queued.as_ref())
         .bind(metadata)
+        .bind(request)
         .fetch_one(&self.pool)
         .await?;
 
         row.try_into()
+    }
+
+    pub async fn execution_request(&self, execution_id: &str) -> Result<Value, SessionStoreError> {
+        sqlx::query_scalar::<_, Value>(
+            r#"
+            select request
+            from session_executions
+            where execution_id = $1
+            "#,
+        )
+        .bind(execution_id)
+        .fetch_optional(&self.pool)
+        .await?
+        .ok_or_else(|| SessionStoreError::ExecutionNotFound {
+            execution_id: execution_id.to_owned(),
+        })
     }
 
     pub async fn active_execution_for_thread(
@@ -1591,6 +1624,8 @@ pub enum SessionStoreError {
     },
     #[error("invalid persisted value: {0}")]
     InvalidPersistedValue(String),
+    #[error("session execution not found for execution_id {execution_id}")]
+    ExecutionNotFound { execution_id: String },
     #[error("invalid notification payload on {channel}: {payload}: {error}")]
     InvalidNotification {
         channel: String,
@@ -2036,6 +2071,71 @@ mod tests {
                 .proxy_labels,
             labels
         );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn execution_requests_are_durable_and_idempotent() {
+        let Some(store) = test_store().await else {
+            return;
+        };
+        let thread_key =
+            ThreadKey::parse(format!("test:execution-request-{}", Uuid::new_v4())).unwrap();
+        store
+            .create_or_get_session(
+                &thread_key,
+                &HarnessType::Codex,
+                None,
+                json!({}),
+                Default::default(),
+            )
+            .await
+            .expect("create session");
+        let first_request = json!({
+            "idempotency_key": "slack-message-1",
+            "input_lines": ["{\"type\":\"user\",\"text\":\"first\"}"],
+            "metadata": {"source": "slackbotv2"},
+            "idle_timeout_ms": 1000,
+            "max_duration_ms": null
+        });
+        let first = store
+            .create_execution_with_request(
+                &thread_key,
+                Some("slack-message-1"),
+                json!({"source": "slackbotv2"}),
+                first_request.clone(),
+            )
+            .await
+            .expect("create execution with request");
+
+        let replay = store
+            .create_execution_with_request(
+                &thread_key,
+                Some("slack-message-1"),
+                json!({"source": "different-replay"}),
+                json!({"input_lines": ["different replay"]}),
+            )
+            .await
+            .expect("replay idempotent execution request");
+
+        assert!(first.created);
+        assert!(!replay.created);
+        assert_eq!(replay.execution.execution_id, first.execution.execution_id);
+        assert_eq!(
+            store
+                .execution_request(&first.execution.execution_id)
+                .await
+                .expect("load persisted execution request"),
+            first_request
+        );
+
+        store
+            .mark_execution_running(&first.execution.execution_id)
+            .await
+            .expect("mark execution running");
+        store
+            .complete_execution(&first.execution.execution_id)
+            .await
+            .expect("complete execution");
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/services/api-rs/crates/centaur-session-sqlx/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-sqlx/src/lib.rs
@@ -527,124 +527,31 @@ impl PgSessionStore {
         })
     }
 
-    /// Atomically transitions a queued execution to running and assigns its
-    /// stdout owner. Keeping both changes in one transaction prevents a
-    /// running execution from becoming visible without an owner during a
-    /// control-plane shutdown.
-    pub async fn claim_execution_for_stdout(
+    pub async fn requeue_execution_if_running_without_stdout_owner(
         &self,
         execution_id: &str,
-        owner_id: &str,
-        lease: Duration,
-    ) -> Result<ClaimExecutionResult, SessionStoreError> {
-        let lease_expires_at = stdout_lease_expires_at(lease);
-        let mut tx = self.pool.begin().await?;
-        let maybe_row = sqlx::query_as::<_, SessionExecutionRow>(
-            r#"
-            update session_executions
-            set status = $2,
-                started_at = coalesce(started_at, now()),
-                stdout_owner_id = $3,
-                stdout_owner_lease_expires_at = $4,
-                updated_at = now()
-            where execution_id = $1 and status = $5
-            returning execution_id, idempotency_key, thread_key, status, metadata, error, created_at, updated_at, started_at, completed_at
-            "#,
-        )
-        .bind(execution_id)
-        .bind(ExecutionStatus::Running.as_ref())
-        .bind(owner_id)
-        .bind(lease_expires_at)
-        .bind(ExecutionStatus::Queued.as_ref())
-        .fetch_optional(&mut *tx)
-        .await?;
-
-        let Some(row) = maybe_row else {
-            let row = sqlx::query_as::<_, SessionExecutionRow>(
-                r#"
-                select execution_id, idempotency_key, thread_key, status, metadata, error, created_at, updated_at, started_at, completed_at
-                from session_executions
-                where execution_id = $1
-                "#,
-            )
-            .bind(execution_id)
-            .fetch_one(&mut *tx)
-            .await?;
-            tx.commit().await?;
-            return Ok(ClaimExecutionResult {
-                execution: row.try_into()?,
-                claimed: false,
-            });
-        };
-
-        sqlx::query(
-            r#"
-            update sessions
-            set status = $2, updated_at = now()
-            where thread_key = $1
-            "#,
-        )
-        .bind(&row.thread_key)
-        .bind(SessionStatus::Executing.as_ref())
-        .execute(&mut *tx)
-        .await?;
-        tx.commit().await?;
-
-        Ok(ClaimExecutionResult {
-            execution: row.try_into()?,
-            claimed: true,
-        })
-    }
-
-    /// Returns a claimed execution to the durable queue before its input has
-    /// been delivered. The owner predicate prevents a stale control-plane
-    /// process from requeueing work after ownership has moved elsewhere.
-    pub async fn requeue_execution_if_active_and_stdout_owner(
-        &self,
-        execution_id: &str,
-        owner_id: &str,
     ) -> Result<Option<SessionExecution>, SessionStoreError> {
-        let mut tx = self.pool.begin().await?;
         let row = sqlx::query_as::<_, SessionExecutionRow>(
             r#"
             update session_executions
-            set status = $2,
-                error = null,
-                started_at = null,
-                completed_at = null,
-                stdout_owner_id = null,
-                stdout_owner_lease_expires_at = null,
-                updated_at = now()
+            set status = $2, started_at = null, updated_at = now()
             where execution_id = $1
               and status = $3
-              and stdout_owner_id = $4
+              and stdout_owner_id is null
             returning execution_id, idempotency_key, thread_key, status, metadata, error, created_at, updated_at, started_at, completed_at
             "#,
         )
         .bind(execution_id)
         .bind(ExecutionStatus::Queued.as_ref())
         .bind(ExecutionStatus::Running.as_ref())
-        .bind(owner_id)
-        .fetch_optional(&mut *tx)
+        .fetch_optional(&self.pool)
         .await?;
 
         let Some(row) = row else {
-            tx.commit().await?;
             return Ok(None);
         };
-        sqlx::query(
-            r#"
-            update sessions
-            set status = $2, updated_at = now()
-            where thread_key = $1
-            "#,
-        )
-        .bind(&row.thread_key)
-        .bind(SessionStatus::Idle.as_ref())
-        .execute(&mut *tx)
-        .await?;
-        tx.commit().await?;
-
+        self.set_session_status(&row.thread_key, SessionStatus::Idle)
+            .await?;
         row.try_into().map(Some)
     }
 
@@ -2064,7 +1971,7 @@ fn stdout_lease_expires_at(lease: Duration) -> OffsetDateTime {
 mod tests {
     use std::{collections::BTreeMap, time::Duration};
 
-    use centaur_session_core::{ExecutionStatus, HarnessType, SessionStatus, ThreadKey};
+    use centaur_session_core::{HarnessType, ThreadKey};
     use serde_json::json;
     use time::{Duration as TimeDuration, OffsetDateTime};
     use uuid::Uuid;
@@ -2248,100 +2155,6 @@ mod tests {
                 .expect("load persisted execution request"),
             first_request
         );
-
-        store
-            .mark_execution_running(&first.execution.execution_id)
-            .await
-            .expect("mark execution running");
-        store
-            .complete_execution(&first.execution.execution_id)
-            .await
-            .expect("complete execution");
-    }
-
-    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn execution_claim_sets_running_status_and_stdout_owner_together() {
-        let Some(store) = test_store().await else {
-            return;
-        };
-        let thread_key =
-            ThreadKey::parse(format!("test:execution-claim-{}", Uuid::new_v4())).unwrap();
-        store
-            .create_or_get_session(
-                &thread_key,
-                &HarnessType::Codex,
-                None,
-                json!({}),
-                Default::default(),
-            )
-            .await
-            .expect("create session");
-        let execution_id = store
-            .create_execution(&thread_key, None, json!({}))
-            .await
-            .expect("create execution")
-            .execution
-            .execution_id;
-
-        let claim = store
-            .claim_execution_for_stdout(&execution_id, "claim-owner", Duration::from_secs(30))
-            .await
-            .expect("claim execution and stdout");
-        assert!(claim.claimed);
-        assert_eq!(claim.execution.status, ExecutionStatus::Running);
-
-        let ownership = store
-            .list_active_executions_with_ownership()
-            .await
-            .expect("load execution ownership")
-            .into_iter()
-            .find(|candidate| candidate.execution.execution_id == execution_id)
-            .expect("claimed execution remains active");
-        assert_eq!(ownership.stdout_owner_id.as_deref(), Some("claim-owner"));
-        assert!(ownership.stdout_owner_lease_active);
-        assert_eq!(
-            store
-                .get_session(&thread_key)
-                .await
-                .expect("load session")
-                .status,
-            SessionStatus::Executing
-        );
-
-        let replay = store
-            .claim_execution_for_stdout(&execution_id, "other-owner", Duration::from_secs(30))
-            .await
-            .expect("repeat claim");
-        assert!(!replay.claimed);
-        assert_eq!(replay.execution.status, ExecutionStatus::Running);
-        let requeued = store
-            .requeue_execution_if_active_and_stdout_owner(&execution_id, "claim-owner")
-            .await
-            .expect("requeue execution")
-            .expect("owner should requeue its active execution");
-        assert_eq!(requeued.status, ExecutionStatus::Queued);
-        assert!(requeued.started_at.is_none());
-        let ownership = store
-            .list_active_executions_with_ownership()
-            .await
-            .expect("load requeued execution ownership")
-            .into_iter()
-            .find(|candidate| candidate.execution.execution_id == execution_id)
-            .expect("requeued execution remains active");
-        assert!(ownership.stdout_owner_id.is_none());
-        assert!(!ownership.stdout_owner_lease_active);
-        assert_eq!(
-            store
-                .get_session(&thread_key)
-                .await
-                .expect("load requeued session")
-                .status,
-            SessionStatus::Idle
-        );
-        store
-            .fail_execution_if_active(&execution_id, "test cleanup")
-            .await
-            .expect("terminalize execution");
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/services/api-rs/rfcs/0002-session-control-plane.md
+++ b/services/api-rs/rfcs/0002-session-control-plane.md
@@ -229,9 +229,11 @@ that should be written to the sandbox.
 POST /api/session/{thread_key}/execute
 ```
 
-Requests one execution of the session. The API serializes executions per
-session, ensures there is a usable current sandbox, writes caller-supplied input
-lines to sandbox stdin, and stores each stdout line as a durable session event.
+Requests one execution of the session. The API validates and durably stores the
+complete request with a queued execution before responding. A background driver
+serializes executions per session, ensures there is a usable current sandbox,
+writes caller-supplied input lines to sandbox stdin, and stores each stdout line
+as a durable session event.
 
 The API is deliberately oblivious to the producer/consumer format. Codex
 app-server JSONL, Anthropic-shaped turns, or any future protocol are just opaque
@@ -265,7 +267,11 @@ Example response:
 
 Execution rules:
 
+- A successful response means the opaque execution request is committed in
+  Postgres and can be replayed after a control-plane restart.
 - Only one execution may run for a session at a time.
+- Queued executions are claimed atomically, so the accepting process and the
+  recovery scanner may safely race without writing the input twice.
 - If no sandbox is assigned, the API creates one and stores its `sandbox_id`.
 - If the assigned sandbox is gone, the API replaces it and overwrites
   `sandbox_id`.
@@ -347,7 +353,9 @@ Internally, execution follows this shape:
 
 ```text
 load session
-claim session execution lock
+persist queued execution and opaque input_lines
+return execution_id to caller
+claim queued execution in background
 ensure current sandbox exists
 write request input_lines to sandbox stdin
 persist stdout lines as session.output.line events

--- a/services/slackbotv2/test/chat-sdk-emulate.test.ts
+++ b/services/slackbotv2/test/chat-sdk-emulate.test.ts
@@ -776,6 +776,7 @@ describe('slackbotv2', () => {
     expect(
       await sharedState.get<Record<string, unknown>>(`thread-state:${threadKey(parent.ts)}`)
     ).toEqual(expect.objectContaining({ model: null }))
+    expect(await threadText(parent.ts)).toContain("The requested model '5.6-sol' does not exist.")
 
     await runTurn(
       'Ev-after-invalid-sticky-model',


### PR DESCRIPTION
Persists opaque session execution requests in Postgres and returns from `/execute` once the request is queued, allowing Slack webhook handoff to complete without waiting for sandbox provisioning. Both immediate dispatch and recovery claim the exact persisted execution ID, including requests without an idempotency key, and recovery schedules sandbox work concurrently.

If shutdown rejects stdout ownership after an execution was claimed, the ownerless row is returned to the durable queue for replay. Failure-recording ownership mismatches are logged instead of silently ignored. Young legacy rows without persisted requests retain rollout grace, and Slackbot coverage confirms asynchronous execution failures render visibly to users.