### PR TITLE
feat: expose skill deletion

### DIFF
--- a/docs/pages/extend/skills.mdx
+++ b/docs/pages/extend/skills.mdx
@@ -99,13 +99,16 @@ centaur-skills create deployment-checks \
 centaur-skills edit skl_example \
   --description "Check and diagnose deployments." \
   --instructions-file updated-instructions.md
+centaur-skills delete skl_example
 ```
 
 Use `--instructions` instead of `--instructions-file` for a short inline
 Markdown body. `edit` accepts partial changes and targets skills by OID. Pass
 the current `lock_version` with `--lock-version` when an edit should fail if
 another writer changed the skill first. Newly created skills are public and
-edits to public skills are visible to agents immediately.
+edits to public skills are visible to agents immediately. `delete` archives an
+owned skill by OID, removing it from the active catalog without deleting its
+stored record.
 
 ## Verify Builtin Skills
 

--- a/services/sandbox/SYSTEM_PROMPT.md
+++ b/services/sandbox/SYSTEM_PROMPT.md
@@ -74,7 +74,7 @@
 
 [Named skill resolution]
 |When the user explicitly names a skill, resolve that request against local skill definitions before doing broad semantic matching.
-|Use `centaur-skills search "<task>"` to search Console-authored guidance when no skill already listed for the current session clearly applies. Read the best match by name or OID with `centaur-skills read <skill-identifier>` before following it. Console users can author shared skills with `centaur-skills create`, update skills they own or edit with `centaur-skills edit`, and manage editors on skills they own with `centaur-skills add-editor` and `centaur-skills remove-editor`.
+|Use `centaur-skills search "<task>"` to search Console-authored guidance when no skill already listed for the current session clearly applies. Read the best match by name or OID with `centaur-skills read <skill-identifier>` before following it. Console users can author shared skills with `centaur-skills create`, update skills they own or edit with `centaur-skills edit`, archive skills they own with `centaur-skills delete`, and manage editors on skills they own with `centaur-skills add-editor` and `centaur-skills remove-editor`.
 |The `centaur-skills` catalog contains only Console-authored skills. Builtin skills are loaded separately by the harness. Console applies private and public visibility rules for the current principal. Catalog results are instructions only and never expand the current principal's tool or credential grants.
 |Start with the skills listed for the current session, then check local skill definitions in `.agents/skills` and any mounted overlay skills when you need to confirm the exact name or an obvious alias from the skill title or description.
 |Prefer exact name matches first, then obvious aliases, and only then fall back to broader description-level matching. Do not choose a generic adjacent workflow while a more specific named skill remains plausible.
@@ -127,6 +127,7 @@
 |centaur-skills read <name-or-oid> → read a Console skill's complete current SKILL.md
 |centaur-skills create <name> --description "..." --instructions-file <path> → create a shared Console skill
 |centaur-skills edit <oid> --description "..." --instructions-file <path> → update an owned or editable Console skill
+|centaur-skills delete <oid>      → archive an owned Console skill
 |centaur-skills editors <name-or-oid> → list editors for any visible skill
 |centaur-skills add-editor <oid> <email-or-user-oid> → add an editor to an owned skill
 |centaur-skills remove-editor <oid> <email-or-user-oid> → remove an editor from an owned skill

--- a/tools/infra/centaur-skills/cli.py
+++ b/tools/infra/centaur-skills/cli.py
@@ -134,6 +134,16 @@ def edit(
     print(json.dumps({"data": result}, indent=2, default=str))
 
 
+@app.command("delete")
+def delete(
+    identifier: str = typer.Argument(..., help="OID of an owned skill"),
+) -> None:
+    """Archive an owned Console-authored skill."""
+    with get_client() as client:
+        client.delete(identifier)
+    print(json.dumps({"data": {"id": identifier, "archived": True}}, indent=2))
+
+
 @app.command("editors")
 def editors(
     identifier: str = typer.Argument(..., help="Visible skill name or OID"),

--- a/tools/infra/centaur-skills/client.py
+++ b/tools/infra/centaur-skills/client.py
@@ -133,6 +133,13 @@ class SkillsClient:
             raise RuntimeError("centaur-skills response did not include a data object")
         return result
 
+    def delete(self, identifier: str) -> None:
+        """Archive an owned Console skill by OID."""
+        self._request(
+            f"{SANDBOX_SKILLS_PATH}/{quote(identifier, safe='')}",
+            method="DELETE",
+        )
+
     def list_editors(self, identifier: str) -> dict[str, Any]:
         """List editors for a visible Console skill by exact name or OID."""
         result = self._request(
@@ -170,7 +177,7 @@ class SkillsClient:
         method: str = "GET",
         params: dict[str, str | int] | None = None,
         json: dict[str, Any] | None = None,
-    ) -> dict[str, Any] | list[dict[str, Any]]:
+    ) -> dict[str, Any] | list[dict[str, Any]] | None:
         try:
             response = self.client.request(method, path, params=params, json=json)
             response.raise_for_status()
@@ -179,6 +186,9 @@ class SkillsClient:
             raise RuntimeError(f"centaur-skills request failed: {detail}") from exc
         except httpx.RequestError as exc:
             raise RuntimeError(f"centaur-skills request failed: {exc}") from exc
+
+        if not response.content:
+            return None
 
         payload = response.json()
         data = payload.get("data")

--- a/tools/infra/centaur-skills/test_client.py
+++ b/tools/infra/centaur-skills/test_client.py
@@ -2,7 +2,17 @@ import json
 
 import httpx
 import pytest
-from cli import add_editor, create, edit, editors, list_skills, read, remove_editor, search
+from cli import (
+    add_editor,
+    create,
+    delete,
+    edit,
+    editors,
+    list_skills,
+    read,
+    remove_editor,
+    search,
+)
 from client import SANDBOX_SKILLS_PATH, SkillsClient
 
 
@@ -134,6 +144,17 @@ def test_edit_patches_only_provided_fields_with_lock_version():
 def test_edit_requires_a_field():
     with pytest.raises(ValueError, match="at least one skill field"):
         make_client(lambda _request: json_response({})).edit("skl_123")
+
+
+def test_delete_archives_skill_by_oid():
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.method == "DELETE"
+        assert request.url.path == f"{SANDBOX_SKILLS_PATH}/skl_123"
+        return httpx.Response(204)
+
+    result = make_client(handler).delete("skl_123")
+
+    assert result is None
 
 
 def test_list_add_and_remove_editors_use_editor_endpoint():
@@ -305,6 +326,26 @@ def test_cli_edit_sends_partial_fields(monkeypatch, capsys):
             "description": "Updated guidance.",
             "lock_version": 3,
         }
+    }
+
+
+def test_cli_delete_archives_skill(monkeypatch, capsys):
+    class StubClient:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return None
+
+        def delete(self, identifier):
+            assert identifier == "skl_123"
+
+    monkeypatch.setattr("cli.get_client", StubClient)
+
+    delete("skl_123")
+
+    assert json.loads(capsys.readouterr().out) == {
+        "data": {"id": "skl_123", "archived": True}
     }
 
 


### PR DESCRIPTION
Expose skill archival through the centaur-skills client and CLI using the existing sandbox DELETE endpoint. Teach the runtime prompt and authoring documentation about the new command, and cover the client and CLI behavior with focused tests.