### PR TITLE
feat: add sandbox API JWT capabilities

### DIFF
--- a/centaur_sdk/tests/test_tool_sdk.py
+++ b/centaur_sdk/tests/test_tool_sdk.py
@@ -117,22 +117,6 @@ def test_current_session_context_fetches_api_context(monkeypatch: pytest.MonkeyP
         reset_tool_context(token)
 
 
-def test_current_session_context_requires_api_server_capability(
-    monkeypatch: pytest.MonkeyPatch,
-):
-    monkeypatch.setattr(
-        registry,
-        "_backend",
-        MappingBackend({"CENTAUR_SANDBOX_API_SERVER_ENABLED": "false"}),
-    )
-    token = set_tool_context(ToolContext(name="fake-tool", thread_key="slack:C123:123.456"))
-    try:
-        with pytest.raises(RuntimeError, match="API server sandbox capability"):
-            current_session_context()
-    finally:
-        reset_tool_context(token)
-
-
 def test_current_slack_thread_returns_api_slack_destination(
     monkeypatch: pytest.MonkeyPatch,
 ):
@@ -408,23 +392,6 @@ def test_save_attachment_writes_to_sandbox_uploads_dir(
         "source_url": "https://example.test/report",
         "size_bytes": 5,
     }
-
-
-def test_save_attachment_requires_api_server_capability_without_uploads_dir(
-    monkeypatch: pytest.MonkeyPatch,
-):
-    monkeypatch.delenv("CENTAUR_UPLOADS_DIR", raising=False)
-    monkeypatch.setattr(
-        registry,
-        "_backend",
-        MappingBackend({"CENTAUR_SANDBOX_API_SERVER_ENABLED": "false"}),
-    )
-    token = set_tool_context(ToolContext(name="fake-tool", thread_key="slack:C123:123.456"))
-    try:
-        with pytest.raises(RuntimeError, match="API server sandbox capability"):
-            save_attachment(name="report.txt", data=b"hello")
-    finally:
-        reset_tool_context(token)
 
 
 def test_save_attachment_uses_unique_local_name_on_collision(

--- a/centaur_sdk/tool_sdk.py
+++ b/centaur_sdk/tool_sdk.py
@@ -79,14 +79,6 @@ def secret(key: str, default: str | None = None) -> str:
     raise KeyError(f"Missing secret '{key}'{ctx_name}")
 
 
-def _require_api_server_enabled(operation: str) -> None:
-    if secret("CENTAUR_SANDBOX_API_SERVER_ENABLED", "true").strip().lower() == "false":
-        raise RuntimeError(
-            f"{operation} requires the API server sandbox capability, but it is disabled "
-            "for this principal."
-        )
-
-
 def current_thread_key() -> str:
     """Return the active thread key for a tool call."""
     try:
@@ -108,7 +100,6 @@ def current_session_context() -> dict[str, Any]:
     ``slack.thread_ts``. The API remains the source of truth so warm pooled
     sandboxes do not need per-thread environment mutation.
     """
-    _require_api_server_enabled("current_session_context")
     thread_key = current_thread_key()
     base_url = secret("CENTAUR_API_URL", "http://api:8000").rstrip("/")
     request = urllib.request.Request(
@@ -290,7 +281,6 @@ def save_attachment(
             uploads_dir=uploads_dir,
         )
 
-    _require_api_server_enabled("save_attachment")
     thread_key = current_thread_key()
     base_url = secret("CENTAUR_API_URL", "http://api:8000").rstrip("/")
     payload = json.dumps(

--- a/contrib/chart/Chart.yaml
+++ b/contrib/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: centaur
 description: Helm chart for the trusted Centaur control plane
 type: application
-version: 0.1.117
+version: 0.1.118
 appVersion: "0.1.0"
 dependencies:
   - name: connect

--- a/contrib/chart/templates/networkpolicy.yaml
+++ b/contrib/chart/templates/networkpolicy.yaml
@@ -192,11 +192,11 @@ spec:
         - podSelector:
             matchLabels:
 {{ include "centaur.componentSelectorLabels" (dict "root" . "component" "console-worker") | nindent 14 }}
-        # New sandboxes call back into the control plane only when their
-        # principal has the API server sandbox capability.
+        # Sandboxes reach authenticated api-rs routes through their paired
+        # iron-proxy; sandbox pods never connect to api-rs directly.
         - podSelector:
             matchLabels:
-              centaur.ai/api-server-enabled: "true"
+              centaur.ai/iron-proxy: "true"
 {{- range .Values.networkPolicy.apiIngressSourceNamespaces }}
         - namespaceSelector:
             matchLabels:
@@ -206,19 +206,19 @@ spec:
         - protocol: TCP
           port: {{ .Values.apiRs.port }}
 ---
-# Sandboxes with the API server capability may call api-rs. New sandbox and
-# proxy pods receive centaur.ai/api-server-enabled=true from api-rs only when
-# the principal has the capability, so default-deny blocks new pods without it.
+# Only iron-proxy pods may call api-rs on behalf of sandboxes. api-rs enforces
+# the principal JWT's endpoint capabilities; sandbox pods remain limited to
+# their paired proxy by the per-sandbox policies rendered by api-rs.
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: {{ include "centaur.fullname" . }}-sandbox-api-server
+  name: {{ include "centaur.fullname" . }}-proxy-api-server
   labels:
 {{ include "centaur.labels" . | nindent 4 }}
 spec:
   podSelector:
     matchLabels:
-      centaur.ai/api-server-enabled: "true"
+      centaur.ai/iron-proxy: "true"
   policyTypes:
     - Egress
   egress:

--- a/services/api-rs/crates/centaur-api-server/src/auth.rs
+++ b/services/api-rs/crates/centaur-api-server/src/auth.rs
@@ -20,7 +20,6 @@ const STATIC_ADMIN_IDENTITY: &str = "api-rs-admin";
 pub(crate) enum Capability {
     SessionsRead,
     SessionsWrite,
-    SlackProxy,
     SandboxesDrain,
     WorkflowsRead,
     WorkflowsWrite,
@@ -30,10 +29,9 @@ pub(crate) enum Capability {
 }
 
 impl Capability {
-    const ALL: [Self; 9] = [
+    const ALL: [Self; 8] = [
         Self::SessionsRead,
         Self::SessionsWrite,
-        Self::SlackProxy,
         Self::SandboxesDrain,
         Self::WorkflowsRead,
         Self::WorkflowsWrite,
@@ -255,13 +253,35 @@ impl ApiAuthConfig {
             Some(ApiJwtTokenUse::ConsoleService) => Err(ApiError::Unauthorized(
                 "invalid Console service token subject".to_owned(),
             )),
-            None => Ok(AuthenticatedCaller {
-                class: CallerClass::Principal,
-                identity: subject.clone(),
-                capabilities: BTreeSet::from([Capability::SessionsRead, Capability::SlackProxy]),
-                platform_prefix: None,
-                principal_subject: Some(subject),
-            }),
+            None => {
+                let mut capabilities = BTreeSet::new();
+                match claims.capabilities {
+                    Some(jwt_capabilities) => {
+                        if jwt_capabilities.sessions_read {
+                            capabilities.insert(Capability::SessionsRead);
+                        }
+                        if jwt_capabilities.workflows_read {
+                            capabilities.insert(Capability::WorkflowsRead);
+                        }
+                        if jwt_capabilities.workflows_write {
+                            capabilities.insert(Capability::WorkflowsWrite);
+                        }
+                    }
+                    // Tokens minted before capability claims were deployed had
+                    // session read access. Preserve that access during rolling
+                    // upgrades; new tokens always carry the explicit object.
+                    None => {
+                        capabilities.insert(Capability::SessionsRead);
+                    }
+                }
+                Ok(AuthenticatedCaller {
+                    class: CallerClass::Principal,
+                    identity: subject.clone(),
+                    capabilities,
+                    platform_prefix: None,
+                    principal_subject: Some(subject),
+                })
+            }
         }
     }
 }
@@ -278,6 +298,17 @@ pub enum ApiAuthConfigError {
 struct ApiJwtClaims {
     sub: String,
     token_use: Option<ApiJwtTokenUse>,
+    capabilities: Option<ApiJwtCapabilities>,
+}
+
+#[derive(Deserialize)]
+struct ApiJwtCapabilities {
+    #[serde(default)]
+    sessions_read: bool,
+    #[serde(default)]
+    workflows_read: bool,
+    #[serde(default)]
+    workflows_write: bool,
 }
 
 #[derive(Deserialize)]
@@ -430,7 +461,7 @@ mod tests {
     }
 
     #[test]
-    fn authenticates_principal_jwt_with_limited_capabilities() {
+    fn authenticates_legacy_principal_jwt_with_session_read_capability() {
         let auth = ApiAuthConfig::testing("jwt-secret");
         let token = encode(
             &Header::new(Algorithm::HS256),
@@ -454,6 +485,38 @@ mod tests {
         assert_eq!(caller.principal_subject(), Some("prn_test"));
         assert!(caller.has_capability(Capability::SessionsRead));
         assert!(!caller.has_capability(Capability::SessionsWrite));
+    }
+
+    #[test]
+    fn authenticates_principal_jwt_with_explicit_capabilities() {
+        let auth = ApiAuthConfig::testing("jwt-secret");
+        let token = encode(
+            &Header::new(Algorithm::HS256),
+            &json!({
+                "iss": "centaur-console",
+                "sub": "prn_test",
+                "aud": "centaur-api",
+                "iat": 1_700_000_000i64,
+                "exp": 4_102_444_800i64,
+                "capabilities": {
+                    "sessions_read": false,
+                    "workflows_read": true,
+                    "workflows_write": true,
+                },
+            }),
+            &EncodingKey::from_secret(b"jwt-secret"),
+        )
+        .unwrap();
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            header::AUTHORIZATION,
+            format!("Bearer {token}").parse().unwrap(),
+        );
+
+        let caller = auth.authenticate(&headers).unwrap();
+        assert!(!caller.has_capability(Capability::SessionsRead));
+        assert!(caller.has_capability(Capability::WorkflowsRead));
+        assert!(caller.has_capability(Capability::WorkflowsWrite));
     }
 
     #[test]

--- a/services/api-rs/crates/centaur-api-server/src/lib.rs
+++ b/services/api-rs/crates/centaur-api-server/src/lib.rs
@@ -81,6 +81,11 @@ mod tests {
                 "aud": "centaur-api",
                 "iat": 1_700_000_000i64,
                 "exp": 4_102_444_800i64,
+                "capabilities": {
+                    "sessions_read": false,
+                    "workflows_read": false,
+                    "workflows_write": false
+                },
                 "slack": {
                     "upload_channels": [],
                     "download_channels": [],
@@ -131,7 +136,6 @@ mod tests {
             name: "Test".to_owned(),
             labels: Default::default(),
             sandbox_observability_enabled: true,
-            sandbox_api_server_enabled: true,
         }
     }
 
@@ -429,7 +433,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn principal_jwt_is_read_only_and_archive_exception_is_subject_scoped() {
+    async fn principal_jwt_is_capability_scoped_and_archive_exception_is_subject_scoped() {
         let principal = principal_token("prn_sandbox");
         let write_response = build_router_with_app_state(AppState::unready(test_auth()))
             .oneshot(
@@ -444,6 +448,19 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(write_response.status(), StatusCode::FORBIDDEN);
+
+        let slack_response = build_router_with_app_state(AppState::unready(test_auth()))
+            .oneshot(
+                Request::builder()
+                    .uri("/api/slack/channels")
+                    .header(header::AUTHORIZATION, format!("Bearer {principal}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_ne!(slack_response.status(), StatusCode::UNAUTHORIZED);
+        assert_ne!(slack_response.status(), StatusCode::FORBIDDEN);
 
         let pool =
             PgPool::connect_lazy("postgres://postgres:postgres@localhost/centaur_test").unwrap();

--- a/services/api-rs/crates/centaur-api-server/src/routes.rs
+++ b/services/api-rs/crates/centaur-api-server/src/routes.rs
@@ -450,7 +450,7 @@ async fn metrics(State(state): State<AppState>) -> Response {
 #[derive(Clone, Copy)]
 enum RouteAccess {
     Capability(Capability),
-    PrincipalSlackProxy,
+    PrincipalOnly,
     ArchiveDownload,
 }
 
@@ -487,10 +487,7 @@ async fn authorize_api_request(
 
     let allowed = match access {
         RouteAccess::Capability(capability) => caller.has_capability(capability),
-        RouteAccess::PrincipalSlackProxy => {
-            caller.class() == CallerClass::Principal
-                && caller.has_capability(Capability::SlackProxy)
-        }
+        RouteAccess::PrincipalOnly => caller.class() == CallerClass::Principal,
         RouteAccess::ArchiveDownload => {
             caller.has_capability(Capability::AdminArchive)
                 || caller
@@ -565,7 +562,7 @@ fn route_access(method: &Method, route: &str) -> Option<RouteAccess> {
         (&Method::POST, "/api/admin/slack/archive-imports/{import_id}/download-url") => {
             Some(RouteAccess::ArchiveDownload)
         }
-        (_, route) if route.starts_with("/api/slack/") => Some(RouteAccess::PrincipalSlackProxy),
+        (_, route) if route.starts_with("/api/slack/") => Some(RouteAccess::PrincipalOnly),
         (_, route) if route.starts_with("/api/admin/slack/archive-imports") => {
             capability(Capability::AdminArchive)
         }

--- a/services/api-rs/crates/centaur-iron-control/src/models.rs
+++ b/services/api-rs/crates/centaur-iron-control/src/models.rs
@@ -480,8 +480,6 @@ pub struct Principal {
     pub labels: BTreeMap<String, String>,
     #[serde(default = "default_true")]
     pub sandbox_observability_enabled: bool,
-    #[serde(default = "default_true")]
-    pub sandbox_api_server_enabled: bool,
 }
 
 /// Request body for creating/updating one Slack permission row on a principal.

--- a/services/api-rs/crates/centaur-sandbox-agent-k8s/src/iron_proxy.rs
+++ b/services/api-rs/crates/centaur-sandbox-agent-k8s/src/iron_proxy.rs
@@ -24,8 +24,8 @@ use serde_json::{Value, json};
 use tokio::time::{Instant, sleep};
 
 use crate::{
-    API_SERVER_ENABLED_LABEL, AgentSandboxBackend, MANAGED_BY_LABEL, MANAGED_BY_VALUE,
-    OBSERVABILITY_ENABLED_LABEL, OtlpEgressTarget, SANDBOX_ID_LABEL, is_not_found, map_kube_error,
+    AgentSandboxBackend, MANAGED_BY_LABEL, MANAGED_BY_VALUE, OBSERVABILITY_ENABLED_LABEL,
+    OtlpEgressTarget, SANDBOX_ID_LABEL, is_not_found, map_kube_error,
 };
 
 const IRON_PROXY_LABEL: &str = "centaur.ai/iron-proxy";
@@ -154,14 +154,12 @@ pub(crate) struct ResolvedIronProxy {
     // env, so it survives api-rs restarts and respects env overrides.
     management_api_key: String,
     observability_enabled: bool,
-    api_server_enabled: bool,
 }
 
 struct ResolvedIronProxyRuntime {
     pg: Option<ResolvedPg>,
     replace_placeholders: BTreeMap<String, String>,
     observability_enabled: bool,
-    api_server_enabled: bool,
 }
 
 /// The single Postgres listener the proxy multiplexes every upstream through.
@@ -226,7 +224,6 @@ impl AgentSandboxBackend {
                 pg,
                 replace_placeholders,
                 observability_enabled: spec.capabilities.observability_enabled,
-                api_server_enabled: spec.capabilities.api_server_enabled,
             },
         )))
     }
@@ -309,13 +306,6 @@ impl AgentSandboxBackend {
             "observability",
             id.as_str(),
         );
-        let api_server_enabled = resolve_resume_capability(
-            sandbox_api_server_enabled(&sandbox, &self.config.container_name),
-            sandbox.metadata.labels.as_ref(),
-            API_SERVER_ENABLED_LABEL,
-            "api_server",
-            id.as_str(),
-        );
         Ok(Some(self.resolved_iron_proxy_for_principal(
             id,
             principal_id,
@@ -325,7 +315,6 @@ impl AgentSandboxBackend {
                 pg,
                 replace_placeholders,
                 observability_enabled,
-                api_server_enabled,
             },
         )))
     }
@@ -350,7 +339,6 @@ impl AgentSandboxBackend {
             replace_placeholders: runtime.replace_placeholders,
             management_api_key: new_proxy_management_api_key(),
             observability_enabled: runtime.observability_enabled,
-            api_server_enabled: runtime.api_server_enabled,
         }
     }
 
@@ -682,24 +670,6 @@ impl AgentSandboxBackend {
                 );
                 false
             });
-        let api_server_enabled = sandbox
-            .as_ref()
-            .map(|sandbox| {
-                resolve_resume_capability(
-                    sandbox_api_server_enabled(sandbox, &self.config.container_name),
-                    sandbox.metadata.labels.as_ref(),
-                    API_SERVER_ENABLED_LABEL,
-                    "api_server",
-                    id.as_str(),
-                )
-            })
-            .unwrap_or_else(|| {
-                tracing::warn!(
-                    sandbox_id = id.as_str(),
-                    "sandbox CR missing during proxy repair; failing closed for API server network policy"
-                );
-                false
-            });
         let resolved = self.resolved_iron_proxy_for_principal(
             id,
             principal_id,
@@ -709,7 +679,6 @@ impl AgentSandboxBackend {
                 pg,
                 replace_placeholders,
                 observability_enabled,
-                api_server_enabled,
             },
         );
         self.create_iron_proxy_resources(id, Some(&resolved))
@@ -1282,11 +1251,7 @@ fn build_iron_proxy_pod(
     Pod {
         metadata: object_meta_with_annotations(
             resolved.proxy_pod_name.clone(),
-            iron_proxy_labels(
-                id,
-                resolved.observability_enabled,
-                resolved.api_server_enabled,
-            ),
+            iron_proxy_labels(id, resolved.observability_enabled),
             annotations,
         ),
         spec: Some(PodSpec {
@@ -1493,18 +1458,10 @@ fn build_iron_proxy_service(id: &SandboxId, resolved: &ResolvedIronProxy) -> Ser
     Service {
         metadata: object_meta(
             iron_proxy_service_name(id),
-            iron_proxy_labels(
-                id,
-                resolved.observability_enabled,
-                resolved.api_server_enabled,
-            ),
+            iron_proxy_labels(id, resolved.observability_enabled),
         ),
         spec: Some(ServiceSpec {
-            selector: Some(iron_proxy_labels(
-                id,
-                resolved.observability_enabled,
-                resolved.api_server_enabled,
-            )),
+            selector: Some(iron_proxy_labels(id, resolved.observability_enabled)),
             ports: Some(ports),
             ..Default::default()
         }),
@@ -1523,11 +1480,7 @@ fn build_iron_proxy_network_policies(
     let sandbox_to_proxy_ports = sandbox_to_proxy_ports(resolved);
     let sandbox_egress = vec![
         egress_to(
-            vec![pod_peer(iron_proxy_labels(
-                id,
-                observability_enabled,
-                resolved.api_server_enabled,
-            ))],
+            vec![pod_peer(iron_proxy_labels(id, observability_enabled))],
             sandbox_to_proxy_ports.clone(),
         ),
         dns_egress_rule(),
@@ -1548,14 +1501,10 @@ fn build_iron_proxy_network_policies(
         NetworkPolicy {
             metadata: object_meta(
                 iron_proxy_policy_name(id),
-                iron_proxy_labels(id, observability_enabled, resolved.api_server_enabled),
+                iron_proxy_labels(id, observability_enabled),
             ),
             spec: Some(NetworkPolicySpec {
-                pod_selector: Some(label_selector(iron_proxy_labels(
-                    id,
-                    observability_enabled,
-                    resolved.api_server_enabled,
-                ))),
+                pod_selector: Some(label_selector(iron_proxy_labels(id, observability_enabled))),
                 policy_types: Some(vec!["Ingress".to_owned(), "Egress".to_owned()]),
                 ingress: Some(vec![
                     NetworkPolicyIngressRule {
@@ -1814,18 +1763,6 @@ pub(crate) fn sandbox_observability_enabled(
     sandbox_env_value(
         sandbox,
         "CENTAUR_SANDBOX_OBSERVABILITY_ENABLED",
-        container_name,
-    )
-    .and_then(|value| value.parse().ok())
-}
-
-pub(crate) fn sandbox_api_server_enabled(
-    sandbox: &crate::crd::Sandbox,
-    container_name: &str,
-) -> Option<bool> {
-    sandbox_env_value(
-        sandbox,
-        "CENTAUR_SANDBOX_API_SERVER_ENABLED",
         container_name,
     )
     .and_then(|value| value.parse().ok())
@@ -2123,11 +2060,7 @@ fn sandbox_labels(id: &SandboxId) -> BTreeMap<String, String> {
     ])
 }
 
-fn iron_proxy_labels(
-    id: &SandboxId,
-    observability_enabled: bool,
-    api_server_enabled: bool,
-) -> BTreeMap<String, String> {
+fn iron_proxy_labels(id: &SandboxId, observability_enabled: bool) -> BTreeMap<String, String> {
     let mut labels = BTreeMap::from([
         (MANAGED_BY_LABEL.to_owned(), MANAGED_BY_VALUE.to_owned()),
         (SANDBOX_ID_LABEL.to_owned(), id.as_str().to_owned()),
@@ -2135,9 +2068,6 @@ fn iron_proxy_labels(
     ]);
     if observability_enabled {
         labels.insert(OBSERVABILITY_ENABLED_LABEL.to_owned(), "true".to_owned());
-    }
-    if api_server_enabled {
-        labels.insert(API_SERVER_ENABLED_LABEL.to_owned(), "true".to_owned());
     }
     labels
 }
@@ -2187,17 +2117,12 @@ mod tests {
             replace_placeholders: BTreeMap::new(),
             management_api_key: "test-management-key".to_owned(),
             observability_enabled: true,
-            api_server_enabled: true,
         }
     }
 
-    fn resolved_with_capabilities(
-        observability_enabled: bool,
-        api_server_enabled: bool,
-    ) -> ResolvedIronProxy {
+    fn resolved_with_observability(observability_enabled: bool) -> ResolvedIronProxy {
         ResolvedIronProxy {
             observability_enabled,
-            api_server_enabled,
             ..resolved()
         }
     }
@@ -2382,24 +2307,17 @@ mod tests {
     }
 
     #[test]
-    fn iron_proxy_labels_capabilities_when_enabled() {
+    fn iron_proxy_labels_observability_when_enabled() {
         let id = SandboxId::new("asbx-test");
 
         assert_eq!(
-            iron_proxy_labels(&id, true, true)
+            iron_proxy_labels(&id, true)
                 .get(OBSERVABILITY_ENABLED_LABEL)
                 .map(String::as_str),
             Some("true")
         );
-        assert_eq!(
-            iron_proxy_labels(&id, true, true)
-                .get(API_SERVER_ENABLED_LABEL)
-                .map(String::as_str),
-            Some("true")
-        );
-        let restricted_labels = iron_proxy_labels(&id, false, false);
+        let restricted_labels = iron_proxy_labels(&id, false);
         assert!(!restricted_labels.contains_key(OBSERVABILITY_ENABLED_LABEL));
-        assert!(!restricted_labels.contains_key(API_SERVER_ENABLED_LABEL));
     }
 
     #[test]
@@ -2504,14 +2422,6 @@ mod tests {
                 .map(String::as_str),
             Some("true")
         );
-        assert_eq!(
-            pod.metadata
-                .labels
-                .as_ref()
-                .and_then(|labels| labels.get(API_SERVER_ENABLED_LABEL))
-                .map(String::as_str),
-            Some("true")
-        );
 
         let service = build_iron_proxy_service(&id, &resolved);
         assert_eq!(
@@ -2525,28 +2435,10 @@ mod tests {
         );
         assert_eq!(
             service
-                .metadata
-                .labels
-                .as_ref()
-                .and_then(|labels| labels.get(API_SERVER_ENABLED_LABEL))
-                .map(String::as_str),
-            Some("true")
-        );
-        assert_eq!(
-            service
                 .spec
                 .as_ref()
                 .and_then(|spec| spec.selector.as_ref())
                 .and_then(|selector| selector.get(OBSERVABILITY_ENABLED_LABEL))
-                .map(String::as_str),
-            Some("true")
-        );
-        assert_eq!(
-            service
-                .spec
-                .as_ref()
-                .and_then(|spec| spec.selector.as_ref())
-                .and_then(|selector| selector.get(API_SERVER_ENABLED_LABEL))
                 .map(String::as_str),
             Some("true")
         );
@@ -2571,15 +2463,6 @@ mod tests {
         );
         assert_eq!(
             proxy_policy
-                .metadata
-                .labels
-                .as_ref()
-                .and_then(|labels| labels.get(API_SERVER_ENABLED_LABEL))
-                .map(String::as_str),
-            Some("true")
-        );
-        assert_eq!(
-            proxy_policy
                 .spec
                 .as_ref()
                 .and_then(|spec| spec.pod_selector.as_ref())
@@ -2588,23 +2471,13 @@ mod tests {
                 .map(String::as_str),
             Some("true")
         );
-        assert_eq!(
-            proxy_policy
-                .spec
-                .as_ref()
-                .and_then(|spec| spec.pod_selector.as_ref())
-                .and_then(|selector| selector.match_labels.as_ref())
-                .and_then(|labels| labels.get(API_SERVER_ENABLED_LABEL))
-                .map(String::as_str),
-            Some("true")
-        );
     }
 
     #[test]
-    fn iron_proxy_resources_omit_capability_labels_when_disabled() {
+    fn iron_proxy_resources_omit_observability_label_when_disabled() {
         let id = SandboxId::new("asbx-test");
         let iron_proxy = IronProxyConfig::new("proxy:test", "ca-cert", "ca-key");
-        let resolved = resolved_with_capabilities(false, false);
+        let resolved = resolved_with_observability(false);
         let sync = ProxySyncEnv {
             proxy_id: "iprx_test".to_owned(),
             control_url: "http://console:3000".to_owned(),
@@ -2623,15 +2496,12 @@ mod tests {
         );
         let pod_labels = pod.metadata.labels.as_ref().unwrap();
         assert!(!pod_labels.contains_key(OBSERVABILITY_ENABLED_LABEL));
-        assert!(!pod_labels.contains_key(API_SERVER_ENABLED_LABEL));
 
         let service = build_iron_proxy_service(&id, &resolved);
         let service_labels = service.metadata.labels.as_ref().unwrap();
         assert!(!service_labels.contains_key(OBSERVABILITY_ENABLED_LABEL));
-        assert!(!service_labels.contains_key(API_SERVER_ENABLED_LABEL));
         let service_selector = service.spec.as_ref().unwrap().selector.as_ref().unwrap();
         assert!(!service_selector.contains_key(OBSERVABILITY_ENABLED_LABEL));
-        assert!(!service_selector.contains_key(API_SERVER_ENABLED_LABEL));
 
         let policies = build_iron_proxy_network_policies(
             &id,
@@ -2644,7 +2514,6 @@ mod tests {
         let proxy_policy = &policies[1];
         let policy_labels = proxy_policy.metadata.labels.as_ref().unwrap();
         assert!(!policy_labels.contains_key(OBSERVABILITY_ENABLED_LABEL));
-        assert!(!policy_labels.contains_key(API_SERVER_ENABLED_LABEL));
         let policy_selector = proxy_policy
             .spec
             .as_ref()
@@ -2656,7 +2525,6 @@ mod tests {
             .as_ref()
             .unwrap();
         assert!(!policy_selector.contains_key(OBSERVABILITY_ENABLED_LABEL));
-        assert!(!policy_selector.contains_key(API_SERVER_ENABLED_LABEL));
     }
 
     #[test]
@@ -2732,7 +2600,6 @@ mod tests {
     fn resume_capability_prefers_valid_env_and_fails_closed_without_it() {
         let mut labels = BTreeMap::new();
         labels.insert(OBSERVABILITY_ENABLED_LABEL.to_owned(), "true".to_owned());
-        labels.insert(API_SERVER_ENABLED_LABEL.to_owned(), "true".to_owned());
 
         assert!(resolve_resume_capability(
             Some(true),
@@ -2760,27 +2627,6 @@ mod tests {
             Some(&BTreeMap::new()),
             OBSERVABILITY_ENABLED_LABEL,
             "observability",
-            "asbx-test",
-        ));
-        assert!(!resolve_resume_capability(
-            None,
-            None,
-            API_SERVER_ENABLED_LABEL,
-            "api_server",
-            "asbx-test",
-        ));
-        assert!(!resolve_resume_capability(
-            Some(false),
-            None,
-            API_SERVER_ENABLED_LABEL,
-            "api_server",
-            "asbx-test",
-        ));
-        assert!(resolve_resume_capability(
-            Some(true),
-            None,
-            API_SERVER_ENABLED_LABEL,
-            "api_server",
             "asbx-test",
         ));
     }

--- a/services/api-rs/crates/centaur-sandbox-agent-k8s/src/lib.rs
+++ b/services/api-rs/crates/centaur-sandbox-agent-k8s/src/lib.rs
@@ -39,7 +39,6 @@ const DEFAULT_CONTAINER_NAME: &str = "agent";
 const MANAGED_BY_LABEL: &str = "centaur.ai/managed-by";
 const SANDBOX_ID_LABEL: &str = "centaur.ai/sandbox-id";
 const OBSERVABILITY_ENABLED_LABEL: &str = "centaur.ai/observability-enabled";
-const API_SERVER_ENABLED_LABEL: &str = "centaur.ai/api-server-enabled";
 const MANAGED_BY_VALUE: &str = "api-rs";
 // iron-control principal OID the sandbox's proxy binds to, stamped at create
 // so resume (which has only the sandbox id) can rebind without the spec or any
@@ -524,10 +523,8 @@ impl SandboxBackend for AgentSandboxBackend {
         // sandbox's own recorded env (the durable source of truth `resolve_
         // iron_proxy_for_resume` already reads for the same purpose) and
         // reassert them on both the Sandbox and its pod template, so the
-        // recreated agent pod keeps the labels the create path applied —
-        // otherwise it loses `centaur.ai/api-server-enabled` /
-        // `observability-enabled` and the chart's NetworkPolicy stops
-        // routing its model-proxy egress.
+        // recreated agent pod keeps the observability label the create path
+        // applied.
         let capability_labels = sandbox
             .as_ref()
             .map(|sandbox| {
@@ -593,16 +590,6 @@ fn sandbox_capability_labels(
             sandbox.metadata.labels.as_ref(),
             OBSERVABILITY_ENABLED_LABEL,
             "observability",
-            sandbox_id,
-        ),
-    );
-    labels.insert(
-        API_SERVER_ENABLED_LABEL,
-        iron_proxy::resolve_resume_capability(
-            iron_proxy::sandbox_api_server_enabled(sandbox, container_name),
-            sandbox.metadata.labels.as_ref(),
-            API_SERVER_ENABLED_LABEL,
-            "api_server",
             sandbox_id,
         ),
     );
@@ -678,10 +665,6 @@ fn build_agent_sandbox(
     if spec.capabilities.observability_enabled {
         labels.insert(OBSERVABILITY_ENABLED_LABEL.to_owned(), "true".to_owned());
     }
-    if spec.capabilities.api_server_enabled {
-        labels.insert(API_SERVER_ENABLED_LABEL.to_owned(), "true".to_owned());
-    }
-
     let mut pod_labels = labels.clone();
     pod_labels.insert(
         "app.kubernetes.io/name".to_owned(),
@@ -1202,7 +1185,6 @@ mod tests {
         let spec = SandboxSpec::new("centaur-agent:latest").capabilities(SandboxCapabilities {
             repo_cache: RepoCacheAccess::All,
             observability_enabled: true,
-            api_server_enabled: true,
         });
         let config = AgentSandboxConfig::new("centaur", test_iron_control_settings());
 
@@ -1225,37 +1207,16 @@ mod tests {
                 .as_ref()
                 .and_then(|metadata| metadata.labels.as_ref())
                 .and_then(|labels| labels.get(OBSERVABILITY_ENABLED_LABEL))
-                .map(String::as_str),
-            Some("true")
-        );
-        assert_eq!(
-            sandbox
-                .metadata
-                .labels
-                .as_ref()
-                .and_then(|labels| labels.get(API_SERVER_ENABLED_LABEL))
-                .map(String::as_str),
-            Some("true")
-        );
-        assert_eq!(
-            sandbox
-                .spec
-                .pod_template
-                .metadata
-                .as_ref()
-                .and_then(|metadata| metadata.labels.as_ref())
-                .and_then(|labels| labels.get(API_SERVER_ENABLED_LABEL))
                 .map(String::as_str),
             Some("true")
         );
     }
 
     #[test]
-    fn omits_api_server_label_for_restricted_sandboxes() {
+    fn omits_observability_label_for_restricted_sandboxes() {
         let spec = SandboxSpec::new("centaur-agent:latest").capabilities(SandboxCapabilities {
             repo_cache: RepoCacheAccess::All,
             observability_enabled: false,
-            api_server_enabled: false,
         });
         let config = AgentSandboxConfig::new("centaur", test_iron_control_settings());
 
@@ -1277,31 +1238,14 @@ mod tests {
                 .and_then(|metadata| metadata.labels.as_ref())
                 .is_none_or(|labels| !labels.contains_key(OBSERVABILITY_ENABLED_LABEL))
         );
-        assert!(
-            sandbox
-                .metadata
-                .labels
-                .as_ref()
-                .is_none_or(|labels| !labels.contains_key(API_SERVER_ENABLED_LABEL))
-        );
-        assert!(
-            sandbox
-                .spec
-                .pod_template
-                .metadata
-                .as_ref()
-                .and_then(|metadata| metadata.labels.as_ref())
-                .is_none_or(|labels| !labels.contains_key(API_SERVER_ENABLED_LABEL))
-        );
     }
 
     /// A pod deleted out from under a sandbox (janitor, node pressure, manual
     /// reap) comes back through `resume`, which only has the sandbox id, not
     /// the original `SandboxSpec`. Regression test for the recreated agent
-    /// pod losing `centaur.ai/api-server-enabled` and
-    /// `centaur.ai/observability-enabled`: the resume patch must restore both
-    /// labels (derived from the sandbox's own recorded capability env, the
-    /// same durable source `resolve_iron_proxy_for_resume` already trusts)
+    /// pod losing `centaur.ai/observability-enabled`: the resume patch must
+    /// restore the label (derived from the sandbox's own recorded capability
+    /// env, the same durable source `resolve_iron_proxy_for_resume` already trusts)
     /// on the Sandbox and its pod template, matching what `build_agent_sandbox`
     /// would have applied for these capabilities.
     #[test]
@@ -1313,10 +1257,8 @@ mod tests {
             .capabilities(SandboxCapabilities {
                 repo_cache: RepoCacheAccess::All,
                 observability_enabled: true,
-                api_server_enabled: true,
             })
-            .env("CENTAUR_SANDBOX_OBSERVABILITY_ENABLED", "true")
-            .env("CENTAUR_SANDBOX_API_SERVER_ENABLED", "true");
+            .env("CENTAUR_SANDBOX_OBSERVABILITY_ENABLED", "true");
         let config = AgentSandboxConfig::new("centaur", test_iron_control_settings());
         let mut sandbox =
             build_agent_sandbox(&SandboxId::new("asbx-test"), &spec, &config).unwrap();
@@ -1332,16 +1274,13 @@ mod tests {
             .and_then(|metadata| metadata.labels.as_mut())
         {
             labels.remove(OBSERVABILITY_ENABLED_LABEL);
-            labels.remove(API_SERVER_ENABLED_LABEL);
         }
         if let Some(labels) = sandbox.metadata.labels.as_mut() {
             labels.remove(OBSERVABILITY_ENABLED_LABEL);
-            labels.remove(API_SERVER_ENABLED_LABEL);
         }
 
         let labels = sandbox_capability_labels(&sandbox, DEFAULT_CONTAINER_NAME, "asbx-test");
         assert_eq!(labels.get(OBSERVABILITY_ENABLED_LABEL), Some(&true));
-        assert_eq!(labels.get(API_SERVER_ENABLED_LABEL), Some(&true));
 
         let patch = sandbox_resume_patch(&labels);
         assert_eq!(
@@ -1349,15 +1288,7 @@ mod tests {
             json!("true")
         );
         assert_eq!(
-            patch["metadata"]["labels"][API_SERVER_ENABLED_LABEL],
-            json!("true")
-        );
-        assert_eq!(
             patch["spec"]["podTemplate"]["metadata"]["labels"][OBSERVABILITY_ENABLED_LABEL],
-            json!("true")
-        );
-        assert_eq!(
-            patch["spec"]["podTemplate"]["metadata"]["labels"][API_SERVER_ENABLED_LABEL],
             json!("true")
         );
     }
@@ -1369,27 +1300,21 @@ mod tests {
         let spec = SandboxSpec::new("centaur-agent:latest").capabilities(SandboxCapabilities {
             repo_cache: RepoCacheAccess::All,
             observability_enabled: false,
-            api_server_enabled: false,
         });
         let config = AgentSandboxConfig::new("centaur", test_iron_control_settings());
         let sandbox = build_agent_sandbox(&SandboxId::new("asbx-test"), &spec, &config).unwrap();
 
         let labels = sandbox_capability_labels(&sandbox, DEFAULT_CONTAINER_NAME, "asbx-test");
         assert_eq!(labels.get(OBSERVABILITY_ENABLED_LABEL), Some(&false));
-        assert_eq!(labels.get(API_SERVER_ENABLED_LABEL), Some(&false));
 
         // A JSON merge patch null removes the key rather than writing
         // "false", matching how `build_agent_sandbox` omits (not falsifies)
         // the label for a disabled capability.
         let patch = sandbox_resume_patch(&labels);
         assert!(patch["metadata"]["labels"][OBSERVABILITY_ENABLED_LABEL].is_null());
-        assert!(patch["metadata"]["labels"][API_SERVER_ENABLED_LABEL].is_null());
         assert!(
             patch["spec"]["podTemplate"]["metadata"]["labels"][OBSERVABILITY_ENABLED_LABEL]
                 .is_null()
-        );
-        assert!(
-            patch["spec"]["podTemplate"]["metadata"]["labels"][API_SERVER_ENABLED_LABEL].is_null()
         );
     }
 
@@ -1448,7 +1373,6 @@ mod tests {
         let spec = SandboxSpec::new("centaur-agent:latest").capabilities(SandboxCapabilities {
             repo_cache: RepoCacheAccess::None,
             observability_enabled: true,
-            api_server_enabled: true,
         });
         let mut tools = ToolsConfig::new("paradigmxyz/centaur", "api:test");
         tools.repo_cache_path = Some("/var/lib/centaur/repos".to_owned());

--- a/services/api-rs/crates/centaur-sandbox-core/src/spec.rs
+++ b/services/api-rs/crates/centaur-sandbox-core/src/spec.rs
@@ -30,7 +30,6 @@ pub struct SandboxCapabilities {
     #[serde(default)]
     pub repo_cache: RepoCacheAccess,
     pub observability_enabled: bool,
-    pub api_server_enabled: bool,
 }
 
 impl SandboxCapabilities {
@@ -38,12 +37,11 @@ impl SandboxCapabilities {
         Self {
             repo_cache: RepoCacheAccess::All,
             observability_enabled: true,
-            api_server_enabled: true,
         }
     }
 
     pub fn is_default_enabled(&self) -> bool {
-        self.repo_cache.enabled() && self.observability_enabled && self.api_server_enabled
+        self.repo_cache.enabled() && self.observability_enabled
     }
 }
 

--- a/services/api-rs/crates/centaur-session-core/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-core/src/lib.rs
@@ -416,7 +416,6 @@ pub struct SandboxCapabilities {
     #[serde(default)]
     pub repo_cache: SandboxRepoCacheAccess,
     pub observability_enabled: bool,
-    pub api_server_enabled: bool,
 }
 
 impl SandboxCapabilities {
@@ -424,14 +423,11 @@ impl SandboxCapabilities {
         Self {
             repo_cache: SandboxRepoCacheAccess::All,
             observability_enabled: true,
-            api_server_enabled: true,
         }
     }
 
     pub const fn is_default_enabled(&self) -> bool {
-        matches!(self.repo_cache, SandboxRepoCacheAccess::All)
-            && self.observability_enabled
-            && self.api_server_enabled
+        matches!(self.repo_cache, SandboxRepoCacheAccess::All) && self.observability_enabled
     }
 
     pub const fn repo_cache_enabled(&self) -> bool {

--- a/services/api-rs/crates/centaur-session-runtime/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-runtime/src/lib.rs
@@ -2365,7 +2365,6 @@ impl SessionRuntime {
             sandbox_repo_cache_access = desired_capabilities.repo_cache.as_str(),
             sandbox_repo_cache_enabled = desired_capabilities.repo_cache_enabled(),
             sandbox_observability_enabled = desired_capabilities.observability_enabled,
-            sandbox_api_server_enabled = desired_capabilities.api_server_enabled,
         );
         let ensure_started = Instant::now();
         let result = async {
@@ -2404,7 +2403,6 @@ impl SessionRuntime {
                         sandbox_repo_cache_access = desired_capabilities.repo_cache.as_str(),
                         sandbox_repo_cache_enabled = desired_capabilities.repo_cache_enabled(),
                         sandbox_observability_enabled = desired_capabilities.observability_enabled,
-                        sandbox_api_server_enabled = desired_capabilities.api_server_enabled,
                         "replacing existing sandbox whose capabilities do not match"
                     );
                 } else {
@@ -5587,7 +5585,6 @@ fn sandbox_capabilities_from_principal(
     SessionSandboxCapabilities {
         repo_cache: sandbox_repo_cache_access_from_principal(principal),
         observability_enabled: principal.sandbox_observability_enabled,
-        api_server_enabled: principal.sandbox_api_server_enabled,
     }
 }
 
@@ -5599,7 +5596,6 @@ fn apply_sandbox_capabilities(spec: &mut SandboxSpec, capabilities: &SessionSand
             SessionRepoCacheAccess::All => RepoCacheAccess::All,
         },
         observability_enabled: capabilities.observability_enabled,
-        api_server_enabled: capabilities.api_server_enabled,
     };
     upsert_spec_env(
         spec,
@@ -5615,11 +5611,6 @@ fn apply_sandbox_capabilities(spec: &mut SandboxSpec, capabilities: &SessionSand
         spec,
         "CENTAUR_SANDBOX_OBSERVABILITY_ENABLED",
         capabilities.observability_enabled.to_string(),
-    );
-    upsert_spec_env(
-        spec,
-        "CENTAUR_SANDBOX_API_SERVER_ENABLED",
-        capabilities.api_server_enabled.to_string(),
     );
     match capabilities.repo_cache {
         SessionRepoCacheAccess::None => {
@@ -6941,7 +6932,6 @@ mod tests {
         let capabilities = SessionSandboxCapabilities {
             repo_cache: SessionRepoCacheAccess::Public,
             observability_enabled: true,
-            api_server_enabled: true,
         };
 
         apply_sandbox_capabilities(&mut spec, &capabilities);
@@ -6969,7 +6959,6 @@ mod tests {
         let capabilities = SessionSandboxCapabilities {
             repo_cache: SessionRepoCacheAccess::Public,
             observability_enabled: true,
-            api_server_enabled: true,
         };
 
         apply_sandbox_capabilities(&mut spec, &capabilities);
@@ -6996,7 +6985,6 @@ mod tests {
         let capabilities = SessionSandboxCapabilities {
             repo_cache: SessionRepoCacheAccess::Public,
             observability_enabled: true,
-            api_server_enabled: true,
         };
 
         apply_sandbox_capabilities(&mut spec, &capabilities);
@@ -7029,7 +7017,6 @@ mod tests {
         let capabilities = SessionSandboxCapabilities {
             repo_cache: SessionRepoCacheAccess::None,
             observability_enabled: true,
-            api_server_enabled: true,
         };
 
         apply_sandbox_capabilities(&mut spec, &capabilities);
@@ -7050,7 +7037,6 @@ mod tests {
             name: "Test".to_owned(),
             labels,
             sandbox_observability_enabled: true,
-            sandbox_api_server_enabled: true,
         }
     }
 
@@ -8478,7 +8464,6 @@ mod adoption_tests {
             name: "Test".to_owned(),
             labels: BTreeMap::new(),
             sandbox_observability_enabled: true,
-            sandbox_api_server_enabled: true,
         }
     }
 
@@ -9037,7 +9022,6 @@ mod adoption_tests {
         SessionSandboxCapabilities {
             repo_cache: SessionRepoCacheAccess::None,
             observability_enabled: false,
-            api_server_enabled: false,
         }
     }
 
@@ -9142,13 +9126,8 @@ mod adoption_tests {
         let spec = backend.created_specs().pop().expect("created cold spec");
         assert!(!spec.capabilities.repo_cache.enabled());
         assert!(!spec.capabilities.observability_enabled);
-        assert!(!spec.capabilities.api_server_enabled);
         assert_eq!(
             env_value(&spec, "CENTAUR_SANDBOX_OBSERVABILITY_ENABLED"),
-            Some("false")
-        );
-        assert_eq!(
-            env_value(&spec, "CENTAUR_SANDBOX_API_SERVER_ENABLED"),
             Some("false")
         );
         let blocklist = env_value(&spec, "TOOL_BLOCKLIST").unwrap_or("");
@@ -9239,7 +9218,6 @@ mod adoption_tests {
         let spec = backend.created_specs().pop().expect("created cold spec");
         assert!(!spec.capabilities.repo_cache.enabled());
         assert!(!spec.capabilities.observability_enabled);
-        assert!(!spec.capabilities.api_server_enabled);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/services/api-rs/crates/centaur-session-sqlx/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-sqlx/src/lib.rs
@@ -175,7 +175,7 @@ impl PgSessionStore {
     pub async fn get_session(&self, thread_key: &ThreadKey) -> Result<Session, SessionStoreError> {
         let row = sqlx::query_as::<_, SessionRow>(
             r#"
-            select thread_key, title, sandbox_id, sandbox_repo_cache_enabled, sandbox_repo_cache_access, sandbox_observability_enabled, sandbox_api_server_enabled, harness_type, harness_thread_id, persona_id, status, iron_control_principal, proxy_labels, sandbox_last_active_at, created_at, updated_at
+            select thread_key, title, sandbox_id, sandbox_repo_cache_enabled, sandbox_repo_cache_access, sandbox_observability_enabled, harness_type, harness_thread_id, persona_id, status, iron_control_principal, proxy_labels, sandbox_last_active_at, created_at, updated_at
             from sessions
             where thread_key = $1
             "#,
@@ -1177,14 +1177,13 @@ impl PgSessionStore {
                 sandbox_repo_cache_enabled = null,
                 sandbox_repo_cache_access = null,
                 sandbox_observability_enabled = null,
-                sandbox_api_server_enabled = null,
                 sandbox_last_active_at = case
                     when $2::text is null then null
                     else now()
                 end,
                 updated_at = now()
             where thread_key = $1
-            returning thread_key, title, sandbox_id, sandbox_repo_cache_enabled, sandbox_repo_cache_access, sandbox_observability_enabled, sandbox_api_server_enabled, harness_type, harness_thread_id, persona_id, status, iron_control_principal, proxy_labels, sandbox_last_active_at, created_at, updated_at
+            returning thread_key, title, sandbox_id, sandbox_repo_cache_enabled, sandbox_repo_cache_access, sandbox_observability_enabled, harness_type, harness_thread_id, persona_id, status, iron_control_principal, proxy_labels, sandbox_last_active_at, created_at, updated_at
             "#,
         )
         .bind(thread_key.as_str())
@@ -1209,11 +1208,13 @@ impl PgSessionStore {
                 sandbox_repo_cache_enabled = $3,
                 sandbox_repo_cache_access = $4,
                 sandbox_observability_enabled = $5,
-                sandbox_api_server_enabled = $6,
+                -- Keep the deprecated column populated during rolling upgrades
+                -- so older api-rs pods can read assignments made by this version.
+                sandbox_api_server_enabled = true,
                 sandbox_last_active_at = now(),
                 updated_at = now()
             where thread_key = $1
-            returning thread_key, title, sandbox_id, sandbox_repo_cache_enabled, sandbox_repo_cache_access, sandbox_observability_enabled, sandbox_api_server_enabled, harness_type, harness_thread_id, persona_id, status, iron_control_principal, proxy_labels, sandbox_last_active_at, created_at, updated_at
+            returning thread_key, title, sandbox_id, sandbox_repo_cache_enabled, sandbox_repo_cache_access, sandbox_observability_enabled, harness_type, harness_thread_id, persona_id, status, iron_control_principal, proxy_labels, sandbox_last_active_at, created_at, updated_at
             "#,
         )
         .bind(thread_key.as_str())
@@ -1221,7 +1222,6 @@ impl PgSessionStore {
         .bind(capabilities.repo_cache_enabled())
         .bind(capabilities.repo_cache.as_str())
         .bind(capabilities.observability_enabled)
-        .bind(capabilities.api_server_enabled)
         .fetch_one(&self.pool)
         .await?;
 
@@ -1241,7 +1241,6 @@ impl PgSessionStore {
                 sandbox_repo_cache_enabled = null,
                 sandbox_repo_cache_access = null,
                 sandbox_observability_enabled = null,
-                sandbox_api_server_enabled = null,
                 sandbox_last_active_at = null,
                 updated_at = now()
             where thread_key = $1 and sandbox_id = $2
@@ -1272,12 +1271,11 @@ impl PgSessionStore {
                 sandbox_repo_cache_enabled = null,
                 sandbox_repo_cache_access = null,
                 sandbox_observability_enabled = null,
-                sandbox_api_server_enabled = null,
                 sandbox_last_active_at = null,
                 status = $3,
                 updated_at = now()
             where thread_key = $1
-            returning thread_key, title, sandbox_id, sandbox_repo_cache_enabled, sandbox_repo_cache_access, sandbox_observability_enabled, sandbox_api_server_enabled, harness_type, harness_thread_id, persona_id, status, iron_control_principal, proxy_labels, sandbox_last_active_at, created_at, updated_at
+            returning thread_key, title, sandbox_id, sandbox_repo_cache_enabled, sandbox_repo_cache_access, sandbox_observability_enabled, harness_type, harness_thread_id, persona_id, status, iron_control_principal, proxy_labels, sandbox_last_active_at, created_at, updated_at
             "#,
         )
         .bind(thread_key.as_str())
@@ -1302,7 +1300,7 @@ impl PgSessionStore {
             update sessions
             set iron_control_principal = $2, updated_at = now()
             where thread_key = $1
-            returning thread_key, title, sandbox_id, sandbox_repo_cache_enabled, sandbox_repo_cache_access, sandbox_observability_enabled, sandbox_api_server_enabled, harness_type, harness_thread_id, persona_id, status, iron_control_principal, proxy_labels, sandbox_last_active_at, created_at, updated_at
+            returning thread_key, title, sandbox_id, sandbox_repo_cache_enabled, sandbox_repo_cache_access, sandbox_observability_enabled, harness_type, harness_thread_id, persona_id, status, iron_control_principal, proxy_labels, sandbox_last_active_at, created_at, updated_at
             "#,
         )
         .bind(thread_key.as_str())
@@ -1472,7 +1470,7 @@ impl PgSessionStore {
             update sessions
             set harness_thread_id = $2, updated_at = now()
             where thread_key = $1
-            returning thread_key, title, sandbox_id, sandbox_repo_cache_enabled, sandbox_repo_cache_access, sandbox_observability_enabled, sandbox_api_server_enabled, harness_type, harness_thread_id, persona_id, status, iron_control_principal, proxy_labels, sandbox_last_active_at, created_at, updated_at
+            returning thread_key, title, sandbox_id, sandbox_repo_cache_enabled, sandbox_repo_cache_access, sandbox_observability_enabled, harness_type, harness_thread_id, persona_id, status, iron_control_principal, proxy_labels, sandbox_last_active_at, created_at, updated_at
             "#,
         )
         .bind(thread_key.as_str())
@@ -1613,7 +1611,6 @@ struct SessionRow {
     sandbox_repo_cache_enabled: Option<bool>,
     sandbox_repo_cache_access: Option<String>,
     sandbox_observability_enabled: Option<bool>,
-    sandbox_api_server_enabled: Option<bool>,
     harness_type: String,
     harness_thread_id: Option<String>,
     persona_id: Option<String>,
@@ -1637,23 +1634,18 @@ impl TryFrom<SessionRow> for Session {
                 row.sandbox_repo_cache_enabled,
                 row.sandbox_repo_cache_access,
                 row.sandbox_observability_enabled,
-                row.sandbox_api_server_enabled,
             ) {
-                (
-                    Some(repo_cache_enabled),
-                    repo_cache_access,
-                    Some(observability_enabled),
-                    Some(api_server_enabled),
-                ) => Some(SandboxCapabilities {
-                    repo_cache: repo_cache_access
-                        .as_deref()
-                        .and_then(SandboxRepoCacheAccess::parse)
-                        .unwrap_or_else(|| {
-                            SandboxRepoCacheAccess::from_legacy_enabled(repo_cache_enabled)
-                        }),
-                    observability_enabled,
-                    api_server_enabled,
-                }),
+                (Some(repo_cache_enabled), repo_cache_access, Some(observability_enabled)) => {
+                    Some(SandboxCapabilities {
+                        repo_cache: repo_cache_access
+                            .as_deref()
+                            .and_then(SandboxRepoCacheAccess::parse)
+                            .unwrap_or_else(|| {
+                                SandboxRepoCacheAccess::from_legacy_enabled(repo_cache_enabled)
+                            }),
+                        observability_enabled,
+                    })
+                }
                 _ => None,
             },
             harness_type: parse_persisted(row.harness_type)?,

--- a/services/console/app/controllers/api/v1/principals_controller.rb
+++ b/services/console/app/controllers/api/v1/principals_controller.rb
@@ -86,7 +86,9 @@ module Api
           effective_slack_channel_permissions: principal.effective_slack_channel_permissions_payload,
           sandbox_repo_cache: principal.sandbox_repo_cache,
           sandbox_observability_enabled: principal.sandbox_observability_enabled,
-          sandbox_api_server_enabled: principal.sandbox_api_server_enabled,
+          sandbox_sessions_read_enabled: principal.sandbox_sessions_read_enabled,
+          sandbox_workflows_read_enabled: principal.sandbox_workflows_read_enabled,
+          sandbox_workflows_write_enabled: principal.sandbox_workflows_write_enabled,
           created_at: principal.created_at,
           updated_at: principal.updated_at
         }
@@ -103,7 +105,9 @@ module Api
           :console_user_id,
           :sandbox_repo_cache,
           :sandbox_observability_enabled,
-          :sandbox_api_server_enabled,
+          :sandbox_sessions_read_enabled,
+          :sandbox_workflows_read_enabled,
+          :sandbox_workflows_write_enabled,
           labels: {}
         )
       end

--- a/services/console/app/controllers/api/v1/sandbox/permissions_controller.rb
+++ b/services/console/app/controllers/api/v1/sandbox/permissions_controller.rb
@@ -45,7 +45,9 @@ module Api
           {
             sandbox_repo_cache: principal.sandbox_repo_cache,
             sandbox_observability_enabled: principal.sandbox_observability_enabled,
-            sandbox_api_server_enabled: principal.sandbox_api_server_enabled
+            sandbox_sessions_read_enabled: principal.sandbox_sessions_read_enabled,
+            sandbox_workflows_read_enabled: principal.sandbox_workflows_read_enabled,
+            sandbox_workflows_write_enabled: principal.sandbox_workflows_write_enabled
           }
         end
 

--- a/services/console/app/controllers/console/principals_controller.rb
+++ b/services/console/app/controllers/console/principals_controller.rb
@@ -38,7 +38,9 @@ module Console
       @principal.update!(
         sandbox_repo_cache: params[:sandbox_repo_cache],
         sandbox_observability_enabled: ActiveModel::Type::Boolean.new.cast(params[:sandbox_observability_enabled]),
-        sandbox_api_server_enabled: ActiveModel::Type::Boolean.new.cast(params[:sandbox_api_server_enabled])
+        sandbox_sessions_read_enabled: ActiveModel::Type::Boolean.new.cast(params[:sandbox_sessions_read_enabled]),
+        sandbox_workflows_read_enabled: ActiveModel::Type::Boolean.new.cast(params[:sandbox_workflows_read_enabled]),
+        sandbox_workflows_write_enabled: ActiveModel::Type::Boolean.new.cast(params[:sandbox_workflows_write_enabled])
       )
       redirect_to console_principal_path(@principal.oid), notice: "Updated sandbox access."
     rescue ActiveRecord::RecordInvalid => e

--- a/services/console/app/controllers/console/system_settings_controller.rb
+++ b/services/console/app/controllers/console/system_settings_controller.rb
@@ -31,7 +31,9 @@ module Console
       params.require(:system_setting).permit(
         :default_sandbox_repo_cache,
         :default_sandbox_observability_enabled,
-        :default_sandbox_api_server_enabled
+        :default_sandbox_sessions_read_enabled,
+        :default_sandbox_workflows_read_enabled,
+        :default_sandbox_workflows_write_enabled
       )
     end
 

--- a/services/console/app/models/principal.rb
+++ b/services/console/app/models/principal.rb
@@ -136,8 +136,14 @@ class Principal < ApplicationRecord
     unless supplied_key?(supplied, :sandbox_observability_enabled)
       self.sandbox_observability_enabled = defaults[:sandbox_observability_enabled]
     end
-    unless supplied_key?(supplied, :sandbox_api_server_enabled)
-      self.sandbox_api_server_enabled = defaults[:sandbox_api_server_enabled]
+    unless supplied_key?(supplied, :sandbox_sessions_read_enabled)
+      self.sandbox_sessions_read_enabled = defaults[:sandbox_sessions_read_enabled]
+    end
+    unless supplied_key?(supplied, :sandbox_workflows_read_enabled)
+      self.sandbox_workflows_read_enabled = defaults[:sandbox_workflows_read_enabled]
+    end
+    unless supplied_key?(supplied, :sandbox_workflows_write_enabled)
+      self.sandbox_workflows_write_enabled = defaults[:sandbox_workflows_write_enabled]
     end
   end
 
@@ -364,8 +370,8 @@ class Principal < ApplicationRecord
 
   def sync_config_fields_changed?
     %w[
-      name labels sandbox_api_server_enabled kind slack_user_id slack_channel_id slack_team_id slack_email
-      console_user_id
+      name labels sandbox_sessions_read_enabled sandbox_workflows_read_enabled
+      sandbox_workflows_write_enabled kind slack_user_id slack_channel_id slack_team_id slack_email console_user_id
     ].any? do |field|
       previous_changes.key?(field)
     end

--- a/services/console/app/models/principal_sync_config_snapshot.rb
+++ b/services/console/app/models/principal_sync_config_snapshot.rb
@@ -158,8 +158,6 @@ class PrincipalSyncConfigSnapshot < ApplicationRecord
   end
 
   def api_server_jwt_window_stale?(principal)
-    return false unless principal.sandbox_api_server_enabled?
-
     return false if ENV["CENTAUR_JWT_SIGNING_SECRET"].to_s.blank?
 
     updated_at.to_i < ApiServer::Jwt.window_start_for(principal, Time.current.to_i)
@@ -376,8 +374,6 @@ class PrincipalSyncConfigSnapshot < ApplicationRecord
   private_class_method :generated_proxy_secrets_for
 
   def self.api_server_jwt_secret_for(principal)
-    return nil unless principal.sandbox_api_server_enabled?
-
     token = ApiServer::Jwt.encode_for_principal(principal)
     return nil if token.blank?
 

--- a/services/console/app/models/system_setting.rb
+++ b/services/console/app/models/system_setting.rb
@@ -6,7 +6,9 @@ class SystemSetting < ApplicationRecord
   validates :singleton, inclusion: { in: [ true ] }, uniqueness: true
   validates :default_sandbox_repo_cache, inclusion: { in: Principal::SANDBOX_REPO_CACHE_VALUES }
   validates :default_sandbox_observability_enabled, inclusion: { in: [ true, false ] }
-  validates :default_sandbox_api_server_enabled, inclusion: { in: [ true, false ] }
+  validates :default_sandbox_sessions_read_enabled, inclusion: { in: [ true, false ] }
+  validates :default_sandbox_workflows_read_enabled, inclusion: { in: [ true, false ] }
+  validates :default_sandbox_workflows_write_enabled, inclusion: { in: [ true, false ] }
 
   def self.current
     first || create!(singleton: true)
@@ -18,7 +20,9 @@ class SystemSetting < ApplicationRecord
     {
       sandbox_repo_cache: default_sandbox_repo_cache,
       sandbox_observability_enabled: default_sandbox_observability_enabled,
-      sandbox_api_server_enabled: default_sandbox_api_server_enabled
+      sandbox_sessions_read_enabled: default_sandbox_sessions_read_enabled,
+      sandbox_workflows_read_enabled: default_sandbox_workflows_read_enabled,
+      sandbox_workflows_write_enabled: default_sandbox_workflows_write_enabled
     }
   end
 

--- a/services/console/app/views/console/principal.html.erb
+++ b/services/console/app/views/console/principal.html.erb
@@ -71,14 +71,36 @@
         </span>
       </label>
       <label class="flex items-start gap-3">
-        <%= hidden_field_tag :sandbox_api_server_enabled, "0" %>
-        <%= check_box_tag :sandbox_api_server_enabled,
+        <%= hidden_field_tag :sandbox_sessions_read_enabled, "0" %>
+        <%= check_box_tag :sandbox_sessions_read_enabled,
                           "1",
-                          @principal.sandbox_api_server_enabled,
+                          @principal.sandbox_sessions_read_enabled,
                           class: checkbox_class %>
         <span>
-          <span class="block text-sm font-medium text-zinc-100">API server</span>
-          <span class="block text-xs text-zinc-500">Allow sandbox access to the api-rs control plane.</span>
+          <span class="block text-sm font-medium text-zinc-100">Read sessions</span>
+          <span class="block text-xs text-zinc-500">Allow sandbox API tokens to read sessions and session events.</span>
+        </span>
+      </label>
+      <label class="flex items-start gap-3">
+        <%= hidden_field_tag :sandbox_workflows_read_enabled, "0" %>
+        <%= check_box_tag :sandbox_workflows_read_enabled,
+                          "1",
+                          @principal.sandbox_workflows_read_enabled,
+                          class: checkbox_class %>
+        <span>
+          <span class="block text-sm font-medium text-zinc-100">Read workflows</span>
+          <span class="block text-xs text-zinc-500">Allow sandbox API tokens to list workflow schedules and inspect runs.</span>
+        </span>
+      </label>
+      <label class="flex items-start gap-3">
+        <%= hidden_field_tag :sandbox_workflows_write_enabled, "0" %>
+        <%= check_box_tag :sandbox_workflows_write_enabled,
+                          "1",
+                          @principal.sandbox_workflows_write_enabled,
+                          class: checkbox_class %>
+        <span>
+          <span class="block text-sm font-medium text-zinc-100">Write workflows</span>
+          <span class="block text-xs text-zinc-500">Allow sandbox API tokens to create and cancel workflow runs.</span>
         </span>
       </label>
       <div>

--- a/services/console/app/views/console/system_settings/edit.html.erb
+++ b/services/console/app/views/console/system_settings/edit.html.erb
@@ -48,10 +48,26 @@
       </label>
 
       <label class="flex items-start gap-3 rounded border border-ink-700 bg-ink-850/60 p-4">
-        <%= form.check_box :default_sandbox_api_server_enabled, class: checkbox_class %>
+        <%= form.check_box :default_sandbox_sessions_read_enabled, class: checkbox_class %>
         <span>
-          <span class="block text-sm font-medium text-zinc-100">API server</span>
-          <span class="block text-xs text-zinc-500">Allow new sandboxes to call the api-rs control plane.</span>
+          <span class="block text-sm font-medium text-zinc-100">Read sessions</span>
+          <span class="block text-xs text-zinc-500">Allow new sandbox API tokens to read sessions and session events.</span>
+        </span>
+      </label>
+
+      <label class="flex items-start gap-3 rounded border border-ink-700 bg-ink-850/60 p-4">
+        <%= form.check_box :default_sandbox_workflows_read_enabled, class: checkbox_class %>
+        <span>
+          <span class="block text-sm font-medium text-zinc-100">Read workflows</span>
+          <span class="block text-xs text-zinc-500">Allow new sandbox API tokens to list workflow schedules and inspect runs.</span>
+        </span>
+      </label>
+
+      <label class="flex items-start gap-3 rounded border border-ink-700 bg-ink-850/60 p-4">
+        <%= form.check_box :default_sandbox_workflows_write_enabled, class: checkbox_class %>
+        <span>
+          <span class="block text-sm font-medium text-zinc-100">Write workflows</span>
+          <span class="block text-xs text-zinc-500">Allow new sandbox API tokens to create and cancel workflow runs.</span>
         </span>
       </label>
     </div>

--- a/services/console/db/migrate/20260814180000_add_api_jwt_capabilities_to_principals.rb
+++ b/services/console/db/migrate/20260814180000_add_api_jwt_capabilities_to_principals.rb
@@ -1,0 +1,29 @@
+class AddApiJwtCapabilitiesToPrincipals < ActiveRecord::Migration[8.1]
+  def change
+    add_column :principals, :sandbox_sessions_read_enabled, :boolean, null: false, default: false
+    add_column :principals, :sandbox_workflows_read_enabled, :boolean, null: false, default: false
+    add_column :principals, :sandbox_workflows_write_enabled, :boolean, null: false, default: false
+
+    reversible do |direction|
+      direction.up do
+        execute <<~SQL.squish
+          UPDATE principals
+          SET sandbox_sessions_read_enabled = sandbox_api_server_enabled
+        SQL
+      end
+    end
+
+    add_column :system_settings, :default_sandbox_sessions_read_enabled, :boolean, null: false, default: false
+    add_column :system_settings, :default_sandbox_workflows_read_enabled, :boolean, null: false, default: false
+    add_column :system_settings, :default_sandbox_workflows_write_enabled, :boolean, null: false, default: false
+
+    reversible do |direction|
+      direction.up do
+        execute <<~SQL.squish
+          UPDATE system_settings
+          SET default_sandbox_sessions_read_enabled = default_sandbox_api_server_enabled
+        SQL
+      end
+    end
+  end
+end

--- a/services/console/db/schema.rb
+++ b/services/console/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_13_212224) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_14_180000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_search"
@@ -308,6 +308,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_13_212224) do
     t.boolean "sandbox_api_server_enabled", default: true, null: false
     t.boolean "sandbox_observability_enabled", default: true, null: false
     t.string "sandbox_repo_cache", default: "all", null: false
+    t.boolean "sandbox_sessions_read_enabled", default: false, null: false
+    t.boolean "sandbox_workflows_read_enabled", default: false, null: false
+    t.boolean "sandbox_workflows_write_enabled", default: false, null: false
     t.string "slack_channel_id"
     t.string "slack_email"
     t.string "slack_team_id"
@@ -469,6 +472,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_13_212224) do
     t.boolean "default_sandbox_api_server_enabled", default: true, null: false
     t.boolean "default_sandbox_observability_enabled", default: true, null: false
     t.string "default_sandbox_repo_cache", default: "all", null: false
+    t.boolean "default_sandbox_sessions_read_enabled", default: false, null: false
+    t.boolean "default_sandbox_workflows_read_enabled", default: false, null: false
+    t.boolean "default_sandbox_workflows_write_enabled", default: false, null: false
     t.boolean "singleton", default: true, null: false
     t.datetime "updated_at", null: false
     t.index ["singleton"], name: "index_system_settings_on_singleton", unique: true

--- a/services/console/lib/api_server/jwt.rb
+++ b/services/console/lib/api_server/jwt.rb
@@ -23,6 +23,11 @@ module ApiServer
         now: now,
         claims: {
           "sub" => principal.oid,
+          "capabilities" => {
+            "sessions_read" => principal.sandbox_sessions_read_enabled,
+            "workflows_read" => principal.sandbox_workflows_read_enabled,
+            "workflows_write" => principal.sandbox_workflows_write_enabled
+          },
           "slack" => {
             "upload_channels" => upload_channels,
             "download_channels" => download_channels,

--- a/services/console/test/controllers/api/v1/principals_controller_test.rb
+++ b/services/console/test/controllers/api/v1/principals_controller_test.rb
@@ -54,7 +54,9 @@ module Api
         assert_equal "all", data["sandbox_repo_cache"]
         assert_not data.key?("sandbox_repo_cache_enabled")
         assert_equal true, data["sandbox_observability_enabled"]
-        assert_equal true, data["sandbox_api_server_enabled"]
+        assert_equal false, data["sandbox_sessions_read_enabled"]
+        assert_equal false, data["sandbox_workflows_read_enabled"]
+        assert_equal false, data["sandbox_workflows_write_enabled"]
       end
 
       test "GET returns 404 for an unknown oid" do
@@ -115,7 +117,9 @@ module Api
         assert_equal "all", data["sandbox_repo_cache"]
         assert_not data.key?("sandbox_repo_cache_enabled")
         assert_equal true, data["sandbox_observability_enabled"]
-        assert_equal true, data["sandbox_api_server_enabled"]
+        assert_equal false, data["sandbox_sessions_read_enabled"]
+        assert_equal false, data["sandbox_workflows_read_enabled"]
+        assert_equal false, data["sandbox_workflows_write_enabled"]
       end
 
       test "POST preserves a label named namespace" do
@@ -138,7 +142,9 @@ module Api
         system_settings(:default).update!(
           default_sandbox_repo_cache: "public",
           default_sandbox_observability_enabled: false,
-          default_sandbox_api_server_enabled: false
+          default_sandbox_sessions_read_enabled: true,
+          default_sandbox_workflows_read_enabled: true,
+          default_sandbox_workflows_write_enabled: true
         )
         body = {
           data: {
@@ -152,7 +158,9 @@ module Api
         data = json_body.fetch("data")
         assert_equal "public", data["sandbox_repo_cache"]
         assert_equal false, data["sandbox_observability_enabled"]
-        assert_equal false, data["sandbox_api_server_enabled"]
+        assert_equal true, data["sandbox_sessions_read_enabled"]
+        assert_equal true, data["sandbox_workflows_read_enabled"]
+        assert_equal true, data["sandbox_workflows_write_enabled"]
       end
 
       test "POST applies all configured default roles" do
@@ -173,14 +181,18 @@ module Api
         system_settings(:default).update!(
           default_sandbox_repo_cache: "none",
           default_sandbox_observability_enabled: false,
-          default_sandbox_api_server_enabled: false
+          default_sandbox_sessions_read_enabled: false,
+          default_sandbox_workflows_read_enabled: false,
+          default_sandbox_workflows_write_enabled: false
         )
         body = {
           data: {
             foreign_id: "U-explicit-capabilities",
             sandbox_repo_cache: "all",
             sandbox_observability_enabled: true,
-            sandbox_api_server_enabled: true
+            sandbox_sessions_read_enabled: true,
+            sandbox_workflows_read_enabled: true,
+            sandbox_workflows_write_enabled: true
           }
         }
 
@@ -190,7 +202,9 @@ module Api
         data = json_body.fetch("data")
         assert_equal "all", data["sandbox_repo_cache"]
         assert_equal true, data["sandbox_observability_enabled"]
-        assert_equal true, data["sandbox_api_server_enabled"]
+        assert_equal true, data["sandbox_sessions_read_enabled"]
+        assert_equal true, data["sandbox_workflows_read_enabled"]
+        assert_equal true, data["sandbox_workflows_write_enabled"]
       end
 
       test "POST overwrites explicit repo-cache label with system default" do
@@ -252,7 +266,9 @@ module Api
         principal.update!(
           sandbox_repo_cache: "none",
           sandbox_observability_enabled: false,
-          sandbox_api_server_enabled: false
+          sandbox_sessions_read_enabled: false,
+          sandbox_workflows_read_enabled: false,
+          sandbox_workflows_write_enabled: false
         )
         body = { data: { name: "Acme Slack channel" } }
 
@@ -263,7 +279,9 @@ module Api
         assert_equal "Acme Slack channel", principal.name
         assert_equal "none", principal.sandbox_repo_cache
         assert_equal false, principal.sandbox_observability_enabled
-        assert_equal false, principal.sandbox_api_server_enabled
+        assert_equal false, principal.sandbox_sessions_read_enabled
+        assert_equal false, principal.sandbox_workflows_read_enabled
+        assert_equal false, principal.sandbox_workflows_write_enabled
       end
 
       test "PUT updates sandbox access flags" do
@@ -272,7 +290,9 @@ module Api
           data: {
             sandbox_repo_cache: "public",
             sandbox_observability_enabled: false,
-            sandbox_api_server_enabled: false
+            sandbox_sessions_read_enabled: false,
+            sandbox_workflows_read_enabled: false,
+            sandbox_workflows_write_enabled: false
           }
         }
 
@@ -282,13 +302,17 @@ module Api
         principal.reload
         assert_equal "public", principal.sandbox_repo_cache
         assert_equal false, principal.sandbox_observability_enabled
-        assert_equal false, principal.sandbox_api_server_enabled
+        assert_equal false, principal.sandbox_sessions_read_enabled
+        assert_equal false, principal.sandbox_workflows_read_enabled
+        assert_equal false, principal.sandbox_workflows_write_enabled
 
         data = json_body.fetch("data")
         assert_equal "public", data["sandbox_repo_cache"]
         assert_not data.key?("sandbox_repo_cache_enabled")
         assert_equal false, data["sandbox_observability_enabled"]
-        assert_equal false, data["sandbox_api_server_enabled"]
+        assert_equal false, data["sandbox_sessions_read_enabled"]
+        assert_equal false, data["sandbox_workflows_read_enabled"]
+        assert_equal false, data["sandbox_workflows_write_enabled"]
       end
 
       test "POST returns 422 when foreign_id already exists" do
@@ -1001,7 +1025,9 @@ module Api
         system_settings(:default).update!(
           default_sandbox_repo_cache: "public",
           default_sandbox_observability_enabled: false,
-          default_sandbox_api_server_enabled: false
+          default_sandbox_sessions_read_enabled: false,
+          default_sandbox_workflows_read_enabled: false,
+          default_sandbox_workflows_write_enabled: false
         )
         body = { data: { name: "Upserted" } }
         assert_difference -> { Principal.count } => 1 do
@@ -1014,7 +1040,9 @@ module Api
         assert_equal "Upserted", data["name"]
         assert_equal "public", data["sandbox_repo_cache"]
         assert_equal false, data["sandbox_observability_enabled"]
-        assert_equal false, data["sandbox_api_server_enabled"]
+        assert_equal false, data["sandbox_sessions_read_enabled"]
+        assert_equal false, data["sandbox_workflows_read_enabled"]
+        assert_equal false, data["sandbox_workflows_write_enabled"]
       end
 
       test "PUT by foreign_id updates an existing principal without creating" do

--- a/services/console/test/controllers/api/v1/sandbox_permissions_controller_test.rb
+++ b/services/console/test/controllers/api/v1/sandbox_permissions_controller_test.rb
@@ -57,6 +57,9 @@ module Api
         assert_equal @proxy.principal.oid, data.fetch("principal_id")
         refute data.fetch("principal").key?("namespace")
         assert_equal @proxy.principal.sandbox_repo_cache, data.dig("capabilities", "sandbox_repo_cache")
+        assert_equal false, data.dig("capabilities", "sandbox_sessions_read_enabled")
+        assert_equal false, data.dig("capabilities", "sandbox_workflows_read_enabled")
+        assert_equal false, data.dig("capabilities", "sandbox_workflows_write_enabled")
         assert_equal 1, data.fetch("slack_channel_permissions").length
         assert_equal [
           {

--- a/services/console/test/controllers/console/principals_controller_test.rb
+++ b/services/console/test/controllers/console/principals_controller_test.rb
@@ -36,7 +36,9 @@ module Console
       system_settings(:default).update!(
         default_sandbox_repo_cache: "public",
         default_sandbox_observability_enabled: false,
-        default_sandbox_api_server_enabled: false
+        default_sandbox_sessions_read_enabled: false,
+        default_sandbox_workflows_read_enabled: false,
+        default_sandbox_workflows_write_enabled: false
       )
       Role.update_all(assign_by_default: false)
       roles(:acme_infra).update!(assign_by_default: true)
@@ -68,7 +70,9 @@ module Console
       )
       assert_equal "public", principal.sandbox_repo_cache
       assert_equal false, principal.sandbox_observability_enabled
-      assert_equal false, principal.sandbox_api_server_enabled
+      assert_equal false, principal.sandbox_sessions_read_enabled
+      assert_equal false, principal.sandbox_workflows_read_enabled
+      assert_equal false, principal.sandbox_workflows_write_enabled
       expected = [ roles(:acme_infra), roles(:globex_infra) ].sort_by(&:id)
       assert_equal expected, principal.roles.order(:id).to_a
       assert_equal @operator, principal.created_by
@@ -99,7 +103,9 @@ module Console
             params: {
               sandbox_repo_cache: "public",
               sandbox_observability_enabled: "0",
-              sandbox_api_server_enabled: "0"
+              sandbox_sessions_read_enabled: "0",
+              sandbox_workflows_read_enabled: "0",
+              sandbox_workflows_write_enabled: "0"
             }
 
       assert_redirected_to console_principal_path(principal.oid)
@@ -108,7 +114,9 @@ module Console
       assert_equal "public", principal.sandbox_repo_cache
       assert_equal "public", principal.labels[Principal::SANDBOX_REPO_CACHE_LABEL]
       assert_equal false, principal.sandbox_observability_enabled
-      assert_equal false, principal.sandbox_api_server_enabled
+      assert_equal false, principal.sandbox_sessions_read_enabled
+      assert_equal false, principal.sandbox_workflows_read_enabled
+      assert_equal false, principal.sandbox_workflows_write_enabled
     end
 
     test "update_slack_channel_permissions stores selected Slack channel permissions" do

--- a/services/console/test/controllers/console/system_settings_controller_test.rb
+++ b/services/console/test/controllers/console/system_settings_controller_test.rb
@@ -26,7 +26,9 @@ module Console
       assert_select ".console-control-tab-active", text: "Settings"
       assert_select "select[name='system_setting[default_sandbox_repo_cache]']"
       assert_select "input[name='system_setting[default_sandbox_observability_enabled]']"
-      assert_select "input[name='system_setting[default_sandbox_api_server_enabled]']"
+      assert_select "input[name='system_setting[default_sandbox_sessions_read_enabled]']"
+      assert_select "input[name='system_setting[default_sandbox_workflows_read_enabled]']"
+      assert_select "input[name='system_setting[default_sandbox_workflows_write_enabled]']"
       assert_select "input[name='system_setting[default_role_ids][]'][value=?]", roles(:acme_infra).id.to_s
     end
 
@@ -38,7 +40,9 @@ module Console
               system_setting: {
                 default_sandbox_repo_cache: "public",
                 default_sandbox_observability_enabled: "0",
-                default_sandbox_api_server_enabled: "0",
+                default_sandbox_sessions_read_enabled: "0",
+                default_sandbox_workflows_read_enabled: "0",
+                default_sandbox_workflows_write_enabled: "0",
                 default_role_ids: [ roles(:acme_infra).id, roles(:globex_infra).id ]
               }
             }
@@ -48,7 +52,9 @@ module Console
       settings = system_settings(:default).reload
       assert_equal "public", settings.default_sandbox_repo_cache
       assert_equal false, settings.default_sandbox_observability_enabled
-      assert_equal false, settings.default_sandbox_api_server_enabled
+      assert_equal false, settings.default_sandbox_sessions_read_enabled
+      assert_equal false, settings.default_sandbox_workflows_read_enabled
+      assert_equal false, settings.default_sandbox_workflows_write_enabled
       assert_predicate roles(:acme_infra).reload, :assign_by_default?
       assert_predicate roles(:globex_infra).reload, :assign_by_default?
       assert_not roles(:default_infra).reload.assign_by_default?

--- a/services/console/test/fixtures/system_settings.yml
+++ b/services/console/test/fixtures/system_settings.yml
@@ -2,4 +2,6 @@ default:
   singleton: true
   default_sandbox_repo_cache: all
   default_sandbox_observability_enabled: true
-  default_sandbox_api_server_enabled: true
+  default_sandbox_sessions_read_enabled: false
+  default_sandbox_workflows_read_enabled: false
+  default_sandbox_workflows_write_enabled: false

--- a/services/console/test/lib/api_server/jwt_test.rb
+++ b/services/console/test/lib/api_server/jwt_test.rb
@@ -1,6 +1,28 @@
 require "test_helper"
 
 class ApiServerJwtTest < ActiveSupport::TestCase
+  test "Principal token materializes sandbox API capabilities" do
+    principal = principals(:acme_channel)
+    principal.update!(
+      sandbox_sessions_read_enabled: false,
+      sandbox_workflows_read_enabled: true,
+      sandbox_workflows_write_enabled: true
+    )
+
+    with_env("CENTAUR_JWT_SIGNING_SECRET" => "test-secret") do
+      claims = CentaurJwt::Hs256.decode(
+        ApiServer::Jwt.encode_for_principal(principal),
+        signing_secret: "test-secret",
+        iss: ApiServer::Jwt::DEFAULT_ISSUER,
+        aud: ApiServer::Jwt::DEFAULT_AUDIENCE
+      )
+
+      assert_equal false, claims.dig("capabilities", "sessions_read")
+      assert_equal true, claims.dig("capabilities", "workflows_read")
+      assert_equal true, claims.dig("capabilities", "workflows_write")
+    end
+  end
+
   test "Console service token is purpose bound and short lived" do
     now = Time.current
 

--- a/services/console/test/models/principal_sync_config_snapshot_test.rb
+++ b/services/console/test/models/principal_sync_config_snapshot_test.rb
@@ -177,6 +177,9 @@ class PrincipalSyncConfigSnapshotTest < ActiveSupport::TestCase
       assert_equal "centaur-console", claims.fetch("iss")
       assert_equal "centaur-api", claims.fetch("aud")
       assert_equal principal.oid, claims.fetch("sub")
+      assert_equal false, claims.dig("capabilities", "sessions_read")
+      assert_equal false, claims.dig("capabilities", "workflows_read")
+      assert_equal false, claims.dig("capabilities", "workflows_write")
       assert_equal [ "C0123456789" ], claims.dig("slack", "upload_channels")
       assert_equal [ "G9876543210" ], claims.dig("slack", "download_channels")
       assert_equal [ "C0123456789" ], claims.dig("slack", "history_channels")
@@ -206,28 +209,6 @@ class PrincipalSyncConfigSnapshotTest < ActiveSupport::TestCase
       assert_empty claims.dig("slack", "upload_channels")
       assert_empty claims.dig("slack", "download_channels")
       assert_empty claims.dig("slack", "history_channels")
-    end
-  end
-
-  test "config_for omits api server JWT when sandbox api access is disabled" do
-    with_env("CENTAUR_JWT_SIGNING_SECRET" => "test-secret") do
-      principal = principals(:acme_channel)
-      principal.update!(
-        sandbox_api_server_enabled: false
-      )
-      SlackChannelPermission.create!(
-        principal: principal,
-        channel_id: "C0123456789",
-        upload_enabled: true
-      )
-
-      config = PrincipalSyncConfigSnapshot.config_for(principal)
-      entry = config.fetch("secrets").find do |secret|
-        secret.dig("inject", "header") == "Authorization" &&
-          secret.dig("source", "type") == "control_plane"
-      end
-
-      assert_nil entry
     end
   end
 
@@ -570,31 +551,6 @@ class PrincipalSyncConfigSnapshotTest < ActiveSupport::TestCase
         assert refreshed.fresh_for?(@principal)
         refute_equal original_token, refreshed_token
         refute_equal original_hash, proxy.reload.sync_config_snapshot.fetch(:config_hash)
-      end
-    end
-  end
-
-  test "fetch_for does not rebuild api server JWT snapshots when sandbox api access is disabled" do
-    with_env("CENTAUR_JWT_SIGNING_SECRET" => "test-secret") do
-      @principal.update!(
-        sandbox_api_server_enabled: false
-      )
-      SlackChannelPermission.create!(
-        principal: @principal,
-        channel_id: "C0123456789",
-        upload_enabled: true
-      )
-      boundary = 1_700_001_000 + ApiServer::Jwt.rotation_offset(@principal)
-      current_time = Time.zone.at(boundary + 60)
-      previous_window_time = Time.zone.at(boundary - 60)
-
-      snapshot = PrincipalSyncConfigSnapshot.fetch_for(@principal)
-      snapshot.update_columns(updated_at: previous_window_time)
-
-      travel_to current_time do
-        assert_no_changes -> { snapshot.reload.updated_at } do
-          assert_equal snapshot, PrincipalSyncConfigSnapshot.fetch_for(@principal)
-        end
       end
     end
   end

--- a/services/console/test/models/principal_test.rb
+++ b/services/console/test/models/principal_test.rb
@@ -181,13 +181,15 @@ class PrincipalTest < ActiveSupport::TestCase
     assert_equal({ Principal::SANDBOX_REPO_CACHE_LABEL => "all" }, principal.reload.labels)
   end
 
-  test "sandbox access defaults to enabled" do
+  test "API sandbox access defaults to disabled" do
     principal = Principal.create!(default_attrs(foreign_id: "C-default-sandbox-access"))
     principal.reload
 
     assert_equal "all", principal.sandbox_repo_cache
     assert_predicate principal, :sandbox_observability_enabled
-    assert_predicate principal, :sandbox_api_server_enabled
+    assert_not principal.sandbox_sessions_read_enabled
+    assert_not principal.sandbox_workflows_read_enabled
+    assert_not principal.sandbox_workflows_write_enabled
   end
 
   test "new principals with no roles receive all configured defaults" do
@@ -499,6 +501,19 @@ class PrincipalTest < ActiveSupport::TestCase
       slack_user_id: "U0123456789",
       slack_team_id: "T0123456789",
       slack_email: "a@example.com"
+    )
+
+    assert_equal previous_version + 1, principal.reload.sync_config_cache_version
+  end
+
+  test "API JWT capability changes invalidate the sync config cache" do
+    principal = principals(:acme_channel)
+    previous_version = principal.sync_config_cache_version
+
+    principal.update!(
+      sandbox_sessions_read_enabled: true,
+      sandbox_workflows_read_enabled: true,
+      sandbox_workflows_write_enabled: true
     )
 
     assert_equal previous_version + 1, principal.reload.sync_config_cache_version

--- a/services/console/test/models/system_setting_test.rb
+++ b/services/console/test/models/system_setting_test.rb
@@ -5,14 +5,16 @@ class SystemSettingTest < ActiveSupport::TestCase
     assert_equal system_settings(:default), SystemSetting.current
   end
 
-  test "defaults enable all sandbox capabilities" do
+  test "defaults API sandbox capabilities to disabled" do
     SystemSetting.destroy_all
 
     settings = SystemSetting.current
 
     assert_equal "all", settings.default_sandbox_repo_cache
     assert_equal true, settings.default_sandbox_observability_enabled
-    assert_equal true, settings.default_sandbox_api_server_enabled
+    assert_equal false, settings.default_sandbox_sessions_read_enabled
+    assert_equal false, settings.default_sandbox_workflows_read_enabled
+    assert_equal false, settings.default_sandbox_workflows_write_enabled
   end
 
   test "repo-cache setting is validated" do

--- a/services/sandbox/SYSTEM_PROMPT.md
+++ b/services/sandbox/SYSTEM_PROMPT.md
@@ -72,6 +72,12 @@
 |For your own active persona and overlay state specifically, prefer `$AGENT_PERSONA` or `$CENTAUR_PERSONA_ID` and `$CENTAUR_OVERLAY_DIR`. For the harness, prefer current session context, then the PID 1 command; use `$CENTAUR_HARNESS_TYPE` only when it is set.
 |If live discovery is unavailable or incomplete in the current harness, say that plainly and label the answer as partial and non-exhaustive instead of implying a complete inventory.
 
+[Sandbox API permissions]
+|Before using api-rs to read a session or its events, or to read, create, or cancel workflow runs, fetch the current sandbox permissions with `centaur-console permissions` and inspect its `capabilities` object.
+|Require `sandbox_sessions_read_enabled` for session and session-event reads, `sandbox_workflows_read_enabled` for workflow schedule and run reads, and `sandbox_workflows_write_enabled` for creating or canceling workflow runs. Workflow write access does not imply workflow read access.
+|Treat a false or missing capability as denied. Do not attempt the protected operation; tell the user which capability is unavailable.
+|If the permissions lookup fails, do not assume access. Say that the live sandbox permissions could not be verified and include the tool error briefly.
+
 [Named skill resolution]
 |When the user explicitly names a skill, resolve that request against local skill definitions before doing broad semantic matching.
 |Use `centaur-skills search "<task>"` to search Console-authored guidance when no skill already listed for the current session clearly applies. Read the best match by name or OID with `centaur-skills read <skill-identifier>` before following it. Console users can author shared skills with `centaur-skills create`, update skills they own or edit with `centaur-skills edit`, and manage editors on skills they own with `centaur-skills add-editor` and `centaur-skills remove-editor`.

--- a/services/sandbox/entrypoint.sh
+++ b/services/sandbox/entrypoint.sh
@@ -421,16 +421,6 @@ This sandbox does not have Centaur observability access. Do not use vlogs, vmetr
 EOF
 fi
 
-if [ "${CENTAUR_SANDBOX_API_SERVER_ENABLED:-true}" = "false" ] && [ -f "$TARGET_PROMPT" ]; then
-    cat >> "$TARGET_PROMPT" <<'EOF'
-
----
-
-[API server access]
-This sandbox does not have Centaur API server access. Do not use workflows or tool options that call the api-rs control plane, such as dispatching background agent sessions or downloading Centaur attachment handles.
-EOF
-fi
-
 # Persona prompt injection is done by the API when it writes AGENTS_BASE.md.
 
 # Switch to workspace so the harness reads workspace/AGENTS.md (with persona overlay)

--- a/services/sandbox/test_system_prompt.py
+++ b/services/sandbox/test_system_prompt.py
@@ -66,5 +66,17 @@ class SystemPromptTest(unittest.TestCase):
         self.assertIn("personal `provider_email`", prompt)
         self.assertIn("Centaur can use their personal connected account", prompt)
 
+    def test_sandbox_api_permission_guidance_is_present(self) -> None:
+        prompt = SYSTEM_PROMPT.read_text()
+
+        self.assertIn("[Sandbox API permissions]", prompt)
+        self.assertIn("fetch the current sandbox permissions with `centaur-console permissions`", prompt)
+        self.assertIn("`sandbox_sessions_read_enabled`", prompt)
+        self.assertIn("`sandbox_workflows_read_enabled`", prompt)
+        self.assertIn("`sandbox_workflows_write_enabled`", prompt)
+        self.assertIn("Workflow write access does not imply workflow read access", prompt)
+        self.assertIn("Treat a false or missing capability as denied", prompt)
+        self.assertIn("do not assume access", prompt)
+
 if __name__ == "__main__":
     unittest.main()

--- a/services/sandbox/test_system_prompt.py
+++ b/services/sandbox/test_system_prompt.py
@@ -66,17 +66,5 @@ class SystemPromptTest(unittest.TestCase):
         self.assertIn("personal `provider_email`", prompt)
         self.assertIn("Centaur can use their personal connected account", prompt)
 
-    def test_sandbox_api_permission_guidance_is_present(self) -> None:
-        prompt = SYSTEM_PROMPT.read_text()
-
-        self.assertIn("[Sandbox API permissions]", prompt)
-        self.assertIn("fetch the current sandbox permissions with `centaur-console permissions`", prompt)
-        self.assertIn("`sandbox_sessions_read_enabled`", prompt)
-        self.assertIn("`sandbox_workflows_read_enabled`", prompt)
-        self.assertIn("`sandbox_workflows_write_enabled`", prompt)
-        self.assertIn("Workflow write access does not imply workflow read access", prompt)
-        self.assertIn("Treat a false or missing capability as denied", prompt)
-        self.assertIn("do not assume access", prompt)
-
 if __name__ == "__main__":
     unittest.main()

--- a/tools/productivity/gsuite/client.py
+++ b/tools/productivity/gsuite/client.py
@@ -756,11 +756,6 @@ def _download_attachment_bytes(
     attachment_url: str | None = None,
 ) -> bytes:
     """Fetch bytes from Centaur's thread-scoped attachment API."""
-    if secret("CENTAUR_SANDBOX_API_SERVER_ENABLED", "true").strip().lower() == "false":
-        raise RuntimeError(
-            "Drive uploads from Centaur attachments require the API server sandbox capability, "
-            "but it is disabled for this principal."
-        )
     path = attachment_url
     if attachment_id:
         path = f"/agent/attachments/{attachment_id}/download"

--- a/tools/productivity/slack/client.py
+++ b/tools/productivity/slack/client.py
@@ -166,10 +166,6 @@ class SlackClient:
         except ValueError:
             return cls._DEFAULT_API_TIMEOUT_SECONDS
 
-    def _api_server_proxy_enabled(self) -> bool:
-        """Return whether the sandbox API-server proxy is enabled."""
-        return secret("CENTAUR_SANDBOX_API_SERVER_ENABLED", "true").strip().lower() != "false"
-
     def _clean_channel_ref(self, channel: str) -> str:
         """Normalize #name, ID, and <#ID|name> Slack channel references."""
         raw = str(channel).strip()
@@ -1207,12 +1203,6 @@ class SlackClient:
         Slack credentials. `channel_id` must be an explicit Slack conversation
         ID authorized by the principal's `slack.history_channels` claim.
         """
-        if not self._api_server_proxy_enabled():
-            raise RuntimeError(
-                "Slack channel history proxy requires the API server sandbox capability, "
-                "but it is disabled for this principal."
-            )
-
         normalized_channel_id = self._clean_channel_ref(channel_id).upper()
         if len(normalized_channel_id) < 9 or not self._looks_like_channel_id(normalized_channel_id):
             raise ValueError("channel_id must be a Slack conversation ID like C123456789")
@@ -1248,12 +1238,6 @@ class SlackClient:
         oldest: str | int | float | None = None,
     ) -> dict[str, Any]:
         """Fetch Slack thread replies through the Centaur API server."""
-        if not self._api_server_proxy_enabled():
-            raise RuntimeError(
-                "Slack thread replies require the API server sandbox capability, "
-                "but it is disabled for this principal."
-            )
-
         normalized_channel_id = self._normalize_explicit_channel_id(channel_id)
         normalized_thread_ts = self._normalize_ts(thread_ts)
         if normalized_thread_ts is None:
@@ -1507,12 +1491,6 @@ class SlackClient:
 
     def list_channels_proxy(self, limit: int = 200, history_only: bool = False) -> list[dict]:
         """List Slack channels exposed by the Centaur API server proxy JWT."""
-        if not self._api_server_proxy_enabled():
-            raise RuntimeError(
-                "Slack channel listing proxy requires the API server sandbox capability, "
-                "but it is disabled for this principal."
-            )
-
         response = self._centaur_api_get_json("/api/slack/channels", {})
         channels = response.get("channels", []) or []
         if history_only:
@@ -1546,12 +1524,6 @@ class SlackClient:
         This maps to Slack's `files.list` for channels authorized by the
         principal's `slack.download_channels` claim.
         """
-        if not self._api_server_proxy_enabled():
-            raise RuntimeError(
-                "Slack file listing proxy requires the API server sandbox capability, "
-                "but it is disabled for this principal."
-            )
-
         requested_limit: int | None = None
         if limit is not None:
             requested_limit = int(limit)
@@ -1573,12 +1545,6 @@ class SlackClient:
 
     def get_channel_members_proxy(self, channel_id: str, limit: int = 1000) -> list[dict]:
         """List Slack channel members through the Centaur API server proxy."""
-        if not self._api_server_proxy_enabled():
-            raise RuntimeError(
-                "Slack channel members proxy requires the API server sandbox capability, "
-                "but it is disabled for this principal."
-            )
-
         requested_limit = int(limit)
         if not 1 <= requested_limit <= 10_000:
             raise ValueError("limit must be between 1 and 10000")
@@ -2095,11 +2061,6 @@ class SlackClient:
         as base64, and the API server handles Slack credentials and channel
         authorization through the principal-scoped JWT.
         """
-        if not self._api_server_proxy_enabled():
-            raise RuntimeError(
-                "Slack file upload proxy requires the API server sandbox capability, "
-                "but it is disabled for this principal."
-            )
         normalized_channel_id = self._normalize_explicit_channel_id(channel_id)
         effective_filename = str(filename).strip()
         if not effective_filename:
@@ -2133,11 +2094,6 @@ class SlackClient:
 
         Returns base64-encoded file bytes plus filename, content type, and size.
         """
-        if not self._api_server_proxy_enabled():
-            raise RuntimeError(
-                "Slack file download proxy requires the API server sandbox capability, "
-                "but it is disabled for this principal."
-            )
         normalized_file_id = self._normalize_file_id(file_id)
         normalized_channel_id = self._normalize_explicit_channel_id(channel_id)
         body, headers = self._centaur_api_get_bytes(
@@ -2161,11 +2117,6 @@ class SlackClient:
 
     def file_info_proxy(self, file_id: str, channel_id: str) -> dict[str, Any]:
         """Fetch Slack file metadata through the Centaur API server proxy."""
-        if not self._api_server_proxy_enabled():
-            raise RuntimeError(
-                "Slack file info proxy requires the API server sandbox capability, "
-                "but it is disabled for this principal."
-            )
         normalized_file_id = self._normalize_file_id(file_id)
         normalized_channel_id = self._normalize_explicit_channel_id(channel_id)
         return self._centaur_api_get_json(
@@ -2341,11 +2292,6 @@ class SlackClient:
             List of file dicts with id, name, title, filetype, user, channels, permalink
         """
         requested_limit = max(1, int(max_results))
-        if not self._api_server_proxy_enabled():
-            raise RuntimeError(
-                "Slack file listing proxy requires the API server sandbox capability, "
-                "but it is disabled for this principal."
-            )
         results: list[dict] = []
         user_cache = self._get_user_cache()
         page_limit = self._MAX_SLACK_FILES_LIST_PAGE_SIZE

--- a/tools/productivity/slack/tests/test_client.py
+++ b/tools/productivity/slack/tests/test_client.py
@@ -854,11 +854,8 @@ def test_file_proxy_methods_validate_inputs() -> None:
         client.get_channel_members_proxy(channel_id="general")
 
 
-def test_search_files_uses_proxy_with_user_cache(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+def test_search_files_uses_proxy_with_user_cache() -> None:
     client, _ = _make_client()
-    monkeypatch.setenv("CENTAUR_SANDBOX_API_SERVER_ENABLED", "true")
     client._get_user_cache = lambda: {"U123456789": "alice"}  # type: ignore[method-assign]
 
     def fake_list_files_proxy(**kwargs):
@@ -912,16 +909,6 @@ def test_search_files_uses_proxy_with_user_cache(
             "created": 1700000000,
         }
     ]
-
-
-def test_search_files_raises_when_api_proxy_disabled(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    client, _ = _make_client()
-    monkeypatch.setenv("CENTAUR_SANDBOX_API_SERVER_ENABLED", "false")
-
-    with pytest.raises(RuntimeError, match="proxy requires"):
-        client.search_files("C123456789", "report", max_results=10)
 
 
 def test_search_files_paginates_proxy_until_enough_matches() -> None:
@@ -980,11 +967,8 @@ def test_search_files_paginates_proxy_until_enough_matches() -> None:
     assert [result["id"] for result in results] == ["F123456789"]
 
 
-def test_search_files_direct_uses_direct_files_list_when_api_proxy_enabled(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+def test_search_files_direct_uses_direct_files_list() -> None:
     client, fake_web_client = _make_client()
-    monkeypatch.setenv("CENTAUR_SANDBOX_API_SERVER_ENABLED", "true")
     client._get_user_cache = lambda: {"U123456789": "alice"}  # type: ignore[method-assign]
     client.list_files_proxy = pytest.fail  # type: ignore[method-assign]
     fake_web_client.files_list_pages = [


### PR DESCRIPTION
Adds per-principal session-read, workflow-read, and workflow-write capabilities to sandbox API JWTs and maps them to api-rs route authorization. It backfills session-read settings from the legacy API switch, defaults workflow access to disabled, removes the master-switch runtime gates, and restricts API NetworkPolicy access to iron-proxy pods. It also removes the redundant SlackProxy capability in favor of the principal caller class and handler-level Slack claims. The sandbox system prompt checks live permissions before attempting capability-controlled session or workflow operations.