### PR TITLE
fix(chart): give console worker Slack token

### DIFF
--- a/contrib/chart/Chart.yaml
+++ b/contrib/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: centaur
 description: Helm chart for the trusted Centaur control plane
 type: application
-version: 0.1.117
+version: 0.1.118
 appVersion: "0.1.0"
 dependencies:
   - name: connect

--- a/contrib/chart/templates/console-worker.yaml
+++ b/contrib/chart/templates/console-worker.yaml
@@ -90,6 +90,14 @@ spec:
                 secretKeyRef:
                   name: {{ $secretEnv }}
                   key: {{ printf "%sDATABASE_URL" $prefix }}
+            # Slack channel catalog refresh jobs run in this worker, so it
+            # needs the same bot token as the web Console process.
+            - name: CENTAUR_CONSOLE_SLACK_BOT_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secretEnv }}
+                  key: {{ printf "%sSLACK_BOT_TOKEN" $prefix }}
+                  optional: true
             - name: IRON_CONTROL_INITIAL_USER_EMAIL
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
## Summary
- inject `CENTAUR_CONSOLE_SLACK_BOT_TOKEN` into the Console Solid Queue worker
- allow asynchronous Slack channel catalog refresh jobs to populate the shared cache
- bump the Helm chart version to `0.1.118`

## Validation
- `git diff --check`
- Helm lint deferred to CI because Helm is unavailable in the sandbox

Prompted by: mslipper