### PR TITLE
feat: send capability-gated Slack app DMs

### DIFF
--- a/docs/pages/reference/configuration.mdx
+++ b/docs/pages/reference/configuration.mdx
@@ -117,7 +117,7 @@ created. Changing a default does not rewrite existing principals.
 | `apiRs.metrics.path` | Helm value, default `/metrics`. | Metrics scrape path for annotation-based discovery. |
 | `apiRs.metrics.annotations` | Helm value. | Additional scrape annotations for Prometheus-compatible collectors. |
 | `apiRs.activitySummary.*` | Helm values, default disabled. | Enables API-RS to summarize live session activity into durable `session.activity_summary` events. |
-| `SLACK_BOT_TOKEN` | Explicit `secretKeyRef` from `secretManager.existingSecretName`. | Slack Web API access for api-rs Slack proxy and workflow Slack helpers. |
+| `SLACK_BOT_TOKEN` | Explicit `secretKeyRef` from `secretManager.existingSecretName`. | Slack Web API access for api-rs Slack proxy, capability-gated app DMs, and workflow Slack helpers. Keep this server-side; sandbox callers use their API JWT instead. |
 | `OPENAI_API_KEY` | Secret mounted into api-rs, or `apiRs.extraEnv` for local/dev overrides. | OpenAI credential for activity summaries; the feature stays disabled when no key is present. |
 | `SESSION_ACTIVITY_SUMMARY_MODEL` | `apiRs.activitySummary.model`, default `gpt-5.4-nano`. | Model used for the short live activity sentence. |
 

--- a/docs/pages/reference/tool-directory.mdx
+++ b/docs/pages/reference/tool-directory.mdx
@@ -21,6 +21,12 @@ To inspect a specific tool's CLI:
 linear --help
 ```
 
+The Slack tool exposes two DM paths. `slack dm` uses the caller's injected Slack
+credential. `slack app-dm USER MESSAGE --idempotency-key KEY` sends as the
+deployment's Slack app through api-rs, adds verified requester attribution, and
+requires the principal's **Send Slack app DMs** capability. Use a stable key for
+the same workflow step so retries do not create duplicate messages.
+
 The `API key / credential` column uses the secret names declared by each tool's `[tool.centaur]` config. `None` means the base tool declares no required tool-specific credential; optional credentials are called out separately.
 
 ## Common out-of-box tools
@@ -31,7 +37,7 @@ These are broadly useful across most deployments and are good candidates to conf
 |---|---|---|
 | `linear` | Search, create, update, and comment on Linear issues, projects, cycles, teams, and labels | `LINEAR_API_KEY` |
 | `notion` | Search and update Notion pages, databases, blocks, and comments | `NOTION_API_KEY` |
-| `slack` | Search Slack, read threads, inspect channels/users, and send or upload messages | `SLACK_BOT_TOKEN`; optional: `SLACK_SEARCH_TOKEN`, `SLACK_ETL_TOKEN` |
+| `slack` | Search Slack, read threads, inspect channels/users, and send or upload messages | Optional: `SLACK_BOT_TOKEN`, `SLACK_SEARCH_TOKEN`, `SLACK_ETL_TOKEN` |
 | `gsuite` | Use Gmail, Calendar, Drive, Docs, Sheets, Slides, and Google Analytics | `GOOGLE_TOKEN_JSON` |
 | `websearch` | Free web search via Parallel and deep research | None; `PARALLEL_API_KEY` for `deep_research`; `ANTHROPIC_API_KEY` for search synthesis |
 | `company_context` | Search indexed company history, private Slack conversations, and Google Docs | None |
@@ -83,7 +89,7 @@ These are broadly useful across most deployments and are good candidates to conf
 | `linear` | Linear issues, projects, cycles, teams, workflow states, and labels | `LINEAR_API_KEY` |
 | `notion` | Notion pages, databases, blocks, comments, and users | `NOTION_API_KEY` |
 | `opentable` | Search OpenTable restaurant reservations | None |
-| `slack` | Slack messages, files, channels, threads, users, and usergroups | `SLACK_BOT_TOKEN`; optional: `SLACK_SEARCH_TOKEN`, `SLACK_ETL_TOKEN` |
+| `slack` | Slack messages, files, channels, threads, users, and usergroups | Optional: `SLACK_BOT_TOKEN`, `SLACK_SEARCH_TOKEN`, `SLACK_ETL_TOKEN` |
 
 ## Research
 

--- a/services/api-rs/crates/centaur-api-server/src/auth.rs
+++ b/services/api-rs/crates/centaur-api-server/src/auth.rs
@@ -20,6 +20,7 @@ const STATIC_ADMIN_IDENTITY: &str = "api-rs-admin";
 pub(crate) enum Capability {
     SessionsRead,
     SessionsWrite,
+    SlackAppDm,
     SandboxesDrain,
     WorkflowsRead,
     WorkflowsWrite,
@@ -29,9 +30,10 @@ pub(crate) enum Capability {
 }
 
 impl Capability {
-    const ALL: [Self; 8] = [
+    const ALL: [Self; 9] = [
         Self::SessionsRead,
         Self::SessionsWrite,
+        Self::SlackAppDm,
         Self::SandboxesDrain,
         Self::WorkflowsRead,
         Self::WorkflowsWrite,
@@ -67,6 +69,7 @@ pub(crate) struct AuthenticatedCaller {
     capabilities: BTreeSet<Capability>,
     platform_prefix: Option<&'static str>,
     principal_subject: Option<String>,
+    display_name: Option<String>,
 }
 
 impl AuthenticatedCaller {
@@ -88,6 +91,10 @@ impl AuthenticatedCaller {
 
     pub(crate) fn principal_subject(&self) -> Option<&str> {
         self.principal_subject.as_deref()
+    }
+
+    pub(crate) fn display_name(&self) -> Option<&str> {
+        self.display_name.as_deref()
     }
 }
 
@@ -248,6 +255,7 @@ impl ApiAuthConfig {
                     capabilities: Capability::ALL.into_iter().collect(),
                     platform_prefix: None,
                     principal_subject: None,
+                    display_name: None,
                 })
             }
             Some(ApiJwtTokenUse::ConsoleService) => Err(ApiError::Unauthorized(
@@ -266,6 +274,9 @@ impl ApiAuthConfig {
                         if jwt_capabilities.workflows_write {
                             capabilities.insert(Capability::WorkflowsWrite);
                         }
+                        if jwt_capabilities.slack_app_dm {
+                            capabilities.insert(Capability::SlackAppDm);
+                        }
                     }
                     // Tokens minted before capability claims were deployed had
                     // session read access. Preserve that access during rolling
@@ -280,6 +291,7 @@ impl ApiAuthConfig {
                     capabilities,
                     platform_prefix: None,
                     principal_subject: Some(subject),
+                    display_name: claims.actor_name.filter(|name| !name.trim().is_empty()),
                 })
             }
         }
@@ -299,6 +311,7 @@ struct ApiJwtClaims {
     sub: String,
     token_use: Option<ApiJwtTokenUse>,
     capabilities: Option<ApiJwtCapabilities>,
+    actor_name: Option<String>,
 }
 
 #[derive(Deserialize)]
@@ -309,6 +322,8 @@ struct ApiJwtCapabilities {
     workflows_read: bool,
     #[serde(default)]
     workflows_write: bool,
+    #[serde(default)]
+    slack_app_dm: bool,
 }
 
 #[derive(Deserialize)]
@@ -339,6 +354,7 @@ fn static_caller(
             capabilities: capabilities.into_iter().collect(),
             platform_prefix,
             principal_subject: None,
+            display_name: None,
         },
     }
 }
@@ -498,10 +514,12 @@ mod tests {
                 "aud": "centaur-api",
                 "iat": 1_700_000_000i64,
                 "exp": 4_102_444_800i64,
+                "actor_name": "Test Operator",
                 "capabilities": {
                     "sessions_read": false,
                     "workflows_read": true,
                     "workflows_write": true,
+                    "slack_app_dm": true,
                 },
             }),
             &EncodingKey::from_secret(b"jwt-secret"),
@@ -517,6 +535,8 @@ mod tests {
         assert!(!caller.has_capability(Capability::SessionsRead));
         assert!(caller.has_capability(Capability::WorkflowsRead));
         assert!(caller.has_capability(Capability::WorkflowsWrite));
+        assert!(caller.has_capability(Capability::SlackAppDm));
+        assert_eq!(caller.display_name(), Some("Test Operator"));
     }
 
     #[test]

--- a/services/api-rs/crates/centaur-api-server/src/lib.rs
+++ b/services/api-rs/crates/centaur-api-server/src/lib.rs
@@ -73,6 +73,10 @@ mod tests {
     }
 
     fn principal_token(subject: &str) -> String {
+        principal_token_with_slack_app_dm(subject, false)
+    }
+
+    fn principal_token_with_slack_app_dm(subject: &str, slack_app_dm: bool) -> String {
         encode(
             &Header::new(Algorithm::HS256),
             &json!({
@@ -84,7 +88,8 @@ mod tests {
                 "capabilities": {
                     "sessions_read": false,
                     "workflows_read": false,
-                    "workflows_write": false
+                    "workflows_write": false,
+                    "slack_app_dm": slack_app_dm
                 },
                 "slack": {
                     "upload_channels": [],
@@ -448,6 +453,31 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(write_response.status(), StatusCode::FORBIDDEN);
+
+        let app_dm_request = |token: &str| {
+            Request::builder()
+                .method(Method::POST)
+                .uri("/api/slack/app-dms")
+                .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(
+                    r#"{"user_id":"U12345678","text":"hello","idempotency_key":"run-1"}"#,
+                ))
+                .unwrap()
+        };
+        let denied_app_dm = build_router_with_app_state(AppState::unready(test_auth()))
+            .oneshot(app_dm_request(&principal))
+            .await
+            .unwrap();
+        assert_eq!(denied_app_dm.status(), StatusCode::FORBIDDEN);
+
+        let permitted = principal_token_with_slack_app_dm("prn_sandbox", true);
+        let permitted_app_dm = build_router_with_app_state(AppState::unready(test_auth()))
+            .oneshot(app_dm_request(&permitted))
+            .await
+            .unwrap();
+        assert_ne!(permitted_app_dm.status(), StatusCode::UNAUTHORIZED);
+        assert_ne!(permitted_app_dm.status(), StatusCode::FORBIDDEN);
 
         let slack_response = build_router_with_app_state(AppState::unready(test_auth()))
             .oneshot(

--- a/services/api-rs/crates/centaur-api-server/src/routes.rs
+++ b/services/api-rs/crates/centaur-api-server/src/routes.rs
@@ -559,6 +559,7 @@ fn route_access(method: &Method, route: &str) -> Option<RouteAccess> {
             capability(Capability::WorkflowsWrite)
         }
         (&Method::POST, "/api/workflows/events") => capability(Capability::WorkflowsEvents),
+        (&Method::POST, "/api/slack/app-dms") => capability(Capability::SlackAppDm),
         (&Method::POST, "/api/admin/slack/archive-imports/{import_id}/download-url") => {
             Some(RouteAccess::ArchiveDownload)
         }

--- a/services/api-rs/crates/centaur-api-server/src/slack_proxy.rs
+++ b/services/api-rs/crates/centaur-api-server/src/slack_proxy.rs
@@ -1,7 +1,7 @@
 use std::{collections::BTreeSet, sync::OnceLock, time::Duration};
 
 use axum::{
-    Json, Router,
+    Extension, Json, Router,
     body::Body,
     extract::{DefaultBodyLimit, Path, Query},
     http::{HeaderMap, HeaderValue, header},
@@ -14,6 +14,7 @@ use serde_json::{Value, json};
 use crate::{
     ApiError,
     api_jwt::{bearer_token, verify_console_jwt},
+    auth::AuthenticatedCaller,
     routes::{AppState, non_empty_env, positive_env_u64},
 };
 
@@ -21,6 +22,9 @@ const DEFAULT_SLACK_API_URL: &str = "https://slack.com/api";
 const DEFAULT_MAX_UPLOAD_BYTES: u64 = 100 * 1024 * 1024;
 const DEFAULT_SLACK_FILES_LIST_LIMIT: u16 = 100;
 const MAX_SLACK_FILES_LIST_LIMIT: u16 = 200;
+const MAX_SLACK_APP_DM_TEXT_CHARS: usize = 3_500;
+const SLACK_APP_DM_IDEMPOTENCY_NAMESPACE: uuid::Uuid =
+    uuid::Uuid::from_u128(0x3f69d9cc17174f5795b39eafeb5f02e0);
 const HTTP_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
 const HTTP_READ_TIMEOUT: Duration = Duration::from_secs(60);
 
@@ -37,6 +41,7 @@ fn http_client() -> &'static reqwest::Client {
 
 pub(crate) fn slack_proxy_router() -> Router<AppState> {
     Router::new()
+        .route("/api/slack/app-dms", post(send_slack_app_dm))
         .route("/api/slack/files", get(get_slack_files))
         .route(
             "/api/slack/files/upload",
@@ -125,6 +130,14 @@ struct SlackChannelMembersQuery {
 }
 
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct SlackAppDmRequest {
+    user_id: String,
+    text: String,
+    idempotency_key: String,
+}
+
+#[derive(Debug, Deserialize)]
 struct SlackFileProxyClaims {
     slack: SlackProxyClaims,
 }
@@ -185,6 +198,45 @@ struct SlackChannelItem {
     can_upload: bool,
     can_download: bool,
     can_read_history: bool,
+}
+
+#[derive(Debug, Serialize)]
+struct SlackAppDmResponse {
+    ok: bool,
+    channel: String,
+    ts: String,
+    requested_by: String,
+}
+
+async fn send_slack_app_dm(
+    Extension(caller): Extension<AuthenticatedCaller>,
+    Json(request): Json<SlackAppDmRequest>,
+) -> Result<Json<SlackAppDmResponse>, ApiError> {
+    validate_slack_user_id(&request.user_id)?;
+    validate_slack_app_dm_text(&request.text)?;
+    validate_idempotency_key(&request.idempotency_key)?;
+
+    let requested_by = caller
+        .display_name()
+        .unwrap_or_else(|| caller.identity())
+        .trim();
+    let text = attributed_slack_app_dm_text(&request.text, requested_by);
+    let client_msg_id = slack_app_dm_client_msg_id(caller.identity(), &request.idempotency_key);
+    let form = slack_app_dm_form(&request.user_id, &text, &client_msg_id);
+    let value = slack_api_post_form(
+        http_client(),
+        slack_proxy_config()?,
+        "chat.postMessage",
+        &form,
+    )
+    .await?;
+
+    Ok(Json(SlackAppDmResponse {
+        ok: true,
+        channel: required_slack_string(&value, "channel")?,
+        ts: required_slack_string(&value, "ts")?,
+        requested_by: requested_by.to_owned(),
+    }))
 }
 
 async fn upload_slack_file(
@@ -1030,6 +1082,75 @@ fn validate_slack_channel_id(channel_id: &str) -> Result<(), ApiError> {
     Err(ApiError::BadRequest("invalid Slack channel ID".to_owned()))
 }
 
+fn validate_slack_user_id(user_id: &str) -> Result<(), ApiError> {
+    if user_id.len() >= 9
+        && matches!(user_id.as_bytes().first(), Some(b'U' | b'W'))
+        && user_id
+            .bytes()
+            .all(|byte| byte.is_ascii_uppercase() || byte.is_ascii_digit())
+    {
+        return Ok(());
+    }
+    Err(ApiError::BadRequest("invalid Slack user ID".to_owned()))
+}
+
+fn validate_slack_app_dm_text(text: &str) -> Result<(), ApiError> {
+    let length = text.chars().count();
+    if text.trim().is_empty() || length > MAX_SLACK_APP_DM_TEXT_CHARS {
+        return Err(ApiError::BadRequest(format!(
+            "Slack app DM text must contain 1 to {MAX_SLACK_APP_DM_TEXT_CHARS} characters"
+        )));
+    }
+    Ok(())
+}
+
+fn validate_idempotency_key(key: &str) -> Result<(), ApiError> {
+    if key.is_empty() || key.len() > 256 || key.chars().any(|ch| ch.is_ascii_control()) {
+        return Err(ApiError::BadRequest("invalid idempotency_key".to_owned()));
+    }
+    Ok(())
+}
+
+fn attributed_slack_app_dm_text(text: &str, requested_by: &str) -> String {
+    let actor = requested_by
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+        .chars()
+        .take(100)
+        .collect::<String>();
+    let safe_actor = actor
+        .replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;");
+    format!(
+        "{}\n\n_(Triggered by {safe_actor} via Centaur)_",
+        text.trim_end()
+    )
+}
+
+fn slack_app_dm_client_msg_id(principal: &str, idempotency_key: &str) -> String {
+    uuid::Uuid::new_v5(
+        &SLACK_APP_DM_IDEMPOTENCY_NAMESPACE,
+        format!("{principal}\0{idempotency_key}").as_bytes(),
+    )
+    .to_string()
+}
+
+fn slack_app_dm_form(
+    user_id: &str,
+    text: &str,
+    client_msg_id: &str,
+) -> Vec<(&'static str, String)> {
+    vec![
+        ("channel", user_id.to_owned()),
+        ("text", text.to_owned()),
+        ("client_msg_id", client_msg_id.to_owned()),
+        ("unfurl_links", "false".to_owned()),
+        ("unfurl_media", "false".to_owned()),
+    ]
+}
+
 fn validate_slack_file_id(file_id: &str) -> Result<(), ApiError> {
     if file_id.len() >= 9
         && file_id.starts_with('F')
@@ -1587,6 +1708,46 @@ mod tests {
         assert!(channels.contains("D111111111"));
         assert!(channels.contains("C222222222"));
         assert!(channels.contains("G222222222"));
+    }
+
+    #[test]
+    fn app_dm_validates_and_attributes_message() {
+        validate_slack_user_id("U12345678").unwrap();
+        validate_slack_user_id("W12345678").unwrap();
+        for invalid in ["", "D12345678", "U123", "U1234abcd"] {
+            assert!(validate_slack_user_id(invalid).is_err());
+        }
+
+        validate_slack_app_dm_text("hello").unwrap();
+        assert!(validate_slack_app_dm_text("   ").is_err());
+        assert!(validate_slack_app_dm_text(&"x".repeat(3_501)).is_err());
+        assert!(validate_idempotency_key("workflow:run-1:step-2").is_ok());
+        assert!(validate_idempotency_key("bad\nkey").is_err());
+
+        assert_eq!(
+            attributed_slack_app_dm_text("hello\n", "A&B <admin>"),
+            "hello\n\n_(Triggered by A&amp;B &lt;admin&gt; via Centaur)_"
+        );
+    }
+
+    #[test]
+    fn app_dm_form_is_retry_safe_and_disables_unfurls() {
+        let first = slack_app_dm_client_msg_id("prn_test", "run-1:step-2");
+        let retry = slack_app_dm_client_msg_id("prn_test", "run-1:step-2");
+        let other = slack_app_dm_client_msg_id("prn_test", "run-1:step-3");
+        assert_eq!(first, retry);
+        assert_ne!(first, other);
+
+        assert_eq!(
+            slack_app_dm_form("U12345678", "hello", &first),
+            vec![
+                ("channel", "U12345678".to_owned()),
+                ("text", "hello".to_owned()),
+                ("client_msg_id", first),
+                ("unfurl_links", "false".to_owned()),
+                ("unfurl_media", "false".to_owned()),
+            ]
+        );
     }
 
     #[test]

--- a/services/api-rs/crates/centaur-workflows/src/lib.rs
+++ b/services/api-rs/crates/centaur-workflows/src/lib.rs
@@ -3802,6 +3802,7 @@ async fn post_python_slack_message(
         .ok_or_else(|| {
             WorkflowRuntimeError::BadRequest("ctx.post_to_slack requires channel".to_owned())
         })?;
+    reject_direct_message_target(channel)?;
     let text = message.get("text").and_then(Value::as_str).ok_or_else(|| {
         WorkflowRuntimeError::BadRequest("ctx.post_to_slack requires text".to_owned())
     })?;
@@ -3823,6 +3824,22 @@ async fn post_python_slack_message(
     let response = send_slack_message(&token, payload).await?;
     serde_json::to_value(slack_post_result_from_response(channel, response))
         .map_err(WorkflowRuntimeError::from)
+}
+
+fn reject_direct_message_target(channel: &str) -> Result<(), WorkflowRuntimeError> {
+    let target = channel.trim().to_ascii_uppercase();
+    let is_direct_target = target.len() >= 9
+        && matches!(target.as_bytes().first(), Some(b'D' | b'U' | b'W'))
+        && target
+            .bytes()
+            .all(|byte| byte.is_ascii_uppercase() || byte.is_ascii_digit());
+    if is_direct_target {
+        return Err(WorkflowRuntimeError::BadRequest(
+            "ctx.post_to_slack cannot send direct messages; use slack.send_app_dm so the principal permission and attribution are enforced"
+                .to_owned(),
+        ));
+    }
+    Ok(())
 }
 
 fn python_slack_message_payload(
@@ -4382,6 +4399,16 @@ mod tests {
         assert_eq!(payload["reply_broadcast"], json!(true));
         assert_eq!(payload["unfurl_links"], json!(true));
         assert_eq!(payload["unfurl_media"], json!(true));
+    }
+
+    #[test]
+    fn python_slack_rejects_direct_message_targets() {
+        for target in ["U12345678", "W12345678", "D12345678"] {
+            let error = reject_direct_message_target(target).unwrap_err();
+            assert!(error.to_string().contains("slack.send_app_dm"));
+        }
+        assert!(reject_direct_message_target("C12345678").is_ok());
+        assert!(reject_direct_message_target("eng-ai").is_ok());
     }
 
     #[test]

--- a/services/console/app/controllers/api/v1/principals_controller.rb
+++ b/services/console/app/controllers/api/v1/principals_controller.rb
@@ -89,6 +89,7 @@ module Api
           sandbox_sessions_read_enabled: principal.sandbox_sessions_read_enabled,
           sandbox_workflows_read_enabled: principal.sandbox_workflows_read_enabled,
           sandbox_workflows_write_enabled: principal.sandbox_workflows_write_enabled,
+          sandbox_slack_app_dm_enabled: principal.sandbox_slack_app_dm_enabled,
           created_at: principal.created_at,
           updated_at: principal.updated_at
         }
@@ -108,6 +109,7 @@ module Api
           :sandbox_sessions_read_enabled,
           :sandbox_workflows_read_enabled,
           :sandbox_workflows_write_enabled,
+          :sandbox_slack_app_dm_enabled,
           labels: {}
         )
       end

--- a/services/console/app/controllers/api/v1/sandbox/permissions_controller.rb
+++ b/services/console/app/controllers/api/v1/sandbox/permissions_controller.rb
@@ -47,7 +47,8 @@ module Api
             sandbox_observability_enabled: principal.sandbox_observability_enabled,
             sandbox_sessions_read_enabled: principal.sandbox_sessions_read_enabled,
             sandbox_workflows_read_enabled: principal.sandbox_workflows_read_enabled,
-            sandbox_workflows_write_enabled: principal.sandbox_workflows_write_enabled
+            sandbox_workflows_write_enabled: principal.sandbox_workflows_write_enabled,
+            sandbox_slack_app_dm_enabled: principal.sandbox_slack_app_dm_enabled
           }
         end
 

--- a/services/console/app/controllers/console/principals_controller.rb
+++ b/services/console/app/controllers/console/principals_controller.rb
@@ -40,7 +40,8 @@ module Console
         sandbox_observability_enabled: ActiveModel::Type::Boolean.new.cast(params[:sandbox_observability_enabled]),
         sandbox_sessions_read_enabled: ActiveModel::Type::Boolean.new.cast(params[:sandbox_sessions_read_enabled]),
         sandbox_workflows_read_enabled: ActiveModel::Type::Boolean.new.cast(params[:sandbox_workflows_read_enabled]),
-        sandbox_workflows_write_enabled: ActiveModel::Type::Boolean.new.cast(params[:sandbox_workflows_write_enabled])
+        sandbox_workflows_write_enabled: ActiveModel::Type::Boolean.new.cast(params[:sandbox_workflows_write_enabled]),
+        sandbox_slack_app_dm_enabled: ActiveModel::Type::Boolean.new.cast(params[:sandbox_slack_app_dm_enabled])
       )
       redirect_to console_principal_path(@principal.oid), notice: "Updated sandbox access."
     rescue ActiveRecord::RecordInvalid => e

--- a/services/console/app/controllers/console/system_settings_controller.rb
+++ b/services/console/app/controllers/console/system_settings_controller.rb
@@ -33,7 +33,8 @@ module Console
         :default_sandbox_observability_enabled,
         :default_sandbox_sessions_read_enabled,
         :default_sandbox_workflows_read_enabled,
-        :default_sandbox_workflows_write_enabled
+        :default_sandbox_workflows_write_enabled,
+        :default_sandbox_slack_app_dm_enabled
       )
     end
 

--- a/services/console/app/models/principal.rb
+++ b/services/console/app/models/principal.rb
@@ -145,6 +145,9 @@ class Principal < ApplicationRecord
     unless supplied_key?(supplied, :sandbox_workflows_write_enabled)
       self.sandbox_workflows_write_enabled = defaults[:sandbox_workflows_write_enabled]
     end
+    unless supplied_key?(supplied, :sandbox_slack_app_dm_enabled)
+      self.sandbox_slack_app_dm_enabled = defaults[:sandbox_slack_app_dm_enabled]
+    end
   end
 
   # Slackbot only sends a DM partner's email when that user belongs to the
@@ -371,7 +374,8 @@ class Principal < ApplicationRecord
   def sync_config_fields_changed?
     %w[
       name labels sandbox_sessions_read_enabled sandbox_workflows_read_enabled
-      sandbox_workflows_write_enabled kind slack_user_id slack_channel_id slack_team_id slack_email console_user_id
+      sandbox_workflows_write_enabled sandbox_slack_app_dm_enabled kind slack_user_id slack_channel_id slack_team_id
+      slack_email console_user_id
     ].any? do |field|
       previous_changes.key?(field)
     end

--- a/services/console/app/models/system_setting.rb
+++ b/services/console/app/models/system_setting.rb
@@ -9,6 +9,7 @@ class SystemSetting < ApplicationRecord
   validates :default_sandbox_sessions_read_enabled, inclusion: { in: [ true, false ] }
   validates :default_sandbox_workflows_read_enabled, inclusion: { in: [ true, false ] }
   validates :default_sandbox_workflows_write_enabled, inclusion: { in: [ true, false ] }
+  validates :default_sandbox_slack_app_dm_enabled, inclusion: { in: [ true, false ] }
 
   def self.current
     first || create!(singleton: true)
@@ -22,7 +23,8 @@ class SystemSetting < ApplicationRecord
       sandbox_observability_enabled: default_sandbox_observability_enabled,
       sandbox_sessions_read_enabled: default_sandbox_sessions_read_enabled,
       sandbox_workflows_read_enabled: default_sandbox_workflows_read_enabled,
-      sandbox_workflows_write_enabled: default_sandbox_workflows_write_enabled
+      sandbox_workflows_write_enabled: default_sandbox_workflows_write_enabled,
+      sandbox_slack_app_dm_enabled: default_sandbox_slack_app_dm_enabled
     }
   end
 

--- a/services/console/app/views/console/principal.html.erb
+++ b/services/console/app/views/console/principal.html.erb
@@ -103,6 +103,17 @@
           <span class="block text-xs text-zinc-500">Allow sandbox API tokens to create and cancel workflow runs.</span>
         </span>
       </label>
+      <label class="flex items-start gap-3">
+        <%= hidden_field_tag :sandbox_slack_app_dm_enabled, "0" %>
+        <%= check_box_tag :sandbox_slack_app_dm_enabled,
+                          "1",
+                          @principal.sandbox_slack_app_dm_enabled,
+                          class: checkbox_class %>
+        <span>
+          <span class="block text-sm font-medium text-zinc-100">Send Slack app DMs</span>
+          <span class="block text-xs text-zinc-500">Allow this principal to send attributed DMs as the Slack app.</span>
+        </span>
+      </label>
       <div>
         <%= submit_tag "Save sandbox access", class: "btn-primary" %>
       </div>

--- a/services/console/app/views/console/system_settings/edit.html.erb
+++ b/services/console/app/views/console/system_settings/edit.html.erb
@@ -70,6 +70,14 @@
           <span class="block text-xs text-zinc-500">Allow new sandbox API tokens to create and cancel workflow runs.</span>
         </span>
       </label>
+
+      <label class="flex items-start gap-3 rounded border border-ink-700 bg-ink-850/60 p-4">
+        <%= form.check_box :default_sandbox_slack_app_dm_enabled, class: checkbox_class %>
+        <span>
+          <span class="block text-sm font-medium text-zinc-100">Send Slack app DMs</span>
+          <span class="block text-xs text-zinc-500">Allow new principals to send attributed DMs as the Slack app.</span>
+        </span>
+      </label>
     </div>
   </section>
 

--- a/services/console/db/migrate/20260815180000_add_slack_app_dm_capability.rb
+++ b/services/console/db/migrate/20260815180000_add_slack_app_dm_capability.rb
@@ -1,0 +1,6 @@
+class AddSlackAppDmCapability < ActiveRecord::Migration[8.1]
+  def change
+    add_column :principals, :sandbox_slack_app_dm_enabled, :boolean, null: false, default: false
+    add_column :system_settings, :default_sandbox_slack_app_dm_enabled, :boolean, null: false, default: false
+  end
+end

--- a/services/console/db/schema.rb
+++ b/services/console/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_14_180000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_15_180000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_search"
@@ -309,6 +309,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_14_180000) do
     t.boolean "sandbox_observability_enabled", default: true, null: false
     t.string "sandbox_repo_cache", default: "all", null: false
     t.boolean "sandbox_sessions_read_enabled", default: false, null: false
+    t.boolean "sandbox_slack_app_dm_enabled", default: false, null: false
     t.boolean "sandbox_workflows_read_enabled", default: false, null: false
     t.boolean "sandbox_workflows_write_enabled", default: false, null: false
     t.string "slack_channel_id"
@@ -473,6 +474,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_14_180000) do
     t.boolean "default_sandbox_observability_enabled", default: true, null: false
     t.string "default_sandbox_repo_cache", default: "all", null: false
     t.boolean "default_sandbox_sessions_read_enabled", default: false, null: false
+    t.boolean "default_sandbox_slack_app_dm_enabled", default: false, null: false
     t.boolean "default_sandbox_workflows_read_enabled", default: false, null: false
     t.boolean "default_sandbox_workflows_write_enabled", default: false, null: false
     t.boolean "singleton", default: true, null: false
@@ -573,6 +575,4 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_14_180000) do
   add_foreign_key "thread_shares", "users", column: "created_by_id"
   add_foreign_key "user_identities", "users"
   add_foreign_key "users", "users", column: "approved_by_id"
-
-  add_bm25_index :skills, fields: { id: {}, name: {}, description: {}, content: {} }, key_field: :id, name: "index_skills_on_search_document"
 end

--- a/services/console/lib/api_server/jwt.rb
+++ b/services/console/lib/api_server/jwt.rb
@@ -23,10 +23,12 @@ module ApiServer
         now: now,
         claims: {
           "sub" => principal.oid,
+          "actor_name" => principal.name.presence || principal.foreign_id.presence || principal.oid,
           "capabilities" => {
             "sessions_read" => principal.sandbox_sessions_read_enabled,
             "workflows_read" => principal.sandbox_workflows_read_enabled,
-            "workflows_write" => principal.sandbox_workflows_write_enabled
+            "workflows_write" => principal.sandbox_workflows_write_enabled,
+            "slack_app_dm" => principal.sandbox_slack_app_dm_enabled
           },
           "slack" => {
             "upload_channels" => upload_channels,

--- a/services/console/test/controllers/api/v1/principals_controller_test.rb
+++ b/services/console/test/controllers/api/v1/principals_controller_test.rb
@@ -57,6 +57,7 @@ module Api
         assert_equal false, data["sandbox_sessions_read_enabled"]
         assert_equal false, data["sandbox_workflows_read_enabled"]
         assert_equal false, data["sandbox_workflows_write_enabled"]
+        assert_equal false, data["sandbox_slack_app_dm_enabled"]
       end
 
       test "GET returns 404 for an unknown oid" do
@@ -144,7 +145,8 @@ module Api
           default_sandbox_observability_enabled: false,
           default_sandbox_sessions_read_enabled: true,
           default_sandbox_workflows_read_enabled: true,
-          default_sandbox_workflows_write_enabled: true
+          default_sandbox_workflows_write_enabled: true,
+          default_sandbox_slack_app_dm_enabled: true
         )
         body = {
           data: {
@@ -161,6 +163,7 @@ module Api
         assert_equal true, data["sandbox_sessions_read_enabled"]
         assert_equal true, data["sandbox_workflows_read_enabled"]
         assert_equal true, data["sandbox_workflows_write_enabled"]
+        assert_equal true, data["sandbox_slack_app_dm_enabled"]
       end
 
       test "POST applies all configured default roles" do
@@ -183,7 +186,8 @@ module Api
           default_sandbox_observability_enabled: false,
           default_sandbox_sessions_read_enabled: false,
           default_sandbox_workflows_read_enabled: false,
-          default_sandbox_workflows_write_enabled: false
+          default_sandbox_workflows_write_enabled: false,
+          default_sandbox_slack_app_dm_enabled: false
         )
         body = {
           data: {
@@ -192,7 +196,8 @@ module Api
             sandbox_observability_enabled: true,
             sandbox_sessions_read_enabled: true,
             sandbox_workflows_read_enabled: true,
-            sandbox_workflows_write_enabled: true
+            sandbox_workflows_write_enabled: true,
+            sandbox_slack_app_dm_enabled: true
           }
         }
 
@@ -205,6 +210,7 @@ module Api
         assert_equal true, data["sandbox_sessions_read_enabled"]
         assert_equal true, data["sandbox_workflows_read_enabled"]
         assert_equal true, data["sandbox_workflows_write_enabled"]
+        assert_equal true, data["sandbox_slack_app_dm_enabled"]
       end
 
       test "POST overwrites explicit repo-cache label with system default" do

--- a/services/console/test/controllers/api/v1/sandbox_permissions_controller_test.rb
+++ b/services/console/test/controllers/api/v1/sandbox_permissions_controller_test.rb
@@ -60,6 +60,7 @@ module Api
         assert_equal false, data.dig("capabilities", "sandbox_sessions_read_enabled")
         assert_equal false, data.dig("capabilities", "sandbox_workflows_read_enabled")
         assert_equal false, data.dig("capabilities", "sandbox_workflows_write_enabled")
+        assert_equal false, data.dig("capabilities", "sandbox_slack_app_dm_enabled")
         assert_equal 1, data.fetch("slack_channel_permissions").length
         assert_equal [
           {

--- a/services/console/test/controllers/console/principals_controller_test.rb
+++ b/services/console/test/controllers/console/principals_controller_test.rb
@@ -38,7 +38,8 @@ module Console
         default_sandbox_observability_enabled: false,
         default_sandbox_sessions_read_enabled: false,
         default_sandbox_workflows_read_enabled: false,
-        default_sandbox_workflows_write_enabled: false
+        default_sandbox_workflows_write_enabled: false,
+        default_sandbox_slack_app_dm_enabled: false
       )
       Role.update_all(assign_by_default: false)
       roles(:acme_infra).update!(assign_by_default: true)
@@ -73,6 +74,7 @@ module Console
       assert_equal false, principal.sandbox_sessions_read_enabled
       assert_equal false, principal.sandbox_workflows_read_enabled
       assert_equal false, principal.sandbox_workflows_write_enabled
+      assert_equal false, principal.sandbox_slack_app_dm_enabled
       expected = [ roles(:acme_infra), roles(:globex_infra) ].sort_by(&:id)
       assert_equal expected, principal.roles.order(:id).to_a
       assert_equal @operator, principal.created_by
@@ -105,7 +107,8 @@ module Console
               sandbox_observability_enabled: "0",
               sandbox_sessions_read_enabled: "0",
               sandbox_workflows_read_enabled: "0",
-              sandbox_workflows_write_enabled: "0"
+              sandbox_workflows_write_enabled: "0",
+              sandbox_slack_app_dm_enabled: "1"
             }
 
       assert_redirected_to console_principal_path(principal.oid)
@@ -117,6 +120,7 @@ module Console
       assert_equal false, principal.sandbox_sessions_read_enabled
       assert_equal false, principal.sandbox_workflows_read_enabled
       assert_equal false, principal.sandbox_workflows_write_enabled
+      assert_equal true, principal.sandbox_slack_app_dm_enabled
     end
 
     test "update_slack_channel_permissions stores selected Slack channel permissions" do

--- a/services/console/test/controllers/console/system_settings_controller_test.rb
+++ b/services/console/test/controllers/console/system_settings_controller_test.rb
@@ -29,6 +29,7 @@ module Console
       assert_select "input[name='system_setting[default_sandbox_sessions_read_enabled]']"
       assert_select "input[name='system_setting[default_sandbox_workflows_read_enabled]']"
       assert_select "input[name='system_setting[default_sandbox_workflows_write_enabled]']"
+      assert_select "input[name='system_setting[default_sandbox_slack_app_dm_enabled]']"
       assert_select "input[name='system_setting[default_role_ids][]'][value=?]", roles(:acme_infra).id.to_s
     end
 
@@ -43,6 +44,7 @@ module Console
                 default_sandbox_sessions_read_enabled: "0",
                 default_sandbox_workflows_read_enabled: "0",
                 default_sandbox_workflows_write_enabled: "0",
+                default_sandbox_slack_app_dm_enabled: "1",
                 default_role_ids: [ roles(:acme_infra).id, roles(:globex_infra).id ]
               }
             }
@@ -55,6 +57,7 @@ module Console
       assert_equal false, settings.default_sandbox_sessions_read_enabled
       assert_equal false, settings.default_sandbox_workflows_read_enabled
       assert_equal false, settings.default_sandbox_workflows_write_enabled
+      assert_equal true, settings.default_sandbox_slack_app_dm_enabled
       assert_predicate roles(:acme_infra).reload, :assign_by_default?
       assert_predicate roles(:globex_infra).reload, :assign_by_default?
       assert_not roles(:default_infra).reload.assign_by_default?

--- a/services/console/test/fixtures/system_settings.yml
+++ b/services/console/test/fixtures/system_settings.yml
@@ -5,3 +5,4 @@ default:
   default_sandbox_sessions_read_enabled: false
   default_sandbox_workflows_read_enabled: false
   default_sandbox_workflows_write_enabled: false
+  default_sandbox_slack_app_dm_enabled: false

--- a/services/console/test/lib/api_server/jwt_test.rb
+++ b/services/console/test/lib/api_server/jwt_test.rb
@@ -6,7 +6,8 @@ class ApiServerJwtTest < ActiveSupport::TestCase
     principal.update!(
       sandbox_sessions_read_enabled: false,
       sandbox_workflows_read_enabled: true,
-      sandbox_workflows_write_enabled: true
+      sandbox_workflows_write_enabled: true,
+      sandbox_slack_app_dm_enabled: true
     )
 
     with_env("CENTAUR_JWT_SIGNING_SECRET" => "test-secret") do
@@ -20,6 +21,8 @@ class ApiServerJwtTest < ActiveSupport::TestCase
       assert_equal false, claims.dig("capabilities", "sessions_read")
       assert_equal true, claims.dig("capabilities", "workflows_read")
       assert_equal true, claims.dig("capabilities", "workflows_write")
+      assert_equal true, claims.dig("capabilities", "slack_app_dm")
+      assert_equal principal.foreign_id, claims.fetch("actor_name")
     end
   end
 

--- a/services/console/test/models/principal_test.rb
+++ b/services/console/test/models/principal_test.rb
@@ -190,6 +190,7 @@ class PrincipalTest < ActiveSupport::TestCase
     assert_not principal.sandbox_sessions_read_enabled
     assert_not principal.sandbox_workflows_read_enabled
     assert_not principal.sandbox_workflows_write_enabled
+    assert_not principal.sandbox_slack_app_dm_enabled
   end
 
   test "new principals with no roles receive all configured defaults" do

--- a/services/console/test/models/system_setting_test.rb
+++ b/services/console/test/models/system_setting_test.rb
@@ -15,6 +15,7 @@ class SystemSettingTest < ActiveSupport::TestCase
     assert_equal false, settings.default_sandbox_sessions_read_enabled
     assert_equal false, settings.default_sandbox_workflows_read_enabled
     assert_equal false, settings.default_sandbox_workflows_write_enabled
+    assert_equal false, settings.default_sandbox_slack_app_dm_enabled
   end
 
   test "repo-cache setting is validated" do

--- a/tools/productivity/slack/cli.py
+++ b/tools/productivity/slack/cli.py
@@ -103,6 +103,28 @@ def dm(
         raise typer.Exit(1)
 
 
+@app.command("app-dm")
+def app_dm(
+    user_id: str = typer.Argument(..., help="Slack user ID, e.g. U12345678"),
+    message: str = typer.Argument(..., help="Message text to send"),
+    idempotency_key: str = typer.Option(
+        ...,
+        "--idempotency-key",
+        help="Stable key used to prevent duplicate sends when a workflow retries",
+    ),
+):
+    """Send an attributed direct message as the Centaur Slack app."""
+    from .client import send_app_dm
+
+    try:
+        result = send_app_dm(user_id, message, idempotency_key)
+        console.print("[green]✓ App DM sent[/]")
+        console.print(f"[dim]{result['permalink']}[/]")
+    except (RuntimeError, ValueError) as e:
+        console.print(f"[red]Error: {e}[/]")
+        raise typer.Exit(1)
+
+
 @app.command()
 def search(
     query: str = typer.Argument(..., help="Text to search for (supports multiple terms)"),

--- a/tools/productivity/slack/client.py
+++ b/tools/productivity/slack/client.py
@@ -1873,6 +1873,32 @@ class SlackClient:
             unfurl_media=unfurl_media,
         )
 
+    def send_app_dm(self, user_id: str, text: str, idempotency_key: str) -> dict:
+        """Send an attributed DM as the Centaur Slack app via the API server."""
+        clean_user_id = self._clean_user_ref(user_id).upper()
+        if not self._looks_like_user_id(clean_user_id):
+            raise ValueError("user_id must be a Slack user ID such as U12345678")
+        if not str(idempotency_key).strip():
+            raise ValueError("idempotency_key is required")
+
+        payload = {
+            "user_id": clean_user_id,
+            "text": self._normalize_message_text(text),
+            "idempotency_key": str(idempotency_key),
+        }
+        result = self._centaur_api_post_bytes_json(
+            "/api/slack/app-dms",
+            {},
+            json.dumps(payload).encode("utf-8"),
+            "application/json",
+        )
+        channel = str(result.get("channel", ""))
+        timestamp = str(result.get("ts", ""))
+        result["permalink"] = (
+            f"https://slack.com/archives/{channel}/p{timestamp.replace('.', '')}"
+        )
+        return result
+
     @staticmethod
     def _preview_for_bytes(data: bytes, filename: str) -> dict[str, Any]:
         """Return cheap metadata that helps identify generated artifacts."""
@@ -2613,6 +2639,10 @@ def send_message(*args, **kwargs):
 
 def send_dm(*args, **kwargs):
     return _client().send_dm(*args, **kwargs)
+
+
+def send_app_dm(*args, **kwargs):
+    return _client().send_app_dm(*args, **kwargs)
 
 
 def upload_file(*args, **kwargs):

--- a/tools/productivity/slack/pyproject.toml
+++ b/tools/productivity/slack/pyproject.toml
@@ -27,10 +27,9 @@ packages = ["."]
 
 [tool.centaur]
 module = "client.py"
-secrets = [
-    {type = "http", name = "SLACK_BOT_TOKEN", match_headers = ["Authorization"], hosts = ["slack.com"]},
-]
+secrets = []
 optional_secrets = [
+    {type = "http", name = "SLACK_BOT_TOKEN", match_headers = ["Authorization"], hosts = ["slack.com"]},
     {type = "http", name = "SLACK_SEARCH_TOKEN", match_headers = ["Authorization"], hosts = ["slack.com"]},
     {type = "http", name = "SLACK_ETL_TOKEN", match_headers = ["Authorization"], hosts = ["slack.com", "files.slack.com"]},
 ]

--- a/tools/productivity/slack/tests/test_client.py
+++ b/tools/productivity/slack/tests/test_client.py
@@ -204,6 +204,55 @@ def test_send_dm_opens_dm_and_posts_message() -> None:
     assert fake_web_client.last_kwargs["unfurl_links"] is False
 
 
+def test_send_app_dm_calls_centaur_api(monkeypatch: pytest.MonkeyPatch) -> None:
+    import urllib.request
+
+    client, fake_web_client = _make_client()
+    request_info: dict[str, object] = {}
+
+    def fake_urlopen(req, *args, **kwargs):
+        request_info["url"] = req.full_url
+        request_info["authorization"] = req.get_header("Authorization")
+        request_info["content_type"] = req.get_header("Content-type")
+        request_info["body"] = json.loads(req.data.decode("utf-8"))
+        body = json.dumps(
+            {
+                "ok": True,
+                "channel": "D12345678",
+                "ts": "123.456",
+                "requested_by": "Vijith",
+            }
+        ).encode()
+        return _FakeHTTPResponse(body, "application/json")
+
+    monkeypatch.setenv("CENTAUR_API_URL", "http://api.internal:8080")
+    monkeypatch.setenv("CENTAUR_API_BEARER_TOKEN", "test-jwt")
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+
+    result = client.send_app_dm("<@u12345678>", "hello\\nworld", "workflow:run-1:step-2")
+
+    assert request_info == {
+        "url": "http://api.internal:8080/api/slack/app-dms",
+        "authorization": "Bearer test-jwt",
+        "content_type": "application/json",
+        "body": {
+            "user_id": "U12345678",
+            "text": "hello\nworld",
+            "idempotency_key": "workflow:run-1:step-2",
+        },
+    }
+    assert fake_web_client.last_kwargs is None
+    assert result["requested_by"] == "Vijith"
+    assert result["permalink"] == "https://slack.com/archives/D12345678/p123456"
+
+
+def test_send_app_dm_rejects_invalid_user_id() -> None:
+    client, _ = _make_client()
+
+    with pytest.raises(ValueError, match="Slack user ID"):
+        client.send_app_dm("#general", "hello", "run-1")
+
+
 def _restore_real_resolve_channel(client: SlackClient) -> None:
     client._resolve_channel = SlackClient._resolve_channel.__get__(client)  # type: ignore[method-assign]
 


### PR DESCRIPTION
## Summary

- add `POST /api/slack/app-dms`, which uses api-rs's server-side `SLACK_BOT_TOKEN` to DM a Slack user as the Centaur app
- add a false-by-default `slack_app_dm` principal capability across Console settings, API payloads, and signed sandbox JWTs
- expose `slack.send_app_dm(user_id, text, idempotency_key)` plus the `slack app-dm` CLI command
- append server-controlled `Triggered by ... via Centaur` attribution and use a deterministic Slack `client_msg_id` for retry safety
- prevent `ctx.post_to_slack` from targeting user or DM conversation IDs, so workflows cannot bypass the dedicated permission
- make the injected Slack credential optional so principals with only the app-DM capability can load and use the Slack tool

## Security model

- the bot token never enters the sandbox or response
- exact-route authorization requires the signed `slack_app_dm` capability
- the recipient must be a Slack `U...` or `W...` user ID; arbitrary channels and DM channel IDs are rejected
- text and idempotency keys are bounded and validated; unknown request fields are rejected
- attribution is derived from a signed Console claim, normalized, escaped, and appended by api-rs
- blocks and link/media unfurls are not caller-controlled

## Dependency

This is intentionally stacked on #1394, which introduces the per-principal sandbox JWT capability model. Retarget this PR to `main` after #1394 merges.

## Validation

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- Slack client tests: 56 passed
- focused Console model/JWT/controller tests: 160 passed
- `bundle exec rubocop`: 368 files, no offenses
- `bundle exec brakeman --quiet --no-pager --exit-on-warn --exit-on-error`: no warnings
- full Console suite: 1,517 passed; 3 existing ParadeDB search tests could not run against local PostgreSQL because the `pdb` schema is unavailable
