### PR TITLE
fix: exclude workflow sandboxes from session cleanup

### DIFF
--- a/services/api-rs/crates/centaur-sandbox-agent-k8s/src/lib.rs
+++ b/services/api-rs/crates/centaur-sandbox-agent-k8s/src/lib.rs
@@ -245,6 +245,7 @@ impl AgentSandboxBackend {
         let pod = self.get_pod(id).await?;
         let status = sandbox_status_from_pod(replicas, pod.as_ref());
         Ok(ObservedSandbox::new(id.clone(), BACKEND_NAME, status)
+            .with_labels(sandbox.metadata.labels.clone().unwrap_or_default())
             .with_created_at(sandbox_creation_time(sandbox))
             .with_suspended_since(sandbox_paused_at(sandbox)))
     }

--- a/services/api-rs/crates/centaur-sandbox-core/src/lifecycle.rs
+++ b/services/api-rs/crates/centaur-sandbox-core/src/lifecycle.rs
@@ -1,4 +1,4 @@
-use std::time::SystemTime;
+use std::{collections::BTreeMap, time::SystemTime};
 
 use serde::{Deserialize, Serialize};
 
@@ -98,6 +98,9 @@ pub struct ObservedSandbox {
     pub backend: String,
     /// Current portable lifecycle status.
     pub status: SandboxStatus,
+    /// Backend metadata used to scope lifecycle reconciliation to an owner.
+    #[serde(default)]
+    pub labels: BTreeMap<String, String>,
     /// Backend-owned diagnostic reason for the observed status.
     pub reason: Option<String>,
     /// When the backend created the sandbox, if the backend records it.
@@ -117,10 +120,16 @@ impl ObservedSandbox {
             id: id.into(),
             backend: backend.into(),
             status,
+            labels: BTreeMap::new(),
             reason: None,
             created_at: None,
             suspended_since: None,
         }
+    }
+
+    pub fn with_labels(mut self, labels: BTreeMap<String, String>) -> Self {
+        self.labels = labels;
+        self
     }
 
     pub fn with_created_at(mut self, created_at: Option<SystemTime>) -> Self {

--- a/services/api-rs/crates/centaur-sandbox-local/src/lib.rs
+++ b/services/api-rs/crates/centaur-sandbox-local/src/lib.rs
@@ -5,7 +5,7 @@
 //! the shared sandbox trait.
 
 use std::{
-    collections::HashMap,
+    collections::{BTreeMap, HashMap},
     process::Stdio,
     sync::{
         Arc,
@@ -40,6 +40,7 @@ struct LocalSandbox {
     stdout: Option<ChildStdout>,
     stderr: Option<ChildStderr>,
     status: SandboxStatus,
+    labels: BTreeMap<String, String>,
 }
 
 impl LocalSandboxBackend {
@@ -101,6 +102,7 @@ impl SandboxBackend for LocalSandboxBackend {
                 stdout,
                 stderr,
                 status: SandboxStatus::Running,
+                labels: spec.labels,
             })),
         );
 
@@ -146,11 +148,11 @@ impl SandboxBackend for LocalSandboxBackend {
     }
 
     async fn observe(&self, id: &SandboxId) -> SandboxResult<ObservedSandbox> {
-        Ok(ObservedSandbox::new(
-            id.clone(),
-            self.name(),
-            self.status(id).await?,
-        ))
+        let sandbox = self.sandbox(id).await?;
+        let mut sandbox = sandbox.lock().await;
+        let status = refresh_status(&mut sandbox).await?;
+        Ok(ObservedSandbox::new(id.clone(), self.name(), status)
+            .with_labels(sandbox.labels.clone()))
     }
 
     async fn list_observed(&self) -> SandboxResult<Vec<ObservedSandbox>> {
@@ -288,6 +290,25 @@ mod tests {
             .unwrap();
 
         assert_eq!(read, b"ping\n");
+        manager.stop(&handle.id).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn local_backend_preserves_observation_labels() {
+        let backend = Arc::new(LocalSandboxBackend::new());
+        let manager = SandboxManager::new(backend);
+        let spec = cat_spec().label("centaur.ai/component", "workflow-run");
+        let handle = manager.create_running(spec).await.unwrap();
+
+        let observed = manager.observe(&handle.id).await.unwrap();
+        assert_eq!(
+            observed
+                .labels
+                .get("centaur.ai/component")
+                .map(String::as_str),
+            Some("workflow-run")
+        );
+
         manager.stop(&handle.id).await.unwrap();
     }
 

--- a/services/api-rs/crates/centaur-session-runtime/src/cleanup.rs
+++ b/services/api-rs/crates/centaur-session-runtime/src/cleanup.rs
@@ -6,6 +6,9 @@ use tracing::{info, warn};
 
 use crate::{RuntimeContext, SessionRuntimeError, record_idle_pause};
 
+const COMPONENT_LABEL: &str = "centaur.ai/component";
+const WORKFLOW_RUN_COMPONENT: &str = "workflow-run";
+
 #[derive(Clone, Copy, Debug)]
 pub struct SessionSandboxCleanupConfig {
     /// How often to sweep. `None` disables the cleanup worker entirely.
@@ -171,6 +174,9 @@ fn orphan_reap_eligible(sandbox: &ObservedSandbox, referenced: &BTreeSet<String>
     if referenced.contains(sandbox.id.as_str()) {
         return false;
     }
+    if sandbox.labels.get(COMPONENT_LABEL).map(String::as_str) == Some(WORKFLOW_RUN_COMPONENT) {
+        return false;
+    }
     !matches!(
         sandbox.status,
         SandboxStatus::Created | SandboxStatus::Stopped | SandboxStatus::Gone
@@ -179,10 +185,19 @@ fn orphan_reap_eligible(sandbox: &ObservedSandbox, referenced: &BTreeSet<String>
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeMap;
+
     use super::*;
 
     fn observed(id: &str, status: SandboxStatus) -> ObservedSandbox {
         ObservedSandbox::new(SandboxId::new(id), "test", status)
+    }
+
+    fn workflow_observed(id: &str, status: SandboxStatus) -> ObservedSandbox {
+        ObservedSandbox::new(SandboxId::new(id), "test", status).with_labels(BTreeMap::from([(
+            COMPONENT_LABEL.to_owned(),
+            WORKFLOW_RUN_COMPONENT.to_owned(),
+        )]))
     }
 
     fn referenced(ids: &[&str]) -> BTreeSet<String> {
@@ -256,6 +271,20 @@ mod tests {
         assert_eq!(
             select_orphan_reap_candidates(&[], &referenced(&[]), &mut pending),
             Vec::<String>::new()
+        );
+        assert!(pending.is_empty());
+    }
+
+    #[test]
+    fn workflow_sandbox_is_not_owned_by_session_cleanup() {
+        let observed = [workflow_observed("asbx-workflow", SandboxStatus::Running)];
+        let mut pending = BTreeSet::new();
+
+        assert!(
+            select_orphan_reap_candidates(&observed, &referenced(&[]), &mut pending).is_empty()
+        );
+        assert!(
+            select_orphan_reap_candidates(&observed, &referenced(&[]), &mut pending).is_empty()
         );
         assert!(pending.is_empty());
     }


### PR DESCRIPTION
Session cleanup currently treats active workflow-run sandboxes as unreferenced because they are not owned by a session or warm-pool record. This change propagates existing sandbox labels into lifecycle observations and excludes sandboxes labeled `centaur.ai/component=workflow-run` from session orphan cleanup, while preserving cleanup behavior for other managed sandboxes.