### PR TITLE
feat: add optional Console Sentry reporting

### DIFF
--- a/contrib/chart/Chart.yaml
+++ b/contrib/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: centaur
 description: Helm chart for the trusted Centaur control plane
 type: application
-version: 0.1.118
+version: 0.1.119
 appVersion: "0.1.0"
 dependencies:
   - name: connect

--- a/contrib/chart/templates/console-worker.yaml
+++ b/contrib/chart/templates/console-worker.yaml
@@ -142,6 +142,10 @@ spec:
             - name: CENTAUR_CONSOLE_PUBLIC_URL
               value: {{ $console.publicUrl | quote }}
 {{- end }}
+{{- with $console.sentryDsn }}
+            - name: SENTRY_DSN
+              value: {{ . | quote }}
+{{- end }}
 {{- if $mcpPublicUrl }}
             - name: CENTAUR_MCP_PUBLIC_URL
               value: {{ $mcpPublicUrl | quote }}

--- a/contrib/chart/templates/console.yaml
+++ b/contrib/chart/templates/console.yaml
@@ -186,6 +186,10 @@ spec:
             - name: CENTAUR_CONSOLE_PUBLIC_URL
               value: {{ $console.publicUrl | quote }}
 {{- end }}
+{{- with $console.sentryDsn }}
+            - name: SENTRY_DSN
+              value: {{ . | quote }}
+{{- end }}
 {{- if $mcpPublicUrl }}
             - name: CENTAUR_MCP_PUBLIC_URL
               value: {{ $mcpPublicUrl | quote }}

--- a/contrib/chart/values.schema.json
+++ b/contrib/chart/values.schema.json
@@ -7,6 +7,7 @@
       "properties": {
         "replicaCount": { "type": "integer" },
         "publicUrl": { "type": "string" },
+        "sentryDsn": { "type": "string" },
         "railsEnv": { "type": "string" },
         "image": {
           "type": "object",

--- a/contrib/chart/values.yaml
+++ b/contrib/chart/values.yaml
@@ -107,6 +107,9 @@ console:
   # When set, the slackbotv2 deployment also links the first assistant message
   # in a Slack thread to the Console session view; leave empty to omit the link.
   publicUrl: ""
+  # Optional Sentry DSN for Console web requests and background jobs. Empty by
+  # default, so the Sentry SDK remains disabled unless explicitly configured.
+  sentryDsn: ""
   # Break-glass email/password login. Disable when console is reachable from
   # the public internet and SSO is configured.
   passwordLoginEnabled: true

--- a/services/console/Gemfile
+++ b/services/console/Gemfile
@@ -28,6 +28,8 @@ gem "stimulus-rails"
 gem "jbuilder"
 # Collapse multi-line request logs into a single JSON event [https://github.com/roidrage/lograge]
 gem "lograge"
+# Report unhandled Rails and background-job errors when SENTRY_DSN is configured.
+gem "sentry-rails", "~> 6.7"
 
 # Use Active Model has_secure_password [https://guides.rubyonrails.org/active_model_basics.html#securepassword]
 gem "bcrypt", "~> 3.1.7"

--- a/services/console/Gemfile
+++ b/services/console/Gemfile
@@ -29,6 +29,7 @@ gem "jbuilder"
 # Collapse multi-line request logs into a single JSON event [https://github.com/roidrage/lograge]
 gem "lograge"
 # Report unhandled Rails and background-job errors when SENTRY_DSN is configured.
+gem "sentry-ruby", "~> 6.7"
 gem "sentry-rails", "~> 6.7"
 
 # Use Active Model has_secure_password [https://guides.rubyonrails.org/active_model_basics.html#securepassword]

--- a/services/console/Gemfile.lock
+++ b/services/console/Gemfile.lock
@@ -320,6 +320,13 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 4.0)
       websocket (~> 1.0)
+    sentry-rails (6.7.0)
+      railties (>= 5.2.0)
+      sentry-ruby (~> 6.7.0)
+    sentry-ruby (6.7.0)
+      bigdecimal
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      logger
     simpleidn (0.2.3)
     solid_cable (4.0.2)
       actioncable (>= 7.2)
@@ -416,6 +423,7 @@ DEPENDENCIES
   rubocop-rails-omakase
   ruby-vips (~> 2.2)
   selenium-webdriver
+  sentry-rails (~> 6.7)
   solid_cable
   solid_cache
   solid_queue

--- a/services/console/Gemfile.lock
+++ b/services/console/Gemfile.lock
@@ -424,6 +424,7 @@ DEPENDENCIES
   ruby-vips (~> 2.2)
   selenium-webdriver
   sentry-rails (~> 6.7)
+  sentry-ruby (~> 6.7)
   solid_cable
   solid_cache
   solid_queue

--- a/services/console/config/initializers/sentry.rb
+++ b/services/console/config/initializers/sentry.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+if ENV["SENTRY_DSN"].present?
+  Sentry.init do |config|
+    config.breadcrumbs_logger = [ :active_support_logger ]
+    config.dsn = ENV.fetch("SENTRY_DSN")
+  end
+end


### PR DESCRIPTION
Adds the Sentry Rails SDK to Console and initializes it only when a DSN is present. Adds an optional `console.sentryDsn` Helm value that configures both the web and background-worker deployments while leaving Sentry disabled by default.