### PR TITLE
feat(console): add Slack channel autocomplete

### DIFF
--- a/services/console/app/controllers/concerns/console/slack_channel_permission_management.rb
+++ b/services/console/app/controllers/concerns/console/slack_channel_permission_management.rb
@@ -8,10 +8,7 @@ module Console
       @slack_channel_catalog = SlackChannelCatalogProvider.fetch
       @slack_channel_names = @slack_channel_catalog.channels.to_h { |channel| [ channel.id, channel.name ] }
       @slack_channel_permissions = owner.slack_channel_permissions.ordered
-      @slack_channel_options = @slack_channel_catalog.channels.map do |channel|
-        label = "##{channel.name} (#{channel.id}) #{channel.private ? "Private" : "Public"}"
-        [ label, channel.id ]
-      end
+      @slack_channel_options_url = slack_channel_options_url(owner)
     end
 
     def update_slack_channel_permissions_from_form(owner, path, preserve_api_managed_direct_messages: false)
@@ -84,6 +81,14 @@ module Console
       owner.slack_channel_permissions
            .select { |permission| permission.channel_id.to_s.start_with?("D") }
            .map(&:as_permission_json)
+    end
+
+    def slack_channel_options_url(owner)
+      case owner
+      when Principal then console_principal_slack_channel_options_path(owner.oid)
+      when Role then slack_channel_options_console_role_path(owner.oid)
+      else raise ArgumentError, "unsupported Slack channel permission owner"
+      end
     end
   end
 end

--- a/services/console/app/controllers/console/slack_channel_options_controller.rb
+++ b/services/console/app/controllers/console/slack_channel_options_controller.rb
@@ -1,0 +1,38 @@
+module Console
+  class SlackChannelOptionsController < ApplicationController
+    MAX_RESULTS = 20
+
+    before_action :require_admin
+
+    def index
+      response.headers["Cache-Control"] = "no-store"
+      owner = find_owner
+      result = SlackChannelCatalogProvider.search(
+        query: params[:q],
+        limit: MAX_RESULTS,
+        exclude_ids: owner.slack_channel_permissions.pluck(:channel_id)
+      )
+
+      render json: {
+        options: result.channels.map do |channel|
+          {
+            value: channel.id,
+            label: "##{channel.name}",
+            description: "#{channel.id} · #{channel.private ? "Private" : "Public"}"
+          }
+        end,
+        error: result.error
+      }
+    end
+
+    private
+
+    def find_owner
+      case params[:owner_type]
+      when "principal" then Principal.find_by_oid!(params[:id])
+      when "role" then Role.find_by_oid!(params[:id])
+      else raise ActiveRecord::RecordNotFound
+      end
+    end
+  end
+end

--- a/services/console/app/javascript/controllers/slack_channel_autocomplete_controller.js
+++ b/services/console/app/javascript/controllers/slack_channel_autocomplete_controller.js
@@ -152,7 +152,9 @@ export default class extends Controller {
   }
 
   updateSubmitState() {
-    this.submitTarget.disabled = this.valueTarget.value.trim() === ""
+    const hasInput = this.inputTarget.value.trim() !== ""
+    const hasChannelId = this.valueTarget.value.trim() !== ""
+    this.submitTarget.disabled = hasInput && !hasChannelId
   }
 
   resultStatus() {

--- a/services/console/app/javascript/controllers/slack_channel_autocomplete_controller.js
+++ b/services/console/app/javascript/controllers/slack_channel_autocomplete_controller.js
@@ -1,0 +1,180 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["input", "value", "list", "status", "submit"]
+  static values = { url: String }
+
+  connect() {
+    this.options = []
+    this.activeIndex = -1
+    this.opened = false
+    this.selectedDisplay = null
+    this.updateSubmitState()
+  }
+
+  disconnect() {
+    clearTimeout(this.searchTimer)
+    clearTimeout(this.blurTimer)
+    this.abortController?.abort()
+  }
+
+  open() {
+    clearTimeout(this.blurTimer)
+    this.opened = true
+    if (this.inputTarget.value === this.selectedDisplay) this.inputTarget.select()
+    this.search()
+  }
+
+  input() {
+    this.selectedDisplay = null
+    this.opened = true
+    this.syncManualChannelId()
+    clearTimeout(this.searchTimer)
+    this.searchTimer = setTimeout(() => this.search(), 200)
+  }
+
+  keydown(event) {
+    if (event.key === "ArrowDown") {
+      event.preventDefault()
+      this.moveActive(1)
+    } else if (event.key === "ArrowUp") {
+      event.preventDefault()
+      this.moveActive(-1)
+    } else if (event.key === "Enter" && this.activeIndex >= 0) {
+      event.preventDefault()
+      this.select(this.options[this.activeIndex])
+    } else if (event.key === "Escape") {
+      this.hide()
+    }
+  }
+
+  blur() {
+    this.blurTimer = setTimeout(() => {
+      this.opened = false
+      this.hide()
+    }, 150)
+  }
+
+  async search() {
+    this.abortController?.abort()
+    this.abortController = new AbortController()
+
+    const preservingSelection = this.inputTarget.value === this.selectedDisplay
+    if (!preservingSelection) this.setStatus("Loading channels…")
+
+    const query = preservingSelection ? "" : this.inputTarget.value.trim()
+    this.currentQuery = query
+    const url = new URL(this.urlValue, window.location.origin)
+    url.searchParams.set("q", query)
+
+    try {
+      const response = await fetch(url, {
+        credentials: "same-origin",
+        headers: { "Accept": "application/json" },
+        signal: this.abortController.signal,
+      })
+      const body = await response.json().catch(() => ({}))
+      if (!response.ok) throw new Error(body.error || `Request failed with HTTP ${response.status}`)
+
+      this.options = body.options || []
+      this.renderOptions()
+      if (body.error) {
+        this.setStatus(body.error)
+      } else if (!preservingSelection) {
+        this.setStatus(this.resultStatus())
+      }
+    } catch (error) {
+      if (error.name === "AbortError") return
+      this.options = []
+      this.renderOptions()
+      this.setStatus(error.message || "Could not load Slack channels.", true)
+    }
+  }
+
+  renderOptions() {
+    this.listTarget.replaceChildren()
+    this.activeIndex = -1
+
+    this.options.forEach((option, index) => {
+      const button = document.createElement("button")
+      button.type = "button"
+      button.id = `${this.listTarget.id}_option_${index}`
+      button.className = "block min-h-11 w-full px-3 py-2 text-left transition-colors hover:bg-centaur-500/[0.08] focus:bg-centaur-500/[0.08] focus:outline-none"
+      button.setAttribute("role", "option")
+      button.setAttribute("aria-selected", "false")
+      button.addEventListener("pointerdown", (event) => event.preventDefault())
+      button.addEventListener("click", () => this.select(option))
+
+      const label = document.createElement("div")
+      label.className = "text-sm text-zinc-100"
+      label.textContent = option.label
+      const description = document.createElement("div")
+      description.className = "mt-0.5 text-xs text-zinc-500"
+      description.textContent = option.description
+      button.append(label, description)
+      this.listTarget.append(button)
+    })
+
+    const visible = this.opened && this.options.length > 0
+    this.listTarget.hidden = !visible
+    this.inputTarget.setAttribute("aria-expanded", String(visible))
+  }
+
+  moveActive(delta) {
+    if (this.options.length === 0) return
+    this.activeIndex = (this.activeIndex + delta + this.options.length) % this.options.length
+
+    Array.from(this.listTarget.children).forEach((element, index) => {
+      const active = index === this.activeIndex
+      element.setAttribute("aria-selected", String(active))
+      element.classList.toggle("bg-centaur-500/[0.08]", active)
+      if (active) {
+        this.inputTarget.setAttribute("aria-activedescendant", element.id)
+        element.scrollIntoView({ block: "nearest" })
+      }
+    })
+  }
+
+  select(option) {
+    this.inputTarget.value = `${option.label} (${option.value})`
+    this.valueTarget.value = option.value
+    this.selectedDisplay = this.inputTarget.value
+    this.updateSubmitState()
+    this.setStatus(`Selected ${option.label}.`)
+    this.opened = false
+    this.hide()
+  }
+
+  syncManualChannelId() {
+    const value = this.inputTarget.value.trim().toUpperCase()
+    this.valueTarget.value = /^[CDG][A-Z0-9]{8,}$/.test(value) ? value : ""
+    this.updateSubmitState()
+  }
+
+  updateSubmitState() {
+    this.submitTarget.disabled = this.valueTarget.value.trim() === ""
+  }
+
+  resultStatus() {
+    if (this.options.length === 0) return "No matching channels. You can enter a channel ID directly."
+    if (this.options.length === 20) {
+      return this.currentQuery === ""
+        ? "Showing the first 20 channels. Type to search all channels."
+        : "Showing the first 20 matching channels. Keep typing to narrow the results."
+    }
+    return `${this.options.length} matching channel${this.options.length === 1 ? "" : "s"}.`
+  }
+
+  setStatus(message, error = false) {
+    this.statusTarget.textContent = message
+    this.statusTarget.classList.toggle("text-red-300", error)
+    this.statusTarget.classList.toggle("text-zinc-500", !error)
+  }
+
+  hide() {
+    this.listTarget.hidden = true
+    this.inputTarget.setAttribute("aria-expanded", "false")
+    this.inputTarget.removeAttribute("aria-activedescendant")
+    this.activeIndex = -1
+  }
+}

--- a/services/console/app/services/slack_channel_catalog_provider.rb
+++ b/services/console/app/services/slack_channel_catalog_provider.rb
@@ -18,6 +18,24 @@ class SlackChannelCatalogProvider
       payload ? deserialize_result(payload) : loading_result
     end
 
+    def search(query:, limit:, exclude_ids: [])
+      result = fetch
+      excluded = Array(exclude_ids).index_with(true)
+      needle = query.to_s.strip.downcase
+      channels = result.channels.reject { |channel| excluded.key?(channel.id) }
+      if needle.present?
+        channels = channels.select do |channel|
+          channel.name.downcase.include?(needle) || channel.id.downcase.include?(needle)
+        end
+      end
+
+      SlackChannelCatalog::Result.new(
+        channels: channels.first(limit),
+        error: result.error,
+        configured: result.configured
+      )
+    end
+
     def refresh(cache_key:)
       config = configuration
       return unless config && cache_key == self.cache_key(**config)

--- a/services/console/app/views/console/shared/_slack_channel_permissions.html.erb
+++ b/services/console/app/views/console/shared/_slack_channel_permissions.html.erb
@@ -152,11 +152,7 @@
         <div class="px-5 pb-5">
           <%= submit_tag "Save Slack channel permissions",
                          class: "btn-primary disabled:cursor-not-allowed disabled:opacity-50",
-                         disabled: true,
                          data: { slack_channel_autocomplete_target: "submit" } %>
-          <noscript>
-            <%= submit_tag "Save Slack channel permissions", class: "btn-primary" %>
-          </noscript>
         </div>
       </div>
     <% end %>

--- a/services/console/app/views/console/shared/_slack_channel_permissions.html.erb
+++ b/services/console/app/views/console/shared/_slack_channel_permissions.html.erb
@@ -3,14 +3,14 @@
 <% inherited_permissions = local_assigns.fetch(:inherited_permissions, []) %>
 <% api_managed_direct_messages = local_assigns.fetch(:api_managed_direct_messages, false) %>
 <% checkbox_class = "mt-1 h-4 w-4 rounded border-ink-500 bg-ink-800 text-centaur-500 focus:ring-centaur-500" %>
-<% channel_options = @slack_channel_options || [] %>
 <% permissions = @slack_channel_permissions || [] %>
+<% picker_id = dom_id(owner, :slack_channel_picker) %>
 
 <section class="mb-8">
   <div class="mb-4">
     <h2 class="mb-1 text-xs font-semibold uppercase tracking-wider text-zinc-500">Slack Channel Permissions</h2>
   </div>
-  <div class="console-panel">
+  <div class="console-panel overflow-visible">
     <%= form_with model: owner,
                   url: url,
                   method: :patch,
@@ -99,30 +99,65 @@
       <% end %>
 
       <% new_permission = SlackChannelPermission.new(SlackChannelPermission::DEFAULT_ENABLED_ATTRIBUTES) %>
-      <%= form.fields_for :slack_channel_permissions, new_permission do |permission_fields| %>
-        <div class="grid gap-4 border-t border-ink-700 p-5 lg:grid-cols-[minmax(0,1fr)_auto_auto_auto]">
-          <label class="block">
-            <span class="form-label">Add Channel</span>
-            <% if channel_options.any? %>
-              <%= permission_fields.select :channel_id,
-                                           options_for_select([ [ "Select a Slack channel", "" ] ] + channel_options),
-                                           {},
-                                           class: "form-input" %>
-            <% else %>
-              <%= permission_fields.text_field :channel_id, class: "form-input", placeholder: "C0123456789" %>
-            <% end %>
-          </label>
-          <% SlackChannelPermission::PERMISSION_FLAGS.each do |flag| %>
-            <label class="flex items-start gap-3 pt-6">
-              <%= permission_fields.check_box flag.fetch(:attribute), class: checkbox_class %>
-              <span class="text-sm font-medium text-zinc-100"><%= flag.fetch(:label) %></span>
+      <div data-controller="slack-channel-autocomplete"
+           data-slack-channel-autocomplete-url-value="<%= @slack_channel_options_url %>">
+        <%= form.fields_for :slack_channel_permissions, new_permission do |permission_fields| %>
+          <div class="grid gap-4 border-t border-ink-700 p-5 lg:grid-cols-[minmax(0,1fr)_auto_auto_auto]">
+            <label class="block">
+              <span class="form-label">Add Channel</span>
+              <div class="relative">
+                <%= permission_fields.hidden_field :channel_id,
+                                                    data: { slack_channel_autocomplete_target: "value" } %>
+                <%= text_field_tag nil,
+                                   nil,
+                                   id: picker_id,
+                                   class: "form-input",
+                                   placeholder: "Search channels or enter an ID",
+                                   autocomplete: "off",
+                                   role: "combobox",
+                                   aria: {
+                                     autocomplete: "list",
+                                     controls: "#{picker_id}_listbox",
+                                     expanded: "false"
+                                   },
+                                   data: {
+                                     slack_channel_autocomplete_target: "input",
+                                     action: "focus->slack-channel-autocomplete#open input->slack-channel-autocomplete#input keydown->slack-channel-autocomplete#keydown blur->slack-channel-autocomplete#blur"
+                                   } %>
+                <div id="<%= picker_id %>_listbox"
+                     class="absolute z-20 mt-1 max-h-72 w-full overflow-y-auto rounded border border-ink-500 bg-ink-900 shadow-lg"
+                     role="listbox"
+                     hidden
+                     data-slack-channel-autocomplete-target="list"></div>
+                <div class="mt-1 min-h-5 text-xs text-zinc-500"
+                     role="status"
+                     aria-live="polite"
+                     data-slack-channel-autocomplete-target="status"></div>
+                <noscript>
+                  <%= permission_fields.text_field :channel_id,
+                                                   class: "form-input mt-2",
+                                                   placeholder: "C0123456789" %>
+                </noscript>
+              </div>
             </label>
-          <% end %>
-        </div>
-      <% end %>
+            <% SlackChannelPermission::PERMISSION_FLAGS.each do |flag| %>
+              <label class="flex items-start gap-3 pt-6">
+                <%= permission_fields.check_box flag.fetch(:attribute), class: checkbox_class %>
+                <span class="text-sm font-medium text-zinc-100"><%= flag.fetch(:label) %></span>
+              </label>
+            <% end %>
+          </div>
+        <% end %>
 
-      <div class="px-5 pb-5">
-        <%= submit_tag "Save Slack channel permissions", class: "btn-primary" %>
+        <div class="px-5 pb-5">
+          <%= submit_tag "Save Slack channel permissions",
+                         class: "btn-primary disabled:cursor-not-allowed disabled:opacity-50",
+                         disabled: true,
+                         data: { slack_channel_autocomplete_target: "submit" } %>
+          <noscript>
+            <%= submit_tag "Save Slack channel permissions", class: "btn-primary" %>
+          </noscript>
+        </div>
       </div>
     <% end %>
 

--- a/services/console/config/routes.rb
+++ b/services/console/config/routes.rb
@@ -74,6 +74,8 @@ Rails.application.routes.draw do
   namespace :console do
     resources :roles, only: %i[index show new create edit update] do
       member do
+        get "slack_channel_options", to: "slack_channel_options#index",
+            defaults: { owner_type: "role" }, as: :slack_channel_options
         post "grants", to: "roles#grant_secret", as: :grant_secret
         delete "grants/:grant_id", to: "roles#revoke_grant", as: :revoke_grant
         patch "slack_channel_permissions", to: "roles#update_slack_channel_permissions",
@@ -88,6 +90,8 @@ Rails.application.routes.draw do
   # and avoid clobbering the console_principal_path helper.
   namespace :console do
     delete "principals/:id",                  to: "principals#destroy", as: :delete_principal
+    get    "principals/:id/slack_channel_options", to: "slack_channel_options#index",
+           defaults: { owner_type: "principal" }, as: :principal_slack_channel_options
     patch  "principals/:id/sandbox_access",   to: "principals#update_sandbox_access", as: :principal_sandbox_access
     patch  "principals/:id/slack_channel_permissions", to: "principals#update_slack_channel_permissions", as: :principal_slack_channel_permissions
     post   "principals/:id/roles",            to: "principals#assign_role",   as: :principal_assign_role

--- a/services/console/test/controllers/console/slack_channel_options_controller_test.rb
+++ b/services/console/test/controllers/console/slack_channel_options_controller_test.rb
@@ -1,0 +1,69 @@
+require "test_helper"
+
+module Console
+  class SlackChannelOptionsControllerTest < ActionDispatch::IntegrationTest
+    setup do
+      @operator = users(:acme_admin)
+      post login_url, params: { email: @operator.email, password: "password123456" }
+    end
+
+    test "principal options return bounded catalog matches and exclude existing permissions" do
+      principal = principals(:acme_channel)
+      existing = principal.slack_channel_permissions.create!(channel_id: "C0123456789", upload_enabled: true)
+      captured = nil
+      result = SlackChannelCatalog::Result.new(
+        channels: [ SlackChannelCatalog::Channel.new(id: "C1111111111", name: "engineering", private: false) ],
+        error: nil,
+        configured: true
+      )
+
+      search = lambda do |**args|
+        captured = args
+        result
+      end
+      SlackChannelCatalogProvider.stub(:search, search) do
+        get console_principal_slack_channel_options_url(principal.oid), params: { q: "eng" }
+      end
+
+      assert_response :ok
+      assert_equal "no-store", response.headers.fetch("Cache-Control")
+      assert_equal "eng", captured.fetch(:query)
+      assert_equal 20, captured.fetch(:limit)
+      assert_includes captured.fetch(:exclude_ids), existing.channel_id
+      assert_equal(
+        {
+          "options" => [
+            {
+              "value" => "C1111111111",
+              "label" => "#engineering",
+              "description" => "C1111111111 · Public"
+            }
+          ],
+          "error" => nil
+        },
+        response.parsed_body
+      )
+    end
+
+    test "role options use the same lookup endpoint" do
+      role = roles(:acme_infra)
+      result = SlackChannelCatalog::Result.new(channels: [], error: nil, configured: true)
+
+      SlackChannelCatalogProvider.stub(:search, result) do
+        get slack_channel_options_console_role_url(role.oid)
+      end
+
+      assert_response :ok
+      assert_equal [], response.parsed_body.fetch("options")
+    end
+
+    test "non-admins cannot search the catalog" do
+      delete logout_url
+      post login_url, params: { email: users(:member_user).email, password: "password123456" }
+
+      get console_principal_slack_channel_options_url(principals(:acme_channel).oid)
+
+      assert_redirected_to console_threads_path
+    end
+  end
+end

--- a/services/console/test/controllers/console_controller_test.rb
+++ b/services/console/test/controllers/console_controller_test.rb
@@ -284,7 +284,7 @@ class ConsoleControllerTest < ActionDispatch::IntegrationTest
     assert_select "input[role=combobox][aria-controls]"
     assert_select "[data-slack-channel-autocomplete-url-value=?]",
                   console_principal_slack_channel_options_path(principal.oid)
-    assert_select "input[type=submit][data-slack-channel-autocomplete-target=submit][disabled]",
+    assert_select "input[type=submit][data-slack-channel-autocomplete-target=submit]:not([disabled])",
                   value: "Save Slack channel permissions"
     assert_select "select[name$='[channel_id]']", count: 0
     assert_select "body", text: /#unused/, count: 0

--- a/services/console/test/controllers/console_controller_test.rb
+++ b/services/console/test/controllers/console_controller_test.rb
@@ -267,7 +267,8 @@ class ConsoleControllerTest < ActionDispatch::IntegrationTest
     catalog = SlackChannelCatalog::Result.new(
       channels: [
         SlackChannelCatalog::Channel.new(id: "C0123456789", name: "general", private: false),
-        SlackChannelCatalog::Channel.new(id: "G9876543210", name: "private", private: true)
+        SlackChannelCatalog::Channel.new(id: "G9876543210", name: "private", private: true),
+        SlackChannelCatalog::Channel.new(id: "C1111111111", name: "unused", private: false)
       ],
       error: nil,
       configured: true
@@ -280,6 +281,13 @@ class ConsoleControllerTest < ActionDispatch::IntegrationTest
     assert_select "h3", text: "Inherited From Roles"
     assert_select "td", text: /#private/
     assert_select "input[type=checkbox][disabled]", minimum: 3
+    assert_select "input[role=combobox][aria-controls]"
+    assert_select "[data-slack-channel-autocomplete-url-value=?]",
+                  console_principal_slack_channel_options_path(principal.oid)
+    assert_select "input[type=submit][data-slack-channel-autocomplete-target=submit][disabled]",
+                  value: "Save Slack channel permissions"
+    assert_select "select[name$='[channel_id]']", count: 0
+    assert_select "body", text: /#unused/, count: 0
   end
 
   test "credentials table combines id, shows status, and links to detail" do

--- a/services/console/test/services/slack_channel_catalog_provider_test.rb
+++ b/services/console/test/services/slack_channel_catalog_provider_test.rb
@@ -149,6 +149,28 @@ class SlackChannelCatalogProviderTest < ActiveJob::TestCase
     end
   end
 
+  test "search returns bounded matches and excludes assigned channels" do
+    result = SlackChannelCatalog::Result.new(
+      channels: [
+        SlackChannelCatalog::Channel.new(id: "C000000001", name: "engineering", private: false),
+        SlackChannelCatalog::Channel.new(id: "C000000002", name: "engineering-private", private: true),
+        SlackChannelCatalog::Channel.new(id: "C000000003", name: "general", private: false)
+      ],
+      error: nil,
+      configured: true
+    )
+
+    SlackChannelCatalogProvider.stub(:fetch, result) do
+      matches = SlackChannelCatalogProvider.search(
+        query: "ENGINEER",
+        limit: 1,
+        exclude_ids: [ "C000000001" ]
+      )
+
+      assert_equal [ "C000000002" ], matches.channels.map(&:id)
+    end
+  end
+
   private
 
   def with_catalog_env(&)


### PR DESCRIPTION
## Summary

- replace the full Slack channel selector on principal and role detail pages with a server-backed typeahead
- return at most 20 cached catalog matches while excluding channels already assigned to the owner
- support keyboard navigation, direct channel ID entry, accessible status text, and selection-aware save state

## Why

PR #1345 removed synchronous Slack API work from detail-page requests, but the page still rendered the complete cached channel catalog into its HTML. That makes the assignment control increasingly expensive and difficult to use as a workspace grows.

This follow-up keeps the cached catalog provider introduced by #1345, searches that snapshot through a bounded JSON endpoint, and only renders matching options when the operator opens or types into the control.

## User impact

Operators can search channels by name or ID on both principal and role detail pages. The first 20 channels are shown initially, typing searches the full cached catalog, and a valid direct channel ID remains available as a fallback. The save action stays disabled until the control contains a selected or valid channel ID.

## Validation

- `bundle exec rails test` — 1,524 runs, 6,065 assertions, 0 failures, 34 skips
- `bundle exec rubocop` — 365 files, no offenses
- `bundle exec brakeman --quiet --no-pager --exit-on-warn --exit-on-error` — 0 warnings
- `bundle exec rails tailwindcss:build` — successful
- browser verification — page rendered without an error overlay; disabled, valid-ID, and cleared save states behaved correctly
- local 1,000-channel fixture — bounded initial results, full-catalog search, keyboard selection, exclusion, and dropdown behavior verified
