### PR TITLE
fix: preserve unchanged Slack message timestamps

### DIFF
--- a/workflows/slack/shared.py
+++ b/workflows/slack/shared.py
@@ -447,7 +447,9 @@ _MESSAGE_UPSERT_SQL = (
     "raw_payload = EXCLUDED.raw_payload, "
     "source_run_id = EXCLUDED.source_run_id, "
     "last_seen_at = NOW(), "
-    "updated_at = NOW()"
+    "updated_at = CASE WHEN slack_sync_messages.raw_payload "
+    "IS DISTINCT FROM EXCLUDED.raw_payload "
+    "THEN NOW() ELSE slack_sync_messages.updated_at END"
 )
 
 

--- a/workflows/slack/tests/test_shared_attachments.py
+++ b/workflows/slack/tests/test_shared_attachments.py
@@ -891,6 +891,15 @@ def test_upsert_messages_batches_writes_in_one_executemany():
     assert message_calls[0][1][1][0:2] == ("C123", "1770000000.000400")
 
 
+def test_message_upsert_only_updates_timestamp_when_content_changes():
+    assert (
+        "updated_at = CASE WHEN slack_sync_messages.raw_payload "
+        "IS DISTINCT FROM EXCLUDED.raw_payload "
+        "THEN NOW() ELSE slack_sync_messages.updated_at END"
+        in shared._MESSAGE_UPSERT_SQL
+    )
+
+
 def test_upsert_messages_dedupes_duplicate_message_keys_last_row_wins():
     conn = FakeConn()
     pool = FakePool(conn)


### PR DESCRIPTION
Preserves a Slack message's existing updated_at when its normalized raw payload has not changed. Sync bookkeeping still refreshes source_run_id and last_seen_at, while actual payload changes continue to advance updated_at.