### PR TITLE
fix(slack): use MCP user token for message search

### DIFF
--- a/services/console/app/controllers/oauth/flows_controller.rb
+++ b/services/console/app/controllers/oauth/flows_controller.rb
@@ -43,12 +43,13 @@ module Oauth
       unless @app.scopes_allowed?(requested_scopes)
         return render_result(:error, status: :unprocessable_entity, message: "One or more requested scopes are not allowed for this integration.")
       end
+      consent_scopes = requested_scopes | provider_required_scopes
 
       nonce = SecureRandom.urlsafe_base64(32)
       code_verifier = SecureRandom.urlsafe_base64(64)
 
       state = Rails.application.message_verifier(STATE_PURPOSE).generate(
-        { "app" => @app.oid, "scopes" => requested_scopes, "nonce" => nonce },
+        { "app" => @app.oid, "scopes" => consent_scopes, "nonce" => nonce },
         purpose: STATE_PURPOSE, expires_in: FLOW_TTL
       )
 
@@ -59,7 +60,7 @@ module Oauth
         expires: FLOW_TTL.from_now, httponly: true, same_site: :lax
       }
 
-      redirect_to authorization_url(requested_scopes, state, code_verifier), allow_other_host: true
+      redirect_to authorization_url(consent_scopes, state, code_verifier), allow_other_host: true
     end
 
     # GET /oauth/:slug/callback?code=&state=  (or ?error=)
@@ -143,6 +144,12 @@ module Oauth
       uri = URI.parse(@provider.authorization_endpoint)
       uri.query = URI.encode_www_form(query)
       uri.to_s
+    end
+
+    def provider_required_scopes
+      return [] unless @provider.respond_to?(:required_scopes)
+
+      Array(@provider.required_scopes)
     end
 
     def exchange_code(code, code_verifier)

--- a/services/console/app/models/oauth_app.rb
+++ b/services/console/app/models/oauth_app.rb
@@ -49,6 +49,18 @@ class OauthApp < ApplicationRecord
   # True when every requested scope is within the allowlist.
   def scopes_allowed?(requested) = (Array(requested) - Array(allowed_scopes)).empty?
 
+  # Provider-level scopes are capabilities Centaur itself requires, independent
+  # of the operator-selectable allowlist. A credential minted before one was
+  # introduced must be re-consented before it can satisfy the current contract.
+  def required_scopes
+    strategy = provider_strategy
+    strategy.respond_to?(:required_scopes) ? Array(strategy.required_scopes) : []
+  end
+
+  def credential_needs_reconnect?(credential)
+    credential.dead? || (required_scopes - Array(credential.scopes)).any?
+  end
+
   private
 
   def slug_does_not_shadow_oid

--- a/services/console/app/views/console/integrations/index.html.erb
+++ b/services/console/app/views/console/integrations/index.html.erb
@@ -30,10 +30,11 @@
         <div class="mt-auto flex items-center justify-between gap-3 pt-1">
           <% credential = @credentials_by_app_id[app.id] %>
           <% if credential %>
+            <% needs_reconnect = app.credential_needs_reconnect?(credential) %>
             <a href="<%= start_url %>" class="btn-secondary inline-block">Reconnect</a>
-            <span class="flex items-center gap-1.5 text-xs <%= credential.dead? ? "text-amber-300" : "text-emerald-300" %>">
-              <span class="size-1.5 rounded-full <%= credential.dead? ? "bg-amber-400" : "bg-emerald-400" %>"></span>
-              <%= credential.dead? ? "Needs reconnecting" : "Connected" %>
+            <span class="flex items-center gap-1.5 text-xs <%= needs_reconnect ? "text-amber-300" : "text-emerald-300" %>">
+              <span class="size-1.5 rounded-full <%= needs_reconnect ? "bg-amber-400" : "bg-emerald-400" %>"></span>
+              <%= needs_reconnect ? "Needs reconnecting" : "Connected" %>
             </span>
           <% else %>
             <a href="<%= start_url %>" class="btn-primary inline-block">Connect</a>

--- a/services/console/db/seeds.rb
+++ b/services/console/db/seeds.rb
@@ -51,7 +51,7 @@ unless Rails.env.production?
       slug: "slack",
       provider: "slack",
       description: "Slack workspace access for messages and channels",
-      allowed_scopes: %w[chat:write channels:history channels:read users:read]
+      allowed_scopes: %w[chat:write channels:history channels:read users:read search:read]
     },
     {
       slug: "github",

--- a/services/console/lib/oauth/providers/slack.rb
+++ b/services/console/lib/oauth/providers/slack.rb
@@ -10,6 +10,11 @@ module Oauth
       # Do not add Sign in with Slack scopes here. Slack rejects requests that
       # mix SIWS scopes with normal API scopes such as channels:history.
       IDENTITY_SCOPES = [].freeze
+      # search.messages only accepts a user token carrying search:read. Centaur's
+      # Slack MCP tool depends on that method for workspace-wide search, so every
+      # Slack consent must request it even when an older operator-managed OAuth
+      # app allowlist does not include it yet.
+      REQUIRED_SCOPES = %w[search:read].freeze
       API_HOSTS = %w[slack.com].freeze
       VALID_ISSUERS = %w[https://slack.com].freeze
 
@@ -18,6 +23,7 @@ module Oauth
       def authorization_endpoint = AUTHORIZATION_ENDPOINT
       def token_endpoint = TOKEN_ENDPOINT
       def identity_scopes = IDENTITY_SCOPES
+      def required_scopes = REQUIRED_SCOPES
       def api_hosts = API_HOSTS
       def authorization_scope_param = "user_scope"
       def scope_separator = ","

--- a/services/console/test/controllers/console/integrations_controller_test.rb
+++ b/services/console/test/controllers/console/integrations_controller_test.rb
@@ -71,6 +71,31 @@ class Console::IntegrationsControllerTest < ActionDispatch::IntegrationTest
     assert_select "a.btn-secondary[href=?]", "http://www.example.com/oauth/google/start", text: "Reconnect"
   end
 
+  test "a Slack credential without search scope asks the user to reconnect" do
+    post login_url, params: { email: users(:member_user).email, password: "password123456" }
+
+    credential = BrokerCredential.create!(
+      oauth_app: oauth_apps(:acme_slack),
+      namespace: "acme",
+      foreign_id: "slack-slack-member-sub",
+      name: "Slack – Member",
+      token_endpoint: "https://slack.com/api/oauth.v2.access",
+      provider_subject: "U-MEMBER",
+      provider_email: users(:member_user).email,
+      external_user_key: "slack-member-key",
+      scopes: %w[chat:write]
+    )
+
+    get console_integrations_url
+    assert_response :ok
+    assert_select "a.btn-secondary[href=?]", "http://www.example.com/oauth/slack/start", text: "Reconnect"
+    assert_match "Needs reconnecting", response.body
+
+    credential.update!(scopes: %w[chat:write search:read])
+    get console_integrations_url
+    assert_match "Connected", response.body
+  end
+
   test "a credential minted for someone else's email does not mark the app connected" do
     post login_url, params: { email: users(:member_user).email, password: "password123456" }
 

--- a/services/console/test/controllers/console/integrations_controller_test.rb
+++ b/services/console/test/controllers/console/integrations_controller_test.rb
@@ -76,7 +76,6 @@ class Console::IntegrationsControllerTest < ActionDispatch::IntegrationTest
 
     credential = BrokerCredential.create!(
       oauth_app: oauth_apps(:acme_slack),
-      namespace: "acme",
       foreign_id: "slack-slack-member-sub",
       name: "Slack – Member",
       token_endpoint: "https://slack.com/api/oauth.v2.access",

--- a/services/console/test/controllers/oauth/flows_controller_test.rb
+++ b/services/console/test/controllers/oauth/flows_controller_test.rb
@@ -67,7 +67,7 @@ module Oauth
       }.merge(overrides).to_json
     end
 
-    def slack_token_body(sub: "U0R7MFMJM", scope: "chat:write", id_token_value: nil, **overrides)
+    def slack_token_body(sub: "U0R7MFMJM", scope: "chat:write,search:read", id_token_value: nil, **overrides)
       {
         ok: true, access_token: "xoxe.xoxb-1-bot", refresh_token: "xoxe-1-bot-refresh",
         expires_in: 43_200, token_type: "bot", scope: "commands",
@@ -106,7 +106,7 @@ module Oauth
           id: "USTATIC",
           user: "static-grace",
           access_token: "xoxp-non-rotating-user",
-          scope: "chat:write",
+          scope: "chat:write,search:read",
           token_type: "user"
         }
       )
@@ -211,6 +211,7 @@ module Oauth
       scopes = q["user_scope"].split(",")
       assert_includes scopes, "chat:write"
       assert_includes scopes, "channels:history"
+      assert_includes scopes, "search:read"
       refute_includes scopes, "openid"
       refute_includes scopes, "email"
       refute_includes scopes, "profile"
@@ -336,7 +337,7 @@ module Oauth
       assert_equal "Slack – grace", cred.name
       assert_equal "https://slack.com/api/oauth.v2.access", cred.token_endpoint
       assert_nil cred.provider_email
-      assert_equal %w[chat:write], cred.scopes
+      assert_equal %w[chat:write search:read], cred.scopes
       assert_equal "xoxe.xoxp-1-user", cred.access_token
       assert_equal "xoxe-1-refresh", cred.refresh_token
       assert cred.next_attempt_at.present?
@@ -357,7 +358,7 @@ module Oauth
       app = oauth_apps(:acme_slack)
       cred = BrokerCredential.find_by(oauth_app: app, provider_subject: "USTATIC")
       assert_equal "Slack – static-grace", cred.name
-      assert_equal %w[chat:write], cred.scopes
+      assert_equal %w[chat:write search:read], cred.scopes
       assert_equal "xoxp-non-rotating-user", cred.access_token
       assert_nil cred.refresh_token
       assert_nil cred.expires_at

--- a/services/console/test/lib/oauth/providers/slack_test.rb
+++ b/services/console/test/lib/oauth/providers/slack_test.rb
@@ -7,6 +7,10 @@ module Oauth
 
       def strategy = Slack.new
 
+      test "requires user search scope for MCP message search" do
+        assert_equal %w[search:read], strategy.required_scopes
+      end
+
       def result_with(claims:, scope: "openid,email,profile", **overrides)
         payload = Base64.urlsafe_encode64(claims.to_json, padding: false)
         id_token = "h.#{payload}.s"

--- a/services/console/test/models/oauth_app_test.rb
+++ b/services/console/test/models/oauth_app_test.rb
@@ -73,6 +73,25 @@ class OauthAppTest < ActiveSupport::TestCase
     refute app.scopes_allowed?(%w[a z])
   end
 
+  test "Slack credentials missing the provider-required search scope need reconnecting" do
+    app = build_app(provider: "slack", allowed_scopes: %w[chat:write])
+    app.save!
+    credential = BrokerCredential.create!(
+      oauth_app: app,
+      namespace: "default",
+      foreign_id: "slack-user-#{SecureRandom.hex(4)}",
+      token_endpoint: "https://slack.com/api/oauth.v2.access",
+      provider_subject: "U123",
+      scopes: %w[chat:write]
+    )
+
+    assert_equal %w[search:read], app.required_scopes
+    assert app.credential_needs_reconnect?(credential)
+
+    credential.update!(scopes: %w[chat:write search:read])
+    refute app.credential_needs_reconnect?(credential)
+  end
+
   # --- delete guard ---------------------------------------------------------
 
   test "cannot be destroyed while it has minted credentials" do

--- a/services/console/test/models/oauth_app_test.rb
+++ b/services/console/test/models/oauth_app_test.rb
@@ -78,7 +78,6 @@ class OauthAppTest < ActiveSupport::TestCase
     app.save!
     credential = BrokerCredential.create!(
       oauth_app: app,
-      namespace: "default",
       foreign_id: "slack-user-#{SecureRandom.hex(4)}",
       token_endpoint: "https://slack.com/api/oauth.v2.access",
       provider_subject: "U123",

--- a/services/console/test/models/principal_sync_config_snapshot_test.rb
+++ b/services/console/test/models/principal_sync_config_snapshot_test.rb
@@ -344,6 +344,35 @@ class PrincipalSyncConfigSnapshotTest < ActiveSupport::TestCase
     assert_empty PrincipalSyncConfigSnapshot.sync_transforms_for(principal), "the lower-priority role gcp_auth should be withheld"
   end
 
+  test "a directly linked Slack user token suppresses the MCP role bot token" do
+    principal = principals(:globex_user)
+    role = roles(:globex_infra)
+    PrincipalRole.find_or_create_by!(principal: principal, role: role)
+
+    bot_secret = StaticSecret.new(
+      namespace: "globex",
+      foreign_id: "slack-bot-#{SecureRandom.hex(4)}",
+      replace_config: {
+        "proxy_value" => "SLACK_BOT_TOKEN",
+        "match_headers" => [ "Authorization" ]
+      },
+      created_by: users(:globex_admin)
+    )
+    bot_secret.build_source(source_type: "control_plane", secret: "bot-token")
+    bot_secret.rules.build(host: "slack.com", position: 0)
+    bot_secret.save!
+    Grant.create!(role: role, static_secret: bot_secret, created_by: users(:globex_admin))
+
+    user_secret = grant_direct_static(host: "slack.com", header: "Authorization")
+    served = PrincipalSyncConfigSnapshot.sync_secrets_for(principal)
+
+    assert_equal 1, served.length
+    assert_equal "direct-token", served.first.dig("source", "value")
+    assert_equal "Authorization", served.first.dig("inject", "header")
+    refute_includes served, bot_secret.to_proxy_secret
+    assert_equal user_secret.to_proxy_secret, served.first
+  end
+
   test "credentials writing different headers on the same host both serve" do
     grant_direct_static(host: "api.test.com", header: "X-Api-Key")
     grant_role_gcp(host: "api.test.com")

--- a/services/console/test/models/principal_sync_config_snapshot_test.rb
+++ b/services/console/test/models/principal_sync_config_snapshot_test.rb
@@ -350,7 +350,6 @@ class PrincipalSyncConfigSnapshotTest < ActiveSupport::TestCase
     PrincipalRole.find_or_create_by!(principal: principal, role: role)
 
     bot_secret = StaticSecret.new(
-      namespace: "globex",
       foreign_id: "slack-bot-#{SecureRandom.hex(4)}",
       replace_config: {
         "proxy_value" => "SLACK_BOT_TOKEN",

--- a/tools/productivity/slack/cli.py
+++ b/tools/productivity/slack/cli.py
@@ -116,12 +116,13 @@ def search(
 ):
     """Search messages in bot-accessible channels.
 
-    Searches across Slack native search first, then scans channel history through
-    the Centaur API server proxy. Results are ranked by relevance (exact phrase
-    matches score higher). Use --channels to limit scope.
+    Workspace-wide queries use Slack's native search API. Queries with --channels
+    scan authorized channel history through the Centaur API server proxy and rank
+    results by relevance (exact phrase matches score higher).
 
-    Note: Only searches channels where the bot is a member. To search more channels,
-    invite the bot to those channels first.
+    Native search uses the linked Slack user's token. If the principal has no
+    linked Slack account, search falls back to bot-accessible channel history.
+    Scoped history searches are limited to authorized channels.
 
     Examples:
         slack search "deploy"

--- a/tools/productivity/slack/client.py
+++ b/tools/productivity/slack/client.py
@@ -877,10 +877,11 @@ class SlackClient:
     ) -> list[dict]:
         """Search messages using Slack's native search.messages API.
 
-        Uses Slack's native search.messages API for fast, workspace-wide
-        search. When ``SLACK_SEARCH_TOKEN`` is configured, the native call runs
-        with that dedicated user token and its ``search:read`` scope. Falls
-        back to proxy-backed channel history scanning if the native API fails.
+        Uses Slack's native search.messages API with the current principal's
+        user token for fast, workspace-wide search. Explicitly channel-scoped
+        searches use authorized channel history instead. When no user token is
+        linked, Slack rejects native search and the bot-scoped history path is
+        used as a compatibility fallback.
 
         Supports Slack search modifiers in the query string:
             in:#channel, from:@user, before:YYYY-MM-DD, after:YYYY-MM-DD,
@@ -915,10 +916,23 @@ class SlackClient:
 
         try:
             return self._search_messages_native(search_query, max_results)
-        except (SlackApiError, RuntimeError, SlackRateLimitError):
-            # Fall back to proxy-backed channel history scanning if native search fails.
-            return self._search_messages_local(
-                local_query, max_results, local_channels, local_from_user, messages_per_channel
+        except SlackApiError as error:
+            # search.messages does not accept bot tokens. Preserve the restricted
+            # bot-history path for principals without a linked Slack credential,
+            # but never turn a mis-scoped user token into a workspace-wide scan.
+            if self._slack_error_code(error) == "not_allowed_token_type":
+                return self._search_messages_local(
+                    local_query,
+                    max_results,
+                    local_channels,
+                    local_from_user,
+                    messages_per_channel,
+                )
+            access_path = "search_token" if self._search_client is not self._client else "bot_token"
+            self._raise_slack_api_error(
+                error,
+                slack_method="search.messages",
+                access_path=access_path,
             )
 
     def _search_messages_native(

--- a/tools/productivity/slack/tests/test_client.py
+++ b/tools/productivity/slack/tests/test_client.py
@@ -1136,6 +1136,68 @@ def test_search_messages_falls_back_to_direct_history_and_threads_when_proxy_fai
     assert results[0]["channel"] == "C123456789"
 
 
+def test_unscoped_search_uses_restricted_history_fallback_for_bot_token() -> None:
+    client, _ = _make_client()
+    fallback_result = [{"text": "matched through authorized history"}]
+    fallback_calls: list[tuple] = []
+
+    def fail_native_search(method: str, *, params: dict) -> None:
+        assert method == "search.messages"
+        assert params["query"] == "fire-drill after:2026-08-10"
+        raise _make_slack_error(error="not_allowed_token_type", status_code=200)
+
+    def search_local(*args):
+        fallback_calls.append(args)
+        return fallback_result
+
+    client._search_client.api_call = fail_native_search  # type: ignore[method-assign]
+    client._search_messages_local = search_local  # type: ignore[method-assign]
+
+    assert client.search_messages("fire-drill after:2026-08-10") == fallback_result
+    assert fallback_calls == [
+        ("fire-drill after:2026-08-10", 20, None, None, 200),
+    ]
+
+
+def test_unscoped_search_surfaces_missing_user_scope_without_scanning_history() -> None:
+    client, _ = _make_client()
+    search_client = _FakeWebClient()
+
+    def fail_native_search(method: str, *, params: dict) -> None:
+        assert method == "search.messages"
+        raise _make_slack_error(error="missing_scope", status_code=200)
+
+    search_client.api_call = fail_native_search  # type: ignore[method-assign]
+    client._search_client = search_client
+    client._search_messages_local = pytest.fail  # type: ignore[method-assign]
+
+    with pytest.raises(SlackAuthError) as exc_info:
+        client.search_messages("fire-drill after:2026-08-10")
+
+    assert exc_info.value.payload == {
+        "error": "slack_auth_failed",
+        "message": "Slack authentication failed for search.messages via search_token",
+        "slack_method": "search.messages",
+        "access_path": "search_token",
+        "error_code": "missing_scope",
+        "status_code": 200,
+        "requested_channel": None,
+        "resolved_channel": None,
+    }
+
+
+def test_unscoped_search_surfaces_native_runtime_failure_without_scanning_history() -> None:
+    client, fake_web_client = _make_client()
+    client._search_messages_local = pytest.fail  # type: ignore[method-assign]
+    fake_web_client.api_call = lambda method, *, params: {  # type: ignore[method-assign]
+        "ok": False,
+        "error": "internal_error",
+    }
+
+    with pytest.raises(RuntimeError, match="internal_error"):
+        client.search_messages("fire-drill after:2026-08-10")
+
+
 def test_list_channels_returns_cache_when_slack_rate_limited() -> None:
     client, fake_web_client = _make_client()
     cached_channels = [{"id": "C123", "name": "cached", "is_private": False}]


### PR DESCRIPTION
## Summary

- require the Slack user-token `search:read` scope in every Slack OAuth consent
- flag existing Slack credentials without the required scope as needing reconnection
- verify a principal-linked Slack user token overrides the role-level bot token in proxy config
- fall back to restricted bot-accessible history only when Slack explicitly rejects the token type
- surface missing user scopes immediately instead of scanning every bot-accessible channel

## Root cause

MCP principals already preferred directly linked Slack OAuth credentials over role-granted bot credentials, but Slack consents were not guaranteed to include `search:read`. A `missing_scope` response from `search.messages` was caught by the broad fallback path, which then scanned channel history across the workspace and timed out.

## Impact

Workspace-wide MCP Slack search uses the connected user's Slack visibility and native search API. Users with older credentials are prompted to reconnect so Slack can grant the required scope. Principals without a linked Slack account retain the restricted bot-history fallback.

## Validation

- Slack tool tests: 77 passed
- RuboCop on changed console Ruby files
- Ruff on changed Slack Python files
- `git diff --check`
- Before rebasing onto current main: full console suite passed (1,332 tests) and focused console suite passed (98 tests)
- Current-main console execution is locally blocked during `db:prepare` because the host PostgreSQL installation lacks the newly required `pg_search` extension; CI uses the repository database image
