### PR TITLE
fix(auth): grant owned credentials to MCP users

### DIFF
--- a/services/console/app/services/principal_credential_reconciliation.rb
+++ b/services/console/app/services/principal_credential_reconciliation.rb
@@ -30,10 +30,10 @@ class PrincipalCredentialReconciliation
   USER_KIND = "user"
   # Minted by the MCP OAuth flow (Mcp::OauthController#principal_for_current_user)
   # for a console user connecting an MCP client. These principals match
-  # credentials only through their console User record (primary email plus
-  # verified identity emails) -- never through mutable principal labels or
-  # provider-subject labels, which would widen the trust boundary beyond the
-  # authenticated user.
+  # credentials only through their console User record (credential ownership,
+  # primary email, or verified identity emails) -- never through mutable
+  # principal labels or provider-subject labels, which would widen the trust
+  # boundary beyond the authenticated user.
   CONSOLE_USER_KIND = "console_user"
   SLACK_PROVIDER = Oauth::Providers::Slack::KEY
   GOOGLE_PROVIDER = Oauth::Providers::Google::KEY
@@ -154,6 +154,7 @@ class PrincipalCredentialReconciliation
         subject_index: indexes[provider][:subjects],
         email_index: indexes[provider][:emails],
         owner_index: indexes[provider][:owners],
+        console_user_index: indexes[provider][:console_users],
         emails: emails
       )
       acc[provider] = matched if matched.any?
@@ -184,7 +185,8 @@ class PrincipalCredentialReconciliation
       {
         subjects: index_by_subject(credentials),
         emails: index_by_email(credentials),
-        owners: index_by_owner_identity(credentials)
+        owners: index_by_owner_identity(credentials),
+        console_users: index_by_console_user(credentials)
       }
     end
   end
@@ -233,12 +235,39 @@ class PrincipalCredentialReconciliation
     end
   end
 
-  def provider_credentials_for(principal, provider:, subject_index:, email_index:, owner_index:, emails:)
+  def index_by_console_user(credentials)
+    credentials.each_with_object(Hash.new { |hash, key| hash[key] = [] }) do |credential, acc|
+      acc[credential.created_by_id] << credential if credential.created_by_id
+    end
+  end
+
+  def provider_credentials_for(
+    principal,
+    provider:,
+    subject_index:,
+    email_index:,
+    owner_index:,
+    console_user_index:,
+    emails:
+  )
+    if console_user_principal?(principal)
+      return (credentials_for_console_user(principal, provider, console_user_index) +
+        credentials_for_emails(principal, emails, email_index, provider)).uniq
+    end
+
     native = credentials_for_subject_labels(principal, provider, subject_index)
     return native if native.any?
 
     (credentials_for_owner_identity(principal, provider, owner_index) +
       credentials_for_emails(principal, emails, email_index, provider)).uniq
+  end
+
+  def credentials_for_console_user(principal, provider, console_user_index)
+    user_id = principal.console_user_id
+    return [] unless user_id
+
+    (console_user_index[user_id] || [])
+      .select { |credential| credential_matches_principal?(principal, credential, provider) }
   end
 
   def credentials_for_subject_labels(principal, provider, subject_index)
@@ -271,7 +300,8 @@ class PrincipalCredentialReconciliation
     return false unless supported_provider?(credential)
     return false if provider == SLACK_PROVIDER && !slack_team_matches?(principal, credential)
     if console_user_principal?(principal)
-      return principal_emails(principal).include?(normalize_email(credential.provider_email))
+      return credential.created_by_id == principal.console_user_id ||
+             principal_emails(principal).include?(normalize_email(credential.provider_email))
     end
 
     subjects = principal_subjects(principal, provider)

--- a/services/console/test/services/principal_credential_reconciliation_test.rb
+++ b/services/console/test/services/principal_credential_reconciliation_test.rb
@@ -426,6 +426,48 @@ class PrincipalCredentialReconciliationTest < ActiveSupport::TestCase
     assert principal.grants.exists?(static_secret: secret)
   end
 
+  test "console user principal matches an owned Slack credential before provider email" do
+    user = users(:member_user)
+    credential = create_credential(
+      oauth_apps(:acme_slack),
+      "U1723456780",
+      "different@example.com",
+      created_by: user
+    )
+    secret = wrap(credential)
+
+    principal = create_console_user_principal(user, foreign_id: "console-user-owned-slack")
+
+    assert principal.grants.exists?(static_secret: secret)
+  end
+
+  test "credential callback grants an owned credential to an existing console user principal" do
+    user = users(:member_user)
+    principal = create_console_user_principal(user, foreign_id: "console-user-existing-owner")
+    credential = create_credential(oauth_apps(:acme_github), "gh-owned-existing", nil, created_by: user)
+
+    secret = wrap(credential)
+
+    assert principal.grants.exists?(static_secret: secret)
+  end
+
+  test "console user principal does not match a credential owned by another user" do
+    credential = create_credential(
+      oauth_apps(:acme_github),
+      "gh-other-owner",
+      nil,
+      created_by: users(:globex_admin)
+    )
+    secret = wrap(credential)
+
+    principal = create_console_user_principal(
+      users(:member_user),
+      foreign_id: "console-user-other-owner"
+    )
+
+    refute principal.grants.exists?(static_secret: secret)
+  end
+
   test "console user principal ignores unverified identity emails" do
     user = users(:member_user)
     user.user_identities.create!(
@@ -579,15 +621,14 @@ class PrincipalCredentialReconciliationTest < ActiveSupport::TestCase
     refute principal.grants.exists?(static_secret: secret)
   end
 
-  test "console user principals do not match through the owner identity" do
+  test "console user principals do not require an owner Slack identity" do
     user = users(:member_user)
-    user.user_identities.create!(provider: "slack", subject: "U1023456789", team_id: "T1023456789")
     credential = create_credential(oauth_apps(:acme_github), "gh-82345", nil, created_by: user)
     secret = wrap(credential)
 
     principal = create_console_user_principal(user, foreign_id: "console-user-owner-identity")
 
-    refute principal.grants.exists?(static_secret: secret)
+    assert principal.grants.exists?(static_secret: secret)
   end
 
   test "requires the owner identity subject to match the principal" do


### PR DESCRIPTION
## Summary

- match OAuth credentials to console-user MCP principals by server-recorded ownership before falling back to verified emails
- cover both principal-side and credential-side reconciliation paths
- preserve provider-subject isolation and reject credentials owned by another console user

## Why

A freshly reconnected Slack credential can have a provider email that differs from the console account. The credential is still owned by that authenticated console user, but email-only reconciliation leaves its wrapper ungranted and the MCP falls back to the invalid legacy shared search token.

## Validation

- `bundle exec rubocop app/services/principal_credential_reconciliation.rb test/services/principal_credential_reconciliation_test.rb`
- `git diff --check`
- Database-backed service test intentionally skipped at request; local ParadeDB was unavailable

## Impact

Existing email-based matching remains as a fallback. Owned credentials reconcile on MCP principal authorization/update or the next credential create/update/refresh callback.