### PR TITLE
sync fork with upstream (2026-08-18)

### DIFF
--- a/tools/infra/sentry/cli.py
+++ b/tools/infra/sentry/cli.py
@@ -1,15 +1,18 @@
-"""CLI for Sentry issues."""
+"""CLI for browsing Sentry issues and events (read-only)."""
 
+import json
+from collections.abc import Callable
+from typing import Any
+
+import typer
 from dotenv import load_dotenv
 
 load_dotenv()
 
-import json
-import typer
-
 app = typer.Typer(
     name="sentry",
     help="Sentry issues — list/search issues, issue details, events, stacktraces, and tag values (read-only)",
+    no_args_is_help=True,
 )
 
 
@@ -18,12 +21,30 @@ def main() -> None:
     """sentry CLI."""
 
 
+def get_client():
+    from .client import _client
+
+    return _client()
+
+
+def _emit(result: Any) -> None:
+    print(json.dumps(result, indent=2, ensure_ascii=False, default=str))
+
+
+def _run(operation: Callable[[Any], Any]) -> None:
+    client = get_client()
+    try:
+        _emit(operation(client))
+    finally:
+        close = getattr(client, "close", None)
+        if callable(close):
+            close()
+
+
 @app.command("health")
 def health():
     """Assert sentry connectivity and auth with a safe read-only check."""
-    from .client import _client
-
-    client = _client()
+    client = get_client()
     try:
         details = client.list_organizations()
         payload = {"ok": True, "tool": "sentry", "error": None, "details": details}
@@ -36,6 +57,97 @@ def health():
         if callable(close):
             close()
     print(json.dumps(payload, indent=2, ensure_ascii=False, default=str))
+
+
+@app.command("list-organizations")
+def list_organizations() -> None:
+    """List Sentry organizations available to the configured token."""
+    _run(lambda client: client.list_organizations())
+
+
+@app.command("list-projects")
+def list_projects(
+    organization_slug: str = typer.Argument(..., help="Sentry organization slug"),
+) -> None:
+    """List projects in a Sentry organization."""
+    _run(lambda client: client.list_projects(organization_slug))
+
+
+@app.command("list-issues")
+def list_issues(
+    organization_slug: str = typer.Argument(..., help="Sentry organization slug"),
+    project_slug: str | None = typer.Option(
+        None, "--project", "-p", help="Restrict results to this project slug"
+    ),
+    query: str = typer.Option(
+        "is:unresolved", "--query", "-q", help="Native Sentry issue search query"
+    ),
+    sort: str = typer.Option("date", "--sort", help="Sort by date, new, freq, user, or priority"),
+    stats_period: str = typer.Option(
+        "14d", "--stats-period", help="Relative search window, e.g. 24h, 14d, or 90d"
+    ),
+    limit: int = typer.Option(25, "--limit", "-n", min=1, help="Maximum issues to return"),
+) -> None:
+    """List or search issues using Sentry's native query syntax."""
+    _run(
+        lambda client: client.list_issues(
+            organization_slug=organization_slug,
+            project_slug=project_slug,
+            query=query,
+            sort=sort,
+            stats_period=stats_period,
+            limit=limit,
+        )
+    )
+
+
+@app.command("get-issue")
+def get_issue(
+    organization_slug: str = typer.Argument(..., help="Sentry organization slug"),
+    issue_id: str = typer.Argument(..., help="Numeric issue id or short id"),
+) -> None:
+    """Get details for one Sentry issue."""
+    _run(lambda client: client.get_issue(organization_slug, issue_id))
+
+
+@app.command("list-issue-events")
+def list_issue_events(
+    organization_slug: str = typer.Argument(..., help="Sentry organization slug"),
+    issue_id: str = typer.Argument(..., help="Numeric issue id or short id"),
+    full: bool = typer.Option(False, "--full", help="Include each full event payload"),
+    limit: int = typer.Option(25, "--limit", "-n", min=1, help="Maximum events to return"),
+) -> None:
+    """List individual events for a Sentry issue."""
+    _run(
+        lambda client: client.list_issue_events(
+            organization_slug=organization_slug,
+            issue_id=issue_id,
+            full=full,
+            limit=limit,
+        )
+    )
+
+
+@app.command("get-event")
+def get_event(
+    organization_slug: str = typer.Argument(..., help="Sentry organization slug"),
+    issue_id: str = typer.Argument(..., help="Numeric issue id or short id"),
+    event_id: str = typer.Option(
+        "latest", "--event-id", "-e", help="Specific event id, latest, or oldest"
+    ),
+) -> None:
+    """Get one full event, including stacktrace and breadcrumbs."""
+    _run(lambda client: client.get_event(organization_slug, issue_id, event_id=event_id))
+
+
+@app.command("get-issue-tag-values")
+def get_issue_tag_values(
+    organization_slug: str = typer.Argument(..., help="Sentry organization slug"),
+    issue_id: str = typer.Argument(..., help="Numeric issue id or short id"),
+    tag_key: str = typer.Argument(..., help="Tag key, e.g. release or browser"),
+) -> None:
+    """Get the value distribution for one tag on a Sentry issue."""
+    _run(lambda client: client.get_issue_tag_values(organization_slug, issue_id, tag_key))
 
 
 if __name__ == "__main__":

--- a/tools/infra/sentry/test_cli.py
+++ b/tools/infra/sentry/test_cli.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import types
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+package = types.ModuleType("centaur_tool_sentry")
+package.__path__ = [str(Path(__file__).parent)]
+sys.modules.setdefault("centaur_tool_sentry", package)
+
+spec = importlib.util.spec_from_file_location(
+    "centaur_tool_sentry.cli", Path(__file__).with_name("cli.py")
+)
+assert spec and spec.loader
+cli = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = cli
+spec.loader.exec_module(cli)
+
+
+class FakeClient:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, tuple, dict]] = []
+        self.closed = 0
+
+    def _record(self, method: str, *args, **kwargs):
+        self.calls.append((method, args, kwargs))
+        return {"method": method}
+
+    def list_organizations(self):
+        return self._record("list_organizations")
+
+    def list_projects(self, organization_slug: str):
+        return self._record("list_projects", organization_slug)
+
+    def list_issues(self, **kwargs):
+        return self._record("list_issues", **kwargs)
+
+    def get_issue(self, organization_slug: str, issue_id: str):
+        return self._record("get_issue", organization_slug, issue_id)
+
+    def list_issue_events(self, **kwargs):
+        return self._record("list_issue_events", **kwargs)
+
+    def get_event(self, organization_slug: str, issue_id: str, event_id: str):
+        return self._record("get_event", organization_slug, issue_id, event_id=event_id)
+
+    def get_issue_tag_values(self, organization_slug: str, issue_id: str, tag_key: str):
+        return self._record("get_issue_tag_values", organization_slug, issue_id, tag_key)
+
+    def close(self) -> None:
+        self.closed += 1
+
+
+def test_commands_wrap_existing_client_methods(monkeypatch) -> None:
+    client = FakeClient()
+    monkeypatch.setattr(cli, "get_client", lambda: client)
+    runner = CliRunner()
+
+    invocations = [
+        (["list-organizations"], "list_organizations"),
+        (["list-projects", "splits"], "list_projects"),
+        (
+            [
+                "list-issues",
+                "splits",
+                "--project",
+                "server",
+                "--query",
+                "is:resolved level:error",
+                "--sort",
+                "freq",
+                "--stats-period",
+                "24h",
+                "--limit",
+                "10",
+            ],
+            "list_issues",
+        ),
+        (["get-issue", "splits", "SERVER-1"], "get_issue"),
+        (
+            ["list-issue-events", "splits", "SERVER-1", "--full", "--limit", "5"],
+            "list_issue_events",
+        ),
+        (["get-event", "splits", "SERVER-1", "--event-id", "deadbeef"], "get_event"),
+        (
+            ["get-issue-tag-values", "splits", "SERVER-1", "release"],
+            "get_issue_tag_values",
+        ),
+    ]
+
+    for args, expected_method in invocations:
+        result = runner.invoke(cli.app, args)
+        assert result.exit_code == 0, result.output
+        assert json.loads(result.output) == {"method": expected_method}
+
+    assert client.calls == [
+        ("list_organizations", (), {}),
+        ("list_projects", ("splits",), {}),
+        (
+            "list_issues",
+            (),
+            {
+                "organization_slug": "splits",
+                "project_slug": "server",
+                "query": "is:resolved level:error",
+                "sort": "freq",
+                "stats_period": "24h",
+                "limit": 10,
+            },
+        ),
+        ("get_issue", ("splits", "SERVER-1"), {}),
+        (
+            "list_issue_events",
+            (),
+            {
+                "organization_slug": "splits",
+                "issue_id": "SERVER-1",
+                "full": True,
+                "limit": 5,
+            },
+        ),
+        ("get_event", ("splits", "SERVER-1"), {"event_id": "deadbeef"}),
+        ("get_issue_tag_values", ("splits", "SERVER-1", "release"), {}),
+    ]
+    assert client.closed == len(invocations)


### PR DESCRIPTION
Brings the fork up to date with upstream `b985a365` (2026-08-18) — 113 upstream commits since the Jul 31 sync (#15).

Same recipe as #15: take upstream **as-is** and re-apply the fork's genuine changes on top. Fork main's content matched upstream `5b78273a` (Jul 31) exactly except one patch, so this branch is upstream main + one commit re-applying the sentry read-only client commands fix (#13).

## ⚠️ Merge with a MERGE COMMIT — do not squash

#15 said the same thing and was squash-merged anyway, which severed the shared history again (that's why a plain `git merge upstream/main` shows phantom conflicts, and why this PR exists in replace-form). The repo allows merge commits — use **"Create a merge commit"**. Squashing this one condemns the next sync to the same wall.

## What rides along

- **Four new migrations** (0049 company-context reader sources, 0050 granola-search RLS, 0051 hermes harness, 0052 session-execution request). They apply on the next api-rs boot after an image rebuild. Deploy api-rs first or together with the bots; note that once applied, rolling api-rs back to a pre-sync image will fail sqlx's migration check — roll forward instead.
- api-rs auth refactor (protected `/api/*` router), workflow durability changes, githubbot/test expansions — the full upstream 2.5 weeks.

## Why now

Testing our upstream PRs (paradigmxyz/centaur#1414, #1415) in this deployment requires the fork to be at upstream parity: #1415 ships migration 0053, which presumes 0049–0052 are applied. After this merges, `upstream-status-command` / `upstream-review-ack` are deployable here essentially 1:1.

## Validation

- `tools/infra/sentry/test_cli.py` passes (the only fork-patched code).
- Every other file is byte-identical to upstream main `b985a365`, which upstream CI validates.
- Sanity: `git diff origin/main HEAD` = exactly upstream's post-Jul-31 delta; `git diff upstream/main HEAD` = the 2 sentry files only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
