### PR TITLE
feat: run workflow agents in parallel

### DIFF
--- a/docs/pages/extend/workflows-v2.mdx
+++ b/docs/pages/extend/workflows-v2.mdx
@@ -59,6 +59,7 @@ Supported v2 primitives:
 | `handler(inp, ctx)` | Supported |
 | `ctx.step(name, fn)` | Supported |
 | `ctx.agent_turn(...)` / `ctx.run_agent(...)` | Supported |
+| `ctx.run_agents(...)` | Supported for bounded concurrent agent turns with ordered outcomes |
 | `ctx.call_tool(...)` | Supported through the generated `centaur-tools call` bridge in the workflow-host sandbox |
 | `ctx.post_to_slack(...)` | Supported |
 | `ctx._pool` | Supported when the workflow-host sandbox receives `DATABASE_URL` |
@@ -133,6 +134,22 @@ session runtime.
     "result_text": "the agent's final text",
 }
 ```
+
+Use `ctx.run_agents(...)` for independent work that should run concurrently:
+
+```python
+reviews = await ctx.run_agents(
+    [
+        {"name": "correctness", "text": "Review the PR for correctness."},
+        {"name": "security", "text": "Review the PR for security issues."},
+    ],
+    max_concurrency=2,
+)
+```
+
+Each item uses a separate workflow-owned session. Results stay in input order.
+An individual agent failure produces an item with `ok: false`; it does not fail
+the whole batch or discard successful results.
 
 #### Declare Workflow-Host Permissions
 

--- a/docs/pages/extend/workflows.mdx
+++ b/docs/pages/extend/workflows.mdx
@@ -130,9 +130,10 @@ discarding successful reviews:
 {
   "results": [
     {"index": 0, "name": "correctness", "ok": true, "result": {"result_text": "..."}},
-    {"index": 1, "name": "security", "ok": false, "error": "agent unavailable"}
+    {"index": 1, "name": "security", "ok": false, "error": "agent unavailable"},
+    {"index": 2, "name": "tests", "ok": true, "result": {"result_text": "..."}}
   ],
-  "succeeded": 1,
+  "succeeded": 2,
   "failed": 1
 }
 ```

--- a/docs/pages/extend/workflows.mdx
+++ b/docs/pages/extend/workflows.mdx
@@ -83,10 +83,8 @@ disabled.
 | `ctx.sleep_until(name, when)` | Resume at a specific time. |
 | `ctx.wait_for_event(name, event_type, correlation_id)` | Wait for an external event. |
 | `ctx.start_workflow(...)` | Start a child workflow and continue immediately. |
-| `ctx.wait_for_workflow(...)` | Wait for a child workflow to finish. |
-| `ctx.run_workflow(...)` | Start and wait in one call. |
-| `ctx.start_agent(...)` | Start an agent turn. |
-| `ctx.run_agent(...)` | Start an agent turn and wait for the result. |
+| `ctx.agent_turn(...)` / `ctx.run_agent(...)` / `ctx.start_agent(...)` | Run one agent turn and wait for the result. |
+| `ctx.run_agents(...)` | Run a bounded group of named agent turns concurrently and wait for every outcome. |
 
 The handler may re-execute after a restart. Put external side effects behind
 `ctx.step(...)` so completed work is not repeated.
@@ -99,10 +97,50 @@ These primitives compose into larger automations:
   billing state, deploy health, or vendor exports.
 - **Event-driven flows**: wait for a webhook, approval, upload, or callback and
   continue from the last checkpoint.
-- **Fan-out/fan-in orchestration**: start child workflows for independent work
-  and wait for all of them before producing a final result.
+- **Fan-out/fan-in orchestration**: run independent named agents concurrently,
+  then combine their successful results into one final result.
 - **Agent orchestration**: use agents for judgment-heavy steps while the
   workflow owns timing, retries, state, and final delivery.
+
+### Run Agents Concurrently
+
+Use `ctx.run_agents(...)` when independent reviewers or researchers should run
+at the same time:
+
+```python
+reviews = await ctx.run_agents(
+    [
+        {"name": "correctness", "text": "Review the PR for correctness."},
+        {"name": "security", "text": "Review the PR for security issues."},
+        {"name": "tests", "text": "Review the PR's test coverage."},
+    ],
+    max_concurrency=3,
+)
+```
+
+Every agent needs a unique, non-empty `name`. Centaur assigns each one a
+separate workflow-owned session and stable idempotency keys. The maximum
+concurrency defaults to 4 and may be set from 1 through 16. A batch supports up
+to 32 agents.
+
+The result preserves input order and reports individual failures without
+discarding successful reviews:
+
+```json
+{
+  "results": [
+    {"index": 0, "name": "correctness", "ok": true, "result": {"result_text": "..."}},
+    {"index": 1, "name": "security", "ok": false, "error": "agent unavailable"}
+  ],
+  "succeeded": 1,
+  "failed": 1
+}
+```
+
+Batch items accept the same model, provider, reasoning, harness, persona,
+prompt, content, idle timeout, maximum duration, and metadata options as
+`ctx.agent_turn(...)`. Session and idempotency fields are reserved because the
+batch runtime assigns them independently for each agent.
 
 ## Run a workflow
 

--- a/services/api-rs/crates/centaur-workflows/src/lib.rs
+++ b/services/api-rs/crates/centaur-workflows/src/lib.rs
@@ -1,6 +1,7 @@
 use std::{
     collections::{BTreeMap, BTreeSet},
     env,
+    future::Future,
     path::PathBuf,
     str::FromStr,
     sync::{Arc, RwLock},
@@ -22,7 +23,7 @@ use centaur_session_sqlx::PgSessionStore;
 use chrono::{DateTime, Utc};
 use chrono_tz::Tz;
 use cron::Schedule;
-use futures_util::{TryStreamExt, pin_mut};
+use futures_util::{StreamExt, TryStreamExt, pin_mut, stream};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use sqlx::Row;
@@ -47,6 +48,10 @@ const PYTHON_HOST_INTERPRETER_ENV: &str = "PYTHON_WORKFLOW_HOST_PYTHON";
 const WORKFLOW_TOOL_API_URL_ENV: &str = "WORKFLOW_TOOL_API_URL";
 const DEFAULT_AGENT_IDLE_TIMEOUT_MS: u64 = 60_000;
 const DEFAULT_AGENT_MAX_DURATION_MS: u64 = 30 * 60 * 1_000;
+const DEFAULT_AGENT_BATCH_CONCURRENCY: usize = 4;
+const MAX_AGENT_BATCH_CONCURRENCY: usize = 16;
+const MAX_AGENT_BATCH_SIZE: usize = 32;
+const MAX_AGENT_BATCH_NAME_BYTES: usize = 128;
 const WORKFLOW_HOST_CLAIM_EXTENSION: Duration = Duration::from_secs(5 * 60);
 const WORKFLOW_HOST_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(60);
 const WORKFLOW_RECONCILE_INTERVAL_SECS_ENV: &str = "WORKFLOW_RECONCILE_INTERVAL_SECS";
@@ -3348,7 +3353,22 @@ async fn handle_python_context_request(
         }
         Some("ctx.agent_turn") => {
             let args = message.get("args").cloned().unwrap_or_else(|| json!({}));
-            match run_python_agent_turn(session_runtime.clone(), ctx, input, args, &request_id)
+            match run_python_agent_turn(
+                session_runtime.clone(),
+                ctx,
+                input,
+                args,
+                &request_id,
+                None,
+            )
+            .await
+            {
+                Ok(value) => Ok(value),
+                Err(error) => Err(error.to_string()),
+            }
+        }
+        Some("ctx.run_agents") => {
+            match run_python_agent_batch(session_runtime.clone(), ctx, input, message, &request_id)
                 .await
             {
                 Ok(value) => Ok(value),
@@ -3505,6 +3525,7 @@ async fn run_python_agent_turn(
     input: &WorkflowTaskInput,
     args: Value,
     request_id: &str,
+    default_thread_key: Option<String>,
 ) -> Result<Value, WorkflowRuntimeError> {
     let text = args
         .get("text")
@@ -3535,11 +3556,13 @@ async fn run_python_agent_turn(
         .map(ToOwned::to_owned);
     let workflow_owned_thread = explicit_thread_key.is_none();
     let thread_key = explicit_thread_key.unwrap_or_else(|| {
-        format!(
-            "wf:{}:agent:{}",
-            ctx.task_id().replace('-', ""),
-            input.workflow_name
-        )
+        default_thread_key.unwrap_or_else(|| {
+            format!(
+                "wf:{}:agent:{}",
+                ctx.task_id().replace('-', ""),
+                input.workflow_name
+            )
+        })
     });
     let harness_type = parse_agent_harness(&args)?.unwrap_or_else(|| input.harness_type.clone());
     let persona_id = args
@@ -3623,6 +3646,214 @@ async fn run_python_agent_turn(
     )
     .await?;
     serde_json::to_value(result).map_err(WorkflowRuntimeError::from)
+}
+
+#[derive(Debug, Clone, PartialEq)]
+struct PythonAgentBatchItem {
+    index: usize,
+    name: String,
+    args: Value,
+}
+
+fn parse_python_agent_batch(
+    message: &Value,
+    request_id: &str,
+) -> Result<(Vec<PythonAgentBatchItem>, usize), WorkflowRuntimeError> {
+    let raw_agents = message
+        .get("agents")
+        .and_then(Value::as_array)
+        .ok_or_else(|| {
+            WorkflowRuntimeError::BadRequest("ctx.run_agents requires an agents array".to_owned())
+        })?;
+    if raw_agents.is_empty() {
+        return Err(WorkflowRuntimeError::BadRequest(
+            "ctx.run_agents requires at least one agent".to_owned(),
+        ));
+    }
+    if raw_agents.len() > MAX_AGENT_BATCH_SIZE {
+        return Err(WorkflowRuntimeError::BadRequest(format!(
+            "ctx.run_agents supports at most {MAX_AGENT_BATCH_SIZE} agents"
+        )));
+    }
+
+    let max_concurrency = match message.get("max_concurrency") {
+        Some(value) => value.as_u64().ok_or_else(|| {
+            WorkflowRuntimeError::BadRequest(
+                "ctx.run_agents max_concurrency must be an integer".to_owned(),
+            )
+        })? as usize,
+        None => DEFAULT_AGENT_BATCH_CONCURRENCY,
+    };
+    if !(1..=MAX_AGENT_BATCH_CONCURRENCY).contains(&max_concurrency) {
+        return Err(WorkflowRuntimeError::BadRequest(format!(
+            "ctx.run_agents max_concurrency must be between 1 and {MAX_AGENT_BATCH_CONCURRENCY}"
+        )));
+    }
+
+    let reserved_fields = [
+        "thread_key",
+        "message_id",
+        "client_message_id",
+        "idempotency_key",
+        "execution_idempotency_key",
+    ];
+    let mut names = BTreeSet::new();
+    let mut agents = Vec::with_capacity(raw_agents.len());
+    for (index, raw_agent) in raw_agents.iter().enumerate() {
+        let mut args = raw_agent.as_object().cloned().ok_or_else(|| {
+            WorkflowRuntimeError::BadRequest(format!(
+                "ctx.run_agents agent at index {index} must be an object"
+            ))
+        })?;
+        let name = args
+            .get("name")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|name| !name.is_empty())
+            .ok_or_else(|| {
+                WorkflowRuntimeError::BadRequest(format!(
+                    "ctx.run_agents agent at index {index} requires a non-empty name"
+                ))
+            })?
+            .to_owned();
+        if name.len() > MAX_AGENT_BATCH_NAME_BYTES {
+            return Err(WorkflowRuntimeError::BadRequest(format!(
+                "ctx.run_agents agent name at index {index} must be at most {MAX_AGENT_BATCH_NAME_BYTES} bytes"
+            )));
+        }
+        if !names.insert(name.clone()) {
+            return Err(WorkflowRuntimeError::BadRequest(format!(
+                "ctx.run_agents agent names must be unique; duplicate {name:?}"
+            )));
+        }
+        if let Some(field) = reserved_fields
+            .iter()
+            .find(|field| args.contains_key(**field))
+        {
+            return Err(WorkflowRuntimeError::BadRequest(format!(
+                "ctx.run_agents agent {name:?} cannot set reserved field {field:?}"
+            )));
+        }
+
+        let metadata = args
+            .entry("metadata".to_owned())
+            .or_insert_with(|| json!({}));
+        if !metadata.is_object() {
+            *metadata = json!({});
+        }
+        object_insert(metadata, "workflow_agent_batch_name", json!(name));
+        object_insert(metadata, "workflow_agent_batch_index", json!(index));
+        object_insert(
+            metadata,
+            "workflow_agent_batch_request_id",
+            json!(request_id),
+        );
+
+        agents.push(PythonAgentBatchItem {
+            index,
+            name,
+            args: Value::Object(args),
+        });
+    }
+    Ok((agents, max_concurrency))
+}
+
+async fn run_bounded_ordered<T, R, F, Fut>(
+    items: Vec<T>,
+    max_concurrency: usize,
+    mut run: F,
+) -> Vec<R>
+where
+    F: FnMut(T) -> Fut,
+    Fut: Future<Output = R>,
+{
+    let item_count = items.len();
+    let futures = items
+        .into_iter()
+        .enumerate()
+        .map(|(index, item)| {
+            let future = run(item);
+            async move { (index, future.await) }
+        })
+        .collect::<Vec<_>>();
+    let completed = stream::iter(futures)
+        .buffer_unordered(max_concurrency)
+        .collect::<Vec<_>>()
+        .await;
+    let mut ordered = (0..item_count).map(|_| None).collect::<Vec<_>>();
+    for (index, result) in completed {
+        ordered[index] = Some(result);
+    }
+    ordered
+        .into_iter()
+        .map(|result| result.expect("every bounded batch future must produce one result"))
+        .collect()
+}
+
+async fn run_python_agent_batch(
+    session_runtime: SessionRuntime,
+    ctx: &TaskContext,
+    input: &WorkflowTaskInput,
+    message: &Value,
+    request_id: &str,
+) -> Result<Value, WorkflowRuntimeError> {
+    let (agents, max_concurrency) = parse_python_agent_batch(message, request_id)?;
+    let task_id = ctx.task_id().replace('-', "");
+    let batch_request_id = request_id.to_owned();
+    let outcomes = run_bounded_ordered(agents, max_concurrency, |agent| {
+        let session_runtime = session_runtime.clone();
+        let agent_slug = slugify(&agent.name);
+        let default_thread_key = format!(
+            "wf:{task_id}:agent-batch:{batch_request_id}:{}:{agent_slug}",
+            agent.index,
+        );
+        let agent_request_id = format!("{batch_request_id}:{}", agent.index);
+        async move {
+            let result = run_python_agent_turn(
+                session_runtime,
+                ctx,
+                input,
+                agent.args.clone(),
+                &agent_request_id,
+                Some(default_thread_key),
+            )
+            .await;
+            (agent, result)
+        }
+    })
+    .await;
+
+    let mut succeeded = 0;
+    let mut failed = 0;
+    let results = outcomes
+        .into_iter()
+        .map(|(agent, result)| match result {
+            Ok(result) => {
+                succeeded += 1;
+                json!({
+                    "index": agent.index,
+                    "name": agent.name,
+                    "ok": true,
+                    "result": result,
+                })
+            }
+            Err(error) => {
+                failed += 1;
+                json!({
+                    "index": agent.index,
+                    "name": agent.name,
+                    "ok": false,
+                    "error": error.to_string(),
+                })
+            }
+        })
+        .collect::<Vec<_>>();
+
+    Ok(json!({
+        "results": results,
+        "succeeded": succeeded,
+        "failed": failed,
+    }))
 }
 
 /// Returns the first arg key that holds a non-empty (trimmed) string, owned.
@@ -4198,6 +4429,133 @@ mod tests {
         );
         assert_eq!(first_str_arg(&json!({}), &["model"]), None);
         assert_eq!(first_str_arg(&json!({"model": "   "}), &["model"]), None);
+    }
+
+    #[test]
+    fn parse_agent_batch_requires_unique_names_and_adds_metadata() {
+        let message = json!({
+            "type": "ctx.run_agents",
+            "max_concurrency": 2,
+            "agents": [
+                {
+                    "name": "correctness",
+                    "text": "Review correctness",
+                    "metadata": {"pr": 42}
+                },
+                {"name": "security", "text": "Review security"}
+            ]
+        });
+
+        let (agents, max_concurrency) = parse_python_agent_batch(&message, "7").unwrap();
+
+        assert_eq!(max_concurrency, 2);
+        assert_eq!(
+            agents
+                .iter()
+                .map(|agent| agent.name.as_str())
+                .collect::<Vec<_>>(),
+            vec!["correctness", "security"]
+        );
+        assert_eq!(agents[0].args.pointer("/metadata/pr"), Some(&json!(42)));
+        assert_eq!(
+            agents[0]
+                .args
+                .pointer("/metadata/workflow_agent_batch_name"),
+            Some(&json!("correctness"))
+        );
+        assert_eq!(
+            agents[1]
+                .args
+                .pointer("/metadata/workflow_agent_batch_index"),
+            Some(&json!(1))
+        );
+        assert_eq!(
+            agents[1]
+                .args
+                .pointer("/metadata/workflow_agent_batch_request_id"),
+            Some(&json!("7"))
+        );
+    }
+
+    #[test]
+    fn parse_agent_batch_rejects_duplicate_names_and_identity_overrides() {
+        let duplicate = json!({
+            "agents": [
+                {"name": "security", "text": "first"},
+                {"name": "security", "text": "second"}
+            ]
+        });
+        let error = parse_python_agent_batch(&duplicate, "1").unwrap_err();
+        assert!(error.to_string().contains("names must be unique"));
+
+        let overridden_identity = json!({
+            "agents": [{
+                "name": "security",
+                "text": "review",
+                "thread_key": "workflow:shared"
+            }]
+        });
+        let error = parse_python_agent_batch(&overridden_identity, "1").unwrap_err();
+        assert!(error.to_string().contains("reserved field \"thread_key\""));
+    }
+
+    #[test]
+    fn parse_agent_batch_enforces_size_and_concurrency_bounds() {
+        let empty = json!({"agents": []});
+        let error = parse_python_agent_batch(&empty, "1").unwrap_err();
+        assert!(error.to_string().contains("at least one agent"));
+
+        for max_concurrency in [0, MAX_AGENT_BATCH_CONCURRENCY + 1] {
+            let message = json!({
+                "agents": [{"name": "correctness", "text": "review"}],
+                "max_concurrency": max_concurrency,
+            });
+            let error = parse_python_agent_batch(&message, "1").unwrap_err();
+            assert!(
+                error
+                    .to_string()
+                    .contains("max_concurrency must be between")
+            );
+        }
+
+        let too_many = json!({
+            "agents": (0..=MAX_AGENT_BATCH_SIZE)
+                .map(|index| json!({"name": format!("reviewer-{index}"), "text": "review"}))
+                .collect::<Vec<_>>(),
+        });
+        let error = parse_python_agent_batch(&too_many, "1").unwrap_err();
+        assert!(error.to_string().contains("supports at most"));
+    }
+
+    #[tokio::test]
+    async fn bounded_batch_limits_concurrency_and_restores_input_order() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let active = Arc::new(AtomicUsize::new(0));
+        let peak = Arc::new(AtomicUsize::new(0));
+        let results = run_bounded_ordered(vec![0_u64, 1, 2, 3], 2, {
+            let active = active.clone();
+            let peak = peak.clone();
+            move |item| {
+                let active = active.clone();
+                let peak = peak.clone();
+                async move {
+                    let now_active = active.fetch_add(1, Ordering::SeqCst) + 1;
+                    peak.fetch_max(now_active, Ordering::SeqCst);
+                    tokio::time::sleep(Duration::from_millis(4 * (4 - item))).await;
+                    active.fetch_sub(1, Ordering::SeqCst);
+                    if item == 2 {
+                        Err("review failed")
+                    } else {
+                        Ok(item)
+                    }
+                }
+            }
+        })
+        .await;
+
+        assert_eq!(results, vec![Ok(0), Ok(1), Err("review failed"), Ok(3)]);
+        assert_eq!(peak.load(Ordering::SeqCst), 2);
     }
 
     #[test]

--- a/services/api-rs/rfcs/0003-python-workflow-host.md
+++ b/services/api-rs/rfcs/0003-python-workflow-host.md
@@ -96,6 +96,7 @@ Absurd queue: centaur_workflows
                  |
                  +--> ctx.step       -> api-rs / Absurd checkpoint RPC
                  +--> ctx.agent_turn -> api-rs SessionRuntime
+                 +--> ctx.run_agents -> bounded parallel SessionRuntime turns
                  +--> ctx.call_tool  -> api-rs tool route
                  +--> ctx.post_to_slack
                  +--> ctx._pool      -> direct Postgres
@@ -200,9 +201,10 @@ While a workflow is running, the host may send requests:
 {"type":"ctx.step.get","request_id":"1","step":"load_state"}
 {"type":"ctx.step.put","request_id":"2","step":"load_state","value":{}}
 {"type":"ctx.agent_turn","request_id":"3","args":{}}
-{"type":"ctx.call_tool","request_id":"4","tool":"slack","method":"send_message","args":{}}
-{"type":"ctx.post_to_slack","request_id":"5","channel":"C123","text":"hello","args":{}}
-{"type":"ctx.log","request_id":"6","message":"workflow_event","fields":{}}
+{"type":"ctx.run_agents","request_id":"4","agents":[{"name":"security","text":"Review security"}],"max_concurrency":4}
+{"type":"ctx.call_tool","request_id":"5","tool":"slack","method":"send_message","args":{}}
+{"type":"ctx.post_to_slack","request_id":"6","channel":"C123","text":"hello","args":{}}
+{"type":"ctx.log","request_id":"7","message":"workflow_event","fields":{}}
 ```
 
 api-rs responds:
@@ -229,6 +231,7 @@ class WorkflowContext:
 
     async def step(self, name, fn, *, retry=None, timeout=None): ...
     async def agent_turn(self, text=None, **kwargs): ...
+    async def run_agents(self, agents, *, max_concurrency=None): ...
     async def call_tool(self, tool, method, args=None): ...
     async def post_to_slack(self, channel, text, **kwargs): ...
     def log(self, message, **fields): ...
@@ -274,6 +277,15 @@ Rules:
 - pass through `metadata`, `delivery`, `harness`, `persona`, and prompt override
 - wait for terminal session result and return the same result shape existing
   workflows expect
+
+### `ctx.run_agents`
+
+api-rs handles a named batch as bounded concurrent `ctx.agent_turn` operations.
+Each item receives its own workflow-owned thread key, message id, execution
+idempotency key, and batch metadata. Results preserve input order and report
+individual failures without failing the entire batch. The runtime rejects
+duplicate names and caller-supplied session or idempotency fields so two batch
+items cannot accidentally serialize through the same session.
 
 ### `ctx.call_tool`
 

--- a/services/workflow-python/api/workflow_engine.py
+++ b/services/workflow-python/api/workflow_engine.py
@@ -138,6 +138,30 @@ class WorkflowContext:
     async def start_agent(self, *args: Any, text: str | None = None, **kwargs: Any) -> Any:
         return await self.run_agent(*args, text=text, **kwargs)
 
+    async def run_agents(
+        self,
+        agents: list[dict[str, Any]],
+        *,
+        max_concurrency: int | None = None,
+    ) -> dict[str, Any]:
+        """Run named agent turns concurrently and return every outcome in input order."""
+        if not isinstance(agents, list):
+            raise TypeError("run_agents agents must be a list")
+
+        normalized_agents: list[dict[str, Any]] = []
+        for index, agent in enumerate(agents):
+            if not isinstance(agent, dict):
+                raise TypeError(f"run_agents agent at index {index} must be a dict")
+            normalized_agents.append({**self._agent_defaults, **agent})
+
+        request: dict[str, Any] = {
+            "type": "ctx.run_agents",
+            "agents": normalized_agents,
+        }
+        if max_concurrency is not None:
+            request["max_concurrency"] = max_concurrency
+        return await self._rpc.request(request)
+
     async def start_workflow(
         self,
         workflow_name: str,

--- a/services/workflow-python/tests/test_workflow_host.py
+++ b/services/workflow-python/tests/test_workflow_host.py
@@ -65,6 +65,20 @@ class RequestRpc(FakeRpc):
             }
         if message_type == "ctx.agent_turn":
             return payload["args"]
+        if message_type == "ctx.run_agents":
+            return {
+                "results": [
+                    {
+                        "index": index,
+                        "name": agent["name"],
+                        "ok": True,
+                        "result": agent,
+                    }
+                    for index, agent in enumerate(payload["agents"])
+                ],
+                "succeeded": len(payload["agents"]),
+                "failed": 0,
+            }
         if message_type == "ctx.workflow.start":
             return {
                 "workflow_name": payload["workflow_name"],
@@ -297,6 +311,77 @@ class WorkflowHostTests(unittest.TestCase):
             result,
             {"model": "claude-opus-4-8", "reasoning": "low", "text": "cheap step"},
         )
+
+    def test_run_agents_applies_defaults_and_preserves_input_order(self) -> None:
+        host = load_workflow_host()
+        rpc = RequestRpc()
+        ctx = host.WorkflowContext(
+            rpc,
+            run_id="run-123",
+            task_id="task-456",
+            workflow_name="sample",
+            agent_defaults={"harness": "codex", "reasoning": "high"},
+        )
+
+        result = asyncio.run(
+            ctx.run_agents(
+                [
+                    {"name": "correctness", "text": "Review correctness"},
+                    {
+                        "name": "security",
+                        "text": "Review security",
+                        "reasoning": "medium",
+                    },
+                ],
+                max_concurrency=2,
+            )
+        )
+
+        self.assertEqual(rpc.requests[-1]["type"], "ctx.run_agents")
+        self.assertEqual(rpc.requests[-1]["max_concurrency"], 2)
+        self.assertEqual(
+            rpc.requests[-1]["agents"],
+            [
+                {
+                    "harness": "codex",
+                    "reasoning": "high",
+                    "name": "correctness",
+                    "text": "Review correctness",
+                },
+                {
+                    "harness": "codex",
+                    "reasoning": "medium",
+                    "name": "security",
+                    "text": "Review security",
+                },
+            ],
+        )
+        self.assertEqual(
+            [item["name"] for item in result["results"]],
+            ["correctness", "security"],
+        )
+
+    def test_run_agents_rejects_non_mapping_items_before_rpc(self) -> None:
+        host = load_workflow_host()
+        rpc = RequestRpc()
+        ctx = host.WorkflowContext(
+            rpc,
+            run_id="run-123",
+            task_id="task-456",
+            workflow_name="sample",
+        )
+
+        with self.assertRaisesRegex(TypeError, "agent at index 1 must be a dict"):
+            asyncio.run(
+                ctx.run_agents(
+                    [
+                        {"name": "correctness", "text": "Review correctness"},
+                        "not-an-agent",  # type: ignore[list-item]
+                    ]
+                )
+            )
+
+        self.assertEqual(rpc.requests, [])
 
     def test_start_workflow_enqueues_durable_child_with_idempotency_key(self) -> None:
         host = load_workflow_host()
@@ -649,6 +734,70 @@ class WorkflowHostTests(unittest.TestCase):
                 response["result"],
                 {"agent_result": {"text": "daily digest"}},
             )
+            proc.wait(timeout=2)
+            self.assertEqual(proc.returncode, 0)
+            assert proc.stderr is not None
+            self.assertEqual(proc.stderr.read(), "")
+
+    def test_workflow_host_round_trips_agent_batch_result(self) -> None:
+        source = (
+            "WORKFLOW_NAME = 'review_workflow'\n"
+            "async def handler(inp, ctx):\n"
+            "    return await ctx.run_agents([\n"
+            "        {'name': 'correctness', 'text': 'Review correctness'},\n"
+            "        {'name': 'security', 'text': 'Review security'},\n"
+            "    ], max_concurrency=2)\n"
+        )
+        with self.workflow_host(source) as proc:
+            self.send_host_message(
+                proc,
+                {
+                    "type": "workflow.start",
+                    "run_id": "run-123",
+                    "task_id": "task-456",
+                    "workflow_name": "review_workflow",
+                    "input": {},
+                },
+            )
+
+            request = self.read_host_message(proc)
+            self.assertEqual(request["type"], "ctx.run_agents")
+            self.assertEqual(request["max_concurrency"], 2)
+            self.assertEqual(
+                [agent["name"] for agent in request["agents"]],
+                ["correctness", "security"],
+            )
+            result = {
+                "results": [
+                    {
+                        "index": 0,
+                        "name": "correctness",
+                        "ok": True,
+                        "result": {"result_text": "looks good"},
+                    },
+                    {
+                        "index": 1,
+                        "name": "security",
+                        "ok": False,
+                        "error": "agent unavailable",
+                    },
+                ],
+                "succeeded": 1,
+                "failed": 1,
+            }
+            self.send_host_message(
+                proc,
+                {
+                    "type": "ctx.response",
+                    "request_id": request["request_id"],
+                    "ok": True,
+                    "value": result,
+                },
+            )
+
+            response = self.read_host_message(proc)
+            self.assertEqual(response["type"], "workflow.result")
+            self.assertEqual(response["result"], result)
             proc.wait(timeout=2)
             self.assertEqual(proc.returncode, 0)
             assert proc.stderr is not None


### PR DESCRIPTION
Adds a bounded ctx.run_agents batch primitive that dispatches named workflow agent turns through independent sessions. Results preserve input order, isolate failures, and use deterministic workflow-owned identities for replay safety. Updates the workflow host API, Rust runtime, protocol coverage, and documentation.