### PR TITLE
feat(attio): add task mutations

### DIFF
--- a/tools/business/attio/cli.py
+++ b/tools/business/attio/cli.py
@@ -694,6 +694,31 @@ def add_task(
     console.print(f"[cyan]ID:[/] {task_id}")
 
 
+@app.command("complete-task")
+def complete_task(
+    task_id: str = typer.Argument(..., help="Task ID"),
+):
+    """Mark a task complete."""
+    client = _get_client()
+    task = client.update_task(task_id, is_completed=True)
+    content = task.get("content_plaintext", task_id)
+    console.print(f"[green]✓ Completed {content}[/]")
+
+
+@app.command("delete-task")
+def delete_task(
+    task_id: str = typer.Argument(..., help="Task ID"),
+    yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation"),
+):
+    """Permanently delete a task."""
+    if not yes and not typer.confirm(f"Delete task {task_id}?"):
+        raise typer.Abort()
+
+    client = _get_client()
+    client.delete_task(task_id)
+    console.print(f"[green]✓ Deleted task {task_id}[/]")
+
+
 @app.command()
 def members():
     """List workspace members."""

--- a/tools/business/attio/client.py
+++ b/tools/business/attio/client.py
@@ -408,6 +408,41 @@ class AttioClient:
         data = self._request("POST", "/tasks", json=body)
         return data.get("data", {})
 
+    def update_task(
+        self,
+        task_id: str,
+        is_completed: bool | None = None,
+        deadline: str | None = None,
+        assignees: list[str] | None = None,
+        linked_records: list[dict] | None = None,
+    ) -> dict:
+        """Update an existing task's status, deadline, assignees, or linked records."""
+        updates: dict[str, Any] = {}
+        if is_completed is not None:
+            updates["is_completed"] = is_completed
+        if deadline is not None:
+            updates["deadline_at"] = deadline
+        if assignees is not None:
+            updates["assignees"] = [
+                {
+                    "referenced_actor_type": "workspace-member",
+                    "referenced_actor_id": assignee,
+                }
+                for assignee in assignees
+            ]
+        if linked_records is not None:
+            updates["linked_records"] = linked_records
+        if not updates:
+            raise ValueError("At least one task field must be provided")
+
+        data = self._request("PATCH", f"/tasks/{task_id}", json={"data": updates})
+        return data.get("data", {})
+
+    def delete_task(self, task_id: str) -> bool:
+        """Delete a task by ID."""
+        self._request("DELETE", f"/tasks/{task_id}")
+        return True
+
     def list_workspace_members(self) -> list[dict]:
         """List workspace members."""
         data = self._request("GET", "/workspace_members")

--- a/tools/business/attio/test_client.py
+++ b/tools/business/attio/test_client.py
@@ -47,3 +47,52 @@ def test_upload_file_rejects_missing_path(tmp_path: Path) -> None:
 
     with pytest.raises(ValueError, match="does not exist"):
         client.upload_file("companies", "record-id", str(tmp_path / "missing.pdf"))
+
+
+def test_update_task_marks_task_complete() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.method == "PATCH"
+        assert request.url.path == "/v2/tasks/task-123"
+        assert request.read() == b'{"data":{"is_completed":true}}'
+        return httpx.Response(
+            200,
+            json={
+                "data": {
+                    "id": {"task_id": "task-123"},
+                    "content_plaintext": "Follow up",
+                    "is_completed": True,
+                }
+            },
+        )
+
+    client = AttioClient(api_key="test-key")
+    client._client = httpx.Client(
+        base_url="https://api.attio.com/v2",
+        transport=httpx.MockTransport(handler),
+    )
+
+    result = client.update_task("task-123", is_completed=True)
+
+    assert result["is_completed"] is True
+
+
+def test_update_task_rejects_empty_update() -> None:
+    client = AttioClient(api_key="test-key")
+
+    with pytest.raises(ValueError, match="At least one task field"):
+        client.update_task("task-123")
+
+
+def test_delete_task() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.method == "DELETE"
+        assert request.url.path == "/v2/tasks/task-123"
+        return httpx.Response(200, json={})
+
+    client = AttioClient(api_key="test-key")
+    client._client = httpx.Client(
+        base_url="https://api.attio.com/v2",
+        transport=httpx.MockTransport(handler),
+    )
+
+    assert client.delete_task("task-123") is True


### PR DESCRIPTION
## Summary

- add Attio task update and delete client methods
- expose `complete-task` and confirmation-gated `delete-task` CLI commands
- cover task completion, deletion, and empty updates with focused tests

## Validation

- `PYTHONPATH="$PWD:$PWD/tools/business/attio" uv run --no-project --with pytest --with httpx --with typer --with rich --with python-dotenv pytest -q tools/business/attio/test_client.py`
- `uv build tools/business/attio --out-dir /tmp/attio-dist`
- rendered `attio --help`, `attio complete-task --help`, and `attio delete-task --help` from the built wheel

Prompted by: @caro-phil
