### PR TITLE
feat: allow workflows to select principals

### DIFF
--- a/docs/pages/extend/workflows-v2.mdx
+++ b/docs/pages/extend/workflows-v2.mdx
@@ -223,7 +223,9 @@ result = await ctx.agent_turn(
 ```
 
 Principal lookup failures fail the turn. Put `principal` in `AGENT_DEFAULTS`
-when every agent turn in the workflow should use the same principal.
+when every agent turn in the workflow should use the same principal. An
+existing session bound to another principal returns a conflict and is not
+rebound.
 
 ### Declare webhook metadata in the workflow
 

--- a/docs/pages/extend/workflows-v2.mdx
+++ b/docs/pages/extend/workflows-v2.mdx
@@ -171,9 +171,16 @@ cargo run -p centaur-perms -- \
   --tool slack
 ```
 
-The principal id is always `workflow-` plus the slugged `WORKFLOW_NAME`.
-Workflow code cannot choose another principal id, display name, or labels.
-`WORKFLOW_PRINCIPAL = True` requires `apiRs.workflowHostSandbox=true`, which
+To use an existing principal instead, declare its foreign ID:
+
+```python
+WORKFLOW_PRINCIPAL = "finance-automation"
+```
+
+The string form resolves the existing principal and fails startup when it does
+not exist. It does not create or update the principal. The `True` form remains
+`workflow-` plus the slugged `WORKFLOW_NAME`. Any `WORKFLOW_PRINCIPAL` value
+requires `apiRs.workflowHostSandbox=true`, which
 renders `WORKFLOW_HOST_SANDBOX=true`; startup fails if a workflow declares a
 principal while workflow-host sandboxing is disabled.
 
@@ -204,6 +211,19 @@ async def handler(inp: Input, ctx: WorkflowContext) -> dict[str, Any]:
 Keep `harness` and `model` together — a model is only meaningful within its
 harness, and because kwargs override `AGENT_DEFAULTS` key by key, overriding one
 without the other can strand a model on the wrong harness.
+
+Agent turns can also select an existing principal by foreign ID. This applies
+to `ctx.agent_turn(...)`, its aliases, and each `ctx.run_agents(...)` item:
+
+```python
+result = await ctx.agent_turn(
+    "Prepare the finance report.",
+    principal="finance-automation",
+)
+```
+
+Principal lookup failures fail the turn. Put `principal` in `AGENT_DEFAULTS`
+when every agent turn in the workflow should use the same principal.
 
 ### Declare webhook metadata in the workflow
 

--- a/docs/pages/extend/workflows.mdx
+++ b/docs/pages/extend/workflows.mdx
@@ -156,7 +156,9 @@ result = await ctx.agent_turn(
 ```
 
 The principal is resolved before the session is created. An unknown or empty
-foreign ID fails the turn instead of using the thread-derived principal.
+foreign ID fails the turn instead of using the thread-derived principal. If the
+session already exists under another principal, the turn returns a conflict
+instead of rebinding it.
 
 ## Run a workflow
 

--- a/docs/pages/extend/workflows.mdx
+++ b/docs/pages/extend/workflows.mdx
@@ -66,11 +66,13 @@ async def handler(inp: Input, ctx: WorkflowContext) -> dict[str, Any]:
 
 `WORKFLOW_PRINCIPAL` is optional. Use it when the workflow host calls tools
 directly with `ctx.call_tool(...)` and should have its own credential boundary.
-The API derives and registers the `workflow-nightly-report` principal from
-`WORKFLOW_NAME` and runs that workflow-host sandbox under it. Workflow code
-cannot choose another principal id, display name, or labels. Grant the required
-tool roles or secrets to the derived principal. `WORKFLOW_PRINCIPAL = True`
-requires `apiRs.workflowHostSandbox=true`, which renders
+Set it to `True` to have the API derive and register the
+`workflow-nightly-report` principal from `WORKFLOW_NAME`. Set it to an existing
+principal foreign ID, such as `WORKFLOW_PRINCIPAL = "finance-automation"`, to
+run the workflow-host sandbox under that principal instead. An unknown foreign
+ID fails startup. Grant the required tool roles or secrets to the selected
+principal. Any `WORKFLOW_PRINCIPAL` value requires
+`apiRs.workflowHostSandbox=true`, which renders
 `WORKFLOW_HOST_SANDBOX=true`; startup fails if workflow-host sandboxing is
 disabled.
 
@@ -139,9 +141,22 @@ discarding successful reviews:
 ```
 
 Batch items accept the same model, provider, reasoning, harness, persona,
-prompt, content, idle timeout, maximum duration, and metadata options as
-`ctx.agent_turn(...)`. Session and idempotency fields are reserved because the
-batch runtime assigns them independently for each agent.
+principal, prompt, content, idle timeout, maximum duration, and metadata
+options as `ctx.agent_turn(...)`. Session and idempotency fields are reserved
+because the batch runtime assigns them independently for each agent.
+
+Set `principal` to an existing principal foreign ID when an agent turn needs a
+specific credential boundary:
+
+```python
+result = await ctx.agent_turn(
+    "Prepare the finance report.",
+    principal="finance-automation",
+)
+```
+
+The principal is resolved before the session is created. An unknown or empty
+foreign ID fails the turn instead of using the thread-derived principal.
 
 ## Run a workflow
 

--- a/docs/pages/secrets/advanced-permissioning.mdx
+++ b/docs/pages/secrets/advanced-permissioning.mdx
@@ -63,6 +63,7 @@ The stable principal ids follow these rules:
 | Teams personal chat | `teams-user-<user-id>` | That Teams user |
 | Teams channel or group conversation | `teams-conversation-<conversation-id>` | Everyone using Centaur in that conversation |
 | Workflow with `WORKFLOW_PRINCIPAL = True` | `workflow-<workflow-name>` | Runs of that workflow |
+| Workflow with `WORKFLOW_PRINCIPAL = "<foreign-id>"` | The selected existing principal | Runs of that workflow |
 | Other session key | `thread-<session-key>` | That session key |
 
 Values are lowercased and converted to URL-safe slugs. The team scope is
@@ -405,9 +406,12 @@ credential. Grant that wrapper secret to a user, channel, or role like any
 other secret. See [OAuth Apps](/secrets/oauth-apps) for registration and
 consent.
 
-Workflows opt into isolated permissions with `WORKFLOW_PRINCIPAL = True`.
-Centaur derives `workflow-<workflow-name>` and does not let workflow code choose
-another identity. Grant the workflow only the roles or secrets it needs. See
+Workflows opt into isolated permissions with `WORKFLOW_PRINCIPAL = True`, which
+derives `workflow-<workflow-name>`. They can instead set `WORKFLOW_PRINCIPAL` to
+an existing principal foreign ID. Agent turns can select an existing principal
+with `ctx.agent_turn(..., principal="<foreign-id>")`. Unknown foreign IDs fail
+instead of falling back to a broader identity. Grant workflows and agent turns
+only the roles or secrets they need. See
 [Creating Workflows](/extend/workflows#define-a-workflow).
 
 ## Operational Checklist

--- a/services/api-rs/crates/centaur-api-server/src/error.rs
+++ b/services/api-rs/crates/centaur-api-server/src/error.rs
@@ -67,6 +67,9 @@ impl IntoResponse for ApiError {
             Self::Runtime(SessionRuntimeError::Store(SessionStoreError::PersonaConflict {
                 ..
             })) => StatusCode::CONFLICT,
+            Self::Runtime(SessionRuntimeError::Store(SessionStoreError::PrincipalConflict {
+                ..
+            })) => StatusCode::CONFLICT,
             Self::Runtime(SessionRuntimeError::IronControl(
                 centaur_iron_control::IronControlError::PrincipalDerivation(_),
             )) => StatusCode::BAD_REQUEST,
@@ -109,6 +112,16 @@ impl IntoResponse for ApiError {
             body["existing_harness"] = json!(existing);
             body["requested_harness"] = json!(requested);
         }
+        if let Self::Runtime(SessionRuntimeError::Store(SessionStoreError::PrincipalConflict {
+            existing,
+            requested,
+            ..
+        })) = &self
+        {
+            body["code"] = json!("principal_conflict");
+            body["existing_principal"] = json!(existing);
+            body["requested_principal"] = json!(requested);
+        }
         let mut response = (status, Json(body)).into_response();
         if status == StatusCode::UNAUTHORIZED {
             response
@@ -138,6 +151,7 @@ pub(crate) fn error_chain(error: &dyn std::error::Error) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use axum::body::to_bytes;
     use centaur_iron_control::{IronControlError, PrincipalDerivationError};
 
     #[test]
@@ -148,5 +162,26 @@ mod tests {
         .into_response();
 
         assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn principal_conflicts_include_structured_details() {
+        let response = ApiError::Runtime(SessionRuntimeError::Store(
+            SessionStoreError::PrincipalConflict {
+                thread_key: "workflow:report".to_owned(),
+                existing: "prn_finance".to_owned(),
+                requested: "prn_support".to_owned(),
+            },
+        ))
+        .into_response();
+
+        assert_eq!(response.status(), StatusCode::CONFLICT);
+        let body = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("read response body");
+        let body: serde_json::Value = serde_json::from_slice(&body).expect("decode response body");
+        assert_eq!(body["code"], json!("principal_conflict"));
+        assert_eq!(body["existing_principal"], json!("prn_finance"));
+        assert_eq!(body["requested_principal"], json!("prn_support"));
     }
 }

--- a/services/api-rs/crates/centaur-session-runtime/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-runtime/src/lib.rs
@@ -1428,7 +1428,7 @@ impl SessionRuntime {
             if let Some(context) = persona_resolution.context.as_ref() {
                 add_persona_metadata(&mut session_metadata, context);
             }
-            let session = match self
+            match self
                 .store
                 .create_or_get_session(
                     thread_key,
@@ -1464,6 +1464,14 @@ impl SessionRuntime {
                 }
                 Err(error) => return Err(error.into()),
             };
+            // Persist the principal OID on the session row so a resumed session
+            // can recreate its sandbox after a restart without re-deriving it.
+            // Existing sessions are immutable at this boundary: changing their
+            // credential identity requires a different session.
+            let session = self
+                .store
+                .bind_iron_control_principal(thread_key, &registered_principal.id)
+                .await?;
             if let Some(context) = self.resolve_stored_persona(
                 session.persona_id.as_deref(),
                 harness_type,
@@ -1482,12 +1490,6 @@ impl SessionRuntime {
                     )
                     .await?;
             }
-            // Persist the principal OID on the session row so a resumed session
-            // can recreate its sandbox after a restart without re-deriving it.
-            let session = self
-                .store
-                .set_iron_control_principal(thread_key, Some(&registered_principal.id))
-                .await?;
             info!(
                 component = COMPONENT_SESSION_RUNTIME,
                 event = "session_create_or_get_completed",
@@ -9234,6 +9236,35 @@ mod adoption_tests {
 
         assert_eq!(
             outcome.session.iron_control_principal.as_deref(),
+            Some("finance-automation")
+        );
+
+        let error = runtime
+            .create_or_get_session_with_principal(
+                &thread_key,
+                &HarnessType::Codex,
+                None,
+                Some(json!({})),
+                HarnessConflictPolicy::Reject,
+                Some("support-automation"),
+            )
+            .await
+            .expect_err("existing session principal must not be rebound");
+        assert!(matches!(
+            error,
+            SessionRuntimeError::Store(SessionStoreError::PrincipalConflict {
+                existing,
+                requested,
+                ..
+            }) if existing == "finance-automation" && requested == "support-automation"
+        ));
+        assert_eq!(
+            store
+                .get_session(&thread_key)
+                .await
+                .expect("get session after conflict")
+                .iron_control_principal
+                .as_deref(),
             Some("finance-automation")
         );
     }

--- a/services/api-rs/crates/centaur-session-runtime/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-runtime/src/lib.rs
@@ -1356,6 +1356,38 @@ impl SessionRuntime {
         metadata: Option<Value>,
         on_harness_conflict: HarnessConflictPolicy,
     ) -> Result<CreateOrGetSessionOutcome, SessionRuntimeError> {
+        self.create_or_get_session_with_principal(
+            thread_key,
+            harness_type,
+            persona_id,
+            metadata,
+            on_harness_conflict,
+            None,
+        )
+        .await
+    }
+
+    /// Create or load a session and bind it to an existing iron-control
+    /// principal selected by foreign ID. When no foreign ID is supplied, the
+    /// session keeps the normal principal derived from its thread key.
+    pub async fn create_or_get_session_with_principal(
+        &self,
+        thread_key: &ThreadKey,
+        harness_type: &HarnessType,
+        persona_id: Option<&str>,
+        metadata: Option<Value>,
+        on_harness_conflict: HarnessConflictPolicy,
+        principal_foreign_id: Option<&str>,
+    ) -> Result<CreateOrGetSessionOutcome, SessionRuntimeError> {
+        let principal_foreign_id = match principal_foreign_id {
+            Some(foreign_id) if foreign_id.trim().is_empty() => {
+                return Err(SessionRuntimeError::BadRequest(
+                    "principal must be a non-empty foreign ID".to_owned(),
+                ));
+            }
+            Some(foreign_id) => Some(foreign_id.trim()),
+            None => None,
+        };
         let span = info_span!(
             "centaur.api_rs.session.create_or_get",
             component = COMPONENT_SESSION_RUNTIME,
@@ -1382,10 +1414,14 @@ impl SessionRuntime {
             let mut harness_switched = false;
             let mut session_metadata = default_metadata(metadata);
             let proxy_labels = proxy_labels_from_session_metadata(thread_key, &session_metadata);
-            let registered_principal = self
-                .iron_control
-                .register_session(thread_key.as_str(), Some(&session_metadata))
-                .await?;
+            let registered_principal = match principal_foreign_id {
+                Some(foreign_id) => self.iron_control.get_principal(foreign_id).await?,
+                None => {
+                    self.iron_control
+                        .register_session(thread_key.as_str(), Some(&session_metadata))
+                        .await?
+                }
+            };
             let desired_capabilities = sandbox_capabilities_from_principal(&registered_principal);
             let persona_resolution =
                 self.resolve_persona_for_create(persona_id, &desired_capabilities)?;
@@ -9171,6 +9207,35 @@ mod adoption_tests {
             SandboxRuntime::backend(backend, SandboxSpec::new("mock")),
             TestSessionPrincipalRegistrar,
         )
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn create_session_can_select_principal_by_foreign_id() {
+        let Some(store) = test_store().await else {
+            return;
+        };
+        let _serial = TEST_LOCK.lock().await;
+        let thread_key =
+            ThreadKey::parse(format!("test:principal-{}", uuid::Uuid::new_v4())).unwrap();
+        let backend = Arc::new(MockBackend::new(SandboxStatus::Running, Vec::new()));
+        let runtime = runtime_with(&store, backend);
+
+        let outcome = runtime
+            .create_or_get_session_with_principal(
+                &thread_key,
+                &HarnessType::Codex,
+                None,
+                Some(json!({})),
+                HarnessConflictPolicy::Reject,
+                Some(" finance-automation "),
+            )
+            .await
+            .expect("create session with selected principal");
+
+        assert_eq!(
+            outcome.session.iron_control_principal.as_deref(),
+            Some("finance-automation")
+        );
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/services/api-rs/crates/centaur-session-sqlx/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-sqlx/src/lib.rs
@@ -1372,6 +1372,47 @@ impl PgSessionStore {
         row.try_into()
     }
 
+    /// Bind a principal to a session without allowing an existing binding to
+    /// change. The conditional update makes concurrent first bindings atomic:
+    /// one caller wins, and a caller selecting a different principal receives
+    /// a conflict instead of rebinding the session.
+    pub async fn bind_iron_control_principal(
+        &self,
+        thread_key: &ThreadKey,
+        iron_control_principal: &str,
+    ) -> Result<Session, SessionStoreError> {
+        let row = sqlx::query_as::<_, SessionRow>(
+            r#"
+            update sessions
+            set iron_control_principal = $2, updated_at = now()
+            where thread_key = $1
+              and (iron_control_principal is null or iron_control_principal = $2)
+            returning thread_key, title, sandbox_id, sandbox_repo_cache_enabled, sandbox_repo_cache_access, sandbox_observability_enabled, harness_type, harness_thread_id, persona_id, status, iron_control_principal, proxy_labels, sandbox_last_active_at, created_at, updated_at
+            "#,
+        )
+        .bind(thread_key.as_str())
+        .bind(iron_control_principal)
+        .fetch_optional(&self.pool)
+        .await?;
+
+        if let Some(row) = row {
+            return row.try_into();
+        }
+
+        let session = self.get_session(thread_key).await?;
+        match session.iron_control_principal {
+            Some(existing) => Err(SessionStoreError::PrincipalConflict {
+                thread_key: thread_key.as_str().to_owned(),
+                existing,
+                requested: iron_control_principal.to_owned(),
+            }),
+            None => Err(SessionStoreError::InvalidPersistedValue(format!(
+                "session {} remained unbound after principal binding",
+                thread_key.as_str()
+            ))),
+        }
+    }
+
     pub async fn insert_ready_warm_sandbox(
         &self,
         sandbox_id: &str,
@@ -1649,6 +1690,12 @@ pub enum SessionStoreError {
         thread_key: String,
         existing: Option<String>,
         requested: Option<String>,
+    },
+    #[error("session {thread_key} already exists with principal {existing}, requested {requested}")]
+    PrincipalConflict {
+        thread_key: String,
+        existing: String,
+        requested: String,
     },
     #[error("invalid persisted value: {0}")]
     InvalidPersistedValue(String),

--- a/services/api-rs/crates/centaur-workflows/src/lib.rs
+++ b/services/api-rs/crates/centaur-workflows/src/lib.rs
@@ -195,7 +195,7 @@ impl WorkflowEnablement {
         });
         metadata
             .principals
-            .retain(|workflow_name| self.is_enabled(workflow_name));
+            .retain(|workflow_name, _| self.is_enabled(workflow_name));
     }
 }
 
@@ -227,6 +227,12 @@ pub struct WorkflowHostSandboxRuntime {
 struct WorkflowPrincipalAssignments {
     required: BTreeSet<String>,
     registered: BTreeMap<String, String>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+enum WorkflowPrincipalDeclaration {
+    Managed,
+    Existing(String),
 }
 
 impl WorkflowPrincipalAssignments {
@@ -298,24 +304,30 @@ impl WorkflowPrincipalRegistrar {
 
     async fn register_workflow_principals(
         &self,
-        principals: &BTreeSet<String>,
+        principals: &BTreeMap<String, WorkflowPrincipalDeclaration>,
     ) -> Result<BTreeMap<String, String>, WorkflowRuntimeError> {
         let mut registered = BTreeMap::new();
-        for workflow_name in principals {
-            let foreign_id = canonical_workflow_principal_foreign_id(workflow_name);
-            let record = self
-                .client
-                .upsert_principal(&PrincipalInput {
-                    foreign_id,
-                    name: format!("Workflow {workflow_name}"),
-                    labels: workflow_principal_labels(workflow_name),
-                    kind: Some("workflow".to_owned()),
-                    slack_user_id: None,
-                    slack_channel_id: None,
-                    slack_team_id: None,
-                    slack_email: None,
-                })
-                .await?;
+        for (workflow_name, declaration) in principals {
+            let record = match declaration {
+                WorkflowPrincipalDeclaration::Managed => {
+                    let foreign_id = canonical_workflow_principal_foreign_id(workflow_name);
+                    self.client
+                        .upsert_principal(&PrincipalInput {
+                            foreign_id,
+                            name: format!("Workflow {workflow_name}"),
+                            labels: workflow_principal_labels(workflow_name),
+                            kind: Some("workflow".to_owned()),
+                            slack_user_id: None,
+                            slack_channel_id: None,
+                            slack_team_id: None,
+                            slack_email: None,
+                        })
+                        .await?
+                }
+                WorkflowPrincipalDeclaration::Existing(foreign_id) => {
+                    self.client.get_principal(foreign_id).await?
+                }
+            };
             registered.insert(workflow_name.clone(), record.id);
         }
         Ok(registered)
@@ -1657,7 +1669,14 @@ struct PythonWorkflowDiscovery {
     #[serde(default)]
     schedule: Option<Value>,
     #[serde(default)]
-    principal: Option<bool>,
+    principal: Option<PythonWorkflowPrincipal>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum PythonWorkflowPrincipal {
+    Enabled(bool),
+    ForeignId(String),
 }
 
 #[derive(Debug, Deserialize)]
@@ -1670,7 +1689,7 @@ struct PythonWorkflowMetadata {
     webhooks: Vec<RegisteredWorkflowWebhook>,
     schedules: Vec<Value>,
     workflow_names: BTreeSet<String>,
-    principals: BTreeSet<String>,
+    principals: BTreeMap<String, WorkflowPrincipalDeclaration>,
 }
 
 fn metadata_from_discovery_payload(
@@ -1693,8 +1712,22 @@ fn metadata_from_discovery_payload(
             }
             metadata.schedules.push(schedule);
         }
-        if workflow.principal.unwrap_or(false) {
-            metadata.principals.insert(workflow.workflow_name);
+        match workflow.principal {
+            Some(PythonWorkflowPrincipal::Enabled(true)) => {
+                metadata.principals.insert(
+                    workflow.workflow_name,
+                    WorkflowPrincipalDeclaration::Managed,
+                );
+            }
+            Some(PythonWorkflowPrincipal::ForeignId(foreign_id))
+                if !foreign_id.trim().is_empty() =>
+            {
+                metadata.principals.insert(
+                    workflow.workflow_name,
+                    WorkflowPrincipalDeclaration::Existing(foreign_id.trim().to_owned()),
+                );
+            }
+            _ => {}
         }
     }
     metadata
@@ -1710,7 +1743,7 @@ async fn prepare_workflow_host_sandbox(
         if !discovery.principals.is_empty() {
             let workflow_names = discovery
                 .principals
-                .iter()
+                .keys()
                 .cloned()
                 .collect::<Vec<_>>()
                 .join(", ");
@@ -1737,15 +1770,16 @@ async fn reconcile_workflow_principals(
     enablement: &WorkflowEnablement,
 ) -> Result<(), WorkflowRuntimeError> {
     let mut principals = discovery.principals.clone();
-    principals.retain(|workflow_name| enablement.is_enabled(workflow_name));
+    principals.retain(|workflow_name, _| enablement.is_enabled(workflow_name));
+    let required = principals.keys().cloned().collect();
     let registered = match registrar.register_workflow_principals(&principals).await {
         Ok(registered) => registered,
         Err(error) => {
-            sandbox.update_workflow_principals(BTreeMap::new(), principals);
+            sandbox.update_workflow_principals(BTreeMap::new(), required);
             return Err(error);
         }
     };
-    sandbox.update_workflow_principals(registered, principals);
+    sandbox.update_workflow_principals(registered, required);
     Ok(())
 }
 
@@ -2661,6 +2695,7 @@ async fn run_centaur_workflow_inner(
                 .get("max_duration_ms")
                 .and_then(Value::as_u64)
                 .unwrap_or(DEFAULT_AGENT_MAX_DURATION_MS);
+            let principal_foreign_id = parse_agent_principal(&input.input).map_err(absurd_error)?;
             let agent = ctx
                 .step("agent_turn", || {
                     let session_runtime = session_runtime.clone();
@@ -2683,6 +2718,7 @@ async fn run_centaur_workflow_inner(
                                 thread_key,
                                 harness_type,
                                 persona_id: None,
+                                principal_foreign_id,
                                 parts: vec![json!({"type": "text", "text": prompt})],
                                 client_message_id: client_message_id.clone(),
                                 session_metadata: metadata.clone(),
@@ -3570,6 +3606,7 @@ async fn run_python_agent_turn(
         .or_else(|| args.get("persona"))
         .and_then(Value::as_str)
         .map(ToOwned::to_owned);
+    let principal_foreign_id = parse_agent_principal(&args)?;
     let client_message_id = args
         .get("message_id")
         .or_else(|| args.get("client_message_id"))
@@ -3598,6 +3635,13 @@ async fn run_python_agent_turn(
     }
     if let Some(engine) = args.get("engine").and_then(Value::as_str) {
         object_insert(&mut execution_metadata, "engine", json!(engine));
+    }
+    if let Some(principal) = principal_foreign_id.as_deref() {
+        object_insert(
+            &mut execution_metadata,
+            "principal_foreign_id",
+            json!(principal),
+        );
     }
     let idle_timeout_ms = args
         .get("idle_timeout_ms")
@@ -3630,6 +3674,7 @@ async fn run_python_agent_turn(
             thread_key,
             harness_type,
             persona_id,
+            principal_foreign_id,
             parts,
             client_message_id,
             session_metadata,
@@ -3863,6 +3908,26 @@ fn first_str_arg(args: &Value, keys: &[&str]) -> Option<String> {
         .map(str::trim)
         .find(|value| !value.is_empty())
         .map(ToOwned::to_owned)
+}
+
+fn parse_agent_principal(args: &Value) -> Result<Option<String>, WorkflowRuntimeError> {
+    let Some(value) = args
+        .get("principal")
+        .or_else(|| args.get("principal_foreign_id"))
+    else {
+        return Ok(None);
+    };
+    let foreign_id = value.as_str().map(str::trim).ok_or_else(|| {
+        WorkflowRuntimeError::BadRequest(
+            "ctx.agent_turn principal must be a non-empty foreign ID".to_owned(),
+        )
+    })?;
+    if foreign_id.is_empty() {
+        return Err(WorkflowRuntimeError::BadRequest(
+            "ctx.agent_turn principal must be a non-empty foreign ID".to_owned(),
+        ));
+    }
+    Ok(Some(foreign_id.to_owned()))
 }
 
 fn parse_agent_harness(args: &Value) -> Result<Option<HarnessType>, WorkflowRuntimeError> {
@@ -4130,6 +4195,7 @@ struct AgentTurnRequest {
     thread_key: String,
     harness_type: HarnessType,
     persona_id: Option<String>,
+    principal_foreign_id: Option<String>,
     parts: Vec<Value>,
     client_message_id: String,
     session_metadata: Value,
@@ -4185,6 +4251,7 @@ async fn run_agent_session_turn(
         thread_key,
         harness_type,
         persona_id,
+        principal_foreign_id,
         parts,
         client_message_id,
         session_metadata,
@@ -4204,12 +4271,13 @@ async fn run_agent_session_turn(
         object_insert(&mut session_metadata, "workflow_owned_thread", json!(true));
     }
     session_runtime
-        .create_or_get_session(
+        .create_or_get_session_with_principal(
             &thread_key,
             &harness_type,
             persona_id.as_deref(),
             Some(session_metadata),
             HarnessConflictPolicy::Reject,
+            principal_foreign_id.as_deref(),
         )
         .await?;
     session_runtime
@@ -4432,6 +4500,21 @@ mod tests {
     }
 
     #[test]
+    fn parse_agent_principal_accepts_foreign_id_and_rejects_invalid_values() {
+        assert_eq!(
+            parse_agent_principal(&json!({"principal": " finance-automation "})).unwrap(),
+            Some("finance-automation".to_owned())
+        );
+        assert_eq!(
+            parse_agent_principal(&json!({"principal_foreign_id": "support"})).unwrap(),
+            Some("support".to_owned())
+        );
+        assert_eq!(parse_agent_principal(&json!({})).unwrap(), None);
+        assert!(parse_agent_principal(&json!({"principal": "  "})).is_err());
+        assert!(parse_agent_principal(&json!({"principal": true})).is_err());
+    }
+
+    #[test]
     fn parse_agent_batch_requires_unique_names_and_adds_metadata() {
         let message = json!({
             "type": "ctx.run_agents",
@@ -4440,6 +4523,7 @@ mod tests {
                 {
                     "name": "correctness",
                     "text": "Review correctness",
+                    "principal": "security-reviewers",
                     "metadata": {"pr": 42}
                 },
                 {"name": "security", "text": "Review security"}
@@ -4457,6 +4541,10 @@ mod tests {
             vec!["correctness", "security"]
         );
         assert_eq!(agents[0].args.pointer("/metadata/pr"), Some(&json!(42)));
+        assert_eq!(
+            agents[0].args.get("principal"),
+            Some(&json!("security-reviewers"))
+        );
         assert_eq!(
             agents[0]
                 .args
@@ -4836,6 +4924,7 @@ mod tests {
                 {
                     "workflow_name": "manual_workflow",
                     "source_path": "workflows/manual_workflow.py",
+                    "principal": "finance-automation",
                 },
             ],
         }))
@@ -4853,7 +4942,16 @@ mod tests {
             metadata.schedules[0].get("workflow_name"),
             Some(&json!("scheduled_workflow"))
         );
-        assert!(metadata.principals.contains("scheduled_workflow"));
+        assert_eq!(
+            metadata.principals.get("scheduled_workflow"),
+            Some(&WorkflowPrincipalDeclaration::Managed)
+        );
+        assert_eq!(
+            metadata.principals.get("manual_workflow"),
+            Some(&WorkflowPrincipalDeclaration::Existing(
+                "finance-automation".to_owned()
+            ))
+        );
     }
 
     #[test]
@@ -4911,7 +5009,10 @@ mod tests {
     #[tokio::test]
     async fn workflow_principal_requires_workflow_host_sandbox() {
         let discovery = PythonWorkflowMetadata {
-            principals: BTreeSet::from(["nightly_report".to_owned()]),
+            principals: BTreeMap::from([(
+                "nightly_report".to_owned(),
+                WorkflowPrincipalDeclaration::Managed,
+            )]),
             workflow_names: BTreeSet::from(["nightly_report".to_owned()]),
             ..PythonWorkflowMetadata::default()
         };
@@ -5123,7 +5224,7 @@ mod tests {
         assert_eq!(metadata.webhooks.len(), 1);
         assert_eq!(metadata.webhooks[0].workflow_name, "allowed_workflow");
         assert_eq!(
-            metadata.principals.iter().cloned().collect::<Vec<_>>(),
+            metadata.principals.keys().cloned().collect::<Vec<_>>(),
             vec!["allowed_workflow".to_owned()]
         );
     }

--- a/services/workflow-python/tests/test_workflow_host.py
+++ b/services/workflow-python/tests/test_workflow_host.py
@@ -312,6 +312,25 @@ class WorkflowHostTests(unittest.TestCase):
             {"model": "claude-opus-4-8", "reasoning": "low", "text": "cheap step"},
         )
 
+    def test_agent_turn_forwards_principal_foreign_id(self) -> None:
+        host = load_workflow_host()
+        rpc = RequestRpc()
+        ctx = host.WorkflowContext(
+            rpc,
+            run_id="run-123",
+            task_id="task-456",
+            workflow_name="sample",
+        )
+
+        result = asyncio.run(
+            ctx.agent_turn("do the thing", principal="finance-automation")
+        )
+
+        self.assertEqual(
+            result,
+            {"principal": "finance-automation", "text": "do the thing"},
+        )
+
     def test_run_agents_applies_defaults_and_preserves_input_order(self) -> None:
         host = load_workflow_host()
         rpc = RequestRpc()
@@ -577,6 +596,21 @@ class WorkflowHostTests(unittest.TestCase):
 
         assert registered is not None
         self.assertEqual(host.normalize_principal(registered), True)
+
+    def test_load_workflow_file_reads_workflow_principal_foreign_id(self) -> None:
+        host = load_workflow_host()
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "principal_workflow.py"
+            path.write_text(
+                "WORKFLOW_NAME = 'principal_workflow'\n"
+                "WORKFLOW_PRINCIPAL = ' finance-automation '\n"
+                "def handler(inp, ctx):\n"
+                "    return None\n"
+            )
+            registered = host.load_workflow_file(path)
+
+        assert registered is not None
+        self.assertEqual(host.normalize_principal(registered), "finance-automation")
 
     def test_workflow_name_from_source_reads_string_constant(self) -> None:
         host = load_workflow_host()

--- a/services/workflow-python/workflow_host.py
+++ b/services/workflow-python/workflow_host.py
@@ -356,9 +356,14 @@ def normalize_schedule(workflow: RegisteredWorkflow) -> dict[str, Any] | None:
     return schedule
 
 
-def normalize_principal(workflow: RegisteredWorkflow) -> bool | None:
+def normalize_principal(workflow: RegisteredWorkflow) -> bool | str | None:
     raw = workflow.principal
-    return raw if isinstance(raw, bool) and raw else None
+    if isinstance(raw, bool):
+        return raw or None
+    if isinstance(raw, str):
+        foreign_id = raw.strip()
+        return foreign_id or None
+    return None
 
 
 async def run_workflow(message: dict[str, Any], rpc: RpcClient) -> dict[str, Any]:


### PR DESCRIPTION
Allows workflow definitions and individual agent turns to select an existing iron-control principal by foreign ID while preserving the existing managed workflow-principal behavior. Principal lookup is fail-closed, applies to batched agent turns and workflow defaults, and now returns a structured conflict without rebinding when a session already belongs to another principal. The behavior is documented with focused Rust and Python coverage.