### PR TITLE
build: add GitHubKit to workflow host

### DIFF
--- a/services/workflow-python/pyproject.toml
+++ b/services/workflow-python/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "google-auth-httplib2>=0.2.0",
     "google-auth-oauthlib>=1.2.0",
     "google-cloud-bigquery>=3.25.0",
+    "githubkit>=0.16.1",
     "httplib2>=0.20.0",
     "httpx>=0.28.0",
     "openai>=2.53.0",


### PR DESCRIPTION
Adds GitHubKit to the Python workflow host so durable workflows can use its async REST and GraphQL clients. This is required by the Centaur review agent workflow in centaur-paradigm.