### PR TITLE
feat: add githubkit workflow dependency

### DIFF
--- a/services/sandbox/Dockerfile
+++ b/services/sandbox/Dockerfile
@@ -57,6 +57,7 @@ RUN --mount=type=cache,target=/root/.cache/pip,sharing=locked \
     "openai>=2.53.0" \
     opentelemetry-proto==1.42.1 \
     "psycopg[binary]>=3.2.0" \
+    "githubkit>=0.16.1" \
     pysocks>=1.7.1 \
     rich>=13.0.0 \
     slack-sdk==3.39.0 \

--- a/services/workflow-python/pyproject.toml
+++ b/services/workflow-python/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "httpx>=0.28.0",
     "openai>=2.53.0",
     "psycopg[binary]>=3.2.0",
+    "githubkit>=0.16.1",
     "pysocks>=1.7.1",
     "rich>=13.0.0",
     "slack-sdk>=3.39.0",


### PR DESCRIPTION
Adds githubkit to the Python workflow host and sandbox image so workflows can use its typed async GitHub client. The workflow host test suite passes with the new dependency installed.