### PR TITLE
fix(granola): resolve shared meeting links

### DIFF
--- a/services/sandbox/SYSTEM_PROMPT.md
+++ b/services/sandbox/SYSTEM_PROMPT.md
@@ -49,6 +49,10 @@
 |When a user asks for the transcript, exact quote or verbatim lines, recap, or summary of a specific audio/video source — such as a podcast, episode, video, interview, webinar, livestream, talk, or recording — first confirm that you can access that exact original source or its official transcript. If the exact source is unavailable, say so plainly and ask before using show notes, clips, related coverage, adjacent interviews, or other substitute materials.
 |Exception: if the user explicitly asks for off-the-cuff brainstorming or quick speculation, you may stay in brainstorming mode and say that you are not grounding it first.
 
+[Granola share links]
+|When a user provides a `notes.granola.ai` link, pass that exact link to `granola get` before using semantic search or related meeting results. The tool resolves both `/d/<meeting-uuid>` and `/t/<meeting-uuid>-<share-suffix>` links to the same meeting.
+|If direct retrieval fails, report that the linked meeting could not be accessed. Do not substitute a similarly titled meeting or infer the linked meeting's contents from search results.
+
 [Company-context retrieval]
 |For questions about internal history, discussions, decisions, themes, or prior work, use `company_context search` before source-specific tools.
 |Use hybrid search by default for conceptual, thematic, or natural-language queries. Preserve the user's wording for the first query and add no more than one or two focused semantic variants when needed.

--- a/services/sandbox/test_system_prompt.py
+++ b/services/sandbox/test_system_prompt.py
@@ -20,6 +20,14 @@ class SystemPromptTest(unittest.TestCase):
         self.assertIn("Distinguish direct internal views from AI-generated research", prompt)
         self.assertIn("If retrieval remains weak", prompt)
 
+    def test_granola_share_links_require_direct_retrieval(self) -> None:
+        prompt = SYSTEM_PROMPT.read_text()
+
+        self.assertIn("[Granola share links]", prompt)
+        self.assertIn("pass that exact link to `granola get`", prompt)
+        self.assertIn("both `/d/<meeting-uuid>` and `/t/<meeting-uuid>-<share-suffix>`", prompt)
+        self.assertIn("Do not substitute a similarly titled meeting", prompt)
+
     def test_mpp_fallback_discovery_guidance_is_present(self) -> None:
         prompt = SYSTEM_PROMPT.read_text()
 

--- a/tools/productivity/granola/cli.py
+++ b/tools/productivity/granola/cli.py
@@ -87,7 +87,7 @@ def list_notes(
 
 @app.command("get")
 def get_note(
-    note_id: str = typer.Argument(..., help="Note ID (e.g. not_xxxxxxxxxxxxx)"),
+    note_id: str = typer.Argument(..., help="Note ID, meeting UUID, or Granola share link"),
     raw: bool = typer.Option(False, "--raw", "-r", help="Output raw markdown"),
     transcript: bool = typer.Option(False, "--transcript", "-t", help="Include transcript"),
 ):
@@ -131,7 +131,7 @@ def get_note(
 
 @app.command("transcript")
 def get_transcript(
-    note_id: str = typer.Argument(..., help="Note ID"),
+    note_id: str = typer.Argument(..., help="Note ID, meeting UUID, or Granola share link"),
 ):
     """Get the transcript for a meeting note."""
     from .client import _client

--- a/tools/productivity/granola/client.py
+++ b/tools/productivity/granola/client.py
@@ -19,10 +19,27 @@ from typing import Any
 from xml.etree import ElementTree
 
 import httpx
+
 from centaur_sdk import secret
 
 API_BASE = "https://public-api.granola.ai"
 MCP_URL = "https://mcp.granola.ai/mcp"
+_NOTE_ID_RE = re.compile(r"^not_[a-zA-Z0-9]{14}$")
+_SHARE_ID_RE = re.compile(
+    r"(?<![0-9a-f])([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?![0-9a-f])",
+    re.IGNORECASE,
+)
+
+
+def _normalize_note_ref(note_ref: str) -> str:
+    """Return a Granola API note ID or meeting UUID from an ID/share link."""
+    value = note_ref.strip().removeprefix("<").split("|", 1)[0].removesuffix(">")
+    if _NOTE_ID_RE.fullmatch(value):
+        return value
+    match = _SHARE_ID_RE.search(value)
+    if match:
+        return match.group(1).lower()
+    raise ValueError("expected a Granola not_* ID, meeting UUID, or notes.granola.ai share link")
 
 
 class GranolaClient:
@@ -77,12 +94,33 @@ class GranolaClient:
             params["updated_after"] = updated_after
         return self._get("/v1/notes", params=params)
 
+    def _resolve_note_id(self, note_ref: str) -> str:
+        normalized = _normalize_note_ref(note_ref)
+        if _NOTE_ID_RE.fullmatch(normalized):
+            return normalized
+
+        cursor: str | None = None
+        while True:
+            page = self.list_notes(page_size=30, cursor=cursor)
+            for note in page.get("notes", []):
+                try:
+                    web_id = _normalize_note_ref(note.get("web_url") or "")
+                except ValueError:
+                    continue
+                if web_id == normalized:
+                    return note["id"]
+            cursor = page.get("cursor")
+            if not page.get("hasMore") or not cursor:
+                break
+        raise RuntimeError(f"meeting {normalized} not found in accessible Granola notes")
+
     def get_note(self, note_id: str, include_transcript: bool = False) -> dict[str, Any]:
         """Fetch a single note by ID (not_* format, e.g. not_1d3tmYTlCICgjy).
 
         Returns full note with title, owner, attendees, summary_markdown,
         calendar_event, folder_membership, and optionally transcript.
         """
+        note_id = self._resolve_note_id(note_id)
         params: dict[str, Any] = {}
         if include_transcript:
             params["include"] = "transcript"
@@ -294,6 +332,7 @@ class GranolaMcpClient:
     def get_note(self, note_id: str, include_transcript: bool = False) -> dict[str, Any]:
         """Fetch a single meeting by UUID, REST-shaped (title, owner, attendees,
         summary_markdown, optionally transcript)."""
+        note_id = _normalize_note_ref(note_id)
         text = self._call_tool("get_meetings", {"meeting_ids": [note_id]})
         notes = _parse_meetings(text)
         if not notes:
@@ -306,6 +345,7 @@ class GranolaMcpClient:
     def get_transcript(self, note_id: str) -> list[dict[str, Any]]:
         """Fetch the transcript for a meeting. Returns a list of utterances
         (single block if the MCP text is not line-structured)."""
+        note_id = _normalize_note_ref(note_id)
         text = self._call_tool("get_meeting_transcript", {"meeting_id": note_id})
         if not text.strip():
             return []

--- a/tools/productivity/granola/test_client.py
+++ b/tools/productivity/granola/test_client.py
@@ -1,4 +1,53 @@
-from client import _parse_meeting_date, _parse_meetings, _parse_participants
+from client import (
+    GranolaClient,
+    _normalize_note_ref,
+    _parse_meeting_date,
+    _parse_meetings,
+    _parse_participants,
+)
+
+
+def test_normalize_note_ref_accepts_both_granola_share_link_forms():
+    meeting_id = "57db2e7a-2aee-40b4-9db2-a20ec81c41c5"
+
+    assert _normalize_note_ref(f"https://notes.granola.ai/d/{meeting_id}") == meeting_id
+    assert (
+        _normalize_note_ref(f"<https://notes.granola.ai/t/{meeting_id}-008umkv4|notes.granola.ai>")
+        == meeting_id
+    )
+
+
+def test_rest_client_resolves_share_link_before_getting_note():
+    meeting_id = "57db2e7a-2aee-40b4-9db2-a20ec81c41c5"
+    client = GranolaClient(api_key="test")
+    calls = []
+
+    def fake_get(path, params=None):
+        calls.append((path, params))
+        if path == "/v1/notes":
+            return {
+                "notes": [
+                    {
+                        "id": "not_1234567890abcd",
+                        "web_url": f"https://notes.granola.ai/d/{meeting_id}",
+                    }
+                ],
+                "hasMore": False,
+                "cursor": None,
+            }
+        return {"id": "not_1234567890abcd", "title": "Stripe risk"}
+
+    client._get = fake_get
+    try:
+        note = client.get_note(f"https://notes.granola.ai/t/{meeting_id}-008umkv4")
+    finally:
+        client.close()
+
+    assert note["title"] == "Stripe risk"
+    assert calls == [
+        ("/v1/notes", {"page_size": 30}),
+        ("/v1/notes/not_1234567890abcd", {}),
+    ]
 
 
 def test_parse_meetings_accepts_extra_attributes_and_decodes_entities():


### PR DESCRIPTION
## Summary

- accept Granola `/d/<uuid>` and `/t/<uuid>-<suffix>` share links directly in `granola get` and `granola transcript`
- resolve share UUIDs to REST `not_*` IDs through canonical `web_url` values while passing normalized UUIDs to MCP
- require direct linked-meeting retrieval and fail closed instead of substituting semantic-search results

## Testing

- `PYTHONPATH=.:tools/productivity/granola uv run --no-project --with pytest --with httpx --with typer --with rich --with python-dotenv pytest -q tools/productivity/granola/test_client.py`
- `uv run --no-project python -m unittest services/sandbox/test_system_prompt.py`
- `uvx ruff check tools/productivity/granola/client.py tools/productivity/granola/test_client.py`
- `uvx ruff check --ignore E402,I001 tools/productivity/granola/cli.py`
- `git diff --check`

Prompted by: @snario