### PR TITLE
fix(api-rs): authorize githubbot for all its session key families

### DIFF
--- a/services/api-rs/crates/centaur-api-server/src/auth.rs
+++ b/services/api-rs/crates/centaur-api-server/src/auth.rs
@@ -65,7 +65,7 @@ pub(crate) struct AuthenticatedCaller {
     class: CallerClass,
     identity: String,
     capabilities: BTreeSet<Capability>,
-    platform_prefix: Option<&'static str>,
+    platform_prefixes: Option<&'static [&'static str]>,
     principal_subject: Option<String>,
 }
 
@@ -82,8 +82,8 @@ impl AuthenticatedCaller {
         &self.identity
     }
 
-    pub(crate) const fn platform_prefix(&self) -> Option<&'static str> {
-        self.platform_prefix
+    pub(crate) const fn platform_prefixes(&self) -> Option<&'static [&'static str]> {
+        self.platform_prefixes
     }
 
     pub(crate) fn principal_subject(&self) -> Option<&str> {
@@ -123,38 +123,7 @@ impl ApiAuthConfig {
                 None,
             ));
         }
-        for spec in [
-            IngressSpec {
-                env_var: "SLACKBOT_API_KEY",
-                identity: "slackbot",
-                platform_prefix: "slack:",
-                workflow_events: true,
-            },
-            IngressSpec {
-                env_var: "DISCORDBOT_API_KEY",
-                identity: "discordbot",
-                platform_prefix: "discord:",
-                workflow_events: false,
-            },
-            IngressSpec {
-                env_var: "GITHUBBOT_API_KEY",
-                identity: "githubbot",
-                platform_prefix: "github:",
-                workflow_events: true,
-            },
-            IngressSpec {
-                env_var: "LINEARBOT_API_KEY",
-                identity: "linearbot",
-                platform_prefix: "linear:",
-                workflow_events: false,
-            },
-            IngressSpec {
-                env_var: "TEAMSBOT_API_KEY",
-                identity: "teamsbot",
-                platform_prefix: "teams:",
-                workflow_events: false,
-            },
-        ] {
+        for spec in INGRESS_SPECS {
             let Some(token) = optional_env(spec.env_var) else {
                 continue;
             };
@@ -167,7 +136,7 @@ impl ApiAuthConfig {
                 CallerClass::Ingress,
                 token,
                 capabilities,
-                Some(spec.platform_prefix),
+                Some(spec.platform_prefixes),
             ));
         }
 
@@ -203,7 +172,7 @@ impl ApiAuthConfig {
                 Capability::SessionsWrite,
                 Capability::WorkflowsEvents,
             ],
-            Some("slack:"),
+            Some(&["slack:"]),
         )];
         Self {
             static_callers: Arc::new(callers),
@@ -246,7 +215,7 @@ impl ApiAuthConfig {
                     class: CallerClass::Console,
                     identity: subject,
                     capabilities: Capability::ALL.into_iter().collect(),
-                    platform_prefix: None,
+                    platform_prefixes: None,
                     principal_subject: None,
                 })
             }
@@ -278,7 +247,7 @@ impl ApiAuthConfig {
                     class: CallerClass::Principal,
                     identity: subject.clone(),
                     capabilities,
-                    platform_prefix: None,
+                    platform_prefixes: None,
                     principal_subject: Some(subject),
                 })
             }
@@ -317,10 +286,53 @@ enum ApiJwtTokenUse {
     ConsoleService,
 }
 
+/// Every ingress key and the session thread-key families it is allowed to
+/// touch. The platform scoping in `authorize_api_request` denies any
+/// `/api/session/*` call outside them, so a family missing here locks a bot
+/// out of its own sessions.
+const INGRESS_SPECS: &[IngressSpec] = &[
+    IngressSpec {
+        env_var: "SLACKBOT_API_KEY",
+        identity: "slackbot",
+        platform_prefixes: &["slack:"],
+        workflow_events: true,
+    },
+    IngressSpec {
+        env_var: "DISCORDBOT_API_KEY",
+        identity: "discordbot",
+        platform_prefixes: &["discord:"],
+        workflow_events: false,
+    },
+    IngressSpec {
+        env_var: "GITHUBBOT_API_KEY",
+        identity: "githubbot",
+        platform_prefixes: &[
+            "github:",
+            "github-issue:",
+            "github-manage:",
+            "github-review:",
+        ],
+        workflow_events: true,
+    },
+    IngressSpec {
+        env_var: "LINEARBOT_API_KEY",
+        identity: "linearbot",
+        platform_prefixes: &["linear:"],
+        workflow_events: false,
+    },
+    IngressSpec {
+        env_var: "TEAMSBOT_API_KEY",
+        identity: "teamsbot",
+        platform_prefixes: &["teams:"],
+        workflow_events: false,
+    },
+];
+
 struct IngressSpec {
     env_var: &'static str,
     identity: &'static str,
-    platform_prefix: &'static str,
+    /// Every session thread-key prefix this ingress mints.
+    platform_prefixes: &'static [&'static str],
     workflow_events: bool,
 }
 
@@ -329,7 +341,7 @@ fn static_caller(
     class: CallerClass,
     token: String,
     capabilities: impl IntoIterator<Item = Capability>,
-    platform_prefix: Option<&'static str>,
+    platform_prefixes: Option<&'static [&'static str]>,
 ) -> StaticCaller {
     StaticCaller {
         token_digest: Sha256::digest(token.as_bytes()).into(),
@@ -337,7 +349,7 @@ fn static_caller(
             class,
             identity: identity.to_owned(),
             capabilities: capabilities.into_iter().collect(),
-            platform_prefix,
+            platform_prefixes,
             principal_subject: None,
         },
     }
@@ -428,7 +440,7 @@ mod tests {
                 .into_iter()
                 .all(|capability| caller.has_capability(capability))
         );
-        assert_eq!(caller.platform_prefix(), None);
+        assert_eq!(caller.platform_prefixes(), None);
         assert_eq!(caller.principal_subject(), None);
     }
 
@@ -520,6 +532,40 @@ mod tests {
     }
 
     #[test]
+    fn githubbot_ingress_covers_every_thread_key_family_it_mints() {
+        // Mirrors services/githubbot/src: chat threads (body-mention.ts), issue
+        // work (issue-manager.ts), owned-PR management (pr-manager.ts) and review
+        // runs (review.ts). githubbot/test/thread-keys.test.ts pins the producer
+        // side; dropping a family here 403s the bot out of its own sessions.
+        let githubbot = INGRESS_SPECS
+            .iter()
+            .find(|spec| spec.identity == "githubbot")
+            .expect("githubbot ingress spec");
+
+        assert_eq!(
+            githubbot.platform_prefixes,
+            [
+                "github:",
+                "github-issue:",
+                "github-manage:",
+                "github-review:"
+            ]
+            .as_slice()
+        );
+    }
+
+    #[test]
+    fn every_ingress_scopes_itself_to_at_least_one_prefix() {
+        for spec in INGRESS_SPECS {
+            assert!(
+                !spec.platform_prefixes.is_empty(),
+                "{} would be scoped to no session at all",
+                spec.identity
+            );
+        }
+    }
+
+    #[test]
     fn duplicate_tokens_are_rejected() {
         let callers = vec![
             static_caller(
@@ -527,14 +573,14 @@ mod tests {
                 CallerClass::Ingress,
                 "same".to_owned(),
                 [Capability::SessionsWrite],
-                Some("slack:"),
+                Some(&["slack:"]),
             ),
             static_caller(
                 "githubbot",
                 CallerClass::Ingress,
                 "same".to_owned(),
                 [Capability::SessionsWrite],
-                Some("github:"),
+                Some(&["github:"]),
             ),
         ];
 

--- a/services/api-rs/crates/centaur-api-server/src/routes.rs
+++ b/services/api-rs/crates/centaur-api-server/src/routes.rs
@@ -513,10 +513,10 @@ async fn authorize_api_request(
             .into_response();
     }
 
-    if let Some(prefix) = caller.platform_prefix()
+    if let Some(prefixes) = caller.platform_prefixes()
         && route.starts_with("/api/session/")
         && let Some(thread_key) = session_thread_key_from_request(&request)
-        && !thread_key.as_str().starts_with(prefix)
+        && !thread_key_matches_platform(prefixes, thread_key.as_str())
     {
         record_api_authentication(caller.class().as_str(), "forbidden");
         tracing::warn!(
@@ -526,7 +526,7 @@ async fn authorize_api_request(
             } else {
                 caller.identity()
             },
-            expected_thread_prefix = prefix,
+            expected_thread_prefixes = ?prefixes,
             "ingress caller denied for another platform's session"
         );
         return ApiError::Forbidden("caller is not authorized for this session".to_owned())
@@ -608,6 +608,13 @@ fn matched_route<B>(request: &Request<B>) -> String {
 
 fn session_thread_key_from_request<B>(request: &Request<B>) -> Option<ThreadKey> {
     session_thread_key_from_path(request.uri().path())
+}
+
+/// Whether an ingress caller scoped to `prefixes` may touch this session.
+/// A bot can mint several thread-key families (githubbot: `github:`,
+/// `github-manage:`, `github-review:`), so the caller carries them all.
+fn thread_key_matches_platform(prefixes: &[&str], thread_key: &str) -> bool {
+    prefixes.iter().any(|prefix| thread_key.starts_with(prefix))
 }
 
 fn session_thread_key_from_path(path: &str) -> Option<ThreadKey> {
@@ -1073,7 +1080,36 @@ fn principal_subject_owns_session(subject: Option<&str>, session_principal: Opti
 
 #[cfg(test)]
 mod session_authorization_tests {
-    use super::principal_subject_owns_session;
+    use super::{principal_subject_owns_session, thread_key_matches_platform};
+
+    #[test]
+    fn ingress_scope_covers_every_family_the_bot_mints() {
+        let github = [
+            "github:",
+            "github-issue:",
+            "github-manage:",
+            "github-review:",
+        ];
+        assert!(thread_key_matches_platform(&github, "github:acme/repo:12"));
+        assert!(thread_key_matches_platform(
+            &github,
+            "github-issue:acme/repo:12"
+        ));
+        assert!(thread_key_matches_platform(
+            &github,
+            "github-manage:acme/repo:12"
+        ));
+        assert!(thread_key_matches_platform(
+            &github,
+            "github-review:acme/repo:12"
+        ));
+        assert!(!thread_key_matches_platform(&github, "slack:C123:1.2"));
+        // `github-anything:` outside the listed families stays denied.
+        assert!(!thread_key_matches_platform(
+            &github,
+            "githubx:acme/repo:12"
+        ));
+    }
 
     #[test]
     fn principal_session_reads_require_exact_persisted_owner() {

--- a/services/githubbot/src/review.ts
+++ b/services/githubbot/src/review.ts
@@ -43,6 +43,18 @@ const REVIEW_DEDUP_TTL_MS = 7 * 24 * 60 * 60 * 1000;
 const TEAM_MEMBERSHIP_CACHE_TTL_MS = 10 * 60 * 1000;
 
 /**
+ * Session thread key for a PR's review run. api-rs authorizes githubbot per
+ * thread-key prefix, so this family is listed in its ingress spec.
+ */
+export function reviewThreadKey(
+  owner: string,
+  repo: string,
+  number: number,
+): string {
+  return `github-review:${owner}/${repo}:${number}`;
+}
+
+/**
  * Review-on-request trigger. The GitHub chat adapter only surfaces comment
  * threads, so the `pull_request` lifecycle event (action `review_requested`)
  * arrives as a raw webhook we handle here: when the bot's teammate account is
@@ -83,7 +95,7 @@ export function handleReviewRequest(
   const teamSlug = stringValue(payload.requested_team?.slug);
   if (!directMatch && !teamSlug) return null;
 
-  const reviewThreadKey = `github-review:${owner}/${repo}:${number}`;
+  const threadKey = reviewThreadKey(owner, repo, number);
   const title = stringValue(payload.pull_request?.title) ?? `#${number}`;
   const url =
     stringValue(payload.pull_request?.html_url) ??
@@ -94,11 +106,11 @@ export function handleReviewRequest(
 
   const trace: GithubbotTrace = {
     includeContext: false,
-    messageId: `review-${reviewThreadKey}-${input.deliveryId}`,
+    messageId: `review-${threadKey}-${input.deliveryId}`,
     mode: "execute",
     openStream: true,
     startedAtMs: nowMs(),
-    threadId: reviewThreadKey,
+    threadId: threadKey,
   };
 
   return (async () => {
@@ -114,7 +126,7 @@ export function handleReviewRequest(
     // Claim the delivery before the background run so a redelivery never
     // double-reviews. State-keyed (not Chat-thread-keyed) because the review
     // thread is synthetic and never touches the adapter.
-    const dedupKey = `${options.stateKeyPrefix ?? "centaur-githubbot"}:review-delivery:${reviewThreadKey}:${input.deliveryId}`;
+    const dedupKey = `${options.stateKeyPrefix ?? "centaur-githubbot"}:review-delivery:${threadKey}:${input.deliveryId}`;
     let claimed = true;
     try {
       claimed = await state.setIfNotExists(dedupKey, "1", REVIEW_DEDUP_TTL_MS);
@@ -151,7 +163,7 @@ export function handleReviewRequest(
         owner,
         repo,
         requester,
-        threadKey: reviewThreadKey,
+        threadKey,
         title,
         url,
       }),
@@ -162,7 +174,7 @@ export function handleReviewRequest(
         forwardInput.afterEventId = lastEventId;
       },
       openStream: false,
-      threadId: reviewThreadKey,
+      threadId: threadKey,
       trace,
     };
 

--- a/services/githubbot/test/thread-keys.test.ts
+++ b/services/githubbot/test/thread-keys.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from "bun:test";
+import { issueWorkThreadKey } from "../src/issue-manager";
+import { managementThreadKey } from "../src/pr-manager";
+import { reviewThreadKey } from "../src/review";
+
+// api-rs scopes githubbot's API key to a fixed set of thread-key prefixes, so
+// every family minted here has to stay listed in its ingress spec
+// (services/api-rs/crates/centaur-api-server/src/auth.rs). Renaming one without
+// updating that list 403s the whole flow, and only in background paths where
+// the failure never reaches a human.
+describe("session thread-key families", () => {
+  test("issue-work, management and review keys keep their prefixes", () => {
+    expect(issueWorkThreadKey("acme", "repo", 7)).toBe(
+      "github-issue:acme/repo:7",
+    );
+    expect(managementThreadKey("acme", "repo", 7)).toBe(
+      "github-manage:acme/repo:7",
+    );
+    expect(reviewThreadKey("acme", "repo", 7)).toBe(
+      "github-review:acme/repo:7",
+    );
+  });
+});


### PR DESCRIPTION
We noticed our githubbot getting 403s from api-rs after syncing with upstream.

This seems to be since #1374. But I'm surprised there hasn't been an issue or other talk about so far. Has anyone else noticed it too?

## What's happening

#1374 scopes each ingress API key to a single session thread-key prefix — `github:` for githubbot. But githubbot mints four families:

| prefix | used for |
| --- | --- |
| `github:` | issue / PR comment threads |
| `github-issue:` | issue-work runs (issue assigned to the bot) |
| `github-manage:` | owned-PR management (CI fixes, merges, escalation) |
| `github-review:` | review runs |

Only the first is authorized, so anything touching the other three now comes back `caller is not authorized for this session`. All three have been minted that way since #956 (Jul 7), so this affects every githubbot version paired with api-rs at or past #1374.

We found it after picking up #1374 in a fork — a review request on one of our PRs silently went nowhere.
