### PR TITLE
fix(slackbotv2): forward reasoning efforts for custom-provider models

### DIFF
--- a/services/slackbotv2/src/console-session-link.ts
+++ b/services/slackbotv2/src/console-session-link.ts
@@ -42,6 +42,14 @@ const GPT_5_6_REASONING_EFFORTS = new Set([
   ...STANDARD_CODEX_REASONING_EFFORTS,
   'max'
 ])
+// Every effort any Codex model accepts. Models absent from the table below
+// (custom `model_providers.*` models pointing Codex at an OpenAI-compatible
+// endpoint) are validated against this canonical set instead of being
+// rejected outright.
+const ALL_CODEX_REASONING_EFFORTS = new Set([
+  ...GPT_5_6_REASONING_EFFORTS,
+  'minimal'
+])
 const CODEX_REASONING_EFFORTS_BY_MODEL: Record<string, ReadonlySet<string>> = {
   'gpt-5.2': STANDARD_CODEX_REASONING_EFFORTS,
   'gpt-5.2-codex': CODEX_MODEL_REASONING_EFFORTS,
@@ -189,7 +197,16 @@ export function reasoningForModel(
   const supported = Object.entries(CODEX_REASONING_EFFORTS_BY_MODEL).find(
     ([modelId]) => selectedModel === modelId || selectedModel.startsWith(`${modelId}-20`)
   )?.[1]
-  return supported?.has(effectiveEffort) ? effort : undefined
+  // A model the table doesn't know is a custom-provider model (a
+  // `model_providers.*` entry pointing Codex at an OpenAI-compatible
+  // endpoint), whose supported efforts this table cannot know. Forward any
+  // canonical effort rather than silently dropping the user's explicit
+  // request - the provider is the authority on its own models and rejects
+  // unsupported efforts itself.
+  if (!supported) {
+    return ALL_CODEX_REASONING_EFFORTS.has(effectiveEffort) ? effort : undefined
+  }
+  return supported.has(effectiveEffort) ? effort : undefined
 }
 
 function reasoningDisplayName(reasoning: string | null | undefined): string | undefined {

--- a/services/slackbotv2/test/console-session-link.test.ts
+++ b/services/slackbotv2/test/console-session-link.test.ts
@@ -88,7 +88,23 @@ describe('reasoningForModel', () => {
     expect(reasoningForModel('codex', 'gpt-5.5-pro-2026-07-01', 'low')).toBeUndefined()
     expect(reasoningForModel('nanocodex', 'gpt-5.5-pro-2026-07-01', 'low')).toBeUndefined()
     expect(reasoningForModel('codex', 'gpt-5.4-2026-03-05', 'xhigh')).toBe('xhigh')
-    expect(reasoningForModel('codex', 'gpt-5.3', 'high')).toBeUndefined()
+  })
+
+  test('forwards canonical efforts for models the table does not know', () => {
+    // Custom `model_providers.*` models (Codex pointed at an OpenAI-compatible
+    // endpoint) cannot appear in the per-model table; dropping the user's
+    // explicit request would silently pin such deployments to the default
+    // effort. The provider rejects unsupported efforts itself.
+    for (const effort of allEfforts) {
+      expect(reasoningForModel('codex', 'my-custom-model', effort)).toBe(effort)
+    }
+    expect(reasoningForModel('codex', 'gpt-5.3', 'high')).toBe('high')
+    expect(reasoningForModel('nanocodex', 'my-custom-model', 'minimal')).toBe('minimal')
+  })
+
+  test('still rejects non-canonical efforts for unknown models', () => {
+    expect(reasoningForModel('codex', 'my-custom-model', 'superduper')).toBeUndefined()
+    expect(reasoningForModel('codex', 'my-custom-model', '')).toBeUndefined()
   })
 
   test('rejects Codex efforts for the currently selected non-Codex model', () => {


### PR DESCRIPTION
## Problem

`reasoningForModel()` in `services/slackbotv2/src/console-session-link.ts` validates a requested reasoning effort against a hardcoded table of known Codex model ids, and returns `undefined` for any model it does not recognize. Deployments that point Codex at an OpenAI-compatible endpoint through a custom `model_providers.*` entry — the pattern supported since #1410 and described in the production docs with `CODEX_MODEL` / `CODEX_MODEL_PROVIDER` — necessarily use model names that table can never contain.

The effect is that a user's explicit `-rsn high` (and any `SLACKBOTV2_CHANNEL_DEFAULTS` reasoning entry) is silently discarded on such deployments: no error, no feedback, and every turn runs at the deployment default effort.

## Fix

Models absent from the per-model table are now validated against the canonical effort set (the union of every effort any Codex model accepts, including `minimal` for the Nanocodex mapping) and forwarded. The provider is the authority on what its own models support and rejects unsupported efforts itself — a visible upstream error is strictly better than a silently ignored request. Known models keep their exact per-model validation, including the `gpt-5.6` alias and dated-snapshot handling.

This deliberately changes one documented expectation: `reasoningForModel('codex', 'gpt-5.3', 'high')` previously returned `undefined` (unknown-model-as-typo). A mistyped model fails the turn anyway with a model-not-found from the provider, so pre-rejecting its effort adds no safety — while the old behavior broke a real, docs-recommended configuration.

## Tests

- New: unknown models forward every canonical effort (codex and nanocodex, including `minimal`); non-canonical values (`superduper`, empty) still return `undefined`; non-Codex harnesses unchanged.
- Updated: the `gpt-5.3` expectation moved into the forward-through case per the rationale above.
- Rebased on current `main`; ran the CI-equivalent locally (`pnpm install --frozen-lockfile`, then `bun test test` in `services/slackbotv2`): 251 pass / 1 skip / 0 fail.
- `check:types` fails identically on a clean `main` checkout (`fetch.preconnect` typings in `test/slack-user.test.ts`, untouched by this change, under Bun 1.3.x); CI does not gate slackbotv2 on `check:types`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
