### PR TITLE
feat(workflows): resolve principals by OID

### DIFF
--- a/docs/pages/extend/workflows-v2.mdx
+++ b/docs/pages/extend/workflows-v2.mdx
@@ -180,16 +180,17 @@ cargo run -p centaur-perms -- \
   --tool slack
 ```
 
-To use an existing principal instead, declare its foreign ID:
+To use an existing principal instead, declare its foreign ID or `prn_`-prefixed
+OID:
 
 ```python
 WORKFLOW_PRINCIPAL = "finance-automation"
 ```
 
-The string form resolves the existing principal and fails startup when it does
-not exist. It does not create or update the principal. The `True` form remains
-`workflow-` plus the slugged `WORKFLOW_NAME`. Any `WORKFLOW_PRINCIPAL` value
-requires `apiRs.workflowHostSandbox=true`, which
+The string form resolves the existing principal by foreign ID or OID and fails
+startup when it does not exist. It does not create or update the principal. The
+`True` form remains `workflow-` plus the slugged `WORKFLOW_NAME`. Any
+`WORKFLOW_PRINCIPAL` value requires `apiRs.workflowHostSandbox=true`, which
 renders `WORKFLOW_HOST_SANDBOX=true`; startup fails if a workflow declares a
 principal while workflow-host sandboxing is disabled.
 

--- a/docs/pages/extend/workflows.mdx
+++ b/docs/pages/extend/workflows.mdx
@@ -68,11 +68,11 @@ async def handler(inp: Input, ctx: WorkflowContext) -> dict[str, Any]:
 directly with `ctx.call_tool(...)` and should have its own credential boundary.
 Set it to `True` to have the API derive and register the
 `workflow-nightly-report` principal from `WORKFLOW_NAME`. Set it to an existing
-principal foreign ID, such as `WORKFLOW_PRINCIPAL = "finance-automation"`, to
-run the workflow-host sandbox under that principal instead. An unknown foreign
-ID fails startup. Grant the required tool roles or secrets to the selected
-principal. Any `WORKFLOW_PRINCIPAL` value requires
-`apiRs.workflowHostSandbox=true`, which renders
+principal foreign ID, such as `WORKFLOW_PRINCIPAL = "finance-automation"`, or
+to a `prn_`-prefixed OID to run the workflow-host sandbox under that principal
+instead. An unknown principal reference fails startup. Grant the required tool
+roles or secrets to the selected principal. Any `WORKFLOW_PRINCIPAL` value
+requires `apiRs.workflowHostSandbox=true`, which renders
 `WORKFLOW_HOST_SANDBOX=true`; startup fails if workflow-host sandboxing is
 disabled.
 

--- a/docs/pages/secrets/advanced-permissioning.mdx
+++ b/docs/pages/secrets/advanced-permissioning.mdx
@@ -63,7 +63,7 @@ The stable principal ids follow these rules:
 | Teams personal chat | `teams-user-<user-id>` | That Teams user |
 | Teams channel or group conversation | `teams-conversation-<conversation-id>` | Everyone using Centaur in that conversation |
 | Workflow with `WORKFLOW_PRINCIPAL = True` | `workflow-<workflow-name>` | Runs of that workflow |
-| Workflow with `WORKFLOW_PRINCIPAL = "<foreign-id>"` | The selected existing principal | Runs of that workflow |
+| Workflow with `WORKFLOW_PRINCIPAL = "<foreign-id-or-oid>"` | The selected existing principal | Runs of that workflow |
 | Other session key | `thread-<session-key>` | That session key |
 
 Values are lowercased and converted to URL-safe slugs. The team scope is
@@ -408,10 +408,10 @@ consent.
 
 Workflows opt into isolated permissions with `WORKFLOW_PRINCIPAL = True`, which
 derives `workflow-<workflow-name>`. They can instead set `WORKFLOW_PRINCIPAL` to
-an existing principal foreign ID. Agent turns can select an existing principal
-with `ctx.agent_turn(..., principal="<foreign-id>")`. Unknown foreign IDs fail
-instead of falling back to a broader identity. Grant workflows and agent turns
-only the roles or secrets they need. See
+an existing principal foreign ID or `prn_`-prefixed OID. Agent turns can select
+an existing principal with `ctx.agent_turn(..., principal="<foreign-id>")`.
+Unknown foreign IDs fail instead of falling back to a broader identity. Grant
+workflows and agent turns only the roles or secrets they need. See
 [Creating Workflows](/extend/workflows#define-a-workflow).
 
 ## Operational Checklist

--- a/services/api-rs/crates/centaur-workflows/src/lib.rs
+++ b/services/api-rs/crates/centaur-workflows/src/lib.rs
@@ -324,8 +324,8 @@ impl WorkflowPrincipalRegistrar {
                         })
                         .await?
                 }
-                WorkflowPrincipalDeclaration::Existing(foreign_id) => {
-                    self.client.get_principal(foreign_id).await?
+                WorkflowPrincipalDeclaration::Existing(reference) => {
+                    self.client.get_principal(reference).await?
                 }
             };
             registered.insert(workflow_name.clone(), record.id);
@@ -1681,7 +1681,7 @@ struct PythonWorkflowDiscovery {
 #[serde(untagged)]
 enum PythonWorkflowPrincipal {
     Enabled(bool),
-    ForeignId(String),
+    Reference(String),
 }
 
 #[derive(Debug, Deserialize)]
@@ -1724,12 +1724,10 @@ fn metadata_from_discovery_payload(
                     WorkflowPrincipalDeclaration::Managed,
                 );
             }
-            Some(PythonWorkflowPrincipal::ForeignId(foreign_id))
-                if !foreign_id.trim().is_empty() =>
-            {
+            Some(PythonWorkflowPrincipal::Reference(reference)) if !reference.trim().is_empty() => {
                 metadata.principals.insert(
                     workflow.workflow_name,
-                    WorkflowPrincipalDeclaration::Existing(foreign_id.trim().to_owned()),
+                    WorkflowPrincipalDeclaration::Existing(reference.trim().to_owned()),
                 );
             }
             _ => {}
@@ -4973,6 +4971,27 @@ mod tests {
             metadata.principals.get("manual_workflow"),
             Some(&WorkflowPrincipalDeclaration::Existing(
                 "finance-automation".to_owned()
+            ))
+        );
+    }
+
+    #[test]
+    fn discovery_metadata_preserves_workflow_principal_oid() {
+        let payload: PythonWorkflowDiscoveryPayload = serde_json::from_value(json!({
+            "workflows": [{
+                "workflow_name": "oid_workflow",
+                "source_path": "workflows/oid_workflow.py",
+                "principal": " prn_01k2m3n4p5 ",
+            }],
+        }))
+        .unwrap();
+
+        let metadata = metadata_from_discovery_payload(payload);
+
+        assert_eq!(
+            metadata.principals.get("oid_workflow"),
+            Some(&WorkflowPrincipalDeclaration::Existing(
+                "prn_01k2m3n4p5".to_owned()
             ))
         );
     }

--- a/services/workflow-python/tests/test_workflow_host.py
+++ b/services/workflow-python/tests/test_workflow_host.py
@@ -634,7 +634,7 @@ class WorkflowHostTests(unittest.TestCase):
         assert registered is not None
         self.assertEqual(host.normalize_principal(registered), True)
 
-    def test_load_workflow_file_reads_workflow_principal_foreign_id(self) -> None:
+    def test_load_workflow_file_reads_workflow_principal_reference(self) -> None:
         host = load_workflow_host()
         with tempfile.TemporaryDirectory() as tmp:
             path = Path(tmp) / "principal_workflow.py"
@@ -648,6 +648,9 @@ class WorkflowHostTests(unittest.TestCase):
 
         assert registered is not None
         self.assertEqual(host.normalize_principal(registered), "finance-automation")
+
+        registered.principal = " prn_01k2m3n4p5 "
+        self.assertEqual(host.normalize_principal(registered), "prn_01k2m3n4p5")
 
     def test_workflow_name_from_source_reads_string_constant(self) -> None:
         host = load_workflow_host()

--- a/services/workflow-python/workflow_host.py
+++ b/services/workflow-python/workflow_host.py
@@ -361,8 +361,8 @@ def normalize_principal(workflow: RegisteredWorkflow) -> bool | str | None:
     if isinstance(raw, bool):
         return raw or None
     if isinstance(raw, str):
-        foreign_id = raw.strip()
-        return foreign_id or None
+        reference = raw.strip()
+        return reference or None
     return None
 
 


### PR DESCRIPTION
Allows string-form WORKFLOW_PRINCIPAL declarations to represent either an existing principal foreign ID or a prn_-prefixed OID. Renames the discovery value to a general principal reference, adds Rust and Python coverage for OIDs, and updates the workflow permissioning docs.