### PR TITLE
fix: retry transient Slack sync failures

### DIFF
--- a/services/console/app/jobs/slack_dm/sync_credential_job.rb
+++ b/services/console/app/jobs/slack_dm/sync_credential_job.rb
@@ -1,6 +1,6 @@
 module SlackDm
   class SyncCredentialJob < ApplicationJob
-    MAX_RATE_LIMIT_EXECUTIONS = 2
+    MAX_RETRYABLE_EXECUTIONS = 2
 
     queue_as :default
 
@@ -15,10 +15,10 @@ module SlackDm
       return unless SlackDm::SyncCredential.required_scopes_granted?(credential.scopes)
 
       SlackDm::SyncCredential.new(credential).call
-    rescue SlackDm::SyncCredential::RateLimitedError => e
-      if executions >= MAX_RATE_LIMIT_EXECUTIONS
+    rescue SlackDm::SyncCredential::RetryableApiError => e
+      if executions >= MAX_RETRYABLE_EXECUTIONS
         Rails.logger.warn do
-          "Slack sync job dropped after repeated rate limits: " \
+          "Slack sync job dropped after repeated retryable API failures: " \
             "credential_id=#{credential_id} executions=#{executions}"
         end
         return

--- a/services/console/app/services/slack_dm/sync_credential.rb
+++ b/services/console/app/services/slack_dm/sync_credential.rb
@@ -13,16 +13,21 @@ module SlackDm
     CONVERSATIONS_HISTORY_ENDPOINT = "https://slack.com/api/conversations.history"
     CONVERSATIONS_REPLIES_ENDPOINT = "https://slack.com/api/conversations.replies"
     API_READ_TIMEOUT_SECONDS = 120
+    TRANSIENT_API_ERRORS = %w[fatal_error internal_error].freeze
+    TRANSIENT_API_RETRY_AFTER_SECONDS = 30
 
     SlackApiError = Class.new(StandardError)
-    class RateLimitedError < SlackApiError
+    class RetryableApiError < SlackApiError
       attr_reader :retry_after
 
       def initialize(retry_after:)
         @retry_after = retry_after
-        super("Slack API rate limited; retry after #{retry_after} seconds")
+        super("Slack API request is retryable after #{retry_after} seconds")
       end
     end
+
+    class RateLimitedError < RetryableApiError; end
+    class TransientApiError < RetryableApiError; end
 
     class << self
       attr_accessor :slack_api_http
@@ -71,7 +76,7 @@ module SlackDm
         sync_history(conversation, home_team_id, checkpoints[conversation.fetch("id")], batch)
         batch[:run][:conversations_synced] += 1
       rescue StandardError => e
-        raise if e.is_a?(RateLimitedError)
+        raise if e.is_a?(RetryableApiError)
         raise if Rails.env.test?
 
         batch[:run][:conversations_failed] += 1
@@ -347,6 +352,9 @@ module SlackDm
 
       parsed = response.json
       raise SlackApiError, "Slack API returned HTTP #{response.status}" unless response.success?
+      if TRANSIENT_API_ERRORS.include?(parsed["error"])
+        raise TransientApiError.new(retry_after: TRANSIENT_API_RETRY_AFTER_SECONDS)
+      end
       raise SlackApiError, "Slack API returned #{parsed['error']}" unless parsed["ok"] == true
 
       parsed

--- a/services/console/test/jobs/slack_dm/jobs_test.rb
+++ b/services/console/test/jobs/slack_dm/jobs_test.rb
@@ -75,13 +75,29 @@ module SlackDm
     test "SyncCredentialJob allows only one delayed rate-limit retry" do
       credential = slack_credential(app: slack_app)
       job = SlackDm::SyncCredentialJob.new(credential.id)
-      job.executions = SlackDm::SyncCredentialJob::MAX_RATE_LIMIT_EXECUTIONS - 1
+      job.executions = SlackDm::SyncCredentialJob::MAX_RETRYABLE_EXECUTIONS - 1
 
       SlackDm::SyncCredential.stub(:new, ->(*) { rate_limited_sync(retry_after: 120) }) do
         assert_no_enqueued_jobs { job.perform_now }
       end
 
-      assert_equal SlackDm::SyncCredentialJob::MAX_RATE_LIMIT_EXECUTIONS, job.executions
+      assert_equal SlackDm::SyncCredentialJob::MAX_RETRYABLE_EXECUTIONS, job.executions
+    end
+
+    test "SyncCredentialJob defers transient Slack API failures" do
+      credential = slack_credential(app: slack_app)
+      sync = Object.new
+      sync.define_singleton_method(:call) do
+        raise SlackDm::SyncCredential::TransientApiError.new(retry_after: 30)
+      end
+
+      SlackDm::SyncCredential.stub(:new, ->(*) { sync }) do
+        SlackDm::SyncCredentialJob.perform_now(credential.id)
+      end
+
+      retry_job = enqueued_jobs.sole
+      assert_equal SlackDm::SyncCredentialJob, retry_job[:job]
+      assert_equal [ credential.id ], retry_job[:args]
     end
 
     private

--- a/services/console/test/services/slack_dm/sync_credential_test.rb
+++ b/services/console/test/services/slack_dm/sync_credential_test.rb
@@ -329,5 +329,24 @@ module SlackDm
         assert_equal expected, error.retry_after
       end
     end
+
+    test "transient Slack API errors request deferred job execution" do
+      %w[fatal_error internal_error].each do |error_code|
+        response = HttpClient::Response.new(
+          status: 200,
+          body: { ok: false, error: error_code }.to_json,
+          headers: { "content-type" => "application/json" }
+        )
+
+        error = assert_raises(SlackDm::SyncCredential::TransientApiError) do
+          SlackDm::SyncCredential.new(
+            credential,
+            http_client: FakeHttpClient.new(response)
+          ).call
+        end
+
+        assert_equal SlackDm::SyncCredential::TRANSIENT_API_RETRY_AFTER_SECONDS, error.retry_after
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary
- classify Slack `fatal_error` and `internal_error` responses as retryable
- reuse the bounded delayed retry path for transient API failures
- add service and job regression coverage

## Validation
- `git diff --check`
- Rails tests not run locally: Ruby is unavailable and the sandbox Docker daemon is not running

Prompted by: mslipper