### PR TITLE
fix(workflows): return canonical agent turn result

### DIFF
--- a/services/api-rs/crates/centaur-workflows/src/lib.rs
+++ b/services/api-rs/crates/centaur-workflows/src/lib.rs
@@ -4338,7 +4338,7 @@ async fn run_agent_session_turn(
                     thread_key: thread_key.into_string(),
                     execution_id: execution.execution_id,
                     status: "completed".to_owned(),
-                    result_text: result_text_from_output_lines(&output_lines),
+                    result_text: agent_turn_result_text(&event.payload, &output_lines),
                     output_lines,
                 });
             }
@@ -4347,7 +4347,7 @@ async fn run_agent_session_turn(
                     thread_key: thread_key.into_string(),
                     execution_id: execution.execution_id,
                     status: event.event_type,
-                    result_text: result_text_from_output_lines(&output_lines),
+                    result_text: agent_turn_result_text(&event.payload, &output_lines),
                     output_lines,
                 };
                 return Err(WorkflowRuntimeError::Upstream(format!(
@@ -4364,19 +4364,62 @@ async fn run_agent_session_turn(
     ))
 }
 
-fn result_text_from_output_lines(lines: &[String]) -> String {
-    lines
+fn agent_turn_result_text(terminal_payload: &Value, output_lines: &[String]) -> String {
+    if let Some(result_text) = terminal_payload.get("result_text").and_then(Value::as_str) {
+        return result_text.to_owned();
+    }
+
+    output_lines
         .iter()
-        .filter_map(|line| serde_json::from_str::<Value>(line).ok())
-        .filter_map(|value| {
-            value
-                .get("delta")
-                .or_else(|| value.pointer("/params/delta"))
-                .and_then(Value::as_str)
-                .map(ToOwned::to_owned)
-        })
-        .collect::<Vec<_>>()
-        .join("")
+        .rev()
+        .find_map(|line| completed_final_answer_text(line))
+        .unwrap_or_default()
+}
+
+fn completed_final_answer_text(line: &str) -> Option<String> {
+    let value = serde_json::from_str::<Value>(line).ok()?;
+    if value.get("type").and_then(Value::as_str) == Some("assistant.message") {
+        let payload = value.get("payload")?;
+        if !matches!(
+            payload.get("phase").and_then(Value::as_str),
+            Some("final_answer" | "answer") | None
+        ) {
+            return None;
+        }
+        return non_empty_text(payload.get("text"));
+    }
+
+    if !matches!(
+        value.get("method").and_then(Value::as_str),
+        Some("item/completed")
+    ) && !matches!(
+        value.get("type").and_then(Value::as_str),
+        Some("item.completed")
+    ) {
+        return None;
+    }
+
+    let item = value
+        .get("item")
+        .or_else(|| value.pointer("/params/item"))?;
+    if !matches!(
+        item.get("type").and_then(Value::as_str),
+        Some("agentMessage" | "agent_message")
+    ) || !matches!(
+        item.get("phase").and_then(Value::as_str),
+        Some("final_answer" | "answer") | None
+    ) {
+        return None;
+    }
+    non_empty_text(item.get("text"))
+}
+
+fn non_empty_text(value: Option<&Value>) -> Option<String> {
+    value
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|text| !text.is_empty())
+        .map(ToOwned::to_owned)
 }
 
 fn workflow_run_from_row(row: sqlx::postgres::PgRow) -> Result<WorkflowRun, WorkflowRuntimeError> {
@@ -4495,6 +4538,81 @@ mod tests {
         assert_eq!(value.get("provider"), Some(&json!("amazon-bedrock")));
         assert_eq!(value.get("reasoning"), Some(&json!("high")));
         assert_eq!(value.pointer("/message/content"), Some(&json!(parts)));
+    }
+
+    #[test]
+    fn agent_turn_uses_terminal_result_text_instead_of_stream_deltas() {
+        let output_lines = vec![
+            json!({
+                "method": "item/reasoning/summaryTextDelta",
+                "params": {"delta": "internal reasoning"}
+            })
+            .to_string(),
+            json!({
+                "method": "item/agentMessage/delta",
+                "params": {"delta": "streamed draft"}
+            })
+            .to_string(),
+        ];
+
+        assert_eq!(
+            agent_turn_result_text(
+                &json!({"result_text": "Canonical final answer."}),
+                &output_lines
+            ),
+            "Canonical final answer."
+        );
+    }
+
+    #[test]
+    fn agent_turn_result_fallback_uses_only_completed_final_answer() {
+        let output_lines = vec![
+            json!({
+                "method": "item/reasoning/summaryTextDelta",
+                "params": {"delta": "internal reasoning"}
+            })
+            .to_string(),
+            json!({
+                "method": "item/agentMessage/delta",
+                "params": {"delta": "streamed commentary"}
+            })
+            .to_string(),
+            json!({
+                "method": "item/completed",
+                "params": {
+                    "item": {
+                        "type": "agentMessage",
+                        "phase": "commentary",
+                        "text": "Commentary update."
+                    }
+                }
+            })
+            .to_string(),
+            json!({
+                "type": "item.completed",
+                "item": {
+                    "type": "agentMessage",
+                    "phase": "final_answer",
+                    "text": "Fallback final answer."
+                }
+            })
+            .to_string(),
+        ];
+
+        assert_eq!(
+            agent_turn_result_text(&json!({}), &output_lines),
+            "Fallback final answer."
+        );
+    }
+
+    #[test]
+    fn agent_turn_result_fallback_does_not_return_untyped_deltas() {
+        let output_lines = vec![
+            json!({"type": "reasoning.delta", "delta": "internal reasoning"}).to_string(),
+            json!({"type": "item.agentMessage.delta", "delta": "ambiguous draft"}).to_string(),
+        ];
+
+        assert_eq!(agent_turn_result_text(&json!({}), &output_lines), "");
     }
 
     #[test]


### PR DESCRIPTION
Use the session completion event's canonical result_text for ctx.agent_turn instead of concatenating every streamed delta. Retain a narrowly scoped fallback for completed final-answer messages so reasoning and commentary cannot leak into workflow results. Adds regression coverage for terminal precedence and fallback filtering.