### PR TITLE
fix: format scheduled task results for Slack

### DIFF
--- a/services/api-rs/crates/centaur-workflows/src/lib.rs
+++ b/services/api-rs/crates/centaur-workflows/src/lib.rs
@@ -4149,6 +4149,9 @@ fn python_slack_message_payload(
     if let Some(reply_broadcast) = args.get("reply_broadcast").and_then(Value::as_bool) {
         payload["reply_broadcast"] = json!(reply_broadcast);
     }
+    if let Some(mrkdwn) = args.get("mrkdwn").and_then(Value::as_bool) {
+        payload["mrkdwn"] = json!(mrkdwn);
+    }
     if let Some(blocks) = args.get("blocks") {
         payload["blocks"] = blocks.clone();
     }
@@ -4945,6 +4948,7 @@ mod tests {
                 "reply_broadcast": true,
                 "unfurl_links": true,
                 "unfurl_media": true,
+                "mrkdwn": true,
                 "username": "The Date Goblin",
                 "icon_emoji": ":female_mage:",
             }),
@@ -4957,6 +4961,7 @@ mod tests {
         assert_eq!(payload["reply_broadcast"], json!(true));
         assert_eq!(payload["unfurl_links"], json!(true));
         assert_eq!(payload["unfurl_media"], json!(true));
+        assert_eq!(payload["mrkdwn"], json!(true));
         assert_eq!(payload["username"], json!("The Date Goblin"));
         assert_eq!(payload["icon_emoji"], json!(":female_mage:"));
     }

--- a/workflows/console_workflow.py
+++ b/workflows/console_workflow.py
@@ -6,6 +6,7 @@ from typing import Any
 
 WORKFLOW_NAME = "console_workflow"
 SLACK_MESSAGE_MAX_LENGTH = 50_000
+SLACK_DM_CHUNK_MAX_LENGTH = 3_800
 SLACK_MRKDWN_INSTRUCTIONS = """\
 Format the final response for Slack using Slack mrkdwn, not standard Markdown.
 Use *bold*, _italics_, ~strikethrough~, `inline code`, and <https://example.com|link text>.
@@ -24,10 +25,60 @@ def _required_string(params: Any, key: str) -> str:
 
 async def _deliver_to_slack(ctx: Any, channel: str, text: str) -> Any:
     truncated = text[:SLACK_MESSAGE_MAX_LENGTH]
-    return await ctx.step(
-        "post_result",
-        lambda: ctx.post_to_slack(channel, truncated, mrkdwn=True),
+    chunks = (
+        _split_slack_text(truncated, SLACK_DM_CHUNK_MAX_LENGTH)
+        if _is_direct_message_destination(channel)
+        else [truncated]
     )
+    root = await ctx.step(
+        "post_result",
+        lambda: ctx.post_to_slack(channel, chunks[0], mrkdwn=True),
+    )
+    if len(chunks) == 1:
+        return root
+    if not isinstance(root, dict):
+        raise RuntimeError("Slack root delivery did not return a result object")
+
+    thread_ts = str(root.get("ts") or "").strip()
+    if not thread_ts:
+        raise RuntimeError("Slack root delivery did not return a message timestamp")
+    reply_channel = str(root.get("channel") or channel).strip()
+    replies = []
+    for index, chunk in enumerate(chunks[1:], start=1):
+        reply = await ctx.step(
+            f"post_result_reply_{index}",
+            lambda chunk=chunk: ctx.post_to_slack(
+                reply_channel,
+                chunk,
+                mrkdwn=True,
+                thread_ts=thread_ts,
+            ),
+        )
+        replies.append(reply)
+    return {**root, "replies": replies}
+
+
+def _is_direct_message_destination(channel: str) -> bool:
+    return channel[:1].upper() in {"D", "U", "W"}
+
+
+def _split_slack_text(text: str, limit: int) -> list[str]:
+    chunks = []
+    remaining = text
+    while len(remaining) > limit:
+        window = remaining[:limit]
+        minimum_boundary = limit // 2
+        end = limit
+        for separator in ("\n\n", "\n", " "):
+            boundary = window.rfind(separator)
+            if boundary >= minimum_boundary:
+                end = boundary + len(separator)
+                break
+        chunks.append(remaining[:end])
+        remaining = remaining[end:]
+    if remaining:
+        chunks.append(remaining)
+    return chunks
 
 
 def _prompt_for_slack(prompt: str) -> str:

--- a/workflows/console_workflow.py
+++ b/workflows/console_workflow.py
@@ -6,7 +6,8 @@ from typing import Any
 
 WORKFLOW_NAME = "console_workflow"
 SLACK_MESSAGE_MAX_LENGTH = 50_000
-SLACK_DM_CHUNK_MAX_LENGTH = 3_800
+# Stay below Slack's 4,000-character soft limit so it cannot create extra roots.
+SLACK_MESSAGE_CHUNK_MAX_LENGTH = 3_800
 SLACK_MRKDWN_INSTRUCTIONS = """\
 Format the final response for Slack using Slack mrkdwn, not standard Markdown.
 Use *bold*, _italics_, ~strikethrough~, `inline code`, and <https://example.com|link text>.
@@ -25,11 +26,7 @@ def _required_string(params: Any, key: str) -> str:
 
 async def _deliver_to_slack(ctx: Any, channel: str, text: str) -> Any:
     truncated = text[:SLACK_MESSAGE_MAX_LENGTH]
-    chunks = (
-        _split_slack_text(truncated, SLACK_DM_CHUNK_MAX_LENGTH)
-        if _is_direct_message_destination(channel)
-        else [truncated]
-    )
+    chunks = _split_slack_text(truncated, SLACK_MESSAGE_CHUNK_MAX_LENGTH)
     root = await ctx.step(
         "post_result",
         lambda: ctx.post_to_slack(channel, chunks[0], mrkdwn=True),
@@ -56,10 +53,6 @@ async def _deliver_to_slack(ctx: Any, channel: str, text: str) -> Any:
         )
         replies.append(reply)
     return {**root, "replies": replies}
-
-
-def _is_direct_message_destination(channel: str) -> bool:
-    return channel[:1].upper() in {"D", "U", "W"}
 
 
 def _split_slack_text(text: str, limit: int) -> list[str]:

--- a/workflows/console_workflow.py
+++ b/workflows/console_workflow.py
@@ -6,6 +6,11 @@ from typing import Any
 
 WORKFLOW_NAME = "console_workflow"
 SLACK_MESSAGE_MAX_LENGTH = 50_000
+SLACK_MRKDWN_INSTRUCTIONS = """\
+Format the final response for Slack using Slack mrkdwn, not standard Markdown.
+Use *bold*, _italics_, ~strikethrough~, `inline code`, and <https://example.com|link text>.
+Use bold text instead of Markdown headings and lists instead of Markdown tables.
+Return only the message that should be posted to Slack."""
 
 
 def _required_string(params: Any, key: str) -> str:
@@ -21,8 +26,12 @@ async def _deliver_to_slack(ctx: Any, channel: str, text: str) -> Any:
     truncated = text[:SLACK_MESSAGE_MAX_LENGTH]
     return await ctx.step(
         "post_result",
-        lambda: ctx.post_to_slack(channel, truncated),
+        lambda: ctx.post_to_slack(channel, truncated, mrkdwn=True),
     )
+
+
+def _prompt_for_slack(prompt: str) -> str:
+    return f"{prompt}\n\n{SLACK_MRKDWN_INSTRUCTIONS}"
 
 
 async def handler(params: Any, ctx: Any) -> dict[str, Any]:
@@ -32,7 +41,7 @@ async def handler(params: Any, ctx: Any) -> dict[str, Any]:
     scheduled_task_id = _required_string(params, "scheduled_task_id")
 
     result = await ctx.agent_turn(
-        prompt,
+        _prompt_for_slack(prompt),
         principal=principal,
         metadata={
             "scheduled_task_id": scheduled_task_id,

--- a/workflows/tests/test_console_workflow.py
+++ b/workflows/tests/test_console_workflow.py
@@ -80,7 +80,7 @@ def test_handler_runs_one_scoped_agent_turn_and_delivers_its_text():
     assert result["delivery"]["ts"] == "123.1"
 
 
-def test_handler_truncates_long_slack_results():
+def test_handler_threads_and_truncates_long_channel_results():
     response_text = "x" * (console_workflow.SLACK_MESSAGE_MAX_LENGTH + 25)
     context = FakeContext(result_text=response_text)
 
@@ -96,15 +96,32 @@ def test_handler_truncates_long_slack_results():
         )
     )
 
-    assert context.step_calls == ["post_result"]
-    assert len(context.slack_calls) == 1
-    assert len(context.slack_calls[0][1]) == console_workflow.SLACK_MESSAGE_MAX_LENGTH
+    expected_chunks = (
+        console_workflow.SLACK_MESSAGE_MAX_LENGTH
+        + console_workflow.SLACK_MESSAGE_CHUNK_MAX_LENGTH
+        - 1
+    ) // console_workflow.SLACK_MESSAGE_CHUNK_MAX_LENGTH
+    assert context.step_calls == ["post_result"] + [
+        f"post_result_reply_{index}" for index in range(1, expected_chunks)
+    ]
+    assert len(context.slack_calls) == expected_chunks
+    assert "".join(call[1] for call in context.slack_calls) == response_text[
+        : console_workflow.SLACK_MESSAGE_MAX_LENGTH
+    ]
+    assert all(
+        len(call[1]) <= console_workflow.SLACK_MESSAGE_CHUNK_MAX_LENGTH
+        for call in context.slack_calls
+    )
     assert context.slack_calls[0][2] == {"mrkdwn": True}
+    assert all(
+        call[2] == {"mrkdwn": True, "thread_ts": "123.1"}
+        for call in context.slack_calls[1:]
+    )
     assert result["delivery"]["ts"] == "123.1"
 
 
 def test_handler_posts_long_dm_results_as_replies_to_the_first_message():
-    response_text = "a" * (console_workflow.SLACK_DM_CHUNK_MAX_LENGTH * 2 + 25)
+    response_text = "a" * (console_workflow.SLACK_MESSAGE_CHUNK_MAX_LENGTH * 2 + 25)
     context = FakeContext(result_text=response_text, slack_response_channel="D0123456789")
     params = {
         "prompt": "Summarize open incidents",
@@ -122,12 +139,12 @@ def test_handler_posts_long_dm_results_as_replies_to_the_first_message():
     ]
     assert "".join(call[1] for call in context.slack_calls) == response_text
     assert all(
-        len(call[1]) <= console_workflow.SLACK_DM_CHUNK_MAX_LENGTH
+        len(call[1]) <= console_workflow.SLACK_MESSAGE_CHUNK_MAX_LENGTH
         for call in context.slack_calls
     )
     assert context.slack_calls[0] == (
         "U0123456789",
-        "a" * console_workflow.SLACK_DM_CHUNK_MAX_LENGTH,
+        "a" * console_workflow.SLACK_MESSAGE_CHUNK_MAX_LENGTH,
         {"mrkdwn": True},
     )
     assert all(

--- a/workflows/tests/test_console_workflow.py
+++ b/workflows/tests/test_console_workflow.py
@@ -9,9 +9,15 @@ class FakeContext:
     run_id = "run-123"
     task_id = "task-456"
 
-    def __init__(self, result_text: str = "Daily summary", output_lines=None) -> None:
+    def __init__(
+        self,
+        result_text: str = "Daily summary",
+        output_lines=None,
+        slack_response_channel=None,
+    ) -> None:
         self.result_text = result_text
         self.output_lines = output_lines or []
+        self.slack_response_channel = slack_response_channel
         self.agent_calls = []
         self.step_calls = []
         self.step_results = {}
@@ -33,7 +39,10 @@ class FakeContext:
 
     async def post_to_slack(self, channel, text, **kwargs):
         self.slack_calls.append((channel, text, kwargs))
-        return {"channel": channel, "ts": f"123.{len(self.slack_calls)}"}
+        return {
+            "channel": self.slack_response_channel or channel,
+            "ts": f"123.{len(self.slack_calls)}",
+        }
 
 
 def test_handler_runs_one_scoped_agent_turn_and_delivers_its_text():
@@ -92,6 +101,50 @@ def test_handler_truncates_long_slack_results():
     assert len(context.slack_calls[0][1]) == console_workflow.SLACK_MESSAGE_MAX_LENGTH
     assert context.slack_calls[0][2] == {"mrkdwn": True}
     assert result["delivery"]["ts"] == "123.1"
+
+
+def test_handler_posts_long_dm_results_as_replies_to_the_first_message():
+    response_text = "a" * (console_workflow.SLACK_DM_CHUNK_MAX_LENGTH * 2 + 25)
+    context = FakeContext(result_text=response_text, slack_response_channel="D0123456789")
+    params = {
+        "prompt": "Summarize open incidents",
+        "principal": "console-user-author",
+        "channel": "U0123456789",
+        "scheduled_task_id": "tsk_123",
+    }
+
+    result = asyncio.run(console_workflow.handler(params, context))
+
+    assert context.step_calls == [
+        "post_result",
+        "post_result_reply_1",
+        "post_result_reply_2",
+    ]
+    assert "".join(call[1] for call in context.slack_calls) == response_text
+    assert all(
+        len(call[1]) <= console_workflow.SLACK_DM_CHUNK_MAX_LENGTH
+        for call in context.slack_calls
+    )
+    assert context.slack_calls[0] == (
+        "U0123456789",
+        "a" * console_workflow.SLACK_DM_CHUNK_MAX_LENGTH,
+        {"mrkdwn": True},
+    )
+    assert all(
+        call[0] == "D0123456789"
+        and call[2] == {"mrkdwn": True, "thread_ts": "123.1"}
+        for call in context.slack_calls[1:]
+    )
+    assert len(result["delivery"]["replies"]) == 2
+
+    asyncio.run(console_workflow.handler(params, context))
+
+    assert context.step_calls == [
+        "post_result",
+        "post_result_reply_1",
+        "post_result_reply_2",
+    ] * 2
+    assert len(context.slack_calls) == 3
 
 
 def test_handler_delivers_canonical_result_text_instead_of_output_lines():

--- a/workflows/tests/test_console_workflow.py
+++ b/workflows/tests/test_console_workflow.py
@@ -54,7 +54,10 @@ def test_handler_runs_one_scoped_agent_turn_and_delivers_its_text():
 
     assert len(context.agent_calls) == 1
     prompt, kwargs = context.agent_calls[0]
-    assert prompt == "Summarize open incidents"
+    assert prompt == (
+        "Summarize open incidents\n\n"
+        f"{console_workflow.SLACK_MRKDWN_INSTRUCTIONS}"
+    )
     assert kwargs["principal"] == "console-user-author"
     assert "thread_key" not in kwargs
     assert kwargs["metadata"] == {
@@ -62,7 +65,9 @@ def test_handler_runs_one_scoped_agent_turn_and_delivers_its_text():
         "scheduled_task_name": "Incident summary",
     }
     assert context.step_calls == ["post_result"]
-    assert context.slack_calls == [("C0123456789", "Daily summary", {})]
+    assert context.slack_calls == [
+        ("C0123456789", "Daily summary", {"mrkdwn": True})
+    ]
     assert result["delivery"]["ts"] == "123.1"
 
 
@@ -85,7 +90,7 @@ def test_handler_truncates_long_slack_results():
     assert context.step_calls == ["post_result"]
     assert len(context.slack_calls) == 1
     assert len(context.slack_calls[0][1]) == console_workflow.SLACK_MESSAGE_MAX_LENGTH
-    assert context.slack_calls[0][2] == {}
+    assert context.slack_calls[0][2] == {"mrkdwn": True}
     assert result["delivery"]["ts"] == "123.1"
 
 
@@ -115,7 +120,7 @@ def test_handler_delivers_canonical_result_text_instead_of_output_lines():
         (
             "C0123456789",
             "Cold scoops kiss the cone\nSummer sunlight melts to cream\nSweet stars on my tongue",
-            {},
+            {"mrkdwn": True},
         )
     ]
 
@@ -133,7 +138,9 @@ def test_handler_does_not_repeat_checkpointed_slack_posts():
     asyncio.run(console_workflow.handler(params, context))
 
     assert context.step_calls == ["post_result", "post_result"]
-    assert context.slack_calls == [("C0123456789", "Daily summary", {})]
+    assert context.slack_calls == [
+        ("C0123456789", "Daily summary", {"mrkdwn": True})
+    ]
 
 
 def test_handler_rejects_missing_required_input_before_starting_an_agent():


### PR DESCRIPTION
Formats scheduled task agent responses using Slack's mrkdwn dialect and explicitly enables mrkdwn on delivery. Long results are split below Slack's soft limit, with overflow delivered as checkpointed replies under the first message for both channels and DMs. Adds workflow and Slack payload coverage for the delivery contract.