### PR TITLE
fix(console): accept private-use scheme redirect URIs for MCP OAuth clients

### DIFF
--- a/services/console/app/models/mcp_oauth_client.rb
+++ b/services/console/app/models/mcp_oauth_client.rb
@@ -66,11 +66,22 @@ class McpOauthClient < ApplicationRecord
 
   def self.allowed_redirect_uri?(value)
     uri = URI.parse(value.to_s)
-    return false unless uri.host.present?
+    return false if uri.scheme.blank?
     return false if uri.fragment.present?
     return false if value.to_s.include?("*")
 
-    uri.scheme == "https" || (uri.scheme == "http" && loopback_host?(uri.host))
+    case uri.scheme
+    when "https"
+      uri.host.present?
+    when "http"
+      uri.host.present? && loopback_host?(uri.host)
+    else
+      # RFC 8252 §7.1 private-use URI scheme, how native apps receive the
+      # callback (e.g. Cursor's cursor://anysphere.cursor-mcp/oauth/callback).
+      # Matched by exact string equality only in redirect_uri_allowed?; PKCE
+      # protects the code if another app claims the same scheme.
+      true
+    end
   rescue URI::InvalidURIError
     false
   end

--- a/services/console/test/controllers/mcp/oauth_controller_test.rb
+++ b/services/console/test/controllers/mcp/oauth_controller_test.rb
@@ -73,6 +73,22 @@ module Mcp
       assert_equal [ "https://claude.ai/api/mcp/auth_callback" ], body.fetch("redirect_uris")
     end
 
+    test "dynamic client registration creates a private-use scheme native client" do
+      assert_difference -> { McpOauthClient.count }, 1 do
+        post "/mcp/oauth/register",
+             params: {
+               client_name: "Cursor",
+               redirect_uris: [ "cursor://anysphere.cursor-mcp/oauth/callback" ],
+               scope: "mcp:tools"
+             },
+             as: :json
+      end
+
+      assert_response :created
+      body = JSON.parse(response.body)
+      assert_equal [ "cursor://anysphere.cursor-mcp/oauth/callback" ], body.fetch("redirect_uris")
+    end
+
     test "dynamic client registration rejects non-loopback plain HTTP redirect URIs" do
       assert_no_difference -> { McpOauthClient.count } do
         post "/mcp/oauth/register",

--- a/services/console/test/models/mcp_oauth_client_test.rb
+++ b/services/console/test/models/mcp_oauth_client_test.rb
@@ -14,13 +14,38 @@ class McpOauthClientTest < ActiveSupport::TestCase
     refute McpOauthClient.allowed_redirect_uri?("http://localhost.evil.com/callback")
   end
 
+  test "allowed redirect URI accepts private-use scheme redirects" do
+    assert McpOauthClient.allowed_redirect_uri?("cursor://anysphere.cursor-mcp/oauth/callback")
+    assert McpOauthClient.allowed_redirect_uri?("vscode://mcp/callback")
+    assert McpOauthClient.allowed_redirect_uri?("com.example.app:/oauth2redirect")
+
+    refute McpOauthClient.allowed_redirect_uri?("/oauth/callback")
+    refute McpOauthClient.allowed_redirect_uri?("callback")
+  end
+
   test "allowed redirect URI rejects wildcard redirects" do
     refute McpOauthClient.allowed_redirect_uri?("https://*.example.com/callback")
     refute McpOauthClient.allowed_redirect_uri?("https://example.com/*")
+    refute McpOauthClient.allowed_redirect_uri?("cursor://anysphere.cursor-mcp/*")
   end
 
   test "allowed redirect URI rejects fragments" do
     refute McpOauthClient.allowed_redirect_uri?("https://example.com/callback#token")
+    refute McpOauthClient.allowed_redirect_uri?("cursor://anysphere.cursor-mcp/oauth/callback#token")
+  end
+
+  test "private-use scheme redirects match by exact string equality only" do
+    client = McpOauthClient.create!(
+      name: "Cursor",
+      redirect_uris: [ "cursor://anysphere.cursor-mcp/oauth/callback" ],
+      grant_types: McpOauthClient::DEFAULT_GRANT_TYPES,
+      response_types: McpOauthClient::DEFAULT_RESPONSE_TYPES,
+      scopes: McpOauthClient::DEFAULT_SCOPES
+    )
+
+    assert client.redirect_uri_allowed?("cursor://anysphere.cursor-mcp/oauth/callback")
+    refute client.redirect_uri_allowed?("cursor://anysphere.cursor-mcp/oauth/callback/extra")
+    refute client.redirect_uri_allowed?("cursor://evil/oauth/callback")
   end
 
   test "redirect matching rejects attacker controlled 127-looking hostnames" do


### PR DESCRIPTION
Native MCP clients receive the OAuth callback on a private-use URI scheme (RFC 8252 §7.1) — Cursor registers `cursor://anysphere.cursor-mcp/oauth/callback` — but `McpOauthClient.allowed_redirect_uri?` only accepts `https` and loopback `http`, so dynamic client registration returns 400 `invalid_client_metadata` and those clients can never connect (Cursor surfaces it as `Transient error connecting to streamableHttp server`).

Accept custom schemes for public clients, keeping the existing guardrails:
- no wildcards, no fragments;
- matched by exact string equality only — the loopback port flexibility stays `http`-only;
- PKCE (already mandatory for these clients) protects the authorization code if another app claims the same scheme, the standard RFC 8252 posture.

Follows #1059, which did the same for hosted `https` clients.