### PR TITLE
feat: manage scheduled tasks from centaur-console

### DIFF
--- a/services/console/app/controllers/api/v1/sandbox/scheduled_tasks_controller.rb
+++ b/services/console/app/controllers/api/v1/sandbox/scheduled_tasks_controller.rb
@@ -1,0 +1,102 @@
+module Api
+  module V1
+    module Sandbox
+      class ScheduledTasksController < Api::SandboxBaseController
+        before_action :require_linked_user!
+        before_action :disable_caching
+
+        def index
+          tasks = task_author.scheduled_tasks.order(:name, :id)
+          render json: { data: tasks.map { |task| task_payload(task) } }
+        end
+
+        def show
+          render json: { data: task_payload(owned_task) }
+        end
+
+        def create
+          task = task_author.scheduled_tasks.create!(task_attributes)
+          render json: { data: task_payload(task) }, status: :created
+        end
+
+        def update
+          task = owned_task
+          task.update!(task_attributes)
+          render json: { data: task_payload(task) }
+        end
+
+        def destroy
+          owned_task.destroy!
+          head :no_content
+        end
+
+        def run
+          task = owned_task
+          queued_job = ScheduledTaskRunJob.perform_later(task.id, Time.current.iso8601)
+          unless queued_job
+            return render_error(status: :service_unavailable, message: "scheduled task run could not be queued")
+          end
+
+          render json: { data: task_payload(task).merge(queued: true) }, status: :accepted
+        end
+
+        private
+
+        def disable_caching
+          response.headers["Cache-Control"] = "no-store"
+        end
+
+        def require_linked_user!
+          return if task_author
+
+          render_error(status: :forbidden, message: "sandbox principal is not linked to an active Console user")
+        end
+
+        def task_author
+          return @task_author if defined?(@task_author)
+
+          user = current_proxy.principal.console_user
+          @task_author = user if user&.active?
+        end
+
+        def owned_task
+          task_author.scheduled_tasks.find_by_oid!(params[:id])
+        end
+
+        def task_attributes
+          attributes = params.require(:data).permit(
+            :name,
+            :prompt,
+            :delivery_channel,
+            :cron_expression,
+            :enabled
+          )
+          if attributes[:delivery_channel].to_s.strip.casecmp?("dm")
+            attributes[:delivery_channel] = SlackDeliveryPolicy.new(task_author).direct_message_user_id
+          end
+          attributes
+        end
+
+        def task_payload(task)
+          {
+            id: task.oid,
+            name: task.name,
+            prompt: task.prompt,
+            delivery_channel: task.delivery_channel,
+            cron_expression: task.cron_expression,
+            timezone: task.timezone,
+            schedule_label: task.schedule_label,
+            enabled: task.enabled,
+            next_run_at: task.next_run_at,
+            last_enqueued_at: task.last_enqueued_at,
+            last_run_id: task.last_run_id,
+            last_run_at: task.last_run_at,
+            last_error: task.last_error,
+            created_at: task.created_at,
+            updated_at: task.updated_at
+          }
+        end
+      end
+    end
+  end
+end

--- a/services/console/app/controllers/application_controller.rb
+++ b/services/console/app/controllers/application_controller.rb
@@ -109,15 +109,15 @@ class ApplicationController < ActionController::Base
   end
 
   # Guard for admin-only controllers (the Control and Data Sync sections, user
-  # management). Not a global gate. Bounces non-admins to their only available
-  # section. Keep this redirect silent: direct/admin-default URLs are not
+  # management). Not a global gate. Bounces non-admins to their default section.
+  # Keep this redirect silent: direct/admin-default URLs are not
   # actionable errors for non-admin operators, especially on a fresh visit.
   def require_admin
     redirect_to console_threads_path unless acting_admin?
   end
 
   # Where a signed-in user lands when no explicit destination applies: admins get
-  # the Control section, everyone else the threads view (their only section).
+  # the Control section, everyone else gets the threads view.
   def default_console_landing_path
     acting_admin? ? console_principals_path : console_threads_path
   end

--- a/services/console/app/controllers/console/scheduled_tasks_controller.rb
+++ b/services/console/app/controllers/console/scheduled_tasks_controller.rb
@@ -1,6 +1,5 @@
 class Console::ScheduledTasksController < ApplicationController
   layout "console"
-  before_action :require_admin
   before_action :set_task, only: %i[edit update destroy run]
 
   def index

--- a/services/console/app/controllers/console/slack_channel_options_controller.rb
+++ b/services/console/app/controllers/console/slack_channel_options_controller.rb
@@ -2,7 +2,7 @@ module Console
   class SlackChannelOptionsController < ApplicationController
     MAX_RESULTS = 20
 
-    before_action :require_admin
+    before_action :require_admin, unless: :scheduled_task_request?
 
     def index
       response.headers["Cache-Control"] = "no-store"
@@ -16,6 +16,10 @@ module Console
     end
 
     private
+
+    def scheduled_task_request?
+      params[:owner_type] == "scheduled_task" && params[:id].blank?
+    end
 
     def channel_scope
       return scheduled_task_delivery_policy.allowed_channels if params[:owner_type] == "scheduled_task"

--- a/services/console/app/views/layouts/console.html.erb
+++ b/services/console/app/views/layouts/console.html.erb
@@ -1876,16 +1876,16 @@
             </a>
           </div>
 
-          <% if acting_admin? %>
-            <div class="console-thread-group">
-              <a href="<%= console_scheduled_tasks_path %>"
-                 class="console-thread-group-title <%= "console-thread-group-title-active" if scheduled_tasks_view %>"
-                 title="Scheduled">
-                <span class="console-nav-icon"><%= console_icon("clock", classes: "size-4") %></span>
-                <span class="console-nav-label">Scheduled</span>
-              </a>
-            </div>
+          <div class="console-thread-group">
+            <a href="<%= console_scheduled_tasks_path %>"
+               class="console-thread-group-title <%= "console-thread-group-title-active" if scheduled_tasks_view %>"
+               title="Scheduled">
+              <span class="console-nav-icon"><%= console_icon("clock", classes: "size-4") %></span>
+              <span class="console-nav-label">Scheduled</span>
+            </a>
+          </div>
 
+          <% if acting_admin? %>
             <div class="console-thread-group">
               <a href="<%= console_workflows_path %>"
                  class="console-thread-group-title <%= "console-thread-group-title-active" if workflows_view %>"

--- a/services/console/config/routes.rb
+++ b/services/console/config/routes.rb
@@ -272,6 +272,9 @@ Rails.application.routes.draw do
       namespace :sandbox do
         resource :permissions, only: :show
         resources :oauth_apps, only: :index
+        resources :scheduled_tasks, only: %i[index show create update destroy] do
+          post :run, on: :member
+        end
         resources :skills, only: %i[index show create update destroy] do
           collection { get :search }
           member do

--- a/services/console/docs/API.md
+++ b/services/console/docs/API.md
@@ -1438,6 +1438,23 @@ Returns `201`. The plaintext `token` is included **only** in this create respons
 | `GET`    | `/api/v1/api_keys/:id` | Fetch one (no token). |
 | `DELETE` | `/api/v1/api_keys/:id` | Revoke (soft delete). Returns `204`. Revoking the key used for the current request returns `422` with `"cannot revoke the API key used for this request"`. |
 
+## Scheduled Tasks
+
+Scheduled tasks run one agent prompt on a five-field cron schedule in Pacific Time and deliver the result to Slack. Task IDs use the `tsk_` prefix. The `delivery_channel` can be a Slack channel ID available to the task author, or the special value `dm`, which resolves to the linked user's Slack direct message when the task is created or updated.
+
+These endpoints use the sandbox entitlement JWT injected by `iron-proxy`. Every operation requires an active Console user linked to the sandbox principal and is scoped to tasks owned by that user. A task owned by another user returns `404`.
+
+| Method | Path | Notes |
+| ------ | ---- | ----- |
+| `GET` | `/api/v1/sandbox/scheduled_tasks` | List the linked user's tasks. |
+| `GET` | `/api/v1/sandbox/scheduled_tasks/:id` | Read one owned task by `tsk_...` OID. |
+| `POST` | `/api/v1/sandbox/scheduled_tasks` | Create a task from `data.name`, `data.prompt`, `data.cron_expression`, `data.delivery_channel`, and optional `data.enabled`. |
+| `PUT`/`PATCH` | `/api/v1/sandbox/scheduled_tasks/:id` | Update any supplied task fields. |
+| `DELETE` | `/api/v1/sandbox/scheduled_tasks/:id` | Delete an owned task. Returns `204`. |
+| `POST` | `/api/v1/sandbox/scheduled_tasks/:id/run` | Queue an immediate run. Returns `202`. |
+
+Responses include the task's cron expression, fixed timezone, human-readable schedule, enabled state, next run time, and latest run metadata. The `centaur-console` CLI exposes the same operations through `tasks`, `task`, `create-task`, `update-task`, `delete-task`, and `run-task`.
+
 ## Skills
 
 Skills are mutable `SKILL.md` documents authored by signed-in users in Console. There is no revision or draft resource: updating a public skill changes the document returned to agents immediately. Skill IDs use the `skl_` prefix.

--- a/services/console/test/controllers/api/v1/sandbox_scheduled_tasks_controller_test.rb
+++ b/services/console/test/controllers/api/v1/sandbox_scheduled_tasks_controller_test.rb
@@ -1,0 +1,178 @@
+require "test_helper"
+
+class Api::V1::SandboxScheduledTasksControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = users(:member_user)
+    @user.user_identities.create!(
+      provider: "slack",
+      subject: "U0123456789",
+      team_id: "T0123456789"
+    )
+    principal = Principal.create!(
+      foreign_id: "scheduled-task-user",
+      name: "Scheduled Task User",
+      kind: :console_user,
+      console_user: @user,
+      labels: {},
+      created_by: @user
+    )
+    @proxy = Proxy.create!(
+      name: "scheduled-task-proxy",
+      principal: principal,
+      bearer_token_hash: Digest::SHA256.hexdigest("iprx_#{'e' * 64}")
+    )
+  end
+
+  test "linked user creates reads updates and deletes a scheduled task" do
+    assert_difference("ScheduledTask.count", 1) do
+      with_token(@proxy) do |headers|
+        post "/api/v1/sandbox/scheduled_tasks",
+             params: {
+               data: {
+                 name: "Daily briefing",
+                 prompt: "Summarize the important updates.",
+                 delivery_channel: "dm",
+                 cron_expression: "0 9 * * *",
+                 enabled: true
+               }
+             },
+             headers: headers,
+             as: :json
+      end
+    end
+    assert_response :created
+
+    task = @user.scheduled_tasks.find_by!(name: "Daily briefing")
+    assert_equal "U0123456789", task.delivery_channel
+    assert_equal task.oid, json_body.dig("data", "id")
+    assert_equal ScheduledTask::DEFAULT_TIMEZONE, json_body.dig("data", "timezone")
+    assert_equal "Daily at 9:00 PT", json_body.dig("data", "schedule_label")
+    assert_not_nil json_body.dig("data", "next_run_at")
+
+    with_token(@proxy) do |headers|
+      get "/api/v1/sandbox/scheduled_tasks/#{task.oid}", headers: headers
+    end
+    assert_response :ok
+    assert_equal "Summarize the important updates.", json_body.dig("data", "prompt")
+
+    with_token(@proxy) do |headers|
+      patch "/api/v1/sandbox/scheduled_tasks/#{task.oid}",
+            params: { data: { name: "Morning briefing", enabled: false } },
+            headers: headers,
+            as: :json
+    end
+    assert_response :ok
+    assert_equal "Morning briefing", task.reload.name
+    assert_not task.enabled?
+    assert_nil task.next_run_at
+
+    assert_difference("ScheduledTask.count", -1) do
+      with_token(@proxy) do |headers|
+        delete "/api/v1/sandbox/scheduled_tasks/#{task.oid}", headers: headers
+      end
+    end
+    assert_response :no_content
+  end
+
+  test "list and lookup are limited to the linked user's tasks" do
+    own_task = create_task(author: @user, name: "My task")
+    other_task = create_task(author: users(:globex_admin), name: "Other task")
+
+    with_token(@proxy) do |headers|
+      get "/api/v1/sandbox/scheduled_tasks", headers: headers
+    end
+    assert_response :ok
+    assert_equal "no-store", response.headers["Cache-Control"]
+    assert_equal [ own_task.oid ], json_body.fetch("data").map { |task| task.fetch("id") }
+
+    with_token(@proxy) do |headers|
+      get "/api/v1/sandbox/scheduled_tasks/#{other_task.oid}", headers: headers
+    end
+    assert_response :not_found
+  end
+
+  test "invalid task attributes return validation details" do
+    assert_no_difference("ScheduledTask.count") do
+      with_token(@proxy) do |headers|
+        post "/api/v1/sandbox/scheduled_tasks",
+             params: {
+               data: {
+                 name: "Broken task",
+                 prompt: "Do something.",
+                 delivery_channel: "not-a-channel",
+                 cron_expression: "not cron"
+               }
+             },
+             headers: headers,
+             as: :json
+      end
+    end
+    assert_response :unprocessable_entity
+    assert_equal "validation failed", json_body.dig("error", "message")
+    assert_includes json_body.dig("error", "details", "cron_expression"), "is not a valid cron schedule"
+  end
+
+  test "linked user queues an immediate run" do
+    task = create_task(author: @user, name: "Run me")
+
+    assert_enqueued_jobs 1, only: ScheduledTaskRunJob do
+      with_token(@proxy) do |headers|
+        post "/api/v1/sandbox/scheduled_tasks/#{task.oid}/run", headers: headers
+      end
+    end
+    assert_response :accepted
+    assert_equal true, json_body.dig("data", "queued")
+  end
+
+  test "run reports when the task could not be queued" do
+    task = create_task(author: @user, name: "Do not run")
+
+    ScheduledTaskRunJob.stub(:perform_later, false) do
+      with_token(@proxy) do |headers|
+        post "/api/v1/sandbox/scheduled_tasks/#{task.oid}/run", headers: headers
+      end
+    end
+
+    assert_response :service_unavailable
+    assert_equal "scheduled task run could not be queued", json_body.dig("error", "message")
+  end
+
+  test "principal without an active linked user cannot manage tasks" do
+    with_token(proxies(:acme_proxy)) do |headers|
+      get "/api/v1/sandbox/scheduled_tasks", headers: headers
+    end
+    assert_response :forbidden
+  end
+
+  test "disabled linked user cannot manage tasks" do
+    @user.update!(status: :disabled)
+
+    with_token(@proxy) do |headers|
+      get "/api/v1/sandbox/scheduled_tasks", headers: headers
+    end
+
+    assert_response :forbidden
+  end
+
+  private
+
+  def create_task(author:, name:)
+    ScheduledTask.create!(
+      name: name,
+      prompt: "Summarize updates.",
+      author: author,
+      delivery_channel: "C0123456789",
+      cron_expression: "0 * * * *"
+    )
+  end
+
+  def with_token(proxy)
+    with_env("CENTAUR_JWT_SIGNING_SECRET" => "test-secret") do
+      yield "Authorization" => "Bearer #{SandboxEntitlements::Jwt.encode_for_proxy(proxy)}"
+    end
+  end
+
+  def json_body
+    JSON.parse(response.body)
+  end
+end

--- a/services/console/test/controllers/console/scheduled_tasks_controller_test.rb
+++ b/services/console/test/controllers/console/scheduled_tasks_controller_test.rb
@@ -144,15 +144,36 @@ class Console::ScheduledTasksControllerTest < ActionDispatch::IntegrationTest
     assert_response :not_found
   end
 
-  test "non-admins cannot author tasks" do
+  test "non-admins can create and manage their own tasks" do
     delete logout_url
-    post login_url, params: { email: users(:member_user).email, password: "password123456" }
+    member = users(:member_user)
+    post login_url, params: { email: member.email, password: "password123456" }
 
-    assert_no_difference -> { ScheduledTask.count } do
+    get new_console_scheduled_task_url
+    assert_response :ok
+    assert_select "a[href=?]", console_scheduled_tasks_path, text: "Scheduled"
+
+    assert_difference -> { ScheduledTask.count }, 1 do
       post console_scheduled_tasks_url, params: { scheduled_task: task_params }
     end
+    task = member.scheduled_tasks.find_by!(name: task_params.fetch(:name))
+    assert_redirected_to console_scheduled_tasks_path
 
-    assert_redirected_to console_threads_path
+    patch console_scheduled_task_url(task.oid), params: {
+      scheduled_task: task_params.merge(name: "Updated member task")
+    }
+    assert_redirected_to console_scheduled_tasks_path
+    assert_equal "Updated member task", task.reload.name
+
+    assert_enqueued_jobs 1, only: ScheduledTaskRunJob do
+      post run_console_scheduled_task_url(task.oid)
+    end
+    assert_redirected_to console_scheduled_tasks_path
+
+    assert_difference -> { ScheduledTask.count }, -1 do
+      delete console_scheduled_task_url(task.oid)
+    end
+    assert_redirected_to console_scheduled_tasks_path
   end
 
   private

--- a/services/console/test/controllers/console/slack_channel_options_controller_test.rb
+++ b/services/console/test/controllers/console/slack_channel_options_controller_test.rb
@@ -167,9 +167,22 @@ module Console
       delete logout_url
       post login_url, params: { email: users(:member_user).email, password: "password123456" }
 
-      get console_principal_slack_channel_options_url(principals(:acme_channel).oid)
+      get console_principal_slack_channel_options_url(principals(:acme_channel).oid),
+          params: { owner_type: "scheduled_task" }
 
       assert_redirected_to console_threads_path
+    end
+
+    test "non-admins can search scheduled task delivery channels" do
+      delete logout_url
+      post login_url, params: { email: users(:member_user).email, password: "password123456" }
+
+      with_catalog do
+        get slack_channel_options_console_scheduled_tasks_url, params: { q: "general" }
+      end
+
+      assert_response :ok
+      assert_equal "C0123456789", response.parsed_body.fetch("options").sole.fetch("value")
     end
 
     private

--- a/services/console/test/controllers/console/workflows_controller_test.rb
+++ b/services/console/test/controllers/console/workflows_controller_test.rb
@@ -124,7 +124,7 @@ class Console::WorkflowsControllerTest < ActionDispatch::IntegrationTest
     assert_select ".console-nav-link", text: "Control", count: 0
     assert_select ".console-nav-link", text: "Data Sync", count: 0
     assert_select ".console-thread-group-title", text: /Chats/
-    assert_select ".console-thread-group-title", text: /Scheduled/, count: 0
+    assert_select "a[href=?]", console_scheduled_tasks_path, text: /Scheduled/
     assert_select ".console-thread-group-title", text: /Workflows/, count: 0
   end
 

--- a/services/sandbox/SYSTEM_PROMPT.md
+++ b/services/sandbox/SYSTEM_PROMPT.md
@@ -218,6 +218,11 @@
 |If the credential is not present yet, ask the user to confirm which email they used in the provider consent flow or to retry the returned start URL. Do not claim the account is connected until `centaur-console permissions` shows the matching email.
 |If the requested app is missing from the endpoint response, say that it is not currently configured for self-service connection in this deployment. If the endpoint call fails, say you cannot retrieve connection links right now and include the tool error briefly.
 
+[Scheduled tasks]
+|When a user asks to create or manage recurring agent work, use `centaur-console tasks`, `task`, `create-task`, `update-task`, `delete-task`, or `run-task`. These commands only access tasks owned by the Console user linked to the current sandbox.
+|Scheduled tasks use five-field cron expressions in Pacific Time. Use `dm` as the delivery channel for the user's linked Slack direct message, or use a Slack channel ID allowed by their current delivery permissions.
+|After a mutation, report the returned task ID, schedule, delivery destination, enabled state, and next run time. Treat the first successful mutation response as authoritative and do not repeat it to improve formatting.
+
 [Tool discovery — discover before you call]
 |IMPORTANT: Before using any unfamiliar tool CLI, run `<tool> --help` to see commands, parameters, and descriptions.
 |This tells you exactly which command to use and avoids redundant calls.

--- a/services/sandbox/test_system_prompt.py
+++ b/services/sandbox/test_system_prompt.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import unittest
 from pathlib import Path
 
-
 SYSTEM_PROMPT = Path(__file__).with_name("SYSTEM_PROMPT.md")
 
 
@@ -73,6 +72,21 @@ class SystemPromptTest(unittest.TestCase):
         self.assertIn("look in `oauth_credentials`", prompt)
         self.assertIn("personal `provider_email`", prompt)
         self.assertIn("Centaur can use their personal connected account", prompt)
+
+    def test_scheduled_task_guidance_is_present(self) -> None:
+        prompt = SYSTEM_PROMPT.read_text()
+
+        self.assertIn("[Scheduled tasks]", prompt)
+        self.assertIn("`centaur-console tasks`", prompt)
+        self.assertIn(
+            "`task`, `create-task`, `update-task`, `delete-task`, or `run-task`", prompt
+        )
+        self.assertIn("five-field cron expressions in Pacific Time", prompt)
+        self.assertIn("Use `dm` as the delivery channel", prompt)
+        self.assertIn(
+            "Treat the first successful mutation response as authoritative", prompt
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tools/README.md
+++ b/tools/README.md
@@ -64,7 +64,8 @@ The open-source tool inventory lives in this `tools/` tree and changes over time
 
 - `centaur_investigator`: parse Centaur Slack thread references and enrich them
   with best-effort vlogs/vmetrics context without exposing message context.
-- `centaur-console`: inspect sandbox permissions and configured OAuth apps.
+- `centaur-console`: inspect sandbox permissions and configured OAuth apps, and
+  manage the linked user's scheduled tasks.
 - `centaur-skills`: discover, author, and manage editors for private and public Console-authored skills.
 - `datadog`: query Datadog logs, metrics, monitors, hosts, and dashboards
   read-only with `DD_API_KEY` and `DD_APP_KEY`.

--- a/tools/infra/centaur-console/cli.py
+++ b/tools/infra/centaur-console/cli.py
@@ -12,7 +12,7 @@ load_dotenv()
 
 app = typer.Typer(
     name="centaur-console",
-    help="Inspect the current sandbox's centaur-console permissions",
+    help="Inspect Console permissions and manage the current user's scheduled tasks",
 )
 console = Console()
 
@@ -55,6 +55,148 @@ def oauth_apps(
     """Print enabled OAuth apps and their consent start URLs as JSON."""
     with get_client(url=url, bearer_token=bearer_token) as client:
         result = client.sandbox_oauth_apps()
+    console.print_json(json.dumps({"data": result}, default=str))
+
+
+@app.command("tasks")
+def scheduled_tasks(
+    url: str | None = typer.Option(None, "--url", help="centaur-console base URL"),
+    bearer_token: str | None = typer.Option(
+        None,
+        "--bearer-token",
+        help="Local/debug bearer token override",
+        envvar="CENTAUR_CONSOLE_BEARER_TOKEN",
+    ),
+) -> None:
+    """List scheduled tasks owned by the current Console user."""
+    with get_client(url=url, bearer_token=bearer_token) as client:
+        result = client.scheduled_tasks()
+    console.print_json(json.dumps({"data": result}, default=str))
+
+
+@app.command("task")
+def scheduled_task(
+    task_id: str = typer.Argument(..., help="Scheduled task OID"),
+    url: str | None = typer.Option(None, "--url", help="centaur-console base URL"),
+    bearer_token: str | None = typer.Option(
+        None,
+        "--bearer-token",
+        help="Local/debug bearer token override",
+        envvar="CENTAUR_CONSOLE_BEARER_TOKEN",
+    ),
+) -> None:
+    """Read one scheduled task owned by the current Console user."""
+    with get_client(url=url, bearer_token=bearer_token) as client:
+        result = client.scheduled_task(task_id)
+    console.print_json(json.dumps({"data": result}, default=str))
+
+
+@app.command("create-task")
+def create_scheduled_task(
+    name: str = typer.Argument(..., help="Unique task name"),
+    prompt: str = typer.Option(..., "--prompt", "-p", help="Prompt to run"),
+    cron_expression: str = typer.Option(
+        ...,
+        "--cron",
+        help="Five-field cron expression in Pacific Time",
+    ),
+    delivery_channel: str = typer.Option(
+        "dm",
+        "--delivery-channel",
+        help="dm or a permitted Slack channel ID",
+    ),
+    enabled: bool = typer.Option(True, "--enabled/--disabled"),
+    url: str | None = typer.Option(None, "--url", help="centaur-console base URL"),
+    bearer_token: str | None = typer.Option(
+        None,
+        "--bearer-token",
+        help="Local/debug bearer token override",
+        envvar="CENTAUR_CONSOLE_BEARER_TOKEN",
+    ),
+) -> None:
+    """Create a scheduled task owned by the current Console user."""
+    with get_client(url=url, bearer_token=bearer_token) as client:
+        result = client.create_scheduled_task(
+            name=name,
+            prompt=prompt,
+            cron_expression=cron_expression,
+            delivery_channel=delivery_channel,
+            enabled=enabled,
+        )
+    console.print_json(json.dumps({"data": result}, default=str))
+
+
+@app.command("update-task")
+def update_scheduled_task(
+    task_id: str = typer.Argument(..., help="Scheduled task OID"),
+    name: str | None = typer.Option(None, "--name", help="New task name"),
+    prompt: str | None = typer.Option(None, "--prompt", "-p", help="New prompt"),
+    cron_expression: str | None = typer.Option(
+        None,
+        "--cron",
+        help="New five-field cron expression in Pacific Time",
+    ),
+    delivery_channel: str | None = typer.Option(
+        None,
+        "--delivery-channel",
+        help="dm or a permitted Slack channel ID",
+    ),
+    enabled: bool | None = typer.Option(None, "--enabled/--disabled"),
+    url: str | None = typer.Option(None, "--url", help="centaur-console base URL"),
+    bearer_token: str | None = typer.Option(
+        None,
+        "--bearer-token",
+        help="Local/debug bearer token override",
+        envvar="CENTAUR_CONSOLE_BEARER_TOKEN",
+    ),
+) -> None:
+    """Update selected fields on a scheduled task."""
+    if all(value is None for value in (name, prompt, cron_expression, delivery_channel, enabled)):
+        raise typer.BadParameter("provide at least one task field to update")
+
+    with get_client(url=url, bearer_token=bearer_token) as client:
+        result = client.update_scheduled_task(
+            task_id,
+            name=name,
+            prompt=prompt,
+            cron_expression=cron_expression,
+            delivery_channel=delivery_channel,
+            enabled=enabled,
+        )
+    console.print_json(json.dumps({"data": result}, default=str))
+
+
+@app.command("delete-task")
+def delete_scheduled_task(
+    task_id: str = typer.Argument(..., help="Scheduled task OID"),
+    url: str | None = typer.Option(None, "--url", help="centaur-console base URL"),
+    bearer_token: str | None = typer.Option(
+        None,
+        "--bearer-token",
+        help="Local/debug bearer token override",
+        envvar="CENTAUR_CONSOLE_BEARER_TOKEN",
+    ),
+) -> None:
+    """Delete a scheduled task owned by the current Console user."""
+    with get_client(url=url, bearer_token=bearer_token) as client:
+        client.delete_scheduled_task(task_id)
+    console.print_json(json.dumps({"data": {"id": task_id, "deleted": True}}))
+
+
+@app.command("run-task")
+def run_scheduled_task(
+    task_id: str = typer.Argument(..., help="Scheduled task OID"),
+    url: str | None = typer.Option(None, "--url", help="centaur-console base URL"),
+    bearer_token: str | None = typer.Option(
+        None,
+        "--bearer-token",
+        help="Local/debug bearer token override",
+        envvar="CENTAUR_CONSOLE_BEARER_TOKEN",
+    ),
+) -> None:
+    """Queue an immediate run of a scheduled task."""
+    with get_client(url=url, bearer_token=bearer_token) as client:
+        result = client.run_scheduled_task(task_id)
     console.print_json(json.dumps({"data": result}, default=str))
 
 

--- a/tools/infra/centaur-console/client.py
+++ b/tools/infra/centaur-console/client.py
@@ -4,11 +4,13 @@ from __future__ import annotations
 
 import os
 from typing import Any
+from urllib.parse import quote
 
 import httpx
 
 SANDBOX_PERMISSIONS_PATH = "/api/v1/sandbox/permissions"
 SANDBOX_OAUTH_APPS_PATH = "/api/v1/sandbox/oauth_apps"
+SANDBOX_SCHEDULED_TASKS_PATH = "/api/v1/sandbox/scheduled_tasks"
 
 
 class ConsoleClient:
@@ -93,6 +95,107 @@ class ConsoleClient:
         """Alias for tool bridge calls."""
         return self.sandbox_oauth_apps()
 
+    def scheduled_tasks(self) -> list[dict[str, Any]]:
+        """List scheduled tasks owned by the current Console user."""
+        result = self._scheduled_task_request(SANDBOX_SCHEDULED_TASKS_PATH)
+        if not isinstance(result, list):
+            raise RuntimeError(
+                "centaur-console scheduled tasks response did not include a data array"
+            )
+        return result
+
+    def scheduled_task(self, task_id: str) -> dict[str, Any]:
+        """Read one scheduled task owned by the current Console user."""
+        result = self._scheduled_task_request(
+            f"{SANDBOX_SCHEDULED_TASKS_PATH}/{quote(task_id, safe='')}"
+        )
+        if not isinstance(result, dict):
+            raise RuntimeError(
+                "centaur-console scheduled task response did not include a data object"
+            )
+        return result
+
+    def create_scheduled_task(
+        self,
+        name: str,
+        prompt: str,
+        cron_expression: str,
+        delivery_channel: str = "dm",
+        enabled: bool = True,
+    ) -> dict[str, Any]:
+        """Create a Pacific Time cron task; deliver to dm or a permitted Slack channel ID."""
+        result = self._scheduled_task_request(
+            SANDBOX_SCHEDULED_TASKS_PATH,
+            method="POST",
+            json={
+                "data": {
+                    "name": name,
+                    "prompt": prompt,
+                    "cron_expression": cron_expression,
+                    "delivery_channel": delivery_channel,
+                    "enabled": enabled,
+                }
+            },
+        )
+        if not isinstance(result, dict):
+            raise RuntimeError(
+                "centaur-console scheduled task response did not include a data object"
+            )
+        return result
+
+    def update_scheduled_task(
+        self,
+        task_id: str,
+        name: str | None = None,
+        prompt: str | None = None,
+        cron_expression: str | None = None,
+        delivery_channel: str | None = None,
+        enabled: bool | None = None,
+    ) -> dict[str, Any]:
+        """Update selected fields on a scheduled task owned by the current Console user."""
+        attributes: dict[str, str | bool] = {}
+        for key, value in {
+            "name": name,
+            "prompt": prompt,
+            "cron_expression": cron_expression,
+            "delivery_channel": delivery_channel,
+            "enabled": enabled,
+        }.items():
+            if value is not None:
+                attributes[key] = value
+        if not attributes:
+            raise ValueError("at least one scheduled task field must be provided")
+
+        result = self._scheduled_task_request(
+            f"{SANDBOX_SCHEDULED_TASKS_PATH}/{quote(task_id, safe='')}",
+            method="PATCH",
+            json={"data": attributes},
+        )
+        if not isinstance(result, dict):
+            raise RuntimeError(
+                "centaur-console scheduled task response did not include a data object"
+            )
+        return result
+
+    def delete_scheduled_task(self, task_id: str) -> None:
+        """Delete a scheduled task owned by the current Console user."""
+        self._scheduled_task_request(
+            f"{SANDBOX_SCHEDULED_TASKS_PATH}/{quote(task_id, safe='')}",
+            method="DELETE",
+        )
+
+    def run_scheduled_task(self, task_id: str) -> dict[str, Any]:
+        """Queue an immediate run of a scheduled task owned by the current Console user."""
+        result = self._scheduled_task_request(
+            f"{SANDBOX_SCHEDULED_TASKS_PATH}/{quote(task_id, safe='')}/run",
+            method="POST",
+        )
+        if not isinstance(result, dict):
+            raise RuntimeError(
+                "centaur-console scheduled task response did not include a data object"
+            )
+        return result
+
     def health(self) -> dict[str, Any]:
         """Assert the sandbox permissions endpoint is reachable and authorized."""
         try:
@@ -114,6 +217,30 @@ class ConsoleClient:
                 "error": str(exc),
                 "details": {},
             }
+
+    def _scheduled_task_request(
+        self,
+        path: str,
+        method: str = "GET",
+        json: dict[str, Any] | None = None,
+    ) -> dict[str, Any] | list[dict[str, Any]] | None:
+        try:
+            response = self.client.request(method, path, json=json)
+            response.raise_for_status()
+        except httpx.HTTPStatusError as exc:
+            detail = _response_error_detail(exc.response)
+            raise RuntimeError(f"centaur-console scheduled task request failed: {detail}") from exc
+        except httpx.RequestError as exc:
+            raise RuntimeError(f"centaur-console scheduled task request failed: {exc}") from exc
+
+        if not response.content:
+            return None
+
+        payload = response.json()
+        data = payload.get("data")
+        if not isinstance(data, (dict, list)):
+            raise RuntimeError("centaur-console scheduled task response did not include data")
+        return data
 
     def close(self) -> None:
         if self._client:

--- a/tools/infra/centaur-console/pyproject.toml
+++ b/tools/infra/centaur-console/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "centaur-console"
-description = "Centaur console sandbox permission introspection"
+description = "Inspect Centaur Console permissions and manage scheduled tasks"
 version = "0.1.0"
 requires-python = ">=3.11"
 dependencies = [

--- a/tools/infra/centaur-console/test_client.py
+++ b/tools/infra/centaur-console/test_client.py
@@ -1,8 +1,11 @@
+import json
+
 import httpx
 import pytest
 from client import (
     SANDBOX_OAUTH_APPS_PATH,
     SANDBOX_PERMISSIONS_PATH,
+    SANDBOX_SCHEDULED_TASKS_PATH,
     ConsoleClient,
 )
 
@@ -91,6 +94,100 @@ def test_sandbox_oauth_apps_wraps_http_errors():
 
     with pytest.raises(RuntimeError, match="HTTP 401"):
         make_client(handler).sandbox_oauth_apps()
+
+
+def test_scheduled_tasks_list_and_read_owned_tasks():
+    requests = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        if request.url.path == SANDBOX_SCHEDULED_TASKS_PATH:
+            return json_response({"data": [{"id": "tsk_123", "name": "Daily briefing"}]})
+        return json_response({"data": {"id": "tsk_123", "prompt": "Summarize updates."}})
+
+    client = make_client(handler)
+    tasks = client.scheduled_tasks()
+    task = client.scheduled_task("tsk_123")
+
+    assert tasks == [{"id": "tsk_123", "name": "Daily briefing"}]
+    assert task["prompt"] == "Summarize updates."
+    assert [request.method for request in requests] == ["GET", "GET"]
+    assert requests[1].url.path == f"{SANDBOX_SCHEDULED_TASKS_PATH}/tsk_123"
+
+
+def test_create_scheduled_task_posts_schedule_and_delivery():
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.method == "POST"
+        assert request.url.path == SANDBOX_SCHEDULED_TASKS_PATH
+        assert json.loads(request.content) == {
+            "data": {
+                "name": "Daily briefing",
+                "prompt": "Summarize updates.",
+                "cron_expression": "0 9 * * *",
+                "delivery_channel": "dm",
+                "enabled": True,
+            }
+        }
+        return json_response({"data": {"id": "tsk_123", "delivery_channel": "U0123456789"}}, 201)
+
+    result = make_client(handler).create_scheduled_task(
+        name="Daily briefing",
+        prompt="Summarize updates.",
+        cron_expression="0 9 * * *",
+    )
+
+    assert result == {"id": "tsk_123", "delivery_channel": "U0123456789"}
+
+
+def test_update_scheduled_task_patches_only_provided_fields():
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.method == "PATCH"
+        assert request.url.path == f"{SANDBOX_SCHEDULED_TASKS_PATH}/tsk_123"
+        assert json.loads(request.content) == {
+            "data": {"name": "Morning briefing", "enabled": False}
+        }
+        return json_response(
+            {"data": {"id": "tsk_123", "name": "Morning briefing", "enabled": False}}
+        )
+
+    result = make_client(handler).update_scheduled_task(
+        "tsk_123",
+        name="Morning briefing",
+        enabled=False,
+    )
+
+    assert result["enabled"] is False
+
+
+def test_update_scheduled_task_requires_a_field():
+    with pytest.raises(ValueError, match="at least one scheduled task field"):
+        make_client(lambda _request: json_response({})).update_scheduled_task("tsk_123")
+
+
+def test_delete_and_run_scheduled_task_use_member_routes():
+    requests = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        if request.method == "DELETE":
+            return httpx.Response(204)
+        return json_response({"data": {"id": "tsk_123", "queued": True}}, 202)
+
+    client = make_client(handler)
+    assert client.delete_scheduled_task("tsk_123") is None
+    run = client.run_scheduled_task("tsk_123")
+
+    assert run["queued"] is True
+    assert [request.method for request in requests] == ["DELETE", "POST"]
+    assert requests[1].url.path == f"{SANDBOX_SCHEDULED_TASKS_PATH}/tsk_123/run"
+
+
+def test_scheduled_task_requests_wrap_http_errors():
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return json_response({"error": {"message": "task not found"}}, status_code=404)
+
+    with pytest.raises(RuntimeError, match="HTTP 404"):
+        make_client(handler).scheduled_task("tsk_missing")
 
 
 def test_health_returns_identity_details():


### PR DESCRIPTION
Adds sandbox-scoped scheduled task CRUD and run-now endpoints tied to the linked active Console user. Extends the centaur-console tool bridge and CLI with commands to list, inspect, create, update, delete, and immediately run tasks. Documents the API and adds agent guidance plus ownership, validation, and enqueue coverage.