### PR TITLE
fix(rendering): separate codex agent messages with paragraph breaks

### DIFF
--- a/packages/rendering/src/codex-app-server.test.ts
+++ b/packages/rendering/src/codex-app-server.test.ts
@@ -53,6 +53,95 @@ describe('CodexAppServerRendererEventMapper', () => {
     })
   })
 
+  it('separates successive agent messages with a paragraph break instead of gluing them', () => {
+    const mapper = new CodexAppServerRendererEventMapper()
+
+    mapper.process({
+      type: 'item.started',
+      item: { id: 'cmd-1', type: 'commandExecution', command: 'aws logs tail' }
+    })
+
+    const first = mapper.process({
+      type: 'item.completed',
+      item: { id: 'msg-1', type: 'agentMessage', text: 'Found the application group.' }
+    })
+    expect(first).toContainEqual({
+      type: 'renderer.message.delta',
+      delta: 'Found the application group.',
+      force: false,
+      planPrefix: true
+    })
+
+    const second = mapper.process({
+      type: 'item.completed',
+      item: { id: 'msg-2', type: 'agentMessage', text: 'No errors in the past hour.' }
+    })
+    expect(second).toContainEqual({
+      type: 'renderer.message.delta',
+      delta: '\n\nNo errors in the past hour.',
+      force: false,
+      planPrefix: true
+    })
+  })
+
+  it('separates streamed final answer items without rewriting already-streamed text', () => {
+    const mapper = new CodexAppServerRendererEventMapper()
+
+    mapper.process({
+      type: 'item.started',
+      item: { id: 'cmd-1', type: 'commandExecution', command: 'pnpm test' }
+    })
+    mapper.process({
+      type: 'item.started',
+      item: { id: 'msg-1', type: 'agentMessage', phase: 'final_answer' }
+    })
+    mapper.process({ type: 'item.agentMessage.delta', itemId: 'msg-1', delta: 'First message.' })
+    mapper.process({
+      type: 'item.completed',
+      item: { id: 'msg-1', type: 'agentMessage', phase: 'final_answer', text: 'First message.' }
+    })
+    mapper.process({
+      type: 'item.started',
+      item: { id: 'msg-2', type: 'agentMessage', phase: 'final_answer' }
+    })
+
+    const events = mapper.process({
+      type: 'item.agentMessage.delta',
+      itemId: 'msg-2',
+      delta: 'Second message.'
+    })
+    expect(events).toContainEqual({
+      type: 'renderer.message.delta',
+      delta: '\n\nSecond message.',
+      force: false,
+      planPrefix: true
+    })
+  })
+
+  it('does not double paragraph breaks when a message already ends with one', () => {
+    const mapper = new CodexAppServerRendererEventMapper()
+
+    mapper.process({
+      type: 'item.started',
+      item: { id: 'cmd-1', type: 'commandExecution', command: 'pnpm test' }
+    })
+    mapper.process({
+      type: 'item.completed',
+      item: { id: 'msg-1', type: 'agentMessage', text: 'Heads up.\n\n' }
+    })
+
+    const events = mapper.process({
+      type: 'item.completed',
+      item: { id: 'msg-2', type: 'agentMessage', text: 'Details follow.' }
+    })
+    expect(events).toContainEqual({
+      type: 'renderer.message.delta',
+      delta: 'Details follow.',
+      force: false,
+      planPrefix: true
+    })
+  })
+
   it('suppresses commentary thinking blocks', () => {
     const mapper = new CodexAppServerRendererEventMapper()
 
@@ -699,7 +788,7 @@ describe('CodexAppServerRendererEventMapper', () => {
     run({ type: 'item.agentMessage.delta', itemId: 'A', delta: 'there ' })
 
     const streamed = deltas.join('')
-    expect(streamed).toBe('Hello world.')
+    expect(streamed).toBe('Hello \n\nworld.')
     expect(streamed).not.toContain('world.world.')
     expect(logs).toContain('codex_renderer_stream_divergence_suppressed')
     // The signal is recorded once per render, not on every subsequent event.

--- a/packages/rendering/src/codex-app-server.ts
+++ b/packages/rendering/src/codex-app-server.ts
@@ -867,8 +867,21 @@ function recomposeBuffers(state: CodexMapperState): void {
 
 function compose(byItemId: Map<string, string>, trailing: string): string {
   let out = ''
-  for (const value of byItemId.values()) out += value
-  return trailing ? out + trailing : out
+  for (const value of byItemId.values()) out = joinSegments(out, value)
+  return joinSegments(out, trailing)
+}
+
+// Each map entry (and the trailing harness buffer) is a distinct message:
+// bare concatenation glues the end of one sentence to the start of the next
+// ("…the log group.No errors…"). Join with a paragraph break, respecting
+// separators already present (ensureCommentarySegmentBreak pre-appends \n\n),
+// and only ever appending after the prior segment so already-streamed text
+// stays a prefix of the recomposed buffer.
+function joinSegments(prior: string, next: string): string {
+  if (!prior || !next) return prior + next
+  if (prior.endsWith('\n\n')) return prior + next
+  if (prior.endsWith('\n')) return `${prior}\n${next}`
+  return `${prior}\n\n${next}`
 }
 
 function extractDeltaText(event: any): string {


### PR DESCRIPTION
## Problem

Codex (app-server) emits each interstitial status update as its own `agentMessage` item. The renderer's `compose()` concatenates the per-item buffers — and the trailing harness buffer — with bare `+=`, no separator. In Slack (and any chat surface fed by `@centaur/rendering`), a multi-step turn renders as a single run-on paragraph with the end of one sentence glued to the start of the next:

> I'll identify the live CloudWatch tool, then query recent `unbiased-admin` errors.**CloudWatch is available; I'm checking its query contract now.**Next I'll locate the exact log group and pull its newest errors.…

These items arrive unphased from codex, so they are classified into the answer buffer (`codex_renderer_unphased_final_agent_message_classified`) and all stream into the message body. The inbound twin of this bug (Slack rich-text blocks gluing paragraph boundaries) was already fixed in the vendored adapter patch (`extractPlainText`/`plainTextPreservingBlocks`); this is the outbound side.

## Fix

`compose()` now joins non-empty segments with a paragraph break (`joinSegments`):

- Respects separators already present, so segments pre-broken by `ensureCommentarySegmentBreak` are not double-spaced (`\n\n` → nothing added, single `\n` → one more `\n`).
- The separator is only ever appended **after** the prior segment's already-streamed text, so `answerText` remains a prefix-extension of `streamedAnswerText` and the streaming continuation invariant in `emitPendingAssistantText` is preserved.
- The trailing harness buffer (legacy `assistant` events, terminal result text, failure notices) gets the same treatment — those are distinct messages too.

## Tests

- New: two unphased `item.completed` agent messages emit `\n\n`-separated deltas (the production repro).
- New: streamed final-answer items across two item ids continue with a paragraph break without rewriting streamed text.
- New: a message already ending in a blank line does not get double-spaced.
- Updated: the divergence-suppression test's expected streamed text now includes the separator between its two concurrent items; its actual assertions (no duplication, single divergence log) are unchanged.
- `packages/rendering`: 40/40 pass. `services/slackbotv2`: 235 pass / 14 fail — identical pass/fail set on clean `origin/main` in the same environment (pre-existing, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L6Z7BjusjZdg5V7gzh6w2k