### PR TITLE
feat: improve scheduled task scheduling

### DIFF
--- a/services/console/app/controllers/console/scheduled_tasks_controller.rb
+++ b/services/console/app/controllers/console/scheduled_tasks_controller.rb
@@ -57,11 +57,16 @@ class Console::ScheduledTasksController < ApplicationController
   def task_attributes
     attributes = task_params
     delivery_mode = attributes.delete(:delivery_mode)
-    attributes.except(:schedule_preset).merge(
+    schedule_preset = attributes.delete(:schedule_preset)
+    custom_days = attributes.delete(:custom_days)
+    custom_time = attributes.delete(:custom_time)
+    attributes.merge(
       delivery_channel: delivery_channel_for(delivery_mode, attributes[:delivery_channel]),
       cron_expression: ScheduledTask.cron_for(
-        attributes[:schedule_preset],
-        attributes[:cron_expression]
+        schedule_preset,
+        nil,
+        custom_days: custom_days,
+        custom_time: custom_time
       )
     )
   end
@@ -80,13 +85,22 @@ class Console::ScheduledTasksController < ApplicationController
       :delivery_mode,
       :delivery_channel,
       :schedule_preset,
-      :cron_expression,
-      :enabled
+      :custom_time,
+      :enabled,
+      custom_days: []
     )
   end
 
   def prepare_form
     @slack_dm_user_id = SlackDeliveryPolicy.new(current_user).direct_message_user_id
+    submitted_schedule = params[:scheduled_task]
+    @schedule_preset = submitted_schedule&.[](:schedule_preset).presence || @task.schedule_preset
+    @custom_schedule_days = if submitted_schedule&.key?(:custom_days)
+      Array(submitted_schedule[:custom_days])
+    else
+      @task.custom_schedule_days
+    end
+    @custom_schedule_time = submitted_schedule&.[](:custom_time).presence || @task.custom_schedule_time
   end
 
   def slack_destination_names

--- a/services/console/app/javascript/controllers/schedule_fields_controller.js
+++ b/services/console/app/javascript/controllers/schedule_fields_controller.js
@@ -1,16 +1,15 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
-  static targets = ["preset", "cron", "expression"]
+  static targets = ["preset", "custom", "customTime"]
 
   connect() {
     this.update()
   }
 
   update() {
-    const cronSelected = this.presetTarget.value === "cron"
-    this.cronTarget.hidden = !cronSelected
-    this.expressionTarget.disabled = !cronSelected
-    this.expressionTarget.required = cronSelected
+    const customSelected = this.presetTarget.value === "custom"
+    this.customTarget.hidden = !customSelected
+    this.customTimeTarget.required = customSelected
   }
 }

--- a/services/console/app/models/scheduled_task.rb
+++ b/services/console/app/models/scheduled_task.rb
@@ -8,15 +8,32 @@ class ScheduledTask < ApplicationRecord
   WORKFLOW_NAME = "console_workflow".freeze
   DEFAULT_TIMEZONE = "America/Los_Angeles".freeze
   SCHEDULE_PRESETS = {
-    "hourly" => "0 * * * *",
     "daily" => "0 9 * * *",
-    "weekdays" => "0 9 * * 1-5"
+    "weekdays" => "0 9 * * 1-5",
+    "mondays" => "0 9 * * 1",
+    "fridays" => "0 9 * * 5"
   }.freeze
   SCHEDULE_PRESET_LABELS = {
-    "hourly" => "Hourly",
-    "daily" => "Daily at 9:00 PT",
-    "weekdays" => "Weekdays at 9:00 PT"
+    "daily" => "Every day",
+    "weekdays" => "Every weekday",
+    "mondays" => "Mondays",
+    "fridays" => "Fridays"
   }.freeze
+  SCHEDULE_LABELS = {
+    "daily" => "Daily at 9:00 PT",
+    "weekdays" => "Weekdays at 9:00 PT",
+    "mondays" => "Mondays at 9:00 PT",
+    "fridays" => "Fridays at 9:00 PT"
+  }.freeze
+  CUSTOM_SCHEDULE_DAYS = [
+    [ "Mon", "1" ],
+    [ "Tue", "2" ],
+    [ "Wed", "3" ],
+    [ "Thu", "4" ],
+    [ "Fri", "5" ],
+    [ "Sat", "6" ],
+    [ "Sun", "0" ]
+  ].freeze
   DELIVERY_DESTINATION_FORMAT = /\A[CDGUW][A-Z0-9]{8,}\z/
 
   belongs_to :author, class_name: "User"
@@ -43,18 +60,44 @@ class ScheduledTask < ApplicationRecord
   validate :cron_schedule_is_valid
   validate :delivery_destination_is_available_to_author
 
-  def self.cron_for(preset, custom_expression)
+  def self.cron_for(preset, custom_expression = nil, custom_days: [], custom_time: nil)
     return custom_expression.to_s.strip if preset.to_s == "cron"
+    return custom_cron(custom_days, custom_time) if preset.to_s == "custom"
 
     SCHEDULE_PRESETS.fetch(preset.to_s, custom_expression.to_s.strip)
   end
 
+  def self.custom_cron(days, time)
+    ordered_days = CUSTOM_SCHEDULE_DAYS.filter_map do |(_label, value)|
+      value if Array(days).map(&:to_s).include?(value)
+    end
+    match = /\A(?<hour>\d{2}):(?<minute>\d{2})\z/.match(time.to_s)
+    return "" if ordered_days.empty? || match.blank?
+
+    hour = match[:hour].to_i
+    minute = match[:minute].to_i
+    return "" unless hour.between?(0, 23) && minute.between?(0, 59)
+
+    "#{minute} #{hour} * * #{ordered_days.join(',')}"
+  end
+
   def schedule_preset
-    SCHEDULE_PRESETS.key(cron_expression) || "cron"
+    SCHEDULE_PRESETS.key(cron_expression) || "custom"
   end
 
   def schedule_label
-    SCHEDULE_PRESET_LABELS.fetch(schedule_preset, cron_expression)
+    preset_label = SCHEDULE_LABELS[schedule_preset]
+    return preset_label if preset_label.present?
+
+    custom_schedule_label || cron_expression
+  end
+
+  def custom_schedule_days
+    simple_weekly_schedule&.fetch(:days, nil) || []
+  end
+
+  def custom_schedule_time
+    simple_weekly_schedule&.fetch(:time, nil) || "09:00"
   end
 
   def next_occurrence(after: Time.current)
@@ -80,6 +123,52 @@ class ScheduledTask < ApplicationRecord
   end
 
   private
+
+  def simple_weekly_schedule
+    fields = cron_expression.to_s.split
+    return unless fields.length == 5 && fields[2] == "*" && fields[3] == "*"
+    return unless fields[0].match?(/\A\d+\z/) && fields[1].match?(/\A\d+\z/)
+
+    minute = fields[0].to_i
+    hour = fields[1].to_i
+    return unless minute.between?(0, 59) && hour.between?(0, 23)
+
+    days = expand_schedule_days(fields[4])
+    return if days.empty?
+
+    { days: days, time: format("%02d:%02d", hour, minute) }
+  end
+
+  def expand_schedule_days(day_expression)
+    return CUSTOM_SCHEDULE_DAYS.map(&:last) if day_expression == "*"
+
+    selected = day_expression.split(",").flat_map do |part|
+      if (range = /\A([0-7])-([0-7])\z/.match(part))
+        (range[1].to_i..range[2].to_i).map(&:to_s)
+      elsif part.match?(/\A[0-7]\z/)
+        [ part ]
+      else
+        []
+      end
+    end.map { |day| day == "7" ? "0" : day }.uniq
+
+    CUSTOM_SCHEDULE_DAYS.filter_map { |(_label, value)| value if selected.include?(value) }
+  end
+
+  def custom_schedule_label
+    schedule = simple_weekly_schedule
+    return if schedule.blank?
+
+    day_labels = CUSTOM_SCHEDULE_DAYS.filter_map do |label, value|
+      label if schedule[:days].include?(value)
+    end
+    hour, minute = schedule[:time].split(":").map(&:to_i)
+    meridiem = hour < 12 ? "AM" : "PM"
+    display_hour = hour % 12
+    display_hour = 12 if display_hour.zero?
+
+    "#{day_labels.join(', ')} at #{display_hour}:#{format('%02d', minute)} #{meridiem} PT"
+  end
 
   def parsed_cron
     Fugit::Cron.parse("#{cron_expression} #{timezone}")

--- a/services/console/app/views/console/scheduled_tasks/_form.html.erb
+++ b/services/console/app/views/console/scheduled_tasks/_form.html.erb
@@ -86,14 +86,14 @@
     <% end %>
   </fieldset>
 
-  <% cron_schedule = task.schedule_preset == "cron" %>
-  <div class="grid gap-5 lg:grid-cols-2" data-controller="schedule-fields">
+  <% custom_schedule = @schedule_preset == "custom" %>
+  <div data-controller="schedule-fields">
     <div>
       <%= form.label :schedule_preset, "Schedule", class: "mb-2 block text-sm font-medium text-zinc-200" %>
       <%= form.select :schedule_preset,
             options_for_select(
-              ScheduledTask::SCHEDULE_PRESET_LABELS.map { |preset, label| [ label, preset ] } + [ [ "Cron", "cron" ] ],
-              task.schedule_preset
+              ScheduledTask::SCHEDULE_PRESET_LABELS.map { |preset, label| [ label, preset ] } + [ [ "Custom", "custom" ] ],
+              @schedule_preset
             ),
             {},
             class: "form-input",
@@ -101,20 +101,48 @@
               schedule_fields_target: "preset",
               action: "schedule-fields#update"
             } %>
-      <p class="mt-2 text-xs text-zinc-500">All schedules use Pacific Time.</p>
+      <p class="mt-2 text-xs text-zinc-500">Presets run at 9:00 AM Pacific Time.</p>
     </div>
 
-    <div data-schedule-fields-target="cron" <%= "hidden" unless cron_schedule %>>
-      <%= form.label :cron_expression, "Cron expression", class: "mb-2 block text-sm font-medium text-zinc-200" %>
-      <%= form.text_field :cron_expression,
-            required: cron_schedule,
-            disabled: !cron_schedule,
-            placeholder: "0 9 * * 1-5",
-            class: "form-input font-mono",
-            data: { schedule_fields_target: "expression" } %>
-      <p class="mt-2 text-xs text-zinc-500">Cron expressions are evaluated in Pacific Time.</p>
-    </div>
+    <fieldset class="mt-4 rounded-lg border border-ink-600 bg-ink-900/50 p-4"
+              data-schedule-fields-target="custom"
+              <%= "hidden" unless custom_schedule %>>
+      <legend class="px-1 text-sm font-medium text-zinc-200">Custom schedule</legend>
+
+      <div>
+        <span class="mb-2 block text-xs font-medium text-zinc-400">Days</span>
+        <div class="grid grid-cols-4 gap-2 sm:grid-cols-7">
+          <% ScheduledTask::CUSTOM_SCHEDULE_DAYS.each do |label, value| %>
+            <% checkbox_id = "scheduled_task_custom_day_#{value}" %>
+            <label for="<%= checkbox_id %>"
+                   class="flex cursor-pointer items-center justify-center gap-2 rounded border border-ink-600 bg-ink-800 px-2 py-2 text-sm text-zinc-300 hover:border-centaur-500/50 hover:text-zinc-100">
+              <%= check_box_tag "scheduled_task[custom_days][]",
+                                value,
+                                @custom_schedule_days.include?(value),
+                                id: checkbox_id,
+                                class: "rounded border-ink-500 bg-ink-900 text-centaur-500" %>
+              <span><%= label %></span>
+            </label>
+          <% end %>
+        </div>
+      </div>
+
+      <div class="mt-4 max-w-xs">
+        <%= label_tag "scheduled_task_custom_time", "Time", class: "mb-2 block text-xs font-medium text-zinc-400" %>
+        <%= time_field_tag "scheduled_task[custom_time]",
+                           @custom_schedule_time,
+                           id: "scheduled_task_custom_time",
+                           required: custom_schedule,
+                           class: "form-input",
+                           data: { schedule_fields_target: "customTime" } %>
+        <p class="mt-2 text-xs text-zinc-500">Custom schedules use Pacific Time.</p>
+      </div>
+    </fieldset>
   </div>
+
+  <% if task.errors[:cron_expression].any? %>
+    <p class="-mt-3 text-xs text-red-400">Choose at least one day and a time.</p>
+  <% end %>
 
   <label class="flex items-start gap-3 rounded border border-ink-700 bg-ink-900/50 px-4 py-3">
     <%= form.check_box :enabled, class: "mt-0.5 rounded border-ink-500 bg-ink-900 text-centaur-500" %>

--- a/services/console/app/views/console/scheduled_tasks/index.html.erb
+++ b/services/console/app/views/console/scheduled_tasks/index.html.erb
@@ -34,7 +34,7 @@
               <% end %>
             </td>
             <td class="console-td text-xs text-zinc-400">
-              <div class="<%= "font-mono" if task.schedule_preset == "cron" %>"><%= task.schedule_label %></div>
+              <div class="<%= "font-mono" if task.schedule_label == task.cron_expression %>"><%= task.schedule_label %></div>
               <% unless task.enabled? %>
                 <div class="mt-1 text-zinc-600">Disabled</div>
               <% end %>

--- a/services/console/test/controllers/console/scheduled_tasks_controller_test.rb
+++ b/services/console/test/controllers/console/scheduled_tasks_controller_test.rb
@@ -18,10 +18,18 @@ class Console::ScheduledTasksControllerTest < ActionDispatch::IntegrationTest
     assert_select "textarea[name='scheduled_task[prompt]']"
     assert_select "select[name='scheduled_task[principal_oid]']", count: 0
     assert_select "select[name='scheduled_task[schedule_preset]']"
+    assert_select "select[name='scheduled_task[schedule_preset]'] option", 5
+    assert_select "option", text: "Every day"
+    assert_select "option", text: "Every weekday"
+    assert_select "option", text: "Mondays"
+    assert_select "option", text: "Fridays"
+    assert_select "option", text: "Custom"
     assert_select "select[name='scheduled_task[timezone]']", count: 0
-    assert_select "[data-schedule-fields-target=cron][hidden]"
-    assert_select "input[name='scheduled_task[cron_expression]'][disabled]"
-    assert_select "p", text: "All schedules use Pacific Time."
+    assert_select "[data-schedule-fields-target=custom][hidden]"
+    assert_select "input[type=checkbox][name='scheduled_task[custom_days][]']", 7
+    assert_select "input[type=time][name='scheduled_task[custom_time]']"
+    assert_select "input[name='scheduled_task[cron_expression]']", count: 0
+    assert_select "p", text: "Presets run at 9:00 AM Pacific Time."
     assert_select "form[data-controller='slack-channel-autocomplete']"
     assert_select "[data-slack-channel-autocomplete-url-value=?]",
                   slack_channel_options_console_scheduled_tasks_path
@@ -81,16 +89,54 @@ class Console::ScheduledTasksControllerTest < ActionDispatch::IntegrationTest
     assert_select "input[role=combobox][value=?]", task.delivery_channel
   end
 
-  test "edit form shows the cron expression for a cron schedule" do
+  test "edit form maps a weekly cron schedule to custom day and time fields" do
     task = create_task
-    task.update!(cron_expression: "15 6 * * *")
+    task.update!(cron_expression: "15 6 * * 1,3,5")
 
     get edit_console_scheduled_task_url(task.oid)
 
     assert_response :ok
-    assert_select "option[value=cron][selected]"
-    assert_select "[data-schedule-fields-target=cron]:not([hidden])"
-    assert_select "input[name='scheduled_task[cron_expression]'][required]:not([disabled])"
+    assert_select "option[value=custom][selected]"
+    assert_select "[data-schedule-fields-target=custom]:not([hidden])"
+    assert_select "input[name='scheduled_task[custom_days][]'][value=1][checked]"
+    assert_select "input[name='scheduled_task[custom_days][]'][value=3][checked]"
+    assert_select "input[name='scheduled_task[custom_days][]'][value=5][checked]"
+    assert_select "input[name='scheduled_task[custom_days][]'][value=2]:not([checked])"
+    assert_select "input[name='scheduled_task[custom_time]'][value='06:15'][required]"
+  end
+
+  test "creates a task from custom weekdays and time" do
+    assert_difference -> { ScheduledTask.count }, 1 do
+      post console_scheduled_tasks_url, params: {
+        scheduled_task: task_params.merge(
+          schedule_preset: "custom",
+          custom_days: %w[1 3 5],
+          custom_time: "14:30"
+        )
+      }
+    end
+
+    task = ScheduledTask.order(:id).last
+    assert_redirected_to console_scheduled_tasks_path
+    assert_equal "30 14 * * 1,3,5", task.cron_expression
+    assert_equal "Mon, Wed, Fri at 2:30 PM PT", task.schedule_label
+  end
+
+  test "rejects a custom schedule without any days" do
+    assert_no_difference -> { ScheduledTask.count } do
+      post console_scheduled_tasks_url, params: {
+        scheduled_task: task_params.merge(
+          schedule_preset: "custom",
+          custom_days: [],
+          custom_time: "14:30"
+        )
+      }
+    end
+
+    assert_response :unprocessable_entity
+    assert_select "option[value=custom][selected]"
+    assert_select "[data-schedule-fields-target=custom]:not([hidden])"
+    assert_select "p", text: "Choose at least one day and a time."
   end
 
   test "shows scheduled tasks on their dedicated page" do
@@ -101,7 +147,7 @@ class Console::ScheduledTasksControllerTest < ActionDispatch::IntegrationTest
     assert_select ".console-thread-group-title-active", text: /Scheduled/
     assert_select "h1", text: "Scheduled Tasks"
     assert_select "a[href=?]", edit_console_scheduled_task_path(task.oid), text: task.name
-    assert_select "td", text: /Hourly/
+    assert_select "td", text: /0 \* \* \* \*/
     assert_select "td", text: /#general/
     assert_select "td", text: /#{task.delivery_channel}/
     assert_no_match task.timezone, response.body

--- a/services/console/test/models/scheduled_task_test.rb
+++ b/services/console/test/models/scheduled_task_test.rb
@@ -26,10 +26,36 @@ class ScheduledTaskTest < ActiveSupport::TestCase
     end
   end
 
-  test "uses the cron expression as the schedule label when it does not match a preset" do
-    task = ScheduledTask.new(valid_attributes(cron_expression: "15 6 * * *"))
+  test "maps the requested weekday presets to cron schedules" do
+    assert_equal "0 9 * * 1-5", ScheduledTask.cron_for("weekdays")
+    assert_equal "0 9 * * 1", ScheduledTask.cron_for("mondays")
+    assert_equal "0 9 * * 5", ScheduledTask.cron_for("fridays")
+  end
 
-    assert_equal "15 6 * * *", task.schedule_label
+  test "builds a custom cron schedule from selected days and time" do
+    cron = ScheduledTask.cron_for(
+      "custom",
+      custom_days: %w[5 1 3 9],
+      custom_time: "14:30"
+    )
+    task = ScheduledTask.new(valid_attributes(cron_expression: cron))
+
+    assert_equal "30 14 * * 1,3,5", cron
+    assert_equal "custom", task.schedule_preset
+    assert_equal %w[1 3 5], task.custom_schedule_days
+    assert_equal "14:30", task.custom_schedule_time
+    assert_equal "Mon, Wed, Fri at 2:30 PM PT", task.schedule_label
+  end
+
+  test "rejects incomplete custom schedules" do
+    assert_empty ScheduledTask.cron_for("custom", custom_days: [], custom_time: "09:00")
+    assert_empty ScheduledTask.cron_for("custom", custom_days: %w[1], custom_time: "25:00")
+  end
+
+  test "uses the cron expression as the schedule label when it cannot be edited as a weekly schedule" do
+    task = ScheduledTask.new(valid_attributes(cron_expression: "0 * * * *"))
+
+    assert_equal "0 * * * *", task.schedule_label
   end
 
   test "validates custom cron schedules and Slack delivery channels" do

--- a/services/sandbox/SYSTEM_PROMPT.md
+++ b/services/sandbox/SYSTEM_PROMPT.md
@@ -220,6 +220,7 @@
 
 [Scheduled tasks]
 |When a user asks to create or manage recurring agent work, use `centaur-console tasks`, `task`, `create-task`, `update-task`, `delete-task`, or `run-task`. These commands only access tasks owned by the Console user linked to the current sandbox.
+|Only create scheduled tasks from MCP or direct-message (DM) sessions. If a user asks to create one from any other session type, explain that restriction and ask them to retry from MCP or a DM.
 |Scheduled tasks use five-field cron expressions in Pacific Time. Use `dm` as the delivery channel for the user's linked Slack direct message, or use a Slack channel ID allowed by their current delivery permissions.
 |After a mutation, report the returned task ID, schedule, delivery destination, enabled state, and next run time. Treat the first successful mutation response as authoritative and do not repeat it to improve formatting.
 

--- a/services/sandbox/test_system_prompt.py
+++ b/services/sandbox/test_system_prompt.py
@@ -81,6 +81,10 @@ class SystemPromptTest(unittest.TestCase):
         self.assertIn(
             "`task`, `create-task`, `update-task`, `delete-task`, or `run-task`", prompt
         )
+        self.assertIn(
+            "Only create scheduled tasks from MCP or direct-message (DM) sessions",
+            prompt,
+        )
         self.assertIn("five-field cron expressions in Pacific Time", prompt)
         self.assertIn("Use `dm` as the delivery channel", prompt)
         self.assertIn(


### PR DESCRIPTION
Adds the requested daily, weekday, Monday, Friday, and custom schedule presets to the Console task form. Custom schedules provide weekday checkboxes and a Pacific Time picker while preserving the cron-backed task model and readable schedule labels. Also limits scheduled-task creation guidance to MCP and DM sessions.