### PR TITLE
fix(console): retry Slack DM sync after DNS failures

### DIFF
--- a/services/console/app/services/slack_dm/sync_credential.rb
+++ b/services/console/app/services/slack_dm/sync_credential.rb
@@ -329,6 +329,12 @@ module SlackDm
         headers: { "Authorization" => "Bearer #{@credential.access_token}" }
       )
       SlackApi.parse_response!(response, max_rate_limit_wait: rate_limit_max_wait)
+    rescue Socket::ResolutionError => e
+      raise SlackApi::TransientError.new(
+        "Slack API hostname resolution failed: #{e.message}",
+        retry_after: SlackApi::DEFAULT_TRANSIENT_RETRY_AFTER_SECONDS,
+        code: "hostname_resolution_failed"
+      )
     end
 
     def max_slack_ts(left, right)

--- a/services/console/test/services/slack_dm/sync_credential_test.rb
+++ b/services/console/test/services/slack_dm/sync_credential_test.rb
@@ -348,5 +348,20 @@ module SlackDm
         assert_equal SlackApi::DEFAULT_TRANSIENT_RETRY_AFTER_SECONDS, error.retry_after
       end
     end
+
+    test "hostname resolution failures request deferred job execution" do
+      http_client = Object.new
+      http_client.define_singleton_method(:get) do |*|
+        raise Socket::ResolutionError, "Temporary failure in name resolution"
+      end
+
+      error = assert_raises(SlackApi::TransientError) do
+        SlackDm::SyncCredential.new(credential, http_client: http_client).call
+      end
+
+      assert_equal "hostname_resolution_failed", error.code
+      assert_equal SlackApi::DEFAULT_TRANSIENT_RETRY_AFTER_SECONDS, error.retry_after
+      assert_instance_of Socket::ResolutionError, error.cause
+    end
   end
 end


### PR DESCRIPTION
## Summary
- convert Slack hostname resolution failures into `SlackApi::TransientError`
- reuse the existing 30-second deferred retry policy
- add regression coverage for the observed `Socket::ResolutionError`

## Validation
- `git diff --check`
- Rails tests not run locally: Ruby is unavailable in this sandbox (`/usr/bin/env: ruby: No such file or directory`)

Prompted by: mslipper