### PR TITLE
chore: bump iron-proxy image to v0.50.0-rc.3

### DIFF
--- a/services/iron-proxy/Dockerfile
+++ b/services/iron-proxy/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.7
 
-FROM ironsh/iron-proxy:0.49.0@sha256:c4628019c24f4cc8d77564a26b7c9cedb00accee6f93d06270e85fb8f9c6a7da
+FROM ironsh/iron-proxy:0.50.0-rc.3@sha256:5861d7774d49b41ec86afa75156574ca5c0deaabd59bee0b2448ddbd1838881d
 
 USER root
 RUN --mount=type=cache,target=/var/cache/apk,sharing=locked \


### PR DESCRIPTION
## Summary

Bumps the pinned `iron-proxy` base image from 0.49.0 to 0.50.0-rc.3.

0.49.0 predates ironsh/iron-proxy#212, so its MITM leaf certificates advertise no ALPN protocols and the HTTPS/CONNECT listeners serve only HTTP/1.1. Any ALPN-enforcing gRPC client (grpc-go >= 1.67) behind the sandbox proxy fails the TLS handshake with no ALPN negotiated — observed in production sandboxes where a gRPC CLI could not reach its upstream through the proxy.

The rc line contains #212 plus three retry-handling fixes (#217, #219, #221); no config-breaking changes.

## Validation

- Before/after on an identical local rig (MITM mode, throwaway CA): `ironsh/iron-proxy:0.49.0` → `No ALPN negotiated`; `ironsh/iron-proxy:0.50.0-rc.3` → `ALPN protocol: h2`.
- The image built from this Dockerfile (real entrypoint, seeded default config, CA mount) serves the MITM leaf with `ALPN protocol: h2`.
- `sh -n services/iron-proxy/entrypoint.sh` and `cargo test -p centaur-iron-proxy` (13/13) pass.
