### PR TITLE
fix(repo-cache): use blobless partial clones

### DIFF
--- a/services/sandbox/repo_cache_sync.py
+++ b/services/sandbox/repo_cache_sync.py
@@ -49,6 +49,13 @@ def _repository_visibilities(value: str, repositories: list[str]) -> dict[str, s
     return visibilities
 
 
+def _normalize_git_filter(value: str | None) -> str | None:
+    git_filter = (value or "").strip()
+    if not git_filter or git_filter.lower() in {"0", "false", "none", "off"}:
+        return None
+    return git_filter
+
+
 def _atomic_write(path: Path, content: str) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     tmp = path.with_name(f"{path.name}.tmp")
@@ -77,6 +84,7 @@ class RepoCacheSync:
         repository_visibilities: dict[str, str],
         sync_interval_seconds: float,
         github_token_file: Path,
+        git_filter: str | None = "blob:none",
     ) -> None:
         self.cache_dir = cache_dir
         self.repositories = repositories
@@ -84,6 +92,7 @@ class RepoCacheSync:
         self.repository_visibilities = repository_visibilities
         self.sync_interval_seconds = sync_interval_seconds
         self.github_token_file = github_token_file
+        self.git_filter = _normalize_git_filter(git_filter)
         self.git_env: dict[str, str] | None = None
         self.ready_file = self.cache_dir / ".repo-cache-ready"
 
@@ -159,7 +168,11 @@ class RepoCacheSync:
             github_token_file=Path(
                 os.environ.get("GITHUB_TOKEN_FILE", "/github-token/token")
             ),
+            git_filter=os.environ.get("REPO_CACHE_GIT_FILTER", "blob:none"),
         )
+
+    def git_filter_args(self) -> list[str]:
+        return ["--filter", self.git_filter] if self.git_filter else []
 
     def _git_env(self) -> dict[str, str]:
         env = os.environ.copy()
@@ -261,6 +274,7 @@ class RepoCacheSync:
                         "-c",
                         "gc.auto=0",
                         "fetch",
+                        *self.git_filter_args(),
                         "--prune",
                         "--tags",
                         "origin",
@@ -319,6 +333,7 @@ class RepoCacheSync:
                     "-c",
                     "gc.auto=0",
                     "fetch",
+                    *self.git_filter_args(),
                     "--prune",
                     "--tags",
                     "origin",
@@ -336,10 +351,23 @@ class RepoCacheSync:
         for stale_tmp in glob.glob(f"{target}.tmp*"):
             _remove_path(Path(stale_tmp))
         _remove_path(target)
-        self._run_git(["clone", "--quiet", repo_url, str(tmp)], f"clone {repo}")
+        self._run_git(
+            ["clone", "--quiet", *self.git_filter_args(), repo_url, str(tmp)],
+            f"clone {repo}",
+        )
         self._git_ok(tmp, "config", "gc.auto", "0")
         self._run_git(
-            ["-C", str(tmp), "-c", "gc.auto=0", "fetch", "--prune", "--tags", "origin"],
+            [
+                "-C",
+                str(tmp),
+                "-c",
+                "gc.auto=0",
+                "fetch",
+                *self.git_filter_args(),
+                "--prune",
+                "--tags",
+                "origin",
+            ],
             f"fetch {repo}",
         )
         self._git_ok(tmp, "remote", "set-head", "origin", "-a")

--- a/services/sandbox/test_repo_cache_sync.py
+++ b/services/sandbox/test_repo_cache_sync.py
@@ -50,6 +50,54 @@ class RepoCacheSyncTest(unittest.TestCase):
             os.environ.clear()
             os.environ.update(old_env)
 
+    def test_git_filter_args_default_to_blobless_partial_clone(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            sync = repo_cache_sync.RepoCacheSync(
+                cache_dir=root / "cache",
+                repositories=["acme/centaur"],
+                repository_refs={},
+                repository_visibilities={},
+                sync_interval_seconds=30,
+                github_token_file=root / "missing-token",
+            )
+
+            self.assertEqual(sync.git_filter_args(), ["--filter", "blob:none"])
+
+    def test_from_env_allows_custom_repo_cache_git_filter(self) -> None:
+        old_env = os.environ.copy()
+        try:
+            os.environ.update(
+                {
+                    "REPOSITORIES": "acme/centaur",
+                    "REPO_CACHE_GIT_FILTER": "tree:0",
+                }
+            )
+
+            sync = repo_cache_sync.RepoCacheSync.from_env()
+
+            self.assertEqual(sync.git_filter_args(), ["--filter", "tree:0"])
+        finally:
+            os.environ.clear()
+            os.environ.update(old_env)
+
+    def test_from_env_can_disable_repo_cache_git_filter(self) -> None:
+        old_env = os.environ.copy()
+        try:
+            os.environ.update(
+                {
+                    "REPOSITORIES": "acme/centaur",
+                    "REPO_CACHE_GIT_FILTER": "off",
+                }
+            )
+
+            sync = repo_cache_sync.RepoCacheSync.from_env()
+
+            self.assertEqual(sync.git_filter_args(), [])
+        finally:
+            os.environ.clear()
+            os.environ.update(old_env)
+
     def test_write_ready_preserves_readiness_format(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)


### PR DESCRIPTION
Summary
- use blobless partial clone/fetch filtering by default for repo-cache sync operations
- add REPO_CACHE_GIT_FILTER so operators can override the filter or disable it with off/false/none/0
- cover default, custom, and disabled filter argument handling in repo-cache tests

Fixes #1436.

Testing
- uv run python -m unittest test_repo_cache_sync.RepoCacheSyncTest.test_git_filter_args_default_to_blobless_partial_clone test_repo_cache_sync.RepoCacheSyncTest.test_from_env_allows_custom_repo_cache_git_filter test_repo_cache_sync.RepoCacheSyncTest.test_from_env_can_disable_repo_cache_git_filter
- git diff --check

Note: the full Windows sandbox unittest discovery now starts with uv installed, but still fails in unrelated existing Windows-host gaps: git-branch subprocess shim execution, install_tool_shims importing fcntl, repo-cache umask expectations, and POSIX file-mode assertions in seed_hermes_codex_auth.