### PR TITLE
feat(api-rs): persist MCP console user metadata

### DIFF
--- a/services/api-rs/crates/centaur-api-server/src/mcp.rs
+++ b/services/api-rs/crates/centaur-api-server/src/mcp.rs
@@ -78,6 +78,8 @@ struct CentaurToolMcpArguments {
 struct McpPrincipal {
     token_id: String,
     principal_id: String,
+    console_user_email: Option<String>,
+    console_user_name: Option<String>,
     name: String,
     scopes: Vec<String>,
     expires_at: Option<OffsetDateTime>,
@@ -423,6 +425,8 @@ async fn run_tool_host_centaur_tool(
     let output = runtime
         .run_tool_host_call(ToolHostCallInput {
             principal_id: principal.principal_id.clone(),
+            console_user_email: principal.console_user_email.clone(),
+            console_user_name: principal.console_user_name.clone(),
             token_id: Some(principal.token_id.clone()),
             tool_name: tool.name.clone(),
             method: method.to_owned(),
@@ -638,9 +642,11 @@ fn verify_mcp_jwt(token: &str, headers: &HeaderMap) -> Result<Option<McpPrincipa
         let digest = Sha256::digest(token.as_bytes());
         format!("mcp_jwt_{}", hex::encode(&digest[..12]))
     });
+    let console_user_email = first_non_empty_owned([claims.email]);
+    let console_user_name = first_non_empty_owned([claims.name]);
     let name = first_non_empty_owned([
-        claims.name,
-        claims.email,
+        console_user_name.clone(),
+        console_user_email.clone(),
         claims.sub,
         Some(claims.principal_id.clone()),
     ])
@@ -649,6 +655,8 @@ fn verify_mcp_jwt(token: &str, headers: &HeaderMap) -> Result<Option<McpPrincipa
     Ok(Some(McpPrincipal {
         token_id,
         principal_id: claims.principal_id,
+        console_user_email,
+        console_user_name,
         name,
         scopes,
         expires_at,
@@ -1075,6 +1083,8 @@ def search(query, limit=20):
             &AppState::unready(crate::ApiAuthConfig::testing("test-secret")),
             &McpPrincipal {
                 principal_id: "mcp:test".to_owned(),
+                console_user_email: None,
+                console_user_name: None,
                 token_id: "mcp_tok_test".to_owned(),
                 name: "test".to_owned(),
                 scopes: vec!["mcp:tools".to_owned()],
@@ -1104,6 +1114,8 @@ def search(query, limit=20):
             &AppState::unready(crate::ApiAuthConfig::testing("test-secret")),
             &McpPrincipal {
                 principal_id: "mcp:test".to_owned(),
+                console_user_email: None,
+                console_user_name: None,
                 token_id: "mcp_tok_test".to_owned(),
                 name: "test".to_owned(),
                 scopes: vec!["mcp:tools".to_owned()],
@@ -1139,6 +1151,8 @@ def search(query, limit=20):
             &AppState::unready(crate::ApiAuthConfig::testing("test-secret")),
             &McpPrincipal {
                 principal_id: "mcp:test".to_owned(),
+                console_user_email: None,
+                console_user_name: None,
                 token_id: "mcp_tok_test".to_owned(),
                 name: "test".to_owned(),
                 scopes: vec!["mcp:tools".to_owned()],
@@ -1194,6 +1208,7 @@ def search(query, limit=20):
                 "scope": "mcp:tools",
                 "principal_id": "prn_test",
                 "email": "test@example.com",
+                "name": "Test User",
             }),
         );
 
@@ -1203,7 +1218,12 @@ def search(query, limit=20):
 
         assert_eq!(principal.token_id, "mcpjwt_test");
         assert_eq!(principal.principal_id, "prn_test");
-        assert_eq!(principal.name, "test@example.com");
+        assert_eq!(
+            principal.console_user_email.as_deref(),
+            Some("test@example.com")
+        );
+        assert_eq!(principal.console_user_name.as_deref(), Some("Test User"));
+        assert_eq!(principal.name, "Test User");
         assert_eq!(principal.scopes, vec!["mcp:tools"]);
         assert!(principal.expires_at.is_some());
     }

--- a/services/api-rs/crates/centaur-session-runtime/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-runtime/src/lib.rs
@@ -1084,16 +1084,13 @@ impl SessionRuntime {
             tool_host_session_metadata(principal_id, console_user_email, console_user_name);
         let session = self
             .store
-            .create_or_get_session(
+            .create_or_get_session_merging_metadata(
                 thread_key,
                 &harness,
                 None,
-                metadata.clone(),
+                metadata,
                 BTreeMap::new(),
             )
-            .await?;
-        self.store
-            .merge_session_metadata(thread_key, metadata)
             .await?;
         if session.iron_control_principal.as_deref() != Some(principal_id) {
             self.store

--- a/services/api-rs/crates/centaur-session-runtime/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-runtime/src/lib.rs
@@ -374,6 +374,8 @@ pub struct InterruptExecutionOutcome {
 #[derive(Debug)]
 pub struct ToolHostCallInput {
     pub principal_id: String,
+    pub console_user_email: Option<String>,
+    pub console_user_name: Option<String>,
     pub token_id: Option<String>,
     pub tool_name: String,
     pub method: String,
@@ -1009,14 +1011,21 @@ impl SessionRuntime {
     ) -> Result<ToolHostCallOutput, SessionRuntimeError> {
         let ToolHostCallInput {
             principal_id,
+            console_user_email,
+            console_user_name,
             token_id,
             tool_name,
             method,
             arguments,
             timeout,
         } = input;
-        self.create_or_get_tool_host_session(thread_key, &principal_id)
-            .await?;
+        self.create_or_get_tool_host_session(
+            thread_key,
+            &principal_id,
+            console_user_email.as_deref(),
+            console_user_name.as_deref(),
+        )
+        .await?;
 
         let request_id = format!("mcp-call-{}", Uuid::new_v4().simple());
         let request = ToolHostRequest {
@@ -1063,16 +1072,28 @@ impl SessionRuntime {
         &self,
         thread_key: &ThreadKey,
         principal_id: &str,
+        console_user_email: Option<&str>,
+        console_user_name: Option<&str>,
     ) -> Result<(), SessionRuntimeError> {
         let harness = self
             .sandbox_runtime
             .warm_harness
             .clone()
             .unwrap_or(HarnessType::Codex);
-        let metadata = tool_host_session_metadata(principal_id);
+        let metadata =
+            tool_host_session_metadata(principal_id, console_user_email, console_user_name);
         let session = self
             .store
-            .create_or_get_session(thread_key, &harness, None, metadata, BTreeMap::new())
+            .create_or_get_session(
+                thread_key,
+                &harness,
+                None,
+                metadata.clone(),
+                BTreeMap::new(),
+            )
+            .await?;
+        self.store
+            .merge_session_metadata(thread_key, metadata)
             .await?;
         if session.iron_control_principal.as_deref() != Some(principal_id) {
             self.store
@@ -1273,7 +1294,7 @@ impl SessionRuntime {
         // same principal cannot interleave with session setup.
         let call_lock = self.tool_host_call_lock(&thread_key);
         let _call_guard = call_lock.lock().await;
-        let metadata = tool_host_session_metadata(principal_id);
+        let metadata = tool_host_session_metadata(principal_id, None, None);
         let principal = self
             .iron_control
             .register_session(thread_key.as_str(), Some(&metadata))
@@ -6677,11 +6698,32 @@ fn tool_host_thread_key(principal_id: &str) -> Result<ThreadKey, SessionRuntimeE
 
 /// Session/principal metadata recorded for observability; runtime behavior
 /// derives from the `mcp:` thread-key prefix, not from these fields.
-fn tool_host_session_metadata(principal_id: &str) -> Value {
-    json!({
-        "mcp_tool_host": true,
-        "mcp_principal_id": principal_id,
-    })
+fn tool_host_session_metadata(
+    principal_id: &str,
+    console_user_email: Option<&str>,
+    console_user_name: Option<&str>,
+) -> Value {
+    let mut metadata = serde_json::Map::from_iter([
+        ("mcp_tool_host".to_owned(), Value::Bool(true)),
+        (
+            "mcp_principal_id".to_owned(),
+            Value::String(principal_id.to_owned()),
+        ),
+    ]);
+    insert_non_empty_metadata_string(&mut metadata, "console_user_email", console_user_email);
+    insert_non_empty_metadata_string(&mut metadata, "console_user_name", console_user_name);
+    Value::Object(metadata)
+}
+
+fn insert_non_empty_metadata_string(
+    metadata: &mut serde_json::Map<String, Value>,
+    key: &str,
+    value: Option<&str>,
+) {
+    let Some(value) = value.map(str::trim).filter(|value| !value.is_empty()) else {
+        return;
+    };
+    metadata.insert(key.to_owned(), Value::String(value.to_owned()));
 }
 
 fn proxy_labels_from_session_metadata(
@@ -7134,6 +7176,30 @@ mod tests {
         assert_eq!(spec.command, Some(vec!["/entrypoint.sh".to_owned()]));
         assert_eq!(spec.args, vec!["centaur-tool-host"]);
         assert_eq!(env_value(&spec, "TOOL_DIRS"), Some("/app/tools"));
+    }
+
+    #[test]
+    fn tool_host_session_metadata_includes_console_identity() {
+        assert_eq!(
+            tool_host_session_metadata("prn_test", Some(" test@example.com "), Some(" Test User "),),
+            json!({
+                "mcp_tool_host": true,
+                "mcp_principal_id": "prn_test",
+                "console_user_email": "test@example.com",
+                "console_user_name": "Test User",
+            })
+        );
+    }
+
+    #[test]
+    fn tool_host_session_metadata_omits_missing_console_identity() {
+        assert_eq!(
+            tool_host_session_metadata("prn_test", Some("  "), None),
+            json!({
+                "mcp_tool_host": true,
+                "mcp_principal_id": "prn_test",
+            })
+        );
     }
 
     #[test]

--- a/services/api-rs/crates/centaur-session-sqlx/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-sqlx/src/lib.rs
@@ -190,6 +190,31 @@ impl PgSessionStore {
         row.try_into()
     }
 
+    /// Merge durable session metadata, with the supplied keys replacing older
+    /// values. This is used for identity display data that can be learned or
+    /// refreshed after a session was first created.
+    pub async fn merge_session_metadata(
+        &self,
+        thread_key: &ThreadKey,
+        metadata: Value,
+    ) -> Result<Value, SessionStoreError> {
+        sqlx::query_scalar::<_, Value>(
+            r#"
+            update sessions
+            set metadata = metadata || $2, updated_at = now()
+            where thread_key = $1
+            returning metadata
+            "#,
+        )
+        .bind(thread_key.as_str())
+        .bind(metadata)
+        .fetch_optional(&self.pool)
+        .await?
+        .ok_or_else(|| SessionStoreError::NotFound {
+            thread_key: thread_key.as_str().to_owned(),
+        })
+    }
+
     pub async fn get_session_title(
         &self,
         thread_key: &ThreadKey,
@@ -2174,6 +2199,50 @@ mod tests {
                 .expect("get session")
                 .proxy_labels,
             labels
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn session_metadata_merges_new_identity_values() {
+        let Some(store) = test_store().await else {
+            return;
+        };
+        let thread_key =
+            ThreadKey::parse(format!("test:metadata-merge-{}", Uuid::new_v4())).unwrap();
+        store
+            .create_or_get_session(
+                &thread_key,
+                &HarnessType::Codex,
+                None,
+                json!({
+                    "mcp_tool_host": true,
+                    "mcp_principal_id": "prn_test",
+                    "console_user_name": "Old Name",
+                }),
+                Default::default(),
+            )
+            .await
+            .expect("create session");
+
+        let metadata = store
+            .merge_session_metadata(
+                &thread_key,
+                json!({
+                    "console_user_email": "test@example.com",
+                    "console_user_name": "Test User",
+                }),
+            )
+            .await
+            .expect("merge session metadata");
+
+        assert_eq!(
+            metadata,
+            json!({
+                "mcp_tool_host": true,
+                "mcp_principal_id": "prn_test",
+                "console_user_email": "test@example.com",
+                "console_user_name": "Test User",
+            })
         );
     }
 

--- a/services/api-rs/crates/centaur-session-sqlx/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-sqlx/src/lib.rs
@@ -124,21 +124,79 @@ impl PgSessionStore {
         metadata: Value,
         proxy_labels: BTreeMap<String, String>,
     ) -> Result<Session, SessionStoreError> {
-        sqlx::query(
-            r#"
-            insert into sessions (thread_key, harness_type, persona_id, status, metadata, proxy_labels)
-            values ($1, $2, $3, $4, $5, $6)
-            on conflict (thread_key) do nothing
-            "#,
+        self.create_or_get_session_inner(
+            thread_key,
+            harness_type,
+            persona_id,
+            metadata,
+            proxy_labels,
+            false,
         )
-        .bind(thread_key.as_str())
-        .bind(harness_type.as_ref())
-        .bind(persona_id)
-        .bind(SessionStatus::Idle.as_ref())
-        .bind(metadata)
-        .bind(Json(proxy_labels.clone()))
-        .execute(&self.pool)
-        .await?;
+        .await
+    }
+
+    /// Create or load a session while merging newly learned metadata into an
+    /// existing row. The conflict update is skipped when every supplied value
+    /// is already present, so unchanged calls do not write or touch updated_at.
+    pub async fn create_or_get_session_merging_metadata(
+        &self,
+        thread_key: &ThreadKey,
+        harness_type: &HarnessType,
+        persona_id: Option<&str>,
+        metadata: Value,
+        proxy_labels: BTreeMap<String, String>,
+    ) -> Result<Session, SessionStoreError> {
+        self.create_or_get_session_inner(
+            thread_key,
+            harness_type,
+            persona_id,
+            metadata,
+            proxy_labels,
+            true,
+        )
+        .await
+    }
+
+    async fn create_or_get_session_inner(
+        &self,
+        thread_key: &ThreadKey,
+        harness_type: &HarnessType,
+        persona_id: Option<&str>,
+        metadata: Value,
+        proxy_labels: BTreeMap<String, String>,
+        merge_metadata: bool,
+    ) -> Result<Session, SessionStoreError> {
+        let query = if merge_metadata {
+            sqlx::query(
+                r#"
+                insert into sessions (thread_key, harness_type, persona_id, status, metadata, proxy_labels)
+                values ($1, $2, $3, $4, $5, $6)
+                on conflict (thread_key) do update
+                set metadata = sessions.metadata || excluded.metadata,
+                    updated_at = now()
+                where sessions.harness_type = excluded.harness_type
+                  and sessions.persona_id is not distinct from excluded.persona_id
+                  and not sessions.metadata @> excluded.metadata
+                "#,
+            )
+        } else {
+            sqlx::query(
+                r#"
+                insert into sessions (thread_key, harness_type, persona_id, status, metadata, proxy_labels)
+                values ($1, $2, $3, $4, $5, $6)
+                on conflict (thread_key) do nothing
+                "#,
+            )
+        };
+        query
+            .bind(thread_key.as_str())
+            .bind(harness_type.as_ref())
+            .bind(persona_id)
+            .bind(SessionStatus::Idle.as_ref())
+            .bind(metadata)
+            .bind(Json(proxy_labels.clone()))
+            .execute(&self.pool)
+            .await?;
 
         if !proxy_labels.is_empty() {
             sqlx::query(
@@ -188,31 +246,6 @@ impl PgSessionStore {
         })?;
 
         row.try_into()
-    }
-
-    /// Merge durable session metadata, with the supplied keys replacing older
-    /// values. This is used for identity display data that can be learned or
-    /// refreshed after a session was first created.
-    pub async fn merge_session_metadata(
-        &self,
-        thread_key: &ThreadKey,
-        metadata: Value,
-    ) -> Result<Value, SessionStoreError> {
-        sqlx::query_scalar::<_, Value>(
-            r#"
-            update sessions
-            set metadata = metadata || $2, updated_at = now()
-            where thread_key = $1
-            returning metadata
-            "#,
-        )
-        .bind(thread_key.as_str())
-        .bind(metadata)
-        .fetch_optional(&self.pool)
-        .await?
-        .ok_or_else(|| SessionStoreError::NotFound {
-            thread_key: thread_key.as_str().to_owned(),
-        })
     }
 
     pub async fn get_session_title(
@@ -2203,14 +2236,14 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn session_metadata_merges_new_identity_values() {
+    async fn create_or_get_session_merges_only_changed_metadata() {
         let Some(store) = test_store().await else {
             return;
         };
         let thread_key =
             ThreadKey::parse(format!("test:metadata-merge-{}", Uuid::new_v4())).unwrap();
-        store
-            .create_or_get_session(
+        let created = store
+            .create_or_get_session_merging_metadata(
                 &thread_key,
                 &HarnessType::Codex,
                 None,
@@ -2224,16 +2257,47 @@ mod tests {
             .await
             .expect("create session");
 
-        let metadata = store
-            .merge_session_metadata(
+        let updated = store
+            .create_or_get_session_merging_metadata(
                 &thread_key,
+                &HarnessType::Codex,
+                None,
                 json!({
+                    "mcp_tool_host": true,
+                    "mcp_principal_id": "prn_test",
                     "console_user_email": "test@example.com",
                     "console_user_name": "Test User",
                 }),
+                Default::default(),
             )
             .await
             .expect("merge session metadata");
+        assert!(updated.updated_at >= created.updated_at);
+
+        let unchanged = store
+            .create_or_get_session_merging_metadata(
+                &thread_key,
+                &HarnessType::Codex,
+                None,
+                json!({
+                    "mcp_tool_host": true,
+                    "mcp_principal_id": "prn_test",
+                    "console_user_email": "test@example.com",
+                    "console_user_name": "Test User",
+                }),
+                Default::default(),
+            )
+            .await
+            .expect("load session with unchanged metadata");
+        assert_eq!(unchanged.updated_at, updated.updated_at);
+
+        let metadata = sqlx::query_scalar::<_, serde_json::Value>(
+            "select metadata from sessions where thread_key = $1",
+        )
+        .bind(thread_key.as_str())
+        .fetch_one(store.pool())
+        .await
+        .expect("load session metadata");
 
         assert_eq!(
             metadata,


### PR DESCRIPTION
Carry the Console user's email and name from the existing MCP access JWT into durable tool-host session metadata as `console_user_email` and `console_user_name`. Existing MCP sessions merge refreshed identity values through the normal create-or-get query, with conflict updates skipped when metadata is unchanged, while retaining the authoritative `mcp_principal_id` binding. Adds focused JWT decoding, metadata shaping, and SQLx conditional-merge coverage.