### PR TITLE
fix(console): serialize Slack DM credential sync

### DIFF
--- a/services/console/app/jobs/slack_dm/poll_sync_job.rb
+++ b/services/console/app/jobs/slack_dm/poll_sync_job.rb
@@ -1,24 +1,5 @@
 module SlackDm
-  class PollSyncJob < ApplicationJob
-    queue_as :default
-
-    def perform(oauth_app_slug = SlackDm::SyncCredential.oauth_app_slug)
-      credentials = BrokerCredential
-        .includes(:oauth_app)
-        .joins(:oauth_app)
-        .where(dead: false)
-        .where(oauth_apps: {
-          provider: Oauth::Providers::Slack::KEY,
-          slug: oauth_app_slug,
-          enabled: true
-        })
-
-      credentials.find_each do |credential|
-        next if credential.access_token.blank?
-        next unless SlackDm::SyncCredential.required_scopes_granted?(credential.scopes)
-
-        SlackDm::SyncCredentialJob.perform_later(credential.id)
-      end
-    end
-  end
+  # Keep already-enqueued jobs from the previous recurring configuration
+  # compatible during rollout.
+  class PollSyncJob < SyncCredentialJob; end
 end

--- a/services/console/app/jobs/slack_dm/sync_credential_job.rb
+++ b/services/console/app/jobs/slack_dm/sync_credential_job.rb
@@ -1,30 +1,87 @@
 module SlackDm
   class SyncCredentialJob < ApplicationJob
-    MAX_RETRYABLE_EXECUTIONS = 2
+    CONCURRENCY_DURATION = 6.hours
+    RUN_TIME_BUDGET = 30.minutes
 
     queue_as :default
 
-    limits_concurrency to: 1, key: ->(credential_id) { "slack_dm_sync_#{credential_id}" }
+    limits_concurrency(
+      to: 1,
+      key: ->(*) { "slack_dm_sync" },
+      group: "SlackDmSync",
+      duration: CONCURRENCY_DURATION,
+      on_conflict: :discard
+    )
 
-    def perform(credential_id)
-      credential = BrokerCredential.includes(:oauth_app).find_by(id: credential_id)
-      return unless credential
-      return if credential.dead?
-      return if credential.access_token.blank?
-      return unless credential.oauth_app&.provider == Oauth::Providers::Slack::KEY
-      return unless SlackDm::SyncCredential.required_scopes_granted?(credential.scopes)
+    def perform(oauth_app_slug = SlackDm::SyncCredential.oauth_app_slug)
+      # Credential IDs were the argument before this became a global cursor job.
+      # Ignore any of those jobs that were already queued during deployment.
+      return unless oauth_app_slug.is_a?(String)
 
-      SlackDm::SyncCredential.new(credential).call
-    rescue SlackApi::RetryableError => e
-      if executions >= MAX_RETRYABLE_EXECUTIONS
-        Rails.logger.warn do
-          "Slack sync job dropped after repeated retryable API failures: " \
-            "credential_id=#{credential_id} executions=#{executions}"
-        end
+      cursor = SlackDmSyncCursor.find_or_create_by!(oauth_app_slug: oauth_app_slug)
+      return if cursor.not_before&.future?
+
+      credentials = eligible_credentials(oauth_app_slug)
+      if credentials.empty?
+        cursor.update!(next_credential_id: nil, not_before: nil)
         return
       end
 
-      retry_job wait: e.retry_after.seconds, error: e
+      deadline = RUN_TIME_BUDGET.from_now
+      credentials = ordered_credentials(credentials, cursor.next_credential_id)
+      credentials.each_with_index do |credential, index|
+        break if Time.current >= deadline
+        return unless sync_credential(cursor, credential)
+
+        next_credential = credentials[index + 1] || credentials.first
+        cursor.update!(next_credential_id: next_credential.id, not_before: nil)
+      end
+    end
+
+    private
+
+    def credentials_for(oauth_app_slug)
+      BrokerCredential
+        .includes(:oauth_app)
+        .joins(:oauth_app)
+        .where(dead: false)
+        .where(oauth_apps: {
+          provider: Oauth::Providers::Slack::KEY,
+          slug: oauth_app_slug,
+          enabled: true
+        })
+    end
+
+    def eligible_credentials(oauth_app_slug)
+      credentials_for(oauth_app_slug).order(:id).select do |credential|
+        credential.access_token.present? &&
+          SlackDm::SyncCredential.required_scopes_granted?(credential.scopes)
+      end
+    end
+
+    def ordered_credentials(credentials, next_credential_id)
+      return credentials unless next_credential_id
+
+      start_index = credentials.index { |credential| credential.id >= next_credential_id } || 0
+      credentials.rotate(start_index)
+    end
+
+    def sync_credential(cursor, credential)
+      SlackDm::SyncCredential.new(credential).call
+      true
+    rescue SlackApi::RateLimitedError => e
+      retry_at = e.retry_after.seconds.from_now
+      cursor.update!(next_credential_id: credential.id, not_before: retry_at)
+      Rails.logger.info do
+        "Slack DM sync paused after rate limit: credential_id=#{credential.id} " \
+          "retry_at=#{retry_at.iso8601}"
+      end
+      false
+    rescue SlackApi::Error => e
+      Rails.logger.warn do
+        "Slack DM sync failed for credential #{credential.id}: #{e.class}: #{e.message}"
+      end
+      true
     end
   end
 end

--- a/services/console/app/jobs/slack_dm/sync_credential_job.rb
+++ b/services/console/app/jobs/slack_dm/sync_credential_job.rb
@@ -23,7 +23,7 @@ module SlackDm
 
       credentials = eligible_credentials(oauth_app_slug)
       if credentials.empty?
-        cursor.update!(next_credential_id: nil, not_before: nil)
+        cursor.update!(next_credential_id: nil, next_conversation_id: nil, not_before: nil)
         return
       end
 
@@ -31,10 +31,14 @@ module SlackDm
       credentials = ordered_credentials(credentials, cursor.next_credential_id)
       credentials.each_with_index do |credential, index|
         break if Time.current >= deadline
-        return unless sync_credential(cursor, credential)
+        return unless sync_credential(cursor, credential, deadline)
 
         next_credential = credentials[index + 1] || credentials.first
-        cursor.update!(next_credential_id: next_credential.id, not_before: nil)
+        cursor.update!(
+          next_credential_id: next_credential.id,
+          next_conversation_id: nil,
+          not_before: nil
+        )
       end
     end
 
@@ -66,9 +70,17 @@ module SlackDm
       credentials.rotate(start_index)
     end
 
-    def sync_credential(cursor, credential)
-      SlackDm::SyncCredential.new(credential).call
-      true
+    def sync_credential(cursor, credential, deadline)
+      SlackDm::SyncCredential.new(credential).call(
+        starting_conversation_id: cursor.next_conversation_id,
+        deadline: deadline
+      ) do |conversation_id|
+        cursor.update!(
+          next_credential_id: credential.id,
+          next_conversation_id: conversation_id,
+          not_before: nil
+        )
+      end
     rescue SlackApi::RateLimitedError => e
       retry_at = e.retry_after.seconds.from_now
       cursor.update!(next_credential_id: credential.id, not_before: retry_at)

--- a/services/console/app/models/slack_dm_sync_cursor.rb
+++ b/services/console/app/models/slack_dm_sync_cursor.rb
@@ -1,0 +1,3 @@
+class SlackDmSyncCursor < ApplicationRecord
+  validates :oauth_app_slug, presence: true, uniqueness: true
+end

--- a/services/console/app/services/centaur_api_client.rb
+++ b/services/console/app/services/centaur_api_client.rb
@@ -2,7 +2,14 @@ require "cgi"
 require "uri"
 
 class CentaurApiClient
-  Error = Class.new(StandardError)
+  class Error < StandardError
+    attr_reader :status
+
+    def initialize(message = nil, status: nil)
+      @status = status
+      super(message)
+    end
+  end
 
   DEFAULT_TIMEOUT_SECONDS = 20
 
@@ -139,7 +146,10 @@ class CentaurApiClient
     return parsed if response.status.between?(200, 299)
 
     message = parsed.is_a?(Hash) ? parsed["error"] || parsed["message"] || parsed["detail"] : nil
-    raise Error, message.presence || "Centaur API returned HTTP #{response.status}"
+    raise Error.new(
+      message.presence || "Centaur API returned HTTP #{response.status}",
+      status: response.status
+    )
   end
 
   def request_headers

--- a/services/console/app/services/slack_api.rb
+++ b/services/console/app/services/slack_api.rb
@@ -35,9 +35,10 @@ module SlackApi
     if response.status == 429
       retry_after = Float(response["retry-after"], exception: false)
       retry_after = 1 unless retry_after&.positive?
+      retry_after = [ retry_after, max_rate_limit_wait ].min if max_rate_limit_wait
       raise RateLimitedError.new(
         "Slack API rate limited#{context}.",
-        retry_after: [ retry_after, max_rate_limit_wait ].min,
+        retry_after: retry_after,
         code: "ratelimited"
       )
     end

--- a/services/console/app/services/slack_dm/sync_credential.rb
+++ b/services/console/app/services/slack_dm/sync_credential.rb
@@ -42,40 +42,64 @@ module SlackDm
       @run_id = "sdms_#{SecureRandom.hex(16)}"
       @messages_fetched = 0
       @replies_fetched = 0
+      @messages_upserted = 0
+      @replies_upserted = 0
     end
 
-    def call
+    def call(starting_conversation_id: nil, deadline: nil)
       auth = slack_api(AUTH_TEST_ENDPOINT)
       home_team_id = auth.fetch("team_id")
       source_user_id = auth["user_id"].presence || @credential.provider_subject.to_s
       checkpoints = load_checkpoints(home_team_id)
-      batch = empty_batch(home_team_id, source_user_id)
+      conversations = list_conversations.sort_by { |conversation| conversation.fetch("id") }
+      conversations = remaining_conversations(conversations, starting_conversation_id)
+      run = empty_batch(home_team_id, source_user_id).fetch(:run)
+      run[:conversations_requested] = conversations.length
+      checkpointed_conversation_id = starting_conversation_id
 
-      conversations = list_conversations
-      batch[:run][:conversations_requested] = conversations.length
+      conversations.each_with_index do |conversation, index|
+        if deadline && Time.current >= deadline
+          finish_run(run, status: "partial")
+          return false
+        end
 
-      conversations.each do |conversation|
-        normalize_conversation(conversation, home_team_id, batch)
-        normalize_members(conversation, home_team_id, batch)
-        sync_history(conversation, home_team_id, checkpoints[conversation.fetch("id")], batch)
-        batch[:run][:conversations_synced] += 1
-      rescue StandardError => e
-        raise if e.is_a?(SlackApi::RetryableError)
-        raise if Rails.env.test?
+        conversation_id = conversation.fetch("id")
+        if conversation_id != checkpointed_conversation_id
+          yield conversation_id if block_given?
+          checkpointed_conversation_id = conversation_id
+        end
 
-        batch[:run][:conversations_failed] += 1
-        Rails.logger.warn do
-          "slack DM sync failed for conversation #{conversation['id']}: #{e.class}: #{e.message}"
+        batch = empty_batch(home_team_id, source_user_id)
+        conversation_failed = false
+        begin
+          normalize_conversation(conversation, home_team_id, batch)
+          normalize_members(conversation, home_team_id, batch)
+          sync_history(conversation, home_team_id, checkpoints[conversation_id], batch)
+        rescue StandardError => e
+          raise if e.is_a?(SlackApi::RetryableError)
+          raise if Rails.env.test?
+
+          conversation_failed = true
+          run[:conversations_failed] += 1
+          Rails.logger.warn do
+            "slack DM sync failed for conversation #{conversation_id}: #{e.class}: #{e.message}"
+          end
+        end
+        unless conversation_failed
+          run[:conversations_synced] += 1
+          ingest_conversation_batch(batch, run)
+        end
+
+        next_conversation_id = conversations[index + 1]&.fetch("id")
+        if next_conversation_id
+          yield next_conversation_id if block_given?
+          checkpointed_conversation_id = next_conversation_id
         end
       end
 
-      batch[:run][:status] = batch[:run][:conversations_failed].positive? ? "partial" : "completed"
-      batch[:run][:messages_fetched] = @messages_fetched
-      batch[:run][:messages_upserted] = batch[:messages].length
-      batch[:run][:replies_fetched] = @replies_fetched
-      batch[:run][:replies_upserted] = batch[:messages].count { |message| message[:parent_message_ts].present? }
-      batch[:run][:finished] = true
-      @api_client.ingest_slack_dm_sync_batch(sanitize_for_postgres(batch))
+      status = run[:conversations_failed].positive? ? "partial" : "completed"
+      finish_run(run, status: status)
+      true
     end
 
     private
@@ -118,6 +142,46 @@ module SlackDm
         attachments: [],
         checkpoints: []
       }
+    end
+
+    def remaining_conversations(conversations, starting_conversation_id)
+      return conversations if starting_conversation_id.blank?
+
+      conversations.drop_while do |conversation|
+        conversation.fetch("id") < starting_conversation_id
+      end
+    end
+
+    def ingest_conversation_batch(batch, run)
+      replies_upserted = batch[:messages].count do |message|
+        message[:parent_message_ts].present?
+      end
+      @messages_upserted += batch[:messages].length
+      @replies_upserted += replies_upserted
+      update_run_counts(run)
+      batch[:run] = run.merge(finished: false)
+      @api_client.ingest_slack_dm_sync_batch(sanitize_for_postgres(batch))
+    end
+
+    def finish_run(run, status:)
+      update_run_counts(run)
+      batch = {
+        run: run.merge(status: status, finished: true),
+        replace_memberships: false,
+        conversations: [],
+        members: [],
+        messages: [],
+        attachments: [],
+        checkpoints: []
+      }
+      @api_client.ingest_slack_dm_sync_batch(sanitize_for_postgres(batch))
+    end
+
+    def update_run_counts(run)
+      run[:messages_fetched] = @messages_fetched
+      run[:messages_upserted] = @messages_upserted
+      run[:replies_fetched] = @replies_fetched
+      run[:replies_upserted] = @replies_upserted
     end
 
     def list_conversations

--- a/services/console/app/services/slack_dm/sync_credential.rb
+++ b/services/console/app/services/slack_dm/sync_credential.rb
@@ -328,7 +328,7 @@ module SlackDm
         params: params,
         headers: { "Authorization" => "Bearer #{@credential.access_token}" }
       )
-      SlackApi.parse_response!(response, max_rate_limit_wait: rate_limit_max_wait)
+      SlackApi.parse_response!(response, max_rate_limit_wait: nil)
     rescue Socket::ResolutionError => e
       raise SlackApi::TransientError.new(
         "Slack API hostname resolution failed: #{e.message}",
@@ -365,7 +365,6 @@ module SlackDm
     end
 
     def slack_timeout = positive_env("SLACK_DM_SYNC_TIMEOUT_SECONDS", 20)
-    def rate_limit_max_wait = positive_env("SLACK_DM_SYNC_RATE_LIMIT_MAX_WAIT_SECONDS", 5.minutes.to_i)
     def list_page_size = positive_env("SLACK_DM_SYNC_LIST_PAGE_SIZE", 200)
     def list_max_pages = positive_env("SLACK_DM_SYNC_LIST_MAX_PAGES", 10)
     def members_page_size = positive_env("SLACK_DM_SYNC_MEMBERS_PAGE_SIZE", 200)

--- a/services/console/app/services/slack_dm/sync_credential.rb
+++ b/services/console/app/services/slack_dm/sync_credential.rb
@@ -13,6 +13,7 @@ module SlackDm
     CONVERSATIONS_HISTORY_ENDPOINT = "https://slack.com/api/conversations.history"
     CONVERSATIONS_REPLIES_ENDPOINT = "https://slack.com/api/conversations.replies"
     API_READ_TIMEOUT_SECONDS = 120
+    SKIPPABLE_INGEST_STATUSES = [ 400, 413, 422 ].freeze
     class << self
       attr_accessor :slack_api_http
 
@@ -86,8 +87,17 @@ module SlackDm
           end
         end
         unless conversation_failed
-          run[:conversations_synced] += 1
-          ingest_conversation_batch(batch, run)
+          begin
+            ingest_conversation_batch(batch, run)
+          rescue CentaurApiClient::Error => e
+            raise unless SKIPPABLE_INGEST_STATUSES.include?(e.status)
+
+            run[:conversations_failed] += 1
+            Rails.logger.warn do
+              "Slack DM ingest rejected conversation #{conversation_id}: " \
+                "status=#{e.status} error=#{e.message}"
+            end
+          end
         end
 
         next_conversation_id = conversations[index + 1]&.fetch("id")
@@ -153,14 +163,23 @@ module SlackDm
     end
 
     def ingest_conversation_batch(batch, run)
-      replies_upserted = batch[:messages].count do |message|
+      batch_replies_upserted = batch[:messages].count do |message|
         message[:parent_message_ts].present?
       end
-      @messages_upserted += batch[:messages].length
-      @replies_upserted += replies_upserted
-      update_run_counts(run)
-      batch[:run] = run.merge(finished: false)
+      messages_upserted = @messages_upserted + batch[:messages].length
+      replies_upserted = @replies_upserted + batch_replies_upserted
+      batch[:run] = run.merge(
+        conversations_synced: run[:conversations_synced] + 1,
+        messages_fetched: @messages_fetched,
+        messages_upserted: messages_upserted,
+        replies_fetched: @replies_fetched,
+        replies_upserted: replies_upserted,
+        finished: false
+      )
       @api_client.ingest_slack_dm_sync_batch(sanitize_for_postgres(batch))
+      run[:conversations_synced] += 1
+      @messages_upserted = messages_upserted
+      @replies_upserted = replies_upserted
     end
 
     def finish_run(run, status:)

--- a/services/console/config/recurring.yml
+++ b/services/console/config/recurring.yml
@@ -20,7 +20,7 @@ production:
     class: "Broker::PollRefreshJob"
     schedule: every minute
   slack_dm_poll_sync:
-    class: "SlackDm::PollSyncJob"
+    class: "SlackDm::SyncCredentialJob"
     schedule: every 10 minutes
   slack_channel_catalog_refresh:
     class: "SlackChannelCatalogRefreshJob"

--- a/services/console/db/migrate/20260823054500_create_slack_dm_sync_cursors.rb
+++ b/services/console/db/migrate/20260823054500_create_slack_dm_sync_cursors.rb
@@ -3,6 +3,7 @@ class CreateSlackDmSyncCursors < ActiveRecord::Migration[8.1]
     create_table :slack_dm_sync_cursors do |t|
       t.string :oauth_app_slug, null: false
       t.bigint :next_credential_id
+      t.string :next_conversation_id
       t.datetime :not_before
 
       t.timestamps

--- a/services/console/db/migrate/20260823054500_create_slack_dm_sync_cursors.rb
+++ b/services/console/db/migrate/20260823054500_create_slack_dm_sync_cursors.rb
@@ -1,0 +1,13 @@
+class CreateSlackDmSyncCursors < ActiveRecord::Migration[8.1]
+  def change
+    create_table :slack_dm_sync_cursors do |t|
+      t.string :oauth_app_slug, null: false
+      t.bigint :next_credential_id
+      t.datetime :not_before
+
+      t.timestamps
+    end
+
+    add_index :slack_dm_sync_cursors, :oauth_app_slug, unique: true
+  end
+end

--- a/services/console/db/schema.rb
+++ b/services/console/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_20_191500) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_23_054500) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_search"
@@ -487,6 +487,15 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_20_191500) do
     t.index ["principal_id"], name: "index_slack_channel_permissions_on_principal_id"
     t.index ["role_id", "channel_id"], name: "idx_slack_permissions_unique_role_channel", unique: true, where: "(role_id IS NOT NULL)"
     t.check_constraint "(principal_id IS NOT NULL) <> (role_id IS NOT NULL)", name: "slack_channel_permissions_exactly_one_grantee"
+  end
+
+  create_table "slack_dm_sync_cursors", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.bigint "next_credential_id"
+    t.datetime "not_before"
+    t.string "oauth_app_slug", null: false
+    t.datetime "updated_at", null: false
+    t.index ["oauth_app_slug"], name: "index_slack_dm_sync_cursors_on_oauth_app_slug", unique: true
   end
 
   create_table "static_secrets", force: :cascade do |t|

--- a/services/console/db/schema.rb
+++ b/services/console/db/schema.rb
@@ -491,6 +491,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_23_054500) do
 
   create_table "slack_dm_sync_cursors", force: :cascade do |t|
     t.datetime "created_at", null: false
+    t.string "next_conversation_id"
     t.bigint "next_credential_id"
     t.datetime "not_before"
     t.string "oauth_app_slug", null: false

--- a/services/console/test/jobs/slack_dm/jobs_test.rb
+++ b/services/console/test/jobs/slack_dm/jobs_test.rb
@@ -32,82 +32,157 @@ module SlackDm
       )
     end
 
-    test "PollSyncJob enqueues credentials with any supported private conversation scopes" do
+    test "SyncCredentialJob syncs eligible credentials serially" do
       app = slack_app
       good = slack_credential(app: app)
       dm_only = slack_credential(app: app, scopes: SlackDm::SyncCredential::DM_REQUIRED_SCOPES)
-      missing_scope = slack_credential(app: app, scopes: %w[chat:write])
-      no_token = slack_credential(app: app, access_token: nil)
+      slack_credential(app: app, scopes: %w[chat:write])
+      slack_credential(app: app, access_token: nil)
       other_app = slack_app(slug: "other-slack")
-      other = slack_credential(app: other_app)
-
-      SlackDm::PollSyncJob.perform_now("slack-dms")
-
-      enqueued_ids = enqueued_jobs
-        .select { |job| job[:job] == SlackDm::SyncCredentialJob }
-        .map { |job| job[:args].first }
-      assert_includes enqueued_ids, good.id
-      assert_includes enqueued_ids, dm_only.id
-      refute_includes enqueued_ids, missing_scope.id
-      refute_includes enqueued_ids, no_token.id
-      refute_includes enqueued_ids, other.id
-    end
-
-    test "SyncCredentialJob is a no-op for missing credentials" do
-      assert_nothing_raised { SlackDm::SyncCredentialJob.perform_now(-1) }
-    end
-
-    test "SyncCredentialJob defers rate-limited work using Retry-After" do
-      credential = slack_credential(app: slack_app)
-      sync = rate_limited_sync(retry_after: 120)
-      now = Time.zone.parse("2026-08-12 12:00:00")
-
-      SlackDm::SyncCredential.stub(:new, ->(*) { sync }) do
-        travel_to(now) { SlackDm::SyncCredentialJob.perform_now(credential.id) }
-      end
-
-      retry_job = enqueued_jobs.sole
-      assert_equal SlackDm::SyncCredentialJob, retry_job[:job]
-      assert_equal [ credential.id ], retry_job[:args]
-      assert_in_delta now.to_f + 120, retry_job[:at], 0.001
-    end
-
-    test "SyncCredentialJob allows only one delayed rate-limit retry" do
-      credential = slack_credential(app: slack_app)
-      job = SlackDm::SyncCredentialJob.new(credential.id)
-      job.executions = SlackDm::SyncCredentialJob::MAX_RETRYABLE_EXECUTIONS - 1
-
-      SlackDm::SyncCredential.stub(:new, ->(*) { rate_limited_sync(retry_after: 120) }) do
-        assert_no_enqueued_jobs { job.perform_now }
-      end
-
-      assert_equal SlackDm::SyncCredentialJob::MAX_RETRYABLE_EXECUTIONS, job.executions
-    end
-
-    test "SyncCredentialJob defers transient Slack API failures" do
-      credential = slack_credential(app: slack_app)
-      sync = Object.new
-      sync.define_singleton_method(:call) do
-        raise SlackApi::TransientError.new(retry_after: 30)
-      end
-
-      SlackDm::SyncCredential.stub(:new, ->(*) { sync }) do
-        SlackDm::SyncCredentialJob.perform_now(credential.id)
-      end
-
-      retry_job = enqueued_jobs.sole
-      assert_equal SlackDm::SyncCredentialJob, retry_job[:job]
-      assert_equal [ credential.id ], retry_job[:args]
-    end
-
-    private
-
-    def rate_limited_sync(retry_after:)
-      Object.new.tap do |sync|
-        sync.define_singleton_method(:call) do
-          raise SlackApi::RateLimitedError.new(retry_after: retry_after)
+      slack_credential(app: other_app)
+      synced_ids = []
+      sync_factory = lambda do |credential|
+        Object.new.tap do |sync|
+          sync.define_singleton_method(:call) { synced_ids << credential.id }
         end
       end
+
+      SlackDm::SyncCredential.stub(:new, sync_factory) do
+        assert_no_enqueued_jobs { SlackDm::SyncCredentialJob.perform_now("slack-dms") }
+      end
+
+      assert_equal [ good.id, dm_only.id ], synced_ids
+      cursor = SlackDmSyncCursor.find_by!(oauth_app_slug: "slack-dms")
+      assert_equal good.id, cursor.next_credential_id
+      assert_nil cursor.not_before
+    end
+
+    test "SyncCredentialJob resumes from the persisted credential cursor" do
+      app = slack_app
+      first = slack_credential(app: app)
+      second = slack_credential(app: app)
+      third = slack_credential(app: app)
+      SlackDmSyncCursor.create!(oauth_app_slug: "slack-dms", next_credential_id: second.id)
+      synced_ids = []
+      sync_factory = lambda do |credential|
+        Object.new.tap do |sync|
+          sync.define_singleton_method(:call) { synced_ids << credential.id }
+        end
+      end
+
+      SlackDm::SyncCredential.stub(:new, sync_factory) do
+        SlackDm::SyncCredentialJob.perform_now("slack-dms")
+      end
+
+      assert_equal [ second.id, third.id, first.id ], synced_ids
+      assert_equal second.id,
+                   SlackDmSyncCursor.find_by!(oauth_app_slug: "slack-dms").next_credential_id
+    end
+
+    test "SyncCredentialJob configures duplicate global runs to be discarded" do
+      first = SlackDm::SyncCredentialJob.new("slack-dms")
+      duplicate = SlackDm::SyncCredentialJob.new("slack-dms")
+      other_app = SlackDm::SyncCredentialJob.new("other-slack")
+      legacy_poll = SlackDm::PollSyncJob.new("slack-dms")
+
+      assert_equal :discard, SlackDm::SyncCredentialJob.concurrency_on_conflict
+      assert_equal 6.hours, SlackDm::SyncCredentialJob.concurrency_duration
+      assert_equal 30.minutes, SlackDm::SyncCredentialJob::RUN_TIME_BUDGET
+      assert_equal first.concurrency_key, duplicate.concurrency_key
+      assert_equal first.concurrency_key, other_app.concurrency_key
+      assert_equal first.concurrency_key, legacy_poll.concurrency_key
+    end
+
+    test "SyncCredentialJob ignores credential IDs queued by the previous job shape" do
+      assert_no_difference -> { SlackDmSyncCursor.count } do
+        SlackDm::SyncCredentialJob.perform_now(123)
+      end
+    end
+
+    test "SyncCredentialJob continues after one credential has a Slack API error" do
+      app = slack_app
+      first = slack_credential(app: app)
+      second = slack_credential(app: app)
+      attempted_ids = []
+      sync_factory = lambda do |credential|
+        Object.new.tap do |sync|
+          sync.define_singleton_method(:call) do
+            attempted_ids << credential.id
+            raise SlackApi::Error, "invalid_auth" if credential == first
+          end
+        end
+      end
+
+      SlackDm::SyncCredential.stub(:new, sync_factory) do
+        SlackDm::SyncCredentialJob.perform_now("slack-dms")
+      end
+
+      assert_equal [ first.id, second.id ], attempted_ids
+    end
+
+    test "SyncCredentialJob pauses the cursor until Slack Retry-After elapses" do
+      app = slack_app
+      first = slack_credential(app: app)
+      second = slack_credential(app: app)
+      attempted_ids = []
+      rate_limited = true
+      sync_factory = lambda do |credential|
+        Object.new.tap do |sync|
+          sync.define_singleton_method(:call) do
+            attempted_ids << credential.id
+            if credential == first && rate_limited
+              raise SlackApi::RateLimitedError.new(retry_after: 20.minutes.to_i)
+            end
+          end
+        end
+      end
+      now = Time.zone.parse("2026-08-23 12:00:00")
+
+      SlackDm::SyncCredential.stub(:new, sync_factory) do
+        travel_to(now) { SlackDm::SyncCredentialJob.perform_now("slack-dms") }
+
+        cursor = SlackDmSyncCursor.find_by!(oauth_app_slug: "slack-dms")
+        assert_equal first.id, cursor.next_credential_id
+        assert_equal now + 20.minutes, cursor.not_before
+        assert_equal [ first.id ], attempted_ids
+
+        travel_to(now + 10.minutes) { SlackDm::SyncCredentialJob.perform_now("slack-dms") }
+        assert_equal [ first.id ], attempted_ids
+
+        rate_limited = false
+        travel_to(now + 20.minutes) { SlackDm::SyncCredentialJob.perform_now("slack-dms") }
+      end
+
+      assert_equal [ first.id, first.id, second.id ], attempted_ids
+      cursor = SlackDmSyncCursor.find_by!(oauth_app_slug: "slack-dms")
+      assert_equal first.id, cursor.next_credential_id
+      assert_nil cursor.not_before
+    end
+
+    test "SyncCredentialJob stops between credentials after its runtime budget" do
+      app = slack_app
+      first = slack_credential(app: app)
+      second = slack_credential(app: app)
+      attempted_ids = []
+      advance_clock = -> { travel SlackDm::SyncCredentialJob::RUN_TIME_BUDGET + 1.second }
+      sync_factory = lambda do |credential|
+        Object.new.tap do |sync|
+          sync.define_singleton_method(:call) do
+            attempted_ids << credential.id
+            advance_clock.call
+          end
+        end
+      end
+
+      SlackDm::SyncCredential.stub(:new, sync_factory) do
+        travel_to(Time.zone.parse("2026-08-23 12:00:00")) do
+          SlackDm::SyncCredentialJob.perform_now("slack-dms")
+        end
+      end
+
+      assert_equal [ first.id ], attempted_ids
+      assert_equal second.id,
+                   SlackDmSyncCursor.find_by!(oauth_app_slug: "slack-dms").next_credential_id
     end
   end
 end

--- a/services/console/test/jobs/slack_dm/jobs_test.rb
+++ b/services/console/test/jobs/slack_dm/jobs_test.rb
@@ -43,7 +43,10 @@ module SlackDm
       synced_ids = []
       sync_factory = lambda do |credential|
         Object.new.tap do |sync|
-          sync.define_singleton_method(:call) { synced_ids << credential.id }
+          sync.define_singleton_method(:call) do |**|
+            synced_ids << credential.id
+            true
+          end
         end
       end
 
@@ -66,7 +69,10 @@ module SlackDm
       synced_ids = []
       sync_factory = lambda do |credential|
         Object.new.tap do |sync|
-          sync.define_singleton_method(:call) { synced_ids << credential.id }
+          sync.define_singleton_method(:call) do |**|
+            synced_ids << credential.id
+            true
+          end
         end
       end
 
@@ -106,9 +112,11 @@ module SlackDm
       attempted_ids = []
       sync_factory = lambda do |credential|
         Object.new.tap do |sync|
-          sync.define_singleton_method(:call) do
+          sync.define_singleton_method(:call) do |**|
             attempted_ids << credential.id
             raise SlackApi::Error, "invalid_auth" if credential == first
+
+            true
           end
         end
       end
@@ -128,11 +136,14 @@ module SlackDm
       rate_limited = true
       sync_factory = lambda do |credential|
         Object.new.tap do |sync|
-          sync.define_singleton_method(:call) do
+          sync.define_singleton_method(:call) do |**_kwargs, &checkpoint|
             attempted_ids << credential.id
             if credential == first && rate_limited
+              checkpoint.call("D200")
               raise SlackApi::RateLimitedError.new(retry_after: 20.minutes.to_i)
             end
+
+            true
           end
         end
       end
@@ -143,6 +154,7 @@ module SlackDm
 
         cursor = SlackDmSyncCursor.find_by!(oauth_app_slug: "slack-dms")
         assert_equal first.id, cursor.next_credential_id
+        assert_equal "D200", cursor.next_conversation_id
         assert_equal now + 20.minutes, cursor.not_before
         assert_equal [ first.id ], attempted_ids
 
@@ -156,6 +168,7 @@ module SlackDm
       assert_equal [ first.id, first.id, second.id ], attempted_ids
       cursor = SlackDmSyncCursor.find_by!(oauth_app_slug: "slack-dms")
       assert_equal first.id, cursor.next_credential_id
+      assert_nil cursor.next_conversation_id
       assert_nil cursor.not_before
     end
 
@@ -167,9 +180,10 @@ module SlackDm
       advance_clock = -> { travel SlackDm::SyncCredentialJob::RUN_TIME_BUDGET + 1.second }
       sync_factory = lambda do |credential|
         Object.new.tap do |sync|
-          sync.define_singleton_method(:call) do
+          sync.define_singleton_method(:call) do |**|
             attempted_ids << credential.id
             advance_clock.call
+            true
           end
         end
       end
@@ -183,6 +197,32 @@ module SlackDm
       assert_equal [ first.id ], attempted_ids
       assert_equal second.id,
                    SlackDmSyncCursor.find_by!(oauth_app_slug: "slack-dms").next_credential_id
+    end
+
+    test "SyncCredentialJob preserves a conversation cursor when the budget expires" do
+      app = slack_app
+      first = slack_credential(app: app)
+      slack_credential(app: app)
+      attempted_ids = []
+      sync_factory = lambda do |credential|
+        Object.new.tap do |sync|
+          sync.define_singleton_method(:call) do |**_kwargs, &checkpoint|
+            attempted_ids << credential.id
+            checkpoint.call("D200")
+            false
+          end
+        end
+      end
+
+      SlackDm::SyncCredential.stub(:new, sync_factory) do
+        SlackDm::SyncCredentialJob.perform_now("slack-dms")
+      end
+
+      cursor = SlackDmSyncCursor.find_by!(oauth_app_slug: "slack-dms")
+      assert_equal [ first.id ], attempted_ids
+      assert_equal first.id, cursor.next_credential_id
+      assert_equal "D200", cursor.next_conversation_id
+      assert_nil cursor.not_before
     end
   end
 end

--- a/services/console/test/models/slack_dm_sync_cursor_test.rb
+++ b/services/console/test/models/slack_dm_sync_cursor_test.rb
@@ -1,0 +1,11 @@
+require "test_helper"
+
+class SlackDmSyncCursorTest < ActiveSupport::TestCase
+  test "oauth app slugs identify a single cursor" do
+    SlackDmSyncCursor.create!(oauth_app_slug: "slack-dms")
+
+    duplicate = SlackDmSyncCursor.new(oauth_app_slug: "slack-dms")
+    assert_not duplicate.valid?
+    assert_includes duplicate.errors[:oauth_app_slug], "has already been taken"
+  end
+end

--- a/services/console/test/services/centaur_api_client_test.rb
+++ b/services/console/test/services/centaur_api_client_test.rb
@@ -56,6 +56,7 @@ class CentaurApiClientTest < ActiveSupport::TestCase
     end
     http.verify
     assert_equal "bad archive", error.message
+    assert_equal 400, error.status
   end
 
   test "fails before the request when the service JWT cannot be minted" do
@@ -71,6 +72,7 @@ class CentaurApiClientTest < ActiveSupport::TestCase
     end
 
     assert_equal "Console API service JWT could not be minted", error.message
+    assert_nil error.status
   end
 
   test "lists Slack DM sync checkpoints for a broker credential" do

--- a/services/console/test/services/slack_dm/sync_credential_test.rb
+++ b/services/console/test/services/slack_dm/sync_credential_test.rb
@@ -3,7 +3,19 @@ require "test_helper"
 module SlackDm
   class SyncCredentialTest < ActiveSupport::TestCase
     class FakeApiClient
-      attr_reader :batch
+      attr_reader :batches
+
+      def initialize
+        @batches = []
+      end
+
+      def batch
+        @batches.find { |payload| payload[:conversations].any? }
+      end
+
+      def final_batch
+        @batches.last
+      end
 
       def list_slack_dm_sync_checkpoints(broker_credential_id:, home_team_id:)
         {
@@ -19,7 +31,7 @@ module SlackDm
       end
 
       def ingest_slack_dm_sync_batch(payload)
-        @batch = payload
+        @batches << payload
         { "ok" => true }
       end
     end
@@ -192,7 +204,7 @@ module SlackDm
       ).call
 
       batch = api_client.batch
-      assert_equal "completed", batch[:run][:status]
+      assert_equal "running", batch[:run][:status]
       assert_equal credential.oid, batch[:run][:broker_credential_id]
       assert_equal 1, batch[:conversations].length
       assert_equal "im", batch[:conversations].first[:conversation_type]
@@ -206,6 +218,8 @@ module SlackDm
       assert_equal "note.txt", batch[:attachments].first[:name]
       assert_equal "note.txt", batch[:attachments].first[:raw_payload]["name"]
       assert_equal "1700000000.000002", batch[:checkpoints].first[:watermark_ts]
+      assert_equal "completed", api_client.final_batch[:run][:status]
+      assert api_client.final_batch[:run][:finished]
     end
 
     test "sync ingests private channels and their complete member list" do
@@ -305,6 +319,124 @@ module SlackDm
       assert_nil api_client.batch
     ensure
       previous.nil? ? ENV.delete(env_key) : ENV[env_key] = previous
+    end
+
+    test "sync ingests completed conversations separately and resumes at its cursor" do
+      api_client = FakeApiClient.new
+      rate_limited = true
+      history_calls = []
+      slack_http = lambda do |endpoint:, params:, access_token:|
+        assert_equal "xoxp-live", access_token
+        case endpoint
+        when SlackDm::SyncCredential::AUTH_TEST_ENDPOINT
+          { "ok" => true, "team_id" => "T123", "user_id" => "U_ME" }
+        when SlackDm::SyncCredential::CONVERSATIONS_LIST_ENDPOINT
+          {
+            "ok" => true,
+            "channels" => [
+              { "id" => "D100", "is_im" => true, "user" => "U_ONE" },
+              { "id" => "D200", "is_im" => true, "user" => "U_TWO" }
+            ],
+            "response_metadata" => { "next_cursor" => "" }
+          }
+        when SlackDm::SyncCredential::CONVERSATIONS_HISTORY_ENDPOINT
+          conversation_id = params.fetch("channel")
+          history_calls << conversation_id
+          if conversation_id == "D200" && rate_limited
+            raise SlackApi::RateLimitedError.new(retry_after: 20.minutes.to_i)
+          end
+
+          {
+            "ok" => true,
+            "messages" => [
+              {
+                "type" => "message",
+                "ts" => "1700000000.000001",
+                "user" => "U_OTHER",
+                "text" => conversation_id
+              }
+            ],
+            "response_metadata" => { "next_cursor" => "" }
+          }
+        else
+          flunk "unexpected Slack endpoint #{endpoint}"
+        end
+      end
+      conversation_cursor = nil
+
+      assert_raises(SlackApi::RateLimitedError) do
+        SlackDm::SyncCredential.new(
+          credential,
+          api_client: api_client,
+          slack_api_http: slack_http
+        ).call do |conversation_id|
+          conversation_cursor = conversation_id
+        end
+      end
+
+      assert_equal "D200", conversation_cursor
+      ingested_conversation_ids = api_client.batches.flat_map do |batch|
+        batch[:conversations].map { |conversation| conversation[:conversation_id] }
+      end
+      assert_equal [ "D100" ], ingested_conversation_ids
+
+      rate_limited = false
+      SlackDm::SyncCredential.new(
+        credential,
+        api_client: api_client,
+        slack_api_http: slack_http
+      ).call(starting_conversation_id: conversation_cursor)
+
+      assert_equal %w[D100 D200 D200], history_calls
+      ingested_conversation_ids = api_client.batches.flat_map do |batch|
+        batch[:conversations].map { |conversation| conversation[:conversation_id] }
+      end
+      assert_equal %w[D100 D200], ingested_conversation_ids
+    end
+
+    test "sync checkpoints the next conversation before stopping at its deadline" do
+      api_client = FakeApiClient.new
+      conversation_cursor = nil
+      now = Time.zone.parse("2026-08-23 12:00:00")
+      slack_http = lambda do |endpoint:, params:, access_token:|
+        assert_equal "xoxp-live", access_token
+        case endpoint
+        when SlackDm::SyncCredential::AUTH_TEST_ENDPOINT
+          { "ok" => true, "team_id" => "T123", "user_id" => "U_ME" }
+        when SlackDm::SyncCredential::CONVERSATIONS_LIST_ENDPOINT
+          {
+            "ok" => true,
+            "channels" => [
+              { "id" => "D100", "is_im" => true, "user" => "U_ONE" },
+              { "id" => "D200", "is_im" => true, "user" => "U_TWO" }
+            ],
+            "response_metadata" => { "next_cursor" => "" }
+          }
+        when SlackDm::SyncCredential::CONVERSATIONS_HISTORY_ENDPOINT
+          travel 31.minutes if params.fetch("channel") == "D100"
+          { "ok" => true, "messages" => [], "response_metadata" => { "next_cursor" => "" } }
+        else
+          flunk "unexpected Slack endpoint #{endpoint}"
+        end
+      end
+
+      completed = travel_to(now) do
+        SlackDm::SyncCredential.new(
+          credential,
+          api_client: api_client,
+          slack_api_http: slack_http
+        ).call(deadline: now + 30.minutes) do |conversation_id|
+          conversation_cursor = conversation_id
+        end
+      end
+
+      assert_not completed
+      assert_equal "D200", conversation_cursor
+      ingested_conversation_ids = api_client.batches.flat_map do |batch|
+        batch[:conversations].map { |conversation| conversation[:conversation_id] }
+      end
+      assert_equal [ "D100" ], ingested_conversation_ids
+      assert_equal "partial", api_client.final_batch[:run][:status]
     end
 
     test "429 responses expose the full Retry-After to the cursor job" do

--- a/services/console/test/services/slack_dm/sync_credential_test.rb
+++ b/services/console/test/services/slack_dm/sync_credential_test.rb
@@ -5,8 +5,9 @@ module SlackDm
     class FakeApiClient
       attr_reader :batches
 
-      def initialize
+      def initialize(&ingest_handler)
         @batches = []
+        @ingest_handler = ingest_handler
       end
 
       def batch
@@ -32,6 +33,7 @@ module SlackDm
 
       def ingest_slack_dm_sync_batch(payload)
         @batches << payload
+        @ingest_handler&.call(payload)
         { "ok" => true }
       end
     end
@@ -69,6 +71,42 @@ module SlackDm
         scopes: SlackDm::SyncCredential::REQUIRED_SCOPES,
         provider_subject: "U_ME"
       )
+    end
+
+    def two_conversation_slack_http(history_calls)
+      lambda do |endpoint:, params:, access_token:|
+        assert_equal "xoxp-live", access_token
+        case endpoint
+        when SlackDm::SyncCredential::AUTH_TEST_ENDPOINT
+          { "ok" => true, "team_id" => "T123", "user_id" => "U_ME" }
+        when SlackDm::SyncCredential::CONVERSATIONS_LIST_ENDPOINT
+          {
+            "ok" => true,
+            "channels" => [
+              { "id" => "D100", "is_im" => true, "user" => "U_ONE" },
+              { "id" => "D200", "is_im" => true, "user" => "U_TWO" }
+            ],
+            "response_metadata" => { "next_cursor" => "" }
+          }
+        when SlackDm::SyncCredential::CONVERSATIONS_HISTORY_ENDPOINT
+          conversation_id = params.fetch("channel")
+          history_calls << conversation_id
+          {
+            "ok" => true,
+            "messages" => [
+              {
+                "type" => "message",
+                "ts" => conversation_id == "D100" ? "1700000000.000001" : "1700000000.000002",
+                "user" => "U_OTHER",
+                "text" => conversation_id
+              }
+            ],
+            "response_metadata" => { "next_cursor" => "" }
+          }
+        else
+          flunk "unexpected Slack endpoint #{endpoint}"
+        end
+      end
     end
 
     test "uses an extended API read timeout by default" do
@@ -437,6 +475,67 @@ module SlackDm
       end
       assert_equal [ "D100" ], ingested_conversation_ids
       assert_equal "partial", api_client.final_batch[:run][:status]
+    end
+
+    test "sync skips a conversation rejected by the ingest API" do
+      api_client = FakeApiClient.new do |payload|
+        conversation_id = payload.dig(:conversations, 0, :conversation_id)
+        if conversation_id == "D100"
+          raise CentaurApiClient::Error.new("invalid message timestamp", status: 400)
+        end
+      end
+      history_calls = []
+      conversation_cursor = nil
+
+      completed = SlackDm::SyncCredential.new(
+        credential,
+        api_client: api_client,
+        slack_api_http: two_conversation_slack_http(history_calls)
+      ).call do |conversation_id|
+        conversation_cursor = conversation_id
+      end
+
+      attempted_conversation_ids = api_client.batches.filter_map do |batch|
+        batch.dig(:conversations, 0, :conversation_id)
+      end
+      assert completed
+      assert_equal %w[D100 D200], history_calls
+      assert_equal %w[D100 D200], attempted_conversation_ids
+      assert_equal "D200", conversation_cursor
+      assert_equal "partial", api_client.final_batch[:run][:status]
+      assert_equal 1, api_client.final_batch[:run][:conversations_failed]
+      assert_equal 1, api_client.final_batch[:run][:conversations_synced]
+      assert_equal 2, api_client.final_batch[:run][:messages_fetched]
+      assert_equal 1, api_client.final_batch[:run][:messages_upserted]
+    end
+
+    test "sync retries a conversation after a transient ingest API failure" do
+      api_client = FakeApiClient.new do |payload|
+        conversation_id = payload.dig(:conversations, 0, :conversation_id)
+        if conversation_id == "D100"
+          raise CentaurApiClient::Error.new("temporary failure", status: 500)
+        end
+      end
+      history_calls = []
+      conversation_cursor = nil
+
+      error = assert_raises(CentaurApiClient::Error) do
+        SlackDm::SyncCredential.new(
+          credential,
+          api_client: api_client,
+          slack_api_http: two_conversation_slack_http(history_calls)
+        ).call do |conversation_id|
+          conversation_cursor = conversation_id
+        end
+      end
+
+      attempted_conversation_ids = api_client.batches.filter_map do |batch|
+        batch.dig(:conversations, 0, :conversation_id)
+      end
+      assert_equal 500, error.status
+      assert_equal [ "D100" ], history_calls
+      assert_equal [ "D100" ], attempted_conversation_ids
+      assert_equal "D100", conversation_cursor
     end
 
     test "429 responses expose the full Retry-After to the cursor job" do

--- a/services/console/test/services/slack_dm/sync_credential_test.rb
+++ b/services/console/test/services/slack_dm/sync_credential_test.rb
@@ -307,10 +307,10 @@ module SlackDm
       previous.nil? ? ENV.delete(env_key) : ENV[env_key] = previous
     end
 
-    test "429 responses expose Retry-After for deferred job execution" do
+    test "429 responses expose the full Retry-After to the cursor job" do
       [
         [ "120", 120 ],
-        [ "600", 5.minutes.to_i ],
+        [ "600", 600 ],
         [ "invalid", 1 ]
       ].each do |header, expected|
         response = HttpClient::Response.new(


### PR DESCRIPTION
Serializes Slack DM sync into one global credential loop backed by a persistent credential and conversation cursor with a 30-minute soft runtime budget. Each conversation is ingested independently, so rate limits and budget cutoffs resume at the current conversation without refetching conversations already committed. Rate limits honor Slack's full Retry-After, while deterministic 400/413/422 ingest rejections mark only the affected conversation failed so later work can continue. The former poll job remains compatible with already-enqueued work during rollout.