### PR TITLE
fix(console): resume rate-limited Slack DM syncs

### DIFF
--- a/services/console/app/jobs/slack_dm/sync_credential_job.rb
+++ b/services/console/app/jobs/slack_dm/sync_credential_job.rb
@@ -13,12 +13,13 @@ module SlackDm
       on_conflict: :discard
     )
 
-    def perform(oauth_app_slug = SlackDm::SyncCredential.oauth_app_slug)
+    def perform(oauth_app_slug = SlackDm::SyncCredential.oauth_app_slug, expected_not_before = nil)
       # Credential IDs were the argument before this became a global cursor job.
       # Ignore any of those jobs that were already queued during deployment.
       return unless oauth_app_slug.is_a?(String)
 
       cursor = SlackDmSyncCursor.find_or_create_by!(oauth_app_slug: oauth_app_slug)
+      return if expected_not_before && cursor.not_before != expected_not_before
       return if cursor.not_before&.future?
 
       credentials = eligible_credentials(oauth_app_slug)
@@ -84,9 +85,14 @@ module SlackDm
     rescue SlackApi::RateLimitedError => e
       retry_at = e.retry_after.seconds.from_now
       cursor.update!(next_credential_id: credential.id, not_before: retry_at)
+      persisted_retry_at = cursor.reload.not_before
+      self.class.set(wait_until: persisted_retry_at).perform_later(
+        cursor.oauth_app_slug,
+        persisted_retry_at
+      )
       Rails.logger.info do
         "Slack DM sync paused after rate limit: credential_id=#{credential.id} " \
-          "retry_at=#{retry_at.iso8601}"
+          "retry_at=#{persisted_retry_at.iso8601}"
       end
       false
     rescue SlackApi::Error => e

--- a/services/console/app/jobs/slack_dm/sync_credential_job.rb
+++ b/services/console/app/jobs/slack_dm/sync_credential_job.rb
@@ -24,7 +24,12 @@ module SlackDm
 
       credentials = eligible_credentials(oauth_app_slug)
       if credentials.empty?
-        cursor.update!(next_credential_id: nil, next_conversation_id: nil, not_before: nil)
+        cursor.update!(
+          next_credential_id: nil,
+          next_conversation_id: nil,
+          conversation_state: {},
+          not_before: nil
+        )
         return
       end
 
@@ -38,6 +43,7 @@ module SlackDm
         cursor.update!(
           next_credential_id: next_credential.id,
           next_conversation_id: nil,
+          conversation_state: {},
           not_before: nil
         )
       end
@@ -74,11 +80,17 @@ module SlackDm
     def sync_credential(cursor, credential, deadline)
       SlackDm::SyncCredential.new(credential).call(
         starting_conversation_id: cursor.next_conversation_id,
+        conversation_state: cursor.conversation_state,
         deadline: deadline
-      ) do |conversation_id|
+      ) do |conversation_id, conversation_state|
+        persisted_state = conversation_state.to_h.deep_stringify_keys.merge(
+          "_broker_credential_id" => credential.oid,
+          "_conversation_id" => conversation_id
+        )
         cursor.update!(
           next_credential_id: credential.id,
           next_conversation_id: conversation_id,
+          conversation_state: persisted_state,
           not_before: nil
         )
       end

--- a/services/console/app/services/slack_dm/sync_credential.rb
+++ b/services/console/app/services/slack_dm/sync_credential.rb
@@ -47,7 +47,7 @@ module SlackDm
       @replies_upserted = 0
     end
 
-    def call(starting_conversation_id: nil, deadline: nil)
+    def call(starting_conversation_id: nil, conversation_state: {}, deadline: nil)
       auth = slack_api(AUTH_TEST_ENDPOINT)
       home_team_id = auth.fetch("team_id")
       source_user_id = auth["user_id"].presence || @credential.provider_subject.to_s
@@ -57,6 +57,10 @@ module SlackDm
       run = empty_batch(home_team_id, source_user_id).fetch(:run)
       run[:conversations_requested] = conversations.length
       checkpointed_conversation_id = starting_conversation_id
+      active_conversation_state = resumable_conversation_state(
+        conversation_state,
+        starting_conversation_id
+      )
 
       conversations.each_with_index do |conversation, index|
         if deadline && Time.current >= deadline
@@ -66,43 +70,50 @@ module SlackDm
 
         conversation_id = conversation.fetch("id")
         if conversation_id != checkpointed_conversation_id
-          yield conversation_id if block_given?
+          active_conversation_state = {}
+          yield conversation_id, active_conversation_state if block_given?
           checkpointed_conversation_id = conversation_id
         end
 
-        batch = empty_batch(home_team_id, source_user_id)
-        conversation_failed = false
         begin
-          normalize_conversation(conversation, home_team_id, batch)
-          normalize_members(conversation, home_team_id, batch)
-          sync_history(conversation, home_team_id, checkpoints[conversation_id], batch)
+          completed = sync_conversation(
+            conversation,
+            home_team_id,
+            source_user_id,
+            checkpoints[conversation_id],
+            active_conversation_state,
+            run,
+            deadline
+          ) do |new_state|
+            active_conversation_state = new_state
+            yield conversation_id, new_state if block_given?
+          end
+          unless completed
+            finish_run(run, status: "partial")
+            return false
+          end
+        rescue CentaurApiClient::Error => e
+          raise unless SKIPPABLE_INGEST_STATUSES.include?(e.status)
+
+          run[:conversations_failed] += 1
+          Rails.logger.warn do
+            "Slack DM ingest rejected conversation #{conversation_id}: " \
+              "status=#{e.status} error=#{e.message}"
+          end
         rescue StandardError => e
           raise if e.is_a?(SlackApi::RetryableError)
           raise if Rails.env.test?
 
-          conversation_failed = true
           run[:conversations_failed] += 1
           Rails.logger.warn do
             "slack DM sync failed for conversation #{conversation_id}: #{e.class}: #{e.message}"
           end
         end
-        unless conversation_failed
-          begin
-            ingest_conversation_batch(batch, run)
-          rescue CentaurApiClient::Error => e
-            raise unless SKIPPABLE_INGEST_STATUSES.include?(e.status)
-
-            run[:conversations_failed] += 1
-            Rails.logger.warn do
-              "Slack DM ingest rejected conversation #{conversation_id}: " \
-                "status=#{e.status} error=#{e.message}"
-            end
-          end
-        end
 
         next_conversation_id = conversations[index + 1]&.fetch("id")
         if next_conversation_id
-          yield next_conversation_id if block_given?
+          active_conversation_state = {}
+          yield next_conversation_id, active_conversation_state if block_given?
           checkpointed_conversation_id = next_conversation_id
         end
       end
@@ -124,7 +135,7 @@ module SlackDm
       end
     end
 
-    def empty_batch(home_team_id, source_user_id)
+    def empty_batch(home_team_id, source_user_id, replace_memberships: true)
       {
         run: {
           run_id: @run_id,
@@ -145,13 +156,242 @@ module SlackDm
             credential_id: @credential.oid
           }
         },
-        replace_memberships: true,
+        replace_memberships: replace_memberships,
         conversations: [],
         members: [],
         messages: [],
         attachments: [],
         checkpoints: []
       }
+    end
+
+    def sync_conversation(conversation, home_team_id, source_user_id, checkpoint,
+                          conversation_state, run, deadline)
+      state = normalized_conversation_state(conversation_state, checkpoint)
+      yield state if conversation_state.blank?
+      pages_processed = Hash.new(0)
+
+      loop do
+        return false if deadline && Time.current >= deadline
+
+        case state.fetch("phase")
+        when "members"
+          return false if pages_processed["members"] >= members_max_pages
+
+          state = sync_members_page(conversation, state)
+          pages_processed["members"] += 1 unless conversation["is_im"]
+          yield state
+        when "members_ingest"
+          batch = empty_batch(home_team_id, source_user_id)
+          normalize_conversation(conversation, home_team_id, batch)
+          normalize_members(conversation, home_team_id, state.fetch("member_ids"), batch)
+          ingest_sync_batch(batch, run)
+          state = {
+            "phase" => "history",
+            "history_cursor" => nil,
+            "oldest_ts" => state["oldest_ts"],
+            "max_message_ts" => state["max_message_ts"]
+          }
+          yield state
+        when "history"
+          return false if pages_processed["history"] >= history_max_pages
+
+          state = sync_history_page(
+            conversation,
+            home_team_id,
+            source_user_id,
+            state,
+            run
+          )
+          pages_processed["history"] += 1
+          yield state
+        when "replies"
+          return false if pages_processed["replies"] >= replies_max_pages
+
+          state = sync_replies_page(
+            conversation,
+            home_team_id,
+            source_user_id,
+            state,
+            run
+          )
+          pages_processed["replies"] += 1
+          yield state
+        when "complete"
+          finish_conversation(conversation, home_team_id, source_user_id, state, run)
+          return true
+        else
+          raise SlackApi::Error,
+                "Invalid Slack conversation sync phase #{state['phase'].inspect}"
+        end
+      end
+    end
+
+    def normalized_conversation_state(conversation_state, checkpoint)
+      state = conversation_state.to_h.deep_stringify_keys
+      return state unless state.empty?
+
+      {
+        "phase" => "members",
+        "members_cursor" => nil,
+        "member_ids" => [],
+        "oldest_ts" => checkpoint,
+        "max_message_ts" => checkpoint
+      }
+    end
+
+    def resumable_conversation_state(conversation_state, conversation_id)
+      state = conversation_state.to_h.deep_stringify_keys
+      broker_credential_id = state.delete("_broker_credential_id")
+      state_conversation_id = state.delete("_conversation_id")
+      has_identity = broker_credential_id.present? || state_conversation_id.present?
+      return state unless has_identity
+      return {} unless broker_credential_id == @credential.oid
+      return {} unless state_conversation_id == conversation_id
+
+      state
+    end
+
+    def sync_members_page(conversation, state)
+      if conversation["is_im"] && conversation["user"].present?
+        member_ids = [ conversation["user"], @credential.provider_subject ].compact_blank.uniq
+        return state.merge("phase" => "members_ingest", "member_ids" => member_ids)
+      end
+
+      page = slack_api(
+        CONVERSATIONS_MEMBERS_ENDPOINT,
+        {
+          "channel" => conversation.fetch("id"),
+          "limit" => members_page_size,
+          "cursor" => state["members_cursor"]
+        }.compact
+      )
+      member_ids = (Array(state["member_ids"]) + Array(page["members"])).compact
+      cursor = page.dig("response_metadata", "next_cursor").presence
+      if cursor
+        state.merge("members_cursor" => cursor, "member_ids" => member_ids.uniq)
+      else
+        member_ids << @credential.provider_subject if @credential.provider_subject.present?
+        state.merge(
+          "phase" => "members_ingest",
+          "members_cursor" => nil,
+          "member_ids" => member_ids.uniq
+        )
+      end
+    end
+
+    def sync_history_page(conversation, home_team_id, source_user_id, state, run)
+      conversation_id = conversation.fetch("id")
+      params = history_params(conversation_id, state["oldest_ts"])
+      params["cursor"] = state["history_cursor"] if state["history_cursor"].present?
+      page = slack_api(CONVERSATIONS_HISTORY_ENDPOINT, params)
+      batch = empty_batch(home_team_id, source_user_id, replace_memberships: false)
+      max_message_ts = state["max_message_ts"]
+      pending_threads = []
+
+      Array(page["messages"]).each do |message|
+        @messages_fetched += 1
+        max_message_ts = max_slack_ts(max_message_ts, message["ts"])
+        normalize_message(message, home_team_id, conversation_id, nil, batch)
+        normalize_files(message, home_team_id, conversation_id, batch)
+        if message["reply_count"].to_i.positive?
+          pending_threads << {
+            "thread_ts" => message["thread_ts"].presence || message.fetch("ts"),
+            "root_message_ts" => message.fetch("ts")
+          }
+        end
+      end
+
+      ingest_sync_batch(batch, run)
+      history_cursor = page.dig("response_metadata", "next_cursor").presence
+      if pending_threads.any?
+        {
+          "phase" => "replies",
+          "history_cursor" => history_cursor,
+          "oldest_ts" => state["oldest_ts"],
+          "max_message_ts" => max_message_ts,
+          "pending_threads" => pending_threads,
+          "replies_cursor" => nil
+        }
+      elsif history_cursor
+        {
+          "phase" => "history",
+          "history_cursor" => history_cursor,
+          "oldest_ts" => state["oldest_ts"],
+          "max_message_ts" => max_message_ts
+        }
+      else
+        {
+          "phase" => "complete",
+          "oldest_ts" => state["oldest_ts"],
+          "max_message_ts" => max_message_ts
+        }
+      end
+    end
+
+    def sync_replies_page(conversation, home_team_id, source_user_id, state, run)
+      conversation_id = conversation.fetch("id")
+      pending_threads = Array(state["pending_threads"])
+      thread = pending_threads.first || raise(
+        SlackApi::Error,
+        "Slack replies state has no pending thread for #{conversation_id}"
+      )
+      params = {
+        "channel" => conversation_id,
+        "ts" => thread.fetch("thread_ts"),
+        "limit" => replies_page_size,
+        "cursor" => state["replies_cursor"]
+      }.compact
+      page = slack_api(CONVERSATIONS_REPLIES_ENDPOINT, params)
+      batch = empty_batch(home_team_id, source_user_id, replace_memberships: false)
+
+      Array(page["messages"]).each do |reply|
+        next if reply["ts"] == thread.fetch("root_message_ts")
+
+        @replies_fetched += 1
+        normalize_message(
+          reply,
+          home_team_id,
+          conversation_id,
+          thread.fetch("root_message_ts"),
+          batch
+        )
+        normalize_files(reply, home_team_id, conversation_id, batch)
+      end
+
+      ingest_sync_batch(batch, run)
+      replies_cursor = page.dig("response_metadata", "next_cursor").presence
+      return state.merge("replies_cursor" => replies_cursor) if replies_cursor
+
+      pending_threads = pending_threads.drop(1)
+      if pending_threads.any?
+        state.merge("pending_threads" => pending_threads, "replies_cursor" => nil)
+      elsif state["history_cursor"].present?
+        {
+          "phase" => "history",
+          "history_cursor" => state["history_cursor"],
+          "oldest_ts" => state["oldest_ts"],
+          "max_message_ts" => state["max_message_ts"]
+        }
+      else
+        {
+          "phase" => "complete",
+          "oldest_ts" => state["oldest_ts"],
+          "max_message_ts" => state["max_message_ts"]
+        }
+      end
+    end
+
+    def finish_conversation(conversation, home_team_id, source_user_id, state, run)
+      batch = empty_batch(home_team_id, source_user_id, replace_memberships: false)
+      batch[:checkpoints] << {
+        broker_credential_id: @credential.oid,
+        home_team_id: home_team_id,
+        conversation_id: conversation.fetch("id"),
+        watermark_ts: state["max_message_ts"],
+        last_run_id: @run_id
+      }
+      ingest_sync_batch(batch, run, conversation_completed: true)
     end
 
     def remaining_conversations(conversations, starting_conversation_id)
@@ -162,14 +402,15 @@ module SlackDm
       end
     end
 
-    def ingest_conversation_batch(batch, run)
+    def ingest_sync_batch(batch, run, conversation_completed: false)
       batch_replies_upserted = batch[:messages].count do |message|
         message[:parent_message_ts].present?
       end
       messages_upserted = @messages_upserted + batch[:messages].length
       replies_upserted = @replies_upserted + batch_replies_upserted
+      conversations_synced = run[:conversations_synced] + (conversation_completed ? 1 : 0)
       batch[:run] = run.merge(
-        conversations_synced: run[:conversations_synced] + 1,
+        conversations_synced: conversations_synced,
         messages_fetched: @messages_fetched,
         messages_upserted: messages_upserted,
         replies_fetched: @replies_fetched,
@@ -177,7 +418,7 @@ module SlackDm
         finished: false
       )
       @api_client.ingest_slack_dm_sync_batch(sanitize_for_postgres(batch))
-      run[:conversations_synced] += 1
+      run[:conversations_synced] = conversations_synced
       @messages_upserted = messages_upserted
       @replies_upserted = replies_upserted
     end
@@ -225,10 +466,9 @@ module SlackDm
       }
     end
 
-    def normalize_members(conversation, home_team_id, batch)
+    def normalize_members(conversation, home_team_id, member_ids, batch)
       conversation_id = conversation.fetch("id")
-      members = conversation_members(conversation)
-      members.each do |member_id|
+      member_ids.each do |member_id|
         batch[:members] << {
           home_team_id: home_team_id,
           conversation_id: conversation_id,
@@ -240,89 +480,12 @@ module SlackDm
       end
     end
 
-    def conversation_members(conversation)
-      if conversation["is_im"] && conversation["user"].present?
-        members = [ conversation["user"] ]
-        members << @credential.provider_subject if @credential.provider_subject.present?
-        return members.uniq
-      end
-
-      complete = true
-      pages = each_page(
-        CONVERSATIONS_MEMBERS_ENDPOINT,
-        { "channel" => conversation.fetch("id"), "limit" => members_page_size },
-        max_pages: members_max_pages
-      ) do |_page, truncated|
-        complete = false if truncated
-      end
-      unless complete
-        raise SlackApi::Error,
-              "Slack membership pagination truncated for #{conversation.fetch('id')}"
-      end
-
-      members = pages.flat_map { |page| Array(page["members"]) }.compact
-      members << @credential.provider_subject if @credential.provider_subject.present?
-      members.uniq
-    end
-
     def conversation_type(conversation)
       return "mpim" if conversation["is_mpim"]
       return "im" if conversation["is_im"]
       return "private_channel" if conversation["is_private"]
 
       raise SlackApi::Error, "Unsupported Slack conversation #{conversation['id']}"
-    end
-
-    def sync_history(conversation, home_team_id, checkpoint, batch)
-      conversation_id = conversation.fetch("id")
-      max_message_ts = checkpoint
-      completed = true
-      pages = each_page(
-        CONVERSATIONS_HISTORY_ENDPOINT,
-        history_params(conversation_id, checkpoint),
-        max_pages: history_max_pages
-      ) do |_page, truncated|
-        completed = false if truncated
-      end
-
-      pages.each do |page|
-        Array(page["messages"]).each do |message|
-          @messages_fetched += 1
-          max_message_ts = max_slack_ts(max_message_ts, message["ts"])
-          normalize_message(message, home_team_id, conversation_id, nil, batch)
-          normalize_files(message, home_team_id, conversation_id, batch)
-          sync_replies(message, home_team_id, conversation_id, batch) if message["reply_count"].to_i.positive?
-        end
-      end
-
-      return unless completed
-
-      batch[:checkpoints] << {
-        broker_credential_id: @credential.oid,
-        home_team_id: home_team_id,
-        conversation_id: conversation_id,
-        watermark_ts: max_message_ts,
-        last_run_id: @run_id
-      }
-    end
-
-    def sync_replies(root_message, home_team_id, conversation_id, batch)
-      thread_ts = root_message["thread_ts"].presence || root_message["ts"]
-      pages = each_page(
-        CONVERSATIONS_REPLIES_ENDPOINT,
-        { "channel" => conversation_id, "ts" => thread_ts, "limit" => replies_page_size },
-        max_pages: replies_max_pages
-      )
-
-      pages.each do |page|
-        Array(page["messages"]).each do |reply|
-          next if reply["ts"] == root_message["ts"]
-
-          @replies_fetched += 1
-          normalize_message(reply, home_team_id, conversation_id, root_message["ts"], batch)
-          normalize_files(reply, home_team_id, conversation_id, batch)
-        end
-      end
     end
 
     def normalize_message(message, home_team_id, conversation_id, parent_message_ts, batch)

--- a/services/console/db/migrate/20260824032738_add_conversation_state_to_slack_dm_sync_cursors.rb
+++ b/services/console/db/migrate/20260824032738_add_conversation_state_to_slack_dm_sync_cursors.rb
@@ -1,0 +1,5 @@
+class AddConversationStateToSlackDmSyncCursors < ActiveRecord::Migration[8.1]
+  def change
+    add_column :slack_dm_sync_cursors, :conversation_state, :jsonb, null: false, default: {}
+  end
+end

--- a/services/console/db/schema.rb
+++ b/services/console/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_23_054500) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_24_032738) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_search"
@@ -490,6 +490,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_23_054500) do
   end
 
   create_table "slack_dm_sync_cursors", force: :cascade do |t|
+    t.jsonb "conversation_state", default: {}, null: false
     t.datetime "created_at", null: false
     t.string "next_conversation_id"
     t.bigint "next_credential_id"

--- a/services/console/test/jobs/slack_dm/jobs_test.rb
+++ b/services/console/test/jobs/slack_dm/jobs_test.rb
@@ -148,21 +148,30 @@ module SlackDm
         end
       end
       now = Time.zone.parse("2026-08-23 12:00:00")
+      retry_at = now + 20.minutes
 
       SlackDm::SyncCredential.stub(:new, sync_factory) do
-        travel_to(now) { SlackDm::SyncCredentialJob.perform_now("slack-dms") }
+        assert_enqueued_with(
+          job: SlackDm::SyncCredentialJob,
+          args: [ "slack-dms", retry_at ],
+          at: retry_at
+        ) do
+          travel_to(now) { SlackDm::SyncCredentialJob.perform_now("slack-dms") }
+        end
 
         cursor = SlackDmSyncCursor.find_by!(oauth_app_slug: "slack-dms")
         assert_equal first.id, cursor.next_credential_id
         assert_equal "D200", cursor.next_conversation_id
-        assert_equal now + 20.minutes, cursor.not_before
+        assert_equal retry_at, cursor.not_before
         assert_equal [ first.id ], attempted_ids
 
         travel_to(now + 10.minutes) { SlackDm::SyncCredentialJob.perform_now("slack-dms") }
         assert_equal [ first.id ], attempted_ids
 
         rate_limited = false
-        travel_to(now + 20.minutes) { SlackDm::SyncCredentialJob.perform_now("slack-dms") }
+        travel_to(retry_at) do
+          perform_enqueued_jobs(only: SlackDm::SyncCredentialJob)
+        end
       end
 
       assert_equal [ first.id, first.id, second.id ], attempted_ids
@@ -170,6 +179,30 @@ module SlackDm
       assert_equal first.id, cursor.next_credential_id
       assert_nil cursor.next_conversation_id
       assert_nil cursor.not_before
+    end
+
+    test "SyncCredentialJob ignores a delayed retry after another run clears the pause" do
+      app = slack_app
+      slack_credential(app: app)
+      attempted_ids = []
+      retry_at = Time.zone.parse("2026-08-23 12:20:00")
+      SlackDmSyncCursor.create!(oauth_app_slug: "slack-dms")
+      sync_factory = lambda do |credential|
+        attempted_ids << credential.id
+        Object.new
+      end
+
+      SlackDm::SyncCredential.stub(:new, sync_factory) do
+        SlackDm::SyncCredentialJob.set(wait_until: retry_at).perform_later(
+          "slack-dms",
+          retry_at
+        )
+        travel_to(retry_at) do
+          perform_enqueued_jobs(only: SlackDm::SyncCredentialJob)
+        end
+      end
+
+      assert_empty attempted_ids
     end
 
     test "SyncCredentialJob stops between credentials after its runtime budget" do

--- a/services/console/test/jobs/slack_dm/jobs_test.rb
+++ b/services/console/test/jobs/slack_dm/jobs_test.rb
@@ -133,13 +133,25 @@ module SlackDm
       first = slack_credential(app: app)
       second = slack_credential(app: app)
       attempted_ids = []
+      observed_states = []
       rate_limited = true
+      page_state = {
+        "phase" => "history",
+        "history_cursor" => "history-2",
+        "oldest_ts" => "1700000000.000001",
+        "max_message_ts" => "1700000000.000003"
+      }
+      persisted_page_state = page_state.merge(
+        "_broker_credential_id" => first.oid,
+        "_conversation_id" => "D200"
+      )
       sync_factory = lambda do |credential|
         Object.new.tap do |sync|
-          sync.define_singleton_method(:call) do |**_kwargs, &checkpoint|
+          sync.define_singleton_method(:call) do |conversation_state:, **_kwargs, &checkpoint|
             attempted_ids << credential.id
+            observed_states << [ credential.id, conversation_state.deep_dup ]
             if credential == first && rate_limited
-              checkpoint.call("D200")
+              checkpoint.call("D200", page_state)
               raise SlackApi::RateLimitedError.new(retry_after: 20.minutes.to_i)
             end
 
@@ -162,6 +174,7 @@ module SlackDm
         cursor = SlackDmSyncCursor.find_by!(oauth_app_slug: "slack-dms")
         assert_equal first.id, cursor.next_credential_id
         assert_equal "D200", cursor.next_conversation_id
+        assert_equal persisted_page_state, cursor.conversation_state
         assert_equal retry_at, cursor.not_before
         assert_equal [ first.id ], attempted_ids
 
@@ -175,9 +188,15 @@ module SlackDm
       end
 
       assert_equal [ first.id, first.id, second.id ], attempted_ids
+      assert_equal [
+        [ first.id, {} ],
+        [ first.id, persisted_page_state ],
+        [ second.id, {} ]
+      ], observed_states
       cursor = SlackDmSyncCursor.find_by!(oauth_app_slug: "slack-dms")
       assert_equal first.id, cursor.next_credential_id
       assert_nil cursor.next_conversation_id
+      assert_empty cursor.conversation_state
       assert_nil cursor.not_before
     end
 

--- a/services/console/test/models/slack_dm_sync_cursor_test.rb
+++ b/services/console/test/models/slack_dm_sync_cursor_test.rb
@@ -2,8 +2,9 @@ require "test_helper"
 
 class SlackDmSyncCursorTest < ActiveSupport::TestCase
   test "oauth app slugs identify a single cursor" do
-    SlackDmSyncCursor.create!(oauth_app_slug: "slack-dms")
+    cursor = SlackDmSyncCursor.create!(oauth_app_slug: "slack-dms")
 
+    assert_empty cursor.conversation_state
     duplicate = SlackDmSyncCursor.new(oauth_app_slug: "slack-dms")
     assert_not duplicate.valid?
     assert_includes duplicate.errors[:oauth_app_slug], "has already been taken"

--- a/services/console/test/services/slack_dm/sync_credential_test.rb
+++ b/services/console/test/services/slack_dm/sync_credential_test.rb
@@ -11,7 +11,20 @@ module SlackDm
       end
 
       def batch
-        @batches.find { |payload| payload[:conversations].any? }
+        data_batches = @batches.select do |payload|
+          %i[conversations members messages attachments checkpoints].any? do |key|
+            payload[key].any?
+          end
+        end
+        return if data_batches.empty?
+
+        data_batches.last.merge(
+          conversations: data_batches.flat_map { |payload| payload[:conversations] },
+          members: data_batches.flat_map { |payload| payload[:members] },
+          messages: data_batches.flat_map { |payload| payload[:messages] },
+          attachments: data_batches.flat_map { |payload| payload[:attachments] },
+          checkpoints: data_batches.flat_map { |payload| payload[:checkpoints] }
+        )
       end
 
       def final_batch
@@ -319,11 +332,12 @@ module SlackDm
       assert_equal "private roadmap", batch[:messages].first[:text]
     end
 
-    test "sync never replaces membership from truncated pagination" do
+    test "sync checkpoints truncated membership pagination without replacing members" do
       env_key = "CENTAUR_CONSOLE_SLACK_DM_SYNC_MEMBERS_MAX_PAGES"
       previous = ENV[env_key]
       ENV[env_key] = "1"
       api_client = FakeApiClient.new
+      member_cursors = []
       slack_http = lambda do |endpoint:, params:, access_token:|
         assert_equal "xoxp-live", access_token
         case endpoint
@@ -336,25 +350,52 @@ module SlackDm
             "response_metadata" => { "next_cursor" => "" }
           }
         when SlackDm::SyncCredential::CONVERSATIONS_MEMBERS_ENDPOINT
-          {
-            "ok" => true,
-            "members" => [ "U_ME" ],
-            "response_metadata" => { "next_cursor" => "more" }
-          }
+          member_cursors << params["cursor"]
+          if params["cursor"] == "more"
+            {
+              "ok" => true,
+              "members" => [ "U_TWO" ],
+              "response_metadata" => { "next_cursor" => "" }
+            }
+          else
+            {
+              "ok" => true,
+              "members" => [ "U_ONE" ],
+              "response_metadata" => { "next_cursor" => "more" }
+            }
+          end
+        when SlackDm::SyncCredential::CONVERSATIONS_HISTORY_ENDPOINT
+          { "ok" => true, "messages" => [], "response_metadata" => { "next_cursor" => "" } }
         else
           flunk "unexpected Slack endpoint #{endpoint} with #{params}"
         end
       end
 
-      error = assert_raises(SlackApi::Error) do
-        SlackDm::SyncCredential.new(
+      conversation_state = nil
+      completed = SlackDm::SyncCredential.new(
           credential,
           api_client: api_client,
           slack_api_http: slack_http
-        ).call
-      end
-      assert_match "membership pagination truncated", error.message
+        ).call do |_conversation_id, state|
+          conversation_state = state
+        end
+      assert_not completed
+      assert_equal "members", conversation_state.fetch("phase")
+      assert_equal "more", conversation_state.fetch("members_cursor")
+      assert_equal [ "U_ONE" ], conversation_state.fetch("member_ids")
       assert_nil api_client.batch
+
+      SlackDm::SyncCredential.new(
+        credential,
+        api_client: api_client,
+        slack_api_http: slack_http
+      ).call(
+        starting_conversation_id: "G123",
+        conversation_state: conversation_state
+      )
+
+      assert_equal [ nil, "more" ], member_cursors
+      assert_equal %w[U_ONE U_TWO U_ME], api_client.batch[:members].map { |member| member[:user_id] }
     ensure
       previous.nil? ? ENV.delete(env_key) : ENV[env_key] = previous
     end
@@ -401,29 +442,35 @@ module SlackDm
         end
       end
       conversation_cursor = nil
+      conversation_state = nil
 
       assert_raises(SlackApi::RateLimitedError) do
         SlackDm::SyncCredential.new(
           credential,
           api_client: api_client,
           slack_api_http: slack_http
-        ).call do |conversation_id|
+        ).call do |conversation_id, state|
           conversation_cursor = conversation_id
+          conversation_state = state
         end
       end
 
       assert_equal "D200", conversation_cursor
-      ingested_conversation_ids = api_client.batches.flat_map do |batch|
-        batch[:conversations].map { |conversation| conversation[:conversation_id] }
+      assert_equal "history", conversation_state.fetch("phase")
+      ingested_message_conversation_ids = api_client.batches.flat_map do |batch|
+        batch[:messages].map { |message| message[:conversation_id] }
       end
-      assert_equal [ "D100" ], ingested_conversation_ids
+      assert_equal [ "D100" ], ingested_message_conversation_ids
 
       rate_limited = false
       SlackDm::SyncCredential.new(
         credential,
         api_client: api_client,
         slack_api_http: slack_http
-      ).call(starting_conversation_id: conversation_cursor)
+      ).call(
+        starting_conversation_id: conversation_cursor,
+        conversation_state: conversation_state
+      )
 
       assert_equal %w[D100 D200 D200], history_calls
       ingested_conversation_ids = api_client.batches.flat_map do |batch|
@@ -432,9 +479,215 @@ module SlackDm
       assert_equal %w[D100 D200], ingested_conversation_ids
     end
 
+    test "sync resumes at the next history page after a rate limit" do
+      api_client = FakeApiClient.new
+      rate_limited = true
+      history_cursors = []
+      conversation_state = nil
+      slack_http = lambda do |endpoint:, params:, access_token:|
+        assert_equal "xoxp-live", access_token
+        case endpoint
+        when SlackDm::SyncCredential::AUTH_TEST_ENDPOINT
+          { "ok" => true, "team_id" => "T123", "user_id" => "U_ME" }
+        when SlackDm::SyncCredential::CONVERSATIONS_LIST_ENDPOINT
+          {
+            "ok" => true,
+            "channels" => [ { "id" => "D100", "is_im" => true, "user" => "U_ONE" } ],
+            "response_metadata" => { "next_cursor" => "" }
+          }
+        when SlackDm::SyncCredential::CONVERSATIONS_HISTORY_ENDPOINT
+          history_cursors << params["cursor"]
+          if params["cursor"] == "history-2" && rate_limited
+            raise SlackApi::RateLimitedError.new(retry_after: 20.minutes.to_i)
+          end
+
+          {
+            "ok" => true,
+            "messages" => [
+              {
+                "type" => "message",
+                "ts" => params["cursor"] == "history-2" ?
+                  "1700000000.000002" : "1700000000.000003",
+                "user" => "U_OTHER",
+                "text" => params["cursor"] || "history-1"
+              }
+            ],
+            "response_metadata" => {
+              "next_cursor" => params["cursor"] == "history-2" ? "" : "history-2"
+            }
+          }
+        else
+          flunk "unexpected Slack endpoint #{endpoint}"
+        end
+      end
+
+      assert_raises(SlackApi::RateLimitedError) do
+        SlackDm::SyncCredential.new(
+          credential,
+          api_client: api_client,
+          slack_api_http: slack_http
+        ).call do |_conversation_id, state|
+          conversation_state = state
+        end
+      end
+
+      assert_equal "history", conversation_state.fetch("phase")
+      assert_equal "history-2", conversation_state.fetch("history_cursor")
+      message_timestamps = api_client.batch[:messages].map do |message|
+        message[:message_ts]
+      end
+      assert_equal [ "1700000000.000003" ], message_timestamps
+
+      rate_limited = false
+      SlackDm::SyncCredential.new(
+        credential,
+        api_client: api_client,
+        slack_api_http: slack_http
+      ).call(
+        starting_conversation_id: "D100",
+        conversation_state: conversation_state
+      )
+
+      assert_equal [ nil, "history-2", "history-2" ], history_cursors
+      message_timestamps = api_client.batch[:messages].map do |message|
+        message[:message_ts]
+      end
+      assert_equal %w[1700000000.000003 1700000000.000002], message_timestamps
+      assert_equal 1, api_client.batch[:conversations].length
+      assert_equal "1700000000.000003", api_client.batch[:checkpoints].last[:watermark_ts]
+    end
+
+    test "sync resumes at the next replies page after a rate limit" do
+      api_client = FakeApiClient.new
+      rate_limited = true
+      history_calls = 0
+      replies_cursors = []
+      conversation_state = nil
+      slack_http = lambda do |endpoint:, params:, access_token:|
+        assert_equal "xoxp-live", access_token
+        case endpoint
+        when SlackDm::SyncCredential::AUTH_TEST_ENDPOINT
+          { "ok" => true, "team_id" => "T123", "user_id" => "U_ME" }
+        when SlackDm::SyncCredential::CONVERSATIONS_LIST_ENDPOINT
+          {
+            "ok" => true,
+            "channels" => [ { "id" => "D100", "is_im" => true, "user" => "U_ONE" } ],
+            "response_metadata" => { "next_cursor" => "" }
+          }
+        when SlackDm::SyncCredential::CONVERSATIONS_HISTORY_ENDPOINT
+          history_calls += 1
+          {
+            "ok" => true,
+            "messages" => [
+              {
+                "type" => "message",
+                "ts" => "1700000000.000001",
+                "user" => "U_OTHER",
+                "text" => "root",
+                "reply_count" => 2
+              }
+            ],
+            "response_metadata" => { "next_cursor" => "" }
+          }
+        when SlackDm::SyncCredential::CONVERSATIONS_REPLIES_ENDPOINT
+          replies_cursors << params["cursor"]
+          if params["cursor"] == "replies-2" && rate_limited
+            raise SlackApi::RateLimitedError.new(retry_after: 20.minutes.to_i)
+          end
+
+          messages = if params["cursor"] == "replies-2"
+            [
+              {
+                "type" => "message",
+                "ts" => "1700000000.000003",
+                "user" => "U_TWO",
+                "text" => "reply 2"
+              }
+            ]
+          else
+            [
+              {
+                "type" => "message",
+                "ts" => "1700000000.000001",
+                "user" => "U_OTHER",
+                "text" => "root"
+              },
+              {
+                "type" => "message",
+                "ts" => "1700000000.000002",
+                "user" => "U_ONE",
+                "text" => "reply 1"
+              }
+            ]
+          end
+          {
+            "ok" => true,
+            "messages" => messages,
+            "response_metadata" => {
+              "next_cursor" => params["cursor"] == "replies-2" ? "" : "replies-2"
+            }
+          }
+        else
+          flunk "unexpected Slack endpoint #{endpoint}"
+        end
+      end
+
+      assert_raises(SlackApi::RateLimitedError) do
+        SlackDm::SyncCredential.new(
+          credential,
+          api_client: api_client,
+          slack_api_http: slack_http
+        ).call do |_conversation_id, state|
+          conversation_state = state
+        end
+      end
+
+      assert_equal "replies", conversation_state.fetch("phase")
+      assert_equal "replies-2", conversation_state.fetch("replies_cursor")
+
+      rate_limited = false
+      SlackDm::SyncCredential.new(
+        credential,
+        api_client: api_client,
+        slack_api_http: slack_http
+      ).call(
+        starting_conversation_id: "D100",
+        conversation_state: conversation_state
+      )
+
+      assert_equal 1, history_calls
+      assert_equal [ nil, "replies-2", "replies-2" ], replies_cursors
+      assert_equal %w[1700000000.000001 1700000000.000002 1700000000.000003],
+                   api_client.batch[:messages].map { |message| message[:message_ts] }
+      assert_equal 1, api_client.batch[:conversations].length
+      assert_equal "1700000000.000001", api_client.batch[:checkpoints].last[:watermark_ts]
+    end
+
+    test "sync ignores page state belonging to another credential" do
+      api_client = FakeApiClient.new
+      history_calls = []
+
+      SlackDm::SyncCredential.new(
+        credential,
+        api_client: api_client,
+        slack_api_http: two_conversation_slack_http(history_calls)
+      ).call(
+        starting_conversation_id: "D100",
+        conversation_state: {
+          "_broker_credential_id" => "bcr_other",
+          "_conversation_id" => "D100",
+          "phase" => "complete",
+          "max_message_ts" => "1700000000.000009"
+        }
+      )
+
+      assert_equal %w[D100 D200], history_calls
+    end
+
     test "sync checkpoints the next conversation before stopping at its deadline" do
       api_client = FakeApiClient.new
       conversation_cursor = nil
+      conversation_state = nil
       now = Time.zone.parse("2026-08-23 12:00:00")
       slack_http = lambda do |endpoint:, params:, access_token:|
         assert_equal "xoxp-live", access_token
@@ -463,13 +716,15 @@ module SlackDm
           credential,
           api_client: api_client,
           slack_api_http: slack_http
-        ).call(deadline: now + 30.minutes) do |conversation_id|
+        ).call(deadline: now + 30.minutes) do |conversation_id, state|
           conversation_cursor = conversation_id
+          conversation_state = state
         end
       end
 
       assert_not completed
-      assert_equal "D200", conversation_cursor
+      assert_equal "D100", conversation_cursor
+      assert_equal "complete", conversation_state.fetch("phase")
       ingested_conversation_ids = api_client.batches.flat_map do |batch|
         batch[:conversations].map { |conversation| conversation[:conversation_id] }
       end
@@ -479,8 +734,8 @@ module SlackDm
 
     test "sync skips a conversation rejected by the ingest API" do
       api_client = FakeApiClient.new do |payload|
-        conversation_id = payload.dig(:conversations, 0, :conversation_id)
-        if conversation_id == "D100"
+        message_conversation_id = payload.dig(:messages, 0, :conversation_id)
+        if message_conversation_id == "D100"
           raise CentaurApiClient::Error.new("invalid message timestamp", status: 400)
         end
       end
@@ -511,8 +766,8 @@ module SlackDm
 
     test "sync retries a conversation after a transient ingest API failure" do
       api_client = FakeApiClient.new do |payload|
-        conversation_id = payload.dig(:conversations, 0, :conversation_id)
-        if conversation_id == "D100"
+        message_conversation_id = payload.dig(:messages, 0, :conversation_id)
+        if message_conversation_id == "D100"
           raise CentaurApiClient::Error.new("temporary failure", status: 500)
         end
       end


### PR DESCRIPTION
Schedules a delayed Slack DM sync job for the persisted Retry-After time while retaining the ten-minute recurring schedule as a fallback. Persists the active conversation's membership, history, and replies pagination state so successfully ingested pages are not fetched again after a rate limit or runtime cutoff. Page state is scoped to its credential and conversation, and stale delayed jobs exit if another run has already advanced or replaced the cursor.