### PR TITLE
fix(console): retry rate-limited Slack DM requests

### DIFF
--- a/services/console/app/jobs/slack_dm/sync_credential_job.rb
+++ b/services/console/app/jobs/slack_dm/sync_credential_job.rb
@@ -2,7 +2,6 @@ module SlackDm
   class SyncCredentialJob < ApplicationJob
     CONCURRENCY_DURATION = 6.hours
     RUN_TIME_BUDGET = 30.minutes
-    INLINE_RETRY_AFTER_THRESHOLD = 5.minutes.to_i
 
     queue_as :default
 
@@ -84,15 +83,6 @@ module SlackDm
         )
       end
     rescue SlackApi::RateLimitedError => e
-      if e.retry_after < INLINE_RETRY_AFTER_THRESHOLD
-        Rails.logger.info do
-          "Slack DM sync sleeping after rate limit: credential_id=#{credential.id} " \
-            "retry_after=#{e.retry_after}"
-        end
-        sleep(e.retry_after)
-        retry
-      end
-
       retry_at = e.retry_after.seconds.from_now
       cursor.update!(next_credential_id: credential.id, not_before: retry_at)
       persisted_retry_at = cursor.reload.not_before

--- a/services/console/app/jobs/slack_dm/sync_credential_job.rb
+++ b/services/console/app/jobs/slack_dm/sync_credential_job.rb
@@ -13,12 +13,13 @@ module SlackDm
       on_conflict: :discard
     )
 
-    def perform(oauth_app_slug = SlackDm::SyncCredential.oauth_app_slug)
+    def perform(oauth_app_slug = SlackDm::SyncCredential.oauth_app_slug, expected_not_before = nil)
       # Credential IDs were the argument before this became a global cursor job.
       # Ignore any of those jobs that were already queued during deployment.
       return unless oauth_app_slug.is_a?(String)
 
       cursor = SlackDmSyncCursor.find_or_create_by!(oauth_app_slug: oauth_app_slug)
+      return if expected_not_before && cursor.not_before != expected_not_before
       return if cursor.not_before&.future?
 
       credentials = eligible_credentials(oauth_app_slug)
@@ -84,9 +85,14 @@ module SlackDm
     rescue SlackApi::RateLimitedError => e
       retry_at = e.retry_after.seconds.from_now
       cursor.update!(next_credential_id: credential.id, not_before: retry_at)
+      persisted_retry_at = cursor.reload.not_before
+      self.class.set(wait_until: persisted_retry_at).perform_later(
+        cursor.oauth_app_slug,
+        persisted_retry_at
+      )
       Rails.logger.info do
         "Slack DM sync paused after rate limit: credential_id=#{credential.id} " \
-          "retry_at=#{retry_at.iso8601}"
+          "retry_at=#{persisted_retry_at.iso8601}"
       end
       false
     rescue SlackApi::Error => e

--- a/services/console/app/jobs/slack_dm/sync_credential_job.rb
+++ b/services/console/app/jobs/slack_dm/sync_credential_job.rb
@@ -2,6 +2,7 @@ module SlackDm
   class SyncCredentialJob < ApplicationJob
     CONCURRENCY_DURATION = 6.hours
     RUN_TIME_BUDGET = 30.minutes
+    INLINE_RETRY_AFTER_THRESHOLD = 5.minutes.to_i
 
     queue_as :default
 
@@ -83,6 +84,15 @@ module SlackDm
         )
       end
     rescue SlackApi::RateLimitedError => e
+      if e.retry_after < INLINE_RETRY_AFTER_THRESHOLD
+        Rails.logger.info do
+          "Slack DM sync sleeping after rate limit: credential_id=#{credential.id} " \
+            "retry_after=#{e.retry_after}"
+        end
+        sleep(e.retry_after)
+        retry
+      end
+
       retry_at = e.retry_after.seconds.from_now
       cursor.update!(next_credential_id: credential.id, not_before: retry_at)
       persisted_retry_at = cursor.reload.not_before

--- a/services/console/app/services/slack_dm/sync_credential.rb
+++ b/services/console/app/services/slack_dm/sync_credential.rb
@@ -13,6 +13,7 @@ module SlackDm
     CONVERSATIONS_HISTORY_ENDPOINT = "https://slack.com/api/conversations.history"
     CONVERSATIONS_REPLIES_ENDPOINT = "https://slack.com/api/conversations.replies"
     API_READ_TIMEOUT_SECONDS = 120
+    INLINE_RATE_LIMIT_WAIT_THRESHOLD_SECONDS = 5.minutes.to_i
     SKIPPABLE_INGEST_STATUSES = [ 400, 413, 422 ].freeze
     class << self
       attr_accessor :slack_api_http
@@ -397,27 +398,45 @@ module SlackDm
     end
 
     def slack_api(endpoint, params = {})
-      if @slack_api_http
-        return @slack_api_http.call(
-          endpoint: endpoint,
-          params: params,
-          access_token: @credential.access_token
-        )
+      with_rate_limit_guard(endpoint) do
+        if @slack_api_http
+          @slack_api_http.call(
+            endpoint: endpoint,
+            params: params,
+            access_token: @credential.access_token
+          )
+        else
+          http_client = @http_client || HttpClient.new(
+            open_timeout: slack_timeout,
+            read_timeout: slack_timeout
+          )
+          response = http_client.get(
+            endpoint,
+            params: params,
+            headers: { "Authorization" => "Bearer #{@credential.access_token}" }
+          )
+          SlackApi.parse_response!(response, max_rate_limit_wait: nil)
+        end
       end
-
-      http_client = @http_client || HttpClient.new(open_timeout: slack_timeout, read_timeout: slack_timeout)
-      response = http_client.get(
-        endpoint,
-        params: params,
-        headers: { "Authorization" => "Bearer #{@credential.access_token}" }
-      )
-      SlackApi.parse_response!(response, max_rate_limit_wait: nil)
     rescue Socket::ResolutionError => e
       raise SlackApi::TransientError.new(
         "Slack API hostname resolution failed: #{e.message}",
         retry_after: SlackApi::DEFAULT_TRANSIENT_RETRY_AFTER_SECONDS,
         code: "hostname_resolution_failed"
       )
+    end
+
+    def with_rate_limit_guard(endpoint)
+      yield
+    rescue SlackApi::RateLimitedError => e
+      raise unless e.retry_after < INLINE_RATE_LIMIT_WAIT_THRESHOLD_SECONDS
+
+      Rails.logger.info do
+        "Slack DM sync sleeping after rate limit: credential_id=#{@credential.id} " \
+          "endpoint=#{endpoint} retry_after=#{e.retry_after}"
+      end
+      sleep(e.retry_after)
+      retry
     end
 
     def max_slack_ts(left, right)

--- a/services/console/app/services/slack_dm/sync_credential.rb
+++ b/services/console/app/services/slack_dm/sync_credential.rb
@@ -14,6 +14,7 @@ module SlackDm
     CONVERSATIONS_REPLIES_ENDPOINT = "https://slack.com/api/conversations.replies"
     API_READ_TIMEOUT_SECONDS = 120
     INLINE_RATE_LIMIT_WAIT_THRESHOLD_SECONDS = 5.minutes.to_i
+    MAX_INLINE_RATE_LIMIT_RETRIES = 5
     SKIPPABLE_INGEST_STATUSES = [ 400, 413, 422 ].freeze
     class << self
       attr_accessor :slack_api_http
@@ -427,16 +428,21 @@ module SlackDm
     end
 
     def with_rate_limit_guard(endpoint)
-      yield
-    rescue SlackApi::RateLimitedError => e
-      raise unless e.retry_after < INLINE_RATE_LIMIT_WAIT_THRESHOLD_SECONDS
+      retries = 0
+      begin
+        yield
+      rescue SlackApi::RateLimitedError => e
+        raise unless e.retry_after < INLINE_RATE_LIMIT_WAIT_THRESHOLD_SECONDS
+        raise if retries >= MAX_INLINE_RATE_LIMIT_RETRIES
 
-      Rails.logger.info do
-        "Slack DM sync sleeping after rate limit: credential_id=#{@credential.id} " \
-          "endpoint=#{endpoint} retry_after=#{e.retry_after}"
+        retries += 1
+        Rails.logger.info do
+          "Slack DM sync sleeping after rate limit: credential_id=#{@credential.id} " \
+            "endpoint=#{endpoint} retry_after=#{e.retry_after} retry=#{retries}"
+        end
+        sleep(e.retry_after)
+        retry
       end
-      sleep(e.retry_after)
-      retry
     end
 
     def max_slack_ts(left, right)

--- a/services/console/test/jobs/slack_dm/jobs_test.rb
+++ b/services/console/test/jobs/slack_dm/jobs_test.rb
@@ -128,40 +128,6 @@ module SlackDm
       assert_equal [ first.id, second.id ], attempted_ids
     end
 
-    test "SyncCredentialJob sleeps in-thread for short Slack Retry-After delays" do
-      app = slack_app
-      first = slack_credential(app: app)
-      second = slack_credential(app: app)
-      attempted_ids = []
-      rate_limited = true
-      sync_factory = lambda do |credential|
-        Object.new.tap do |sync|
-          sync.define_singleton_method(:call) do |**|
-            attempted_ids << credential.id
-            if credential == first && rate_limited
-              rate_limited = false
-              raise SlackApi::RateLimitedError.new(retry_after: 5.minutes.to_i - 1)
-            end
-
-            true
-          end
-        end
-      end
-      sleeps = []
-      job = SlackDm::SyncCredentialJob.new("slack-dms")
-
-      SlackDm::SyncCredential.stub(:new, sync_factory) do
-        assert_no_enqueued_jobs do
-          job.stub(:sleep, ->(seconds) { sleeps << seconds }) { job.perform_now }
-        end
-      end
-
-      assert_equal [ 5.minutes.to_i - 1 ], sleeps
-      assert_equal [ first.id, first.id, second.id ], attempted_ids
-      cursor = SlackDmSyncCursor.find_by!(oauth_app_slug: "slack-dms")
-      assert_nil cursor.not_before
-    end
-
     test "SyncCredentialJob pauses the cursor until Slack Retry-After elapses" do
       app = slack_app
       first = slack_credential(app: app)

--- a/services/console/test/jobs/slack_dm/jobs_test.rb
+++ b/services/console/test/jobs/slack_dm/jobs_test.rb
@@ -128,6 +128,40 @@ module SlackDm
       assert_equal [ first.id, second.id ], attempted_ids
     end
 
+    test "SyncCredentialJob sleeps in-thread for short Slack Retry-After delays" do
+      app = slack_app
+      first = slack_credential(app: app)
+      second = slack_credential(app: app)
+      attempted_ids = []
+      rate_limited = true
+      sync_factory = lambda do |credential|
+        Object.new.tap do |sync|
+          sync.define_singleton_method(:call) do |**|
+            attempted_ids << credential.id
+            if credential == first && rate_limited
+              rate_limited = false
+              raise SlackApi::RateLimitedError.new(retry_after: 5.minutes.to_i - 1)
+            end
+
+            true
+          end
+        end
+      end
+      sleeps = []
+      job = SlackDm::SyncCredentialJob.new("slack-dms")
+
+      SlackDm::SyncCredential.stub(:new, sync_factory) do
+        assert_no_enqueued_jobs do
+          job.stub(:sleep, ->(seconds) { sleeps << seconds }) { job.perform_now }
+        end
+      end
+
+      assert_equal [ 5.minutes.to_i - 1 ], sleeps
+      assert_equal [ first.id, first.id, second.id ], attempted_ids
+      cursor = SlackDmSyncCursor.find_by!(oauth_app_slug: "slack-dms")
+      assert_nil cursor.not_before
+    end
+
     test "SyncCredentialJob pauses the cursor until Slack Retry-After elapses" do
       app = slack_app
       first = slack_credential(app: app)
@@ -140,7 +174,7 @@ module SlackDm
             attempted_ids << credential.id
             if credential == first && rate_limited
               checkpoint.call("D200")
-              raise SlackApi::RateLimitedError.new(retry_after: 20.minutes.to_i)
+              raise SlackApi::RateLimitedError.new(retry_after: 5.minutes.to_i)
             end
 
             true
@@ -148,7 +182,7 @@ module SlackDm
         end
       end
       now = Time.zone.parse("2026-08-23 12:00:00")
-      retry_at = now + 20.minutes
+      retry_at = now + 5.minutes
 
       SlackDm::SyncCredential.stub(:new, sync_factory) do
         assert_enqueued_with(
@@ -165,7 +199,7 @@ module SlackDm
         assert_equal retry_at, cursor.not_before
         assert_equal [ first.id ], attempted_ids
 
-        travel_to(now + 10.minutes) { SlackDm::SyncCredentialJob.perform_now("slack-dms") }
+        travel_to(now + 4.minutes) { SlackDm::SyncCredentialJob.perform_now("slack-dms") }
         assert_equal [ first.id ], attempted_ids
 
         rate_limited = false

--- a/services/console/test/jobs/slack_dm/jobs_test.rb
+++ b/services/console/test/jobs/slack_dm/jobs_test.rb
@@ -148,21 +148,30 @@ module SlackDm
         end
       end
       now = Time.zone.parse("2026-08-23 12:00:00")
+      retry_at = now + 20.minutes
 
       SlackDm::SyncCredential.stub(:new, sync_factory) do
-        travel_to(now) { SlackDm::SyncCredentialJob.perform_now("slack-dms") }
+        assert_enqueued_with(
+          job: SlackDm::SyncCredentialJob,
+          args: [ "slack-dms", retry_at ],
+          at: retry_at
+        ) do
+          travel_to(now) { SlackDm::SyncCredentialJob.perform_now("slack-dms") }
+        end
 
         cursor = SlackDmSyncCursor.find_by!(oauth_app_slug: "slack-dms")
         assert_equal first.id, cursor.next_credential_id
         assert_equal "D200", cursor.next_conversation_id
-        assert_equal now + 20.minutes, cursor.not_before
+        assert_equal retry_at, cursor.not_before
         assert_equal [ first.id ], attempted_ids
 
         travel_to(now + 10.minutes) { SlackDm::SyncCredentialJob.perform_now("slack-dms") }
         assert_equal [ first.id ], attempted_ids
 
         rate_limited = false
-        travel_to(now + 20.minutes) { SlackDm::SyncCredentialJob.perform_now("slack-dms") }
+        travel_to(retry_at) do
+          perform_enqueued_jobs(only: SlackDm::SyncCredentialJob)
+        end
       end
 
       assert_equal [ first.id, first.id, second.id ], attempted_ids
@@ -170,6 +179,30 @@ module SlackDm
       assert_equal first.id, cursor.next_credential_id
       assert_nil cursor.next_conversation_id
       assert_nil cursor.not_before
+    end
+
+    test "SyncCredentialJob ignores a delayed retry after another run clears the pause" do
+      app = slack_app
+      slack_credential(app: app)
+      attempted_ids = []
+      retry_at = Time.zone.parse("2026-08-23 12:20:00")
+      SlackDmSyncCursor.create!(oauth_app_slug: "slack-dms")
+      sync_factory = lambda do |credential|
+        attempted_ids << credential.id
+        Object.new
+      end
+
+      SlackDm::SyncCredential.stub(:new, sync_factory) do
+        SlackDm::SyncCredentialJob.set(wait_until: retry_at).perform_later(
+          "slack-dms",
+          retry_at
+        )
+        travel_to(retry_at) do
+          perform_enqueued_jobs(only: SlackDm::SyncCredentialJob)
+        end
+      end
+
+      assert_empty attempted_ids
     end
 
     test "SyncCredentialJob stops between credentials after its runtime budget" do

--- a/services/console/test/services/slack_dm/sync_credential_test.rb
+++ b/services/console/test/services/slack_dm/sync_credential_test.rb
@@ -585,6 +585,25 @@ module SlackDm
       assert_equal [ nil, "page-2", "page-2" ], list_cursors
     end
 
+    test "short rate limits escape after five retries of one Slack call" do
+      attempts = 0
+      slack_http = lambda do |endpoint:, **|
+        assert_equal SlackDm::SyncCredential::AUTH_TEST_ENDPOINT, endpoint
+        attempts += 1
+        raise SlackApi::RateLimitedError.new(retry_after: 1)
+      end
+      client = SlackDm::SyncCredential.new(credential, slack_api_http: slack_http)
+      sleeps = []
+
+      error = assert_raises(SlackApi::RateLimitedError) do
+        client.stub(:sleep, ->(seconds) { sleeps << seconds }) { client.call }
+      end
+
+      assert_equal 1, error.retry_after
+      assert_equal SlackDm::SyncCredential::MAX_INLINE_RATE_LIMIT_RETRIES + 1, attempts
+      assert_equal Array.new(SlackDm::SyncCredential::MAX_INLINE_RATE_LIMIT_RETRIES, 1), sleeps
+    end
+
     test "long 429 responses expose the full Retry-After to the cursor job" do
       [
         [ "300", 300 ],

--- a/services/console/test/services/slack_dm/sync_credential_test.rb
+++ b/services/console/test/services/slack_dm/sync_credential_test.rb
@@ -538,11 +538,57 @@ module SlackDm
       assert_equal "D100", conversation_cursor
     end
 
-    test "429 responses expose the full Retry-After to the cursor job" do
+    test "short rate limits retry the same paginated Slack call" do
+      api_client = FakeApiClient.new
+      list_cursors = []
+      rate_limited = true
+      slack_http = lambda do |endpoint:, params:, access_token:|
+        assert_equal "xoxp-live", access_token
+        case endpoint
+        when SlackDm::SyncCredential::AUTH_TEST_ENDPOINT
+          { "ok" => true, "team_id" => "T123", "user_id" => "U_ME" }
+        when SlackDm::SyncCredential::CONVERSATIONS_LIST_ENDPOINT
+          cursor = params["cursor"]
+          list_cursors << cursor
+          if cursor.nil?
+            {
+              "ok" => true,
+              "channels" => [],
+              "response_metadata" => { "next_cursor" => "page-2" }
+            }
+          elsif rate_limited
+            rate_limited = false
+            raise SlackApi::RateLimitedError.new(retry_after: 5.minutes.to_i - 1)
+          else
+            {
+              "ok" => true,
+              "channels" => [],
+              "response_metadata" => { "next_cursor" => "" }
+            }
+          end
+        else
+          flunk "unexpected Slack endpoint #{endpoint}"
+        end
+      end
+      client = SlackDm::SyncCredential.new(
+        credential,
+        api_client: api_client,
+        slack_api_http: slack_http
+      )
+      sleeps = []
+
+      client.stub(:sleep, ->(seconds) { sleeps << seconds }) do
+        assert client.call
+      end
+
+      assert_equal [ 5.minutes.to_i - 1 ], sleeps
+      assert_equal [ nil, "page-2", "page-2" ], list_cursors
+    end
+
+    test "long 429 responses expose the full Retry-After to the cursor job" do
       [
-        [ "120", 120 ],
-        [ "600", 600 ],
-        [ "invalid", 1 ]
+        [ "300", 300 ],
+        [ "600", 600 ]
       ].each do |header, expected|
         response = HttpClient::Response.new(
           status: 429,


### PR DESCRIPTION
Retry individual Slack DM API requests in-thread when Retry-After is under five minutes, preserving pagination progress instead of restarting the credential sync. Cap inline retries at five per request. Longer waits and exhausted inline retries persist the cursor pause and enqueue a guarded delayed retry.