### PR TITLE
fix(session-sqlx): let failed executions re-run

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -31,8 +31,8 @@ permissions:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAMESPACE: paradigmxyz/centaur
-  IMAGE_SOURCE: https://github.com/paradigmxyz/centaur
+  IMAGE_NAMESPACE: uriel-xyz/centaur
+  IMAGE_SOURCE: https://github.com/uriel-xyz/centaur
   # Main/tags keep optimized release images. PRs and manual branch publishes
   # use debug builds so staging/dev iteration does not spend minutes optimizing
   # Rust binaries that are immediately replaced by the next test build.

--- a/services/api-rs/crates/centaur-session-runtime/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-runtime/src/lib.rs
@@ -3582,23 +3582,6 @@ impl SessionRuntime {
             return Ok(OrphanAdoption::Failed);
         };
         let id = SandboxId::new(sandbox_id);
-        let status = match self.sandbox_runtime.manager.status(&id).await {
-            Ok(status) => status,
-            Err(SandboxError::NotFound(_)) => SandboxStatus::Gone,
-            // Transient status failures must not fail a possibly live
-            // execution; surface the error and retry on the next startup.
-            Err(error) => return Err(SessionRuntimeError::Sandbox(error)),
-        };
-        if !status.can_open_io() {
-            self.fail_orphaned_execution(
-                thread_key,
-                execution_id,
-                sandbox_id,
-                &format!("sandbox no longer accepts io (status {status:?})"),
-            )
-            .await;
-            return Ok(OrphanAdoption::Failed);
-        }
         if !self.claim_expired_stdout_owner(execution_id).await? {
             // Deferrals repeat on every periodic scan while another control
             // plane pumps the execution; only the first observation is worth
@@ -3657,6 +3640,10 @@ impl SessionRuntime {
             Ok(lines) => lines,
             Err(SandboxError::Unsupported { .. }) => Vec::new(),
             Err(error) => {
+                // Transient read failure. The recorded output is the only
+                // source of truth once the container terminalized, so
+                // swallowing it here would fail live turns; release the
+                // claim and let the next scan retry the read.
                 warn!(
                     component = COMPONENT_SESSION_RUNTIME,
                     event = "execution_adoption_log_read_failed",
@@ -3664,9 +3651,32 @@ impl SessionRuntime {
                     execution_id,
                     sandbox_id,
                     %error,
-                    "failed to read recorded sandbox output; adopting live"
+                    "failed to read recorded sandbox output; releasing claim, retrying on the next scan"
                 );
-                Vec::new()
+                let _ = self
+                    .store
+                    .release_stdout_owner(execution_id, &self.stdout_owner_id)
+                    .await;
+                if let Some(span) = self.execution_spans.lock().await.remove(execution_id) {
+                    finish_execution_trace_span(&span, "retrying");
+                }
+                return Err(SessionRuntimeError::Sandbox(error));
+            }
+        };
+        let status = match self.sandbox_runtime.manager.status(&id).await {
+            Ok(status) => status,
+            Err(SandboxError::NotFound(_)) => SandboxStatus::Gone,
+            Err(error) => {
+                // Transient status failures must not fail a possibly live
+                // execution; release the claim and retry on the next scan.
+                let _ = self
+                    .store
+                    .release_stdout_owner(execution_id, &self.stdout_owner_id)
+                    .await;
+                if let Some(span) = self.execution_spans.lock().await.remove(execution_id) {
+                    finish_execution_trace_span(&span, "retrying");
+                }
+                return Err(SessionRuntimeError::Sandbox(error));
             }
         };
         if let Some(terminal) = terminal_output_from_lines(&lines) {
@@ -3697,6 +3707,47 @@ impl SessionRuntime {
             )
             .await?;
             return Ok(OrphanAdoption::Adopted);
+        }
+
+        if !status.can_open_io() {
+            // No terminal in the recorded output and no live sandbox to
+            // reattach to. A young non-terminal sandbox may still be
+            // coming up (or the status read is transient): retry on the
+            // next scan instead of failing the turn.
+            let running_since = execution.started_at.unwrap_or(execution.created_at);
+            let age = SystemTime::now()
+                .duration_since(SystemTime::from(running_since))
+                .unwrap_or_default();
+            if !status.is_terminal() && age < PRE_SANDBOX_ORPHAN_GRACE {
+                let _ = self
+                    .store
+                    .release_stdout_owner(execution_id, &self.stdout_owner_id)
+                    .await;
+                if let Some(span) = self.execution_spans.lock().await.remove(execution_id) {
+                    finish_execution_trace_span(&span, "skipped");
+                }
+                debug!(
+                    component = COMPONENT_SESSION_RUNTIME,
+                    event = "execution_adoption_skipped",
+                    thread_key = %thread_key,
+                    execution_id,
+                    sandbox_id,
+                    ?status,
+                    age_ms = duration_millis_u64(age),
+                    "skipping young execution with a sandbox not yet open for io"
+                );
+                return Ok(OrphanAdoption::Skipped);
+            }
+            self.fail_orphaned_execution(
+                thread_key,
+                execution_id,
+                sandbox_id,
+                &format!(
+                    "sandbox not openable (status {status:?}) with no recorded terminal output"
+                ),
+            )
+            .await;
+            return Ok(OrphanAdoption::Failed);
         }
 
         // No terminal in the recorded output: treat the turn as still in
@@ -4444,22 +4495,33 @@ fn spawn_stdout_pump_loop(state: StdoutPumpLoop) {
                 }
             };
 
-            if recover_detached_terminal_output(&ctx, &thread_key, &sandbox_id, &execution)
-                .await
-                .unwrap_or_else(|error| {
-                    warn!(
-                        component = COMPONENT_SESSION_RUNTIME,
-                        event = "session_stdout_recovery_failed",
-                        thread_key = %thread_key,
-                        sandbox_id = %sandbox_id,
-                        execution_id = %execution.execution_id,
-                        %error,
-                        "failed to recover detached stdout from recorded output"
-                    );
-                    false
-                })
-            {
-                break;
+            // The container may have terminalized while the attach stream
+            // was gone: the recorded output then holds the turn's outcome,
+            // and a live reattach against a terminal sandbox can only fail
+            // the turn. Retry the read on transient failure (bounded, so a
+            // dead backend cannot stall the loop) before falling back to
+            // the live reattach.
+            for _ in 0..SESSION_PIPE_MAX_REATTACH_ATTEMPTS {
+                match recover_detached_terminal_output(&ctx, &thread_key, &sandbox_id, &execution)
+                    .await
+                {
+                    Ok(true) => break 'pump,
+                    Ok(false) => break,
+                    Err(error) => {
+                        warn!(
+                            component = COMPONENT_SESSION_RUNTIME,
+                            event = "session_stdout_recovery_failed",
+                            thread_key = %thread_key,
+                            sandbox_id = %sandbox_id,
+                            execution_id = %execution.execution_id,
+                            %error,
+                            "failed to recover detached stdout from recorded output; retrying before live reattach"
+                        );
+                        last_reattach_detail =
+                            format!("recorded sandbox output unreadable: {error}");
+                        sleep(SESSION_PIPE_REATTACH_DELAY).await;
+                    }
+                }
             }
 
             if lines_pumped > 0 {
@@ -4608,6 +4670,11 @@ async fn recover_detached_terminal_output(
         Ok(lines) => lines,
         Err(SandboxError::Unsupported { .. }) => return Ok(false),
         Err(error) => {
+            // Transient read failures surface to the pump loop, which
+            // retries before falling back to a live reattach; returning
+            // Ok(false) here would reattach against a container that may
+            // already have terminalized and fail the turn even though the
+            // recorded output can still hold its outcome.
             warn!(
                 component = COMPONENT_SESSION_RUNTIME,
                 event = "session_stdout_recorded_output_read_failed",
@@ -4615,9 +4682,9 @@ async fn recover_detached_terminal_output(
                 execution_id = %execution.execution_id,
                 sandbox_id,
                 %error,
-                "failed to read recorded sandbox output; reattaching live"
+                "failed to read recorded sandbox output; surfacing for retry"
             );
-            return Ok(false);
+            return Err(SessionRuntimeError::Sandbox(error));
         }
     };
 
@@ -8547,6 +8614,7 @@ mod adoption_tests {
         stopped: std::sync::Mutex<Vec<String>>,
         proxy_ensures: std::sync::Mutex<Vec<ProxyEnsure>>,
         missing_on_stop: std::sync::Mutex<BTreeSet<String>>,
+        read_output_failures: std::sync::Mutex<Option<usize>>,
     }
 
     impl MockBackend {
@@ -8565,6 +8633,7 @@ mod adoption_tests {
                 stopped: std::sync::Mutex::new(Vec::new()),
                 proxy_ensures: std::sync::Mutex::new(Vec::new()),
                 missing_on_stop: std::sync::Mutex::new(BTreeSet::new()),
+                read_output_failures: std::sync::Mutex::new(None),
             }
         }
 
@@ -8616,6 +8685,11 @@ mod adoption_tests {
                 .insert(sandbox_id.to_owned());
         }
 
+        /// Makes the next `count` `read_output_since` calls fail transiently.
+        fn fail_next_read_output(&self, count: usize) {
+            *self.read_output_failures.lock().unwrap() = Some(count);
+        }
+
         fn stopped(&self) -> Vec<String> {
             self.stopped.lock().unwrap().clone()
         }
@@ -8663,6 +8737,16 @@ mod adoption_tests {
             _id: &SandboxId,
             _since: Option<SystemTime>,
         ) -> SandboxResult<Vec<String>> {
+            let mut failures = self.read_output_failures.lock().unwrap();
+            if let Some(remaining) = *failures {
+                if remaining > 0 {
+                    *failures = Some(remaining - 1);
+                    return Err(SandboxError::io(format!(
+                        "mock transient recorded-output read failure ({remaining})"
+                    )));
+                }
+                *failures = None;
+            }
             Ok(self.recorded_output.lock().unwrap().clone())
         }
 
@@ -10701,6 +10785,224 @@ mod adoption_tests {
             }),
             "expected a live adoption event"
         );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn adopts_completed_execution_when_sandbox_stopped_with_recorded_terminal() {
+        let Some(store) = test_store().await else {
+            return;
+        };
+        let _serial = TEST_LOCK.lock().await;
+        let thread_key =
+            ThreadKey::parse(format!("test:adopt-stopped-{}", uuid::Uuid::new_v4())).unwrap();
+        orphaned_execution(&store, &thread_key, Some("sbx-stopped"), true).await;
+
+        // The container terminalized while the old control plane was rolling:
+        // the recorded output still holds the turn's outcome even though the
+        // sandbox no longer accepts io.
+        let backend = Arc::new(MockBackend::new(
+            SandboxStatus::Stopped,
+            completed_output_lines("Finished while unattached."),
+        ));
+        let runtime = runtime_with(&store, backend.clone());
+        runtime.adopt_orphaned_executions().await;
+
+        wait_for_event(&store, &thread_key, "session.execution_completed").await;
+        let all = events(&store, &thread_key).await;
+        assert!(
+            !all.iter()
+                .any(|event| event.event_type == "session.execution_failed"),
+            "stopped sandbox with recorded terminal output must not fail the turn"
+        );
+        let completed = all
+            .iter()
+            .find(|event| event.event_type == "session.execution_completed")
+            .expect("completed event");
+        assert_eq!(
+            completed.payload["result_text"].as_str(),
+            Some("Finished while unattached.")
+        );
+        assert_eq!(backend.opens(), 0);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn adoption_retries_after_transient_recorded_output_read_failure() {
+        let Some(store) = test_store().await else {
+            return;
+        };
+        let _serial = TEST_LOCK.lock().await;
+        let thread_key =
+            ThreadKey::parse(format!("test:adopt-retry-read-{}", uuid::Uuid::new_v4())).unwrap();
+        orphaned_execution(&store, &thread_key, Some("sbx-retry-read"), true).await;
+
+        let backend = Arc::new(MockBackend::new(
+            SandboxStatus::Stopped,
+            completed_output_lines("Recovered on the second read."),
+        ));
+        backend.fail_next_read_output(1);
+        let runtime = runtime_with(&store, backend.clone());
+
+        // The first scan hits the transient read failure: it must surface
+        // the error so the next scan retries, not fail the execution.
+        let execution = store
+            .latest_execution_for_thread(&thread_key)
+            .await
+            .expect("load execution")
+            .expect("execution exists");
+        let error = runtime
+            .adopt_orphaned_execution(&execution, false, None)
+            .await
+            .expect_err("transient read failure must propagate");
+        assert!(
+            matches!(error, SessionRuntimeError::Sandbox(_)),
+            "unexpected error: {error:?}"
+        );
+        let still_running = store
+            .latest_execution_for_thread(&thread_key)
+            .await
+            .expect("reload execution")
+            .expect("execution exists");
+        assert_eq!(still_running.status, ExecutionStatus::Running);
+        assert!(
+            !events(&store, &thread_key)
+                .await
+                .iter()
+                .any(|event| event.event_type == "session.execution_failed"),
+            "transient read failure must not fail the execution"
+        );
+
+        // The lease was released: the next scan re-claims and recovers the
+        // terminal output that was already on disk.
+        runtime.adopt_orphaned_executions().await;
+        wait_for_event(&store, &thread_key, "session.execution_completed").await;
+        let all = events(&store, &thread_key).await;
+        let completed = all
+            .iter()
+            .find(|event| event.event_type == "session.execution_completed")
+            .expect("completed event");
+        assert_eq!(
+            completed.payload["result_text"].as_str(),
+            Some("Recovered on the second read.")
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn adoption_skips_young_sandbox_not_open_for_io() {
+        let Some(store) = test_store().await else {
+            return;
+        };
+        let _serial = TEST_LOCK.lock().await;
+        let thread_key =
+            ThreadKey::parse(format!("test:adopt-young-{}", uuid::Uuid::new_v4())).unwrap();
+        orphaned_execution(&store, &thread_key, Some("sbx-young"), true).await;
+
+        let backend = Arc::new(MockBackend::new(SandboxStatus::Created, Vec::new()));
+        let runtime = runtime_with(&store, backend.clone());
+        runtime.adopt_orphaned_executions().await;
+
+        // A young execution whose sandbox is not openable yet is skipped
+        // (the periodic scan retries it), not failed.
+        let execution = store
+            .latest_execution_for_thread(&thread_key)
+            .await
+            .expect("load execution")
+            .expect("execution exists");
+        assert_eq!(execution.status, ExecutionStatus::Running);
+        assert_eq!(backend.opens(), 0);
+        assert!(
+            !events(&store, &thread_key)
+                .await
+                .iter()
+                .any(|event| event.event_type == "session.execution_failed"),
+            "young non-openable sandbox must not fail the execution"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn adoption_fails_old_non_openable_sandbox_without_recorded_terminal() {
+        let Some(store) = test_store().await else {
+            return;
+        };
+        let _serial = TEST_LOCK.lock().await;
+        let thread_key =
+            ThreadKey::parse(format!("test:adopt-old-gone-{}", uuid::Uuid::new_v4())).unwrap();
+        let execution_id =
+            orphaned_execution(&store, &thread_key, Some("sbx-old-gone"), true).await;
+        backdate_execution(&store, &execution_id, 300.0).await;
+
+        let backend = Arc::new(MockBackend::new(SandboxStatus::Stopped, Vec::new()));
+        let runtime = runtime_with(&store, backend.clone());
+        runtime.adopt_orphaned_executions().await;
+
+        wait_for_event(&store, &thread_key, "session.execution_failed").await;
+        let all = events(&store, &thread_key).await;
+        let failed = all
+            .iter()
+            .find(|event| event.event_type == "session.execution_failed")
+            .expect("failed event");
+        let error = failed.payload["error"].as_str().unwrap_or_default();
+        assert!(
+            error.contains("sandbox not openable (status Stopped)"),
+            "unexpected error: {error}"
+        );
+        assert!(
+            error.contains("no recorded terminal output"),
+            "unexpected error: {error}"
+        );
+        assert_eq!(backend.opens(), 0);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn stdout_eof_retries_recorded_output_before_live_reattach() {
+        let Some(store) = test_store().await else {
+            return;
+        };
+        let _serial = TEST_LOCK.lock().await;
+        let thread_key =
+            ThreadKey::parse(format!("test:eof-retry-read-{}", uuid::Uuid::new_v4())).unwrap();
+        orphaned_execution(&store, &thread_key, Some("sbx-eof-retry"), true).await;
+
+        let backend = Arc::new(MockBackend::new(SandboxStatus::Running, Vec::new()));
+        let (io, stdout, _stdin) = mock_io();
+        backend.push_io(io).await;
+
+        let runtime = runtime_with(&store, backend.clone());
+        runtime
+            .ensure_session_pipe(&thread_key, "sbx-eof-retry")
+            .await
+            .expect("open initial pipe");
+        backend.set_recorded_output(completed_output_lines(
+            "Recovered after a transient read failure.",
+        ));
+        backend.fail_next_read_output(1);
+        drop(stdout);
+
+        wait_for_event(&store, &thread_key, "session.execution_completed").await;
+        let all = events(&store, &thread_key).await;
+        assert!(
+            !all.iter()
+                .any(|event| event.event_type == "session.execution_failed"),
+            "transient recorded-output read failure must not fail the turn"
+        );
+        assert!(
+            all.iter()
+                .any(|event| event.event_type == "session.stdout_pump_recovered"),
+            "expected recorded-output recovery event"
+        );
+        assert!(
+            !all.iter()
+                .any(|event| event.event_type == "session.stdout_pump_reattached"),
+            "recovery should avoid a live reattach"
+        );
+        let completed = all
+            .iter()
+            .find(|event| event.event_type == "session.execution_completed")
+            .expect("completed event");
+        assert_eq!(
+            completed.payload["result_text"].as_str(),
+            Some("Recovered after a transient read failure.")
+        );
+        assert_eq!(backend.opens(), 1);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/services/api-rs/crates/centaur-session-sqlx/migrations/0053_session_execution_retry_idempotency.sql
+++ b/services/api-rs/crates/centaur-session-sqlx/migrations/0053_session_execution_retry_idempotency.sql
@@ -1,0 +1,18 @@
+-- A failed or cancelled execution must not block a fresh execution that
+-- carries the same idempotency key. The original index covered every row,
+-- so once a turn died -- for example on a control-plane roll before the
+-- adoption hardening landed -- the stable key of its trigger (a GitHub
+-- review is keyed per commit) made the work permanently un-rerunnable:
+-- the insert hit the index and the caller got the dead row back with
+-- created = false.
+--
+-- The index now covers only rows whose outcome still matters for dedupe:
+-- in-flight work (queued / running) and completed work. Failed and
+-- cancelled rows fall out of the index, so the next insert with the same
+-- key creates a fresh execution instead of resurrecting the dead one.
+drop index if exists session_executions_thread_idempotency_idx;
+
+create unique index if not exists session_executions_active_idempotency_idx
+    on session_executions (thread_key, idempotency_key)
+    where idempotency_key is not null
+      and status in ('queued', 'running', 'completed');

--- a/services/api-rs/crates/centaur-session-sqlx/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-sqlx/src/lib.rs
@@ -401,6 +401,7 @@ impl PgSessionStore {
             values ($1, $2, $3, $4, $5, $6)
             on conflict (thread_key, idempotency_key)
                 where idempotency_key is not null
+                  and status in ('queued', 'running', 'completed')
             do update set
                 idempotency_key = excluded.idempotency_key,
                 request = case
@@ -2379,6 +2380,91 @@ mod tests {
                 .await
                 .expect("load persisted execution request"),
             first_request
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn failed_execution_does_not_block_rerun_on_same_idempotency_key() {
+        let Some(store) = test_store().await else {
+            return;
+        };
+        let thread_key = ThreadKey::parse(format!("test:retry-idem-{}", Uuid::new_v4())).unwrap();
+        store
+            .create_or_get_session(
+                &thread_key,
+                &HarnessType::Codex,
+                None,
+                json!({}),
+                Default::default(),
+            )
+            .await
+            .expect("create session");
+        let key = "review-commit-abc123";
+        let first = store
+            .create_execution_with_request(&thread_key, Some(key), json!({}), json!({}))
+            .await
+            .expect("create execution with request");
+        assert!(first.created);
+        store
+            .fail_execution(
+                &first.execution.execution_id,
+                "sandbox stdout closed before terminal output; stdout reattach attempts exhausted",
+            )
+            .await
+            .expect("fail execution");
+
+        // A failed row must not shadow a fresh run on the same stable key:
+        // a turn killed by a control-plane roll has to be retryable.
+        let retry = store
+            .create_execution_with_request(&thread_key, Some(key), json!({}), json!({}))
+            .await
+            .expect("retry execution with request");
+        assert!(
+            retry.created,
+            "rerun after failure must create a fresh execution"
+        );
+        assert_ne!(
+            retry.execution.execution_id, first.execution.execution_id,
+            "retry must not resurrect the failed row"
+        );
+
+        // In-flight rows still dedupe.
+        let duplicate = store
+            .create_execution_with_request(&thread_key, Some(key), json!({}), json!({}))
+            .await
+            .expect("duplicate queued execution");
+        assert!(!duplicate.created);
+        assert_eq!(
+            duplicate.execution.execution_id,
+            retry.execution.execution_id
+        );
+        store
+            .mark_execution_running(&retry.execution.execution_id)
+            .await
+            .expect("mark retry running");
+        let duplicate_running = store
+            .create_execution_with_request(&thread_key, Some(key), json!({}), json!({}))
+            .await
+            .expect("duplicate running execution");
+        assert!(!duplicate_running.created);
+        assert_eq!(
+            duplicate_running.execution.execution_id,
+            retry.execution.execution_id
+        );
+
+        // Completed rows still dedupe.
+        store
+            .complete_execution(&retry.execution.execution_id)
+            .await
+            .expect("complete retry");
+        let duplicate_completed = store
+            .create_execution_with_request(&thread_key, Some(key), json!({}), json!({}))
+            .await
+            .expect("duplicate completed execution");
+        assert!(!duplicate_completed.created);
+        assert_eq!(
+            duplicate_completed.execution.execution_id,
+            retry.execution.execution_id
         );
     }
 


### PR DESCRIPTION
Towards URI-587

## Context

The unique idempotency index on `session_executions` covered every row, so a
failed execution permanently blocked a fresh execution carrying the same
`(thread_key, idempotency_key)`. For triggers with a stable key per commit
(GitHub reviews), a turn killed by a control-plane roll became un-rerunnable:
the insert hit the index and api-rs returned the dead row with
`created = false`. That is what happened to the `uriel-core#211` review on
2026-08-24: the work was lost and could not even be retried.

## Changes

- Migration 0053: drops `session_executions_thread_idempotency_idx` and
  creates `session_executions_active_idempotency_idx`, which covers only
  `queued`, `running` and `completed` rows.
- The `create_execution_with_request` upsert conflict clause is narrowed to
  match the index predicate exactly.
- Failed and cancelled rows fall out of the index, so a retry with the same
  key creates a fresh execution; in-flight and completed work still dedupes.

## Testing

- `cargo +nightly fmt --all --check` and `cargo +nightly clippy -p
  centaur-session-sqlx --all-targets`: clean.
- `cargo test -p centaur-session-sqlx`: 24 pass. New Postgres-gated test
  `failed_execution_does_not_block_rerun_on_same_idempotency_key`:
  - failed row with key K: a fresh `create_execution_with_request` with K
    returns `created = true` and a new execution id;
  - queued row with K: `created = false`, same id;
  - running row with K: `created = false`, same id;
  - completed row with K: `created = false`, same id.
