### PR TITLE
refactor(console): make Google Docs sync incremental

### DIFF
--- a/services/api-rs/crates/centaur-api-server/src/lib.rs
+++ b/services/api-rs/crates/centaur-api-server/src/lib.rs
@@ -309,6 +309,13 @@ mod tests {
                 .body(Body::empty())
                 .unwrap(),
             Request::builder()
+                .method(Method::POST)
+                .uri("/api/admin/google/docs-sync/content-status")
+                .header(header::AUTHORIZATION, format!("Bearer {}", console_token()))
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(r#"{"files":[]}"#))
+                .unwrap(),
+            Request::builder()
                 .uri("/api/admin/granola/sync/checkpoint")
                 .header(header::AUTHORIZATION, format!("Bearer {}", console_token()))
                 .body(Body::empty())

--- a/services/api-rs/crates/centaur-api-server/src/routes.rs
+++ b/services/api-rs/crates/centaur-api-server/src/routes.rs
@@ -1580,7 +1580,7 @@ struct GoogleDocsSyncBatchRequest {
     #[serde(default)]
     observation_deactivations: Vec<GoogleDocsObservationDeactivationPayload>,
     #[serde(default)]
-    observation_sweeps: Vec<GoogleDocsObservationSweepPayload>,
+    replace_observation_credentials: Vec<String>,
     #[serde(default)]
     contents: Vec<GoogleDocsSyncContentPayload>,
     #[serde(default)]
@@ -1703,12 +1703,6 @@ struct GoogleDocsSyncObservationPayload {
 struct GoogleDocsObservationDeactivationPayload {
     broker_credential_id: String,
     observed_file_id: String,
-}
-
-#[derive(Debug, Deserialize)]
-struct GoogleDocsObservationSweepPayload {
-    broker_credential_id: String,
-    initial_crawl_id: String,
 }
 
 #[derive(Debug, Deserialize)]
@@ -2506,6 +2500,17 @@ async fn ingest_google_docs_sync_batch(
         .await?;
     }
 
+    for broker_credential_id in &request.replace_observation_credentials {
+        sqlx::query(
+            "UPDATE google_docs_sync_file_observations \
+             SET active = FALSE, updated_at = NOW() \
+             WHERE broker_credential_id = $1 AND active = TRUE",
+        )
+        .bind(broker_credential_id)
+        .execute(&mut *tx)
+        .await?;
+    }
+
     for observation in &request.observations {
         sqlx::query(
             "INSERT INTO google_docs_sync_file_observations (\
@@ -2558,19 +2563,6 @@ async fn ingest_google_docs_sync_batch(
         )
         .bind(&deactivation.broker_credential_id)
         .bind(&deactivation.observed_file_id)
-        .execute(&mut *tx)
-        .await?;
-    }
-
-    for sweep in &request.observation_sweeps {
-        sqlx::query(
-            "UPDATE google_docs_sync_file_observations \
-             SET active = FALSE, updated_at = NOW() \
-             WHERE broker_credential_id = $1 AND active = TRUE \
-             AND COALESCE(raw_payload->>'initial_crawl_id', '') <> $2",
-        )
-        .bind(&sweep.broker_credential_id)
-        .bind(&sweep.initial_crawl_id)
         .execute(&mut *tx)
         .await?;
     }
@@ -2694,7 +2686,7 @@ async fn ingest_google_docs_sync_batch(
              provider_subject = EXCLUDED.provider_subject, \
              provider_email = EXCLUDED.provider_email, \
              start_page_token = COALESCE(NULLIF(EXCLUDED.start_page_token, ''), google_docs_sync_checkpoints.start_page_token), \
-             changes_page_token = COALESCE(NULLIF(EXCLUDED.changes_page_token, ''), google_docs_sync_checkpoints.changes_page_token), \
+             changes_page_token = EXCLUDED.changes_page_token, \
              last_full_sync_at = COALESCE(EXCLUDED.last_full_sync_at, google_docs_sync_checkpoints.last_full_sync_at), \
              last_incremental_sync_at = COALESCE(EXCLUDED.last_incremental_sync_at, google_docs_sync_checkpoints.last_incremental_sync_at), \
              last_run_id = EXCLUDED.last_run_id, \
@@ -2729,7 +2721,7 @@ async fn ingest_google_docs_sync_batch(
         "counts": {
             "files": request.files.len(),
             "observations": request.observations.len(),
-            "observation_sweeps": request.observation_sweeps.len(),
+            "observation_replacements": request.replace_observation_credentials.len(),
             "contents": request.contents.len(),
             "context_documents": request.context_documents.len(),
             "checkpoint": request.checkpoint.is_some(),
@@ -3472,15 +3464,8 @@ fn validate_google_docs_sync_batch(request: &GoogleDocsSyncBatchRequest) -> Resu
             &deactivation.observed_file_id,
         )?;
     }
-    for sweep in &request.observation_sweeps {
-        require_non_empty(
-            "observation_sweep.broker_credential_id",
-            &sweep.broker_credential_id,
-        )?;
-        require_non_empty(
-            "observation_sweep.initial_crawl_id",
-            &sweep.initial_crawl_id,
-        )?;
+    for broker_credential_id in &request.replace_observation_credentials {
+        require_non_empty("replace_observation_credential", broker_credential_id)?;
     }
     for content in &request.contents {
         require_non_empty("content.file_id", &content.file_id)?;

--- a/services/api-rs/crates/centaur-api-server/src/routes.rs
+++ b/services/api-rs/crates/centaur-api-server/src/routes.rs
@@ -2378,7 +2378,33 @@ async fn get_google_docs_sync_checkpoint(
     .fetch_optional(&pool)
     .await?;
 
-    Ok(Json(json!({ "ok": true, "checkpoint": checkpoint })))
+    let initial_sync_active = sqlx::query_scalar::<_, bool>(
+        "SELECT EXISTS (\
+         SELECT 1 FROM google_docs_sync_runs AS runs \
+         WHERE runs.broker_credential_id = $1 \
+         AND runs.mode = 'initial' \
+         AND runs.status = 'running' \
+         AND runs.finished_at IS NULL \
+         AND (\
+           runs.started_at >= NOW() - INTERVAL '1 hour' \
+           OR EXISTS (\
+             SELECT 1 FROM google_docs_sync_file_observations AS observations \
+             WHERE observations.broker_credential_id = $1 \
+             AND observations.source_run_id = runs.run_id \
+             AND observations.last_seen_at >= NOW() - INTERVAL '1 hour'\
+           )\
+         )\
+         )",
+    )
+    .bind(&query.broker_credential_id)
+    .fetch_one(&pool)
+    .await?;
+
+    Ok(Json(json!({
+        "ok": true,
+        "checkpoint": checkpoint,
+        "initial_sync_active": initial_sync_active,
+    })))
 }
 
 async fn get_google_docs_content_status(

--- a/services/api-rs/crates/centaur-api-server/src/routes.rs
+++ b/services/api-rs/crates/centaur-api-server/src/routes.rs
@@ -2378,33 +2378,7 @@ async fn get_google_docs_sync_checkpoint(
     .fetch_optional(&pool)
     .await?;
 
-    let initial_sync_active = sqlx::query_scalar::<_, bool>(
-        "SELECT EXISTS (\
-         SELECT 1 FROM google_docs_sync_runs AS runs \
-         WHERE runs.broker_credential_id = $1 \
-         AND runs.mode = 'initial' \
-         AND runs.status = 'running' \
-         AND runs.finished_at IS NULL \
-         AND (\
-           runs.started_at >= NOW() - INTERVAL '1 hour' \
-           OR EXISTS (\
-             SELECT 1 FROM google_docs_sync_file_observations AS observations \
-             WHERE observations.broker_credential_id = $1 \
-             AND observations.source_run_id = runs.run_id \
-             AND observations.last_seen_at >= NOW() - INTERVAL '1 hour'\
-           )\
-         )\
-         )",
-    )
-    .bind(&query.broker_credential_id)
-    .fetch_one(&pool)
-    .await?;
-
-    Ok(Json(json!({
-        "ok": true,
-        "checkpoint": checkpoint,
-        "initial_sync_active": initial_sync_active,
-    })))
+    Ok(Json(json!({ "ok": true, "checkpoint": checkpoint })))
 }
 
 async fn get_google_docs_content_status(

--- a/services/api-rs/crates/centaur-api-server/src/routes.rs
+++ b/services/api-rs/crates/centaur-api-server/src/routes.rs
@@ -1580,8 +1580,6 @@ struct GoogleDocsSyncBatchRequest {
     #[serde(default)]
     observation_deactivations: Vec<GoogleDocsObservationDeactivationPayload>,
     #[serde(default)]
-    reset_observation_credentials: Vec<String>,
-    #[serde(default)]
     observation_sweeps: Vec<GoogleDocsObservationSweepPayload>,
     #[serde(default)]
     contents: Vec<GoogleDocsSyncContentPayload>,
@@ -2457,17 +2455,6 @@ async fn ingest_google_docs_sync_batch(
 
     if let Some(run) = &request.run {
         upsert_google_docs_sync_run(&mut tx, run).await?;
-    }
-
-    for broker_credential_id in &request.reset_observation_credentials {
-        sqlx::query(
-            "UPDATE google_docs_sync_file_observations \
-             SET active = FALSE, updated_at = NOW() \
-             WHERE broker_credential_id = $1 AND active = TRUE",
-        )
-        .bind(broker_credential_id)
-        .execute(&mut *tx)
-        .await?;
     }
 
     for file in &request.files {
@@ -3484,9 +3471,6 @@ fn validate_google_docs_sync_batch(request: &GoogleDocsSyncBatchRequest) -> Resu
             "observation_deactivation.observed_file_id",
             &deactivation.observed_file_id,
         )?;
-    }
-    for broker_credential_id in &request.reset_observation_credentials {
-        require_non_empty("reset_observation_credential", broker_credential_id)?;
     }
     for sweep in &request.observation_sweeps {
         require_non_empty(

--- a/services/api-rs/crates/centaur-api-server/src/routes.rs
+++ b/services/api-rs/crates/centaur-api-server/src/routes.rs
@@ -312,6 +312,10 @@ pub fn build_router_with_app_state(state: AppState) -> Router {
             get(get_google_docs_sync_checkpoint),
         )
         .route(
+            "/api/admin/google/docs-sync/content-status",
+            post(get_google_docs_content_status),
+        )
+        .route(
             "/api/admin/google/docs-sync/batch",
             post(ingest_google_docs_sync_batch).layer(DefaultBodyLimit::disable()),
         )
@@ -1574,6 +1578,10 @@ struct GoogleDocsSyncBatchRequest {
     #[serde(default)]
     observations: Vec<GoogleDocsSyncObservationPayload>,
     #[serde(default)]
+    observation_deactivations: Vec<GoogleDocsObservationDeactivationPayload>,
+    #[serde(default)]
+    reset_observation_credentials: Vec<String>,
+    #[serde(default)]
     contents: Vec<GoogleDocsSyncContentPayload>,
     #[serde(default)]
     context_documents: Vec<GoogleDocsContextDocumentPayload>,
@@ -1581,6 +1589,19 @@ struct GoogleDocsSyncBatchRequest {
     checkpoint: Option<GoogleDocsSyncCheckpointPayload>,
     #[serde(default = "default_true")]
     replace_context_documents: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct GoogleDocsContentStatusRequest {
+    #[serde(default)]
+    files: Vec<GoogleDocsContentVersionPayload>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+struct GoogleDocsContentVersionPayload {
+    file_id: String,
+    #[serde(default)]
+    source_version: String,
 }
 
 #[derive(Debug, Deserialize)]
@@ -1676,6 +1697,12 @@ struct GoogleDocsSyncObservationPayload {
     raw_payload: Value,
     #[serde(default)]
     source_run_id: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GoogleDocsObservationDeactivationPayload {
+    broker_credential_id: String,
+    observed_file_id: String,
 }
 
 #[derive(Debug, Deserialize)]
@@ -2348,6 +2375,70 @@ async fn get_google_docs_sync_checkpoint(
     Ok(Json(json!({ "ok": true, "checkpoint": checkpoint })))
 }
 
+async fn get_google_docs_content_status(
+    State(state): State<AppState>,
+    Json(request): Json<GoogleDocsContentStatusRequest>,
+) -> Result<Json<Value>, ApiError> {
+    let pool = db_pool(&state)?;
+    for file in &request.files {
+        require_non_empty("file.file_id", &file.file_id)?;
+    }
+
+    let file_ids = request
+        .files
+        .iter()
+        .map(|file| file.file_id.as_str())
+        .collect::<Vec<_>>();
+    let available = sqlx::query_as::<_, (String, String)>(
+        "SELECT file_id, source_version \
+         FROM google_docs_sync_document_contents \
+         WHERE file_id = ANY($1) AND last_error = ''",
+    )
+    .bind(&file_ids)
+    .fetch_all(&pool)
+    .await?
+    .into_iter()
+    .collect::<BTreeMap<_, _>>();
+    let missing = request
+        .files
+        .into_iter()
+        .filter(|file| {
+            !available
+                .get(&file.file_id)
+                .is_some_and(|stored| content_version_satisfies(stored, &file.source_version))
+        })
+        .collect::<Vec<_>>();
+
+    Ok(Json(json!({ "ok": true, "missing": missing })))
+}
+
+fn content_version_satisfies(stored: &str, requested: &str) -> bool {
+    stored == requested
+        || stored
+            .parse::<u128>()
+            .ok()
+            .zip(requested.parse::<u128>().ok())
+            .is_some_and(|(stored, requested)| stored >= requested)
+}
+
+#[cfg(test)]
+mod google_docs_content_status_tests {
+    use super::content_version_satisfies;
+
+    #[test]
+    fn newer_numeric_google_drive_versions_satisfy_older_requests() {
+        assert!(content_version_satisfies("12", "7"));
+        assert!(content_version_satisfies("7", "7"));
+        assert!(!content_version_satisfies("6", "7"));
+    }
+
+    #[test]
+    fn opaque_versions_only_satisfy_exact_requests() {
+        assert!(content_version_satisfies("version-a", "version-a"));
+        assert!(!content_version_satisfies("version-b", "version-a"));
+    }
+}
+
 async fn ingest_google_docs_sync_batch(
     State(state): State<AppState>,
     Json(request): Json<GoogleDocsSyncBatchRequest>,
@@ -2358,6 +2449,17 @@ async fn ingest_google_docs_sync_batch(
 
     if let Some(run) = &request.run {
         upsert_google_docs_sync_run(&mut tx, run).await?;
+    }
+
+    for broker_credential_id in &request.reset_observation_credentials {
+        sqlx::query(
+            "UPDATE google_docs_sync_file_observations \
+             SET active = FALSE, updated_at = NOW() \
+             WHERE broker_credential_id = $1 AND active = TRUE",
+        )
+        .bind(broker_credential_id)
+        .execute(&mut *tx)
+        .await?;
     }
 
     for file in &request.files {
@@ -2449,6 +2551,18 @@ async fn ingest_google_docs_sync_batch(
         .bind(observation.active)
         .bind(&observation.raw_payload)
         .bind(empty_to_none(observation.source_run_id.as_deref()))
+        .execute(&mut *tx)
+        .await?;
+    }
+
+    for deactivation in &request.observation_deactivations {
+        sqlx::query(
+            "UPDATE google_docs_sync_file_observations \
+             SET active = FALSE, updated_at = NOW() \
+             WHERE broker_credential_id = $1 AND observed_file_id = $2",
+        )
+        .bind(&deactivation.broker_credential_id)
+        .bind(&deactivation.observed_file_id)
         .execute(&mut *tx)
         .await?;
     }
@@ -3338,6 +3452,19 @@ fn validate_google_docs_sync_batch(request: &GoogleDocsSyncBatchRequest) -> Resu
             false,
         )?;
         validate_json_shape("observation.raw_payload", &observation.raw_payload, true)?;
+    }
+    for deactivation in &request.observation_deactivations {
+        require_non_empty(
+            "observation_deactivation.broker_credential_id",
+            &deactivation.broker_credential_id,
+        )?;
+        require_non_empty(
+            "observation_deactivation.observed_file_id",
+            &deactivation.observed_file_id,
+        )?;
+    }
+    for broker_credential_id in &request.reset_observation_credentials {
+        require_non_empty("reset_observation_credential", broker_credential_id)?;
     }
     for content in &request.contents {
         require_non_empty("content.file_id", &content.file_id)?;

--- a/services/api-rs/crates/centaur-api-server/src/routes.rs
+++ b/services/api-rs/crates/centaur-api-server/src/routes.rs
@@ -1582,6 +1582,8 @@ struct GoogleDocsSyncBatchRequest {
     #[serde(default)]
     reset_observation_credentials: Vec<String>,
     #[serde(default)]
+    observation_sweeps: Vec<GoogleDocsObservationSweepPayload>,
+    #[serde(default)]
     contents: Vec<GoogleDocsSyncContentPayload>,
     #[serde(default)]
     context_documents: Vec<GoogleDocsContextDocumentPayload>,
@@ -1703,6 +1705,12 @@ struct GoogleDocsSyncObservationPayload {
 struct GoogleDocsObservationDeactivationPayload {
     broker_credential_id: String,
     observed_file_id: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct GoogleDocsObservationSweepPayload {
+    broker_credential_id: String,
+    initial_crawl_id: String,
 }
 
 #[derive(Debug, Deserialize)]
@@ -2567,6 +2575,19 @@ async fn ingest_google_docs_sync_batch(
         .await?;
     }
 
+    for sweep in &request.observation_sweeps {
+        sqlx::query(
+            "UPDATE google_docs_sync_file_observations \
+             SET active = FALSE, updated_at = NOW() \
+             WHERE broker_credential_id = $1 AND active = TRUE \
+             AND COALESCE(raw_payload->>'initial_crawl_id', '') <> $2",
+        )
+        .bind(&sweep.broker_credential_id)
+        .bind(&sweep.initial_crawl_id)
+        .execute(&mut *tx)
+        .await?;
+    }
+
     for content in &request.contents {
         sqlx::query(
             "INSERT INTO google_docs_sync_document_contents (\
@@ -2721,6 +2742,7 @@ async fn ingest_google_docs_sync_batch(
         "counts": {
             "files": request.files.len(),
             "observations": request.observations.len(),
+            "observation_sweeps": request.observation_sweeps.len(),
             "contents": request.contents.len(),
             "context_documents": request.context_documents.len(),
             "checkpoint": request.checkpoint.is_some(),
@@ -3465,6 +3487,16 @@ fn validate_google_docs_sync_batch(request: &GoogleDocsSyncBatchRequest) -> Resu
     }
     for broker_credential_id in &request.reset_observation_credentials {
         require_non_empty("reset_observation_credential", broker_credential_id)?;
+    }
+    for sweep in &request.observation_sweeps {
+        require_non_empty(
+            "observation_sweep.broker_credential_id",
+            &sweep.broker_credential_id,
+        )?;
+        require_non_empty(
+            "observation_sweep.initial_crawl_id",
+            &sweep.initial_crawl_id,
+        )?;
     }
     for content in &request.contents {
         require_non_empty("content.file_id", &content.file_id)?;

--- a/services/api-rs/crates/centaur-api-server/src/routes.rs
+++ b/services/api-rs/crates/centaur-api-server/src/routes.rs
@@ -1580,7 +1580,7 @@ struct GoogleDocsSyncBatchRequest {
     #[serde(default)]
     observation_deactivations: Vec<GoogleDocsObservationDeactivationPayload>,
     #[serde(default)]
-    replace_observation_credentials: Vec<String>,
+    observation_sweeps: Vec<GoogleDocsObservationSweepPayload>,
     #[serde(default)]
     contents: Vec<GoogleDocsSyncContentPayload>,
     #[serde(default)]
@@ -1703,6 +1703,12 @@ struct GoogleDocsSyncObservationPayload {
 struct GoogleDocsObservationDeactivationPayload {
     broker_credential_id: String,
     observed_file_id: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct GoogleDocsObservationSweepPayload {
+    broker_credential_id: String,
+    source_run_id: String,
 }
 
 #[derive(Debug, Deserialize)]
@@ -2500,17 +2506,6 @@ async fn ingest_google_docs_sync_batch(
         .await?;
     }
 
-    for broker_credential_id in &request.replace_observation_credentials {
-        sqlx::query(
-            "UPDATE google_docs_sync_file_observations \
-             SET active = FALSE, updated_at = NOW() \
-             WHERE broker_credential_id = $1 AND active = TRUE",
-        )
-        .bind(broker_credential_id)
-        .execute(&mut *tx)
-        .await?;
-    }
-
     for observation in &request.observations {
         sqlx::query(
             "INSERT INTO google_docs_sync_file_observations (\
@@ -2551,6 +2546,19 @@ async fn ingest_google_docs_sync_batch(
         .bind(observation.active)
         .bind(&observation.raw_payload)
         .bind(empty_to_none(observation.source_run_id.as_deref()))
+        .execute(&mut *tx)
+        .await?;
+    }
+
+    for sweep in &request.observation_sweeps {
+        sqlx::query(
+            "UPDATE google_docs_sync_file_observations \
+             SET active = FALSE, updated_at = NOW() \
+             WHERE broker_credential_id = $1 AND active = TRUE \
+             AND source_run_id IS DISTINCT FROM $2",
+        )
+        .bind(&sweep.broker_credential_id)
+        .bind(&sweep.source_run_id)
         .execute(&mut *tx)
         .await?;
     }
@@ -2721,7 +2729,7 @@ async fn ingest_google_docs_sync_batch(
         "counts": {
             "files": request.files.len(),
             "observations": request.observations.len(),
-            "observation_replacements": request.replace_observation_credentials.len(),
+            "observation_sweeps": request.observation_sweeps.len(),
             "contents": request.contents.len(),
             "context_documents": request.context_documents.len(),
             "checkpoint": request.checkpoint.is_some(),
@@ -3464,8 +3472,12 @@ fn validate_google_docs_sync_batch(request: &GoogleDocsSyncBatchRequest) -> Resu
             &deactivation.observed_file_id,
         )?;
     }
-    for broker_credential_id in &request.replace_observation_credentials {
-        require_non_empty("replace_observation_credential", broker_credential_id)?;
+    for sweep in &request.observation_sweeps {
+        require_non_empty(
+            "observation_sweep.broker_credential_id",
+            &sweep.broker_credential_id,
+        )?;
+        require_non_empty("observation_sweep.source_run_id", &sweep.source_run_id)?;
     }
     for content in &request.contents {
         require_non_empty("content.file_id", &content.file_id)?;

--- a/services/console/app/jobs/google_docs/base_job.rb
+++ b/services/console/app/jobs/google_docs/base_job.rb
@@ -1,0 +1,27 @@
+module GoogleDocs
+  class BaseJob < ApplicationJob
+    queue_as :default
+
+    retry_on GoogleDocs::SyncCredential::GoogleApiError,
+      CentaurApiClient::Error,
+      wait: :polynomially_longer,
+      attempts: 5
+
+    private
+
+    def eligible_credential(credential_id)
+      credential = BrokerCredential.includes(:oauth_app).find_by(id: credential_id)
+      return unless GoogleDocs::SyncCredential.syncable?(credential)
+
+      credential
+    end
+
+    def api_client
+      @api_client ||= CentaurApiClient.new
+    end
+
+    def sync_client(credential)
+      GoogleDocs::SyncCredential.new(credential)
+    end
+  end
+end

--- a/services/console/app/jobs/google_docs/base_job.rb
+++ b/services/console/app/jobs/google_docs/base_job.rb
@@ -1,6 +1,6 @@
 module GoogleDocs
   class BaseJob < ApplicationJob
-    queue_as :default
+    queue_as :google_docs
 
     retry_on GoogleDocs::SyncCredential::GoogleApiError,
       CentaurApiClient::Error,

--- a/services/console/app/jobs/google_docs/fetch_document_job.rb
+++ b/services/console/app/jobs/google_docs/fetch_document_job.rb
@@ -1,0 +1,49 @@
+module GoogleDocs
+  class FetchDocumentJob < ApplicationJob
+    CONCURRENCY_DURATION = 10.minutes
+
+    queue_as :default
+
+    limits_concurrency(
+      to: 1,
+      key: lambda { |_credential_id, file|
+        file_id = file["id"] || file[:id]
+        "google_docs_content_#{file_id}"
+      },
+      group: "GoogleDocsContentFetch",
+      duration: CONCURRENCY_DURATION
+    )
+
+    retry_on GoogleDocs::SyncCredential::GoogleApiError,
+      CentaurApiClient::Error,
+      wait: :polynomially_longer,
+      attempts: 5
+
+    def perform(credential_id, file)
+      credential = eligible_credential(credential_id)
+      return unless credential
+
+      sync = GoogleDocs::SyncCredential.new(credential)
+      version = sync.content_version(file)
+      api_client = CentaurApiClient.new
+      missing = api_client
+        .get_google_docs_content_status(files: [ version ])
+        .fetch("missing")
+      return if Array(missing).empty?
+
+      api_client.ingest_google_docs_sync_batch(sync.document_batch(file))
+    end
+
+    private
+
+    def eligible_credential(credential_id)
+      credential = BrokerCredential.includes(:oauth_app).find_by(id: credential_id)
+      return unless credential
+      return if credential.dead? || credential.access_token.blank?
+      return unless credential.oauth_app&.provider == Oauth::Providers::Google::KEY
+      return unless GoogleDocs::SyncCredential.required_scopes_granted?(credential.scopes)
+
+      credential
+    end
+  end
+end

--- a/services/console/app/jobs/google_docs/fetch_document_job.rb
+++ b/services/console/app/jobs/google_docs/fetch_document_job.rb
@@ -1,8 +1,6 @@
 module GoogleDocs
-  class FetchDocumentJob < ApplicationJob
+  class FetchDocumentJob < BaseJob
     CONCURRENCY_DURATION = 10.minutes
-
-    queue_as :default
 
     limits_concurrency(
       to: 1,
@@ -14,36 +12,18 @@ module GoogleDocs
       duration: CONCURRENCY_DURATION
     )
 
-    retry_on GoogleDocs::SyncCredential::GoogleApiError,
-      CentaurApiClient::Error,
-      wait: :polynomially_longer,
-      attempts: 5
-
     def perform(credential_id, file)
       credential = eligible_credential(credential_id)
       return unless credential
 
-      sync = GoogleDocs::SyncCredential.new(credential)
+      sync = sync_client(credential)
       version = sync.content_version(file)
-      api_client = CentaurApiClient.new
       missing = api_client
         .get_google_docs_content_status(files: [ version ])
         .fetch("missing")
       return if Array(missing).empty?
 
       api_client.ingest_google_docs_sync_batch(sync.document_batch(file))
-    end
-
-    private
-
-    def eligible_credential(credential_id)
-      credential = BrokerCredential.includes(:oauth_app).find_by(id: credential_id)
-      return unless credential
-      return if credential.dead? || credential.access_token.blank?
-      return unless credential.oauth_app&.provider == Oauth::Providers::Google::KEY
-      return unless GoogleDocs::SyncCredential.required_scopes_granted?(credential.scopes)
-
-      credential
     end
   end
 end

--- a/services/console/app/jobs/google_docs/fetch_document_job.rb
+++ b/services/console/app/jobs/google_docs/fetch_document_job.rb
@@ -1,17 +1,5 @@
 module GoogleDocs
   class FetchDocumentJob < BaseJob
-    CONCURRENCY_DURATION = 10.minutes
-
-    limits_concurrency(
-      to: 1,
-      key: lambda { |_credential_id, file|
-        file_id = file["id"] || file[:id]
-        "google_docs_content_#{file_id}"
-      },
-      group: "GoogleDocsContentFetch",
-      duration: CONCURRENCY_DURATION
-    )
-
     def perform(credential_id, file)
       credential = eligible_credential(credential_id)
       return unless credential

--- a/services/console/app/jobs/google_docs/incremental_sync_job.rb
+++ b/services/console/app/jobs/google_docs/incremental_sync_job.rb
@@ -2,7 +2,7 @@ module GoogleDocs
   class IncrementalSyncJob < SyncJob
     private
 
-    def sync_page(credential, sync, checkpoint)
+    def sync_page(credential, sync, checkpoint, _continuation = nil)
       page_token = high_water_mark(checkpoint)
       unless page_token
         schedule(GoogleDocs::InitialSyncJob, credential.id)

--- a/services/console/app/jobs/google_docs/incremental_sync_job.rb
+++ b/services/console/app/jobs/google_docs/incremental_sync_job.rb
@@ -10,7 +10,7 @@ module GoogleDocs
         return
       end
       unless checkpoint&.fetch("changes_page_token", nil).present?
-        schedule(GoogleDocs::InitialSyncJob, credential.id)
+        restart_initial_sync(credential, checkpoint)
         return
       end
 
@@ -50,6 +50,8 @@ module GoogleDocs
         )
       )
       schedule(self.class, credential.id) if next_page_token
+    rescue GoogleDocs::SyncCredential::InvalidPageTokenError
+      restart_initial_sync(credential, checkpoint)
     end
 
     private

--- a/services/console/app/jobs/google_docs/incremental_sync_job.rb
+++ b/services/console/app/jobs/google_docs/incremental_sync_job.rb
@@ -1,0 +1,75 @@
+module GoogleDocs
+  class IncrementalSyncJob < SyncJob
+    def perform(credential_id)
+      credential = eligible_credential(credential_id)
+      return unless credential
+
+      checkpoint = load_checkpoint(credential)
+      if %w[pending listing].include?(checkpoint_phase(checkpoint))
+        schedule(GoogleDocs::InitialSyncJob, credential.id)
+        return
+      end
+      unless checkpoint&.fetch("changes_page_token", nil).present?
+        schedule(GoogleDocs::InitialSyncJob, credential.id)
+        return
+      end
+
+      sync = sync_client(credential)
+      page = sync.list_changes_page(page_token: checkpoint.fetch("changes_page_token"))
+      files, deactivations = normalize_changes(sync, page["changes"])
+      run_id = ingest_metadata_page(
+        credential,
+        sync,
+        files: files,
+        deactivations: deactivations,
+        mode: "incremental",
+        source: "drive.changes.list"
+      )
+      next_page_token = page["nextPageToken"].presence
+      new_start_page_token = page["newStartPageToken"].presence
+      if next_page_token.nil? && new_start_page_token.nil?
+        raise GoogleDocs::SyncCredential::GoogleApiError,
+          "Google Drive returned neither a next page token nor a new start page token"
+      end
+
+      catching_up = checkpoint_phase(checkpoint) == "catching_up"
+      finished = next_page_token.nil?
+      finish_page(
+        credential,
+        run_id,
+        mode: "incremental",
+        files_seen: files.length,
+        checkpoint: checkpoint_payload(
+          credential,
+          checkpoint,
+          phase: finished ? "ready" : checkpoint_phase(checkpoint),
+          changes_page_token: next_page_token || new_start_page_token,
+          run_id: run_id,
+          full_sync_finished: finished && catching_up,
+          incremental_sync_finished: finished
+        )
+      )
+      schedule(self.class, credential.id) if next_page_token
+    end
+
+    private
+
+    def normalize_changes(sync, changes)
+      latest_changes = Array(changes).each_with_object({}) do |change, latest|
+        file_id = change["fileId"].presence || change.dig("file", "id").presence
+        latest[file_id] = change if file_id
+      end
+      files = []
+      deactivations = []
+      latest_changes.each do |file_id, change|
+        file = change["file"]
+        if change["removed"] == true || !sync.eligible_file?(file)
+          deactivations << sync.observation_deactivation(file_id)
+        else
+          files << file
+        end
+      end
+      [ files, deactivations ]
+    end
+  end
+end

--- a/services/console/app/jobs/google_docs/incremental_sync_job.rb
+++ b/services/console/app/jobs/google_docs/incremental_sync_job.rb
@@ -14,14 +14,6 @@ module GoogleDocs
 
       page = sync.list_changes_page(page_token: checkpoint.fetch("changes_page_token"))
       files, deactivations = partition_changes(sync, page["changes"])
-      run_id = ingest_metadata_page(
-        credential,
-        sync,
-        files: files,
-        deactivations: deactivations,
-        mode: "incremental",
-        source: "drive.changes.list"
-      )
       next_page_token = page["nextPageToken"].presence
       new_start_page_token = page["newStartPageToken"].presence
       if next_page_token.nil? && new_start_page_token.nil?
@@ -31,11 +23,15 @@ module GoogleDocs
 
       catching_up = checkpoint_phase(checkpoint) == "catching_up"
       finished = next_page_token.nil?
-      finish_page(
+      run_id = new_run_id
+      ingest_page(
         credential,
-        run_id,
+        sync,
+        run_id: run_id,
+        files: files,
+        deactivations: deactivations,
         mode: "incremental",
-        files_seen: files.length,
+        source: "drive.changes.list",
         checkpoint: checkpoint_payload(
           credential,
           checkpoint,

--- a/services/console/app/jobs/google_docs/incremental_sync_job.rb
+++ b/services/console/app/jobs/google_docs/incremental_sync_job.rb
@@ -3,46 +3,41 @@ module GoogleDocs
     private
 
     def sync_page(credential, sync, checkpoint)
-      if self.class.job_class_for(checkpoint) == InitialSyncJob
+      page_token = high_water_mark(checkpoint)
+      unless page_token
         schedule(GoogleDocs::InitialSyncJob, credential.id)
         return
       end
-      unless checkpoint&.fetch("changes_page_token", nil).present?
-        restart_initial_sync(credential, checkpoint)
-        return
-      end
 
-      page = sync.list_changes_page(page_token: checkpoint.fetch("changes_page_token"))
-      files, deactivations = partition_changes(sync, page["changes"])
-      next_page_token = page["nextPageToken"].presence
-      new_start_page_token = page["newStartPageToken"].presence
-      if next_page_token.nil? && new_start_page_token.nil?
-        raise GoogleDocs::SyncCredential::GoogleApiError,
-          "Google Drive returned neither a next page token nor a new start page token"
-      end
-
-      catching_up = checkpoint_phase(checkpoint) == "catching_up"
-      finished = next_page_token.nil?
-      run_id = new_run_id
-      ingest_page(
-        credential,
-        sync,
-        run_id: run_id,
-        files: files,
-        deactivations: deactivations,
-        mode: "incremental",
-        source: "drive.changes.list",
-        checkpoint: checkpoint_payload(
+      loop do
+        page = sync.list_changes_page(page_token: page_token)
+        files, deactivations = partition_changes(sync, page["changes"])
+        run_id = ingest_page(
           credential,
-          checkpoint,
-          phase: finished ? "ready" : checkpoint_phase(checkpoint),
-          changes_page_token: next_page_token || new_start_page_token,
-          run_id: run_id,
-          full_sync_finished: finished && catching_up,
-          incremental_sync_finished: finished
+          sync,
+          files: files,
+          deactivations: deactivations,
+          mode: "incremental",
+          source: "drive.changes.list"
         )
-      )
-      schedule(self.class, credential.id) if next_page_token
+        enqueue_content_fetches(credential, files)
+
+        page_token = page["nextPageToken"].presence
+        next if page_token
+
+        new_start_page_token = page["newStartPageToken"].presence
+        unless new_start_page_token
+          raise GoogleDocs::SyncCredential::GoogleApiError,
+            "Google Drive returned no new start page token"
+        end
+        persist_checkpoint(
+          credential,
+          changes_page_token: new_start_page_token,
+          run_id: run_id,
+          incremental_sync_finished: true
+        )
+        break
+      end
     end
 
     def partition_changes(sync, changes)

--- a/services/console/app/jobs/google_docs/incremental_sync_job.rb
+++ b/services/console/app/jobs/google_docs/incremental_sync_job.rb
@@ -2,10 +2,10 @@ module GoogleDocs
   class IncrementalSyncJob < SyncJob
     private
 
-    def sync_page(credential, sync, checkpoint, _continuation = nil)
+    def sync_page(credential, sync, checkpoint)
       page_token = high_water_mark(checkpoint)
       unless page_token
-        schedule(GoogleDocs::InitialSyncJob, credential.id)
+        GoogleDocs::InitialSyncJob.perform_later(credential.id)
         return
       end
 

--- a/services/console/app/jobs/google_docs/incremental_sync_job.rb
+++ b/services/console/app/jobs/google_docs/incremental_sync_job.rb
@@ -41,15 +41,20 @@ module GoogleDocs
     end
 
     def partition_changes(sync, changes)
-      file_changes, deactivation_changes = Array(changes).partition do |change|
-        change["removed"] != true && sync.eligible_file?(change["file"])
-      end
-      [
-        file_changes.map { |change| change.fetch("file") },
-        deactivation_changes.map do |change|
-          sync.observation_deactivation(change.fetch("fileId"))
+      files = []
+      deactivations = []
+      Array(changes).each do |change|
+        file_id = change["fileId"].presence || change.dig("file", "id").presence
+        next unless file_id
+
+        file = change["file"]
+        if change["removed"] == true || !sync.eligible_file?(file)
+          deactivations << sync.observation_deactivation(file_id)
+        else
+          files << file
         end
-      ]
+      end
+      [ files, deactivations ]
     end
   end
 end

--- a/services/console/app/jobs/google_docs/incremental_sync_job.rb
+++ b/services/console/app/jobs/google_docs/incremental_sync_job.rb
@@ -1,11 +1,9 @@
 module GoogleDocs
   class IncrementalSyncJob < SyncJob
-    def perform(credential_id)
-      credential = eligible_credential(credential_id)
-      return unless credential
+    private
 
-      checkpoint = load_checkpoint(credential)
-      if %w[pending listing].include?(checkpoint_phase(checkpoint))
+    def sync_page(credential, sync, checkpoint)
+      if self.class.job_class_for(checkpoint) == InitialSyncJob
         schedule(GoogleDocs::InitialSyncJob, credential.id)
         return
       end
@@ -14,9 +12,8 @@ module GoogleDocs
         return
       end
 
-      sync = sync_client(credential)
       page = sync.list_changes_page(page_token: checkpoint.fetch("changes_page_token"))
-      files, deactivations = normalize_changes(sync, page["changes"])
+      files, deactivations = partition_changes(sync, page["changes"])
       run_id = ingest_metadata_page(
         credential,
         sync,
@@ -50,28 +47,18 @@ module GoogleDocs
         )
       )
       schedule(self.class, credential.id) if next_page_token
-    rescue GoogleDocs::SyncCredential::InvalidPageTokenError
-      restart_initial_sync(credential, checkpoint)
     end
 
-    private
-
-    def normalize_changes(sync, changes)
-      latest_changes = Array(changes).each_with_object({}) do |change, latest|
-        file_id = change["fileId"].presence || change.dig("file", "id").presence
-        latest[file_id] = change if file_id
+    def partition_changes(sync, changes)
+      file_changes, deactivation_changes = Array(changes).partition do |change|
+        change["removed"] != true && sync.eligible_file?(change["file"])
       end
-      files = []
-      deactivations = []
-      latest_changes.each do |file_id, change|
-        file = change["file"]
-        if change["removed"] == true || !sync.eligible_file?(file)
-          deactivations << sync.observation_deactivation(file_id)
-        else
-          files << file
+      [
+        file_changes.map { |change| change.fetch("file") },
+        deactivation_changes.map do |change|
+          sync.observation_deactivation(change.fetch("fileId"))
         end
-      end
-      [ files, deactivations ]
+      ]
     end
   end
 end

--- a/services/console/app/jobs/google_docs/initial_sync_job.rb
+++ b/services/console/app/jobs/google_docs/initial_sync_job.rb
@@ -3,64 +3,42 @@ module GoogleDocs
     private
 
     def sync_page(credential, sync, checkpoint)
-      if self.class.job_class_for(checkpoint) == IncrementalSyncJob
-        if checkpoint&.fetch("changes_page_token", nil).present?
-          schedule(GoogleDocs::IncrementalSyncJob, credential.id)
-        else
-          restart_initial_sync(credential, checkpoint)
-        end
+      if high_water_mark(checkpoint)
+        schedule(GoogleDocs::IncrementalSyncJob, credential.id)
         return
       end
-      unless checkpoint_phase(checkpoint) == "listing" && initial_crawl_id(checkpoint)
-        checkpoint = initialize_crawl(credential, sync, checkpoint)
-      end
-      crawl_id = initial_crawl_id(checkpoint)
-      page = sync.list_files_page(page_token: initial_page_token(checkpoint))
-      files = Array(page["files"]).select { |file| sync.eligible_file?(file) }
-      run_id = new_run_id
-      next_page_token = page["nextPageToken"].presence
-      next_phase = next_page_token ? "listing" : "catching_up"
-      ingest_page(
+
+      start_page_token = sync.start_page_token
+      files = list_all_files(sync)
+      run_id = ingest_page(
         credential,
         sync,
-        run_id: run_id,
         files: files,
         deactivations: [],
         mode: "initial",
         source: "drive.files.list",
-        initial_crawl_id: crawl_id,
-        observation_sweeps: next_page_token ? [] : [ {
-          broker_credential_id: credential.oid,
-          initial_crawl_id: crawl_id
-        } ],
-        checkpoint: checkpoint_payload(
-          credential,
-          checkpoint,
-          phase: next_phase,
-          initial_page_token: next_page_token,
-          run_id: run_id
-        )
+        replace_observation_credentials: [ credential.oid ]
       )
-
-      schedule(next_page_token ? self.class : GoogleDocs::IncrementalSyncJob, credential.id)
+      enqueue_content_fetches(credential, files)
+      persist_checkpoint(
+        credential,
+        changes_page_token: start_page_token,
+        run_id: run_id,
+        full_sync_finished: true
+      )
+      schedule(GoogleDocs::IncrementalSyncJob, credential.id)
     end
 
-    def initialize_crawl(credential, sync, checkpoint)
-      start_page_token = sync.start_page_token
-      crawl_id = SecureRandom.uuid
-      payload = checkpoint_payload(
-        credential,
-        checkpoint,
-        phase: "listing",
-        initial_crawl_id: crawl_id,
-        start_page_token: start_page_token,
-        changes_page_token: start_page_token
-      )
-      api_client.ingest_google_docs_sync_batch(
-        checkpoint: payload,
-        replace_context_documents: false
-      )
-      payload.deep_stringify_keys
+    def list_all_files(sync)
+      files = []
+      page_token = nil
+      loop do
+        page = sync.list_files_page(page_token: page_token)
+        files.concat(Array(page["files"]).select { |file| sync.eligible_file?(file) })
+        page_token = page["nextPageToken"].presence
+        break unless page_token
+      end
+      files
     end
   end
 end

--- a/services/console/app/jobs/google_docs/initial_sync_job.rb
+++ b/services/console/app/jobs/google_docs/initial_sync_job.rb
@@ -17,22 +17,18 @@ module GoogleDocs
       crawl_id = initial_crawl_id(checkpoint)
       page = sync.list_files_page(page_token: initial_page_token(checkpoint))
       files = Array(page["files"]).select { |file| sync.eligible_file?(file) }
-      run_id = ingest_metadata_page(
+      run_id = new_run_id
+      next_page_token = page["nextPageToken"].presence
+      next_phase = next_page_token ? "listing" : "catching_up"
+      ingest_page(
         credential,
         sync,
+        run_id: run_id,
         files: files,
         deactivations: [],
         mode: "initial",
         source: "drive.files.list",
-        initial_crawl_id: crawl_id
-      )
-      next_page_token = page["nextPageToken"].presence
-      next_phase = next_page_token ? "listing" : "catching_up"
-      finish_page(
-        credential,
-        run_id,
-        mode: "initial",
-        files_seen: files.length,
+        initial_crawl_id: crawl_id,
         observation_sweeps: next_page_token ? [] : [ {
           broker_credential_id: credential.oid,
           initial_crawl_id: crawl_id

--- a/services/console/app/jobs/google_docs/initial_sync_job.rb
+++ b/services/console/app/jobs/google_docs/initial_sync_job.rb
@@ -1,12 +1,9 @@
 module GoogleDocs
   class InitialSyncJob < SyncJob
-    def perform(credential_id)
-      credential = eligible_credential(credential_id)
-      return unless credential
+    private
 
-      sync = sync_client(credential)
-      checkpoint = load_checkpoint(credential)
-      if %w[catching_up ready].include?(checkpoint_phase(checkpoint))
+    def sync_page(credential, sync, checkpoint)
+      if self.class.job_class_for(checkpoint) == IncrementalSyncJob
         if checkpoint&.fetch("changes_page_token", nil).present?
           schedule(GoogleDocs::IncrementalSyncJob, credential.id)
         else
@@ -50,11 +47,7 @@ module GoogleDocs
       )
 
       schedule(next_page_token ? self.class : GoogleDocs::IncrementalSyncJob, credential.id)
-    rescue GoogleDocs::SyncCredential::InvalidPageTokenError
-      restart_initial_sync(credential, checkpoint)
     end
-
-    private
 
     def initialize_crawl(credential, sync, checkpoint)
       start_page_token = sync.start_page_token

--- a/services/console/app/jobs/google_docs/initial_sync_job.rb
+++ b/services/console/app/jobs/google_docs/initial_sync_job.rb
@@ -1,0 +1,62 @@
+module GoogleDocs
+  class InitialSyncJob < SyncJob
+    def perform(credential_id)
+      credential = eligible_credential(credential_id)
+      return unless credential
+
+      sync = sync_client(credential)
+      checkpoint = load_checkpoint(credential)
+      if %w[catching_up ready].include?(checkpoint_phase(checkpoint))
+        schedule(GoogleDocs::IncrementalSyncJob, credential.id)
+        return
+      end
+      checkpoint = initialize_crawl(credential, sync, checkpoint) unless checkpoint_phase(checkpoint) == "listing"
+      page = sync.list_files_page(page_token: initial_page_token(checkpoint))
+      files = Array(page["files"]).select { |file| sync.eligible_file?(file) }
+      run_id = ingest_metadata_page(
+        credential,
+        sync,
+        files: files,
+        deactivations: [],
+        mode: "initial",
+        source: "drive.files.list"
+      )
+      next_page_token = page["nextPageToken"].presence
+      next_phase = next_page_token ? "listing" : "catching_up"
+      finish_page(
+        credential,
+        run_id,
+        mode: "initial",
+        files_seen: files.length,
+        checkpoint: checkpoint_payload(
+          credential,
+          checkpoint,
+          phase: next_phase,
+          initial_page_token: next_page_token,
+          run_id: run_id
+        )
+      )
+
+      schedule(next_page_token ? self.class : GoogleDocs::IncrementalSyncJob, credential.id)
+    end
+
+    private
+
+    def initialize_crawl(credential, sync, checkpoint)
+      start_page_token = sync.start_page_token
+      payload = checkpoint_payload(
+        credential,
+        checkpoint,
+        phase: "listing",
+        start_page_token: start_page_token,
+        changes_page_token: start_page_token
+      )
+      api_client.ingest_google_docs_sync_batch(
+        reset_observation_credentials: [ credential.oid ],
+        checkpoint: payload,
+        replace_context_documents: false
+      )
+      payload.deep_stringify_keys
+    end
+  end
+end

--- a/services/console/app/jobs/google_docs/initial_sync_job.rb
+++ b/services/console/app/jobs/google_docs/initial_sync_job.rb
@@ -7,10 +7,17 @@ module GoogleDocs
       sync = sync_client(credential)
       checkpoint = load_checkpoint(credential)
       if %w[catching_up ready].include?(checkpoint_phase(checkpoint))
-        schedule(GoogleDocs::IncrementalSyncJob, credential.id)
+        if checkpoint&.fetch("changes_page_token", nil).present?
+          schedule(GoogleDocs::IncrementalSyncJob, credential.id)
+        else
+          restart_initial_sync(credential, checkpoint)
+        end
         return
       end
-      checkpoint = initialize_crawl(credential, sync, checkpoint) unless checkpoint_phase(checkpoint) == "listing"
+      unless checkpoint_phase(checkpoint) == "listing" && initial_crawl_id(checkpoint)
+        checkpoint = initialize_crawl(credential, sync, checkpoint)
+      end
+      crawl_id = initial_crawl_id(checkpoint)
       page = sync.list_files_page(page_token: initial_page_token(checkpoint))
       files = Array(page["files"]).select { |file| sync.eligible_file?(file) }
       run_id = ingest_metadata_page(
@@ -19,7 +26,8 @@ module GoogleDocs
         files: files,
         deactivations: [],
         mode: "initial",
-        source: "drive.files.list"
+        source: "drive.files.list",
+        initial_crawl_id: crawl_id
       )
       next_page_token = page["nextPageToken"].presence
       next_phase = next_page_token ? "listing" : "catching_up"
@@ -28,6 +36,10 @@ module GoogleDocs
         run_id,
         mode: "initial",
         files_seen: files.length,
+        observation_sweeps: next_page_token ? [] : [ {
+          broker_credential_id: credential.oid,
+          initial_crawl_id: crawl_id
+        } ],
         checkpoint: checkpoint_payload(
           credential,
           checkpoint,
@@ -38,21 +50,24 @@ module GoogleDocs
       )
 
       schedule(next_page_token ? self.class : GoogleDocs::IncrementalSyncJob, credential.id)
+    rescue GoogleDocs::SyncCredential::InvalidPageTokenError
+      restart_initial_sync(credential, checkpoint)
     end
 
     private
 
     def initialize_crawl(credential, sync, checkpoint)
       start_page_token = sync.start_page_token
+      crawl_id = SecureRandom.uuid
       payload = checkpoint_payload(
         credential,
         checkpoint,
         phase: "listing",
+        initial_crawl_id: crawl_id,
         start_page_token: start_page_token,
         changes_page_token: start_page_token
       )
       api_client.ingest_google_docs_sync_batch(
-        reset_observation_credentials: [ credential.oid ],
         checkpoint: payload,
         replace_context_documents: false
       )

--- a/services/console/app/jobs/google_docs/initial_sync_job.rb
+++ b/services/console/app/jobs/google_docs/initial_sync_job.rb
@@ -2,54 +2,34 @@ module GoogleDocs
   class InitialSyncJob < SyncJob
     private
 
-    def sync_page(credential, sync, checkpoint, continuation = nil)
-      if high_water_mark(checkpoint)
-        schedule(GoogleDocs::IncrementalSyncJob, credential.id)
-        return
-      end
+    def sync_page(credential, sync, checkpoint)
+      return if high_water_mark(checkpoint)
 
-      state = continuation_state(sync, continuation)
-      page = sync.list_files_page(page_token: state["page_token"].presence)
-      files = Array(page["files"]).select { |file| sync.eligible_file?(file) }
-      files_seen = state.fetch("files_seen").to_i + files.length
-      ingest_page(
-        credential,
-        sync,
-        files: files,
-        deactivations: [],
-        mode: "initial",
-        source: "drive.files.list",
-        run_id: state.fetch("run_id"),
-        files_seen: files_seen,
-        finished: false
-      )
-      enqueue_content_fetches(credential, files)
-
-      next_page_token = page["nextPageToken"].presence
-      if next_page_token
-        schedule(
-          GoogleDocs::InitialSyncJob,
-          credential.id,
-          state.merge("page_token" => next_page_token, "files_seen" => files_seen)
+      start_page_token = sync.start_page_token
+      run_id = "gdocs_#{SecureRandom.hex(16)}"
+      page_token = nil
+      files_seen = 0
+      loop do
+        page = sync.list_files_page(page_token: page_token)
+        files = Array(page["files"]).select { |file| sync.eligible_file?(file) }
+        files_seen += files.length
+        ingest_page(
+          credential,
+          sync,
+          files: files,
+          deactivations: [],
+          mode: "initial",
+          source: "drive.files.list",
+          run_id: run_id,
+          files_seen: files_seen,
+          finished: false
         )
-      else
-        complete_crawl(credential, state, files_seen)
+        enqueue_content_fetches(credential, files)
+
+        page_token = page["nextPageToken"].presence
+        break unless page_token
       end
-    end
 
-    def continuation_state(sync, continuation)
-      return continuation.stringify_keys if continuation
-
-      {
-        "run_id" => "gdocs_#{SecureRandom.hex(16)}",
-        "start_page_token" => sync.start_page_token,
-        "page_token" => nil,
-        "files_seen" => 0
-      }
-    end
-
-    def complete_crawl(credential, state, files_seen)
-      run_id = state.fetch("run_id")
       api_client.ingest_google_docs_sync_batch(
         run: run_payload(
           credential,
@@ -63,13 +43,13 @@ module GoogleDocs
         ],
         checkpoint: checkpoint_payload(
           credential,
-          changes_page_token: state.fetch("start_page_token"),
+          changes_page_token: start_page_token,
           run_id: run_id,
           full_sync_finished: true
         ),
         replace_context_documents: false
       )
-      schedule(GoogleDocs::IncrementalSyncJob, credential.id)
+      GoogleDocs::IncrementalSyncJob.perform_later(credential.id)
     end
   end
 end

--- a/services/console/app/jobs/google_docs/initial_sync_job.rb
+++ b/services/console/app/jobs/google_docs/initial_sync_job.rb
@@ -2,43 +2,74 @@ module GoogleDocs
   class InitialSyncJob < SyncJob
     private
 
-    def sync_page(credential, sync, checkpoint)
+    def sync_page(credential, sync, checkpoint, continuation = nil)
       if high_water_mark(checkpoint)
         schedule(GoogleDocs::IncrementalSyncJob, credential.id)
         return
       end
 
-      start_page_token = sync.start_page_token
-      files = list_all_files(sync)
-      run_id = ingest_page(
+      state = continuation_state(sync, continuation)
+      page = sync.list_files_page(page_token: state["page_token"].presence)
+      files = Array(page["files"]).select { |file| sync.eligible_file?(file) }
+      files_seen = state.fetch("files_seen").to_i + files.length
+      ingest_page(
         credential,
         sync,
         files: files,
         deactivations: [],
         mode: "initial",
         source: "drive.files.list",
-        replace_observation_credentials: [ credential.oid ]
+        run_id: state.fetch("run_id"),
+        files_seen: files_seen,
+        finished: false
       )
       enqueue_content_fetches(credential, files)
-      persist_checkpoint(
-        credential,
-        changes_page_token: start_page_token,
-        run_id: run_id,
-        full_sync_finished: true
-      )
-      schedule(GoogleDocs::IncrementalSyncJob, credential.id)
+
+      next_page_token = page["nextPageToken"].presence
+      if next_page_token
+        schedule(
+          GoogleDocs::InitialSyncJob,
+          credential.id,
+          state.merge("page_token" => next_page_token, "files_seen" => files_seen)
+        )
+      else
+        complete_crawl(credential, state, files_seen)
+      end
     end
 
-    def list_all_files(sync)
-      files = []
-      page_token = nil
-      loop do
-        page = sync.list_files_page(page_token: page_token)
-        files.concat(Array(page["files"]).select { |file| sync.eligible_file?(file) })
-        page_token = page["nextPageToken"].presence
-        break unless page_token
-      end
-      files
+    def continuation_state(sync, continuation)
+      return continuation.stringify_keys if continuation
+
+      {
+        "run_id" => "gdocs_#{SecureRandom.hex(16)}",
+        "start_page_token" => sync.start_page_token,
+        "page_token" => nil,
+        "files_seen" => 0
+      }
+    end
+
+    def complete_crawl(credential, state, files_seen)
+      run_id = state.fetch("run_id")
+      api_client.ingest_google_docs_sync_batch(
+        run: run_payload(
+          credential,
+          run_id,
+          mode: "initial",
+          files_seen: files_seen,
+          finished: true
+        ),
+        observation_sweeps: [
+          { broker_credential_id: credential.oid, source_run_id: run_id }
+        ],
+        checkpoint: checkpoint_payload(
+          credential,
+          changes_page_token: state.fetch("start_page_token"),
+          run_id: run_id,
+          full_sync_finished: true
+        ),
+        replace_context_documents: false
+      )
+      schedule(GoogleDocs::IncrementalSyncJob, credential.id)
     end
   end
 end

--- a/services/console/app/jobs/google_docs/poll_sync_job.rb
+++ b/services/console/app/jobs/google_docs/poll_sync_job.rb
@@ -17,10 +17,13 @@ module GoogleDocs
       credentials.find_each do |credential|
         next unless GoogleDocs::SyncCredential.syncable?(credential, oauth_app_slug: oauth_app_slug)
 
-        checkpoint = api_client
+        sync_state = api_client
           .get_google_docs_sync_checkpoint(broker_credential_id: credential.oid)
-          .fetch("checkpoint")
-        job_class = SyncJob.high_water_mark(checkpoint) ? IncrementalSyncJob : InitialSyncJob
+        checkpoint = sync_state.fetch("checkpoint")
+        high_water_mark = SyncJob.high_water_mark(checkpoint)
+        next if !high_water_mark && sync_state["initial_sync_active"] == true
+
+        job_class = high_water_mark ? IncrementalSyncJob : InitialSyncJob
         job_class.perform_later(credential.id)
       rescue CentaurApiClient::Error => e
         Rails.logger.warn do

--- a/services/console/app/jobs/google_docs/poll_sync_job.rb
+++ b/services/console/app/jobs/google_docs/poll_sync_job.rb
@@ -17,13 +17,10 @@ module GoogleDocs
       credentials.find_each do |credential|
         next unless GoogleDocs::SyncCredential.syncable?(credential, oauth_app_slug: oauth_app_slug)
 
-        sync_state = api_client
+        checkpoint = api_client
           .get_google_docs_sync_checkpoint(broker_credential_id: credential.oid)
-        checkpoint = sync_state.fetch("checkpoint")
-        high_water_mark = SyncJob.high_water_mark(checkpoint)
-        next if !high_water_mark && sync_state["initial_sync_active"] == true
-
-        job_class = high_water_mark ? IncrementalSyncJob : InitialSyncJob
+          .fetch("checkpoint")
+        job_class = SyncJob.high_water_mark(checkpoint) ? IncrementalSyncJob : InitialSyncJob
         job_class.perform_later(credential.id)
       rescue CentaurApiClient::Error => e
         Rails.logger.warn do

--- a/services/console/app/jobs/google_docs/poll_sync_job.rb
+++ b/services/console/app/jobs/google_docs/poll_sync_job.rb
@@ -3,6 +3,7 @@ module GoogleDocs
     queue_as :default
 
     def perform(oauth_app_slug = GoogleDocs::SyncCredential.oauth_app_slug)
+      api_client = CentaurApiClient.new
       credentials = BrokerCredential
         .includes(:oauth_app)
         .joins(:oauth_app)
@@ -16,7 +17,16 @@ module GoogleDocs
       credentials.find_each do |credential|
         next unless GoogleDocs::SyncCredential.syncable?(credential, oauth_app_slug: oauth_app_slug)
 
-        IncrementalSyncJob.perform_later(credential.id)
+        checkpoint = api_client
+          .get_google_docs_sync_checkpoint(broker_credential_id: credential.oid)
+          .fetch("checkpoint")
+        job_class = SyncJob.high_water_mark(checkpoint) ? IncrementalSyncJob : InitialSyncJob
+        job_class.perform_later(credential.id)
+      rescue CentaurApiClient::Error => e
+        Rails.logger.warn do
+          "Google Docs poll failed to load checkpoint for credential #{credential.id}: " \
+            "#{e.class}: #{e.message}"
+        end
       end
     end
   end

--- a/services/console/app/jobs/google_docs/poll_sync_job.rb
+++ b/services/console/app/jobs/google_docs/poll_sync_job.rb
@@ -15,15 +15,12 @@ module GoogleDocs
         })
 
       credentials.find_each do |credential|
-        next if credential.access_token.blank?
-        next unless GoogleDocs::SyncCredential.required_scopes_granted?(credential.scopes)
+        next unless GoogleDocs::SyncCredential.syncable?(credential, oauth_app_slug: oauth_app_slug)
 
         checkpoint = api_client
           .get_google_docs_sync_checkpoint(broker_credential_id: credential.oid)
           .fetch("checkpoint")
-        phase = checkpoint&.dig("metadata", "phase")
-        job_class = %w[catching_up ready].include?(phase) ? IncrementalSyncJob : InitialSyncJob
-        job_class.perform_later(credential.id)
+        SyncJob.job_class_for(checkpoint).perform_later(credential.id)
       rescue CentaurApiClient::Error => e
         Rails.logger.warn do
           "Google Docs poll failed to load checkpoint for credential #{credential.id}: " \

--- a/services/console/app/jobs/google_docs/poll_sync_job.rb
+++ b/services/console/app/jobs/google_docs/poll_sync_job.rb
@@ -3,7 +3,6 @@ module GoogleDocs
     queue_as :default
 
     def perform(oauth_app_slug = GoogleDocs::SyncCredential.oauth_app_slug)
-      api_client = CentaurApiClient.new
       credentials = BrokerCredential
         .includes(:oauth_app)
         .joins(:oauth_app)
@@ -17,15 +16,7 @@ module GoogleDocs
       credentials.find_each do |credential|
         next unless GoogleDocs::SyncCredential.syncable?(credential, oauth_app_slug: oauth_app_slug)
 
-        checkpoint = api_client
-          .get_google_docs_sync_checkpoint(broker_credential_id: credential.oid)
-          .fetch("checkpoint")
-        SyncJob.job_class_for(checkpoint).perform_later(credential.id)
-      rescue CentaurApiClient::Error => e
-        Rails.logger.warn do
-          "Google Docs poll failed to load checkpoint for credential #{credential.id}: " \
-            "#{e.class}: #{e.message}"
-        end
+        IncrementalSyncJob.perform_later(credential.id)
       end
     end
   end

--- a/services/console/app/jobs/google_docs/poll_sync_job.rb
+++ b/services/console/app/jobs/google_docs/poll_sync_job.rb
@@ -3,6 +3,7 @@ module GoogleDocs
     queue_as :default
 
     def perform(oauth_app_slug = GoogleDocs::SyncCredential.oauth_app_slug)
+      api_client = CentaurApiClient.new
       credentials = BrokerCredential
         .includes(:oauth_app)
         .joins(:oauth_app)
@@ -17,7 +18,17 @@ module GoogleDocs
         next if credential.access_token.blank?
         next unless GoogleDocs::SyncCredential.required_scopes_granted?(credential.scopes)
 
-        GoogleDocs::SyncCredentialJob.perform_later(credential.id)
+        checkpoint = api_client
+          .get_google_docs_sync_checkpoint(broker_credential_id: credential.oid)
+          .fetch("checkpoint")
+        phase = checkpoint&.dig("metadata", "phase")
+        job_class = %w[catching_up ready].include?(phase) ? IncrementalSyncJob : InitialSyncJob
+        job_class.perform_later(credential.id)
+      rescue CentaurApiClient::Error => e
+        Rails.logger.warn do
+          "Google Docs poll failed to load checkpoint for credential #{credential.id}: " \
+            "#{e.class}: #{e.message}"
+        end
       end
     end
   end

--- a/services/console/app/jobs/google_docs/sync_credential_job.rb
+++ b/services/console/app/jobs/google_docs/sync_credential_job.rb
@@ -1,18 +1,10 @@
 module GoogleDocs
-  # Compatibility router for jobs enqueued before the paginated sync rollout.
+  # Discard jobs enqueued before the paginated sync rollout.
   class SyncCredentialJob < ApplicationJob
     queue_as :default
 
-    def perform(credential_id)
-      credential = BrokerCredential.find_by(id: credential_id)
-      return unless credential
-
-      checkpoint = CentaurApiClient.new
-        .get_google_docs_sync_checkpoint(broker_credential_id: credential.oid)
-        .fetch("checkpoint")
-      phase = checkpoint&.dig("metadata", "phase")
-      job_class = %w[catching_up ready].include?(phase) ? IncrementalSyncJob : InitialSyncJob
-      job_class.perform_later(credential.id)
+    def perform(*)
+      nil
     end
   end
 end

--- a/services/console/app/jobs/google_docs/sync_credential_job.rb
+++ b/services/console/app/jobs/google_docs/sync_credential_job.rb
@@ -1,18 +1,18 @@
 module GoogleDocs
+  # Compatibility router for jobs enqueued before the paginated sync rollout.
   class SyncCredentialJob < ApplicationJob
     queue_as :default
 
-    limits_concurrency to: 1, key: ->(credential_id) { "google_docs_sync_#{credential_id}" }
-
     def perform(credential_id)
-      credential = BrokerCredential.includes(:oauth_app).find_by(id: credential_id)
+      credential = BrokerCredential.find_by(id: credential_id)
       return unless credential
-      return if credential.dead?
-      return if credential.access_token.blank?
-      return unless credential.oauth_app&.provider == Oauth::Providers::Google::KEY
-      return unless GoogleDocs::SyncCredential.required_scopes_granted?(credential.scopes)
 
-      GoogleDocs::SyncCredential.new(credential).call
+      checkpoint = CentaurApiClient.new
+        .get_google_docs_sync_checkpoint(broker_credential_id: credential.oid)
+        .fetch("checkpoint")
+      phase = checkpoint&.dig("metadata", "phase")
+      job_class = %w[catching_up ready].include?(phase) ? IncrementalSyncJob : InitialSyncJob
+      job_class.perform_later(credential.id)
     end
   end
 end

--- a/services/console/app/jobs/google_docs/sync_job.rb
+++ b/services/console/app/jobs/google_docs/sync_job.rb
@@ -1,14 +1,10 @@
 module GoogleDocs
   class SyncJob < BaseJob
     CONCURRENCY_DURATION = 1.hour
-    # Solid Queue orders lower priorities first. Enqueueing the next crawl node
-    # at this priority while the current node holds the semaphore gives the
-    # continuation precedence over poll-created root jobs already waiting.
-    CONTINUATION_PRIORITY = -10
 
     limits_concurrency(
       to: 1,
-      key: ->(credential_id, *) { "google_docs_sync_#{credential_id}" },
+      key: ->(credential_id) { "google_docs_sync_#{credential_id}" },
       group: "GoogleDocsCredentialSync",
       duration: CONCURRENCY_DURATION,
       on_conflict: :block
@@ -18,18 +14,18 @@ module GoogleDocs
       checkpoint&.fetch("changes_page_token", nil).presence
     end
 
-    def perform(credential_id, *arguments)
+    def perform(credential_id)
       credential = eligible_credential(credential_id)
       return unless credential
 
-      sync_page(credential, sync_client(credential), load_checkpoint(credential), *arguments)
+      sync_page(credential, sync_client(credential), load_checkpoint(credential))
     rescue GoogleDocs::SyncCredential::InvalidPageTokenError
       restart_initial_sync(credential)
     end
 
     private
 
-    def sync_page(*)
+    def sync_page(_credential, _sync, _checkpoint)
       raise NotImplementedError
     end
 
@@ -128,13 +124,9 @@ module GoogleDocs
       }
     end
 
-    def schedule(job_class, *arguments)
-      job_class.set(priority: CONTINUATION_PRIORITY).perform_later(*arguments)
-    end
-
     def restart_initial_sync(credential)
       persist_checkpoint(credential, changes_page_token: "", run_id: nil)
-      schedule(GoogleDocs::InitialSyncJob, credential.id)
+      GoogleDocs::InitialSyncJob.perform_later(credential.id)
     end
   end
 end

--- a/services/console/app/jobs/google_docs/sync_job.rb
+++ b/services/console/app/jobs/google_docs/sync_job.rb
@@ -5,7 +5,7 @@ module GoogleDocs
 
     limits_concurrency(
       to: 1,
-      key: ->(credential_id) { "google_docs_sync_#{credential_id}" },
+      key: ->(credential_id, *) { "google_docs_sync_#{credential_id}" },
       group: "GoogleDocsCredentialSync",
       duration: CONCURRENCY_DURATION,
       on_conflict: :discard
@@ -15,11 +15,11 @@ module GoogleDocs
       checkpoint&.fetch("changes_page_token", nil).presence
     end
 
-    def perform(credential_id)
+    def perform(credential_id, *arguments)
       credential = eligible_credential(credential_id)
       return unless credential
 
-      sync_page(credential, sync_client(credential), load_checkpoint(credential))
+      sync_page(credential, sync_client(credential), load_checkpoint(credential), *arguments)
     rescue GoogleDocs::SyncCredential::InvalidPageTokenError
       restart_initial_sync(credential)
     end
@@ -69,17 +69,24 @@ module GoogleDocs
       deactivations:,
       mode:,
       source:,
-      replace_observation_credentials: []
+      run_id: nil,
+      files_seen: files.length,
+      finished: true
     )
-      run_id = "gdocs_#{SecureRandom.hex(16)}"
+      run_id ||= "gdocs_#{SecureRandom.hex(16)}"
       api_client.ingest_google_docs_sync_batch(
-        run: run_payload(credential, run_id, mode: mode, files_seen: files.length),
+        run: run_payload(
+          credential,
+          run_id,
+          mode: mode,
+          files_seen: files_seen,
+          finished: finished
+        ),
         files: files.map { |file| sync.file_payload(file, run_id: run_id) },
         observations: files.map do |file|
           sync.observation_payload(file, run_id: run_id, source: source)
         end,
         observation_deactivations: deactivations,
-        replace_observation_credentials: replace_observation_credentials,
         replace_context_documents: false
       )
       run_id
@@ -103,23 +110,23 @@ module GoogleDocs
       )
     end
 
-    def run_payload(credential, run_id, mode:, files_seen:)
+    def run_payload(credential, run_id, mode:, files_seen:, finished: true)
       {
         run_id: run_id,
         mode: mode,
-        status: "completed",
+        status: finished ? "completed" : "running",
         broker_credential_id: credential.oid,
         provider_subject: credential.provider_subject.to_s,
         provider_email: credential.provider_email.to_s,
         files_seen: files_seen,
         files_upserted: files_seen,
-        finished: true,
+        finished: finished,
         metadata: { oauth_app_slug: credential.oauth_app&.slug }
       }
     end
 
-    def schedule(job_class, credential_id)
-      job_class.set(wait: HANDOFF_DELAY).perform_later(credential_id)
+    def schedule(job_class, *arguments)
+      job_class.set(wait: HANDOFF_DELAY).perform_later(*arguments)
     end
 
     def restart_initial_sync(credential)

--- a/services/console/app/jobs/google_docs/sync_job.rb
+++ b/services/console/app/jobs/google_docs/sync_job.rb
@@ -1,0 +1,159 @@
+module GoogleDocs
+  class SyncJob < ApplicationJob
+    CONCURRENCY_DURATION = 1.hour
+    HANDOFF_DELAY = 2.seconds
+
+    queue_as :default
+
+    limits_concurrency(
+      to: 1,
+      key: ->(credential_id) { "google_docs_sync_#{credential_id}" },
+      group: "GoogleDocsCredentialSync",
+      duration: CONCURRENCY_DURATION,
+      on_conflict: :discard
+    )
+
+    retry_on GoogleDocs::SyncCredential::GoogleApiError,
+      CentaurApiClient::Error,
+      wait: :polynomially_longer,
+      attempts: 5
+
+    private
+
+    def eligible_credential(credential_id)
+      credential = BrokerCredential.includes(:oauth_app).find_by(id: credential_id)
+      return unless credential
+      return if credential.dead?
+      return if credential.access_token.blank?
+      return unless credential.oauth_app&.provider == Oauth::Providers::Google::KEY
+      return unless GoogleDocs::SyncCredential.required_scopes_granted?(credential.scopes)
+
+      credential
+    end
+
+    def api_client
+      @api_client ||= CentaurApiClient.new
+    end
+
+    def sync_client(credential)
+      GoogleDocs::SyncCredential.new(credential)
+    end
+
+    def load_checkpoint(credential)
+      api_client
+        .get_google_docs_sync_checkpoint(broker_credential_id: credential.oid)
+        .fetch("checkpoint")
+    end
+
+    def checkpoint_phase(checkpoint)
+      checkpoint&.dig("metadata", "phase").presence || "pending"
+    end
+
+    def initial_page_token(checkpoint)
+      checkpoint&.dig("metadata", "initial_page_token").presence
+    end
+
+    def checkpoint_payload(
+      credential,
+      checkpoint,
+      phase:,
+      initial_page_token: nil,
+      start_page_token: nil,
+      changes_page_token: nil,
+      run_id: nil,
+      full_sync_finished: false,
+      incremental_sync_finished: false
+    )
+      metadata = checkpoint&.fetch("metadata", {})
+      metadata = {} unless metadata.is_a?(Hash)
+      payload = {
+        broker_credential_id: credential.oid,
+        provider_subject: credential.provider_subject.to_s,
+        provider_email: credential.provider_email.to_s,
+        last_run_id: run_id,
+        last_error: "",
+        metadata: metadata.merge(
+          "phase" => phase,
+          "initial_page_token" => initial_page_token.to_s
+        )
+      }
+      payload[:start_page_token] = start_page_token if start_page_token
+      payload[:changes_page_token] = changes_page_token if changes_page_token
+      now = Time.current.iso8601
+      payload[:last_full_sync_at] = now if full_sync_finished
+      payload[:last_incremental_sync_at] = now if incremental_sync_finished
+      payload
+    end
+
+    def ingest_metadata_page(credential, sync, files:, deactivations:, mode:, source:)
+      run_id = "gdocs_#{SecureRandom.hex(16)}"
+      api_client.ingest_google_docs_sync_batch(
+        run: run_payload(
+          credential,
+          run_id,
+          mode: mode,
+          status: "running",
+          files_seen: files.length
+        ),
+        files: files.map { |file| sync.file_payload(file, run_id: run_id) },
+        observations: files.map do |file|
+          sync.observation_payload(file, run_id: run_id, source: source)
+        end,
+        observation_deactivations: deactivations,
+        replace_context_documents: false
+      )
+      enqueue_missing_content(credential, sync, files)
+      run_id
+    end
+
+    def finish_page(credential, run_id, mode:, files_seen:, checkpoint:)
+      api_client.ingest_google_docs_sync_batch(
+        run: run_payload(
+          credential,
+          run_id,
+          mode: mode,
+          status: "completed",
+          files_seen: files_seen
+        ),
+        checkpoint: checkpoint,
+        replace_context_documents: false
+      )
+    end
+
+    def enqueue_missing_content(credential, sync, files)
+      return if files.empty?
+
+      versions = files.map { |file| sync.content_version(file) }
+      missing = api_client.get_google_docs_content_status(files: versions).fetch("missing")
+      missing_versions = Array(missing).to_h do |file|
+        [ [ file.fetch("file_id"), file.fetch("source_version", "") ], true ]
+      end
+      files.each do |file|
+        version = sync.content_version(file)
+        key = [ version.fetch(:file_id), version.fetch(:source_version) ]
+        next unless missing_versions[key]
+
+        GoogleDocs::FetchDocumentJob.perform_later(credential.id, file)
+      end
+    end
+
+    def run_payload(credential, run_id, mode:, status:, files_seen:)
+      {
+        run_id: run_id,
+        mode: mode,
+        status: status,
+        broker_credential_id: credential.oid,
+        provider_subject: credential.provider_subject.to_s,
+        provider_email: credential.provider_email.to_s,
+        files_seen: files_seen,
+        files_upserted: files_seen,
+        finished: status == "completed",
+        metadata: { oauth_app_slug: credential.oauth_app&.slug }
+      }
+    end
+
+    def schedule(job_class, credential_id)
+      job_class.set(wait: HANDOFF_DELAY).perform_later(credential_id)
+    end
+  end
+end

--- a/services/console/app/jobs/google_docs/sync_job.rb
+++ b/services/console/app/jobs/google_docs/sync_job.rb
@@ -53,11 +53,16 @@ module GoogleDocs
       checkpoint&.dig("metadata", "initial_page_token").presence
     end
 
+    def initial_crawl_id(checkpoint)
+      checkpoint&.dig("metadata", "initial_crawl_id").presence
+    end
+
     def checkpoint_payload(
       credential,
       checkpoint,
       phase:,
       initial_page_token: nil,
+      initial_crawl_id: nil,
       start_page_token: nil,
       changes_page_token: nil,
       run_id: nil,
@@ -66,16 +71,18 @@ module GoogleDocs
     )
       metadata = checkpoint&.fetch("metadata", {})
       metadata = {} unless metadata.is_a?(Hash)
+      checkpoint_metadata = metadata.merge(
+        "phase" => phase,
+        "initial_page_token" => initial_page_token.to_s
+      )
+      checkpoint_metadata["initial_crawl_id"] = initial_crawl_id if initial_crawl_id
       payload = {
         broker_credential_id: credential.oid,
         provider_subject: credential.provider_subject.to_s,
         provider_email: credential.provider_email.to_s,
         last_run_id: run_id,
         last_error: "",
-        metadata: metadata.merge(
-          "phase" => phase,
-          "initial_page_token" => initial_page_token.to_s
-        )
+        metadata: checkpoint_metadata
       }
       payload[:start_page_token] = start_page_token if start_page_token
       payload[:changes_page_token] = changes_page_token if changes_page_token
@@ -85,7 +92,15 @@ module GoogleDocs
       payload
     end
 
-    def ingest_metadata_page(credential, sync, files:, deactivations:, mode:, source:)
+    def ingest_metadata_page(
+      credential,
+      sync,
+      files:,
+      deactivations:,
+      mode:,
+      source:,
+      initial_crawl_id: nil
+    )
       run_id = "gdocs_#{SecureRandom.hex(16)}"
       api_client.ingest_google_docs_sync_batch(
         run: run_payload(
@@ -97,7 +112,12 @@ module GoogleDocs
         ),
         files: files.map { |file| sync.file_payload(file, run_id: run_id) },
         observations: files.map do |file|
-          sync.observation_payload(file, run_id: run_id, source: source)
+          sync.observation_payload(
+            file,
+            run_id: run_id,
+            source: source,
+            initial_crawl_id: initial_crawl_id
+          )
         end,
         observation_deactivations: deactivations,
         replace_context_documents: false
@@ -106,7 +126,7 @@ module GoogleDocs
       run_id
     end
 
-    def finish_page(credential, run_id, mode:, files_seen:, checkpoint:)
+    def finish_page(credential, run_id, mode:, files_seen:, checkpoint:, observation_sweeps: [])
       api_client.ingest_google_docs_sync_batch(
         run: run_payload(
           credential,
@@ -115,6 +135,7 @@ module GoogleDocs
           status: "completed",
           files_seen: files_seen
         ),
+        observation_sweeps: observation_sweeps,
         checkpoint: checkpoint,
         replace_context_documents: false
       )
@@ -154,6 +175,18 @@ module GoogleDocs
 
     def schedule(job_class, credential_id)
       job_class.set(wait: HANDOFF_DELAY).perform_later(credential_id)
+    end
+
+    def restart_initial_sync(credential, checkpoint)
+      api_client.ingest_google_docs_sync_batch(
+        checkpoint: checkpoint_payload(
+          credential,
+          checkpoint,
+          phase: "pending"
+        ),
+        replace_context_documents: false
+      )
+      schedule(GoogleDocs::InitialSyncJob, credential.id)
     end
   end
 end

--- a/services/console/app/jobs/google_docs/sync_job.rb
+++ b/services/console/app/jobs/google_docs/sync_job.rb
@@ -90,22 +90,24 @@ module GoogleDocs
       payload
     end
 
-    def ingest_metadata_page(
+    def ingest_page(
       credential,
       sync,
+      run_id:,
       files:,
       deactivations:,
       mode:,
       source:,
-      initial_crawl_id: nil
+      checkpoint:,
+      initial_crawl_id: nil,
+      observation_sweeps: []
     )
-      run_id = "gdocs_#{SecureRandom.hex(16)}"
+      enqueue_content_fetches(credential, files)
       api_client.ingest_google_docs_sync_batch(
         run: run_payload(
           credential,
           run_id,
           mode: mode,
-          status: "running",
           files_seen: files.length
         ),
         files: files.map { |file| sync.file_payload(file, run_id: run_id) },
@@ -118,55 +120,33 @@ module GoogleDocs
           )
         end,
         observation_deactivations: deactivations,
-        replace_context_documents: false
-      )
-      enqueue_missing_content(credential, sync, files)
-      run_id
-    end
-
-    def finish_page(credential, run_id, mode:, files_seen:, checkpoint:, observation_sweeps: [])
-      api_client.ingest_google_docs_sync_batch(
-        run: run_payload(
-          credential,
-          run_id,
-          mode: mode,
-          status: "completed",
-          files_seen: files_seen
-        ),
         observation_sweeps: observation_sweeps,
         checkpoint: checkpoint,
         replace_context_documents: false
       )
     end
 
-    def enqueue_missing_content(credential, sync, files)
-      return if files.empty?
+    def new_run_id
+      "gdocs_#{SecureRandom.hex(16)}"
+    end
 
-      versions = files.map { |file| sync.content_version(file) }
-      missing = api_client.get_google_docs_content_status(files: versions).fetch("missing")
-      missing_versions = Array(missing).to_h do |file|
-        [ [ file.fetch("file_id"), file.fetch("source_version", "") ], true ]
-      end
+    def enqueue_content_fetches(credential, files)
       files.each do |file|
-        version = sync.content_version(file)
-        key = [ version.fetch(:file_id), version.fetch(:source_version) ]
-        next unless missing_versions[key]
-
         GoogleDocs::FetchDocumentJob.perform_later(credential.id, file)
       end
     end
 
-    def run_payload(credential, run_id, mode:, status:, files_seen:)
+    def run_payload(credential, run_id, mode:, files_seen:)
       {
         run_id: run_id,
         mode: mode,
-        status: status,
+        status: "completed",
         broker_credential_id: credential.oid,
         provider_subject: credential.provider_subject.to_s,
         provider_email: credential.provider_email.to_s,
         files_seen: files_seen,
         files_upserted: files_seen,
-        finished: status == "completed",
+        finished: true,
         metadata: { oauth_app_slug: credential.oauth_app&.slug }
       }
     end

--- a/services/console/app/jobs/google_docs/sync_job.rb
+++ b/services/console/app/jobs/google_docs/sync_job.rb
@@ -1,14 +1,17 @@
 module GoogleDocs
   class SyncJob < BaseJob
     CONCURRENCY_DURATION = 1.hour
-    HANDOFF_DELAY = 2.seconds
+    # Solid Queue orders lower priorities first. Enqueueing the next crawl node
+    # at this priority while the current node holds the semaphore gives the
+    # continuation precedence over poll-created root jobs already waiting.
+    CONTINUATION_PRIORITY = -10
 
     limits_concurrency(
       to: 1,
       key: ->(credential_id, *) { "google_docs_sync_#{credential_id}" },
       group: "GoogleDocsCredentialSync",
       duration: CONCURRENCY_DURATION,
-      on_conflict: :discard
+      on_conflict: :block
     )
 
     def self.high_water_mark(checkpoint)
@@ -126,7 +129,7 @@ module GoogleDocs
     end
 
     def schedule(job_class, *arguments)
-      job_class.set(wait: HANDOFF_DELAY).perform_later(*arguments)
+      job_class.set(priority: CONTINUATION_PRIORITY).perform_later(*arguments)
     end
 
     def restart_initial_sync(credential)

--- a/services/console/app/jobs/google_docs/sync_job.rb
+++ b/services/console/app/jobs/google_docs/sync_job.rb
@@ -2,7 +2,6 @@ module GoogleDocs
   class SyncJob < BaseJob
     CONCURRENCY_DURATION = 1.hour
     HANDOFF_DELAY = 2.seconds
-    INCREMENTAL_PHASES = %w[catching_up ready].freeze
 
     limits_concurrency(
       to: 1,
@@ -12,23 +11,17 @@ module GoogleDocs
       on_conflict: :discard
     )
 
-    def self.checkpoint_phase(checkpoint)
-      checkpoint&.dig("metadata", "phase").presence || "pending"
-    end
-
-    def self.job_class_for(checkpoint)
-      INCREMENTAL_PHASES.include?(checkpoint_phase(checkpoint)) ? IncrementalSyncJob : InitialSyncJob
+    def self.high_water_mark(checkpoint)
+      checkpoint&.fetch("changes_page_token", nil).presence
     end
 
     def perform(credential_id)
       credential = eligible_credential(credential_id)
       return unless credential
 
-      sync = sync_client(credential)
-      checkpoint = load_checkpoint(credential)
-      sync_page(credential, sync, checkpoint)
+      sync_page(credential, sync_client(credential), load_checkpoint(credential))
     rescue GoogleDocs::SyncCredential::InvalidPageTokenError
-      restart_initial_sync(credential, checkpoint)
+      restart_initial_sync(credential)
     end
 
     private
@@ -43,47 +36,26 @@ module GoogleDocs
         .fetch("checkpoint")
     end
 
-    def checkpoint_phase(checkpoint)
-      self.class.checkpoint_phase(checkpoint)
-    end
-
-    def initial_page_token(checkpoint)
-      checkpoint&.dig("metadata", "initial_page_token").presence
-    end
-
-    def initial_crawl_id(checkpoint)
-      checkpoint&.dig("metadata", "initial_crawl_id").presence
+    def high_water_mark(checkpoint)
+      self.class.high_water_mark(checkpoint)
     end
 
     def checkpoint_payload(
       credential,
-      checkpoint,
-      phase:,
-      initial_page_token: nil,
-      initial_crawl_id: nil,
-      start_page_token: nil,
-      changes_page_token: nil,
+      changes_page_token:,
       run_id: nil,
       full_sync_finished: false,
       incremental_sync_finished: false
     )
-      metadata = checkpoint&.fetch("metadata", {})
-      metadata = {} unless metadata.is_a?(Hash)
-      checkpoint_metadata = metadata.merge(
-        "phase" => phase,
-        "initial_page_token" => initial_page_token.to_s
-      )
-      checkpoint_metadata["initial_crawl_id"] = initial_crawl_id if initial_crawl_id
       payload = {
         broker_credential_id: credential.oid,
         provider_subject: credential.provider_subject.to_s,
         provider_email: credential.provider_email.to_s,
+        changes_page_token: changes_page_token,
         last_run_id: run_id,
         last_error: "",
-        metadata: checkpoint_metadata
+        metadata: {}
       }
-      payload[:start_page_token] = start_page_token if start_page_token
-      payload[:changes_page_token] = changes_page_token if changes_page_token
       now = Time.current.iso8601
       payload[:last_full_sync_at] = now if full_sync_finished
       payload[:last_incremental_sync_at] = now if incremental_sync_finished
@@ -93,47 +65,42 @@ module GoogleDocs
     def ingest_page(
       credential,
       sync,
-      run_id:,
       files:,
       deactivations:,
       mode:,
       source:,
-      checkpoint:,
-      initial_crawl_id: nil,
-      observation_sweeps: []
+      replace_observation_credentials: []
     )
-      enqueue_content_fetches(credential, files)
+      run_id = "gdocs_#{SecureRandom.hex(16)}"
       api_client.ingest_google_docs_sync_batch(
-        run: run_payload(
-          credential,
-          run_id,
-          mode: mode,
-          files_seen: files.length
-        ),
+        run: run_payload(credential, run_id, mode: mode, files_seen: files.length),
         files: files.map { |file| sync.file_payload(file, run_id: run_id) },
         observations: files.map do |file|
-          sync.observation_payload(
-            file,
-            run_id: run_id,
-            source: source,
-            initial_crawl_id: initial_crawl_id
-          )
+          sync.observation_payload(file, run_id: run_id, source: source)
         end,
         observation_deactivations: deactivations,
-        observation_sweeps: observation_sweeps,
-        checkpoint: checkpoint,
+        replace_observation_credentials: replace_observation_credentials,
         replace_context_documents: false
       )
-    end
-
-    def new_run_id
-      "gdocs_#{SecureRandom.hex(16)}"
+      run_id
     end
 
     def enqueue_content_fetches(credential, files)
       files.each do |file|
         GoogleDocs::FetchDocumentJob.perform_later(credential.id, file)
       end
+    end
+
+    def persist_checkpoint(credential, changes_page_token:, run_id:, **timestamps)
+      api_client.ingest_google_docs_sync_batch(
+        checkpoint: checkpoint_payload(
+          credential,
+          changes_page_token: changes_page_token,
+          run_id: run_id,
+          **timestamps
+        ),
+        replace_context_documents: false
+      )
     end
 
     def run_payload(credential, run_id, mode:, files_seen:)
@@ -155,15 +122,8 @@ module GoogleDocs
       job_class.set(wait: HANDOFF_DELAY).perform_later(credential_id)
     end
 
-    def restart_initial_sync(credential, checkpoint)
-      api_client.ingest_google_docs_sync_batch(
-        checkpoint: checkpoint_payload(
-          credential,
-          checkpoint,
-          phase: "pending"
-        ),
-        replace_context_documents: false
-      )
+    def restart_initial_sync(credential)
+      persist_checkpoint(credential, changes_page_token: "", run_id: nil)
       schedule(GoogleDocs::InitialSyncJob, credential.id)
     end
   end

--- a/services/console/app/jobs/google_docs/sync_job.rb
+++ b/services/console/app/jobs/google_docs/sync_job.rb
@@ -1,9 +1,8 @@
 module GoogleDocs
-  class SyncJob < ApplicationJob
+  class SyncJob < BaseJob
     CONCURRENCY_DURATION = 1.hour
     HANDOFF_DELAY = 2.seconds
-
-    queue_as :default
+    INCREMENTAL_PHASES = %w[catching_up ready].freeze
 
     limits_concurrency(
       to: 1,
@@ -13,30 +12,29 @@ module GoogleDocs
       on_conflict: :discard
     )
 
-    retry_on GoogleDocs::SyncCredential::GoogleApiError,
-      CentaurApiClient::Error,
-      wait: :polynomially_longer,
-      attempts: 5
+    def self.checkpoint_phase(checkpoint)
+      checkpoint&.dig("metadata", "phase").presence || "pending"
+    end
+
+    def self.job_class_for(checkpoint)
+      INCREMENTAL_PHASES.include?(checkpoint_phase(checkpoint)) ? IncrementalSyncJob : InitialSyncJob
+    end
+
+    def perform(credential_id)
+      credential = eligible_credential(credential_id)
+      return unless credential
+
+      sync = sync_client(credential)
+      checkpoint = load_checkpoint(credential)
+      sync_page(credential, sync, checkpoint)
+    rescue GoogleDocs::SyncCredential::InvalidPageTokenError
+      restart_initial_sync(credential, checkpoint)
+    end
 
     private
 
-    def eligible_credential(credential_id)
-      credential = BrokerCredential.includes(:oauth_app).find_by(id: credential_id)
-      return unless credential
-      return if credential.dead?
-      return if credential.access_token.blank?
-      return unless credential.oauth_app&.provider == Oauth::Providers::Google::KEY
-      return unless GoogleDocs::SyncCredential.required_scopes_granted?(credential.scopes)
-
-      credential
-    end
-
-    def api_client
-      @api_client ||= CentaurApiClient.new
-    end
-
-    def sync_client(credential)
-      GoogleDocs::SyncCredential.new(credential)
+    def sync_page(*)
+      raise NotImplementedError
     end
 
     def load_checkpoint(credential)
@@ -46,7 +44,7 @@ module GoogleDocs
     end
 
     def checkpoint_phase(checkpoint)
-      checkpoint&.dig("metadata", "phase").presence || "pending"
+      self.class.checkpoint_phase(checkpoint)
     end
 
     def initial_page_token(checkpoint)

--- a/services/console/app/services/centaur_api_client.rb
+++ b/services/console/app/services/centaur_api_client.rb
@@ -73,6 +73,10 @@ class CentaurApiClient
     post("/api/admin/google/docs-sync/batch", payload)
   end
 
+  def get_google_docs_content_status(files:)
+    post("/api/admin/google/docs-sync/content-status", { files: files })
+  end
+
   def get_granola_sync_checkpoint(scope_id:)
     get("/api/admin/granola/sync/checkpoint", scope_id: scope_id)
   end

--- a/services/console/app/services/google_docs/sync_credential.rb
+++ b/services/console/app/services/google_docs/sync_credential.rb
@@ -284,31 +284,22 @@ module GoogleDocs
       return parsed if response.success?
 
       message = parsed.dig("error", "message") if parsed.is_a?(Hash)
-      error_class = if invalid_page_token_response?(response.status, parsed, params)
+      error_class = if invalid_page_token_response?(response.status, params)
         InvalidPageTokenError
       else
         GoogleApiError
       end
       raise error_class, message.presence || "Google API returned HTTP #{response.status}"
     rescue JSON::ParserError
-      if params["pageToken"].present? && response&.status == 410
+      if invalid_page_token_response?(response&.status, params)
         raise InvalidPageTokenError, "Google API rejected the page token"
       end
 
       raise GoogleApiError, "Google API returned invalid JSON"
     end
 
-    def invalid_page_token_response?(status, parsed, params)
-      return false unless params["pageToken"].present?
-      return true if status == 410
-      return false unless [ 400, 404 ].include?(status)
-
-      error = parsed["error"] if parsed.is_a?(Hash)
-      details = error.is_a?(Hash) ? Array(error["errors"]) : []
-      details.any? { |detail| detail.is_a?(Hash) && detail["location"] == "pageToken" } ||
-        ([ error.is_a?(Hash) ? error["message"] : nil ] + details.flat_map do |detail|
-          detail.is_a?(Hash) ? detail.values_at("message", "reason") : []
-        end).compact.any? { |value| value.match?(/page[\s_-]*token/i) }
+    def invalid_page_token_response?(status, params)
+      params["pageToken"].present? && [ 400, 404, 410 ].include?(status)
     end
   end
 end

--- a/services/console/app/services/google_docs/sync_credential.rb
+++ b/services/console/app/services/google_docs/sync_credential.rb
@@ -21,7 +21,8 @@ module GoogleDocs
       "version"
     ].join(",")
 
-    GoogleApiError = Class.new(StandardError)
+    class GoogleApiError < StandardError; end
+    class InvalidPageTokenError < GoogleApiError; end
 
     class << self
       attr_accessor :google_api_http
@@ -122,7 +123,9 @@ module GoogleDocs
       }
     end
 
-    def observation_payload(file, run_id: nil, source:)
+    def observation_payload(file, run_id: nil, source:, initial_crawl_id: nil)
+      raw_payload = { "source" => source }
+      raw_payload["initial_crawl_id"] = initial_crawl_id if initial_crawl_id
       {
         broker_credential_id: credential.oid,
         observed_file_id: file.fetch("id"),
@@ -135,7 +138,7 @@ module GoogleDocs
         role_hint: role_hint(file),
         permission_ids: [],
         active: true,
-        raw_payload: { "source" => source },
+        raw_payload: raw_payload,
         source_run_id: run_id
       }
     end
@@ -275,9 +278,31 @@ module GoogleDocs
       return parsed if response.success?
 
       message = parsed.dig("error", "message") if parsed.is_a?(Hash)
-      raise GoogleApiError, message.presence || "Google API returned HTTP #{response.status}"
+      error_class = if invalid_page_token_response?(response.status, parsed, params)
+        InvalidPageTokenError
+      else
+        GoogleApiError
+      end
+      raise error_class, message.presence || "Google API returned HTTP #{response.status}"
     rescue JSON::ParserError
+      if params["pageToken"].present? && response&.status == 410
+        raise InvalidPageTokenError, "Google API rejected the page token"
+      end
+
       raise GoogleApiError, "Google API returned invalid JSON"
+    end
+
+    def invalid_page_token_response?(status, parsed, params)
+      return false unless params["pageToken"].present?
+      return true if status == 410
+      return false unless [ 400, 404 ].include?(status)
+
+      error = parsed["error"] if parsed.is_a?(Hash)
+      details = error.is_a?(Hash) ? Array(error["errors"]) : []
+      details.any? { |detail| detail.is_a?(Hash) && detail["location"] == "pageToken" } ||
+        ([ error.is_a?(Hash) ? error["message"] : nil ] + details.flat_map do |detail|
+          detail.is_a?(Hash) ? detail.values_at("message", "reason") : []
+        end).compact.any? { |value| value.match?(/page[\s_-]*token/i) }
     end
   end
 end

--- a/services/console/app/services/google_docs/sync_credential.rb
+++ b/services/console/app/services/google_docs/sync_credential.rb
@@ -1,5 +1,5 @@
-require "digest"
 require "cgi"
+require "digest"
 require "json"
 
 module GoogleDocs
@@ -11,7 +11,15 @@ module GoogleDocs
     EXPORT_MIME_TYPE = "text/plain"
 
     FILES_LIST_ENDPOINT = "https://www.googleapis.com/drive/v3/files"
+    CHANGES_LIST_ENDPOINT = "https://www.googleapis.com/drive/v3/changes"
+    START_PAGE_TOKEN_ENDPOINT = "https://www.googleapis.com/drive/v3/changes/startPageToken"
     DOCS_GET_ENDPOINT = "https://docs.googleapis.com/v1/documents"
+
+    FILE_FIELDS = [
+      "id", "name", "mimeType", "webViewLink", "driveId", "owners", "lastModifyingUser",
+      "capabilities", "labelInfo", "trashed", "explicitlyTrashed", "createdTime", "modifiedTime",
+      "version"
+    ].join(",")
 
     GoogleApiError = Class.new(StandardError)
 
@@ -32,10 +40,6 @@ module GoogleDocs
         positive_int(ConsoleEnv["GOOGLE_DOCS_SYNC_PAGE_SIZE"], 100)
       end
 
-      def max_pages
-        positive_int(ConsoleEnv["GOOGLE_DOCS_SYNC_MAX_PAGES"], 10)
-      end
-
       def chunk_chars
         positive_int(ConsoleEnv["GOOGLE_DOCS_SYNC_CHUNK_CHARS"], 12_000)
       end
@@ -46,125 +50,59 @@ module GoogleDocs
       end
     end
 
-    def initialize(credential, api_client: CentaurApiClient.new, google_api_http: nil)
+    attr_reader :credential
+
+    def initialize(credential, google_api_http: nil)
       @credential = credential
-      @api_client = api_client
       @google_api_http = google_api_http || self.class.google_api_http
-      @run_id = "gdocs_#{SecureRandom.hex(16)}"
-      @files_seen = 0
-      @docs_fetched = 0
-      @docs_failed = 0
-      @chunks_upserted = 0
-      @max_modified_at = nil
-      @truncated = false
     end
 
-    def call
-      checkpoint = load_checkpoint
-      batch = empty_batch
-      modified_after = checkpoint && checkpoint["last_incremental_sync_at"].presence
-
-      files = list_files(modified_after: modified_after)
-      batch[:run][:files_seen] = files.length
-
-      files.each do |file|
-        normalize_file(file, batch)
-        normalize_observation(file, batch)
-        sync_content(file, batch)
-      rescue StandardError => e
-        raise if Rails.env.test?
-
-        @docs_failed += 1
-        Rails.logger.warn do
-          "Google Docs sync failed for file #{file['id']}: #{e.class}: #{e.message}"
-        end
-      end
-
-      finish_batch(batch)
-      @api_client.ingest_google_docs_sync_batch(batch)
+    def start_page_token
+      google_api(
+        START_PAGE_TOKEN_ENDPOINT,
+        "supportsAllDrives" => "true"
+      ).fetch("startPageToken")
+    rescue KeyError
+      raise GoogleApiError, "Google Drive returned no start page token"
     end
 
-    private
-
-    def load_checkpoint
-      @api_client
-        .get_google_docs_sync_checkpoint(broker_credential_id: @credential.oid)
-        .fetch("checkpoint")
+    def list_files_page(page_token: nil)
+      google_api(
+        FILES_LIST_ENDPOINT,
+        {
+          "q" => "mimeType = '#{GOOGLE_DOC_MIME_TYPE}' and trashed = false",
+          "pageSize" => self.class.page_size,
+          "fields" => "nextPageToken,files(#{FILE_FIELDS})",
+          "includeItemsFromAllDrives" => "true",
+          "supportsAllDrives" => "true",
+          "orderBy" => "modifiedTime,name",
+          "pageToken" => page_token
+        }.compact
+      )
     end
 
-    def empty_batch
+    def list_changes_page(page_token:)
+      google_api(
+        CHANGES_LIST_ENDPOINT,
+        {
+          "pageToken" => page_token,
+          "pageSize" => self.class.page_size,
+          "fields" => "nextPageToken,newStartPageToken,changes(fileId,removed,file(#{FILE_FIELDS}))",
+          "includeItemsFromAllDrives" => "true",
+          "includeRemoved" => "true",
+          "supportsAllDrives" => "true",
+          "spaces" => "drive"
+        }
+      )
+    end
+
+    def eligible_file?(file)
+      file.is_a?(Hash) && file["id"].present? &&
+        file["mimeType"] == GOOGLE_DOC_MIME_TYPE && file["trashed"] != true
+    end
+
+    def file_payload(file, run_id: nil)
       {
-        run: {
-          run_id: @run_id,
-          mode: "incremental",
-          status: "running",
-          broker_credential_id: @credential.oid,
-          provider_subject: @credential.provider_subject.to_s,
-          provider_email: @credential.provider_email.to_s,
-          files_seen: 0,
-          files_upserted: 0,
-          docs_fetched: 0,
-          docs_upserted: 0,
-          chunks_upserted: 0,
-          metadata: {
-            oauth_app_slug: @credential.oauth_app&.slug,
-            credential_id: @credential.oid
-          }
-        },
-        replace_context_documents: true,
-        files: [],
-        observations: [],
-        contents: [],
-        context_documents: []
-      }
-    end
-
-    def list_files(modified_after:)
-      files = []
-      page_token = nil
-      self.class.max_pages.times do |index|
-        page = google_api(
-          FILES_LIST_ENDPOINT,
-          files_list_params(modified_after: modified_after, page_token: page_token)
-        )
-        page_files = Array(page["files"]).select do |file|
-          file["id"].present? && file["mimeType"] == GOOGLE_DOC_MIME_TYPE
-        end
-        files.concat(page_files)
-        page_files.each { |file| track_modified_at(file["modifiedTime"]) }
-        page_token = page["nextPageToken"].presence
-        if page_token.present? && index == self.class.max_pages - 1
-          @truncated = true
-        end
-        break if page_token.blank?
-      end
-      @files_seen = files.length
-      files
-    end
-
-    def files_list_params(modified_after:, page_token:)
-      query = [
-        "mimeType = '#{GOOGLE_DOC_MIME_TYPE}'",
-        "trashed = false"
-      ]
-      query << "modifiedTime > '#{drive_literal(modified_after)}'" if modified_after.present?
-      {
-        "q" => query.join(" and "),
-        "pageSize" => self.class.page_size,
-        "fields" => [
-          "nextPageToken,",
-          "files(id,name,mimeType,webViewLink,driveId,owners,lastModifyingUser,",
-          "capabilities,labelInfo,trashed,explicitlyTrashed,createdTime,modifiedTime,version)"
-        ].join,
-        "includeItemsFromAllDrives" => "true",
-        "supportsAllDrives" => "true",
-        "orderBy" => "modifiedTime",
-        "pageToken" => page_token
-      }.compact
-    end
-
-    def normalize_file(file, batch)
-      batch[:files] << {
         file_id: file.fetch("id"),
         drive_id: file["driveId"].to_s,
         name: file["name"].to_s,
@@ -178,66 +116,78 @@ module GoogleDocs
         explicitly_trashed: file["explicitlyTrashed"] == true,
         source_created_at: file["createdTime"],
         source_modified_at: file["modifiedTime"],
-        source_version: file["version"].to_s,
+        source_version: source_version(file),
         raw_payload: file,
-        source_run_id: @run_id
+        source_run_id: run_id
       }
     end
 
-    def normalize_observation(file, batch)
-      batch[:observations] << {
-        broker_credential_id: @credential.oid,
+    def observation_payload(file, run_id: nil, source:)
+      {
+        broker_credential_id: credential.oid,
         observed_file_id: file.fetch("id"),
         file_id: file.fetch("id"),
-        provider_subject: @credential.provider_subject.to_s,
-        provider_email: @credential.provider_email.to_s,
+        provider_subject: credential.provider_subject.to_s,
+        provider_email: credential.provider_email.to_s,
         observed_name: file["name"].to_s,
         observed_mime_type: file["mimeType"].to_s,
         observed_web_view_link: file["webViewLink"].to_s,
         role_hint: role_hint(file),
         permission_ids: [],
         active: true,
-        raw_payload: { "source" => "drive.files.list" },
-        source_run_id: @run_id
+        raw_payload: { "source" => source },
+        source_run_id: run_id
       }
     end
 
-    def sync_content(file, batch)
-      doc = docs_get(file.fetch("id"))
-      text = docs_text_from_document(doc)
-      @docs_fetched += 1
-      title = doc["title"].presence || file["name"].to_s
-      text_hash = content_hash(text)
-      exported_at = Time.current.iso8601
-      batch[:contents] << {
-        file_id: file.fetch("id"),
-        title: title,
-        text_content: text,
-        text_hash: text_hash,
-        export_mime_type: EXPORT_MIME_TYPE,
-        exported_at: exported_at,
-        source_modified_at: file["modifiedTime"],
-        source_version: file["version"].to_s,
-        source_run_id: @run_id
+    def observation_deactivation(file_id)
+      {
+        broker_credential_id: credential.oid,
+        observed_file_id: file_id
       }
+    end
 
-      chunks_for(text).each_with_index do |chunk, index|
-        chunk_id = format("chunk-%04d", index)
-        batch[:context_documents] << context_document(file, title, chunk, chunk_id)
-        @chunks_upserted += 1
-      end
-    rescue StandardError => e
-      @docs_failed += 1
-      batch[:contents] << {
+    def content_version(file)
+      {
         file_id: file.fetch("id"),
-        title: file["name"].to_s,
-        text_hash: "",
-        export_mime_type: EXPORT_MIME_TYPE,
-        source_modified_at: file["modifiedTime"],
-        source_version: file["version"].to_s,
-        source_run_id: @run_id,
-        last_error: "#{e.class}: #{e.message}"
+        source_version: source_version(file)
       }
+    end
+
+    def document_batch(file)
+      doc = google_api(
+        "#{DOCS_GET_ENDPOINT}/#{CGI.escape(file.fetch('id'))}",
+        "includeTabsContent" => "true"
+      )
+      text = docs_text_from_document(doc)
+      title = doc["title"].presence || file["name"].to_s
+      exported_at = Time.current.iso8601
+      contents = [
+        {
+          file_id: file.fetch("id"),
+          title: title,
+          text_content: text,
+          text_hash: content_hash(text),
+          export_mime_type: EXPORT_MIME_TYPE,
+          exported_at: exported_at,
+          source_modified_at: file["modifiedTime"],
+          source_version: source_version(file)
+        }
+      ]
+      context_documents = chunks_for(text).each_with_index.map do |chunk, index|
+        context_document(file, title, chunk, format("chunk-%04d", index))
+      end
+      {
+        contents: contents,
+        context_documents: context_documents,
+        replace_context_documents: true
+      }
+    end
+
+    private
+
+    def source_version(file)
+      file["version"].presence || file["modifiedTime"].to_s
     end
 
     def context_document(file, title, body, chunk_id)
@@ -255,51 +205,10 @@ module GoogleDocs
         drive_id: file["driveId"].to_s,
         source_created_at: file["createdTime"],
         source_modified_at: file["modifiedTime"],
-        source_version: file["version"].to_s,
+        source_version: source_version(file),
         content_hash: content_hash(file.fetch("id"), chunk_id, title, body),
-        metadata: {
-          source: "google_docs",
-          provider_subject: @credential.provider_subject.to_s,
-          provider_email: @credential.provider_email.to_s,
-          broker_credential_id: @credential.oid
-        }
+        metadata: { source: "google_docs" }
       }
-    end
-
-    def finish_batch(batch)
-      batch[:run][:files_upserted] = batch[:files].length
-      batch[:run][:docs_fetched] = @docs_fetched
-      batch[:run][:docs_upserted] = batch[:contents].count { |content| content[:last_error].blank? }
-      batch[:run][:chunks_upserted] = @chunks_upserted
-      batch[:run][:finished] = true
-
-      successful = @docs_failed.zero? && !@truncated
-      batch[:run][:status] = successful ? "completed" : "partial_failed"
-      batch[:run][:error_text] = if @truncated
-        "Google Docs sync hit max page limit"
-      elsif @docs_failed.positive?
-        "#{@docs_failed} Google Doc(s) failed"
-      else
-        ""
-      end
-
-      batch[:checkpoint] = {
-        broker_credential_id: @credential.oid,
-        provider_subject: @credential.provider_subject.to_s,
-        provider_email: @credential.provider_email.to_s,
-        last_run_id: @run_id,
-        last_error: batch[:run][:error_text].to_s,
-        metadata: { "page_size" => self.class.page_size, "max_pages" => self.class.max_pages }
-      }
-      if successful
-        now = Time.current.iso8601
-        batch[:checkpoint][:last_incremental_sync_at] = (@max_modified_at&.iso8601 || now)
-        batch[:checkpoint][:last_full_sync_at] = now
-      end
-    end
-
-    def docs_get(file_id)
-      google_api("#{DOCS_GET_ENDPOINT}/#{CGI.escape(file_id)}", { "includeTabsContent" => "true" })
     end
 
     def docs_text_from_document(doc)
@@ -337,18 +246,8 @@ module GoogleDocs
       return "" unless capabilities.is_a?(Hash)
       return "writer" if capabilities["canEdit"] == true
       return "commenter" if capabilities["canComment"] == true
+
       "reader"
-    end
-
-    def track_modified_at(value)
-      parsed = Time.iso8601(value.to_s)
-      @max_modified_at = parsed if @max_modified_at.nil? || parsed > @max_modified_at
-    rescue ArgumentError
-      nil
-    end
-
-    def drive_literal(value)
-      value.to_s.gsub("\\", "\\\\").gsub("'", "\\\\'")
     end
 
     def content_hash(*parts)
@@ -357,7 +256,7 @@ module GoogleDocs
 
     def google_api(endpoint, params = {})
       response = if @google_api_http
-        @google_api_http.call(endpoint: endpoint, params: params, access_token: @credential.access_token)
+        @google_api_http.call(endpoint: endpoint, params: params, access_token: credential.access_token)
       else
         net_http_get(endpoint, params)
       end
@@ -370,7 +269,7 @@ module GoogleDocs
       response = HttpClient.new.get(
         endpoint,
         params: params,
-        headers: { "Authorization" => "Bearer #{@credential.access_token}" }
+        headers: { "Authorization" => "Bearer #{credential.access_token}" }
       )
       parsed = response.json
       return parsed if response.success?

--- a/services/console/app/services/google_docs/sync_credential.rb
+++ b/services/console/app/services/google_docs/sync_credential.rb
@@ -95,7 +95,8 @@ module GoogleDocs
         {
           "pageToken" => page_token,
           "pageSize" => self.class.page_size,
-          "fields" => "nextPageToken,newStartPageToken,changes(fileId,removed,file(#{FILE_FIELDS}))",
+          "fields" => "nextPageToken,newStartPageToken," \
+            "changes(changeType,driveId,fileId,removed,file(#{FILE_FIELDS}))",
           "includeItemsFromAllDrives" => "true",
           "includeRemoved" => "true",
           "supportsAllDrives" => "true",

--- a/services/console/app/services/google_docs/sync_credential.rb
+++ b/services/console/app/services/google_docs/sync_credential.rb
@@ -130,9 +130,7 @@ module GoogleDocs
       }
     end
 
-    def observation_payload(file, run_id: nil, source:, initial_crawl_id: nil)
-      raw_payload = { "source" => source }
-      raw_payload["initial_crawl_id"] = initial_crawl_id if initial_crawl_id
+    def observation_payload(file, run_id: nil, source:)
       {
         broker_credential_id: credential.oid,
         observed_file_id: file.fetch("id"),
@@ -145,7 +143,7 @@ module GoogleDocs
         role_hint: role_hint(file),
         permission_ids: [],
         active: true,
-        raw_payload: raw_payload,
+        raw_payload: { "source" => source },
         source_run_id: run_id
       }
     end

--- a/services/console/app/services/google_docs/sync_credential.rb
+++ b/services/console/app/services/google_docs/sync_credential.rb
@@ -24,8 +24,8 @@ module GoogleDocs
 
       def required_scopes_granted?(scopes)
         granted = Array(scopes)
-        granted.include?(DOCS_READONLY_SCOPE) &&
-          (granted.include?(DRIVE_METADATA_SCOPE) || granted.include?(DRIVE_READONLY_SCOPE))
+        granted.include?(DRIVE_READONLY_SCOPE) ||
+          (granted.include?(DRIVE_METADATA_SCOPE) && granted.include?(DOCS_READONLY_SCOPE))
       end
 
       def page_size

--- a/services/console/app/services/google_docs/sync_credential.rb
+++ b/services/console/app/services/google_docs/sync_credential.rb
@@ -37,6 +37,13 @@ module GoogleDocs
           (granted.include?(DRIVE_METADATA_SCOPE) && granted.include?(DOCS_READONLY_SCOPE))
       end
 
+      def syncable?(credential, oauth_app_slug: nil)
+        credential.present? && !credential.dead? && credential.access_token.present? &&
+          credential.oauth_app&.provider == Oauth::Providers::Google::KEY &&
+          credential.oauth_app.enabled? && required_scopes_granted?(credential.scopes) &&
+          (oauth_app_slug.nil? || credential.oauth_app.slug == oauth_app_slug)
+      end
+
       def page_size
         positive_int(ConsoleEnv["GOOGLE_DOCS_SYNC_PAGE_SIZE"], 100)
       end

--- a/services/console/config/queue.yml
+++ b/services/console/config/queue.yml
@@ -3,9 +3,13 @@ default: &default
     - polling_interval: 1
       batch_size: 500
   workers:
-    - queues: "*"
+    - queues: default
       threads: 3
       processes: <%= ConsoleEnv.fetch("JOB_CONCURRENCY", 1) %>
+      polling_interval: 0.1
+    - queues: google_docs
+      threads: 1
+      processes: 1
       polling_interval: 0.1
 
 development:

--- a/services/console/test/jobs/google_docs/jobs_test.rb
+++ b/services/console/test/jobs/google_docs/jobs_test.rb
@@ -3,17 +3,21 @@ require "test_helper"
 module GoogleDocs
   class JobsTest < ActiveJob::TestCase
     class FakeApiClient
-      attr_accessor :checkpoint, :missing
+      attr_accessor :checkpoint, :initial_sync_active, :missing
       attr_reader :batches
 
-      def initialize(checkpoint: nil, missing: nil)
+      def initialize(checkpoint: nil, initial_sync_active: false, missing: nil)
         @checkpoint = checkpoint
+        @initial_sync_active = initial_sync_active
         @missing = missing
         @batches = []
       end
 
       def get_google_docs_sync_checkpoint(broker_credential_id:)
-        { "checkpoint" => checkpoint }
+        {
+          "checkpoint" => checkpoint,
+          "initial_sync_active" => initial_sync_active
+        }
       end
 
       def ingest_google_docs_sync_batch(payload)
@@ -70,6 +74,10 @@ module GoogleDocs
       assert_enqueued_with(job: InitialSyncJob, args: [ credential.id ])
 
       clear_enqueued_jobs
+      api_client.initial_sync_active = true
+      CentaurApiClient.stub(:new, api_client) { PollSyncJob.perform_now(app.slug) }
+      assert_no_enqueued_jobs
+
       api_client.checkpoint = checkpoint_for(credential, changes_page_token: "change-200")
       CentaurApiClient.stub(:new, api_client) { PollSyncJob.perform_now(app.slug) }
       assert_enqueued_with(job: IncrementalSyncJob, args: [ credential.id ])
@@ -117,7 +125,11 @@ module GoogleDocs
       assert_equal [ "doc-123" ], first_page[:observations].pluck(:observed_file_id)
       refute first_page.key?(:observation_sweeps)
       refute first_page.key?(:checkpoint)
-      assert_enqueued_with(job: InitialSyncJob, args: [ credential.id, continuation ])
+      assert_enqueued_with(
+        job: InitialSyncJob,
+        args: [ credential.id, continuation ],
+        priority: SyncJob::CONTINUATION_PRIORITY
+      )
 
       with_clients(api_client, google_http) do
         InitialSyncJob.perform_now(credential.id, continuation)
@@ -216,7 +228,10 @@ module GoogleDocs
           }
         else
           {
-            "changes" => [ { "fileId" => "doc-removed", "removed" => true } ],
+            "changes" => [
+              { "changeType" => "drive", "driveId" => "shared-drive-1" },
+              { "fileId" => "doc-removed", "removed" => true }
+            ],
             "newStartPageToken" => "change-200"
           }
         end
@@ -313,15 +328,16 @@ module GoogleDocs
       assert_equal "google_docs:doc-123:chunk-0000", batch[:context_documents].first[:document_id]
     end
 
-    test "credential crawler jobs share a long-lived discard concurrency group" do
+    test "credential crawler jobs block conflicts and prioritize chain continuations" do
       assert_equal "GoogleDocsCredentialSync", InitialSyncJob.concurrency_group
       assert_equal InitialSyncJob.concurrency_group, IncrementalSyncJob.concurrency_group
-      assert_equal :discard, InitialSyncJob.concurrency_on_conflict
+      assert_equal :block, InitialSyncJob.concurrency_on_conflict
       assert_equal 1.hour, InitialSyncJob.concurrency_duration
 
       initial = InitialSyncJob.new(123)
       continuation = InitialSyncJob.new(123, { "page_token" => "files-2" })
       assert_equal initial.concurrency_key, continuation.concurrency_key
+      assert_equal(-10, SyncJob::CONTINUATION_PRIORITY)
     end
 
     private

--- a/services/console/test/jobs/google_docs/jobs_test.rb
+++ b/services/console/test/jobs/google_docs/jobs_test.rb
@@ -1,0 +1,31 @@
+require "test_helper"
+
+module GoogleDocs
+  class JobsTest < ActiveJob::TestCase
+    test "poll job enqueues a credential with drive readonly scope alone" do
+      app = OauthApp.create!(
+        provider: "google",
+        slug: "google-docs-job-#{SecureRandom.hex(6)}",
+        client_id: "google-client",
+        client_secret: "secret",
+        allowed_scopes: [ SyncCredential::DRIVE_READONLY_SCOPE ],
+        enabled: true,
+        created_by: users(:acme_admin)
+      )
+      credential = BrokerCredential.create!(
+        oauth_app: app,
+        foreign_id: "google-docs-job-#{SecureRandom.hex(6)}",
+        token_endpoint: "https://oauth2.googleapis.com/token",
+        access_token: "token",
+        refresh_token: "refresh",
+        last_refresh: Time.current,
+        expires_at: 1.hour.from_now,
+        scopes: [ SyncCredential::DRIVE_READONLY_SCOPE ]
+      )
+
+      PollSyncJob.perform_now(app.slug)
+
+      assert_enqueued_with(job: SyncCredentialJob, args: [ credential.id ])
+    end
+  end
+end

--- a/services/console/test/jobs/google_docs/jobs_test.rb
+++ b/services/console/test/jobs/google_docs/jobs_test.rb
@@ -61,26 +61,11 @@ module GoogleDocs
       )
     end
 
-    test "poll job routes a Drive readonly credential to its current phase" do
+    test "poll job enqueues the incremental entry job for a Drive readonly credential" do
       app = create_google_app
       credential = create_credential(app: app)
-      api_client = FakeApiClient.new
 
-      CentaurApiClient.stub(:new, api_client) do
-        PollSyncJob.perform_now(app.slug)
-      end
-
-      assert_enqueued_with(job: InitialSyncJob, args: [ credential.id ])
-
-      clear_enqueued_jobs
-      api_client.checkpoint = {
-        "broker_credential_id" => credential.oid,
-        "changes_page_token" => "change-2",
-        "metadata" => { "phase" => "ready" }
-      }
-      CentaurApiClient.stub(:new, api_client) do
-        PollSyncJob.perform_now(app.slug)
-      end
+      PollSyncJob.perform_now(app.slug)
 
       assert_enqueued_with(job: IncrementalSyncJob, args: [ credential.id ])
     end
@@ -107,12 +92,13 @@ module GoogleDocs
       end
 
       initialization = api_client.batches.first
-      refute initialization.key?(:reset_observation_credentials)
       assert_equal "change-100", initialization.dig(:checkpoint, :start_page_token)
       assert_equal "change-100", initialization.dig(:checkpoint, :changes_page_token)
       crawl_id = initialization.dig(:checkpoint, :metadata, "initial_crawl_id")
       assert crawl_id.present?
       metadata_batch = api_client.batches.second
+      assert_equal "completed", metadata_batch.dig(:run, :status)
+      assert metadata_batch[:checkpoint]
       assert_equal [ "doc-123" ], metadata_batch[:files].pluck(:file_id)
       assert_equal [ "doc-123" ], metadata_batch[:observations].pluck(:observed_file_id)
       assert_equal crawl_id, metadata_batch[:observations].first.dig(:raw_payload, "initial_crawl_id")
@@ -185,8 +171,7 @@ module GoogleDocs
           credential,
           phase: "catching_up",
           changes_page_token: "change-100"
-        ),
-        missing: []
+        )
       )
       file = google_doc
       google_http = lambda do |endpoint:, params:, **|
@@ -206,6 +191,8 @@ module GoogleDocs
       end
 
       metadata_batch = api_client.batches.first
+      assert_equal 1, api_client.batches.length
+      assert_equal "completed", metadata_batch.dig(:run, :status)
       assert_equal [ "doc-123" ], metadata_batch[:files].pluck(:file_id)
       assert_equal(
         [ { broker_credential_id: credential.oid, observed_file_id: "doc-removed" } ],
@@ -225,8 +212,7 @@ module GoogleDocs
           credential,
           phase: "ready",
           changes_page_token: "change-200"
-        ),
-        missing: []
+        )
       )
       google_http = lambda do |endpoint:, params:, **|
         assert_equal SyncCredential::CHANGES_LIST_ENDPOINT, endpoint
@@ -286,7 +272,19 @@ module GoogleDocs
       assert_no_enqueued_jobs(only: IncrementalSyncJob)
     end
 
-    test "stale crawler jobs hand off without moving a checkpoint backward" do
+    test "crawler entry jobs hand off without moving a checkpoint backward" do
+      credential = create_credential
+      api_client = FakeApiClient.new
+      google_http = ->(**) { flunk "a routing job should not call Google" }
+
+      with_clients(api_client, google_http) do
+        IncrementalSyncJob.perform_now(credential.id)
+      end
+
+      assert_empty api_client.batches
+      assert_enqueued_with(job: InitialSyncJob, args: [ credential.id ])
+
+      clear_enqueued_jobs
       credential = create_credential
       api_client = FakeApiClient.new(
         checkpoint: checkpoint_for(
@@ -295,8 +293,6 @@ module GoogleDocs
           changes_page_token: "change-200"
         )
       )
-      google_http = ->(**) { flunk "a stale initial job should not call Google" }
-
       with_clients(api_client, google_http) do
         InitialSyncJob.perform_now(credential.id)
       end

--- a/services/console/test/jobs/google_docs/jobs_test.rb
+++ b/services/console/test/jobs/google_docs/jobs_test.rb
@@ -85,7 +85,7 @@ module GoogleDocs
       assert_enqueued_with(job: IncrementalSyncJob, args: [ credential.id ])
     end
 
-    test "initial sync captures a change token, resets visibility, and persists one file page" do
+    test "initial sync captures a change token and marks observations without resetting visibility" do
       credential = create_credential
       api_client = FakeApiClient.new
       file = google_doc
@@ -107,14 +107,18 @@ module GoogleDocs
       end
 
       initialization = api_client.batches.first
-      assert_equal [ credential.oid ], initialization[:reset_observation_credentials]
+      refute initialization.key?(:reset_observation_credentials)
       assert_equal "change-100", initialization.dig(:checkpoint, :start_page_token)
       assert_equal "change-100", initialization.dig(:checkpoint, :changes_page_token)
+      crawl_id = initialization.dig(:checkpoint, :metadata, "initial_crawl_id")
+      assert crawl_id.present?
       metadata_batch = api_client.batches.second
       assert_equal [ "doc-123" ], metadata_batch[:files].pluck(:file_id)
       assert_equal [ "doc-123" ], metadata_batch[:observations].pluck(:observed_file_id)
+      assert_equal crawl_id, metadata_batch[:observations].first.dig(:raw_payload, "initial_crawl_id")
       assert_equal "files-2", api_client.checkpoint.dig("metadata", "initial_page_token")
       assert_equal "listing", api_client.checkpoint.dig("metadata", "phase")
+      assert_empty api_client.batches.last[:observation_sweeps]
       assert_enqueued_with(job: FetchDocumentJob, args: [ credential.id, file ])
       assert_enqueued_with(job: InitialSyncJob, args: [ credential.id ])
     end
@@ -126,7 +130,8 @@ module GoogleDocs
           credential,
           phase: "listing",
           changes_page_token: "change-100",
-          initial_page_token: "files-2"
+          initial_page_token: "files-2",
+          initial_crawl_id: "crawl-123"
         )
       )
       google_http = lambda do |endpoint:, params:, **|
@@ -141,7 +146,36 @@ module GoogleDocs
 
       assert_equal "catching_up", api_client.checkpoint.dig("metadata", "phase")
       assert_equal "change-100", api_client.checkpoint["changes_page_token"]
+      assert_equal(
+        [ { broker_credential_id: credential.oid, initial_crawl_id: "crawl-123" } ],
+        api_client.batches.last[:observation_sweeps]
+      )
       assert_enqueued_with(job: IncrementalSyncJob, args: [ credential.id ])
+    end
+
+    test "a rejected initial page token resets the checkpoint and restarts the initial crawl" do
+      credential = create_credential
+      api_client = FakeApiClient.new(
+        checkpoint: checkpoint_for(
+          credential,
+          phase: "listing",
+          changes_page_token: "change-100",
+          initial_page_token: "files-expired",
+          initial_crawl_id: "crawl-123"
+        )
+      )
+      google_http = lambda do |endpoint:, **|
+        assert_equal SyncCredential::FILES_LIST_ENDPOINT, endpoint
+        raise SyncCredential::InvalidPageTokenError, "Page token expired"
+      end
+
+      with_clients(api_client, google_http) do
+        InitialSyncJob.perform_now(credential.id)
+      end
+
+      assert_equal "pending", api_client.checkpoint.dig("metadata", "phase")
+      assert_equal "", api_client.checkpoint.dig("metadata", "initial_page_token")
+      assert_enqueued_with(job: InitialSyncJob, args: [ credential.id ])
     end
 
     test "incremental sync applies current files and removals before advancing its token" do
@@ -208,6 +242,48 @@ module GoogleDocs
       assert_equal "change-201", api_client.checkpoint["changes_page_token"]
       assert_nil api_client.checkpoint["last_incremental_sync_at"]
       assert_enqueued_with(job: IncrementalSyncJob, args: [ credential.id ])
+    end
+
+    test "a rejected changes token resets the checkpoint and restarts the initial crawl" do
+      credential = create_credential
+      api_client = FakeApiClient.new(
+        checkpoint: checkpoint_for(
+          credential,
+          phase: "ready",
+          changes_page_token: "change-expired"
+        )
+      )
+      google_http = lambda do |endpoint:, **|
+        assert_equal SyncCredential::CHANGES_LIST_ENDPOINT, endpoint
+        raise SyncCredential::InvalidPageTokenError, "Page token expired"
+      end
+
+      with_clients(api_client, google_http) do
+        IncrementalSyncJob.perform_now(credential.id)
+      end
+
+      assert_equal "pending", api_client.checkpoint.dig("metadata", "phase")
+      assert_enqueued_with(job: InitialSyncJob, args: [ credential.id ])
+    end
+
+    test "a missing changes token resets the checkpoint instead of bouncing between crawlers" do
+      credential = create_credential
+      api_client = FakeApiClient.new(
+        checkpoint: checkpoint_for(
+          credential,
+          phase: "ready",
+          changes_page_token: ""
+        )
+      )
+      google_http = ->(**) { flunk "a missing token should not call Google" }
+
+      with_clients(api_client, google_http) do
+        IncrementalSyncJob.perform_now(credential.id)
+      end
+
+      assert_equal "pending", api_client.checkpoint.dig("metadata", "phase")
+      assert_enqueued_with(job: InitialSyncJob, args: [ credential.id ])
+      assert_no_enqueued_jobs(only: IncrementalSyncJob)
     end
 
     test "stale crawler jobs hand off without moving a checkpoint backward" do
@@ -288,14 +364,21 @@ module GoogleDocs
       SyncCredential.google_api_http = previous_http
     end
 
-    def checkpoint_for(credential, phase:, changes_page_token:, initial_page_token: nil)
+    def checkpoint_for(
+      credential,
+      phase:,
+      changes_page_token:,
+      initial_page_token: nil,
+      initial_crawl_id: nil
+    )
       {
         "broker_credential_id" => credential.oid,
         "start_page_token" => "change-100",
         "changes_page_token" => changes_page_token,
         "metadata" => {
           "phase" => phase,
-          "initial_page_token" => initial_page_token.to_s
+          "initial_page_token" => initial_page_token.to_s,
+          "initial_crawl_id" => initial_crawl_id
         }
       }
     end

--- a/services/console/test/jobs/google_docs/jobs_test.rb
+++ b/services/console/test/jobs/google_docs/jobs_test.rb
@@ -2,8 +2,40 @@ require "test_helper"
 
 module GoogleDocs
   class JobsTest < ActiveJob::TestCase
-    test "poll job enqueues a credential with drive readonly scope alone" do
-      app = OauthApp.create!(
+    class FakeApiClient
+      attr_accessor :checkpoint, :missing
+      attr_reader :batches
+
+      def initialize(checkpoint: nil, missing: nil)
+        @checkpoint = checkpoint
+        @missing = missing
+        @batches = []
+      end
+
+      def get_google_docs_sync_checkpoint(broker_credential_id:)
+        { "checkpoint" => checkpoint }
+      end
+
+      def ingest_google_docs_sync_batch(payload)
+        @batches << payload
+        update_checkpoint(payload[:checkpoint]) if payload[:checkpoint]
+        { "ok" => true }
+      end
+
+      def get_google_docs_content_status(files:)
+        requested = files.map(&:deep_stringify_keys)
+        { "missing" => missing.nil? ? requested : missing }
+      end
+
+      private
+
+      def update_checkpoint(payload)
+        @checkpoint = (checkpoint || {}).merge(payload.deep_stringify_keys)
+      end
+    end
+
+    def create_google_app
+      OauthApp.create!(
         provider: "google",
         slug: "google-docs-job-#{SecureRandom.hex(6)}",
         client_id: "google-client",
@@ -12,7 +44,10 @@ module GoogleDocs
         enabled: true,
         created_by: users(:acme_admin)
       )
-      credential = BrokerCredential.create!(
+    end
+
+    def create_credential(app: create_google_app)
+      BrokerCredential.create!(
         oauth_app: app,
         foreign_id: "google-docs-job-#{SecureRandom.hex(6)}",
         token_endpoint: "https://oauth2.googleapis.com/token",
@@ -20,12 +55,264 @@ module GoogleDocs
         refresh_token: "refresh",
         last_refresh: Time.current,
         expires_at: 1.hour.from_now,
-        scopes: [ SyncCredential::DRIVE_READONLY_SCOPE ]
+        scopes: [ SyncCredential::DRIVE_READONLY_SCOPE ],
+        provider_subject: "google-subject-#{SecureRandom.hex(4)}",
+        provider_email: "person@example.com"
       )
+    end
 
-      PollSyncJob.perform_now(app.slug)
+    test "poll job routes a Drive readonly credential to its current phase" do
+      app = create_google_app
+      credential = create_credential(app: app)
+      api_client = FakeApiClient.new
 
-      assert_enqueued_with(job: SyncCredentialJob, args: [ credential.id ])
+      CentaurApiClient.stub(:new, api_client) do
+        PollSyncJob.perform_now(app.slug)
+      end
+
+      assert_enqueued_with(job: InitialSyncJob, args: [ credential.id ])
+
+      clear_enqueued_jobs
+      api_client.checkpoint = {
+        "broker_credential_id" => credential.oid,
+        "changes_page_token" => "change-2",
+        "metadata" => { "phase" => "ready" }
+      }
+      CentaurApiClient.stub(:new, api_client) do
+        PollSyncJob.perform_now(app.slug)
+      end
+
+      assert_enqueued_with(job: IncrementalSyncJob, args: [ credential.id ])
+    end
+
+    test "initial sync captures a change token, resets visibility, and persists one file page" do
+      credential = create_credential
+      api_client = FakeApiClient.new
+      file = google_doc
+      google_http = lambda do |endpoint:, params:, access_token:|
+        assert_equal "token", access_token
+        case endpoint
+        when SyncCredential::START_PAGE_TOKEN_ENDPOINT
+          { "startPageToken" => "change-100" }
+        when SyncCredential::FILES_LIST_ENDPOINT
+          assert_nil params["pageToken"]
+          { "files" => [ file ], "nextPageToken" => "files-2" }
+        else
+          flunk "unexpected Google endpoint #{endpoint}"
+        end
+      end
+
+      with_clients(api_client, google_http) do
+        InitialSyncJob.perform_now(credential.id)
+      end
+
+      initialization = api_client.batches.first
+      assert_equal [ credential.oid ], initialization[:reset_observation_credentials]
+      assert_equal "change-100", initialization.dig(:checkpoint, :start_page_token)
+      assert_equal "change-100", initialization.dig(:checkpoint, :changes_page_token)
+      metadata_batch = api_client.batches.second
+      assert_equal [ "doc-123" ], metadata_batch[:files].pluck(:file_id)
+      assert_equal [ "doc-123" ], metadata_batch[:observations].pluck(:observed_file_id)
+      assert_equal "files-2", api_client.checkpoint.dig("metadata", "initial_page_token")
+      assert_equal "listing", api_client.checkpoint.dig("metadata", "phase")
+      assert_enqueued_with(job: FetchDocumentJob, args: [ credential.id, file ])
+      assert_enqueued_with(job: InitialSyncJob, args: [ credential.id ])
+    end
+
+    test "initial sync hands its baseline token to incremental catch-up after the final page" do
+      credential = create_credential
+      api_client = FakeApiClient.new(
+        checkpoint: checkpoint_for(
+          credential,
+          phase: "listing",
+          changes_page_token: "change-100",
+          initial_page_token: "files-2"
+        )
+      )
+      google_http = lambda do |endpoint:, params:, **|
+        assert_equal SyncCredential::FILES_LIST_ENDPOINT, endpoint
+        assert_equal "files-2", params["pageToken"]
+        { "files" => [] }
+      end
+
+      with_clients(api_client, google_http) do
+        InitialSyncJob.perform_now(credential.id)
+      end
+
+      assert_equal "catching_up", api_client.checkpoint.dig("metadata", "phase")
+      assert_equal "change-100", api_client.checkpoint["changes_page_token"]
+      assert_enqueued_with(job: IncrementalSyncJob, args: [ credential.id ])
+    end
+
+    test "incremental sync applies current files and removals before advancing its token" do
+      credential = create_credential
+      api_client = FakeApiClient.new(
+        checkpoint: checkpoint_for(
+          credential,
+          phase: "catching_up",
+          changes_page_token: "change-100"
+        ),
+        missing: []
+      )
+      file = google_doc
+      google_http = lambda do |endpoint:, params:, **|
+        assert_equal SyncCredential::CHANGES_LIST_ENDPOINT, endpoint
+        assert_equal "change-100", params["pageToken"]
+        {
+          "changes" => [
+            { "fileId" => "doc-removed", "removed" => true },
+            { "fileId" => "doc-123", "file" => file }
+          ],
+          "newStartPageToken" => "change-200"
+        }
+      end
+
+      with_clients(api_client, google_http) do
+        IncrementalSyncJob.perform_now(credential.id)
+      end
+
+      metadata_batch = api_client.batches.first
+      assert_equal [ "doc-123" ], metadata_batch[:files].pluck(:file_id)
+      assert_equal(
+        [ { broker_credential_id: credential.oid, observed_file_id: "doc-removed" } ],
+        metadata_batch[:observation_deactivations]
+      )
+      assert_equal "ready", api_client.checkpoint.dig("metadata", "phase")
+      assert_equal "change-200", api_client.checkpoint["changes_page_token"]
+      assert api_client.checkpoint["last_full_sync_at"].present?
+      assert api_client.checkpoint["last_incremental_sync_at"].present?
+      assert_no_enqueued_jobs(only: IncrementalSyncJob)
+    end
+
+    test "incremental sync persists each change page before scheduling the next page" do
+      credential = create_credential
+      api_client = FakeApiClient.new(
+        checkpoint: checkpoint_for(
+          credential,
+          phase: "ready",
+          changes_page_token: "change-200"
+        ),
+        missing: []
+      )
+      google_http = lambda do |endpoint:, params:, **|
+        assert_equal SyncCredential::CHANGES_LIST_ENDPOINT, endpoint
+        assert_equal "change-200", params["pageToken"]
+        { "changes" => [], "nextPageToken" => "change-201" }
+      end
+
+      with_clients(api_client, google_http) do
+        IncrementalSyncJob.perform_now(credential.id)
+      end
+
+      assert_equal "ready", api_client.checkpoint.dig("metadata", "phase")
+      assert_equal "change-201", api_client.checkpoint["changes_page_token"]
+      assert_nil api_client.checkpoint["last_incremental_sync_at"]
+      assert_enqueued_with(job: IncrementalSyncJob, args: [ credential.id ])
+    end
+
+    test "stale crawler jobs hand off without moving a checkpoint backward" do
+      credential = create_credential
+      api_client = FakeApiClient.new(
+        checkpoint: checkpoint_for(
+          credential,
+          phase: "ready",
+          changes_page_token: "change-200"
+        )
+      )
+      google_http = ->(**) { flunk "a stale initial job should not call Google" }
+
+      with_clients(api_client, google_http) do
+        InitialSyncJob.perform_now(credential.id)
+      end
+
+      assert_empty api_client.batches
+      assert_equal "change-200", api_client.checkpoint["changes_page_token"]
+      assert_enqueued_with(job: IncrementalSyncJob, args: [ credential.id ])
+    end
+
+    test "document fetch skips a canonical version that is already present" do
+      credential = create_credential
+      api_client = FakeApiClient.new(missing: [])
+      google_http = ->(**) { flunk "documents.get should not be called" }
+
+      with_clients(api_client, google_http) do
+        FetchDocumentJob.perform_now(credential.id, google_doc)
+      end
+
+      assert_empty api_client.batches
+    end
+
+    test "document fetch ingests a missing canonical version" do
+      credential = create_credential
+      api_client = FakeApiClient.new
+      google_http = lambda do |endpoint:, **|
+        assert_equal "#{SyncCredential::DOCS_GET_ENDPOINT}/doc-123", endpoint
+        {
+          "title" => "Launch Plan",
+          "body" => {
+            "content" => [
+              {
+                "paragraph" => {
+                  "elements" => [ { "textRun" => { "content" => "Ship it.\n" } } ]
+                }
+              }
+            ]
+          }
+        }
+      end
+
+      with_clients(api_client, google_http) do
+        FetchDocumentJob.perform_now(credential.id, google_doc)
+      end
+
+      batch = api_client.batches.fetch(0)
+      assert_equal "doc-123", batch[:contents].first[:file_id]
+      assert_equal "Ship it.\n", batch[:contents].first[:text_content]
+      assert_equal "google_docs:doc-123:chunk-0000", batch[:context_documents].first[:document_id]
+    end
+
+    test "credential crawler jobs share a long-lived discard concurrency group" do
+      assert_equal "GoogleDocsCredentialSync", InitialSyncJob.concurrency_group
+      assert_equal InitialSyncJob.concurrency_group, IncrementalSyncJob.concurrency_group
+      assert_equal :discard, InitialSyncJob.concurrency_on_conflict
+      assert_equal 1.hour, InitialSyncJob.concurrency_duration
+    end
+
+    private
+
+    def with_clients(api_client, google_http)
+      previous_http = SyncCredential.google_api_http
+      SyncCredential.google_api_http = google_http
+      CentaurApiClient.stub(:new, api_client) { yield }
+    ensure
+      SyncCredential.google_api_http = previous_http
+    end
+
+    def checkpoint_for(credential, phase:, changes_page_token:, initial_page_token: nil)
+      {
+        "broker_credential_id" => credential.oid,
+        "start_page_token" => "change-100",
+        "changes_page_token" => changes_page_token,
+        "metadata" => {
+          "phase" => phase,
+          "initial_page_token" => initial_page_token.to_s
+        }
+      }
+    end
+
+    def google_doc
+      {
+        "id" => "doc-123",
+        "name" => "Launch Plan",
+        "mimeType" => SyncCredential::GOOGLE_DOC_MIME_TYPE,
+        "webViewLink" => "https://docs.google.com/document/d/doc-123/edit",
+        "owners" => [ { "permissionId" => "owner-1", "displayName" => "Alice" } ],
+        "capabilities" => { "canEdit" => true },
+        "trashed" => false,
+        "createdTime" => "2026-06-01T12:00:00Z",
+        "modifiedTime" => "2026-06-02T12:00:00Z",
+        "version" => "7"
+      }
     end
   end
 end

--- a/services/console/test/jobs/google_docs/jobs_test.rb
+++ b/services/console/test/jobs/google_docs/jobs_test.rb
@@ -3,21 +3,17 @@ require "test_helper"
 module GoogleDocs
   class JobsTest < ActiveJob::TestCase
     class FakeApiClient
-      attr_accessor :checkpoint, :initial_sync_active, :missing
+      attr_accessor :checkpoint, :missing
       attr_reader :batches
 
-      def initialize(checkpoint: nil, initial_sync_active: false, missing: nil)
+      def initialize(checkpoint: nil, missing: nil)
         @checkpoint = checkpoint
-        @initial_sync_active = initial_sync_active
         @missing = missing
         @batches = []
       end
 
       def get_google_docs_sync_checkpoint(broker_credential_id:)
-        {
-          "checkpoint" => checkpoint,
-          "initial_sync_active" => initial_sync_active
-        }
+        { "checkpoint" => checkpoint }
       end
 
       def ingest_google_docs_sync_batch(payload)
@@ -74,16 +70,12 @@ module GoogleDocs
       assert_enqueued_with(job: InitialSyncJob, args: [ credential.id ])
 
       clear_enqueued_jobs
-      api_client.initial_sync_active = true
-      CentaurApiClient.stub(:new, api_client) { PollSyncJob.perform_now(app.slug) }
-      assert_no_enqueued_jobs
-
       api_client.checkpoint = checkpoint_for(credential, changes_page_token: "change-200")
       CentaurApiClient.stub(:new, api_client) { PollSyncJob.perform_now(app.slug) }
       assert_enqueued_with(job: IncrementalSyncJob, args: [ credential.id ])
     end
 
-    test "initial sync durably chains pages before sweeping and publishing its high-water mark" do
+    test "initial sync ingests bounded pages before sweeping and publishing its high-water mark" do
       credential = create_credential
       api_client = FakeApiClient.new
       first_file = google_doc
@@ -111,32 +103,14 @@ module GoogleDocs
       end
 
       run_id = api_client.batches.first.dig(:run, :run_id)
-      continuation = {
-        "run_id" => run_id,
-        "start_page_token" => "change-100",
-        "page_token" => "files-2",
-        "files_seen" => 1
-      }
-      assert_equal [ nil ], file_page_tokens
-      assert_equal 1, api_client.batches.length
+      assert_equal [ nil, "files-2" ], file_page_tokens
+      assert_equal 3, api_client.batches.length
       first_page = api_client.batches.first
       assert_equal "running", first_page.dig(:run, :status)
       assert_equal [ "doc-123" ], first_page[:files].pluck(:file_id)
       assert_equal [ "doc-123" ], first_page[:observations].pluck(:observed_file_id)
       refute first_page.key?(:observation_sweeps)
       refute first_page.key?(:checkpoint)
-      assert_enqueued_with(
-        job: InitialSyncJob,
-        args: [ credential.id, continuation ],
-        priority: SyncJob::CONTINUATION_PRIORITY
-      )
-
-      with_clients(api_client, google_http) do
-        InitialSyncJob.perform_now(credential.id, continuation)
-      end
-
-      assert_equal [ nil, "files-2" ], file_page_tokens
-      assert_equal 3, api_client.batches.length
       second_page = api_client.batches.second
       assert_equal run_id, second_page.dig(:run, :run_id)
       assert_equal 2, second_page.dig(:run, :files_seen)
@@ -160,7 +134,7 @@ module GoogleDocs
       assert_enqueued_with(job: IncrementalSyncJob, args: [ credential.id ])
     end
 
-    test "an initial job with a completed high-water mark hands off without crawling" do
+    test "a stale initial job with a completed high-water mark is a no-op" do
       credential = create_credential
       api_client = FakeApiClient.new(
         checkpoint: checkpoint_for(credential, changes_page_token: "change-200")
@@ -172,7 +146,7 @@ module GoogleDocs
       end
 
       assert_empty api_client.batches
-      assert_enqueued_with(job: IncrementalSyncJob, args: [ credential.id ])
+      assert_no_enqueued_jobs
     end
 
     test "a rejected initial page token leaves no high-water mark and restarts the crawl" do
@@ -193,16 +167,6 @@ module GoogleDocs
       end
 
       with_clients(api_client, google_http) { InitialSyncJob.perform_now(credential.id) }
-      run_id = api_client.batches.first.dig(:run, :run_id)
-      continuation = {
-        "run_id" => run_id,
-        "start_page_token" => "change-100",
-        "page_token" => "files-expired",
-        "files_seen" => 1
-      }
-      with_clients(api_client, google_http) do
-        InitialSyncJob.perform_now(credential.id, continuation)
-      end
 
       assert_equal "", api_client.checkpoint["changes_page_token"]
       assert_equal 2, api_client.batches.length
@@ -328,16 +292,11 @@ module GoogleDocs
       assert_equal "google_docs:doc-123:chunk-0000", batch[:context_documents].first[:document_id]
     end
 
-    test "credential crawler jobs block conflicts and prioritize chain continuations" do
+    test "credential crawler jobs block conflicts for the full crawl" do
       assert_equal "GoogleDocsCredentialSync", InitialSyncJob.concurrency_group
       assert_equal InitialSyncJob.concurrency_group, IncrementalSyncJob.concurrency_group
       assert_equal :block, InitialSyncJob.concurrency_on_conflict
       assert_equal 1.hour, InitialSyncJob.concurrency_duration
-
-      initial = InitialSyncJob.new(123)
-      continuation = InitialSyncJob.new(123, { "page_token" => "files-2" })
-      assert_equal initial.concurrency_key, continuation.concurrency_key
-      assert_equal(-10, SyncJob::CONTINUATION_PRIORITY)
     end
 
     private

--- a/services/console/test/jobs/google_docs/jobs_test.rb
+++ b/services/console/test/jobs/google_docs/jobs_test.rb
@@ -61,27 +61,38 @@ module GoogleDocs
       )
     end
 
-    test "poll job enqueues the incremental entry job for a Drive readonly credential" do
+    test "poll job chooses initial or incremental sync from the completed high-water mark" do
       app = create_google_app
       credential = create_credential(app: app)
+      api_client = FakeApiClient.new
 
-      PollSyncJob.perform_now(app.slug)
+      CentaurApiClient.stub(:new, api_client) { PollSyncJob.perform_now(app.slug) }
+      assert_enqueued_with(job: InitialSyncJob, args: [ credential.id ])
 
+      clear_enqueued_jobs
+      api_client.checkpoint = checkpoint_for(credential, changes_page_token: "change-200")
+      CentaurApiClient.stub(:new, api_client) { PollSyncJob.perform_now(app.slug) }
       assert_enqueued_with(job: IncrementalSyncJob, args: [ credential.id ])
     end
 
-    test "initial sync captures a change token and marks observations without resetting visibility" do
+    test "initial sync replaces the complete observation snapshot before publishing its high-water mark" do
       credential = create_credential
       api_client = FakeApiClient.new
-      file = google_doc
+      first_file = google_doc
+      second_file = google_doc("doc-456")
+      file_page_tokens = []
       google_http = lambda do |endpoint:, params:, access_token:|
         assert_equal "token", access_token
         case endpoint
         when SyncCredential::START_PAGE_TOKEN_ENDPOINT
           { "startPageToken" => "change-100" }
         when SyncCredential::FILES_LIST_ENDPOINT
-          assert_nil params["pageToken"]
-          { "files" => [ file ], "nextPageToken" => "files-2" }
+          file_page_tokens << params["pageToken"]
+          if params["pageToken"]
+            { "files" => [ second_file ] }
+          else
+            { "files" => [ first_file ], "nextPageToken" => "files-2" }
+          end
         else
           flunk "unexpected Google endpoint #{endpoint}"
         end
@@ -91,153 +102,111 @@ module GoogleDocs
         InitialSyncJob.perform_now(credential.id)
       end
 
-      initialization = api_client.batches.first
-      assert_equal "change-100", initialization.dig(:checkpoint, :start_page_token)
-      assert_equal "change-100", initialization.dig(:checkpoint, :changes_page_token)
-      crawl_id = initialization.dig(:checkpoint, :metadata, "initial_crawl_id")
-      assert crawl_id.present?
-      metadata_batch = api_client.batches.second
-      assert_equal "completed", metadata_batch.dig(:run, :status)
-      assert metadata_batch[:checkpoint]
-      assert_equal [ "doc-123" ], metadata_batch[:files].pluck(:file_id)
-      assert_equal [ "doc-123" ], metadata_batch[:observations].pluck(:observed_file_id)
-      assert_equal crawl_id, metadata_batch[:observations].first.dig(:raw_payload, "initial_crawl_id")
-      assert_equal "files-2", api_client.checkpoint.dig("metadata", "initial_page_token")
-      assert_equal "listing", api_client.checkpoint.dig("metadata", "phase")
-      assert_empty api_client.batches.last[:observation_sweeps]
-      assert_enqueued_with(job: FetchDocumentJob, args: [ credential.id, file ])
-      assert_enqueued_with(job: InitialSyncJob, args: [ credential.id ])
-    end
+      assert_equal [ nil, "files-2" ], file_page_tokens
+      assert_equal 2, api_client.batches.length
+      snapshot = api_client.batches.first
+      assert_equal "completed", snapshot.dig(:run, :status)
+      assert_equal [ "doc-123", "doc-456" ], snapshot[:files].pluck(:file_id)
+      assert_equal [ "doc-123", "doc-456" ], snapshot[:observations].pluck(:observed_file_id)
+      assert_equal [ credential.oid ], snapshot[:replace_observation_credentials]
+      refute snapshot.key?(:checkpoint)
 
-    test "initial sync hands its baseline token to incremental catch-up after the final page" do
-      credential = create_credential
-      api_client = FakeApiClient.new(
-        checkpoint: checkpoint_for(
-          credential,
-          phase: "listing",
-          changes_page_token: "change-100",
-          initial_page_token: "files-2",
-          initial_crawl_id: "crawl-123"
-        )
-      )
-      google_http = lambda do |endpoint:, params:, **|
-        assert_equal SyncCredential::FILES_LIST_ENDPOINT, endpoint
-        assert_equal "files-2", params["pageToken"]
-        { "files" => [] }
-      end
-
-      with_clients(api_client, google_http) do
-        InitialSyncJob.perform_now(credential.id)
-      end
-
-      assert_equal "catching_up", api_client.checkpoint.dig("metadata", "phase")
-      assert_equal "change-100", api_client.checkpoint["changes_page_token"]
-      assert_equal(
-        [ { broker_credential_id: credential.oid, initial_crawl_id: "crawl-123" } ],
-        api_client.batches.last[:observation_sweeps]
-      )
+      checkpoint = api_client.batches.second.fetch(:checkpoint)
+      assert_equal "change-100", checkpoint[:changes_page_token]
+      assert_equal({}, checkpoint[:metadata])
+      assert checkpoint[:last_full_sync_at].present?
+      assert_enqueued_with(job: FetchDocumentJob, args: [ credential.id, first_file ])
+      assert_enqueued_with(job: FetchDocumentJob, args: [ credential.id, second_file ])
       assert_enqueued_with(job: IncrementalSyncJob, args: [ credential.id ])
     end
 
-    test "a rejected initial page token resets the checkpoint and restarts the initial crawl" do
+    test "an initial job with a completed high-water mark hands off without crawling" do
       credential = create_credential
       api_client = FakeApiClient.new(
-        checkpoint: checkpoint_for(
-          credential,
-          phase: "listing",
-          changes_page_token: "change-100",
-          initial_page_token: "files-expired",
-          initial_crawl_id: "crawl-123"
-        )
+        checkpoint: checkpoint_for(credential, changes_page_token: "change-200")
       )
-      google_http = lambda do |endpoint:, **|
-        assert_equal SyncCredential::FILES_LIST_ENDPOINT, endpoint
-        raise SyncCredential::InvalidPageTokenError, "Page token expired"
+      google_http = ->(**) { flunk "a stale initial job should not call Google" }
+
+      with_clients(api_client, google_http) do
+        InitialSyncJob.perform_now(credential.id)
+      end
+
+      assert_empty api_client.batches
+      assert_enqueued_with(job: IncrementalSyncJob, args: [ credential.id ])
+    end
+
+    test "a rejected initial page token leaves no high-water mark and restarts the crawl" do
+      credential = create_credential
+      api_client = FakeApiClient.new
+      google_http = lambda do |endpoint:, params:, **|
+        case endpoint
+        when SyncCredential::START_PAGE_TOKEN_ENDPOINT
+          { "startPageToken" => "change-100" }
+        when SyncCredential::FILES_LIST_ENDPOINT
+          if params["pageToken"]
+            raise SyncCredential::InvalidPageTokenError, "Page token expired"
+          end
+          { "files" => [ google_doc ], "nextPageToken" => "files-expired" }
+        else
+          flunk "unexpected Google endpoint #{endpoint}"
+        end
       end
 
       with_clients(api_client, google_http) do
         InitialSyncJob.perform_now(credential.id)
       end
 
-      assert_equal "pending", api_client.checkpoint.dig("metadata", "phase")
-      assert_equal "", api_client.checkpoint.dig("metadata", "initial_page_token")
+      assert_equal "", api_client.checkpoint["changes_page_token"]
+      assert_equal 1, api_client.batches.length
       assert_enqueued_with(job: InitialSyncJob, args: [ credential.id ])
     end
 
-    test "incremental sync applies current files and removals before advancing its token" do
+    test "incremental sync drains all pages before advancing its high-water mark" do
       credential = create_credential
       api_client = FakeApiClient.new(
-        checkpoint: checkpoint_for(
-          credential,
-          phase: "catching_up",
-          changes_page_token: "change-100"
-        )
+        checkpoint: checkpoint_for(credential, changes_page_token: "change-100")
       )
       file = google_doc
+      change_page_tokens = []
       google_http = lambda do |endpoint:, params:, **|
         assert_equal SyncCredential::CHANGES_LIST_ENDPOINT, endpoint
-        assert_equal "change-100", params["pageToken"]
-        {
-          "changes" => [
-            { "fileId" => "doc-removed", "removed" => true },
-            { "fileId" => "doc-123", "file" => file }
-          ],
-          "newStartPageToken" => "change-200"
-        }
+        change_page_tokens << params["pageToken"]
+        if params["pageToken"] == "change-100"
+          {
+            "changes" => [ { "fileId" => "doc-123", "file" => file } ],
+            "nextPageToken" => "change-101"
+          }
+        else
+          {
+            "changes" => [ { "fileId" => "doc-removed", "removed" => true } ],
+            "newStartPageToken" => "change-200"
+          }
+        end
       end
 
       with_clients(api_client, google_http) do
         IncrementalSyncJob.perform_now(credential.id)
       end
 
-      metadata_batch = api_client.batches.first
-      assert_equal 1, api_client.batches.length
-      assert_equal "completed", metadata_batch.dig(:run, :status)
-      assert_equal [ "doc-123" ], metadata_batch[:files].pluck(:file_id)
+      assert_equal [ "change-100", "change-101" ], change_page_tokens
+      assert_equal 3, api_client.batches.length
+      assert_equal [ "doc-123" ], api_client.batches.first[:files].pluck(:file_id)
       assert_equal(
         [ { broker_credential_id: credential.oid, observed_file_id: "doc-removed" } ],
-        metadata_batch[:observation_deactivations]
+        api_client.batches.second[:observation_deactivations]
       )
-      assert_equal "ready", api_client.checkpoint.dig("metadata", "phase")
-      assert_equal "change-200", api_client.checkpoint["changes_page_token"]
-      assert api_client.checkpoint["last_full_sync_at"].present?
-      assert api_client.checkpoint["last_incremental_sync_at"].present?
-      assert_no_enqueued_jobs(only: IncrementalSyncJob)
+      refute api_client.batches.first.key?(:checkpoint)
+      refute api_client.batches.second.key?(:checkpoint)
+      checkpoint = api_client.batches.last.fetch(:checkpoint)
+      assert_equal "change-200", checkpoint[:changes_page_token]
+      assert checkpoint[:last_incremental_sync_at].present?
+      assert_enqueued_with(job: FetchDocumentJob, args: [ credential.id, file ])
     end
 
-    test "incremental sync persists each change page before scheduling the next page" do
+    test "a rejected Changes token clears the high-water mark and restarts initial sync" do
       credential = create_credential
       api_client = FakeApiClient.new(
-        checkpoint: checkpoint_for(
-          credential,
-          phase: "ready",
-          changes_page_token: "change-200"
-        )
-      )
-      google_http = lambda do |endpoint:, params:, **|
-        assert_equal SyncCredential::CHANGES_LIST_ENDPOINT, endpoint
-        assert_equal "change-200", params["pageToken"]
-        { "changes" => [], "nextPageToken" => "change-201" }
-      end
-
-      with_clients(api_client, google_http) do
-        IncrementalSyncJob.perform_now(credential.id)
-      end
-
-      assert_equal "ready", api_client.checkpoint.dig("metadata", "phase")
-      assert_equal "change-201", api_client.checkpoint["changes_page_token"]
-      assert_nil api_client.checkpoint["last_incremental_sync_at"]
-      assert_enqueued_with(job: IncrementalSyncJob, args: [ credential.id ])
-    end
-
-    test "a rejected changes token resets the checkpoint and restarts the initial crawl" do
-      credential = create_credential
-      api_client = FakeApiClient.new(
-        checkpoint: checkpoint_for(
-          credential,
-          phase: "ready",
-          changes_page_token: "change-expired"
-        )
+        checkpoint: checkpoint_for(credential, changes_page_token: "change-expired")
       )
       google_http = lambda do |endpoint:, **|
         assert_equal SyncCredential::CHANGES_LIST_ENDPOINT, endpoint
@@ -248,31 +217,11 @@ module GoogleDocs
         IncrementalSyncJob.perform_now(credential.id)
       end
 
-      assert_equal "pending", api_client.checkpoint.dig("metadata", "phase")
+      assert_equal "", api_client.checkpoint["changes_page_token"]
       assert_enqueued_with(job: InitialSyncJob, args: [ credential.id ])
     end
 
-    test "a missing changes token resets the checkpoint instead of bouncing between crawlers" do
-      credential = create_credential
-      api_client = FakeApiClient.new(
-        checkpoint: checkpoint_for(
-          credential,
-          phase: "ready",
-          changes_page_token: ""
-        )
-      )
-      google_http = ->(**) { flunk "a missing token should not call Google" }
-
-      with_clients(api_client, google_http) do
-        IncrementalSyncJob.perform_now(credential.id)
-      end
-
-      assert_equal "pending", api_client.checkpoint.dig("metadata", "phase")
-      assert_enqueued_with(job: InitialSyncJob, args: [ credential.id ])
-      assert_no_enqueued_jobs(only: IncrementalSyncJob)
-    end
-
-    test "crawler entry jobs hand off without moving a checkpoint backward" do
+    test "incremental sync without a high-water mark hands off to initial sync" do
       credential = create_credential
       api_client = FakeApiClient.new
       google_http = ->(**) { flunk "a routing job should not call Google" }
@@ -283,23 +232,6 @@ module GoogleDocs
 
       assert_empty api_client.batches
       assert_enqueued_with(job: InitialSyncJob, args: [ credential.id ])
-
-      clear_enqueued_jobs
-      credential = create_credential
-      api_client = FakeApiClient.new(
-        checkpoint: checkpoint_for(
-          credential,
-          phase: "ready",
-          changes_page_token: "change-200"
-        )
-      )
-      with_clients(api_client, google_http) do
-        InitialSyncJob.perform_now(credential.id)
-      end
-
-      assert_empty api_client.batches
-      assert_equal "change-200", api_client.checkpoint["changes_page_token"]
-      assert_enqueued_with(job: IncrementalSyncJob, args: [ credential.id ])
     end
 
     test "document fetch skips a canonical version that is already present" do
@@ -360,31 +292,20 @@ module GoogleDocs
       SyncCredential.google_api_http = previous_http
     end
 
-    def checkpoint_for(
-      credential,
-      phase:,
-      changes_page_token:,
-      initial_page_token: nil,
-      initial_crawl_id: nil
-    )
+    def checkpoint_for(credential, changes_page_token:)
       {
         "broker_credential_id" => credential.oid,
-        "start_page_token" => "change-100",
         "changes_page_token" => changes_page_token,
-        "metadata" => {
-          "phase" => phase,
-          "initial_page_token" => initial_page_token.to_s,
-          "initial_crawl_id" => initial_crawl_id
-        }
+        "metadata" => {}
       }
     end
 
-    def google_doc
+    def google_doc(id = "doc-123")
       {
-        "id" => "doc-123",
+        "id" => id,
         "name" => "Launch Plan",
         "mimeType" => SyncCredential::GOOGLE_DOC_MIME_TYPE,
-        "webViewLink" => "https://docs.google.com/document/d/doc-123/edit",
+        "webViewLink" => "https://docs.google.com/document/d/#{id}/edit",
         "owners" => [ { "permissionId" => "owner-1", "displayName" => "Alice" } ],
         "capabilities" => { "canEdit" => true },
         "trashed" => false,

--- a/services/console/test/jobs/google_docs/jobs_test.rb
+++ b/services/console/test/jobs/google_docs/jobs_test.rb
@@ -293,6 +293,9 @@ module GoogleDocs
     end
 
     test "credential crawler jobs block conflicts for the full crawl" do
+      assert_equal "google_docs", InitialSyncJob.queue_name
+      assert_equal InitialSyncJob.queue_name, IncrementalSyncJob.queue_name
+      assert_equal InitialSyncJob.queue_name, FetchDocumentJob.queue_name
       assert_equal "GoogleDocsCredentialSync", InitialSyncJob.concurrency_group
       assert_equal InitialSyncJob.concurrency_group, IncrementalSyncJob.concurrency_group
       assert_equal :block, InitialSyncJob.concurrency_on_conflict

--- a/services/console/test/jobs/google_docs/jobs_test.rb
+++ b/services/console/test/jobs/google_docs/jobs_test.rb
@@ -75,7 +75,7 @@ module GoogleDocs
       assert_enqueued_with(job: IncrementalSyncJob, args: [ credential.id ])
     end
 
-    test "initial sync replaces the complete observation snapshot before publishing its high-water mark" do
+    test "initial sync durably chains pages before sweeping and publishing its high-water mark" do
       credential = create_credential
       api_client = FakeApiClient.new
       first_file = google_doc
@@ -102,16 +102,44 @@ module GoogleDocs
         InitialSyncJob.perform_now(credential.id)
       end
 
-      assert_equal [ nil, "files-2" ], file_page_tokens
-      assert_equal 2, api_client.batches.length
-      snapshot = api_client.batches.first
-      assert_equal "completed", snapshot.dig(:run, :status)
-      assert_equal [ "doc-123", "doc-456" ], snapshot[:files].pluck(:file_id)
-      assert_equal [ "doc-123", "doc-456" ], snapshot[:observations].pluck(:observed_file_id)
-      assert_equal [ credential.oid ], snapshot[:replace_observation_credentials]
-      refute snapshot.key?(:checkpoint)
+      run_id = api_client.batches.first.dig(:run, :run_id)
+      continuation = {
+        "run_id" => run_id,
+        "start_page_token" => "change-100",
+        "page_token" => "files-2",
+        "files_seen" => 1
+      }
+      assert_equal [ nil ], file_page_tokens
+      assert_equal 1, api_client.batches.length
+      first_page = api_client.batches.first
+      assert_equal "running", first_page.dig(:run, :status)
+      assert_equal [ "doc-123" ], first_page[:files].pluck(:file_id)
+      assert_equal [ "doc-123" ], first_page[:observations].pluck(:observed_file_id)
+      refute first_page.key?(:observation_sweeps)
+      refute first_page.key?(:checkpoint)
+      assert_enqueued_with(job: InitialSyncJob, args: [ credential.id, continuation ])
 
-      checkpoint = api_client.batches.second.fetch(:checkpoint)
+      with_clients(api_client, google_http) do
+        InitialSyncJob.perform_now(credential.id, continuation)
+      end
+
+      assert_equal [ nil, "files-2" ], file_page_tokens
+      assert_equal 3, api_client.batches.length
+      second_page = api_client.batches.second
+      assert_equal run_id, second_page.dig(:run, :run_id)
+      assert_equal 2, second_page.dig(:run, :files_seen)
+      assert_equal [ "doc-456" ], second_page[:files].pluck(:file_id)
+      refute second_page.key?(:observation_sweeps)
+      refute second_page.key?(:checkpoint)
+
+      completion = api_client.batches.third
+      assert_equal "completed", completion.dig(:run, :status)
+      assert_equal 2, completion.dig(:run, :files_seen)
+      assert_equal(
+        [ { broker_credential_id: credential.oid, source_run_id: run_id } ],
+        completion[:observation_sweeps]
+      )
+      checkpoint = completion.fetch(:checkpoint)
       assert_equal "change-100", checkpoint[:changes_page_token]
       assert_equal({}, checkpoint[:metadata])
       assert checkpoint[:last_full_sync_at].present?
@@ -152,12 +180,22 @@ module GoogleDocs
         end
       end
 
+      with_clients(api_client, google_http) { InitialSyncJob.perform_now(credential.id) }
+      run_id = api_client.batches.first.dig(:run, :run_id)
+      continuation = {
+        "run_id" => run_id,
+        "start_page_token" => "change-100",
+        "page_token" => "files-expired",
+        "files_seen" => 1
+      }
       with_clients(api_client, google_http) do
-        InitialSyncJob.perform_now(credential.id)
+        InitialSyncJob.perform_now(credential.id, continuation)
       end
 
       assert_equal "", api_client.checkpoint["changes_page_token"]
-      assert_equal 1, api_client.batches.length
+      assert_equal 2, api_client.batches.length
+      refute api_client.batches.first.key?(:observation_sweeps)
+      refute api_client.batches.first.key?(:checkpoint)
       assert_enqueued_with(job: InitialSyncJob, args: [ credential.id ])
     end
 
@@ -280,6 +318,10 @@ module GoogleDocs
       assert_equal InitialSyncJob.concurrency_group, IncrementalSyncJob.concurrency_group
       assert_equal :discard, InitialSyncJob.concurrency_on_conflict
       assert_equal 1.hour, InitialSyncJob.concurrency_duration
+
+      initial = InitialSyncJob.new(123)
+      continuation = InitialSyncJob.new(123, { "page_token" => "files-2" })
+      assert_equal initial.concurrency_key, continuation.concurrency_key
     end
 
     private

--- a/services/console/test/services/centaur_api_client_test.rb
+++ b/services/console/test/services/centaur_api_client_test.rb
@@ -154,6 +154,25 @@ class CentaurApiClientTest < ActiveSupport::TestCase
     http.verify
   end
 
+  test "gets Google Docs content status" do
+    http = Minitest::Mock.new
+    expect_request(http, status: 200, body: { missing: [] }.to_json) do |request|
+      assert_equal :post, request[:method]
+      assert_equal "http://api.internal:8080/api/admin/google/docs-sync/content-status", request[:url]
+      assert_equal(
+        { "files" => [ { "file_id" => "doc-123", "source_version" => "7" } ] },
+        JSON.parse(request[:body])
+      )
+    end
+    client = api_client(base_url: "http://api.internal:8080", http: http)
+
+    client.get_google_docs_content_status(
+      files: [ { file_id: "doc-123", source_version: "7" } ]
+    )
+
+    http.verify
+  end
+
   test "creates app sessions with encoded thread keys" do
     http = Minitest::Mock.new
     expect_request(http, status: 200, body: { ok: true }.to_json) do |request|

--- a/services/console/test/services/google_docs/sync_credential_test.rb
+++ b/services/console/test/services/google_docs/sync_credential_test.rb
@@ -118,14 +118,8 @@ module GoogleDocs
 
     test "classifies a rejected Drive page token for crawl recovery" do
       response = HttpClient::Response.new(
-        status: 404,
-        body: {
-          error: {
-            code: 404,
-            message: "Page token expired",
-            errors: [ { reason: "notFound", location: "pageToken" } ]
-          }
-        }.to_json,
+        status: 400,
+        body: { error: { message: "Bad request" } }.to_json,
         headers: {}
       )
       api = Object.new

--- a/services/console/test/services/google_docs/sync_credential_test.rb
+++ b/services/console/test/services/google_docs/sync_credential_test.rb
@@ -76,17 +76,19 @@ module GoogleDocs
       end
     end
 
-    test "required scopes allow drive readonly or metadata plus docs readonly" do
+    test "required scopes allow drive readonly alone or metadata plus docs readonly" do
       assert GoogleDocs::SyncCredential.required_scopes_granted?([
         GoogleDocs::SyncCredential::DRIVE_METADATA_SCOPE,
         GoogleDocs::SyncCredential::DOCS_READONLY_SCOPE
       ])
       assert GoogleDocs::SyncCredential.required_scopes_granted?([
-        GoogleDocs::SyncCredential::DRIVE_READONLY_SCOPE,
-        GoogleDocs::SyncCredential::DOCS_READONLY_SCOPE
+        GoogleDocs::SyncCredential::DRIVE_READONLY_SCOPE
       ])
       refute GoogleDocs::SyncCredential.required_scopes_granted?([
         GoogleDocs::SyncCredential::DRIVE_METADATA_SCOPE
+      ])
+      refute GoogleDocs::SyncCredential.required_scopes_granted?([
+        GoogleDocs::SyncCredential::DOCS_READONLY_SCOPE
       ])
     end
 

--- a/services/console/test/services/google_docs/sync_credential_test.rb
+++ b/services/console/test/services/google_docs/sync_credential_test.rb
@@ -74,6 +74,17 @@ module GoogleDocs
       ])
     end
 
+    test "syncable credentials centralize app, token, and scope eligibility" do
+      current_credential = credential
+      app = current_credential.oauth_app
+
+      assert GoogleDocs::SyncCredential.syncable?(current_credential, oauth_app_slug: app.slug)
+      refute GoogleDocs::SyncCredential.syncable?(current_credential, oauth_app_slug: "another-app")
+
+      app.update!(enabled: false)
+      refute GoogleDocs::SyncCredential.syncable?(current_credential.reload)
+    end
+
     test "uses bounded Drive file and change pages" do
       calls = []
       google_http = lambda do |endpoint:, params:, access_token:|

--- a/services/console/test/services/google_docs/sync_credential_test.rb
+++ b/services/console/test/services/google_docs/sync_credential_test.rb
@@ -113,6 +113,7 @@ module GoogleDocs
       changes_params = calls.find { |endpoint, _| endpoint == GoogleDocs::SyncCredential::CHANGES_LIST_ENDPOINT }.last
       assert_equal "change-100", changes_params["pageToken"]
       assert_equal "true", changes_params["includeRemoved"]
+      assert_includes changes_params["fields"], "changes(changeType,driveId,fileId,removed"
     end
 
     test "classifies a rejected Drive page token for crawl recovery" do

--- a/services/console/test/services/google_docs/sync_credential_test.rb
+++ b/services/console/test/services/google_docs/sync_credential_test.rb
@@ -104,6 +104,29 @@ module GoogleDocs
       assert_equal "true", changes_params["includeRemoved"]
     end
 
+    test "classifies a rejected Drive page token for crawl recovery" do
+      response = HttpClient::Response.new(
+        status: 404,
+        body: {
+          error: {
+            code: 404,
+            message: "Page token expired",
+            errors: [ { reason: "notFound", location: "pageToken" } ]
+          }
+        }.to_json,
+        headers: {}
+      )
+      api = Object.new
+      api.define_singleton_method(:get) { |*, **| response }
+      sync = GoogleDocs::SyncCredential.new(credential)
+
+      HttpClient.stub(:new, api) do
+        assert_raises(GoogleDocs::SyncCredential::InvalidPageTokenError) do
+          sync.list_changes_page(page_token: "rejected-token")
+        end
+      end
+    end
+
     test "normalizes canonical content without credential-specific metadata" do
       file = google_doc
       google_http = lambda do |endpoint:, params:, access_token:|

--- a/services/console/test/services/google_docs/sync_credential_test.rb
+++ b/services/console/test/services/google_docs/sync_credential_test.rb
@@ -2,24 +2,6 @@ require "test_helper"
 
 module GoogleDocs
   class SyncCredentialTest < ActiveSupport::TestCase
-    class FakeApiClient
-      attr_reader :batch
-
-      def get_google_docs_sync_checkpoint(broker_credential_id:)
-        {
-          "checkpoint" => {
-            "broker_credential_id" => broker_credential_id,
-            "last_incremental_sync_at" => "2026-06-01T00:00:00Z"
-          }
-        }
-      end
-
-      def ingest_google_docs_sync_batch(payload)
-        @batch = payload
-        { "ok" => true }
-      end
-    end
-
     def google_app
       OauthApp.create!(
         provider: "google",
@@ -92,84 +74,90 @@ module GoogleDocs
       ])
     end
 
-    test "sync normalizes files observations contents context docs and checkpoint" do
-      api_client = FakeApiClient.new
+    test "uses bounded Drive file and change pages" do
+      calls = []
       google_http = lambda do |endpoint:, params:, access_token:|
         assert_equal "ya29.live", access_token
+        calls << [ endpoint, params ]
         case endpoint
+        when GoogleDocs::SyncCredential::START_PAGE_TOKEN_ENDPOINT
+          { "startPageToken" => "change-100" }
         when GoogleDocs::SyncCredential::FILES_LIST_ENDPOINT
-          assert_includes params["q"], "modifiedTime > '2026-06-01T00:00:00Z'"
-          assert_equal(
-            "nextPageToken,files(id,name,mimeType,webViewLink,driveId,owners," \
-              "lastModifyingUser,capabilities,labelInfo,trashed,explicitlyTrashed," \
-              "createdTime,modifiedTime,version)",
-            params["fields"]
-          )
-          {
-            "files" => [
-              {
-                "id" => "doc-123",
-                "name" => "Launch Plan",
-                "mimeType" => GoogleDocs::SyncCredential::GOOGLE_DOC_MIME_TYPE,
-                "webViewLink" => "https://docs.google.com/document/d/doc-123/edit",
-                "driveId" => "drive-1",
-                "owners" => [
-                  {
-                    "permissionId" => "perm-owner",
-                    "displayName" => "Alice",
-                    "emailAddress" => "alice@example.com"
-                  }
-                ],
-                "lastModifyingUser" => { "displayName" => "Bob" },
-                "capabilities" => { "canEdit" => true },
-                "labelInfo" => { "labels" => [] },
-                "trashed" => false,
-                "explicitlyTrashed" => false,
-                "createdTime" => "2026-06-01T12:00:00Z",
-                "modifiedTime" => "2026-06-02T12:00:00Z",
-                "version" => "7"
-              }
-            ],
-            "nextPageToken" => ""
-          }
-        when "#{GoogleDocs::SyncCredential::DOCS_GET_ENDPOINT}/doc-123"
-          {
-            "title" => "Launch Plan",
-            "body" => {
-              "content" => [
-                {
-                  "paragraph" => {
-                    "elements" => [
-                      { "textRun" => { "content" => "Ship the Google Docs ingest flow.\n" } }
-                    ]
-                  }
-                }
-              ]
-            }
-          }
+          { "files" => [], "nextPageToken" => "file-2" }
+        when GoogleDocs::SyncCredential::CHANGES_LIST_ENDPOINT
+          { "changes" => [], "newStartPageToken" => "change-101" }
         else
           flunk "unexpected Google endpoint #{endpoint}"
         end
       end
+      sync = GoogleDocs::SyncCredential.new(credential, google_api_http: google_http)
 
-      GoogleDocs::SyncCredential.new(
-        credential,
-        api_client: api_client,
-        google_api_http: google_http
-      ).call
+      assert_equal "change-100", sync.start_page_token
+      assert_equal "file-2", sync.list_files_page["nextPageToken"]
+      assert_equal "change-101", sync.list_changes_page(page_token: "change-100")["newStartPageToken"]
 
-      batch = api_client.batch
-      assert_equal "completed", batch[:run][:status]
-      assert_equal credential.oid, batch[:run][:broker_credential_id]
-      assert_equal "google-sub-alice", batch[:run][:provider_subject]
-      assert_equal 1, batch[:files].length
-      assert_equal "doc-123", batch[:files].first[:file_id]
-      assert_equal "writer", batch[:observations].first[:role_hint]
+      files_params = calls.find { |endpoint, _| endpoint == GoogleDocs::SyncCredential::FILES_LIST_ENDPOINT }.last
+      assert_equal 100, files_params["pageSize"]
+      assert_includes files_params["q"], "trashed = false"
+      changes_params = calls.find { |endpoint, _| endpoint == GoogleDocs::SyncCredential::CHANGES_LIST_ENDPOINT }.last
+      assert_equal "change-100", changes_params["pageToken"]
+      assert_equal "true", changes_params["includeRemoved"]
+    end
+
+    test "normalizes canonical content without credential-specific metadata" do
+      file = google_doc
+      google_http = lambda do |endpoint:, params:, access_token:|
+        assert_equal "#{GoogleDocs::SyncCredential::DOCS_GET_ENDPOINT}/doc-123", endpoint
+        assert_equal({ "includeTabsContent" => "true" }, params)
+        assert_equal "ya29.live", access_token
+        {
+          "title" => "Launch Plan",
+          "body" => {
+            "content" => [
+              {
+                "paragraph" => {
+                  "elements" => [
+                    { "textRun" => { "content" => "Ship the Google Docs ingest flow.\n" } }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      end
+      sync = GoogleDocs::SyncCredential.new(credential, google_api_http: google_http)
+
+      batch = sync.document_batch(file)
+
       assert_equal "Ship the Google Docs ingest flow.\n", batch[:contents].first[:text_content]
+      assert_equal "7", batch[:contents].first[:source_version]
       assert_equal "google_docs:doc-123:chunk-0000", batch[:context_documents].first[:document_id]
-      assert_equal "Launch Plan", batch[:context_documents].first[:title]
-      assert_equal "2026-06-02T12:00:00Z", batch[:checkpoint][:last_incremental_sync_at]
-      assert_equal "", batch[:checkpoint][:last_error]
+      assert_equal({ source: "google_docs" }, batch[:context_documents].first[:metadata])
+      refute_includes batch[:context_documents].first[:metadata], :broker_credential_id
+    end
+
+    private
+
+    def google_doc
+      {
+        "id" => "doc-123",
+        "name" => "Launch Plan",
+        "mimeType" => GoogleDocs::SyncCredential::GOOGLE_DOC_MIME_TYPE,
+        "webViewLink" => "https://docs.google.com/document/d/doc-123/edit",
+        "driveId" => "drive-1",
+        "owners" => [
+          {
+            "permissionId" => "perm-owner",
+            "displayName" => "Alice",
+            "emailAddress" => "alice@example.com"
+          }
+        ],
+        "capabilities" => { "canEdit" => true },
+        "trashed" => false,
+        "createdTime" => "2026-06-01T12:00:00Z",
+        "modifiedTime" => "2026-06-02T12:00:00Z",
+        "version" => "7"
+      }
     end
   end
 end


### PR DESCRIPTION
Replace the monolithic Google Docs sync with distinct initial and incremental crawls backed by the Drive Changes API. Initial sync holds the per-credential semaphore for one job execution while ingesting one listing page at a time, then atomically sweeps unseen observations and publishes the high-water mark; stale poll jobs block and no-op once that mark exists. Incremental sync drains change pages before advancing the checkpoint, ignores shared-drive records without file IDs, and restarts a full crawl when Google rejects a page token. Google Docs crawl and content-fetch work runs in a dedicated one-thread queue so it cannot consume default worker capacity. Canonical document bodies remain deduplicated across credentials, Drive readonly credentials are eligible, and legacy queued sync jobs drain as no-ops.