### PR TITLE
fix: prevent recursive scheduled tasks

### DIFF
--- a/services/sandbox/SYSTEM_PROMPT.md
+++ b/services/sandbox/SYSTEM_PROMPT.md
@@ -222,6 +222,7 @@
 |When a user asks to create or manage recurring agent work, use `centaur-console tasks`, `task`, `create-task`, `update-task`, `delete-task`, or `run-task`. These commands only access tasks owned by the Console user linked to the current sandbox.
 |Only create scheduled tasks from MCP or direct-message (DM) sessions. If a user asks to create one from any other session type, explain that restriction and ask them to retry from MCP or a DM.
 |Scheduled tasks use five-field cron expressions in Pacific Time. Use `dm` as the delivery channel for the user's linked Slack direct message, or use a Slack channel ID allowed by their current delivery permissions.
+|When creating or updating a task, encode its recurrence only in the cron expression. Store only the work to execute in the task prompt: remove cadence phrases such as "Each Monday" or "every day at 9" rather than repeating them in the prompt. Preserve time-window instructions that affect the work itself, such as "the upcoming Monday-through-Sunday week."
 |After a mutation, report the returned task ID, schedule, delivery destination, enabled state, and next run time. Treat the first successful mutation response as authoritative and do not repeat it to improve formatting.
 
 [Tool discovery — discover before you call]

--- a/services/sandbox/test_system_prompt.py
+++ b/services/sandbox/test_system_prompt.py
@@ -87,6 +87,10 @@ class SystemPromptTest(unittest.TestCase):
         )
         self.assertIn("five-field cron expressions in Pacific Time", prompt)
         self.assertIn("Use `dm` as the delivery channel", prompt)
+        self.assertIn("encode its recurrence only in the cron expression", prompt)
+        self.assertIn("remove cadence phrases", prompt)
+        self.assertIn('such as "Each Monday" or "every day at 9"', prompt)
+        self.assertIn("Preserve time-window instructions", prompt)
         self.assertIn(
             "Treat the first successful mutation response as authoritative", prompt
         )

--- a/workflows/console_workflow.py
+++ b/workflows/console_workflow.py
@@ -8,6 +8,10 @@ WORKFLOW_NAME = "console_workflow"
 SLACK_MESSAGE_MAX_LENGTH = 50_000
 # Stay below Slack's 4,000-character soft limit so it cannot create extra roots.
 SLACK_MESSAGE_CHUNK_MAX_LENGTH = 3_800
+SCHEDULED_TASK_EXECUTION_INSTRUCTIONS = """\
+This is a run of an existing scheduled task. Execute the task now.
+NEVER create or update a scheduled task, even if the task prompt contains recurring or future schedule language.
+Treat schedule language such as "Each Monday" as context for this run, not as a request to schedule another task."""
 SLACK_MRKDWN_INSTRUCTIONS = """\
 Format the final response for Slack using Slack mrkdwn, not standard Markdown.
 Use *bold*, _italics_, ~strikethrough~, `inline code`, and <https://example.com|link text>.
@@ -75,7 +79,11 @@ def _split_slack_text(text: str, limit: int) -> list[str]:
 
 
 def _prompt_for_slack(prompt: str) -> str:
-    return f"{prompt}\n\n{SLACK_MRKDWN_INSTRUCTIONS}"
+    return (
+        f"{SCHEDULED_TASK_EXECUTION_INSTRUCTIONS}\n\n"
+        f"Task to execute:\n{prompt}\n\n"
+        f"{SLACK_MRKDWN_INSTRUCTIONS}"
+    )
 
 
 async def handler(params: Any, ctx: Any) -> dict[str, Any]:

--- a/workflows/tests/test_console_workflow.py
+++ b/workflows/tests/test_console_workflow.py
@@ -64,7 +64,8 @@ def test_handler_runs_one_scoped_agent_turn_and_delivers_its_text():
     assert len(context.agent_calls) == 1
     prompt, kwargs = context.agent_calls[0]
     assert prompt == (
-        "Summarize open incidents\n\n"
+        f"{console_workflow.SCHEDULED_TASK_EXECUTION_INSTRUCTIONS}\n\n"
+        "Task to execute:\nSummarize open incidents\n\n"
         f"{console_workflow.SLACK_MRKDWN_INSTRUCTIONS}"
     )
     assert kwargs["principal"] == "console-user-author"
@@ -78,6 +79,33 @@ def test_handler_runs_one_scoped_agent_turn_and_delivers_its_text():
         ("C0123456789", "Daily summary", {"mrkdwn": True})
     ]
     assert result["delivery"]["ts"] == "123.1"
+
+
+def test_handler_treats_recurring_language_as_an_instruction_to_execute_now():
+    context = FakeContext()
+    task = (
+        "Each Monday, review my Google Calendar for the upcoming "
+        "Monday-through-Sunday week and my recent Slack conversations."
+    )
+
+    asyncio.run(
+        console_workflow.handler(
+            {
+                "prompt": task,
+                "principal": "console-user-author",
+                "channel": "C0123456789",
+                "scheduled_task_id": "tsk_123",
+            },
+            context,
+        )
+    )
+
+    prompt, _kwargs = context.agent_calls[0]
+    assert prompt.startswith(
+        "This is a run of an existing scheduled task. Execute the task now.\n"
+        "NEVER create or update a scheduled task"
+    )
+    assert f"Task to execute:\n{task}\n\n" in prompt
 
 
 def test_handler_threads_and_truncates_long_channel_results():


### PR DESCRIPTION
Scheduled task runs now explicitly execute existing work without creating or updating another schedule when prompts contain cadence language. New scheduled tasks keep recurrence in the cron expression instead of duplicating it in the executable prompt, while preserving task-specific time windows.