### PR TITLE
feat: add scheduled task attribution footer

### DIFF
--- a/services/console/app/models/scheduled_task.rb
+++ b/services/console/app/models/scheduled_task.rb
@@ -109,7 +109,8 @@ class ScheduledTask < ApplicationRecord
   end
 
   def api_input
-    unless SlackDeliveryPolicy.new(author).allowed?(delivery_channel)
+    delivery_policy = SlackDeliveryPolicy.new(author)
+    unless delivery_policy.allowed?(delivery_channel)
       raise DeliveryDestinationUnavailable, "Slack delivery destination is no longer available to the author"
     end
 
@@ -117,6 +118,7 @@ class ScheduledTask < ApplicationRecord
       prompt: prompt,
       principal: execution_principal.foreign_id,
       channel: delivery_channel,
+      slack_user_id: delivery_policy.slack_user_id,
       scheduled_task_id: oid,
       scheduled_task_name: name
     }

--- a/services/console/test/jobs/scheduled_task_jobs_test.rb
+++ b/services/console/test/jobs/scheduled_task_jobs_test.rb
@@ -77,6 +77,7 @@ class ScheduledTaskJobsTest < ActiveJob::TestCase
     assert_equal users(:acme_admin), task.execution_principal.console_user
     assert_equal "Summarize open incidents.", request.dig(:input, :prompt)
     assert_equal "C0123456789", request.dig(:input, :channel)
+    assert_equal "U0123456789", request.dig(:input, :slack_user_id)
     assert_equal "scheduled-task:#{task.id}:2026-08-19T12:00:00Z", request[:idempotency_key]
     assert_equal ScheduledTaskRunJob::MAX_ATTEMPTS, request[:max_attempts]
     assert_equal "run-123", task.reload.last_run_id

--- a/services/console/test/models/scheduled_task_test.rb
+++ b/services/console/test/models/scheduled_task_test.rb
@@ -96,6 +96,7 @@ class ScheduledTaskTest < ActiveSupport::TestCase
         prompt: "Summarize open incidents.",
         principal: principal.foreign_id,
         channel: "C0123456789",
+        slack_user_id: "U0123456789",
         scheduled_task_id: task.oid,
         scheduled_task_name: "Incident summary"
       },

--- a/workflows/console_workflow.py
+++ b/workflows/console_workflow.py
@@ -2,12 +2,18 @@
 
 from __future__ import annotations
 
+import re
 from typing import Any
 
 WORKFLOW_NAME = "console_workflow"
 SLACK_MESSAGE_MAX_LENGTH = 50_000
 # Stay below Slack's 4,000-character soft limit so it cannot create extra roots.
 SLACK_MESSAGE_CHUNK_MAX_LENGTH = 3_800
+# Slack section block text is limited to 3,000 characters.
+SLACK_SECTION_MAX_LENGTH = 3_000
+SLACK_USER_ID_PATTERN = re.compile(r"[UW][A-Z0-9]{8,}")
+SCHEDULED_TASK_FOOTER = "Sent by <@{slack_user_id}>'s scheduled task"
+SCHEDULED_TASK_FOOTER_FALLBACK = "Sent by a scheduled task"
 SCHEDULED_TASK_EXECUTION_INSTRUCTIONS = """\
 This is a run of an existing scheduled task. Execute the task now.
 NEVER create or update a scheduled task, even if the task prompt contains recurring or future schedule language.
@@ -28,12 +34,32 @@ def _required_string(params: Any, key: str) -> str:
     return value.strip()
 
 
-async def _deliver_to_slack(ctx: Any, channel: str, text: str) -> Any:
-    truncated = text[:SLACK_MESSAGE_MAX_LENGTH]
-    chunks = _split_slack_text(truncated, SLACK_MESSAGE_CHUNK_MAX_LENGTH)
+async def _deliver_to_slack(
+    ctx: Any,
+    channel: str,
+    text: str,
+    slack_user_id: str,
+) -> Any:
+    footer = _scheduled_task_footer(slack_user_id)
+    footer_suffix = f"\n\n{footer}"
+    body_limit = SLACK_MESSAGE_MAX_LENGTH - len(footer_suffix)
+    chunks = _split_slack_text(text[:body_limit], SLACK_MESSAGE_CHUNK_MAX_LENGTH)
+    final_body = chunks[-1]
+    if len(final_body) + len(footer_suffix) <= SLACK_MESSAGE_CHUNK_MAX_LENGTH:
+        chunks[-1] = f"{final_body}{footer_suffix}"
+    else:
+        final_body = ""
+        chunks.append(footer)
+
+    def message_args(index: int) -> dict[str, Any]:
+        args: dict[str, Any] = {"mrkdwn": True}
+        if index == len(chunks) - 1:
+            args["blocks"] = _scheduled_task_blocks(final_body, footer)
+        return args
+
     root = await ctx.step(
         "post_result",
-        lambda: ctx.post_to_slack(channel, chunks[0], mrkdwn=True),
+        lambda: ctx.post_to_slack(channel, chunks[0], **message_args(0)),
     )
     if len(chunks) == 1:
         return root
@@ -51,12 +77,37 @@ async def _deliver_to_slack(ctx: Any, channel: str, text: str) -> Any:
             lambda chunk=chunk: ctx.post_to_slack(
                 reply_channel,
                 chunk,
-                mrkdwn=True,
                 thread_ts=thread_ts,
+                **message_args(index),
             ),
         )
         replies.append(reply)
     return {**root, "replies": replies}
+
+
+def _scheduled_task_footer(slack_user_id: str) -> str:
+    return (
+        SCHEDULED_TASK_FOOTER.format(slack_user_id=slack_user_id)
+        if SLACK_USER_ID_PATTERN.fullmatch(slack_user_id)
+        else SCHEDULED_TASK_FOOTER_FALLBACK
+    )
+
+
+def _scheduled_task_blocks(body: str, footer: str) -> list[dict[str, Any]]:
+    blocks = [
+        {
+            "type": "section",
+            "text": {"type": "mrkdwn", "text": section},
+        }
+        for section in _split_slack_text(body, SLACK_SECTION_MAX_LENGTH)
+    ]
+    blocks.append(
+        {
+            "type": "context",
+            "elements": [{"type": "mrkdwn", "text": footer}],
+        }
+    )
+    return blocks
 
 
 def _split_slack_text(text: str, limit: int) -> list[str]:
@@ -91,6 +142,7 @@ async def handler(params: Any, ctx: Any) -> dict[str, Any]:
     principal = _required_string(params, "principal")
     channel = _required_string(params, "channel")
     scheduled_task_id = _required_string(params, "scheduled_task_id")
+    slack_user_id = str(params.get("slack_user_id") or "").strip()
 
     result = await ctx.agent_turn(
         _prompt_for_slack(prompt),
@@ -103,7 +155,12 @@ async def handler(params: Any, ctx: Any) -> dict[str, Any]:
     response_text = str(result.get("result_text") or "").strip()
     if not response_text:
         response_text = "The task completed without a text response."
-    delivery = await _deliver_to_slack(ctx, channel, response_text)
+    delivery = await _deliver_to_slack(
+        ctx,
+        channel,
+        response_text,
+        slack_user_id,
+    )
 
     return {
         "agent_result": result,

--- a/workflows/tests/test_console_workflow.py
+++ b/workflows/tests/test_console_workflow.py
@@ -45,8 +45,27 @@ class FakeContext:
         }
 
 
+def scheduled_task_blocks(body: str, footer: str):
+    blocks = []
+    if body:
+        blocks.append(
+            {
+                "type": "section",
+                "text": {"type": "mrkdwn", "text": body},
+            }
+        )
+    blocks.append(
+        {
+            "type": "context",
+            "elements": [{"type": "mrkdwn", "text": footer}],
+        }
+    )
+    return blocks
+
+
 def test_handler_runs_one_scoped_agent_turn_and_delivers_its_text():
     context = FakeContext()
+    footer = "Sent by <@U0123456789>'s scheduled task"
 
     result = asyncio.run(
         console_workflow.handler(
@@ -54,6 +73,7 @@ def test_handler_runs_one_scoped_agent_turn_and_delivers_its_text():
                 "prompt": "Summarize open incidents",
                 "principal": "console-user-author",
                 "channel": "C0123456789",
+                "slack_user_id": "U0123456789",
                 "scheduled_task_id": "tsk_123",
                 "scheduled_task_name": "Incident summary",
             },
@@ -76,7 +96,14 @@ def test_handler_runs_one_scoped_agent_turn_and_delivers_its_text():
     }
     assert context.step_calls == ["post_result"]
     assert context.slack_calls == [
-        ("C0123456789", "Daily summary", {"mrkdwn": True})
+        (
+            "C0123456789",
+            f"Daily summary\n\n{footer}",
+            {
+                "mrkdwn": True,
+                "blocks": scheduled_task_blocks("Daily summary", footer),
+            },
+        )
     ]
     assert result["delivery"]["ts"] == "123.1"
 
@@ -94,6 +121,7 @@ def test_handler_treats_recurring_language_as_an_instruction_to_execute_now():
                 "prompt": task,
                 "principal": "console-user-author",
                 "channel": "C0123456789",
+                "slack_user_id": "U0123456789",
                 "scheduled_task_id": "tsk_123",
             },
             context,
@@ -118,6 +146,7 @@ def test_handler_threads_and_truncates_long_channel_results():
                 "prompt": "Summarize open incidents",
                 "principal": "console-user-author",
                 "channel": "C0123456789",
+                "slack_user_id": "U0123456789",
                 "scheduled_task_id": "tsk_123",
             },
             context,
@@ -133,9 +162,11 @@ def test_handler_threads_and_truncates_long_channel_results():
         f"post_result_reply_{index}" for index in range(1, expected_chunks)
     ]
     assert len(context.slack_calls) == expected_chunks
-    assert "".join(call[1] for call in context.slack_calls) == response_text[
-        : console_workflow.SLACK_MESSAGE_MAX_LENGTH
-    ]
+    footer = "Sent by <@U0123456789>'s scheduled task"
+    body_limit = console_workflow.SLACK_MESSAGE_MAX_LENGTH - len(footer) - 2
+    assert "".join(call[1] for call in context.slack_calls) == (
+        f"{response_text[:body_limit]}\n\n{footer}"
+    )
     assert all(
         len(call[1]) <= console_workflow.SLACK_MESSAGE_CHUNK_MAX_LENGTH
         for call in context.slack_calls
@@ -143,8 +174,14 @@ def test_handler_threads_and_truncates_long_channel_results():
     assert context.slack_calls[0][2] == {"mrkdwn": True}
     assert all(
         call[2] == {"mrkdwn": True, "thread_ts": "123.1"}
-        for call in context.slack_calls[1:]
+        for call in context.slack_calls[1:-1]
     )
+    final_body = context.slack_calls[-1][1].removesuffix(f"\n\n{footer}")
+    assert context.slack_calls[-1][2] == {
+        "thread_ts": "123.1",
+        "mrkdwn": True,
+        "blocks": scheduled_task_blocks(final_body, footer),
+    }
     assert result["delivery"]["ts"] == "123.1"
 
 
@@ -155,6 +192,7 @@ def test_handler_posts_long_dm_results_as_replies_to_the_first_message():
         "prompt": "Summarize open incidents",
         "principal": "console-user-author",
         "channel": "U0123456789",
+        "slack_user_id": "U0123456789",
         "scheduled_task_id": "tsk_123",
     }
 
@@ -165,7 +203,9 @@ def test_handler_posts_long_dm_results_as_replies_to_the_first_message():
         "post_result_reply_1",
         "post_result_reply_2",
     ]
-    assert "".join(call[1] for call in context.slack_calls) == response_text
+    assert "".join(call[1] for call in context.slack_calls) == (
+        f"{response_text}\n\nSent by <@U0123456789>'s scheduled task"
+    )
     assert all(
         len(call[1]) <= console_workflow.SLACK_MESSAGE_CHUNK_MAX_LENGTH
         for call in context.slack_calls
@@ -178,7 +218,18 @@ def test_handler_posts_long_dm_results_as_replies_to_the_first_message():
     assert all(
         call[0] == "D0123456789"
         and call[2] == {"mrkdwn": True, "thread_ts": "123.1"}
-        for call in context.slack_calls[1:]
+        for call in context.slack_calls[1:-1]
+    )
+    footer = "Sent by <@U0123456789>'s scheduled task"
+    final_body = context.slack_calls[-1][1].removesuffix(f"\n\n{footer}")
+    assert context.slack_calls[-1] == (
+        "D0123456789",
+        f"{final_body}\n\n{footer}",
+        {
+            "thread_ts": "123.1",
+            "mrkdwn": True,
+            "blocks": scheduled_task_blocks(final_body, footer),
+        },
     )
     assert len(result["delivery"]["replies"]) == 2
 
@@ -193,12 +244,14 @@ def test_handler_posts_long_dm_results_as_replies_to_the_first_message():
 
 
 def test_handler_delivers_canonical_result_text_instead_of_output_lines():
+    body = (
+        "Cold scoops kiss the cone\n"
+        "Summer sunlight melts to cream\n"
+        "Sweet stars on my tongue"
+    )
+    footer = "Sent by <@U0123456789>'s scheduled task"
     context = FakeContext(
-        result_text=(
-            "Cold scoops kiss the cone\n"
-            "Summer sunlight melts to cream\n"
-            "Sweet stars on my tongue"
-        ),
+        result_text=body,
         output_lines=["Commentary...", "Downloading packages...", "Traceback..."],
     )
 
@@ -206,6 +259,62 @@ def test_handler_delivers_canonical_result_text_instead_of_output_lines():
         console_workflow.handler(
             {
                 "prompt": "Write a haiku about ice cream",
+                "principal": "console-user-author",
+                "channel": "C0123456789",
+                "slack_user_id": "U0123456789",
+                "scheduled_task_id": "tsk_123",
+            },
+            context,
+        )
+    )
+
+    assert context.slack_calls == [
+        (
+            "C0123456789",
+            f"{body}\n\n{footer}",
+            {
+                "mrkdwn": True,
+                "blocks": scheduled_task_blocks(body, footer),
+            },
+        )
+    ]
+
+
+def test_handler_does_not_repeat_checkpointed_slack_posts():
+    context = FakeContext()
+    footer = "Sent by <@U0123456789>'s scheduled task"
+    params = {
+        "prompt": "Summarize open incidents",
+        "principal": "console-user-author",
+        "channel": "C0123456789",
+        "slack_user_id": "U0123456789",
+        "scheduled_task_id": "tsk_123",
+    }
+
+    asyncio.run(console_workflow.handler(params, context))
+    asyncio.run(console_workflow.handler(params, context))
+
+    assert context.step_calls == ["post_result", "post_result"]
+    assert context.slack_calls == [
+        (
+            "C0123456789",
+            f"Daily summary\n\n{footer}",
+            {
+                "mrkdwn": True,
+                "blocks": scheduled_task_blocks("Daily summary", footer),
+            },
+        )
+    ]
+
+
+def test_handler_uses_a_generic_footer_for_an_in_flight_run_without_an_author():
+    context = FakeContext()
+    footer = "Sent by a scheduled task"
+
+    asyncio.run(
+        console_workflow.handler(
+            {
+                "prompt": "Summarize open incidents",
                 "principal": "console-user-author",
                 "channel": "C0123456789",
                 "scheduled_task_id": "tsk_123",
@@ -217,27 +326,12 @@ def test_handler_delivers_canonical_result_text_instead_of_output_lines():
     assert context.slack_calls == [
         (
             "C0123456789",
-            "Cold scoops kiss the cone\nSummer sunlight melts to cream\nSweet stars on my tongue",
-            {"mrkdwn": True},
+            f"Daily summary\n\n{footer}",
+            {
+                "mrkdwn": True,
+                "blocks": scheduled_task_blocks("Daily summary", footer),
+            },
         )
-    ]
-
-
-def test_handler_does_not_repeat_checkpointed_slack_posts():
-    context = FakeContext()
-    params = {
-        "prompt": "Summarize open incidents",
-        "principal": "console-user-author",
-        "channel": "C0123456789",
-        "scheduled_task_id": "tsk_123",
-    }
-
-    asyncio.run(console_workflow.handler(params, context))
-    asyncio.run(console_workflow.handler(params, context))
-
-    assert context.step_calls == ["post_result", "post_result"]
-    assert context.slack_calls == [
-        ("C0123456789", "Daily summary", {"mrkdwn": True})
     ]
 
 


### PR DESCRIPTION
Adds a Slack Block Kit context footer to scheduled task messages that attributes the task to its author. Passes the author's Slack user ID into the workflow, preserves mrkdwn formatting and chunked delivery, and keeps a generic fallback for in-flight runs created before the new input field.