### PR TITLE
fix: allow rollback across newer migrations

### DIFF
--- a/services/api-rs/crates/centaur-session-sqlx/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-sqlx/src/lib.rs
@@ -18,11 +18,16 @@ use thiserror::Error;
 use time::{Duration as TimeDuration, OffsetDateTime};
 use uuid::Uuid;
 
-// The API binary embeds these migrations at compile time.
-static MIGRATOR: sqlx::migrate::Migrator = sqlx::migrate!("./migrations");
-
 pub const SESSION_EVENTS_CHANNEL: &str = "centaur_session_events";
 const DEFAULT_MAX_CONNECTIONS: u32 = 500;
+
+fn embedded_migrator() -> sqlx::migrate::Migrator {
+    let mut migrator = sqlx::migrate!("./migrations");
+    // A rollback binary must accept schema versions introduced by the release
+    // it replaces while SQLx continues to verify every migration it knows.
+    migrator.set_ignore_missing(true);
+    migrator
+}
 
 #[derive(Clone, Debug)]
 pub struct CreateExecutionResult {
@@ -106,7 +111,7 @@ impl PgSessionStore {
     }
 
     pub async fn run_migrations(&self) -> Result<(), SessionStoreError> {
-        MIGRATOR.run(&self.pool).await?;
+        embedded_migrator().run(&self.pool).await?;
         Ok(())
     }
 
@@ -2110,7 +2115,14 @@ mod tests {
     use time::{Duration as TimeDuration, OffsetDateTime};
     use uuid::Uuid;
 
-    use super::{IdleSandboxCandidateRow, PgSessionStore, SessionEventNotification};
+    use super::{
+        IdleSandboxCandidateRow, PgSessionStore, SessionEventNotification, embedded_migrator,
+    };
+
+    #[test]
+    fn embedded_migrations_allow_forward_schema_versions_for_rollback() {
+        assert!(embedded_migrator().ignore_missing);
+    }
 
     async fn test_store() -> Option<PgSessionStore> {
         let Ok(url) = std::env::var("SESSION_RUNTIME_TEST_DATABASE_URL") else {

--- a/services/api-rs/crates/centaur-session-sqlx/tests/migration_rollback_compatibility.rs
+++ b/services/api-rs/crates/centaur-session-sqlx/tests/migration_rollback_compatibility.rs
@@ -1,0 +1,72 @@
+use std::{
+    env,
+    error::Error,
+    str::FromStr,
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+use centaur_session_sqlx::{PgSessionStore, SessionStoreError};
+use sqlx::{
+    Connection, Executor, PgConnection,
+    postgres::{PgConnectOptions, PgPoolOptions},
+};
+
+#[tokio::test]
+#[ignore = "requires SESSION_SQLX_TEST_DATABASE_URL"]
+async fn embedded_migrator_accepts_future_versions_but_checks_known_versions()
+-> Result<(), Box<dyn Error>> {
+    let database_url = test_database_url()?;
+    let mut admin_conn = PgConnection::connect(&database_url).await?;
+    let nanos = SystemTime::now().duration_since(UNIX_EPOCH)?.as_nanos();
+    let name = format!(
+        "centaur_migration_rollback_{}_{}",
+        std::process::id(),
+        nanos
+    );
+    admin_conn
+        .execute(format!(r#"create database "{name}""#).as_str())
+        .await?;
+
+    let result = async {
+        let options = PgConnectOptions::from_str(&database_url)?.database(&name);
+        let pool = PgPoolOptions::new().connect_with(options).await?;
+        let store = PgSessionStore::new(pool);
+        store.run_migrations().await?;
+
+        sqlx::query(
+            r#"
+            insert into _sqlx_migrations
+                (version, description, installed_on, success, checksum, execution_time)
+            values
+                (9223372036854775807, 'future migration', now(), true, decode(repeat('00', 48), 'hex'), 0)
+            "#,
+        )
+        .execute(store.pool())
+        .await?;
+        store.run_migrations().await?;
+
+        sqlx::query("update _sqlx_migrations set checksum = decode(repeat('ff', 48), 'hex') where version = 1")
+            .execute(store.pool())
+            .await?;
+        let error = store.run_migrations().await.unwrap_err();
+        assert!(matches!(
+            error,
+            SessionStoreError::Migrate(sqlx::migrate::MigrateError::VersionMismatch(1))
+        ));
+        store.pool().close().await;
+        Ok::<(), Box<dyn Error>>(())
+    }
+    .await;
+
+    let drop_result = admin_conn
+        .execute(format!(r#"drop database if exists "{name}""#).as_str())
+        .await;
+    result?;
+    drop_result?;
+    Ok(())
+}
+
+fn test_database_url() -> Result<String, env::VarError> {
+    env::var("SESSION_SQLX_TEST_DATABASE_URL")
+        .or_else(|_| env::var("SESSION_RUNTIME_TEST_DATABASE_URL"))
+}


### PR DESCRIPTION
Rolling back api-rs to an older image while the database already carries newer migrations fails at startup: the sqlx migrator reports `VersionMissing` for applied migrations the older binary does not embed, so the rollback target crashloops and the only way out is rolling forward.

Set `ignore_missing` on the migrator so an older binary boots cleanly against a newer schema. Checksum validation for the migrations the binary does know is unchanged, and pending migrations still apply in order; the regression test covers booting a binary whose embedded set is a strict prefix of the applied ledger.

We run Centaur at CyberConnect and have carried this as a local patch since 0.1.115.