### PR TITLE
fix: expose stable initial workflow run identity

### DIFF
--- a/services/api-rs/crates/centaur-api-integration-test/src/main.rs
+++ b/services/api-rs/crates/centaur-api-integration-test/src/main.rs
@@ -535,6 +535,96 @@ async fn test_workflows_api(http: &HttpClient, base_url: &str) -> Result<()> {
     wait_for_workflow_schedule(http, base_url, &workflow_name, true)
         .await
         .context("wait for added workflow schedule to be discovered")?;
+    let idempotency_key = format!("{workflow_name}-concurrent-idempotency");
+    let start_url = format!("{base_url}/api/workflows/runs");
+    let start_request = json!({
+        "workflow_name": workflow_name,
+        "input": {
+            "case": "concurrent-idempotent-start",
+            "sleep_ms": 0,
+        },
+        "idempotency_key": idempotency_key,
+        "max_attempts": 2,
+    });
+    let (first_start, second_start) = tokio::join!(
+        post_json_ok(http, start_url.clone(), start_request.clone()),
+        post_json_ok(http, start_url, start_request),
+    );
+    let first_start = first_start.context("first concurrent workflow start")?;
+    let second_start = second_start.context("second concurrent workflow start")?;
+    if first_start.get("run_id") != second_start.get("run_id")
+        || first_start.get("initial_run_id") != second_start.get("initial_run_id")
+        || first_start.get("task_id") != second_start.get("task_id")
+    {
+        bail!("concurrent idempotent workflow starts diverged: {first_start} vs {second_start}");
+    }
+    let mut created = [
+        first_start.get("created").and_then(Value::as_bool),
+        second_start.get("created").and_then(Value::as_bool),
+    ];
+    created.sort_unstable();
+    if created != [Some(false), Some(true)] {
+        bail!(
+            "concurrent idempotent workflow starts returned unexpected created values: {created:?}"
+        );
+    }
+    if first_start.get("initial_run_id") != first_start.get("run_id") {
+        bail!("first workflow start did not expose its initial run identity: {first_start}");
+    }
+
+    let retry_idempotency_key = format!("{workflow_name}-retrying-idempotency");
+    let retry_request = json!({
+        "workflow_name": workflow_name,
+        "input": {
+            "case": "stable-initial-run-id",
+            "always_fail": true,
+        },
+        "idempotency_key": retry_idempotency_key,
+        "max_attempts": 2,
+    });
+    let retrying = post_json_ok(
+        http,
+        format!("{base_url}/api/workflows/runs"),
+        retry_request.clone(),
+    )
+    .await
+    .context("start retrying workflow")?;
+    let retrying_initial_run_id = required_string(&retrying, "initial_run_id")?;
+    if retrying.get("run_id") != retrying.get("initial_run_id") {
+        bail!("new retrying workflow did not start at its initial run: {retrying}");
+    }
+    wait_for_workflow_run_status(http, base_url, &retrying_initial_run_id, &["failed"])
+        .await
+        .context("wait for retrying workflow to exhaust attempts")?;
+    let replayed = post_json_ok(
+        http,
+        format!("{base_url}/api/workflows/runs"),
+        retry_request,
+    )
+    .await
+    .context("replay retrying workflow start")?;
+    if replayed.get("created").and_then(Value::as_bool) != Some(false)
+        || replayed.get("task_id") != retrying.get("task_id")
+        || replayed.get("initial_run_id") != retrying.get("initial_run_id")
+        || replayed.get("run_id") == retrying.get("run_id")
+    {
+        bail!(
+            "workflow replay did not preserve additive initial identity and legacy current run: {retrying} vs {replayed}"
+        );
+    }
+    let replayed_run = get_json_ok(
+        http,
+        format!("{base_url}/api/workflows/runs/{retrying_initial_run_id}"),
+    )
+    .await
+    .context("get retrying workflow by initial run")?;
+    if replayed_run
+        .pointer("/run/initial_run_id")
+        .and_then(Value::as_str)
+        != Some(retrying_initial_run_id.as_str())
+    {
+        bail!("workflow get did not expose the stable initial identity: {replayed_run}");
+    }
 
     let completed_run_id = create_workflow_run(
         http,
@@ -738,6 +828,8 @@ async def handler(params, ctx):
     sleep_ms = int(params.get("sleep_ms") or 0)
     if sleep_ms:
         await asyncio.sleep(sleep_ms / 1000)
+    if params.get("always_fail"):
+        raise RuntimeError("simulated retrying workflow failure")
     return {{
         "workflow_name": ctx.workflow_name,
         "run_id": ctx.run_id,
@@ -843,6 +935,14 @@ async fn create_workflow_run(
         .and_then(Value::as_str)
         .map(ToOwned::to_owned)
         .context("workflow create response missing run_id")
+}
+
+fn required_string(value: &Value, field: &str) -> Result<String> {
+    value
+        .get(field)
+        .and_then(Value::as_str)
+        .map(ToOwned::to_owned)
+        .with_context(|| format!("response missing {field}: {value}"))
 }
 
 async fn wait_for_workflow_run_status(

--- a/services/api-rs/crates/centaur-workflows/src/lib.rs
+++ b/services/api-rs/crates/centaur-workflows/src/lib.rs
@@ -362,6 +362,7 @@ pub struct CreateWorkflowRunRequest {
 pub struct CreateWorkflowRunResponse {
     pub ok: bool,
     pub run_id: String,
+    pub initial_run_id: String,
     pub task_id: String,
     pub status: String,
     pub created: bool,
@@ -370,6 +371,7 @@ pub struct CreateWorkflowRunResponse {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct WorkflowRun {
     pub run_id: String,
+    pub initial_run_id: String,
     pub task_id: String,
     pub workflow_name: String,
     pub status: String,
@@ -856,13 +858,39 @@ impl WorkflowRuntime {
                 },
             )
             .await?;
+        let initial_run_id = self.initial_run_id(workflow_name, &spawn.task_id).await?;
         Ok(CreateWorkflowRunResponse {
             ok: true,
             run_id: spawn.run_id,
+            initial_run_id,
             task_id: spawn.task_id,
             status: "queued".to_owned(),
             created: spawn.created,
         })
+    }
+
+    pub async fn initial_run_id(
+        &self,
+        workflow_name: &str,
+        task_id: &str,
+    ) -> Result<String, WorkflowRuntimeError> {
+        let queue_name = queue_name_for_class(workflow_queue_class(workflow_name));
+        let (_, run_table) = absurd_queue_tables(queue_name)?;
+        let row = sqlx::query(&format!(
+            r#"
+            select run_id::text as run_id
+            from {run_table}
+            where task_id = $1::uuid
+            order by attempt, run_id
+            limit 1
+            "#,
+        ))
+        .bind(task_id)
+        .fetch_optional(self.inner.client.pool())
+        .await?;
+        row.map(|row| row.try_get("run_id"))
+            .transpose()?
+            .ok_or_else(|| WorkflowRuntimeError::NotFound(task_id.to_owned()))
     }
 
     pub async fn list_runs(
@@ -908,6 +936,13 @@ impl WorkflowRuntime {
             r#"
             select
                 r.run_id::text as run_id,
+                (
+                    select initial.run_id::text
+                    from {run_table} initial
+                    where initial.task_id = t.task_id
+                    order by initial.attempt, initial.run_id
+                    limit 1
+                ) as initial_run_id,
                 t.task_id::text as task_id,
                 t.task_name,
                 t.params,
@@ -959,6 +994,13 @@ impl WorkflowRuntime {
             r#"
             select
                 r.run_id::text as run_id,
+                (
+                    select initial.run_id::text
+                    from {run_table} initial
+                    where initial.task_id = t.task_id
+                    order by initial.attempt, initial.run_id
+                    limit 1
+                ) as initial_run_id,
                 t.task_id::text as task_id,
                 t.task_name,
                 t.params,
@@ -4435,6 +4477,7 @@ fn workflow_run_from_row(row: sqlx::postgres::PgRow) -> Result<WorkflowRun, Work
         .to_owned();
     Ok(WorkflowRun {
         run_id: row.try_get("run_id")?,
+        initial_run_id: row.try_get("initial_run_id")?,
         task_id: row.try_get("task_id")?,
         workflow_name,
         status: row.try_get("state")?,
@@ -5040,6 +5083,7 @@ mod tests {
             + time::Duration::nanoseconds(44_019_000);
         let run = WorkflowRun {
             run_id: "run".to_owned(),
+            initial_run_id: "initial-run".to_owned(),
             task_id: "task".to_owned(),
             workflow_name: "workflow".to_owned(),
             status: "completed".to_owned(),
@@ -5051,6 +5095,7 @@ mod tests {
             updated_at: at,
         };
         let value = serde_json::to_value(run).unwrap();
+        assert_eq!(value["initial_run_id"], json!("initial-run"));
         assert_eq!(value["created_at"], json!("2026-06-09T13:35:05.044019Z"));
         assert_eq!(value["updated_at"], json!("2026-06-09T13:35:05.044019Z"));
     }


### PR DESCRIPTION
Workflow create is idempotent, but its response only carries the *current* `run_id`. After a retry or recovery replaces the run, a caller that persisted the original create response holds an identifier that no longer matches anything it can correlate later, and re-issuing the create returns a different `run_id` again.

Expose an additive `initial_run_id` on the standard create and get responses: the identity of the first run for the task, stable across idempotent re-creates and recoveries. The legacy `run_id` field is unchanged, so existing callers are unaffected. Tests pin the field through concurrent idempotent creates (`tokio::join!`) and across run replacement.

We run Centaur at CyberConnect and have carried this as a local patch since 0.1.115.