### PR TITLE
feat: allow admins to demote other admins

### DIFF
--- a/services/console/app/controllers/console/users_controller.rb
+++ b/services/console/app/controllers/console/users_controller.rb
@@ -1,12 +1,12 @@
 module Console
   # Operator (console user) management: approve pending sign-ins, disable access,
-  # or promote a user to admin. Admin-only -- the gate is require_admin, layered on
-  # top of the app-wide require_login/require_active_account gates.
+  # promote a user to admin, or demote an admin to user. Admin-only -- the gate is
+  # require_admin, layered on top of the app-wide require_login/require_active_account gates.
   class UsersController < ApplicationController
     layout "console"
 
     before_action :require_admin
-    before_action :set_user, only: %i[approve disable promote]
+    before_action :set_user, only: %i[approve disable promote demote]
 
     def index
       @pending = User.pending.includes(:user_identities).order(:created_at)
@@ -30,6 +30,15 @@ module Console
       # Promoting also activates: an admin must be able to use the console.
       @user.update!(admin: true, status: :active)
       redirect_to console_users_path, notice: "#{@user.email} is now an admin."
+    end
+
+    def demote
+      if @user == current_user
+        return redirect_to console_users_path, alert: "You can't demote your own account."
+      end
+
+      @user.update!(admin: false)
+      redirect_to console_users_path, notice: "#{@user.email} is now a user."
     end
 
     private

--- a/services/console/app/views/console/users/index.html.erb
+++ b/services/console/app/views/console/users/index.html.erb
@@ -4,7 +4,7 @@
 
 <%= render "console/page_header",
            title: "Users",
-           subtitle: "Operator accounts. Approve pending sign-ins, promote admins, or disable access." %>
+           subtitle: "Operator accounts. Approve pending sign-ins, change roles, or disable access." %>
 
 <% if @pending.any? %>
   <h2 class="mb-3 text-xs font-semibold uppercase tracking-wider text-amber-300/80"><%= pluralize(@pending.size, "pending approval") %></h2>
@@ -56,7 +56,11 @@
           <td class="console-td"><%= user_idp_chips(user) %></td>
           <td class="console-td">
             <div class="flex items-center justify-end gap-2">
-              <% unless user.admin? %>
+              <% if user.admin? && user != current_user %>
+                <%= button_to "Make user", demote_console_user_path(user.oid), method: :post,
+                      form: { data: { turbo_confirm: "Make #{user.email} a user?" } },
+                      class: "cursor-pointer rounded border border-ink-600 px-3 py-1.5 text-zinc-400 transition-colors hover:border-centaur-500/40 hover:text-centaur-300" %>
+              <% elsif !user.admin? %>
                 <%= button_to "Make admin", promote_console_user_path(user.oid), method: :post,
                       class: "cursor-pointer rounded border border-ink-600 px-3 py-1.5 text-zinc-400 transition-colors hover:border-centaur-500/40 hover:text-centaur-300" %>
               <% end %>

--- a/services/console/config/routes.rb
+++ b/services/console/config/routes.rb
@@ -160,6 +160,7 @@ Rails.application.routes.draw do
         post :approve
         post :disable
         post :promote
+        post :demote
       end
     end
     resource :system_settings, only: %i[edit update], path: "settings"

--- a/services/console/test/controllers/console/users_controller_test.rb
+++ b/services/console/test/controllers/console/users_controller_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 module Console
   # Covers the admin-only operator management screen: who can reach it, and the
-  # approve/disable/promote state transitions (including the self-disable guard).
+  # approve/disable/promote/demote state transitions (including self-action guards).
   class UsersControllerTest < ActionDispatch::IntegrationTest
     def sign_in(user)
       post login_url, params: { email: user.email, password: "password123456" }
@@ -48,6 +48,19 @@ module Console
       assert_select "span", text: "Google"   # acme_admin is linked via Google
       assert_select "span", text: "Slack"    # pending_user is linked via Slack
       assert_select "span", text: "Password" # member_user has no linked identity
+    end
+
+    test "the index offers role changes without offering self-demotion" do
+      sign_in users(:acme_admin)
+      get console_users_url
+
+      assert_select "form[action=?]", demote_console_user_path(users(:globex_admin).oid) do
+        assert_select "button", text: "Make user"
+      end
+      assert_select "form[action=?]", demote_console_user_path(users(:acme_admin).oid), count: 0
+      assert_select "form[action=?]", promote_console_user_path(users(:member_user).oid) do
+        assert_select "button", text: "Make admin"
+      end
     end
 
     test "approve activates a pending user and records the approver" do
@@ -111,12 +124,35 @@ module Console
       assert target.active?
     end
 
+    test "demote makes an admin a user" do
+      sign_in users(:acme_admin)
+      target = users(:globex_admin)
+      post demote_console_user_url(target.oid)
+      assert_redirected_to console_users_path
+      assert_not target.reload.admin?
+      assert_equal "#{target.email} is now a user.", flash[:notice]
+    end
+
+    test "an admin cannot demote their own account" do
+      admin = users(:acme_admin)
+      sign_in admin
+      post demote_console_user_url(admin.oid)
+      assert_redirected_to console_users_path
+      assert_equal "You can't demote your own account.", flash[:alert]
+      assert admin.reload.admin?
+    end
+
     test "a non-admin cannot perform actions" do
       sign_in users(:member_user)
       target = users(:pending_user)
       post approve_console_user_url(target.oid)
       assert_redirected_to console_threads_path
       assert target.reload.pending?
+
+      admin = users(:globex_admin)
+      post demote_console_user_url(admin.oid)
+      assert_redirected_to console_threads_path
+      assert admin.reload.admin?
     end
   end
 end


### PR DESCRIPTION
Adds a confirmed Make user action to the console Users screen so admins can demote other admins. Prevents self-demotion and enforces the existing admin authorization boundary, with controller coverage for rendering and role transitions.