### PR TITLE
feat: add PayBox MCP support

### DIFF
--- a/docs/pages/reference/tool-directory.mdx
+++ b/docs/pages/reference/tool-directory.mdx
@@ -137,6 +137,7 @@ These tools ship in the base repo because many Centaur users need onchain or mar
 | `messari` | Crypto asset prices, metrics, profiles, markets, news, and timeseries | `MESSARI_API_KEY` |
 | `mpp` | Paid MPP requests | None |
 | `nansen` | Wallet labels, smart-money activity, token flows, holders, and PnL | `NANSEN_API_KEY` |
+| `paybox` | Scoped payments, wallet signing, portfolio reads, and x402 services over MCP | User-scoped PayBox OAuth |
 | `polymarket` | Prediction market events, markets, prices, books, and trades | None |
 | `snapshot` | Offchain governance spaces, proposals, votes, and voting power | `SNAPSHOT_API_KEY` |
 | `standard-metrics` | Portfolio company metrics, documents, notes, funds, and budgets | `STANDARD_METRICS_CLIENT_ID`, `STANDARD_METRICS_CLIENT_SECRET` |

--- a/docs/pages/secrets/oauth-apps.mdx
+++ b/docs/pages/secrets/oauth-apps.mdx
@@ -22,6 +22,7 @@ Centaur Console.
 | `granola` | Granola MCP tokens for `mcp.granola.ai`. |
 | `linear` | Linear tokens for `api.linear.app`. |
 | `attio` | Attio workspace tokens for `api.attio.com`. |
+| `paybox` | PayBox MCP access for `api.paybox.sh`. |
 
 ## Set Up An App
 
@@ -61,6 +62,27 @@ curl -sS -X POST https://mcp-auth.granola.ai/oauth2/register \
 ```
 
 Use `mcp` as the allowed scope for the app.
+
+### PayBox
+
+PayBox uses OAuth public clients with PKCE, so it does not issue a client
+secret. Dynamically register the Console callback URL before adding the app:
+
+```bash
+curl -sS -X POST https://api.paybox.sh/oauth/register \
+  -H "Content-Type: application/json" \
+  -d '{
+    "client_name": "Centaur Console",
+    "redirect_uris": ["<CENTAUR_CONSOLE_PUBLIC_URL>/oauth/paybox/callback"],
+    "token_endpoint_auth_method": "none",
+    "grant_types": ["authorization_code", "refresh_token"],
+    "response_types": ["code"]
+  }'
+```
+
+Create a Console OAuth app with provider and slug `paybox`, the returned
+`client_id`, a blank client secret, and allowed scopes `mcp` and
+`offline_access`.
 
 ## Grant The Credential
 

--- a/services/console/app/controllers/api/v1/oauth_apps_controller.rb
+++ b/services/console/app/controllers/api/v1/oauth_apps_controller.rb
@@ -2,8 +2,8 @@ module Api
   module V1
     # Operator CRUD for OAuth apps. An app's whole identity is its globally-unique
     # `slug`, so it is addressed by oid or slug (no namespace/foreign_id), and
-    # `PUT` upserts by slug. client_secret is required and write-only: it is
-    # accepted on writes but NEVER serialized back.
+    # `PUT` upserts by slug. client_secret is write-only and is required for
+    # confidential providers but omitted for public-client providers.
     class OauthAppsController < Api::BaseController
       def index
         records, meta = paginated_apps
@@ -93,8 +93,7 @@ module Api
         app.save!
       end
 
-      # Observability only. The client_secret is deliberately never included (it is
-      # required, so its presence is implied).
+      # Observability only. The client_secret is deliberately never included.
       def record_payload(app)
         {
           id: app.oid,

--- a/services/console/app/models/oauth_app.rb
+++ b/services/console/app/models/oauth_app.rb
@@ -38,13 +38,19 @@ class OauthApp < ApplicationRecord
   validate :slug_does_not_shadow_oid
   validates :provider, inclusion: { in: ->(_) { Oauth::Providers.keys }, message: "is not a supported provider" }
   validates :client_id, presence: true
-  validates :client_secret, presence: true
+  validates :client_secret, presence: true, if: :client_secret_required?
   validate :labels_is_a_hash
   validate :allowed_scopes_valid
 
   # The provider strategy backing this app, or nil if the provider column somehow
   # holds an unknown key (the inclusion validation normally prevents that).
   def provider_strategy = Oauth::Providers.fetch(provider)
+
+  # OAuth public clients authenticate with PKCE rather than a client secret.
+  def client_secret_required?
+    strategy = provider_strategy
+    strategy.nil? || !strategy.respond_to?(:public_client?) || !strategy.public_client?
+  end
 
   # True when every requested scope is within the allowlist.
   def scopes_allowed?(requested) = (Array(requested) - Array(allowed_scopes)).empty?

--- a/services/console/app/views/console/oauth_apps/_form.html.erb
+++ b/services/console/app/views/console/oauth_apps/_form.html.erb
@@ -26,7 +26,7 @@
         <div>
           <label class="form-label" for="oauth_app_provider">Provider *</label>
           <%= select_tag "oauth_app[provider]",
-                options_for_select(Oauth::Providers.keys.map { |k| [ k.capitalize, k ] }, app.provider),
+                options_for_select(Oauth::Providers.keys.map { |k| [ Oauth::Providers.fetch(k).display_name, k ] }, app.provider),
                 id: "oauth_app_provider", class: "form-input #{field_error_class(app, :provider)}" %>
           <%= field_error(app, :provider) %>
         </div>
@@ -37,10 +37,10 @@
           <p class="form-hint">Not secret. Sent on every authorization and refresh.</p>
         </div>
         <div>
-          <label class="form-label" for="oauth_app_client_secret">Client secret<%= " *".html_safe if app.new_record? %></label>
+          <label class="form-label" for="oauth_app_client_secret">Client secret</label>
           <%= password_field_tag "oauth_app[client_secret]", nil, id: "oauth_app_client_secret", class: "form-input #{field_error_class(app, :client_secret)}", autocomplete: "off", placeholder: app.new_record? ? nil : "•••••••• (unchanged)" %>
           <%= field_error(app, :client_secret) %>
-          <p class="form-hint">Stored encrypted.<%= " Leave blank to keep the current secret." unless app.new_record? %></p>
+          <p class="form-hint">Stored encrypted. Required unless the provider uses public clients (PayBox).<%= " Leave blank to keep the current secret." unless app.new_record? %></p>
         </div>
       </div>
     </section>

--- a/services/console/lib/oauth/providers.rb
+++ b/services/console/lib/oauth/providers.rb
@@ -15,6 +15,7 @@ module Oauth
         Google::KEY => Google.new,
         Granola::KEY => Granola.new,
         Linear::KEY => Linear.new,
+        Paybox::KEY => Paybox.new,
         Slack::KEY => Slack.new
       }.freeze
     end

--- a/services/console/lib/oauth/providers/paybox.rb
+++ b/services/console/lib/oauth/providers/paybox.rb
@@ -1,0 +1,78 @@
+require "base64"
+require "json"
+
+module Oauth
+  module Providers
+    # PayBox OAuth 2.1 consent-flow strategy for its MCP endpoint. PayBox uses
+    # dynamically registered public clients, PKCE S256, and rotating refresh
+    # tokens. The access token is a JWT audience-bound to the MCP resource.
+    class Paybox
+      KEY = "paybox"
+      ISSUER = "https://api.paybox.sh"
+      AUTHORIZATION_ENDPOINT = "#{ISSUER}/oauth/authorize"
+      TOKEN_ENDPOINT = "#{ISSUER}/oauth/token"
+      REGISTRATION_ENDPOINT = "#{ISSUER}/oauth/register"
+      MCP_RESOURCE = "#{ISSUER}/mcp"
+      IDENTITY_SCOPES = [].freeze
+      API_HOSTS = %w[api.paybox.sh].freeze
+
+      def key = KEY
+      def display_name = "PayBox"
+      def authorization_endpoint = AUTHORIZATION_ENDPOINT
+      def token_endpoint = TOKEN_ENDPOINT
+      def identity_scopes = IDENTITY_SCOPES
+      def api_hosts = API_HOSTS
+      def authorization_scope_param = "scope"
+      def scope_separator = " "
+      def extra_authorization_params = { "resource" => MCP_RESOURCE }
+      def refreshable? = true
+      def public_client? = true
+
+      def parse_granted_scopes(scope) = scope.to_s.split
+
+      # PayBox binds scopes to the rotating refresh-token family; its documented
+      # refresh request does not send a scope parameter.
+      def refresh_scopes(_scopes) = []
+
+      # PayBox returns no OIDC id_token. Decode the access-token claims to obtain
+      # the stable subject. The token came directly from PayBox's token endpoint
+      # over TLS; issuer, audience, and client id are still checked before use.
+      def identity_from(result, client_id:, http_client: nil)
+        claims = decode_access_token_claims(result.access_token)
+        unless claims["iss"] == ISSUER
+          raise Broker::ExchangeError.new("access token iss was not PayBox",
+                                          stage: "oauth", code: "access_token_iss_invalid")
+        end
+
+        audiences = Array(claims["aud"])
+        unless audiences.include?(MCP_RESOURCE)
+          raise Broker::ExchangeError.new("access token aud did not include the PayBox MCP resource",
+                                          stage: "oauth", code: "access_token_aud_mismatch")
+        end
+
+        if claims["cid"].present? && claims["cid"] != client_id
+          raise Broker::ExchangeError.new("access token cid did not match client_id",
+                                          stage: "oauth", code: "access_token_client_mismatch")
+        end
+
+        subject = claims["sub"]
+        if subject.blank?
+          raise Broker::ExchangeError.new("access token carried no sub",
+                                          stage: "oauth", code: "access_token_missing_sub")
+        end
+
+        { subject: subject, email: claims["email"].presence }
+      end
+
+      private
+
+      def decode_access_token_claims(access_token)
+        segment = access_token.to_s.split(".")[1].to_s
+        segment += "=" * ((4 - segment.length % 4) % 4)
+        JSON.parse(Base64.urlsafe_decode64(segment))
+      rescue ArgumentError, JSON::ParserError
+        raise Broker::ExchangeError.new("access token payload did not decode", stage: "parse")
+      end
+    end
+  end
+end

--- a/services/console/test/controllers/oauth/flows_controller_test.rb
+++ b/services/console/test/controllers/oauth/flows_controller_test.rb
@@ -37,9 +37,9 @@ module Oauth
       @identity_http_mocks.each(&:verify)
     end
 
-    def stub_exchange(status:, body:, expected: true)
+    def stub_exchange(status:, body:, expected: true, &assert_request)
       http = Minitest::Mock.new
-      expect_http_call(http, status: status, body: body) if expected
+      expect_http_call(http, status: status, body: body, &assert_request) if expected
       @exchange_http_mocks << http
       FlowsController.exchange_client_factory = -> { Broker::AuthorizationCodeClient.new(http: http) }
     end
@@ -134,6 +134,20 @@ module Oauth
         token_type: "Bearer",
         expires_in: 86_399,
         scope: scope
+      }.merge(overrides).to_json
+    end
+
+    def paybox_token_body(client_id:, **overrides)
+      claims = {
+        "iss" => Oauth::Providers::Paybox::ISSUER,
+        "aud" => Oauth::Providers::Paybox::MCP_RESOURCE,
+        "sub" => "paybox-user-1",
+        "cid" => client_id,
+        "email" => "paybox@example.com"
+      }
+      {
+        access_token: id_token(claims), refresh_token: "paybox-refresh",
+        expires_in: 3600, scope: "mcp offline_access"
       }.merge(overrides).to_json
     end
 
@@ -250,6 +264,25 @@ module Oauth
       scopes = q["scope"].split(",")
       assert_includes scopes, "read"
       assert_includes scopes, "write"
+    end
+
+    test "start redirects to PayBox with the MCP resource and public client" do
+      app = OauthApp.create!(
+        provider: "paybox", slug: "paybox", client_id: "pbx-oauth-client",
+        client_secret: nil, allowed_scopes: %w[mcp offline_access],
+        enabled: true, created_by: users(:acme_admin)
+      )
+
+      get oauth_start_url(slug: app.slug)
+      assert_response :redirect
+      uri = URI.parse(response.location)
+      assert_equal "api.paybox.sh", uri.host
+      assert_equal "/oauth/authorize", uri.path
+      query = URI.decode_www_form(uri.query).to_h
+      assert_equal "pbx-oauth-client", query["client_id"]
+      assert_equal "https://api.paybox.sh/mcp", query["resource"]
+      assert_equal "mcp offline_access", query["scope"]
+      assert_equal "S256", query["code_challenge_method"]
     end
 
     test "start redirects signed-out users to login" do
@@ -512,6 +545,31 @@ module Oauth
       assert cred.next_attempt_at.present?
       assert_equal [ "api.linear.app" ], cred.static_secret.rules.map(&:host)
       assert_equal "Linear – Ada Lovelace token", cred.static_secret.name
+    end
+
+    test "callback supports PayBox public-client tokens without a client secret" do
+      app = OauthApp.create!(
+        provider: "paybox", slug: "paybox", client_id: "pbx-oauth-client",
+        client_secret: nil, allowed_scopes: %w[mcp offline_access],
+        enabled: true, created_by: users(:acme_admin)
+      )
+      state = start_flow(slug: app.slug)
+      stub_exchange(status: 200, body: paybox_token_body(client_id: app.client_id)) do |request|
+        assert_nil request[:form]["client_secret"]
+        assert_equal app.client_id, request[:form]["client_id"]
+      end
+
+      assert_difference -> { BrokerCredential.count } => 1 do
+        get oauth_callback_url(slug: app.slug), params: { state: state, code: "auth-code" }
+      end
+      assert_redirected_to console_integrations_path
+
+      credential = BrokerCredential.find_by!(oauth_app: app, provider_subject: "paybox-user-1")
+      assert_equal "PayBox – paybox@example.com", credential.name
+      assert_equal "https://api.paybox.sh/oauth/token", credential.token_endpoint
+      assert_equal %w[mcp offline_access], credential.scopes
+      assert_equal "paybox-refresh", credential.refresh_token
+      assert_equal [ "api.paybox.sh" ], credential.static_secret.rules.map(&:host)
     end
 
     test "GitHub re-consent updates the existing credential synchronously" do

--- a/services/console/test/lib/oauth/providers/paybox_test.rb
+++ b/services/console/test/lib/oauth/providers/paybox_test.rb
@@ -1,0 +1,74 @@
+require "test_helper"
+
+module Oauth
+  module Providers
+    class PayboxTest < ActiveSupport::TestCase
+      CLIENT_ID = "pbx-oauth-client".freeze
+
+      def strategy = Paybox.new
+
+      def result_with(claims)
+        payload = Base64.urlsafe_encode64(claims.to_json, padding: false)
+        Broker::AuthorizationCodeClient::Result.new(
+          access_token: "h.#{payload}.s",
+          refresh_token: "RT",
+          expires_in: 3600,
+          scope: "mcp offline_access",
+          id_token: nil,
+          response: {}
+        )
+      end
+
+      def valid_claims(**overrides)
+        {
+          "iss" => Paybox::ISSUER,
+          "aud" => Paybox::MCP_RESOURCE,
+          "sub" => "paybox-user-123",
+          "cid" => CLIENT_ID,
+          "email" => "user@example.com"
+        }.merge(overrides)
+      end
+
+      test "extracts identity from an audience-bound access token" do
+        identity = strategy.identity_from(result_with(valid_claims), client_id: CLIENT_ID)
+        assert_equal "paybox-user-123", identity[:subject]
+        assert_equal "user@example.com", identity[:email]
+      end
+
+      test "rejects a token for another MCP resource" do
+        error = assert_raises(Broker::ExchangeError) do
+          strategy.identity_from(result_with(valid_claims("aud" => "https://evil.example/mcp")), client_id: CLIENT_ID)
+        end
+        assert_equal "access_token_aud_mismatch", error.code
+      end
+
+      test "rejects a token for another client" do
+        error = assert_raises(Broker::ExchangeError) do
+          strategy.identity_from(result_with(valid_claims("cid" => "other-client")), client_id: CLIENT_ID)
+        end
+        assert_equal "access_token_client_mismatch", error.code
+      end
+
+      test "rejects an undecodable access token" do
+        result = Broker::AuthorizationCodeClient::Result.new(
+          access_token: "not-a-jwt", refresh_token: "RT", expires_in: 3600,
+          scope: "mcp offline_access", id_token: nil, response: {}
+        )
+        error = assert_raises(Broker::ExchangeError) do
+          strategy.identity_from(result, client_id: CLIENT_ID)
+        end
+        assert_equal "parse", error.stage
+      end
+
+      test "exposes PayBox public-client OAuth configuration" do
+        assert_equal "https://api.paybox.sh/oauth/authorize", strategy.authorization_endpoint
+        assert_equal "https://api.paybox.sh/oauth/token", strategy.token_endpoint
+        assert_equal({ "resource" => "https://api.paybox.sh/mcp" }, strategy.extra_authorization_params)
+        assert_equal %w[api.paybox.sh], strategy.api_hosts
+        assert_predicate strategy, :public_client?
+        assert_predicate strategy, :refreshable?
+        assert_equal [], strategy.refresh_scopes(%w[mcp offline_access])
+      end
+    end
+  end
+end

--- a/services/console/test/models/oauth_app_test.rb
+++ b/services/console/test/models/oauth_app_test.rb
@@ -20,12 +20,18 @@ class OauthAppTest < ActiveSupport::TestCase
     refute build_app(provider: "nope").valid?
     assert build_app(provider: "github").valid?
     assert build_app(provider: "google").valid?
+    assert build_app(provider: "paybox", client_secret: nil).valid?
     assert build_app(provider: "slack").valid?
   end
 
   test "client_id and client_secret are required" do
     refute build_app(client_id: nil).valid?
     refute build_app(client_secret: nil).valid?
+  end
+
+  test "public OAuth clients do not require a client secret" do
+    assert build_app(provider: "paybox", client_secret: nil).valid?
+    refute build_app(provider: "google", client_secret: nil).valid?
   end
 
   test "slug is required, url-safe, and globally unique" do

--- a/tools/README.md
+++ b/tools/README.md
@@ -70,6 +70,7 @@ The open-source tool inventory lives in this `tools/` tree and changes over time
   read-only with `DD_API_KEY` and `DD_APP_KEY`.
 - `preqin`: query Preqin Operational API fund and fund-manager data, with
   redacted auth diagnostics for `PREQIN_*` credentials.
+- `paybox`: call the PayBox MCP server with user-scoped OAuth access.
 
 ## Sandbox Tool Paths
 

--- a/tools/crypto/paybox/.env.example
+++ b/tools/crypto/paybox/.env.example
@@ -1,0 +1,4 @@
+# Optional for local development. Production uses user-scoped Console OAuth.
+PAYBOX_ACCESS_TOKEN=OAuth access token
+# A personal PayBox API key can also be used as a bearer token.
+PAYBOX_API_KEY=pbx_live_...

--- a/tools/crypto/paybox/cli.py
+++ b/tools/crypto/paybox/cli.py
@@ -1,0 +1,73 @@
+from dotenv import load_dotenv
+
+load_dotenv()
+
+import json  # noqa: E402
+from typing import Any  # noqa: E402
+
+import typer  # noqa: E402
+from rich.console import Console  # noqa: E402
+from rich.markdown import Markdown  # noqa: E402
+
+app = typer.Typer(name="paybox", help="Call the PayBox MCP server")
+console = Console()
+
+
+def _emit(value: Any, markdown: bool, json_output: bool) -> None:
+    if markdown and json_output:
+        raise typer.BadParameter("choose either --json or --markdown")
+    rendered = json.dumps(value, indent=2, ensure_ascii=False, default=str)
+    if markdown:
+        console.print(Markdown(f"```json\n{rendered}\n```"))
+    else:
+        print(rendered)
+
+
+@app.command("health")
+def health(
+    json_output: bool = typer.Option(False, "--json", help="Render as JSON"),
+    markdown: bool = typer.Option(False, "--markdown", help="Render as Markdown"),
+) -> None:
+    """Assert authenticated PayBox MCP connectivity."""
+    from .client import _client
+
+    with _client() as client:
+        _emit(client.health(), markdown, json_output)
+
+
+@app.command("list-tools")
+def list_tools(
+    json_output: bool = typer.Option(False, "--json", help="Render as JSON"),
+    markdown: bool = typer.Option(False, "--markdown", help="Render as Markdown"),
+) -> None:
+    """List MCP tools enabled for the connected user."""
+    from .client import _client
+
+    with _client() as client:
+        _emit(client.list_tools(), markdown, json_output)
+
+
+@app.command("call")
+def call_tool(
+    tool_name: str = typer.Argument(..., help="PayBox MCP tool name"),
+    arguments: str = typer.Option("{}", "--arguments", "-a", help="JSON object of tool arguments"),
+    confirm: bool = typer.Option(False, "--confirm", help="Confirm a sensitive operation"),
+    json_output: bool = typer.Option(False, "--json", help="Render as JSON"),
+    markdown: bool = typer.Option(False, "--markdown", help="Render as Markdown"),
+) -> None:
+    """Call a PayBox MCP tool by name."""
+    from .client import _client
+
+    try:
+        parsed = json.loads(arguments)
+    except json.JSONDecodeError as exc:
+        raise typer.BadParameter("--arguments must be valid JSON") from exc
+    if not isinstance(parsed, dict):
+        raise typer.BadParameter("--arguments must decode to a JSON object")
+
+    with _client() as client:
+        _emit(client.execute(tool_name, parsed, confirm=confirm), markdown, json_output)
+
+
+if __name__ == "__main__":
+    app()

--- a/tools/crypto/paybox/client.py
+++ b/tools/crypto/paybox/client.py
@@ -1,0 +1,216 @@
+"""PayBox Streamable HTTP MCP client."""
+
+from __future__ import annotations
+
+import json
+import uuid
+from typing import Any
+
+import httpx
+
+from centaur_sdk import secret
+
+MCP_URL = "https://api.paybox.sh/mcp"
+MCP_PROTOCOL_VERSION = "2025-06-18"
+
+# These calls do not request money movement, signatures, or credential output.
+READ_ONLY_TOOLS = frozenset(
+    {
+        "discover_services",
+        "get_buy_link",
+        "get_portfolio",
+        "get_request",
+        "list_credentials",
+        "list_requests",
+        "request_account_change",
+        "verify_solana_balance",
+    }
+)
+
+
+class PayboxClient:
+    """Client for PayBox's user-scoped MCP server.
+
+    In a Centaur sandbox, iron-proxy injects the connected user's OAuth bearer
+    token. For local development, set PAYBOX_ACCESS_TOKEN or PAYBOX_API_KEY.
+    """
+
+    def __init__(
+        self,
+        token: str | None = None,
+        http_client: httpx.Client | None = None,
+        timeout: float = 60.0,
+    ):
+        headers = {
+            "Accept": "application/json, text/event-stream",
+            "Content-Type": "application/json",
+            "MCP-Protocol-Version": MCP_PROTOCOL_VERSION,
+        }
+        token = token or secret("PAYBOX_ACCESS_TOKEN", "") or secret("PAYBOX_API_KEY", "")
+        if token:
+            headers["Authorization"] = f"Bearer {token}"
+        self._client = http_client or httpx.Client(headers=headers, timeout=timeout)
+        if http_client is not None:
+            self._client.headers.update(headers)
+        self._session_id: str | None = None
+        self._initialized = False
+
+    def close(self) -> None:
+        self._client.close()
+
+    def __enter__(self) -> PayboxClient:
+        return self
+
+    def __exit__(self, *args: Any) -> None:
+        self.close()
+
+    def _decode_response(self, response: httpx.Response) -> dict[str, Any]:
+        response.raise_for_status()
+        if not response.content:
+            return {}
+
+        body = response.text
+        content_type = response.headers.get("content-type", "").lower()
+        if "text/event-stream" not in content_type and not body.lstrip().startswith("data:"):
+            return response.json()
+
+        payloads: list[str] = []
+        lines: list[str] = []
+        for raw_line in body.splitlines():
+            if raw_line.startswith("data:"):
+                lines.append(raw_line[5:].lstrip())
+            elif not raw_line and lines:
+                payloads.append("\n".join(lines))
+                lines = []
+        if lines:
+            payloads.append("\n".join(lines))
+        if not payloads:
+            raise RuntimeError("PayBox MCP returned an empty event stream")
+        return json.loads(payloads[-1])
+
+    def _send(self, method: str, params: dict[str, Any] | None = None) -> dict[str, Any]:
+        headers = {"Mcp-Session-Id": self._session_id} if self._session_id else None
+        response = self._client.post(
+            MCP_URL,
+            headers=headers,
+            json={
+                "jsonrpc": "2.0",
+                "id": str(uuid.uuid4()),
+                "method": method,
+                "params": params or {},
+            },
+        )
+        session_id = response.headers.get("Mcp-Session-Id")
+        if session_id:
+            self._session_id = session_id
+        message = self._decode_response(response)
+        if "error" in message:
+            raise RuntimeError(f"PayBox MCP {method} failed: {message['error']}")
+        return message.get("result", {})
+
+    def _notify_initialized(self) -> None:
+        headers = {"Mcp-Session-Id": self._session_id} if self._session_id else None
+        response = self._client.post(
+            MCP_URL,
+            headers=headers,
+            json={"jsonrpc": "2.0", "method": "notifications/initialized"},
+        )
+        response.raise_for_status()
+
+    def _ensure_initialized(self) -> None:
+        if self._initialized:
+            return
+        self._send(
+            "initialize",
+            {
+                "protocolVersion": MCP_PROTOCOL_VERSION,
+                "capabilities": {},
+                "clientInfo": {"name": "centaur-paybox", "version": "0.1.0"},
+            },
+        )
+        self._notify_initialized()
+        self._initialized = True
+
+    def _call_tool(self, tool_name: str, arguments: dict[str, Any] | None = None) -> Any:
+        self._ensure_initialized()
+        result = self._send("tools/call", {"name": tool_name, "arguments": arguments or {}})
+        if result.get("isError"):
+            text = "; ".join(
+                item.get("text", "")
+                for item in result.get("content", [])
+                if isinstance(item, dict) and item.get("type") == "text"
+            )
+            raise RuntimeError(f"PayBox MCP tool {tool_name} failed: {text or result}")
+
+        if result.get("structuredContent") is not None:
+            return result["structuredContent"]
+        content = result.get("content", [])
+        texts = [
+            item.get("text", "")
+            for item in content
+            if isinstance(item, dict) and item.get("type") == "text"
+        ]
+        if len(texts) == 1:
+            try:
+                return json.loads(texts[0])
+            except json.JSONDecodeError:
+                return {"text": texts[0]}
+        return {"content": content}
+
+    def health(self) -> dict[str, Any]:
+        """Check authenticated MCP connectivity and return the tool count."""
+        tools = self.list_tools()
+        return {"ok": True, "tool": "paybox", "tool_count": len(tools)}
+
+    def list_tools(self) -> list[dict[str, Any]]:
+        """List the PayBox MCP tools enabled for the connected user."""
+        self._ensure_initialized()
+        result = self._send("tools/list")
+        return result.get("tools", [])
+
+    def execute(
+        self,
+        tool_name: str,
+        arguments: dict[str, Any] | None = None,
+        confirm: bool = False,
+    ) -> Any:
+        """Call any PayBox MCP tool.
+
+        Set confirm=true only after the user explicitly approves all material
+        payment, signing, secret, recipient, and amount fields. Known read-only
+        tools do not require confirmation.
+        """
+        if tool_name not in READ_ONLY_TOOLS and not confirm:
+            raise RuntimeError(
+                f"PayBox tool {tool_name!r} may create or advance a sensitive operation; "
+                "retry with confirm=true only after explicit user approval"
+            )
+        return self._call_tool(tool_name, arguments)
+
+    def list_credentials(self) -> Any:
+        """List credentials granted to this PayBox connector."""
+        return self._call_tool("list_credentials")
+
+    def get_portfolio(self, address: str, network_ids: str | None = None) -> Any:
+        """Read token balances for an EVM or Solana wallet address."""
+        arguments = {"address": address}
+        if network_ids:
+            arguments["network_ids"] = network_ids
+        return self._call_tool("get_portfolio", arguments)
+
+    def get_request(self, request_id: str) -> Any:
+        """Read the current state of a PayBox request; never re-submit writes."""
+        return self._call_tool("get_request", {"request_id": request_id})
+
+    def list_requests(self) -> Any:
+        """List recent PayBox requests for the connected client."""
+        return self._call_tool("list_requests")
+
+    def discover_services(self, query: str | None = None) -> Any:
+        """Discover curated x402 services without paying for them."""
+        arguments = {"query": query} if query else {}
+        return self._call_tool("discover_services", arguments)
+
+
+def _client() -> PayboxClient:
+    return PayboxClient()

--- a/tools/crypto/paybox/pyproject.toml
+++ b/tools/crypto/paybox/pyproject.toml
@@ -1,0 +1,30 @@
+[project]
+name = "paybox"
+description = "PayBox MCP client for scoped payments, wallet signing, and x402 services"
+version = "0.1.0"
+requires-python = ">=3.11"
+dependencies = [
+    "httpx>=0.27.0",
+    "typer>=0.12.0",
+    "rich>=13.0.0",
+    "python-dotenv>=1.0.0",
+]
+
+[project.scripts]
+paybox = "centaur_tool_paybox.cli:app"
+
+[tool.hatch.build.targets.wheel]
+packages = ["."]
+
+[tool.hatch.build.targets.wheel.sources]
+"." = "centaur_tool_paybox"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.centaur]
+module = "client.py"
+# The Console OAuth credential injects Authorization for this host. Local
+# development may set PAYBOX_ACCESS_TOKEN or PAYBOX_API_KEY instead.
+hosts = ["api.paybox.sh"]

--- a/tools/crypto/paybox/test_client.py
+++ b/tools/crypto/paybox/test_client.py
@@ -1,0 +1,85 @@
+import json
+
+import httpx
+import pytest
+from client import PayboxClient
+
+
+def rpc_response(payload: dict, session_id: str | None = None) -> httpx.Response:
+    headers = {"content-type": "application/json"}
+    if session_id:
+        headers["Mcp-Session-Id"] = session_id
+    return httpx.Response(200, headers=headers, json=payload)
+
+
+def test_initializes_session_and_lists_tools() -> None:
+    requests: list[dict] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content)
+        requests.append(body)
+        if body["method"] == "initialize":
+            assert request.headers["authorization"] == "Bearer token"
+            return rpc_response({"jsonrpc": "2.0", "id": body["id"], "result": {}}, "session-1")
+        if body["method"] == "notifications/initialized":
+            assert request.headers["mcp-session-id"] == "session-1"
+            return httpx.Response(202)
+        assert request.headers["mcp-session-id"] == "session-1"
+        return rpc_response(
+            {
+                "jsonrpc": "2.0",
+                "id": body["id"],
+                "result": {"tools": [{"name": "list_credentials"}]},
+            }
+        )
+
+    client = PayboxClient(
+        token="token", http_client=httpx.Client(transport=httpx.MockTransport(handler))
+    )
+    try:
+        assert client.list_tools() == [{"name": "list_credentials"}]
+    finally:
+        client.close()
+    assert [request["method"] for request in requests] == [
+        "initialize",
+        "notifications/initialized",
+        "tools/list",
+    ]
+
+
+def test_execute_requires_confirmation_for_sensitive_tools() -> None:
+    client = PayboxClient(
+        token="token", http_client=httpx.Client(transport=httpx.MockTransport(lambda _: None))
+    )
+    try:
+        with pytest.raises(RuntimeError, match="explicit user approval"):
+            client.execute("request_swap", {"amount": "1"})
+    finally:
+        client.close()
+
+
+def test_tool_call_prefers_structured_content() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content)
+        if body["method"] == "initialize":
+            return rpc_response({"jsonrpc": "2.0", "id": body["id"], "result": {}})
+        if body["method"] == "notifications/initialized":
+            return httpx.Response(202)
+        return rpc_response(
+            {
+                "jsonrpc": "2.0",
+                "id": body["id"],
+                "result": {
+                    "content": [{"type": "text", "text": "fallback"}],
+                    "structuredContent": {"credentials": []},
+                },
+            }
+        )
+
+    client = PayboxClient(
+        token="token", http_client=httpx.Client(transport=httpx.MockTransport(handler))
+    )
+    try:
+        assert client.list_credentials() == {"credentials": []}
+    finally:
+        client.close()


### PR DESCRIPTION
## Summary

- add a PayBox OAuth 2.1 provider for PKCE public clients and rotating refresh tokens
- add a Streamable HTTP MCP tool with discovery, read helpers, and confirmation-gated sensitive calls
- document dynamic client registration and PayBox tool setup

## Validation

- `pytest -q tools/crypto/paybox/test_client.py` (3 passed)
- Ruff check and format check
- PayBox sdist and wheel build
- local Centaur tool catalog discovery and `paybox call --help`
- changed Ruby files parsed successfully with tree-sitter

Full Rails tests were not run because Ruby is not installed in this sandbox image.

Prompted by: ishan
