### PR TITLE
refactor(console): clarify user-scoped Google Docs sync

### DIFF
--- a/services/console/app/jobs/google_docs/incremental_sync_job.rb
+++ b/services/console/app/jobs/google_docs/incremental_sync_job.rb
@@ -3,14 +3,14 @@ module GoogleDocs
     private
 
     def sync_page(credential, sync, checkpoint)
-      page_token = high_water_mark(checkpoint)
+      page_token = user_changes_page_token(checkpoint)
       unless page_token
         GoogleDocs::InitialSyncJob.perform_later(credential.id)
         return
       end
 
       loop do
-        page = sync.list_changes_page(page_token: page_token)
+        page = sync.list_user_changes_page(page_token: page_token)
         files, deactivations = partition_changes(sync, page["changes"])
         run_id = ingest_page(
           credential,
@@ -25,14 +25,14 @@ module GoogleDocs
         page_token = page["nextPageToken"].presence
         next if page_token
 
-        new_start_page_token = page["newStartPageToken"].presence
-        unless new_start_page_token
+        next_user_changes_page_token = page["newStartPageToken"].presence
+        unless next_user_changes_page_token
           raise GoogleDocs::SyncCredential::GoogleApiError,
             "Google Drive returned no new start page token"
         end
-        persist_checkpoint(
+        persist_user_checkpoint(
           credential,
-          changes_page_token: new_start_page_token,
+          user_changes_page_token: next_user_changes_page_token,
           run_id: run_id,
           incremental_sync_finished: true
         )
@@ -44,6 +44,9 @@ module GoogleDocs
       files = []
       deactivations = []
       Array(changes).each do |change|
+        # User change logs contain Shared Drive membership events without a
+        # file ID. A future drive-scoped sync will process those drives and
+        # their independent change logs.
         file_id = change["fileId"].presence || change.dig("file", "id").presence
         next unless file_id
 

--- a/services/console/app/jobs/google_docs/initial_sync_job.rb
+++ b/services/console/app/jobs/google_docs/initial_sync_job.rb
@@ -3,14 +3,14 @@ module GoogleDocs
     private
 
     def sync_page(credential, sync, checkpoint)
-      return if high_water_mark(checkpoint)
+      return if user_changes_page_token(checkpoint)
 
-      start_page_token = sync.start_page_token
+      user_start_page_token = sync.user_start_page_token
       run_id = "gdocs_#{SecureRandom.hex(16)}"
       page_token = nil
       files_seen = 0
       loop do
-        page = sync.list_files_page(page_token: page_token)
+        page = sync.list_user_files_page(page_token: page_token)
         files = Array(page["files"]).select { |file| sync.eligible_file?(file) }
         files_seen += files.length
         ingest_page(
@@ -43,7 +43,7 @@ module GoogleDocs
         ],
         checkpoint: checkpoint_payload(
           credential,
-          changes_page_token: start_page_token,
+          user_changes_page_token: user_start_page_token,
           run_id: run_id,
           full_sync_finished: true
         ),

--- a/services/console/app/jobs/google_docs/poll_sync_job.rb
+++ b/services/console/app/jobs/google_docs/poll_sync_job.rb
@@ -20,7 +20,7 @@ module GoogleDocs
         checkpoint = api_client
           .get_google_docs_sync_checkpoint(broker_credential_id: credential.oid)
           .fetch("checkpoint")
-        job_class = SyncJob.high_water_mark(checkpoint) ? IncrementalSyncJob : InitialSyncJob
+        job_class = SyncJob.user_changes_page_token(checkpoint) ? IncrementalSyncJob : InitialSyncJob
         job_class.perform_later(credential.id)
       rescue CentaurApiClient::Error => e
         Rails.logger.warn do

--- a/services/console/app/jobs/google_docs/sync_job.rb
+++ b/services/console/app/jobs/google_docs/sync_job.rb
@@ -10,7 +10,9 @@ module GoogleDocs
       on_conflict: :block
     )
 
-    def self.high_water_mark(checkpoint)
+    def self.user_changes_page_token(checkpoint)
+      # The persisted field predates shared-drive scopes. It contains only the
+      # credential's user change-log token.
       checkpoint&.fetch("changes_page_token", nil).presence
     end
 
@@ -35,13 +37,13 @@ module GoogleDocs
         .fetch("checkpoint")
     end
 
-    def high_water_mark(checkpoint)
-      self.class.high_water_mark(checkpoint)
+    def user_changes_page_token(checkpoint)
+      self.class.user_changes_page_token(checkpoint)
     end
 
     def checkpoint_payload(
       credential,
-      changes_page_token:,
+      user_changes_page_token:,
       run_id: nil,
       full_sync_finished: false,
       incremental_sync_finished: false
@@ -50,7 +52,7 @@ module GoogleDocs
         broker_credential_id: credential.oid,
         provider_subject: credential.provider_subject.to_s,
         provider_email: credential.provider_email.to_s,
-        changes_page_token: changes_page_token,
+        changes_page_token: user_changes_page_token,
         last_run_id: run_id,
         last_error: "",
         metadata: {}
@@ -97,11 +99,11 @@ module GoogleDocs
       end
     end
 
-    def persist_checkpoint(credential, changes_page_token:, run_id:, **timestamps)
+    def persist_user_checkpoint(credential, user_changes_page_token:, run_id:, **timestamps)
       api_client.ingest_google_docs_sync_batch(
         checkpoint: checkpoint_payload(
           credential,
-          changes_page_token: changes_page_token,
+          user_changes_page_token: user_changes_page_token,
           run_id: run_id,
           **timestamps
         ),
@@ -125,7 +127,7 @@ module GoogleDocs
     end
 
     def restart_initial_sync(credential)
-      persist_checkpoint(credential, changes_page_token: "", run_id: nil)
+      persist_user_checkpoint(credential, user_changes_page_token: "", run_id: nil)
       GoogleDocs::InitialSyncJob.perform_later(credential.id)
     end
   end

--- a/services/console/app/services/google_docs/sync_credential.rb
+++ b/services/console/app/services/google_docs/sync_credential.rb
@@ -9,6 +9,7 @@ module GoogleDocs
     DOCS_READONLY_SCOPE = "https://www.googleapis.com/auth/documents.readonly"
     GOOGLE_DOC_MIME_TYPE = "application/vnd.google-apps.document"
     EXPORT_MIME_TYPE = "text/plain"
+    USER_CORPUS = "user"
 
     FILES_LIST_ENDPOINT = "https://www.googleapis.com/drive/v3/files"
     CHANGES_LIST_ENDPOINT = "https://www.googleapis.com/drive/v3/changes"
@@ -65,7 +66,7 @@ module GoogleDocs
       @google_api_http = google_api_http || self.class.google_api_http
     end
 
-    def start_page_token
+    def user_start_page_token
       google_api(
         START_PAGE_TOKEN_ENDPOINT,
         "supportsAllDrives" => "true"
@@ -74,13 +75,14 @@ module GoogleDocs
       raise GoogleApiError, "Google Drive returned no start page token"
     end
 
-    def list_files_page(page_token: nil)
+    def list_user_files_page(page_token: nil)
       google_api(
         FILES_LIST_ENDPOINT,
         {
           "q" => "mimeType = '#{GOOGLE_DOC_MIME_TYPE}' and trashed = false",
           "pageSize" => self.class.page_size,
           "fields" => "nextPageToken,files(#{FILE_FIELDS})",
+          "corpora" => USER_CORPUS,
           "includeItemsFromAllDrives" => "true",
           "supportsAllDrives" => "true",
           "orderBy" => "modifiedTime,name",
@@ -89,7 +91,7 @@ module GoogleDocs
       )
     end
 
-    def list_changes_page(page_token:)
+    def list_user_changes_page(page_token:)
       google_api(
         CHANGES_LIST_ENDPOINT,
         {

--- a/services/console/test/jobs/google_docs/jobs_test.rb
+++ b/services/console/test/jobs/google_docs/jobs_test.rb
@@ -61,7 +61,7 @@ module GoogleDocs
       )
     end
 
-    test "poll job chooses initial or incremental sync from the completed high-water mark" do
+    test "poll job chooses initial or incremental sync from the completed user checkpoint" do
       app = create_google_app
       credential = create_credential(app: app)
       api_client = FakeApiClient.new
@@ -70,12 +70,12 @@ module GoogleDocs
       assert_enqueued_with(job: InitialSyncJob, args: [ credential.id ])
 
       clear_enqueued_jobs
-      api_client.checkpoint = checkpoint_for(credential, changes_page_token: "change-200")
+      api_client.checkpoint = checkpoint_for(credential, user_changes_page_token: "change-200")
       CentaurApiClient.stub(:new, api_client) { PollSyncJob.perform_now(app.slug) }
       assert_enqueued_with(job: IncrementalSyncJob, args: [ credential.id ])
     end
 
-    test "initial sync ingests bounded pages before sweeping and publishing its high-water mark" do
+    test "initial sync ingests bounded pages before sweeping and publishing its user checkpoint" do
       credential = create_credential
       api_client = FakeApiClient.new
       first_file = google_doc
@@ -134,10 +134,10 @@ module GoogleDocs
       assert_enqueued_with(job: IncrementalSyncJob, args: [ credential.id ])
     end
 
-    test "a stale initial job with a completed high-water mark is a no-op" do
+    test "a stale initial job with a completed user checkpoint is a no-op" do
       credential = create_credential
       api_client = FakeApiClient.new(
-        checkpoint: checkpoint_for(credential, changes_page_token: "change-200")
+        checkpoint: checkpoint_for(credential, user_changes_page_token: "change-200")
       )
       google_http = ->(**) { flunk "a stale initial job should not call Google" }
 
@@ -149,7 +149,7 @@ module GoogleDocs
       assert_no_enqueued_jobs
     end
 
-    test "a rejected initial page token leaves no high-water mark and restarts the crawl" do
+    test "a rejected initial page token leaves no user checkpoint and restarts the crawl" do
       credential = create_credential
       api_client = FakeApiClient.new
       google_http = lambda do |endpoint:, params:, **|
@@ -175,10 +175,10 @@ module GoogleDocs
       assert_enqueued_with(job: InitialSyncJob, args: [ credential.id ])
     end
 
-    test "incremental sync drains all pages before advancing its high-water mark" do
+    test "incremental sync drains all pages before advancing its user checkpoint" do
       credential = create_credential
       api_client = FakeApiClient.new(
-        checkpoint: checkpoint_for(credential, changes_page_token: "change-100")
+        checkpoint: checkpoint_for(credential, user_changes_page_token: "change-100")
       )
       file = google_doc
       change_page_tokens = []
@@ -220,10 +220,10 @@ module GoogleDocs
       assert_enqueued_with(job: FetchDocumentJob, args: [ credential.id, file ])
     end
 
-    test "a rejected Changes token clears the high-water mark and restarts initial sync" do
+    test "a rejected user Changes token clears the checkpoint and restarts initial sync" do
       credential = create_credential
       api_client = FakeApiClient.new(
-        checkpoint: checkpoint_for(credential, changes_page_token: "change-expired")
+        checkpoint: checkpoint_for(credential, user_changes_page_token: "change-expired")
       )
       google_http = lambda do |endpoint:, **|
         assert_equal SyncCredential::CHANGES_LIST_ENDPOINT, endpoint
@@ -238,7 +238,7 @@ module GoogleDocs
       assert_enqueued_with(job: InitialSyncJob, args: [ credential.id ])
     end
 
-    test "incremental sync without a high-water mark hands off to initial sync" do
+    test "incremental sync without a user checkpoint hands off to initial sync" do
       credential = create_credential
       api_client = FakeApiClient.new
       google_http = ->(**) { flunk "a routing job should not call Google" }
@@ -312,10 +312,10 @@ module GoogleDocs
       SyncCredential.google_api_http = previous_http
     end
 
-    def checkpoint_for(credential, changes_page_token:)
+    def checkpoint_for(credential, user_changes_page_token:)
       {
         "broker_credential_id" => credential.oid,
-        "changes_page_token" => changes_page_token,
+        "changes_page_token" => user_changes_page_token,
         "metadata" => {}
       }
     end

--- a/services/console/test/services/google_docs/sync_credential_test.rb
+++ b/services/console/test/services/google_docs/sync_credential_test.rb
@@ -85,7 +85,7 @@ module GoogleDocs
       refute GoogleDocs::SyncCredential.syncable?(current_credential.reload)
     end
 
-    test "uses bounded Drive file and change pages" do
+    test "uses bounded user-corpus Drive file and change pages" do
       calls = []
       google_http = lambda do |endpoint:, params:, access_token:|
         assert_equal "ya29.live", access_token
@@ -103,16 +103,28 @@ module GoogleDocs
       end
       sync = GoogleDocs::SyncCredential.new(credential, google_api_http: google_http)
 
-      assert_equal "change-100", sync.start_page_token
-      assert_equal "file-2", sync.list_files_page["nextPageToken"]
-      assert_equal "change-101", sync.list_changes_page(page_token: "change-100")["newStartPageToken"]
+      assert_equal "change-100", sync.user_start_page_token
+      assert_equal "file-2", sync.list_user_files_page["nextPageToken"]
+      assert_equal "change-101", sync.list_user_changes_page(page_token: "change-100")["newStartPageToken"]
 
+      start_token_params = calls.find do |endpoint, _|
+        endpoint == GoogleDocs::SyncCredential::START_PAGE_TOKEN_ENDPOINT
+      end.last
+      assert_equal "true", start_token_params["supportsAllDrives"]
+      refute_includes start_token_params, "driveId"
       files_params = calls.find { |endpoint, _| endpoint == GoogleDocs::SyncCredential::FILES_LIST_ENDPOINT }.last
       assert_equal 100, files_params["pageSize"]
+      assert_equal "user", files_params["corpora"]
+      assert_equal "true", files_params["includeItemsFromAllDrives"]
+      assert_equal "true", files_params["supportsAllDrives"]
+      refute_includes files_params, "driveId"
       assert_includes files_params["q"], "trashed = false"
       changes_params = calls.find { |endpoint, _| endpoint == GoogleDocs::SyncCredential::CHANGES_LIST_ENDPOINT }.last
       assert_equal "change-100", changes_params["pageToken"]
       assert_equal "true", changes_params["includeRemoved"]
+      assert_equal "true", changes_params["includeItemsFromAllDrives"]
+      assert_equal "true", changes_params["supportsAllDrives"]
+      refute_includes changes_params, "driveId"
       assert_includes changes_params["fields"], "changes(changeType,driveId,fileId,removed"
     end
 
@@ -128,7 +140,7 @@ module GoogleDocs
 
       HttpClient.stub(:new, api) do
         assert_raises(GoogleDocs::SyncCredential::InvalidPageTokenError) do
-          sync.list_changes_page(page_token: "rejected-token")
+          sync.list_user_changes_page(page_token: "rejected-token")
         end
       end
     end


### PR DESCRIPTION
Make the Google Docs sync explicitly request the user corpus and rename its Drive requests and checkpoint helpers as user-scoped. Keep the existing all-drives flags and persisted checkpoint contract unchanged, while documenting that drive-level membership events belong to a future Shared Drive sync path.