### PR TITLE
fix: retry Google Docs network failures

### DIFF
--- a/services/console/app/services/google_docs/sync_credential.rb
+++ b/services/console/app/services/google_docs/sync_credential.rb
@@ -25,6 +25,17 @@ module GoogleDocs
     class GoogleApiError < StandardError; end
     class InvalidPageTokenError < GoogleApiError; end
 
+    NETWORK_ERRORS = [
+      EOFError,
+      Errno::ECONNREFUSED,
+      Errno::ECONNRESET,
+      Errno::EHOSTUNREACH,
+      Errno::EPIPE,
+      Errno::ETIMEDOUT,
+      SocketError,
+      Timeout::Error
+    ].freeze
+
     class << self
       attr_accessor :google_api_http
 
@@ -274,6 +285,8 @@ module GoogleDocs
       return response if response.is_a?(Hash)
 
       raise GoogleApiError, "Google API returned invalid response"
+    rescue *NETWORK_ERRORS => error
+      raise GoogleApiError, "Google API network request failed: #{error.class}"
     end
 
     def net_http_get(endpoint, params)

--- a/services/console/test/services/google_docs/sync_credential_test.rb
+++ b/services/console/test/services/google_docs/sync_credential_test.rb
@@ -150,6 +150,7 @@ module GoogleDocs
         Net::ReadTimeout.new("read timed out"),
         Net::OpenTimeout.new("open timed out"),
         SocketError.new("host unavailable"),
+        Socket::ResolutionError.new("temporary DNS failure"),
         Errno::ECONNRESET.new
       ].each do |network_error|
         google_http = ->(**) { raise network_error }

--- a/services/console/test/services/google_docs/sync_credential_test.rb
+++ b/services/console/test/services/google_docs/sync_credential_test.rb
@@ -145,6 +145,25 @@ module GoogleDocs
       end
     end
 
+    test "classifies transient network failures for job retries" do
+      [
+        Net::ReadTimeout.new("read timed out"),
+        Net::OpenTimeout.new("open timed out"),
+        SocketError.new("host unavailable"),
+        Errno::ECONNRESET.new
+      ].each do |network_error|
+        google_http = ->(**) { raise network_error }
+        sync = GoogleDocs::SyncCredential.new(credential, google_api_http: google_http)
+
+        error = assert_raises(GoogleDocs::SyncCredential::GoogleApiError) do
+          sync.user_start_page_token
+        end
+
+        assert_equal network_error, error.cause
+        assert_includes error.message, network_error.class.name
+      end
+    end
+
     test "normalizes canonical content without credential-specific metadata" do
       file = google_doc
       google_http = lambda do |endpoint:, params:, access_token:|


### PR DESCRIPTION
## Summary
- normalize transient Google API transport failures as `GoogleApiError`
- route timeouts, socket failures, and connection resets through the existing five-attempt job retry policy
- add regression coverage for representative network exceptions and preserved causes

## Validation
- `git diff --check`
- Rails tests not run: Ruby is unavailable in the sandbox and no Docker daemon is mounted

Prompted by: mslipper