### PR TITLE
fix: extend Google Docs sync fetch timeout

### DIFF
--- a/services/console/app/services/google_docs/sync_credential.rb
+++ b/services/console/app/services/google_docs/sync_credential.rb
@@ -10,6 +10,7 @@ module GoogleDocs
     GOOGLE_DOC_MIME_TYPE = "application/vnd.google-apps.document"
     EXPORT_MIME_TYPE = "text/plain"
     USER_CORPUS = "user"
+    FETCH_READ_TIMEOUT_SECONDS = 60
 
     FILES_LIST_ENDPOINT = "https://www.googleapis.com/drive/v3/files"
     CHANGES_LIST_ENDPOINT = "https://www.googleapis.com/drive/v3/changes"
@@ -290,7 +291,7 @@ module GoogleDocs
     end
 
     def net_http_get(endpoint, params)
-      response = HttpClient.new.get(
+      response = HttpClient.new(read_timeout: FETCH_READ_TIMEOUT_SECONDS).get(
         endpoint,
         params: params,
         headers: { "Authorization" => "Bearer #{credential.access_token}" }

--- a/services/console/test/services/google_docs/sync_credential_test.rb
+++ b/services/console/test/services/google_docs/sync_credential_test.rb
@@ -145,6 +145,25 @@ module GoogleDocs
       end
     end
 
+    test "uses an extended read timeout for Google API fetches" do
+      response = HttpClient::Response.new(
+        status: 200,
+        body: { "startPageToken" => "change-100" }.to_json,
+        headers: {}
+      )
+      api = Object.new
+      api.define_singleton_method(:get) { |*, **| response }
+      factory = lambda do |read_timeout:|
+        assert_equal GoogleDocs::SyncCredential::FETCH_READ_TIMEOUT_SECONDS, read_timeout
+        api
+      end
+      sync = GoogleDocs::SyncCredential.new(credential)
+
+      HttpClient.stub(:new, factory) do
+        assert_equal "change-100", sync.user_start_page_token
+      end
+    end
+
     test "classifies transient network failures for job retries" do
       [
         Net::ReadTimeout.new("read timed out"),


### PR DESCRIPTION
Extends the Google Docs sync HTTP read timeout from 5 seconds to 60 seconds so larger document fetches have time to complete. Adds regression coverage for the Google API client timeout configuration.