### PR TITLE
feat(k8s): sandbox priority class, pause-proxy teardown, quota-ready init resources

### DIFF
--- a/contrib/chart/Chart.yaml
+++ b/contrib/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: centaur
 description: Helm chart for the trusted Centaur control plane
 type: application
-version: 0.1.126
+version: 0.1.127
 appVersion: "0.1.0"
 dependencies:
   - name: connect

--- a/contrib/chart/templates/apirs.yaml
+++ b/contrib/chart/templates/apirs.yaml
@@ -200,6 +200,9 @@ spec:
         centaur.ai/observability-enabled: "true"
     spec:
       terminationGracePeriodSeconds: {{ .Values.apiRs.terminationGracePeriodSeconds }}
+{{- with .Values.apiRs.priorityClassName }}
+      priorityClassName: {{ . | quote }}
+{{- end }}
       automountServiceAccountToken: true
       serviceAccountName: {{ $apiRsName }}
       {{- with .Values.global.imagePullSecrets }}
@@ -371,6 +374,10 @@ spec:
 {{- if and .Values.sandbox.runtimeClassName (not (hasKey .Values.apiRs.extraEnv "SESSION_SANDBOX_RUNTIME_CLASS_NAME")) }}
             - name: SESSION_SANDBOX_RUNTIME_CLASS_NAME
               value: {{ .Values.sandbox.runtimeClassName | quote }}
+{{- end }}
+{{- if and .Values.sandbox.priorityClassName (not (hasKey .Values.apiRs.extraEnv "SESSION_SANDBOX_PRIORITY_CLASS_NAME")) }}
+            - name: SESSION_SANDBOX_PRIORITY_CLASS_NAME
+              value: {{ .Values.sandbox.priorityClassName | quote }}
 {{- end }}
             # Sandboxes call back into this control plane via the in-cluster Service.
             - name: SESSION_SANDBOX_CENTAUR_API_URL

--- a/contrib/chart/values.yaml
+++ b/contrib/chart/values.yaml
@@ -315,6 +315,11 @@ sandbox:
   #   effect: NoSchedule
   # RuntimeClass for sandbox + iron-proxy pods, e.g. gVisor.
   runtimeClassName: ""
+  # PriorityClass for sandbox + iron-proxy pods. Point this at a dedicated
+  # (low-priority) PriorityClass to scope a ResourceQuota to sandbox
+  # workloads and let the kubelet/scheduler sacrifice them before the
+  # control plane under node pressure.
+  priorityClassName: ""
   reposPath: ""
   # How the in-sandbox harness authenticates upstream. Single source of truth:
   # the control plane reads it to register the matching iron-proxy credential
@@ -544,6 +549,10 @@ apiRs:
   terminationGracePeriodSeconds: 35
   extraEnv: {}
   resources: {}
+  # PriorityClass for the api-rs control plane pod itself. Pair with
+  # Guaranteed-QoS resources so runaway sandboxes are evicted before the
+  # control plane.
+  priorityClassName: ""
 
 # Chat SDK Slackbot v2. Forwards Slack events to the api-rs control plane
 # (:8080) and streams responses back. Listens on :3001.

--- a/services/api-rs/crates/centaur-api-server/src/args.rs
+++ b/services/api-rs/crates/centaur-api-server/src/args.rs
@@ -680,6 +680,15 @@ struct SandboxArgs {
         env = "SESSION_SANDBOX_RUNTIME_CLASS_NAME"
     )]
     runtime_class_name: Option<String>,
+    /// `priorityClassName` for sandbox and iron-proxy pods. Giving sandbox
+    /// workloads a dedicated (low) PriorityClass lets the cluster scope a
+    /// ResourceQuota to them and evict/preempt them before the control plane.
+    /// The chart renders `sandbox.priorityClassName` into this.
+    #[arg(
+        long = "session-sandbox-priority-class-name",
+        env = "SESSION_SANDBOX_PRIORITY_CLASS_NAME"
+    )]
+    priority_class_name: Option<String>,
     #[command(flatten)]
     tools: ToolDiscoveryArgs,
     #[command(flatten)]
@@ -1466,6 +1475,12 @@ impl TryFrom<&SandboxArgs> for AgentSandboxConfig {
         config.tolerations = args.tolerations()?;
         config.runtime_class_name = args
             .runtime_class_name
+            .as_deref()
+            .map(str::trim)
+            .filter(|name| !name.is_empty())
+            .map(str::to_owned);
+        config.priority_class_name = args
+            .priority_class_name
             .as_deref()
             .map(str::trim)
             .filter(|name| !name.is_empty())
@@ -2836,6 +2851,8 @@ mod tests {
             r#"[{"key":"example.com/sandbox","operator":"Exists","effect":"NoSchedule"}]"#,
             "--session-sandbox-runtime-class-name",
             "gvisor",
+            "--session-sandbox-priority-class-name",
+            "centaur-sandbox",
         ])
         .unwrap();
 
@@ -2845,6 +2862,10 @@ mod tests {
         );
         assert_eq!(args.sandbox.tolerations().unwrap().len(), 1);
         assert_eq!(args.sandbox.runtime_class_name.as_deref(), Some("gvisor"));
+        assert_eq!(
+            args.sandbox.priority_class_name.as_deref(),
+            Some("centaur-sandbox")
+        );
     }
 
     #[test]
@@ -2858,6 +2879,7 @@ mod tests {
 
         assert!(args.sandbox.node_selector().unwrap().is_empty());
         assert!(args.sandbox.tolerations().unwrap().is_empty());
+        assert!(args.sandbox.priority_class_name.is_none());
     }
 
     /// Unlike `SESSION_SANDBOX_EXTRA_ENV`, bad node steering fails startup:

--- a/services/api-rs/crates/centaur-sandbox-agent-k8s/src/iron_proxy.rs
+++ b/services/api-rs/crates/centaur-sandbox-agent-k8s/src/iron_proxy.rs
@@ -388,6 +388,7 @@ impl AgentSandboxBackend {
                     &self.config.node_selector,
                     &self.config.tolerations,
                     self.config.runtime_class_name.as_deref(),
+                    self.config.priority_class_name.as_deref(),
                 ),
             )
             .await
@@ -1233,6 +1234,7 @@ fn build_iron_proxy_pod(
     node_selector: &BTreeMap<String, String>,
     tolerations: &[k8s_openapi::api::core::v1::Toleration],
     runtime_class_name: Option<&str>,
+    priority_class_name: Option<&str>,
 ) -> Pod {
     let annotations = BTreeMap::from([
         (
@@ -1245,6 +1247,10 @@ fn build_iron_proxy_pod(
         ),
     ]);
     let runtime_class = runtime_class_name
+        .map(str::trim)
+        .filter(|name| !name.is_empty())
+        .map(str::to_owned);
+    let priority_class = priority_class_name
         .map(str::trim)
         .filter(|name| !name.is_empty())
         .map(str::to_owned);
@@ -1265,6 +1271,7 @@ fn build_iron_proxy_pod(
             node_selector: (!node_selector.is_empty()).then(|| node_selector.clone()),
             tolerations: (!tolerations.is_empty()).then(|| tolerations.to_vec()),
             runtime_class_name: runtime_class,
+            priority_class_name: priority_class,
             ..Default::default()
         }),
         ..Default::default()
@@ -2347,6 +2354,7 @@ mod tests {
             &BTreeMap::new(),
             &[],
             None,
+            None,
         );
 
         let resources = pod.spec.as_ref().unwrap().containers[0]
@@ -2388,6 +2396,7 @@ mod tests {
             &BTreeMap::new(),
             &[],
             None,
+            None,
         );
 
         assert!(pod.spec.as_ref().unwrap().containers[0].resources.is_none());
@@ -2412,6 +2421,7 @@ mod tests {
             &sync,
             &BTreeMap::new(),
             &[],
+            None,
             None,
         );
         assert_eq!(
@@ -2493,6 +2503,7 @@ mod tests {
             &BTreeMap::new(),
             &[],
             None,
+            None,
         );
         let pod_labels = pod.metadata.labels.as_ref().unwrap();
         assert!(!pod_labels.contains_key(OBSERVABILITY_ENABLED_LABEL));
@@ -2556,6 +2567,7 @@ mod tests {
             &node_selector,
             &tolerations,
             Some("gvisor"),
+            Some("centaur-sandbox"),
         );
         let pod_spec = pod.spec.unwrap();
         assert_eq!(
@@ -2568,6 +2580,10 @@ mod tests {
         );
         assert_eq!(pod_spec.tolerations.as_ref().unwrap().len(), 1);
         assert_eq!(pod_spec.runtime_class_name.as_deref(), Some("gvisor"));
+        assert_eq!(
+            pod_spec.priority_class_name.as_deref(),
+            Some("centaur-sandbox")
+        );
     }
 
     #[test]
@@ -2588,6 +2604,7 @@ mod tests {
             &sync,
             &BTreeMap::new(),
             &[],
+            None,
             None,
         );
         let pod_spec = pod.spec.unwrap();

--- a/services/api-rs/crates/centaur-sandbox-agent-k8s/src/iron_proxy.rs
+++ b/services/api-rs/crates/centaur-sandbox-agent-k8s/src/iron_proxy.rs
@@ -385,10 +385,12 @@ impl AgentSandboxBackend {
                     iron_proxy,
                     resolved,
                     &sync,
-                    &self.config.node_selector,
-                    &self.config.tolerations,
-                    self.config.runtime_class_name.as_deref(),
-                    self.config.priority_class_name.as_deref(),
+                    ProxyPodScheduling {
+                        node_selector: &self.config.node_selector,
+                        tolerations: &self.config.tolerations,
+                        runtime_class_name: self.config.runtime_class_name.as_deref(),
+                        priority_class_name: self.config.priority_class_name.as_deref(),
+                    },
                 ),
             )
             .await
@@ -1226,15 +1228,21 @@ pub(crate) fn sandbox_ca_volume_json(iron_proxy: &IronProxyConfig) -> Value {
     })
 }
 
+/// Pod-scheduling knobs copied from [`AgentSandboxConfig`] onto each proxy
+/// pod so it lands under the same constraints as its sandbox.
+struct ProxyPodScheduling<'a> {
+    node_selector: &'a BTreeMap<String, String>,
+    tolerations: &'a [k8s_openapi::api::core::v1::Toleration],
+    runtime_class_name: Option<&'a str>,
+    priority_class_name: Option<&'a str>,
+}
+
 fn build_iron_proxy_pod(
     id: &SandboxId,
     iron_proxy: &IronProxyConfig,
     resolved: &ResolvedIronProxy,
     sync: &ProxySyncEnv,
-    node_selector: &BTreeMap<String, String>,
-    tolerations: &[k8s_openapi::api::core::v1::Toleration],
-    runtime_class_name: Option<&str>,
-    priority_class_name: Option<&str>,
+    scheduling: ProxyPodScheduling<'_>,
 ) -> Pod {
     let annotations = BTreeMap::from([
         (
@@ -1246,11 +1254,13 @@ fn build_iron_proxy_pod(
             resolved.principal_id.clone(),
         ),
     ]);
-    let runtime_class = runtime_class_name
+    let runtime_class = scheduling
+        .runtime_class_name
         .map(str::trim)
         .filter(|name| !name.is_empty())
         .map(str::to_owned);
-    let priority_class = priority_class_name
+    let priority_class = scheduling
+        .priority_class_name
         .map(str::trim)
         .filter(|name| !name.is_empty())
         .map(str::to_owned);
@@ -1268,8 +1278,10 @@ fn build_iron_proxy_pod(
             // Co-locate the per-sandbox proxy with its sandbox: it scales 1:1
             // with sandboxes and processes untrusted traffic, so it must share
             // the same node pool / RuntimeClass (e.g. gVisor) constraints.
-            node_selector: (!node_selector.is_empty()).then(|| node_selector.clone()),
-            tolerations: (!tolerations.is_empty()).then(|| tolerations.to_vec()),
+            node_selector: (!scheduling.node_selector.is_empty())
+                .then(|| scheduling.node_selector.clone()),
+            tolerations: (!scheduling.tolerations.is_empty())
+                .then(|| scheduling.tolerations.to_vec()),
             runtime_class_name: runtime_class,
             priority_class_name: priority_class,
             ..Default::default()
@@ -2111,6 +2123,16 @@ fn unique_suffix() -> String {
 mod tests {
     use super::*;
 
+    fn no_scheduling() -> ProxyPodScheduling<'static> {
+        static EMPTY_SELECTOR: BTreeMap<String, String> = BTreeMap::new();
+        ProxyPodScheduling {
+            node_selector: &EMPTY_SELECTOR,
+            tolerations: &[],
+            runtime_class_name: None,
+            priority_class_name: None,
+        }
+    }
+
     fn resolved() -> ResolvedIronProxy {
         ResolvedIronProxy {
             proxy_host: "asbx-test-iron-proxy".to_owned(),
@@ -2346,16 +2368,7 @@ mod tests {
             config_hash: None,
         };
 
-        let pod = build_iron_proxy_pod(
-            &id,
-            &iron_proxy,
-            &resolved(),
-            &sync,
-            &BTreeMap::new(),
-            &[],
-            None,
-            None,
-        );
+        let pod = build_iron_proxy_pod(&id, &iron_proxy, &resolved(), &sync, no_scheduling());
 
         let resources = pod.spec.as_ref().unwrap().containers[0]
             .resources
@@ -2388,16 +2401,7 @@ mod tests {
             config_hash: None,
         };
 
-        let pod = build_iron_proxy_pod(
-            &id,
-            &iron_proxy,
-            &resolved(),
-            &sync,
-            &BTreeMap::new(),
-            &[],
-            None,
-            None,
-        );
+        let pod = build_iron_proxy_pod(&id, &iron_proxy, &resolved(), &sync, no_scheduling());
 
         assert!(pod.spec.as_ref().unwrap().containers[0].resources.is_none());
     }
@@ -2414,16 +2418,7 @@ mod tests {
             config_hash: None,
         };
 
-        let pod = build_iron_proxy_pod(
-            &id,
-            &iron_proxy,
-            &resolved,
-            &sync,
-            &BTreeMap::new(),
-            &[],
-            None,
-            None,
-        );
+        let pod = build_iron_proxy_pod(&id, &iron_proxy, &resolved, &sync, no_scheduling());
         assert_eq!(
             pod.metadata
                 .labels
@@ -2495,16 +2490,7 @@ mod tests {
             config_hash: None,
         };
 
-        let pod = build_iron_proxy_pod(
-            &id,
-            &iron_proxy,
-            &resolved,
-            &sync,
-            &BTreeMap::new(),
-            &[],
-            None,
-            None,
-        );
+        let pod = build_iron_proxy_pod(&id, &iron_proxy, &resolved, &sync, no_scheduling());
         let pod_labels = pod.metadata.labels.as_ref().unwrap();
         assert!(!pod_labels.contains_key(OBSERVABILITY_ENABLED_LABEL));
 
@@ -2564,10 +2550,12 @@ mod tests {
             &iron_proxy,
             &resolved,
             &sync,
-            &node_selector,
-            &tolerations,
-            Some("gvisor"),
-            Some("centaur-sandbox"),
+            ProxyPodScheduling {
+                node_selector: &node_selector,
+                tolerations: &tolerations,
+                runtime_class_name: Some("gvisor"),
+                priority_class_name: Some("centaur-sandbox"),
+            },
         );
         let pod_spec = pod.spec.unwrap();
         assert_eq!(
@@ -2597,16 +2585,7 @@ mod tests {
             token: "proxy-token".to_owned(),
             config_hash: None,
         };
-        let pod = build_iron_proxy_pod(
-            &id,
-            &iron_proxy,
-            &resolved,
-            &sync,
-            &BTreeMap::new(),
-            &[],
-            None,
-            None,
-        );
+        let pod = build_iron_proxy_pod(&id, &iron_proxy, &resolved, &sync, no_scheduling());
         let pod_spec = pod.spec.unwrap();
         assert!(pod_spec.node_selector.is_none());
         assert!(pod_spec.tolerations.is_none());

--- a/services/api-rs/crates/centaur-sandbox-agent-k8s/src/lib.rs
+++ b/services/api-rs/crates/centaur-sandbox-agent-k8s/src/lib.rs
@@ -74,6 +74,11 @@ pub struct AgentSandboxConfig {
     pub tolerations: Vec<Toleration>,
     /// RuntimeClass for sandbox and iron-proxy pods (e.g. `gvisor`).
     pub runtime_class_name: Option<String>,
+    /// PriorityClass for sandbox and iron-proxy pods. A dedicated (low)
+    /// class lets the cluster scope a ResourceQuota to sandbox workloads and
+    /// makes the kubelet/scheduler sacrifice them before the control plane
+    /// under node pressure. Empty leaves the cluster default untouched.
+    pub priority_class_name: Option<String>,
     pub state_volume: Option<StateVolumeConfig>,
     pub iron_proxy: Option<IronProxyConfig>,
     pub iron_control: IronControlSettings,
@@ -130,6 +135,7 @@ impl AgentSandboxConfig {
             node_selector: BTreeMap::new(),
             tolerations: Vec::new(),
             runtime_class_name: None,
+            priority_class_name: None,
             state_volume: None,
             iron_proxy: None,
             iron_control,
@@ -492,7 +498,15 @@ impl SandboxBackend for AgentSandboxBackend {
 
     async fn pause(&self, id: &SandboxId) -> SandboxResult<()> {
         self.patch_sandbox_merge(id, sandbox_pause_patch(jiff::Timestamp::now()))
-            .await
+            .await?;
+        // A paused sandbox has no agent pod, so its egress proxy is idle;
+        // keeping it running holds a node pod slot per suspended sandbox for
+        // the whole retention window (at ~500 pods per kubelet that starves
+        // the cluster of schedulable slots). Delete the proxy resources here:
+        // `resume()` unconditionally recreates them from the principal
+        // recorded at create, and already handles proxies deleted out from
+        // under a suspended sandbox.
+        self.delete_iron_proxy_resources(id).await
     }
 
     async fn resume(&self, id: &SandboxId) -> SandboxResult<()> {
@@ -827,6 +841,15 @@ fn build_agent_sandbox(
             .map(str::trim)
             .filter(|name| !name.is_empty()),
     );
+    insert_optional(
+        &mut pod_spec,
+        "priorityClassName",
+        config
+            .priority_class_name
+            .as_deref()
+            .map(str::trim)
+            .filter(|name| !name.is_empty()),
+    );
 
     let mut agent_spec = json!({
         "replicas": 1,
@@ -1116,6 +1139,7 @@ mod tests {
             ..Default::default()
         }];
         config.runtime_class_name = Some("gvisor".to_owned());
+        config.priority_class_name = Some("centaur-sandbox".to_owned());
 
         let sandbox = build_agent_sandbox(&SandboxId::new("asbx-test"), &spec, &config).unwrap();
         let pod_spec = &sandbox.spec.pod_template.spec;
@@ -1136,6 +1160,10 @@ mod tests {
         assert_eq!(tolerations[0].key.as_deref(), Some("example.com/sandbox"));
         assert_eq!(tolerations[0].effect.as_deref(), Some("NoSchedule"));
         assert_eq!(pod_spec.runtime_class_name.as_deref(), Some("gvisor"));
+        assert_eq!(
+            pod_spec.priority_class_name.as_deref(),
+            Some("centaur-sandbox")
+        );
     }
 
     #[test]
@@ -1149,6 +1177,7 @@ mod tests {
         assert!(pod_spec.node_selector.is_none());
         assert!(pod_spec.tolerations.is_none());
         assert!(pod_spec.runtime_class_name.is_none());
+        assert!(pod_spec.priority_class_name.is_none());
     }
 
     #[test]

--- a/services/api-rs/crates/centaur-sandbox-agent-k8s/src/tools.rs
+++ b/services/api-rs/crates/centaur-sandbox-agent-k8s/src/tools.rs
@@ -434,6 +434,15 @@ CENTAUR_TOOLS_METADATA"
         "command": ["/bin/sh", "-ec", script],
         "volumeMounts": volume_mounts,
         "securityContext": security_context_json(),
+        // Explicit requests/limits so a ResourceQuota over cpu/memory
+        // requests admits the pod: quota admission requires every container,
+        // init containers included, to carry requests. Kept small so the
+        // effective pod request stays driven by the agent container
+        // (Kubernetes takes the max of init and main-container requests).
+        "resources": {
+            "requests": { "cpu": "50m", "memory": "64Mi" },
+            "limits": { "cpu": "1", "memory": "512Mi" },
+        },
     });
     if let Some(policy) = &tools.image_pull_policy {
         container["imagePullPolicy"] = json!(policy);


### PR DESCRIPTION
Follow-up to the 2026-08-26 prd-centaur-na outages: runaway sandbox pods (no limits) starved a kubelet and killed the api-rs control plane, and suspended sandboxes leaked their egress-proxy pods for the full reaper lifetime (~880 of 1500 kubelet pod slots consumed).

## Changes

- **`SESSION_SANDBOX_PRIORITY_CLASS_NAME`** (new arg/env, mirrors `SESSION_SANDBOX_RUNTIME_CLASS_NAME` plumbing): sets `priorityClassName` on agent sandbox pods **and** their iron-proxy pods. Lets an operator make sandboxes first-evicted/preempted under node pressure and scope a `ResourceQuota` to exactly these pods via a PriorityClass scope selector.
- **`pause()` now deletes iron-proxy resources** (pod + configmap) alongside scaling the Sandbox to zero replicas. `resume()` already unconditionally recreates them from the principal recorded at create, so suspension stays transparent. Previously a suspended sandbox kept its proxy pod running until the reaper deleted the whole sandbox (default 3 days).
- **tools-bootstrap init container carries explicit requests/limits** (50m/64Mi req, 1cpu/512Mi lim): ResourceQuota admission requires requests on every container, init containers included. Small enough that the effective pod request stays driven by the agent container.
- **Chart**: `sandbox.priorityClassName` and `apiRs.priorityClassName` values (default `""`, omitted from rendered specs when unset).

## Validation

- `cargo test -p centaur-sandbox-agent-k8s -p centaur-api-server`: 59 passed
- `cargo fmt --check`: clean
- `helm template` with production values: envs, priorityClassName, and resources render as expected

Infra companion PR (tempoxyz/prd-centaur-infra) adds the PriorityClasses, scoped ResourceQuota, and per-pod resource values.