### PR TITLE
feat: add Airtable table creation

### DIFF
--- a/tools/productivity/airtable/cli.py
+++ b/tools/productivity/airtable/cli.py
@@ -77,6 +77,29 @@ def schema(base_id: str) -> None:
 
 
 @app.command()
+def create_table(
+    base_id: str,
+    name: str,
+    fields: str | None = typer.Option(
+        None,
+        "--fields",
+        help=('Fields as a JSON array. Defaults to a single-line text primary field named "Name".'),
+    ),
+    description: str | None = typer.Option(None, "--description"),
+) -> None:
+    """Create a table in an existing base."""
+    parsed_fields = _json_object_list(fields) if fields is not None else None
+    _print(
+        AirtableClient().create_table(
+            base_id,
+            name,
+            fields=parsed_fields,
+            description=description,
+        )
+    )
+
+
+@app.command()
 def records(
     base_id: str,
     table: str,

--- a/tools/productivity/airtable/client.py
+++ b/tools/productivity/airtable/client.py
@@ -554,6 +554,32 @@ class AirtableClient:
         """Get tables, fields, and views for a base."""
         return self._request("GET", f"{META_URL}/bases/{_path_part(base_id)}/tables")
 
+    def create_table(
+        self,
+        base_id: str,
+        name: str,
+        fields: list[dict[str, Any]] | None = None,
+        description: str | None = None,
+    ) -> dict[str, Any]:
+        """Create a table in an existing Airtable base.
+
+        When `fields` is omitted, Airtable's required primary field is created as a
+        single-line text field named ``Name``. The API key needs Airtable's
+        `schema.bases:write` scope for the target base.
+        """
+        if not name.strip():
+            raise ValueError("Table name must not be empty.")
+
+        table_fields = fields or [{"name": "Name", "type": "singleLineText"}]
+        payload: dict[str, Any] = {"name": name, "fields": table_fields}
+        if description is not None:
+            payload["description"] = description
+        return self._request(
+            "POST",
+            f"{META_URL}/bases/{_path_part(base_id)}/tables",
+            json=payload,
+        )
+
     def list_tables(self, base_id: str) -> list[dict[str, Any]]:
         """List tables, fields, and views in a base."""
         tables = self.schema(base_id).get("tables", [])

--- a/tools/productivity/airtable/pyproject.toml
+++ b/tools/productivity/airtable/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "airtable"
-description = "Airtable API client for bases, schemas, views, records, and record writes"
+description = "Airtable API client for bases, schemas, tables, views, and record writes"
 version = "0.1.0"
 requires-python = ">=3.11"
 dependencies = [

--- a/tools/productivity/airtable/test_client.py
+++ b/tools/productivity/airtable/test_client.py
@@ -323,6 +323,103 @@ def test_create_record_posts_fields_and_compacts_response() -> None:
     }
 
 
+def test_create_table_posts_default_primary_field() -> None:
+    module = _load_airtable_module()
+    client = module.AirtableClient(api_key="test-key")
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.method == "POST"
+        assert request.url.path == "/v0/meta/bases/appBase123/tables"
+        assert json.loads(request.content) == {
+            "name": "Dan's House Party",
+            "fields": [{"name": "Name", "type": "singleLineText"}],
+        }
+        return httpx.Response(
+            200,
+            request=request,
+            json={
+                "id": "tblParty123",
+                "name": "Dan's House Party",
+                "fields": [{"id": "fldName123", "name": "Name", "type": "singleLineText"}],
+                "views": [],
+            },
+        )
+
+    _mock_client(client, handler)
+    try:
+        result = client.create_table("appBase123", "Dan's House Party")
+    finally:
+        client.close()
+
+    assert result["id"] == "tblParty123"
+    assert result["name"] == "Dan's House Party"
+
+
+def test_create_table_posts_custom_fields_and_description() -> None:
+    module = _load_airtable_module()
+    client = module.AirtableClient(api_key="test-key")
+    fields = [
+        {"name": "Event", "type": "singleLineText"},
+        {"name": "Date", "type": "date", "options": {"dateFormat": {"name": "iso"}}},
+    ]
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content)
+        assert body == {
+            "name": "Events",
+            "description": "Upcoming events",
+            "fields": fields,
+        }
+        return httpx.Response(200, request=request, json={"id": "tblEvents", **body})
+
+    _mock_client(client, handler)
+    try:
+        result = client.create_table(
+            "appBase123",
+            "Events",
+            fields=fields,
+            description="Upcoming events",
+        )
+    finally:
+        client.close()
+
+    assert result["fields"] == fields
+
+
+def test_cli_create_table_uses_default_field(monkeypatch) -> None:
+    cli = _load_airtable_cli_module()
+    calls: list[dict] = []
+
+    class FakeClient:
+        def create_table(self, base_id, name, fields=None, description=None) -> dict:
+            calls.append(
+                {
+                    "base_id": base_id,
+                    "name": name,
+                    "fields": fields,
+                    "description": description,
+                }
+            )
+            return {"id": "tblParty123", "name": name}
+
+    monkeypatch.setattr(cli, "AirtableClient", FakeClient)
+
+    result = CliRunner().invoke(
+        cli.app,
+        ["create-table", "appBase123", "Dan's House Party"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert calls == [
+        {
+            "base_id": "appBase123",
+            "name": "Dan's House Party",
+            "fields": None,
+            "description": None,
+        }
+    ]
+
+
 def test_update_records_batches_and_uses_patch() -> None:
     module = _load_airtable_module()
     client = module.AirtableClient(api_key="test-key")


### PR DESCRIPTION
## Summary

- add a registered `create_table` client method using Airtable’s schema API
- add an `airtable create-table` CLI command with a default primary field
- cover default and custom schemas plus CLI behavior with tests

## Testing

- `uv run --with pytest --with httpx --with typer --with rich --with python-dotenv pytest tools/productivity/airtable/test_client.py -q`
- `uvx ruff check tools/productivity/airtable/client.py tools/productivity/airtable/cli.py tools/productivity/airtable/test_client.py`
- `uvx ruff format --check tools/productivity/airtable/client.py tools/productivity/airtable/cli.py tools/productivity/airtable/test_client.py`

Prompted by: mslipper