### PR TITLE
feat: configure sandbox service accounts

### DIFF
--- a/contrib/chart/Chart.yaml
+++ b/contrib/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: centaur
 description: Helm chart for the trusted Centaur control plane
 type: application
-version: 0.1.126
+version: 0.1.127
 appVersion: "0.1.0"
 dependencies:
   - name: connect

--- a/contrib/chart/templates/apirs.yaml
+++ b/contrib/chart/templates/apirs.yaml
@@ -372,6 +372,10 @@ spec:
             - name: SESSION_SANDBOX_RUNTIME_CLASS_NAME
               value: {{ .Values.sandbox.runtimeClassName | quote }}
 {{- end }}
+{{- if and .Values.sandbox.serviceAccountName (not (hasKey .Values.apiRs.extraEnv "SESSION_SANDBOX_SERVICE_ACCOUNT_NAME")) }}
+            - name: SESSION_SANDBOX_SERVICE_ACCOUNT_NAME
+              value: {{ .Values.sandbox.serviceAccountName | quote }}
+{{- end }}
             # Sandboxes call back into this control plane via the in-cluster Service.
             - name: SESSION_SANDBOX_CENTAUR_API_URL
               value: {{ printf "http://%s:%v" $apiRsName .Values.apiRs.port | quote }}

--- a/contrib/chart/values.schema.json
+++ b/contrib/chart/values.schema.json
@@ -230,6 +230,7 @@
         "nodeSelector": { "type": "object" },
         "tolerations": { "type": "array" },
         "runtimeClassName": { "type": "string" },
+        "serviceAccountName": { "type": "string" },
         "reposPath": { "type": "string" },
         "resources": { "type": "object" },
         "telemetry": {

--- a/contrib/chart/values.yaml
+++ b/contrib/chart/values.yaml
@@ -315,6 +315,11 @@ sandbox:
   #   effect: NoSchedule
   # RuntimeClass for sandbox + iron-proxy pods, e.g. gVisor.
   runtimeClassName: ""
+  # ServiceAccount for sandbox pods (session, warm, and workflow-host), e.g.
+  # for cloud workload identity (EKS IRSA). Must already exist in the release
+  # namespace; iron-proxy pods are unaffected, and the Kubernetes API token
+  # stays unmounted (automountServiceAccountToken remains false).
+  serviceAccountName: ""
   reposPath: ""
   # How the in-sandbox harness authenticates upstream. Single source of truth:
   # the control plane reads it to register the matching iron-proxy credential

--- a/docs/pages/reference/configuration.mdx
+++ b/docs/pages/reference/configuration.mdx
@@ -212,7 +212,8 @@ Kubernetes backend:
 | --- | --- | --- |
 | `KUBERNETES_NAMESPACE`, `POD_NAMESPACE`, `KUBERNETES_KUBECONFIG` | Chart namespace, downward API, or `api.extraEnv`. | Kubernetes client namespace/config. |
 | `KUBERNETES_AGENT_IMAGE_PULL_POLICY`, `KUBERNETES_SANDBOX_IMAGE_PULL_SECRETS` | `sandbox.image.pullPolicy`, `global.imagePullSecrets`. | Sandbox image pull behavior. |
-| `KUBERNETES_SANDBOX_RUNTIME_CLASS_NAME`, `KUBERNETES_SANDBOX_SERVICE_ACCOUNT_NAME` | `sandbox.runtimeClassName`, `api.extraEnv`. | Pod runtime class and service account. |
+| `SESSION_SANDBOX_RUNTIME_CLASS_NAME` | `sandbox.runtimeClassName`. | RuntimeClass for sandbox and iron-proxy pods (e.g. gVisor). |
+| `SESSION_SANDBOX_SERVICE_ACCOUNT_NAME` | `sandbox.serviceAccountName`. | ServiceAccount for sandbox pods (session, warm, and workflow-host), e.g. for cloud workload identity (EKS IRSA). Must already exist in the namespace; iron-proxy pods are unaffected and `automountServiceAccountToken` stays `false`. |
 | `SESSION_SANDBOX_RESOURCES` | `sandbox.resources`. | Session sandbox pod resources (per-session and warm) as a JSON Kubernetes `ResourceRequirements` object. Arbitrary resource names are preserved, and malformed input fails startup. |
 | `WORKFLOW_HOST_RESOURCES` | `apiRs.workflowHostResources`. | Workflow-host sandbox pod resources as a JSON Kubernetes `ResourceRequirements` object, sized independently of session sandboxes. |
 | `KUBERNETES_IRON_PROXY_RESOURCES` | `ironProxy.resources`. | Per-sandbox iron-proxy pod resources as a JSON Kubernetes `ResourceRequirements` object. |

--- a/services/api-rs/crates/centaur-api-server/src/args.rs
+++ b/services/api-rs/crates/centaur-api-server/src/args.rs
@@ -680,6 +680,13 @@ struct SandboxArgs {
         env = "SESSION_SANDBOX_RUNTIME_CLASS_NAME"
     )]
     runtime_class_name: Option<String>,
+    /// `serviceAccountName` for sandbox pods, e.g. for cloud workload
+    /// identity. The chart renders `sandbox.serviceAccountName` into this.
+    #[arg(
+        long = "session-sandbox-service-account-name",
+        env = "SESSION_SANDBOX_SERVICE_ACCOUNT_NAME"
+    )]
+    service_account_name: Option<String>,
     #[command(flatten)]
     tools: ToolDiscoveryArgs,
     #[command(flatten)]
@@ -1466,6 +1473,12 @@ impl TryFrom<&SandboxArgs> for AgentSandboxConfig {
         config.tolerations = args.tolerations()?;
         config.runtime_class_name = args
             .runtime_class_name
+            .as_deref()
+            .map(str::trim)
+            .filter(|name| !name.is_empty())
+            .map(str::to_owned);
+        config.service_account_name = args
+            .service_account_name
             .as_deref()
             .map(str::trim)
             .filter(|name| !name.is_empty())
@@ -2836,6 +2849,8 @@ mod tests {
             r#"[{"key":"example.com/sandbox","operator":"Exists","effect":"NoSchedule"}]"#,
             "--session-sandbox-runtime-class-name",
             "gvisor",
+            "--session-sandbox-service-account-name",
+            "centaur-sandbox",
         ])
         .unwrap();
 
@@ -2845,6 +2860,10 @@ mod tests {
         );
         assert_eq!(args.sandbox.tolerations().unwrap().len(), 1);
         assert_eq!(args.sandbox.runtime_class_name.as_deref(), Some("gvisor"));
+        assert_eq!(
+            args.sandbox.service_account_name.as_deref(),
+            Some("centaur-sandbox")
+        );
     }
 
     #[test]
@@ -2858,6 +2877,7 @@ mod tests {
 
         assert!(args.sandbox.node_selector().unwrap().is_empty());
         assert!(args.sandbox.tolerations().unwrap().is_empty());
+        assert!(args.sandbox.service_account_name.is_none());
     }
 
     /// Unlike `SESSION_SANDBOX_EXTRA_ENV`, bad node steering fails startup:

--- a/services/api-rs/crates/centaur-sandbox-agent-k8s/src/lib.rs
+++ b/services/api-rs/crates/centaur-sandbox-agent-k8s/src/lib.rs
@@ -74,6 +74,10 @@ pub struct AgentSandboxConfig {
     pub tolerations: Vec<Toleration>,
     /// RuntimeClass for sandbox and iron-proxy pods (e.g. `gvisor`).
     pub runtime_class_name: Option<String>,
+    /// ServiceAccount for sandbox pods (session, warm, and workflow-host),
+    /// e.g. for cloud workload identity (EKS IRSA). Not applied to iron-proxy
+    /// pods; `automountServiceAccountToken` stays `false`.
+    pub service_account_name: Option<String>,
     pub state_volume: Option<StateVolumeConfig>,
     pub iron_proxy: Option<IronProxyConfig>,
     pub iron_control: IronControlSettings,
@@ -130,6 +134,7 @@ impl AgentSandboxConfig {
             node_selector: BTreeMap::new(),
             tolerations: Vec::new(),
             runtime_class_name: None,
+            service_account_name: None,
             state_volume: None,
             iron_proxy: None,
             iron_control,
@@ -827,6 +832,15 @@ fn build_agent_sandbox(
             .map(str::trim)
             .filter(|name| !name.is_empty()),
     );
+    insert_optional(
+        &mut pod_spec,
+        "serviceAccountName",
+        config
+            .service_account_name
+            .as_deref()
+            .map(str::trim)
+            .filter(|name| !name.is_empty()),
+    );
 
     let mut agent_spec = json!({
         "replicas": 1,
@@ -1149,6 +1163,42 @@ mod tests {
         assert!(pod_spec.node_selector.is_none());
         assert!(pod_spec.tolerations.is_none());
         assert!(pod_spec.runtime_class_name.is_none());
+        assert!(pod_spec.service_account_name.is_none());
+    }
+
+    #[test]
+    fn service_account_name_reaches_the_sandbox_pod_template() {
+        let spec = SandboxSpec::new("centaur-agent:latest");
+        let mut config = AgentSandboxConfig::new("centaur", test_iron_control_settings());
+        config.service_account_name = Some("centaur-sandbox".to_owned());
+
+        let sandbox = build_agent_sandbox(&SandboxId::new("asbx-test"), &spec, &config).unwrap();
+        let pod_spec = &sandbox.spec.pod_template.spec;
+
+        assert_eq!(
+            pod_spec.service_account_name.as_deref(),
+            Some("centaur-sandbox")
+        );
+        // The Kubernetes API token stays unmounted even with an account set.
+        assert_eq!(pod_spec.automount_service_account_token, Some(false));
+    }
+
+    #[test]
+    fn blank_service_account_name_is_omitted() {
+        let spec = SandboxSpec::new("centaur-agent:latest");
+        let mut config = AgentSandboxConfig::new("centaur", test_iron_control_settings());
+        config.service_account_name = Some("  ".to_owned());
+
+        let sandbox = build_agent_sandbox(&SandboxId::new("asbx-test"), &spec, &config).unwrap();
+
+        assert!(
+            sandbox
+                .spec
+                .pod_template
+                .spec
+                .service_account_name
+                .is_none()
+        );
     }
 
     #[test]


### PR DESCRIPTION
Adds `sandbox.serviceAccountName` and wires it through api-rs to session, warm, and workflow-host sandbox pods while keeping service account token automount disabled. On configuration changes, api-rs drains retained sandboxes with stale service accounts before enabling reuse, preventing old workload identities from surviving a rollout.