### PR TITLE
fix: inject selected persona prompts into sandboxes

### DIFF
--- a/services/api-rs/Cargo.lock
+++ b/services/api-rs/Cargo.lock
@@ -1066,6 +1066,7 @@ name = "centaur-session-runtime"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "base64 0.23.1",
  "centaur-iron-control",
  "centaur-sandbox-core",
  "centaur-sandbox-manager",

--- a/services/api-rs/Cargo.lock
+++ b/services/api-rs/Cargo.lock
@@ -1017,6 +1017,7 @@ dependencies = [
  "bytes",
  "centaur-sandbox-core",
  "centaur-sandbox-manager",
+ "tempfile",
  "tokio",
 ]
 
@@ -1066,7 +1067,6 @@ name = "centaur-session-runtime"
 version = "0.1.0"
 dependencies = [
  "async-trait",
- "base64 0.23.1",
  "centaur-iron-control",
  "centaur-sandbox-core",
  "centaur-sandbox-manager",
@@ -4975,7 +4975,7 @@ dependencies = [
  "base64 0.21.7",
  "hmac-sha256",
  "http 1.4.2",
- "thiserror 1.0.69",
+ "thiserror 2.0.20",
  "time",
 ]
 
@@ -5080,6 +5080,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.2",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/services/api-rs/Cargo.toml
+++ b/services/api-rs/Cargo.toml
@@ -90,6 +90,7 @@ subtle = "2"
 standardwebhooks = "1.0.1"
 test-case = "3.3.1"
 thiserror = "2"
+tempfile = "3"
 url = "2"
 time = { version = "0.3", features = ["serde", "serde-well-known"] }
 tokio = "1"

--- a/services/api-rs/crates/centaur-sandbox-agent-k8s/src/lib.rs
+++ b/services/api-rs/crates/centaur-sandbox-agent-k8s/src/lib.rs
@@ -3,7 +3,7 @@
 //! The Agent Sandbox CRD types are generated from the upstream CRD with
 //! `just codegen-agent-sandbox-crd`.
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::pin::Pin;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -15,11 +15,12 @@ use centaur_sandbox_core::{
     MountKind, ObservedSandbox, SandboxBackend, SandboxError, SandboxHandle, SandboxId, SandboxIo,
     SandboxResult, SandboxSpec, SandboxStatus,
 };
-use k8s_openapi::api::core::v1::{PersistentVolumeClaim, Pod};
+use k8s_openapi::api::core::v1::{ConfigMap, PersistentVolumeClaim, Pod};
+use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
 use kube::api::{
     AttachParams, DeleteParams, ListParams, LogParams, Patch, PatchParams, PostParams,
 };
-use kube::{Api, Client, Error};
+use kube::{Api, Client, Error, Resource};
 use serde_json::{Map, Value, json};
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::sync::Mutex;
@@ -40,6 +41,8 @@ const MANAGED_BY_LABEL: &str = "centaur.ai/managed-by";
 const SANDBOX_ID_LABEL: &str = "centaur.ai/sandbox-id";
 const OBSERVABILITY_ENABLED_LABEL: &str = "centaur.ai/observability-enabled";
 const MANAGED_BY_VALUE: &str = "api-rs";
+const SANDBOX_HOME_FILES_VOLUME: &str = "sandbox-home-files";
+const SANDBOX_HOME_PATH: &str = "/home/agent";
 // iron-control principal OID the sandbox's proxy binds to, stamped at create
 // so resume (which has only the sandbox id) can rebind without the spec or any
 // in-memory state. Survives pause and api-rs restarts.
@@ -231,6 +234,10 @@ impl AgentSandboxBackend {
         Api::namespaced(self.client.clone(), &self.config.namespace)
     }
 
+    fn config_maps(&self) -> Api<ConfigMap> {
+        Api::namespaced(self.client.clone(), &self.config.namespace)
+    }
+
     async fn get_sandbox(&self, id: &SandboxId) -> SandboxResult<Option<crd::Sandbox>> {
         match self.sandboxes().get(id.as_str()).await {
             Ok(sandbox) => Ok(Some(sandbox)),
@@ -323,6 +330,59 @@ impl AgentSandboxBackend {
         }
     }
 
+    async fn create_sandbox_files_config_map(
+        &self,
+        id: &SandboxId,
+        spec: &SandboxSpec,
+    ) -> SandboxResult<()> {
+        let Some(config_map) = build_sandbox_files_config_map(id, spec)? else {
+            return Ok(());
+        };
+        self.config_maps()
+            .create(&PostParams::default(), &config_map)
+            .await
+            .map(|_| ())
+            .map_err(|error| map_kube_error("create sandbox files config map", error))
+    }
+
+    async fn adopt_sandbox_files_config_map(
+        &self,
+        id: &SandboxId,
+        sandbox: &crd::Sandbox,
+    ) -> SandboxResult<()> {
+        let Some(owner_reference) = sandbox_owner_reference(sandbox) else {
+            return Ok(());
+        };
+        let patch = Patch::Merge(json!({
+            "metadata": { "ownerReferences": [owner_reference] },
+        }));
+        match self
+            .config_maps()
+            .patch(
+                &sandbox_files_config_map_name(id),
+                &PatchParams::default(),
+                &patch,
+            )
+            .await
+        {
+            Ok(_) => Ok(()),
+            Err(error) if is_not_found(&error) => Ok(()),
+            Err(error) => Err(map_kube_error("adopt sandbox files config map", error)),
+        }
+    }
+
+    async fn delete_sandbox_files_config_map(&self, id: &SandboxId) -> SandboxResult<()> {
+        match self
+            .config_maps()
+            .delete(&sandbox_files_config_map_name(id), &DeleteParams::default())
+            .await
+        {
+            Ok(_) => Ok(()),
+            Err(error) if is_not_found(&error) => Ok(()),
+            Err(error) => Err(map_kube_error("delete sandbox files config map", error)),
+        }
+    }
+
     async fn wait_until_running(&self, id: &SandboxId) -> SandboxResult<()> {
         let deadline = Instant::now() + self.config.ready_timeout;
         loop {
@@ -400,7 +460,18 @@ impl SandboxBackend for AgentSandboxBackend {
             let _ = self.delete_iron_proxy_resources(&id).await;
             return Err(err);
         }
-        let sandbox = build_agent_sandbox(&id, &spec, &self.config)?;
+        if let Err(error) = self.create_sandbox_files_config_map(&id, &spec).await {
+            let _ = self.delete_iron_proxy_resources(&id).await;
+            return Err(error);
+        }
+        let sandbox = match build_agent_sandbox(&id, &spec, &self.config) {
+            Ok(sandbox) => sandbox,
+            Err(error) => {
+                let _ = self.delete_sandbox_files_config_map(&id).await;
+                let _ = self.delete_iron_proxy_resources(&id).await;
+                return Err(error);
+            }
+        };
         let created = match self
             .sandboxes()
             .create(&PostParams::default(), &sandbox)
@@ -408,6 +479,7 @@ impl SandboxBackend for AgentSandboxBackend {
         {
             Ok(created) => created,
             Err(err) => {
+                let _ = self.delete_sandbox_files_config_map(&id).await;
                 let _ = self.delete_iron_proxy_resources(&id).await;
                 return Err(map_kube_error("create sandbox", err));
             }
@@ -420,6 +492,13 @@ impl SandboxBackend for AgentSandboxBackend {
                 sandbox_id = id.as_str(),
                 %error,
                 "failed to set ownerReferences on iron-proxy resources"
+            );
+        }
+        if let Err(error) = self.adopt_sandbox_files_config_map(&id, &created).await {
+            tracing::warn!(
+                sandbox_id = id.as_str(),
+                %error,
+                "failed to set ownerReference on sandbox files config map"
             );
         }
         if let Err(err) = self.wait_until_running(&id).await {
@@ -500,6 +579,7 @@ impl SandboxBackend for AgentSandboxBackend {
 
     async fn stop(&self, id: &SandboxId) -> SandboxResult<()> {
         let proxy_result = self.delete_iron_proxy_resources(id).await;
+        let files_result = self.delete_sandbox_files_config_map(id).await;
         match self
             .sandboxes()
             .delete(id.as_str(), &DeleteParams::default())
@@ -507,10 +587,12 @@ impl SandboxBackend for AgentSandboxBackend {
         {
             Ok(_) => {
                 proxy_result?;
+                files_result?;
                 self.delete_state_pvc(id).await
             }
             Err(err) if is_not_found(&err) => {
                 proxy_result?;
+                files_result?;
                 self.delete_state_pvc(id).await
             }
             Err(err) => Err(map_kube_error("delete sandbox", err)),
@@ -787,6 +869,24 @@ fn build_agent_sandbox(
     insert_optional(&mut container, "resources", resources_json(spec));
 
     let (mut volumes, mut volume_mounts) = mount_json(spec);
+    if !spec.home_files.is_empty() {
+        volumes.push(json!({
+            "name": SANDBOX_HOME_FILES_VOLUME,
+            "configMap": {
+                "name": sandbox_files_config_map_name(id),
+                "defaultMode": 0o444,
+            },
+        }));
+        for (index, file) in spec.home_files.iter().enumerate() {
+            validate_sandbox_home_file_path(&file.path)?;
+            volume_mounts.push(json!({
+                "name": SANDBOX_HOME_FILES_VOLUME,
+                "mountPath": format!("{SANDBOX_HOME_PATH}/{}", file.path),
+                "subPath": sandbox_file_key(index),
+                "readOnly": true,
+            }));
+        }
+    }
     let mut init_containers = Vec::new();
     if let Some(state_volume) = &config.state_volume {
         volume_mounts.push(json!({
@@ -981,6 +1081,74 @@ fn mount_json(spec: &SandboxSpec) -> (Vec<Value>, Vec<Value>) {
     (volumes, mounts)
 }
 
+fn sandbox_files_config_map_name(id: &SandboxId) -> String {
+    format!("{}-files", id.as_str())
+}
+
+fn sandbox_file_key(index: usize) -> String {
+    format!("file-{index}")
+}
+
+fn validate_sandbox_home_file_path(path: &str) -> SandboxResult<()> {
+    let path = std::path::Path::new(path);
+    if path.as_os_str().is_empty()
+        || path.is_absolute()
+        || path
+            .components()
+            .any(|component| !matches!(component, std::path::Component::Normal(_)))
+    {
+        return Err(SandboxError::InvalidSpec(format!(
+            "invalid sandbox home file path {path:?}"
+        )));
+    }
+    Ok(())
+}
+
+fn build_sandbox_files_config_map(
+    id: &SandboxId,
+    spec: &SandboxSpec,
+) -> SandboxResult<Option<ConfigMap>> {
+    if spec.home_files.is_empty() {
+        return Ok(None);
+    }
+    let mut paths = BTreeSet::new();
+    let mut data = BTreeMap::new();
+    for (index, file) in spec.home_files.iter().enumerate() {
+        validate_sandbox_home_file_path(&file.path)?;
+        if !paths.insert(file.path.as_str()) {
+            return Err(SandboxError::InvalidSpec(format!(
+                "duplicate sandbox home file path {:?}",
+                file.path
+            )));
+        }
+        data.insert(sandbox_file_key(index), file.contents.clone());
+    }
+    Ok(Some(ConfigMap {
+        metadata: ObjectMeta {
+            name: Some(sandbox_files_config_map_name(id)),
+            labels: Some(BTreeMap::from([
+                (MANAGED_BY_LABEL.to_owned(), MANAGED_BY_VALUE.to_owned()),
+                (SANDBOX_ID_LABEL.to_owned(), id.as_str().to_owned()),
+            ])),
+            ..ObjectMeta::default()
+        },
+        data: Some(data),
+        immutable: Some(true),
+        ..ConfigMap::default()
+    }))
+}
+
+fn sandbox_owner_reference(sandbox: &crd::Sandbox) -> Option<Value> {
+    let name = sandbox.metadata.name.as_ref()?;
+    let uid = sandbox.metadata.uid.as_ref()?;
+    Some(json!({
+        "apiVersion": crd::Sandbox::api_version(&()),
+        "kind": crd::Sandbox::kind(&()),
+        "name": name,
+        "uid": uid,
+    }))
+}
+
 fn resources_json(spec: &SandboxSpec) -> Option<Value> {
     let resources = spec.resources.as_ref()?;
     (!resources.is_empty()).then(|| json!(resources))
@@ -1151,6 +1319,44 @@ mod tests {
         assert_eq!(
             resources.limits.as_ref().unwrap().get("example.com/gpu"),
             Some(&quantity("1"))
+        );
+    }
+
+    #[test]
+    fn mounts_large_sandbox_home_files_without_putting_contents_in_env() {
+        let prompt = "p".repeat(256 * 1024);
+        let spec =
+            SandboxSpec::new("centaur-agent:latest").home_file("AGENTS_PERSONA.md", prompt.clone());
+        let id = SandboxId::new("asbx-test");
+        let config_map = build_sandbox_files_config_map(&id, &spec)
+            .unwrap()
+            .expect("sandbox files config map");
+
+        assert_eq!(
+            config_map.data.as_ref().and_then(|data| data.get("file-0")),
+            Some(&prompt)
+        );
+
+        let config = AgentSandboxConfig::new("centaur", test_iron_control_settings());
+        let sandbox = build_agent_sandbox(&id, &spec, &config).unwrap();
+        let sandbox = serde_json::to_value(sandbox).unwrap();
+        let container = &sandbox["spec"]["podTemplate"]["spec"]["containers"][0];
+        assert!(container["env"].as_array().is_none_or(|env| {
+            env.iter().all(|entry| {
+                entry["value"] != prompt && entry["name"] != "CENTAUR_PERSONA_PROMPT_PATH"
+            })
+        }));
+        assert!(
+            container["volumeMounts"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .any(|mount| {
+                    mount["name"] == SANDBOX_HOME_FILES_VOLUME
+                        && mount["mountPath"] == "/home/agent/AGENTS_PERSONA.md"
+                        && mount["subPath"] == "file-0"
+                        && mount["readOnly"] == true
+                })
         );
     }
 

--- a/services/api-rs/crates/centaur-sandbox-agent-k8s/src/lib.rs
+++ b/services/api-rs/crates/centaur-sandbox-agent-k8s/src/lib.rs
@@ -41,8 +41,7 @@ const MANAGED_BY_LABEL: &str = "centaur.ai/managed-by";
 const SANDBOX_ID_LABEL: &str = "centaur.ai/sandbox-id";
 const OBSERVABILITY_ENABLED_LABEL: &str = "centaur.ai/observability-enabled";
 const MANAGED_BY_VALUE: &str = "api-rs";
-const SANDBOX_HOME_FILES_VOLUME: &str = "sandbox-home-files";
-const SANDBOX_HOME_PATH: &str = "/home/agent";
+const SANDBOX_FILES_VOLUME: &str = "sandbox-files";
 // iron-control principal OID the sandbox's proxy binds to, stamped at create
 // so resume (which has only the sandbox id) can rebind without the spec or any
 // in-memory state. Survives pause and api-rs restarts.
@@ -869,19 +868,19 @@ fn build_agent_sandbox(
     insert_optional(&mut container, "resources", resources_json(spec));
 
     let (mut volumes, mut volume_mounts) = mount_json(spec);
-    if !spec.home_files.is_empty() {
+    if !spec.files.is_empty() {
         volumes.push(json!({
-            "name": SANDBOX_HOME_FILES_VOLUME,
+            "name": SANDBOX_FILES_VOLUME,
             "configMap": {
                 "name": sandbox_files_config_map_name(id),
                 "defaultMode": 0o444,
             },
         }));
-        for (index, file) in spec.home_files.iter().enumerate() {
-            validate_sandbox_home_file_path(&file.path)?;
+        for (index, file) in spec.files.iter().enumerate() {
+            validate_sandbox_file_target_path(&file.target_path)?;
             volume_mounts.push(json!({
-                "name": SANDBOX_HOME_FILES_VOLUME,
-                "mountPath": format!("{SANDBOX_HOME_PATH}/{}", file.path),
+                "name": SANDBOX_FILES_VOLUME,
+                "mountPath": file.target_path,
                 "subPath": sandbox_file_key(index),
                 "readOnly": true,
             }));
@@ -1089,16 +1088,20 @@ fn sandbox_file_key(index: usize) -> String {
     format!("file-{index}")
 }
 
-fn validate_sandbox_home_file_path(path: &str) -> SandboxResult<()> {
+fn validate_sandbox_file_target_path(path: &str) -> SandboxResult<()> {
     let path = std::path::Path::new(path);
     if path.as_os_str().is_empty()
-        || path.is_absolute()
-        || path
-            .components()
-            .any(|component| !matches!(component, std::path::Component::Normal(_)))
+        || !path.is_absolute()
+        || path.file_name().is_none()
+        || path.components().any(|component| {
+            !matches!(
+                component,
+                std::path::Component::RootDir | std::path::Component::Normal(_)
+            )
+        })
     {
         return Err(SandboxError::InvalidSpec(format!(
-            "invalid sandbox home file path {path:?}"
+            "invalid sandbox file target path {path:?}"
         )));
     }
     Ok(())
@@ -1108,17 +1111,17 @@ fn build_sandbox_files_config_map(
     id: &SandboxId,
     spec: &SandboxSpec,
 ) -> SandboxResult<Option<ConfigMap>> {
-    if spec.home_files.is_empty() {
+    if spec.files.is_empty() {
         return Ok(None);
     }
     let mut paths = BTreeSet::new();
     let mut data = BTreeMap::new();
-    for (index, file) in spec.home_files.iter().enumerate() {
-        validate_sandbox_home_file_path(&file.path)?;
-        if !paths.insert(file.path.as_str()) {
+    for (index, file) in spec.files.iter().enumerate() {
+        validate_sandbox_file_target_path(&file.target_path)?;
+        if !paths.insert(file.target_path.as_str()) {
             return Err(SandboxError::InvalidSpec(format!(
-                "duplicate sandbox home file path {:?}",
-                file.path
+                "duplicate sandbox file target path {:?}",
+                file.target_path
             )));
         }
         data.insert(sandbox_file_key(index), file.contents.clone());
@@ -1323,10 +1326,11 @@ mod tests {
     }
 
     #[test]
-    fn mounts_large_sandbox_home_files_without_putting_contents_in_env() {
+    fn mounts_large_sandbox_files_without_putting_contents_in_env() {
         let prompt = "p".repeat(256 * 1024);
-        let spec =
-            SandboxSpec::new("centaur-agent:latest").home_file("AGENTS_PERSONA.md", prompt.clone());
+        let spec = SandboxSpec::new("centaur-agent:latest")
+            .file("/home/agent/AGENTS_PERSONA.md", prompt.clone())
+            .file("/tmp/runtime-config", "runtime config");
         let id = SandboxId::new("asbx-test");
         let config_map = build_sandbox_files_config_map(&id, &spec)
             .unwrap()
@@ -1335,6 +1339,14 @@ mod tests {
         assert_eq!(
             config_map.data.as_ref().and_then(|data| data.get("file-0")),
             Some(&prompt)
+        );
+        assert_eq!(
+            config_map
+                .data
+                .as_ref()
+                .and_then(|data| data.get("file-1"))
+                .map(String::as_str),
+            Some("runtime config")
         );
 
         let config = AgentSandboxConfig::new("centaur", test_iron_control_settings());
@@ -1352,9 +1364,21 @@ mod tests {
                 .unwrap()
                 .iter()
                 .any(|mount| {
-                    mount["name"] == SANDBOX_HOME_FILES_VOLUME
+                    mount["name"] == SANDBOX_FILES_VOLUME
                         && mount["mountPath"] == "/home/agent/AGENTS_PERSONA.md"
                         && mount["subPath"] == "file-0"
+                        && mount["readOnly"] == true
+                })
+        );
+        assert!(
+            container["volumeMounts"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .any(|mount| {
+                    mount["name"] == SANDBOX_FILES_VOLUME
+                        && mount["mountPath"] == "/tmp/runtime-config"
+                        && mount["subPath"] == "file-1"
                         && mount["readOnly"] == true
                 })
         );

--- a/services/api-rs/crates/centaur-sandbox-agent-k8s/src/lib.rs
+++ b/services/api-rs/crates/centaur-sandbox-agent-k8s/src/lib.rs
@@ -1353,11 +1353,11 @@ mod tests {
         let sandbox = build_agent_sandbox(&id, &spec, &config).unwrap();
         let sandbox = serde_json::to_value(sandbox).unwrap();
         let container = &sandbox["spec"]["podTemplate"]["spec"]["containers"][0];
-        assert!(container["env"].as_array().is_none_or(|env| {
-            env.iter().all(|entry| {
-                entry["value"] != prompt && entry["name"] != "CENTAUR_PERSONA_PROMPT_PATH"
-            })
-        }));
+        assert!(
+            container["env"]
+                .as_array()
+                .is_none_or(|env| { env.iter().all(|entry| entry["value"] != prompt) })
+        );
         assert!(
             container["volumeMounts"]
                 .as_array()

--- a/services/api-rs/crates/centaur-sandbox-core/src/lib.rs
+++ b/services/api-rs/crates/centaur-sandbox-core/src/lib.rs
@@ -18,5 +18,5 @@ pub use lifecycle::{
 };
 pub use spec::{
     EnvVar, Mount, MountKind, RepoCacheAccess, ResourceClaim, ResourceRequirements,
-    SandboxCapabilities, SandboxSpec,
+    SandboxCapabilities, SandboxHomeFile, SandboxSpec,
 };

--- a/services/api-rs/crates/centaur-sandbox-core/src/lib.rs
+++ b/services/api-rs/crates/centaur-sandbox-core/src/lib.rs
@@ -18,5 +18,5 @@ pub use lifecycle::{
 };
 pub use spec::{
     EnvVar, Mount, MountKind, RepoCacheAccess, ResourceClaim, ResourceRequirements,
-    SandboxCapabilities, SandboxHomeFile, SandboxSpec,
+    SandboxCapabilities, SandboxFile, SandboxSpec,
 };

--- a/services/api-rs/crates/centaur-sandbox-core/src/lib.rs
+++ b/services/api-rs/crates/centaur-sandbox-core/src/lib.rs
@@ -10,6 +10,9 @@ mod io;
 mod lifecycle;
 mod spec;
 
+/// Home directory used by the sandbox agent image.
+pub const SANDBOX_AGENT_HOME: &str = "/home/agent";
+
 pub use backend::SandboxBackend;
 pub use error::{BoxedError, SandboxError, SandboxResult};
 pub use io::{SandboxIo, SandboxIoGuard, SandboxIoParts, SandboxRead, SandboxWrite};

--- a/services/api-rs/crates/centaur-sandbox-core/src/spec.rs
+++ b/services/api-rs/crates/centaur-sandbox-core/src/spec.rs
@@ -59,10 +59,10 @@ pub struct SandboxSpec {
     pub command: Option<Vec<String>>,
     pub args: Vec<String>,
     pub env: Vec<EnvVar>,
-    /// Files materialized in the sandbox user's home before the workload
-    /// starts. Paths are relative to that home and must not traverse upward.
+    /// Files materialized in the sandbox before the workload starts.
+    /// Target paths are absolute paths inside the sandbox.
     #[serde(default)]
-    pub home_files: Vec<SandboxHomeFile>,
+    pub files: Vec<SandboxFile>,
     pub working_dir: Option<String>,
     pub mounts: Vec<Mount>,
     pub resources: Option<ResourceRequirements>,
@@ -93,7 +93,7 @@ impl SandboxSpec {
             command: None,
             args: Vec::new(),
             env: Vec::new(),
-            home_files: Vec::new(),
+            files: Vec::new(),
             working_dir: None,
             mounts: Vec::new(),
             resources: None,
@@ -134,8 +134,8 @@ impl SandboxSpec {
         self
     }
 
-    pub fn home_file(mut self, path: impl Into<String>, contents: impl Into<String>) -> Self {
-        self.home_files.push(SandboxHomeFile::new(path, contents));
+    pub fn file(mut self, target_path: impl Into<String>, contents: impl Into<String>) -> Self {
+        self.files.push(SandboxFile::new(target_path, contents));
         self
     }
 
@@ -156,16 +156,16 @@ impl SandboxSpec {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
-pub struct SandboxHomeFile {
-    /// Path relative to the sandbox user's home directory.
-    pub path: String,
+pub struct SandboxFile {
+    /// Absolute destination path inside the sandbox.
+    pub target_path: String,
     pub contents: String,
 }
 
-impl SandboxHomeFile {
-    pub fn new(path: impl Into<String>, contents: impl Into<String>) -> Self {
+impl SandboxFile {
+    pub fn new(target_path: impl Into<String>, contents: impl Into<String>) -> Self {
         Self {
-            path: path.into(),
+            target_path: target_path.into(),
             contents: contents.into(),
         }
     }

--- a/services/api-rs/crates/centaur-sandbox-core/src/spec.rs
+++ b/services/api-rs/crates/centaur-sandbox-core/src/spec.rs
@@ -59,6 +59,10 @@ pub struct SandboxSpec {
     pub command: Option<Vec<String>>,
     pub args: Vec<String>,
     pub env: Vec<EnvVar>,
+    /// Files materialized in the sandbox user's home before the workload
+    /// starts. Paths are relative to that home and must not traverse upward.
+    #[serde(default)]
+    pub home_files: Vec<SandboxHomeFile>,
     pub working_dir: Option<String>,
     pub mounts: Vec<Mount>,
     pub resources: Option<ResourceRequirements>,
@@ -89,6 +93,7 @@ impl SandboxSpec {
             command: None,
             args: Vec::new(),
             env: Vec::new(),
+            home_files: Vec::new(),
             working_dir: None,
             mounts: Vec::new(),
             resources: None,
@@ -129,6 +134,11 @@ impl SandboxSpec {
         self
     }
 
+    pub fn home_file(mut self, path: impl Into<String>, contents: impl Into<String>) -> Self {
+        self.home_files.push(SandboxHomeFile::new(path, contents));
+        self
+    }
+
     pub fn working_dir(mut self, working_dir: impl Into<String>) -> Self {
         self.working_dir = Some(working_dir.into());
         self
@@ -142,6 +152,22 @@ impl SandboxSpec {
     pub fn resources(mut self, resources: ResourceRequirements) -> Self {
         self.resources = Some(resources);
         self
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct SandboxHomeFile {
+    /// Path relative to the sandbox user's home directory.
+    pub path: String,
+    pub contents: String,
+}
+
+impl SandboxHomeFile {
+    pub fn new(path: impl Into<String>, contents: impl Into<String>) -> Self {
+        Self {
+            path: path.into(),
+            contents: contents.into(),
+        }
     }
 }
 

--- a/services/api-rs/crates/centaur-sandbox-local/Cargo.toml
+++ b/services/api-rs/crates/centaur-sandbox-local/Cargo.toml
@@ -9,6 +9,7 @@ repository.workspace = true
 async-trait.workspace = true
 bytes.workspace = true
 centaur-sandbox-core.workspace = true
+tempfile.workspace = true
 tokio = { workspace = true, features = ["io-util", "process", "sync", "time"] }
 
 [dev-dependencies]

--- a/services/api-rs/crates/centaur-sandbox-local/src/lib.rs
+++ b/services/api-rs/crates/centaur-sandbox-local/src/lib.rs
@@ -15,7 +15,7 @@ use std::{
 
 use async_trait::async_trait;
 use centaur_sandbox_core::{
-    ObservedSandbox, SandboxBackend, SandboxError, SandboxHandle, SandboxHomeFile, SandboxId,
+    ObservedSandbox, SandboxBackend, SandboxError, SandboxFile, SandboxHandle, SandboxId,
     SandboxIo, SandboxRead, SandboxResult, SandboxSpec, SandboxStatus, SandboxWrite,
 };
 use tempfile::TempDir;
@@ -74,7 +74,7 @@ impl SandboxBackend for LocalSandboxBackend {
 
     async fn create(&self, spec: SandboxSpec) -> SandboxResult<SandboxHandle> {
         let (program, args) = command_parts(&spec)?;
-        let materialized_home = materialize_home_files(&spec.home_files)?;
+        let materialized_home = materialize_files(&spec.files)?;
         let mut command = Command::new(program);
         command.args(args);
         command.stdin(Stdio::piped());
@@ -208,7 +208,7 @@ impl SandboxBackend for LocalSandboxBackend {
     }
 }
 
-fn materialize_home_files(files: &[SandboxHomeFile]) -> SandboxResult<Option<TempDir>> {
+fn materialize_files(files: &[SandboxFile]) -> SandboxResult<Option<TempDir>> {
     if files.is_empty() {
         return Ok(None);
     }
@@ -217,18 +217,14 @@ fn materialize_home_files(files: &[SandboxHomeFile]) -> SandboxResult<Option<Tem
         .tempdir()
         .map_err(|error| SandboxError::backend_source("create sandbox home directory", error))?;
     for file in files {
-        let relative_path = std::path::Path::new(&file.path);
-        if file.path.trim().is_empty()
-            || relative_path.is_absolute()
-            || relative_path
-                .components()
-                .any(|component| !matches!(component, std::path::Component::Normal(_)))
-        {
-            return Err(SandboxError::InvalidSpec(format!(
-                "invalid sandbox home file path {:?}",
-                file.path
-            )));
-        }
+        let target_path = std::path::Path::new(&file.target_path);
+        let relative_path = target_path.strip_prefix("/home/agent").map_err(|_| {
+            SandboxError::InvalidSpec(format!(
+                "local sandbox files must target /home/agent, got {:?}",
+                file.target_path
+            ))
+        })?;
+        validate_local_file_path(relative_path, &file.target_path)?;
         let path = dir.path().join(relative_path);
         if let Some(parent) = path.parent() {
             std::fs::create_dir_all(parent).map_err(|error| {
@@ -239,6 +235,20 @@ fn materialize_home_files(files: &[SandboxHomeFile]) -> SandboxResult<Option<Tem
             .map_err(|error| SandboxError::backend_source("write sandbox home file", error))?;
     }
     Ok(Some(dir))
+}
+
+fn validate_local_file_path(path: &std::path::Path, target_path: &str) -> SandboxResult<()> {
+    if path.as_os_str().is_empty()
+        || path.is_absolute()
+        || path
+            .components()
+            .any(|component| !matches!(component, std::path::Component::Normal(_)))
+    {
+        return Err(SandboxError::InvalidSpec(format!(
+            "invalid sandbox file target path {target_path:?}"
+        )));
+    }
+    Ok(())
 }
 
 fn command_parts(spec: &SandboxSpec) -> SandboxResult<(&str, Vec<&str>)> {
@@ -353,14 +363,14 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn local_backend_materializes_sandbox_home_files() {
+    async fn local_backend_materializes_sandbox_files() {
         let backend = Arc::new(LocalSandboxBackend::new());
         let manager = SandboxManager::new(backend);
         let prompt = "large persona prompt\n";
         let spec = SandboxSpec::new("/bin/sh")
             .command(["/bin/sh", "-lc"])
             .args(["cat \"$HOME/AGENTS_PERSONA.md\"; cat"])
-            .home_file("AGENTS_PERSONA.md", prompt);
+            .file("/home/agent/AGENTS_PERSONA.md", prompt);
         let handle = manager.create_running(spec).await.unwrap();
         let mut io = manager.open_io(&handle.id).await.unwrap().into_parts();
 

--- a/services/api-rs/crates/centaur-sandbox-local/src/lib.rs
+++ b/services/api-rs/crates/centaur-sandbox-local/src/lib.rs
@@ -15,8 +15,8 @@ use std::{
 
 use async_trait::async_trait;
 use centaur_sandbox_core::{
-    ObservedSandbox, SandboxBackend, SandboxError, SandboxFile, SandboxHandle, SandboxId,
-    SandboxIo, SandboxRead, SandboxResult, SandboxSpec, SandboxStatus, SandboxWrite,
+    ObservedSandbox, SANDBOX_AGENT_HOME, SandboxBackend, SandboxError, SandboxFile, SandboxHandle,
+    SandboxId, SandboxIo, SandboxRead, SandboxResult, SandboxSpec, SandboxStatus, SandboxWrite,
 };
 use tempfile::TempDir;
 use tokio::{
@@ -218,10 +218,10 @@ fn materialize_files(files: &[SandboxFile]) -> SandboxResult<Option<TempDir>> {
         .map_err(|error| SandboxError::backend_source("create sandbox home directory", error))?;
     for file in files {
         let target_path = std::path::Path::new(&file.target_path);
-        let relative_path = target_path.strip_prefix("/home/agent").map_err(|_| {
+        let relative_path = target_path.strip_prefix(SANDBOX_AGENT_HOME).map_err(|_| {
             SandboxError::InvalidSpec(format!(
-                "local sandbox files must target /home/agent, got {:?}",
-                file.target_path
+                "local sandbox files must target {SANDBOX_AGENT_HOME}, got {:?}",
+                file.target_path,
             ))
         })?;
         validate_local_file_path(relative_path, &file.target_path)?;

--- a/services/api-rs/crates/centaur-sandbox-local/src/lib.rs
+++ b/services/api-rs/crates/centaur-sandbox-local/src/lib.rs
@@ -15,9 +15,10 @@ use std::{
 
 use async_trait::async_trait;
 use centaur_sandbox_core::{
-    ObservedSandbox, SandboxBackend, SandboxError, SandboxHandle, SandboxId, SandboxIo,
-    SandboxRead, SandboxResult, SandboxSpec, SandboxStatus, SandboxWrite,
+    ObservedSandbox, SandboxBackend, SandboxError, SandboxHandle, SandboxHomeFile, SandboxId,
+    SandboxIo, SandboxRead, SandboxResult, SandboxSpec, SandboxStatus, SandboxWrite,
 };
+use tempfile::TempDir;
 use tokio::{
     process::{Child, ChildStderr, ChildStdin, ChildStdout, Command},
     sync::Mutex,
@@ -41,6 +42,7 @@ struct LocalSandbox {
     stderr: Option<ChildStderr>,
     status: SandboxStatus,
     labels: BTreeMap<String, String>,
+    _home_dir: Option<TempDir>,
 }
 
 impl LocalSandboxBackend {
@@ -72,6 +74,7 @@ impl SandboxBackend for LocalSandboxBackend {
 
     async fn create(&self, spec: SandboxSpec) -> SandboxResult<SandboxHandle> {
         let (program, args) = command_parts(&spec)?;
+        let materialized_home = materialize_home_files(&spec.home_files)?;
         let mut command = Command::new(program);
         command.args(args);
         command.stdin(Stdio::piped());
@@ -83,6 +86,9 @@ impl SandboxBackend for LocalSandboxBackend {
         }
         for env in &spec.env {
             command.env(&env.name, &env.value);
+        }
+        if let Some(home) = &materialized_home {
+            command.env("HOME", home.path());
         }
 
         let mut child = command
@@ -103,6 +109,7 @@ impl SandboxBackend for LocalSandboxBackend {
                 stderr,
                 status: SandboxStatus::Running,
                 labels: spec.labels,
+                _home_dir: materialized_home,
             })),
         );
 
@@ -199,6 +206,39 @@ impl SandboxBackend for LocalSandboxBackend {
         sandbox.status = SandboxStatus::Running;
         Ok(())
     }
+}
+
+fn materialize_home_files(files: &[SandboxHomeFile]) -> SandboxResult<Option<TempDir>> {
+    if files.is_empty() {
+        return Ok(None);
+    }
+    let dir = tempfile::Builder::new()
+        .prefix("centaur-sandbox-home-")
+        .tempdir()
+        .map_err(|error| SandboxError::backend_source("create sandbox home directory", error))?;
+    for file in files {
+        let relative_path = std::path::Path::new(&file.path);
+        if file.path.trim().is_empty()
+            || relative_path.is_absolute()
+            || relative_path
+                .components()
+                .any(|component| !matches!(component, std::path::Component::Normal(_)))
+        {
+            return Err(SandboxError::InvalidSpec(format!(
+                "invalid sandbox home file path {:?}",
+                file.path
+            )));
+        }
+        let path = dir.path().join(relative_path);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).map_err(|error| {
+                SandboxError::backend_source("create sandbox home file directory", error)
+            })?;
+        }
+        std::fs::write(&path, &file.contents)
+            .map_err(|error| SandboxError::backend_source("write sandbox home file", error))?;
+    }
+    Ok(Some(dir))
 }
 
 fn command_parts(spec: &SandboxSpec) -> SandboxResult<(&str, Vec<&str>)> {
@@ -309,6 +349,28 @@ mod tests {
             Some("workflow-run")
         );
 
+        manager.stop(&handle.id).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn local_backend_materializes_sandbox_home_files() {
+        let backend = Arc::new(LocalSandboxBackend::new());
+        let manager = SandboxManager::new(backend);
+        let prompt = "large persona prompt\n";
+        let spec = SandboxSpec::new("/bin/sh")
+            .command(["/bin/sh", "-lc"])
+            .args(["cat \"$HOME/AGENTS_PERSONA.md\"; cat"])
+            .home_file("AGENTS_PERSONA.md", prompt);
+        let handle = manager.create_running(spec).await.unwrap();
+        let mut io = manager.open_io(&handle.id).await.unwrap().into_parts();
+
+        let mut read = vec![0; prompt.len()];
+        timeout(Duration::from_secs(1), io.stdout.read_exact(&mut read))
+            .await
+            .expect("stdout read timed out")
+            .unwrap();
+
+        assert_eq!(read, prompt.as_bytes());
         manager.stop(&handle.id).await.unwrap();
     }
 

--- a/services/api-rs/crates/centaur-session-runtime/Cargo.toml
+++ b/services/api-rs/crates/centaur-session-runtime/Cargo.toml
@@ -7,6 +7,7 @@ repository.workspace = true
 
 [dependencies]
 async-trait.workspace = true
+base64.workspace = true
 centaur-iron-control.workspace = true
 centaur-sandbox-core.workspace = true
 centaur-sandbox-manager.workspace = true

--- a/services/api-rs/crates/centaur-session-runtime/Cargo.toml
+++ b/services/api-rs/crates/centaur-session-runtime/Cargo.toml
@@ -7,7 +7,6 @@ repository.workspace = true
 
 [dependencies]
 async-trait.workspace = true
-base64.workspace = true
 centaur-iron-control.workspace = true
 centaur-sandbox-core.workspace = true
 centaur-sandbox-manager.workspace = true

--- a/services/api-rs/crates/centaur-session-runtime/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-runtime/src/lib.rs
@@ -5736,8 +5736,6 @@ fn apply_persona_spec(mut spec: SandboxSpec, persona: Option<&PersonaContext>) -
     for name in [
         "AGENT_PERSONA",
         "CENTAUR_PERSONA_ID",
-        "CENTAUR_PERSONA_PROMPT_BASE64",
-        "CENTAUR_PERSONA_PROMPT_PATH",
         "CENTAUR_PERSONA_PROMPT_HASH",
         "CENTAUR_PERSONA_SOURCE_PATH",
         "CENTAUR_PERSONA_SOURCE_REF",
@@ -8005,7 +8003,6 @@ mod tests {
         assert_eq!(spec.files.len(), 1);
         assert_eq!(spec.files[0].target_path, "/home/agent/AGENTS_PERSONA.md");
         assert_eq!(spec.files[0].contents, "eng persona prompt");
-        assert_eq!(env_value(&spec, "CENTAUR_PERSONA_PROMPT_BASE64"), None);
         assert_eq!(
             env_value(&spec, "CENTAUR_PERSONA_PROMPT_HASH"),
             Some(expected_prompt_hash.as_str())

--- a/services/api-rs/crates/centaur-session-runtime/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-runtime/src/lib.rs
@@ -5744,18 +5744,17 @@ fn apply_persona_spec(mut spec: SandboxSpec, persona: Option<&PersonaContext>) -
     ] {
         remove_spec_env(&mut spec, name);
     }
-    spec.home_files
-        .retain(|file| file.path != "AGENTS_PERSONA.md");
+    spec.files
+        .retain(|file| file.target_path != "/home/agent/AGENTS_PERSONA.md");
     let Some(persona) = persona else {
         return spec;
     };
     upsert_spec_env(&mut spec, "AGENT_PERSONA", persona.persona_id.clone());
     upsert_spec_env(&mut spec, "CENTAUR_PERSONA_ID", persona.persona_id.clone());
-    spec.home_files
-        .push(centaur_sandbox_core::SandboxHomeFile::new(
-            "AGENTS_PERSONA.md",
-            persona.prompt.clone(),
-        ));
+    spec.files.push(centaur_sandbox_core::SandboxFile::new(
+        "/home/agent/AGENTS_PERSONA.md",
+        persona.prompt.clone(),
+    ));
     upsert_spec_env(
         &mut spec,
         "CENTAUR_PERSONA_PROMPT_HASH",
@@ -8003,9 +8002,9 @@ mod tests {
 
         assert_eq!(env_value(&spec, "AGENT_PERSONA"), Some("eng"));
         assert_eq!(env_value(&spec, "CENTAUR_PERSONA_ID"), Some("eng"));
-        assert_eq!(spec.home_files.len(), 1);
-        assert_eq!(spec.home_files[0].path, "AGENTS_PERSONA.md");
-        assert_eq!(spec.home_files[0].contents, "eng persona prompt");
+        assert_eq!(spec.files.len(), 1);
+        assert_eq!(spec.files[0].target_path, "/home/agent/AGENTS_PERSONA.md");
+        assert_eq!(spec.files[0].contents, "eng persona prompt");
         assert_eq!(env_value(&spec, "CENTAUR_PERSONA_PROMPT_BASE64"), None);
         assert_eq!(
             env_value(&spec, "CENTAUR_PERSONA_PROMPT_HASH"),
@@ -8016,7 +8015,7 @@ mod tests {
             Some("abc123")
         );
         assert_eq!(env_value(&workload.warm_spec(), "AGENT_PERSONA"), None);
-        assert!(workload.warm_spec().home_files.is_empty());
+        assert!(workload.warm_spec().files.is_empty());
     }
 
     #[test]

--- a/services/api-rs/crates/centaur-session-runtime/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-runtime/src/lib.rs
@@ -13,9 +13,9 @@ use std::{
 
 use centaur_iron_control::{IronControlError, Principal, SessionRegistrar};
 use centaur_sandbox_core::{
-    Mount, RepoCacheAccess, ResourceRequirements, SandboxBackend,
-    SandboxCapabilities as BackendSandboxCapabilities, SandboxError, SandboxId, SandboxIoGuard,
-    SandboxRead, SandboxSpec, SandboxStatus, SandboxWrite,
+    Mount, RepoCacheAccess, ResourceRequirements, SANDBOX_AGENT_HOME, SandboxBackend,
+    SandboxCapabilities as BackendSandboxCapabilities, SandboxError, SandboxFile, SandboxId,
+    SandboxIoGuard, SandboxRead, SandboxSpec, SandboxStatus, SandboxWrite,
 };
 use centaur_sandbox_manager::{
     SandboxManager, SandboxReaper, SandboxReaperConfig, WarmPoolConfig, WarmPoolError,
@@ -5733,6 +5733,7 @@ fn append_spec_env_csv(spec: &mut SandboxSpec, name: &str, values: &str) {
 }
 
 fn apply_persona_spec(mut spec: SandboxSpec, persona: Option<&PersonaContext>) -> SandboxSpec {
+    let persona_prompt_path = format!("{SANDBOX_AGENT_HOME}/AGENTS_PERSONA.md");
     for name in [
         "AGENT_PERSONA",
         "CENTAUR_PERSONA_ID",
@@ -5743,14 +5744,14 @@ fn apply_persona_spec(mut spec: SandboxSpec, persona: Option<&PersonaContext>) -
         remove_spec_env(&mut spec, name);
     }
     spec.files
-        .retain(|file| file.target_path != "/home/agent/AGENTS_PERSONA.md");
+        .retain(|file| file.target_path != persona_prompt_path);
     let Some(persona) = persona else {
         return spec;
     };
     upsert_spec_env(&mut spec, "AGENT_PERSONA", persona.persona_id.clone());
     upsert_spec_env(&mut spec, "CENTAUR_PERSONA_ID", persona.persona_id.clone());
-    spec.files.push(centaur_sandbox_core::SandboxFile::new(
-        "/home/agent/AGENTS_PERSONA.md",
+    spec.files.push(SandboxFile::new(
+        persona_prompt_path,
         persona.prompt.clone(),
     ));
     upsert_spec_env(

--- a/services/api-rs/crates/centaur-session-runtime/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-runtime/src/lib.rs
@@ -11,7 +11,6 @@ use std::{
     time::{Duration, SystemTime},
 };
 
-use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64_STANDARD};
 use centaur_iron_control::{IronControlError, Principal, SessionRegistrar};
 use centaur_sandbox_core::{
     Mount, RepoCacheAccess, ResourceRequirements, SandboxBackend,
@@ -4140,7 +4139,7 @@ impl SandboxWorkloadMode {
         persona: Option<&PersonaContext>,
     ) -> SandboxSpec {
         match self {
-            Self::MockAppServer { image } => apply_persona_spec_env(
+            Self::MockAppServer { image } => apply_persona_spec(
                 SandboxSpec::new(image)
                     .command(["/bin/sh", "-lc"])
                     .args([mock_app_server_script()])
@@ -4173,7 +4172,7 @@ impl SandboxWorkloadMode {
                 for (name, value) in env {
                     spec = spec.env(name.clone(), value.clone());
                 }
-                apply_persona_spec_env(spec, persona)
+                apply_persona_spec(spec, persona)
             }
         }
     }
@@ -5733,27 +5732,30 @@ fn append_spec_env_csv(spec: &mut SandboxSpec, name: &str, values: &str) {
     upsert_spec_env(spec, name, merged.join(","));
 }
 
-fn apply_persona_spec_env(mut spec: SandboxSpec, persona: Option<&PersonaContext>) -> SandboxSpec {
+fn apply_persona_spec(mut spec: SandboxSpec, persona: Option<&PersonaContext>) -> SandboxSpec {
     for name in [
         "AGENT_PERSONA",
         "CENTAUR_PERSONA_ID",
         "CENTAUR_PERSONA_PROMPT_BASE64",
+        "CENTAUR_PERSONA_PROMPT_PATH",
         "CENTAUR_PERSONA_PROMPT_HASH",
         "CENTAUR_PERSONA_SOURCE_PATH",
         "CENTAUR_PERSONA_SOURCE_REF",
     ] {
         remove_spec_env(&mut spec, name);
     }
+    spec.home_files
+        .retain(|file| file.path != "AGENTS_PERSONA.md");
     let Some(persona) = persona else {
         return spec;
     };
     upsert_spec_env(&mut spec, "AGENT_PERSONA", persona.persona_id.clone());
     upsert_spec_env(&mut spec, "CENTAUR_PERSONA_ID", persona.persona_id.clone());
-    upsert_spec_env(
-        &mut spec,
-        "CENTAUR_PERSONA_PROMPT_BASE64",
-        BASE64_STANDARD.encode(persona.prompt.as_bytes()),
-    );
+    spec.home_files
+        .push(centaur_sandbox_core::SandboxHomeFile::new(
+            "AGENTS_PERSONA.md",
+            persona.prompt.clone(),
+        ));
     upsert_spec_env(
         &mut spec,
         "CENTAUR_PERSONA_PROMPT_HASH",
@@ -8001,15 +8003,10 @@ mod tests {
 
         assert_eq!(env_value(&spec, "AGENT_PERSONA"), Some("eng"));
         assert_eq!(env_value(&spec, "CENTAUR_PERSONA_ID"), Some("eng"));
-        assert_eq!(
-            BASE64_STANDARD
-                .decode(
-                    env_value(&spec, "CENTAUR_PERSONA_PROMPT_BASE64")
-                        .expect("persona prompt payload")
-                )
-                .expect("base64 persona prompt"),
-            b"eng persona prompt"
-        );
+        assert_eq!(spec.home_files.len(), 1);
+        assert_eq!(spec.home_files[0].path, "AGENTS_PERSONA.md");
+        assert_eq!(spec.home_files[0].contents, "eng persona prompt");
+        assert_eq!(env_value(&spec, "CENTAUR_PERSONA_PROMPT_BASE64"), None);
         assert_eq!(
             env_value(&spec, "CENTAUR_PERSONA_PROMPT_HASH"),
             Some(expected_prompt_hash.as_str())
@@ -8019,10 +8016,7 @@ mod tests {
             Some("abc123")
         );
         assert_eq!(env_value(&workload.warm_spec(), "AGENT_PERSONA"), None);
-        assert_eq!(
-            env_value(&workload.warm_spec(), "CENTAUR_PERSONA_PROMPT_BASE64"),
-            None
-        );
+        assert!(workload.warm_spec().home_files.is_empty());
     }
 
     #[test]

--- a/services/api-rs/crates/centaur-session-runtime/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-runtime/src/lib.rs
@@ -11,6 +11,7 @@ use std::{
     time::{Duration, SystemTime},
 };
 
+use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64_STANDARD};
 use centaur_iron_control::{IronControlError, Principal, SessionRegistrar};
 use centaur_sandbox_core::{
     Mount, RepoCacheAccess, ResourceRequirements, SandboxBackend,
@@ -195,6 +196,8 @@ pub struct PersonaContext {
     pub source_path: String,
     pub source_ref: Option<String>,
     pub prompt_hash: String,
+    #[serde(skip_serializing)]
+    pub prompt: String,
     pub defaulted: bool,
     pub overlay_chain: Vec<String>,
 }
@@ -281,6 +284,7 @@ impl PersonaRegistry {
             source_path: persona.source_path.clone(),
             source_ref: persona.source_ref.clone(),
             prompt_hash: persona.prompt_hash.clone(),
+            prompt: persona.prompt.clone(),
             defaulted,
             overlay_chain: self.overlay_chain.clone(),
         })
@@ -5733,6 +5737,7 @@ fn apply_persona_spec_env(mut spec: SandboxSpec, persona: Option<&PersonaContext
     for name in [
         "AGENT_PERSONA",
         "CENTAUR_PERSONA_ID",
+        "CENTAUR_PERSONA_PROMPT_BASE64",
         "CENTAUR_PERSONA_PROMPT_HASH",
         "CENTAUR_PERSONA_SOURCE_PATH",
         "CENTAUR_PERSONA_SOURCE_REF",
@@ -5744,6 +5749,11 @@ fn apply_persona_spec_env(mut spec: SandboxSpec, persona: Option<&PersonaContext
     };
     upsert_spec_env(&mut spec, "AGENT_PERSONA", persona.persona_id.clone());
     upsert_spec_env(&mut spec, "CENTAUR_PERSONA_ID", persona.persona_id.clone());
+    upsert_spec_env(
+        &mut spec,
+        "CENTAUR_PERSONA_PROMPT_BASE64",
+        BASE64_STANDARD.encode(persona.prompt.as_bytes()),
+    );
     upsert_spec_env(
         &mut spec,
         "CENTAUR_PERSONA_PROMPT_HASH",
@@ -7209,6 +7219,16 @@ mod tests {
                 .get("prompt")
                 .is_none()
         );
+        let context = registry
+            .context_for_access("eng", false, &SessionRepoCacheAccess::All)
+            .unwrap();
+        assert_eq!(context.prompt, "secret prompt");
+        assert!(
+            serde_json::to_value(context)
+                .unwrap()
+                .get("prompt")
+                .is_none()
+        );
         assert!(PersonaRegistry::new(Vec::new(), Some("missing".to_owned()), Vec::new()).is_err());
     }
 
@@ -7975,20 +7995,34 @@ mod tests {
         );
         let thread_key = ThreadKey::parse("chat:C123:1780000000.000000").unwrap();
         let persona = test_persona_context("eng");
+        let expected_prompt_hash = persona.prompt_hash.clone();
 
         let spec = workload.spec(&thread_key, &HarnessType::Codex, Some(&persona));
 
         assert_eq!(env_value(&spec, "AGENT_PERSONA"), Some("eng"));
         assert_eq!(env_value(&spec, "CENTAUR_PERSONA_ID"), Some("eng"));
         assert_eq!(
+            BASE64_STANDARD
+                .decode(
+                    env_value(&spec, "CENTAUR_PERSONA_PROMPT_BASE64")
+                        .expect("persona prompt payload")
+                )
+                .expect("base64 persona prompt"),
+            b"eng persona prompt"
+        );
+        assert_eq!(
             env_value(&spec, "CENTAUR_PERSONA_PROMPT_HASH"),
-            Some("sha256:prompt")
+            Some(expected_prompt_hash.as_str())
         );
         assert_eq!(
             env_value(&spec, "CENTAUR_PERSONA_SOURCE_REF"),
             Some("abc123")
         );
         assert_eq!(env_value(&workload.warm_spec(), "AGENT_PERSONA"), None);
+        assert_eq!(
+            env_value(&workload.warm_spec(), "CENTAUR_PERSONA_PROMPT_BASE64"),
+            None
+        );
     }
 
     #[test]
@@ -8463,12 +8497,14 @@ mod tests {
     }
 
     fn test_persona_context(persona_id: &str) -> PersonaContext {
+        let prompt = format!("{persona_id} persona prompt");
         PersonaContext {
             persona_id: persona_id.to_owned(),
             source_root: "/repo/tools".to_owned(),
             source_path: format!("/repo/tools/personas/{persona_id}"),
             source_ref: Some("abc123".to_owned()),
-            prompt_hash: "sha256:prompt".to_owned(),
+            prompt_hash: format!("sha256:{}", hex::encode(Sha256::digest(prompt.as_bytes()))),
+            prompt,
             defaulted: false,
             overlay_chain: vec!["/repo/tools".to_owned()],
         }

--- a/services/sandbox/compose_system_prompt.py
+++ b/services/sandbox/compose_system_prompt.py
@@ -2,20 +2,28 @@
 from __future__ import annotations
 
 import argparse
+import base64
+import binascii
+import hashlib
 import os
 from pathlib import Path
 
 
 SEPARATOR = "\n\n---\n\n"
 OVERLAY_PROMPT = Path("services/sandbox/SYSTEM_PROMPT.md")
+OBSERVABILITY_DISABLED_PROMPT = """[Observability access]
+This sandbox does not have Centaur observability access. Do not use vlogs, vmetrics, Grafana, or related internal logs/metrics tools.
+"""
 
 
-def _append_prompt(target: Path, source: Path) -> bool:
-    if not source.is_file() or not target.is_file():
+def _sha256(contents: str) -> str:
+    return f"sha256:{hashlib.sha256(contents.encode()).hexdigest()}"
+
+
+def _append_file_fragment(fragments: list[str], source: Path) -> bool:
+    if not source.is_file():
         return False
-    with target.open("a") as target_file:
-        target_file.write(SEPARATOR)
-        target_file.write(source.read_text())
+    fragments.append(source.read_text())
     return True
 
 
@@ -35,20 +43,38 @@ def compose_system_prompt(
     home_dir: Path,
     target_prompt: Path,
     repo_mount: Path,
+    persona_id: str | None = None,
+    persona_prompt: str | None = None,
+    persona_prompt_hash: str | None = None,
+    observability_enabled: bool = True,
 ) -> None:
     base_prompt = home_dir / "AGENTS_BASE.md"
     baked_prompt = home_dir / "AGENTS.md"
-    if base_prompt.is_file():
-        target_prompt.write_text(base_prompt.read_text())
-    elif baked_prompt.is_file():
-        target_prompt.write_text(baked_prompt.read_text())
-    else:
+    selected_base = base_prompt if base_prompt.is_file() else baked_prompt
+    if not selected_base.is_file():
         return
 
+    persona_fields = (persona_id, persona_prompt, persona_prompt_hash)
+    if any(value is not None for value in persona_fields) and not all(
+        value is not None for value in persona_fields
+    ):
+        raise ValueError(
+            "persona id, prompt, and prompt hash must either all be set or all be absent"
+        )
+    if persona_id == "":
+        raise ValueError("persona id must not be empty")
+    if persona_prompt is not None:
+        actual_hash = _sha256(persona_prompt)
+        if actual_hash != persona_prompt_hash:
+            raise ValueError(
+                f"persona prompt hash mismatch: expected {persona_prompt_hash}, got {actual_hash}"
+            )
+
+    fragments = [selected_base.read_text()]
     appended: set[Path] = set()
 
     home_overlay = home_dir / "AGENTS_OVERLAY.md"
-    if _append_prompt(target_prompt, home_overlay):
+    if _append_file_fragment(fragments, home_overlay):
         appended.add(home_overlay.resolve())
 
     for prompt_path in _mounted_overlay_prompts(repo_mount, baked_prompt):
@@ -57,8 +83,27 @@ def compose_system_prompt(
         resolved = prompt_path.resolve()
         if resolved in appended:
             continue
-        if _append_prompt(target_prompt, prompt_path):
+        if _append_file_fragment(fragments, prompt_path):
             appended.add(resolved)
+
+    if persona_prompt is not None:
+        fragments.append(persona_prompt)
+
+    if not observability_enabled:
+        fragments.append(OBSERVABILITY_DISABLED_PROMPT)
+
+    effective_prompt = SEPARATOR.join(fragments)
+    target_prompt.write_text(effective_prompt)
+
+
+def _persona_prompt_from_environment() -> str | None:
+    encoded = os.environ.get("CENTAUR_PERSONA_PROMPT_BASE64")
+    if encoded is None:
+        return None
+    try:
+        return base64.b64decode(encoded, validate=True).decode("utf-8")
+    except (binascii.Error, UnicodeDecodeError) as error:
+        raise ValueError("CENTAUR_PERSONA_PROMPT_BASE64 is not valid base64 UTF-8") from error
 
 
 def main() -> int:
@@ -73,6 +118,13 @@ def main() -> int:
         home_dir=home_dir,
         target_prompt=Path(args.target_prompt),
         repo_mount=Path(args.repo_mount) if args.repo_mount else home_dir / "github",
+        persona_id=os.environ.get("CENTAUR_PERSONA_ID"),
+        persona_prompt=_persona_prompt_from_environment(),
+        persona_prompt_hash=os.environ.get("CENTAUR_PERSONA_PROMPT_HASH"),
+        observability_enabled=os.environ.get(
+            "CENTAUR_SANDBOX_OBSERVABILITY_ENABLED", "true"
+        ).lower()
+        != "false",
     )
     return 0
 

--- a/services/sandbox/compose_system_prompt.py
+++ b/services/sandbox/compose_system_prompt.py
@@ -2,22 +2,16 @@
 from __future__ import annotations
 
 import argparse
-import base64
-import binascii
-import hashlib
 import os
 from pathlib import Path
 
 
 SEPARATOR = "\n\n---\n\n"
 OVERLAY_PROMPT = Path("services/sandbox/SYSTEM_PROMPT.md")
+PERSONA_PROMPT = Path("AGENTS_PERSONA.md")
 OBSERVABILITY_DISABLED_PROMPT = """[Observability access]
 This sandbox does not have Centaur observability access. Do not use vlogs, vmetrics, Grafana, or related internal logs/metrics tools.
 """
-
-
-def _sha256(contents: str) -> str:
-    return f"sha256:{hashlib.sha256(contents.encode()).hexdigest()}"
 
 
 def _append_file_fragment(fragments: list[str], source: Path) -> bool:
@@ -43,9 +37,6 @@ def compose_system_prompt(
     home_dir: Path,
     target_prompt: Path,
     repo_mount: Path,
-    persona_id: str | None = None,
-    persona_prompt: str | None = None,
-    persona_prompt_hash: str | None = None,
     observability_enabled: bool = True,
 ) -> None:
     base_prompt = home_dir / "AGENTS_BASE.md"
@@ -53,22 +44,6 @@ def compose_system_prompt(
     selected_base = base_prompt if base_prompt.is_file() else baked_prompt
     if not selected_base.is_file():
         return
-
-    persona_fields = (persona_id, persona_prompt, persona_prompt_hash)
-    if any(value is not None for value in persona_fields) and not all(
-        value is not None for value in persona_fields
-    ):
-        raise ValueError(
-            "persona id, prompt, and prompt hash must either all be set or all be absent"
-        )
-    if persona_id == "":
-        raise ValueError("persona id must not be empty")
-    if persona_prompt is not None:
-        actual_hash = _sha256(persona_prompt)
-        if actual_hash != persona_prompt_hash:
-            raise ValueError(
-                f"persona prompt hash mismatch: expected {persona_prompt_hash}, got {actual_hash}"
-            )
 
     fragments = [selected_base.read_text()]
     appended: set[Path] = set()
@@ -86,24 +61,15 @@ def compose_system_prompt(
         if _append_file_fragment(fragments, prompt_path):
             appended.add(resolved)
 
-    if persona_prompt is not None:
-        fragments.append(persona_prompt)
+    persona_prompt_path = home_dir / PERSONA_PROMPT
+    if persona_prompt_path.is_file():
+        fragments.append(persona_prompt_path.read_text())
 
     if not observability_enabled:
         fragments.append(OBSERVABILITY_DISABLED_PROMPT)
 
     effective_prompt = SEPARATOR.join(fragments)
     target_prompt.write_text(effective_prompt)
-
-
-def _persona_prompt_from_environment() -> str | None:
-    encoded = os.environ.get("CENTAUR_PERSONA_PROMPT_BASE64")
-    if encoded is None:
-        return None
-    try:
-        return base64.b64decode(encoded, validate=True).decode("utf-8")
-    except (binascii.Error, UnicodeDecodeError) as error:
-        raise ValueError("CENTAUR_PERSONA_PROMPT_BASE64 is not valid base64 UTF-8") from error
 
 
 def main() -> int:
@@ -118,9 +84,6 @@ def main() -> int:
         home_dir=home_dir,
         target_prompt=Path(args.target_prompt),
         repo_mount=Path(args.repo_mount) if args.repo_mount else home_dir / "github",
-        persona_id=os.environ.get("CENTAUR_PERSONA_ID"),
-        persona_prompt=_persona_prompt_from_environment(),
-        persona_prompt_hash=os.environ.get("CENTAUR_PERSONA_PROMPT_HASH"),
         observability_enabled=os.environ.get(
             "CENTAUR_SANDBOX_OBSERVABILITY_ENABLED", "true"
         ).lower()

--- a/services/sandbox/entrypoint.sh
+++ b/services/sandbox/entrypoint.sh
@@ -437,19 +437,9 @@ unset _centaur_tools_auto_reload
 # Base prompt: mounted as AGENTS_BASE.md when present, fallback to baked-in AGENTS.md.
 # Prompt overlays from mounted repos are appended when present.
 TARGET_PROMPT="$WORKSPACE_DIR/AGENTS.md"
-compose-system-prompt --home-dir "$HOME_DIR" --target-prompt "$TARGET_PROMPT"
-
-if [ "${CENTAUR_SANDBOX_OBSERVABILITY_ENABLED:-true}" = "false" ] && [ -f "$TARGET_PROMPT" ]; then
-    cat >> "$TARGET_PROMPT" <<'EOF'
-
----
-
-[Observability access]
-This sandbox does not have Centaur observability access. Do not use vlogs, vmetrics, Grafana, or related internal logs/metrics tools.
-EOF
-fi
-
-# Persona prompt injection is done by the API when it writes AGENTS_BASE.md.
+compose-system-prompt \
+    --home-dir "$HOME_DIR" \
+    --target-prompt "$TARGET_PROMPT"
 
 # Switch to workspace so the harness reads workspace/AGENTS.md (with persona overlay)
 cd "$WORKSPACE_DIR"

--- a/services/sandbox/entrypoint.sh
+++ b/services/sandbox/entrypoint.sh
@@ -436,6 +436,7 @@ unset _centaur_tools_auto_reload
 # ── Assemble system prompt from bind mounts ──────────────────────────────────
 # Base prompt: mounted as AGENTS_BASE.md when present, fallback to baked-in AGENTS.md.
 # Prompt overlays from mounted repos are appended when present.
+# The selected persona is appended when AGENTS_PERSONA.md exists in the sandbox home.
 TARGET_PROMPT="$WORKSPACE_DIR/AGENTS.md"
 compose-system-prompt \
     --home-dir "$HOME_DIR" \

--- a/services/sandbox/test_compose_system_prompt.py
+++ b/services/sandbox/test_compose_system_prompt.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import os
 import tempfile
 import unittest
+from unittest import mock
 from pathlib import Path
 
 import compose_system_prompt
@@ -63,6 +65,76 @@ class ComposeSystemPromptTest(unittest.TestCase):
             self.assertEqual(
                 target.read_text(),
                 "persona base\n\n\n---\n\nhome overlay\n\n\n---\n\nrepo overlay\n",
+            )
+
+    def test_appends_persona_after_deployment_overlays_and_restrictions_last(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            home = root / "home"
+            workspace = root / "workspace"
+            home.mkdir()
+            workspace.mkdir()
+            (home / "AGENTS.md").write_text("base\n")
+            (home / "AGENTS_OVERLAY.md").write_text("home overlay\n")
+
+            repo_mount = home / "github"
+            repo_overlay = (
+                repo_mount
+                / "acme"
+                / "overlay"
+                / "services"
+                / "sandbox"
+                / "SYSTEM_PROMPT.md"
+            )
+            repo_overlay.parent.mkdir(parents=True)
+            repo_overlay.write_text("repo overlay\n")
+
+            persona_prompt = "engineering persona\n"
+            target = workspace / "AGENTS.md"
+            compose_system_prompt.compose_system_prompt(
+                home_dir=home,
+                target_prompt=target,
+                repo_mount=repo_mount,
+                persona_id="eng",
+                persona_prompt=persona_prompt,
+                persona_prompt_hash=compose_system_prompt._sha256(persona_prompt),
+                observability_enabled=False,
+            )
+
+            self.assertEqual(
+                target.read_text(),
+                "base\n\n\n---\n\nhome overlay\n\n\n---\n\nrepo overlay\n"
+                "\n\n---\n\nengineering persona\n\n\n---\n\n"
+                f"{compose_system_prompt.OBSERVABILITY_DISABLED_PROMPT}",
+            )
+
+    def test_rejects_persona_prompt_with_wrong_hash(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            home = root / "home"
+            workspace = root / "workspace"
+            home.mkdir()
+            workspace.mkdir()
+            (home / "AGENTS.md").write_text("base\n")
+
+            with self.assertRaisesRegex(ValueError, "persona prompt hash mismatch"):
+                compose_system_prompt.compose_system_prompt(
+                    home_dir=home,
+                    target_prompt=workspace / "AGENTS.md",
+                    repo_mount=home / "github",
+                    persona_id="eng",
+                    persona_prompt="engineering persona\n",
+                    persona_prompt_hash="sha256:wrong",
+                )
+
+    def test_decodes_persona_prompt_bootstrap_payload(self) -> None:
+        with mock.patch.dict(
+            os.environ,
+            {"CENTAUR_PERSONA_PROMPT_BASE64": "ZW5naW5lZXJpbmcgcGVyc29uYQo="},
+        ):
+            self.assertEqual(
+                compose_system_prompt._persona_prompt_from_environment(),
+                "engineering persona\n",
             )
 
     def test_skips_mounted_copy_of_baked_root_prompt(self) -> None:

--- a/services/sandbox/test_compose_system_prompt.py
+++ b/services/sandbox/test_compose_system_prompt.py
@@ -1,9 +1,7 @@
 from __future__ import annotations
 
-import os
 import tempfile
 import unittest
-from unittest import mock
 from pathlib import Path
 
 import compose_system_prompt
@@ -90,14 +88,12 @@ class ComposeSystemPromptTest(unittest.TestCase):
             repo_overlay.write_text("repo overlay\n")
 
             persona_prompt = "engineering persona\n"
+            (home / "AGENTS_PERSONA.md").write_text(persona_prompt)
             target = workspace / "AGENTS.md"
             compose_system_prompt.compose_system_prompt(
                 home_dir=home,
                 target_prompt=target,
                 repo_mount=repo_mount,
-                persona_id="eng",
-                persona_prompt=persona_prompt,
-                persona_prompt_hash=compose_system_prompt._sha256(persona_prompt),
                 observability_enabled=False,
             )
 
@@ -106,35 +102,6 @@ class ComposeSystemPromptTest(unittest.TestCase):
                 "base\n\n\n---\n\nhome overlay\n\n\n---\n\nrepo overlay\n"
                 "\n\n---\n\nengineering persona\n\n\n---\n\n"
                 f"{compose_system_prompt.OBSERVABILITY_DISABLED_PROMPT}",
-            )
-
-    def test_rejects_persona_prompt_with_wrong_hash(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp:
-            root = Path(tmp)
-            home = root / "home"
-            workspace = root / "workspace"
-            home.mkdir()
-            workspace.mkdir()
-            (home / "AGENTS.md").write_text("base\n")
-
-            with self.assertRaisesRegex(ValueError, "persona prompt hash mismatch"):
-                compose_system_prompt.compose_system_prompt(
-                    home_dir=home,
-                    target_prompt=workspace / "AGENTS.md",
-                    repo_mount=home / "github",
-                    persona_id="eng",
-                    persona_prompt="engineering persona\n",
-                    persona_prompt_hash="sha256:wrong",
-                )
-
-    def test_decodes_persona_prompt_bootstrap_payload(self) -> None:
-        with mock.patch.dict(
-            os.environ,
-            {"CENTAUR_PERSONA_PROMPT_BASE64": "ZW5naW5lZXJpbmcgcGVyc29uYQo="},
-        ):
-            self.assertEqual(
-                compose_system_prompt._persona_prompt_from_environment(),
-                "engineering persona\n",
             )
 
     def test_skips_mounted_copy_of_baked_root_prompt(self) -> None:


### PR DESCRIPTION
Materializes the selected persona as a read-only /home/agent/AGENTS_PERSONA.md file and appends it to the effective AGENTS.md when the file exists. Adds generic backend-neutral sandbox file delivery with explicit absolute target paths, backed by read-only ConfigMap mounts on Kubernetes and safe /home/agent emulation for the local backend. Deployment overlays remain ahead of the persona, with capability restrictions applied last.