### PR TITLE
feat(gsuite): add Google Slides editing

### DIFF
--- a/tools/productivity/gsuite/cli.py
+++ b/tools/productivity/gsuite/cli.py
@@ -1620,6 +1620,52 @@ def sheets_create_cmd(
 # Slides commands
 
 
+@slides_app.command("get")
+def slides_get_cmd(
+    presentation_id: str = typer.Argument(..., help="Presentation ID or Google Slides URL"),
+):
+    """Get a Google Slides presentation as JSON."""
+    from .client import slides_get
+
+    result = slides_get(extract_drive_file_id(presentation_id))
+    print(json.dumps(result, indent=2, ensure_ascii=False))
+
+
+@slides_app.command("batch-update")
+def slides_batch_update_cmd(
+    presentation_id: str = typer.Argument(..., help="Presentation ID or Google Slides URL"),
+    requests_file: Path = typer.Argument(
+        ...,
+        exists=True,
+        dir_okay=False,
+        readable=True,
+        help="JSON file containing a request array or an object with a requests array",
+    ),
+    required_revision_id: str | None = typer.Option(
+        None,
+        "--required-revision-id",
+        help="Only update if this presentation revision is still current",
+    ),
+):
+    """Apply native Google Slides API batchUpdate requests from a JSON file."""
+    from .client import slides_batch_update
+
+    try:
+        payload = json.loads(requests_file.read_text())
+        requests = payload.get("requests") if isinstance(payload, dict) else payload
+        if not isinstance(requests, list):
+            raise ValueError("JSON must be a request array or an object with a requests array")
+        result = slides_batch_update(
+            extract_drive_file_id(presentation_id),
+            requests,
+            required_revision_id=required_revision_id,
+        )
+        print(json.dumps(result, indent=2, ensure_ascii=False))
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        console.print(f"[red]Error: {exc}[/]")
+        raise typer.Exit(1) from exc
+
+
 @slides_app.command("create")
 def slides_create_cmd(
     title: str = typer.Argument(..., help="Presentation title"),

--- a/tools/productivity/gsuite/client.py
+++ b/tools/productivity/gsuite/client.py
@@ -2345,6 +2345,54 @@ def slides_create(title: str) -> dict:
     }
 
 
+def slides_get(presentation_id: str) -> dict:
+    """Get a Google Slides presentation, including its current revision ID.
+
+    Args:
+        presentation_id: The presentation ID (from URL)
+
+    Returns:
+        The Google Slides presentation resource
+    """
+    service = get_slides_service()
+    return service.presentations().get(presentationId=presentation_id).execute()
+
+
+def slides_batch_update(
+    presentation_id: str,
+    requests: list[dict],
+    required_revision_id: str | None = None,
+) -> dict:
+    """Apply native Google Slides API requests to a presentation.
+
+    Args:
+        presentation_id: The presentation ID (from URL)
+        requests: Google Slides API batchUpdate request objects
+        required_revision_id: Optional revision that must still be current
+
+    Returns:
+        Dict with the presentation ID, replies, and resulting revision ID
+    """
+    if not requests or any(not isinstance(request, dict) for request in requests):
+        raise ValueError("requests must be a non-empty list of request objects")
+
+    service = get_slides_service()
+    body: dict = {"requests": requests}
+    if required_revision_id:
+        body["writeControl"] = {"requiredRevisionId": required_revision_id}
+
+    result = (
+        service.presentations()
+        .batchUpdate(presentationId=presentation_id, body=body)
+        .execute()
+    )
+    return {
+        "presentation_id": result.get("presentationId", presentation_id),
+        "replies": result.get("replies", []),
+        "revision_id": result.get("writeControl", {}).get("requiredRevisionId", ""),
+    }
+
+
 # Google Analytics functions
 
 _analytics_property_id: str | None = None
@@ -3513,6 +3561,39 @@ class GSuiteClient:
             Dict with presentation_id, title, and url
         """
         return slides_create(title)
+
+    def slides_get(self, presentation_id: str) -> dict:
+        """Get a Google Slides presentation, including its current revision ID.
+
+        Args:
+            presentation_id: The presentation ID (from URL)
+
+        Returns:
+            The Google Slides presentation resource
+        """
+        return slides_get(presentation_id)
+
+    def slides_batch_update(
+        self,
+        presentation_id: str,
+        requests: list[dict],
+        required_revision_id: str | None = None,
+    ) -> dict:
+        """Apply native Google Slides API requests to a presentation.
+
+        Args:
+            presentation_id: The presentation ID (from URL)
+            requests: Google Slides API batchUpdate request objects
+            required_revision_id: Optional revision that must still be current
+
+        Returns:
+            Dict with the presentation ID, replies, and resulting revision ID
+        """
+        return slides_batch_update(
+            presentation_id,
+            requests,
+            required_revision_id=required_revision_id,
+        )
 
     # --- Analytics ---
 

--- a/tools/productivity/gsuite/test_cli.py
+++ b/tools/productivity/gsuite/test_cli.py
@@ -25,6 +25,75 @@ def test_extract_drive_file_id_accepts_editor_and_drive_urls():
     assert extract_drive_file_id("raw-file-id") == "raw-file-id"
 
 
+def test_slides_get_command_accepts_url_and_outputs_json(monkeypatch):
+    calls: list[str] = []
+    monkeypatch.setattr(
+        client,
+        "slides_get",
+        lambda presentation_id: (
+            calls.append(presentation_id)
+            or {"presentationId": presentation_id, "revisionId": "rev-123"}
+        ),
+    )
+
+    result = runner.invoke(
+        app,
+        ["slides", "get", "https://docs.google.com/presentation/d/slides-123/edit"],
+    )
+
+    assert result.exit_code == 0
+    assert json.loads(result.output)["revisionId"] == "rev-123"
+    assert calls == ["slides-123"]
+
+
+def test_slides_batch_update_command_reads_requests_file(tmp_path, monkeypatch):
+    calls: list[dict] = []
+    requests_file = tmp_path / "requests.json"
+    requests_file.write_text(
+        json.dumps({"requests": [{"createSlide": {"objectId": "slide-2"}}]})
+    )
+    monkeypatch.setattr(
+        client,
+        "slides_batch_update",
+        lambda presentation_id, requests, required_revision_id: (
+            calls.append(
+                {
+                    "presentation_id": presentation_id,
+                    "requests": requests,
+                    "required_revision_id": required_revision_id,
+                }
+            )
+            or {
+                "presentation_id": presentation_id,
+                "replies": [{}],
+                "revision_id": "rev-124",
+            }
+        ),
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "slides",
+            "batch-update",
+            "slides-123",
+            str(requests_file),
+            "--required-revision-id",
+            "rev-123",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert json.loads(result.output)["revision_id"] == "rev-124"
+    assert calls == [
+        {
+            "presentation_id": "slides-123",
+            "requests": [{"createSlide": {"objectId": "slide-2"}}],
+            "required_revision_id": "rev-123",
+        }
+    ]
+
+
 def test_drive_list_full_text_flag_is_passed_to_client(monkeypatch):
     calls: list[dict] = []
 

--- a/tools/productivity/gsuite/test_client.py
+++ b/tools/productivity/gsuite/test_client.py
@@ -230,6 +230,95 @@ class _FakeDocsService:
         return self.documents_api
 
 
+class _FakeSlidesPresentationsApi:
+    def __init__(self):
+        self.get_calls: list[dict] = []
+        self.batch_update_calls: list[dict] = []
+
+    def get(self, **kwargs):
+        self.get_calls.append(kwargs)
+        return _CreateRequest(
+            {
+                "presentationId": kwargs["presentationId"],
+                "title": "Asset One-Pagers",
+                "revisionId": "rev-123",
+                "slides": [],
+            }
+        )
+
+    def batchUpdate(self, **kwargs):
+        self.batch_update_calls.append(kwargs)
+        return _CreateRequest(
+            {
+                "presentationId": kwargs["presentationId"],
+                "replies": [{} for _ in kwargs["body"]["requests"]],
+                "writeControl": {"requiredRevisionId": "rev-124"},
+            }
+        )
+
+
+class _FakeSlidesService:
+    def __init__(self):
+        self.presentations_api = _FakeSlidesPresentationsApi()
+
+    def presentations(self):
+        return self.presentations_api
+
+
+def test_slides_get_returns_presentation_and_revision(monkeypatch):
+    fake_service = _FakeSlidesService()
+    monkeypatch.setattr(client, "get_slides_service", lambda: fake_service)
+
+    result = client.slides_get("slides-123")
+
+    assert result["presentationId"] == "slides-123"
+    assert result["revisionId"] == "rev-123"
+    assert fake_service.presentations_api.get_calls == [
+        {"presentationId": "slides-123"}
+    ]
+
+
+def test_slides_batch_update_uses_revision_guard(monkeypatch):
+    fake_service = _FakeSlidesService()
+    monkeypatch.setattr(client, "get_slides_service", lambda: fake_service)
+    requests = [{"createSlide": {"objectId": "slide-2"}}]
+
+    result = client.slides_batch_update(
+        "slides-123",
+        requests,
+        required_revision_id="rev-123",
+    )
+
+    assert result == {
+        "presentation_id": "slides-123",
+        "replies": [{}],
+        "revision_id": "rev-124",
+    }
+    assert fake_service.presentations_api.batch_update_calls == [
+        {
+            "presentationId": "slides-123",
+            "body": {
+                "requests": requests,
+                "writeControl": {"requiredRevisionId": "rev-123"},
+            },
+        }
+    ]
+
+
+def test_slides_batch_update_rejects_empty_requests(monkeypatch):
+    fake_service = _FakeSlidesService()
+    monkeypatch.setattr(client, "get_slides_service", lambda: fake_service)
+
+    try:
+        client.slides_batch_update("slides-123", [])
+    except ValueError as exc:
+        assert str(exc) == "requests must be a non-empty list of request objects"
+    else:
+        raise AssertionError("Expected ValueError")
+
+    assert fake_service.presentations_api.batch_update_calls == []
+
+
 def _paragraph(start_index: int, text: str, *, bullet: bool = False) -> dict:
     paragraph = {"elements": [{"textRun": {"content": text}}]}
     if bullet:


### PR DESCRIPTION
## Summary

- add a read command for existing Google Slides presentations
- add native Slides batch updates with optional revision guards
- expose both operations through the agent client and CLI

## Validation

- 44 gsuite client and CLI tests passed
- live read of the referenced presentation succeeded and returned its revision ID
- focused Ruff fatal-error checks and git diff checks passed

Prompted by: @imfromthebay