### PR TITLE
fix(k8s): restart iron-proxy containers on failure

### DIFF
--- a/services/api-rs/crates/centaur-sandbox-agent-k8s/src/iron_proxy.rs
+++ b/services/api-rs/crates/centaur-sandbox-agent-k8s/src/iron_proxy.rs
@@ -1272,7 +1272,14 @@ fn build_iron_proxy_pod(
         ),
         spec: Some(PodSpec {
             automount_service_account_token: Some(false),
-            restart_policy: Some("Never".to_owned()),
+            // OnFailure so a crashed/OOM-killed proxy container is restarted
+            // in place (same pod IP, Service keeps routing) instead of leaving
+            // the pod Failed and the sandbox with no egress for the rest of
+            // the session: nothing repairs a dead proxy until the next
+            // execute. A 512Mi limit + Never turned proxy OOM kills into 40+
+            // mid-turn "stream disconnected" failures (2026-08-27/28,
+            // prd-centaur-na).
+            restart_policy: Some("OnFailure".to_owned()),
             containers: vec![iron_proxy_container(iron_proxy, resolved, sync)],
             volumes: Some(iron_proxy_volumes(iron_proxy)),
             // Co-locate the per-sandbox proxy with its sandbox: it scales 1:1


### PR DESCRIPTION
## Problem

Per-sandbox iron-proxy pods are created with `restartPolicy: Never`. Any container crash leaves the pod permanently `Failed` while the sandbox keeps running with **zero egress** — Codex gets connection refused to api.openai.com, in-sandbox tools fail, and the turn dies. Nothing repairs the proxy until the next session execute (`assign_proxy_principal` → recreate), so every in-flight turn on that sandbox is lost and the user has to re-message.

This went from latent to load-bearing on prd-centaur-na when tempoxyz/prd-centaur-infra#669 added a 512Mi memory limit to proxy pods: iron-proxy buffers bodies while proxying, so large transfers burst from ~8Mi past the limit in seconds (one pod OOMed 17s after start). Result: 40+ mid-turn failures with `stream disconnected before completion: error sending request for url (https://api.openai.com/v1/responses)` since 2026-08-27 01:54 UTC, plus an OOM-kill wave on the node (node_vmstat_oom_kill 34/101/31 per 3h). Three proxy pods were sitting Failed/OOMKilled (exit 137) during the investigation, each followed ~30s later by a failed execution with that exact error.

## Fix

`OnFailure`: the kubelet restarts the container in place — same pod IP, the per-sandbox Service keeps routing, and the proxy re-syncs its principal config from iron-control on startup — so an OOM becomes a seconds-long blip instead of a dead session.

Interaction with existing logic:
- `pod_running()` requires the `Ready` condition, so `has_usable_iron_proxy_resources` still reports a crash-looping proxy as unusable.
- `wait_until_proxy_running` no longer fails fast on a first startup crash (`pod_stopped` is effectively unreachable under OnFailure); a proxy that never comes up is now bounded by `ready_timeout`.

Immediate mitigation for the limit itself: tempoxyz/prd-centaur-infra#671 (512Mi → 2Gi). Longer-term the buffering burst deserves a streaming fix in iron-proxy.

## Testing

- `cargo test -p centaur-sandbox-agent-k8s` (64 passed)
- `cargo clippy -p centaur-sandbox-agent-k8s` clean

Investigation: https://ampcode.com/threads/T-01a048d9-a0bb-72f0-b6cd-4769da726fdc