### PR TITLE
docs: propose overlay-native external MCP servers

### DIFF
--- a/services/api-rs/rfcs/0006-overlay-native-external-mcp.md
+++ b/services/api-rs/rfcs/0006-overlay-native-external-mcp.md
@@ -8,150 +8,94 @@ Target: `services/api-rs`, `services/sandbox`, `services/console`,
 ## Summary
 
 Let an overlay register a remote Model Context Protocol server by extending the
-existing per-tool `pyproject.toml` contract. Centaur should discover one typed,
-normalized declaration, publish it as versioned control-plane state, render the
-authorized server into each supported harness, and compile the same declaration
-into principal-scoped iron-proxy gateway, egress, credential, protocol, and tool
-policy.
+existing per-tool `pyproject.toml` contract. Centaur should discover one typed
+declaration, publish it as versioned control-plane state, render the authorized
+server into each supported harness, and compile the same declaration into
+principal-scoped iron-proxy route, egress, credential, method, and tool policy.
 
-Version 1 is deliberately a **remote, tool-only Streamable HTTP profile**. It
-allows the MCP lifecycle plus `tools/list` and explicitly authorized
-`tools/call` requests. Resources, prompts, completion, sampling, roots,
-elicitation, logging control, unknown methods, and local stdio servers remain
-out of scope until Centaur can enforce them explicitly in both protocol
-directions.
-
-An operator should not need to:
-
-- hand-write a different MCP config for every harness;
-- copy a token into a sandbox;
-- implement a bespoke Python JSON-RPC client for every MCP server; or
-- add a second root-level overlay manifest that duplicates tool, secret, role,
-  and source metadata Centaur already discovers.
+Version 1 is a remote, tool-only Streamable HTTP profile. It supports the MCP
+lifecycle, `tools/list`, and explicitly authorized `tools/call` requests.
+Resources, prompts, sampling, roots, elicitation, unrestricted extension
+methods, general MCP OAuth, and local stdio servers are deferred until Centaur
+can enforce them explicitly.
 
 The proposed unit remains a tool package directory, but its capabilities become
 explicit. A directory may provide a CLI, one remote MCP server, or both. An
 MCP-only directory does not synthesize a CLI or appear in Centaur's existing
-public `/mcp` tool catalog. Skills remain in `.agents/skills/`, where the overlay
-loader already supports them, and may use the same slug to document the
-corresponding CLI and MCP capability.
+public `/mcp` tool catalog. Matching skills remain instructions only and grant
+no CLI, MCP, network, or credential access.
 
-This RFC covers Centaur acting as an MCP **client** inside agent sandboxes. It
-does not replace or modify the existing `/mcp` endpoint, where Centaur acts as
-an MCP server for external clients.
+This RFC covers Centaur acting as an MCP client inside agent sandboxes. It does
+not replace or modify the existing `/mcp` endpoint, where Centaur acts as an MCP
+server for external clients.
 
 ## Motivation
 
-Centaur has native overlay delivery for tools, workflows, skills, personas, and
-prompts. Tools already use `pyproject.toml` as a declarative boundary for CLI
-scripts, secret references, allowed credential hosts, and per-tool labels.
-There is no equivalent supported path for a sandbox to consume a third-party
-MCP server.
-
 The current escape hatch is harness-specific configuration such as
-`CODEX_CONFIG_OVERLAY`. It can make a remote server reachable, but it is not a
-sufficient product contract because it:
+`CODEX_CONFIG_OVERLAY`. It proves a remote MCP server can be reached, but it
+does not provide a shared declaration, principal-scoped visibility, managed
+proxy policy, route-only credential delivery, or warm-pool lifecycle handling.
 
-- configures one harness rather than all supported harnesses;
-- is deployment-wide rather than a discovered overlay capability;
-- does not create principal-scoped managed proxy policy;
-- cannot safely bind a credential only to an MCP gateway route;
-- cannot drive principal-specific discoverability;
-- has no shared validation for URLs, transports, methods, tools, credentials,
-  or route identity; and
-- cannot participate in warm-pool assignment and revocation barriers.
-
-The repository also contains MCP-specific clients for individual integrations.
-Those clients prove demand but repeat transport, session, error, and response
-parsing that a shared MCP implementation should own once.
+Bespoke Python MCP clients solve individual integrations but repeat transport,
+session, SSE, error, schema, and protocol handling. A shared declaration should
+drive both the native harness configuration and the actual authorization
+boundary.
 
 Related work:
 
 - [#1176](https://github.com/paradigmxyz/centaur/issues/1176) describes the
-  external-MCP client gap and a working Codex-only configuration workaround.
-- [#1385](https://github.com/paradigmxyz/centaur/issues/1385) explains why the
-  static `iron-proxy.yaml` allowlist is not a Kubernetes managed-mode control
-  surface.
+  external-MCP client gap.
+- [#1385](https://github.com/paradigmxyz/centaur/issues/1385) explains why
+  static `iron-proxy.yaml` changes do not cover Kubernetes managed mode.
 - [#205](https://github.com/paradigmxyz/centaur/pull/205) identified protocol
   headers required by stateful Streamable HTTP sessions.
 - [#883](https://github.com/paradigmxyz/centaur/pull/883) proposes role-based
-  visibility for Centaur's MCP server direction. This RFC follows the same
-  role-oriented control-plane pattern without depending on that PR being
-  merged.
+  tool visibility in the opposite MCP direction.
 - [#841](https://github.com/paradigmxyz/centaur/pull/841) implements Centaur as
-  an MCP server. This RFC addresses the opposite direction.
+  an MCP server.
 
 ## Goals
 
 - Declare a remote Streamable HTTP MCP server in an overlay tool directory.
 - Make CLI and external MCP capabilities independently discoverable and
   grantable.
-- Use one normalized declaration to configure every supported harness.
-- Reuse existing secret source types and grant patterns without turning an MCP
-  credential into a generic host-scoped sandbox credential.
+- Use one normalized declaration for every supported harness and for managed
+  proxy policy.
+- Reuse existing secret declarations and source types without granting the MCP
+  credential as a generic host-scoped sandbox secret.
 - Keep real credentials out of sandbox files, environment variables, process
   arguments, and logs.
-- Route every authorized MCP connection through a generated gateway route whose
-  upstream egress and optional credential are route-only.
-- Apply default-deny MCP method and tool policy at the iron-proxy boundary in
-  both protocol directions.
-- Make server visibility follow an explicit principal authorization formula.
-- Preserve existing CLI, secret, skill, persona, and overlay behavior when no
-  external MCP declaration is present.
-- Publish source-attributed catalog generations that Console, iron-control,
-  sandbox assignment, and diagnostics can reconcile deterministically.
-- Make anonymous MCP servers possible without making them implicitly available
-  to every principal.
+- Route authorized MCP traffic through a generated gateway route.
+- Apply default-deny MCP method and tool policy at iron-proxy.
+- Make visibility follow an explicit session/requester authorization formula.
+- Preserve existing CLI, secret, skill, persona, overlay, and warm-pool behavior
+  when no external MCP server is assigned.
+- Publish source-attributed catalog generations that downstream components can
+  reconcile and diagnose.
 - Fail a new external-MCP assignment before agent input when proxy and harness
   generations cannot be proven consistent.
 
 ## Non-Goals
 
-- Replacing or changing the existing CLI tool, secret, skill, persona, or
-  workflow formats.
-- Changing existing `tool-<slug>` grants or existing generic HTTP secret
-  behavior.
-- Changing the behavior of sandboxes that have no authorized external MCP
-  servers.
-- Adding a root `centaur.integrations.toml` manifest.
-- Supporting legacy HTTP+SSE transport in the first implementation.
-- Supporting MCP resources, prompts, completion, sampling, roots, elicitation,
-  or unrestricted server-to-client requests in version 1.
+- Replacing or changing existing CLI, secret, skill, persona, or workflow
+  formats.
+- Changing existing `tool-<slug>` grants or generic HTTP secret behavior.
+- Changing sandbox assignment when no external MCP server is authorized.
+- Adding a root overlay manifest.
+- Supporting legacy HTTP+SSE transport.
+- Supporting arbitrary MCP resources, prompts, sampling, roots, elicitation, or
+  extension methods in version 1.
 - Running arbitrary install or shell commands from overlay metadata.
 - Solving general MCP OAuth discovery, browser consent, or dynamic client
-  registration in the first implementation.
-- Aggregating external MCP servers into Centaur's public `/mcp` endpoint.
-- Treating harness configuration as an authorization boundary. iron-proxy and
-  principal grants remain the enforcement boundary.
-- Supporting local stdio MCP packages in the first implementation. See
-  [Local stdio servers](#local-stdio-servers) for the follow-up shape.
-- Retrofitting the new route-only MCP policy onto existing direct HTTP or CLI
-  integrations.
-
-## Prior Art
-
-[add-mcp](https://github.com/neon-solutions/add-mcp) demonstrates the useful
-client-side half of this design: normalize one MCP server declaration, then
-write the native configuration expected by different agent clients. Centaur
-needs the same renderer boundary plus principal grants, overlay shadowing,
-managed egress, gateway-only credentials, catalog generations, and assignment
-barriers.
-
-[FastMCP's proxy provider](https://gofastmcp.com/servers/providers/proxy) can
-bridge MCP transports without reimplementing the protocol in each integration.
-It is a candidate for local stdio compatibility, while direct native harness
-configuration remains the simpler path for remote Streamable HTTP servers.
-
-[iron-proxy's MCP policy and gateway](https://github.com/paradigmxyz/iron-proxy#mcp-policy)
-already provide useful enforcement primitives. Version 1 requires those
-primitives, plus route-only upstream authorization, gateway-only credential
-binding, and a tool-only method profile, to be available through Centaur's
-managed control-plane path before the feature is enabled.
+  registration.
+- Aggregating external servers into Centaur's public `/mcp` endpoint.
+- Treating harness configuration as an authorization boundary.
+- Supporting local stdio MCP servers in version 1.
+- Retrofitting route-only MCP policy onto existing direct HTTP integrations.
 
 ## Proposed Overlay Shape
 
-An anonymous remote server needs only metadata and an explicit authorization
-choice:
+An anonymous MCP-only package can contain only metadata:
 
 ```toml
 [project]
@@ -166,19 +110,18 @@ transport = "streamable-http"
 url = "https://ethereum-mcp.example.com/mcp"
 public = false
 allowed_tools = [
-    "get_balance",
-    "get_block",
-    "get_transaction",
-    "read_contract",
+  "get_balance",
+  "get_block",
+  "get_transaction",
+  "read_contract",
 ]
 ```
 
-No `client.py` or `[project.scripts]` entry is required for an MCP-only
-directory. The new discovery path classifies this package as MCP-only and does
-not add a synthetic executable tool entry.
+No `client.py` or `[project.scripts]` entry is required. Discovery classifies
+this as MCP-only and does not add a synthetic executable tool entry.
 
-A directory that also exposes a CLI keeps the existing packaging contract. The
-CLI and MCP server still receive independent capability identities:
+A package may also expose an ordinary CLI and reuse an existing secret
+declaration as the source for a gateway-only credential:
 
 ```toml
 [project]
@@ -186,7 +129,6 @@ name = "chain-tools"
 description = "Chain CLI and remote MCP server"
 version = "0.1.0"
 requires-python = ">=3.11"
-dependencies = ["chain-tools-cli==1.2.3"]
 
 [project.scripts]
 chain = "chain_tools.cli:app"
@@ -206,28 +148,22 @@ credential = "CHAIN_MCP_TOKEN"
 type = "http"
 name = "CHAIN_MCP_TOKEN"
 secret_ref = "CHAIN_MCP_TOKEN"
-usage = "mcp-gateway"
 mode = "inject"
 inject_header = "Authorization"
 inject_formatter = "Bearer {{ .Value }}"
 hosts = ["mcp.chain-tools.example.com"]
 ```
 
-`credential` references a same-directory secret declaration whose new
-`usage = "mcp-gateway"` marker makes it eligible only for generated MCP gateway
-bindings. It reuses the existing secret source and host-scoping schema, but it
-is not emitted into the ordinary generic `secrets` or `transforms` sections.
-Existing secret declarations without `usage = "mcp-gateway"` retain their
-current behavior.
+`credential` references a same-directory secret declaration. The MCP compiler
+reuses its source type, source reference, host scope, and formatter, but the MCP
+role compiles it into a gateway-only binding rather than granting the ordinary
+generic secret resource. Existing CLI grants and existing secret behavior are
+unchanged.
 
-A package that intentionally needs the same underlying value for both a CLI and
-MCP should declare two policy identities with distinct `name` values and the
-same `secret_ref`: one existing generic declaration for the CLI and one
-`mcp-gateway` declaration for the MCP route. This keeps the two grants and wire
-behaviors independently auditable.
-
-The exact array/table syntax should extend the existing tool parser rather than
-introducing a second manifest or parser.
+A package that intentionally needs the same value for both direct CLI HTTP and
+MCP may use distinct secret names with the same `secret_ref`. Those remain
+separate grant and policy identities. A separate existing generic grant is
+separate authority and is not constrained by this RFC.
 
 ### MCP fields
 
@@ -237,57 +173,32 @@ introducing a second manifest or parser.
 | `transport` | yes | `streamable-http` in version 1. |
 | `url` | yes | HTTPS upstream URL with a DNS hostname and normalized path. |
 | `allowed_tools` | yes | Explicit upstream tool names accepted by policy. |
-| `credential` | no | Same-directory `mcp-gateway` secret name used only by the generated route. |
-| `public` | no | Explicitly expose a credentialless server without a role; defaults to `false`. |
-| `role` | no | Explicit role foreign ID; defaults to a generated MCP-specific role. |
-| `startup_timeout_sec` | no | Harness-neutral connection timeout with bounded limits. |
-| `tool_timeout_sec` | no | Harness-neutral call timeout with bounded limits. |
-| `enabled_harnesses` | no | Narrowing-only list; omitted means all compatible harnesses. |
+| `credential` | no | Same-directory secret name compiled only into the MCP route. |
+| `public` | no | Expose a credentialless server without a role; defaults to `false`. |
+| `role` | no | Explicit role foreign ID; defaults to an MCP-specific role. |
+| `startup_timeout_sec` | no | Bounded connection/startup timeout. |
+| `tool_timeout_sec` | no | Bounded tool-call timeout. |
+| `enabled_harnesses` | no | Narrowing-only list of compatible harnesses. |
 
-The URL is declarative because api-rs and Console must derive route identity,
-egress, credential scope, and diagnostics without importing or executing
-overlay code. URL templates, shell interpolation, fragments, literal
-authorization headers, IP-literal hosts, and userinfo are rejected.
+The URL is declarative so api-rs and Console can derive route identity, egress,
+credential scope, and diagnostics without executing overlay code. URL
+templates, shell interpolation, fragments, IP-literal hosts, literal
+authorization headers, and userinfo are rejected.
 
-The MCP URL itself is the source of the upstream host. Existing
-`[tool.centaur].hosts` remains available for existing CLI secret behavior but is
-not required for an MCP-only package. A referenced `mcp-gateway` secret must be
-scoped to the normalized upstream host and, where supported, the narrowest
-practical path.
+The URL supplies the MCP upstream host. Existing `[tool.centaur].hosts` remains
+available for ordinary CLI secret behavior but is not required for an MCP-only
+package. A referenced credential must be scoped to the normalized upstream host
+and, where the existing secret model supports it, the narrowest practical path.
 
-`allowed_tools` is deliberately explicit. Version 1 has no `allow_all_tools`
-form and no argument-condition syntax. A later typed tool-table form may add
-argument conditions after the pinned proxy contract and cross-parser behavior
-are specified and tested. Centaur must never convert an absent or empty list
-into allow-all.
+`allowed_tools` is mandatory and non-empty. Version 1 has no allow-all or
+argument-condition syntax. A later typed tool-table form may add conditions once
+the pinned proxy representation is specified and tested.
 
-`public = true` is accepted only for a credentialless server, remains subject to
-an operator-level deployment policy, and is deliberately conspicuous. An
-anonymous server may still perform consequential actions, so credential
-presence is not an authorization predicate.
+`public = true` is accepted only for a credentialless server and remains subject
+to an operator-level deployment policy. Credential presence is not used as an
+authorization predicate.
 
-### Capability bundles and skills
-
-No new bundle manifest is necessary. Existing overlay paths already describe
-the useful surfaces:
-
-```text
-centaur-overlay/
-├── tools/
-│   └── ethereum/
-│       ├── pyproject.toml       # CLI and/or remote MCP declaration
-│       ├── client.py            # optional ordinary tool methods
-│       └── ethereum_tool/       # optional CLI implementation
-└── .agents/
-    └── skills/
-        └── ethereum/
-            └── SKILL.md         # how and when to use the capability
-```
-
-Matching slugs are a convention, not a new ownership model. The skill remains
-instructions and never grants MCP, CLI, network, or credential access.
-
-## Capability Identity and Authorization
+## Capability Identity, Authorization, and Discovery
 
 External MCP servers use a separate role by default:
 
@@ -295,32 +206,20 @@ External MCP servers use a separate role by default:
 mcp-<package-slug>-<server-slug>
 ```
 
-The generated role follows the existing role and grant patterns, but does not
-silently expand an existing `tool-<slug>` CLI grant. An operator may set an
-explicit existing role in trusted overlay metadata when CLI and MCP are
-intentionally one indivisible capability.
+This follows the existing role/grant pattern without silently expanding an
+existing CLI role. Trusted overlay metadata may explicitly select an existing
+role when the operator intends the CLI and MCP surface to be one capability.
 
-For interactive sessions, the effective external MCP catalog is computed as:
+For interactive sessions, an MCP server is visible only when:
 
-1. the conversation/session principal must hold the MCP role; and
-2. when a requester principal is present, the requester must also hold the MCP
-   role.
+1. the conversation/session principal holds the MCP role; and
+2. when a requester principal is present, the requester also holds the role.
 
-Workflow, tool-host, and other service sessions with no requester use their
-service principal alone. Future requester-hoisted or always-available MCP roles
-require a separate explicit grant type; they are not inferred from credential
-hoisting.
+Workflow, tool-host, and other sessions without a requester use their service
+principal alone. Requester-hoisted or always-available MCP roles require a
+separate explicit design; they are not inferred from credential hoisting.
 
-A principal role assignment grants the server capability, not a raw URL or
-credential. When the server references a credential, the role also authorizes
-the corresponding gateway-only binding. The compiler must verify that the
-credential source is resolvable for the effective principal set before it emits
-the route.
-
-## Normalized Control-Plane Model
-
-Discovery should produce explicit package capabilities rather than assuming
-every `pyproject.toml` directory is executable:
+Discovery produces independent package capabilities:
 
 ```text
 DiscoveredPackage {
@@ -351,507 +250,322 @@ ExternalMcpServer {
 ```
 
 An MCP-only package contributes `external_mcp` but no `cli`. It is not inserted
-into existing executable tool discovery, CLI shim installation, or Centaur's
-existing public `/mcp` tool catalog.
+into existing executable discovery, CLI shim installation, or Centaur's public
+MCP tool catalog.
 
 ### MCP-specific overlay shadowing
 
-The new external MCP catalog uses the same ordered overlay inputs but has
-fail-closed shadowing semantics for MCP declarations only:
+External MCP declarations use the existing ordered overlay inputs but fail
+closed independently from current CLI and persona behavior:
 
-- a later package directory claims its external MCP package identity before the
-  declaration is fully validated;
+- a later package claims its external MCP identity before full validation;
 - a valid later declaration replaces the earlier declaration;
-- an invalid later declaration creates a visible tombstone and suppresses the
-  earlier external MCP declaration; and
-- existing CLI, persona, skill, and secret shadowing behavior remains unchanged.
+- an invalid later declaration creates a diagnostic tombstone and suppresses
+  the earlier external MCP declaration; and
+- existing CLI, secret, persona, and skill shadowing remains unchanged.
 
-Two active packages that normalize to the same logical harness or route name
-without an overlay relationship are invalid. Logical names, DNS-safe route IDs,
-and display names are distinct fields so slugification collisions cannot
-silently merge capabilities.
+Logical names, display names, and route IDs are distinct normalized fields.
+Collisions after normalization are invalid rather than silently merged.
 
-Discovery fails or tombstones the individual external MCP declaration, with a
-visible diagnostic, when:
+A declaration is invalid when:
 
 - the URL is not HTTPS, lacks a DNS hostname, contains userinfo or a fragment,
   uses an IP literal, or uses an unsupported transport;
-- the normalized upstream resolves to a private, loopback, link-local, or
-  metadata address without a separate trusted internal-host policy;
-- a referenced credential is absent, is not marked `mcp-gateway`, or is not
-  scoped to the upstream host;
+- a referenced credential is absent or is not scoped to the upstream host;
 - `public = true` is combined with a credential;
 - `allowed_tools` is empty, duplicated, or invalid;
 - the generated or explicit role is invalid;
-- two active entries collide after logical-name or route-ID normalization; or
+- active entries collide after name or route normalization; or
 - a timeout or harness name is unsupported.
 
-The API should expose the normalized catalog and validation status to Console
-and diagnostics. Ordinary repository discovery must not execute a server's
-`tools/list` or otherwise contact the declared URL.
+Ordinary discovery must not contact the upstream or execute `tools/list`.
 
-## Catalog Publication and Generations
+## Catalog Generations
 
-api-rs owns parsing overlay TOML. Console and iron-control consume a normalized,
-authenticated catalog generation and must not independently reparse the
-manifest.
+api-rs owns parsing overlay TOML. Console and iron-control consume an
+authenticated normalized catalog generation and must not independently reparse
+the manifest.
 
-Each published generation contains:
+A generation records:
 
-- source repository, ref, commit, and configured overlay order;
+- source repository, ref, commit, and overlay order;
 - normalized entries and tombstones;
-- generated role identities and credential references, never credential values;
-- a canonical catalog digest; and
-- parser and validation diagnostics.
+- role identities and credential references, never values;
+- validation diagnostics; and
+- a canonical catalog hash.
 
-Publication is an idempotent compare-and-swap keyed by the configured source
-identity and commit. A deployment must designate one reconciler for a source so
-multiple api-rs replicas cannot overwrite the same source with competing
-commits. Removal publishes a tombstone or a newer generation; absence is not
-interpreted as a successful empty catalog until the source generation is known.
+Publication is idempotent and source-attributed. One designated reconciler owns
+a configured source so competing api-rs replicas cannot publish different
+commits as the same generation. Removal is represented by a newer generation or
+tombstone, not by silently treating missing input as a valid empty catalog.
 
 Downstream state carries separate hashes:
 
-1. `catalog_hash` for normalized overlay declarations;
+1. `catalog_hash` for normalized declarations;
 2. `grant_hash` for the effective principal authorization set;
-3. `proxy_config_hash` for the rendered managed proxy section; and
-4. `harness_config_hash` for the final parsed harness configuration after
-   operator overlays.
+3. `proxy_config_hash` for managed proxy policy; and
+4. `harness_config_hash` for the final parsed harness configuration.
 
-The hashes may be combined into an assignment generation for convenience, but
-diagnostics retain the individual values so operators can distinguish catalog,
-grant, proxy, and harness drift.
+The hashes may be combined into an assignment generation, but diagnostics retain
+the individual values.
 
-## Tool-Only MCP Protocol Profile
+## Managed Proxy and Protocol Enforcement
 
-Version 1 exposes a fixed, default-deny protocol profile. The generated proxy
-policy permits only:
+Version 1 exposes a fixed, default-deny tool-only protocol profile. The route
+permits initialization and lifecycle messages, ping, cancellation/progress
+needed by an authorized call, `tools/list`, and `tools/call` for listed tool
+names. Other client-to-server and server-to-client methods are denied.
 
-- Streamable HTTP initialization and normal lifecycle messages;
-- ping;
-- cancellation and progress messages required by an authorized call;
-- `tools/list`;
-- `tools/call` for explicitly listed tool names; and
-- session termination and resumability operations required by the pinned
-  Streamable HTTP protocol version.
+Filtering `tools/list` is a discoverability feature, not the authorization
+boundary. Requests and server-originated JSON-RPC messages are checked before
+they reach the other side.
 
-All other client-to-server and server-to-client JSON-RPC methods are denied.
-This includes resources, prompts, completion, sampling, roots, elicitation,
-logging control, and unknown extension methods. Server-originated requests and
-notifications are policy-checked before reaching the harness; filtering only
-`tools/list` is not treated as the authorization boundary.
+External MCP requires three route-scoped guarantees:
 
-The generated route also carries a route-specific protocol header and HTTP
-method profile. It preserves the headers and methods required by the pinned
-Streamable HTTP transport, including `MCP-Session-Id`,
+1. **Route-only upstream authority.** The upstream host/path is authorized only
+   for traffic entering through the generated MCP route. A direct sandbox
+   request to that upstream does not inherit authority from the MCP grant.
+2. **Gateway-only credential binding.** A referenced secret is resolved and
+   injected by the route after MCP authorization. The MCP grant does not emit it
+   into ordinary generic secrets, transforms, or sandbox environment.
+3. **Bidirectional method and tool policy.** The fixed method profile and
+   explicit tool allowlist apply to both protocol directions.
+
+These are additive external-MCP fields in the managed iron-control and Console
+snapshot path. They do not require changing unrelated proxy traffic or the
+behavior of existing generic credentials.
+
+For each granted server, managed proxy configuration contains:
+
+- a stable client-facing route and collision-checked route ID;
+- an MCP policy matching that route;
+- the fixed method profile and explicit tool allowlist;
+- a gateway mapping to the HTTPS upstream;
+- optional gateway-only credential source metadata;
+- the minimum route-specific upstream and token-endpoint egress; and
+- catalog, grant, and rendered policy hashes.
+
+The client-facing route must not use the special-use `.local` suffix. It may use
+the existing per-sandbox proxy service plus a generated route path or a
+deployment-controlled internal DNS suffix.
+
+The route-local HTTP profile preserves the headers and methods required by the
+pinned Streamable HTTP protocol, including `Mcp-Session-Id`,
 `MCP-Protocol-Version`, `Last-Event-ID`, content negotiation, POST, GET, and
-negotiated DELETE semantics. This is new route-local configuration and does not
-require changing unrelated proxy traffic.
+negotiated session termination. Redirects may not escape the declared host and
+path policy or carry credentials to a different authority.
 
-## Runtime Flow
+The policy order is:
 
-1. api-rs scans ordered `TOOL_DIRS` and parses CLI, secret, and external MCP
-   metadata into independent capability records.
-2. MCP-specific overlay shadowing selects valid entries or fail-closed
-   tombstones.
-3. The designated reconciler publishes the normalized catalog generation to
-   Console/iron-control.
-4. The control plane computes the effective server set from the session and
-   requester authorization formula.
-5. Console/iron-control renders each granted server into the managed proxy
-   assignment using route-only upstream egress, tool-only MCP policy, and an
-   optional gateway-only credential binding.
-6. A strict external-MCP assignment barrier confirms the proxy has applied the
-   expected `proxy_config_hash` before the harness receives the server.
-7. The sandbox renderer atomically writes the authorized MCP catalog into the
-   selected harness's native format and reparses the final configuration after
-   operator overlays.
-8. The adapter hot-reloads or restarts the harness as required, then reports the
-   applied `harness_config_hash`.
-9. Only after both hashes match the assignment generation may Centaur deliver
-   the first agent input.
-10. The harness connects only to the generated client-facing route. iron-proxy
-    applies the tool-only method profile, filters `tools/list`, denies unlisted
-    calls, injects the route credential after authorization, and records
-    protocol-aware audit metadata.
+```text
+harness
+  -> principal's iron-proxy
+  -> generated MCP route
+  -> route-only upstream authorization
+  -> bidirectional method policy
+  -> tools/call allowlist
+  -> gateway-only credential injection
+  -> remote MCP server
+```
 
-The strict barrier is new and applies only when an assignment includes external
-MCP servers. Existing sandbox assignment behavior remains unchanged for
-sessions without external MCP capabilities.
+The sandbox receives only the client-facing URL and proxy CA. Real credential
+values never appear in harness configuration or a shared adapter.
 
-## Harness Rendering
+## Runtime and Lifecycle
 
-Harness-specific syntax belongs in `services/sandbox`, not in overlay repos.
-The renderer consumes one normalized JSON representation generated by the
-control plane and writes:
+The runtime flow is:
 
-- Codex `[mcp_servers.<name>]` TOML;
-- Claude Code `mcpServers` JSON;
-- Amp's MCP settings; and
-- equivalent native configuration for other explicitly supported harnesses.
+1. api-rs parses CLI, secret, and external MCP metadata into independent
+   capability records.
+2. MCP-specific shadowing selects valid entries or tombstones.
+3. The reconciler publishes the catalog generation.
+4. The control plane computes the effective server set from session and
+   requester roles.
+5. Console/iron-control renders the granted routes and managed proxy policy.
+6. The proxy applies and reports the expected `proxy_config_hash`.
+7. The sandbox renders, reparses, and applies the harness configuration.
+8. Centaur delivers agent input only after the proxy and harness hashes match
+   the assignment generation.
 
-The client-facing URL must not use the special-use `.local` suffix described
-by [RFC 6762](https://www.rfc-editor.org/rfc/rfc6762.html). It should use either
-the existing per-sandbox proxy service with a generated route path or a
-deployment-controlled internal DNS suffix. The logical MCP name remains
-separate from the transport route ID.
+The strict barrier is new and applies only to assignments containing external
+MCP servers. Existing assignment behavior remains unchanged otherwise.
 
-The current `CODEX_CONFIG_OVERLAY` and `CLAUDE_SETTINGS_OVERLAY` remain operator
-escape hatches and apply after generated configuration. An operator override
-may narrow, rename, or remove generated harness entries, but it cannot widen
-proxy policy or create a route that the effective assignment did not authorize.
+Harness-specific syntax belongs in `services/sandbox`, not in overlays. The
+renderer writes native Codex, Claude Code, Amp, or other explicitly supported
+configuration from one normalized JSON representation.
 
-The final merged configuration must be parsed again. Invalid output or a
-reference to an unauthorized route is an assignment failure, not a warning
-followed by a missing or partially configured server.
+`CODEX_CONFIG_OVERLAY` and `CLAUDE_SETTINGS_OVERLAY` remain operator escape
+hatches and apply after generated configuration. They may narrow, rename, or
+remove harness entries, but cannot create proxy authority. The final merged
+configuration is reparsed; invalid output or an unauthorized route is an
+assignment failure.
 
-### Warm pools and refresh
+Each enabled harness adapter must provide one of:
 
-Warm sandboxes make principal-specific MCP configuration a lifecycle concern.
-Writing config only at image startup is insufficient because the principal is
-not known until claim time, and many harnesses read MCP configuration only at
-process startup.
+- authenticated hot reload with an applied-generation response;
+- controlled restart after assignment and before first input; or
+- a stable local broker whose applied catalog generation is queryable.
 
-Before enabling an adapter, it must implement one of:
-
-- an authenticated hot-reload operation with an applied-generation response;
-- a controlled harness restart after assignment but before first input; or
-- a stable preconfigured local broker whose catalog is filtered after
-  assignment and whose applied generation is queryable.
-
-A warm-pool claim with external MCP is a transaction from the session's point
+A warm-pool claim with external MCP is transactional from the session's point
 of view:
 
 1. reserve the sandbox;
 2. compute the effective assignment generation;
 3. apply and verify proxy policy;
 4. render and verify harness configuration;
-5. expose the harness to agent input; or
-6. mark the sandbox failed and remove it from the pool.
+5. expose the harness to input; or
+6. mark and remove the sandbox when the barrier fails.
 
-Repository additions do not become visible in a live session until an explicit
-execution boundary or successful adapter reload. Removal and role revocation
-fail closed: the proxy route is revoked first, active gateway sessions are
-closed, new calls are denied, and harness visibility is removed afterward.
-In-flight upstream requests may complete, but no new request may start under the
-revoked generation.
+Additions become visible at a successful execution boundary or adapter reload.
+Removal and role revocation fail closed: revoke the proxy route first, close
+active gateway sessions, deny new calls, and remove harness visibility
+afterward. An already-running upstream request may complete, but no new request
+may start under the revoked generation.
 
-## iron-proxy and iron-control
+## Required Invariants
 
-The pinned iron-proxy already has useful unmanaged concepts:
+Implementation must preserve these security and compatibility properties:
 
-- `mcp.servers` for `tools/call` enforcement and filtered `tools/list`
-  responses;
-- `mcp_gateway.routes` for stable client-facing routes and upstream selection;
-- ordinary egress policy; and
-- existing secret source and transformation types.
-
-External MCP requires a managed representation of those concepts plus three
-new route-scoped guarantees:
-
-1. **route-only upstream egress:** the upstream connection is authorized only
-   when the request entered through the generated MCP route; a direct sandbox
-   request to the upstream host or path does not inherit that authorization;
-2. **gateway-only credential binding:** a referenced `mcp-gateway` secret is
-   resolved and injected by the route after MCP authorization, and is never
-   emitted as a generic host-scoped secret or transform; and
-3. **tool-only bidirectional method policy:** both request and response streams
-   are checked against the fixed version 1 profile.
-
-Centaur must carry these fields through the managed iron-control and Console
-snapshot path. Editing only `services/iron-proxy/iron-proxy.yaml` is not an
-implementation because Kubernetes sandboxes use managed proxy sync.
-
-For each granted MCP declaration, the managed proxy config contains:
-
-1. a stable client-facing route using the per-sandbox proxy endpoint or a
-   deployment-controlled internal suffix;
-2. a route ID derived from package and MCP logical identity with collision
-   validation;
-3. an MCP server policy matching the route host and path;
-4. the fixed version 1 method profile and explicit tool allowlist;
-5. a route-only gateway mapping to the declared HTTPS upstream;
-6. an optional gateway-only credential source binding;
-7. the minimum upstream and token-endpoint egress required by that route; and
-8. catalog, grant, and rendered policy hashes for audit and barriers.
-
-The sandbox sees only the client-facing route and proxy CA. Neither the
-generated harness config nor a shared adapter receives the real token.
-
-### Policy ordering
-
-The desired request boundary is:
-
-```text
-harness
-  -> principal's iron-proxy
-  -> generated MCP route match
-  -> route-only egress authorization
-  -> bidirectional MCP method profile
-  -> tools/call allowlist
-  -> gateway-only credential injection
-  -> remote MCP server
-```
-
-The response boundary applies the corresponding method policy and filters
-`tools/list` before content reaches the harness. Authorization is enforced on
-every call; catalog filtering is not the security boundary.
-
-### Credential handling
-
-The MCP declaration names a gateway credential capability, not a value. The
-same-directory `mcp-gateway` declaration reuses existing source kinds,
-resolution, labels, and host scoping. The generated MCP role and effective
-principal grants determine whether the route can resolve it.
-
-The route is absent when a required credential is ungranted or unresolved. The
-credential binding is never copied into sandbox environment variables, harness
-files, process arguments, logs, or the ordinary generic proxy secret catalog.
-
-Static bearer, brokered token, or existing OAuth-token source kinds may be used
-when their lifecycle already fits a non-interactive route. General MCP OAuth
-discovery, browser consent, audience negotiation, dynamic registration, and
-per-user refresh ownership require a separate RFC.
-
-## Compatibility and Unchanged Behavior
-
-This proposal is additive. Implementations must prove the following invariants:
-
-- a package without `[tool.centaur.mcp]` produces the same existing CLI, secret,
-  persona, skill, and proxy behavior as before;
-- an existing secret without `usage = "mcp-gateway"` keeps its existing
-  registration and wire behavior;
-- existing `tool-<slug>` roles do not gain external MCP capabilities by default;
-- existing CLI and persona overlay shadowing is unchanged;
-- the existing public `/mcp` endpoint and its tool catalog are unchanged;
-- existing harness operator overlays remain available;
-- existing proxy assignment and warm-pool behavior is unchanged when no
-  external MCP server is assigned; and
-- no static-only proxy configuration is introduced into the Kubernetes path.
-
-## Local stdio Servers
-
-Some packages expose a CLI, skills, and `--mcp` stdio mode from one artifact.
-That is a useful later phase, but it has a different security boundary:
-iron-proxy can constrain the child process's outbound HTTP, but it cannot
-inspect the local stdio JSON-RPC stream.
-
-A later declaration could look like:
-
-```toml
-[tool.centaur.mcp]
-name = "ens"
-transport = "stdio"
-command = "ens"
-args = ["--mcp"]
-allowed_tools = ["get_address", "available", "price"]
-```
-
-The command must name an installed script from the same reviewed tool package;
-absolute paths, shell strings, and arbitrary environment interpolation are
-rejected. To preserve default-deny method and tool policy, Centaur would need
-either:
-
-- a shared local MCP bridge that filters both protocol directions before
-  connecting the harness to the child process; or
-- equivalent filtering implemented and tested in every harness adapter.
-
-FastMCP's proxy provider is a candidate for a shared Python bridge because it
-can proxy remote or local transports and present a local stdio server. It is an
-implementation option, not part of the overlay schema. The official MCP SDK or
-another maintained bridge can satisfy the same contract. Per-integration
-Python files should not be required when a generated invocation of the shared
-bridge is sufficient.
-
-## Security Considerations
-
-- External MCP descriptions, schemas, notifications, and tool results are
-  untrusted input to the model.
-- Tool and method names are policy identities from the upstream protocol, not
-  display names rewritten by a harness.
-- A server declaration alone never creates a role or credential grant for a
-  principal.
-- An anonymous server still requires its MCP-specific role unless explicitly
-  marked `public = true` and permitted by deployment policy.
-- URLs are validated without fetching them during discovery, avoiding
-  control-plane SSRF.
-- Route creation revalidates DNS and denies private, loopback, link-local, and
-  metadata addresses unless a separate trusted internal-host policy applies.
-- DNS is checked at connection time so validation cannot be bypassed by later
-  resolution changes.
-- The gateway route, not a broad host allowlist, owns upstream egress.
-- Gateway credentials are scoped to exact hosts and the narrowest practical
-  paths and are injected only after method and tool authorization.
-- Direct upstream HTTP requests do not receive route egress or credentials.
-- Redirects cannot escape the declared host and path policy or carry a
-  credential to a different authority.
-- Tool and method policy is default-deny. An absent, stale, or failed external
-  MCP managed-policy sync makes the route unavailable.
-- Operator harness overlays cannot create proxy authority.
-- Catalog, role, and route removal revoke proxy authority before removing
-  harness visibility.
-- Audit logs may record source generation, principal set, server, MCP method,
-  tool, decision, route, and policy version, but never authorization headers,
-  likely-secret arguments, or response bodies by default.
-- Overlay refresh is a policy change attributable to repository, ref, commit,
-  overlay order, and catalog digest.
+- Packages without `[tool.centaur.mcp]` retain existing behavior.
+- Existing secrets retain existing behavior unless referenced by a new MCP
+  route; the MCP grant itself does not grant the generic secret.
+- Existing `tool-<slug>` roles do not gain MCP authority by default.
+- Existing CLI, persona, skill, and secret shadowing is unchanged.
+- MCP-only packages do not synthesize CLI entries or appear in Centaur's public
+  `/mcp` catalog.
+- Existing warm-pool and assignment behavior is unchanged without external MCP.
+- Static-only proxy configuration is not introduced into the Kubernetes path.
+- A declaration alone never grants a role or credential to a principal.
+- Direct upstream requests receive neither MCP route authority nor the
+  gateway-only credential.
+- Private, loopback, link-local, and metadata destinations remain denied unless
+  a separate trusted internal-host policy explicitly permits them.
+- DNS is rechecked at connection time so later resolution changes cannot bypass
+  address policy.
+- Unknown tools, unknown methods, stale generations, and failed managed-policy
+  syncs fail closed.
+- Operator harness overlays cannot widen proxy policy.
+- External descriptions, schemas, notifications, and results are untrusted
+  model input.
+- Audit logs may record source generation, principal set, server, method, tool,
+  decision, route, and policy version, but not authorization headers, likely
+  secret arguments, or response bodies by default.
 
 ## Rollout Plan
 
-### Phase 1: Typed discovery only
+### Phase 1: Typed discovery
 
-- Parse `[tool.centaur.mcp]` and `usage = "mcp-gateway"` into typed capability
-  records.
-- Classify MCP-only packages without adding them to existing executable or
-  public MCP catalogs.
-- Add MCP-specific fail-closed shadowing, tombstones, diagnostics, source
-  attribution, and unit tests.
-- Do not publish, render, or execute external MCP yet.
+- Parse `[tool.centaur.mcp]` into independent capability records.
+- Classify MCP-only packages without changing existing executable catalogs.
+- Add validation, fail-closed MCP shadowing, tombstones, and diagnostics.
+- Do not publish, render, or execute external MCP.
 
-### Phase 2: Catalog publication and grants
+Exit condition: valid and invalid overlay fixtures produce deterministic,
+source-attributed catalogs while existing fixtures remain unchanged.
 
-- Add normalized catalog-generation storage and authenticated idempotent
-  publication.
-- Add MCP-specific role registration and the session/requester authorization
-  formula.
-- Add gateway-only credential bindings that reuse existing source kinds without
-  entering the generic secret catalog.
+### Phase 2: Catalogs and grants
+
+- Persist authenticated catalog generations.
+- Add MCP-specific roles and the session/requester authorization formula.
+- Normalize referenced credentials into gateway-only bindings.
 - Expose catalog and grant hashes to diagnostics.
+
+Exit condition: the control plane can deterministically answer which servers
+and credential sources a principal set may receive.
 
 ### Phase 3: Managed proxy enforcement
 
-- Extend iron-control and Console proxy snapshots for routes, route-only egress,
-  gateway-only credentials, tool-only bidirectional method policy, and
-  route-local Streamable HTTP headers and methods.
-- Require a pinned iron-proxy version that enforces those fields.
-- Test direct upstream denial, redirects, DNS changes, anonymous servers, and
-  credentialed servers through managed mode.
+- Extend managed snapshots for routes, route-only authority, gateway-only
+  credentials, method policy, tool policy, and route-local transport headers.
+- Pin an iron-proxy version that enforces the new fields.
+- Verify direct-upstream denial and anonymous and credentialed routes.
 
-### Phase 4: Harness rendering and assignment barrier
+Exit condition: managed Kubernetes proxies enforce the complete version 1
+boundary without harness configuration being trusted.
 
-- Render the normalized catalog for Codex first, then Claude Code and Amp.
-- Add the strict external-MCP proxy-and-harness assignment generation barrier.
-- Implement warm-pool claim failure and disposal when the barrier cannot be
-  satisfied.
-- Add controlled refresh and revocation behavior before enabling by default.
+### Phase 4: Harnesses and lifecycle
 
-### Phase 5: Local stdio and package pass-through
+- Render Codex first, then Claude Code and Amp.
+- Add the strict proxy-and-harness assignment barrier.
+- Add warm-pool failure/disposal, refresh, and revocation behavior.
+- Enable only harness adapters that can report an applied generation.
 
-- Add a controlled package/command declaration.
-- Choose and pin a shared bidirectional protocol bridge.
-- Enforce method and tool policy before the local child process receives a
-  call.
+Exit condition: end-to-end tests prove cold and warm assignments expose exactly
+the authorized server generation and revoke it in the required order.
 
-These phases should be separate PRs. The first implementation is a cross-service
-feature rather than a small overlay change: discovery is focused, while catalog
-reconciliation, managed proxy enforcement, and warm-pool correctness are the
-larger pieces.
+Local stdio support is a separate follow-up after a shared bridge can enforce
+the same bidirectional method and tool policy.
 
 ## Validation Plan
 
-- Parser fixtures for valid, shadowed, tombstoned, malformed, anonymous,
-  public, credentialed, CLI-plus-MCP, and MCP-only declarations.
-- Compatibility tests proving packages without new metadata and secrets without
-  the new usage marker retain byte-equivalent normalized outputs.
-- Tests proving MCP-only packages do not synthesize CLI entries or appear in
-  Centaur's existing public `/mcp` catalog.
-- Tests proving an invalid later MCP overlay suppresses an earlier MCP entry
-  without changing the package's existing CLI shadowing behavior.
-- Cross-parser tests proving api-rs and `centaur-perms` interpret
-  `mcp-gateway` declarations, roles, sources, and hosts identically.
-- Catalog publication tests for idempotency, competing replicas, source commit
-  changes, tombstones, and removals.
-- Authorization tests for conversation principals, requester principals,
-  service principals, explicit roles, and `public = true`.
-- Snapshot tests for Codex, Claude Code, and Amp renderers, including operator
-  narrowing and unauthorized-route rejection.
-- Managed-mode proxy tests for initialize, lifecycle notifications, ping,
-  cancellation/progress, `tools/list`, `tools/call`, GET/SSE resumability,
-  negotiated DELETE/session termination, and required protocol headers.
-- Tests that resources, prompts, completion, sampling, roots, elicitation,
-  logging control, unknown methods, and unauthorized server-originated messages
-  are denied before reaching the other side.
-- Tests that unlisted tools are filtered and denied before upstream receives
-  them.
-- Tests that direct requests to the upstream host or path receive neither route
-  egress nor credentials, including raw HTTP, non-JSON bodies, redirects, and
-  alternate DNS answers.
-- Tests that a shared underlying `secret_ref` can back distinct generic and
-  gateway-only declarations without merging their grants or wire behavior.
-- Tests that an ungranted principal sees no server route and cannot use the
-  generated gateway.
-- Tests that the sandbox contains no real credential.
-- Assignment-generation tests for cold create, warm-pool claim, role change,
-  overlay refresh, proxy lag, harness reload failure, and sandbox disposal.
-- Revocation tests proving the proxy route disappears first, active streams are
-  closed, and new calls fail before harness visibility is removed.
-- One real anonymous remote server and one controlled credentialed server in
-  the local Kubernetes stack.
+Validation is organized by boundary rather than as one exhaustive test list:
+
+- **Discovery:** valid, malformed, shadowed, tombstoned, public, credentialed,
+  CLI-plus-MCP, and MCP-only fixtures; name and route collision tests.
+- **Compatibility:** unchanged normalized output for packages without new
+  metadata; no synthetic CLI or public `/mcp` entries for MCP-only packages.
+- **Authorization:** session, requester, and service-principal formulas;
+  explicit roles; public policy; ungranted and unresolved credentials.
+- **Proxy enforcement:** lifecycle and transport headers; allowed and denied
+  methods; filtered and denied tools; gateway-only credential injection;
+  direct upstream, redirect, and DNS-rebinding denial.
+- **Lifecycle:** cold create, warm claim, proxy lag, harness reload failure,
+  overlay refresh, role change, revocation order, and sandbox disposal.
+- **End to end:** one controlled anonymous server and one credentialed server
+  through the local Kubernetes managed-mode stack.
+
+Implementation PRs should expand these categories into concrete cases for the
+component they change.
 
 ## Open Questions
 
-- Should catalog publication be owned by a dedicated reconciler process or by a
+- Should catalog publication be owned by a dedicated reconciler or a
   leader-elected api-rs replica?
-- Should the client-facing route use the existing per-sandbox proxy service and
-  path, or a deployment-controlled internal DNS suffix?
-- Which harnesses can return an authenticated applied-generation result after
-  hot reload, and which require a controlled restart?
-- Should additions affect existing sessions only at execution boundaries, or
-  may an adapter opt into immediate reload after proving the same assignment
-  generation?
-- Which existing secret source kinds are safe for a non-interactive
-  `mcp-gateway` binding in version 1?
-- Is general MCP OAuth best modeled as a new Console integration type or as an
-  extension of brokered credentials?
-- Should local stdio servers share the Python-based FastMCP proxy provider, the
-  official SDK, or a small runtime-native bridge?
+- Should client-facing routes use the existing per-sandbox proxy service and
+  paths or a deployment-controlled internal suffix?
+- Which harnesses can report an authenticated applied generation after reload,
+  and which require restart?
+- Should catalog additions affect existing sessions only at execution
+  boundaries, or may an adapter opt into immediate verified reload?
+- Which existing secret source kinds are safe for non-interactive gateway-only
+  use in version 1?
+- Should future MCP OAuth be a Console integration type or an extension of
+  brokered credentials?
+- Which shared bridge should enforce policy for a later local stdio profile?
 
 ## Rejected Alternatives
 
 ### Root overlay manifest
 
-A root manifest can list CLIs, MCP servers, and skills in one file, but it
-duplicates discovery roots, secret metadata, role labels, shadowing, and package
-identity. It also creates a non-operative file in existing overlays until every
-control-plane consumer learns it. Extending the current per-tool contract keeps
-one declarative source of truth.
+A root manifest duplicates discovery roots, package identity, source metadata,
+secret declarations, roles, and overlay precedence. Extending the current
+per-package contract keeps one source of truth.
 
-### Bespoke Python client per MCP server
+### Bespoke Python client per server
 
-This works today and is appropriate when an integration intentionally exposes a
-smaller domain API. It is wasteful as the generic MCP path: each client repeats
-session initialization, JSON-RPC envelopes, SSE parsing, errors, schema
-discovery, and protocol evolution.
+This remains appropriate for intentionally narrower domain APIs, but a generic
+MCP path should not repeat session, SSE, JSON-RPC, and schema handling for every
+integration.
 
 ### Harness overlays only
 
-Harness overlays are useful escape hatches and have proven the transport can
-work. They do not provide normalized validation, cross-harness portability,
-principal visibility, managed egress, gateway-only credentials, or
-protocol-aware proxy policy.
+Harness overlays provide client configuration but not principal authorization,
+managed egress, gateway-only credentials, protocol policy, or lifecycle
+barriers.
 
 ### Static iron-proxy configuration only
 
-The static file is not consumed by Kubernetes managed-mode proxies. Supporting
-only that path would create a local success case while leaving the production
-control-plane path unimplemented.
+Kubernetes sandboxes use managed proxy sync. A static-only implementation would
+work in local unmanaged environments without implementing the production path.
 
-### Direct upstream URLs in harness configuration
+### Direct upstream URLs
 
-Pointing a harness directly at the upstream URL makes the route identity,
-credential injection, and tool policy optional client behavior. Version 1
-requires a generated gateway route so the proxy remains the enforcement
-boundary.
-
-### Reusing a generic HTTP secret as the MCP credential
-
-A generic host-scoped secret can authorize traffic outside the MCP route. The
-new `mcp-gateway` usage reuses source resolution and host scoping while keeping
-the credential out of ordinary generic proxy transforms.
+Direct harness URLs make policy and credential delivery optional client
+behavior. Version 1 requires a generated route so iron-proxy remains the
+enforcement boundary.
 
 ### Reusing the CLI role by default
 
-A package's CLI and remote MCP surface may have different risk and lifecycle.
-Silently expanding an existing `tool-<slug>` grant would make an overlay refresh
-an implicit privilege escalation. External MCP therefore uses a separate role
-unless trusted metadata explicitly selects an existing role.
+A local CLI and a remote MCP surface can have different risk. Silently expanding
+an existing `tool-<slug>` grant would make an overlay refresh an implicit
+privilege increase, so MCP uses a separate role unless explicitly configured.

--- a/services/api-rs/rfcs/0006-overlay-native-external-mcp.md
+++ b/services/api-rs/rfcs/0006-overlay-native-external-mcp.md
@@ -1,4 +1,4 @@
-# RFC 0006: Overlay-Native External MCP Servers
+# RFC 0006: Policy-Enforced Overlay-Native External MCP Tools
 
 Status: Draft
 Owner: TBD
@@ -7,52 +7,63 @@ Target: `services/api-rs`, `services/sandbox`, `services/console`,
 
 ## Summary
 
-Let an overlay register a remote MCP server by extending the existing
-per-tool `pyproject.toml` contract. Centaur should discover one normalized MCP
-declaration, render it into each supported harness, and compile the same
-declaration into principal-scoped iron-proxy egress, credential, gateway, and
-tool policy.
+Let an overlay register a remote Model Context Protocol server by extending the
+existing per-tool `pyproject.toml` contract. Centaur should discover one typed,
+normalized declaration, publish it as versioned control-plane state, render the
+authorized server into each supported harness, and compile the same declaration
+into principal-scoped iron-proxy gateway, egress, credential, protocol, and tool
+policy.
+
+Version 1 is deliberately a **remote, tool-only Streamable HTTP profile**. It
+allows the MCP lifecycle plus `tools/list` and explicitly authorized
+`tools/call` requests. Resources, prompts, completion, sampling, roots,
+elicitation, logging control, unknown methods, and local stdio servers remain
+out of scope until Centaur can enforce them explicitly in both protocol
+directions.
 
 An operator should not need to:
 
 - hand-write a different MCP config for every harness;
 - copy a token into a sandbox;
 - implement a bespoke Python JSON-RPC client for every MCP server; or
-- add a second root-level overlay manifest that duplicates tool, secret, and
-  role metadata Centaur already discovers.
+- add a second root-level overlay manifest that duplicates tool, secret, role,
+  and source metadata Centaur already discovers.
 
-The proposed unit remains a tool directory. A directory may provide a CLI, a
-remote MCP server, or both. Skills remain in `.agents/skills/`, where the
-overlay loader already supports them, and may use the same slug to document the
-corresponding CLI and MCP surface.
+The proposed unit remains a tool package directory, but its capabilities become
+explicit. A directory may provide a CLI, one remote MCP server, or both. An
+MCP-only directory does not synthesize a CLI or appear in Centaur's existing
+public `/mcp` tool catalog. Skills remain in `.agents/skills/`, where the overlay
+loader already supports them, and may use the same slug to document the
+corresponding CLI and MCP capability.
 
 This RFC covers Centaur acting as an MCP **client** inside agent sandboxes. It
-does not replace the existing `/mcp` endpoint, where Centaur acts as an MCP
-server for external clients.
+does not replace or modify the existing `/mcp` endpoint, where Centaur acts as
+an MCP server for external clients.
 
 ## Motivation
 
-Centaur has native overlay delivery for tools, workflows, skills, personas,
-and prompts. Tools already use `pyproject.toml` as a declarative boundary for
-CLI scripts, secret references, allowed credential hosts, and per-tool labels.
+Centaur has native overlay delivery for tools, workflows, skills, personas, and
+prompts. Tools already use `pyproject.toml` as a declarative boundary for CLI
+scripts, secret references, allowed credential hosts, and per-tool labels.
 There is no equivalent supported path for a sandbox to consume a third-party
 MCP server.
 
 The current escape hatch is harness-specific configuration such as
-`CODEX_CONFIG_OVERLAY`. It can make a remote server work, but it has several
-properties that make it unsuitable as the product contract:
+`CODEX_CONFIG_OVERLAY`. It can make a remote server reachable, but it is not a
+sufficient product contract because it:
 
-- it only configures one harness;
-- malformed configuration is ignored and fails as a missing server later;
-- it is deployment-wide rather than a discovered overlay capability;
-- it does not create a managed iron-proxy MCP policy or egress grant;
-- it cannot drive principal-specific discoverability; and
-- it has no shared validation for URLs, transports, credentials, or tool
-  policy.
+- configures one harness rather than all supported harnesses;
+- is deployment-wide rather than a discovered overlay capability;
+- does not create principal-scoped managed proxy policy;
+- cannot safely bind a credential only to an MCP gateway route;
+- cannot drive principal-specific discoverability;
+- has no shared validation for URLs, transports, methods, tools, credentials,
+  or route identity; and
+- cannot participate in warm-pool assignment and revocation barriers.
 
 The repository also contains MCP-specific clients for individual integrations.
 Those clients prove demand but repeat transport, session, error, and response
-parsing that an MCP implementation should own once.
+parsing that a shared MCP implementation should own once.
 
 Related work:
 
@@ -61,40 +72,61 @@ Related work:
 - [#1385](https://github.com/paradigmxyz/centaur/issues/1385) explains why the
   static `iron-proxy.yaml` allowlist is not a Kubernetes managed-mode control
   surface.
-- [#205](https://github.com/paradigmxyz/centaur/pull/205) identified the MCP
-  session and protocol headers required through iron-proxy.
-- [#883](https://github.com/paradigmxyz/centaur/pull/883) proposes per-tool role
-  filtering for Centaur's MCP server direction. External MCP visibility should
-  use the same role vocabulary.
+- [#205](https://github.com/paradigmxyz/centaur/pull/205) identified protocol
+  headers required by stateful Streamable HTTP sessions.
+- [#883](https://github.com/paradigmxyz/centaur/pull/883) proposes role-based
+  visibility for Centaur's MCP server direction. This RFC follows the same
+  role-oriented control-plane pattern without depending on that PR being
+  merged.
 - [#841](https://github.com/paradigmxyz/centaur/pull/841) implements Centaur as
   an MCP server. This RFC addresses the opposite direction.
 
 ## Goals
 
 - Declare a remote Streamable HTTP MCP server in an overlay tool directory.
+- Make CLI and external MCP capabilities independently discoverable and
+  grantable.
 - Use one normalized declaration to configure every supported harness.
-- Reuse existing secret declarations and principal grants.
+- Reuse existing secret source types and grant patterns without turning an MCP
+  credential into a generic host-scoped sandbox credential.
 - Keep real credentials out of sandbox files, environment variables, process
   arguments, and logs.
-- Apply default-deny MCP tool policy at the iron-proxy boundary.
-- Make server visibility follow the principal's integration grant.
-- Preserve ordered overlay shadowing and repo-cache refresh behavior.
-- Validate the complete declaration before a sandbox receives it.
-- Make anonymous MCP servers possible without making them implicitly public to
-  every principal.
+- Route every authorized MCP connection through a generated gateway route whose
+  upstream egress and optional credential are route-only.
+- Apply default-deny MCP method and tool policy at the iron-proxy boundary in
+  both protocol directions.
+- Make server visibility follow an explicit principal authorization formula.
+- Preserve existing CLI, secret, skill, persona, and overlay behavior when no
+  external MCP declaration is present.
+- Publish source-attributed catalog generations that Console, iron-control,
+  sandbox assignment, and diagnostics can reconcile deterministically.
+- Make anonymous MCP servers possible without making them implicitly available
+  to every principal.
+- Fail a new external-MCP assignment before agent input when proxy and harness
+  generations cannot be proven consistent.
 
 ## Non-Goals
 
-- Replacing the existing CLI tool or skill formats.
+- Replacing or changing the existing CLI tool, secret, skill, persona, or
+  workflow formats.
+- Changing existing `tool-<slug>` grants or existing generic HTTP secret
+  behavior.
+- Changing the behavior of sandboxes that have no authorized external MCP
+  servers.
 - Adding a root `centaur.integrations.toml` manifest.
 - Supporting legacy HTTP+SSE transport in the first implementation.
+- Supporting MCP resources, prompts, completion, sampling, roots, elicitation,
+  or unrestricted server-to-client requests in version 1.
 - Running arbitrary install or shell commands from overlay metadata.
-- Solving general MCP OAuth discovery in the first implementation.
+- Solving general MCP OAuth discovery, browser consent, or dynamic client
+  registration in the first implementation.
 - Aggregating external MCP servers into Centaur's public `/mcp` endpoint.
 - Treating harness configuration as an authorization boundary. iron-proxy and
   principal grants remain the enforcement boundary.
 - Supporting local stdio MCP packages in the first implementation. See
   [Local stdio servers](#local-stdio-servers) for the follow-up shape.
+- Retrofitting the new route-only MCP policy onto existing direct HTTP or CLI
+  integrations.
 
 ## Prior Art
 
@@ -102,21 +134,24 @@ Related work:
 client-side half of this design: normalize one MCP server declaration, then
 write the native configuration expected by different agent clients. Centaur
 needs the same renderer boundary plus principal grants, overlay shadowing,
-managed egress, and credential-safe proxy policy.
+managed egress, gateway-only credentials, catalog generations, and assignment
+barriers.
 
 [FastMCP's proxy provider](https://gofastmcp.com/servers/providers/proxy) can
 bridge MCP transports without reimplementing the protocol in each integration.
 It is a candidate for local stdio compatibility, while direct native harness
 configuration remains the simpler path for remote Streamable HTTP servers.
 
-[iron-proxy's MCP policy and gateway](https://github.com/ironsh/iron-proxy#mcp-policy)
-already define the enforcement primitives this proposal should compile to.
-Centaur's missing piece is carrying those primitives through discovery,
-iron-control managed mode, principal grants, and sandbox assignment.
+[iron-proxy's MCP policy and gateway](https://github.com/paradigmxyz/iron-proxy#mcp-policy)
+already provide useful enforcement primitives. Version 1 requires those
+primitives, plus route-only upstream authorization, gateway-only credential
+binding, and a tool-only method profile, to be available through Centaur's
+managed control-plane path before the feature is enabled.
 
 ## Proposed Overlay Shape
 
-An anonymous remote server needs only metadata:
+An anonymous remote server needs only metadata and an explicit authorization
+choice:
 
 ```toml
 [project]
@@ -125,13 +160,11 @@ description = "Ethereum developer tools exposed over MCP"
 version = "0.1.0"
 requires-python = ">=3.11"
 
-[tool.centaur]
-hosts = ["ethereum-mcp.example.com"]
-
 [tool.centaur.mcp]
 name = "ethereum"
 transport = "streamable-http"
 url = "https://ethereum-mcp.example.com/mcp"
+public = false
 allowed_tools = [
     "get_balance",
     "get_block",
@@ -141,8 +174,11 @@ allowed_tools = [
 ```
 
 No `client.py` or `[project.scripts]` entry is required for an MCP-only
-directory. A directory that also exposes a CLI keeps using the existing
-packaging contract:
+directory. The new discovery path classifies this package as MCP-only and does
+not add a synthetic executable tool entry.
+
+A directory that also exposes a CLI keeps the existing packaging contract. The
+CLI and MCP server still receive independent capability identities:
 
 ```toml
 [project]
@@ -157,7 +193,7 @@ chain = "chain_tools.cli:app"
 
 [tool.centaur]
 module = "client.py"
-hosts = ["mcp.chain-tools.example.com"]
+hosts = ["api.chain-tools.example.com"]
 
 [tool.centaur.mcp]
 name = "chain"
@@ -169,43 +205,71 @@ credential = "CHAIN_MCP_TOKEN"
 [[tool.centaur.secrets]]
 type = "http"
 name = "CHAIN_MCP_TOKEN"
+secret_ref = "CHAIN_MCP_TOKEN"
+usage = "mcp-gateway"
 mode = "inject"
 inject_header = "Authorization"
 inject_formatter = "Bearer {{ .Value }}"
 hosts = ["mcp.chain-tools.example.com"]
 ```
 
-`credential` references a secret declared in the same directory. It never
-contains a secret value. The exact array/table syntax should follow the
-existing tool parser; the examples above illustrate the proposed semantic
-contract rather than a second parser.
+`credential` references a same-directory secret declaration whose new
+`usage = "mcp-gateway"` marker makes it eligible only for generated MCP gateway
+bindings. It reuses the existing secret source and host-scoping schema, but it
+is not emitted into the ordinary generic `secrets` or `transforms` sections.
+Existing secret declarations without `usage = "mcp-gateway"` retain their
+current behavior.
+
+A package that intentionally needs the same underlying value for both a CLI and
+MCP should declare two policy identities with distinct `name` values and the
+same `secret_ref`: one existing generic declaration for the CLI and one
+`mcp-gateway` declaration for the MCP route. This keeps the two grants and wire
+behaviors independently auditable.
+
+The exact array/table syntax should extend the existing tool parser rather than
+introducing a second manifest or parser.
 
 ### MCP fields
 
 | Field | Required | Meaning |
 | --- | --- | --- |
-| `name` | yes | Stable harness and audit name; unique after overlay shadowing. |
-| `transport` | yes | `streamable-http` in v1. |
+| `name` | yes | Stable logical, harness, and audit name within the package. |
+| `transport` | yes | `streamable-http` in version 1. |
 | `url` | yes | HTTPS upstream URL with a DNS hostname and normalized path. |
-| `allowed_tools` | yes | Explicit remote tool names accepted by policy. |
-| `credential` | no | Same-directory secret name used by the gateway. |
-| `startup_timeout_sec` | no | Harness-neutral startup timeout with bounded limits. |
+| `allowed_tools` | yes | Explicit upstream tool names accepted by policy. |
+| `credential` | no | Same-directory `mcp-gateway` secret name used only by the generated route. |
+| `public` | no | Explicitly expose a credentialless server without a role; defaults to `false`. |
+| `role` | no | Explicit role foreign ID; defaults to a generated MCP-specific role. |
+| `startup_timeout_sec` | no | Harness-neutral connection timeout with bounded limits. |
 | `tool_timeout_sec` | no | Harness-neutral call timeout with bounded limits. |
 | `enabled_harnesses` | no | Narrowing-only list; omitted means all compatible harnesses. |
 
-The URL is declarative because api-rs and Console must derive egress and
-credential rules without importing or executing overlay code. URL templates,
-shell interpolation, and literal authorization headers are rejected.
+The URL is declarative because api-rs and Console must derive route identity,
+egress, credential scope, and diagnostics without importing or executing
+overlay code. URL templates, shell interpolation, fragments, literal
+authorization headers, IP-literal hosts, and userinfo are rejected.
 
-`allowed_tools` is deliberately explicit. A future `allow_all_tools = true`
-may be added as a conspicuous opt-in, but it must have a tested representation
-in the pinned iron-proxy version. Centaur must not silently convert an absent
-list into allow-all.
+The MCP URL itself is the source of the upstream host. Existing
+`[tool.centaur].hosts` remains available for existing CLI secret behavior but is
+not required for an MCP-only package. A referenced `mcp-gateway` secret must be
+scoped to the normalized upstream host and, where supported, the narrowest
+practical path.
+
+`allowed_tools` is deliberately explicit. Version 1 has no `allow_all_tools`
+form and no argument-condition syntax. A later typed tool-table form may add
+argument conditions after the pinned proxy contract and cross-parser behavior
+are specified and tested. Centaur must never convert an absent or empty list
+into allow-all.
+
+`public = true` is accepted only for a credentialless server, remains subject to
+an operator-level deployment policy, and is deliberately conspicuous. An
+anonymous server may still perform consequential actions, so credential
+presence is not an authorization predicate.
 
 ### Capability bundles and skills
 
 No new bundle manifest is necessary. Existing overlay paths already describe
-the three useful surfaces:
+the useful surfaces:
 
 ```text
 centaur-overlay/
@@ -223,12 +287,49 @@ centaur-overlay/
 Matching slugs are a convention, not a new ownership model. The skill remains
 instructions and never grants MCP, CLI, network, or credential access.
 
-## Normalized Control-Plane Model
+## Capability Identity and Authorization
 
-Tool discovery should produce a typed record in addition to the current CLI
-catalog and secret proxy fragments:
+External MCP servers use a separate role by default:
 
 ```text
+mcp-<package-slug>-<server-slug>
+```
+
+The generated role follows the existing role and grant patterns, but does not
+silently expand an existing `tool-<slug>` CLI grant. An operator may set an
+explicit existing role in trusted overlay metadata when CLI and MCP are
+intentionally one indivisible capability.
+
+For interactive sessions, the effective external MCP catalog is computed as:
+
+1. the conversation/session principal must hold the MCP role; and
+2. when a requester principal is present, the requester must also hold the MCP
+   role.
+
+Workflow, tool-host, and other service sessions with no requester use their
+service principal alone. Future requester-hoisted or always-available MCP roles
+require a separate explicit grant type; they are not inferred from credential
+hoisting.
+
+A principal role assignment grants the server capability, not a raw URL or
+credential. When the server references a credential, the role also authorizes
+the corresponding gateway-only binding. The compiler must verify that the
+credential source is resolvable for the effective principal set before it emits
+the route.
+
+## Normalized Control-Plane Model
+
+Discovery should produce explicit package capabilities rather than assuming
+every `pyproject.toml` directory is executable:
+
+```text
+DiscoveredPackage {
+  package
+  source
+  cli?
+  external_mcp?
+}
+
 ExternalMcpServer {
   name
   package
@@ -238,73 +339,171 @@ ExternalMcpServer {
   upstream_host
   allowed_tools
   credential_ref?
+  public
   required_role
   startup_timeout?
   tool_timeout?
   enabled_harnesses?
+  source_repo
+  source_ref
+  source_commit
 }
 ```
 
-The default role is `tool-<slug>`, consistent with the role naming proposed in
-#883. Unlike today's secretless CLI behavior, an anonymous external MCP server
-is not automatically public. An operator must grant its role or explicitly
-mark the declaration public. Remote tools can perform consequential actions
-without needing a Centaur-managed credential, so secret presence is not an
-adequate authorization predicate.
+An MCP-only package contributes `external_mcp` but no `cli`. It is not inserted
+into existing executable tool discovery, CLI shim installation, or Centaur's
+existing public `/mcp` tool catalog.
 
-Discovery should fail the individual MCP declaration, with a visible
-diagnostic, when:
+### MCP-specific overlay shadowing
 
-- the URL is not HTTPS, lacks a DNS hostname, contains userinfo, or uses an
-  unsupported transport;
-- the URL host and declared host/credential policy disagree;
-- a referenced credential is absent or not scoped to the upstream host;
+The new external MCP catalog uses the same ordered overlay inputs but has
+fail-closed shadowing semantics for MCP declarations only:
+
+- a later package directory claims its external MCP package identity before the
+  declaration is fully validated;
+- a valid later declaration replaces the earlier declaration;
+- an invalid later declaration creates a visible tombstone and suppresses the
+  earlier external MCP declaration; and
+- existing CLI, persona, skill, and secret shadowing behavior remains unchanged.
+
+Two active packages that normalize to the same logical harness or route name
+without an overlay relationship are invalid. Logical names, DNS-safe route IDs,
+and display names are distinct fields so slugification collisions cannot
+silently merge capabilities.
+
+Discovery fails or tombstones the individual external MCP declaration, with a
+visible diagnostic, when:
+
+- the URL is not HTTPS, lacks a DNS hostname, contains userinfo or a fragment,
+  uses an IP literal, or uses an unsupported transport;
+- the normalized upstream resolves to a private, loopback, link-local, or
+  metadata address without a separate trusted internal-host policy;
+- a referenced credential is absent, is not marked `mcp-gateway`, or is not
+  scoped to the upstream host;
+- `public = true` is combined with a credential;
 - `allowed_tools` is empty, duplicated, or invalid;
-- two active overlays produce the same MCP name without normal shadowing; or
+- the generated or explicit role is invalid;
+- two active entries collide after logical-name or route-ID normalization; or
 - a timeout or harness name is unsupported.
 
 The API should expose the normalized catalog and validation status to Console
-and diagnostics. It should not execute a server's `tools/list` during ordinary
-repository discovery.
+and diagnostics. Ordinary repository discovery must not execute a server's
+`tools/list` or otherwise contact the declared URL.
+
+## Catalog Publication and Generations
+
+api-rs owns parsing overlay TOML. Console and iron-control consume a normalized,
+authenticated catalog generation and must not independently reparse the
+manifest.
+
+Each published generation contains:
+
+- source repository, ref, commit, and configured overlay order;
+- normalized entries and tombstones;
+- generated role identities and credential references, never credential values;
+- a canonical catalog digest; and
+- parser and validation diagnostics.
+
+Publication is an idempotent compare-and-swap keyed by the configured source
+identity and commit. A deployment must designate one reconciler for a source so
+multiple api-rs replicas cannot overwrite the same source with competing
+commits. Removal publishes a tombstone or a newer generation; absence is not
+interpreted as a successful empty catalog until the source generation is known.
+
+Downstream state carries separate hashes:
+
+1. `catalog_hash` for normalized overlay declarations;
+2. `grant_hash` for the effective principal authorization set;
+3. `proxy_config_hash` for the rendered managed proxy section; and
+4. `harness_config_hash` for the final parsed harness configuration after
+   operator overlays.
+
+The hashes may be combined into an assignment generation for convenience, but
+diagnostics retain the individual values so operators can distinguish catalog,
+grant, proxy, and harness drift.
+
+## Tool-Only MCP Protocol Profile
+
+Version 1 exposes a fixed, default-deny protocol profile. The generated proxy
+policy permits only:
+
+- Streamable HTTP initialization and normal lifecycle messages;
+- ping;
+- cancellation and progress messages required by an authorized call;
+- `tools/list`;
+- `tools/call` for explicitly listed tool names; and
+- session termination and resumability operations required by the pinned
+  Streamable HTTP protocol version.
+
+All other client-to-server and server-to-client JSON-RPC methods are denied.
+This includes resources, prompts, completion, sampling, roots, elicitation,
+logging control, and unknown extension methods. Server-originated requests and
+notifications are policy-checked before reaching the harness; filtering only
+`tools/list` is not treated as the authorization boundary.
+
+The generated route also carries a route-specific protocol header and HTTP
+method profile. It preserves the headers and methods required by the pinned
+Streamable HTTP transport, including `MCP-Session-Id`,
+`MCP-Protocol-Version`, `Last-Event-ID`, content negotiation, POST, GET, and
+negotiated DELETE semantics. This is new route-local configuration and does not
+require changing unrelated proxy traffic.
 
 ## Runtime Flow
 
-1. api-rs scans ordered `TOOL_DIRS` and parses CLI, secret, and MCP metadata.
-2. Existing overlay shadowing selects one active declaration for each name.
-3. The control plane intersects the catalog with the sandbox principal's
-   effective roles.
-4. Console/iron-control renders the granted servers into the proxy assignment.
-5. The config barrier confirms the proxy has the matching egress, MCP, gateway,
-   and credential policy before agent input runs.
-6. The sandbox renderer atomically writes the granted MCP servers into the
-   selected harness's native format.
-7. The harness connects through the sandbox's existing iron-proxy route.
-8. iron-proxy filters `tools/list`, denies unlisted `tools/call` requests,
-   injects the real credential if one is granted, and records protocol-aware
-   audit metadata.
+1. api-rs scans ordered `TOOL_DIRS` and parses CLI, secret, and external MCP
+   metadata into independent capability records.
+2. MCP-specific overlay shadowing selects valid entries or fail-closed
+   tombstones.
+3. The designated reconciler publishes the normalized catalog generation to
+   Console/iron-control.
+4. The control plane computes the effective server set from the session and
+   requester authorization formula.
+5. Console/iron-control renders each granted server into the managed proxy
+   assignment using route-only upstream egress, tool-only MCP policy, and an
+   optional gateway-only credential binding.
+6. A strict external-MCP assignment barrier confirms the proxy has applied the
+   expected `proxy_config_hash` before the harness receives the server.
+7. The sandbox renderer atomically writes the authorized MCP catalog into the
+   selected harness's native format and reparses the final configuration after
+   operator overlays.
+8. The adapter hot-reloads or restarts the harness as required, then reports the
+   applied `harness_config_hash`.
+9. Only after both hashes match the assignment generation may Centaur deliver
+   the first agent input.
+10. The harness connects only to the generated client-facing route. iron-proxy
+    applies the tool-only method profile, filters `tools/list`, denies unlisted
+    calls, injects the route credential after authorization, and records
+    protocol-aware audit metadata.
 
-Every downstream representation should carry a digest of the normalized MCP
-catalog and principal grant set. Diagnostics can then distinguish repository
-refresh, proxy sync, sandbox render, and harness load failures.
+The strict barrier is new and applies only when an assignment includes external
+MCP servers. Existing sandbox assignment behavior remains unchanged for
+sessions without external MCP capabilities.
 
 ## Harness Rendering
 
 Harness-specific syntax belongs in `services/sandbox`, not in overlay repos.
-The renderer consumes one JSON representation generated by the control plane
-and writes:
+The renderer consumes one normalized JSON representation generated by the
+control plane and writes:
 
 - Codex `[mcp_servers.<name>]` TOML;
 - Claude Code `mcpServers` JSON;
 - Amp's MCP settings; and
-- equivalent native configuration for other supported harnesses.
+- equivalent native configuration for other explicitly supported harnesses.
+
+The client-facing URL must not use the special-use `.local` suffix described
+by [RFC 6762](https://www.rfc-editor.org/rfc/rfc6762.html). It should use either
+the existing per-sandbox proxy service with a generated route path or a
+deployment-controlled internal DNS suffix. The logical MCP name remains
+separate from the transport route ID.
 
 The current `CODEX_CONFIG_OVERLAY` and `CLAUDE_SETTINGS_OVERLAY` remain operator
 escape hatches and apply after generated configuration. An operator override
-may narrow or replace generated settings, but it must not widen proxy policy.
+may narrow, rename, or remove generated harness entries, but it cannot widen
+proxy policy or create a route that the effective assignment did not authorize.
 
-Generated configuration must be parsed again after rendering. Invalid output
-is a sandbox startup or assignment error, not a warning followed by a missing
-server.
+The final merged configuration must be parsed again. Invalid output or a
+reference to an unauthorized route is an assignment failure, not a warning
+followed by a missing or partially configured server.
 
 ### Warm pools and refresh
 
@@ -313,54 +512,71 @@ Writing config only at image startup is insufficient because the principal is
 not known until claim time, and many harnesses read MCP configuration only at
 process startup.
 
-Before implementation, each harness adapter must define one of:
+Before enabling an adapter, it must implement one of:
 
-- an authenticated hot-reload operation;
+- an authenticated hot-reload operation with an applied-generation response;
 - a controlled harness restart after assignment but before first input; or
-- a stable preconfigured local gateway whose catalog is filtered after
-  assignment.
+- a stable preconfigured local broker whose catalog is filtered after
+  assignment and whose applied generation is queryable.
 
-The config barrier must cover both proxy sync and harness visibility. Repo-cache
-refresh during a live session should not expose a newly added server until the
-principal policy and harness catalog advance to the same digest. Removal should
-fail closed: revoke proxy policy first, then remove harness visibility.
+A warm-pool claim with external MCP is a transaction from the session's point
+of view:
+
+1. reserve the sandbox;
+2. compute the effective assignment generation;
+3. apply and verify proxy policy;
+4. render and verify harness configuration;
+5. expose the harness to agent input; or
+6. mark the sandbox failed and remove it from the pool.
+
+Repository additions do not become visible in a live session until an explicit
+execution boundary or successful adapter reload. Removal and role revocation
+fail closed: the proxy route is revoked first, active gateway sessions are
+closed, new calls are denied, and harness visibility is removed afterward.
+In-flight upstream requests may complete, but no new request may start under the
+revoked generation.
 
 ## iron-proxy and iron-control
 
-The pinned iron-proxy already has the relevant unmanaged configuration
-concepts:
+The pinned iron-proxy already has useful unmanaged concepts:
 
-- `mcp.servers` for default-deny `tools/call` enforcement and filtered
-  `tools/list` responses;
-- `mcp_gateway.routes` for stable client-facing routes, upstream selection,
-  and credential injection;
-- the ordinary domain allowlist for egress; and
-- the secrets transform for existing placeholder replacement.
+- `mcp.servers` for `tools/call` enforcement and filtered `tools/list`
+  responses;
+- `mcp_gateway.routes` for stable client-facing routes and upstream selection;
+- ordinary egress policy; and
+- existing secret source and transformation types.
 
-Centaur does not yet propagate all of those concepts through managed mode. The
-implementation must extend the iron-control model and Console snapshot rather
-than editing only `services/iron-proxy/iron-proxy.yaml`. A static-file-only
-change would work in unmanaged development and remain absent from Kubernetes.
+External MCP requires a managed representation of those concepts plus three
+new route-scoped guarantees:
 
-For each granted MCP declaration, the managed proxy config should contain:
+1. **route-only upstream egress:** the upstream connection is authorized only
+   when the request entered through the generated MCP route; a direct sandbox
+   request to the upstream host or path does not inherit that authorization;
+2. **gateway-only credential binding:** a referenced `mcp-gateway` secret is
+   resolved and injected by the route after MCP authorization, and is never
+   emitted as a generic host-scoped secret or transform; and
+3. **tool-only bidirectional method policy:** both request and response streams
+   are checked against the fixed version 1 profile.
 
-1. a stable client-facing route, preferably `<name>.mcp.local`, used by harness
-   configuration;
-2. an MCP server policy matching that host and path;
-3. the explicit tool allowlist and any argument conditions;
-4. a gateway route to the declared HTTPS upstream;
-5. a reference to the principal-granted credential source, when required; and
-6. the minimum egress policy needed for the route and any OAuth token endpoint.
+Centaur must carry these fields through the managed iron-control and Console
+snapshot path. Editing only `services/iron-proxy/iron-proxy.yaml` is not an
+implementation because Kubernetes sandboxes use managed proxy sync.
 
-The sandbox sees only the stable route and proxy CA. The proxy resolves the
-credential through iron-control and injects it after policy accepts the MCP
-request. Neither the generated harness config nor a shared Python adapter needs
-the real token.
+For each granted MCP declaration, the managed proxy config contains:
 
-Centaur's base header allowlist must also preserve the protocol-defined
-`Mcp-Session-Id` and `Mcp-Protocol-Version` headers. This is required even when
-the initial handshake succeeds; stateful servers need the session header on
-subsequent requests.
+1. a stable client-facing route using the per-sandbox proxy endpoint or a
+   deployment-controlled internal suffix;
+2. a route ID derived from package and MCP logical identity with collision
+   validation;
+3. an MCP server policy matching the route host and path;
+4. the fixed version 1 method profile and explicit tool allowlist;
+5. a route-only gateway mapping to the declared HTTPS upstream;
+6. an optional gateway-only credential source binding;
+7. the minimum upstream and token-endpoint egress required by that route; and
+8. catalog, grant, and rendered policy hashes for audit and barriers.
+
+The sandbox sees only the client-facing route and proxy CA. Neither the
+generated harness config nor a shared adapter receives the real token.
 
 ### Policy ordering
 
@@ -369,35 +585,56 @@ The desired request boundary is:
 ```text
 harness
   -> principal's iron-proxy
-  -> host/path egress policy
-  -> MCP server match
-  -> tools/call allowlist and argument policy
-  -> gateway credential injection
+  -> generated MCP route match
+  -> route-only egress authorization
+  -> bidirectional MCP method profile
+  -> tools/call allowlist
+  -> gateway-only credential injection
   -> remote MCP server
 ```
 
-The response boundary filters `tools/list` before the result reaches the
-harness. Authorization is still enforced on `tools/call`; filtering is not the
-security boundary.
+The response boundary applies the corresponding method policy and filters
+`tools/list` before content reaches the harness. Authorization is enforced on
+every call; catalog filtering is not the security boundary.
 
 ### Credential handling
 
-The MCP declaration names a credential capability, not a value. Existing
-Console grants determine whether the current principal can resolve it. The
-rendered route must be absent when a required credential is ungranted.
+The MCP declaration names a gateway credential capability, not a value. The
+same-directory `mcp-gateway` declaration reuses existing source kinds,
+resolution, labels, and host scoping. The generated MCP role and effective
+principal grants determine whether the route can resolve it.
 
-Static bearer injection can reuse the current HTTP secret model. Brokered or
-OAuth credentials should reuse existing secret sources where their lifecycle
-fits. General MCP OAuth discovery, browser consent, token audience handling,
-and refresh ownership require a separate follow-up because they introduce
-principal and session state beyond a static gateway route.
+The route is absent when a required credential is ungranted or unresolved. The
+credential binding is never copied into sandbox environment variables, harness
+files, process arguments, logs, or the ordinary generic proxy secret catalog.
+
+Static bearer, brokered token, or existing OAuth-token source kinds may be used
+when their lifecycle already fits a non-interactive route. General MCP OAuth
+discovery, browser consent, audience negotiation, dynamic registration, and
+per-user refresh ownership require a separate RFC.
+
+## Compatibility and Unchanged Behavior
+
+This proposal is additive. Implementations must prove the following invariants:
+
+- a package without `[tool.centaur.mcp]` produces the same existing CLI, secret,
+  persona, skill, and proxy behavior as before;
+- an existing secret without `usage = "mcp-gateway"` keeps its existing
+  registration and wire behavior;
+- existing `tool-<slug>` roles do not gain external MCP capabilities by default;
+- existing CLI and persona overlay shadowing is unchanged;
+- the existing public `/mcp` endpoint and its tool catalog are unchanged;
+- existing harness operator overlays remain available;
+- existing proxy assignment and warm-pool behavior is unchanged when no
+  external MCP server is assigned; and
+- no static-only proxy configuration is introduced into the Kubernetes path.
 
 ## Local stdio Servers
 
 Some packages expose a CLI, skills, and `--mcp` stdio mode from one artifact.
-That is a useful phase two, but it has a different security boundary:
-iron-proxy can constrain the process's outbound HTTP, but it cannot inspect the
-local stdio JSON-RPC stream.
+That is a useful later phase, but it has a different security boundary:
+iron-proxy can constrain the child process's outbound HTTP, but it cannot
+inspect the local stdio JSON-RPC stream.
 
 A later declaration could look like:
 
@@ -412,10 +649,11 @@ allowed_tools = ["get_address", "available", "price"]
 
 The command must name an installed script from the same reviewed tool package;
 absolute paths, shell strings, and arbitrary environment interpolation are
-rejected. To preserve default-deny tool policy, Centaur would need either:
+rejected. To preserve default-deny method and tool policy, Centaur would need
+either:
 
-- a shared local MCP bridge that filters the protocol before connecting the
-  harness to the child process; or
+- a shared local MCP bridge that filters both protocol directions before
+  connecting the harness to the child process; or
 - equivalent filtering implemented and tested in every harness adapter.
 
 FastMCP's proxy provider is a candidate for a shared Python bridge because it
@@ -427,89 +665,142 @@ bridge is sufficient.
 
 ## Security Considerations
 
-- External MCP descriptions and tool results are untrusted input to the model.
-- Tool names must be policy identities from the upstream protocol, not display
-  names rewritten by a harness.
-- A server declaration alone never creates a credential grant.
-- An anonymous server still requires an integration role unless explicitly
-  public.
-- URLs are validated without fetching them during discovery, avoiding SSRF from
-  the control plane.
-- iron-proxy must deny private, loopback, link-local, and metadata addresses
-  after DNS resolution unless explicitly supported by a separate internal-host
-  policy.
+- External MCP descriptions, schemas, notifications, and tool results are
+  untrusted input to the model.
+- Tool and method names are policy identities from the upstream protocol, not
+  display names rewritten by a harness.
+- A server declaration alone never creates a role or credential grant for a
+  principal.
+- An anonymous server still requires its MCP-specific role unless explicitly
+  marked `public = true` and permitted by deployment policy.
+- URLs are validated without fetching them during discovery, avoiding
+  control-plane SSRF.
+- Route creation revalidates DNS and denies private, loopback, link-local, and
+  metadata addresses unless a separate trusted internal-host policy applies.
+- DNS is checked at connection time so validation cannot be bypassed by later
+  resolution changes.
+- The gateway route, not a broad host allowlist, owns upstream egress.
 - Gateway credentials are scoped to exact hosts and the narrowest practical
-  paths.
-- Tool policy is default-deny. An absent or failed managed-policy sync makes the
-  server unavailable.
-- Audit logs may record server, MCP method, tool, decision, and policy version,
-  but never authorization headers, arguments likely to contain secrets, or
-  response bodies by default.
-- Overlay refresh is a policy change and should be attributable to repo, ref,
-  commit, and normalized catalog digest.
+  paths and are injected only after method and tool authorization.
+- Direct upstream HTTP requests do not receive route egress or credentials.
+- Redirects cannot escape the declared host and path policy or carry a
+  credential to a different authority.
+- Tool and method policy is default-deny. An absent, stale, or failed external
+  MCP managed-policy sync makes the route unavailable.
+- Operator harness overlays cannot create proxy authority.
+- Catalog, role, and route removal revoke proxy authority before removing
+  harness visibility.
+- Audit logs may record source generation, principal set, server, MCP method,
+  tool, decision, route, and policy version, but never authorization headers,
+  likely-secret arguments, or response bodies by default.
+- Overlay refresh is a policy change attributable to repository, ref, commit,
+  overlay order, and catalog digest.
 
 ## Rollout Plan
 
-### Phase 1: Typed discovery
+### Phase 1: Typed discovery only
 
-- Parse `[tool.centaur.mcp]` into a normalized catalog.
-- Add validation, overlay shadowing, diagnostics, and unit tests.
-- Do not render it to sandboxes yet.
+- Parse `[tool.centaur.mcp]` and `usage = "mcp-gateway"` into typed capability
+  records.
+- Classify MCP-only packages without adding them to existing executable or
+  public MCP catalogs.
+- Add MCP-specific fail-closed shadowing, tombstones, diagnostics, source
+  attribution, and unit tests.
+- Do not publish, render, or execute external MCP yet.
 
-### Phase 2: Managed proxy policy
+### Phase 2: Catalog publication and grants
 
-- Extend iron-control and Console snapshot models for MCP servers, gateway
-  routes, and hostname egress policy.
-- Preserve MCP protocol headers.
-- Test anonymous and credentialed Streamable HTTP servers through managed mode.
+- Add normalized catalog-generation storage and authenticated idempotent
+  publication.
+- Add MCP-specific role registration and the session/requester authorization
+  formula.
+- Add gateway-only credential bindings that reuse existing source kinds without
+  entering the generic secret catalog.
+- Expose catalog and grant hashes to diagnostics.
 
-### Phase 3: Harness rendering
+### Phase 3: Managed proxy enforcement
+
+- Extend iron-control and Console proxy snapshots for routes, route-only egress,
+  gateway-only credentials, tool-only bidirectional method policy, and
+  route-local Streamable HTTP headers and methods.
+- Require a pinned iron-proxy version that enforces those fields.
+- Test direct upstream denial, redirects, DNS changes, anonymous servers, and
+  credentialed servers through managed mode.
+
+### Phase 4: Harness rendering and assignment barrier
 
 - Render the normalized catalog for Codex first, then Claude Code and Amp.
-- Define warm-pool claim and live-refresh behavior before enabling by default.
-- Add end-to-end tests proving role changes update both visibility and policy.
+- Add the strict external-MCP proxy-and-harness assignment generation barrier.
+- Implement warm-pool claim failure and disposal when the barrier cannot be
+  satisfied.
+- Add controlled refresh and revocation behavior before enabling by default.
 
-### Phase 4: Local stdio and package pass-through
+### Phase 5: Local stdio and package pass-through
 
 - Add a controlled package/command declaration.
-- Choose and pin a shared protocol bridge.
-- Enforce tool policy before the local child process receives a call.
+- Choose and pin a shared bidirectional protocol bridge.
+- Enforce method and tool policy before the local child process receives a
+  call.
 
-These phases should be separate PRs. The first implementation is approximately
-a medium cross-service feature rather than a small overlay change: discovery
-and one harness are focused, while managed iron-control propagation and
-warm-pool correctness are the larger pieces.
+These phases should be separate PRs. The first implementation is a cross-service
+feature rather than a small overlay change: discovery is focused, while catalog
+reconciliation, managed proxy enforcement, and warm-pool correctness are the
+larger pieces.
 
 ## Validation Plan
 
-- Parser fixtures for valid, shadowed, malformed, anonymous, and credentialed
-  MCP declarations.
-- Cross-parser tests proving api-rs and `centaur-perms` interpret secrets and
-  roles identically.
-- Snapshot tests for Codex, Claude Code, and Amp renderers.
-- Managed-mode proxy tests for `initialize`, `notifications/initialized`,
-  `tools/list`, and `tools/call` with session headers.
-- Tests that an unlisted tool is filtered and denied before upstream receives
-  it.
-- Tests that an ungranted principal sees no server route and cannot reach the
-  upstream directly.
+- Parser fixtures for valid, shadowed, tombstoned, malformed, anonymous,
+  public, credentialed, CLI-plus-MCP, and MCP-only declarations.
+- Compatibility tests proving packages without new metadata and secrets without
+  the new usage marker retain byte-equivalent normalized outputs.
+- Tests proving MCP-only packages do not synthesize CLI entries or appear in
+  Centaur's existing public `/mcp` catalog.
+- Tests proving an invalid later MCP overlay suppresses an earlier MCP entry
+  without changing the package's existing CLI shadowing behavior.
+- Cross-parser tests proving api-rs and `centaur-perms` interpret
+  `mcp-gateway` declarations, roles, sources, and hosts identically.
+- Catalog publication tests for idempotency, competing replicas, source commit
+  changes, tombstones, and removals.
+- Authorization tests for conversation principals, requester principals,
+  service principals, explicit roles, and `public = true`.
+- Snapshot tests for Codex, Claude Code, and Amp renderers, including operator
+  narrowing and unauthorized-route rejection.
+- Managed-mode proxy tests for initialize, lifecycle notifications, ping,
+  cancellation/progress, `tools/list`, `tools/call`, GET/SSE resumability,
+  negotiated DELETE/session termination, and required protocol headers.
+- Tests that resources, prompts, completion, sampling, roots, elicitation,
+  logging control, unknown methods, and unauthorized server-originated messages
+  are denied before reaching the other side.
+- Tests that unlisted tools are filtered and denied before upstream receives
+  them.
+- Tests that direct requests to the upstream host or path receive neither route
+  egress nor credentials, including raw HTTP, non-JSON bodies, redirects, and
+  alternate DNS answers.
+- Tests that a shared underlying `secret_ref` can back distinct generic and
+  gateway-only declarations without merging their grants or wire behavior.
+- Tests that an ungranted principal sees no server route and cannot use the
+  generated gateway.
 - Tests that the sandbox contains no real credential.
-- Warm-pool tests for claim, role change, overlay refresh, and revocation.
+- Assignment-generation tests for cold create, warm-pool claim, role change,
+  overlay refresh, proxy lag, harness reload failure, and sandbox disposal.
+- Revocation tests proving the proxy route disappears first, active streams are
+  closed, and new calls fail before harness visibility is removed.
 - One real anonymous remote server and one controlled credentialed server in
   the local Kubernetes stack.
 
 ## Open Questions
 
-- Should anonymous MCP integrations require `tool-<slug>` by default, or use a
-  separate `mcp-<slug>` role?
-- Does the pinned iron-proxy version have a safe explicit allow-all tool form,
-  or should Centaur require concrete names until that contract exists?
-- Should a stable gateway alias be mandatory, or may anonymous servers use
-  their upstream URL directly?
-- Which harnesses can hot-reload MCP configuration, and which require a restart
-  on warm-pool claim?
-- Should overlay refresh affect existing sessions immediately or only new
-  executions after an explicit catalog generation change?
+- Should catalog publication be owned by a dedicated reconciler process or by a
+  leader-elected api-rs replica?
+- Should the client-facing route use the existing per-sandbox proxy service and
+  path, or a deployment-controlled internal DNS suffix?
+- Which harnesses can return an authenticated applied-generation result after
+  hot reload, and which require a controlled restart?
+- Should additions affect existing sessions only at execution boundaries, or
+  may an adapter opt into immediate reload after proving the same assignment
+  generation?
+- Which existing secret source kinds are safe for a non-interactive
+  `mcp-gateway` binding in version 1?
 - Is general MCP OAuth best modeled as a new Console integration type or as an
   extension of brokered credentials?
 - Should local stdio servers share the Python-based FastMCP proxy provider, the
@@ -520,10 +811,10 @@ warm-pool correctness are the larger pieces.
 ### Root overlay manifest
 
 A root manifest can list CLIs, MCP servers, and skills in one file, but it
-duplicates discovery roots, secret metadata, role labels, shadowing, and
-package identity. It also creates a non-operative file in existing overlays
-until every control-plane consumer learns it. Extending the current per-tool
-contract keeps one declarative source of truth.
+duplicates discovery roots, secret metadata, role labels, shadowing, and package
+identity. It also creates a non-operative file in existing overlays until every
+control-plane consumer learns it. Extending the current per-tool contract keeps
+one declarative source of truth.
 
 ### Bespoke Python client per MCP server
 
@@ -536,10 +827,31 @@ discovery, and protocol evolution.
 
 Harness overlays are useful escape hatches and have proven the transport can
 work. They do not provide normalized validation, cross-harness portability,
-principal visibility, managed egress, or protocol-aware proxy policy.
+principal visibility, managed egress, gateway-only credentials, or
+protocol-aware proxy policy.
 
 ### Static iron-proxy configuration only
 
 The static file is not consumed by Kubernetes managed-mode proxies. Supporting
 only that path would create a local success case while leaving the production
 control-plane path unimplemented.
+
+### Direct upstream URLs in harness configuration
+
+Pointing a harness directly at the upstream URL makes the route identity,
+credential injection, and tool policy optional client behavior. Version 1
+requires a generated gateway route so the proxy remains the enforcement
+boundary.
+
+### Reusing a generic HTTP secret as the MCP credential
+
+A generic host-scoped secret can authorize traffic outside the MCP route. The
+new `mcp-gateway` usage reuses source resolution and host scoping while keeping
+the credential out of ordinary generic proxy transforms.
+
+### Reusing the CLI role by default
+
+A package's CLI and remote MCP surface may have different risk and lifecycle.
+Silently expanding an existing `tool-<slug>` grant would make an overlay refresh
+an implicit privilege escalation. External MCP therefore uses a separate role
+unless trusted metadata explicitly selects an existing role.

--- a/services/api-rs/rfcs/0006-overlay-native-external-mcp.md
+++ b/services/api-rs/rfcs/0006-overlay-native-external-mcp.md
@@ -1,0 +1,545 @@
+# RFC 0006: Overlay-Native External MCP Servers
+
+Status: Draft
+Owner: TBD
+Target: `services/api-rs`, `services/sandbox`, `services/console`,
+`services/iron-proxy`
+
+## Summary
+
+Let an overlay register a remote MCP server by extending the existing
+per-tool `pyproject.toml` contract. Centaur should discover one normalized MCP
+declaration, render it into each supported harness, and compile the same
+declaration into principal-scoped iron-proxy egress, credential, gateway, and
+tool policy.
+
+An operator should not need to:
+
+- hand-write a different MCP config for every harness;
+- copy a token into a sandbox;
+- implement a bespoke Python JSON-RPC client for every MCP server; or
+- add a second root-level overlay manifest that duplicates tool, secret, and
+  role metadata Centaur already discovers.
+
+The proposed unit remains a tool directory. A directory may provide a CLI, a
+remote MCP server, or both. Skills remain in `.agents/skills/`, where the
+overlay loader already supports them, and may use the same slug to document the
+corresponding CLI and MCP surface.
+
+This RFC covers Centaur acting as an MCP **client** inside agent sandboxes. It
+does not replace the existing `/mcp` endpoint, where Centaur acts as an MCP
+server for external clients.
+
+## Motivation
+
+Centaur has native overlay delivery for tools, workflows, skills, personas,
+and prompts. Tools already use `pyproject.toml` as a declarative boundary for
+CLI scripts, secret references, allowed credential hosts, and per-tool labels.
+There is no equivalent supported path for a sandbox to consume a third-party
+MCP server.
+
+The current escape hatch is harness-specific configuration such as
+`CODEX_CONFIG_OVERLAY`. It can make a remote server work, but it has several
+properties that make it unsuitable as the product contract:
+
+- it only configures one harness;
+- malformed configuration is ignored and fails as a missing server later;
+- it is deployment-wide rather than a discovered overlay capability;
+- it does not create a managed iron-proxy MCP policy or egress grant;
+- it cannot drive principal-specific discoverability; and
+- it has no shared validation for URLs, transports, credentials, or tool
+  policy.
+
+The repository also contains MCP-specific clients for individual integrations.
+Those clients prove demand but repeat transport, session, error, and response
+parsing that an MCP implementation should own once.
+
+Related work:
+
+- [#1176](https://github.com/paradigmxyz/centaur/issues/1176) describes the
+  external-MCP client gap and a working Codex-only configuration workaround.
+- [#1385](https://github.com/paradigmxyz/centaur/issues/1385) explains why the
+  static `iron-proxy.yaml` allowlist is not a Kubernetes managed-mode control
+  surface.
+- [#205](https://github.com/paradigmxyz/centaur/pull/205) identified the MCP
+  session and protocol headers required through iron-proxy.
+- [#883](https://github.com/paradigmxyz/centaur/pull/883) proposes per-tool role
+  filtering for Centaur's MCP server direction. External MCP visibility should
+  use the same role vocabulary.
+- [#841](https://github.com/paradigmxyz/centaur/pull/841) implements Centaur as
+  an MCP server. This RFC addresses the opposite direction.
+
+## Goals
+
+- Declare a remote Streamable HTTP MCP server in an overlay tool directory.
+- Use one normalized declaration to configure every supported harness.
+- Reuse existing secret declarations and principal grants.
+- Keep real credentials out of sandbox files, environment variables, process
+  arguments, and logs.
+- Apply default-deny MCP tool policy at the iron-proxy boundary.
+- Make server visibility follow the principal's integration grant.
+- Preserve ordered overlay shadowing and repo-cache refresh behavior.
+- Validate the complete declaration before a sandbox receives it.
+- Make anonymous MCP servers possible without making them implicitly public to
+  every principal.
+
+## Non-Goals
+
+- Replacing the existing CLI tool or skill formats.
+- Adding a root `centaur.integrations.toml` manifest.
+- Supporting legacy HTTP+SSE transport in the first implementation.
+- Running arbitrary install or shell commands from overlay metadata.
+- Solving general MCP OAuth discovery in the first implementation.
+- Aggregating external MCP servers into Centaur's public `/mcp` endpoint.
+- Treating harness configuration as an authorization boundary. iron-proxy and
+  principal grants remain the enforcement boundary.
+- Supporting local stdio MCP packages in the first implementation. See
+  [Local stdio servers](#local-stdio-servers) for the follow-up shape.
+
+## Prior Art
+
+[add-mcp](https://github.com/neon-solutions/add-mcp) demonstrates the useful
+client-side half of this design: normalize one MCP server declaration, then
+write the native configuration expected by different agent clients. Centaur
+needs the same renderer boundary plus principal grants, overlay shadowing,
+managed egress, and credential-safe proxy policy.
+
+[FastMCP's proxy provider](https://gofastmcp.com/servers/providers/proxy) can
+bridge MCP transports without reimplementing the protocol in each integration.
+It is a candidate for local stdio compatibility, while direct native harness
+configuration remains the simpler path for remote Streamable HTTP servers.
+
+[iron-proxy's MCP policy and gateway](https://github.com/ironsh/iron-proxy#mcp-policy)
+already define the enforcement primitives this proposal should compile to.
+Centaur's missing piece is carrying those primitives through discovery,
+iron-control managed mode, principal grants, and sandbox assignment.
+
+## Proposed Overlay Shape
+
+An anonymous remote server needs only metadata:
+
+```toml
+[project]
+name = "ethereum-mcp"
+description = "Ethereum developer tools exposed over MCP"
+version = "0.1.0"
+requires-python = ">=3.11"
+
+[tool.centaur]
+hosts = ["ethereum-mcp.example.com"]
+
+[tool.centaur.mcp]
+name = "ethereum"
+transport = "streamable-http"
+url = "https://ethereum-mcp.example.com/mcp"
+allowed_tools = [
+    "get_balance",
+    "get_block",
+    "get_transaction",
+    "read_contract",
+]
+```
+
+No `client.py` or `[project.scripts]` entry is required for an MCP-only
+directory. A directory that also exposes a CLI keeps using the existing
+packaging contract:
+
+```toml
+[project]
+name = "chain-tools"
+description = "Chain CLI and remote MCP server"
+version = "0.1.0"
+requires-python = ">=3.11"
+dependencies = ["chain-tools-cli==1.2.3"]
+
+[project.scripts]
+chain = "chain_tools.cli:app"
+
+[tool.centaur]
+module = "client.py"
+hosts = ["mcp.chain-tools.example.com"]
+
+[tool.centaur.mcp]
+name = "chain"
+transport = "streamable-http"
+url = "https://mcp.chain-tools.example.com/mcp"
+allowed_tools = ["resolve_name", "get_balance"]
+credential = "CHAIN_MCP_TOKEN"
+
+[[tool.centaur.secrets]]
+type = "http"
+name = "CHAIN_MCP_TOKEN"
+mode = "inject"
+inject_header = "Authorization"
+inject_formatter = "Bearer {{ .Value }}"
+hosts = ["mcp.chain-tools.example.com"]
+```
+
+`credential` references a secret declared in the same directory. It never
+contains a secret value. The exact array/table syntax should follow the
+existing tool parser; the examples above illustrate the proposed semantic
+contract rather than a second parser.
+
+### MCP fields
+
+| Field | Required | Meaning |
+| --- | --- | --- |
+| `name` | yes | Stable harness and audit name; unique after overlay shadowing. |
+| `transport` | yes | `streamable-http` in v1. |
+| `url` | yes | HTTPS upstream URL with a DNS hostname and normalized path. |
+| `allowed_tools` | yes | Explicit remote tool names accepted by policy. |
+| `credential` | no | Same-directory secret name used by the gateway. |
+| `startup_timeout_sec` | no | Harness-neutral startup timeout with bounded limits. |
+| `tool_timeout_sec` | no | Harness-neutral call timeout with bounded limits. |
+| `enabled_harnesses` | no | Narrowing-only list; omitted means all compatible harnesses. |
+
+The URL is declarative because api-rs and Console must derive egress and
+credential rules without importing or executing overlay code. URL templates,
+shell interpolation, and literal authorization headers are rejected.
+
+`allowed_tools` is deliberately explicit. A future `allow_all_tools = true`
+may be added as a conspicuous opt-in, but it must have a tested representation
+in the pinned iron-proxy version. Centaur must not silently convert an absent
+list into allow-all.
+
+### Capability bundles and skills
+
+No new bundle manifest is necessary. Existing overlay paths already describe
+the three useful surfaces:
+
+```text
+centaur-overlay/
+├── tools/
+│   └── ethereum/
+│       ├── pyproject.toml       # CLI and/or remote MCP declaration
+│       ├── client.py            # optional ordinary tool methods
+│       └── ethereum_tool/       # optional CLI implementation
+└── .agents/
+    └── skills/
+        └── ethereum/
+            └── SKILL.md         # how and when to use the capability
+```
+
+Matching slugs are a convention, not a new ownership model. The skill remains
+instructions and never grants MCP, CLI, network, or credential access.
+
+## Normalized Control-Plane Model
+
+Tool discovery should produce a typed record in addition to the current CLI
+catalog and secret proxy fragments:
+
+```text
+ExternalMcpServer {
+  name
+  package
+  overlay
+  transport
+  upstream_url
+  upstream_host
+  allowed_tools
+  credential_ref?
+  required_role
+  startup_timeout?
+  tool_timeout?
+  enabled_harnesses?
+}
+```
+
+The default role is `tool-<slug>`, consistent with the role naming proposed in
+#883. Unlike today's secretless CLI behavior, an anonymous external MCP server
+is not automatically public. An operator must grant its role or explicitly
+mark the declaration public. Remote tools can perform consequential actions
+without needing a Centaur-managed credential, so secret presence is not an
+adequate authorization predicate.
+
+Discovery should fail the individual MCP declaration, with a visible
+diagnostic, when:
+
+- the URL is not HTTPS, lacks a DNS hostname, contains userinfo, or uses an
+  unsupported transport;
+- the URL host and declared host/credential policy disagree;
+- a referenced credential is absent or not scoped to the upstream host;
+- `allowed_tools` is empty, duplicated, or invalid;
+- two active overlays produce the same MCP name without normal shadowing; or
+- a timeout or harness name is unsupported.
+
+The API should expose the normalized catalog and validation status to Console
+and diagnostics. It should not execute a server's `tools/list` during ordinary
+repository discovery.
+
+## Runtime Flow
+
+1. api-rs scans ordered `TOOL_DIRS` and parses CLI, secret, and MCP metadata.
+2. Existing overlay shadowing selects one active declaration for each name.
+3. The control plane intersects the catalog with the sandbox principal's
+   effective roles.
+4. Console/iron-control renders the granted servers into the proxy assignment.
+5. The config barrier confirms the proxy has the matching egress, MCP, gateway,
+   and credential policy before agent input runs.
+6. The sandbox renderer atomically writes the granted MCP servers into the
+   selected harness's native format.
+7. The harness connects through the sandbox's existing iron-proxy route.
+8. iron-proxy filters `tools/list`, denies unlisted `tools/call` requests,
+   injects the real credential if one is granted, and records protocol-aware
+   audit metadata.
+
+Every downstream representation should carry a digest of the normalized MCP
+catalog and principal grant set. Diagnostics can then distinguish repository
+refresh, proxy sync, sandbox render, and harness load failures.
+
+## Harness Rendering
+
+Harness-specific syntax belongs in `services/sandbox`, not in overlay repos.
+The renderer consumes one JSON representation generated by the control plane
+and writes:
+
+- Codex `[mcp_servers.<name>]` TOML;
+- Claude Code `mcpServers` JSON;
+- Amp's MCP settings; and
+- equivalent native configuration for other supported harnesses.
+
+The current `CODEX_CONFIG_OVERLAY` and `CLAUDE_SETTINGS_OVERLAY` remain operator
+escape hatches and apply after generated configuration. An operator override
+may narrow or replace generated settings, but it must not widen proxy policy.
+
+Generated configuration must be parsed again after rendering. Invalid output
+is a sandbox startup or assignment error, not a warning followed by a missing
+server.
+
+### Warm pools and refresh
+
+Warm sandboxes make principal-specific MCP configuration a lifecycle concern.
+Writing config only at image startup is insufficient because the principal is
+not known until claim time, and many harnesses read MCP configuration only at
+process startup.
+
+Before implementation, each harness adapter must define one of:
+
+- an authenticated hot-reload operation;
+- a controlled harness restart after assignment but before first input; or
+- a stable preconfigured local gateway whose catalog is filtered after
+  assignment.
+
+The config barrier must cover both proxy sync and harness visibility. Repo-cache
+refresh during a live session should not expose a newly added server until the
+principal policy and harness catalog advance to the same digest. Removal should
+fail closed: revoke proxy policy first, then remove harness visibility.
+
+## iron-proxy and iron-control
+
+The pinned iron-proxy already has the relevant unmanaged configuration
+concepts:
+
+- `mcp.servers` for default-deny `tools/call` enforcement and filtered
+  `tools/list` responses;
+- `mcp_gateway.routes` for stable client-facing routes, upstream selection,
+  and credential injection;
+- the ordinary domain allowlist for egress; and
+- the secrets transform for existing placeholder replacement.
+
+Centaur does not yet propagate all of those concepts through managed mode. The
+implementation must extend the iron-control model and Console snapshot rather
+than editing only `services/iron-proxy/iron-proxy.yaml`. A static-file-only
+change would work in unmanaged development and remain absent from Kubernetes.
+
+For each granted MCP declaration, the managed proxy config should contain:
+
+1. a stable client-facing route, preferably `<name>.mcp.local`, used by harness
+   configuration;
+2. an MCP server policy matching that host and path;
+3. the explicit tool allowlist and any argument conditions;
+4. a gateway route to the declared HTTPS upstream;
+5. a reference to the principal-granted credential source, when required; and
+6. the minimum egress policy needed for the route and any OAuth token endpoint.
+
+The sandbox sees only the stable route and proxy CA. The proxy resolves the
+credential through iron-control and injects it after policy accepts the MCP
+request. Neither the generated harness config nor a shared Python adapter needs
+the real token.
+
+Centaur's base header allowlist must also preserve the protocol-defined
+`Mcp-Session-Id` and `Mcp-Protocol-Version` headers. This is required even when
+the initial handshake succeeds; stateful servers need the session header on
+subsequent requests.
+
+### Policy ordering
+
+The desired request boundary is:
+
+```text
+harness
+  -> principal's iron-proxy
+  -> host/path egress policy
+  -> MCP server match
+  -> tools/call allowlist and argument policy
+  -> gateway credential injection
+  -> remote MCP server
+```
+
+The response boundary filters `tools/list` before the result reaches the
+harness. Authorization is still enforced on `tools/call`; filtering is not the
+security boundary.
+
+### Credential handling
+
+The MCP declaration names a credential capability, not a value. Existing
+Console grants determine whether the current principal can resolve it. The
+rendered route must be absent when a required credential is ungranted.
+
+Static bearer injection can reuse the current HTTP secret model. Brokered or
+OAuth credentials should reuse existing secret sources where their lifecycle
+fits. General MCP OAuth discovery, browser consent, token audience handling,
+and refresh ownership require a separate follow-up because they introduce
+principal and session state beyond a static gateway route.
+
+## Local stdio Servers
+
+Some packages expose a CLI, skills, and `--mcp` stdio mode from one artifact.
+That is a useful phase two, but it has a different security boundary:
+iron-proxy can constrain the process's outbound HTTP, but it cannot inspect the
+local stdio JSON-RPC stream.
+
+A later declaration could look like:
+
+```toml
+[tool.centaur.mcp]
+name = "ens"
+transport = "stdio"
+command = "ens"
+args = ["--mcp"]
+allowed_tools = ["get_address", "available", "price"]
+```
+
+The command must name an installed script from the same reviewed tool package;
+absolute paths, shell strings, and arbitrary environment interpolation are
+rejected. To preserve default-deny tool policy, Centaur would need either:
+
+- a shared local MCP bridge that filters the protocol before connecting the
+  harness to the child process; or
+- equivalent filtering implemented and tested in every harness adapter.
+
+FastMCP's proxy provider is a candidate for a shared Python bridge because it
+can proxy remote or local transports and present a local stdio server. It is an
+implementation option, not part of the overlay schema. The official MCP SDK or
+another maintained bridge can satisfy the same contract. Per-integration
+Python files should not be required when a generated invocation of the shared
+bridge is sufficient.
+
+## Security Considerations
+
+- External MCP descriptions and tool results are untrusted input to the model.
+- Tool names must be policy identities from the upstream protocol, not display
+  names rewritten by a harness.
+- A server declaration alone never creates a credential grant.
+- An anonymous server still requires an integration role unless explicitly
+  public.
+- URLs are validated without fetching them during discovery, avoiding SSRF from
+  the control plane.
+- iron-proxy must deny private, loopback, link-local, and metadata addresses
+  after DNS resolution unless explicitly supported by a separate internal-host
+  policy.
+- Gateway credentials are scoped to exact hosts and the narrowest practical
+  paths.
+- Tool policy is default-deny. An absent or failed managed-policy sync makes the
+  server unavailable.
+- Audit logs may record server, MCP method, tool, decision, and policy version,
+  but never authorization headers, arguments likely to contain secrets, or
+  response bodies by default.
+- Overlay refresh is a policy change and should be attributable to repo, ref,
+  commit, and normalized catalog digest.
+
+## Rollout Plan
+
+### Phase 1: Typed discovery
+
+- Parse `[tool.centaur.mcp]` into a normalized catalog.
+- Add validation, overlay shadowing, diagnostics, and unit tests.
+- Do not render it to sandboxes yet.
+
+### Phase 2: Managed proxy policy
+
+- Extend iron-control and Console snapshot models for MCP servers, gateway
+  routes, and hostname egress policy.
+- Preserve MCP protocol headers.
+- Test anonymous and credentialed Streamable HTTP servers through managed mode.
+
+### Phase 3: Harness rendering
+
+- Render the normalized catalog for Codex first, then Claude Code and Amp.
+- Define warm-pool claim and live-refresh behavior before enabling by default.
+- Add end-to-end tests proving role changes update both visibility and policy.
+
+### Phase 4: Local stdio and package pass-through
+
+- Add a controlled package/command declaration.
+- Choose and pin a shared protocol bridge.
+- Enforce tool policy before the local child process receives a call.
+
+These phases should be separate PRs. The first implementation is approximately
+a medium cross-service feature rather than a small overlay change: discovery
+and one harness are focused, while managed iron-control propagation and
+warm-pool correctness are the larger pieces.
+
+## Validation Plan
+
+- Parser fixtures for valid, shadowed, malformed, anonymous, and credentialed
+  MCP declarations.
+- Cross-parser tests proving api-rs and `centaur-perms` interpret secrets and
+  roles identically.
+- Snapshot tests for Codex, Claude Code, and Amp renderers.
+- Managed-mode proxy tests for `initialize`, `notifications/initialized`,
+  `tools/list`, and `tools/call` with session headers.
+- Tests that an unlisted tool is filtered and denied before upstream receives
+  it.
+- Tests that an ungranted principal sees no server route and cannot reach the
+  upstream directly.
+- Tests that the sandbox contains no real credential.
+- Warm-pool tests for claim, role change, overlay refresh, and revocation.
+- One real anonymous remote server and one controlled credentialed server in
+  the local Kubernetes stack.
+
+## Open Questions
+
+- Should anonymous MCP integrations require `tool-<slug>` by default, or use a
+  separate `mcp-<slug>` role?
+- Does the pinned iron-proxy version have a safe explicit allow-all tool form,
+  or should Centaur require concrete names until that contract exists?
+- Should a stable gateway alias be mandatory, or may anonymous servers use
+  their upstream URL directly?
+- Which harnesses can hot-reload MCP configuration, and which require a restart
+  on warm-pool claim?
+- Should overlay refresh affect existing sessions immediately or only new
+  executions after an explicit catalog generation change?
+- Is general MCP OAuth best modeled as a new Console integration type or as an
+  extension of brokered credentials?
+- Should local stdio servers share the Python-based FastMCP proxy provider, the
+  official SDK, or a small runtime-native bridge?
+
+## Rejected Alternatives
+
+### Root overlay manifest
+
+A root manifest can list CLIs, MCP servers, and skills in one file, but it
+duplicates discovery roots, secret metadata, role labels, shadowing, and
+package identity. It also creates a non-operative file in existing overlays
+until every control-plane consumer learns it. Extending the current per-tool
+contract keeps one declarative source of truth.
+
+### Bespoke Python client per MCP server
+
+This works today and is appropriate when an integration intentionally exposes a
+smaller domain API. It is wasteful as the generic MCP path: each client repeats
+session initialization, JSON-RPC envelopes, SSE parsing, errors, schema
+discovery, and protocol evolution.
+
+### Harness overlays only
+
+Harness overlays are useful escape hatches and have proven the transport can
+work. They do not provide normalized validation, cross-harness portability,
+principal visibility, managed egress, or protocol-aware proxy policy.
+
+### Static iron-proxy configuration only
+
+The static file is not consumed by Kubernetes managed-mode proxies. Supporting
+only that path would create a local success case while leaving the production
+control-plane path unimplemented.


### PR DESCRIPTION
## Summary

- propose a typed `[tool.centaur.mcp]` declaration for remote, tool-only Streamable HTTP MCP servers in overlay tool packages
- keep CLI and external MCP capabilities independent: MCP-only packages do not synthesize executable tools, and external MCP uses a separate role by default
- compile one normalized catalog into native harness configuration and principal-scoped managed proxy routes, method/tool policy, route-only egress, and optional gateway-only credentials
- add source-attributed catalog generations and a strict proxy-plus-harness assignment barrier for external MCP
- preserve existing CLI, skill, persona, generic-secret, operator-overlay, public `/mcp`, and non-MCP sandbox behavior

## Key design decisions

### Tool-only version 1

Version 1 permits the MCP lifecycle, ping, cancellation and progress messages, `tools/list`, explicitly authorized `tools/call`, and the Streamable HTTP session operations required by the pinned protocol version.

Resources, prompts, completion, sampling, roots, elicitation, logging control, unknown methods, unrestricted server-to-client requests, general MCP OAuth, and local stdio are deferred until Centaur can enforce them explicitly.

### Gateway-only authority

A credentialed MCP declaration references an existing same-package secret declaration by name. That reference reuses Centaur’s existing secret-source and grant patterns, but the credential is bound only to the generated MCP gateway route rather than emitted as a generic host-scoped proxy secret.

The generated route owns both upstream egress and credential injection, so direct requests to the upstream URL do not inherit the MCP capability or credential.

### Independent authorization

External MCP defaults to a role such as `mcp-<package>-<server>` rather than silently expanding an existing `tool-<slug>` grant.

Interactive sessions require the conversation principal and, when present, the requester principal to hold the MCP role. Credentialless servers are still private by default; `public = true` is explicit and subject to deployment policy.

### Additive discovery and fail-closed shadowing

The discovery model represents CLI and external MCP capabilities independently, so an MCP-only package contributes no CLI entry and does not appear in Centaur’s existing public `/mcp` catalog.

External MCP declarations get their own fail-closed overlay semantics: an invalid later MCP override suppresses the earlier MCP capability without changing existing CLI, persona, skill, secret, or other overlay behavior.

### Managed generations and warm pools

api-rs remains the TOML parser and publishes a normalized, source-attributed catalog generation to Console and iron-control.

Catalog, grant, proxy, and final harness hashes are tracked separately. For assignments containing external MCP, Centaur verifies both proxy and harness generations before delivering agent input. Existing assignment behavior remains unchanged when no external MCP server is assigned.

## Scope

This is a draft design PR only. It does not make external MCP available or change runtime behavior.

The RFC recommends separate implementation PRs for:

1. typed discovery and MCP-specific overlay tombstones;
2. catalog publication, roles, and gateway-only credential bindings;
3. managed proxy routes, route-only egress, and the tool-only protocol profile;
4. harness rendering and the strict external-MCP assignment barrier; and
5. local stdio support in a later phase.

## Related work

- Related to #1176
- Related to #1385
- Builds on the Streamable HTTP header finding in #205
- Follows the role-oriented direction discussed in #883 without depending on it
- Complements the opposite MCP direction implemented in #841

## Validation described by the RFC

- compatibility tests for packages and secrets without the new MCP metadata
- parser, MCP-only package, shadowing, tombstone, catalog-generation, and principal/requester authorization tests
- managed-mode tests for bidirectional method policy, tool allowlists, sessions, SSE resumability, direct-upstream denial, redirects, DNS changes, and credential isolation
- cold-create, warm-pool, refresh, revocation, and harness-reload generation tests
- end-to-end tests using one anonymous and one controlled credentialed MCP server in the local Kubernetes stack

---

Written by GPT 5.6 Sol in Codex