### PR TITLE
fix(console): accept current Granola MCP meeting tags

### DIFF
--- a/services/console/app/services/granola/sync_credential.rb
+++ b/services/console/app/services/granola/sync_credential.rb
@@ -17,7 +17,7 @@ module Granola
     DEFAULT_MAX_NOTES = 50
     WATERMARK_OVERLAP_SECONDS = 5 * 60
 
-    MEETING_RE = /<meeting\s+id="(?<id>[^"]+)"\s+title="(?<title>[^"]*)"\s+date="(?<date>[^"]*)">(?<body>.*?)<\/meeting>/m
+    MEETING_RE = /<meeting\s+id="(?<id>[^"]+)"\s+title="(?<title>[^"]*)"\s+date="(?<date>[^"]*)"(?:\s+[^>]*)?>(?<body>.*?)<\/meeting>/m
     PARTICIPANTS_RE = /<known_participants>(?<participants>.*?)<\/known_participants>/m
     SUMMARY_RE = /<summary>(?<summary>.*?)<\/summary>/m
     PARTICIPANT_RE = /(?<name>[^,<]+?)\s*<(?<email>[^>]+)>/
@@ -93,6 +93,8 @@ module Granola
           "custom_end" => Time.current.utc.to_date.iso8601
         )
       ).first(self.class.max_notes)
+
+      return [] if meetings.empty?
 
       details = parse_meetings(
         mcp_tool("get_meetings", "meeting_ids" => meetings.map { |meeting| meeting.fetch("id") })

--- a/services/console/test/services/granola/sync_credential_test.rb
+++ b/services/console/test/services/granola/sync_credential_test.rb
@@ -92,6 +92,23 @@ module Granola
       assert_equal "Ada: Ship the Granola sync.", note["transcript"].first["text"]
     end
 
+    test "completes an empty meeting window without requesting details" do
+      api_client = FakeApiClient.new
+      mcp_http = lambda do |tool:, **|
+        case tool
+        when "get_account_info" then { email: "owner@example.com" }.to_json
+        when "list_meetings" then %(<meetings_data count="0"></meetings_data>)
+        else flunk "unexpected Granola MCP tool #{tool}"
+        end
+      end
+
+      SyncCredential.new(credential, api_client: api_client, mcp_http: mcp_http).call
+
+      batch = api_client.batches.fetch(0)
+      assert_equal "completed", batch[:run][:status]
+      assert_empty batch[:notes]
+    end
+
     test "records an API failure against the same OAuth credential scope" do
       api_client = FakeApiClient.new
       mcp_http = lambda do |tool:, **|
@@ -152,7 +169,7 @@ module Granola
 
     def meeting_xml
       <<~XML
-        <meeting id="meeting-1" title="Planning" date="Jul 8, 2026 5:30 PM GMT+2">
+        <meeting id="meeting-1" title="Planning" date="Jul 8, 2026 5:30 PM GMT+2" captured_by_me="true" listed_as_participant="true">
           <known_participants>Ada (note creator) from Acme &lt;ada@example.com&gt;
           Bob &lt;bob@example.com&gt;</known_participants>
           <summary>Ship the Granola sync.</summary>


### PR DESCRIPTION
## What changed

- accept the additional attributes now emitted on Granola MCP `<meeting>` tags
- treat an empty meeting window as a successful empty sync instead of calling `get_meetings` with an invalid empty ID array
- cover both current tag shape and empty-window behavior

## Why

Granola MCP currently emits attributes such as `captured_by_me`, `listed_as_participant`, and `is_workspace_visible` after `date`. The exact-tag regex in 0.1.115 consequently parses 374 returned meetings as zero, then calls `get_meetings` with `meeting_ids: []`, which Granola rejects.

## Verification

```text
4 runs, 30 assertions, 0 failures, 0 errors, 0 skips
```

Ran `test/services/granola/sync_credential_test.rb` in the pinned Console image against an isolated Postgres 16 database.
