### PR TITLE
fix(session-sqlx): let failed executions re-run

### DIFF
--- a/services/api-rs/crates/centaur-session-sqlx/migrations/0053_session_execution_retry_idempotency.sql
+++ b/services/api-rs/crates/centaur-session-sqlx/migrations/0053_session_execution_retry_idempotency.sql
@@ -1,0 +1,18 @@
+-- A failed or cancelled execution must not block a fresh execution that
+-- carries the same idempotency key. The original index covered every row,
+-- so once a turn died -- for example on a control-plane roll before the
+-- adoption hardening landed -- the stable key of its trigger (a GitHub
+-- review is keyed per commit) made the work permanently un-rerunnable:
+-- the insert hit the index and the caller got the dead row back with
+-- created = false.
+--
+-- The index now covers only rows whose outcome still matters for dedupe:
+-- in-flight work (queued / running) and completed work. Failed and
+-- cancelled rows fall out of the index, so the next insert with the same
+-- key creates a fresh execution instead of resurrecting the dead one.
+drop index if exists session_executions_thread_idempotency_idx;
+
+create unique index if not exists session_executions_active_idempotency_idx
+    on session_executions (thread_key, idempotency_key)
+    where idempotency_key is not null
+      and status in ('queued', 'running', 'completed');

--- a/services/api-rs/crates/centaur-session-sqlx/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-sqlx/src/lib.rs
@@ -401,6 +401,7 @@ impl PgSessionStore {
             values ($1, $2, $3, $4, $5, $6)
             on conflict (thread_key, idempotency_key)
                 where idempotency_key is not null
+                  and status in ('queued', 'running', 'completed')
             do update set
                 idempotency_key = excluded.idempotency_key,
                 request = case
@@ -2379,6 +2380,91 @@ mod tests {
                 .await
                 .expect("load persisted execution request"),
             first_request
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn failed_execution_does_not_block_rerun_on_same_idempotency_key() {
+        let Some(store) = test_store().await else {
+            return;
+        };
+        let thread_key = ThreadKey::parse(format!("test:retry-idem-{}", Uuid::new_v4())).unwrap();
+        store
+            .create_or_get_session(
+                &thread_key,
+                &HarnessType::Codex,
+                None,
+                json!({}),
+                Default::default(),
+            )
+            .await
+            .expect("create session");
+        let key = "review-commit-abc123";
+        let first = store
+            .create_execution_with_request(&thread_key, Some(key), json!({}), json!({}))
+            .await
+            .expect("create execution with request");
+        assert!(first.created);
+        store
+            .fail_execution(
+                &first.execution.execution_id,
+                "sandbox stdout closed before terminal output; stdout reattach attempts exhausted",
+            )
+            .await
+            .expect("fail execution");
+
+        // A failed row must not shadow a fresh run on the same stable key:
+        // a turn killed by a control-plane roll has to be retryable.
+        let retry = store
+            .create_execution_with_request(&thread_key, Some(key), json!({}), json!({}))
+            .await
+            .expect("retry execution with request");
+        assert!(
+            retry.created,
+            "rerun after failure must create a fresh execution"
+        );
+        assert_ne!(
+            retry.execution.execution_id, first.execution.execution_id,
+            "retry must not resurrect the failed row"
+        );
+
+        // In-flight rows still dedupe.
+        let duplicate = store
+            .create_execution_with_request(&thread_key, Some(key), json!({}), json!({}))
+            .await
+            .expect("duplicate queued execution");
+        assert!(!duplicate.created);
+        assert_eq!(
+            duplicate.execution.execution_id,
+            retry.execution.execution_id
+        );
+        store
+            .mark_execution_running(&retry.execution.execution_id)
+            .await
+            .expect("mark retry running");
+        let duplicate_running = store
+            .create_execution_with_request(&thread_key, Some(key), json!({}), json!({}))
+            .await
+            .expect("duplicate running execution");
+        assert!(!duplicate_running.created);
+        assert_eq!(
+            duplicate_running.execution.execution_id,
+            retry.execution.execution_id
+        );
+
+        // Completed rows still dedupe.
+        store
+            .complete_execution(&retry.execution.execution_id)
+            .await
+            .expect("complete retry");
+        let duplicate_completed = store
+            .create_execution_with_request(&thread_key, Some(key), json!({}), json!({}))
+            .await
+            .expect("duplicate completed execution");
+        assert!(!duplicate_completed.created);
+        assert_eq!(
+            duplicate_completed.execution.execution_id,
+            retry.execution.execution_id
         );
     }
 


### PR DESCRIPTION
Closes #1507

## Context

The unique idempotency index on `session_executions` covered every row, so a
failed or cancelled execution permanently held its `(thread_key,
idempotency_key)` pair. For any trigger with a stable key the work then became
un-rerunnable: the insert hit the index and the caller got the dead row back
with `created = false`.

A GitHub review is keyed per commit, so this is reachable in normal operation.
A turn killed mid-flight — a control-plane roll, say — leaves a `failed` row
that no identical re-request can ever get past. The only recovery is editing the
row by hand or pushing a new commit to move the key.

## Change

Migration `0053` swaps the index in place so it covers only the statuses where
dedupe is still meaningful:

```sql
create unique index if not exists session_executions_active_idempotency_idx
    on session_executions (thread_key, idempotency_key)
    where idempotency_key is not null
      and status in ('queued', 'running', 'completed');
```

In-flight and completed work still dedupes, so a retried webhook cannot start a
second live turn or resurrect a finished answer. Failed and cancelled rows drop
out of the index, and the next insert with that key creates a fresh execution.
The upsert conflict clause is narrowed to match the new index.

## Testing

- `cargo fmt --all --check` and `cargo clippy -p centaur-session-sqlx
  --all-targets`: clean.
- `cargo test -p centaur-session-sqlx`: passes.

One caveat worth stating plainly: the new test,
`failed_execution_does_not_block_rerun_on_same_idempotency_key`, is
database-backed and returns early when `SESSION_RUNTIME_TEST_DATABASE_URL` is
unset. I had no Postgres available, so **it reported `ok` without executing, and
I have not exercised the migration or the new index locally.** CI has the
database and will actually run it. The test asserts that a failed execution is
followed by a fresh `created = true` execution on the same key.

`0053` is the next free number on top of `0052_session_execution_request.sql` at
the time of writing; it will need renumbering if another migration lands first.
