### PR TITLE
fix(harness-server): stop forwarding rate-limit notifications

### DIFF
--- a/crates/harness-server/src/codex.rs
+++ b/crates/harness-server/src/codex.rs
@@ -608,7 +608,7 @@ impl CodexJsonRpcChild {
                 }
                 return Ok(value.get("result").cloned().unwrap_or(Value::Null));
             }
-            if notification_method(&value).is_some() {
+            if notification_method(&value).is_some_and(should_forward_notification) {
                 write_value(stdout, &value)?;
             }
         }
@@ -910,6 +910,22 @@ fn notification_method(value: &Value) -> Option<&str> {
         return None;
     }
     value.get("method").and_then(Value::as_str)
+}
+
+/// Codex app-server notifications that reach no consumer and so should not be
+/// forwarded onto the blocks stream.
+///
+/// Forwarding is otherwise verbatim, because the wire contract clients parse
+/// (see `packages/harness-events`) is the codex notification shape. That makes
+/// this a deny list rather than an allow list: dropping an unrecognised method
+/// would silently break a client that does understand it.
+///
+/// `account/rateLimits/updated` is the case that earns the list. Nothing in
+/// this crate or in `packages/harness-events` names it, every field arrives
+/// null, and it repeats across every pod, so its only effect is volume on a
+/// stream that is also the sandbox's container log.
+fn should_forward_notification(method: &str) -> bool {
+    method != "account/rateLimits/updated"
 }
 
 fn error_notification_will_retry(value: &Value) -> bool {
@@ -1214,5 +1230,29 @@ mod tests {
         });
         assert!(!is_terminal_notification(&retryable, "thread-1", "turn-1"));
         assert!(is_terminal_notification(&exhausted, "thread-1", "turn-1"));
+    }
+
+    #[test]
+    fn rate_limit_notifications_are_not_forwarded() {
+        assert!(!should_forward_notification("account/rateLimits/updated"));
+    }
+
+    /// The wire contract clients parse is the codex notification shape, so the
+    /// filter is a deny list: anything it does not name keeps flowing, including
+    /// methods this build has never seen.
+    #[test]
+    fn other_notifications_still_forward() {
+        for method in [
+            "item/reasoning/textDelta",
+            "item/reasoning/summaryTextDelta",
+            "turn/completed",
+            "remoteControl/status/changed",
+            "some/method/added/after/this/build",
+        ] {
+            assert!(
+                should_forward_notification(method),
+                "{method} should still forward"
+            );
+        }
     }
 }


### PR DESCRIPTION
Closes #1556.

Part of #1514 — the `rateLimits` half. See below for why the reasoning half is not in here.

## Change

`read_response_or_forward` forwards every codex notification it sees while
waiting on a request, verbatim. `account/rateLimits/updated` is forwarded that
way with every field null, repeatedly, from every pod.

Nothing consumes it. The method appears nowhere else in `crates/harness-server`
and nowhere in `packages/harness-events`, which is where the wire contract
clients parse is defined. Its only effect is volume on a stream that is also the
sandbox's container log.

The filter is a **deny list, not an allow list**, on purpose. Forwarding is
otherwise verbatim because the shape clients parse *is* the codex notification
shape, so dropping an unrecognised method would silently break a client that
does understand it. The test asserts a made-up future method still forwards.

## Why the reasoning half is not here

#1514 proposes stopping protocol frames on stdout, or gating them behind a debug
flag. Two things found while implementing say that cannot be done as written,
and I would rather raise them than guess at your protocol:

1. **Clients parse the raw frames.** `packages/harness-events` types
   `{ method: "item/reasoning/textDelta"; params: ReasoningTextDeltaNotification }`
   directly, and `packages/rendering` has a test for suppressing reasoning
   blocks. Dropping the frames would break rendering, not just quieten logs.
2. **That stdout is also the durable recovery channel.** Adoption recovers a
   turn that completed during a reader gap by reading the sandbox's recorded
   output, which is the pod log. Suppressing frames there would remove the
   record recovery depends on.

So the leak is real but the fix is not "stop writing". The narrower framing is
that reasoning content is durable in the cluster log pipeline for as long as pod
logs are retained, which is a retention decision rather than an emission one —
unless the recovery path moves to a channel that is not the container log.

Happy to follow up with whichever direction you prefer.

## Testing

`cargo test -p harness-server`: 92 unit tests pass, including two new ones for
the filter. `cargo clippy --all-targets -- -D warnings` clean.

`tests/app_server_stdio.rs::turn_interrupt_rejects_wrong_thread_and_turn_without_killing_process`
fails in my environment with `read start log: NotFound`. It fails identically on
an unmodified checkout, so it is a local fixture issue and not this change.

