### PR TITLE
fix(linearbot): stagger assignment turn starts

### DIFF
--- a/services/linearbot/src/assignment-gate.ts
+++ b/services/linearbot/src/assignment-gate.ts
@@ -1,0 +1,164 @@
+/**
+ * Paces the assignment turns linearbot starts, and optionally bounds how many
+ * of them run at once.
+ *
+ * A qualifying `Issue` webhook kicks a turn immediately and independently, so a
+ * burst starts every turn on the same instant. Bursts are routine: someone
+ * hands the bot a batch of issues, Linear redelivers webhooks that failed while
+ * the bot or its control plane was down, and the membership-only fallback means
+ * redelivered `update` payloads for already-delegated issues qualify as fresh
+ * handoffs.
+ *
+ * Two separate problems come out of that, and this handles them separately.
+ *
+ * **Alignment.** Turns that start on the same instant hit sandbox admission in
+ * the same tick, spawn their sandboxes together, and then issue their first
+ * inference call together — the least useful shape for the model serving behind
+ * them. Admission is a limit rather than a queue, so a batch that would have
+ * fit had it arrived spread out can still lose the check-then-act race, and
+ * `runThreadTurn` only retries on the cold-start backoff (250ms, doubling,
+ * three attempts), far too short to outlast a sandbox running someone else's
+ * work. `staggerMs` spaces consecutive starts so they stop colliding. It delays
+ * turns; it never drops or bounds them, and it is on by default.
+ *
+ * **Fleet share.** `concurrency` is something else entirely: a cap on turns in
+ * flight, which only makes sense as this ingress's slice of a sandbox fleet
+ * shared with the other ingresses. Slices are meant to oversubscribe — x/y/z
+ * across n pods, summing to more than n — so that a quiet githubbot leaves its
+ * pods usable rather than idle. That makes it a deployment-wide decision, not
+ * something this file can guess, so it defaults to off (0). Left off, the only
+ * limit is the fleet's own admission limit, which is also off by default
+ * upstream.
+ *
+ * A bound that is set is a queue, not a rejection: surplus turns wait here for
+ * a slot instead of being dropped. Waiting is invisible on the issue, so `run`
+ * reports it — see `onQueued`.
+ */
+
+export type AssignmentGateOptions = {
+  /**
+   * Turns allowed in flight at once, as this ingress's share of the sandbox
+   * fleet. 0 disables the bound, which is the default: a cap set here that is
+   * unrelated to the fleet's real size is a work-in-progress limit nobody asked
+   * for. Values below 0 are treated as 0.
+   */
+  concurrency: number;
+  /**
+   * Minimum spacing between consecutive turn starts. Each start also waits a
+   * random extra delay in `[0, staggerMs)`, so starts scatter instead of
+   * landing on an exact grid; adjacent turns can swap order, which is the
+   * point. 0 disables the delay.
+   */
+  staggerMs: number;
+  /** Injectable for tests. */
+  now?: () => number;
+  /** Injectable for tests. */
+  random?: () => number;
+  /** Injectable for tests. */
+  sleep?: (ms: number) => Promise<void>;
+};
+
+const defaultSleep = (ms: number): Promise<void> =>
+  ms > 0 ? new Promise((resolve) => setTimeout(resolve, ms)) : Promise.resolve();
+
+export class AssignmentGate {
+  private readonly concurrency: number;
+  private readonly staggerMs: number;
+  private readonly now: () => number;
+  private readonly random: () => number;
+  private readonly sleep: (ms: number) => Promise<void>;
+  private active = 0;
+  private readonly waiting: Array<() => void> = [];
+  /**
+   * When the next start is allowed. Held on the instance rather than derived
+   * per-request: bursts arrive as independent webhooks, so the schedule only
+   * spaces anything if they all reserve against one cursor.
+   */
+  private nextStartAtMs = 0;
+
+  constructor(options: AssignmentGateOptions) {
+    this.concurrency = Math.max(0, Math.floor(options.concurrency));
+    this.staggerMs = Math.max(0, Math.floor(options.staggerMs));
+    this.now = options.now ?? Date.now;
+    this.random = options.random ?? Math.random;
+    this.sleep = options.sleep ?? defaultSleep;
+  }
+
+  /** Turns currently in flight. Exposed for tests and diagnostics. */
+  get activeCount(): number {
+    return this.active;
+  }
+
+  /** Turns waiting for a slot. Exposed for tests and diagnostics. */
+  get queuedCount(): number {
+    return this.waiting.length;
+  }
+
+  /**
+   * Claims the next start slot and reports how long this arrival waits for it.
+   *
+   * Synchronous on purpose: the cursor has to move before the caller yields, or
+   * a burst arriving within one tick would all read the same slot. Idle time is
+   * never banked — the cursor is pulled forward to now — so a quiet bot starts
+   * the next assignment immediately.
+   */
+  reserveDelayMs(): number {
+    if (this.staggerMs === 0) return 0;
+    const now = this.now();
+    const startAtMs = Math.max(now, this.nextStartAtMs);
+    this.nextStartAtMs = startAtMs + this.staggerMs;
+    return startAtMs - now + Math.floor(this.random() * this.staggerMs);
+  }
+
+  /**
+   * Runs `task` once a slot is free and its scheduled start comes around.
+   *
+   * `onQueued` fires — with the number of turns already waiting — when this one
+   * has to wait for a slot rather than starting straight away. A queued
+   * assignment is otherwise entirely invisible: nothing posts on the issue, its
+   * status does not move, and the only evidence the bot took the work is that
+   * it is not doing it.
+   *
+   * The slot is released whatever the task does, including throwing: a turn
+   * that fails must not wedge the queue behind it, since the failure modes this
+   * exists to handle are exactly the ones that throw.
+   */
+  async run<T>(
+    task: () => Promise<T>,
+    onQueued?: (queuedAhead: number) => void,
+  ): Promise<T> {
+    await this.acquire(onQueued);
+    try {
+      // Reserve unconditionally so the cursor advances even when this start is
+      // due now; only the waiting is skipped.
+      const delayMs = this.reserveDelayMs();
+      if (delayMs > 0) await this.sleep(delayMs);
+      return await task();
+    } finally {
+      this.release();
+    }
+  }
+
+  private acquire(onQueued?: (queuedAhead: number) => void): Promise<void> {
+    if (this.concurrency === 0 || this.active < this.concurrency) {
+      this.active += 1;
+      return Promise.resolve();
+    }
+    const admitted = new Promise<void>((resolve) => {
+      this.waiting.push(resolve);
+    });
+    onQueued?.(this.waiting.length - 1);
+    return admitted;
+  }
+
+  private release(): void {
+    const next = this.waiting.shift();
+    if (next) {
+      // Hand the slot straight over rather than decrementing and racing: a
+      // burst would otherwise let a newly arrived turn overtake a queued one.
+      next();
+      return;
+    }
+    this.active -= 1;
+  }
+}

--- a/services/linearbot/src/index.ts
+++ b/services/linearbot/src/index.ts
@@ -15,6 +15,8 @@ import {
   type Thread,
 } from "chat";
 import { Hono, type Context } from "hono";
+
+import { AssignmentGate } from "./assignment-gate";
 import pg from "pg";
 import {
   parseIssueAssignmentWebhook,
@@ -369,6 +371,9 @@ const ISSUE_CONTEXT_PREAMBLE_MAX_CHARS = 8_000;
 // itself is the "I've started" signal). Replaced by the live thought, then the
 // final answer, as the run proceeds.
 const WORK_START_HEADLINE = "On it — working on this issue.";
+const ASSIGNMENT_QUEUED_NOTICE =
+  "⏳ Queued — I'm at my limit for assignments running at once. " +
+  "I'll start on this as soon as a slot frees up.";
 const PROFILE_HANDLE_PATTERN = /\/profiles\/([^/?#]+)/;
 
 type ThreadHandlerInput = {
@@ -656,6 +661,28 @@ async function appendThreadFollowup(input: {
  * on the issue's sandbox and post the result as a comment. Uses the Issue
  * webhook (not an AgentSessionEvent) so it survives agent sessions being off.
  */
+// Off: how many turns may run at once is this ingress's slice of a sandbox
+// fleet shared with the others, which only a deployment can size. api-rs leaves
+// its own capacity limit off by default too.
+const DEFAULT_ASSIGNMENT_CONCURRENCY = 0;
+// On: spacing costs a burst a few hundred milliseconds and buys admission,
+// sandbox spawn and first inference not landing on the same instant.
+const DEFAULT_ASSIGNMENT_STAGGER_MS = 250;
+
+/**
+ * One gate per process. Assignment bursts arrive as independent webhooks, so
+ * the bound has to be shared across them rather than per-request.
+ */
+let assignmentGate: AssignmentGate | undefined;
+
+function assignmentGateFor(options: LinearbotOptions): AssignmentGate {
+  assignmentGate ??= new AssignmentGate({
+    concurrency: options.assignmentConcurrency ?? DEFAULT_ASSIGNMENT_CONCURRENCY,
+    staggerMs: options.assignmentStaggerMs ?? DEFAULT_ASSIGNMENT_STAGGER_MS,
+  });
+  return assignmentGate;
+}
+
 function handleIssueAssignment(
   rawBody: string,
   input: ThreadHandlerInput,
@@ -689,19 +716,29 @@ function handleIssueAssignment(
     const client = (thread.adapter as unknown as LinearSessionCapableAdapter)
       .linearClient;
     backgroundWaitUntil(
-      runThreadTurn({
-        announceStart: true,
-        applyStatus: true,
-        botUserId: input.botUserId,
-        client,
-        executeMessage: assignmentInstructionMessage(event, threadKey),
-        issueId: event.issueId,
-        options,
-        overrides: {},
-        thread,
-        threadKey,
-        trace,
-      }),
+      assignmentGateFor(options).run(
+        () =>
+          runThreadTurn({
+            announceStart: true,
+            applyStatus: true,
+            botUserId: input.botUserId,
+            client,
+            executeMessage: assignmentInstructionMessage(event, threadKey),
+            issueId: event.issueId,
+            options,
+            overrides: {},
+            thread,
+            threadKey,
+            trace,
+          }),
+        (queuedAhead) => {
+          traceLog(options, "linearbot_assignment_queued", trace, {
+            issue_id: event.issueId,
+            queued_ahead: queuedAhead,
+          });
+          announceAssignmentQueued(client, event.issueId, options);
+        },
+      ),
     );
   })();
 }
@@ -1020,6 +1057,30 @@ async function runThreadTurn(input: {
     chars: body?.length ?? 0,
     failed,
   });
+}
+
+/**
+ * Says on the issue that the assignment is waiting for a slot. The wait is
+ * otherwise undetectable from Linear: nothing posts, the status does not move,
+ * and the issue is indistinguishable from one the bot never picked up.
+ */
+function announceAssignmentQueued(
+  client: LinearSessionCapableAdapter["linearClient"],
+  issueId: string,
+  options: LinearbotOptions,
+): void {
+  if (!client) return;
+  backgroundWaitUntil(
+    (async () => {
+      try {
+        await postIssueReply(client, { body: ASSIGNMENT_QUEUED_NOTICE, issueId });
+      } catch (error) {
+        (options.logger ?? noopLogger).debug("linearbot_queued_notice_failed", {
+          error: errorMessage(error),
+        });
+      }
+    })(),
+  );
 }
 
 /** Synthetic "work this assigned issue" prompt for an assignment turn. */

--- a/services/linearbot/src/server.ts
+++ b/services/linearbot/src/server.ts
@@ -49,6 +49,8 @@ const options: LinearbotOptions = {
   apiUrl,
   apiKey: optionalEnv("LINEARBOT_API_KEY"),
   defaultHarnessType: optionalEnv("LINEARBOT_DEFAULT_HARNESS"),
+  assignmentConcurrency: optionalNumberEnv("LINEARBOT_ASSIGNMENT_CONCURRENCY"),
+  assignmentStaggerMs: optionalNumberEnv("LINEARBOT_ASSIGNMENT_STAGGER_MS"),
   idleTimeoutMs: optionalNumberEnv("SESSION_IDLE_TIMEOUT_MS"),
   linearAccessToken,
   linearApiKey,

--- a/services/linearbot/src/types.ts
+++ b/services/linearbot/src/types.ts
@@ -90,6 +90,23 @@ export type LinearbotOptions = {
   apiKey?: string;
   apiUrl: string;
   /**
+   * Assignment turns allowed in flight at once — this ingress's share of a
+   * sandbox fleet shared with githubbot, slackbot and the console. Shares are
+   * meant to oversubscribe (x/y/z across n pods, summing past n) so a quiet
+   * ingress leaves its pods usable, which makes the number a deployment-wide
+   * decision. Defaults to 0: unbounded, deferring to the fleet's own admission
+   * limit rather than inventing a second one here. Surplus turns queue; they
+   * are not dropped.
+   */
+  assignmentConcurrency?: number;
+  /**
+   * Minimum spacing between consecutive assignment turn starts, plus a random
+   * extra delay in `[0, staggerMs)`. Keeps a burst of Issue webhooks from
+   * hitting sandbox admission, spawning sandboxes, and issuing their first
+   * inference call all on the same instant. Defaults to 250ms; 0 disables it.
+   */
+  assignmentStaggerMs?: number;
+  /**
    * Connect the Postgres state (and initialize the adapter) at startup.
    * Defaults to true; tests pass false to skip the live connect against mock
    * backends.

--- a/services/linearbot/test/assignment-gate.test.ts
+++ b/services/linearbot/test/assignment-gate.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, it } from "bun:test";
+
+import { AssignmentGate } from "../src/assignment-gate";
+
+/** Clock the tests drive by hand, so nothing waits on a real timer. */
+function fakeClock(startMs = 1_000) {
+  let nowMs = startMs;
+  return {
+    advance: (ms: number): void => {
+      nowMs += ms;
+    },
+    now: (): number => nowMs,
+  };
+}
+
+/** Drains the microtask queue; `run` awaits both acquire and the stagger. */
+const flush = (): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, 0));
+
+function deferred<T = void>() {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, reject, resolve };
+}
+
+describe("AssignmentGate stagger", () => {
+  it("spaces a burst that arrives in one tick", async () => {
+    const clock = fakeClock();
+    const delays: number[] = [];
+    const gate = new AssignmentGate({
+      concurrency: 0,
+      now: clock.now,
+      random: () => 0,
+      sleep: async (ms) => {
+        delays.push(ms);
+      },
+      staggerMs: 250,
+    });
+
+    const started: number[] = [];
+    await Promise.all(
+      [0, 1, 2, 3].map((index) =>
+        gate.run(async () => {
+          started.push(index);
+        }),
+      ),
+    );
+
+    // Four assignments must not become four simultaneous admissions. The
+    // first is due now and never sleeps; the rest are spaced behind it.
+    expect(delays).toEqual([250, 500, 750]);
+    // Nothing is capped: unbounded means every turn still runs.
+    expect(started.toSorted()).toEqual([0, 1, 2, 3]);
+    expect(gate.activeCount).toBe(0);
+  });
+
+  it("never banks idle time", () => {
+    const clock = fakeClock();
+    const gate = new AssignmentGate({
+      concurrency: 0,
+      now: clock.now,
+      random: () => 0,
+      staggerMs: 250,
+    });
+
+    expect(gate.reserveDelayMs()).toBe(0);
+    expect(gate.reserveDelayMs()).toBe(250);
+    // A quiet stretch leaves the next assignment starting at once rather than
+    // credited with the slots it did not use.
+    clock.advance(60_000);
+    expect(gate.reserveDelayMs()).toBe(0);
+    expect(gate.reserveDelayMs()).toBe(250);
+  });
+
+  it("jitters within the spacing so starts miss the grid", () => {
+    const gate = new AssignmentGate({
+      concurrency: 0,
+      now: fakeClock().now,
+      random: () => 0.5,
+      staggerMs: 250,
+    });
+
+    expect(gate.reserveDelayMs()).toBe(125);
+    expect(gate.reserveDelayMs()).toBe(375);
+  });
+
+  it("treats a zero stagger as no delay", async () => {
+    const gate = new AssignmentGate({
+      concurrency: 0,
+      sleep: async () => {
+        throw new Error("should not sleep");
+      },
+      staggerMs: 0,
+    });
+    await expect(gate.run(async () => "ran")).resolves.toBe("ran");
+  });
+});
+
+describe("AssignmentGate fleet share", () => {
+  const unbounded = {
+    now: fakeClock().now,
+    random: () => 0,
+    sleep: async () => undefined,
+    staggerMs: 0,
+  };
+
+  it("does not bound turns at all by default", async () => {
+    const gate = new AssignmentGate({ concurrency: 0, ...unbounded });
+    const held = deferred();
+    const runs = [0, 1, 2, 3, 4, 5].map(() =>
+      gate.run(async () => {
+        await held.promise;
+      }),
+    );
+
+    await flush();
+    // The regression this guards: a share nobody configured must never become
+    // a cluster-wide work-in-progress cap.
+    expect(gate.activeCount).toBe(6);
+    expect(gate.queuedCount).toBe(0);
+    held.resolve();
+    await Promise.all(runs);
+  });
+
+  it("queues past a configured share and reports the wait", async () => {
+    const gate = new AssignmentGate({ concurrency: 2, ...unbounded });
+    const first = deferred();
+    const started: number[] = [];
+    const queuedAhead: number[] = [];
+    const runs = [0, 1, 2, 3].map((index) =>
+      gate.run(
+        async () => {
+          started.push(index);
+          // Both admitted turns hold their slots, or the queue drains before
+          // the assertions below ever see it.
+          if (index < 2) await first.promise;
+        },
+        (ahead) => queuedAhead.push(ahead),
+      ),
+    );
+
+    await flush();
+    expect(started).toEqual([0, 1]);
+    expect(gate.queuedCount).toBe(2);
+    // Waiting is invisible on the issue unless the gate says so.
+    expect(queuedAhead).toEqual([0, 1]);
+
+    first.resolve();
+    await Promise.all(runs);
+    expect(started.toSorted()).toEqual([0, 1, 2, 3]);
+    expect(gate.activeCount).toBe(0);
+  });
+
+  it("releases the slot when a turn throws", async () => {
+    const gate = new AssignmentGate({ concurrency: 1, ...unbounded });
+
+    await expect(
+      gate.run(async () => {
+        throw new Error("admission rejected");
+      }),
+    ).rejects.toThrow("admission rejected");
+
+    // A failed turn must not wedge the queue: the failures this exists for are
+    // the ones that throw.
+    expect(gate.activeCount).toBe(0);
+    await expect(gate.run(async () => "next")).resolves.toBe("next");
+  });
+
+  it("preserves arrival order when a slot frees up", async () => {
+    const gate = new AssignmentGate({ concurrency: 1, ...unbounded });
+    const first = deferred();
+    const order: string[] = [];
+    const running = gate.run(async () => {
+      order.push("first");
+      await first.promise;
+    });
+    await flush();
+    const queuedA = gate.run(async () => {
+      order.push("queued-a");
+    });
+    const queuedB = gate.run(async () => {
+      order.push("queued-b");
+    });
+
+    first.resolve();
+    await Promise.all([running, queuedA, queuedB]);
+    expect(order).toEqual(["first", "queued-a", "queued-b"]);
+  });
+});


### PR DESCRIPTION
Closes #1510

## Change

A qualifying `Issue` webhook kicks a turn immediately and independently, so a
burst of assignments starts every turn on the same instant. They reach sandbox
admission in the same tick, spawn their sandboxes together, and then issue their
first inference call together.

Admission is a limit rather than a queue, so a batch that would have fit had it
arrived spread out can still lose the check-then-act race. `runThreadTurn` does
retry, but on the cold-start backoff (250ms, doubling, three attempts) — far too
short to outlast a sandbox running someone else's work, so the losers just post
an error.

`LINEARBOT_ASSIGNMENT_STAGGER_MS` (default 250) spaces consecutive starts, plus a
random extra delay in `[0, staggerMs)` so they miss the grid. The spacing cursor
lives on the process, not the request, because the whole problem is that these
arrive as independent webhooks. Turns are delayed, never dropped.

## The concurrency knob is deliberately off

`LINEARBOT_ASSIGNMENT_CONCURRENCY` bounds turns in flight, and defaults to 0 —
unbounded.

A cap here only means something as this ingress's share of a sandbox fleet shared
with githubbot, slackbot and the console. Shares are meant to oversubscribe —
x/y/z across n pods, summing past n — so a quiet ingress leaves its pods usable
rather than idle. That makes the number a deployment decision, not one this file
can guess, and api-rs leaves its own capacity limit off by default for the same
reason.

A number guessed here is just an invisible work-in-progress cap. The earlier
revision of this PR defaulted it to 2 and held the slot for the whole turn: on a
fleet of 12 sandboxes that silently limited the bot to 2 issues at a time, which
is exactly the shape of bug the gate was supposed to prevent.

## Queued turns say so

When a share is configured the surplus queues rather than being dropped, and a
queued turn now posts a one-line notice on the issue. Waiting is otherwise
indistinguishable from being ignored: nothing posts, the status never moves, and
the only evidence the bot took the work is that it is not doing it.

## What the tests pin

Stagger: a burst arriving in one tick is spaced (`[250, 500, 750]`, the first
start due immediately); idle time is never banked, so a quiet bot starts the next
assignment at once; jitter lands inside the spacing; a zero stagger never sleeps.

Fleet share: the default bounds nothing — six concurrent turns all run; a
configured share admits its own and queues the rest, reporting the depth to the
caller; a throwing turn releases its slot instead of wedging the queue behind it;
and a freed slot goes to the longest-waiting turn rather than being raced for.

## What this does not change

The dedupe watermark still commits before the turn runs, so a queue lost to a
restart is lost. Moving the watermark after the turn would let a redelivery start
a second turn for an issue whose first is still running — a rare silent drop
traded for routine double-execution. With the bound off by default there is no
standing queue to lose; with one configured it is a real caveat, and I am happy
to follow up on the ordering if you would rather have it the other way.

## Testing

`bun test` in `services/linearbot`: 116 pass. `bun run check:types` clean.