### PR TITLE
fix(sandbox): bound paused proxies to node capacity

### DIFF
--- a/contrib/chart/templates/apirs.yaml
+++ b/contrib/chart/templates/apirs.yaml
@@ -176,6 +176,34 @@ roleRef:
   kind: Role
   name: {{ include "centaur.componentName" (dict "root" . "component" "api-rs-sandbox-manager") }}
 ---
+# Read-only cluster census for the paused-proxy retention sweep: it sizes
+# proxy eviction against each steering node's allocatable pod count, which
+# the namespace-scoped Role above cannot see.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "centaur.componentName" (dict "root" . "component" "api-rs-sandbox-node-budget") }}
+  labels:
+{{ include "centaur.componentLabels" (dict "root" . "component" "api-rs") | nindent 4 }}
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "nodes"]
+    verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "centaur.componentName" (dict "root" . "component" "api-rs-sandbox-node-budget") }}
+  labels:
+{{ include "centaur.componentLabels" (dict "root" . "component" "api-rs") | nindent 4 }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ $apiRsName }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "centaur.componentName" (dict "root" . "component" "api-rs-sandbox-node-budget") }}
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -330,6 +358,15 @@ spec:
               value: {{ .Values.apiRs.sandboxCleanupIntervalSecs | quote }}
             - name: SESSION_SANDBOX_IDLE_CLEANUP_BACKSTOP_SECS
               value: {{ .Values.apiRs.sandboxIdleCleanupBackstopSecs | quote }}
+            # Paused-proxy retention sweep. api-rs needs read-only cluster
+            # pods+nodes to size proxy eviction against each node's
+            # allocatable pod count (see the ClusterRole above).
+            - name: SESSION_SANDBOX_PAUSED_PROXY_SWEEP_INTERVAL_SECS
+              value: {{ .Values.apiRs.sandboxPausedProxySweepIntervalSecs | quote }}
+            - name: SESSION_SANDBOX_PAUSED_PROXY_MARGIN_PODS
+              value: {{ .Values.apiRs.sandboxPausedProxyMarginPods | quote }}
+            - name: SESSION_SANDBOX_PAUSED_PROXY_CAP
+              value: {{ .Values.apiRs.sandboxPausedProxyCap | quote }}
             - name: SESSION_ACTIVITY_SUMMARY_ENABLED
               value: {{ .Values.apiRs.activitySummary.enabled | quote }}
 {{- if .Values.apiRs.activitySummary.enabled }}

--- a/contrib/chart/templates/apirs.yaml
+++ b/contrib/chart/templates/apirs.yaml
@@ -197,8 +197,13 @@ metadata:
   labels:
 {{ include "centaur.componentLabels" (dict "root" . "component" "api-rs") | nindent 4 }}
 subjects:
+  # A ClusterRoleBinding is cluster-scoped, so its ServiceAccount subject must
+  # name the namespace the account lives in; the API server rejects the
+  # binding without it, which is what leaves the sweep's pods+nodes reads
+  # ungranted.
   - kind: ServiceAccount
     name: {{ $apiRsName }}
+    namespace: {{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/contrib/chart/values.schema.json
+++ b/contrib/chart/values.schema.json
@@ -338,6 +338,9 @@
         "mcpPublicUrl": { "type": "string" },
         "sandboxRunningLimit": { "type": "integer", "minimum": 0 },
         "sandboxHotIdleGraceSecs": { "type": "integer", "minimum": 0 },
+        "sandboxPausedProxySweepIntervalSecs": { "type": "integer", "minimum": 0 },
+        "sandboxPausedProxyMarginPods": { "type": "integer", "minimum": 0 },
+        "sandboxPausedProxyCap": { "type": "integer", "minimum": 0 },
         "workflowHostSandbox": { "type": "boolean" },
         "workflowHostResources": { "type": "object" },
         "etl": {

--- a/contrib/chart/values.yaml
+++ b/contrib/chart/values.yaml
@@ -520,6 +520,16 @@ apiRs:
   # idle_timeout_ms. 0 disables the corresponding arm.
   sandboxCleanupIntervalSecs: 300
   sandboxIdleCleanupBackstopSecs: 21600 # 6 hours
+  # Paused-proxy retention sweep: paused sandboxes keep their iron-proxy pod
+  # for fast resume, and this sweep bounds how many a node holds against its
+  # allocatable pod count, evicting the longest-paused first so new sandbox
+  # pods can always schedule. 0 on the interval disables the sweep.
+  # marginPods is the pod headroom kept free per node (a new sandbox
+  # schedules one agent pod and one proxy pod). cap is an absolute ceiling on
+  # retained proxies; 0 sizes the ceiling from node capacity alone.
+  sandboxPausedProxySweepIntervalSecs: 300
+  sandboxPausedProxyMarginPods: 2
+  sandboxPausedProxyCap: 0
   activitySummary:
     enabled: false
     model: gpt-5.4-nano

--- a/docs/pages/reference/configuration.mdx
+++ b/docs/pages/reference/configuration.mdx
@@ -129,9 +129,15 @@ Sandbox lifecycle:
 | `SESSION_MAX_DURATION_MS` | `slackbotv2.extraEnv`. | Optional per-execution max duration forwarded to api-rs. api-rs rejects requests where `idle_timeout_ms` is greater than `max_duration_ms`. |
 | `apiRs.sandboxMaxLifetimeSecs` / `SESSION_SANDBOX_MAX_LIFETIME_SECS` | Helm value, default `259200` (72 hours). | Restart-surviving sandbox deletion backstop. The reaper stops any non-terminal sandbox older than this, regardless of whether it is running or suspended. Set `0` to disable max-lifetime reaping. |
 | `apiRs.sandboxReapIntervalSecs` / `SESSION_SANDBOX_REAP_INTERVAL_SECS` | Helm value, default `300`. | How often api-rs sweeps observed sandboxes for max-lifetime expiry. |
+| `apiRs.sandboxPausedProxySweepIntervalSecs` / `SESSION_SANDBOX_PAUSED_PROXY_SWEEP_INTERVAL_SECS` | Helm value, default `300`. | Paused-proxy retention sweep interval. Paused sandboxes keep their iron-proxy pod for fast resume; this sweep evicts the longest-paused proxies when a node runs out of pod slots for them, so new sandbox pods keep scheduling. `0` disables the sweep. |
+| `apiRs.sandboxPausedProxyMarginPods` / `SESSION_SANDBOX_PAUSED_PROXY_MARGIN_PODS` | Helm value, default `2`. | Pod headroom each node keeps free beyond its current load, covering the agent pod and proxy pod a new sandbox schedules. |
+| `apiRs.sandboxPausedProxyCap` / `SESSION_SANDBOX_PAUSED_PROXY_CAP` | Helm value, default `0` (none). | Absolute ceiling on retained paused proxies; `0` sizes the ceiling from node capacity alone. |
 
 There is no separate suspended-only delete timer. Pausing is controlled by the
 per-execution idle timeout; deletion is controlled by sandbox max lifetime.
+Evicting a paused proxy is not deletion: the sandbox CR survives and resume
+recreates the proxy, so only the evicted session's resume pays a
+cold-create.
 
 Execution tuning:
 

--- a/services/api-rs/crates/centaur-api-server/src/args.rs
+++ b/services/api-rs/crates/centaur-api-server/src/args.rs
@@ -25,7 +25,8 @@ use centaur_iron_proxy::{
 };
 use centaur_sandbox_agent_k8s::{
     AgentSandboxBackend, AgentSandboxConfig, GitHubTokenRef, IronControlSettings, IronProxyConfig,
-    OtlpEgressTarget, Toleration, ToolSource, ToolsConfig,
+    OtlpEgressTarget, PausedProxyRetentionConfig, PausedProxyRetentionSweep, Toleration,
+    ToolSource, ToolsConfig,
 };
 use centaur_sandbox_core::{Mount, MountKind, ResourceRequirements, SandboxSpec};
 use centaur_sandbox_local::LocalSandboxBackend;
@@ -622,6 +623,30 @@ struct SandboxArgs {
         default_value_t = 21_600
     )]
     sandbox_idle_cleanup_backstop_secs: u64,
+    /// How often to evict the longest-paused sandboxes' iron-proxy pods when
+    /// a node runs out of pod slots for them. 0 disables the sweep.
+    #[arg(
+        long = "session-sandbox-paused-proxy-sweep-interval-secs",
+        env = "SESSION_SANDBOX_PAUSED_PROXY_SWEEP_INTERVAL_SECS",
+        default_value_t = 300
+    )]
+    sandbox_paused_proxy_sweep_interval_secs: u64,
+    /// Pod slots each node keeps free beyond its current load, covering the
+    /// agent pod and proxy pod a new sandbox needs to schedule.
+    #[arg(
+        long = "session-sandbox-paused-proxy-margin-pods",
+        env = "SESSION_SANDBOX_PAUSED_PROXY_MARGIN_PODS",
+        default_value_t = 2
+    )]
+    sandbox_paused_proxy_margin_pods: usize,
+    /// Absolute ceiling on paused sandboxes that keep their proxy. 0 leaves
+    /// the ceiling to node capacity.
+    #[arg(
+        long = "session-sandbox-paused-proxy-cap",
+        env = "SESSION_SANDBOX_PAUSED_PROXY_CAP",
+        default_value_t = 0
+    )]
+    sandbox_paused_proxy_cap: usize,
     #[arg(
         long = "session-sandbox-k8s-context",
         alias = "kubernetes-context",
@@ -807,10 +832,14 @@ impl SandboxArgs {
                 self.local_workload_mode()?,
             )),
             SandboxBackendKind::AgentK8s => {
-                let backend = AgentSandboxBackend::new(
+                let backend = Arc::new(AgentSandboxBackend::new(
                     self.kube_client().await?,
                     AgentSandboxConfig::try_from(self)?,
-                );
+                ));
+                // The sweep bounds the paused proxies this runtime creates,
+                // so it is owned here rather than by the workflow-host
+                // runtime, which drives a single long-lived sandbox.
+                PausedProxyRetentionSweep::new(backend.clone()).spawn();
                 let stopped = backend.drain_service_account_mismatches().await?;
                 if !stopped.is_empty() {
                     info!(
@@ -819,7 +848,7 @@ impl SandboxArgs {
                     );
                 }
                 Ok(SandboxRuntime::backend_with_workload(
-                    Arc::new(backend),
+                    backend,
                     self.container_workload_mode()?,
                 ))
             }
@@ -1518,6 +1547,12 @@ impl TryFrom<&SandboxArgs> for AgentSandboxConfig {
         // The chart label policy handles sandbox OTLP egress; keep the
         // per-sandbox proxy's own in-cluster OTLP egress explicit.
         config.otlp_egress = args.sandbox_otlp_egress_target()?;
+        config.paused_proxy_retention = PausedProxyRetentionConfig {
+            interval: (args.sandbox_paused_proxy_sweep_interval_secs > 0)
+                .then(|| Duration::from_secs(args.sandbox_paused_proxy_sweep_interval_secs)),
+            margin_pods: args.sandbox_paused_proxy_margin_pods,
+            cap: (args.sandbox_paused_proxy_cap > 0).then_some(args.sandbox_paused_proxy_cap),
+        };
         Ok(config)
     }
 }
@@ -2907,6 +2942,40 @@ mod tests {
         assert!(args.sandbox.tolerations().unwrap().is_empty());
         assert!(args.sandbox.service_account_name.is_none());
         assert!(args.sandbox.priority_class_name.is_none());
+    }
+
+    #[test]
+    fn paused_proxy_retention_parses_from_args() {
+        let args = Args::try_parse_from([
+            "centaur-api-server",
+            "--database-url",
+            "postgres://postgres:postgres@localhost/centaur",
+            "--session-sandbox-paused-proxy-sweep-interval-secs",
+            "60",
+            "--session-sandbox-paused-proxy-margin-pods",
+            "4",
+            "--session-sandbox-paused-proxy-cap",
+            "25",
+        ])
+        .unwrap();
+
+        assert_eq!(args.sandbox.sandbox_paused_proxy_sweep_interval_secs, 60);
+        assert_eq!(args.sandbox.sandbox_paused_proxy_margin_pods, 4);
+        assert_eq!(args.sandbox.sandbox_paused_proxy_cap, 25);
+    }
+
+    #[test]
+    fn paused_proxy_retention_defaults() {
+        let args = Args::try_parse_from([
+            "centaur-api-server",
+            "--database-url",
+            "postgres://postgres:postgres@localhost/centaur",
+        ])
+        .unwrap();
+
+        assert_eq!(args.sandbox.sandbox_paused_proxy_sweep_interval_secs, 300);
+        assert_eq!(args.sandbox.sandbox_paused_proxy_margin_pods, 2);
+        assert_eq!(args.sandbox.sandbox_paused_proxy_cap, 0);
     }
 
     /// Unlike `SESSION_SANDBOX_EXTRA_ENV`, bad node steering fails startup:

--- a/services/api-rs/crates/centaur-sandbox-agent-k8s/src/iron_proxy.rs
+++ b/services/api-rs/crates/centaur-sandbox-agent-k8s/src/iron_proxy.rs
@@ -28,7 +28,7 @@ use crate::{
     OtlpEgressTarget, SANDBOX_ID_LABEL, is_not_found, map_kube_error,
 };
 
-const IRON_PROXY_LABEL: &str = "centaur.ai/iron-proxy";
+pub(crate) const IRON_PROXY_LABEL: &str = "centaur.ai/iron-proxy";
 const IRON_CONTROL_PROXY_ID_ANNOTATION: &str = "centaur.ai/iron-control-proxy-id";
 const FIREWALL_CA_MOUNT_PATH: &str = "/firewall-certs";
 pub(crate) const FIREWALL_CA_CERT_PATH: &str = "/firewall-certs/ca-cert.pem";
@@ -906,7 +906,10 @@ impl AgentSandboxBackend {
             .find_map(proxy_management_endpoint_from_pod))
     }
 
-    async fn proxy_id_for_sandbox(&self, id: &SandboxId) -> SandboxResult<Option<String>> {
+    pub(crate) async fn proxy_id_for_sandbox(
+        &self,
+        id: &SandboxId,
+    ) -> SandboxResult<Option<String>> {
         if let Some(proxy_id) = self.proxy_ids.lock().await.get(id.as_str()).cloned() {
             return Ok(Some(proxy_id));
         }

--- a/services/api-rs/crates/centaur-sandbox-agent-k8s/src/lib.rs
+++ b/services/api-rs/crates/centaur-sandbox-agent-k8s/src/lib.rs
@@ -29,10 +29,15 @@ use tokio::time::{Instant, sleep};
 pub use generated::agents_x_k8s_io as crd;
 pub use iron_proxy::IronProxyConfig;
 pub use k8s_openapi::api::core::v1::Toleration;
+pub use paused_proxy_retention::{
+    NodePodBudget, PausedProxyRetentionConfig, PausedProxyRetentionReport,
+    PausedProxyRetentionSweep, RetainedPausedProxy, select_evictions,
+};
 pub use tools::{GitHubTokenRef, ToolSource, ToolsConfig};
 
 pub mod generated;
 mod iron_proxy;
+mod paused_proxy_retention;
 mod tools;
 
 const BACKEND_NAME: &str = "agent-sandbox-k8s";
@@ -97,6 +102,10 @@ pub struct AgentSandboxConfig {
     /// the per-sandbox proxy uses this target for its own explicit egress.
     pub otlp_egress: Option<OtlpEgressTarget>,
     pub ready_timeout: Duration,
+    /// Retention policy for paused sandboxes' iron-proxy pods. The sweep
+    /// bounds how many of them a node keeps so they cannot crowd out the
+    /// agent and proxy pods new sandboxes need to schedule.
+    pub paused_proxy_retention: PausedProxyRetentionConfig,
 }
 
 /// Destination of the sandbox's direct OTLP export, expressed as the target
@@ -149,6 +158,7 @@ impl AgentSandboxConfig {
             tools: None,
             otlp_egress: None,
             ready_timeout: Duration::from_secs(60),
+            paused_proxy_retention: PausedProxyRetentionConfig::default(),
         }
     }
 
@@ -197,6 +207,9 @@ pub struct AgentSandboxBackend {
     // sandbox id -> iron-control proxy OID, so the proxy can be deregistered on
     // stop. Only populated for sync-mode sandboxes.
     proxy_ids: Arc<Mutex<HashMap<String, String>>>,
+    // Sandbox ids whose resume is rebuilding their proxy right now, so the
+    // paused-proxy retention sweep leaves those rebuilds alone.
+    resuming: Arc<std::sync::Mutex<BTreeSet<String>>>,
 }
 
 impl AgentSandboxBackend {
@@ -205,6 +218,16 @@ impl AgentSandboxBackend {
             client,
             config,
             proxy_ids: Arc::new(Mutex::new(HashMap::new())),
+            resuming: Arc::new(std::sync::Mutex::new(BTreeSet::new())),
+        }
+    }
+
+    /// Sandbox ids whose resume is rebuilding their proxy. The paused-proxy
+    /// retention sweep consults this so it never evicts a proxy mid-resume.
+    pub(crate) fn resuming_sandbox_ids(&self) -> BTreeSet<String> {
+        match self.resuming.lock() {
+            Ok(set) => set.clone(),
+            Err(_) => BTreeSet::new(),
         }
     }
 
@@ -636,6 +659,13 @@ impl SandboxBackend for AgentSandboxBackend {
     async fn resume(&self, id: &SandboxId) -> SandboxResult<()> {
         // Resume only has the sandbox id, not the spec, so rebind the proxy to
         // the principal recorded at create rather than re-resolving from spec.
+        if let Ok(mut resuming) = self.resuming.lock() {
+            resuming.insert(id.as_str().to_owned());
+        }
+        let _resume_guard = ResumeGuard {
+            set: self.resuming.as_ref(),
+            id: id.as_str().to_owned(),
+        };
         let resolved_iron_proxy = self.resolve_iron_proxy_for_resume(id).await?;
         if let Err(err) = self
             .create_iron_proxy_resources(id, resolved_iron_proxy.as_ref())
@@ -673,6 +703,21 @@ impl SandboxBackend for AgentSandboxBackend {
         self.patch_sandbox_merge(id, sandbox_resume_patch(&capability_labels))
             .await?;
         self.wait_until_running(id).await
+    }
+}
+
+/// Clears the in-resume mark when a resume attempt ends, whatever its
+/// outcome, so the paused-proxy retention sweep evicts it again.
+struct ResumeGuard<'a> {
+    set: &'a std::sync::Mutex<BTreeSet<String>>,
+    id: String,
+}
+
+impl Drop for ResumeGuard<'_> {
+    fn drop(&mut self) {
+        if let Ok(mut set) = self.set.lock() {
+            set.remove(&self.id);
+        }
     }
 }
 

--- a/services/api-rs/crates/centaur-sandbox-agent-k8s/src/paused_proxy_retention.rs
+++ b/services/api-rs/crates/centaur-sandbox-agent-k8s/src/paused_proxy_retention.rs
@@ -1,0 +1,618 @@
+//! Bounding the retained iron-proxy pods of paused sandboxes.
+//!
+//! Pausing tears down the agent pod but keeps the Sandbox CR and its
+//! iron-proxy pod so a session can resume without a cold create. That
+//! retention is deliberate, but it is unbounded against the node's pod
+//! budget: every retained proxy holds one of the node's allocatable pod
+//! slots, and once enough accumulate the scheduler refuses new sandbox
+//! pods with `FailedScheduling: Too many pods`, so a turn dies before it
+//! starts.
+//!
+//! The sweep runs periodically, compares each steering node's current pod
+//! load with its allocatable pod count, and evicts the longest-paused
+//! proxies beyond the node's remaining headroom. An evicted sandbox keeps
+//! its CR; `resume` recreates the proxy on demand, so only the evicted
+//! session's resume pays the cold-create cost.
+
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    sync::Arc,
+    time::Duration,
+};
+
+use centaur_sandbox_core::SandboxResult;
+use jiff::Timestamp;
+use k8s_openapi::api::core::v1::{Node, Pod};
+use kube::api::ListParams;
+use tokio::time::{MissedTickBehavior, interval};
+use tracing::{debug, info, warn};
+
+use crate::iron_proxy::IRON_PROXY_LABEL;
+use crate::{
+    AgentSandboxBackend, MANAGED_BY_LABEL, MANAGED_BY_VALUE, SANDBOX_ID_LABEL, SandboxId,
+    map_kube_error,
+};
+
+/// Retention policy for paused sandboxes' iron-proxy pods.
+#[derive(Clone, Copy, Debug)]
+pub struct PausedProxyRetentionConfig {
+    /// How often to sweep. `None` disables the sweep.
+    pub interval: Option<Duration>,
+    /// Pod slots each node keeps free beyond its current load, covering the
+    /// agent pod and proxy pod a new sandbox needs to schedule.
+    pub margin_pods: usize,
+    /// Absolute ceiling on retained paused proxies. `None` bounds retention
+    /// by node capacity alone.
+    pub cap: Option<usize>,
+}
+
+impl PausedProxyRetentionConfig {
+    pub fn is_enabled(&self) -> bool {
+        self.interval.is_some()
+    }
+}
+
+impl Default for PausedProxyRetentionConfig {
+    /// Retention is bounded by node pod capacity, swept every five minutes,
+    /// with two pod slots of headroom kept free per node.
+    fn default() -> Self {
+        Self {
+            interval: Some(Duration::from_secs(300)),
+            margin_pods: 2,
+            cap: None,
+        }
+    }
+}
+
+/// One steering node's pod budget as a sweep pass observed it.
+#[derive(Clone, Debug)]
+pub struct NodePodBudget {
+    pub name: String,
+    pub allocatable_pods: usize,
+    /// Pods scheduled on the node, excluding terminating pods and evictable
+    /// paused proxies.
+    pub load_pods: usize,
+    /// Evictable paused proxies held on the node.
+    pub retained_pods: usize,
+}
+
+/// A retained proxy a sweep may evict: the proxy pod of a paused sandbox.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RetainedPausedProxy {
+    pub node: String,
+    pub sandbox_id: String,
+    pub paused_at: Timestamp,
+}
+
+/// Indices into `retained` a sweep pass should evict.
+///
+/// Per node, retention may hold at most
+/// `allocatable_pods - load_pods - margin_pods` slots, leaving the headroom
+/// a new sandbox's pods need. When `cap` is set, retention may hold at most
+/// `cap` slots in total. Victims are the longest-paused first; ties break
+/// on sandbox id so the selection is deterministic.
+pub fn select_evictions(
+    budgets: &[NodePodBudget],
+    retained: &[RetainedPausedProxy],
+    margin_pods: usize,
+    cap: Option<usize>,
+) -> BTreeSet<usize> {
+    let order = |a: &usize, b: &usize| {
+        retained[*a]
+            .paused_at
+            .cmp(&retained[*b].paused_at)
+            .then_with(|| retained[*a].sandbox_id.cmp(&retained[*b].sandbox_id))
+    };
+
+    let mut by_node: BTreeMap<&str, Vec<usize>> = BTreeMap::new();
+    for (index, entry) in retained.iter().enumerate() {
+        by_node.entry(entry.node.as_str()).or_default().push(index);
+    }
+
+    let mut evicted: BTreeSet<usize> = BTreeSet::new();
+    for (node, indices) in by_node.iter_mut() {
+        indices.sort_by(order);
+        let Some(budget) = budgets.iter().find(|budget| budget.name == *node) else {
+            // The node is gone or unobservable: its budget is unknown, so
+            // its retained proxies stay (the node may simply have drained).
+            continue;
+        };
+        let allowed = budget
+            .allocatable_pods
+            .saturating_sub(budget.load_pods)
+            .saturating_sub(margin_pods);
+        let excess = indices.len().saturating_sub(allowed);
+        evicted.extend(indices.iter().take(excess).copied());
+    }
+
+    if let Some(cap) = cap {
+        let mut remaining: Vec<usize> = (0..retained.len())
+            .filter(|index| !evicted.contains(index))
+            .collect();
+        remaining.sort_by(order);
+        let excess = remaining.len().saturating_sub(cap);
+        evicted.extend(remaining.into_iter().take(excess));
+    }
+
+    evicted
+}
+
+/// What one sweep pass did.
+#[derive(Clone, Debug, Default)]
+pub struct PausedProxyRetentionReport {
+    pub evicted: usize,
+    pub retained: usize,
+    pub node_budgets: Vec<NodePodBudget>,
+}
+
+pub struct PausedProxyRetentionSweep {
+    backend: Arc<AgentSandboxBackend>,
+}
+
+impl PausedProxyRetentionSweep {
+    pub fn new(backend: Arc<AgentSandboxBackend>) -> Self {
+        Self { backend }
+    }
+
+    /// Run the sweep on its interval. A no-op when the sweep is disabled.
+    ///
+    /// The first pass runs immediately so a restart heals an over-full node
+    /// before new turns try to schedule on it.
+    pub fn spawn(self) {
+        let Some(sweep_interval) = self.backend.config.paused_proxy_retention.interval else {
+            return;
+        };
+        tokio::spawn(async move {
+            let mut tick = interval(sweep_interval);
+            tick.set_missed_tick_behavior(MissedTickBehavior::Delay);
+            loop {
+                tick.tick().await;
+                if let Err(error) = self.sweep_once().await {
+                    warn!(%error, "paused proxy retention sweep failed");
+                }
+            }
+        });
+    }
+
+    /// One sweep pass. A failed eviction is logged and skipped so one
+    /// wedged sandbox cannot stall the pass.
+    pub async fn sweep_once(&self) -> SandboxResult<PausedProxyRetentionReport> {
+        let retention = self.backend.config.paused_proxy_retention;
+        let mut node_budgets = self.observe_node_budgets().await?;
+        if node_budgets.is_empty() {
+            // No steering node exposed a pod budget. Nothing is observable,
+            // so nothing is evicted.
+            return Ok(PausedProxyRetentionReport::default());
+        }
+        let steering: BTreeSet<&str> = node_budgets
+            .iter()
+            .map(|budget| budget.name.as_str())
+            .collect();
+        let (load, candidates) = self.observe_cluster_pods(&steering).await?;
+        let retained = self.paused_proxy_candidates(&candidates).await?;
+
+        for budget in &mut node_budgets {
+            budget.load_pods = load.get(&budget.name).copied().unwrap_or_default();
+            budget.retained_pods = retained
+                .iter()
+                .filter(|entry| entry.node == budget.name)
+                .count();
+        }
+
+        let victims = select_evictions(
+            &node_budgets,
+            &retained,
+            retention.margin_pods,
+            retention.cap,
+        );
+        if victims.is_empty() {
+            debug!(
+                retained = retained.len(),
+                ?node_budgets,
+                "paused proxy retention sweep kept all proxies"
+            );
+            return Ok(PausedProxyRetentionReport {
+                evicted: 0,
+                retained: retained.len(),
+                node_budgets,
+            });
+        }
+
+        let mut ordered: Vec<RetainedPausedProxy> = victims
+            .into_iter()
+            .map(|index| retained[index].clone())
+            .collect();
+        ordered.sort_by(|a, b| {
+            a.paused_at
+                .cmp(&b.paused_at)
+                .then_with(|| a.sandbox_id.cmp(&b.sandbox_id))
+        });
+
+        let mut evicted = 0;
+        for victim in ordered {
+            match self.evict_one(&victim).await {
+                Ok(()) => {
+                    evicted += 1;
+                    info!(
+                        event = "sandbox_paused_proxy_evicted",
+                        sandbox_id = %victim.sandbox_id,
+                        node = %victim.node,
+                        paused_at = %victim.paused_at,
+                        "evicted paused sandbox proxy to free node pod slots"
+                    );
+                }
+                Err(error) => {
+                    warn!(
+                        sandbox_id = %victim.sandbox_id,
+                        node = %victim.node,
+                        %error,
+                        "failed to evict paused sandbox proxy; retrying next sweep"
+                    );
+                }
+            }
+        }
+        info!(
+            event = "sandbox_paused_proxy_retention_sweep",
+            retained = retained.len(),
+            evicted,
+            ?node_budgets,
+            "paused proxy retention sweep completed"
+        );
+        Ok(PausedProxyRetentionReport {
+            evicted,
+            retained: retained.len(),
+            node_budgets,
+        })
+    }
+
+    /// The steering nodes and their allocatable pod counts. Nodes without a
+    /// readable `pods` allocatable are skipped: evicting against an unknown
+    /// budget could free slots a node still needs.
+    async fn observe_node_budgets(&self) -> SandboxResult<Vec<NodePodBudget>> {
+        let nodes = kube::Api::<Node>::all(self.backend.client.clone());
+        let nodes = nodes
+            .list(&ListParams::default())
+            .await
+            .map_err(|err| map_kube_error("list nodes for proxy retention", err))?;
+        let selector = &self.backend.config.node_selector;
+        Ok(nodes
+            .items
+            .iter()
+            .filter(|node| node_matches_selector(node, selector))
+            .filter_map(|node| {
+                let name = node.metadata.name.clone()?;
+                let allocatable = node_allocatable_pods(node)?;
+                Some(NodePodBudget {
+                    name,
+                    allocatable_pods: allocatable,
+                    load_pods: 0,
+                    retained_pods: 0,
+                })
+            })
+            .collect())
+    }
+
+    /// A cluster-wide pod census over the steering nodes: per-node load
+    /// (everything except evictable paused proxies) and the candidate proxy
+    /// pods, keyed by sandbox id with their node.
+    async fn observe_cluster_pods(
+        &self,
+        steering: &BTreeSet<&str>,
+    ) -> SandboxResult<(BTreeMap<String, usize>, BTreeMap<String, String>)> {
+        let pods = kube::Api::<Pod>::all(self.backend.client.clone());
+        let pods = pods
+            .list(&ListParams::default())
+            .await
+            .map_err(|err| map_kube_error("list pods for proxy retention", err))?;
+        let mut load: BTreeMap<String, usize> = BTreeMap::new();
+        let mut candidates: BTreeMap<String, String> = BTreeMap::new();
+        for pod in pods.items {
+            let Some(node_name) = pod.spec.as_ref().and_then(|spec| spec.node_name.clone()) else {
+                continue;
+            };
+            if !steering.contains(node_name.as_str()) || pod.metadata.deletion_timestamp.is_some() {
+                continue;
+            }
+            let labels = pod.metadata.labels.as_ref();
+            let sandbox_id = if labels.is_some_and(|labels| labels.contains_key(IRON_PROXY_LABEL)) {
+                labels
+                    .and_then(|labels| labels.get(SANDBOX_ID_LABEL))
+                    .map(|id| id.to_owned())
+            } else {
+                None
+            };
+            match sandbox_id {
+                // A proxy pod we cannot attribute to a sandbox still counts
+                // as load: it holds a slot the node budget has to cover.
+                Some(sandbox_id) => {
+                    candidates.entry(sandbox_id).or_insert_with(|| node_name);
+                }
+                None => *load.entry(node_name).or_default() += 1,
+            }
+        }
+        Ok((load, candidates))
+    }
+
+    /// The candidates whose sandbox is actually paused. Candidates with a
+    /// missing CR, a running replica, an unorderable pause, or an in-flight
+    /// resume are kept out: eviction only costs resume speed, so anything
+    /// ambiguous stays.
+    async fn paused_proxy_candidates(
+        &self,
+        candidates: &BTreeMap<String, String>,
+    ) -> SandboxResult<Vec<RetainedPausedProxy>> {
+        let params =
+            ListParams::default().labels(&format!("{MANAGED_BY_LABEL}={MANAGED_BY_VALUE}"));
+        let sandboxes = self
+            .backend
+            .sandboxes()
+            .list(&params)
+            .await
+            .map_err(|err| map_kube_error("list sandboxes for proxy retention", err))?;
+        let by_name: BTreeMap<&str, &crate::crd::Sandbox> = sandboxes
+            .items
+            .iter()
+            .filter_map(|sandbox| sandbox.metadata.name.as_deref().map(|name| (name, sandbox)))
+            .collect();
+        let resuming = self.backend.resuming_sandbox_ids();
+        let mut retained = Vec::new();
+        for (sandbox_id, node) in candidates {
+            if resuming.contains(sandbox_id.as_str()) {
+                continue;
+            }
+            let Some(sandbox) = by_name.get(sandbox_id.as_str()) else {
+                continue;
+            };
+            if sandbox.spec.replicas.unwrap_or(1) != 0 {
+                continue;
+            }
+            // Parse the annotation directly: it is the RFC 3339 instant the
+            // pause patch wrote, so no SystemTime round trip can lose it.
+            let Some(raw) = sandbox
+                .metadata
+                .annotations
+                .as_ref()
+                .and_then(|annotations| annotations.get(crate::PAUSED_AT_ANNOTATION))
+            else {
+                continue;
+            };
+            let Ok(paused_at) = raw.parse::<Timestamp>() else {
+                continue;
+            };
+            retained.push(RetainedPausedProxy {
+                node: node.clone(),
+                sandbox_id: sandbox_id.clone(),
+                paused_at,
+            });
+        }
+        Ok(retained)
+    }
+
+    async fn evict_one(&self, victim: &RetainedPausedProxy) -> SandboxResult<()> {
+        let id = SandboxId::new(victim.sandbox_id.as_str());
+        // Deregister the iron-control proxy row by its durable OID (pod
+        // annotation) so the sweep works across api-rs restarts, not just
+        // against the in-memory id map.
+        if let Some(proxy_id) = self.backend.proxy_id_for_sandbox(&id).await? {
+            let _ = self
+                .backend
+                .config
+                .iron_control
+                .client
+                .delete_proxy(&proxy_id)
+                .await;
+        }
+        self.backend.delete_iron_proxy_resources(&id).await
+    }
+}
+
+fn node_matches_selector(node: &Node, selector: &BTreeMap<String, String>) -> bool {
+    selector.iter().all(|(key, value)| {
+        node.metadata
+            .labels
+            .as_ref()
+            .and_then(|labels| labels.get(key))
+            .is_some_and(|label| label == value)
+    })
+}
+
+fn node_allocatable_pods(node: &Node) -> Option<usize> {
+    let allocatable = node.status.as_ref()?.allocatable.as_ref()?.get("pods")?;
+    allocatable.0.trim().parse::<usize>().ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn node(name: &str, allocatable: usize, load: usize) -> NodePodBudget {
+        NodePodBudget {
+            name: name.to_owned(),
+            allocatable_pods: allocatable,
+            load_pods: load,
+            retained_pods: 0,
+        }
+    }
+
+    /// `asbx-000` is the most recently paused; higher indices paused longer
+    /// ago.
+    fn paused_on(node: &str, count: usize) -> Vec<RetainedPausedProxy> {
+        (0..count)
+            .map(|i| RetainedPausedProxy {
+                node: node.to_owned(),
+                sandbox_id: format!("asbx-{i:03}"),
+                paused_at: Timestamp::now() - Duration::from_secs(i as u64),
+            })
+            .collect()
+    }
+
+    #[test]
+    fn evicts_oldest_beyond_node_headroom() {
+        let budgets = [node("node-a", 250, 168)];
+        let retained = paused_on("node-a", 88);
+        // allowed = 250 - 168 - 2 = 80; the 8 longest-paused go.
+        let victims = select_evictions(&budgets, &retained, 2, None);
+        assert_eq!(victims.len(), 8);
+        for index in 80..88 {
+            assert!(
+                victims.contains(&index),
+                "asbx-{index:03} should be evicted"
+            );
+        }
+        for index in 0..80 {
+            assert!(!victims.contains(&index), "asbx-{index:03} should be kept");
+        }
+    }
+
+    #[test]
+    fn keeps_retention_within_headroom() {
+        let budgets = [node("node-a", 250, 100)];
+        let retained = paused_on("node-a", 20);
+        assert!(select_evictions(&budgets, &retained, 2, None).is_empty());
+    }
+
+    #[test]
+    fn saturates_to_zero_when_node_is_full() {
+        let budgets = [node("node-a", 10, 12)];
+        let retained = paused_on("node-a", 3);
+        // allowed = 10 - 12 - 2 = 0; every retained proxy goes.
+        assert_eq!(
+            select_evictions(&budgets, &retained, 2, None),
+            BTreeSet::from([0, 1, 2])
+        );
+    }
+
+    #[test]
+    fn cap_bounds_retention_globally() {
+        let budgets = [node("node-a", 100, 10), node("node-b", 100, 10)];
+        let retained = vec![
+            RetainedPausedProxy {
+                node: "node-a".to_owned(),
+                sandbox_id: "asbx-001".to_owned(),
+                paused_at: Timestamp::now() - Duration::from_secs(40),
+            },
+            RetainedPausedProxy {
+                node: "node-b".to_owned(),
+                sandbox_id: "asbx-002".to_owned(),
+                paused_at: Timestamp::now() - Duration::from_secs(30),
+            },
+            RetainedPausedProxy {
+                node: "node-a".to_owned(),
+                sandbox_id: "asbx-003".to_owned(),
+                paused_at: Timestamp::now() - Duration::from_secs(20),
+            },
+            RetainedPausedProxy {
+                node: "node-b".to_owned(),
+                sandbox_id: "asbx-004".to_owned(),
+                paused_at: Timestamp::now() - Duration::from_secs(10),
+            },
+        ];
+        // Node headroom is ample (allowed 88 each); the cap of 2 evicts the
+        // two globally oldest (asbx-001, asbx-002).
+        assert_eq!(
+            select_evictions(&budgets, &retained, 2, Some(2)),
+            BTreeSet::from([0, 1])
+        );
+    }
+
+    #[test]
+    fn cap_never_expands_node_budget() {
+        let budgets = [node("node-a", 20, 17), node("node-b", 100, 10)];
+        let retained = vec![
+            RetainedPausedProxy {
+                node: "node-a".to_owned(),
+                sandbox_id: "asbx-a1".to_owned(),
+                paused_at: Timestamp::now() - Duration::from_secs(30),
+            },
+            RetainedPausedProxy {
+                node: "node-a".to_owned(),
+                sandbox_id: "asbx-a2".to_owned(),
+                paused_at: Timestamp::now() - Duration::from_secs(20),
+            },
+            RetainedPausedProxy {
+                node: "node-a".to_owned(),
+                sandbox_id: "asbx-a3".to_owned(),
+                paused_at: Timestamp::now() - Duration::from_secs(10),
+            },
+            RetainedPausedProxy {
+                node: "node-b".to_owned(),
+                sandbox_id: "asbx-b1".to_owned(),
+                paused_at: Timestamp::now() - Duration::from_secs(40),
+            },
+        ];
+        // node-a headroom is 20 - 17 - 2 = 1, so its two oldest go no matter
+        // how generous the global cap is; node-b is far under budget.
+        assert_eq!(
+            select_evictions(&budgets, &retained, 2, Some(100)),
+            BTreeSet::from([0, 1])
+        );
+        // A cap tighter than the surviving count reaches into the survivors:
+        // of {asbx-a3, asbx-b1} the globally oldest (asbx-b1) goes.
+        assert_eq!(
+            select_evictions(&budgets, &retained, 2, Some(1)),
+            BTreeSet::from([0, 1, 3])
+        );
+    }
+
+    #[test]
+    fn unobservable_node_keeps_its_proxies() {
+        let base = Timestamp::now();
+        let budgets = [node("node-a", 20, 5)];
+        let retained = vec![
+            RetainedPausedProxy {
+                node: "node-a".to_owned(),
+                sandbox_id: "asbx-a1".to_owned(),
+                paused_at: base - Duration::from_secs(30),
+            },
+            RetainedPausedProxy {
+                node: "node-gone".to_owned(),
+                sandbox_id: "asbx-g1".to_owned(),
+                paused_at: base - Duration::from_secs(40),
+            },
+        ];
+        // node-gone is absent from the budget list (drained or unobservable),
+        // so no node-budget eviction applies to it; node-a headroom (13)
+        // covers its one proxy, and nothing is evicted.
+        assert!(select_evictions(&budgets, &retained, 2, None).is_empty());
+    }
+
+    #[test]
+    fn ties_break_on_sandbox_id() {
+        let base = Timestamp::now();
+        let retained: Vec<RetainedPausedProxy> = ["asbx-z", "asbx-a", "asbx-m"]
+            .into_iter()
+            .map(|sandbox_id| RetainedPausedProxy {
+                node: "node-a".to_owned(),
+                sandbox_id: sandbox_id.to_owned(),
+                paused_at: base,
+            })
+            .collect();
+        // One slot of headroom keeps a single survivor; the paused-at set is
+        // a three-way tie, so the sandbox id orders the victims (asbx-a and
+        // asbx-m go before asbx-z, which is kept).
+        assert_eq!(
+            select_evictions(&[node("node-a", 11, 8)], &retained, 2, None),
+            BTreeSet::from([1, 2])
+        );
+        // Zero headroom: every tied proxy is evicted.
+        assert_eq!(
+            select_evictions(&[node("node-a", 10, 8)], &retained, 2, None),
+            BTreeSet::from([0, 1, 2])
+        );
+    }
+
+    #[test]
+    fn retention_config_defaults_and_toggle() {
+        let default = PausedProxyRetentionConfig::default();
+        assert!(default.is_enabled());
+        assert_eq!(default.interval, Some(Duration::from_secs(300)));
+        assert_eq!(default.margin_pods, 2);
+        assert!(default.cap.is_none());
+
+        let disabled = PausedProxyRetentionConfig {
+            interval: None,
+            ..default
+        };
+        assert!(!disabled.is_enabled());
+    }
+}

--- a/services/api-rs/crates/centaur-sandbox-agent-k8s/src/paused_proxy_retention.rs
+++ b/services/api-rs/crates/centaur-sandbox-agent-k8s/src/paused_proxy_retention.rs
@@ -192,11 +192,17 @@ impl PausedProxyRetentionSweep {
         let retained = self.paused_proxy_candidates(&candidates).await?;
 
         for budget in &mut node_budgets {
-            budget.load_pods = load.get(&budget.name).copied().unwrap_or_default();
-            budget.retained_pods = retained
+            let retained_on_node = retained
                 .iter()
                 .filter(|entry| entry.node == budget.name)
                 .count();
+            // The census counted the evictable paused proxies as load too; they
+            // are the budget being managed, not the load that constrains it, so
+            // take them back out. What remains is the non-evictable load --
+            // agent pods and the proxies of running sandboxes.
+            let total = load.get(&budget.name).copied().unwrap_or_default();
+            budget.load_pods = total.saturating_sub(retained_on_node);
+            budget.retained_pods = retained_on_node;
         }
 
         let victims = select_evictions(
@@ -293,8 +299,10 @@ impl PausedProxyRetentionSweep {
     }
 
     /// A cluster-wide pod census over the steering nodes: per-node load
-    /// (everything except evictable paused proxies) and the candidate proxy
-    /// pods, keyed by sandbox id with their node.
+    /// (every scheduled pod) and the candidate proxy pods, keyed by sandbox id
+    /// with their node. Load includes the proxies because a running sandbox's
+    /// proxy pod holds a real slot; only the evictable paused proxies are
+    /// subtracted back out in `sweep_once`.
     async fn observe_cluster_pods(
         &self,
         steering: &BTreeSet<&str>,
@@ -321,13 +329,15 @@ impl PausedProxyRetentionSweep {
             } else {
                 None
             };
-            match sandbox_id {
-                // A proxy pod we cannot attribute to a sandbox still counts
-                // as load: it holds a slot the node budget has to cover.
-                Some(sandbox_id) => {
-                    candidates.entry(sandbox_id).or_insert_with(|| node_name);
-                }
-                None => *load.entry(node_name).or_default() += 1,
+            // Every scheduled pod counts as load, including proxies: a running
+            // sandbox's proxy pod holds a real slot the node budget has to
+            // cover. Counting the evictable paused proxies here too is safe --
+            // `sweep_once` takes them back out of the per-node load before
+            // sizing the headroom, so the running proxies (which stay) are not
+            // silently dropped from the budget.
+            *load.entry(node_name.clone()).or_default() += 1;
+            if let Some(sandbox_id) = sandbox_id {
+                candidates.entry(sandbox_id).or_insert_with(|| node_name);
             }
         }
         Ok((load, candidates))


### PR DESCRIPTION
Closes #1541

Bounded retention of paused sandboxes' iron-proxy pods, sized from node capacity. Two commits, the Rust half independently cherry-pickable.

## Read this first: what #1502 changed

#1502 made `pause()` tear the proxy down, so **steady-state retention is now zero** and this is not the fix for the incident in #1541 on an up-to-date deployment. I would rather say that up front than have you find it in review.

What it still covers:

1. **Upgrade state.** Sandboxes paused before #1502 keep their proxy indefinitely; nothing else deletes them. A deployment carrying paused sessions across that upgrade inherits the pod-budget exhaustion with no path out but hand-deletion.
2. **Crash window.** `pause()` patches `replicas: 0` then deletes the proxy. A death between the two leaves a paused CR with a live proxy that nothing reclaims.
3. **Regression cover**, and the per-node pod-budget logging, which is useful on its own — today the budget is only visible by reconstructing it from `FailedScheduling` events.

If you read #1502 as making this redundant, say so and I will close it. I think 1 and 2 are real and unaddressed, and 3 is worth having regardless.

## Commit 1 — `fix(sandbox): bound paused proxies to node capacity`

New `paused_proxy_retention` module in `centaur-sandbox-agent-k8s`:

- Censuses steering nodes' `status.allocatable.pods` and scheduled (non-terminating) pod load, and identifies retained paused proxies: iron-proxy pods whose Sandbox CR is at `replicas: 0`.
- Per node, retention holds at most `allocatable − load − margin` slots; beyond that the longest-paused go first, ordered by the existing `centaur.ai/paused-at` annotation with a sandbox-id tiebreak so selection is deterministic.
- Optional absolute cap, which never expands a node's headroom.
- Eviction deregisters the proxy in iron-control by its durable OID (a pod annotation, so it works across api-rs restarts) and deletes the proxy pod, service and network policies. **The Sandbox CR is untouched** — resume takes the existing rebuild path, so only the evicted session pays a cold create.
- Never touches running or warm sandboxes, in-flight resumes (in-process guard set at `resume()` entry and cleared on every exit path), unorderable pauses, or nodes with an unreadable budget. That last one is fail-open on purpose: evicting against an unknown budget is worse than not evicting.

## Commit 2 — `feat(chart): paused-proxy retention knobs and node-budget RBAC`

Renders the three env vars, adds the read-only ClusterRole/Binding (`pods`, `nodes` get/list) that the namespace-scoped sandbox-manager Role cannot provide, documents the knobs, and adds them to `values.schema.json`.

The split keeps commit 1 cherry-pickable on its own: without the chart half the sweep cannot read nodes, fails open, and evicts nothing.

## Testing

10 new tests — 8 on eviction selection (headroom, saturation to zero, cap interaction, cap-never-expands-headroom, unobservable node, tie-breaking, config toggle) and 2 on arg parsing.

`cargo test -p centaur-sandbox-agent-k8s -p centaur-api-server`: 122 and 56 pass. `cargo fmt --all --check` and `cargo clippy --all-targets -- -D warnings` clean. `helm lint` passes and `helm template` renders the env block and both RBAC objects.
