### PR TITLE
fix(sandbox): reconcile agent resources on resume

### DIFF
--- a/services/api-rs/Cargo.lock
+++ b/services/api-rs/Cargo.lock
@@ -2777,6 +2777,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "json-patch"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7421438de105a0827e44fadd05377727847d717c80ce29a229f85fd04c427b72"
+dependencies = [
+ "jsonptr",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.20",
+]
+
+[[package]]
 name = "jsonpath-rust"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2787,6 +2799,16 @@ dependencies = [
  "regex",
  "serde_json",
  "thiserror 2.0.20",
+]
+
+[[package]]
+name = "jsonptr"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5a3cc660ba5d72bce0b3bb295bf20847ccbb40fd423f3f05b61273672e561fe"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -2887,6 +2909,7 @@ dependencies = [
  "form_urlencoded",
  "http 1.4.2",
  "jiff",
+ "json-patch",
  "k8s-openapi",
  "schemars",
  "serde",

--- a/services/api-rs/crates/centaur-api-server/src/args.rs
+++ b/services/api-rs/crates/centaur-api-server/src/args.rs
@@ -1486,6 +1486,12 @@ impl TryFrom<&SandboxArgs> for AgentSandboxConfig {
             .map(str::to_owned)
             .collect();
         config.node_selector = args.node_selector()?;
+        // The same value the create path renders into a new sandbox's pod
+        // template, so resume can bring an older CR back in line with it.
+        config.default_resources = resource_requirements(
+            args.sandbox_resources_json.as_deref(),
+            "SESSION_SANDBOX_RESOURCES",
+        )?;
         config.tolerations = args.tolerations()?;
         config.runtime_class_name = args
             .runtime_class_name

--- a/services/api-rs/crates/centaur-sandbox-agent-k8s/Cargo.toml
+++ b/services/api-rs/crates/centaur-sandbox-agent-k8s/Cargo.toml
@@ -14,7 +14,9 @@ centaur-sandbox-core.workspace = true
 clap.workspace = true
 jiff.workspace = true
 k8s-openapi.workspace = true
-kube = { workspace = true, features = ["derive", "ws"] }
+# jsonpatch: reconciling one container's resources needs a positional
+# replace. A merge patch would rewrite the whole containers array.
+kube = { workspace = true, features = ["derive", "jsonpatch", "ws"] }
 reqwest.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/services/api-rs/crates/centaur-sandbox-agent-k8s/Cargo.toml
+++ b/services/api-rs/crates/centaur-sandbox-agent-k8s/Cargo.toml
@@ -15,7 +15,8 @@ clap.workspace = true
 jiff.workspace = true
 k8s-openapi.workspace = true
 # jsonpatch: reconciling one container's resources needs a positional
-# replace. A merge patch would rewrite the whole containers array.
+# add (insert when absent, replace when present). A merge patch would rewrite
+# the whole containers array.
 kube = { workspace = true, features = ["derive", "jsonpatch", "ws"] }
 reqwest.workspace = true
 serde.workspace = true

--- a/services/api-rs/crates/centaur-sandbox-agent-k8s/src/lib.rs
+++ b/services/api-rs/crates/centaur-sandbox-agent-k8s/src/lib.rs
@@ -285,9 +285,12 @@ impl AgentSandboxBackend {
             return Ok(());
         };
         // A merge patch on `containers` would replace the whole array, so this
-        // has to be a JSON patch at the container's own index.
+        // has to be a JSON patch at the container's own index. `add` rather
+        // than `replace`: a container created before this existed has no
+        // `resources` member, and `replace` errors on a missing target, while
+        // `add` inserts it when absent and replaces it when present.
         let patch = json!([{
-            "op": "replace",
+            "op": "add",
             "path": format!("/spec/podTemplate/spec/containers/{index}/resources"),
             "value": desired_value,
         }]);

--- a/services/api-rs/crates/centaur-sandbox-agent-k8s/src/lib.rs
+++ b/services/api-rs/crates/centaur-sandbox-agent-k8s/src/lib.rs
@@ -12,8 +12,8 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use async_trait::async_trait;
 use centaur_iron_control::IronControlClient;
 use centaur_sandbox_core::{
-    MountKind, ObservedSandbox, SandboxBackend, SandboxError, SandboxHandle, SandboxId, SandboxIo,
-    SandboxResult, SandboxSpec, SandboxStatus,
+    MountKind, ObservedSandbox, ResourceRequirements, SandboxBackend, SandboxError, SandboxHandle,
+    SandboxId, SandboxIo, SandboxResult, SandboxSpec, SandboxStatus,
 };
 use k8s_openapi::api::core::v1::{ConfigMap, PersistentVolumeClaim, Pod};
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
@@ -61,6 +61,15 @@ pub struct AgentSandboxConfig {
     pub namespace: String,
     pub field_manager: String,
     pub container_name: String,
+    /// Fleet-policy resources for the agent container, as currently configured.
+    ///
+    /// The CR stores the pod template rendered at create, and every pod
+    /// recreation re-renders from that stored template, so a session created
+    /// before a resources change keeps the old limits for its whole life --
+    /// including across pod replacement. Reconciling on resume is what lets a
+    /// values change reach an existing session without destroying its CR (and
+    /// with it, its workspace).
+    pub default_resources: Option<ResourceRequirements>,
     pub labels: BTreeMap<String, String>,
     pub annotations: BTreeMap<String, String>,
     pub image_pull_policy: Option<String>,
@@ -134,6 +143,7 @@ impl AgentSandboxConfig {
             namespace: namespace.into(),
             field_manager: "centaur-api-rs".to_owned(),
             container_name: DEFAULT_CONTAINER_NAME.to_owned(),
+            default_resources: None,
             labels: BTreeMap::new(),
             annotations: BTreeMap::new(),
             image_pull_policy: None,
@@ -243,6 +253,60 @@ impl AgentSandboxBackend {
             Err(err) if is_not_found(&err) => Ok(None),
             Err(err) => Err(map_kube_error("get sandbox", err)),
         }
+    }
+
+    /// Bring a paused sandbox's stored pod template back in line with the
+    /// currently configured agent resources.
+    ///
+    /// Only the agent container's `resources` is touched. Everything else in
+    /// the template is session identity -- harness args, env, principal
+    /// annotations -- and re-rendering it from current config would rewrite a
+    /// session's own setup underneath it.
+    ///
+    /// Runs on resume, when `replicas` is still 0 and no pod exists, so this
+    /// never restarts a running pod: the reconciled template is what the next
+    /// pod is built from.
+    async fn reconcile_sandbox_resources(
+        &self,
+        id: &SandboxId,
+        sandbox: &crd::Sandbox,
+    ) -> SandboxResult<()> {
+        let Some(desired) = self.config.default_resources.as_ref() else {
+            return Ok(());
+        };
+        if desired.is_empty() {
+            return Ok(());
+        }
+        let Some((index, desired_value)) = resources_drift(
+            &sandbox.spec.pod_template.spec.containers,
+            &self.config.container_name,
+            desired,
+        ) else {
+            return Ok(());
+        };
+        // A merge patch on `containers` would replace the whole array, so this
+        // has to be a JSON patch at the container's own index.
+        let patch = json!([{
+            "op": "replace",
+            "path": format!("/spec/podTemplate/spec/containers/{index}/resources"),
+            "value": desired_value,
+        }]);
+        self.sandboxes()
+            .patch(
+                id.as_str(),
+                &PatchParams::default(),
+                &Patch::Json::<crd::Sandbox>(serde_json::from_value(patch).map_err(|err| {
+                    SandboxError::backend(format!("build resources patch: {err}"))
+                })?),
+            )
+            .await
+            .map(|_| ())
+            .map_err(|err| map_kube_error("reconcile sandbox resources", err))?;
+        tracing::info!(
+            sandbox_id = id.as_str(),
+            "reconciled sandbox resources with current configuration"
+        );
+        Ok(())
     }
 
     async fn get_pod(&self, id: &SandboxId) -> SandboxResult<Option<Pod>> {
@@ -647,6 +711,17 @@ impl SandboxBackend for AgentSandboxBackend {
         // The proxy resources were recreated, so re-bind them to the sandbox
         // for cascade deletion.
         let sandbox = self.get_sandbox(id).await?;
+        if let Some(sandbox) = &sandbox
+            && let Err(error) = self.reconcile_sandbox_resources(id, sandbox).await
+        {
+            // A drifted limit is worse than a stale one only if it stops the
+            // resume, so this warns rather than failing the turn.
+            tracing::warn!(
+                sandbox_id = id.as_str(),
+                %error,
+                "failed to reconcile sandbox resources with current configuration"
+            );
+        }
         if let Some(sandbox) = &sandbox
             && let Err(error) = self.adopt_iron_proxy_resources(id, sandbox).await
         {
@@ -1150,6 +1225,25 @@ fn sandbox_owner_reference(sandbox: &crd::Sandbox) -> Option<Value> {
         "name": name,
         "uid": uid,
     }))
+}
+
+/// The agent container's index and the desired resources value, when the
+/// stored template has drifted from current configuration.
+///
+/// `None` means nothing to do: no container of that name (do not guess at an
+/// index), or the stored resources already match. Returning the index rather
+/// than patching here keeps the decision testable without a cluster.
+fn resources_drift(
+    containers: &[crd::SandboxPodTemplateSpecContainers],
+    container_name: &str,
+    desired: &ResourceRequirements,
+) -> Option<(usize, Value)> {
+    let index = containers
+        .iter()
+        .position(|container| container.name == container_name)?;
+    let current = serde_json::to_value(&containers[index].resources).unwrap_or(Value::Null);
+    let desired_value = json!(desired);
+    (current != desired_value).then_some((index, desired_value))
 }
 
 fn resources_json(spec: &SandboxSpec) -> Option<Value> {
@@ -1867,5 +1961,64 @@ mod tests {
             }),
             ..Pod::default()
         }
+    }
+
+    fn container_with_resources(
+        name: &str,
+        memory: Option<&str>,
+    ) -> crd::SandboxPodTemplateSpecContainers {
+        let resources = memory.map(|memory| {
+            serde_json::from_value(json!({ "limits": { "memory": memory } })).expect("resources")
+        });
+        crd::SandboxPodTemplateSpecContainers {
+            name: name.to_owned(),
+            resources,
+            ..serde_json::from_value(json!({ "name": name })).expect("container")
+        }
+    }
+
+    fn desired_memory(memory: &str) -> ResourceRequirements {
+        let mut requirements = ResourceRequirements::new();
+        requirements
+            .limits
+            .insert("memory".to_owned(), memory.to_owned());
+        requirements
+    }
+
+    #[test]
+    fn resources_drift_reports_the_agent_container_when_stale() {
+        let containers = vec![
+            container_with_resources("init", Some("1Gi")),
+            container_with_resources("agent", Some("24Gi")),
+        ];
+        let (index, value) =
+            resources_drift(&containers, "agent", &desired_memory("32Gi")).expect("drift");
+        // The agent container is not index 0, so the index has to come from
+        // the name rather than being assumed.
+        assert_eq!(index, 1);
+        assert_eq!(value["limits"]["memory"], "32Gi");
+    }
+
+    #[test]
+    fn resources_drift_is_none_when_already_current() {
+        let containers = vec![container_with_resources("agent", Some("32Gi"))];
+        assert!(resources_drift(&containers, "agent", &desired_memory("32Gi")).is_none());
+    }
+
+    /// Guessing an index would rewrite whichever container happened to sit
+    /// there, so an unrecognised name means leave the CR alone.
+    #[test]
+    fn resources_drift_is_none_without_a_matching_container() {
+        let containers = vec![container_with_resources("sidecar", Some("1Gi"))];
+        assert!(resources_drift(&containers, "agent", &desired_memory("32Gi")).is_none());
+    }
+
+    #[test]
+    fn resources_drift_fills_in_a_container_that_has_none() {
+        let containers = vec![container_with_resources("agent", None)];
+        let (index, value) =
+            resources_drift(&containers, "agent", &desired_memory("32Gi")).expect("drift");
+        assert_eq!(index, 0);
+        assert_eq!(value["limits"]["memory"], "32Gi");
     }
 }


### PR DESCRIPTION
Closes #1545

## Change

`AgentSandboxConfig` gains `default_resources`, populated from the same
`SESSION_SANDBOX_RESOURCES` the create path renders. `resume` reconciles the
stored pod template against it before setting `replicas = 1`.

`resume` only receives a sandbox id, not a spec, which is why the configured
value has to reach the backend through config rather than being re-resolved.

## Four decisions worth reviewing

**It runs while the sandbox is paused.** `replicas` is still 0 and no pod
exists, so nothing is restarted — the reconciled template is simply what the
next pod is built from. That is what makes this safe to do unconditionally on
resume rather than gating it behind an explicit migration.

**Only the agent container's `resources` is touched.** The rest of the template
is session identity — harness args, env, principal annotations — and
re-rendering it from current config would rewrite a session's own setup
underneath it. That is the difference between reconciling fleet policy and
resetting the session.

**A container whose name does not match is left alone**, rather than patched by
index. Guessing would rewrite whichever container happened to sit there; a test
covers the agent container not being index 0.

**The patch is positional JSON, not a merge.** A merge patch on `containers`
replaces the whole array, which would mean round-tripping every container
through the generated types and risking anything they do not model. This is the
one thing here that touches `Cargo.toml`: it enables kube's `jsonpatch` feature.
If you would rather not take that dependency I can rewrite it as a read-modify-
write of the full array, but the positional patch is the smaller blast radius.

A failed reconcile warns rather than failing the resume. A stale limit is worse
than a current one, but both are better than a turn that cannot start.

## Testing

Four new tests over the drift decision, extracted as a pure function so it needs
no cluster: drift reported with the correct index when the agent container is
not first, no drift when already current, no drift (and no patch) when no
container matches the configured name, and a container with no resources at all
being filled in.

`cargo test -p centaur-sandbox-agent-k8s`: 68 pass. `cargo fmt --all --check` and
`cargo clippy --all-targets -- -D warnings` clean on both touched crates.

The reconcile itself talks to the API server, so it is not exercised here — the
tested part is which container to patch and whether to patch at all.
