### PR TITLE
fix(githubbot): tell a PR's sessions when it closes

### DIFF
--- a/services/githubbot/src/pr-manager.ts
+++ b/services/githubbot/src/pr-manager.ts
@@ -2,6 +2,8 @@ import type { GitHubAdapter } from "@chat-adapter/github";
 import type { StateAdapter } from "chat";
 import { backgroundWaitUntil } from "./context";
 import { reactWorkingOnReview, settleReviewReaction } from "./reactions";
+import { reviewThreadKey } from "./review";
+import { forwardToSessionApi } from "./session-api";
 import { runTurnStream } from "./turn";
 import {
   fetchCiEvaluation,
@@ -295,7 +297,20 @@ export async function handlePullRequestEvent(
   if (!repo || !isRecord(prNode)) return;
   const number = numberValue(prNode.number);
   if (number === undefined) return;
-  if (action === "closed") return; // nothing to drive once closed/merged.
+  if (action === "closed") {
+    // A close used to return here, so a turn already working the PR never
+    // learned: it kept running, kept holding a sandbox slot, and kept pushing
+    // to a branch whose PR no longer existed. Worse, a bare close reads to the
+    // agent as "start over" rather than "this was superseded", which has
+    // produced duplicate PRs re-implementing work that was already collapsed
+    // elsewhere.
+    //
+    // Nothing is driven here -- the turn is not cancelled, because cancelling
+    // discards unpushed work. The close is delivered as durable context so the
+    // turn can finish its current step knowing the outcome.
+    await notifyPullRequestClosed(ctx, repo.owner, repo.repo, number, prNode);
+    return;
+  }
 
   const pr = await fetchPr(ctx, repo.owner, repo.repo, number);
   if (!pr || !owns(ctx, pr)) return;
@@ -311,6 +326,68 @@ export async function handlePullRequestEvent(
   // Any other state change that could flip mergeability re-evaluates the merge
   // gate; it's deterministic and idempotent, so over-calling is harmless.
   await tryMerge(ctx, repo.owner, repo.repo, number);
+}
+
+
+/**
+ * Tell the PR's sessions that it closed.
+ *
+ * Delivered as an appended message rather than a turn: this is context for
+ * whatever is already running, not new work. `forwardToSessionApi` with no
+ * `executeMessage` appends and returns without starting an execution, so this
+ * consumes no sandbox slot.
+ *
+ * Both PR-scoped threads are notified. A close matters to the management turn
+ * driving CI and merges, and to a review-response turn addressing feedback on
+ * the same PR; they are separate sessions and either may be mid-flight.
+ */
+async function notifyPullRequestClosed(
+  ctx: PrManagerContext,
+  owner: string,
+  repo: string,
+  number: number,
+  prNode: Record<string, unknown>,
+): Promise<void> {
+  const merged = prNode.merged === true;
+  const title = stringValue(prNode.title) ?? "";
+  const slug = `${owner}/${repo}#${number}`;
+  // Naming the outcome matters more than the fact of the close. "Closed
+  // without merging" is what distinguishes superseded work from finished work,
+  // and getting that wrong is what produced the duplicate PR.
+  const text = merged
+    ? `${slug} (${title}) has been merged. The work on this pull request is complete — do not continue pushing to its branch. If you were mid-task, stop and summarise what you completed.`
+    : `${slug} (${title}) was closed without merging. Do not continue pushing to its branch and do not re-open or re-implement the work as a new pull request: a close usually means the work was superseded or abandoned deliberately. If you were mid-task, stop and summarise what you had done.`;
+  const id = `pr-closed-${owner}-${repo}-${number}-${merged ? "merged" : "closed"}`;
+  const threadKeys = [
+    managementThreadKey(owner, repo, number),
+    reviewThreadKey(owner, repo, number),
+  ];
+  for (const threadKey of threadKeys) {
+    try {
+      await forwardToSessionApi(ctx.options, {
+        afterEventId: 0,
+        conversationName: `${slug}: ${title}`,
+        messages: [managementMessage(id, threadKey, text)],
+        // Append-only: no execution is started, so no event stream to follow.
+        onEventId: () => {},
+        openStream: false,
+        threadId: threadKey,
+        trace: makeTrace(threadKey, id),
+      });
+      traceLog(
+        ctx.options,
+        "githubbot_pr_closed_notified",
+        makeTrace(threadKey, id),
+        { merged, pr: slug },
+      );
+    } catch (error) {
+      // Best effort per thread: one session failing must not stop the other
+      // being told, and a missed notice is not worth failing the webhook over.
+      logger(ctx)?.warn?.(
+        `failed to notify ${threadKey} that ${slug} closed: ${String(error)}`,
+      );
+    }
+  }
 }
 
 /** `pull_request_review` submitted -> address review, or merge on approval. */

--- a/services/githubbot/src/pr-manager.ts
+++ b/services/githubbot/src/pr-manager.ts
@@ -308,6 +308,13 @@ export async function handlePullRequestEvent(
     // Nothing is driven here -- the turn is not cancelled, because cancelling
     // discards unpushed work. The close is delivered as durable context so the
     // turn can finish its current step knowing the outcome.
+    //
+    // Only the bot's own PRs have a management or review session to tell. The
+    // notice is appended via the session API, which mints the session on the
+    // first append, so an unrelated close -- a PR nobody handed to the bot --
+    // would otherwise create two empty sessions per closed PR in the workspace.
+    const pr = await fetchPr(ctx, repo.owner, repo.repo, number);
+    if (!pr || !owns(ctx, pr)) return;
     await notifyPullRequestClosed(ctx, repo.owner, repo.repo, number, prNode);
     return;
   }

--- a/services/githubbot/test/pr-manager.test.ts
+++ b/services/githubbot/test/pr-manager.test.ts
@@ -3,6 +3,7 @@ import { drainBackgroundWork } from "../src/context";
 import {
   decideMerge,
   handleCiEvent,
+  handlePullRequestEvent,
   handleReviewEvent,
   isOwnedPr,
   type PrManagerContext,
@@ -948,5 +949,80 @@ describe("management turn reaction ack", () => {
     await handleReviewEvent(reviewCtx(reactions), submittedReview("changes_requested"));
     await drainBackgroundWork(5_000);
     expect(reactions).toEqual([]);
+  });
+});
+
+describe("pull request closed", () => {
+  function closeCtx(calls: { url: string; body: unknown }[]) {
+    return {
+      octokit: { rest: { pulls: { get: async () => ({ data: {} }) } } },
+      options: {
+        apiUrl: "http://localhost",
+        logger: { debug() {}, warn() {}, error() {}, info() {} },
+        fetch: async (url: string, init?: { body?: string }) => {
+          calls.push({
+            url: String(url),
+            body: init?.body ? JSON.parse(init.body) : undefined,
+          });
+          return new Response(JSON.stringify({ thread_key: "t", created: true }), {
+            headers: { "content-type": "application/json" },
+            status: 200,
+          });
+        },
+      },
+      state: makeState(),
+      userName: "centaur-bot",
+    } as unknown as PrManagerContext;
+  }
+
+  async function runClose(merged: boolean) {
+    const calls: { url: string; body: unknown }[] = [];
+    await handlePullRequestEvent(
+      closeCtx(calls),
+      JSON.stringify({
+        action: "closed",
+        pull_request: { merged, number: 41, title: "Add the thing" },
+        repository: { full_name: "base/repo" },
+      }),
+    );
+    return calls;
+  }
+
+  function appendedTexts(calls: { url: string; body: unknown }[]): string[] {
+    return calls
+      .filter((call) => call.url.endsWith("/messages"))
+      .flatMap((call) => {
+        const body = call.body as
+          | { messages?: { parts?: { text?: string }[] }[] }
+          | undefined;
+        return (body?.messages ?? []).flatMap((message) =>
+          (message.parts ?? []).map((part) => part.text ?? ""),
+        );
+      });
+  }
+
+  test("tells both PR-scoped threads the pull request closed", async () => {
+    const calls = await runClose(false);
+    const urls = calls.map((call) => call.url).join(" ");
+    // A close matters to the management turn and to a review-response turn;
+    // they are separate sessions and either may be mid-flight.
+    expect(urls).toContain(encodeURIComponent("github-manage:base/repo:41"));
+    expect(urls).toContain(encodeURIComponent("github-review:base/repo:41"));
+  });
+
+  test("starts no execution, so a close consumes no sandbox slot", async () => {
+    const calls = await runClose(false);
+    expect(calls.some((call) => call.url.includes("/execute"))).toBe(false);
+  });
+
+  test("names the outcome, because superseded and finished differ", async () => {
+    const closed = appendedTexts(await runClose(false)).join("\n");
+    expect(closed).toContain("closed without merging");
+    // The duplicate-PR failure came from a bare close reading as "start over".
+    expect(closed).toContain("do not re-open or re-implement");
+
+    const merged = appendedTexts(await runClose(true)).join("\n");
+    expect(merged).toContain("has been merged");
+    expect(merged).not.toContain("closed without merging");
   });
 });

--- a/services/githubbot/test/pr-manager.test.ts
+++ b/services/githubbot/test/pr-manager.test.ts
@@ -953,9 +953,23 @@ describe("management turn reaction ack", () => {
 });
 
 describe("pull request closed", () => {
-  function closeCtx(calls: { url: string; body: unknown }[]) {
+  function closeCtx(
+    calls: { url: string; body: unknown }[],
+    owned = true,
+  ) {
+    // fetchPr round-trips through summarizePr, which reads head/labels, so the
+    // mock must be a shaped PR. The bot owns it only when it is an assignee.
+    const data = {
+      number: 41,
+      state: "closed",
+      title: "Add the thing",
+      merged: false,
+      head: { ref: "feature", sha: "abc123" },
+      labels: [],
+      assignees: owned ? [{ login: "centaur-bot" }] : [],
+    };
     return {
-      octokit: { rest: { pulls: { get: async () => ({ data: {} }) } } },
+      octokit: { rest: { pulls: { get: async () => ({ data }) } } },
       options: {
         apiUrl: "http://localhost",
         logger: { debug() {}, warn() {}, error() {}, info() {} },
@@ -975,10 +989,10 @@ describe("pull request closed", () => {
     } as unknown as PrManagerContext;
   }
 
-  async function runClose(merged: boolean) {
+  async function runClose(merged: boolean, owned = true) {
     const calls: { url: string; body: unknown }[] = [];
     await handlePullRequestEvent(
-      closeCtx(calls),
+      closeCtx(calls, owned),
       JSON.stringify({
         action: "closed",
         pull_request: { merged, number: 41, title: "Add the thing" },
@@ -1008,6 +1022,14 @@ describe("pull request closed", () => {
     // they are separate sessions and either may be mid-flight.
     expect(urls).toContain(encodeURIComponent("github-manage:base/repo:41"));
     expect(urls).toContain(encodeURIComponent("github-review:base/repo:41"));
+  });
+
+  test("notifies nothing when the pull request is not the bot's", async () => {
+    // The session API mints a session on the first append, so an unrelated
+    // close must not reach notifyPullRequestClosed at all -- otherwise every
+    // closed PR in the workspace becomes a pair of empty Centaur sessions.
+    const calls = await runClose(false, false);
+    expect(calls).toEqual([]);
   });
 
   test("starts no execution, so a close consumes no sandbox slot", async () => {


### PR DESCRIPTION
Closes #1547

## Change

`handlePullRequestEvent` no longer returns early on `closed`. The close is
appended to the PR's sessions as durable context.

`forwardToSessionApi` with no `executeMessage` appends and returns without
starting an execution, so **a close consumes no sandbox slot** — which matters,
because the whole problem is a turn holding one it should not.

## Three decisions

**The turn is not cancelled.** Cancelling matches the intent of a close but
discards unpushed work, which is the loss a close is often trying to avoid. On a
fleet where turns run for hours that trades one silent loss for another. Telling
the turn is the cheaper half and stops the duplicate-work case on its own; a
cancel or a bound is a reasonable follow-up once the notification exists.

**Merged and closed-without-merging say different things.** A bare close reads
to an agent as "start over", which is what produced a fresh PR re-implementing
work that had already been collapsed elsewhere. The closed message explicitly
says not to re-open or re-implement; the merged one says the work is complete.

**Both PR-scoped threads are notified.** The management turn driving CI and
merges and a review-response turn addressing feedback are separate sessions for
the same PR, and either may be mid-flight. Notification is per-thread
best-effort, so one failing does not stop the other being told, and a missed
notice does not fail the webhook.

## Testing

Three new tests: both thread keys are notified; no `/execute` call is made (the
no-slot property); and the merged and closed wordings differ, with the closed
one carrying the "do not re-implement" instruction.

`bun test` in `services/githubbot`: 104 pass. `bun run check:types` clean.
