### PR TITLE
feat(harness-server): let a deployment name retriable engine errors

### DIFF
--- a/crates/harness-server/src/codex.rs
+++ b/crates/harness-server/src/codex.rs
@@ -869,19 +869,62 @@ fn retry_backoff(retry: u32) -> Duration {
     Duration::from_millis((500u64 << shift).min(5_000))
 }
 
+/// Extra error-message substrings a deployment considers retriable, from
+/// `CODEX_ENGINE_RETRY_PATTERNS` (comma-separated). Empty by default, so
+/// behaviour is unchanged unless a deployment opts in.
+///
+/// The built-in set below covers codex's own engine-registration failures. It
+/// cannot cover the transient failures of an arbitrary inference endpoint, and
+/// a deployment that hits one today has no lever short of patching this binary
+/// -- for example an OpenAI-compatible server rejecting a request body it could
+/// not parse, which is a framing failure that succeeds on resubmission.
+fn configured_retry_patterns() -> Vec<String> {
+    parse_retry_patterns(env::var("CODEX_ENGINE_RETRY_PATTERNS").ok().as_deref())
+}
+
+fn parse_retry_patterns(raw: Option<&str>) -> Vec<String> {
+    raw.map(|raw| {
+        raw.split(',')
+            .map(str::trim)
+            .filter(|pattern| !pattern.is_empty())
+            .map(|pattern| pattern.to_lowercase())
+            .collect()
+    })
+    .unwrap_or_default()
+}
+
 /// True for codex's transient "engine warming up" failure, which surfaces as a
 /// -32602 error notification (`willRetry:false`) whose message ends in
 /// "...status 404 Not Found: Engine not found". These resolve on resubmission;
 /// other -32602s (genuine invalid params) are left untouched.
+///
+/// Retries are bounded by `CODEX_ENGINE_RETRY_MAX` and only reached before the
+/// turn has streamed any output, so a pattern that turns out to match a
+/// deterministic failure costs a few resubmissions and then fails exactly as it
+/// does today.
 fn is_retriable_engine_error(value: &Value) -> bool {
+    is_retriable_error_message(value, &configured_retry_patterns())
+}
+
+fn is_retriable_error_message(value: &Value, extra_patterns: &[String]) -> bool {
     let Some(message) = value
         .pointer("/params/error/message")
         .and_then(Value::as_str)
     else {
         return false;
     };
-    message.contains("Engine not found")
+    if message.contains("Engine not found")
         || (message.contains("Job registration failed") && message.contains("404"))
+    {
+        return true;
+    }
+    if extra_patterns.is_empty() {
+        return false;
+    }
+    let message = message.to_lowercase();
+    extra_patterns
+        .iter()
+        .any(|pattern| message.contains(pattern.as_str()))
 }
 
 /// True for a `thread/status/changed` notification reporting a `systemError`.
@@ -1214,5 +1257,67 @@ mod tests {
         });
         assert!(!is_terminal_notification(&retryable, "thread-1", "turn-1"));
         assert!(is_terminal_notification(&exhausted, "thread-1", "turn-1"));
+    }
+
+    /// The reported failure: an OpenAI-compatible endpoint rejecting a request
+    /// body it could not parse. The 400 comes back in milliseconds with no work
+    /// done, and the same turn succeeds on resubmission.
+    fn malformed_request_error() -> Value {
+        json!({
+            "method": "error",
+            "params": {
+                "error": {
+                    "code": -32602,
+                    "message": "Unterminated string starting at: line 1 column 9 (char 8)"
+                }
+            }
+        })
+    }
+
+    #[test]
+    fn configured_patterns_are_off_by_default() {
+        // Unchanged behaviour unless a deployment opts in.
+        assert!(!is_retriable_error_message(&malformed_request_error(), &[]));
+        assert!(is_retriable_error_message(&engine_error(), &[]));
+    }
+
+    #[test]
+    fn configured_patterns_extend_the_builtin_set() {
+        let patterns = parse_retry_patterns(Some("unterminated string"));
+        assert!(is_retriable_error_message(
+            &malformed_request_error(),
+            &patterns
+        ));
+        // The built-ins still match with extras configured.
+        assert!(is_retriable_error_message(&engine_error(), &patterns));
+    }
+
+    #[test]
+    fn configured_patterns_match_case_insensitively() {
+        let patterns = parse_retry_patterns(Some("UNTERMINATED String"));
+        assert!(is_retriable_error_message(
+            &malformed_request_error(),
+            &patterns
+        ));
+    }
+
+    #[test]
+    fn configured_patterns_do_not_match_unrelated_errors() {
+        let patterns = parse_retry_patterns(Some("unterminated string"));
+        let unrelated = json!({
+            "method": "error",
+            "params": { "error": { "code": -32602, "message": "invalid model" } }
+        });
+        assert!(!is_retriable_error_message(&unrelated, &patterns));
+    }
+
+    #[test]
+    fn retry_patterns_parse_ignores_blanks_and_whitespace() {
+        assert_eq!(parse_retry_patterns(None), Vec::<String>::new());
+        assert_eq!(parse_retry_patterns(Some("  ,, ")), Vec::<String>::new());
+        assert_eq!(
+            parse_retry_patterns(Some(" a , B ,, c ")),
+            vec!["a".to_owned(), "b".to_owned(), "c".to_owned()]
+        );
     }
 }


### PR DESCRIPTION
Closes #1549

## Change

`CODEX_ENGINE_RETRY_PATTERNS` — comma-separated substrings added to the built-in
retriable set, matched case-insensitively. Empty by default, so nothing changes
unless a deployment opts in.

## Why a lever and not a new hardcoded pattern

The case that surfaced this is an OpenAI-compatible endpoint rejecting a request
body it could not parse (`Unterminated string starting at: line 1 column 9`),
returning 400 in 15–25ms with no work done. I could have added that string to
the allowlist. I did not, because **which side truncates the request is still
unidentified** — both the client's encoding on a fresh connection after a long
stream and the server's body read under concurrency remain live candidates, and
settling it needs a captured body.

Hardcoding a pattern for a failure whose cause you cannot verify asserts a
classification into everyone's build. Letting the deployment that can observe it
decide seemed the better trade, and it also fixes the general problem:
`is_retriable_engine_error` covers codex's own registration failures and cannot
cover an arbitrary endpoint's, so any deployment hitting a different transient
failure currently has to patch this binary.

## Why widening is safe

Both existing guards still apply, and they are what make this bounded:

- retries are capped by `CODEX_ENGINE_RETRY_MAX`;
- the retry path is only reached **before the turn has streamed output**
  (`!self.streamed`), so nothing partial is ever re-submitted.

A pattern that turns out to match a deterministic failure therefore costs a few
resubmissions and then fails exactly as it does today.

## Testing

Five new tests over the classifier, split from the env read so they need no
process-global state: off by default (the reported error is not retriable with
no patterns configured, and the built-ins still are), extras extending rather
than replacing the built-in set, case-insensitive matching, an unrelated error
not matching, and the parser ignoring blanks and whitespace.

`cargo test -p harness-server`: 95 unit tests pass. `cargo clippy --all-targets
-- -D warnings` clean.

`tests/app_server_stdio.rs::turn_interrupt_rejects_wrong_thread_and_turn_without_killing_process`
fails in my environment with `read start log: NotFound`, identically on an
unmodified checkout, so it is a local fixture issue rather than this change.
