### PR TITLE
feat(console): let a deployment name extra sandbox entitlements hosts

### DIFF
--- a/contrib/chart/templates/console.yaml
+++ b/contrib/chart/templates/console.yaml
@@ -194,6 +194,10 @@ spec:
             - name: CENTAUR_CONSOLE_ALLOWED_HOSTS
               value: {{ join "," . | quote }}
 {{- end }}
+{{- with $console.entitlementsHosts }}
+            - name: CENTAUR_CONSOLE_ENTITLEMENTS_HOSTS
+              value: {{ join "," . | quote }}
+{{- end }}
 {{- with $console.sentryDsn }}
             - name: SENTRY_DSN
               value: {{ . | quote }}

--- a/contrib/chart/values.schema.json
+++ b/contrib/chart/values.schema.json
@@ -10,6 +10,7 @@
         "allowedHosts": {
           "type": "array",
           "items": { "type": "string" },
+        "entitlementsHosts": { "type": "array", "items": { "type": "string" } },
           "uniqueItems": true
         },
         "sentryDsn": { "type": "string" },

--- a/contrib/chart/values.schema.json
+++ b/contrib/chart/values.schema.json
@@ -10,9 +10,9 @@
         "allowedHosts": {
           "type": "array",
           "items": { "type": "string" },
-        "entitlementsHosts": { "type": "array", "items": { "type": "string" } },
           "uniqueItems": true
         },
+        "entitlementsHosts": { "type": "array", "items": { "type": "string" } },
         "sentryDsn": { "type": "string" },
         "railsEnv": { "type": "string" },
         "image": {

--- a/contrib/chart/values.yaml
+++ b/contrib/chart/values.yaml
@@ -111,6 +111,14 @@ console:
   # service DNS names that differ from the chart's short in-cluster URL;
   # publicUrl and the short service host are already included.
   allowedHosts: []
+  # Additional hosts whose requests get the sandbox entitlements credential
+  # injected by the proxy. The in-cluster console URL is always included.
+  #
+  # Needed when sandboxes cannot reach the console's in-cluster address: they
+  # must then use another host, and without a matching injection rule that
+  # request arrives with no credential and is refused. Set this to whatever
+  # address the sandboxes actually use.
+  entitlementsHosts: []
   # Optional Sentry DSN for Console web requests and background jobs. Empty by
   # default, so the Sentry SDK remains disabled unless explicitly configured.
   sentryDsn: ""

--- a/services/console/app/models/proxy.rb
+++ b/services/console/app/models/proxy.rb
@@ -55,8 +55,35 @@ class Proxy < ApplicationRecord
     sync_config_snapshot.fetch(:config_hash)
   end
 
+  # Hosts whose requests get the sandbox entitlements credential injected by
+  # the proxy.
+  #
+  # `CENTAUR_CONSOLE_URL` is the Console's own in-cluster address, and it is the
+  # only host here by default. That is a problem for any deployment whose
+  # sandboxes cannot reach that address: reaching the Console then needs a host
+  # outside the blocked range, but getting a credential needs the host to equal
+  # the in-cluster one, and the two are mutually exclusive. A sandbox that
+  # fronts the Console on another address gets past the network block and then
+  # 403s, because no injection rule matches the host it actually used.
+  #
+  # `CENTAUR_CONSOLE_ENTITLEMENTS_HOSTS` (comma-separated) names additional
+  # hosts for the same credential. It adds to the default rather than replacing
+  # it, so the in-cluster address keeps working.
   def self.sandbox_entitlements_hosts
-    [ Principal.host_from_url(ENV["CENTAUR_CONSOLE_URL"]) ]
+    Principal.normalize_hosts(
+      [ Principal.host_from_url(ENV["CENTAUR_CONSOLE_URL"]) ] + extra_entitlements_hosts
+    )
+  end
+
+  def self.extra_entitlements_hosts
+    ENV["CENTAUR_CONSOLE_ENTITLEMENTS_HOSTS"].to_s.split(",").filter_map do |entry|
+      entry = entry.strip
+      next if entry.empty?
+
+      # Accept either a bare host or a URL, so the value can be copied from
+      # whatever the deployment already sets CENTAUR_CONSOLE_URL to.
+      entry.include?("//") ? Principal.host_from_url(entry) : entry
+    end
   end
 
   private

--- a/services/console/test/models/proxy_test.rb
+++ b/services/console/test/models/proxy_test.rb
@@ -280,4 +280,48 @@ class ProxyTest < ActiveSupport::TestCase
     assert_nil proxy.requester_principal_id
     assert_equal principals(:acme_channel), proxy.principal
   end
+
+
+  test "sandbox entitlements hosts default to the console url alone" do
+    with_env("CENTAUR_CONSOLE_URL" => "http://centaur-console:3000",
+             "CENTAUR_CONSOLE_ENTITLEMENTS_HOSTS" => nil) do
+      assert_equal [ "centaur-console" ], Proxy.sandbox_entitlements_hosts
+    end
+  end
+
+  test "configured entitlements hosts add to the console url rather than replacing it" do
+    # The in-cluster address has to keep working: replacing it would break the
+    # sync path that already uses it.
+    with_env("CENTAUR_CONSOLE_URL" => "http://centaur-console:3000",
+             "CENTAUR_CONSOLE_ENTITLEMENTS_HOSTS" => "console.example.com") do
+      assert_equal [ "centaur-console", "console.example.com" ],
+                   Proxy.sandbox_entitlements_hosts
+    end
+  end
+
+  test "configured entitlements hosts accept a url or a bare host" do
+    # The value is most often copied from whatever CENTAUR_CONSOLE_URL is set
+    # to, so accepting a URL avoids a silently non-matching rule.
+    with_env("CENTAUR_CONSOLE_URL" => "http://centaur-console:3000",
+             "CENTAUR_CONSOLE_ENTITLEMENTS_HOSTS" => "https://console.example.com:443, other.example.com") do
+      assert_equal [ "centaur-console", "console.example.com", "other.example.com" ],
+                   Proxy.sandbox_entitlements_hosts
+    end
+  end
+
+  test "configured entitlements hosts are normalized and de-duplicated" do
+    with_env("CENTAUR_CONSOLE_URL" => "http://centaur-console:3000",
+             "CENTAUR_CONSOLE_ENTITLEMENTS_HOSTS" => " CONSOLE.example.com. , , console.example.com , centaur-console ") do
+      assert_equal [ "centaur-console", "console.example.com" ],
+                   Proxy.sandbox_entitlements_hosts
+    end
+  end
+
+  def with_env(values)
+    previous = values.keys.index_with { |key| ENV[key] }
+    values.each { |key, value| value.nil? ? ENV.delete(key) : ENV[key] = value }
+    yield
+  ensure
+    previous.each { |key, value| value.nil? ? ENV.delete(key) : ENV[key] = value }
+  end
 end


### PR DESCRIPTION
Closes #1558.

Part of #1486 — the auth half, direction 2 of the three that issue's thread lists.

## The bind

`upstream_deny_cidrs` blocks the cluster service range by design, so sandboxes
cannot reach arbitrary in-cluster services. That also blocks the Console, and it
cannot be relaxed without opening everything else.

Fronting the Console on an address outside the range gets past the network
block, and then 403s. `sandbox_entitlements_hosts` is:

```ruby
def self.sandbox_entitlements_hosts
  [ Principal.host_from_url(ENV["CENTAUR_CONSOLE_URL"]) ]
end
```

One host, from the Console's own env, with no config, admin API or DB row
overriding it. So the injection rule only ever matches the in-cluster address —
the one the sandbox cannot use. **Reaching the Console needs a host outside the
range; getting a credential needs the host inside it.** As shipped those are
mutually exclusive, which is why this is not solvable in a deployment's own
values.

## Change

`CENTAUR_CONSOLE_ENTITLEMENTS_HOSTS` (chart:
`console.entitlementsHosts`) names additional hosts for the same credential.

- **Adds rather than replaces.** The in-cluster address keeps working, including
  for the sync path that already uses it.
- **Accepts a URL or a bare host**, because the value is in practice copied from
  whatever `CENTAUR_CONSOLE_URL` is set to, and a URL silently producing a
  non-matching rule is the failure this is meant to remove.
- **Normalized through the existing `Principal.normalize_hosts`**, so matching
  does not hinge on case, whitespace or a trailing dot, and a host that
  duplicates the default collapses.

Unset, nothing changes.

## Why this direction

The issue lists three shapes. Exempting the control plane from the forwarded
deny is the narrowest, but the deny is enforced by the proxy binary rather than
by this repo, so it is not a change that can be made here. Exposing
`console.extraEnv` is the broadest and least targeted. This one is the smallest
change inside centaur that actually unblocks the pair.

It is the auth half only. A deployment still has to front the Console on a
reachable address; this makes that address work instead of 403ing.

## Testing

Four new model tests: the default is the console URL alone; a configured host
adds to it rather than replacing it; a URL and a bare host are both accepted;
and values are normalized and de-duplicated.

**I could not run them.** The console suite needs `bundle install` and a
prepared database, and this machine has Ruby 2.6 against a Gemfile.lock wanting
bundler 4.0.10, so neither `bin/rails test` nor `bin/rubocop` would start. Both
files pass `ruby -c`, and `filter_map`/`index_with` are already used elsewhere
in this app, but the tests themselves rest on CI. Flagging that rather than
implying otherwise.

`helm lint` passes, the values schema stays valid, and `helm template` renders
`CENTAUR_CONSOLE_ENTITLEMENTS_HOSTS` only when the value is set.

