### PR TITLE
fix(githubbot): log output size on review, issue and management turns

### DIFF
--- a/services/githubbot/src/issue-manager.ts
+++ b/services/githubbot/src/issue-manager.ts
@@ -2,7 +2,7 @@ import { backgroundWaitUntil } from "./context";
 import { DEFAULT_ISSUE_PROMPT } from "./issue-prompt";
 import type { PrManagerContext } from "./pr-manager";
 import { reactWorkingOnSubject, settleSubjectReaction } from "./reactions";
-import { runTurnStream } from "./turn";
+import { runTurnStream, turnOutputChars } from "./turn";
 import type {
   ForwardSessionInput,
   GithubbotApiMessage,
@@ -145,6 +145,7 @@ export function handleIssueEvent(
       runTurnStream(options, forwardInput)
         .then(async (result) => {
           traceLog(options, "githubbot_issue_turn_complete", trace, {
+            chars: turnOutputChars(result),
             failed: result.failed,
           });
           await settleSubjectReaction(

--- a/services/githubbot/src/pr-manager.ts
+++ b/services/githubbot/src/pr-manager.ts
@@ -2,7 +2,7 @@ import type { GitHubAdapter } from "@chat-adapter/github";
 import type { StateAdapter } from "chat";
 import { backgroundWaitUntil } from "./context";
 import { reactWorkingOnReview, settleReviewReaction } from "./reactions";
-import { runTurnStream } from "./turn";
+import { runTurnStream, turnOutputChars } from "./turn";
 import {
   fetchCiEvaluation,
   maybeEmitReviewSubmitted,
@@ -733,6 +733,7 @@ function fireManagementTurn(
     runTurnStream(ctx.options, forwardInput)
       .then(async (result) => {
         traceLog(ctx.options, "githubbot_management_turn_complete", trace, {
+          chars: turnOutputChars(result),
           failed: result.failed,
           work: message.label,
         });

--- a/services/githubbot/src/review.ts
+++ b/services/githubbot/src/review.ts
@@ -3,7 +3,7 @@ import type { StateAdapter } from "chat";
 import { backgroundWaitUntil } from "./context";
 import { reactWorkingOnSubject, settleSubjectReaction } from "./reactions";
 import { DEFAULT_REVIEW_PROMPT } from "./review-prompt";
-import { runTurnStream } from "./turn";
+import { runTurnStream, turnOutputChars } from "./turn";
 import type {
   ForwardSessionInput,
   GithubbotApiMessage,
@@ -182,6 +182,7 @@ export function handleReviewRequest(
       runTurnStream(options, forwardInput)
         .then(async (result) => {
           traceLog(options, "githubbot_review_turn_complete", trace, {
+            chars: turnOutputChars(result),
             failed: result.failed,
           });
           await settleSubjectReaction(

--- a/services/githubbot/src/turn.ts
+++ b/services/githubbot/src/turn.ts
@@ -57,6 +57,25 @@ export type TurnResult = {
   fallbackText: string;
 };
 
+/**
+ * Size of what a turn produced, for the `chars` field on its completion log.
+ *
+ * Turns whose deliverable is not a rendered comment -- a review, issue work, a
+ * PR-management action -- logged no size at all, so a monitor could not tell a
+ * long successful turn from an aborted one and classified every one of them
+ * unverifiable. Any long turn on those surfaces then looks like a failure.
+ *
+ * Measures the answer rather than a rendered body, because these surfaces have
+ * no single body: what they emit is a review comment, an issue comment, or a
+ * push. A failed turn reports its error text for the same reason a failed
+ * comment turn does -- zero would read as "produced nothing", which is a
+ * different fault from "produced an error".
+ */
+export function turnOutputChars(result: TurnResult): number {
+  if (result.failed) return result.errorText.length;
+  return (result.answer || result.fallbackText).length;
+}
+
 const THREAD_KEY_PATTERN =
   /^github:([^/:]+)\/([^:]+):(?:issue:(\d+)|(\d+)(?::rc:(\d+))?)$/;
 

--- a/services/githubbot/src/turn.ts
+++ b/services/githubbot/src/turn.ts
@@ -57,20 +57,6 @@ export type TurnResult = {
   fallbackText: string;
 };
 
-/**
- * Size of what a turn produced, for the `chars` field on its completion log.
- *
- * Turns whose deliverable is not a rendered comment -- a review, issue work, a
- * PR-management action -- logged no size at all, so a monitor could not tell a
- * long successful turn from an aborted one and classified every one of them
- * unverifiable. Any long turn on those surfaces then looks like a failure.
- *
- * Measures the answer rather than a rendered body, because these surfaces have
- * no single body: what they emit is a review comment, an issue comment, or a
- * push. A failed turn reports its error text for the same reason a failed
- * comment turn does -- zero would read as "produced nothing", which is a
- * different fault from "produced an error".
- */
 export function turnOutputChars(result: TurnResult): number {
   if (result.failed) return result.errorText.length;
   return (result.answer || result.fallbackText).length;

--- a/services/githubbot/test/turn.test.ts
+++ b/services/githubbot/test/turn.test.ts
@@ -3,6 +3,8 @@ import {
   githubContextPreamble,
   parseGithubThreadKey,
   reviewCommentContextFromRaw,
+  turnOutputChars,
+  type TurnResult,
 } from "../src/turn";
 
 describe("parseGithubThreadKey", () => {
@@ -99,5 +101,38 @@ describe("githubContextPreamble", () => {
 
   test("returns undefined for an unparseable key", () => {
     expect(githubContextPreamble("not-a-github-key")).toBeUndefined();
+  });
+});
+
+describe("turnOutputChars", () => {
+  function result(overrides: Partial<TurnResult> = {}): TurnResult {
+    return {
+      answer: "",
+      cotLines: [],
+      errorText: "",
+      failed: false,
+      fallbackText: "",
+      ...overrides,
+    };
+  }
+
+  test("measures the answer a turn produced", () => {
+    expect(turnOutputChars(result({ answer: "done" }))).toBe(4);
+  });
+
+  test("falls back to the fallback text when there is no answer", () => {
+    expect(turnOutputChars(result({ fallbackText: "twelve chars" }))).toBe(12);
+  });
+
+  test("reports the error text for a failed turn", () => {
+    // Zero would read as "produced nothing", which is a different fault from
+    // "produced an error" — the distinction the unverifiable state lost.
+    expect(
+      turnOutputChars(result({ errorText: "boom", failed: true })),
+    ).toBe(4);
+  });
+
+  test("is zero only when a successful turn really produced nothing", () => {
+    expect(turnOutputChars(result())).toBe(0);
   });
 });

--- a/services/githubbot/test/turn.test.ts
+++ b/services/githubbot/test/turn.test.ts
@@ -125,8 +125,6 @@ describe("turnOutputChars", () => {
   });
 
   test("reports the error text for a failed turn", () => {
-    // Zero would read as "produced nothing", which is a different fault from
-    // "produced an error" — the distinction the unverifiable state lost.
     expect(
       turnOutputChars(result({ errorText: "boom", failed: true })),
     ).toBe(4);


### PR DESCRIPTION
Closes #1552

## Change

`turnOutputChars` measures what a turn produced, and the review, issue-work and
management completions now log it. `githubbot_thread_turn_complete` already did;
these three logged `failed` alone.

## Two decisions

**It measures the answer, not a rendered body.** The comment path measures the
comment it posts, but these three surfaces have no single body — what they emit
is a review comment, an issue comment, or a push. The answer is the part that
exists on all of them.

**A failed turn reports its error text length, not zero.** Zero would read as
"produced nothing", which is a different fault from "produced an error", and
collapsing them loses exactly the distinction this is meant to restore. The
comment path already does the same thing by rendering its error into the body it
measures.

## Testing

Four new tests: the answer is measured, the fallback text is used when there is
no answer, a failed turn reports its error text, and zero is reported only when
a successful turn genuinely produced nothing.

`bun test` in `services/githubbot`: 105 pass. `bun run check:types` clean.
