### PR TITLE
fix(sandbox): stop counting pod-less sandboxes against the running limit

### DIFF
--- a/services/api-rs/crates/centaur-sandbox-agent-k8s/src/lib.rs
+++ b/services/api-rs/crates/centaur-sandbox-agent-k8s/src/lib.rs
@@ -760,7 +760,11 @@ fn sandbox_status_from_pod(replicas: i32, pod: Option<&Pod>) -> SandboxStatus {
     // The backing Pod Ready condition is the attach boundary; phase alone can be Running while
     // the sandbox is still not ready for I/O.
     let Some(pod) = pod else {
-        return SandboxStatus::Created;
+        // The CR asks for a replica and there is no Pod behind it. Reporting
+        // this as Created made it indistinguishable from a sandbox still
+        // coming up, so it consumed a running slot that nothing could ever
+        // return.
+        return SandboxStatus::Vacant;
     };
     if pod.metadata.deletion_timestamp.is_some() {
         return SandboxStatus::Created;
@@ -1837,7 +1841,10 @@ mod tests {
             sandbox_status_from_pod(1, Some(&unready_pod)),
             SandboxStatus::Created
         );
-        assert_eq!(sandbox_status_from_pod(1, None), SandboxStatus::Created);
+        // A CR asking for a replica with no Pod behind it is vacant, not
+        // starting. Reporting Created here is what let a pod-less CR hold a
+        // running slot nothing could return.
+        assert_eq!(sandbox_status_from_pod(1, None), SandboxStatus::Vacant);
 
         let failed_pod = pod_with_phase_and_ready("Failed", false);
         assert_eq!(

--- a/services/api-rs/crates/centaur-sandbox-core/src/lifecycle.rs
+++ b/services/api-rs/crates/centaur-sandbox-core/src/lifecycle.rs
@@ -63,6 +63,14 @@ impl SandboxHandle {
 pub enum SandboxStatus {
     /// Runtime resources exist but are not yet ready for byte I/O.
     Created,
+    /// The runtime record asks for a process and the backend has none for it.
+    ///
+    /// Distinct from [`SandboxStatus::Created`], where a process exists and is
+    /// still coming up, and from [`SandboxStatus::Suspended`], where nothing is
+    /// asking for one. A vacant runtime holds its record and state volume but
+    /// no compute, so it must not be counted against a running-capacity limit:
+    /// there is nothing running to account for.
+    Vacant,
     /// Runtime is live and should accept `open_io`.
     Running,
     /// Runtime state may exist, but no live process is serving I/O.

--- a/services/api-rs/crates/centaur-sandbox-manager/src/reconcile.rs
+++ b/services/api-rs/crates/centaur-sandbox-manager/src/reconcile.rs
@@ -28,7 +28,9 @@ impl ReconcilePlan {
             DesiredSandboxState::Running(_) => match &observed.status {
                 SandboxStatus::Running | SandboxStatus::Created => ReconcileAction::None,
                 SandboxStatus::Suspended => ReconcileAction::Resume,
-                SandboxStatus::Stopped | SandboxStatus::Gone => {
+                // Vacant is drift, not a state to wait out: the record asks
+                // for a process and the backend has none.
+                SandboxStatus::Stopped | SandboxStatus::Gone | SandboxStatus::Vacant => {
                     ReconcileAction::ReportDrift(DriftReason::MissingWhileRunning)
                 }
                 SandboxStatus::Unknown(value) => {
@@ -37,7 +39,11 @@ impl ReconcilePlan {
             },
             DesiredSandboxState::Suspended(_) => match &observed.status {
                 SandboxStatus::Suspended => ReconcileAction::None,
-                SandboxStatus::Running | SandboxStatus::Created => ReconcileAction::Pause,
+                // Pausing a vacant sandbox is the repair, not a no-op: the
+                // pod is already gone but the record still requests one.
+                SandboxStatus::Running | SandboxStatus::Created | SandboxStatus::Vacant => {
+                    ReconcileAction::Pause
+                }
                 SandboxStatus::Stopped | SandboxStatus::Gone => {
                     ReconcileAction::ReportDrift(DriftReason::MissingWhileSuspended)
                 }
@@ -47,9 +53,10 @@ impl ReconcilePlan {
             },
             DesiredSandboxState::Stopped => match &observed.status {
                 SandboxStatus::Stopped | SandboxStatus::Gone => ReconcileAction::None,
-                SandboxStatus::Created | SandboxStatus::Running | SandboxStatus::Suspended => {
-                    ReconcileAction::Stop
-                }
+                SandboxStatus::Created
+                | SandboxStatus::Running
+                | SandboxStatus::Suspended
+                | SandboxStatus::Vacant => ReconcileAction::Stop,
                 SandboxStatus::Unknown(value) => {
                     ReconcileAction::ReportDrift(DriftReason::UnknownObservedState(value.clone()))
                 }

--- a/services/api-rs/crates/centaur-sandbox-manager/src/warm_pool.rs
+++ b/services/api-rs/crates/centaur-sandbox-manager/src/warm_pool.rs
@@ -263,6 +263,16 @@ mod tests {
     /// Serialize the database-backed tests in this module.
     static TEST_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
 
+    #[test]
+    fn vacant_sandboxes_do_not_consume_running_slots() {
+        // Warm-pool replenishment is gated on the same count as admission, so
+        // a pod-less CR counted here too and blocked the pool from refilling.
+        assert!(!status_consumes_running_slot(&SandboxStatus::Vacant));
+        assert!(status_consumes_running_slot(&SandboxStatus::Created));
+        assert!(status_consumes_running_slot(&SandboxStatus::Running));
+        assert!(!status_consumes_running_slot(&SandboxStatus::Suspended));
+    }
+
     #[tokio::test]
     async fn replenisher_prunes_missing_ready_rows_before_counting() {
         let _serial = TEST_LOCK.lock().await;

--- a/services/api-rs/crates/centaur-session-runtime/src/cleanup.rs
+++ b/services/api-rs/crates/centaur-session-runtime/src/cleanup.rs
@@ -26,6 +26,8 @@ impl SessionSandboxCleanupConfig {
 
 #[derive(Debug, Default)]
 pub struct SessionSandboxCleanupReport {
+    pub retired_vacant: usize,
+    pub failed_vacant_retirements: usize,
     pub stopped_orphans: usize,
     pub failed_orphans: usize,
     pub idle_pause_attempts: usize,
@@ -36,6 +38,7 @@ pub struct SessionSandboxCleanupWorker {
     ctx: RuntimeContext,
     config: SessionSandboxCleanupConfig,
     pending_orphans: BTreeSet<String>,
+    pending_vacant: BTreeSet<String>,
 }
 
 impl SessionSandboxCleanupWorker {
@@ -44,6 +47,7 @@ impl SessionSandboxCleanupWorker {
             ctx,
             config,
             pending_orphans: BTreeSet::new(),
+            pending_vacant: BTreeSet::new(),
         }
     }
 
@@ -67,13 +71,67 @@ impl SessionSandboxCleanupWorker {
         &mut self,
     ) -> Result<SessionSandboxCleanupReport, SessionRuntimeError> {
         let mut report = SessionSandboxCleanupReport::default();
-        self.reap_unreferenced_sandboxes(&mut report).await?;
+        // One observation for both sandbox arms. They do different things to
+        // a sandbox, so they must not disagree about what they saw.
+        let observed = self.ctx.manager.list_observed().await?;
+        self.retire_vacant_sandboxes(&observed, &mut report).await?;
+        self.reap_unreferenced_sandboxes(&observed, &mut report)
+            .await?;
         self.pause_idle_sandboxes(&mut report).await?;
         Ok(report)
     }
 
+    /// Pause sandboxes whose record asks for a process the backend does not
+    /// have.
+    ///
+    /// Not counting a vacant sandbox against the running cap is the actual
+    /// capacity fix; this is the other half. Left alone the record keeps
+    /// requesting a replica that never arrives, so reconciliation reports
+    /// drift on every pass and the CR never settles.
+    ///
+    /// Pausing sets `replicas: 0`, which keeps the CR, its state volume and
+    /// its proxy, so the owning session resumes with its workspace intact.
+    /// Stopping would delete the volume and every uncommitted change on it.
+    /// This path pauses and never stops, whether or not a session still
+    /// references the sandbox.
+    ///
+    /// Two consecutive sweeps, mirroring the orphan arm: a fresh create is
+    /// briefly vacant between the CR landing and its pod being scheduled, and
+    /// pausing that would fight the create it is racing.
+    async fn retire_vacant_sandboxes(
+        &mut self,
+        observed: &[ObservedSandbox],
+        report: &mut SessionSandboxCleanupReport,
+    ) -> Result<(), SessionRuntimeError> {
+        for sandbox_id in select_vacant_retire_candidates(observed, &mut self.pending_vacant) {
+            let id = SandboxId::new(sandbox_id.clone());
+            match self.ctx.manager.pause(&id).await {
+                Ok(()) | Err(SandboxError::NotFound(_)) => {
+                    self.ctx.sandbox_pipes.remove(&sandbox_id);
+                    self.pending_vacant.remove(&sandbox_id);
+                    report.retired_vacant += 1;
+                    info!(
+                        sandbox_id,
+                        reason = "pod_absent",
+                        "session sandbox cleanup worker paused vacant sandbox"
+                    );
+                }
+                Err(error) => {
+                    report.failed_vacant_retirements += 1;
+                    warn!(
+                        sandbox_id,
+                        %error,
+                        "session sandbox cleanup worker failed to pause vacant sandbox"
+                    );
+                }
+            }
+        }
+        Ok(())
+    }
+
     async fn reap_unreferenced_sandboxes(
         &mut self,
+        observed: &[ObservedSandbox],
         report: &mut SessionSandboxCleanupReport,
     ) -> Result<(), SessionRuntimeError> {
         let referenced = self
@@ -83,9 +141,8 @@ impl SessionSandboxCleanupWorker {
             .await?
             .into_iter()
             .collect::<BTreeSet<_>>();
-        let observed = self.ctx.manager.list_observed().await?;
         let candidates =
-            select_orphan_reap_candidates(&observed, &referenced, &mut self.pending_orphans);
+            select_orphan_reap_candidates(observed, &referenced, &mut self.pending_orphans);
 
         for sandbox_id in candidates {
             let id = SandboxId::new(sandbox_id.clone());
@@ -151,6 +208,24 @@ impl SessionSandboxCleanupWorker {
     }
 }
 
+fn select_vacant_retire_candidates(
+    observed: &[ObservedSandbox],
+    pending_vacant: &mut BTreeSet<String>,
+) -> Vec<String> {
+    let current = observed
+        .iter()
+        .filter(|sandbox| matches!(sandbox.status, SandboxStatus::Vacant))
+        .map(|sandbox| sandbox.id.as_str().to_owned())
+        .collect::<BTreeSet<_>>();
+
+    let candidates = current
+        .intersection(pending_vacant)
+        .cloned()
+        .collect::<Vec<_>>();
+    *pending_vacant = current;
+    candidates
+}
+
 fn select_orphan_reap_candidates(
     observed: &[ObservedSandbox],
     referenced: &BTreeSet<String>,
@@ -177,9 +252,16 @@ fn orphan_reap_eligible(sandbox: &ObservedSandbox, referenced: &BTreeSet<String>
     if sandbox.labels.get(COMPONENT_LABEL).map(String::as_str) == Some(WORKFLOW_RUN_COMPONENT) {
         return false;
     }
+    // Vacant belongs to the retire arm, which pauses rather than stops so the
+    // state volume survives. Once that arm has run the CR reads Suspended,
+    // and this arm can reap it on the usual two passes if nothing references
+    // it by then.
     !matches!(
         sandbox.status,
-        SandboxStatus::Created | SandboxStatus::Stopped | SandboxStatus::Gone
+        SandboxStatus::Created
+            | SandboxStatus::Stopped
+            | SandboxStatus::Gone
+            | SandboxStatus::Vacant
     )
 }
 
@@ -202,6 +284,68 @@ mod tests {
 
     fn referenced(ids: &[&str]) -> BTreeSet<String> {
         ids.iter().map(|id| (*id).to_owned()).collect()
+    }
+
+    #[test]
+    fn vacant_retire_requires_two_consecutive_passes() {
+        // A fresh create is briefly vacant between the CR landing and its pod
+        // being scheduled; one pass must not pause the create it is racing.
+        let observed = [observed("asbx-1", SandboxStatus::Vacant)];
+        let mut pending = BTreeSet::new();
+
+        assert_eq!(
+            select_vacant_retire_candidates(&observed, &mut pending),
+            Vec::<String>::new()
+        );
+        assert_eq!(
+            select_vacant_retire_candidates(&observed, &mut pending),
+            vec!["asbx-1".to_owned()]
+        );
+    }
+
+    #[test]
+    fn a_sandbox_that_gets_its_pod_back_is_not_retired() {
+        let mut pending = BTreeSet::new();
+        select_vacant_retire_candidates(&[observed("asbx-1", SandboxStatus::Vacant)], &mut pending);
+        assert_eq!(
+            select_vacant_retire_candidates(
+                &[observed("asbx-1", SandboxStatus::Running)],
+                &mut pending
+            ),
+            Vec::<String>::new()
+        );
+        assert!(pending.is_empty());
+    }
+
+    #[test]
+    fn only_vacant_sandboxes_are_retired() {
+        let observed = [
+            observed("asbx-running", SandboxStatus::Running),
+            observed("asbx-created", SandboxStatus::Created),
+            observed("asbx-suspended", SandboxStatus::Suspended),
+            observed("asbx-vacant", SandboxStatus::Vacant),
+        ];
+        let mut pending = BTreeSet::new();
+        select_vacant_retire_candidates(&observed, &mut pending);
+        assert_eq!(
+            select_vacant_retire_candidates(&observed, &mut pending),
+            vec!["asbx-vacant".to_owned()]
+        );
+    }
+
+    #[test]
+    fn vacant_sandboxes_are_left_to_the_retire_arm() {
+        // The orphan arm stops, which deletes the state volume. A vacant
+        // sandbox is paused instead, and only becomes reapable here once it
+        // reads Suspended.
+        let observed = [observed("asbx-vacant", SandboxStatus::Vacant)];
+        let mut pending = BTreeSet::new();
+
+        select_orphan_reap_candidates(&observed, &referenced(&[]), &mut pending);
+        assert_eq!(
+            select_orphan_reap_candidates(&observed, &referenced(&[]), &mut pending),
+            Vec::<String>::new()
+        );
     }
 
     #[test]

--- a/services/api-rs/crates/centaur-session-runtime/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-runtime/src/lib.rs
@@ -657,7 +657,15 @@ impl SandboxCapacityController {
     ) -> Result<CapacityCandidateAction, SessionRuntimeError> {
         let id = SandboxId::new(candidate.sandbox_id.as_str());
         match self.manager.status(&id).await {
-            Ok(SandboxStatus::Running | SandboxStatus::Created | SandboxStatus::Unknown(_)) => {}
+            // Vacant falls through to the pause below: the pod is already
+            // gone, but the record still requests one, so pausing is what
+            // makes the CR agree with reality.
+            Ok(
+                SandboxStatus::Running
+                | SandboxStatus::Created
+                | SandboxStatus::Vacant
+                | SandboxStatus::Unknown(_),
+            ) => {}
             Ok(SandboxStatus::Suspended) => {
                 return Ok(CapacityCandidateAction::Skipped);
             }
@@ -5462,7 +5470,7 @@ async fn record_idle_pause(
         Ok(SandboxStatus::Suspended | SandboxStatus::Stopped | SandboxStatus::Gone) => {
             return Ok(());
         }
-        Ok(SandboxStatus::Running | SandboxStatus::Created) => {}
+        Ok(SandboxStatus::Running | SandboxStatus::Created | SandboxStatus::Vacant) => {}
         Ok(SandboxStatus::Unknown(_)) => return Ok(()),
         Err(SandboxError::NotFound(_)) => return Ok(()),
         Err(error) => {
@@ -5851,7 +5859,9 @@ enum ExistingSandboxAction {
 fn existing_sandbox_action(status: &SandboxStatus) -> ExistingSandboxAction {
     match status {
         SandboxStatus::Running => ExistingSandboxAction::Reuse,
-        SandboxStatus::Created | SandboxStatus::Suspended => ExistingSandboxAction::ResumeOrReplace,
+        SandboxStatus::Created | SandboxStatus::Suspended | SandboxStatus::Vacant => {
+            ExistingSandboxAction::ResumeOrReplace
+        }
         SandboxStatus::Stopped | SandboxStatus::Gone | SandboxStatus::Unknown(_) => {
             ExistingSandboxAction::Replace
         }
@@ -7018,6 +7028,30 @@ mod tests {
     use centaur_session_core::SessionStatus;
     use serde_json::json;
     use time::OffsetDateTime;
+
+    #[test]
+    fn vacant_sandboxes_do_not_consume_running_slots() {
+        // The capacity bug in one assertion: a CR asking for a replica with
+        // no pod behind it reported Created, so it held a running slot that
+        // no reclamation path could ever return, and admission refused every
+        // later sandbox until someone deleted the CR by hand.
+        assert!(!status_consumes_running_slot(&SandboxStatus::Vacant));
+
+        assert!(status_consumes_running_slot(&SandboxStatus::Created));
+        assert!(status_consumes_running_slot(&SandboxStatus::Running));
+        assert!(!status_consumes_running_slot(&SandboxStatus::Suspended));
+        assert!(!status_consumes_running_slot(&SandboxStatus::Stopped));
+        assert!(!status_consumes_running_slot(&SandboxStatus::Gone));
+    }
+
+    #[test]
+    fn vacant_sandbox_resumes_rather_than_replaces() {
+        // The state volume outlives the pod, so the workspace is still there.
+        assert!(matches!(
+            existing_sandbox_action(&SandboxStatus::Vacant),
+            ExistingSandboxAction::ResumeOrReplace
+        ));
+    }
 
     #[test]
     fn sandbox_repo_cache_label_controls_access() {


### PR DESCRIPTION
Closes #1554.

A `Sandbox` CR with `spec.replicas: 1` and no backing Pod maps to `SandboxStatus::Created`, which consumes a running slot. Nothing can return that slot: the admission controller's stale-retirement arm fires only on `Stopped`/`Gone`/`NotFound`, idle pausing needs a DB-idle-eligible session, the reaper only stops past-max-lifetime sandboxes, and the cleanup worker only reaps sandboxes no session references. So the count drifts permanently above reality, and once it hits `max_running` every `cold_create` and `resume` is refused, the execution is marked failed with no retry, and nothing surfaces on the thread that triggered it.

## The fix

**A portable `SandboxStatus::Vacant`** — the record asks for a process and the backend has none for it. That is a different state from `Created`, where a process exists and is still coming up, and from `Suspended`, where nothing is asking for one. Today `Created` means both, which is exactly why the count and the reclamation paths cannot tell them apart.

Because `status_consumes_running_slot` lists the statuses that *do* count rather than the ones that do not, adding the variant is what fixes the accounting — in the admission path and in the warm pool, whose replenishment is gated on the same count and so was blocked from refilling by the same phantom.

**A second cleanup-worker arm that pauses vacant sandboxes.** Not counting them is the capacity fix; this is the other half. Left alone the CR keeps requesting a replica that never arrives, so reconciliation reports drift on every pass and it never settles.

It pauses and never stops. `replicas: 0` keeps the CR, its state volume and its proxy, so the owning session resumes with its workspace intact; stopping would delete the volume and every uncommitted change on it. That holds whether or not a session still references the sandbox — an unreferenced one reads `Suspended` after this arm runs, and the existing orphan arm can then reap it on its usual two passes.

Retirement needs two consecutive sweeps, mirroring `pending_orphans`, because a fresh create is briefly vacant between the CR landing and its Pod being scheduled.

Both sandbox arms now share one `list_observed` call. They do different things to a sandbox, so they should not disagree about what they saw.

## The other `Vacant` arms

The compiler required a decision at each of these; recording the reasoning since none is forced:

| Site | Behaviour | Why |
| -- | -- | -- |
| `ReconcilePlan`, desired `Running` | `ReportDrift(MissingWhileRunning)` | The record wants a process and there is none. That is drift, not a state to wait out. |
| `ReconcilePlan`, desired `Suspended` | `Pause` | Not a no-op: the Pod is gone but `replicas` is still 1, so pausing is the repair. |
| `ReconcilePlan`, desired `Stopped` | `Stop` | Same as every other non-terminal status. |
| `pause_capacity_candidate` | falls through to its pause | As above, and it frees the slot at admission time rather than waiting for a sweep. |
| `record_idle_pause` | falls through to its pause | Same. |
| `existing_sandbox_action` | `ResumeOrReplace` | The state volume outlived the Pod, so the workspace is still there to resume into. |

## Tests

- `maps_agent_sandbox_replicas_and_pod_readiness_to_status` — `(1, None)` is now `Vacant`.
- `vacant_sandboxes_do_not_consume_running_slots` in both `centaur-session-runtime` and `centaur-sandbox-manager::warm_pool` — the bug in one assertion each.
- `vacant_retire_requires_two_consecutive_passes`, `a_sandbox_that_gets_its_pod_back_is_not_retired`, `only_vacant_sandboxes_are_retired` — the new arm.
- `vacant_sandboxes_are_left_to_the_retire_arm` — the orphan arm does not stop one, so the state volume survives.
- `vacant_sandbox_resumes_rather_than_replaces`.

`cargo test --workspace`, `cargo clippy --workspace --all-targets` and `cargo fmt --all --check` are clean.

## Scope

Capacity accounting and pod-less retirement only. Evicting paused sandboxes under pressure, and queueing instead of dropping at the cap, are separate problems — a turn refused at admission still fails silently with nothing on the originating surface, which this does not change.

`SandboxStatus` is public, so the new variant is a breaking change for anything matching on it exhaustively outside this workspace. Happy to gate it differently if you would rather not take that.