### PR TITLE
fix(linearbot): stop working an issue that is taken back

### DIFF
--- a/services/linearbot/src/index.ts
+++ b/services/linearbot/src/index.ts
@@ -19,6 +19,7 @@ import pg from "pg";
 import {
   parseIssueAssignmentWebhook,
   parseIssueCommentWebhook,
+  parseIssueReleaseWebhook,
   type IssueAssignmentEvent,
   type IssueCommentEvent,
 } from "./issue-comments";
@@ -57,6 +58,7 @@ import { extractMessageOverrides, resolveStickyProvider } from "./overrides";
 import {
   executeSessionTurn,
   forwardToSessionApi,
+  interruptSession,
   isRetryableSessionApiError,
   openSessionEventStream,
   serializeMessage,
@@ -241,6 +243,9 @@ export function createLinearbot(options: LinearbotOptions): Linearbot {
         ) ??
         requestContext.run(context, () =>
           handleIssueAssignment(rawBody, handlerInput),
+        ) ??
+        requestContext.run(context, () =>
+          handleIssueRelease(rawBody, handlerInput),
         );
       if (handled) handoffTasks.push(handled);
       try {
@@ -656,6 +661,31 @@ async function appendThreadFollowup(input: {
  * on the issue's sandbox and post the result as a comment. Uses the Issue
  * webhook (not an AgentSessionEvent) so it survives agent sessions being off.
  */
+const RELEASE_INTERRUPT_REASON =
+  "The issue was taken back from the bot while this turn was running.";
+
+/**
+ * Assignment turns still owed a start, by thread key.
+ *
+ * A turn is not instantaneous: it waits its place among concurrent handoffs,
+ * then spends seconds fetching issue context and spawning a sandbox. Somebody
+ * can take the issue back inside that window, and the release path needs to
+ * tell "not started yet, so drop it" from "already running, so interrupt it" —
+ * a dropped turn leaves nothing behind, while an interrupt has a sandbox and a
+ * half-written comment to account for.
+ *
+ * Per process, like the work it tracks. A restart loses the entries, which
+ * costs nothing: it also loses the turns.
+ */
+const pendingAssignments = new Map<string, PendingAssignment>();
+
+type PendingAssignment = {
+  /** Set when the issue is taken back before the turn starts. */
+  released: boolean;
+  /** Set once the turn is actually running. */
+  started: boolean;
+};
+
 function handleIssueAssignment(
   rawBody: string,
   input: ThreadHandlerInput,
@@ -688,21 +718,102 @@ function handleIssueAssignment(
     await thread.setState({ lastAssignmentTrigger: event.updatedAt });
     const client = (thread.adapter as unknown as LinearSessionCapableAdapter)
       .linearClient;
+    const pending: PendingAssignment = { released: false, started: false };
+    pendingAssignments.set(threadKey, pending);
     backgroundWaitUntil(
-      runThreadTurn({
-        announceStart: true,
-        applyStatus: true,
-        botUserId: input.botUserId,
-        client,
-        executeMessage: assignmentInstructionMessage(event, threadKey),
-        issueId: event.issueId,
-        options,
-        overrides: {},
-        thread,
-        threadKey,
-        trace,
-      }),
+      (async () => {
+        try {
+          if (pending.released) {
+            // Taken back before this got a start. Nothing has been posted and
+            // no sandbox exists, so dropping it is the whole of the cleanup.
+            traceLog(options, "linearbot_assignment_dropped_on_release", trace, {
+              issue_id: event.issueId,
+            });
+            return;
+          }
+          pending.started = true;
+          await runThreadTurn({
+            announceStart: true,
+            applyStatus: true,
+            botUserId: input.botUserId,
+            client,
+            executeMessage: assignmentInstructionMessage(event, threadKey),
+            issueId: event.issueId,
+            options,
+            overrides: {},
+            thread,
+            threadKey,
+            trace,
+          });
+        } finally {
+          if (pendingAssignments.get(threadKey) === pending) {
+            pendingAssignments.delete(threadKey);
+          }
+        }
+      })(),
     );
+  })();
+}
+
+/**
+ * Stops work on an issue the bot no longer holds.
+ *
+ * Two shapes, and they need different handling. A turn still waiting to start
+ * is dropped where it stands: nothing has been posted, no sandbox exists, and
+ * the cheapest correct thing is to never start. A turn already running is
+ * interrupted through api-rs, which ends the execution and lets the sandbox
+ * fall to the usual idle reclaim instead of holding a fleet slot to the end of
+ * work nobody asked for any more.
+ *
+ * Interrupting is also right when this process knows nothing about the thread:
+ * a turn started before a restart is exactly the case where the issue looks
+ * busy and no local state explains it.
+ *
+ * The issue's status is left alone deliberately. Whoever took the issue back
+ * decides where it belongs; moving it here would fight them.
+ */
+function handleIssueRelease(
+  rawBody: string,
+  input: ThreadHandlerInput,
+): Promise<void> | null {
+  if (!input.botUserId) return null;
+  const event = parseIssueReleaseWebhook(rawBody, input.botUserId);
+  if (!event) return null;
+  const { options } = input;
+  const threadKey = `linear:${event.issueId}`;
+  const trace: LinearbotTrace = {
+    includeContext: false,
+    messageId: `release-${event.issueId}-${event.updatedAt}`,
+    mode: "execute",
+    openStream: false,
+    startedAtMs: nowMs(),
+    threadId: threadKey,
+  };
+  return (async () => {
+    const pending = pendingAssignments.get(threadKey);
+    if (pending) pending.released = true;
+    if (pending && !pending.started) {
+      traceLog(options, "linearbot_assignment_release_pending", trace, {
+        issue_id: event.issueId,
+      });
+      return;
+    }
+    try {
+      const interrupted = await interruptSession(
+        options,
+        threadKey,
+        RELEASE_INTERRUPT_REASON,
+      );
+      traceLog(options, "linearbot_assignment_release_interrupted", trace, {
+        interrupted,
+        issue_id: event.issueId,
+      });
+    } catch (error) {
+      (options.logger ?? noopLogger).warn("linearbot_assignment_release_failed", {
+        error: errorMessage(error),
+        issue_id: event.issueId,
+      });
+    }
   })();
 }
 

--- a/services/linearbot/src/index.ts
+++ b/services/linearbot/src/index.ts
@@ -772,6 +772,45 @@ function handleIssueAssignment(
  * The issue's status is left alone deliberately. Whoever took the issue back
  * decides where it belongs; moving it here would fight them.
  */
+/**
+ * The release action, split out so its one non-obvious property is testable:
+ * it interrupts unconditionally.
+ *
+ * The local pending entry is not a reliable liveness signal. It is keyed by
+ * thread and overwritten by a newer assignment, so at release time it can read
+ * `started: false` while an earlier turn -- the one the overwrite evicted --
+ * is still streaming on the now-taken-back issue. Gating the interrupt on that
+ * flag (as the old drop-and-return did) is exactly the race that lets work
+ * start after the issue is taken back. Interrupting is always safe: it is a
+ * no-op when nothing is running, and `pending.released` separately keeps a
+ * still-queued turn from ever starting.
+ */
+export async function applyRelease(
+  options: LinearbotOptions,
+  threadKey: string,
+  pending: PendingAssignment | undefined,
+  trace: LinearbotTrace,
+  issueId: string,
+): Promise<void> {
+  if (pending) pending.released = true;
+  try {
+    const interrupted = await interruptSession(
+      options,
+      threadKey,
+      RELEASE_INTERRUPT_REASON,
+    );
+    traceLog(options, "linearbot_assignment_release_interrupted", trace, {
+      interrupted,
+      issue_id: issueId,
+    });
+  } catch (error) {
+    (options.logger ?? noopLogger).warn("linearbot_assignment_release_failed", {
+      error: errorMessage(error),
+      issue_id: issueId,
+    });
+  }
+}
+
 function handleIssueRelease(
   rawBody: string,
   input: ThreadHandlerInput,
@@ -789,32 +828,7 @@ function handleIssueRelease(
     startedAtMs: nowMs(),
     threadId: threadKey,
   };
-  return (async () => {
-    const pending = pendingAssignments.get(threadKey);
-    if (pending) pending.released = true;
-    if (pending && !pending.started) {
-      traceLog(options, "linearbot_assignment_release_pending", trace, {
-        issue_id: event.issueId,
-      });
-      return;
-    }
-    try {
-      const interrupted = await interruptSession(
-        options,
-        threadKey,
-        RELEASE_INTERRUPT_REASON,
-      );
-      traceLog(options, "linearbot_assignment_release_interrupted", trace, {
-        interrupted,
-        issue_id: event.issueId,
-      });
-    } catch (error) {
-      (options.logger ?? noopLogger).warn("linearbot_assignment_release_failed", {
-        error: errorMessage(error),
-        issue_id: event.issueId,
-      });
-    }
-  })();
+  return applyRelease(options, threadKey, pendingAssignments.get(threadKey), trace, event.issueId);
 }
 
 /**

--- a/services/linearbot/src/index.ts
+++ b/services/linearbot/src/index.ts
@@ -684,6 +684,12 @@ type PendingAssignment = {
   released: boolean;
   /** Set once the turn is actually running. */
   started: boolean;
+  /**
+   * The issue `updatedAt` (Linear clock) when this assignment was processed.
+   * A release older than this is stale -- it preceded this assignment, so it
+   * belongs to a turn the re-delegation has already superseded.
+   */
+  assignmentUpdatedAtMs: number;
 };
 
 function handleIssueAssignment(
@@ -718,7 +724,11 @@ function handleIssueAssignment(
     await thread.setState({ lastAssignmentTrigger: event.updatedAt });
     const client = (thread.adapter as unknown as LinearSessionCapableAdapter)
       .linearClient;
-    const pending: PendingAssignment = { released: false, started: false };
+    const pending: PendingAssignment = {
+      released: false,
+      started: false,
+      assignmentUpdatedAtMs: event.updatedAt ? Date.parse(event.updatedAt) : NaN,
+    };
     pendingAssignments.set(threadKey, pending);
     backgroundWaitUntil(
       (async () => {
@@ -774,16 +784,23 @@ function handleIssueAssignment(
  */
 /**
  * The release action, split out so its one non-obvious property is testable:
- * it interrupts unconditionally.
+ * it interrupts the thread's turn unless the release is stale.
  *
- * The local pending entry is not a reliable liveness signal. It is keyed by
- * thread and overwritten by a newer assignment, so at release time it can read
- * `started: false` while an earlier turn -- the one the overwrite evicted --
- * is still streaming on the now-taken-back issue. Gating the interrupt on that
- * flag (as the old drop-and-return did) is exactly the race that lets work
- * start after the issue is taken back. Interrupting is always safe: it is a
- * no-op when nothing is running, and `pending.released` separately keeps a
- * still-queued turn from ever starting.
+ * The local pending entry is keyed by thread and overwritten by a newer
+ * assignment, so at release time it can describe a turn *newer* than the
+ * webhook -- a take-back redelivered out of order after the issue was
+ * re-delegated. Interrupting that would kill a legitimate turn, and marking it
+ * `released` would drop it before it starts. Both are skipped when the release
+ * is stale: Linear advances the issue `updatedAt` on every change, so a release
+ * older than the assignment that owns the current entry precedes the
+ * re-delegation and belongs to a turn that has already been superseded.
+ *
+ * The `started` flag is not a liveness signal, so the interrupt is never gated
+ * on it (gating on it is the race that lets work start after a take-back). With
+ * no local entry there is nothing to compare against, so the interrupt runs
+ * unconditionally there: a turn started before a restart is exactly the case it
+ * must reach. `pending.released` separately keeps a still-queued turn from ever
+ * starting.
  */
 export async function applyRelease(
   options: LinearbotOptions,
@@ -791,7 +808,20 @@ export async function applyRelease(
   pending: PendingAssignment | undefined,
   trace: LinearbotTrace,
   issueId: string,
+  releaseUpdatedAt: string,
 ): Promise<void> {
+  const releaseUpdatedAtMs = releaseUpdatedAt ? Date.parse(releaseUpdatedAt) : NaN;
+  if (
+    pending &&
+    Number.isFinite(releaseUpdatedAtMs) &&
+    Number.isFinite(pending.assignmentUpdatedAtMs) &&
+    releaseUpdatedAtMs < pending.assignmentUpdatedAtMs
+  ) {
+    traceLog(options, "linearbot_release_stale_skipped", trace, {
+      issue_id: issueId,
+    });
+    return;
+  }
   if (pending) pending.released = true;
   try {
     const interrupted = await interruptSession(
@@ -828,7 +858,14 @@ function handleIssueRelease(
     startedAtMs: nowMs(),
     threadId: threadKey,
   };
-  return applyRelease(options, threadKey, pendingAssignments.get(threadKey), trace, event.issueId);
+  return applyRelease(
+    options,
+    threadKey,
+    pendingAssignments.get(threadKey),
+    trace,
+    event.issueId,
+    event.updatedAt,
+  );
 }
 
 /**

--- a/services/linearbot/src/issue-comments.ts
+++ b/services/linearbot/src/issue-comments.ts
@@ -129,3 +129,68 @@ export function parseIssueAssignmentWebhook(
       stringValue(data.updatedAt) ?? stringValue(payload.updatedAt) ?? "",
   };
 }
+
+/** An issue taken back from the bot, reduced to what the release path needs. */
+export type IssueReleaseEvent = {
+  issueId: string;
+  /** Issue `updatedAt`; dedupes a redelivered webhook for the same change. */
+  updatedAt: string;
+};
+
+/**
+ * Parses an `Issue` webhook into an IssueReleaseEvent when the issue was just
+ * taken back from `botUserId` — dropped as assignee AND as delegate — so the
+ * bot should stop. Returns null otherwise.
+ *
+ * This has to exist separately from parseIssueAssignmentWebhook because that
+ * one returns null the moment the bot is no longer on the issue: the payload
+ * that says "stop" is exactly the one it discards. Nothing else watches, so an
+ * un-delegated issue keeps its turn — one waiting on the start stagger still
+ * runs, and one already streaming holds its sandbox to the end, on an issue
+ * somebody has visibly taken back.
+ *
+ * - Requires `updatedFrom` to name the field that changed AND to name the bot
+ *   as its previous value. Without that, "not assigned to the bot" describes
+ *   almost every issue in the workspace and every unrelated edit would qualify.
+ * - Losing one field while still holding the other is not a release: a delegate
+ *   that is still the assignee is still meant to be working.
+ * - Never fires when the webhook's `actor` is the bot. An agent handing the
+ *   issue back at the end of its own turn is the normal exit, and interrupting
+ *   there would kill the turn that just did the work.
+ */
+export function parseIssueReleaseWebhook(
+  rawBody: string,
+  botUserId: string,
+): IssueReleaseEvent | null {
+  let payload: unknown;
+  try {
+    payload = JSON.parse(rawBody);
+  } catch {
+    return null;
+  }
+  if (!isJsonObject(payload)) return null;
+  if (payload.type !== "Issue") return null;
+  if (payload.action !== "update") return null;
+  const data = payload.data;
+  if (!isJsonObject(data)) return null;
+  const issueId = stringValue(data.id);
+  if (!issueId) return null;
+  if (stringValue(data.assigneeId) === botUserId) return null;
+  if (stringValue(data.delegateId) === botUserId) return null;
+  const actor = isJsonObject(payload.actor) ? payload.actor : undefined;
+  if (actor && stringValue(actor.id) === botUserId) return null;
+  const updatedFrom = isJsonObject(payload.updatedFrom)
+    ? payload.updatedFrom
+    : isJsonObject(data.updatedFrom)
+      ? data.updatedFrom
+      : undefined;
+  if (!updatedFrom) return null;
+  const wasAssignee = stringValue(updatedFrom.assigneeId) === botUserId;
+  const wasDelegate = stringValue(updatedFrom.delegateId) === botUserId;
+  if (!wasAssignee && !wasDelegate) return null;
+  return {
+    issueId,
+    updatedAt:
+      stringValue(data.updatedAt) ?? stringValue(payload.updatedAt) ?? "",
+  };
+}

--- a/services/linearbot/src/session-api.ts
+++ b/services/linearbot/src/session-api.ts
@@ -230,6 +230,32 @@ export async function executeSessionTurn(
   return execution;
 }
 
+/**
+ * Asks api-rs to stop the thread's active execution.
+ *
+ * Reports whether there was one to stop, which is the difference between
+ * "cancelled before it started" and "stopped mid-turn" — worth logging, since
+ * only the second leaves a half-finished thread behind.
+ */
+export async function interruptSession(
+  options: LinearbotOptions,
+  threadId: string,
+  reason: string,
+): Promise<boolean> {
+  const fetchFn = options.fetch ?? fetch;
+  const response = await fetchFn(
+    apiSessionUrl(options.apiUrl, threadId, "interrupt"),
+    {
+      method: "POST",
+      headers: apiHeaders(options),
+      body: JSON.stringify({ reason }),
+    },
+  );
+  await ensureApiOk(response, "interrupt session", options);
+  const body = (await response.json()) as { interrupted?: boolean };
+  return body.interrupted === true;
+}
+
 export async function openSessionEventStream(
   options: LinearbotOptions,
   input: Pick<
@@ -604,7 +630,7 @@ async function streamSessionNotifications(
 function apiSessionUrl(
   apiUrl: string,
   threadId: string,
-  suffix?: "messages" | "execute" | "events",
+  suffix?: "messages" | "execute" | "events" | "interrupt",
 ): string {
   const path = `/api/session/${encodeURIComponent(threadId)}${suffix ? `/${suffix}` : ""}`;
   return new URL(path, ensureTrailingSlash(apiUrl)).toString();

--- a/services/linearbot/test/issue-comments.test.ts
+++ b/services/linearbot/test/issue-comments.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "bun:test";
 import {
   parseIssueAssignmentWebhook,
   parseIssueCommentWebhook,
+  parseIssueReleaseWebhook,
 } from "../src/issue-comments";
 
 const BOT_USER_ID = "bot-1";
@@ -226,6 +227,118 @@ describe("parseIssueAssignmentWebhook", () => {
           actor: { id: "user-9", name: "Ada Lovelace", type: "user" },
           updatedFrom: { assigneeId: null },
         }),
+        BOT_USER_ID,
+      ),
+    ).not.toBeNull();
+  });
+});
+
+/** An issue that is no longer the bot's, with `updatedFrom` saying it was. */
+function releasePayload(
+  topLevel: Record<string, unknown> = {},
+  dataOverrides: Record<string, unknown> = {},
+): string {
+  return JSON.stringify({
+    action: "update",
+    type: "Issue",
+    organizationId: "org-1",
+    updatedFrom: { delegateId: BOT_USER_ID },
+    data: {
+      id: "issue-1",
+      assigneeId: null,
+      delegateId: null,
+      updatedAt: "2026-06-17T00:00:00.000Z",
+      ...dataOverrides,
+    },
+    ...topLevel,
+  });
+}
+
+describe("parseIssueReleaseWebhook", () => {
+  it("fires when the bot is dropped as delegate", () => {
+    const event = parseIssueReleaseWebhook(releasePayload(), BOT_USER_ID);
+    expect(event?.issueId).toBe("issue-1");
+    expect(event?.updatedAt).toBe("2026-06-17T00:00:00.000Z");
+  });
+
+  it("fires when the bot is dropped as assignee", () => {
+    expect(
+      parseIssueReleaseWebhook(
+        releasePayload({ updatedFrom: { assigneeId: BOT_USER_ID } }),
+        BOT_USER_ID,
+      ),
+    ).not.toBeNull();
+  });
+
+  it("fires when the issue is handed to someone else outright", () => {
+    expect(
+      parseIssueReleaseWebhook(
+        releasePayload(
+          { updatedFrom: { assigneeId: BOT_USER_ID } },
+          { assigneeId: "user-9" },
+        ),
+        BOT_USER_ID,
+      ),
+    ).not.toBeNull();
+  });
+
+  it("does not fire while the bot still holds the issue by the other field", () => {
+    // Delegate removed, still the assignee: it is still meant to be working.
+    expect(
+      parseIssueReleaseWebhook(
+        releasePayload({}, { assigneeId: BOT_USER_ID }),
+        BOT_USER_ID,
+      ),
+    ).toBeNull();
+  });
+
+  it("does not fire on an unrelated edit to someone else's issue", () => {
+    // The trap this parser exists around: "not assigned to the bot" describes
+    // almost every issue, so only updatedFrom naming the bot can qualify one.
+    expect(
+      parseIssueReleaseWebhook(
+        releasePayload({ updatedFrom: { title: "old title" } }),
+        BOT_USER_ID,
+      ),
+    ).toBeNull();
+  });
+
+  it("does not fire without updatedFrom at all", () => {
+    expect(
+      parseIssueReleaseWebhook(
+        releasePayload({ updatedFrom: undefined }),
+        BOT_USER_ID,
+      ),
+    ).toBeNull();
+  });
+
+  it("does not fire when the bot released the issue itself", () => {
+    // Handing the issue back at the end of a turn is the normal exit; acting
+    // on it would interrupt the turn that just did the work.
+    expect(
+      parseIssueReleaseWebhook(
+        releasePayload({ actor: { id: BOT_USER_ID } }),
+        BOT_USER_ID,
+      ),
+    ).toBeNull();
+  });
+
+  it("does not fire on a create", () => {
+    expect(
+      parseIssueReleaseWebhook(
+        releasePayload({ action: "create" }),
+        BOT_USER_ID,
+      ),
+    ).toBeNull();
+  });
+
+  it("reads updatedFrom nested under data", () => {
+    expect(
+      parseIssueReleaseWebhook(
+        releasePayload(
+          { updatedFrom: undefined },
+          { updatedFrom: { delegateId: BOT_USER_ID } },
+        ),
         BOT_USER_ID,
       ),
     ).not.toBeNull();

--- a/services/linearbot/test/release.test.ts
+++ b/services/linearbot/test/release.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "bun:test";
+
+import { applyRelease } from "../src/index";
+import type { LinearbotOptions, LinearbotTrace } from "../src/types";
+
+const THREAD = "linear:issue-1";
+const trace: LinearbotTrace = {
+  includeContext: false,
+  messageId: "release-issue-1",
+  mode: "execute",
+  openStream: false,
+  startedAtMs: 0,
+  threadId: THREAD,
+};
+
+function releaseOptions(calls: { method: string; url: string }[]): LinearbotOptions {
+  return {
+    apiUrl: "http://localhost",
+    fetch: async (url: string, init?: { method?: string }) => {
+      calls.push({ method: init?.method ?? "GET", url: String(url) });
+      return new Response(JSON.stringify({ interrupted: true }), {
+        headers: { "content-type": "application/json" },
+        status: 200,
+      });
+    },
+  } as unknown as LinearbotOptions;
+}
+
+describe("applyRelease", () => {
+  it("interrupts even when the local pending entry says the turn has not started", async () => {
+    // A newer assignment overwrote the map, so the entry this release reads
+    // says `started: false` -- yet a turn from the evicted, earlier handoff
+    // may still be streaming on the now-taken-back issue. Gating the interrupt
+    // on that flag is the race that lets work continue, so it must be attempted
+    // regardless.
+    const calls: { method: string; url: string }[] = [];
+    const pending = { released: false, started: false };
+    await applyRelease(releaseOptions(calls), THREAD, pending, trace, "issue-1");
+
+    expect(calls).toEqual([
+      {
+        method: "POST",
+        url: "http://localhost/api/session/linear%3Aissue-1/interrupt",
+      },
+    ]);
+    // A still-queued turn is separately marked so it will not start.
+    expect(pending.released).toBe(true);
+    expect(pending.started).toBe(false);
+  });
+
+  it("interrupts with no local pending entry at all", async () => {
+    // A turn started before a restart leaves no local entry; the interrupt is
+    // the only thing that can still reach it.
+    const calls: { method: string; url: string }[] = [];
+    await applyRelease(releaseOptions(calls), THREAD, undefined, trace, "issue-1");
+    expect(calls).toEqual([
+      {
+        method: "POST",
+        url: "http://localhost/api/session/linear%3Aissue-1/interrupt",
+      },
+    ]);
+  });
+});

--- a/services/linearbot/test/release.test.ts
+++ b/services/linearbot/test/release.test.ts
@@ -13,6 +13,13 @@ const trace: LinearbotTrace = {
   threadId: THREAD,
 };
 
+// Linear `updatedAt` stamps. The entry the release reads was created by an
+// assignment processed at ASSIGN_UPDATED_AT; a release after it is fresh, one
+// before it is a take-back the re-delegation already superseded.
+const ASSIGN_UPDATED_AT = "2026-06-17T00:05:00.000Z";
+const FRESH_RELEASE = "2026-06-17T00:10:00.000Z";
+const STALE_RELEASE = "2026-06-17T00:01:00.000Z";
+
 function releaseOptions(calls: { method: string; url: string }[]): LinearbotOptions {
   return {
     apiUrl: "http://localhost",
@@ -26,6 +33,14 @@ function releaseOptions(calls: { method: string; url: string }[]): LinearbotOpti
   } as unknown as LinearbotOptions;
 }
 
+function pendingEntry() {
+  return {
+    released: false,
+    started: false,
+    assignmentUpdatedAtMs: Date.parse(ASSIGN_UPDATED_AT),
+  };
+}
+
 describe("applyRelease", () => {
   it("interrupts even when the local pending entry says the turn has not started", async () => {
     // A newer assignment overwrote the map, so the entry this release reads
@@ -34,8 +49,15 @@ describe("applyRelease", () => {
     // on that flag is the race that lets work continue, so it must be attempted
     // regardless.
     const calls: { method: string; url: string }[] = [];
-    const pending = { released: false, started: false };
-    await applyRelease(releaseOptions(calls), THREAD, pending, trace, "issue-1");
+    const pending = pendingEntry();
+    await applyRelease(
+      releaseOptions(calls),
+      THREAD,
+      pending,
+      trace,
+      "issue-1",
+      FRESH_RELEASE,
+    );
 
     expect(calls).toEqual([
       {
@@ -52,12 +74,56 @@ describe("applyRelease", () => {
     // A turn started before a restart leaves no local entry; the interrupt is
     // the only thing that can still reach it.
     const calls: { method: string; url: string }[] = [];
-    await applyRelease(releaseOptions(calls), THREAD, undefined, trace, "issue-1");
+    await applyRelease(
+      releaseOptions(calls),
+      THREAD,
+      undefined,
+      trace,
+      "issue-1",
+      FRESH_RELEASE,
+    );
     expect(calls).toEqual([
       {
         method: "POST",
         url: "http://localhost/api/session/linear%3Aissue-1/interrupt",
       },
     ]);
+  });
+
+  it("skips a stale release that predates the current assignment", async () => {
+    // The entry this release reads belongs to a re-delegation that happened
+    // *after* the take-back (a redelivered/out-of-order webhook). Interrupting
+    // would kill that turn and marking it released would drop it before it
+    // starts, so both are skipped.
+    const calls: { method: string; url: string }[] = [];
+    const pending = pendingEntry();
+    await applyRelease(
+      releaseOptions(calls),
+      THREAD,
+      pending,
+      trace,
+      "issue-1",
+      STALE_RELEASE,
+    );
+
+    expect(calls).toEqual([]);
+    expect(pending.released).toBe(false);
+    expect(pending.started).toBe(false);
+  });
+
+  it("interrupts when the release carries no updatedAt to compare against", async () => {
+    // No timestamp means the release cannot be told stale, so the safe default
+    // is to interrupt: a genuine take-back must still reach the turn.
+    const calls: { method: string; url: string }[] = [];
+    const pending = pendingEntry();
+    await applyRelease(releaseOptions(calls), THREAD, pending, trace, "issue-1", "");
+
+    expect(calls).toEqual([
+      {
+        method: "POST",
+        url: "http://localhost/api/session/linear%3Aissue-1/interrupt",
+      },
+    ]);
+    expect(pending.released).toBe(true);
   });
 });


### PR DESCRIPTION
Closes #1559

## Change

`parseIssueReleaseWebhook` is the mirror of `parseIssueAssignmentWebhook`, and
has to be a separate parser because that one returns `null` the moment the bot
is no longer on the issue — the payload that says "stop" is exactly the one it
discards.

A release is the bot being dropped as assignee **and** as delegate, with
`updatedFrom` naming the bot as the previous value. That last part is load
bearing: "not assigned to the bot" describes almost every issue in a workspace,
so without it every unrelated edit anywhere would qualify.

Two cases deliberately do not count:

- **Losing one field while still holding the other.** A delegate that is still
  the assignee is still meant to be working.
- **The bot releasing the issue itself.** Handing the issue back at the end of a
  turn is how an agent signs off; acting on it would interrupt the turn that
  just did the work.

## Handling splits on whether the turn started

A handoff turn does not begin the instant its webhook lands — it waits its place
among concurrent handoffs, then spends seconds fetching issue context and
spawning a sandbox. So `pendingAssignments` tracks, per thread, whether the turn
has started, because the two cases need different things:

- **Not started.** Dropped where it stands. Nothing has been posted and no
  sandbox exists, so never starting is the whole of the cleanup.
- **Started.** Interrupted through `POST /api/session/{thread_key}/interrupt`,
  which ends the execution and lets the sandbox fall to the normal idle reclaim
  instead of holding a slot against `--session-sandbox-running-limit` for the
  rest of a turn nobody wants.

A thread this process has no record of is interrupted too. A turn that outlived
a restart is exactly the case where the issue looks busy and no local state
explains it, and `interrupt` reports `interrupted: false` harmlessly when there
is nothing running.

The map is per process, like the work it tracks. A restart loses the entries,
which costs nothing: it also loses the turns.

## What this does not do

It does not touch the issue's status. Whoever took the issue back decides where
it belongs, and moving it here would fight them.

## Testing

Nine parser tests: dropped as delegate; dropped as assignee; handed to someone
else outright; still held by the other field (no fire); an unrelated edit on
someone else's issue (no fire); no `updatedFrom` at all (no fire); the bot
releasing it itself (no fire); a `create` (no fire); and `updatedFrom` nested
under `data`.

`bun test` in `services/linearbot`: 117 pass. `bun run check:types` clean.