### PR TITLE
fix: resolve Granola share links via note details

### DIFF
--- a/tools/productivity/granola/client.py
+++ b/tools/productivity/granola/client.py
@@ -14,6 +14,7 @@ GRANOLA_BACKEND=mcp|rest.
 
 import json
 import re
+import time
 from datetime import datetime, timedelta, timezone
 from typing import Any
 from xml.etree import ElementTree
@@ -45,7 +46,7 @@ def _normalize_note_ref(note_ref: str) -> str:
 class GranolaClient:
     """Client for Granola Enterprise API (workspace-wide notes access)."""
 
-    def __init__(self, api_key: str | None = None):
+    def __init__(self, api_key: str | None = None, max_rate_limit_retries: int = 2):
         self._api_key = api_key or secret("GRANOLA_API_KEY", "")
         if not self._api_key:
             raise RuntimeError(
@@ -60,13 +61,23 @@ class GranolaClient:
             },
             timeout=30.0,
         )
+        self.max_rate_limit_retries = max_rate_limit_retries
 
     def close(self) -> None:
         self._client.close()
 
     def _get(self, path: str, params: dict[str, Any] | None = None) -> dict[str, Any]:
         """Make authenticated GET request."""
-        response = self._client.get(path, params=params)
+        for attempt in range(self.max_rate_limit_retries + 1):
+            response = self._client.get(path, params=params)
+            if response.status_code != 429 or attempt == self.max_rate_limit_retries:
+                break
+            retry_after = response.headers.get("Retry-After", "1")
+            try:
+                delay = float(retry_after)
+            except ValueError:
+                delay = 1.0
+            time.sleep(min(max(delay, 0.0), 60.0))
         response.raise_for_status()
         return response.json()
 
@@ -103,16 +114,25 @@ class GranolaClient:
         while True:
             page = self.list_notes(page_size=30, cursor=cursor)
             for note in page.get("notes", []):
+                note_id = note.get("id")
+                if not note_id:
+                    continue
+                candidate = note
+                if not candidate.get("web_url"):
+                    candidate = self._get(f"/v1/notes/{note_id}")
                 try:
-                    web_id = _normalize_note_ref(note.get("web_url") or "")
+                    web_id = _normalize_note_ref(candidate.get("web_url") or "")
                 except ValueError:
                     continue
                 if web_id == normalized:
-                    return note["id"]
+                    return note_id
             cursor = page.get("cursor")
             if not page.get("hasMore") or not cursor:
                 break
-        raise RuntimeError(f"meeting {normalized} not found in accessible Granola notes")
+        raise RuntimeError(
+            f"meeting {normalized} not found in accessible Granola notes; "
+            "the note may require user-scoped Granola access"
+        )
 
     def get_note(self, note_id: str, include_transcript: bool = False) -> dict[str, Any]:
         """Fetch a single note by ID (not_* format, e.g. not_1d3tmYTlCICgjy).

--- a/tools/productivity/granola/test_client.py
+++ b/tools/productivity/granola/test_client.py
@@ -1,3 +1,6 @@
+from unittest.mock import patch
+
+import httpx
 from client import (
     GranolaClient,
     _normalize_note_ref,
@@ -29,11 +32,15 @@ def test_rest_client_resolves_share_link_before_getting_note():
                 "notes": [
                     {
                         "id": "not_1234567890abcd",
-                        "web_url": f"https://notes.granola.ai/d/{meeting_id}",
                     }
                 ],
                 "hasMore": False,
                 "cursor": None,
+            }
+        if len(calls) == 2:
+            return {
+                "id": "not_1234567890abcd",
+                "web_url": f"https://notes.granola.ai/d/{meeting_id}",
             }
         return {"id": "not_1234567890abcd", "title": "Stripe risk"}
 
@@ -46,8 +53,33 @@ def test_rest_client_resolves_share_link_before_getting_note():
     assert note["title"] == "Stripe risk"
     assert calls == [
         ("/v1/notes", {"page_size": 30}),
+        ("/v1/notes/not_1234567890abcd", None),
         ("/v1/notes/not_1234567890abcd", {}),
     ]
+
+
+def test_rest_client_retries_rate_limit_response():
+    attempts = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            return httpx.Response(429, headers={"Retry-After": "0"})
+        return httpx.Response(200, json={"notes": [], "hasMore": False, "cursor": None})
+
+    client = GranolaClient(api_key="test")
+    client._client = httpx.Client(
+        base_url="https://public-api.granola.ai",
+        transport=httpx.MockTransport(handler),
+    )
+
+    with patch("client.time.sleep") as sleep:
+        result = client.list_notes()
+
+    assert result == {"notes": [], "hasMore": False, "cursor": None}
+    assert attempts == 2
+    sleep.assert_called_once_with(0.0)
 
 
 def test_parse_meetings_accepts_extra_attributes_and_decodes_entities():


### PR DESCRIPTION
## Summary

- resolve Granola `/d/` and suffixed `/t/` share links using hydrated note details because list responses omit `web_url`
- retry REST rate limits while scanning accessible notes
- clarify when a note requires user-scoped Granola access

## Validation

- `python -m pytest -q test_client.py` (6 passed)
- `ruff check tools/productivity/granola/client.py tools/productivity/granola/test_client.py`
- live resolution of the reported Granola share link

Prompted by: @snario