### PR TITLE
Set default Codex reasoning to medium

### DIFF
--- a/harness/codex/config.toml
+++ b/harness/codex/config.toml
@@ -1,5 +1,5 @@
 model = "gpt-5.6-sol"
-model_reasoning_effort = "low"
+model_reasoning_effort = "medium"
 personality = "pragmatic"
 model_verbosity = "low"
 service_tier = "fast"

--- a/services/slackbotv2/test/chat-sdk-emulate.test.ts
+++ b/services/slackbotv2/test/chat-sdk-emulate.test.ts
@@ -1076,7 +1076,7 @@ describe('slackbotv2', () => {
     await Promise.all(firstWaits)
     expect(metadataBlockTexts(slackApi.calls)).toHaveLength(1)
     expect(metadataBlockTexts(slackApi.calls)[0]).toContain('Codex')
-    expect(metadataBlockTexts(slackApi.calls)[0]).toContain('Low')
+    expect(metadataBlockTexts(slackApi.calls)[0]).toContain('Medium')
     expect(metadataBlockTexts(slackApi.calls)[0]).not.toContain('Fast')
     expect(metadataBlockTexts(slackApi.calls)[0]).not.toContain('Open chat in Console')
 
@@ -1219,7 +1219,7 @@ describe('slackbotv2', () => {
       .map(block => JSON.stringify(block))
       .find(text => text.includes('Open chat in Console'))
     expect(footer).toContain('Nanocodex')
-    expect(footer).toContain('Low')
+    expect(footer).toContain('Medium')
     expect(footer).not.toContain('Codex*')
     expect(codexApi.creates[0]?.body.harness_type).toBe('nanocodex')
     expect(codexApi.creates[0]?.body.metadata.harness_assignment).toEqual(harnessAssignment)

--- a/services/slackbotv2/test/console-session-link.test.ts
+++ b/services/slackbotv2/test/console-session-link.test.ts
@@ -134,7 +134,7 @@ describe('defaultReasoningForHarness', () => {
     .model_reasoning_effort
 
   test('shares the baked Codex reasoning default with Nanocodex', () => {
-    expect(bakedCodexReasoning).toBe('low')
+    expect(bakedCodexReasoning).toBe('medium')
     expect(defaultReasoningForHarness('codex')).toBe(bakedCodexReasoning)
     expect(defaultReasoningForHarness('nanocodex')).toBe(bakedCodexReasoning)
     expect(defaultReasoningForHarness('claudecode')).toBeUndefined()


### PR DESCRIPTION
## Summary
- change the baked Codex reasoning default from low to medium
- update the Slackbot regression assertion for the shared Codex/Nanocodex default

## Testing
- `bun test test/console-session-link.test.ts` (25 passed)
- `bun run check:types` unavailable because the checkout has no installed `tsgo` binary

Prompted by: mslipper