### PR TITLE
feat(slackbotv2): configure model and reasoning aliases

### DIFF
--- a/contrib/chart/templates/slackbotv2.yaml
+++ b/contrib/chart/templates/slackbotv2.yaml
@@ -94,6 +94,14 @@ spec:
               value: {{ .Values.slackbotv2.messageOverridesStrategy.timeoutMs | quote }}
             - name: SLACKBOTV2_MESSAGE_OVERRIDES_MAX_OUTPUT_TOKENS
               value: {{ .Values.slackbotv2.messageOverridesStrategy.maxOutputTokens | quote }}
+{{- if .Values.slackbotv2.modelAliases }}
+            - name: SLACKBOTV2_MODEL_ALIASES
+              value: {{ .Values.slackbotv2.modelAliases | toJson | quote }}
+{{- end }}
+{{- if .Values.slackbotv2.reasoningAliases }}
+            - name: SLACKBOTV2_REASONING_ALIASES
+              value: {{ .Values.slackbotv2.reasoningAliases | toJson | quote }}
+{{- end }}
 {{- if $console.publicUrl }}
             # Public origin of the Console UI (matches the Console's own
             # CENTAUR_CONSOLE_PUBLIC_URL). When set, the first assistant message

--- a/contrib/chart/values.schema.json
+++ b/contrib/chart/values.schema.json
@@ -451,6 +451,30 @@
           "enum": ["first", "always", "never"]
         },
         "responseServiceTierEnabled": { "type": "boolean" },
+        "modelAliases": {
+          "type": "object",
+          "propertyNames": { "pattern": "^[A-Za-z0-9._-]+$" },
+          "additionalProperties": {
+            "type": "object",
+            "required": ["model", "harness"],
+            "properties": {
+              "model": { "type": "string", "minLength": 1 },
+              "harness": {
+                "type": "string",
+                "enum": ["amp", "claude", "claude-code", "claudecode", "codex", "hermes", "nanocodex"]
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "reasoningAliases": {
+          "type": "object",
+          "propertyNames": { "pattern": "^[A-Za-z0-9._-]+$" },
+          "additionalProperties": {
+            "type": "string",
+            "enum": ["none", "minimal", "low", "medium", "high", "xhigh", "max"]
+          }
+        },
         "metrics": {
           "type": "object",
           "properties": {

--- a/contrib/chart/values.yaml
+++ b/contrib/chart/values.yaml
@@ -603,6 +603,18 @@ slackbotv2:
   #     C0ENG: { harness: claude, model: opus, reasoning: high }
   #     C0TRIAGE: { reasoning: low }
   channelDefaults: {}
+  # Additional or replacement aliases used by --model/alias shortcut flags,
+  # channel defaults, and the natural-language message override strategy.
+  # Each model alias names both the canonical model and compatible harness.
+  # Reasoning aliases must resolve to a supported canonical effort:
+  # none|minimal|low|medium|high|xhigh|max.
+  # Example:
+  #   modelAliases:
+  #     frontier: { model: gpt-5.6-sol, harness: codex }
+  #   reasoningAliases:
+  #     strongest: max
+  modelAliases: {}
+  reasoningAliases: {}
   # Message overrides strategy for Slack message text. "flags" keeps the legacy
   # deterministic --model/--claude/-rsn strategy. "llm" asks a small model for
   # normalized overrides, allowing natural language requests such as

--- a/services/slackbotv2/src/channel-defaults.ts
+++ b/services/slackbotv2/src/channel-defaults.ts
@@ -15,7 +15,12 @@
  * onto it like `--claude`/`--codex`; `reasoning` affects Codex and Nanocodex.
  */
 
-import { normalizeHarnessOverrides, type HarnessOverrides } from './overrides'
+import {
+  DEFAULT_OVERRIDE_ALIASES,
+  normalizeHarnessOverrides,
+  type HarnessOverrides,
+  type OverrideAliases
+} from './overrides'
 
 export type ChannelDefaults = Record<string, HarnessOverrides>
 
@@ -26,7 +31,8 @@ export type ChannelDefaults = Record<string, HarnessOverrides>
  */
 export function parseChannelDefaults(
   raw: string | undefined,
-  onError?: (message: string) => void
+  onError?: (message: string) => void,
+  aliases: OverrideAliases = DEFAULT_OVERRIDE_ALIASES
 ): ChannelDefaults {
   const trimmed = raw?.trim()
   if (!trimmed) return {}
@@ -49,7 +55,11 @@ export function parseChannelDefaults(
       onError?.(`channel ${key}: expected an object of harness/model/provider/reasoning fields`)
       continue
     }
-    const overrides = normalizeHarnessOverrides(rawEntry, message => onError?.(`channel ${key}: ${message}`))
+    const overrides = normalizeHarnessOverrides(
+      rawEntry,
+      message => onError?.(`channel ${key}: ${message}`),
+      aliases
+    )
     if (!overrides.harnessType && !overrides.model && !overrides.provider && !overrides.reasoning) {
       onError?.(`channel ${key}: no usable harness/model/provider/reasoning fields`)
       continue

--- a/services/slackbotv2/src/message-overrides-strategy.ts
+++ b/services/slackbotv2/src/message-overrides-strategy.ts
@@ -1,7 +1,9 @@
 import type { Logger } from 'chat'
 import {
+  DEFAULT_OVERRIDE_ALIASES,
   extractMessageOverrides,
-  validateStrategyOverrides
+  validateStrategyOverrides,
+  type OverrideAliases
 } from './overrides'
 import type { JsonObject, MessageOverridesStrategy } from './types'
 import { errorMessage, isJsonObject } from './utils'
@@ -9,7 +11,7 @@ import { errorMessage, isJsonObject } from './utils'
 const DEFAULT_TIMEOUT_MS = 2_000
 const DEFAULT_MAX_OUTPUT_TOKENS = 300
 
-const SYSTEM_PROMPT = [
+const BASE_SYSTEM_PROMPT = [
   'Decide whether the Slack message asks to use a specific AI harness, model, provider, or reasoning effort.',
   'Return only canonical override values from the schema.',
   'Use null for every field when the message does not ask to change model selection.',
@@ -21,13 +23,13 @@ const SYSTEM_PROMPT = [
   'Only return reasoning when the user explicitly asks to change model reasoning or effort. A reasoning word appearing incidentally, in quoted text, pasted model output, code, or task requirements is not a selection request.',
   'When the user explicitly requests a reasoning or effort change, map fuzzy magnitude words to the nearest reasoning value. Examples: tiny/cheap/fast -> low or minimal; normal/default -> medium; deep/strong/intense -> high or xhigh; maximum/superduper/biggest -> max.',
   'Return reasoning even when the requested model is not Codex; validation will ignore reasoning that cannot apply.',
-  'Map OpenAI model aliases to canonical IDs: sol -> gpt-5.6-sol, terra -> gpt-5.6-terra, luna -> gpt-5.6-luna, 5.5 -> gpt-5.5, 5.5 pro -> gpt-5.5-pro, 5.4 -> gpt-5.4, 5.4 pro -> gpt-5.4-pro, 5.4 mini -> gpt-5.4-mini, 5.4 nano -> gpt-5.4-nano.',
-  'Map Claude model aliases to canonical IDs: fable -> claude-fable-5, opus -> claude-opus-4-8, opus 4.7 -> claude-opus-4-7, opus 5 -> claude-opus-5, opus 5 fast -> claude-opus-5-fast, sonnet -> claude-sonnet-4-6, sonnet 5 -> claude-sonnet-5, haiku -> claude-haiku-4-5.',
+  'Map versioned OpenAI model names to canonical IDs: 5.5 pro -> gpt-5.5-pro, 5.4 pro -> gpt-5.4-pro, 5.4 mini -> gpt-5.4-mini, 5.4 nano -> gpt-5.4-nano.',
+  'Map Claude model names to canonical IDs: opus 4.7 -> claude-opus-4-7, opus 5 -> claude-opus-5, opus 5 fast -> claude-opus-5-fast, sonnet 5 -> claude-sonnet-5.',
   'Map Amp model aliases to canonical IDs: deep -> deep, fast -> fast. Select an Amp model only when the user explicitly names Amp or clearly asks for the deep or fast model/mode. Requests such as "use the deep model" and "switch to fast mode" select the corresponding Amp model. Do not infer Amp from superlatives, coined terms, or casual requests to be more intelligent, thorough, or fast.',
   'Words containing or merely evoking model aliases are not model requests. For example, "think deeply", "do a deep analysis", "use your strongest thinking", and "give me a fast answer" do not select Amp. Unless another explicit selector is present, return null for every field.',
   'For example, "use max effort and the sol model" should return model "gpt-5.6-sol" and reasoning "max".',
   'Do not treat ordinary discussion of model names as a selection request.'
-].join('\n')
+]
 
 const MODEL_VALUES = [
   'claude-fable-5',
@@ -77,6 +79,7 @@ const MESSAGE_OVERRIDES_SCHEMA = {
 }
 
 export type OpenAiMessageOverridesStrategyOptions = {
+  aliases?: OverrideAliases
   apiKey: string
   baseUrl?: string
   fetch?: typeof fetch
@@ -93,9 +96,11 @@ type OpenAiMessageOverridesStrategyOutput = {
   reasoning?: unknown
 }
 
-export function createFlagMessageOverridesStrategy(): MessageOverridesStrategy {
+export function createFlagMessageOverridesStrategy(
+  aliases: OverrideAliases = DEFAULT_OVERRIDE_ALIASES
+): MessageOverridesStrategy {
   return async ({ text }) => {
-    const parsed = extractMessageOverrides(text)
+    const parsed = extractMessageOverrides(text, aliases)
     const { cleanedText, ...overrides } = parsed
     return { cleanedText, overrides }
   }
@@ -108,13 +113,16 @@ export function createOpenAiMessageOverridesStrategy(
   const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS
   const maxOutputTokens = options.maxOutputTokens ?? DEFAULT_MAX_OUTPUT_TOKENS
   const fetchFn = options.fetch ?? fetch
+  const aliases = options.aliases ?? DEFAULT_OVERRIDE_ALIASES
+  const systemPrompt = systemPromptForAliases(aliases)
+  const schema = messageOverridesSchema(aliases)
 
   return async ({ text }) => {
     // Explicit flags are a deterministic user command, even when the deployment
     // enables the LLM strategy for natural-language model requests. Handle them
     // first so a strict strategy schema or model failure cannot discard the
     // selection, and so flags never leak into the harness prompt.
-    const { cleanedText, ...explicitOverrides } = extractMessageOverrides(text)
+    const { cleanedText, ...explicitOverrides } = extractMessageOverrides(text, aliases)
     if (Object.values(explicitOverrides).some(value => value !== undefined)) {
       return { cleanedText, overrides: explicitOverrides }
     }
@@ -125,7 +133,7 @@ export function createOpenAiMessageOverridesStrategy(
       const response = await fetchFn(responsesUrl, {
         body: JSON.stringify({
           input: text,
-          instructions: SYSTEM_PROMPT,
+          instructions: systemPrompt,
           max_output_tokens: maxOutputTokens,
           model: options.model,
           reasoning: { effort: 'none' },
@@ -133,7 +141,7 @@ export function createOpenAiMessageOverridesStrategy(
           text: {
             format: {
               name: 'slack_message_overrides',
-              schema: MESSAGE_OVERRIDES_SCHEMA,
+              schema,
               strict: true,
               type: 'json_schema'
             }
@@ -163,7 +171,8 @@ export function createOpenAiMessageOverridesStrategy(
       const parsed = JSON.parse(outputText)
       return {
         overrides: validateStrategyOverrides(
-          isJsonObject(parsed) ? (parsed as OpenAiMessageOverridesStrategyOutput) : null
+          isJsonObject(parsed) ? (parsed as OpenAiMessageOverridesStrategyOutput) : null,
+          aliases
         )
       }
     } catch (error) {
@@ -175,6 +184,48 @@ export function createOpenAiMessageOverridesStrategy(
       return { overrides: {} }
     } finally {
       clearTimeout(timeout)
+    }
+  }
+}
+
+function systemPromptForAliases(aliases: OverrideAliases): string {
+  const modelAliases = Object.entries(aliases.model)
+    .map(([alias, value]) => `${alias} -> ${value.model} (${value.harnessType})`)
+    .join(', ')
+  const reasoningAliases = Object.entries(aliases.reasoning)
+    .filter(([alias, effort]) => alias !== effort)
+    .map(([alias, effort]) => `${alias} -> ${effort}`)
+    .join(', ')
+  return [
+    ...BASE_SYSTEM_PROMPT,
+    `Configured model aliases: ${modelAliases || 'none'}.`,
+    `Configured reasoning aliases: ${reasoningAliases || 'none'}.`
+  ].join('\n')
+}
+
+function messageOverridesSchema(aliases: OverrideAliases) {
+  const models = new Set<unknown>(MODEL_VALUES)
+  for (const [alias, value] of Object.entries(aliases.model)) {
+    models.add(alias)
+    models.add(value.model)
+  }
+  const reasoning = new Set<unknown>([
+    'none',
+    'minimal',
+    'low',
+    'medium',
+    'high',
+    'xhigh',
+    'max',
+    null,
+    ...Object.keys(aliases.reasoning)
+  ])
+  return {
+    ...MESSAGE_OVERRIDES_SCHEMA,
+    properties: {
+      ...MESSAGE_OVERRIDES_SCHEMA.properties,
+      model: { enum: [...models], type: ['string', 'null'] },
+      reasoning: { enum: [...reasoning], type: ['string', 'null'] }
     }
   }
 }

--- a/services/slackbotv2/src/overrides.ts
+++ b/services/slackbotv2/src/overrides.ts
@@ -38,6 +38,16 @@ export type MessageOverrides = HarnessOverrides & {
   cleanedText: string
 }
 
+export type ModelAlias = {
+  harnessType: string
+  model: string
+}
+
+export type OverrideAliases = {
+  model: Record<string, ModelAlias>
+  reasoning: Record<string, string>
+}
+
 // Flag name -> HarnessType wire value (serde lowercase of the Rust enum).
 const HARNESS_FLAGS: Record<string, string> = {
   amp: 'amp',
@@ -59,22 +69,20 @@ const PROVIDER_FLAGS: Record<string, ProviderMapping> = {
   meta: { provider: 'responses', harnessType: 'codex' }
 }
 
-// Claude model aliases, usable both as bare flags (--opus) and as --model
-// values (--model opus). Bare-flag form also implies the claude-code harness.
-const CLAUDE_MODEL_ALIASES: Record<string, string> = {
-  fable: 'claude-fable-5',
-  haiku: 'claude-haiku-4-5',
-  opus: 'claude-opus-4-8',
-  sonnet: 'claude-sonnet-4-6'
+// Built-in model aliases, usable both as bare flags (--opus/--sol) and as
+// --model values (--model opus). Bare-flag form also implies the configured
+// compatible harness.
+const DEFAULT_MODEL_ALIASES: Record<string, ModelAlias> = {
+  '5.4': { harnessType: 'codex', model: 'gpt-5.4' },
+  '5.5': { harnessType: 'codex', model: 'gpt-5.5' },
+  fable: { harnessType: 'claudecode', model: 'claude-fable-5' },
+  haiku: { harnessType: 'claudecode', model: 'claude-haiku-4-5' },
+  luna: { harnessType: 'codex', model: 'gpt-5.6-luna' },
+  opus: { harnessType: 'claudecode', model: 'claude-opus-4-8' },
+  sol: { harnessType: 'codex', model: 'gpt-5.6-sol' },
+  sonnet: { harnessType: 'claudecode', model: 'claude-sonnet-4-6' },
+  terra: { harnessType: 'codex', model: 'gpt-5.6-terra' }
 }
-
-const MODEL_SHORTCUTS: Record<string, { harnessType: string; model: string }> =
-  Object.fromEntries(
-    Object.entries(CLAUDE_MODEL_ALIASES).map(([alias, model]) => [
-      alias,
-      { harnessType: 'claudecode', model }
-    ])
-  )
 
 const STRATEGY_HARNESSES = new Set(['amp', 'claudecode', 'codex', 'hermes', 'nanocodex'])
 const STRATEGY_PROVIDERS = new Set(['amazon-bedrock', 'openrouter', 'responses'])
@@ -128,12 +136,12 @@ const PROVIDER_FLAG_PATTERN = new RegExp(
 // Single dash by design: a short per-turn knob (`-rsn high`), so it can't reuse
 // the `--`-prefixed flagPattern() helper. Value-capturing like --model.
 const REASONING_FLAG_PATTERN = new RegExp(
-  String.raw`(?:^|\s)-rsn${MODEL_VALUE_SEPARATOR}([A-Za-z-]+)${FLAG_VALUE_BOUNDARY}`,
+  String.raw`(?:^|\s)-rsn${MODEL_VALUE_SEPARATOR}([A-Za-z0-9._-]+)${FLAG_VALUE_BOUNDARY}`,
   'i'
 )
 
 // Codex reasoning efforts (turn/start `effort`), plus convenience aliases.
-const REASONING_EFFORTS: Record<string, string> = {
+const DEFAULT_REASONING_ALIASES: Record<string, string> = {
   none: 'none',
   minimal: 'minimal',
   min: 'minimal',
@@ -148,7 +156,44 @@ const REASONING_EFFORTS: Record<string, string> = {
   max: 'max'
 }
 
-export function extractMessageOverrides(text: string): MessageOverrides {
+export const DEFAULT_OVERRIDE_ALIASES: OverrideAliases = {
+  model: DEFAULT_MODEL_ALIASES,
+  reasoning: DEFAULT_REASONING_ALIASES
+}
+
+export function mergeOverrideAliases(
+  custom: Partial<OverrideAliases> | undefined
+): OverrideAliases {
+  return {
+    model: { ...DEFAULT_MODEL_ALIASES, ...custom?.model },
+    reasoning: { ...DEFAULT_REASONING_ALIASES, ...custom?.reasoning }
+  }
+}
+
+export function parseOverrideAliases(
+  modelAliasesRaw: string | undefined,
+  reasoningAliasesRaw: string | undefined,
+  onError?: (message: string) => void
+): OverrideAliases {
+  const model = parseAliasObject(modelAliasesRaw, 'model', onError, value => {
+    if (!isPlainObject(value)) return undefined
+    const model = cleanString(value.model)
+    const harnessRaw = cleanString(value.harness)
+    const harnessType = harnessRaw ? HARNESS_FLAGS[harnessRaw.toLowerCase()] : undefined
+    if (!model || !harnessType) return undefined
+    return { harnessType, model }
+  })
+  const reasoning = parseAliasObject(reasoningAliasesRaw, 'reasoning', onError, value => {
+    const effort = cleanString(value)?.toLowerCase()
+    return effort && STRATEGY_REASONING_EFFORTS.has(effort) ? effort : undefined
+  })
+  return mergeOverrideAliases({ model, reasoning })
+}
+
+export function extractMessageOverrides(
+  text: string,
+  aliases: OverrideAliases = DEFAULT_OVERRIDE_ALIASES
+): MessageOverrides {
   let cleaned = text
   let harnessType: string | undefined
   let model: string | undefined
@@ -158,13 +203,13 @@ export function extractMessageOverrides(text: string): MessageOverrides {
   const modelMatch = MODEL_FLAG_PATTERN.exec(cleaned)
   if (modelMatch) {
     const value = modelMatch[1]!
-    model = CLAUDE_MODEL_ALIASES[value.toLowerCase()] ?? value
+    model = aliases.model[value.toLowerCase()]?.model ?? value
     cleaned = stripMatch(cleaned, modelMatch)
   }
 
   const reasoningMatch = REASONING_FLAG_PATTERN.exec(cleaned)
   if (reasoningMatch) {
-    const normalized = REASONING_EFFORTS[reasoningMatch[1]!.toLowerCase()]
+    const normalized = aliases.reasoning[reasoningMatch[1]!.toLowerCase()]
     if (normalized) {
       reasoning = normalized
       cleaned = stripMatch(cleaned, reasoningMatch)
@@ -187,7 +232,7 @@ export function extractMessageOverrides(text: string): MessageOverrides {
     cleaned = stripMatch(cleaned, match)
   }
 
-  for (const [flag, shortcut] of Object.entries(MODEL_SHORTCUTS)) {
+  for (const [flag, shortcut] of Object.entries(aliases.model)) {
     const match = flagPattern(flag).exec(cleaned)
     if (!match) continue
     model ??= shortcut.model
@@ -219,7 +264,8 @@ export function validateStrategyOverrides(
     model?: unknown
     provider?: unknown
     reasoning?: unknown
-  } | null | undefined
+  } | null | undefined,
+  aliases: OverrideAliases = DEFAULT_OVERRIDE_ALIASES
 ): HarnessOverrides {
   if (!raw || typeof raw !== 'object') return {}
   let harnessType: string | undefined
@@ -245,17 +291,17 @@ export function validateStrategyOverrides(
 
   const modelRaw = cleanString(raw.model)
   if (modelRaw) {
-    const modelHarness = STRATEGY_MODEL_HARNESSES[modelRaw.toLowerCase()]
-    if (!modelHarness) return {}
-    if (harnessType && harnessType !== modelHarness) return {}
-    model = modelRaw.toLowerCase()
-    harnessType = modelHarness
+    const resolved = resolveStrategyModel(modelRaw, aliases)
+    if (!resolved) return {}
+    if (harnessType && harnessType !== resolved.harnessType) return {}
+    model = resolved.model
+    harnessType = resolved.harnessType
   }
 
   const reasoningRaw = cleanString(raw.reasoning)
   if (reasoningRaw) {
-    const normalized = reasoningRaw.toLowerCase()
-    if (!STRATEGY_REASONING_EFFORTS.has(normalized)) return {}
+    const normalized = aliases.reasoning[reasoningRaw.toLowerCase()]
+    if (!normalized) return {}
     reasoning =
       harnessType === undefined || harnessType === 'codex' || harnessType === 'nanocodex'
         ? normalized
@@ -275,7 +321,8 @@ export function validateStrategyOverrides(
  */
 export function normalizeHarnessOverrides(
   raw: { harness?: unknown; model?: unknown; provider?: unknown; reasoning?: unknown },
-  onError?: (message: string) => void
+  onError?: (message: string) => void,
+  aliases: OverrideAliases = DEFAULT_OVERRIDE_ALIASES
 ): HarnessOverrides {
   let harnessType: string | undefined
   let model: string | undefined
@@ -301,11 +348,11 @@ export function normalizeHarnessOverrides(
   }
 
   const modelRaw = cleanString(raw.model)
-  if (modelRaw) model = CLAUDE_MODEL_ALIASES[modelRaw.toLowerCase()] ?? modelRaw
+  if (modelRaw) model = aliases.model[modelRaw.toLowerCase()]?.model ?? modelRaw
 
   const reasoningRaw = cleanString(raw.reasoning)
   if (reasoningRaw) {
-    reasoning = REASONING_EFFORTS[reasoningRaw.toLowerCase()]
+    reasoning = aliases.reasoning[reasoningRaw.toLowerCase()]
     if (!reasoning) onError?.(`unknown reasoning effort "${reasoningRaw}"`)
   }
 
@@ -316,6 +363,53 @@ function cleanString(value: unknown): string | undefined {
   if (typeof value !== 'string') return undefined
   const trimmed = value.trim()
   return trimmed === '' ? undefined : trimmed
+}
+
+function resolveStrategyModel(value: string, aliases: OverrideAliases): ModelAlias | undefined {
+  const normalized = value.toLowerCase()
+  const alias = aliases.model[normalized]
+  if (alias) return alias
+  const configuredModel = Object.values(aliases.model).find(
+    candidate => candidate.model.toLowerCase() === normalized
+  )
+  if (configuredModel) return configuredModel
+  const harnessType = STRATEGY_MODEL_HARNESSES[normalized]
+  return harnessType ? { harnessType, model: normalized } : undefined
+}
+
+function parseAliasObject<T>(
+  raw: string | undefined,
+  kind: string,
+  onError: ((message: string) => void) | undefined,
+  parseValue: (value: unknown) => T | undefined
+): Record<string, T> {
+  if (!raw?.trim()) return {}
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch (error) {
+    onError?.(`${kind} aliases: invalid JSON: ${error instanceof Error ? error.message : String(error)}`)
+    return {}
+  }
+  if (!isPlainObject(parsed)) {
+    onError?.(`${kind} aliases: expected an object keyed by alias`)
+    return {}
+  }
+  const result: Record<string, T> = {}
+  for (const [rawAlias, rawValue] of Object.entries(parsed)) {
+    const alias = rawAlias.trim().toLowerCase()
+    const value = parseValue(rawValue)
+    if (!alias || !/^[a-z0-9._-]+$/.test(alias) || !value) {
+      onError?.(`${kind} aliases: invalid alias entry "${rawAlias}"`)
+      continue
+    }
+    result[alias] = value
+  }
+  return result
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
 }
 
 function providerMapping(value: string): ProviderMapping | undefined {

--- a/services/slackbotv2/src/server.ts
+++ b/services/slackbotv2/src/server.ts
@@ -2,6 +2,7 @@ import { createSlackbotV2, type SlackbotV2Options } from './index'
 import { parseChannelDefaults } from './channel-defaults'
 import { resolveSlackHomeTeamId } from './session-api'
 import { resolveSlackBotUserId } from './slack-user'
+import { parseOverrideAliases } from './overrides'
 import {
   createFlagMessageOverridesStrategy,
   createOpenAiMessageOverridesStrategy
@@ -44,6 +45,12 @@ const consoleLogger = {
   child: () => consoleLogger
 }
 
+const overrideAliases = parseOverrideAliases(
+  optionalEnv('SLACKBOTV2_MODEL_ALIASES'),
+  optionalEnv('SLACKBOTV2_REASONING_ALIASES'),
+  reason => consoleLogger.warn('slackbotv2 alias configuration', { reason })
+)
+
 const options: SlackbotV2Options = {
   apiUrl,
   apiKey: optionalEnv('SLACKBOT_API_KEY'),
@@ -52,8 +59,10 @@ const options: SlackbotV2Options = {
   autoJoinCreatedChannels: booleanEnv('SLACKBOTV2_AUTO_JOIN_CREATED_CHANNELS', false),
   botToken,
   botUserId,
-  channelDefaults: parseChannelDefaults(optionalEnv('SLACKBOTV2_CHANNEL_DEFAULTS'), reason =>
-    consoleLogger.warn('slackbotv2 SLACKBOTV2_CHANNEL_DEFAULTS', { reason })
+  channelDefaults: parseChannelDefaults(
+    optionalEnv('SLACKBOTV2_CHANNEL_DEFAULTS'),
+    reason => consoleLogger.warn('slackbotv2 SLACKBOTV2_CHANNEL_DEFAULTS', { reason }),
+    overrideAliases
   ),
   codexNanocodexRolloutPercent: percentEnv(
     'SLACKBOTV2_CODEX_NANOCODEX_ROLLOUT_PERCENT',
@@ -176,11 +185,14 @@ function percentEnv(name: string, fallback: number): number {
 }
 
 function createMessageOverridesStrategy(): SlackbotV2Options['messageOverridesStrategy'] {
-  if (messageOverridesStrategyMode !== 'llm') return createFlagMessageOverridesStrategy()
+  if (messageOverridesStrategyMode !== 'llm') {
+    return createFlagMessageOverridesStrategy(overrideAliases)
+  }
   if (!messageOverridesStrategyApiKey) {
     return async () => ({ overrides: {} })
   }
   return createOpenAiMessageOverridesStrategy({
+    aliases: overrideAliases,
     apiKey: messageOverridesStrategyApiKey,
     baseUrl: optionalEnv('SLACKBOTV2_MESSAGE_OVERRIDES_OPENAI_BASE_URL'),
     logger: consoleLogger,

--- a/services/slackbotv2/test/overrides.test.ts
+++ b/services/slackbotv2/test/overrides.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, test } from 'bun:test'
 import { SlackFormatConverter } from '@chat-adapter/slack'
 import {
   extractMessageOverrides,
+  mergeOverrideAliases,
   normalizeHarnessOverrides,
+  parseOverrideAliases,
   validateStrategyOverrides
 } from '../src/overrides'
 import { messageOverridesForText } from '../src/index'
@@ -10,6 +12,24 @@ import { createOpenAiMessageOverridesStrategy } from '../src/message-overrides-s
 import type { SlackbotV2Options, SlackbotV2Trace } from '../src/types'
 
 describe('extractMessageOverrides', () => {
+  test('uses configured model and reasoning aliases', () => {
+    const aliases = mergeOverrideAliases({
+      model: {
+        frontier: { harnessType: 'codex', model: 'gpt-frontier' }
+      },
+      reasoning: { strongest: 'max' }
+    })
+    expect(extractMessageOverrides('--frontier -rsn strongest fix it', aliases)).toEqual({
+      cleanedText: 'fix it',
+      harnessType: 'codex',
+      model: 'gpt-frontier',
+      reasoning: 'max'
+    })
+    expect(extractMessageOverrides('--model frontier fix it', aliases).model).toBe(
+      'gpt-frontier'
+    )
+  })
+
   test('returns text untouched without flags', () => {
     const result = extractMessageOverrides('review this PR --not-a-known-flag stays')
     expect(result).toEqual({
@@ -287,6 +307,31 @@ describe('extractMessageOverrides', () => {
   })
 })
 
+describe('parseOverrideAliases', () => {
+  test('loads deployment alias JSON and preserves built-in aliases', () => {
+    const aliases = parseOverrideAliases(
+      JSON.stringify({ frontier: { harness: 'codex', model: 'gpt-frontier' } }),
+      JSON.stringify({ strongest: 'max' })
+    )
+    expect(aliases.model.frontier).toEqual({ harnessType: 'codex', model: 'gpt-frontier' })
+    expect(aliases.model.opus?.model).toBe('claude-opus-4-8')
+    expect(aliases.reasoning.strongest).toBe('max')
+    expect(aliases.reasoning.hi).toBe('high')
+  })
+
+  test('skips invalid alias entries and reports them', () => {
+    const errors: string[] = []
+    const aliases = parseOverrideAliases(
+      JSON.stringify({ bad: { harness: 'unknown', model: 'gpt-frontier' } }),
+      JSON.stringify({ turbo: 'turbo' }),
+      error => errors.push(error)
+    )
+    expect(aliases.model.bad).toBeUndefined()
+    expect(aliases.reasoning.turbo).toBeUndefined()
+    expect(errors).toHaveLength(2)
+  })
+})
+
 // normalizeHarnessOverrides is the object-shaped sibling of
 // extractMessageOverrides: config fields resolve through the SAME vocabulary
 // tables as the inline flags, so a channel default and a Slack flag validate
@@ -429,8 +474,13 @@ describe('validateStrategyOverrides', () => {
     })
   })
 
-  test('rejects aliases and arbitrary model ids from the strategy path', () => {
-    expect(validateStrategyOverrides({ model: 'terra' })).toEqual({})
+  test('accepts configured aliases and rejects arbitrary model ids from the strategy path', () => {
+    expect(validateStrategyOverrides({ model: 'terra' })).toEqual({
+      harnessType: 'codex',
+      model: 'gpt-5.6-terra',
+      provider: undefined,
+      reasoning: undefined
+    })
     expect(validateStrategyOverrides({ model: 'anthropic/claude-fable-5' })).toEqual({})
     expect(validateStrategyOverrides({ model: 'not real model id' })).toEqual({})
   })
@@ -615,6 +665,50 @@ describe('messageOverridesForText strategy invocation', () => {
       }
     })
     expect(JSON.stringify(requestBody)).toContain('nanocodex')
+  })
+
+  test('includes configured aliases in natural-language selection', async () => {
+    let requestBody: Record<string, unknown> | undefined
+    const aliases = mergeOverrideAliases({
+      model: { frontier: { harnessType: 'codex', model: 'gpt-frontier' } },
+      reasoning: { strongest: 'max' }
+    })
+    const strategy = createOpenAiMessageOverridesStrategy({
+      aliases,
+      apiKey: 'test-key',
+      fetch: (async (_input: RequestInfo | URL, init?: RequestInit) => {
+        requestBody = JSON.parse(String(init?.body)) as Record<string, unknown>
+        return Response.json({
+          output: [
+            {
+              content: [
+                {
+                  text: JSON.stringify({
+                    harness: null,
+                    model: 'frontier',
+                    provider: null,
+                    reasoning: 'strongest'
+                  })
+                }
+              ]
+            }
+          ]
+        })
+      }) as unknown as typeof fetch,
+      model: 'gpt-5.4-nano'
+    })
+
+    await expect(strategy({ text: 'use frontier with strongest reasoning' })).resolves.toEqual({
+      overrides: {
+        harnessType: 'codex',
+        model: 'gpt-frontier',
+        provider: undefined,
+        reasoning: 'max'
+      }
+    })
+    expect(JSON.stringify(requestBody)).toContain('frontier')
+    expect(JSON.stringify(requestBody)).toContain('strongest')
+    expect(JSON.stringify(requestBody)).toContain('gpt-frontier')
   })
 })
 


### PR DESCRIPTION
## Summary

- add chart-configurable model and reasoning aliases
- apply the same aliases to flags, channel defaults, and natural-language selection
- validate configuration and cover custom aliases in Slackbot tests

## Testing

- `pnpm --filter slackbotv2 test` (253 passed, 1 skipped)
- `bun test services/slackbotv2/test/overrides.test.ts` (52 passed)
- `jq empty contrib/chart/values.schema.json`
- `git diff --check`
- `pnpm --filter slackbotv2 run check:types` (blocked by three pre-existing `fetch.preconnect` errors in `test/slack-user.test.ts`)
- Helm render not run because `helm` is unavailable in this sandbox

Prompted by: @Zygimantass