### PR TITLE
git-branch: clone from GitHub when the repo is not in the local cache

### DIFF
--- a/services/sandbox/SYSTEM_PROMPT.md
+++ b/services/sandbox/SYSTEM_PROMPT.md
@@ -96,6 +96,7 @@
 |repos: ~/github/{org}/{repo} (READ-ONLY mounts) | git pre-configured | gh authenticated
 |installed: Rust,Node24,Python3+uv,Foundry(forge/cast/anvil),Nushell(nu),rg,fd,jq,tmux,cmake,protobuf
 |To modify a repo (commit, push, open PR): first choose a short descriptive lowercase kebab-case branch slug, then run `git-branch <org/repo> <branch-slug>` → creates writable clone at ~/branches/<org>/<repo> on `centaur/<branch-slug>-<timestamp>`
+|git-branch works for ANY GitHub repo your credential can read: it clones from the local ~/github cache when present, otherwise straight from GitHub. A repo missing from ~/github is NOT a blocker and needs no admin action.
 |Example: for a request to fix auth token refresh, use `git-branch paradigmxyz/centaur fix-auth-token-refresh`
 |Never omit the branch slug or use a generated numeric fallback branch name for PR work; the branch name should describe the requested change.
 |*NEVER run git commit/push inside* ~/github/ — it is read-only. Always use git-branch first.

--- a/services/sandbox/git-branch.sh
+++ b/services/sandbox/git-branch.sh
@@ -1,12 +1,14 @@
 #!/bin/bash
-# git-branch — create a writable working copy from a read-only mounted repo.
+# git-branch — create a writable working copy of a GitHub repo.
 #
 # Usage:  git-branch <org/repo> <branch slug>
 # Example: git-branch owner/centaur fix-flaky-slack-delivery
 #
-# Creates ~/branches/<org>/<repo> as a --shared clone from ~/github/<org>/<repo>
-# with a unique agent branch checked out. The resulting directory is fully writable
-# and supports commit, push, and PR workflows.
+# Creates ~/branches/<org>/<repo> with a unique agent branch checked out: a
+# --shared clone from the read-only mount at ~/github/<org>/<repo> when the repo
+# is cached there, otherwise a clone straight from GitHub using the sandbox's
+# git credentials. The resulting directory is fully writable and supports
+# commit, push, and PR workflows.
 
 set -euo pipefail
 
@@ -69,11 +71,6 @@ if [[ ! "$SLUG" =~ ^[a-z0-9][a-z0-9-]*[a-z0-9]$|^[a-z0-9]$ ]]; then
     exit 1
 fi
 
-if [ ! -d "$SRC/.git" ] && ! git -C "$SRC" rev-parse --git-dir >/dev/null 2>&1; then
-    echo "Error: $SRC is not a valid git repository" >&2
-    exit 1
-fi
-
 if [ -d "$DEST/.git" ]; then
     echo "$DEST already exists — reusing" >&2
     configure_git_identity
@@ -83,17 +80,26 @@ fi
 
 mkdir -p "$(dirname "$DEST")"
 
-if ! git clone --quiet --shared "$SRC" "$DEST"; then
-    echo "shared clone failed; retrying with regular clone" >&2
-    rm -rf "$DEST"
-    git clone --quiet "$SRC" "$DEST"
-fi
+if [ -d "$SRC/.git" ] || git -C "$SRC" rev-parse --git-dir >/dev/null 2>&1; then
+    if ! git clone --quiet --shared "$SRC" "$DEST"; then
+        echo "shared clone failed; retrying with regular clone" >&2
+        rm -rf "$DEST"
+        git clone --quiet "$SRC" "$DEST"
+    fi
 
-# --shared clones set origin to the local path; fix it to the upstream URL
-# so that git push and gh pr create target the real GitHub remote.
-UPSTREAM_URL=$(git -C "$SRC" config --get remote.origin.url 2>/dev/null || echo "")
-if [ -n "$UPSTREAM_URL" ]; then
-    git -C "$DEST" remote set-url origin "$UPSTREAM_URL"
+    # --shared clones set origin to the local path; fix it to the upstream URL
+    # so that git push and gh pr create target the real GitHub remote.
+    UPSTREAM_URL=$(git -C "$SRC" config --get remote.origin.url 2>/dev/null || echo "")
+    if [ -n "$UPSTREAM_URL" ]; then
+        git -C "$DEST" remote set-url origin "$UPSTREAM_URL"
+    fi
+else
+    echo "$REPO is not in the local repo cache; cloning from GitHub" >&2
+    if ! git clone --quiet "https://github.com/$REPO" "$DEST"; then
+        rm -rf "$DEST"
+        echo "Error: could not clone $REPO from GitHub — check the org/repo name and that the active GitHub credential can read it" >&2
+        exit 1
+    fi
 fi
 
 BRANCH="centaur/$SLUG-$(date +%s)"


### PR DESCRIPTION
`git-branch` only knew how to make a shared clone from the read-only repo-cache mount at `~/github`, so for any repo outside a deployment's cached set it failed with "is not a valid git repository". Agents routinely misread that as an infrastructure limitation — telling users an admin must mount the repo, or trying to clone into the read-only mount — when an authenticated clone into `~/branches` works fine. We hit exactly this in our deployment: one session refused a PR request over this error while a same-model session recovered with a manual `gh repo clone` and shipped its PR.

Changes:
- fall back to cloning `https://github.com/<org>/<repo>` (sandbox git credentials apply) into `~/branches/<org>/<repo>` when the repo is not in the local cache
- reuse an existing `~/branches` working copy before checking the cache, so reuse also works for uncached repos
- on remote clone failure, say what to check (repo name, credential read access) instead of a bare git error
- add a system-prompt line stating a repo missing from `~/github` is not a blocker and needs no admin action

Tested all three paths locally (cached shared clone, GitHub fallback, nonexistent repo → clean error, exit 1).
