### PR TITLE
feat: add Centaur agent plugin registry

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "name": "centaur",
+  "interface": {
+    "displayName": "Centaur"
+  },
+  "plugins": [
+    {
+      "name": "centaur",
+      "source": {
+        "source": "local",
+        "path": "./plugins/centaur"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Developer Tools"
+    }
+  ]
+}

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,27 @@
+{
+  "name": "centaur",
+  "owner": {
+    "name": "Paradigm",
+    "url": "https://github.com/paradigmxyz"
+  },
+  "description": "Official Centaur plugins for agent clients.",
+  "version": "0.1.0",
+  "plugins": [
+    {
+      "name": "centaur",
+      "displayName": "Centaur",
+      "source": "./plugins/centaur",
+      "description": "Use your team's approved Centaur tools through MCP.",
+      "version": "0.1.0",
+      "author": {
+        "name": "Paradigm",
+        "url": "https://github.com/paradigmxyz"
+      },
+      "homepage": "https://centaur.run",
+      "repository": "https://github.com/paradigmxyz/centaur",
+      "license": "Apache-2.0 OR MIT",
+      "keywords": ["centaur", "mcp", "tools", "agents"],
+      "category": "developer-tools"
+    }
+  ]
+}

--- a/.github/workflows/validate-agent-plugin.yml
+++ b/.github/workflows/validate-agent-plugin.yml
@@ -1,0 +1,33 @@
+name: Validate agent plugin
+
+on:
+  push:
+    paths:
+      - ".agents/plugins/**"
+      - ".claude-plugin/**"
+      - "plugins/centaur/**"
+      - "scripts/validate_agent_plugin.py"
+      - "scripts/test_validate_agent_plugin.py"
+      - ".github/workflows/validate-agent-plugin.yml"
+  pull_request:
+    paths:
+      - ".agents/plugins/**"
+      - ".claude-plugin/**"
+      - "plugins/centaur/**"
+      - "scripts/validate_agent_plugin.py"
+      - "scripts/test_validate_agent_plugin.py"
+      - ".github/workflows/validate-agent-plugin.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - run: python scripts/test_validate_agent_plugin.py
+      - run: python scripts/validate_agent_plugin.py

--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,9 @@ services/sandbox/repos/
 # Agent / AI IDE config
 .agents/*
 !.agents/skills/
+!.agents/plugins/
+.agents/plugins/*
+!.agents/plugins/marketplace.json
 .amp/
 .claude/
 .cursor/

--- a/README.md
+++ b/README.md
@@ -228,6 +228,7 @@ See [Security](docs/pages/security.mdx) for the full threat model and the mechan
 - [Developer Guide](AGENTS.md) — full local setup, architecture, API contracts, migrations, testing, and conventions
 - [Tools](tools/) — built-in tool plugins
 - [Workflows](workflows/) — external workflow plugins
+- [Agent plugin](plugins/centaur/) — connect Codex, Claude Code, and other MCP clients to Centaur
 - [API service](services/api-rs/) — Rust control plane
 - [Slackbot](services/slackbotv2/) — Slack integration
 - [Sandbox](services/sandbox/) — agent runtime image

--- a/plugins/centaur/.claude-plugin/plugin.json
+++ b/plugins/centaur/.claude-plugin/plugin.json
@@ -1,0 +1,27 @@
+{
+  "name": "centaur",
+  "description": "Use an authenticated Centaur deployment from Claude Code.",
+  "version": "0.1.0",
+  "author": {
+    "name": "Paradigm",
+    "url": "https://github.com/paradigmxyz"
+  },
+  "homepage": "https://centaur.run",
+  "repository": "https://github.com/paradigmxyz/centaur",
+  "license": "Apache-2.0 OR MIT",
+  "keywords": ["centaur", "mcp", "tools", "agents"],
+  "userConfig": {
+    "mcp_url": {
+      "type": "string",
+      "title": "Centaur MCP URL",
+      "description": "The HTTPS URL of your Centaur deployment's /mcp endpoint.",
+      "required": true
+    }
+  },
+  "mcpServers": {
+    "centaur": {
+      "type": "http",
+      "url": "${user_config.mcp_url}"
+    }
+  }
+}

--- a/plugins/centaur/.codex-plugin/plugin.json
+++ b/plugins/centaur/.codex-plugin/plugin.json
@@ -1,0 +1,27 @@
+{
+  "name": "centaur",
+  "version": "0.1.0",
+  "description": "Use an authenticated Centaur deployment from Codex.",
+  "author": {
+    "name": "Paradigm",
+    "url": "https://github.com/paradigmxyz"
+  },
+  "homepage": "https://centaur.run",
+  "repository": "https://github.com/paradigmxyz/centaur",
+  "license": "Apache-2.0 OR MIT",
+  "keywords": ["centaur", "mcp", "tools", "agents"],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Centaur",
+    "shortDescription": "Use your team's approved Centaur tools.",
+    "longDescription": "Connect Codex to an authenticated Centaur MCP deployment and use the tools permitted for your Centaur principal.",
+    "developerName": "Paradigm",
+    "category": "Developer Tools",
+    "capabilities": ["Interactive", "Read", "Write"],
+    "websiteURL": "https://centaur.run",
+    "defaultPrompt": [
+      "Show my Centaur identity and available tools.",
+      "Use Centaur to complete this task."
+    ]
+  }
+}

--- a/plugins/centaur/README.md
+++ b/plugins/centaur/README.md
@@ -1,0 +1,64 @@
+# Centaur agent plugin
+
+Connect Codex, Claude Code, and other MCP clients to the tools approved for your Centaur principal. Each Centaur deployment has its own MCP URL, normally ending in `/mcp`.
+
+## Codex
+
+Add this repository as a marketplace and install the plugin:
+
+```bash
+codex plugin marketplace add paradigmxyz/centaur
+codex plugin add centaur@centaur
+```
+
+Register the deployment as Streamable HTTP and complete OAuth:
+
+```bash
+codex mcp add centaur --url <CENTAUR_MCP_URL>
+codex mcp login centaur
+```
+
+If `centaur` is already registered with the wrong transport, replace it:
+
+```bash
+codex mcp remove centaur
+codex mcp add centaur --url <CENTAUR_MCP_URL>
+codex mcp login centaur
+```
+
+Start a new Codex task after installation so it loads the plugin skill.
+
+## Claude Code
+
+Add the marketplace and install the plugin with your deployment URL:
+
+```bash
+claude plugin marketplace add paradigmxyz/centaur
+claude plugin install centaur@centaur --config mcp_url=<CENTAUR_MCP_URL>
+```
+
+Start Claude Code, open `/mcp`, and authenticate `centaur`. The plugin supplies the remote HTTP configuration and Claude stores OAuth credentials outside the plugin.
+
+For local development, validate and load this checkout directly:
+
+```bash
+claude plugin validate --strict ./plugins/centaur
+claude --plugin-dir ./plugins/centaur
+```
+
+## Other MCP clients
+
+Configure a remote Streamable HTTP server using the deployment-specific URL:
+
+```json
+{
+  "mcpServers": {
+    "centaur": {
+      "type": "http",
+      "url": "<CENTAUR_MCP_URL>"
+    }
+  }
+}
+```
+
+Complete OAuth in the client, then verify that `centaur_whoami` returns the expected principal before performing sensitive actions.

--- a/plugins/centaur/skills/centaur/SKILL.md
+++ b/plugins/centaur/skills/centaur/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: centaur
+description: Use an authenticated Centaur MCP deployment to discover and call team-approved tools. Use when a task requires Centaur, its tool catalog, or the user's Centaur identity and permissions.
+---
+
+# Centaur
+
+Use Centaur's MCP tools for actions and context exposed by the user's deployment.
+
+## Workflow
+
+1. When identity or authorization matters, call `centaur_whoami` before other Centaur tools.
+2. Choose the narrowest Centaur tool that satisfies the request.
+3. Each tool package accepts a `method` and an `arguments` object. If its methods or parameters are unclear, call that tool with `method: "help"` first.
+4. Treat the MCP tool description and help result as the current contract. Do not guess method names or parameters.
+5. Summarize consequential writes and return relevant identifiers or links.
+
+Centaur authorizes calls using the signed-in principal's live roles and grants. Never request, paste, print, or store Centaur OAuth tokens.
+
+## Connection recovery
+
+If no Centaur tools are available, explain that the client still needs the deployment-specific MCP endpoint.
+
+- Codex: register it with `codex mcp add centaur --url <CENTAUR_MCP_URL>`, then run `codex mcp login centaur`. The `--url` flag is required for Streamable HTTP and OAuth.
+- Claude Code: configure the plugin's `mcp_url`, open `/mcp`, and authenticate the `centaur` server.
+- Other MCP clients: configure a remote HTTP server named `centaur` with the deployment's `/mcp` URL and complete its OAuth flow.
+
+Do not substitute a guessed hostname. Ask for the deployment URL when it is not already configured or supplied.

--- a/scripts/test_validate_agent_plugin.py
+++ b/scripts/test_validate_agent_plugin.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Tests for the cross-client Centaur plugin validator."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import shutil
+import tempfile
+import unittest
+
+from validate_agent_plugin import ROOT, validate
+
+
+ARTIFACTS = (
+    ".agents/plugins/marketplace.json",
+    ".claude-plugin/marketplace.json",
+    "plugins/centaur/.codex-plugin/plugin.json",
+    "plugins/centaur/.claude-plugin/plugin.json",
+    "plugins/centaur/skills/centaur/SKILL.md",
+    "plugins/centaur/README.md",
+)
+
+
+class ValidateAgentPluginTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp_dir.name)
+        for relative in ARTIFACTS:
+            source = ROOT / relative
+            target = self.root / relative
+            target.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(source, target)
+
+    def tearDown(self) -> None:
+        self.temp_dir.cleanup()
+
+    def load_json(self, relative: str) -> dict:
+        return json.loads((self.root / relative).read_text())
+
+    def write_json(self, relative: str, value: dict) -> None:
+        (self.root / relative).write_text(json.dumps(value, indent=2) + "\n")
+
+    def test_repository_artifacts_are_valid(self) -> None:
+        self.assertEqual(validate(self.root), [])
+
+    def test_rejects_contract_regressions(self) -> None:
+        cases = (
+            (
+                "mismatched version",
+                "plugins/centaur/.claude-plugin/plugin.json",
+                lambda value: value.update(version="9.9.9"),
+                "versions must match",
+            ),
+            (
+                "stdio transport",
+                "plugins/centaur/.claude-plugin/plugin.json",
+                lambda value: value["mcpServers"]["centaur"].update(type="stdio"),
+                "transport must be http",
+            ),
+            (
+                "hard-coded private host",
+                "plugins/centaur/.claude-plugin/plugin.json",
+                lambda value: value["mcpServers"]["centaur"].update(
+                    url="https://private.example.ts.net/mcp"
+                ),
+                "must not contain private host suffix",
+            ),
+            (
+                "wrong marketplace path",
+                ".claude-plugin/marketplace.json",
+                lambda value: value["plugins"][0].update(source="./centaur"),
+                "source must be ./plugins/centaur",
+            ),
+        )
+        for label, relative, mutate, expected in cases:
+            with self.subTest(label=label):
+                original = (self.root / relative).read_text()
+                value = self.load_json(relative)
+                mutate(value)
+                self.write_json(relative, value)
+                self.assertTrue(any(expected in error for error in validate(self.root)))
+                (self.root / relative).write_text(original)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_validate_agent_plugin.py
+++ b/scripts/test_validate_agent_plugin.py
@@ -72,6 +72,18 @@ class ValidateAgentPluginTest(unittest.TestCase):
                 lambda value: value["plugins"][0].update(source="./centaur"),
                 "source must be ./plugins/centaur",
             ),
+            (
+                "wrong Codex marketplace name",
+                ".agents/plugins/marketplace.json",
+                lambda value: value.update(name="main"),
+                "marketplace name must be centaur",
+            ),
+            (
+                "wrong Claude marketplace name",
+                ".claude-plugin/marketplace.json",
+                lambda value: value.update(name="main"),
+                "marketplace name must be centaur",
+            ),
         )
         for label, relative, mutate, expected in cases:
             with self.subTest(label=label):

--- a/scripts/validate_agent_plugin.py
+++ b/scripts/validate_agent_plugin.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+"""Validate the cross-client Centaur plugin and marketplace contracts."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import re
+import sys
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PLUGIN = Path("plugins/centaur")
+NAME = "centaur"
+PRIVATE_HOST_SUFFIXES = (".ts.net",)
+
+
+def _load_json(root: Path, relative: Path, errors: list[str]) -> dict[str, Any]:
+    path = root / relative
+    try:
+        value = json.loads(path.read_text())
+    except FileNotFoundError:
+        errors.append(f"{relative}: missing file")
+        return {}
+    except json.JSONDecodeError as exc:
+        errors.append(f"{relative}: invalid JSON: {exc}")
+        return {}
+    if not isinstance(value, dict):
+        errors.append(f"{relative}: root must be an object")
+        return {}
+    return value
+
+
+def _require(condition: bool, path: Path, message: str, errors: list[str]) -> None:
+    if not condition:
+        errors.append(f"{path}: {message}")
+
+
+def _validate_marketplace_source(
+    root: Path,
+    path: Path,
+    source: object,
+    errors: list[str],
+) -> None:
+    source_path = source.get("path") if isinstance(source, dict) else source
+    _require(
+        source_path == "./plugins/centaur",
+        path,
+        "source must be ./plugins/centaur",
+        errors,
+    )
+    if source_path == "./plugins/centaur":
+        _require(
+            (root / source_path).is_dir(),
+            path,
+            "source directory does not exist",
+            errors,
+        )
+
+
+def validate(root: Path = ROOT) -> list[str]:
+    """Return all plugin contract violations below *root*."""
+
+    errors: list[str] = []
+    codex_path = PLUGIN / ".codex-plugin/plugin.json"
+    claude_path = PLUGIN / ".claude-plugin/plugin.json"
+    codex_market_path = Path(".agents/plugins/marketplace.json")
+    claude_market_path = Path(".claude-plugin/marketplace.json")
+    skill_path = PLUGIN / "skills/centaur/SKILL.md"
+
+    codex = _load_json(root, codex_path, errors)
+    claude = _load_json(root, claude_path, errors)
+    codex_market = _load_json(root, codex_market_path, errors)
+    claude_market = _load_json(root, claude_market_path, errors)
+
+    versions = {
+        value
+        for value in (
+            codex.get("version"),
+            claude.get("version"),
+            claude_market.get("version"),
+            (claude_market.get("plugins") or [{}])[0].get("version")
+            if isinstance(claude_market.get("plugins"), list)
+            and claude_market.get("plugins")
+            and isinstance(claude_market["plugins"][0], dict)
+            else None,
+        )
+        if value is not None
+    }
+    _require(
+        len(versions) == 1,
+        PLUGIN,
+        "manifest and marketplace versions must match",
+        errors,
+    )
+    _require(codex.get("name") == NAME, codex_path, "name must be centaur", errors)
+    _require(claude.get("name") == NAME, claude_path, "name must be centaur", errors)
+    _require(
+        "mcpServers" not in codex,
+        codex_path,
+        "Codex MCP URL must remain deployment-specific",
+        errors,
+    )
+
+    user_config = claude.get("userConfig")
+    mcp_config = claude.get("mcpServers")
+    mcp_url = None
+    mcp_type = None
+    if isinstance(mcp_config, dict) and isinstance(mcp_config.get(NAME), dict):
+        mcp_url = mcp_config[NAME].get("url")
+        mcp_type = mcp_config[NAME].get("type")
+    _require(
+        isinstance(user_config, dict)
+        and isinstance(user_config.get("mcp_url"), dict)
+        and user_config["mcp_url"].get("required") is True,
+        claude_path,
+        "mcp_url must be required user configuration",
+        errors,
+    )
+    _require(
+        mcp_type == "http", claude_path, "Centaur MCP transport must be http", errors
+    )
+    _require(
+        mcp_url == "${user_config.mcp_url}",
+        claude_path,
+        "MCP URL must come from user_config.mcp_url",
+        errors,
+    )
+
+    codex_plugins = codex_market.get("plugins")
+    _require(
+        isinstance(codex_plugins, list) and len(codex_plugins) == 1,
+        codex_market_path,
+        "marketplace must contain exactly one plugin",
+        errors,
+    )
+    if (
+        isinstance(codex_plugins, list)
+        and codex_plugins
+        and isinstance(codex_plugins[0], dict)
+    ):
+        entry = codex_plugins[0]
+        _require(
+            entry.get("name") == NAME,
+            codex_market_path,
+            "plugin name must be centaur",
+            errors,
+        )
+        _validate_marketplace_source(
+            root, codex_market_path, entry.get("source"), errors
+        )
+        policy = entry.get("policy")
+        _require(
+            isinstance(policy, dict)
+            and policy.get("installation") == "AVAILABLE"
+            and policy.get("authentication") == "ON_INSTALL",
+            codex_market_path,
+            "plugin policy must declare availability and authentication timing",
+            errors,
+        )
+
+    claude_plugins = claude_market.get("plugins")
+    _require(
+        isinstance(claude_plugins, list) and len(claude_plugins) == 1,
+        claude_market_path,
+        "marketplace must contain exactly one plugin",
+        errors,
+    )
+    if (
+        isinstance(claude_plugins, list)
+        and claude_plugins
+        and isinstance(claude_plugins[0], dict)
+    ):
+        entry = claude_plugins[0]
+        _require(
+            entry.get("name") == NAME,
+            claude_market_path,
+            "plugin name must be centaur",
+            errors,
+        )
+        _validate_marketplace_source(
+            root, claude_market_path, entry.get("source"), errors
+        )
+
+    try:
+        skill = (root / skill_path).read_text()
+    except FileNotFoundError:
+        errors.append(f"{skill_path}: missing file")
+        skill = ""
+    _require(
+        bool(re.search(r"(?m)^name:\s*centaur\s*$", skill)),
+        skill_path,
+        "frontmatter name must be centaur",
+        errors,
+    )
+    for invariant in (
+        "centaur_whoami",
+        "method",
+        "arguments",
+        "codex mcp add centaur --url",
+    ):
+        _require(
+            invariant in skill,
+            skill_path,
+            f"missing operational invariant: {invariant}",
+            errors,
+        )
+
+    artifact_paths = [
+        codex_path,
+        claude_path,
+        codex_market_path,
+        claude_market_path,
+        skill_path,
+        PLUGIN / "README.md",
+    ]
+    for relative in artifact_paths:
+        path = root / relative
+        if not path.is_file():
+            continue
+        text = path.read_text().lower()
+        for suffix in PRIVATE_HOST_SUFFIXES:
+            _require(
+                suffix not in text,
+                relative,
+                f"must not contain private host suffix {suffix}",
+                errors,
+            )
+
+    return errors
+
+
+def main() -> int:
+    errors = validate()
+    if errors:
+        print("Agent plugin validation failed:", file=sys.stderr)
+        for error in errors:
+            print(f"- {error}", file=sys.stderr)
+        return 1
+    print("Agent plugin validation passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_agent_plugin.py
+++ b/scripts/validate_agent_plugin.py
@@ -97,6 +97,18 @@ def validate(root: Path = ROOT) -> list[str]:
     _require(codex.get("name") == NAME, codex_path, "name must be centaur", errors)
     _require(claude.get("name") == NAME, claude_path, "name must be centaur", errors)
     _require(
+        codex_market.get("name") == NAME,
+        codex_market_path,
+        "marketplace name must be centaur",
+        errors,
+    )
+    _require(
+        claude_market.get("name") == NAME,
+        claude_market_path,
+        "marketplace name must be centaur",
+        errors,
+    )
+    _require(
         "mcpServers" not in codex,
         codex_path,
         "Codex MCP URL must remain deployment-specific",


### PR DESCRIPTION
## Motivation

Make Centaur installable as a first-class agent plugin while preserving deployment-specific MCP endpoints and OAuth.

## Summary

- add Codex and Claude Code plugin manifests and marketplace catalogs
- publish the canonical install identity as `centaur@centaur`
- add a shared Centaur MCP workflow skill and cross-client setup guide
- add manifest consistency validation, identity regression coverage, and CI enforcement

## Key design considerations

- keep private deployment hostnames out of the repository
- configure Claude MCP URLs through required plugin user configuration
- keep Codex MCP registration separate because each self-hosted deployment has a different endpoint
- lock both marketplace and plugin names to prevent accidental install-identity drift
- keep plugin and marketplace versions synchronized across clients