### PR TITLE
fix: render Slack replies with native formatting

### DIFF
--- a/patches/@chat-adapter__slack@4.31.0.patch
+++ b/patches/@chat-adapter__slack@4.31.0.patch
@@ -278,7 +278,7 @@ index a7048fd884020cfd96a51c48b7071fa7293f3dc4..e5bd30bb8f2d41f8f836e7dee742a67f
          isMe
        },
        metadata: {
-@@ -3452,26 +3685,251 @@ var SlackAdapter = class _SlackAdapter {
+@@ -3452,26 +3685,255 @@ var SlackAdapter = class _SlackAdapter {
      }
      this.logger.debug("Slack: starting stream", { channel, threadTs });
      const token = await this.getToken();
@@ -448,7 +448,11 @@ index a7048fd884020cfd96a51c48b7071fa7293f3dc4..e5bd30bb8f2d41f8f836e7dee742a67f
          return;
        }
 -      await streamer.append({ markdown_text: delta, token });
-+      let remaining = delta;
++      // chat.appendStream's `markdown_text` accepts Slack mrkdwn, not every
++      // CommonMark construct emitted by models (notably labeled links).
++      // Convert each syntactically committable delta at the transport boundary
++      // so every Slack agent gets native rich formatting without prompt rules.
++      let remaining = this.formatConverter.toResponseUrlText({ markdown: delta });
 +      while (remaining.length > 0) {
 +        if (isExpired(current)) {
 +          await rotateCurrentForAge();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,7 +12,7 @@ patchedDependencies:
     hash: fce7a692b030cfe3d325b020a4472b9424b8976aa2f7faded6ad4c83421e9132
     path: patches/@chat-adapter__linear@4.31.0.patch
   '@chat-adapter/slack@4.31.0':
-    hash: b005d7fc3498bc499bfd30ff79be29138a48b63944761da6f1b68bec59ef9d68
+    hash: 5131a8fee43fb4167ce2e3181588e06be5501cdfc3dec497a737d0afae9ba614
     path: patches/@chat-adapter__slack@4.31.0.patch
   '@chat-adapter/state-pg@4.31.0':
     hash: 69262b03c278ca9d4af0bed7b4e05f9d7a5a36d3d79fad31df2a85da4d349274
@@ -220,7 +220,7 @@ importers:
         version: link:../../packages/rendering
       '@chat-adapter/slack':
         specifier: ^4.31.0
-        version: 4.31.0(patch_hash=b005d7fc3498bc499bfd30ff79be29138a48b63944761da6f1b68bec59ef9d68)(zod@4.4.3)
+        version: 4.31.0(patch_hash=5131a8fee43fb4167ce2e3181588e06be5501cdfc3dec497a737d0afae9ba614)(zod@4.4.3)
       '@chat-adapter/state-pg':
         specifier: ^4.31.0
         version: 4.31.0(patch_hash=69262b03c278ca9d4af0bed7b4e05f9d7a5a36d3d79fad31df2a85da4d349274)(zod@4.4.3)
@@ -1992,7 +1992,7 @@ snapshots:
       - supports-color
       - zod
 
-  '@chat-adapter/slack@4.31.0(patch_hash=b005d7fc3498bc499bfd30ff79be29138a48b63944761da6f1b68bec59ef9d68)(zod@4.4.3)':
+  '@chat-adapter/slack@4.31.0(patch_hash=5131a8fee43fb4167ce2e3181588e06be5501cdfc3dec497a737d0afae9ba614)(zod@4.4.3)':
     dependencies:
       '@chat-adapter/shared': 4.31.0(zod@4.4.3)
       '@slack/socket-mode': 2.0.7

--- a/services/slackbotv2/src/index.ts
+++ b/services/slackbotv2/src/index.ts
@@ -14,7 +14,7 @@ import {
   type StateAdapter,
   type Thread
 } from 'chat'
-import { createSlackAdapter } from '@chat-adapter/slack'
+import { createSlackAdapter, SlackFormatConverter } from '@chat-adapter/slack'
 import {
   assertSlackOk,
   callSlackApi,
@@ -133,6 +133,7 @@ type SlackAssistantAdapter = {
   setAssistantTitle?(channelId: string, threadTs: string, title: string): Promise<void>
 }
 
+const slackFormatConverter = new SlackFormatConverter()
 const MAX_SLACK_MESSAGE_ATTACHMENTS = 20
 
 type SlackbotV2RequestContext = {
@@ -1837,7 +1838,7 @@ function slackStreamErrorCode(error: unknown): string {
 const FALLBACK_OPEN_MAX_ATTEMPTS = 4
 
 /**
- * Delivers the durable final answer as a plain thread post after the live
+ * Delivers the durable final answer as a Slack-native thread post after the live
  * Slack streaming render failed. Replays the session event stream from the
  * execution's starting position (the control plane keeps the events durably,
  * so the terminal result is replayable even when the failed render already
@@ -1899,10 +1900,13 @@ async function renderFallbackFinalAnswer(
     }
     const text = fallback.textOrDefault()
     const fallbackText = truncateSlackText(text, SLACK_FALLBACK_TEXT_MAX_CHARS, 'Slack final answer')
+    const fallbackMrkdwn = slackFormatConverter.toResponseUrlText({ markdown: fallbackText })
     if (replacement) {
-      await thread.adapter.editMessage(thread.id, replacement.replaceMessageId, fallbackText)
+      await thread.adapter.editMessage(thread.id, replacement.replaceMessageId, {
+        raw: fallbackMrkdwn
+      })
     } else {
-      await thread.post(fallbackText)
+      await thread.post({ raw: fallbackMrkdwn })
     }
     traceLog(options, 'slackbotv2_render_fallback_complete', trace, {
       chars: text.length,

--- a/services/slackbotv2/test/chat-sdk-emulate.test.ts
+++ b/services/slackbotv2/test/chat-sdk-emulate.test.ts
@@ -2295,6 +2295,61 @@ describe('slackbotv2', () => {
     })
   })
 
+  it('renders root-DM fallback answers as Slack-native rich text', async () => {
+    codexApi.autoRespond = false
+    const opened = await slack.conversations.open({ users: BOT_USER_ID })
+    const dmChannel = String(opened.channel?.id)
+    expect(dmChannel).toStartWith('D')
+    const messageTs = '1788266877.394249'
+    const waits: Promise<unknown>[] = []
+    const response = await bot.app.request(
+      '/api/webhooks/slack',
+      signedSlackEvent({
+        event_id: 'Ev-slackbotv2-root-dm-rich-fallback',
+        event: {
+          type: 'message',
+          user: USER_ID,
+          channel: dmChannel,
+          channel_type: 'im',
+          team: TEAM_ID,
+          ts: messageTs,
+          text: 'book the meeting'
+        }
+      }),
+      {},
+      waitUntilContext(waits)
+    )
+    expect(response.status).toBe(200)
+    await waitFor(() => codexApi.executes.length === 1)
+    await waitFor(() => codexApi.eventRequests.length === 1)
+
+    const commonMarkAnswer = [
+      '**Booked and verified:**',
+      '',
+      '- **Title:** Example meeting',
+      '',
+      '[Join meeting](https://meet.example.test/room)'
+    ].join('\n')
+    codexApi.emitOutputLines(
+      codexApi.executes[0]!.threadKey,
+      sampleCodexOutputLines(commonMarkAnswer)
+    )
+
+    await Promise.all(waits)
+    const fallbackPost = slackApi.calls.find(call =>
+      call.method === 'chat.postMessage'
+      && stringField(call.body.channel) === dmChannel
+      && stringField(call.body.text).includes('Booked and verified')
+    )
+    expect(fallbackPost).toBeDefined()
+    const delivered = stringField(fallbackPost?.body.text)
+    expect(delivered).toContain('*Booked and verified:*')
+    expect(delivered).toContain('• *Title:* Example meeting')
+    expect(delivered).toContain('<https://meet.example.test/room|Join meeting>')
+    expect(delivered).not.toContain('**Title:**')
+    expect(delivered).not.toContain('[Join meeting](')
+  })
+
   it('ignores non-JSON sandbox bootstrap output lines instead of ending the stream', async () => {
     codexApi.autoRespond = false
 
@@ -2329,6 +2384,66 @@ describe('slackbotv2', () => {
     expect(await threadText(mention.ts)).not.toContain(
       'Execution completed, but no final text was captured.'
     )
+  })
+
+  it('renders streamed CommonMark links as Slack-native rich links', async () => {
+    codexApi.autoRespond = false
+
+    const mention = await postUserMessage(`<@${BOT_USER_ID}> report the completed issue`)
+    const waits: Promise<unknown>[] = []
+    const response = await bot.app.request(
+      '/api/webhooks/slack',
+      signedSlackEvent({
+        event_id: 'Ev-slackbotv2-native-rich-link',
+        event: {
+          type: 'app_mention',
+          user: USER_ID,
+          channel: CHANNEL_ID,
+          team: TEAM_ID,
+          ts: mention.ts,
+          text: `<@${BOT_USER_ID}> report the completed issue`
+        }
+      }),
+      {},
+      waitUntilContext(waits)
+    )
+    expect(response.status).toBe(200)
+    await waitFor(() => codexApi.executes.length === 1)
+
+    const commonMarkAnswer =
+      'Completed: [Issue #276](https://github.com/example/widgets/issues/276) was updated.'
+    const fragmentedOutput = sampleCodexOutputLines(commonMarkAnswer).flatMap(line => {
+      const event = JSON.parse(line) as Record<string, unknown>
+      if (
+        event.method !== 'item/agentMessage/delta'
+        || !isRecord(event.params)
+        || event.params.itemId !== 'answer-1'
+      ) {
+        return [line]
+      }
+      const params = event.params
+      return [
+        'Completed: [Issue',
+        ' #276](https://github.com/example/',
+        'widgets/issues/276) was updated.'
+      ].map(delta => JSON.stringify({
+        ...event,
+        params: { ...params, delta }
+      }))
+    })
+    codexApi.emitOutputLines(threadKey(mention.ts), fragmentedOutput)
+
+    await Promise.all(waits)
+    const transcripts = slackStreamTranscripts(slackApi.calls)
+    expect(transcripts).toHaveLength(1)
+    const delivered = transcripts[0]!.chunks
+      .filter(chunk => chunk.type === 'markdown_text')
+      .map(chunk => stringField(chunk.text))
+      .join('')
+    expect(delivered).toBe(
+      'Completed: <https://github.com/example/widgets/issues/276|Issue #276> was updated.'
+    )
+    expect(delivered).not.toContain('[Issue #276](')
   })
 
   it('ignores unmentioned subscribed messages during a stream, including stop', async () => {
@@ -6282,6 +6397,7 @@ type StreamCall = {
     | 'assistant.threads.setTitle'
     | 'chat.startStream'
     | 'chat.appendStream'
+    | 'chat.postMessage'
     | 'chat.stopStream'
     | 'conversations.join'
     | 'reactions.add'
@@ -6588,6 +6704,9 @@ async function handlePatchedSlackRequest(
       )
     )
     return
+  }
+  if (path === '/api/chat.postMessage') {
+    input.calls.push({ method: 'chat.postMessage', body: await requestBody(request.clone()) })
   }
   if (path === '/api/conversations.replies') {
     const body = await requestBody(request.clone())


### PR DESCRIPTION
## Why

The model emits CommonMark, but Slack renders `mrkdwn`. The two overlap enough that most output looked fine, so the mismatches were easy to miss until they showed up in real replies:

| Model output | Slack showed | Should show |
| --- | --- | --- |
| `[Issue #276](https://…/276)` | the literal brackets and URL | a labeled link (`<https://…/276\|Issue #276>`) |
| `**Title:** Example meeting` | `**Title:** Example meeting` | **Title:** Example meeting |

Two delivery paths were sending CommonMark straight to Slack:

1. **Live streaming** — the patched `@chat-adapter/slack` adapter passed each delta to `chat.appendStream` as `markdown_text` unchanged. Slack's `markdown_text` accepts mrkdwn, not full CommonMark, so labeled links in particular came through raw.
2. **Fallback / recovery** — when the streaming render fails, `renderFallbackFinalAnswer` re-posts (or edits in) the durable final answer via `thread.post` / `editMessage` as plain text. Root DMs hit this path constantly: a top-level DM has no `thread_ts`, so `chat.startStream` isn't usable and every answer lands as a `chat.postMessage` — with the CommonMark intact.

Fixing this at the transport boundary (rather than with prompt rules asking the model for mrkdwn) means every Slack agent built on the adapter gets native formatting, and the model can keep producing one canonical Markdown output for all surfaces.

## What changed

**`patches/@chat-adapter__slack@4.31.0.patch`** (+ mechanical `pnpm-lock.yaml` patch-hash bump)
- In the streaming `append` path, run each syntactically committable delta through the adapter's existing `formatConverter.toResponseUrlText()` before handing it to `chat.appendStream`. The existing "commit only complete constructs" buffering is what makes this safe — a link split across deltas (`[Issue` / ` #276](https://…` / `…) was updated.`) is held until it's whole, then converted once.

**`services/slackbotv2/src/index.ts`**
- Instantiate a module-level `SlackFormatConverter` and convert the fallback answer to mrkdwn before both the fresh `thread.post(...)` and the `editMessage(...)` replacement.
- Post/edit with `{ raw: … }` so the chat SDK sends the already-converted mrkdwn as-is instead of running its own Markdown pass over it (which would re-escape or double-convert).

**`services/slackbotv2/test/chat-sdk-emulate.test.ts`**
- `renders streamed CommonMark links as Slack-native rich links` — splits a link across three `item/agentMessage/delta` events and asserts the joined `markdown_text` stream is exactly `Completed: <https://…/276|Issue #276> was updated.`
- `renders root-DM fallback answers as Slack-native rich text` — drives a root DM through the fallback path and asserts bold, a bulleted bold label (`• *Title:*`), and a labeled link all arrive as mrkdwn with no CommonMark residue.
- The emulator now records `chat.postMessage` calls so the fallback path is observable in tests.

## Not changed

- No changes to how the model is prompted; output stays CommonMark.
- No change to threaded (non-root) streaming semantics beyond the per-delta conversion — chunking, rotation, and expiry handling in the patch are untouched.

## Validation

- `bun test test/chat-sdk-emulate.test.ts --test-name-pattern "renders (streamed CommonMark links|root-DM fallback answers)"` — 2 passed
- `bun test test` — 254 passed, 1 skipped
- `git diff --check` — clean
- `bun run check:types` — new code is clean; still reports the three pre-existing `fetch.preconnect` mock errors in `test/slack-user.test.ts` (unrelated, present on `main`)
- Live Slack root DM: bold text, a bullet with a bold label, and a labeled link all rendered natively.
