### PR TITLE
Retry transient console sync connection failures

### DIFF
--- a/services/console/app/jobs/google_docs/base_job.rb
+++ b/services/console/app/jobs/google_docs/base_job.rb
@@ -4,6 +4,7 @@ module GoogleDocs
 
     retry_on GoogleDocs::SyncCredential::GoogleApiError,
       CentaurApiClient::Error,
+      Errno::ECONNREFUSED,
       wait: :polynomially_longer,
       attempts: 5
 

--- a/services/console/app/jobs/granola/sync_credential_job.rb
+++ b/services/console/app/jobs/granola/sync_credential_job.rb
@@ -2,6 +2,8 @@ module Granola
   class SyncCredentialJob < ApplicationJob
     queue_as :default
 
+    retry_on Errno::ECONNREFUSED, wait: :polynomially_longer, attempts: 5
+
     def perform(credential_id)
       credential = BrokerCredential.includes(:oauth_app).find_by(id: credential_id)
       return unless Granola::SyncCredential.syncable?(credential)

--- a/services/console/test/jobs/google_docs/jobs_test.rb
+++ b/services/console/test/jobs/google_docs/jobs_test.rb
@@ -324,6 +324,20 @@ module GoogleDocs
       assert_equal "google_docs:doc-123:chunk-0000", batch[:context_documents].first[:document_id]
     end
 
+    test "document fetch retries when the Centaur API refuses the connection" do
+      credential = create_credential
+      api_client = Object.new
+      api_client.define_singleton_method(:get_google_docs_content_status) do |files:|
+        raise Errno::ECONNREFUSED
+      end
+
+      assert_enqueued_with(job: FetchDocumentJob, args: [ credential.id, google_doc ]) do
+        with_clients(api_client, ->(**) { flunk "documents.get should not be called" }) do
+          FetchDocumentJob.perform_now(credential.id, google_doc)
+        end
+      end
+    end
+
     test "credential crawler jobs block conflicts for the full crawl" do
       assert_equal "google_docs", InitialSyncJob.queue_name
       assert_equal InitialSyncJob.queue_name, IncrementalSyncJob.queue_name

--- a/services/console/test/jobs/granola/jobs_test.rb
+++ b/services/console/test/jobs/granola/jobs_test.rb
@@ -48,10 +48,12 @@ module Granola
     test "sync job retries when the Centaur API refuses the connection" do
       app = create_granola_app
       credential = create_credential(app: app)
-      sync = -> { raise Errno::ECONNREFUSED }
+      sync = Object.new
+      sync.define_singleton_method(:call) { raise Errno::ECONNREFUSED }
+      sync_factory = ->(_credential) { sync }
 
       Granola::SyncCredential.stub(:syncable?, true) do
-        Granola::SyncCredential.stub(:new, sync) do
+        Granola::SyncCredential.stub(:new, sync_factory) do
           assert_enqueued_with(job: SyncCredentialJob, args: [ credential.id ]) do
             SyncCredentialJob.perform_now(credential.id)
           end

--- a/services/console/test/jobs/granola/jobs_test.rb
+++ b/services/console/test/jobs/granola/jobs_test.rb
@@ -44,5 +44,19 @@ module Granola
         .map { |job| job[:args].first }
       assert_equal [ expected.id ], enqueued_ids
     end
+
+    test "sync job retries when the Centaur API refuses the connection" do
+      app = create_granola_app
+      credential = create_credential(app: app)
+      sync = -> { raise Errno::ECONNREFUSED }
+
+      Granola::SyncCredential.stub(:syncable?, true) do
+        Granola::SyncCredential.stub(:new, sync) do
+          assert_enqueued_with(job: SyncCredentialJob, args: [ credential.id ]) do
+            SyncCredentialJob.perform_now(credential.id)
+          end
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary
- retry Granola credential sync jobs when api-rs temporarily refuses connections
- extend the existing Google Docs job retry policy to cover connection refusals
- add regression tests for both job paths

## Runtime evidence
VictoriaLogs showed six console-worker failures during deployment windows over the last 14 days: five `Granola::SyncCredentialJob` failures and one `GoogleDocs::FetchDocumentJob` failure, all connecting to api-rs.

## Validation
- `git diff --check`
- Focused Rails tests added but not executed locally because Ruby 3.4.8 is unavailable in the sandbox and its Docker daemon is not running.

Prompted by: mslipper