### PR TITLE
fix(slack): use canonical message permalinks

### DIFF
--- a/tools/productivity/slack/client.py
+++ b/tools/productivity/slack/client.py
@@ -421,8 +421,23 @@ class SlackClient:
         return body, headers
 
     def _message_permalink(self, channel_id: str, ts: str) -> str:
-        """Build a Slack permalink from channel and timestamp."""
+        """Build a generic fallback permalink from channel and timestamp."""
         return f"https://slack.com/archives/{channel_id}/p{ts.replace('.', '')}"
+
+    def _canonical_message_permalink(self, channel_id: str, ts: str) -> str:
+        """Ask Slack for the workspace-aware permalink for a message."""
+        try:
+            response = self._retry_on_ratelimit(
+                self._client.chat_getPermalink,
+                method_key="chat.getPermalink",
+                channel=channel_id,
+                message_ts=ts,
+            )
+        except (SlackApiError, SlackRateLimitError):
+            return self._message_permalink(channel_id, ts)
+
+        permalink = str(response.get("permalink") or "").strip()
+        return permalink or self._message_permalink(channel_id, ts)
 
     def _resolve_channel_name(self, channel: str, channel_id: str) -> str:
         """Resolve a human-readable channel name when callers passed an ID."""
@@ -1125,7 +1140,12 @@ class SlackClient:
         for msg in scored_results:
             del msg["_score"]
 
-        return scored_results[:max_results]
+        results = scored_results[:max_results]
+        for msg in results:
+            msg["permalink"] = self._canonical_message_permalink(
+                msg["channel_id"], msg["timestamp"]
+            )
+        return results
 
     def get_channel_history_page(
         self,
@@ -1852,10 +1872,11 @@ class SlackClient:
                 kwargs["unfurl_media"] = unfurl_media
             response = self._client.chat_postMessage(**kwargs)
             response_channel = str(response.get("channel") or channel_id)
+            response_ts = str(response.get("ts") or "")
             return {
                 "channel": response_channel,
-                "ts": response.get("ts", ""),
-                "permalink": f"https://slack.com/archives/{response_channel}/p{response.get('ts', '').replace('.', '')}",
+                "ts": response_ts,
+                "permalink": self._canonical_message_permalink(response_channel, response_ts),
             }
         except SlackApiError as e:
             raise RuntimeError(f"Slack API error: {e.response['error']}") from e

--- a/tools/productivity/slack/tests/test_client.py
+++ b/tools/productivity/slack/tests/test_client.py
@@ -35,6 +35,7 @@ class _FakeWebClient:
         self.user_info_response: dict | None = None
         self.user_profile_response: dict | None = None
         self.user_profile_calls: list[dict] = []
+        self.permalink_calls: list[dict] = []
         self.upload_exception: Exception | None = None
         self.upload_count = 0
         # Per-upload-attempt share outcomes consumed by files_upload_v2.
@@ -51,6 +52,15 @@ class _FakeWebClient:
         self.last_kwargs = kwargs
         channel = "D123" if kwargs["channel"].startswith("U") else kwargs["channel"]
         return {"channel": channel, "ts": "123.456"}
+
+    def chat_getPermalink(self, **kwargs):
+        self.permalink_calls.append(kwargs)
+        channel = kwargs["channel"]
+        ts = kwargs["message_ts"]
+        return {
+            "ok": True,
+            "permalink": f"https://acme.slack.com/archives/{channel}/p{ts.replace('.', '')}",
+        }
 
     def conversations_history(self, **kwargs):
         self.history_calls.append(kwargs)
@@ -191,7 +201,22 @@ def test_send_message_posts_directly_to_user_id_without_im_write_scope() -> None
     assert fake_web_client.last_kwargs["channel"] == "U123ABC"
     assert fake_web_client.last_kwargs["text"] == "hello"
     assert result["channel"] == "D123"
-    assert result["permalink"] == "https://slack.com/archives/D123/p123456"
+    assert result["permalink"] == "https://acme.slack.com/archives/D123/p123456"
+    assert fake_web_client.permalink_calls == [{"channel": "D123", "message_ts": "123.456"}]
+
+
+def test_canonical_message_permalink_falls_back_when_slack_rejects_lookup() -> None:
+    client, fake_web_client = _make_client()
+
+    def fail_permalink(**kwargs):
+        raise _make_slack_error(error="message_not_found", status_code=200)
+
+    fake_web_client.chat_getPermalink = fail_permalink  # type: ignore[method-assign]
+
+    assert (
+        client._canonical_message_permalink("C123", "123.456")
+        == "https://slack.com/archives/C123/p123456"
+    )
 
 
 def test_send_dm_posts_directly_to_user_id() -> None:
@@ -1042,6 +1067,11 @@ def test_search_messages_with_channel_ids_scans_proxy_history_without_listing() 
     )
     assert sorted(call["limit"] for call in proxy_calls) == [25, 25, 25]
     assert sorted(item["channel_id"] for item in results) == ["C042WDDP89Y", "C05HUE4KLF2"]
+    assert sorted(fake_web_client.permalink_calls, key=lambda call: call["channel"]) == [
+        {"channel": "C042WDDP89Y", "message_ts": "200.000000"},
+        {"channel": "C05HUE4KLF2", "message_ts": "300.000000"},
+    ]
+    assert all(result["permalink"].startswith("https://acme.slack.com/") for result in results)
 
 
 def test_search_messages_parses_channel_and_user_modifiers_locally() -> None:


### PR DESCRIPTION
## Summary

- resolve workspace-aware Slack permalinks with `chat.getPermalink`
- canonicalize only returned fallback-search results to avoid API calls for every scanned message
- use canonical permalinks for newly sent messages and retain the generic URL as a failure fallback

## Testing

- `uv run --no-sync python -m pytest --import-mode=importlib tests` (79 passed)
- `uvx ruff check tools/productivity/slack/client.py tools/productivity/slack/tests/test_client.py`
- `git diff --check`

Prompted by: @shekhirin