### PR TITLE
feat: trace MCP tool calls in Laminar

### DIFF
--- a/services/api-rs/crates/centaur-api-server/src/mcp.rs
+++ b/services/api-rs/crates/centaur-api-server/src/mcp.rs
@@ -1212,16 +1212,6 @@ mod mcp_tests {
         }
     }
 
-    #[test]
-    fn mcp_tool_trace_input_contains_only_validated_labels() {
-        let input = mcp_tool_trace_input("demo", "search");
-
-        assert_eq!(
-            serde_json::from_str::<Value>(&input).unwrap(),
-            json!({"kind": "centaur", "name": "demo", "method": "search"})
-        );
-    }
-
     fn returned_tool_action(action: McpCentaurToolAction) -> (Value, Option<String>) {
         match action {
             McpCentaurToolAction::Return { result, method } => (result, method),

--- a/services/api-rs/crates/centaur-api-server/src/mcp.rs
+++ b/services/api-rs/crates/centaur-api-server/src/mcp.rs
@@ -15,6 +15,7 @@ use axum::{
 use base64::{Engine as _, engine::general_purpose};
 use centaur_session_runtime::{
     SessionRuntime, ToolHostCallInput, ToolHostCallOutput, ToolHostCallPolicy, ToolHostToolFilter,
+    tool_host_thread_key,
 };
 use hmac::{Hmac, KeyInit, Mac};
 use serde::Deserialize;
@@ -79,30 +80,7 @@ struct CentaurToolMcpArguments {
 
 struct McpToolCallOutcome {
     result: Value,
-    status: &'static str,
-}
-
-impl McpToolCallOutcome {
-    fn completed(result: Value) -> Self {
-        Self {
-            result,
-            status: "completed",
-        }
-    }
-
-    fn failed(result: Value) -> Self {
-        Self {
-            result,
-            status: "failed",
-        }
-    }
-
-    fn timed_out(result: Value) -> Self {
-        Self {
-            result,
-            status: "timed_out",
-        }
-    }
+    timed_out: bool,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -192,16 +170,14 @@ async fn mcp_tool_call_result(
     params: McpToolCallParams,
     tool: Option<(DiscoveredTool, ToolHostCallPolicy)>,
 ) -> Result<Value, ApiError> {
-    let method = mcp_tool_trace_method(&params);
-    let thread_key = format!("mcp:{}", principal.principal_id);
-    let span_input = mcp_tool_trace_input(&params.name, &method);
+    let thread_key = tool_host_thread_key(&principal.principal_id)?;
     let span = info_span!(
         parent: None,
         "centaur.api_rs.mcp.tool",
         component = "mcp",
         event = "mcp_tool_call",
         "lmnr.span.type" = "TOOL",
-        "lmnr.span.input" = span_input,
+        "lmnr.span.input" = tracing::field::Empty,
         "lmnr.span.output" = tracing::field::Empty,
         "lmnr.association.properties.session_id" = thread_key.as_str(),
         "lmnr.association.properties.metadata.thread_key" = thread_key.as_str(),
@@ -211,9 +187,10 @@ async fn mcp_tool_call_result(
         "centaur.thread_key" = thread_key.as_str(),
         "centaur.execution_id" = tracing::field::Empty,
         "centaur.sandbox_id" = tracing::field::Empty,
-        "tool.kind" = "mcp",
+        "tool.kind" = "centaur",
+        "centaur.tool.entry_point" = "mcp",
         "tool.name" = params.name.as_str(),
-        "tool.method" = method.as_str(),
+        "tool.method" = tracing::field::Empty,
         "tool.status" = tracing::field::Empty,
     );
 
@@ -221,11 +198,21 @@ async fn mcp_tool_call_result(
         let outcome = if let Some((tool, policy)) = tool {
             mcp_centaur_tool_result(state, principal, tool, params.arguments, policy).await
         } else {
-            mcp_whoami_result(principal, params.arguments).map(McpToolCallOutcome::completed)
+            mcp_whoami_result(principal, params.arguments).map(|result| McpToolCallOutcome {
+                result,
+                timed_out: false,
+            })
         };
         match outcome {
             Ok(outcome) => {
-                finish_mcp_tool_span(&Span::current(), outcome.status);
+                let status = if outcome.timed_out {
+                    "timed_out"
+                } else if mcp_result_is_error(&outcome.result) {
+                    "failed"
+                } else {
+                    "completed"
+                };
+                finish_mcp_tool_span(&Span::current(), status);
                 Ok(outcome.result)
             }
             Err(error) => {
@@ -238,24 +225,42 @@ async fn mcp_tool_call_result(
     .await
 }
 
-fn mcp_tool_trace_method(params: &McpToolCallParams) -> String {
-    params
-        .arguments
-        .get("method")
-        .and_then(Value::as_str)
-        .map(str::trim)
-        .filter(|method| !method.is_empty())
-        .unwrap_or("call")
-        .to_owned()
-}
-
 fn mcp_tool_trace_input(name: &str, method: &str) -> String {
     json!({
-        "kind": "mcp",
+        "kind": "centaur",
         "name": name,
         "method": method,
     })
     .to_string()
+}
+
+fn record_mcp_tool_method(span: &Span, name: &str, method: &str) {
+    span.record("tool.method", method);
+    span.record("lmnr.span.input", mcp_tool_trace_input(name, method));
+}
+
+fn record_mcp_tool_correlation(
+    span: &Span,
+    request_id: Option<&str>,
+    execution_id: Option<&str>,
+    sandbox_id: Option<&str>,
+) {
+    if let Some(request_id) = request_id {
+        span.record(
+            "lmnr.association.properties.metadata.request_id",
+            request_id,
+        );
+    }
+    if let Some(execution_id) = execution_id {
+        span.record("centaur.execution_id", execution_id);
+        span.record(
+            "lmnr.association.properties.metadata.execution_id",
+            execution_id,
+        );
+    }
+    if let Some(sandbox_id) = sandbox_id.filter(|sandbox_id| !sandbox_id.is_empty()) {
+        span.record("centaur.sandbox_id", sandbox_id);
+    }
 }
 
 fn finish_mcp_tool_span(span: &Span, status: &str) {
@@ -546,12 +551,17 @@ async fn mcp_centaur_tool_result(
     policy: ToolHostCallPolicy,
 ) -> Result<McpToolCallOutcome, ApiError> {
     match prepare_mcp_centaur_tool_call(&tool, arguments)? {
-        McpCentaurToolAction::Return(result) => Ok(if mcp_result_is_error(&result) {
-            McpToolCallOutcome::failed(result)
-        } else {
-            McpToolCallOutcome::completed(result)
-        }),
+        McpCentaurToolAction::Return { result, method } => {
+            if let Some(method) = method.as_deref() {
+                record_mcp_tool_method(&Span::current(), &tool.name, method);
+            }
+            Ok(McpToolCallOutcome {
+                result,
+                timed_out: false,
+            })
+        }
         McpCentaurToolAction::Run { method, arguments } => {
+            record_mcp_tool_method(&Span::current(), &tool.name, &method);
             run_tool_host_centaur_tool(
                 state.runtime()?,
                 principal,
@@ -566,8 +576,14 @@ async fn mcp_centaur_tool_result(
 }
 
 enum McpCentaurToolAction {
-    Return(Value),
-    Run { method: String, arguments: Value },
+    Return {
+        result: Value,
+        method: Option<String>,
+    },
+    Run {
+        method: String,
+        arguments: Value,
+    },
 }
 
 fn prepare_mcp_centaur_tool_call(
@@ -582,32 +598,41 @@ fn prepare_mcp_centaur_tool_call(
     let method = params.method.trim().to_owned();
     let methods = mcp_tool_methods(tool);
     if method == "help" {
-        return mcp_tool_help_result(tool, &methods).map(McpCentaurToolAction::Return);
+        return mcp_tool_help_result(tool, &methods).map(|result| McpCentaurToolAction::Return {
+            result,
+            method: Some(method),
+        });
     }
     if !methods.iter().any(|candidate| candidate.name == method) {
-        return Ok(McpCentaurToolAction::Return(mcp_text_result(
-            format!(
-                "centaur tool {} has no method {method}. Available methods: {}",
-                tool.name,
-                methods
-                    .iter()
-                    .map(|method| method.signature.as_str())
-                    .collect::<Vec<_>>()
-                    .join(", ")
+        return Ok(McpCentaurToolAction::Return {
+            result: mcp_text_result(
+                format!(
+                    "centaur tool {} has no method {method}. Available methods: {}",
+                    tool.name,
+                    methods
+                        .iter()
+                        .map(|method| method.signature.as_str())
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                ),
+                true,
             ),
-            true,
-        )));
+            method: None,
+        });
     }
     let arguments = match normalize_centaur_tool_arguments(params.arguments) {
         Ok(arguments) => arguments,
         Err(kind) => {
-            return Ok(McpCentaurToolAction::Return(mcp_text_result(
-                format!(
-                    "centaur tool {}.{method} arguments must be an object; got {kind}",
-                    tool.name
+            return Ok(McpCentaurToolAction::Return {
+                result: mcp_text_result(
+                    format!(
+                        "centaur tool {}.{method} arguments must be an object; got {kind}",
+                        tool.name
+                    ),
+                    true,
                 ),
-                true,
-            )));
+                method: Some(method),
+            });
         }
     };
     Ok(McpCentaurToolAction::Run { method, arguments })
@@ -646,7 +671,7 @@ async fn run_tool_host_centaur_tool(
     arguments: Value,
     policy: ToolHostCallPolicy,
 ) -> Result<McpToolCallOutcome, ApiError> {
-    let output = runtime
+    let output = match runtime
         .run_tool_host_call(
             ToolHostCallInput {
                 principal_id: principal.principal_id.clone(),
@@ -660,30 +685,39 @@ async fn run_tool_host_centaur_tool(
             },
             policy,
         )
-        .await?;
+        .await
+    {
+        Ok(output) => output,
+        Err(error) => {
+            record_mcp_tool_correlation(
+                &Span::current(),
+                error.request_id(),
+                error.execution_id(),
+                error.sandbox_id(),
+            );
+            return Err(error.into_source().into());
+        }
+    };
     let span = Span::current();
-    span.record("centaur.execution_id", output.execution_id.as_str());
-    span.record(
-        "lmnr.association.properties.metadata.execution_id",
-        output.execution_id.as_str(),
+    record_mcp_tool_correlation(
+        &span,
+        Some(&output.request_id),
+        Some(&output.execution_id),
+        Some(&output.sandbox_id),
     );
-    span.record(
-        "lmnr.association.properties.metadata.request_id",
-        output.request_id.as_str(),
-    );
-    if !output.sandbox_id.is_empty() {
-        span.record("centaur.sandbox_id", output.sandbox_id.as_str());
-    }
     if output.timed_out {
-        return Ok(McpToolCallOutcome::timed_out(mcp_text_result(
-            format!(
-                "centaur tool {}.{method} timed out in {}: {}",
-                tool.name,
-                tool_host_error_context(&output),
-                output.stderr
+        return Ok(McpToolCallOutcome {
+            result: mcp_text_result(
+                format!(
+                    "centaur tool {}.{method} timed out in {}: {}",
+                    tool.name,
+                    tool_host_error_context(&output),
+                    output.stderr
+                ),
+                true,
             ),
-            true,
-        )));
+            timed_out: true,
+        });
     }
     if output.exit_status != Some(0) {
         let raw = if output.stderr.is_empty() {
@@ -692,37 +726,43 @@ async fn run_tool_host_centaur_tool(
             &output.stderr
         };
         let detail = mcp_tool_failure_detail(raw);
-        return Ok(McpToolCallOutcome::failed(mcp_text_result(
-            format!(
-                "centaur tool {}.{method} failed in {} with status {:?}: {detail}\n\nCall the {} tool with method \"help\" to list available methods and their signatures.",
-                tool.name,
-                tool_host_error_context(&output),
-                output.exit_status,
-                tool.name
+        return Ok(McpToolCallOutcome {
+            result: mcp_text_result(
+                format!(
+                    "centaur tool {}.{method} failed in {} with status {:?}: {detail}\n\nCall the {} tool with method \"help\" to list available methods and their signatures.",
+                    tool.name,
+                    tool_host_error_context(&output),
+                    output.exit_status,
+                    tool.name
+                ),
+                true,
             ),
-            true,
-        )));
+            timed_out: false,
+        });
     }
     let stdout = output.stdout.trim();
     if stdout.is_empty() {
-        return Ok(McpToolCallOutcome::completed(mcp_text_result(
-            "null".to_owned(),
-            false,
-        )));
+        return Ok(McpToolCallOutcome {
+            result: mcp_text_result("null".to_owned(), false),
+            timed_out: false,
+        });
     }
     match serde_json::from_str::<Value>(stdout) {
-        Ok(value) => Ok(McpToolCallOutcome::completed(mcp_text_result(
-            serde_json::to_string_pretty(&value)?,
-            false,
-        ))),
-        Err(error) => Ok(McpToolCallOutcome::failed(mcp_text_result(
-            format!(
-                "centaur tool {}.{method} returned non-json output in {}: {error}: {stdout}",
-                tool.name,
-                tool_host_error_context(&output)
+        Ok(value) => Ok(McpToolCallOutcome {
+            result: mcp_text_result(serde_json::to_string_pretty(&value)?, false),
+            timed_out: false,
+        }),
+        Err(error) => Ok(McpToolCallOutcome {
+            result: mcp_text_result(
+                format!(
+                    "centaur tool {}.{method} returned non-json output in {}: {error}: {stdout}",
+                    tool.name,
+                    tool_host_error_context(&output)
+                ),
+                true,
             ),
-            true,
-        ))),
+            timed_out: false,
+        }),
     }
 }
 
@@ -1173,28 +1213,18 @@ mod mcp_tests {
     }
 
     #[test]
-    fn mcp_tool_trace_input_excludes_call_arguments() {
-        let params = McpToolCallParams {
-            name: "demo".to_owned(),
-            arguments: json!({
-                "method": "search",
-                "arguments": {"query": "private search text"},
-            }),
-        };
-
-        let method = mcp_tool_trace_method(&params);
-        let input = mcp_tool_trace_input(&params.name, &method);
+    fn mcp_tool_trace_input_contains_only_validated_labels() {
+        let input = mcp_tool_trace_input("demo", "search");
 
         assert_eq!(
             serde_json::from_str::<Value>(&input).unwrap(),
-            json!({"kind": "mcp", "name": "demo", "method": "search"})
+            json!({"kind": "centaur", "name": "demo", "method": "search"})
         );
-        assert!(!input.contains("private search text"));
     }
 
-    fn returned_tool_action(action: McpCentaurToolAction) -> Value {
+    fn returned_tool_action(action: McpCentaurToolAction) -> (Value, Option<String>) {
         match action {
-            McpCentaurToolAction::Return(result) => result,
+            McpCentaurToolAction::Return { result, method } => (result, method),
             McpCentaurToolAction::Run { .. } => panic!("expected a local tool result"),
         }
     }
@@ -1350,11 +1380,12 @@ def search(query, limit=20):
         .unwrap();
 
         let tool = test_tool(temp.clone());
-        let result = returned_tool_action(
+        let (result, method) = returned_tool_action(
             prepare_mcp_centaur_tool_call(&tool, json!({"method": "missing", "arguments": {}}))
                 .unwrap(),
         );
 
+        assert_eq!(method, None);
         assert!(mcp_result_is_error(&result));
         let text = result["content"][0]["text"].as_str().unwrap();
         assert!(text.contains("has no method missing"));
@@ -1370,11 +1401,12 @@ def search(query, limit=20):
         fs::write(temp.join("client.py"), "def _hidden():\n    return None\n").unwrap();
 
         let tool = test_tool(temp.clone());
-        let result = returned_tool_action(
+        let (result, method) = returned_tool_action(
             prepare_mcp_centaur_tool_call(&tool, json!({"method": "missing", "arguments": {}}))
                 .unwrap(),
         );
 
+        assert_eq!(method, None);
         assert!(mcp_result_is_error(&result));
         let text = result["content"][0]["text"].as_str().unwrap();
         assert!(text.contains("has no method missing"));
@@ -1396,7 +1428,7 @@ def search(query, limit=20):
         .unwrap();
 
         let tool = test_tool(temp.clone());
-        let result = returned_tool_action(
+        let (result, method) = returned_tool_action(
             prepare_mcp_centaur_tool_call(
                 &tool,
                 json!({"method": "search", "arguments": ["not", "an", "object"]}),
@@ -1404,6 +1436,7 @@ def search(query, limit=20):
             .unwrap(),
         );
 
+        assert_eq!(method.as_deref(), Some("search"));
         assert!(mcp_result_is_error(&result));
         let text = result["content"][0]["text"].as_str().unwrap();
         assert!(text.contains("arguments must be an object"));

--- a/services/api-rs/crates/centaur-api-server/src/mcp.rs
+++ b/services/api-rs/crates/centaur-api-server/src/mcp.rs
@@ -21,6 +21,7 @@ use serde::Deserialize;
 use serde_json::{Value, json};
 use sha2::{Digest, Sha256};
 use time::OffsetDateTime;
+use tracing::{Instrument as _, Span, info_span};
 
 use crate::{
     ApiError,
@@ -74,6 +75,34 @@ struct CentaurToolMcpArguments {
     method: String,
     #[serde(default)]
     arguments: Value,
+}
+
+struct McpToolCallOutcome {
+    result: Value,
+    status: &'static str,
+}
+
+impl McpToolCallOutcome {
+    fn completed(result: Value) -> Self {
+        Self {
+            result,
+            status: "completed",
+        }
+    }
+
+    fn failed(result: Value) -> Self {
+        Self {
+            result,
+            status: "failed",
+        }
+    }
+
+    fn timed_out(result: Value) -> Self {
+        Self {
+            result,
+            status: "timed_out",
+        }
+    }
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -134,16 +163,17 @@ pub(crate) async fn mcp_post(
             ensure_mcp_scope(&principal.scopes, "mcp:tools")?;
             let params = serde_json::from_value::<McpToolCallParams>(request.params.clone())
                 .map_err(|error| ApiError::BadRequest(error.to_string()))?;
-            if params.name == "centaur_whoami" {
-                mcp_whoami_result(&principal, params.arguments)?
+            let tool = if params.name == "centaur_whoami" {
+                None
             } else {
                 let policy = mcp_tool_host_call_policy(&state, &principal).await?;
                 let filter = parse_sandbox_tool_filter(policy.tool_filter());
                 let Some(tool) = mcp_find_centaur_tool(&params.name, &filter)? else {
                     return Ok(mcp_json_error(id, -32602, "unknown tool"));
                 };
-                mcp_centaur_tool_result(&state, &principal, tool, params.arguments, policy).await?
-            }
+                Some((tool, policy))
+            };
+            mcp_tool_call_result(&state, &principal, params, tool).await?
         }
         _ => return Ok(mcp_json_error(id, -32601, "method not found")),
     };
@@ -154,6 +184,87 @@ pub(crate) async fn mcp_post(
         "result": result,
     }))
     .into_response())
+}
+
+async fn mcp_tool_call_result(
+    state: &AppState,
+    principal: &McpPrincipal,
+    params: McpToolCallParams,
+    tool: Option<(DiscoveredTool, ToolHostCallPolicy)>,
+) -> Result<Value, ApiError> {
+    let method = mcp_tool_trace_method(&params);
+    let thread_key = format!("mcp:{}", principal.principal_id);
+    let span_input = mcp_tool_trace_input(&params.name, &method);
+    let span = info_span!(
+        parent: None,
+        "centaur.api_rs.mcp.tool",
+        component = "mcp",
+        event = "mcp_tool_call",
+        "lmnr.span.type" = "TOOL",
+        "lmnr.span.input" = span_input,
+        "lmnr.span.output" = tracing::field::Empty,
+        "lmnr.association.properties.session_id" = thread_key.as_str(),
+        "lmnr.association.properties.metadata.thread_key" = thread_key.as_str(),
+        "lmnr.association.properties.metadata.execution_id" = tracing::field::Empty,
+        "lmnr.association.properties.metadata.request_id" = tracing::field::Empty,
+        "otel.status_code" = tracing::field::Empty,
+        "centaur.thread_key" = thread_key.as_str(),
+        "centaur.execution_id" = tracing::field::Empty,
+        "centaur.sandbox_id" = tracing::field::Empty,
+        "tool.kind" = "mcp",
+        "tool.name" = params.name.as_str(),
+        "tool.method" = method.as_str(),
+        "tool.status" = tracing::field::Empty,
+    );
+
+    async move {
+        let outcome = if let Some((tool, policy)) = tool {
+            mcp_centaur_tool_result(state, principal, tool, params.arguments, policy).await
+        } else {
+            mcp_whoami_result(principal, params.arguments).map(McpToolCallOutcome::completed)
+        };
+        match outcome {
+            Ok(outcome) => {
+                finish_mcp_tool_span(&Span::current(), outcome.status);
+                Ok(outcome.result)
+            }
+            Err(error) => {
+                finish_mcp_tool_span(&Span::current(), "failed");
+                Err(error)
+            }
+        }
+    }
+    .instrument(span)
+    .await
+}
+
+fn mcp_tool_trace_method(params: &McpToolCallParams) -> String {
+    params
+        .arguments
+        .get("method")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|method| !method.is_empty())
+        .unwrap_or("call")
+        .to_owned()
+}
+
+fn mcp_tool_trace_input(name: &str, method: &str) -> String {
+    json!({
+        "kind": "mcp",
+        "name": name,
+        "method": method,
+    })
+    .to_string()
+}
+
+fn finish_mcp_tool_span(span: &Span, status: &str) {
+    span.record("tool.status", status);
+    span.record("lmnr.span.output", json!({ "status": status }).to_string());
+    span.record(
+        "otel.status_code",
+        if status == "completed" { "OK" } else { "ERROR" },
+    );
 }
 
 fn mcp_whoami_tool() -> Value {
@@ -433,9 +544,13 @@ async fn mcp_centaur_tool_result(
     tool: DiscoveredTool,
     arguments: Value,
     policy: ToolHostCallPolicy,
-) -> Result<Value, ApiError> {
+) -> Result<McpToolCallOutcome, ApiError> {
     match prepare_mcp_centaur_tool_call(&tool, arguments)? {
-        McpCentaurToolAction::Return(result) => Ok(result),
+        McpCentaurToolAction::Return(result) => Ok(if mcp_result_is_error(&result) {
+            McpToolCallOutcome::failed(result)
+        } else {
+            McpToolCallOutcome::completed(result)
+        }),
         McpCentaurToolAction::Run { method, arguments } => {
             run_tool_host_centaur_tool(
                 state.runtime()?,
@@ -498,6 +613,10 @@ fn prepare_mcp_centaur_tool_call(
     Ok(McpCentaurToolAction::Run { method, arguments })
 }
 
+fn mcp_result_is_error(result: &Value) -> bool {
+    result.get("isError").and_then(Value::as_bool) == Some(true)
+}
+
 fn normalize_centaur_tool_arguments(arguments: Value) -> Result<Value, &'static str> {
     if arguments.is_null() {
         return Ok(json!({}));
@@ -526,7 +645,7 @@ async fn run_tool_host_centaur_tool(
     method: &str,
     arguments: Value,
     policy: ToolHostCallPolicy,
-) -> Result<Value, ApiError> {
+) -> Result<McpToolCallOutcome, ApiError> {
     let output = runtime
         .run_tool_host_call(
             ToolHostCallInput {
@@ -542,8 +661,21 @@ async fn run_tool_host_centaur_tool(
             policy,
         )
         .await?;
+    let span = Span::current();
+    span.record("centaur.execution_id", output.execution_id.as_str());
+    span.record(
+        "lmnr.association.properties.metadata.execution_id",
+        output.execution_id.as_str(),
+    );
+    span.record(
+        "lmnr.association.properties.metadata.request_id",
+        output.request_id.as_str(),
+    );
+    if !output.sandbox_id.is_empty() {
+        span.record("centaur.sandbox_id", output.sandbox_id.as_str());
+    }
     if output.timed_out {
-        return Ok(mcp_text_result(
+        return Ok(McpToolCallOutcome::timed_out(mcp_text_result(
             format!(
                 "centaur tool {}.{method} timed out in {}: {}",
                 tool.name,
@@ -551,7 +683,7 @@ async fn run_tool_host_centaur_tool(
                 output.stderr
             ),
             true,
-        ));
+        )));
     }
     if output.exit_status != Some(0) {
         let raw = if output.stderr.is_empty() {
@@ -560,7 +692,7 @@ async fn run_tool_host_centaur_tool(
             &output.stderr
         };
         let detail = mcp_tool_failure_detail(raw);
-        return Ok(mcp_text_result(
+        return Ok(McpToolCallOutcome::failed(mcp_text_result(
             format!(
                 "centaur tool {}.{method} failed in {} with status {:?}: {detail}\n\nCall the {} tool with method \"help\" to list available methods and their signatures.",
                 tool.name,
@@ -569,25 +701,28 @@ async fn run_tool_host_centaur_tool(
                 tool.name
             ),
             true,
-        ));
+        )));
     }
     let stdout = output.stdout.trim();
     if stdout.is_empty() {
-        return Ok(mcp_text_result("null".to_owned(), false));
+        return Ok(McpToolCallOutcome::completed(mcp_text_result(
+            "null".to_owned(),
+            false,
+        )));
     }
     match serde_json::from_str::<Value>(stdout) {
-        Ok(value) => Ok(mcp_text_result(
+        Ok(value) => Ok(McpToolCallOutcome::completed(mcp_text_result(
             serde_json::to_string_pretty(&value)?,
             false,
-        )),
-        Err(error) => Ok(mcp_text_result(
+        ))),
+        Err(error) => Ok(McpToolCallOutcome::failed(mcp_text_result(
             format!(
                 "centaur tool {}.{method} returned non-json output in {}: {error}: {stdout}",
                 tool.name,
                 tool_host_error_context(&output)
             ),
             true,
-        )),
+        ))),
     }
 }
 
@@ -1037,6 +1172,26 @@ mod mcp_tests {
         }
     }
 
+    #[test]
+    fn mcp_tool_trace_input_excludes_call_arguments() {
+        let params = McpToolCallParams {
+            name: "demo".to_owned(),
+            arguments: json!({
+                "method": "search",
+                "arguments": {"query": "private search text"},
+            }),
+        };
+
+        let method = mcp_tool_trace_method(&params);
+        let input = mcp_tool_trace_input(&params.name, &method);
+
+        assert_eq!(
+            serde_json::from_str::<Value>(&input).unwrap(),
+            json!({"kind": "mcp", "name": "demo", "method": "search"})
+        );
+        assert!(!input.contains("private search text"));
+    }
+
     fn returned_tool_action(action: McpCentaurToolAction) -> Value {
         match action {
             McpCentaurToolAction::Return(result) => result,
@@ -1200,7 +1355,7 @@ def search(query, limit=20):
                 .unwrap(),
         );
 
-        assert_eq!(result["isError"], true);
+        assert!(mcp_result_is_error(&result));
         let text = result["content"][0]["text"].as_str().unwrap();
         assert!(text.contains("has no method missing"));
         assert!(text.contains("search"));
@@ -1220,7 +1375,7 @@ def search(query, limit=20):
                 .unwrap(),
         );
 
-        assert_eq!(result["isError"], true);
+        assert!(mcp_result_is_error(&result));
         let text = result["content"][0]["text"].as_str().unwrap();
         assert!(text.contains("has no method missing"));
 
@@ -1249,7 +1404,7 @@ def search(query, limit=20):
             .unwrap(),
         );
 
-        assert_eq!(result["isError"], true);
+        assert!(mcp_result_is_error(&result));
         let text = result["content"][0]["text"].as_str().unwrap();
         assert!(text.contains("arguments must be an object"));
         assert!(text.contains("demo.search"));

--- a/services/api-rs/crates/centaur-session-runtime/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-runtime/src/lib.rs
@@ -423,7 +423,7 @@ pub struct ToolHostCallError {
     execution_id: Option<String>,
     sandbox_id: Option<String>,
     #[source]
-    source: SessionRuntimeError,
+    source: Box<SessionRuntimeError>,
 }
 
 impl ToolHostCallError {
@@ -432,7 +432,7 @@ impl ToolHostCallError {
             request_id: None,
             execution_id: None,
             sandbox_id: None,
-            source,
+            source: Box::new(source),
         }
     }
 
@@ -441,7 +441,7 @@ impl ToolHostCallError {
             request_id: Some(request_id.to_owned()),
             execution_id: None,
             sandbox_id: None,
-            source,
+            source: Box::new(source),
         }
     }
 
@@ -458,7 +458,7 @@ impl ToolHostCallError {
     }
 
     pub fn into_source(self) -> SessionRuntimeError {
-        self.source
+        *self.source
     }
 }
 
@@ -1242,7 +1242,7 @@ impl SessionRuntime {
             request_id: Some(request_id.to_owned()),
             execution_id,
             sandbox_id,
-            source,
+            source: Box::new(source),
         }
     }
 
@@ -7478,7 +7478,9 @@ mod tests {
             request_id: Some("mcp-call-123".to_owned()),
             execution_id: Some("exe-456".to_owned()),
             sandbox_id: Some("sbx-789".to_owned()),
-            source: SessionRuntimeError::Sandbox(SandboxError::io("stream failed")),
+            source: Box::new(SessionRuntimeError::Sandbox(SandboxError::io(
+                "stream failed",
+            ))),
         };
 
         assert_eq!(error.request_id(), Some("mcp-call-123"));

--- a/services/api-rs/crates/centaur-session-runtime/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-runtime/src/lib.rs
@@ -7482,26 +7482,6 @@ mod tests {
     }
 
     #[test]
-    fn tool_host_call_error_preserves_execution_correlation() {
-        let error = ToolHostCallError {
-            request_id: Some("mcp-call-123".to_owned()),
-            execution_id: Some("exe-456".to_owned()),
-            sandbox_id: Some("sbx-789".to_owned()),
-            source: Box::new(SessionRuntimeError::Sandbox(SandboxError::io(
-                "stream failed",
-            ))),
-        };
-
-        assert_eq!(error.request_id(), Some("mcp-call-123"));
-        assert_eq!(error.execution_id(), Some("exe-456"));
-        assert_eq!(error.sandbox_id(), Some("sbx-789"));
-        assert!(matches!(
-            error.into_source(),
-            SessionRuntimeError::Sandbox(SandboxError::Io { .. })
-        ));
-    }
-
-    #[test]
     fn tool_host_session_metadata_includes_console_identity() {
         assert_eq!(
             tool_host_session_metadata("prn_test", Some(" test@example.com "), Some(" Test User "),),

--- a/services/api-rs/crates/centaur-session-runtime/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-runtime/src/lib.rs
@@ -416,6 +416,58 @@ pub struct ToolHostCallOutput {
     pub timed_out: bool,
 }
 
+#[derive(Debug, Error)]
+#[error("{source}")]
+pub struct ToolHostCallError {
+    request_id: Option<String>,
+    execution_id: Option<String>,
+    sandbox_id: Option<String>,
+    #[source]
+    source: SessionRuntimeError,
+}
+
+impl ToolHostCallError {
+    fn new(source: SessionRuntimeError) -> Self {
+        Self {
+            request_id: None,
+            execution_id: None,
+            sandbox_id: None,
+            source,
+        }
+    }
+
+    fn with_request(source: SessionRuntimeError, request_id: &str) -> Self {
+        Self {
+            request_id: Some(request_id.to_owned()),
+            execution_id: None,
+            sandbox_id: None,
+            source,
+        }
+    }
+
+    pub fn request_id(&self) -> Option<&str> {
+        self.request_id.as_deref()
+    }
+
+    pub fn execution_id(&self) -> Option<&str> {
+        self.execution_id.as_deref()
+    }
+
+    pub fn sandbox_id(&self) -> Option<&str> {
+        self.sandbox_id.as_deref()
+    }
+
+    pub fn into_source(self) -> SessionRuntimeError {
+        self.source
+    }
+}
+
+impl From<SessionRuntimeError> for ToolHostCallError {
+    fn from(source: SessionRuntimeError) -> Self {
+        Self::new(source)
+    }
+}
+
 #[derive(Clone)]
 struct SessionPipe {
     stdin: Arc<Mutex<SessionInputSink>>,
@@ -974,34 +1026,38 @@ impl SessionRuntime {
         &self,
         input: ToolHostCallInput,
         policy: ToolHostCallPolicy,
-    ) -> Result<ToolHostCallOutput, SessionRuntimeError> {
+    ) -> Result<ToolHostCallOutput, ToolHostCallError> {
         let principal_id = input.principal_id.trim().to_owned();
         let tool_name = input.tool_name.trim().to_owned();
         let method = input.method.trim().to_owned();
         if principal_id.is_empty() {
             return Err(SessionRuntimeError::BadRequest(
                 "tool host principal_id is required".to_owned(),
-            ));
+            )
+            .into());
         }
         if tool_name.is_empty() {
             return Err(SessionRuntimeError::BadRequest(
                 "tool host tool_name is required".to_owned(),
-            ));
+            )
+            .into());
         }
         if method.is_empty() {
-            return Err(SessionRuntimeError::BadRequest(
-                "tool host method is required".to_owned(),
-            ));
+            return Err(
+                SessionRuntimeError::BadRequest("tool host method is required".to_owned()).into(),
+            );
         }
         if input.timeout.is_zero() {
             return Err(SessionRuntimeError::BadRequest(
                 "tool host timeout must be non-zero".to_owned(),
-            ));
+            )
+            .into());
         }
         if policy.principal_id != principal_id {
             return Err(SessionRuntimeError::BadRequest(
                 "tool host policy principal does not match the call principal".to_owned(),
-            ));
+            )
+            .into());
         }
 
         let thread_key = tool_host_thread_key(&principal_id)?;
@@ -1068,7 +1124,7 @@ impl SessionRuntime {
         thread_key: &ThreadKey,
         input: ToolHostCallInput,
         sandbox_capabilities: SessionSandboxCapabilities,
-    ) -> Result<ToolHostCallOutput, SessionRuntimeError> {
+    ) -> Result<ToolHostCallOutput, ToolHostCallError> {
         let ToolHostCallInput {
             principal_id,
             console_user_email,
@@ -1097,9 +1153,14 @@ impl SessionRuntime {
             token_id,
             timeout_seconds: timeout.as_secs().max(1),
         };
-        let input_line = serde_json::to_string(&request).map_err(|error| {
-            SessionRuntimeError::Sandbox(SandboxError::io_source("encode tool host request", error))
-        })?;
+        let input_line = serde_json::to_string(&request)
+            .map_err(|error| {
+                SessionRuntimeError::Sandbox(SandboxError::io_source(
+                    "encode tool host request",
+                    error,
+                ))
+            })
+            .map_err(|error| ToolHostCallError::with_request(error, &request_id))?;
         let response_timeout = timeout.saturating_add(Duration::from_secs(5));
         let execution_metadata = tool_host_execution_metadata(
             &request_id,
@@ -1108,7 +1169,7 @@ impl SessionRuntime {
             timeout,
             centaur_telemetry::traceparent_for_span(&Span::current()),
         );
-        let execution = self
+        let execution = match self
             .execute_session_impl(
                 thread_key,
                 ExecuteSessionInput {
@@ -1121,14 +1182,68 @@ impl SessionRuntime {
                 None,
                 Some(sandbox_capabilities),
             )
-            .await?;
-        self.wait_for_tool_host_call(
-            thread_key,
-            &execution.execution_id,
-            &request_id,
-            response_timeout,
-        )
-        .await
+            .await
+        {
+            Ok(execution) => execution,
+            Err(error) => {
+                return Err(self
+                    .correlate_tool_host_call_error(thread_key, &request_id, None, error)
+                    .await);
+            }
+        };
+        let result = self
+            .wait_for_tool_host_call(
+                thread_key,
+                &execution.execution_id,
+                &request_id,
+                response_timeout,
+            )
+            .await;
+        match result {
+            Ok(output) => Ok(output),
+            Err(error) => Err(self
+                .correlate_tool_host_call_error(
+                    thread_key,
+                    &request_id,
+                    Some(&execution.execution_id),
+                    error,
+                )
+                .await),
+        }
+    }
+
+    async fn correlate_tool_host_call_error(
+        &self,
+        thread_key: &ThreadKey,
+        request_id: &str,
+        execution_id: Option<&str>,
+        source: SessionRuntimeError,
+    ) -> ToolHostCallError {
+        let execution_id = match execution_id {
+            Some(execution_id) => Some(execution_id.to_owned()),
+            None => self
+                .store
+                .latest_execution_for_thread(thread_key)
+                .await
+                .ok()
+                .flatten()
+                .filter(|execution| execution.idempotency_key.as_deref() == Some(request_id))
+                .map(|execution| execution.execution_id),
+        };
+        let sandbox_id = if execution_id.is_some() {
+            self.current_sandbox_id(thread_key)
+                .await
+                .ok()
+                .filter(|sandbox_id| !sandbox_id.is_empty())
+        } else {
+            None
+        };
+        ToolHostCallError {
+            request_id: Some(request_id.to_owned()),
+            execution_id,
+            sandbox_id,
+            source,
+        }
     }
 
     async fn create_or_get_tool_host_session(
@@ -6785,8 +6900,8 @@ fn nonzero_duration_millis(value: u64) -> Result<Duration, SessionRuntimeError> 
     Ok(Duration::from_millis(value))
 }
 
-fn tool_host_thread_key(principal_id: &str) -> Result<ThreadKey, SessionRuntimeError> {
-    ThreadKey::parse(format!("mcp:{principal_id}"))
+pub fn tool_host_thread_key(principal_id: &str) -> Result<ThreadKey, SessionRuntimeError> {
+    ThreadKey::parse(format!("mcp:{}", principal_id.trim()))
         .map_err(|error| SessionRuntimeError::BadRequest(error.to_string()))
 }
 
@@ -6797,22 +6912,25 @@ fn tool_host_execution_metadata(
     timeout: Duration,
     traceparent: Option<String>,
 ) -> Value {
-    let mut metadata = json!({
-        "mcp_tool_host_call": true,
-        "request_id": request_id,
-        "tool": tool_name,
-        "method": method,
-        "timeout_ms": duration_millis_u64(timeout),
-    });
-    if let Some(traceparent) = traceparent
-        && let Some(metadata) = metadata.as_object_mut()
-    {
-        metadata.insert(
-            EXECUTION_TRACEPARENT_METADATA_KEY.to_owned(),
-            Value::String(traceparent),
-        );
-    }
-    metadata
+    let mut metadata = serde_json::Map::from_iter([
+        ("mcp_tool_host_call".to_owned(), Value::Bool(true)),
+        (
+            "request_id".to_owned(),
+            Value::String(request_id.to_owned()),
+        ),
+        ("tool".to_owned(), Value::String(tool_name.to_owned())),
+        ("method".to_owned(), Value::String(method.to_owned())),
+        (
+            "timeout_ms".to_owned(),
+            Value::Number(duration_millis_u64(timeout).into()),
+        ),
+    ]);
+    insert_non_empty_metadata_string(
+        &mut metadata,
+        EXECUTION_TRACEPARENT_METADATA_KEY,
+        traceparent.as_deref(),
+    );
+    Value::Object(metadata)
 }
 
 /// Session/principal metadata recorded for observability; runtime behavior
@@ -7344,6 +7462,32 @@ mod tests {
         assert_eq!(metadata["tool"], "search");
         assert_eq!(metadata["method"], "query");
         assert_eq!(metadata["timeout_ms"], 120_000);
+    }
+
+    #[test]
+    fn tool_host_thread_key_trims_principal_id() {
+        assert_eq!(
+            tool_host_thread_key(" prn_test ").unwrap().as_str(),
+            "mcp:prn_test"
+        );
+    }
+
+    #[test]
+    fn tool_host_call_error_preserves_execution_correlation() {
+        let error = ToolHostCallError {
+            request_id: Some("mcp-call-123".to_owned()),
+            execution_id: Some("exe-456".to_owned()),
+            sandbox_id: Some("sbx-789".to_owned()),
+            source: SessionRuntimeError::Sandbox(SandboxError::io("stream failed")),
+        };
+
+        assert_eq!(error.request_id(), Some("mcp-call-123"));
+        assert_eq!(error.execution_id(), Some("exe-456"));
+        assert_eq!(error.sandbox_id(), Some("sbx-789"));
+        assert!(matches!(
+            error.into_source(),
+            SessionRuntimeError::Sandbox(SandboxError::Io { .. })
+        ));
     }
 
     #[test]

--- a/services/api-rs/crates/centaur-session-runtime/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-runtime/src/lib.rs
@@ -1101,18 +1101,19 @@ impl SessionRuntime {
             SessionRuntimeError::Sandbox(SandboxError::io_source("encode tool host request", error))
         })?;
         let response_timeout = timeout.saturating_add(Duration::from_secs(5));
+        let execution_metadata = tool_host_execution_metadata(
+            &request_id,
+            &tool_name,
+            &method,
+            timeout,
+            centaur_telemetry::traceparent_for_span(&Span::current()),
+        );
         let execution = self
             .execute_session_impl(
                 thread_key,
                 ExecuteSessionInput {
                     idempotency_key: Some(request_id.clone()),
-                    metadata: Some(json!({
-                        "mcp_tool_host_call": true,
-                        "request_id": request_id.clone(),
-                        "tool": tool_name,
-                        "method": method,
-                        "timeout_ms": duration_millis_u64(timeout),
-                    })),
+                    metadata: Some(execution_metadata),
                     input_lines: vec![input_line],
                     idle_timeout_ms: None,
                     max_duration_ms: Some(duration_millis_u64(response_timeout)),
@@ -6789,6 +6790,31 @@ fn tool_host_thread_key(principal_id: &str) -> Result<ThreadKey, SessionRuntimeE
         .map_err(|error| SessionRuntimeError::BadRequest(error.to_string()))
 }
 
+fn tool_host_execution_metadata(
+    request_id: &str,
+    tool_name: &str,
+    method: &str,
+    timeout: Duration,
+    traceparent: Option<String>,
+) -> Value {
+    let mut metadata = json!({
+        "mcp_tool_host_call": true,
+        "request_id": request_id,
+        "tool": tool_name,
+        "method": method,
+        "timeout_ms": duration_millis_u64(timeout),
+    });
+    if let Some(traceparent) = traceparent
+        && let Some(metadata) = metadata.as_object_mut()
+    {
+        metadata.insert(
+            EXECUTION_TRACEPARENT_METADATA_KEY.to_owned(),
+            Value::String(traceparent),
+        );
+    }
+    metadata
+}
+
 /// Session/principal metadata recorded for observability; runtime behavior
 /// derives from the `mcp:` thread-key prefix, not from these fields.
 fn tool_host_session_metadata(
@@ -7299,6 +7325,25 @@ mod tests {
         assert_eq!(spec.command, Some(vec!["/entrypoint.sh".to_owned()]));
         assert_eq!(spec.args, vec!["centaur-tool-host"]);
         assert_eq!(env_value(&spec, "TOOL_DIRS"), Some("/app/tools"));
+    }
+
+    #[test]
+    fn tool_host_execution_metadata_propagates_tool_traceparent() {
+        let traceparent = "00-0123456789abcdef0123456789abcdef-1111111111111111-01";
+
+        let metadata = tool_host_execution_metadata(
+            "mcp-call-123",
+            "search",
+            "query",
+            Duration::from_secs(120),
+            Some(traceparent.to_owned()),
+        );
+
+        assert_eq!(metadata[EXECUTION_TRACEPARENT_METADATA_KEY], traceparent);
+        assert_eq!(metadata["request_id"], "mcp-call-123");
+        assert_eq!(metadata["tool"], "search");
+        assert_eq!(metadata["method"], "query");
+        assert_eq!(metadata["timeout_ms"], 120_000);
     }
 
     #[test]

--- a/services/api-rs/crates/centaur-session-runtime/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-runtime/src/lib.rs
@@ -2105,6 +2105,7 @@ impl SessionRuntime {
                 "starting session execution"
             );
             let session = self.store.get_session(thread_key).await?;
+            correlation_sandbox_id = session.sandbox_id.clone();
             let harness_label = session.harness_type.to_string();
             validate_input_lines(&input_lines)?;
             let (idle_timeout, max_duration) = duration_options(idle_timeout_ms, max_duration_ms)?;

--- a/services/api-rs/crates/centaur-session-runtime/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-runtime/src/lib.rs
@@ -468,6 +468,35 @@ impl From<SessionRuntimeError> for ToolHostCallError {
     }
 }
 
+struct SessionExecutionAttempt {
+    execution: SessionExecution,
+    sandbox_id: Option<String>,
+}
+
+struct SessionExecutionAttemptError {
+    execution_id: Option<String>,
+    sandbox_id: Option<String>,
+    source: Box<SessionRuntimeError>,
+}
+
+impl SessionExecutionAttemptError {
+    fn new(
+        execution_id: Option<String>,
+        sandbox_id: Option<String>,
+        source: SessionRuntimeError,
+    ) -> Self {
+        Self {
+            execution_id,
+            sandbox_id,
+            source: Box::new(source),
+        }
+    }
+
+    fn into_source(self) -> SessionRuntimeError {
+        *self.source
+    }
+}
+
 #[derive(Clone)]
 struct SessionPipe {
     stdin: Arc<Mutex<SessionInputSink>>,
@@ -1169,7 +1198,7 @@ impl SessionRuntime {
             timeout,
             centaur_telemetry::traceparent_for_span(&Span::current()),
         );
-        let execution = match self
+        let attempt = match self
             .execute_session_impl(
                 thread_key,
                 ExecuteSessionInput {
@@ -1184,65 +1213,34 @@ impl SessionRuntime {
             )
             .await
         {
-            Ok(execution) => execution,
+            Ok(attempt) => attempt,
             Err(error) => {
-                return Err(self
-                    .correlate_tool_host_call_error(thread_key, &request_id, None, error)
-                    .await);
+                return Err(ToolHostCallError {
+                    request_id: Some(request_id),
+                    execution_id: error.execution_id,
+                    sandbox_id: error.sandbox_id,
+                    source: error.source,
+                });
             }
         };
+        let execution_id = attempt.execution.execution_id;
         let result = self
             .wait_for_tool_host_call(
                 thread_key,
-                &execution.execution_id,
+                &execution_id,
                 &request_id,
+                attempt.sandbox_id.as_deref(),
                 response_timeout,
             )
             .await;
         match result {
             Ok(output) => Ok(output),
-            Err(error) => Err(self
-                .correlate_tool_host_call_error(
-                    thread_key,
-                    &request_id,
-                    Some(&execution.execution_id),
-                    error,
-                )
-                .await),
-        }
-    }
-
-    async fn correlate_tool_host_call_error(
-        &self,
-        thread_key: &ThreadKey,
-        request_id: &str,
-        execution_id: Option<&str>,
-        source: SessionRuntimeError,
-    ) -> ToolHostCallError {
-        let execution_id = match execution_id {
-            Some(execution_id) => Some(execution_id.to_owned()),
-            None => self
-                .store
-                .latest_execution_for_thread(thread_key)
-                .await
-                .ok()
-                .flatten()
-                .filter(|execution| execution.idempotency_key.as_deref() == Some(request_id))
-                .map(|execution| execution.execution_id),
-        };
-        let sandbox_id = if execution_id.is_some() {
-            self.current_sandbox_id(thread_key)
-                .await
-                .ok()
-                .filter(|sandbox_id| !sandbox_id.is_empty())
-        } else {
-            None
-        };
-        ToolHostCallError {
-            request_id: Some(request_id.to_owned()),
-            execution_id,
-            sandbox_id,
-            source: Box::new(source),
+            Err(source) => Err(ToolHostCallError {
+                request_id: Some(request_id),
+                execution_id: Some(execution_id),
+                sandbox_id: attempt.sandbox_id,
+                source: Box::new(source),
+            }),
         }
     }
 
@@ -1283,6 +1281,7 @@ impl SessionRuntime {
         thread_key: &ThreadKey,
         execution_id: &str,
         request_id: &str,
+        sandbox_id: Option<&str>,
         response_timeout: Duration,
     ) -> Result<ToolHostCallOutput, SessionRuntimeError> {
         let events = self
@@ -1296,16 +1295,16 @@ impl SessionRuntime {
                     "session.execution_completed" => {
                         return self
                             .tool_host_completed_output(
-                                thread_key,
                                 &event,
                                 execution_id,
                                 request_id,
+                                sandbox_id,
                             )
                             .await;
                     }
                     "session.execution_failed" => {
                         return self
-                            .tool_host_failed_output(thread_key, &event, execution_id, request_id)
+                            .tool_host_failed_output(&event, execution_id, request_id, sandbox_id)
                             .await;
                     }
                     _ => {}
@@ -1318,15 +1317,10 @@ impl SessionRuntime {
         .await
         {
             Ok(output) => output,
-            // Best-effort sandbox id: a store error must not replace the
-            // timeout result with an internal error.
             Err(_) => Ok(ToolHostCallOutput {
                 request_id: request_id.to_owned(),
                 execution_id: execution_id.to_owned(),
-                sandbox_id: self
-                    .current_sandbox_id(thread_key)
-                    .await
-                    .unwrap_or_default(),
+                sandbox_id: sandbox_id.unwrap_or_default().to_owned(),
                 stdout: String::new(),
                 stderr: format!(
                     "tool host call timed out after {} ms",
@@ -1340,12 +1334,12 @@ impl SessionRuntime {
 
     async fn tool_host_completed_output(
         &self,
-        thread_key: &ThreadKey,
         event: &SessionEvent,
         execution_id: &str,
         request_id: &str,
+        sandbox_id: Option<&str>,
     ) -> Result<ToolHostCallOutput, SessionRuntimeError> {
-        let sandbox_id = self.current_sandbox_id(thread_key).await?;
+        let sandbox_id = sandbox_id.unwrap_or_default().to_owned();
         let Some(result_text) = event.payload.get("result_text").and_then(Value::as_str) else {
             return Ok(ToolHostCallOutput {
                 request_id: request_id.to_owned(),
@@ -1376,10 +1370,10 @@ impl SessionRuntime {
 
     async fn tool_host_failed_output(
         &self,
-        thread_key: &ThreadKey,
         event: &SessionEvent,
         execution_id: &str,
         request_id: &str,
+        sandbox_id: Option<&str>,
     ) -> Result<ToolHostCallOutput, SessionRuntimeError> {
         let error = event
             .payload
@@ -1395,24 +1389,12 @@ impl SessionRuntime {
         Ok(ToolHostCallOutput {
             request_id: request_id.to_owned(),
             execution_id: execution_id.to_owned(),
-            sandbox_id: self.current_sandbox_id(thread_key).await?,
+            sandbox_id: sandbox_id.unwrap_or_default().to_owned(),
             stdout: String::new(),
             stderr: error,
             exit_status: None,
             timed_out,
         })
-    }
-
-    async fn current_sandbox_id(
-        &self,
-        thread_key: &ThreadKey,
-    ) -> Result<String, SessionRuntimeError> {
-        Ok(self
-            .store
-            .get_session(thread_key)
-            .await?
-            .sandbox_id
-            .unwrap_or_default())
     }
 
     async fn claim_stdout_owner(&self, execution_id: &str) -> Result<(), SessionRuntimeError> {
@@ -2046,6 +2028,8 @@ impl SessionRuntime {
     ) -> Result<SessionExecution, SessionRuntimeError> {
         self.execute_session_impl(thread_key, input, None, None)
             .await
+            .map(|attempt| attempt.execution)
+            .map_err(SessionExecutionAttemptError::into_source)
     }
 
     async fn drive_session_execution(
@@ -2056,6 +2040,8 @@ impl SessionRuntime {
     ) -> Result<SessionExecution, SessionRuntimeError> {
         self.execute_session_impl(thread_key, input, Some(execution_id), None)
             .await
+            .map(|attempt| attempt.execution)
+            .map_err(SessionExecutionAttemptError::into_source)
     }
 
     async fn execute_session_impl(
@@ -2066,14 +2052,27 @@ impl SessionRuntime {
         // Present only for an immediately dispatched tool-host call. Durable
         // recovery passes None and resolves the principal's current policy.
         pre_resolved_sandbox_capabilities: Option<SessionSandboxCapabilities>,
-    ) -> Result<SessionExecution, SessionRuntimeError> {
+    ) -> Result<SessionExecutionAttempt, SessionExecutionAttemptError> {
+        let mut execution_id = persisted_execution_id.map(str::to_owned);
+        let mut correlation_sandbox_id = None;
         if self.shutting_down.load(Ordering::SeqCst) {
-            return Err(SessionRuntimeError::ShuttingDown);
+            return Err(SessionExecutionAttemptError::new(
+                execution_id,
+                correlation_sandbox_id,
+                SessionRuntimeError::ShuttingDown,
+            ));
         }
         let persisted_request = persisted_execution_id
             .is_none()
             .then(|| persisted_execute_request(&input))
-            .transpose()?;
+            .transpose()
+            .map_err(|source| {
+                SessionExecutionAttemptError::new(
+                    execution_id.clone(),
+                    correlation_sandbox_id.clone(),
+                    source,
+                )
+            })?;
         let ExecuteSessionInput {
             idempotency_key,
             metadata,
@@ -2125,6 +2124,7 @@ impl SessionRuntime {
                         persisted_request.expect("new executions have a persisted request"),
                     )
                     .await?;
+                execution_id = Some(execution.execution.execution_id.clone());
                 span.record(
                     "centaur.execution_id",
                     execution.execution.execution_id.as_str(),
@@ -2146,6 +2146,7 @@ impl SessionRuntime {
                     .await?
             };
             let execution = claim.execution;
+            execution_id = Some(execution.execution_id.clone());
             if execution.thread_key != *thread_key {
                 return Err(SessionRuntimeError::BadRequest(format!(
                     "execution {} belongs to thread {}, not {}",
@@ -2261,6 +2262,7 @@ impl SessionRuntime {
                     return Err(error);
                 }
             };
+            correlation_sandbox_id = Some(sandbox_id.clone());
             span.record("centaur.sandbox_id", sandbox_id.as_str());
             span.record("sandbox_id", sandbox_id.as_str());
             execution_trace_span.record("centaur.sandbox_id", sandbox_id.as_str());
@@ -2336,6 +2338,13 @@ impl SessionRuntime {
             );
         }
         result
+            .map(|execution| SessionExecutionAttempt {
+                execution,
+                sandbox_id: correlation_sandbox_id.clone(),
+            })
+            .map_err(|source| {
+                SessionExecutionAttemptError::new(execution_id, correlation_sandbox_id, source)
+            })
     }
 
     /// Persist an execution request and return before sandbox provisioning or

--- a/services/api-rs/rfcs/0003-telemetry.md
+++ b/services/api-rs/rfcs/0003-telemetry.md
@@ -45,6 +45,11 @@ Prometheus/VictoriaMetrics metrics, and domain spans in the session runtime.
   Codex usage comes from `thread/tokenUsage/updated`; Claude Code and Amp usage
   comes from their normalized harness events. Native harness tracing is not
   enabled, and api-rs does not reconstruct spans from sandbox stdout.
+- Remote MCP `tools/call` telemetry is implemented at the authenticated API
+  boundary. Each accepted call emits a Laminar `TOOL` span with the tool name,
+  method, status, and correlation identifiers. The tool span's trace context is
+  persisted as the parent of the durable tool-host execution. Arguments,
+  results, stdout, and stderr are not exported.
 - The harness OpenTelemetry SDK batches and exports directly to the configured
   OTLP endpoint. There is no collector or loopback OTLP proxy in the sandbox.
   The api-rs process's own OTLP env
@@ -216,6 +221,7 @@ Initial span set:
 | `centaur.api_rs.sandbox.write_input` | `centaur-session-runtime` |
 | `centaur.api_rs.session.stdout_pump` | `centaur-session-runtime` |
 | `centaur.api_rs.session.events.stream` | `centaur-session-runtime` |
+| `centaur.api_rs.mcp.tool` | `centaur-api-server` |
 | `<harness>.session_task.turn` | `harness-server` |
 | `<harness>.tool.<name>` | `harness-server` |
 
@@ -269,6 +275,11 @@ not a reconstructed model-call tree. Every harness span carries the Laminar
 session association and execution metadata. Tool state is scoped to one turn;
 finishing, failing, cancelling, or dropping the turn closes any unfinished tool
 spans.
+
+Remote MCP calls have no harness turn. The API creates a root `TOOL` span for
+the accepted `tools/call` and uses its `traceparent` when creating the durable
+tool-host execution. This keeps sandbox lifecycle work in the same trace while
+grouping calls by the stable `mcp:<principal_id>` Laminar session association.
 
 ## Implementation Plan
 

--- a/services/api-rs/rfcs/0003-telemetry.md
+++ b/services/api-rs/rfcs/0003-telemetry.md
@@ -46,10 +46,11 @@ Prometheus/VictoriaMetrics metrics, and domain spans in the session runtime.
   comes from their normalized harness events. Native harness tracing is not
   enabled, and api-rs does not reconstruct spans from sandbox stdout.
 - Remote MCP `tools/call` telemetry is implemented at the authenticated API
-  boundary. Each accepted call emits a Laminar `TOOL` span with the tool name,
-  method, status, and correlation identifiers. The tool span's trace context is
-  persisted as the parent of the durable tool-host execution. Arguments,
-  results, stdout, and stderr are not exported.
+  boundary. Each accepted call emits a Laminar `TOOL` span with Centaur tool
+  kind, MCP entry point, validated method, status, and correlation identifiers.
+  Correlation identifiers are retained when the durable execution fails. The
+  tool span's trace context is persisted as the parent of the durable tool-host
+  execution. Arguments, results, stdout, and stderr are not exported.
 - The harness OpenTelemetry SDK batches and exports directly to the configured
   OTLP endpoint. There is no collector or loopback OTLP proxy in the sandbox.
   The api-rs process's own OTLP env
@@ -246,6 +247,7 @@ Spans may carry:
 - `tool.command`
 - `tool.cwd`
 - `tool.status`
+- `centaur.tool.entry_point`
 
 Tool spans must not carry command output, tool results, or prompt content.
 Bounded shell commands, including their arguments, workspace-relative working


### PR DESCRIPTION
Adds Laminar TOOL spans around authenticated remote MCP tool calls and correlates them with durable tool-host executions. The trace records bounded identifiers and outcomes while excluding tool arguments, results, stdout, stderr, and credentials.