### PR TITLE
fix(workflows): route reaction invites to Slack live queue

### DIFF
--- a/services/api-rs/crates/centaur-workflows/src/lib.rs
+++ b/services/api-rs/crates/centaur-workflows/src/lib.rs
@@ -1067,7 +1067,9 @@ enum WorkflowQueueClass {
 
 fn workflow_queue_class(workflow_name: &str) -> WorkflowQueueClass {
     match workflow_name {
-        "slack_sync" => WorkflowQueueClass::SlackLive,
+        "slack_sync"
+        | "slack_reaction_calendar_invites"
+        | "slack_reaction_calendar_invite_sender" => WorkflowQueueClass::SlackLive,
         "slack_backfill" | "slack_archive_import" => WorkflowQueueClass::EtlBackfill,
         "google_calendar_sync"
         | "google_drive_sync"
@@ -4913,6 +4915,15 @@ mod tests {
             workflow_queue_class("slack_sync"),
             WorkflowQueueClass::SlackLive
         );
+        for workflow_name in [
+            "slack_reaction_calendar_invites",
+            "slack_reaction_calendar_invite_sender",
+        ] {
+            assert_eq!(
+                workflow_queue_class(workflow_name),
+                WorkflowQueueClass::SlackLive
+            );
+        }
         for workflow_name in [
             "google_calendar_sync",
             "google_drive_sync",


### PR DESCRIPTION
## Summary

- route the Slack reaction calendar poller to the isolated Slack-live workflow queue
- route its DM sender to the same queue
- cover both workflow names in the queue-classification test

## Validation

- `cargo +nightly fmt --package centaur-workflows -- --check`
- `cargo test -p centaur-workflows scheduled_etls_use_isolated_etl_queues`
- `cargo +nightly clippy -p centaur-workflows --all-targets -- -D warnings`

Prompted by: @letstokenize