### PR TITLE
feat(slackbotv2): start workflows from Slack shortcuts

### DIFF
--- a/services/api-rs/crates/centaur-api-server/src/routes.rs
+++ b/services/api-rs/crates/centaur-api-server/src/routes.rs
@@ -2079,6 +2079,7 @@ async fn start_slack_archive_import(
             idempotency_key: Some(format!("slack_archive_import:{}", import.import_id)),
             harness_type: None,
             max_attempts: Some(1),
+            requester: None,
         })
         .await?;
     let row =
@@ -2127,6 +2128,7 @@ async fn retry_slack_archive_import(
             )),
             harness_type: None,
             max_attempts: Some(1),
+            requester: None,
         })
         .await?;
     let row =
@@ -2980,6 +2982,7 @@ async fn invoke_workflow_webhook(
         idempotency_key: Some(trigger_key),
         harness_type: None,
         max_attempts: None,
+        requester: None,
     };
     let run = workflows.create_run(request).await?;
     let status = if run.created {

--- a/services/api-rs/crates/centaur-iron-control/src/principal.rs
+++ b/services/api-rs/crates/centaur-iron-control/src/principal.rs
@@ -341,7 +341,11 @@ pub fn derive_github_requester_principal(
 /// foreign ids or labels for the same user. ``team`` must be a workspace the
 /// user is proven to belong to, never one inferred from where the message
 /// happened to land.
-fn slack_user_principal(user: &str, team: &str, display_name: Option<&str>) -> PrincipalRef {
+pub(crate) fn slack_user_principal(
+    user: &str,
+    team: &str,
+    display_name: Option<&str>,
+) -> PrincipalRef {
     PrincipalRef {
         foreign_id: format!("slack-user-{}-{}", slugify(team), slugify(user)),
         name: display_name

--- a/services/api-rs/crates/centaur-iron-control/src/session.rs
+++ b/services/api-rs/crates/centaur-iron-control/src/session.rs
@@ -15,6 +15,7 @@ use crate::models::{Principal, PrincipalInput, SlackChannelPermissionInput};
 use crate::principal::{
     PrincipalRef, derive_github_requester_principal, derive_principal_with_slack_team,
     derive_slack_requester_principal, is_direct_message, slack_conversation_id,
+    slack_user_principal,
 };
 
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -139,6 +140,33 @@ impl SessionRegistrar {
                 Ok(Some(self.client.upsert_principal(&input).await?))
             }
         }
+    }
+
+    /// Upsert a Slack user's requester principal for a trusted non-session
+    /// ingress such as a signature-verified message shortcut. The explicit
+    /// home-team comparison prevents Slack Connect identities from borrowing
+    /// credentials belonging to a user in the app's workspace.
+    pub async fn register_slack_user(
+        &self,
+        slack_user_id: &str,
+        slack_team_id: &str,
+        slack_home_team_id: &str,
+        display_name: Option<&str>,
+    ) -> Result<Option<Principal>> {
+        let user = slack_user_id.trim();
+        let team = slack_team_id.trim();
+        let home_team = slack_home_team_id.trim();
+        if user.is_empty() || team.is_empty() || home_team.is_empty() || team != home_team {
+            return Ok(None);
+        }
+        let principal = slack_user_principal(
+            user,
+            team,
+            display_name.map(str::trim).filter(|name| !name.is_empty()),
+        );
+        let mut input = principal.to_principal_input();
+        self.merge_existing_labels(&mut input).await?;
+        Ok(Some(self.client.upsert_principal(&input).await?))
     }
 
     pub async fn get_principal(&self, principal: &str) -> Result<Principal> {
@@ -703,6 +731,43 @@ mod tests {
 
         let principal = registrar
             .register_requester("slack:T_HOME:C123:1773364194.179929", Some(&metadata))
+            .await
+            .unwrap();
+
+        assert_eq!(principal, None);
+        assert!(requests.lock().unwrap().is_empty());
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn register_slack_user_supports_trusted_workflow_ingress() {
+        let (base_url, requests, _bodies, server) = spawn_iron_control_stub(false).await;
+        let registrar = SessionRegistrar::new(IronControlClient::new(base_url, "test-key"));
+
+        let principal = registrar
+            .register_slack_user("U123", "T123", "T123", Some("Ada Lovelace"))
+            .await
+            .unwrap()
+            .expect("home-team workflow requester resolves to a principal");
+
+        assert_eq!(principal.id, "prn_user");
+        let requests = requests.lock().unwrap();
+        assert!(requests.contains(&"PUT /api/v1/principals/slack-user-t123-u123".to_owned()));
+        assert!(
+            !requests
+                .iter()
+                .any(|request| request.ends_with("/slack_channel_permissions"))
+        );
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn register_slack_user_rejects_external_workflow_requester() {
+        let (base_url, requests, _bodies, server) = spawn_iron_control_stub(false).await;
+        let registrar = SessionRegistrar::new(IronControlClient::new(base_url, "test-key"));
+
+        let principal = registrar
+            .register_slack_user("U123", "T_EXTERNAL", "T_HOME", None)
             .await
             .unwrap();
 

--- a/services/api-rs/crates/centaur-workflows/src/lib.rs
+++ b/services/api-rs/crates/centaur-workflows/src/lib.rs
@@ -12,7 +12,9 @@ use absurd::{
     AwaitEventOptions, Client, ClientOptions, CreateQueueOptions, RetryKind, RetryStrategy,
     SpawnOptions, StepHandle, TaskContext, TaskRegistrationOptions, Worker, WorkerOptions,
 };
-use centaur_iron_control::{IronControlClient, IronControlError, PrincipalInput, slugify};
+use centaur_iron_control::{
+    IronControlClient, IronControlError, PrincipalInput, SessionRegistrar, slugify,
+};
 use centaur_sandbox_core::SandboxSpec;
 use centaur_session_core::{HarnessType, MessageRole, SessionMessageInput, ThreadKey};
 use centaur_session_runtime::{
@@ -116,6 +118,7 @@ struct WorkflowRuntimeInner {
     _schedule_worker: Worker,
     webhook_registry: Arc<RwLock<BTreeMap<String, RegisteredWorkflowWebhook>>>,
     schedule_registry: Arc<RwLock<BTreeMap<String, RegisteredWorkflowSchedule>>>,
+    workflow_principal_registrar: WorkflowPrincipalRegistrar,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -276,7 +279,11 @@ impl WorkflowHostSandboxRuntime {
         };
     }
 
-    fn spec_for_workflow(&self, workflow_name: &str) -> Result<SandboxSpec, WorkflowRuntimeError> {
+    fn spec_for_workflow(
+        &self,
+        workflow_name: &str,
+        requester_principal_id: Option<&str>,
+    ) -> Result<SandboxSpec, WorkflowRuntimeError> {
         let mut spec = self.spec.clone();
         let principal = {
             let assignments = self
@@ -288,6 +295,7 @@ impl WorkflowHostSandboxRuntime {
         if let Some(principal) = principal {
             spec.iron_control_principal = Some(principal);
         }
+        spec.iron_control_requester_principal = requester_principal_id.map(ToOwned::to_owned);
         Ok(spec)
     }
 }
@@ -300,6 +308,22 @@ pub struct WorkflowPrincipalRegistrar {
 impl WorkflowPrincipalRegistrar {
     pub fn new(client: IronControlClient) -> Self {
         Self { client }
+    }
+
+    async fn register_requester(
+        &self,
+        requester: &WorkflowRequester,
+    ) -> Result<Option<String>, WorkflowRuntimeError> {
+        let WorkflowRequester::Slack {
+            user_id,
+            team_id,
+            home_team_id,
+            display_name,
+        } = requester;
+        let principal = SessionRegistrar::new(self.client.clone())
+            .register_slack_user(user_id, team_id, home_team_id, Some(display_name))
+            .await?;
+        Ok(principal.map(|principal| principal.id))
     }
 
     async fn register_workflow_principals(
@@ -356,6 +380,23 @@ pub struct CreateWorkflowRunRequest {
     pub harness_type: Option<HarnessType>,
     #[serde(default)]
     pub max_attempts: Option<i32>,
+    /// Verified human identity associated with an interactive trigger. This
+    /// contains identifiers only; OAuth credentials are resolved server-side.
+    #[serde(default)]
+    pub requester: Option<WorkflowRequester>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(tag = "source", rename_all = "snake_case")]
+#[serde(deny_unknown_fields)]
+pub enum WorkflowRequester {
+    Slack {
+        user_id: String,
+        team_id: String,
+        home_team_id: String,
+        #[serde(default)]
+        display_name: String,
+    },
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -472,6 +513,10 @@ struct WorkflowTaskInput {
     workflow_name: String,
     input: Value,
     harness_type: HarnessType,
+    /// Iron-control principal OID only. Credential material is resolved by the
+    /// egress proxy and never serialized into the durable workflow task.
+    #[serde(default)]
+    requester_principal_id: Option<String>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -807,7 +852,7 @@ impl WorkflowRuntime {
                 webhook_registry.clone(),
                 schedule_registry.clone(),
                 workflow_host_sandbox.clone(),
-                workflow_principal_registrar,
+                workflow_principal_registrar.clone(),
                 interval,
             );
         }
@@ -825,6 +870,7 @@ impl WorkflowRuntime {
                 _schedule_worker: schedule_worker,
                 webhook_registry,
                 schedule_registry,
+                workflow_principal_registrar,
             }),
         })
     }
@@ -840,6 +886,15 @@ impl WorkflowRuntime {
             ));
         }
         WorkflowEnablement::from_env()?.ensure_enabled(workflow_name)?;
+        let requester_principal_id = match request.requester.as_ref() {
+            Some(requester) => {
+                self.inner
+                    .workflow_principal_registrar
+                    .register_requester(requester)
+                    .await?
+            }
+            None => None,
+        };
         let client = self.client_for_workflow(workflow_name);
         let spawn = client
             .spawn(
@@ -848,6 +903,7 @@ impl WorkflowRuntime {
                     workflow_name: workflow_name.to_owned(),
                     input: request.input,
                     harness_type: request.harness_type.unwrap_or(HarnessType::Codex),
+                    requester_principal_id,
                 },
                 SpawnOptions {
                     max_attempts: request.max_attempts,
@@ -2410,6 +2466,7 @@ async fn run_schedule_tick(
                 workflow_name: schedule.workflow_name.clone(),
                 input: schedule.input.clone(),
                 harness_type: HarnessType::Codex,
+                requester_principal_id: None,
             },
             SpawnOptions {
                 idempotency_key: Some(fire_key.clone()),
@@ -3048,7 +3105,10 @@ async fn run_python_workflow_host_in_sandbox(
     sandbox: WorkflowHostSandboxRuntime,
     workflow_clients: WorkflowQueueClients,
 ) -> Result<Value, WorkflowRuntimeError> {
-    let mut spec = sandbox.spec_for_workflow(&input.workflow_name)?;
+    let mut spec = sandbox.spec_for_workflow(
+        &input.workflow_name,
+        input.requester_principal_id.as_deref(),
+    )?;
     spec = spec
         .env("WORKFLOW_RUN_ID", ctx.run_id())
         .env("WORKFLOW_TASK_ID", ctx.task_id())
@@ -3491,6 +3551,7 @@ async fn start_python_child_workflow(
                 workflow_name: workflow_name.to_owned(),
                 input: child_input,
                 harness_type: parent.harness_type.clone(),
+                requester_principal_id: parent.requester_principal_id.clone(),
             },
             SpawnOptions {
                 idempotency_key,
@@ -4502,6 +4563,48 @@ pub enum WorkflowRuntimeError {
 mod tests {
     use super::*;
     use chrono::TimeZone;
+
+    #[test]
+    fn workflow_task_without_requester_remains_deserializable() {
+        let task: WorkflowTaskInput = serde_json::from_value(json!({
+            "workflow_name": "treasury_needs_tracker",
+            "input": {},
+            "harness_type": "codex",
+        }))
+        .expect("legacy workflow task should deserialize");
+
+        assert_eq!(task.requester_principal_id, None);
+    }
+
+    #[test]
+    fn workflow_task_persists_only_requester_principal_reference() {
+        let task = WorkflowTaskInput {
+            workflow_name: "treasury_needs_tracker".to_owned(),
+            input: json!({"slack_interaction": {"type": "message_action"}}),
+            harness_type: HarnessType::Codex,
+            requester_principal_id: Some("prn_requester".to_owned()),
+        };
+
+        let serialized = serde_json::to_string(&task).expect("workflow task should serialize");
+        assert!(serialized.contains("prn_requester"));
+        assert!(!serialized.contains("access_token"));
+        assert!(!serialized.contains("refresh_token"));
+        assert!(!serialized.contains("credential"));
+    }
+
+    #[test]
+    fn workflow_requester_rejects_credential_fields() {
+        let error = serde_json::from_value::<WorkflowRequester>(json!({
+            "source": "slack",
+            "user_id": "U123",
+            "team_id": "T123",
+            "home_team_id": "T123",
+            "access_token": "must-not-cross-boundary",
+        }))
+        .expect_err("credential fields must not be accepted");
+
+        assert!(error.to_string().contains("access_token"));
+    }
 
     #[test]
     fn python_event_names_are_collision_free() {

--- a/services/slackbotv2/src/index.ts
+++ b/services/slackbotv2/src/index.ts
@@ -51,6 +51,7 @@ import {
   serializeMessageLinks,
   serializeMessage,
   sessionStreamError,
+  startSlackInteractionWorkflow,
   slackApiTimeoutMs,
   withSlackApiTimeout
 } from './session-api'
@@ -82,6 +83,7 @@ import type {
   SlackbotV2,
   SlackbotV2ApiAttachment,
   SlackbotV2BlockActionPayload,
+  SlackbotV2MessageShortcutPayload,
   SlackbotV2ApiMessage,
   SlackbotV2ExecuteSessionResponse,
   SlackbotV2MessageMode,
@@ -108,6 +110,7 @@ export type {
   SlackbotV2ApiAttachment,
   SlackbotV2ApiAuthor,
   SlackbotV2BlockActionPayload,
+  SlackbotV2MessageShortcutPayload,
   SlackbotV2ApiMessage,
   SlackbotV2AppendMessagesRequest,
   SlackbotV2CreateSessionRequest,
@@ -299,6 +302,15 @@ export function createSlackbotV2(options: SlackbotV2Options): SlackbotV2 {
     }
     try {
       await dispatchSlackBlockAction(options, payload)
+      const workflowName = slackWorkflowName(payload.action_id)
+      if (workflowName) {
+        await startSlackInteractionWorkflow(
+          options,
+          workflowName,
+          payload,
+          slackWorkflowTriggerKey(payload, payload.action_id)
+        )
+      }
     } catch (error) {
       try {
         if (dedupeKey && (await state.get(dedupeKey)) === leaseToken) {
@@ -441,6 +453,40 @@ export function createSlackbotV2(options: SlackbotV2Options): SlackbotV2 {
           }
         })
       })
+      const messageShortcut = response.ok ? slackMessageShortcutPayload(rawBody) : null
+      if (messageShortcut) {
+        const workflowName = slackWorkflowName(messageShortcut.callback_id)
+        if (workflowName) {
+          waitUntil(
+            c,
+            startSlackInteractionWorkflow(
+              options,
+              workflowName,
+              messageShortcut,
+              slackWorkflowTriggerKey(messageShortcut, messageShortcut.callback_id)
+            )
+              .then(() => {
+                traceLog(options, 'slackbotv2_message_shortcut_dispatched', undefined, {
+                  callback_id: messageShortcut.callback_id,
+                  channel_id: messageShortcut.channel_id,
+                  message_ts: messageShortcut.message_ts,
+                  team_id: messageShortcut.team_id,
+                  workflow_name: workflowName
+                })
+              })
+              .catch(error => {
+                traceWarn(options, 'slackbotv2_message_shortcut_dispatch_failed', undefined, {
+                  callback_id: messageShortcut.callback_id,
+                  channel_id: messageShortcut.channel_id,
+                  error: errorMessage(error),
+                  message_ts: messageShortcut.message_ts,
+                  team_id: messageShortcut.team_id,
+                  workflow_name: workflowName
+                })
+              })
+          )
+        }
+      }
       const channelCreatedJoinTask = response.ok && options.autoJoinCreatedChannels === true
         ? joinSlackChannelCreatedEvent(rawBody, options)
         : null
@@ -800,6 +846,52 @@ function slackBlockActionDedupeKey(payload: SlackbotV2BlockActionPayload): strin
     payload.action_id,
     payload.action_ts
   ].join(':')
+}
+
+function slackWorkflowName(interactionId: string): string | undefined {
+  return /^workflow\.([a-z][a-z0-9_]*)$/.exec(interactionId)?.[1]
+}
+
+function slackWorkflowTriggerKey(
+  payload: SlackbotV2BlockActionPayload | SlackbotV2MessageShortcutPayload,
+  interactionId: string
+): string {
+  return [
+    'slack-workflow-trigger',
+    payload.type,
+    payload.team_id,
+    payload.channel_id,
+    payload.message_ts,
+    payload.user_id,
+    interactionId,
+    payload.action_ts
+  ].join(':')
+}
+
+function slackMessageShortcutPayload(rawBody: string): SlackbotV2MessageShortcutPayload | null {
+  const raw = parseSlackWebhookPayload(rawBody)
+  if (!raw || raw.type !== 'message_action') return null
+  const team = isJsonObject(raw.team) ? raw.team : {}
+  const user = isJsonObject(raw.user) ? raw.user : {}
+  const channel = isJsonObject(raw.channel) ? raw.channel : {}
+  const message = isJsonObject(raw.message) ? raw.message : {}
+  const callbackId = stringValue(raw.callback_id)
+  const channelId = stringValue(channel.id)
+  const messageTs = stringValue(message.ts)
+  const userId = stringValue(user.id)
+  if (!callbackId || !channelId || !messageTs || !userId) return null
+  return removeUndefinedValues({
+    action_ts: stringValue(raw.action_ts),
+    callback_id: callbackId,
+    channel_id: channelId,
+    message_text: (stringValue(message.text) ?? '').slice(0, 20_000),
+    message_ts: messageTs,
+    team_id: stringValue(team.id) ?? stringValue(user.team_id),
+    thread_ts: stringValue(message.thread_ts) ?? messageTs,
+    type: 'message_action',
+    user_id: userId,
+    user_name: stringValue(user.username) ?? stringValue(user.name) ?? userId
+  }) as SlackbotV2MessageShortcutPayload
 }
 
 function removeUndefinedValues<T extends Record<string, unknown>>(value: T): Partial<T> {

--- a/services/slackbotv2/src/index.ts
+++ b/services/slackbotv2/src/index.ts
@@ -831,6 +831,7 @@ function slackBlockActionPayload(event: ActionEvent): SlackbotV2BlockActionPaylo
     type: 'block_actions',
     user_id: event.user.userId,
     user_name: event.user.userName,
+    user_team_id: stringValue(user.team_id),
     value: event.value
   }) as SlackbotV2BlockActionPayload
 }
@@ -890,7 +891,8 @@ function slackMessageShortcutPayload(rawBody: string): SlackbotV2MessageShortcut
     thread_ts: stringValue(message.thread_ts) ?? messageTs,
     type: 'message_action',
     user_id: userId,
-    user_name: stringValue(user.username) ?? stringValue(user.name) ?? userId
+    user_name: stringValue(user.username) ?? stringValue(user.name) ?? userId,
+    user_team_id: stringValue(user.team_id)
   }) as SlackbotV2MessageShortcutPayload
 }
 

--- a/services/slackbotv2/src/session-api.ts
+++ b/services/slackbotv2/src/session-api.ts
@@ -564,7 +564,7 @@ export async function dispatchSlackBlockAction(
         {
           body: JSON.stringify({
             event_name: `slack.block_action.${payload.action_id}`,
-            payload
+            payload: workflowSafeInteractionPayload(payload)
           }),
           headers: apiHeaders(options),
           method: 'POST'
@@ -594,8 +594,9 @@ export async function startSlackInteractionWorkflow(
         {
           body: JSON.stringify({
             workflow_name: workflowName,
-            input: { slack_interaction: payload },
-            idempotency_key: idempotencyKey
+            input: { slack_interaction: workflowSafeInteractionPayload(payload) },
+            idempotency_key: idempotencyKey,
+            requester: workflowRequester(options, payload)
           }),
           headers: apiHeaders(options),
           method: 'POST'
@@ -607,6 +608,29 @@ export async function startSlackInteractionWorkflow(
     action
   )
   await ensureApiOk(response, action)
+}
+
+function workflowSafeInteractionPayload(
+  payload: SlackbotV2WorkflowTriggerPayload
+): Omit<SlackbotV2WorkflowTriggerPayload, 'user_team_id'> {
+  const { user_team_id: _, ...safePayload } = payload
+  return safePayload
+}
+
+function workflowRequester(
+  options: SlackbotV2Options,
+  payload: SlackbotV2WorkflowTriggerPayload
+): JsonObject | undefined {
+  const homeTeamId = options.slackHomeTeamId ?? payload.team_id
+  const requesterTeamId = payload.user_team_id ?? payload.team_id
+  if (!homeTeamId || !requesterTeamId) return undefined
+  return {
+    source: 'slack',
+    user_id: payload.user_id,
+    team_id: requesterTeamId,
+    home_team_id: homeTeamId,
+    display_name: payload.user_name
+  }
 }
 
 export async function openSessionEventStream(

--- a/services/slackbotv2/src/session-api.ts
+++ b/services/slackbotv2/src/session-api.ts
@@ -6,6 +6,7 @@ import type {
   ForwardSessionInput,
   JsonObject,
   SlackbotV2BlockActionPayload,
+  SlackbotV2WorkflowTriggerPayload,
   JsonValue,
   SlackbotV2ApiAttachment,
   SlackbotV2ApiMessageLink,
@@ -564,6 +565,37 @@ export async function dispatchSlackBlockAction(
           body: JSON.stringify({
             event_name: `slack.block_action.${payload.action_id}`,
             payload
+          }),
+          headers: apiHeaders(options),
+          method: 'POST'
+        },
+        sessionApiTimeoutMs(options),
+        action
+      ),
+    sessionApiTimeoutMs(options),
+    action
+  )
+  await ensureApiOk(response, action)
+}
+
+export async function startSlackInteractionWorkflow(
+  options: SlackbotV2Options,
+  workflowName: string,
+  payload: SlackbotV2WorkflowTriggerPayload,
+  idempotencyKey: string
+): Promise<void> {
+  const action = `start Slack interaction workflow ${workflowName}`
+  const response = await recordSessionApiOperation(
+    'create_workflow_run',
+    () =>
+      fetchWithTimeout(
+        options.fetch ?? globalThis.fetch,
+        new URL('/api/workflows/runs', ensureTrailingSlash(options.apiUrl)),
+        {
+          body: JSON.stringify({
+            workflow_name: workflowName,
+            input: { slack_interaction: payload },
+            idempotency_key: idempotencyKey
           }),
           headers: apiHeaders(options),
           method: 'POST'

--- a/services/slackbotv2/src/slack-events.ts
+++ b/services/slackbotv2/src/slack-events.ts
@@ -30,6 +30,7 @@ type RawSlackEnvelope = {
 
 type RawSlackInteraction = {
   actions?: JsonValue
+  callback_id?: JsonValue
   team?: JsonValue
   type?: JsonValue
   user?: JsonValue
@@ -56,7 +57,10 @@ export function isAllowedSlackWebhookBody(
 ): boolean {
   const payload = parseSlackWebhookPayload(rawBody)
   if (!payload) return true
-  if (isRawSlackInteraction(payload) && payload.type === 'block_actions') {
+  if (
+    isRawSlackInteraction(payload)
+    && (payload.type === 'block_actions' || payload.type === 'message_action')
+  ) {
     return isAllowedSlackInteraction(payload, options, logger)
   }
   if (!isRawSlackEnvelope(payload) || payload.type !== 'event_callback') return true
@@ -111,7 +115,9 @@ function isAllowedSlackInteraction(
   const actions = Array.isArray(payload.actions) ? payload.actions : []
   const firstAction = actions.find(isJsonObject)
   logger.warn('slackbotv2_event_ignored_external_org_not_allowlisted', {
-    action_id: firstAction ? stringValue(firstAction.action_id) : undefined,
+    action_id: firstAction
+      ? stringValue(firstAction.action_id)
+      : stringValue(payload.callback_id),
     external_team_id: externalTeamId,
     team_id: homeTeamId
   })

--- a/services/slackbotv2/src/types.ts
+++ b/services/slackbotv2/src/types.ts
@@ -122,6 +122,7 @@ export type SlackbotV2BlockActionPayload = {
   type: 'block_actions'
   user_id: string
   user_name: string
+  user_team_id?: string
   value?: string
 }
 
@@ -136,6 +137,7 @@ export type SlackbotV2MessageShortcutPayload = {
   type: 'message_action'
   user_id: string
   user_name: string
+  user_team_id?: string
 }
 
 export type SlackbotV2WorkflowTriggerPayload =

--- a/services/slackbotv2/src/types.ts
+++ b/services/slackbotv2/src/types.ts
@@ -125,6 +125,23 @@ export type SlackbotV2BlockActionPayload = {
   value?: string
 }
 
+export type SlackbotV2MessageShortcutPayload = {
+  action_ts?: string
+  callback_id: string
+  channel_id: string
+  message_text: string
+  message_ts: string
+  team_id?: string
+  thread_ts: string
+  type: 'message_action'
+  user_id: string
+  user_name: string
+}
+
+export type SlackbotV2WorkflowTriggerPayload =
+  | SlackbotV2BlockActionPayload
+  | SlackbotV2MessageShortcutPayload
+
 export type SlackbotV2Options = {
   allowedExternalTeamIds?: readonly string[]
   apiKey?: string

--- a/services/slackbotv2/test/chat-sdk-emulate.test.ts
+++ b/services/slackbotv2/test/chat-sdk-emulate.test.ts
@@ -428,11 +428,42 @@ describe('slackbotv2', () => {
           USER_ID,
           'workflow.treasury_needs_tracker',
           '1700000010.000300'
-        ].join(':')
+        ].join(':'),
+        requester: {
+          source: 'slack',
+          user_id: USER_ID,
+          team_id: TEAM_ID,
+          home_team_id: TEAM_ID,
+          display_name: 'tester'
+        }
       }
     ])
     expect(JSON.stringify(codexApi.workflowRuns)).not.toContain('response_url')
     expect(JSON.stringify(codexApi.workflowRuns)).not.toContain('sensitive-trigger-id')
+    expect(JSON.stringify(codexApi.workflowRuns)).not.toContain('access_token')
+    expect(JSON.stringify(codexApi.workflowRuns)).not.toContain('refresh_token')
+  })
+
+  it('starts shortcut workflows without requester credentials when Slack identity is incomplete', async () => {
+    const waits: Promise<unknown>[] = []
+    const response = await bot.app.request(
+      '/api/slack/actions',
+      signedSlackInteraction({
+        type: 'message_action',
+        callback_id: 'workflow.treasury_needs_tracker',
+        action_ts: '1700000010.000301',
+        user: { id: USER_ID, username: 'tester' },
+        channel: { id: CHANNEL_ID },
+        message: { ts: '1700000009.000201', text: 'Fund Acme.' }
+      }),
+      {},
+      waitUntilContext(waits)
+    )
+
+    expect(response.status).toBe(200)
+    await Promise.all(waits)
+    expect(codexApi.workflowRuns).toHaveLength(1)
+    expect(codexApi.workflowRuns[0]).not.toHaveProperty('requester')
   })
 
   it('starts prefixed workflows from signed Slack block actions', async () => {
@@ -5988,6 +6019,7 @@ type MockWorkflowEventRequest = {
 type MockWorkflowRunRequest = {
   idempotency_key: string
   input: { slack_interaction: Record<string, unknown> }
+  requester?: Record<string, unknown>
   workflow_name: string
 }
 

--- a/services/slackbotv2/test/chat-sdk-emulate.test.ts
+++ b/services/slackbotv2/test/chat-sdk-emulate.test.ts
@@ -377,6 +377,98 @@ describe('slackbotv2', () => {
     expect(JSON.stringify(codexApi.workflowEvents)).not.toContain('sensitive-response-token')
   })
 
+  it('starts prefixed workflows from signed Slack message shortcuts', async () => {
+    const waits: Promise<unknown>[] = []
+    const response = await bot.app.request(
+      '/api/slack/actions',
+      signedSlackInteraction({
+        type: 'message_action',
+        callback_id: 'workflow.treasury_needs_tracker',
+        action_ts: '1700000010.000300',
+        team: { id: TEAM_ID },
+        user: { id: USER_ID, username: 'tester', team_id: TEAM_ID },
+        channel: { id: CHANNEL_ID },
+        message: {
+          ts: '1700000009.000200',
+          thread_ts: '1700000009.000100',
+          text: 'Fund the partner with 250,000 USDC next Friday.'
+        },
+        response_url: 'https://hooks.slack.com/actions/sensitive-response-token',
+        trigger_id: 'sensitive-trigger-id'
+      }),
+      {},
+      waitUntilContext(waits)
+    )
+
+    expect(response.status).toBe(200)
+    await Promise.all(waits)
+    expect(codexApi.workflowRuns).toEqual([
+      {
+        workflow_name: 'treasury_needs_tracker',
+        input: {
+          slack_interaction: {
+            action_ts: '1700000010.000300',
+            callback_id: 'workflow.treasury_needs_tracker',
+            channel_id: CHANNEL_ID,
+            message_text: 'Fund the partner with 250,000 USDC next Friday.',
+            message_ts: '1700000009.000200',
+            team_id: TEAM_ID,
+            thread_ts: '1700000009.000100',
+            type: 'message_action',
+            user_id: USER_ID,
+            user_name: 'tester'
+          }
+        },
+        idempotency_key: [
+          'slack-workflow-trigger',
+          'message_action',
+          TEAM_ID,
+          CHANNEL_ID,
+          '1700000009.000200',
+          USER_ID,
+          'workflow.treasury_needs_tracker',
+          '1700000010.000300'
+        ].join(':')
+      }
+    ])
+    expect(JSON.stringify(codexApi.workflowRuns)).not.toContain('response_url')
+    expect(JSON.stringify(codexApi.workflowRuns)).not.toContain('sensitive-trigger-id')
+  })
+
+  it('starts prefixed workflows from signed Slack block actions', async () => {
+    const waits: Promise<unknown>[] = []
+    const response = await bot.app.request(
+      '/api/slack/actions',
+      signedSlackInteraction({
+        type: 'block_actions',
+        team: { id: TEAM_ID },
+        user: { id: USER_ID, username: 'tester', team_id: TEAM_ID },
+        channel: { id: CHANNEL_ID },
+        message: { ts: '1700000011.000200' },
+        actions: [{
+          action_id: 'workflow.treasury_needs_tracker',
+          action_ts: '1700000012.000300',
+          type: 'button',
+          value: '{"mode":"commit"}'
+        }]
+      }),
+      {},
+      waitUntilContext(waits)
+    )
+
+    expect(response.status).toBe(200)
+    await Promise.all(waits)
+    expect(codexApi.workflowRuns).toHaveLength(1)
+    expect(codexApi.workflowRuns[0]).toEqual(expect.objectContaining({
+      workflow_name: 'treasury_needs_tracker',
+      input: { slack_interaction: expect.objectContaining({
+        action_id: 'workflow.treasury_needs_tracker',
+        type: 'block_actions',
+        value: '{"mode":"commit"}'
+      }) }
+    }))
+  })
+
   it('applies the external-org allowlist to Slack block actions', async () => {
     const interaction = signedSlackInteraction({
       type: 'block_actions',
@@ -5893,6 +5985,12 @@ type MockWorkflowEventRequest = {
   payload: SlackbotV2BlockActionPayload
 }
 
+type MockWorkflowRunRequest = {
+  idempotency_key: string
+  input: { slack_interaction: Record<string, unknown> }
+  workflow_name: string
+}
+
 type MockSessionApi = {
   appends: MockSessionRequest<SlackbotV2AppendMessagesRequest>[]
   autoRespond: boolean
@@ -5912,6 +6010,7 @@ type MockSessionApi = {
   streamCount: number
   url: string
   workflowEvents: MockWorkflowEventRequest[]
+  workflowRuns: MockWorkflowRunRequest[]
 }
 
 async function startMockCodexApi(): Promise<MockSessionApi> {
@@ -5923,6 +6022,7 @@ async function startMockCodexApi(): Promise<MockSessionApi> {
   const idempotentExecutions = new Map<string, string>()
   const streams = new Set<ServerResponse>()
   const workflowEvents: MockWorkflowEventRequest[] = []
+  const workflowRuns: MockWorkflowRunRequest[] = []
   let autoRespond = true
   let executeHold: Promise<void> | null = null
   let executeHoldRelease: (() => void) | null = null
@@ -5973,7 +6073,8 @@ async function startMockCodexApi(): Promise<MockSessionApi> {
         failNextExecuteAfterAccept = value
       },
       streams,
-      workflowEvents
+      workflowEvents,
+      workflowRuns
     }).catch(error => {
       res.writeHead(500, { 'content-type': 'application/json' })
       res.end(JSON.stringify({ error: String(error) }))
@@ -6003,9 +6104,11 @@ async function startMockCodexApi(): Promise<MockSessionApi> {
       failNextExecute = false
       failNextExecuteAfterAccept = false
       workflowEvents.length = 0
+      workflowRuns.length = 0
     },
     url: `http://127.0.0.1:${port}`,
     workflowEvents,
+    workflowRuns,
     closeStreams,
     get autoRespond() {
       return autoRespond
@@ -6101,6 +6204,7 @@ async function handleMockCodexRequest(
     setFailNextExecuteAfterAccept(value: boolean): void
     streams: Set<ServerResponse>
     workflowEvents: MockWorkflowEventRequest[]
+    workflowRuns: MockWorkflowRunRequest[]
   }
 ): Promise<void> {
   const url = new URL(req.url ?? '/', `http://127.0.0.1:${input.port}`)
@@ -6108,6 +6212,18 @@ async function handleMockCodexRequest(
     const request = await nodeRequestToWebRequest(req, url)
     input.workflowEvents.push((await request.json()) as MockWorkflowEventRequest)
     await sendWebResponse(res, Response.json({ ok: true }))
+    return
+  }
+  if (url.pathname === '/api/workflows/runs') {
+    const request = await nodeRequestToWebRequest(req, url)
+    input.workflowRuns.push((await request.json()) as MockWorkflowRunRequest)
+    await sendWebResponse(
+      res,
+      Response.json(
+        { ok: true, run_id: 'run-1', task_id: 'task-1', status: 'queued' },
+        { status: 202 }
+      )
+    )
     return
   }
   const match = /^\/api\/session\/([^/]+)(?:\/(messages|execute|events))?$/.exec(url.pathname)


### PR DESCRIPTION
## Summary

- accept signed Slack `message_action` shortcuts and start idempotent durable workflow runs for `workflow.<name>` callbacks
- pass only the invoking Slack user's identity metadata to API-rs, resolve the matching requester principal server-side, and bind it to the workflow sandbox proxy
- require the actor's Slack team to match the app's home team, preventing Slack Connect users from borrowing home-workspace OAuth credentials
- persist only the opaque requester principal ID in the durable task; reject credential-shaped requester fields and omit Slack response/trigger URLs
- inherit the requester principal for child workflows while scheduled and requester-less runs remain unchanged

## Validation

- `bun test` in `services/slackbotv2` (255 passed, 1 skipped)
- focused `centaur-iron-control` requester tests (2 passed)
- focused `centaur-workflows` tests (19 passed)
- `cargo +nightly fmt --all -- --check`
- `cargo +nightly clippy -p centaur-iron-control -p centaur-workflows -p centaur-api-server --all-targets -- -D warnings`
- `bun run check:types` remains blocked by three pre-existing `fetch.preconnect` typing errors in `test/slack-user.test.ts`

Prompted by: @vinaykantharia
