### PR TITLE
feat: add console chat sunset controls

### DIFF
--- a/contrib/chart/Chart.yaml
+++ b/contrib/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: centaur
 description: Helm chart for the trusted Centaur control plane
 type: application
-version: 0.1.130
+version: 0.1.131
 appVersion: "0.1.0"
 dependencies:
   - name: connect

--- a/contrib/chart/templates/console.yaml
+++ b/contrib/chart/templates/console.yaml
@@ -204,6 +204,8 @@ spec:
 {{- end }}
             - name: CENTAUR_CONSOLE_PASSWORD_LOGIN_ENABLED
               value: {{ $console.passwordLoginEnabled | quote }}
+            - name: CENTAUR_CONSOLE_CHAT_ENABLED
+              value: {{ $console.chat.enabled | quote }}
             - name: CENTAUR_CONSOLE_PUBLIC_SLACK_THREADS_ENABLED
               value: {{ $console.publicSlackThreadsEnabled | quote }}
 {{- with $console.ssoEmailDomains }}

--- a/contrib/chart/values.schema.json
+++ b/contrib/chart/values.schema.json
@@ -14,6 +14,12 @@
         },
         "sentryDsn": { "type": "string" },
         "railsEnv": { "type": "string" },
+        "chat": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean" }
+          }
+        },
         "image": {
           "type": "object",
           "properties": {

--- a/contrib/chart/values.yaml
+++ b/contrib/chart/values.yaml
@@ -117,6 +117,10 @@ console:
   # Break-glass email/password login. Disable when console is reachable from
   # the public internet and SSO is configured.
   passwordLoginEnabled: true
+  # Console's browser-based chat UI is deprecated and will be removed in
+  # October. Disable it to hide chat navigation and reject its HTTP routes.
+  chat:
+    enabled: true
   # When enabled, every authenticated Console user can browse conversations
   # originating in public Slack channels. Private channels and DMs remain
   # owner-only. Requires apiRs.etl.slack.enabled so channel privacy is synced;

--- a/services/console/app/controllers/application_controller.rb
+++ b/services/console/app/controllers/application_controller.rb
@@ -10,6 +10,7 @@ class ApplicationController < ActionController::Base
   rescue_from ActiveRecord::RecordNotFound, with: :render_not_found
 
   helper_method :current_user, :acting_admin?, :descoped?, :password_login_enabled?
+  helper_method :console_chat_enabled?
   helper_method :public_base_url, :oauth_callback_redirect_uri
 
   # The public origin the console is reached at. Derived from the request by
@@ -80,6 +81,10 @@ class ApplicationController < ActionController::Base
     ConsoleAuth.password_login_enabled?
   end
 
+  def console_chat_enabled?
+    ConsoleFeatures.chat_enabled?
+  end
+
   # The permission check console gates use instead of current_user.admin?: a
   # real admin who is not currently descoped. Keeping current_user untouched
   # means audit trails and data displays still see the true account.
@@ -113,13 +118,20 @@ class ApplicationController < ActionController::Base
   # Keep this redirect silent: direct/admin-default URLs are not
   # actionable errors for non-admin operators, especially on a fresh visit.
   def require_admin
-    redirect_to console_threads_path unless acting_admin?
+    redirect_to default_console_landing_path unless acting_admin?
   end
 
   # Where a signed-in user lands when no explicit destination applies: admins get
-  # the Control section, everyone else gets the threads view.
+  # the Control section. Everyone else gets chat, or Integrations when chat is
+  # disabled.
   def default_console_landing_path
-    acting_admin? ? console_principals_path : console_threads_path
+    return console_principals_path if acting_admin?
+
+    console_chat_enabled? ? console_threads_path : console_integrations_path
+  end
+
+  def require_console_chat_enabled
+    head :not_found unless console_chat_enabled?
   end
 
   # Cheap default so every page renders the empty sidebar list without touching

--- a/services/console/app/controllers/console/descopes_controller.rb
+++ b/services/console/app/controllers/console/descopes_controller.rb
@@ -14,7 +14,7 @@ module Console
       session[:descoped] = true
       Rails.logger.info("console_descope_started admin=#{current_user.email}")
       # No flash: the persistent descope banner already announces the state.
-      redirect_to console_threads_path
+      redirect_to default_console_landing_path
     end
 
     def destroy

--- a/services/console/app/controllers/console/threads_controller.rb
+++ b/services/console/app/controllers/console/threads_controller.rb
@@ -1,6 +1,8 @@
 class Console::ThreadsController < ApplicationController
   layout "console"
 
+  before_action :require_console_chat_enabled
+
   # Injectable for tests, mirroring Console::WorkflowsController.
   class_attribute :client_factory, default: -> { CentaurApiClient.new }
 

--- a/services/console/app/services/console_features.rb
+++ b/services/console/app/services/console_features.rb
@@ -1,0 +1,8 @@
+module ConsoleFeatures
+  module_function
+
+  def chat_enabled?
+    raw = ConsoleEnv["CHAT_ENABLED"]
+    raw.nil? || ActiveModel::Type::Boolean.new.cast(raw)
+  end
+end

--- a/services/console/app/views/console/threads/index.html.erb
+++ b/services/console/app/views/console/threads/index.html.erb
@@ -1,5 +1,9 @@
 <% content_for :title, "Chats · Centaur Console" %>
 
+<div class="console-amber-note mb-4 shrink-0 rounded border border-amber-500/30 bg-amber-500/[0.08] px-4 py-3 text-sm text-amber-200" role="status">
+  The Console chat app will be removed in October.
+</div>
+
 <% if @thread_db_unavailable %>
   <div class="console-amber-note mb-4 shrink-0 rounded border border-amber-500/30 bg-amber-500/[0.08] px-4 py-3 text-sm text-amber-200">
     Chat database is unavailable. Set <span class="font-semibold">CENTAUR_CONSOLE_CENTAUR_DATABASE_URL</span>

--- a/services/console/app/views/layouts/console.html.erb
+++ b/services/console/app/views/layouts/console.html.erb
@@ -1896,53 +1896,55 @@
             </div>
           <% end %>
 
-          <%# New chat rides the thread-link machinery with the "new" sentinel
-              key: plain click opens the full-page composer, Cmd/Ctrl-click
-              adds a composer pane to the split view. %>
-          <div class="console-thread-group">
-            <a href="<%= console_threads_path(thread: Console::ThreadsController::NEW_PANE_KEY) %>"
-               class="console-thread-group-title"
-               aria-label="New chat"
-               title="New chat"
-               data-console-thread-link
-               data-console-new-chat>
-              <span class="console-nav-icon"><%= console_icon("plus", classes: "size-4") %></span>
-              <span class="console-nav-label">New chat</span>
-            </a>
-          </div>
-
-          <div class="console-thread-group">
-            <a href="<%= console_threads_path %>"
-               class="console-thread-group-title <%= "console-thread-group-title-active" if threads_view %>"
-               title="Chats">
-              <span class="console-nav-icon"><%= console_icon("message-square", classes: "size-4") %></span>
-              <span class="console-nav-label">Chats</span>
-            </a>
-            <%# The thread list is loaded lazily via a Turbo Frame so the
-                unindexed cross-database sessions query never blocks the primary
-                page render. See ApplicationController#init_console_sidebar_threads
-                and Console::ThreadsController#sidebar.
-
-                The current thread selection rides along on the frame src so the
-                initial out-of-band render can surface and highlight the open
-                thread(s). The wrapper div (not the frame itself — a permanent
-                turbo-frame trips Turbo's frame lifecycle and can wedge the
-                visit progress bar) is turbo-permanent: Turbo Drive carries the
-                loaded list across page visits instead of refetching it, so
-                thread navigation does not repaint the sidebar; the active
-                highlight is re-synced client-side from the page URL. %>
-            <div id="console_sidebar_thread_list"
-                 class="console-thread-list"
-                 data-turbo-permanent>
-              <%= turbo_frame_tag "console_sidebar_threads",
-                                  src: console_sidebar_threads_path(
-                                    thread: (params[:thread].to_s.presence if threads_view)
-                                  ),
-                                  loading: :lazy do %>
-                <div class="console-thread-empty">Loading chats…</div>
-              <% end %>
+          <% if console_chat_enabled? %>
+            <%# New chat rides the thread-link machinery with the "new" sentinel
+                key: plain click opens the full-page composer, Cmd/Ctrl-click
+                adds a composer pane to the split view. %>
+            <div class="console-thread-group">
+              <a href="<%= console_threads_path(thread: Console::ThreadsController::NEW_PANE_KEY) %>"
+                 class="console-thread-group-title"
+                 aria-label="New chat"
+                 title="New chat"
+                 data-console-thread-link
+                 data-console-new-chat>
+                <span class="console-nav-icon"><%= console_icon("plus", classes: "size-4") %></span>
+                <span class="console-nav-label">New chat</span>
+              </a>
             </div>
-          </div>
+
+            <div class="console-thread-group">
+              <a href="<%= console_threads_path %>"
+                 class="console-thread-group-title <%= "console-thread-group-title-active" if threads_view %>"
+                 title="Chats">
+                <span class="console-nav-icon"><%= console_icon("message-square", classes: "size-4") %></span>
+                <span class="console-nav-label">Chats</span>
+              </a>
+              <%# The thread list is loaded lazily via a Turbo Frame so the
+                  unindexed cross-database sessions query never blocks the primary
+                  page render. See ApplicationController#init_console_sidebar_threads
+                  and Console::ThreadsController#sidebar.
+
+                  The current thread selection rides along on the frame src so the
+                  initial out-of-band render can surface and highlight the open
+                  thread(s). The wrapper div (not the frame itself — a permanent
+                  turbo-frame trips Turbo's frame lifecycle and can wedge the
+                  visit progress bar) is turbo-permanent: Turbo Drive carries the
+                  loaded list across page visits instead of refetching it, so
+                  thread navigation does not repaint the sidebar; the active
+                  highlight is re-synced client-side from the page URL. %>
+              <div id="console_sidebar_thread_list"
+                   class="console-thread-list"
+                   data-turbo-permanent>
+                <%= turbo_frame_tag "console_sidebar_threads",
+                                    src: console_sidebar_threads_path(
+                                      thread: (params[:thread].to_s.presence if threads_view)
+                                    ),
+                                    loading: :lazy do %>
+                  <div class="console-thread-empty">Loading chats…</div>
+                <% end %>
+              </div>
+            </div>
+          <% end %>
         </div>
 
         <% if current_user %>

--- a/services/console/app/views/pwa/manifest.json.erb
+++ b/services/console/app/views/pwa/manifest.json.erb
@@ -35,11 +35,13 @@
     "client_mode": "navigate-existing"
   },
   "shortcuts": [
+    <% if ConsoleFeatures.chat_enabled? %>
     {
       "name": "Chats",
       "url": "/console/threads",
       "icons": [{ "src": "/pwa-icon-192.png", "sizes": "192x192", "type": "image/png" }]
     },
+    <% end %>
     {
       "name": "Workflows",
       "url": "/console/workflows",

--- a/services/console/test/controllers/console/integrations_controller_test.rb
+++ b/services/console/test/controllers/console/integrations_controller_test.rb
@@ -6,6 +6,17 @@ class Console::IntegrationsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to login_path
   end
 
+  test "chat navigation is hidden when console chat is disabled" do
+    post login_url, params: { email: users(:member_user).email, password: "password123456" }
+
+    with_env("CENTAUR_CONSOLE_CHAT_ENABLED" => "false") do
+      get console_integrations_url
+      assert_response :ok
+      assert_select "a[aria-label=?]", "New chat", count: 0
+      assert_select ".console-thread-group-title", text: /Chats/, count: 0
+    end
+  end
+
   test "a non-admin sees enabled apps with their start links, logos, and no disabled apps" do
     post login_url, params: { email: users(:member_user).email, password: "password123456" }
 

--- a/services/console/test/controllers/console/threads_controller_test.rb
+++ b/services/console/test/controllers/console/threads_controller_test.rb
@@ -20,6 +20,25 @@ class Console::ThreadsControllerTest < ActionDispatch::IntegrationTest
     post login_url, params: { email: @operator.email, password: "password123456" }
   end
 
+  test "threads page shows the October removal banner" do
+    with_recent_first_error do
+      get console_threads_url
+    end
+
+    assert_response :ok
+    assert_select ".console-amber-note[role=status]", text: /Console chat app will be removed in October/
+  end
+
+  test "threads endpoints are unavailable when console chat is disabled" do
+    with_env("CENTAUR_CONSOLE_CHAT_ENABLED" => "false") do
+      get console_threads_url
+      assert_response :not_found
+
+      post console_threads_url, params: { prompt: "Do not send this" }
+      assert_response :not_found
+    end
+  end
+
   test "an admin sees the Control and Data Sync nav items" do
     with_recent_first_error do
       get console_threads_url

--- a/services/console/test/controllers/sessions_controller_test.rb
+++ b/services/console/test/controllers/sessions_controller_test.rb
@@ -62,6 +62,14 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
     assert_equal member.id, session[:user_id]
   end
 
+  test "a non-admin lands on integrations when console chat is disabled" do
+    member = users(:member_user)
+    with_env("CENTAUR_CONSOLE_CHAT_ENABLED" => "false") do
+      post login_url, params: { email: member.email, password: "password123456" }
+      assert_redirected_to console_integrations_path
+    end
+  end
+
   test "email match is case-insensitive" do
     post login_url, params: { email: @operator.email.upcase, password: "password123456" }
     assert_equal @operator.id, session[:user_id]

--- a/services/console/test/integration/pwa_test.rb
+++ b/services/console/test/integration/pwa_test.rb
@@ -18,6 +18,17 @@ class PwaTest < ActionDispatch::IntegrationTest
                  manifest["shortcuts"].map { |shortcut| shortcut["url"] }
   end
 
+  test "manifest omits the chat shortcut when console chat is disabled" do
+    with_env("CENTAUR_CONSOLE_CHAT_ENABLED" => "false") do
+      get pwa_manifest_url(format: :json)
+      assert_response :ok
+
+      manifest = JSON.parse(response.body)
+      assert_equal %w[/console/workflows /console/integrations],
+                   manifest["shortcuts"].map { |shortcut| shortcut["url"] }
+    end
+  end
+
   test "launch maps web+centaur targets onto in-app paths" do
     post login_url, params: { email: users(:member_user).email, password: "password123456" }
 


### PR DESCRIPTION
Adds an October removal banner to the Console chat UI. Adds the enabled-by-default console.chat.enabled Helm value, which hides chat navigation and PWA entry points, blocks Threads endpoints, and redirects non-admin landing behavior when disabled. Includes focused coverage for the banner and both feature-flag states.