### PR TITLE
fix: hide Slack console links when chat is disabled

### DIFF
--- a/contrib/chart/Chart.yaml
+++ b/contrib/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: centaur
 description: Helm chart for the trusted Centaur control plane
 type: application
-version: 0.1.131
+version: 0.1.132
 appVersion: "0.1.0"
 dependencies:
   - name: connect

--- a/contrib/chart/templates/slackbotv2.yaml
+++ b/contrib/chart/templates/slackbotv2.yaml
@@ -98,10 +98,11 @@ spec:
               value: {{ .Values.slackbotv2.messageOverridesStrategy.timeoutMs | quote }}
             - name: SLACKBOTV2_MESSAGE_OVERRIDES_MAX_OUTPUT_TOKENS
               value: {{ .Values.slackbotv2.messageOverridesStrategy.maxOutputTokens | quote }}
-{{- if $console.publicUrl }}
+{{- if and $console.chat.enabled $console.publicUrl }}
             # Public origin of the Console UI (matches the Console's own
-            # CENTAUR_CONSOLE_PUBLIC_URL). When set, the first assistant message
-            # in a Slack thread gets an "Open session in Console" link.
+            # CENTAUR_CONSOLE_PUBLIC_URL). When chat is enabled, the first
+            # assistant message in a Slack thread gets an "Open chat in Console"
+            # link.
             - name: CENTAUR_CONSOLE_PUBLIC_URL
               value: {{ $console.publicUrl | quote }}
 {{- end }}

--- a/contrib/chart/values.yaml
+++ b/contrib/chart/values.yaml
@@ -104,8 +104,9 @@ console:
   # Public URL users reach in a browser (e.g. https://console.example.com), used
   # as CENTAUR_CONSOLE_PUBLIC_URL. Set this when console is exposed behind
   # Tailscale/Ingress so MCP OAuth issuer metadata and JWT validation agree.
-  # When set, the slackbotv2 deployment also links the first assistant message
-  # in a Slack thread to the Console session view; leave empty to omit the link.
+  # When set and console.chat.enabled is true, the slackbotv2 deployment also
+  # links the first assistant message in a Slack thread to the Console session
+  # view. Leave empty to omit the link.
   publicUrl: ""
   # Additional exact Host headers accepted by Rails Host Authorization. Use for
   # service DNS names that differ from the chart's short in-cluster URL;


### PR DESCRIPTION
Stops injecting the Console public URL into Slackbot when console.chat.enabled is false, which suppresses the Open chat in Console response links while preserving the URL for other consumers. Updates the chart documentation and bumps the chart to 0.1.132.