### PR TITLE
fix: fall back from unavailable personas

### DIFF
--- a/services/api-rs/crates/centaur-api-server/src/routes.rs
+++ b/services/api-rs/crates/centaur-api-server/src/routes.rs
@@ -643,7 +643,7 @@ async fn create_or_get_session(
     Ok(Json(CreateSessionResponse {
         session: outcome.session,
         harness_switched: outcome.harness_switched,
-        persona_fallback: outcome.persona_fallback,
+        unavailable_requested_persona_id: outcome.unavailable_requested_persona_id,
     }))
 }
 

--- a/services/api-rs/crates/centaur-api-server/src/routes.rs
+++ b/services/api-rs/crates/centaur-api-server/src/routes.rs
@@ -643,6 +643,7 @@ async fn create_or_get_session(
     Ok(Json(CreateSessionResponse {
         session: outcome.session,
         harness_switched: outcome.harness_switched,
+        persona_fallback: outcome.persona_fallback,
     }))
 }
 

--- a/services/api-rs/crates/centaur-api-server/src/types.rs
+++ b/services/api-rs/crates/centaur-api-server/src/types.rs
@@ -34,10 +34,10 @@ pub struct CreateSessionResponse {
     pub session: Session,
     /// True when this request restarted the thread onto a different harness.
     pub harness_switched: bool,
-    /// Present only for new-session persona selection. True means the requested
-    /// persona was unavailable and the deployment fallback was used.
+    /// Present only when a new-session request named an unavailable persona
+    /// and the returned session uses the resolved fallback.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub persona_fallback: Option<bool>,
+    pub unavailable_requested_persona_id: Option<String>,
 }
 
 #[derive(Clone, Debug, Serialize)]

--- a/services/api-rs/crates/centaur-api-server/src/types.rs
+++ b/services/api-rs/crates/centaur-api-server/src/types.rs
@@ -9,7 +9,8 @@ use thiserror::Error;
 pub struct CreateSessionRequest {
     pub harness_type: HarnessType,
     /// Used only when creating the session. The first persisted persona stays
-    /// pinned for the lifetime of the thread.
+    /// pinned for the lifetime of the thread. An ID absent from the deployment
+    /// falls back to the eligible deployment default or no persona.
     pub persona_id: Option<String>,
     pub metadata: Option<Value>,
     /// What to do when the session already exists on a different harness.
@@ -33,6 +34,10 @@ pub struct CreateSessionResponse {
     pub session: Session,
     /// True when this request restarted the thread onto a different harness.
     pub harness_switched: bool,
+    /// Present only for new-session persona selection. True means the requested
+    /// persona was unavailable and the deployment fallback was used.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub persona_fallback: Option<bool>,
 }
 
 #[derive(Clone, Debug, Serialize)]

--- a/services/api-rs/crates/centaur-session-runtime/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-runtime/src/lib.rs
@@ -336,9 +336,9 @@ pub struct CreateOrGetSessionOutcome {
     /// True when the session was restarted onto a different harness because
     /// the request asked for [`HarnessConflictPolicy::Restart`].
     pub harness_switched: bool,
-    /// Set only when this request selected a persona for a new session. True
-    /// means the requested persona was unavailable and a fallback was used.
-    pub persona_fallback: Option<bool>,
+    /// Set only when a new-session request named an unavailable persona and
+    /// the returned session uses this request's resolved fallback.
+    pub unavailable_requested_persona_id: Option<String>,
 }
 
 /// Outcome of [`SessionRuntime::drain`]: the sandboxes that were stopped and
@@ -1619,21 +1619,13 @@ impl SessionRuntime {
                 Err(SessionStoreError::NotFound { .. }) => None,
                 Err(error) => return Err(error.into()),
             };
-            let (persona_resolution, persona_fallback) = match existing_persona_id {
-                Some(persona_id) => (
-                    PersonaResolution {
-                        context: None,
-                        persona_id,
-                        unavailable_requested_persona_id: None,
-                    },
-                    None,
-                ),
-                None => {
-                    let resolution =
-                        self.resolve_persona_for_create(persona_id, &desired_capabilities)?;
-                    let fallback = Some(resolution.unavailable_requested_persona_id.is_some());
-                    (resolution, fallback)
-                }
+            let persona_resolution = match existing_persona_id {
+                Some(persona_id) => PersonaResolution {
+                    context: None,
+                    persona_id,
+                    unavailable_requested_persona_id: None,
+                },
+                None => self.resolve_persona_for_create(persona_id, &desired_capabilities)?,
             };
             if let Some(context) = persona_resolution.context.as_ref() {
                 add_persona_metadata(&mut session_metadata, context);
@@ -1669,6 +1661,10 @@ impl SessionRuntime {
                 .store
                 .bind_iron_control_principal(thread_key, &registered_principal.id)
                 .await?;
+            let unavailable_requested_persona_id = confirmed_unavailable_requested_persona_id(
+                &persona_resolution,
+                session.persona_id.as_deref(),
+            );
             if let Some(context) = self.resolve_stored_persona(
                 session.persona_id.as_deref(),
                 harness_type,
@@ -1700,7 +1696,7 @@ impl SessionRuntime {
             Ok(CreateOrGetSessionOutcome {
                 session,
                 harness_switched,
-                persona_fallback,
+                unavailable_requested_persona_id,
             })
         }
         .instrument(span)
@@ -5735,6 +5731,16 @@ fn resolve_persona_selection(
     })
 }
 
+fn confirmed_unavailable_requested_persona_id(
+    resolution: &PersonaResolution,
+    stored_persona_id: Option<&str>,
+) -> Option<String> {
+    if resolution.persona_id.as_deref() != stored_persona_id {
+        return None;
+    }
+    resolution.unavailable_requested_persona_id.clone()
+}
+
 fn upsert_spec_env(spec: &mut SandboxSpec, name: &str, value: String) {
     if let Some(existing) = spec.env.iter_mut().find(|env| env.name == name) {
         existing.value = value;
@@ -7548,6 +7554,25 @@ mod tests {
     }
 
     #[test]
+    fn unavailable_persona_signal_requires_returned_persona_to_match_resolution() {
+        let resolution = resolve_persona_selection(
+            None,
+            Some("honk"),
+            &SessionSandboxCapabilities::default_enabled(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            confirmed_unavailable_requested_persona_id(&resolution, Some("eng")),
+            None
+        );
+        assert_eq!(
+            confirmed_unavailable_requested_persona_id(&resolution, None).as_deref(),
+            Some("honk")
+        );
+    }
+
+    #[test]
     fn inaccessible_requested_persona_still_fails_closed() {
         let registry = PersonaRegistry::new(
             [PersonaDefinition {
@@ -9302,7 +9327,10 @@ mod adoption_tests {
             .await
             .expect("create session with persona fallback");
 
-        assert_eq!(outcome.persona_fallback, Some(true));
+        assert_eq!(
+            outcome.unavailable_requested_persona_id.as_deref(),
+            Some("not-deployed")
+        );
         assert_eq!(outcome.session.persona_id, None);
     }
 
@@ -9327,7 +9355,7 @@ mod adoption_tests {
             )
             .await
             .expect("create original session");
-        assert_eq!(created.persona_fallback, Some(false));
+        assert_eq!(created.unavailable_requested_persona_id, None);
 
         let outcome = runtime
             .create_or_get_session(
@@ -9341,7 +9369,7 @@ mod adoption_tests {
             .expect("restart session on requested harness");
 
         assert!(outcome.harness_switched);
-        assert_eq!(outcome.persona_fallback, None);
+        assert_eq!(outcome.unavailable_requested_persona_id, None);
         assert_eq!(outcome.session.harness_type, HarnessType::ClaudeCode);
         assert_eq!(outcome.session.persona_id.as_deref(), Some("old"));
         assert_eq!(
@@ -9390,7 +9418,7 @@ mod adoption_tests {
             .expect("load session with pinned persona");
 
         assert!(!outcome.harness_switched);
-        assert_eq!(outcome.persona_fallback, None);
+        assert_eq!(outcome.unavailable_requested_persona_id, None);
         assert_eq!(outcome.session.harness_type, HarnessType::Codex);
         assert_eq!(outcome.session.persona_id.as_deref(), Some("old"));
         assert_eq!(

--- a/services/api-rs/crates/centaur-session-runtime/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-runtime/src/lib.rs
@@ -984,55 +984,17 @@ impl SessionRuntime {
         Ok(self.store.get_session(thread_key).await?)
     }
 
-    fn resolve_persona_for_create(
-        &self,
-        requested_persona_id: Option<&str>,
-        capabilities: &SessionSandboxCapabilities,
-    ) -> Result<PersonaResolution, SessionRuntimeError> {
-        let resolution = resolve_persona_selection(
-            self.personas.as_deref(),
-            requested_persona_id,
-            capabilities,
-        )?;
-        if let Some(requested_persona_id) = resolution.unavailable_requested_persona_id.as_deref() {
-            warn!(
-                component = COMPONENT_SESSION_RUNTIME,
-                event = "session_persona_unavailable_fallback",
-                requested_persona_id,
-                resolved_persona_id = resolution.persona_id.as_deref().unwrap_or(""),
-                "requested persona is unavailable; continuing with the deployment fallback"
-            );
-        }
-        Ok(resolution)
-    }
-
     fn resolve_stored_persona(
         &self,
         persona_id: Option<&str>,
-        _harness_type: &HarnessType,
         capabilities: &SessionSandboxCapabilities,
     ) -> Result<Option<PersonaContext>, SessionRuntimeError> {
-        self.resolve_persona_context(persona_id.and_then(clean_persona_id), false, capabilities)
-    }
-
-    fn resolve_persona_context(
-        &self,
-        persona_id: Option<&str>,
-        defaulted: bool,
-        capabilities: &SessionSandboxCapabilities,
-    ) -> Result<Option<PersonaContext>, SessionRuntimeError> {
-        let Some(persona_id) = persona_id else {
-            return Ok(None);
-        };
-        let Some(registry) = self.personas.as_ref() else {
-            return Err(SessionRuntimeError::BadRequest(format!(
-                "persona {persona_id:?} was requested but no persona registry is configured"
-            )));
-        };
-        registry
-            .context_for_access(persona_id, defaulted, &capabilities.repo_cache)
-            .map(Some)
-            .map_err(SessionRuntimeError::BadRequest)
+        resolve_persona_context(
+            self.personas.as_deref(),
+            persona_id.and_then(clean_persona_id),
+            false,
+            capabilities,
+        )
     }
 
     fn default_persona_id(&self) -> Option<&str> {
@@ -1625,7 +1587,11 @@ impl SessionRuntime {
                     persona_id,
                     unavailable_requested_persona_id: None,
                 },
-                None => self.resolve_persona_for_create(persona_id, &desired_capabilities)?,
+                None => resolve_persona_selection(
+                    self.personas.as_deref(),
+                    persona_id,
+                    &desired_capabilities,
+                )?,
             };
             if let Some(context) = persona_resolution.context.as_ref() {
                 add_persona_metadata(&mut session_metadata, context);
@@ -1661,15 +1627,15 @@ impl SessionRuntime {
                 .store
                 .bind_iron_control_principal(thread_key, &registered_principal.id)
                 .await?;
-            let unavailable_requested_persona_id = confirmed_unavailable_requested_persona_id(
-                &persona_resolution,
-                session.persona_id.as_deref(),
-            );
-            if let Some(context) = self.resolve_stored_persona(
-                session.persona_id.as_deref(),
-                harness_type,
-                &desired_capabilities,
-            )? {
+            let unavailable_requested_persona_id = persona_resolution
+                .unavailable_requested_persona_id
+                .filter(|_| {
+                    // Another first-create request may have won with a different resolution.
+                    persona_resolution.persona_id == session.persona_id
+                });
+            if let Some(context) =
+                self.resolve_stored_persona(session.persona_id.as_deref(), &desired_capabilities)?
+            {
                 self.store
                     .append_event(
                         thread_key,
@@ -2843,8 +2809,7 @@ impl SessionRuntime {
         );
         let ensure_started = Instant::now();
         let result = async {
-            let persona_context =
-                self.resolve_stored_persona(persona_id, harness_type, desired_capabilities)?;
+            let persona_context = self.resolve_stored_persona(persona_id, desired_capabilities)?;
             if let Some(sandbox_id) = existing_sandbox_id {
                 let id = SandboxId::new(sandbox_id);
                 if !sandbox_capabilities_match(existing_sandbox_capabilities, desired_capabilities)
@@ -5701,44 +5666,57 @@ fn clean_persona_id(value: &str) -> Option<&str> {
     if value.is_empty() { None } else { Some(value) }
 }
 
+fn resolve_persona_context(
+    personas: Option<&PersonaRegistry>,
+    persona_id: Option<&str>,
+    defaulted: bool,
+    capabilities: &SessionSandboxCapabilities,
+) -> Result<Option<PersonaContext>, SessionRuntimeError> {
+    let Some(persona_id) = persona_id else {
+        return Ok(None);
+    };
+    let Some(registry) = personas else {
+        return Err(SessionRuntimeError::BadRequest(format!(
+            "persona {persona_id:?} was requested but no persona registry is configured"
+        )));
+    };
+    registry
+        .context_for_access(persona_id, defaulted, &capabilities.repo_cache)
+        .map(Some)
+        .map_err(SessionRuntimeError::BadRequest)
+}
+
 fn resolve_persona_selection(
     personas: Option<&PersonaRegistry>,
     requested_persona_id: Option<&str>,
     capabilities: &SessionSandboxCapabilities,
 ) -> Result<PersonaResolution, SessionRuntimeError> {
     let requested = requested_persona_id.and_then(clean_persona_id);
-    let available_requested = requested
-        .filter(|persona_id| personas.is_some_and(|registry| registry.get(persona_id).is_some()));
-    let unavailable_requested_persona_id = requested
-        .filter(|_| available_requested.is_none())
-        .map(str::to_owned);
-    let selected = available_requested.or_else(|| {
-        personas
-            .and_then(|registry| registry.default_persona_id_for_access(&capabilities.repo_cache))
-    });
-    let defaulted = available_requested.is_none() && selected.is_some();
-    let context = match (personas, selected) {
-        (Some(registry), Some(persona_id)) => registry
-            .context_for_access(persona_id, defaulted, &capabilities.repo_cache)
-            .map(Some)
-            .map_err(SessionRuntimeError::BadRequest)?,
-        _ => None,
+    let Some(registry) = personas else {
+        return Ok(PersonaResolution {
+            persona_id: None,
+            context: None,
+            unavailable_requested_persona_id: requested.map(str::to_owned),
+        });
     };
+    let (selected, unavailable_requested_persona_id) = match requested {
+        Some(persona_id) if registry.get(persona_id).is_some() => (Some(persona_id), None),
+        Some(persona_id) => (
+            registry.default_persona_id_for_access(&capabilities.repo_cache),
+            Some(persona_id.to_owned()),
+        ),
+        None => (
+            registry.default_persona_id_for_access(&capabilities.repo_cache),
+            None,
+        ),
+    };
+    let defaulted = selected.is_some() && selected != requested;
+    let context = resolve_persona_context(Some(registry), selected, defaulted, capabilities)?;
     Ok(PersonaResolution {
         persona_id: selected.map(str::to_owned),
         context,
         unavailable_requested_persona_id,
     })
-}
-
-fn confirmed_unavailable_requested_persona_id(
-    resolution: &PersonaResolution,
-    stored_persona_id: Option<&str>,
-) -> Option<String> {
-    if resolution.persona_id.as_deref() != stored_persona_id {
-        return None;
-    }
-    resolution.unavailable_requested_persona_id.clone()
 }
 
 fn upsert_spec_env(spec: &mut SandboxSpec, name: &str, value: String) {
@@ -7486,24 +7464,19 @@ mod tests {
 
     #[test]
     fn unavailable_requested_persona_uses_deployment_fallback() {
-        let persona = |id: &str, source_root: &str| PersonaDefinition {
-            id: id.to_owned(),
-            source_root: source_root.to_owned(),
-            source_path: format!("{source_root}/personas/{id}"),
-            source_ref: None,
-            prompt_hash: format!("sha256:{id}"),
-            prompt: format!("{id} persona"),
-        };
         let default_registry = PersonaRegistry::new(
-            [
-                persona("eng", "/repo/tools"),
-                persona("private", "/repo/private/tools"),
-            ],
+            [PersonaDefinition {
+                id: "eng".to_owned(),
+                source_root: "/repo/tools".to_owned(),
+                source_path: "/repo/tools/personas/eng".to_owned(),
+                source_ref: None,
+                prompt_hash: "sha256:eng".to_owned(),
+                prompt: "engineering persona".to_owned(),
+            }],
             Some("eng".to_owned()),
-            vec!["/repo/tools".to_owned(), "/repo/private/tools".to_owned()],
+            vec!["/repo/tools".to_owned()],
         )
-        .unwrap()
-        .with_public_source_roots(["/repo/tools".to_owned()]);
+        .unwrap();
         let empty_registry = PersonaRegistry::new(Vec::new(), None, Vec::new()).unwrap();
 
         for (registry, expected_persona_id) in [
@@ -7531,34 +7504,6 @@ mod tests {
                 Some("honk")
             );
         }
-
-        let capabilities = SessionSandboxCapabilities {
-            repo_cache: SessionRepoCacheAccess::Public,
-            observability_enabled: false,
-        };
-        assert!(
-            resolve_persona_selection(Some(&default_registry), Some("private"), &capabilities)
-                .is_err()
-        );
-    }
-
-    #[test]
-    fn unavailable_persona_signal_requires_returned_persona_to_match_resolution() {
-        let resolution = resolve_persona_selection(
-            None,
-            Some("honk"),
-            &SessionSandboxCapabilities::default_enabled(),
-        )
-        .unwrap();
-
-        assert_eq!(
-            confirmed_unavailable_requested_persona_id(&resolution, Some("eng")),
-            None
-        );
-        assert_eq!(
-            confirmed_unavailable_requested_persona_id(&resolution, None).as_deref(),
-            Some("honk")
-        );
     }
 
     #[test]

--- a/services/api-rs/crates/centaur-session-runtime/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-runtime/src/lib.rs
@@ -7485,71 +7485,60 @@ mod tests {
     }
 
     #[test]
-    fn unavailable_requested_persona_falls_back_to_deployment_default() {
-        let registry = PersonaRegistry::new(
-            [PersonaDefinition {
-                id: "eng".to_owned(),
-                source_root: "/repo/tools".to_owned(),
-                source_path: "/repo/tools/personas/eng".to_owned(),
-                source_ref: None,
-                prompt_hash: "sha256:eng".to_owned(),
-                prompt: "engineering persona".to_owned(),
-            }],
+    fn unavailable_requested_persona_uses_deployment_fallback() {
+        let persona = |id: &str, source_root: &str| PersonaDefinition {
+            id: id.to_owned(),
+            source_root: source_root.to_owned(),
+            source_path: format!("{source_root}/personas/{id}"),
+            source_ref: None,
+            prompt_hash: format!("sha256:{id}"),
+            prompt: format!("{id} persona"),
+        };
+        let default_registry = PersonaRegistry::new(
+            [
+                persona("eng", "/repo/tools"),
+                persona("private", "/repo/private/tools"),
+            ],
             Some("eng".to_owned()),
-            vec!["/repo/tools".to_owned()],
+            vec!["/repo/tools".to_owned(), "/repo/private/tools".to_owned()],
         )
-        .unwrap();
+        .unwrap()
+        .with_public_source_roots(["/repo/tools".to_owned()]);
+        let empty_registry = PersonaRegistry::new(Vec::new(), None, Vec::new()).unwrap();
 
-        let resolution = resolve_persona_selection(
-            Some(&registry),
-            Some("honk"),
-            &SessionSandboxCapabilities::default_enabled(),
-        )
-        .unwrap();
+        for (registry, expected_persona_id) in [
+            (Some(&default_registry), Some("eng")),
+            (Some(&empty_registry), None),
+            (None, None),
+        ] {
+            let resolution = resolve_persona_selection(
+                registry,
+                Some("honk"),
+                &SessionSandboxCapabilities::default_enabled(),
+            )
+            .unwrap();
 
-        assert_eq!(resolution.persona_id.as_deref(), Some("eng"));
-        assert_eq!(
-            resolution.unavailable_requested_persona_id.as_deref(),
-            Some("honk")
-        );
-        let context = resolution.context.unwrap();
-        assert_eq!(context.persona_id, "eng");
-        assert!(context.defaulted);
-    }
+            assert_eq!(resolution.persona_id.as_deref(), expected_persona_id);
+            assert_eq!(
+                resolution
+                    .context
+                    .as_ref()
+                    .map(|context| context.persona_id.as_str()),
+                expected_persona_id
+            );
+            assert_eq!(
+                resolution.unavailable_requested_persona_id.as_deref(),
+                Some("honk")
+            );
+        }
 
-    #[test]
-    fn unavailable_requested_persona_falls_back_to_no_persona() {
-        let registry = PersonaRegistry::new(Vec::new(), None, Vec::new()).unwrap();
-
-        let resolution = resolve_persona_selection(
-            Some(&registry),
-            Some("honk"),
-            &SessionSandboxCapabilities::default_enabled(),
-        )
-        .unwrap();
-
-        assert_eq!(resolution.persona_id, None);
-        assert_eq!(resolution.context, None);
-        assert_eq!(
-            resolution.unavailable_requested_persona_id.as_deref(),
-            Some("honk")
-        );
-    }
-
-    #[test]
-    fn unavailable_requested_persona_without_registry_falls_back_to_no_persona() {
-        let resolution = resolve_persona_selection(
-            None,
-            Some("honk"),
-            &SessionSandboxCapabilities::default_enabled(),
-        )
-        .unwrap();
-
-        assert_eq!(resolution.persona_id, None);
-        assert_eq!(resolution.context, None);
-        assert_eq!(
-            resolution.unavailable_requested_persona_id.as_deref(),
-            Some("honk")
+        let capabilities = SessionSandboxCapabilities {
+            repo_cache: SessionRepoCacheAccess::Public,
+            observability_enabled: false,
+        };
+        assert!(
+            resolve_persona_selection(Some(&default_registry), Some("private"), &capabilities)
+                .is_err()
         );
     }
 
@@ -7570,33 +7559,6 @@ mod tests {
             confirmed_unavailable_requested_persona_id(&resolution, None).as_deref(),
             Some("honk")
         );
-    }
-
-    #[test]
-    fn inaccessible_requested_persona_still_fails_closed() {
-        let registry = PersonaRegistry::new(
-            [PersonaDefinition {
-                id: "private".to_owned(),
-                source_root: "/repo/private/tools".to_owned(),
-                source_path: "/repo/private/tools/personas/private".to_owned(),
-                source_ref: None,
-                prompt_hash: "sha256:private".to_owned(),
-                prompt: "private persona".to_owned(),
-            }],
-            None,
-            vec!["/repo/private/tools".to_owned()],
-        )
-        .unwrap();
-        let capabilities = SessionSandboxCapabilities {
-            repo_cache: SessionRepoCacheAccess::Public,
-            observability_enabled: false,
-        };
-
-        let error = resolve_persona_selection(Some(&registry), Some("private"), &capabilities)
-            .err()
-            .expect("private persona should be rejected for public access");
-
-        assert!(matches!(error, SessionRuntimeError::BadRequest(_)));
     }
 
     #[test]
@@ -9303,35 +9265,6 @@ mod adoption_tests {
         runtime_with(store, backend).with_personas(
             PersonaRegistry::new(definitions, None, vec!["/repo/tools".to_owned()]).unwrap(),
         )
-    }
-
-    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn new_session_reports_unavailable_persona_fallback() {
-        let Some(store) = test_store().await else {
-            return;
-        };
-        let _serial = TEST_LOCK.lock().await;
-        let thread_key =
-            ThreadKey::parse(format!("test:persona-fallback-{}", uuid::Uuid::new_v4())).unwrap();
-        let backend = Arc::new(MockBackend::new(SandboxStatus::Running, Vec::new()));
-        let runtime = runtime_with_personas(&store, backend);
-
-        let outcome = runtime
-            .create_or_get_session(
-                &thread_key,
-                &HarnessType::Codex,
-                Some("not-deployed"),
-                Some(json!({})),
-                HarnessConflictPolicy::Reject,
-            )
-            .await
-            .expect("create session with persona fallback");
-
-        assert_eq!(
-            outcome.unavailable_requested_persona_id.as_deref(),
-            Some("not-deployed")
-        );
-        assert_eq!(outcome.session.persona_id, None);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/services/api-rs/crates/centaur-session-runtime/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-runtime/src/lib.rs
@@ -336,6 +336,9 @@ pub struct CreateOrGetSessionOutcome {
     /// True when the session was restarted onto a different harness because
     /// the request asked for [`HarnessConflictPolicy::Restart`].
     pub harness_switched: bool,
+    /// Set only when this request selected a persona for a new session. True
+    /// means the requested persona was unavailable and a fallback was used.
+    pub persona_fallback: Option<bool>,
 }
 
 /// Outcome of [`SessionRuntime::drain`]: the sandboxes that were stopped and
@@ -916,6 +919,7 @@ impl SandboxBootMode {
 struct PersonaResolution {
     persona_id: Option<String>,
     context: Option<PersonaContext>,
+    unavailable_requested_persona_id: Option<String>,
 }
 
 impl SessionRuntime {
@@ -985,14 +989,21 @@ impl SessionRuntime {
         requested_persona_id: Option<&str>,
         capabilities: &SessionSandboxCapabilities,
     ) -> Result<PersonaResolution, SessionRuntimeError> {
-        let requested = requested_persona_id.and_then(clean_persona_id);
-        let selected = requested.or_else(|| self.default_persona_id_for_access(capabilities));
-        let defaulted = requested.is_none() && selected.is_some();
-        let context = self.resolve_persona_context(selected, defaulted, capabilities)?;
-        Ok(PersonaResolution {
-            persona_id: selected.map(str::to_owned),
-            context,
-        })
+        let resolution = resolve_persona_selection(
+            self.personas.as_deref(),
+            requested_persona_id,
+            capabilities,
+        )?;
+        if let Some(requested_persona_id) = resolution.unavailable_requested_persona_id.as_deref() {
+            warn!(
+                component = COMPONENT_SESSION_RUNTIME,
+                event = "session_persona_unavailable_fallback",
+                requested_persona_id,
+                resolved_persona_id = resolution.persona_id.as_deref().unwrap_or(""),
+                "requested persona is unavailable; continuing with the deployment fallback"
+            );
+        }
+        Ok(resolution)
     }
 
     fn resolve_stored_persona(
@@ -1028,15 +1039,6 @@ impl SessionRuntime {
         self.personas
             .as_ref()
             .and_then(|personas| personas.default_persona_id())
-    }
-
-    fn default_persona_id_for_access(
-        &self,
-        capabilities: &SessionSandboxCapabilities,
-    ) -> Option<&str> {
-        self.personas
-            .as_ref()
-            .and_then(|personas| personas.default_persona_id_for_access(&capabilities.repo_cache))
     }
 
     fn context(&self) -> RuntimeContext {
@@ -1617,12 +1619,21 @@ impl SessionRuntime {
                 Err(SessionStoreError::NotFound { .. }) => None,
                 Err(error) => return Err(error.into()),
             };
-            let persona_resolution = match existing_persona_id {
-                Some(persona_id) => PersonaResolution {
-                    context: None,
-                    persona_id,
-                },
-                None => self.resolve_persona_for_create(persona_id, &desired_capabilities)?,
+            let (persona_resolution, persona_fallback) = match existing_persona_id {
+                Some(persona_id) => (
+                    PersonaResolution {
+                        context: None,
+                        persona_id,
+                        unavailable_requested_persona_id: None,
+                    },
+                    None,
+                ),
+                None => {
+                    let resolution =
+                        self.resolve_persona_for_create(persona_id, &desired_capabilities)?;
+                    let fallback = Some(resolution.unavailable_requested_persona_id.is_some());
+                    (resolution, fallback)
+                }
             };
             if let Some(context) = persona_resolution.context.as_ref() {
                 add_persona_metadata(&mut session_metadata, context);
@@ -1689,6 +1700,7 @@ impl SessionRuntime {
             Ok(CreateOrGetSessionOutcome {
                 session,
                 harness_switched,
+                persona_fallback,
             })
         }
         .instrument(span)
@@ -5693,6 +5705,36 @@ fn clean_persona_id(value: &str) -> Option<&str> {
     if value.is_empty() { None } else { Some(value) }
 }
 
+fn resolve_persona_selection(
+    personas: Option<&PersonaRegistry>,
+    requested_persona_id: Option<&str>,
+    capabilities: &SessionSandboxCapabilities,
+) -> Result<PersonaResolution, SessionRuntimeError> {
+    let requested = requested_persona_id.and_then(clean_persona_id);
+    let available_requested = requested
+        .filter(|persona_id| personas.is_some_and(|registry| registry.get(persona_id).is_some()));
+    let unavailable_requested_persona_id = requested
+        .filter(|_| available_requested.is_none())
+        .map(str::to_owned);
+    let selected = available_requested.or_else(|| {
+        personas
+            .and_then(|registry| registry.default_persona_id_for_access(&capabilities.repo_cache))
+    });
+    let defaulted = available_requested.is_none() && selected.is_some();
+    let context = match (personas, selected) {
+        (Some(registry), Some(persona_id)) => registry
+            .context_for_access(persona_id, defaulted, &capabilities.repo_cache)
+            .map(Some)
+            .map_err(SessionRuntimeError::BadRequest)?,
+        _ => None,
+    };
+    Ok(PersonaResolution {
+        persona_id: selected.map(str::to_owned),
+        context,
+        unavailable_requested_persona_id,
+    })
+}
+
 fn upsert_spec_env(spec: &mut SandboxSpec, name: &str, value: String) {
     if let Some(existing) = spec.env.iter_mut().find(|env| env.name == name) {
         existing.value = value;
@@ -7437,6 +7479,102 @@ mod tests {
     }
 
     #[test]
+    fn unavailable_requested_persona_falls_back_to_deployment_default() {
+        let registry = PersonaRegistry::new(
+            [PersonaDefinition {
+                id: "eng".to_owned(),
+                source_root: "/repo/tools".to_owned(),
+                source_path: "/repo/tools/personas/eng".to_owned(),
+                source_ref: None,
+                prompt_hash: "sha256:eng".to_owned(),
+                prompt: "engineering persona".to_owned(),
+            }],
+            Some("eng".to_owned()),
+            vec!["/repo/tools".to_owned()],
+        )
+        .unwrap();
+
+        let resolution = resolve_persona_selection(
+            Some(&registry),
+            Some("honk"),
+            &SessionSandboxCapabilities::default_enabled(),
+        )
+        .unwrap();
+
+        assert_eq!(resolution.persona_id.as_deref(), Some("eng"));
+        assert_eq!(
+            resolution.unavailable_requested_persona_id.as_deref(),
+            Some("honk")
+        );
+        let context = resolution.context.unwrap();
+        assert_eq!(context.persona_id, "eng");
+        assert!(context.defaulted);
+    }
+
+    #[test]
+    fn unavailable_requested_persona_falls_back_to_no_persona() {
+        let registry = PersonaRegistry::new(Vec::new(), None, Vec::new()).unwrap();
+
+        let resolution = resolve_persona_selection(
+            Some(&registry),
+            Some("honk"),
+            &SessionSandboxCapabilities::default_enabled(),
+        )
+        .unwrap();
+
+        assert_eq!(resolution.persona_id, None);
+        assert_eq!(resolution.context, None);
+        assert_eq!(
+            resolution.unavailable_requested_persona_id.as_deref(),
+            Some("honk")
+        );
+    }
+
+    #[test]
+    fn unavailable_requested_persona_without_registry_falls_back_to_no_persona() {
+        let resolution = resolve_persona_selection(
+            None,
+            Some("honk"),
+            &SessionSandboxCapabilities::default_enabled(),
+        )
+        .unwrap();
+
+        assert_eq!(resolution.persona_id, None);
+        assert_eq!(resolution.context, None);
+        assert_eq!(
+            resolution.unavailable_requested_persona_id.as_deref(),
+            Some("honk")
+        );
+    }
+
+    #[test]
+    fn inaccessible_requested_persona_still_fails_closed() {
+        let registry = PersonaRegistry::new(
+            [PersonaDefinition {
+                id: "private".to_owned(),
+                source_root: "/repo/private/tools".to_owned(),
+                source_path: "/repo/private/tools/personas/private".to_owned(),
+                source_ref: None,
+                prompt_hash: "sha256:private".to_owned(),
+                prompt: "private persona".to_owned(),
+            }],
+            None,
+            vec!["/repo/private/tools".to_owned()],
+        )
+        .unwrap();
+        let capabilities = SessionSandboxCapabilities {
+            repo_cache: SessionRepoCacheAccess::Public,
+            observability_enabled: false,
+        };
+
+        let error = resolve_persona_selection(Some(&registry), Some("private"), &capabilities)
+            .err()
+            .expect("private persona should be rejected for public access");
+
+        assert!(matches!(error, SessionRuntimeError::BadRequest(_)));
+    }
+
+    #[test]
     fn tool_host_command_preserves_sandbox_entrypoint_for_tool_setup() {
         let thread_key = ThreadKey::parse("mcp:test").unwrap();
         let workload = SandboxWorkloadMode::codex_app_server(
@@ -9143,6 +9281,32 @@ mod adoption_tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn new_session_reports_unavailable_persona_fallback() {
+        let Some(store) = test_store().await else {
+            return;
+        };
+        let _serial = TEST_LOCK.lock().await;
+        let thread_key =
+            ThreadKey::parse(format!("test:persona-fallback-{}", uuid::Uuid::new_v4())).unwrap();
+        let backend = Arc::new(MockBackend::new(SandboxStatus::Running, Vec::new()));
+        let runtime = runtime_with_personas(&store, backend);
+
+        let outcome = runtime
+            .create_or_get_session(
+                &thread_key,
+                &HarnessType::Codex,
+                Some("not-deployed"),
+                Some(json!({})),
+                HarnessConflictPolicy::Reject,
+            )
+            .await
+            .expect("create session with persona fallback");
+
+        assert_eq!(outcome.persona_fallback, Some(true));
+        assert_eq!(outcome.session.persona_id, None);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn harness_restart_preserves_pinned_persona() {
         let Some(store) = test_store().await else {
             return;
@@ -9153,7 +9317,7 @@ mod adoption_tests {
         let backend = Arc::new(MockBackend::new(SandboxStatus::Running, Vec::new()));
         let runtime = runtime_with_personas(&store, backend);
 
-        runtime
+        let created = runtime
             .create_or_get_session(
                 &thread_key,
                 &HarnessType::Codex,
@@ -9163,6 +9327,7 @@ mod adoption_tests {
             )
             .await
             .expect("create original session");
+        assert_eq!(created.persona_fallback, Some(false));
 
         let outcome = runtime
             .create_or_get_session(
@@ -9176,6 +9341,7 @@ mod adoption_tests {
             .expect("restart session on requested harness");
 
         assert!(outcome.harness_switched);
+        assert_eq!(outcome.persona_fallback, None);
         assert_eq!(outcome.session.harness_type, HarnessType::ClaudeCode);
         assert_eq!(outcome.session.persona_id.as_deref(), Some("old"));
         assert_eq!(
@@ -9224,6 +9390,7 @@ mod adoption_tests {
             .expect("load session with pinned persona");
 
         assert!(!outcome.harness_switched);
+        assert_eq!(outcome.persona_fallback, None);
         assert_eq!(outcome.session.harness_type, HarnessType::Codex);
         assert_eq!(outcome.session.persona_id.as_deref(), Some("old"));
         assert_eq!(

--- a/services/slackbotv2/src/console-session-link.ts
+++ b/services/slackbotv2/src/console-session-link.ts
@@ -219,23 +219,14 @@ export type SlackContextBlock = {
   elements: Array<{ type: 'mrkdwn'; text: string }>
 }
 
-export function appendSlackResponseContextNotice(
-  block: SlackContextBlock | undefined,
-  notice: string
-): SlackContextBlock | undefined {
-  const text = notice.trim()
-  if (!text) return block
-  const noticeElement = {
-    type: 'mrkdwn' as const,
-    text: `:warning: ${escapeSlackMrkdwn(text)}`
-  }
-  if (!block) {
-    return { type: 'context', elements: [noticeElement] }
-  }
-  return {
-    ...block,
-    elements: [noticeElement, ...block.elements]
-  }
+export function personaFallbackNotice(
+  unavailablePersonaId: string | undefined,
+  personaId: string | null | undefined
+): string | undefined {
+  if (!unavailablePersonaId) return undefined
+  return personaId
+    ? `Persona "${unavailablePersonaId}" isn't available. Using "${personaId}" instead.`
+    : `Persona "${unavailablePersonaId}" isn't available. Continuing without a persona.`
 }
 
 /**
@@ -248,13 +239,16 @@ export function buildSlackResponseContextBlock(params: {
   harnessType?: string | null
   metadataEnabled?: boolean
   model?: string | null
+  notice?: string | null
   reasoning?: string | null
   serviceTier?: string | null
 }): SlackContextBlock | undefined {
   const url = consoleSessionUrl(params.consoleBaseUrl, params.threadKey)
   const includeMetadata = params.metadataEnabled === true
-  if (!url && !includeMetadata) return undefined
+  const notice = params.notice?.trim()
+  if (!url && !includeMetadata && !notice) return undefined
   const segments: string[] = []
+  if (notice) segments.push(`:warning: ${escapeSlackMrkdwn(notice)}`)
   if (url) segments.push(`<${url}|Open chat in Console>`)
   if (includeMetadata) {
     const model = params.model?.trim()

--- a/services/slackbotv2/src/console-session-link.ts
+++ b/services/slackbotv2/src/console-session-link.ts
@@ -219,6 +219,25 @@ export type SlackContextBlock = {
   elements: Array<{ type: 'mrkdwn'; text: string }>
 }
 
+export function appendSlackResponseContextNotice(
+  block: SlackContextBlock | undefined,
+  notice: string
+): SlackContextBlock | undefined {
+  const text = notice.trim()
+  if (!text) return block
+  const noticeElement = {
+    type: 'mrkdwn' as const,
+    text: `:warning: ${escapeSlackMrkdwn(text)}`
+  }
+  if (!block) {
+    return { type: 'context', elements: [noticeElement] }
+  }
+  return {
+    ...block,
+    elements: [noticeElement, ...block.elements]
+  }
+}
+
 /**
  * Builds a Slack context block containing the optional Console link and
  * response metadata. Metadata inclusion is independent of the Console URL.

--- a/services/slackbotv2/src/index.ts
+++ b/services/slackbotv2/src/index.ts
@@ -1229,7 +1229,6 @@ async function syncThreadMessageToSession(
   const includeResponseMetadata =
     responseMetadataMode === 'always' ||
     (responseMetadataMode === 'first' && isFirstAssistantMessage)
-  let responseContextBlock: SlackContextBlock | undefined
   if (
     overrides.harnessType ||
     overrides.model ||
@@ -1460,6 +1459,7 @@ async function syncThreadMessageToSession(
     return
   }
 
+  let responseContextBlock: SlackContextBlock | undefined
   try {
     await thread.setState({ activeExecution: true })
     traceLog(input.options, 'slackbotv2_forward_active_execution_marked', trace)

--- a/services/slackbotv2/src/index.ts
+++ b/services/slackbotv2/src/index.ts
@@ -1482,23 +1482,24 @@ async function syncThreadMessageToSession(
       onSessionCreated: async outcome => {
         let personaFallbackNotice: string | undefined
         if (outcome.personaId !== undefined) {
-          const requestedPersonaId = stickyOverridesUpdate?.personaId
+          const requestedPersonaId =
+            outcome.unavailableRequestedPersonaId ?? stickyOverridesUpdate?.personaId
           stickyOverridesUpdate = {
             ...(stickyOverridesUpdate ?? {}),
             personaId: outcome.personaId
           }
           forwardInput.personaId = outcome.personaId ?? undefined
-          if (outcome.personaFallback === true && requestedPersonaId !== undefined) {
+          if (outcome.unavailableRequestedPersonaId) {
             personaFallbackNotice =
               outcome.personaId === null
-                ? `Persona "${requestedPersonaId}" isn't available. Continuing without a persona.`
-                : `Persona "${requestedPersonaId}" isn't available. Using "${outcome.personaId}" instead.`
+                ? `Persona "${outcome.unavailableRequestedPersonaId}" isn't available. Continuing without a persona.`
+                : `Persona "${outcome.unavailableRequestedPersonaId}" isn't available. Using "${outcome.personaId}" instead.`
           }
           if (requestedPersonaId !== undefined && outcome.personaId !== requestedPersonaId) {
             traceLog(input.options, 'slackbotv2_session_persona_reconciled', trace, {
               requested_persona_id: requestedPersonaId,
               resolved_persona_id: outcome.personaId,
-              persona_fallback: outcome.personaFallback
+              unavailable_requested_persona_id: outcome.unavailableRequestedPersonaId
             })
           }
         }

--- a/services/slackbotv2/src/index.ts
+++ b/services/slackbotv2/src/index.ts
@@ -55,6 +55,7 @@ import {
   withSlackApiTimeout
 } from './session-api'
 import {
+  appendSlackResponseContextNotice,
   buildSlackResponseContextBlock,
   defaultModelForHarness,
   defaultServiceTierForHarness,
@@ -1479,6 +1480,7 @@ async function syncThreadMessageToSession(
       onExecutionStarted: commitExecutionStarted,
       onMessagesAppended: commitMessagesAppended,
       onSessionCreated: async outcome => {
+        let personaFallbackNotice: string | undefined
         if (outcome.personaId !== undefined) {
           const requestedPersonaId = stickyOverridesUpdate?.personaId
           stickyOverridesUpdate = {
@@ -1486,10 +1488,17 @@ async function syncThreadMessageToSession(
             personaId: outcome.personaId
           }
           forwardInput.personaId = outcome.personaId ?? undefined
+          if (outcome.personaFallback === true && requestedPersonaId !== undefined) {
+            personaFallbackNotice =
+              outcome.personaId === null
+                ? `Persona "${requestedPersonaId}" isn't available. Continuing without a persona.`
+                : `Persona "${requestedPersonaId}" isn't available. Using "${outcome.personaId}" instead.`
+          }
           if (requestedPersonaId !== undefined && outcome.personaId !== requestedPersonaId) {
             traceLog(input.options, 'slackbotv2_session_persona_reconciled', trace, {
               requested_persona_id: requestedPersonaId,
-              resolved_persona_id: outcome.personaId
+              resolved_persona_id: outcome.personaId,
+              persona_fallback: outcome.personaFallback
             })
           }
         }
@@ -1497,7 +1506,15 @@ async function syncThreadMessageToSession(
         const abTested = outcome.harnessAssignment?.experiment === 'codex_nanocodex_ab'
         forwardInput.metadataHarnessType = harnessType
         forwardInput.harnessAssignment = outcome.harnessAssignment
-        if (harnessType === effectiveHarnessType && !abTested) return
+        if (harnessType === effectiveHarnessType && !abTested) {
+          if (personaFallbackNotice) {
+            responseContextBlock = appendSlackResponseContextNotice(
+              responseContextBlock,
+              personaFallbackNotice
+            )
+          }
+          return
+        }
         const model =
           resolvedModel ?? defaultModelForHarness(harnessType, input.options.harnessDefaultModels)
         const requestedReasoning = reasoningForModel(harnessType, model, resolvedReasoning)
@@ -1529,6 +1546,12 @@ async function syncThreadMessageToSession(
           requested_harness_type: effectiveHarnessType,
           resolved_harness_type: harnessType
         })
+        if (personaFallbackNotice) {
+          responseContextBlock = appendSlackResponseContextNotice(
+            responseContextBlock,
+            personaFallbackNotice
+          )
+        }
       },
       onSessionRestarted: handleSessionRestarted
     })

--- a/services/slackbotv2/src/index.ts
+++ b/services/slackbotv2/src/index.ts
@@ -55,11 +55,11 @@ import {
   withSlackApiTimeout
 } from './session-api'
 import {
-  appendSlackResponseContextNotice,
   buildSlackResponseContextBlock,
   defaultModelForHarness,
   defaultServiceTierForHarness,
   effectiveReasoningForHarness,
+  personaFallbackNotice,
   reasoningForModel,
   type SlackContextBlock
 } from './console-session-link'
@@ -1229,20 +1229,7 @@ async function syncThreadMessageToSession(
   const includeResponseMetadata =
     responseMetadataMode === 'always' ||
     (responseMetadataMode === 'first' && isFirstAssistantMessage)
-  let responseContextBlock = isFirstAssistantMessage || includeResponseMetadata
-    ? buildSlackResponseContextBlock({
-        consoleBaseUrl: isFirstAssistantMessage ? input.options.consolePublicUrl : undefined,
-        threadKey: thread.id,
-        harnessType: effectiveHarnessType,
-        metadataEnabled: includeResponseMetadata,
-        model: effectiveModel,
-        reasoning: effectiveReasoning,
-        serviceTier:
-          input.options.responseServiceTierEnabled === true && !resolvedProvider
-            ? defaultServiceTierForHarness(effectiveHarnessType)
-            : undefined
-      })
-    : undefined
+  let responseContextBlock: SlackContextBlock | undefined
   if (
     overrides.harnessType ||
     overrides.model ||
@@ -1480,21 +1467,17 @@ async function syncThreadMessageToSession(
       onExecutionStarted: commitExecutionStarted,
       onMessagesAppended: commitMessagesAppended,
       onSessionCreated: async outcome => {
-        let personaFallbackNotice: string | undefined
+        const fallbackNotice = personaFallbackNotice(
+          outcome.unavailableRequestedPersonaId,
+          outcome.personaId
+        )
         if (outcome.personaId !== undefined) {
-          const requestedPersonaId =
-            outcome.unavailableRequestedPersonaId ?? stickyOverridesUpdate?.personaId
+          const requestedPersonaId = forwardInput.personaId
           stickyOverridesUpdate = {
             ...(stickyOverridesUpdate ?? {}),
             personaId: outcome.personaId
           }
           forwardInput.personaId = outcome.personaId ?? undefined
-          if (outcome.unavailableRequestedPersonaId) {
-            personaFallbackNotice =
-              outcome.personaId === null
-                ? `Persona "${outcome.unavailableRequestedPersonaId}" isn't available. Continuing without a persona.`
-                : `Persona "${outcome.unavailableRequestedPersonaId}" isn't available. Using "${outcome.personaId}" instead.`
-          }
           if (requestedPersonaId !== undefined && outcome.personaId !== requestedPersonaId) {
             traceLog(input.options, 'slackbotv2_session_persona_reconciled', trace, {
               requested_persona_id: requestedPersonaId,
@@ -1507,52 +1490,40 @@ async function syncThreadMessageToSession(
         const abTested = outcome.harnessAssignment?.experiment === 'codex_nanocodex_ab'
         forwardInput.metadataHarnessType = harnessType
         forwardInput.harnessAssignment = outcome.harnessAssignment
-        if (harnessType === effectiveHarnessType && !abTested) {
-          if (personaFallbackNotice) {
-            responseContextBlock = appendSlackResponseContextNotice(
-              responseContextBlock,
-              personaFallbackNotice
-            )
-          }
-          return
-        }
-        const model =
-          resolvedModel ?? defaultModelForHarness(harnessType, input.options.harnessDefaultModels)
-        const requestedReasoning = reasoningForModel(harnessType, model, resolvedReasoning)
-        const reasoning = effectiveReasoningForHarness(
-          harnessType,
-          requestedReasoning,
-          input.options.harnessDefaultReasoning
-        )
-        forwardInput.metadataModel = model
-        forwardInput.reasoning = requestedReasoning
-        if (isFirstAssistantMessage || includeResponseMetadata) {
-          responseContextBlock = buildSlackResponseContextBlock({
-            consoleBaseUrl: isFirstAssistantMessage ? input.options.consolePublicUrl : undefined,
-            threadKey: thread.id,
+        let model = effectiveModel
+        let reasoning = effectiveReasoning
+        if (harnessType !== effectiveHarnessType || abTested) {
+          model =
+            resolvedModel ?? defaultModelForHarness(harnessType, input.options.harnessDefaultModels)
+          const requestedReasoning = reasoningForModel(harnessType, model, resolvedReasoning)
+          reasoning = effectiveReasoningForHarness(
             harnessType,
-            metadataEnabled: includeResponseMetadata,
-            model,
-            reasoning,
-            serviceTier:
-              input.options.responseServiceTierEnabled === true && !resolvedProvider
-                ? defaultServiceTierForHarness(harnessType)
-                : undefined
+            requestedReasoning,
+            input.options.harnessDefaultReasoning
+          )
+          forwardInput.metadataModel = model
+          forwardInput.reasoning = requestedReasoning
+          traceLog(input.options, 'slackbotv2_session_harness_resolved', trace, {
+            ab_tested: abTested,
+            ab_test_experiment: outcome.harnessAssignment?.experiment,
+            ab_test_cohort: outcome.harnessAssignment?.cohort,
+            requested_harness_type: effectiveHarnessType,
+            resolved_harness_type: harnessType
           })
         }
-        traceLog(input.options, 'slackbotv2_session_harness_resolved', trace, {
-          ab_tested: abTested,
-          ab_test_experiment: outcome.harnessAssignment?.experiment,
-          ab_test_cohort: outcome.harnessAssignment?.cohort,
-          requested_harness_type: effectiveHarnessType,
-          resolved_harness_type: harnessType
+        responseContextBlock = buildSlackResponseContextBlock({
+          consoleBaseUrl: isFirstAssistantMessage ? input.options.consolePublicUrl : undefined,
+          threadKey: thread.id,
+          harnessType,
+          metadataEnabled: includeResponseMetadata,
+          model,
+          notice: fallbackNotice,
+          reasoning,
+          serviceTier:
+            input.options.responseServiceTierEnabled === true && !resolvedProvider
+              ? defaultServiceTierForHarness(harnessType)
+              : undefined
         })
-        if (personaFallbackNotice) {
-          responseContextBlock = appendSlackResponseContextNotice(
-            responseContextBlock,
-            personaFallbackNotice
-          )
-        }
       },
       onSessionRestarted: handleSessionRestarted
     })

--- a/services/slackbotv2/src/session-api.ts
+++ b/services/slackbotv2/src/session-api.ts
@@ -887,24 +887,26 @@ async function sessionOutcomeFromResponse(
 ): Promise<CreateSessionOutcome> {
   try {
     const payload = await response.json()
-    const harnessType = isJsonObject(payload) ? stringValue(payload.harness_type) : undefined
+    const payloadIsObject = isJsonObject(payload)
+    const harnessType = rawSlackString(payload, 'harness_type')
     const resolvedAssignment =
       harnessAssignment &&
       (!harnessType || harnessType === 'codex' || harnessType === 'nanocodex')
         ? { ...harnessAssignment, cohort: harnessType ?? harnessAssignment.cohort }
         : undefined
-    const personaId = isJsonObject(payload)
+    const personaId = payloadIsObject
       ? typeof payload.persona_id === 'string'
         ? payload.persona_id
         : 'persona_id' in payload
           ? null
           : undefined
       : undefined
-    const unavailableRequestedPersonaId = isJsonObject(payload)
-      ? stringValue(payload.unavailable_requested_persona_id)
-      : undefined
+    const unavailableRequestedPersonaId = rawSlackString(
+      payload,
+      'unavailable_requested_persona_id'
+    )
     return {
-      harnessSwitched: isJsonObject(payload) && payload.harness_switched === true,
+      harnessSwitched: payloadIsObject && payload.harness_switched === true,
       ...(harnessType ? { harnessType } : {}),
       ...(personaId !== undefined ? { personaId } : {}),
       ...(unavailableRequestedPersonaId ? { unavailableRequestedPersonaId } : {}),

--- a/services/slackbotv2/src/session-api.ts
+++ b/services/slackbotv2/src/session-api.ts
@@ -496,7 +496,7 @@ export async function forwardToSessionApi(
     harness_type: created.harnessType,
     harness_switched: created.harnessSwitched,
     persona_id: created.personaId,
-    persona_fallback: created.personaFallback,
+    unavailable_requested_persona_id: created.unavailableRequestedPersonaId,
     phase_ms: elapsedMs(createStartedAtMs)
   })
   await callbacks.onSessionCreated?.(created)
@@ -770,8 +770,8 @@ type CreateSessionOutcome = {
   harnessAssignment?: SlackbotV2HarnessAssignment
   /** The persona persisted by the API. Null means the session has no persona. */
   personaId?: string | null
-  /** The API replaced an unavailable requested persona while creating the session. */
-  personaFallback?: boolean
+  /** The unavailable persona ID replaced by the API during new-session creation. */
+  unavailableRequestedPersonaId?: string
   /** The API restarted the thread onto the requested harness. */
   harnessSwitched: boolean
 }
@@ -900,15 +900,14 @@ async function sessionOutcomeFromResponse(
           ? null
           : undefined
       : undefined
-    const personaFallback =
-      isJsonObject(payload) && typeof payload.persona_fallback === 'boolean'
-        ? payload.persona_fallback
-        : undefined
+    const unavailableRequestedPersonaId = isJsonObject(payload)
+      ? stringValue(payload.unavailable_requested_persona_id)
+      : undefined
     return {
       harnessSwitched: isJsonObject(payload) && payload.harness_switched === true,
       ...(harnessType ? { harnessType } : {}),
       ...(personaId !== undefined ? { personaId } : {}),
-      ...(personaFallback !== undefined ? { personaFallback } : {}),
+      ...(unavailableRequestedPersonaId ? { unavailableRequestedPersonaId } : {}),
       ...(resolvedAssignment ? { harnessAssignment: resolvedAssignment } : {})
     }
   } catch {

--- a/services/slackbotv2/src/session-api.ts
+++ b/services/slackbotv2/src/session-api.ts
@@ -496,6 +496,7 @@ export async function forwardToSessionApi(
     harness_type: created.harnessType,
     harness_switched: created.harnessSwitched,
     persona_id: created.personaId,
+    persona_fallback: created.personaFallback,
     phase_ms: elapsedMs(createStartedAtMs)
   })
   await callbacks.onSessionCreated?.(created)
@@ -769,6 +770,8 @@ type CreateSessionOutcome = {
   harnessAssignment?: SlackbotV2HarnessAssignment
   /** The persona persisted by the API. Null means the session has no persona. */
   personaId?: string | null
+  /** The API replaced an unavailable requested persona while creating the session. */
+  personaFallback?: boolean
   /** The API restarted the thread onto the requested harness. */
   harnessSwitched: boolean
 }
@@ -897,10 +900,15 @@ async function sessionOutcomeFromResponse(
           ? null
           : undefined
       : undefined
+    const personaFallback =
+      isJsonObject(payload) && typeof payload.persona_fallback === 'boolean'
+        ? payload.persona_fallback
+        : undefined
     return {
       harnessSwitched: isJsonObject(payload) && payload.harness_switched === true,
       ...(harnessType ? { harnessType } : {}),
       ...(personaId !== undefined ? { personaId } : {}),
+      ...(personaFallback !== undefined ? { personaFallback } : {}),
       ...(resolvedAssignment ? { harnessAssignment: resolvedAssignment } : {})
     }
   } catch {

--- a/services/slackbotv2/test/chat-sdk-emulate.test.ts
+++ b/services/slackbotv2/test/chat-sdk-emulate.test.ts
@@ -783,12 +783,7 @@ describe('slackbotv2', () => {
     )
 
     expect(codexApi.creates.map(create => create.body.persona_id)).toEqual(['eng', 'old'])
-    const unavailablePersonaNotices = slackApi.calls
-      .filter(call => call.method === 'chat.stopStream')
-      .flatMap(call => (Array.isArray(call.body.blocks) ? call.body.blocks : []))
-      .map(block => JSON.stringify(block))
-      .filter(block => block.includes("isn't available"))
-    expect(unavailablePersonaNotices).toHaveLength(0)
+    expect(stopStreamBlocksText(slackApi.calls)).not.toContain("isn't available")
     const state = await sharedState.get<Record<string, unknown>>(
       `thread-state:${threadKey(parent.ts)}`
     )
@@ -834,12 +829,9 @@ describe('slackbotv2', () => {
     await Promise.all(waits)
 
     expect(codexApi.creates[0]?.body.persona_id).toBe('honk')
-    const personaNotice = slackApi.calls
-      .filter(call => call.method === 'chat.stopStream')
-      .flatMap(call => (Array.isArray(call.body.blocks) ? call.body.blocks : []))
-      .map(block => JSON.stringify(block))
-      .find(block => block.includes('Persona \\"honk\\" isn\'t available'))
-    expect(personaNotice).toContain('Using \\"eng\\" instead.')
+    expect(stopStreamBlocksText(slackApi.calls)).toContain(
+      `Persona "honk" isn't available. Using "eng" instead.`
+    )
   })
 
   it('clears a sticky model rejected by the harness and accepts a later override', async () => {
@@ -7144,6 +7136,18 @@ function blocksText(value: unknown): string {
     })
     .filter(Boolean)
     .join('\n')
+}
+
+function stopStreamBlocksText(calls: StreamCall[]): string {
+  const blocks = calls
+    .filter(call => call.method === 'chat.stopStream')
+    .flatMap(call => (Array.isArray(call.body.blocks) ? call.body.blocks : []))
+  const elements = blocks.flatMap(block => {
+    if (!block || typeof block !== 'object' || Array.isArray(block)) return []
+    const value = (block as Record<string, unknown>).elements
+    return Array.isArray(value) ? value : []
+  })
+  return blocksText([...blocks, ...elements])
 }
 
 function normalizeApiPath(path: string): string {

--- a/services/slackbotv2/test/chat-sdk-emulate.test.ts
+++ b/services/slackbotv2/test/chat-sdk-emulate.test.ts
@@ -795,7 +795,7 @@ describe('slackbotv2', () => {
     expect(state).toEqual(expect.objectContaining({ personaId: 'old' }))
   })
 
-  it('reports when an unavailable persona falls back to the deployment default', async () => {
+  it('reports a fallback for a stale sticky persona on a plain message', async () => {
     const sharedState = createMemoryState()
     await sharedState.connect()
     bot = createTestBot({ state: sharedState })
@@ -803,12 +803,13 @@ describe('slackbotv2', () => {
       harness_switched: false,
       harness_type: 'codex',
       persona_id: 'eng',
-      persona_fallback: true
+      unavailable_requested_persona_id: 'honk'
     })
 
     const parent = await postUserMessage('Thread default context.')
+    await sharedState.set(`thread-state:${threadKey(parent.ts)}`, { personaId: 'honk' })
     const mention = await postUserMessage(
-      `<@${BOT_USER_ID}> --persona=honk start with the fallback`,
+      `<@${BOT_USER_ID}> start with the fallback`,
       parent.ts
     )
     const waits: Promise<unknown>[] = []
@@ -823,7 +824,7 @@ describe('slackbotv2', () => {
           team: TEAM_ID,
           ts: mention.ts,
           thread_ts: parent.ts,
-          text: `<@${BOT_USER_ID}> --persona=honk start with the fallback`
+          text: `<@${BOT_USER_ID}> start with the fallback`
         }
       }),
       {},
@@ -832,6 +833,7 @@ describe('slackbotv2', () => {
     expect(response.status).toBe(200)
     await Promise.all(waits)
 
+    expect(codexApi.creates[0]?.body.persona_id).toBe('honk')
     const personaNotice = slackApi.calls
       .filter(call => call.method === 'chat.stopStream')
       .flatMap(call => (Array.isArray(call.body.blocks) ? call.body.blocks : []))
@@ -848,7 +850,7 @@ describe('slackbotv2', () => {
       harness_switched: false,
       harness_type: 'codex',
       persona_id: null,
-      persona_fallback: true
+      unavailable_requested_persona_id: 'honk'
     })
 
     const parent = await postUserMessage('Thread default context.')

--- a/services/slackbotv2/test/chat-sdk-emulate.test.ts
+++ b/services/slackbotv2/test/chat-sdk-emulate.test.ts
@@ -842,56 +842,6 @@ describe('slackbotv2', () => {
     expect(personaNotice).toContain('Using \\"eng\\" instead.')
   })
 
-  it('reports when an unavailable persona falls back to no persona', async () => {
-    const sharedState = createMemoryState()
-    await sharedState.connect()
-    bot = createTestBot({ state: sharedState })
-    codexApi.queueCreateResponse({
-      harness_switched: false,
-      harness_type: 'codex',
-      persona_id: null,
-      unavailable_requested_persona_id: 'honk'
-    })
-
-    const parent = await postUserMessage('Thread default context.')
-    const mention = await postUserMessage(
-      `<@${BOT_USER_ID}> --persona=honk start without it if needed`,
-      parent.ts
-    )
-    const waits: Promise<unknown>[] = []
-    const response = await bot.app.request(
-      '/api/webhooks/slack',
-      signedSlackEvent({
-        event_id: 'Ev-slackbotv2-persona-reconcile-none',
-        event: {
-          type: 'app_mention',
-          user: USER_ID,
-          channel: CHANNEL_ID,
-          team: TEAM_ID,
-          ts: mention.ts,
-          thread_ts: parent.ts,
-          text: `<@${BOT_USER_ID}> --persona=honk start without it if needed`
-        }
-      }),
-      {},
-      waitUntilContext(waits)
-    )
-    expect(response.status).toBe(200)
-    await Promise.all(waits)
-
-    expect(codexApi.creates[0]?.body.persona_id).toBe('honk')
-    const personaNotice = slackApi.calls
-      .filter(call => call.method === 'chat.stopStream')
-      .flatMap(call => (Array.isArray(call.body.blocks) ? call.body.blocks : []))
-      .map(block => JSON.stringify(block))
-      .find(block => block.includes('Persona \\"honk\\" isn\'t available'))
-    expect(personaNotice).toContain('Continuing without a persona.')
-    const state = await sharedState.get<Record<string, unknown>>(
-      `thread-state:${threadKey(parent.ts)}`
-    )
-    expect(state).toEqual(expect.objectContaining({ personaId: null }))
-  })
-
   it('clears a sticky model rejected by the harness and accepts a later override', async () => {
     const sharedState = createMemoryState()
     await sharedState.connect()

--- a/services/slackbotv2/test/chat-sdk-emulate.test.ts
+++ b/services/slackbotv2/test/chat-sdk-emulate.test.ts
@@ -738,7 +738,7 @@ describe('slackbotv2', () => {
     )
   })
 
-  it('pins sticky persona state to the persona persisted by the API', async () => {
+  it('pins sticky persona state without labeling a pinned mismatch as unavailable', async () => {
     const sharedState = createMemoryState()
     await sharedState.connect()
     bot = createTestBot({ state: sharedState })
@@ -783,10 +783,111 @@ describe('slackbotv2', () => {
     )
 
     expect(codexApi.creates.map(create => create.body.persona_id)).toEqual(['eng', 'old'])
+    const unavailablePersonaNotices = slackApi.calls
+      .filter(call => call.method === 'chat.stopStream')
+      .flatMap(call => (Array.isArray(call.body.blocks) ? call.body.blocks : []))
+      .map(block => JSON.stringify(block))
+      .filter(block => block.includes("isn't available"))
+    expect(unavailablePersonaNotices).toHaveLength(0)
     const state = await sharedState.get<Record<string, unknown>>(
       `thread-state:${threadKey(parent.ts)}`
     )
     expect(state).toEqual(expect.objectContaining({ personaId: 'old' }))
+  })
+
+  it('reports when an unavailable persona falls back to the deployment default', async () => {
+    const sharedState = createMemoryState()
+    await sharedState.connect()
+    bot = createTestBot({ state: sharedState })
+    codexApi.queueCreateResponse({
+      harness_switched: false,
+      harness_type: 'codex',
+      persona_id: 'eng',
+      persona_fallback: true
+    })
+
+    const parent = await postUserMessage('Thread default context.')
+    const mention = await postUserMessage(
+      `<@${BOT_USER_ID}> --persona=honk start with the fallback`,
+      parent.ts
+    )
+    const waits: Promise<unknown>[] = []
+    const response = await bot.app.request(
+      '/api/webhooks/slack',
+      signedSlackEvent({
+        event_id: 'Ev-slackbotv2-persona-reconcile-default',
+        event: {
+          type: 'app_mention',
+          user: USER_ID,
+          channel: CHANNEL_ID,
+          team: TEAM_ID,
+          ts: mention.ts,
+          thread_ts: parent.ts,
+          text: `<@${BOT_USER_ID}> --persona=honk start with the fallback`
+        }
+      }),
+      {},
+      waitUntilContext(waits)
+    )
+    expect(response.status).toBe(200)
+    await Promise.all(waits)
+
+    const personaNotice = slackApi.calls
+      .filter(call => call.method === 'chat.stopStream')
+      .flatMap(call => (Array.isArray(call.body.blocks) ? call.body.blocks : []))
+      .map(block => JSON.stringify(block))
+      .find(block => block.includes('Persona \\"honk\\" isn\'t available'))
+    expect(personaNotice).toContain('Using \\"eng\\" instead.')
+  })
+
+  it('reports when an unavailable persona falls back to no persona', async () => {
+    const sharedState = createMemoryState()
+    await sharedState.connect()
+    bot = createTestBot({ state: sharedState })
+    codexApi.queueCreateResponse({
+      harness_switched: false,
+      harness_type: 'codex',
+      persona_id: null,
+      persona_fallback: true
+    })
+
+    const parent = await postUserMessage('Thread default context.')
+    const mention = await postUserMessage(
+      `<@${BOT_USER_ID}> --persona=honk start without it if needed`,
+      parent.ts
+    )
+    const waits: Promise<unknown>[] = []
+    const response = await bot.app.request(
+      '/api/webhooks/slack',
+      signedSlackEvent({
+        event_id: 'Ev-slackbotv2-persona-reconcile-none',
+        event: {
+          type: 'app_mention',
+          user: USER_ID,
+          channel: CHANNEL_ID,
+          team: TEAM_ID,
+          ts: mention.ts,
+          thread_ts: parent.ts,
+          text: `<@${BOT_USER_ID}> --persona=honk start without it if needed`
+        }
+      }),
+      {},
+      waitUntilContext(waits)
+    )
+    expect(response.status).toBe(200)
+    await Promise.all(waits)
+
+    expect(codexApi.creates[0]?.body.persona_id).toBe('honk')
+    const personaNotice = slackApi.calls
+      .filter(call => call.method === 'chat.stopStream')
+      .flatMap(call => (Array.isArray(call.body.blocks) ? call.body.blocks : []))
+      .map(block => JSON.stringify(block))
+      .find(block => block.includes('Persona \\"honk\\" isn\'t available'))
+    expect(personaNotice).toContain('Continuing without a persona.')
+    const state = await sharedState.get<Record<string, unknown>>(
+      `thread-state:${threadKey(parent.ts)}`
+    )
+    expect(state).toEqual(expect.objectContaining({ personaId: null }))
   })
 
   it('clears a sticky model rejected by the harness and accepts a later override', async () => {

--- a/services/slackbotv2/test/console-session-link.test.ts
+++ b/services/slackbotv2/test/console-session-link.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 import {
+  appendSlackResponseContextNotice,
   buildSlackResponseContextBlock,
   consoleSessionUrl,
   defaultModelForHarness,
@@ -272,5 +273,39 @@ describe('buildSlackResponseContextBlock', () => {
     })
 
     expect(block?.elements[0]?.text).toBe('GPT-5.6-SOL · Codex · Low · Fast')
+  })
+})
+
+describe('appendSlackResponseContextNotice', () => {
+  test('creates a warning context block when response metadata is absent', () => {
+    expect(
+      appendSlackResponseContextNotice(
+        undefined,
+        'Persona "<unsafe&persona>" cannot be used.'
+      )
+    ).toEqual({
+      type: 'context',
+      elements: [
+        {
+          type: 'mrkdwn',
+          text: ':warning: Persona "&lt;unsafe&amp;persona&gt;" cannot be used.'
+        }
+      ]
+    })
+  })
+
+  test('prepends a notice to an existing response context block', () => {
+    const block = buildSlackResponseContextBlock({
+      consoleBaseUrl: 'https://console.centaur.dev',
+      threadKey: 'slack:C1:1'
+    })
+
+    expect(appendSlackResponseContextNotice(block, 'Using the default persona.')?.elements).toEqual([
+      { type: 'mrkdwn', text: ':warning: Using the default persona.' },
+      {
+        type: 'mrkdwn',
+        text: '<https://console.centaur.dev/console/threads?thread=slack%3AC1%3A1|Open chat in Console>'
+      }
+    ])
   })
 })

--- a/services/slackbotv2/test/console-session-link.test.ts
+++ b/services/slackbotv2/test/console-session-link.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, test } from 'bun:test'
 import {
-  appendSlackResponseContextNotice,
   buildSlackResponseContextBlock,
   consoleSessionUrl,
   defaultModelForHarness,
@@ -8,6 +7,7 @@ import {
   defaultServiceTierForHarness,
   effectiveReasoningForHarness,
   harnessDisplayName,
+  personaFallbackNotice,
   reasoningForModel
 } from '../src/console-session-link'
 import claudeSettings from '../../../harness/claude/settings.json'
@@ -274,15 +274,14 @@ describe('buildSlackResponseContextBlock', () => {
 
     expect(block?.elements[0]?.text).toBe('GPT-5.6-SOL · Codex · Low · Fast')
   })
-})
 
-describe('appendSlackResponseContextNotice', () => {
-  test('creates a warning context block when response metadata is absent', () => {
+  test('renders and escapes a notice when response metadata is absent', () => {
     expect(
-      appendSlackResponseContextNotice(
-        undefined,
-        'Persona "<unsafe&persona>" cannot be used.'
-      )
+      buildSlackResponseContextBlock({
+        consoleBaseUrl: undefined,
+        threadKey: 'slack:C1:1',
+        notice: 'Persona "<unsafe&persona>" cannot be used.'
+      })
     ).toEqual({
       type: 'context',
       elements: [
@@ -293,19 +292,14 @@ describe('appendSlackResponseContextNotice', () => {
       ]
     })
   })
+})
 
-  test('prepends a notice to an existing response context block', () => {
-    const block = buildSlackResponseContextBlock({
-      consoleBaseUrl: 'https://console.centaur.dev',
-      threadKey: 'slack:C1:1'
-    })
-
-    expect(appendSlackResponseContextNotice(block, 'Using the default persona.')?.elements).toEqual([
-      { type: 'mrkdwn', text: ':warning: Using the default persona.' },
-      {
-        type: 'mrkdwn',
-        text: '<https://console.centaur.dev/console/threads?thread=slack%3AC1%3A1|Open chat in Console>'
-      }
-    ])
-  })
+test('personaFallbackNotice describes the resolved fallback', () => {
+  expect(personaFallbackNotice('honk', 'eng')).toBe(
+    `Persona "honk" isn't available. Using "eng" instead.`
+  )
+  expect(personaFallbackNotice('honk', null)).toBe(
+    `Persona "honk" isn't available. Continuing without a persona.`
+  )
+  expect(personaFallbackNotice(undefined, 'eng')).toBeUndefined()
 })

--- a/services/slackbotv2/test/session-api.test.ts
+++ b/services/slackbotv2/test/session-api.test.ts
@@ -636,6 +636,35 @@ describe('forwardToSessionApi overrides', () => {
     )
   })
 
+  test('maps persona fallback from the create response onto the session outcome', async () => {
+    const { fetchFn } = fakeApi({
+      createSession: [
+        {
+          body: {
+            harness_switched: false,
+            harness_type: 'codex',
+            persona_fallback: true,
+            persona_id: 'eng'
+          },
+          status: 200
+        }
+      ]
+    })
+    let personaFallback: boolean | undefined
+
+    await forwardToSessionApi(
+      options(fetchFn),
+      forwardInput(apiMessage('review this'), { personaId: 'honk' }),
+      {
+        onSessionCreated: async outcome => {
+          personaFallback = outcome.personaFallback
+        }
+      }
+    )
+
+    expect(personaFallback).toBe(true)
+  })
+
   test('includes model override on the execute input line', async () => {
     const { fetchFn, requests } = fakeApi()
     await forwardToSessionApi(

--- a/services/slackbotv2/test/session-api.test.ts
+++ b/services/slackbotv2/test/session-api.test.ts
@@ -636,35 +636,6 @@ describe('forwardToSessionApi overrides', () => {
     )
   })
 
-  test('maps the unavailable persona ID from the create response onto the session outcome', async () => {
-    const { fetchFn } = fakeApi({
-      createSession: [
-        {
-          body: {
-            harness_switched: false,
-            harness_type: 'codex',
-            persona_id: 'eng',
-            unavailable_requested_persona_id: 'honk'
-          },
-          status: 200
-        }
-      ]
-    })
-    let unavailableRequestedPersonaId: string | undefined
-
-    await forwardToSessionApi(
-      options(fetchFn),
-      forwardInput(apiMessage('review this'), { personaId: 'honk' }),
-      {
-        onSessionCreated: async outcome => {
-          unavailableRequestedPersonaId = outcome.unavailableRequestedPersonaId
-        }
-      }
-    )
-
-    expect(unavailableRequestedPersonaId).toBe('honk')
-  })
-
   test('includes model override on the execute input line', async () => {
     const { fetchFn, requests } = fakeApi()
     await forwardToSessionApi(

--- a/services/slackbotv2/test/session-api.test.ts
+++ b/services/slackbotv2/test/session-api.test.ts
@@ -636,33 +636,33 @@ describe('forwardToSessionApi overrides', () => {
     )
   })
 
-  test('maps persona fallback from the create response onto the session outcome', async () => {
+  test('maps the unavailable persona ID from the create response onto the session outcome', async () => {
     const { fetchFn } = fakeApi({
       createSession: [
         {
           body: {
             harness_switched: false,
             harness_type: 'codex',
-            persona_fallback: true,
-            persona_id: 'eng'
+            persona_id: 'eng',
+            unavailable_requested_persona_id: 'honk'
           },
           status: 200
         }
       ]
     })
-    let personaFallback: boolean | undefined
+    let unavailableRequestedPersonaId: string | undefined
 
     await forwardToSessionApi(
       options(fetchFn),
       forwardInput(apiMessage('review this'), { personaId: 'honk' }),
       {
         onSessionCreated: async outcome => {
-          personaFallback = outcome.personaFallback
+          unavailableRequestedPersonaId = outcome.unavailableRequestedPersonaId
         }
       }
     )
 
-    expect(personaFallback).toBe(true)
+    expect(unavailableRequestedPersonaId).toBe('honk')
   })
 
   test('includes model override on the execute input line', async () => {


### PR DESCRIPTION
Falls back to the eligible deployment default or no persona when a requested persona is absent, while preserving fail-closed access restrictions. Returns the unavailable requested persona ID only when the created session uses that request's resolved fallback, allowing Slack to show accurate feedback without mislabeling pinned-session reconciliation or create races. Includes runtime, session-client, and Slack emulation coverage.