### PR TITLE
feat: add GPT-6-Astra support

### DIFF
--- a/crates/harness-server/src/codex.rs
+++ b/crates/harness-server/src/codex.rs
@@ -370,7 +370,7 @@ fn run_codex_user_turn<W: Write>(
     }
     // Per-turn reasoning effort (codex `turn/start.effort`), parsed from the
     // `-rsn` message flag. Values match codex's ReasoningEffort enum
-    // (none|minimal|low|medium|high|xhigh|max); validation happens upstream.
+    // (none|minimal|low|medium|high|xhigh|max|ultra); validation happens upstream.
     if let Some(reasoning) = reasoning {
         params["effort"] = Value::String(reasoning);
     }

--- a/services/console/app/controllers/console/threads_controller.rb
+++ b/services/console/app/controllers/console/threads_controller.rb
@@ -100,7 +100,7 @@ class Console::ThreadsController < ApplicationController
   # per-turn reasoning efforts the harness accepts for the model, except
   # Claude Opus 5's `fast` choice, which selects OpenRouter's native fast model
   # variant. Codex's enum lives in crates/harness-server/src/codex.rs, with
-  # `max` being 5.6-specific.
+  # `max` and `ultra` availability depending on the selected model.
   ComposerAgent = Struct.new(:value, :label, :harness, :model, :provider, :efforts, keyword_init: true)
   CODEX_EFFORTS = [
     %w[minimal Minimal],
@@ -108,6 +108,14 @@ class Console::ThreadsController < ApplicationController
     %w[medium Medium],
     %w[high High],
     [ "xhigh", "Extra High" ]
+  ].freeze
+  ASTRA_EFFORTS = [
+    %w[low Low],
+    %w[medium Medium],
+    %w[high High],
+    [ "xhigh", "Extra High" ],
+    %w[max Max],
+    %w[ultra Ultra]
   ].freeze
   MODEL_EFFORT_OVERRIDES = {
     [ "claude-opus-5", "fast" ] => "claude-opus-5-fast"
@@ -119,6 +127,9 @@ class Console::ThreadsController < ApplicationController
     ComposerAgent.new(value: "gpt-5.6-sol", label: "GPT-5.6 Sol",
                       harness: "codex", model: "gpt-5.6-sol",
                       efforts: CODEX_EFFORTS + [ %w[max Max] ]),
+    ComposerAgent.new(value: "gpt-6-astra", label: "GPT-6-Astra",
+                      harness: "codex", model: "gpt-6-astra",
+                      efforts: ASTRA_EFFORTS),
     ComposerAgent.new(value: "nanocodex", label: "Nanocodex (GPT-5.6 Sol)",
                       harness: "nanocodex", model: nil, efforts: []),
     ComposerAgent.new(value: "gpt-5.5", label: "GPT-5.5",

--- a/services/console/test/controllers/console/threads_controller_test.rb
+++ b/services/console/test/controllers/console/threads_controller_test.rb
@@ -874,6 +874,7 @@ class Console::ThreadsControllerTest < ActionDispatch::IntegrationTest
       # through a hidden field, not a native select.
       assert_select "input[type=hidden][name=model]", count: 1
       assert_select "[data-console-model-option][data-value=?]", "amp"
+      assert_select "[data-console-model-option][data-value=?]", "gpt-6-astra"
       assert_select "[data-console-model-option][data-value=?]", "claude-opus-5"
       assert_select "select", count: 0
     end
@@ -882,6 +883,13 @@ class Console::ThreadsControllerTest < ActionDispatch::IntegrationTest
     assert_equal(
       { "label" => "Claude Opus 5", "efforts" => [ %w[fast Fast] ] },
       agents["claude-opus-5"]
+    )
+    assert_equal(
+      { "label" => "GPT-6-Astra", "efforts" => [
+        %w[low Low], %w[medium Medium], %w[high High],
+        [ "xhigh", "Extra High" ], %w[max Max], %w[ultra Ultra]
+      ] },
+      agents["gpt-6-astra"]
     )
     # Submitting replaces the centered empty state with a full-height,
     # bottom-aligned optimistic transcript while the request is in flight.

--- a/services/sandbox/Dockerfile
+++ b/services/sandbox/Dockerfile
@@ -89,7 +89,7 @@ RUN useradd -m -s /bin/bash -u 1001 agent \
     && echo "agent ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers.d/agent
 
 ARG CLAUDE_CODE_VERSION=2.1.154
-ARG CODEX_VERSION=0.144.0
+ARG CODEX_VERSION=0.153.2
 # Hermes Agent (NousResearch) — pinned by commit SHA per the dependency policy.
 ARG HERMES_AGENT_REF=e5e2fb8b2dbe1cae85aa5ad6ce45aef376016e43
 ARG PI_CODING_AGENT_VERSION=0.67.2

--- a/services/slackbotv2/src/console-session-link.ts
+++ b/services/slackbotv2/src/console-session-link.ts
@@ -26,7 +26,8 @@ const REASONING_DISPLAY_NAMES: Record<string, string> = {
   medium: 'Medium',
   high: 'High',
   xhigh: 'XHigh',
-  max: 'Max'
+  max: 'Max',
+  ultra: 'Ultra'
 }
 
 const STANDARD_CODEX_REASONING_EFFORTS = new Set([
@@ -42,6 +43,14 @@ const GPT_5_6_REASONING_EFFORTS = new Set([
   ...STANDARD_CODEX_REASONING_EFFORTS,
   'max'
 ])
+const GPT_6_ASTRA_REASONING_EFFORTS = new Set([
+  'low',
+  'medium',
+  'high',
+  'xhigh',
+  'max',
+  'ultra'
+])
 const CODEX_REASONING_EFFORTS_BY_MODEL: Record<string, ReadonlySet<string>> = {
   'gpt-5.2': STANDARD_CODEX_REASONING_EFFORTS,
   'gpt-5.2-codex': CODEX_MODEL_REASONING_EFFORTS,
@@ -53,7 +62,8 @@ const CODEX_REASONING_EFFORTS_BY_MODEL: Record<string, ReadonlySet<string>> = {
   'gpt-5.5-pro': PRO_CODEX_REASONING_EFFORTS,
   'gpt-5.6-luna': GPT_5_6_REASONING_EFFORTS,
   'gpt-5.6-sol': GPT_5_6_REASONING_EFFORTS,
-  'gpt-5.6-terra': GPT_5_6_REASONING_EFFORTS
+  'gpt-5.6-terra': GPT_5_6_REASONING_EFFORTS,
+  'gpt-6-astra': GPT_6_ASTRA_REASONING_EFFORTS
 }
 
 const CODEX_CONFIG = codexConfig as {

--- a/services/slackbotv2/src/message-overrides-strategy.ts
+++ b/services/slackbotv2/src/message-overrides-strategy.ts
@@ -15,13 +15,13 @@ const SYSTEM_PROMPT = [
   'Use null for every field when the message does not ask to change model selection.',
   'Allowed harness values: codex, claudecode, amp, nanocodex.',
   'Allowed provider values: responses, amazon-bedrock, openrouter.',
-  'Allowed reasoning values: none, minimal, low, medium, high, xhigh, max.',
+  'Allowed reasoning values: none, minimal, low, medium, high, xhigh, max, ultra.',
   'Treat inline flags such as "--claude", "--claude --model=fable", and "--fable" as model selection requests.',
   'In this Slackbot, a request to use Claude without another named Claude model means harness claudecode and model claude-opus-4-8. Examples: "--claude what model are you?" and "using claude:" select harness claudecode and model claude-opus-4-8. Explicit Fable requests such as "--claude --model=fable" and "using claude fable:" select harness claudecode and model claude-fable-5.',
   'Only return reasoning when the user explicitly asks to change model reasoning or effort. A reasoning word appearing incidentally, in quoted text, pasted model output, code, or task requirements is not a selection request.',
   'When the user explicitly requests a reasoning or effort change, map fuzzy magnitude words to the nearest reasoning value. Examples: tiny/cheap/fast -> low or minimal; normal/default -> medium; deep/strong/intense -> high or xhigh; maximum/superduper/biggest -> max.',
   'Return reasoning even when the requested model is not Codex; validation will ignore reasoning that cannot apply.',
-  'Map OpenAI model aliases to canonical IDs: sol -> gpt-5.6-sol, terra -> gpt-5.6-terra, luna -> gpt-5.6-luna, 5.5 -> gpt-5.5, 5.5 pro -> gpt-5.5-pro, 5.4 -> gpt-5.4, 5.4 pro -> gpt-5.4-pro, 5.4 mini -> gpt-5.4-mini, 5.4 nano -> gpt-5.4-nano.',
+  'Map OpenAI model aliases to canonical IDs: astra -> gpt-6-astra, sol -> gpt-5.6-sol, terra -> gpt-5.6-terra, luna -> gpt-5.6-luna, 5.5 -> gpt-5.5, 5.5 pro -> gpt-5.5-pro, 5.4 -> gpt-5.4, 5.4 pro -> gpt-5.4-pro, 5.4 mini -> gpt-5.4-mini, 5.4 nano -> gpt-5.4-nano.',
   'Map Claude model aliases to canonical IDs: fable -> claude-fable-5, opus -> claude-opus-4-8, opus 4.7 -> claude-opus-4-7, opus 5 -> claude-opus-5, opus 5 fast -> claude-opus-5-fast, sonnet -> claude-sonnet-4-6, sonnet 5 -> claude-sonnet-5, haiku -> claude-haiku-4-5.',
   'Map Amp model aliases to canonical IDs: deep -> deep, fast -> fast. Select an Amp model only when the user explicitly names Amp or clearly asks for the deep or fast model/mode. Requests such as "use the deep model" and "switch to fast mode" select the corresponding Amp model. Do not infer Amp from superlatives, coined terms, or casual requests to be more intelligent, thorough, or fast.',
   'Words containing or merely evoking model aliases are not model requests. For example, "think deeply", "do a deep analysis", "use your strongest thinking", and "give me a fast answer" do not select Amp. Unless another explicit selector is present, return null for every field.',
@@ -49,6 +49,7 @@ const MODEL_VALUES = [
   'gpt-5.6-luna',
   'gpt-5.6-sol',
   'gpt-5.6-terra',
+  'gpt-6-astra',
   null
 ] as const
 
@@ -68,7 +69,7 @@ const MESSAGE_OVERRIDES_SCHEMA = {
       type: ['string', 'null']
     },
     reasoning: {
-      enum: ['none', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max', null],
+      enum: ['none', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max', 'ultra', null],
       type: ['string', 'null']
     }
   },

--- a/services/slackbotv2/src/overrides.ts
+++ b/services/slackbotv2/src/overrides.ts
@@ -96,7 +96,8 @@ const STRATEGY_REASONING_EFFORTS = new Set([
   'medium',
   'high',
   'xhigh',
-  'max'
+  'max',
+  'ultra'
 ])
 
 const STRATEGY_MODEL_HARNESSES: Record<string, string> = {
@@ -118,7 +119,8 @@ const STRATEGY_MODEL_HARNESSES: Record<string, string> = {
   'gpt-5.5-pro': 'codex',
   'gpt-5.6-luna': 'codex',
   'gpt-5.6-sol': 'codex',
-  'gpt-5.6-terra': 'codex'
+  'gpt-5.6-terra': 'codex',
+  'gpt-6-astra': 'codex'
 }
 
 // Values are one horizontal-whitespace-delimited token; a newline after the
@@ -152,7 +154,8 @@ const REASONING_EFFORTS: Record<string, string> = {
   xhigh: 'xhigh',
   xhi: 'xhigh',
   'x-high': 'xhigh',
-  max: 'max'
+  max: 'max',
+  ultra: 'ultra'
 }
 
 export function extractMessageOverrides(text: string): MessageOverrides {

--- a/services/slackbotv2/test/console-session-link.test.ts
+++ b/services/slackbotv2/test/console-session-link.test.ts
@@ -39,7 +39,7 @@ describe('harnessDisplayName', () => {
 })
 
 describe('reasoningForModel', () => {
-  const allEfforts = ['none', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max']
+  const allEfforts = ['none', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max', 'ultra']
   const standardEfforts = ['none', 'low', 'medium', 'high', 'xhigh']
   const proEfforts = ['medium', 'high', 'xhigh']
   const codexModelEfforts = ['low', 'medium', 'high', 'xhigh']
@@ -54,7 +54,8 @@ describe('reasoningForModel', () => {
     'gpt-5.5-pro': proEfforts,
     'gpt-5.6-luna': [...standardEfforts, 'max'],
     'gpt-5.6-sol': [...standardEfforts, 'max'],
-    'gpt-5.6-terra': [...standardEfforts, 'max']
+    'gpt-5.6-terra': [...standardEfforts, 'max'],
+    'gpt-6-astra': ['low', 'medium', 'high', 'xhigh', 'max', 'ultra']
   }
 
   test('matches the reasoning efforts advertised by supported Codex models', () => {

--- a/services/slackbotv2/test/overrides.test.ts
+++ b/services/slackbotv2/test/overrides.test.ts
@@ -231,6 +231,10 @@ describe('extractMessageOverrides', () => {
     expect(extractMessageOverrides('-rsn max fix it').reasoning).toBe('max')
   })
 
+  test('-rsn accepts the GPT-6 Astra ultra effort', () => {
+    expect(extractMessageOverrides('-rsn ultra fix it').reasoning).toBe('ultra')
+  })
+
   test('-rsn combines with a harness flag', () => {
     expect(extractMessageOverrides('-rsn high --codex audit this')).toEqual({
       cleanedText: 'audit this',
@@ -375,6 +379,12 @@ describe('validateStrategyOverrides', () => {
   })
 
   test('accepts canonical OpenAI model ids from the model catalog', () => {
+    expect(validateStrategyOverrides({ model: 'gpt-6-astra' })).toEqual({
+      harnessType: 'codex',
+      model: 'gpt-6-astra',
+      provider: undefined,
+      reasoning: undefined
+    })
     expect(validateStrategyOverrides({ model: 'gpt-5.6-terra' })).toEqual({
       harnessType: 'codex',
       model: 'gpt-5.6-terra',


### PR DESCRIPTION
## Summary

- bump the sandbox Codex CLI from 0.144.0 to 0.153.2, which includes the GPT-6-Astra catalog
- add GPT-6-Astra and its `low` through `ultra` reasoning levels to Slack model metadata and the Console composer
- allow the Slack model-selection strategy to resolve Astra

## Validation

- `pnpm exec bun test services/slackbotv2/test/overrides.test.ts services/slackbotv2/test/console-session-link.test.ts` (81 passed)
- `cargo +nightly fmt --manifest-path crates/harness-server/Cargo.toml --check`
- `git diff --check`
- confirmed `@openai/codex@0.153.2` is published

`pnpm --filter slackbotv2 run check:types` still reports the pre-existing Bun `fetch.preconnect` fixture errors in `test/slack-user.test.ts`.

Prompted by: @gakonst
