### PR TITLE
fix: retry Granola MCP server errors

### DIFF
--- a/services/console/app/jobs/granola/sync_credential_job.rb
+++ b/services/console/app/jobs/granola/sync_credential_job.rb
@@ -2,7 +2,10 @@ module Granola
   class SyncCredentialJob < ApplicationJob
     queue_as :default
 
-    retry_on Errno::ECONNREFUSED, wait: :polynomially_longer, attempts: 5
+    retry_on Granola::SyncCredential::TransientGranolaApiError,
+      Errno::ECONNREFUSED,
+      wait: :polynomially_longer,
+      attempts: 5
 
     def perform(credential_id)
       credential = BrokerCredential.includes(:oauth_app).find_by(id: credential_id)

--- a/services/console/app/services/granola/sync_credential.rb
+++ b/services/console/app/services/granola/sync_credential.rb
@@ -15,6 +15,7 @@ module Granola
     PARTICIPANT_RE = /(?<name>[^,<]+?)\s*<(?<email>[^>]+)>/
 
     GranolaApiError = Class.new(StandardError)
+    TransientGranolaApiError = Class.new(GranolaApiError)
 
     class << self
       attr_accessor :mcp_http
@@ -102,6 +103,8 @@ module Granola
 
     def meeting_transcript(meeting_id)
       mcp_tool("get_meeting_transcript", "meeting_id" => meeting_id)
+    rescue TransientGranolaApiError
+      raise
     rescue GranolaApiError => error
       # Transcripts are only available on paid Granola plans. Keep syncing the
       # note metadata when that optional tool is unavailable or access is
@@ -337,7 +340,8 @@ module Granola
         headers: headers
       )
       unless response.success?
-        raise GranolaApiError, "Granola MCP returned HTTP #{response.status}"
+        error_class = response.status.between?(500, 599) ? TransientGranolaApiError : GranolaApiError
+        raise error_class, "Granola MCP returned HTTP #{response.status}"
       end
 
       response

--- a/services/console/test/jobs/granola/jobs_test.rb
+++ b/services/console/test/jobs/granola/jobs_test.rb
@@ -60,5 +60,23 @@ module Granola
         end
       end
     end
+
+    test "sync job retries transient Granola API errors" do
+      app = create_granola_app
+      credential = create_credential(app: app)
+      sync = Object.new
+      sync.define_singleton_method(:call) do
+        raise SyncCredential::TransientGranolaApiError, "Granola MCP returned HTTP 503"
+      end
+      sync_factory = ->(_credential) { sync }
+
+      Granola::SyncCredential.stub(:syncable?, true) do
+        Granola::SyncCredential.stub(:new, sync_factory) do
+          assert_enqueued_with(job: SyncCredentialJob, args: [ credential.id ]) do
+            SyncCredentialJob.perform_now(credential.id)
+          end
+        end
+      end
+    end
   end
 end

--- a/services/console/test/services/granola/sync_credential_test.rb
+++ b/services/console/test/services/granola/sync_credential_test.rb
@@ -243,6 +243,48 @@ module Granola
       mcp_request.verify
     end
 
+    test "classifies MCP server errors as transient" do
+      response = HttpClient::Response.new(status: 503, body: "", headers: {})
+      http_client = Object.new
+      http_client.define_singleton_method(:post) { |*, **| response }
+
+      HttpClient.stub(:new, http_client) do
+        error = assert_raises(SyncCredential::TransientGranolaApiError) do
+          SyncCredential.new(credential, api_client: FakeApiClient.new)
+            .send(:mcp_request, "initialize", {})
+        end
+
+        assert_equal "Granola MCP returned HTTP 503", error.message
+      end
+    end
+
+    test "keeps MCP client errors non-retryable" do
+      response = HttpClient::Response.new(status: 401, body: "", headers: {})
+      http_client = Object.new
+      http_client.define_singleton_method(:post) { |*, **| response }
+
+      HttpClient.stub(:new, http_client) do
+        error = assert_raises(SyncCredential::GranolaApiError) do
+          SyncCredential.new(credential, api_client: FakeApiClient.new)
+            .send(:mcp_request, "initialize", {})
+        end
+
+        refute_kind_of SyncCredential::TransientGranolaApiError, error
+        assert_equal "Granola MCP returned HTTP 401", error.message
+      end
+    end
+
+    test "does not swallow transient transcript errors" do
+      mcp_http = lambda do |**|
+        raise SyncCredential::TransientGranolaApiError, "Granola MCP returned HTTP 503"
+      end
+      sync = SyncCredential.new(credential, api_client: FakeApiClient.new, mcp_http: mcp_http)
+
+      assert_raises(SyncCredential::TransientGranolaApiError) do
+        sync.send(:meeting_transcript, "meeting-1")
+      end
+    end
+
     private
 
     def meeting_xml(id: "meeting-1", date: "Jul 8, 2026 5:30 PM GMT+2")


### PR DESCRIPTION
## Summary
- classify Granola MCP 5xx responses as transient without retrying client/auth failures
- retry transient Granola sync failures with the existing polynomial backoff
- preserve transient failures from optional transcript handling and add regression coverage

Sentry: https://paradigm-operations.sentry.io/issues/7711801834/

## Validation
- `git diff --check`
- Rails tests and RuboCop could not run locally because Ruby is not installed in the sandbox; CI will run the Console suite

Prompted by: mslipper