### PR TITLE
feat: allow reading Google Docs comments

### DIFF
--- a/tools/productivity/gsuite/cli.py
+++ b/tools/productivity/gsuite/cli.py
@@ -1278,6 +1278,63 @@ def docs_read(
         raise typer.Exit(1)
 
 
+@docs_app.command("comments")
+def docs_comments(
+    doc_id: str = typer.Argument(..., help="Document ID or Google Docs URL"),
+    limit: int = typer.Option(100, "--limit", "-n", help="Max comments"),
+    include_deleted: bool = typer.Option(
+        False,
+        "--include-deleted",
+        help="Include deleted comments and replies",
+    ),
+    json_output: bool = typer.Option(False, "--json", help="Output as JSON"),
+):
+    """Read comments and replies on a Google Doc.
+
+    Examples:
+        gsuite docs comments "1abc123"
+        gsuite docs comments "https://docs.google.com/document/d/1abc123/edit" --json
+    """
+    from .client import docs_list_comments
+
+    try:
+        document_id = extract_doc_id(doc_id)
+        comments = docs_list_comments(
+            document_id,
+            max_results=limit,
+            include_deleted=include_deleted,
+        )
+        if json_output:
+            print(json.dumps(comments, indent=2, ensure_ascii=False))
+            return
+        if not comments:
+            console.print("[yellow]No comments found.[/]")
+            return
+
+        for comment in comments:
+            author = comment["author"]["display_name"] or "Unknown author"
+            status = (
+                "deleted" if comment["deleted"] else "resolved" if comment["resolved"] else "open"
+            )
+            console.print(f"Comment {comment['id']} by {author} [{status}]", markup=False)
+            quoted_text = comment["quoted_file_content"]["value"]
+            if quoted_text:
+                console.print(f"  Quoted: {quoted_text}", markup=False)
+            if comment["content"]:
+                console.print(f"  {comment['content']}", markup=False)
+            for reply in comment["replies"]:
+                reply_author = reply["author"]["display_name"] or "Unknown author"
+                reply_action = f" [{reply['action']}]" if reply["action"] else ""
+                console.print(
+                    f"  Reply {reply['id']} by {reply_author}{reply_action}: {reply['content']}",
+                    markup=False,
+                )
+            console.print()
+    except Exception as e:
+        console.print(f"[red]Error: {e}[/]")
+        raise typer.Exit(1) from e
+
+
 @docs_app.command("replace")
 def docs_replace_cmd(
     doc_id: str = typer.Argument(..., help="Document ID or Google Docs URL"),

--- a/tools/productivity/gsuite/client.py
+++ b/tools/productivity/gsuite/client.py
@@ -1759,6 +1759,101 @@ def docs_get_text(document_id: str) -> str:
         return extract_text_from_content(content)
 
 
+DRIVE_COMMENT_FIELDS = (
+    "id,content,htmlContent,anchor,quotedFileContent,resolved,deleted,"
+    "createdTime,modifiedTime,assigneeEmailAddress,mentionedEmailAddresses,"
+    "author(displayName,photoLink,me),"
+    "replies(id,content,htmlContent,action,deleted,createdTime,modifiedTime,"
+    "assigneeEmailAddress,mentionedEmailAddresses,author(displayName,photoLink,me))"
+)
+
+
+def _normalize_drive_comment_user(user: dict) -> dict:
+    return {
+        "display_name": user.get("displayName", ""),
+        "photo_link": user.get("photoLink", ""),
+        "is_me": user.get("me", False),
+    }
+
+
+def _normalize_drive_reply(reply: dict) -> dict:
+    return {
+        "id": reply.get("id", ""),
+        "content": reply.get("content", ""),
+        "html_content": reply.get("htmlContent", ""),
+        "action": reply.get("action", ""),
+        "deleted": reply.get("deleted", False),
+        "created_time": reply.get("createdTime", ""),
+        "modified_time": reply.get("modifiedTime", ""),
+        "author": _normalize_drive_comment_user(reply.get("author") or {}),
+        "assignee_email": reply.get("assigneeEmailAddress", ""),
+        "mentioned_emails": reply.get("mentionedEmailAddresses") or [],
+    }
+
+
+def _normalize_drive_comment(comment: dict) -> dict:
+    quoted_content = comment.get("quotedFileContent") or {}
+    return {
+        "id": comment.get("id", ""),
+        "content": comment.get("content", ""),
+        "html_content": comment.get("htmlContent", ""),
+        "anchor": comment.get("anchor", ""),
+        "quoted_file_content": {
+            "mime_type": quoted_content.get("mimeType", ""),
+            "value": quoted_content.get("value", ""),
+        },
+        "resolved": comment.get("resolved", False),
+        "deleted": comment.get("deleted", False),
+        "created_time": comment.get("createdTime", ""),
+        "modified_time": comment.get("modifiedTime", ""),
+        "author": _normalize_drive_comment_user(comment.get("author") or {}),
+        "assignee_email": comment.get("assigneeEmailAddress", ""),
+        "mentioned_emails": comment.get("mentionedEmailAddresses") or [],
+        "replies": [_normalize_drive_reply(reply) for reply in comment.get("replies", [])],
+    }
+
+
+def docs_list_comments(
+    document_id: str,
+    max_results: int = 100,
+    include_deleted: bool = False,
+) -> list[dict]:
+    """List comments and replies on a Google Doc.
+
+    Args:
+        document_id: The document ID
+        max_results: Maximum number of comments to return
+        include_deleted: Whether to include deleted comments and replies
+
+    Returns:
+        Comments with their quoted document content and replies
+    """
+    if max_results < 1:
+        raise ValueError("max_results must be at least 1")
+
+    service = get_drive_service()
+    comments: list[dict] = []
+    page_token: str | None = None
+
+    while len(comments) < max_results:
+        request_args = {
+            "fileId": document_id,
+            "pageSize": min(100, max_results - len(comments)),
+            "includeDeleted": include_deleted,
+            "fields": f"nextPageToken,comments({DRIVE_COMMENT_FIELDS})",
+        }
+        if page_token:
+            request_args["pageToken"] = page_token
+
+        result = service.comments().list(**request_args).execute()
+        comments.extend(_normalize_drive_comment(comment) for comment in result.get("comments", []))
+        page_token = result.get("nextPageToken")
+        if not page_token:
+            break
+
+    return comments[:max_results]
+
+
 def docs_append(
     document_id: str,
     text: str,
@@ -3225,6 +3320,28 @@ class GSuiteClient:
             Plain text content of the document
         """
         return docs_get_text(document_id)
+
+    def docs_list_comments(
+        self,
+        document_id: str,
+        max_results: int = 100,
+        include_deleted: bool = False,
+    ) -> list[dict]:
+        """List comments and replies on a Google Doc.
+
+        Args:
+            document_id: The document ID
+            max_results: Maximum number of comments to return
+            include_deleted: Whether to include deleted comments and replies
+
+        Returns:
+            Comments with their quoted document content and replies
+        """
+        return docs_list_comments(
+            document_id,
+            max_results=max_results,
+            include_deleted=include_deleted,
+        )
 
     def docs_append(
         self,

--- a/tools/productivity/gsuite/test_cli.py
+++ b/tools/productivity/gsuite/test_cli.py
@@ -100,6 +100,91 @@ def test_docs_bullets_command_prints_verification_summary(monkeypatch):
     assert "tab tab-2 paragraph 4:" in result.output
 
 
+def test_docs_comments_command_accepts_url_and_outputs_json(monkeypatch):
+    calls: list[dict] = []
+    comments = [
+        {
+            "id": "comment-1",
+            "content": "Please clarify this section.",
+            "author": {"display_name": "Ada Lovelace"},
+            "quoted_file_content": {"value": "Draft language"},
+            "resolved": False,
+            "deleted": False,
+            "replies": [],
+        }
+    ]
+    monkeypatch.setattr(
+        client,
+        "docs_list_comments",
+        lambda document_id, max_results, include_deleted: (
+            calls.append(
+                {
+                    "document_id": document_id,
+                    "max_results": max_results,
+                    "include_deleted": include_deleted,
+                }
+            )
+            or comments
+        ),
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "docs",
+            "comments",
+            "https://docs.google.com/document/d/doc-123/edit",
+            "--limit",
+            "25",
+            "--include-deleted",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert json.loads(result.output) == comments
+    assert calls == [
+        {
+            "document_id": "doc-123",
+            "max_results": 25,
+            "include_deleted": True,
+        }
+    ]
+
+
+def test_docs_comments_command_prints_threads_without_rich_markup(monkeypatch):
+    monkeypatch.setattr(
+        client,
+        "docs_list_comments",
+        lambda document_id, max_results, include_deleted: [
+            {
+                "id": "comment-1",
+                "content": "Use [draft] here.",
+                "author": {"display_name": "Ada Lovelace"},
+                "quoted_file_content": {"value": "Original [text]"},
+                "resolved": True,
+                "deleted": False,
+                "replies": [
+                    {
+                        "id": "reply-1",
+                        "content": "Done [now].",
+                        "action": "resolve",
+                        "author": {"display_name": "Grace Hopper"},
+                    }
+                ],
+            }
+        ],
+    )
+
+    result = runner.invoke(app, ["docs", "comments", "doc-123"])
+
+    assert result.exit_code == 0
+    assert "Comment comment-1 by Ada Lovelace [resolved]" in result.output
+    assert "Quoted: Original [text]" in result.output
+    assert "Use [draft] here." in result.output
+    assert "Reply reply-1 by Grace Hopper [resolve]: Done [now]." in result.output
+
+
 def test_drive_revisions_command_accepts_sheets_url_and_outputs_json(monkeypatch):
     calls: list[dict] = []
     monkeypatch.setattr(

--- a/tools/productivity/gsuite/test_client.py
+++ b/tools/productivity/gsuite/test_client.py
@@ -91,23 +91,40 @@ class _FakeRevisionsApi:
         return _CreateRequest(self.get_result)
 
 
+class _FakeCommentsApi:
+    def __init__(self, list_results: list[dict] | None = None):
+        self.list_results = list(list_results or [])
+        self.list_calls: list[dict] = []
+
+    def list(self, **kwargs):
+        self.list_calls.append(kwargs)
+        if not self.list_results:
+            raise AssertionError("Unexpected extra comments.list call")
+        return _CreateRequest(self.list_results.pop(0))
+
+
 class _FakeDriveService:
     def __init__(
         self,
         revision_list_results: list[dict] | None = None,
         revision_get_result: dict | None = None,
+        comment_list_results: list[dict] | None = None,
     ):
         self.files_api = _FakeFilesApi()
         self.revisions_api = _FakeRevisionsApi(
             revision_list_results,
             revision_get_result,
         )
+        self.comments_api = _FakeCommentsApi(comment_list_results)
 
     def files(self):
         return self.files_api
 
     def revisions(self):
         return self.revisions_api
+
+    def comments(self):
+        return self.comments_api
 
 
 class _FakeGmailMessagesApi:
@@ -550,6 +567,149 @@ def test_drive_list_revisions_rejects_non_positive_limit(monkeypatch):
         client.drive_list_revisions("file-123", max_results=0)
 
 
+def test_docs_list_comments_paginates_and_normalizes_threads(monkeypatch):
+    fake_service = _FakeDriveService(
+        comment_list_results=[
+            {
+                "comments": [
+                    {
+                        "id": "comment-1",
+                        "content": "Can we make this more specific?",
+                        "htmlContent": "Can we make this <b>more specific</b>?",
+                        "anchor": '{"r":"head","a":[{"txt":{"o":12,"l":8}}]}',
+                        "quotedFileContent": {
+                            "mimeType": "text/html",
+                            "value": "the proposal",
+                        },
+                        "resolved": True,
+                        "createdTime": "2026-08-10T10:00:00Z",
+                        "modifiedTime": "2026-08-10T11:00:00Z",
+                        "author": {
+                            "displayName": "Ada Lovelace",
+                            "photoLink": "https://example.com/ada.jpg",
+                            "me": False,
+                        },
+                        "assigneeEmailAddress": "grace@example.com",
+                        "mentionedEmailAddresses": ["grace@example.com"],
+                        "replies": [
+                            {
+                                "id": "reply-1",
+                                "content": "Updated.",
+                                "htmlContent": "Updated.",
+                                "action": "resolve",
+                                "createdTime": "2026-08-10T11:00:00Z",
+                                "modifiedTime": "2026-08-10T11:00:00Z",
+                                "author": {"displayName": "Grace Hopper", "me": True},
+                            }
+                        ],
+                    }
+                ],
+                "nextPageToken": "page-2",
+            },
+            {
+                "comments": [
+                    {
+                        "id": "comment-2",
+                        "deleted": True,
+                        "createdTime": "2026-08-11T10:00:00Z",
+                    }
+                ]
+            },
+        ]
+    )
+    monkeypatch.setattr(client, "get_drive_service", lambda: fake_service)
+
+    result = client.docs_list_comments(
+        "doc-123",
+        max_results=2,
+        include_deleted=True,
+    )
+
+    fields = f"nextPageToken,comments({client.DRIVE_COMMENT_FIELDS})"
+    assert fake_service.comments_api.list_calls == [
+        {
+            "fileId": "doc-123",
+            "pageSize": 2,
+            "includeDeleted": True,
+            "fields": fields,
+        },
+        {
+            "fileId": "doc-123",
+            "pageSize": 1,
+            "includeDeleted": True,
+            "fields": fields,
+            "pageToken": "page-2",
+        },
+    ]
+    assert result == [
+        {
+            "id": "comment-1",
+            "content": "Can we make this more specific?",
+            "html_content": "Can we make this <b>more specific</b>?",
+            "anchor": '{"r":"head","a":[{"txt":{"o":12,"l":8}}]}',
+            "quoted_file_content": {
+                "mime_type": "text/html",
+                "value": "the proposal",
+            },
+            "resolved": True,
+            "deleted": False,
+            "created_time": "2026-08-10T10:00:00Z",
+            "modified_time": "2026-08-10T11:00:00Z",
+            "author": {
+                "display_name": "Ada Lovelace",
+                "photo_link": "https://example.com/ada.jpg",
+                "is_me": False,
+            },
+            "assignee_email": "grace@example.com",
+            "mentioned_emails": ["grace@example.com"],
+            "replies": [
+                {
+                    "id": "reply-1",
+                    "content": "Updated.",
+                    "html_content": "Updated.",
+                    "action": "resolve",
+                    "deleted": False,
+                    "created_time": "2026-08-10T11:00:00Z",
+                    "modified_time": "2026-08-10T11:00:00Z",
+                    "author": {
+                        "display_name": "Grace Hopper",
+                        "photo_link": "",
+                        "is_me": True,
+                    },
+                    "assignee_email": "",
+                    "mentioned_emails": [],
+                }
+            ],
+        },
+        {
+            "id": "comment-2",
+            "content": "",
+            "html_content": "",
+            "anchor": "",
+            "quoted_file_content": {"mime_type": "", "value": ""},
+            "resolved": False,
+            "deleted": True,
+            "created_time": "2026-08-11T10:00:00Z",
+            "modified_time": "",
+            "author": {"display_name": "", "photo_link": "", "is_me": False},
+            "assignee_email": "",
+            "mentioned_emails": [],
+            "replies": [],
+        },
+    ]
+
+
+def test_docs_list_comments_rejects_non_positive_limit(monkeypatch):
+    monkeypatch.setattr(
+        client,
+        "get_drive_service",
+        lambda: (_ for _ in ()).throw(AssertionError("Drive API should not be called")),
+    )
+
+    with pytest.raises(ValueError, match="max_results must be at least 1"):
+        client.docs_list_comments("doc-123", max_results=0)
+
+
 def test_drive_get_revision_returns_metadata_and_export_links(monkeypatch):
     fake_service = _FakeDriveService(
         revision_get_result={
@@ -810,6 +970,39 @@ def test_gsuite_client_exposes_drive_revisions(monkeypatch):
         {"file_id": "file-123", "revision_id": "rev-1", "export_format": "pdf"}
     ]
     assert download_calls == [{"file_id": "file-123", "revision_id": "rev-1"}]
+
+
+def test_gsuite_client_exposes_doc_comments(monkeypatch):
+    calls: list[dict] = []
+    monkeypatch.setattr(
+        client,
+        "docs_list_comments",
+        lambda document_id, max_results, include_deleted: (
+            calls.append(
+                {
+                    "document_id": document_id,
+                    "max_results": max_results,
+                    "include_deleted": include_deleted,
+                }
+            )
+            or [{"id": "comment-1"}]
+        ),
+    )
+
+    result = client.GSuiteClient().docs_list_comments(
+        "doc-123",
+        max_results=25,
+        include_deleted=True,
+    )
+
+    assert result == [{"id": "comment-1"}]
+    assert calls == [
+        {
+            "document_id": "doc-123",
+            "max_results": 25,
+            "include_deleted": True,
+        }
+    ]
 
 
 def test_sheets_add_tab_uses_batch_update(monkeypatch):


### PR DESCRIPTION
Adds a paginated `docs_list_comments` GSuite tool method backed by the Drive comments API, returning normalized comment threads with quoted content and replies. Adds `gsuite docs comments` with readable and JSON output, plus focused client and CLI coverage.