### PR TITLE
Add datetime bands and event regions to chart renderer

### DIFF
--- a/tools/infra/chart/client.py
+++ b/tools/infra/chart/client.py
@@ -11,9 +11,87 @@ import pandas as pd
 
 matplotlib.use("Agg")
 
+import matplotlib.dates as mdates
 import matplotlib.pyplot as plt
 
 _OKABE_ITO = ["#0072B2", "#D55E00", "#009E73", "#CC79A7", "#F0E442", "#56B4E9", "#E69F00"]
+
+
+def _prepare_datetime_x(df: pd.DataFrame, x_col: str, extras: dict[str, Any]) -> bool:
+    """Parse and sort an explicitly requested chronological x-axis."""
+    if not extras.get("datetime_x"):
+        return False
+
+    parsed = pd.to_datetime(df[x_col], errors="raise")
+    if parsed.dt.tz is not None:
+        parsed = parsed.dt.tz_convert(None)
+    df[x_col] = parsed
+    df.sort_values(x_col, inplace=True)
+    df.reset_index(drop=True, inplace=True)
+    return True
+
+
+def _apply_comparison_band(
+    ax: plt.Axes,
+    df: pd.DataFrame,
+    x_col: str,
+    extras: dict[str, Any],
+) -> None:
+    band = extras.get("comparison_band")
+    if not isinstance(band, dict):
+        return
+
+    lower = band.get("lower")
+    upper = band.get("upper")
+    if lower not in df.columns or upper not in df.columns:
+        return
+
+    ax.fill_between(
+        df[x_col],
+        pd.to_numeric(df[lower], errors="coerce"),
+        pd.to_numeric(df[upper], errors="coerce"),
+        color=band.get("color", "#0072B2"),
+        alpha=float(band.get("alpha", 0.12)),
+        linewidth=0,
+        label=band.get("label"),
+        zorder=1,
+    )
+
+
+def _apply_event_regions(ax: plt.Axes, extras: dict[str, Any], datetime_x: bool) -> None:
+    regions = extras.get("event_regions")
+    if not isinstance(regions, list):
+        return
+
+    for index, region in enumerate(regions):
+        if not isinstance(region, dict) or "start" not in region:
+            continue
+        start: Any = region["start"]
+        end: Any = region.get("end", start)
+        if datetime_x:
+            start = pd.Timestamp(start)
+            end = pd.Timestamp(end)
+            if end <= start:
+                end = start + pd.Timedelta(days=1)
+        color = region.get("color", _OKABE_ITO[(index + 2) % len(_OKABE_ITO)])
+        alpha = float(region.get("alpha", 0.10))
+        ax.axvspan(start, end, color=color, alpha=alpha, linewidth=0, zorder=0)
+
+        label = region.get("label")
+        if label:
+            midpoint = start + (end - start) / 2
+            ax.text(
+                midpoint,
+                float(region.get("label_y", 0.97)),
+                str(label),
+                transform=ax.get_xaxis_transform(),
+                ha="center",
+                va="top",
+                fontsize=float(region.get("fontsize", 7.5)),
+                color=region.get("text_color", "#374151"),
+                rotation=float(region.get("rotation", 0)),
+                zorder=4,
+            )
 
 
 def _pick_x(df: pd.DataFrame, hint: str | None) -> str:
@@ -98,7 +176,9 @@ class ChartClient:
             source: Optional source line.
             theme_mode: light | dark | editorial.
             x/y: Optional column hints; otherwise first/numeric columns are used.
-            extras: Optional handler-specific settings.
+            extras: Optional handler-specific settings. Line charts support
+                ``datetime_x``, ``comparison_band``, ``event_regions``,
+                ``x_label``, ``y_label``, and ``legend_loc``.
         """
         if not data:
             return ""
@@ -113,6 +193,7 @@ class ChartClient:
         chart_kind = chart_type.lower().replace("_", "-")
         x_col = _pick_x(df, x)
         y_cols = _pick_y(df, x_col, y)
+        datetime_x = _prepare_datetime_x(df, x_col, extras)
 
         fig, ax = plt.subplots(figsize=(8, 4.5))
         if chart_kind in {"pie", "pie-chart", "donut", "donut-chart"}:
@@ -172,6 +253,8 @@ class ChartClient:
             value_col = y_cols[0]
             ax.scatter(df[x_col], df[value_col], color=_OKABE_ITO[0], alpha=0.75, edgecolors="none")
         else:
+            _apply_event_regions(ax, extras, datetime_x)
+            _apply_comparison_band(ax, df, x_col, extras)
             for idx, col in enumerate(y_cols):
                 ax.plot(
                     df[x_col],
@@ -180,14 +263,19 @@ class ChartClient:
                     linewidth=1.8,
                     label=col,
                     color=_OKABE_ITO[idx % len(_OKABE_ITO)],
+                    zorder=3,
                 )
-            if len(df) > 6:
+            if datetime_x:
+                locator = mdates.AutoDateLocator(minticks=4, maxticks=10)
+                ax.xaxis.set_major_locator(locator)
+                ax.xaxis.set_major_formatter(mdates.ConciseDateFormatter(locator))
+            elif len(df) > 6:
                 ax.tick_params(axis="x", labelrotation=30)
 
-        ax.set_xlabel(x_col)
-        ax.set_ylabel(", ".join(y_cols))
+        ax.set_xlabel(extras.get("x_label", x_col))
+        ax.set_ylabel(extras.get("y_label", ", ".join(y_cols)))
         if len(y_cols) > 1:
-            ax.legend(frameon=False)
+            ax.legend(frameon=False, loc=extras.get("legend_loc", "best"))
         _style_axes(ax, title, subtitle, source)
         return _figure_to_base64(fig)
 

--- a/tools/infra/chart/test_client.py
+++ b/tools/infra/chart/test_client.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import base64
+
+import matplotlib.pyplot as plt
+import pandas as pd
+from client import ChartClient, _apply_comparison_band, _apply_event_regions, _prepare_datetime_x
+
+
+def test_prepare_datetime_x_sorts_chronologically() -> None:
+    frame = pd.DataFrame({"date": ["2025-02-01", "2025-01-01"], "value": [2, 1]})
+
+    assert _prepare_datetime_x(frame, "date", {"datetime_x": True})
+    assert frame["date"].tolist() == [pd.Timestamp("2025-01-01"), pd.Timestamp("2025-02-01")]
+
+
+def test_band_and_event_region_are_drawn() -> None:
+    frame = pd.DataFrame(
+        {
+            "date": pd.to_datetime(["2025-01-01", "2025-02-01"]),
+            "actual": [100, 110],
+            "counterfactual": [100, 103],
+        }
+    )
+    _, ax = plt.subplots()
+
+    _apply_comparison_band(
+        ax,
+        frame,
+        "date",
+        {"comparison_band": {"lower": "counterfactual", "upper": "actual"}},
+    )
+    _apply_event_regions(
+        ax,
+        {"event_regions": [{"start": "2025-01-10", "end": "2025-01-20", "label": "Trade"}]},
+        True,
+    )
+
+    assert len(ax.collections) == 1
+    assert len(ax.patches) == 1
+    assert [text.get_text() for text in ax.texts] == ["Trade"]
+    plt.close(ax.figure)
+
+
+def test_render_datetime_chart_with_band_and_region_returns_png() -> None:
+    encoded = ChartClient().render_chart(
+        chart_type="line",
+        data=[
+            {"date": "2025-01-01", "actual": 100, "counterfactual": 100},
+            {"date": "2025-03-01", "actual": 115, "counterfactual": 105},
+        ],
+        x="date",
+        y=["actual", "counterfactual"],
+        extras={
+            "datetime_x": True,
+            "comparison_band": {"lower": "counterfactual", "upper": "actual"},
+            "event_regions": [{"start": "2025-01-15", "end": "2025-02-01", "label": "Buy"}],
+        },
+    )
+
+    assert base64.b64decode(encoded).startswith(b"\x89PNG\r\n\x1a\n")


### PR DESCRIPTION
## Summary
- add opt-in chronological datetime axes for line charts
- add shaded comparison bands and labeled event regions
- add axis and legend placement controls plus focused renderer tests

## Validation
- `PYTHONPATH=. uv run --no-project --with pytest --with 'matplotlib>=3.7' --with 'pandas>=2' pytest -q test_client.py`
- `uvx ruff check client.py test_client.py`
- `uvx ruff format --check client.py test_client.py`

Prompted by: matt