### PR TITLE
oh-my-pi harness support

### DIFF
--- a/contrib/chart/values.yaml
+++ b/contrib/chart/values.yaml
@@ -342,12 +342,13 @@ sandbox:
   #                  subscription token (proxy injects the brokered credential).
   codexAuthMode: api_key
   claudeCodeAuthMode: api_key
-  # The deployment's default harness: codex | amp | claudecode. Decides what
-  # warm sandboxes boot (SESSION_SANDBOX_HARNESS) and which harness auth
-  # fragment is required at startup (the other harnesses' fragments are
-  # registered too when available, so per-session --claude/--amp/--codex
-  # overrides keep working credentials). Per-session sandboxes always run
-  # their session's harness via container args; the sandbox image CMD only
+  # The deployment's default harness: codex | amp | claudecode | omp. Decides
+  # what warm sandboxes boot (SESSION_SANDBOX_HARNESS) and which harness auth
+  # fragment is required at startup (engines with no auth-mode source — amp,
+  # omp — require none; the other harnesses' fragments are registered too when
+  # available, so per-session --claude/--amp/--codex/--omp overrides keep
+  # working credentials). Per-session sandboxes always run their session's
+  # harness via container args; the sandbox image CMD only
   # matters for containers started outside api-rs.
   harnessEngine: codex
   # Copied into every sandbox pod. CLAUDE_MODEL / CODEX_MODEL set here are also

--- a/crates/harness-server/Cargo.lock
+++ b/crates/harness-server/Cargo.lock
@@ -1733,6 +1733,7 @@ dependencies = [
  "serde",
  "serde_json",
  "shell-words",
+ "tempfile",
  "thiserror 2.0.20",
  "tokio",
  "uuid",

--- a/crates/harness-server/Cargo.toml
+++ b/crates/harness-server/Cargo.toml
@@ -35,3 +35,6 @@ shell-words = "1.1"
 thiserror = "2.0"
 tokio = { version = "1.49", features = ["rt-multi-thread", "sync"] }
 uuid = { version = "1.19", features = ["v4"] }
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/harness-server/src/amp.rs
+++ b/crates/harness-server/src/amp.rs
@@ -116,7 +116,7 @@ impl HarnessServer for AmpHarness {
         "amp"
     }
 
-    fn command_for_turn(&self, state: &ThreadState) -> ProcessCommand {
+    fn command_for_turn(&self, state: &ThreadState, _input: &[UserInput]) -> ProcessCommand {
         if let Some(command) = command_from_override("CENTAUR_AMP_APP_BRIDGE_COMMAND") {
             return command;
         }

--- a/crates/harness-server/src/claude.rs
+++ b/crates/harness-server/src/claude.rs
@@ -221,7 +221,7 @@ impl HarnessServer for ClaudeCodeHarness {
         "anthropic"
     }
 
-    fn command_for_turn(&self, state: &ThreadState) -> ProcessCommand {
+    fn command_for_turn(&self, state: &ThreadState, _input: &[UserInput]) -> ProcessCommand {
         if let Some(command) = command_from_override("CENTAUR_CLAUDE_APP_BRIDGE_COMMAND") {
             return command;
         }

--- a/crates/harness-server/src/lib.rs
+++ b/crates/harness-server/src/lib.rs
@@ -6,6 +6,8 @@ mod error;
 pub mod hermes;
 mod nanocodex;
 mod nanocodex_subagents;
+pub mod omp;
+mod omp_rpc;
 mod otel;
 mod server;
 mod traits;

--- a/crates/harness-server/src/main.rs
+++ b/crates/harness-server/src/main.rs
@@ -23,6 +23,7 @@ enum CliCommand {
     Amp(HarnessCommand),
     /// Run Nanocodex directly as a library and stream its native typed events.
     Nanocodex,
+    Omp(HarnessCommand),
     /// Drive Hermes Agent's long-lived JSON-RPC gateway (sessions, memory,
     /// skills, crons survive across turns).
     Hermes,
@@ -59,6 +60,7 @@ fn run() -> Result<()> {
         CliCommand::ClaudeCode(command) => run_mode(HarnessKind::ClaudeCode, command.mode),
         CliCommand::Amp(command) => run_mode(HarnessKind::Amp, command.mode),
         CliCommand::Nanocodex => run_nanocodex_blocks_server(),
+        CliCommand::Omp(command) => run_mode(HarnessKind::Omp, command.mode),
         CliCommand::Hermes => run_hermes_blocks_server(),
         CliCommand::ValidateJsonrpc => run_validate_jsonrpc(),
         CliCommand::ValidateAgentDeltas => run_validate_agent_deltas(),

--- a/crates/harness-server/src/omp.rs
+++ b/crates/harness-server/src/omp.rs
@@ -1,0 +1,740 @@
+use std::collections::BTreeMap;
+use std::env;
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+use std::process::Command as ProcessCommand;
+use std::time::Duration;
+
+use codex_app_server_protocol::UserInput;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::{
+    HarnessKind, HarnessServer, NormalizedContent, NormalizedEvent, NormalizedTokenUsage,
+    NormalizedToolResult, Result, ThreadState, command_from_override, stable_id,
+    user_input_to_anthropic_content,
+};
+
+#[derive(Debug, Default)]
+pub struct OmpHarness;
+
+/// One line of `omp -p --mode json` output. omp runs one agent turn per
+/// process: the first line is always `session` (carrying the durable session
+/// id, echoed verbatim on `-r` resume), tool loops produce several
+/// `turn_start`/`turn_end` pairs, and `agent_end` is the final line before the
+/// process exits.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum OmpStreamEvent {
+    Session {
+        id: String,
+    },
+    AgentStart,
+    TurnStart,
+    MessageStart,
+    MessageUpdate {
+        #[serde(rename = "assistantMessageEvent")]
+        assistant_message_event: OmpAssistantMessageEvent,
+        message: OmpMessageId,
+    },
+    MessageEnd {
+        message: OmpMessage,
+    },
+    ToolExecutionStart,
+    ToolExecutionUpdate,
+    ToolExecutionEnd {
+        #[serde(rename = "toolCallId")]
+        tool_call_id: String,
+        result: Option<OmpToolExecutionResult>,
+        #[serde(default, rename = "isError")]
+        is_error: bool,
+    },
+    TurnEnd,
+    AgentEnd,
+    Error {
+        message: Option<String>,
+        error: Option<Value>,
+    },
+    #[serde(other)]
+    Unknown,
+}
+
+impl OmpStreamEvent {
+    pub fn parse_json_line(line: &str) -> Result<Self> {
+        Ok(serde_json::from_str(line)?)
+    }
+}
+
+/// The streaming `assistantMessageEvent` payload inside `message_update`.
+/// Only text and thinking deltas are consumed; frame boundaries and tool-call
+/// streaming carry nothing the normalized events need (the authoritative tool
+/// call arrives with the message's `message_end`).
+#[derive(Debug, Clone, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum OmpAssistantMessageEvent {
+    TextStart,
+    TextDelta {
+        delta: String,
+    },
+    TextEnd,
+    ThinkingStart,
+    ThinkingDelta {
+        #[serde(rename = "contentIndex")]
+        content_index: usize,
+        delta: String,
+    },
+    ThinkingEnd,
+    ToolcallStart,
+    ToolcallDelta,
+    ToolcallEnd,
+    #[serde(other)]
+    Unknown,
+}
+
+/// The slice of a `message_update`'s partial message the normalizer needs:
+/// the provider response id keying text deltas to their message item. The
+/// full partial (repeated content, usage, cost) is deliberately not parsed —
+/// it is re-sent on every delta line.
+#[derive(Debug, Clone, Deserialize)]
+pub struct OmpMessageId {
+    #[serde(default, rename = "responseId")]
+    pub response_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct OmpMessage {
+    pub role: String,
+    #[serde(default)]
+    pub content: OmpMessageContent,
+    #[serde(default)]
+    pub model: Option<String>,
+    #[serde(default)]
+    pub usage: Option<OmpUsage>,
+    #[serde(default, rename = "stopReason")]
+    pub stop_reason: Option<String>,
+    #[serde(default, rename = "errorMessage")]
+    pub error_message: Option<String>,
+    #[serde(default, rename = "responseId")]
+    pub response_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(untagged)]
+pub enum OmpMessageContent {
+    Blocks(Vec<OmpContentBlock>),
+    Text(String),
+}
+
+impl Default for OmpMessageContent {
+    fn default() -> Self {
+        Self::Blocks(Vec::new())
+    }
+}
+
+impl OmpMessage {
+    fn token_usage(&self) -> Option<NormalizedTokenUsage> {
+        let usage = self.usage.as_ref()?;
+        let normalized = NormalizedTokenUsage {
+            model: self.model.clone(),
+            input_tokens: usage.input,
+            output_tokens: usage.output,
+            cache_creation_input_tokens: usage.cache_write,
+            cache_read_input_tokens: usage.cache_read,
+            reasoning_output_tokens: None,
+            total_tokens: usage.total_tokens,
+        };
+        normalized.has_counts().then_some(normalized)
+    }
+
+    fn into_normalized_content(self) -> Vec<NormalizedContent> {
+        let item_id = assistant_item_id(self.response_id.as_deref());
+        match self.content {
+            OmpMessageContent::Blocks(blocks) => blocks
+                .into_iter()
+                .enumerate()
+                .filter_map(|(index, block)| match block {
+                    OmpContentBlock::Text { text } => Some(NormalizedContent::AgentText {
+                        item_id: item_id.clone(),
+                        text,
+                    }),
+                    OmpContentBlock::Thinking { thinking } => {
+                        Some(NormalizedContent::ReasoningText {
+                            item_id: reasoning_item_id(&item_id, index),
+                            text: thinking,
+                        })
+                    }
+                    OmpContentBlock::ToolCall {
+                        id,
+                        name,
+                        arguments,
+                    } => Some(NormalizedContent::ToolUse {
+                        raw_id: id,
+                        tool: name,
+                        arguments,
+                    }),
+                    OmpContentBlock::Unknown => None,
+                })
+                .collect(),
+            OmpMessageContent::Text(text) => vec![NormalizedContent::AgentText { item_id, text }],
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(tag = "type")]
+pub enum OmpContentBlock {
+    #[serde(rename = "text")]
+    Text { text: String },
+    #[serde(rename = "thinking")]
+    Thinking { thinking: String },
+    #[serde(rename = "toolCall")]
+    ToolCall {
+        id: String,
+        name: String,
+        #[serde(default)]
+        arguments: Value,
+    },
+    #[serde(other)]
+    Unknown,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct OmpUsage {
+    #[serde(default)]
+    pub input: Option<i64>,
+    #[serde(default)]
+    pub output: Option<i64>,
+    #[serde(default, rename = "cacheRead")]
+    pub cache_read: Option<i64>,
+    #[serde(default, rename = "cacheWrite")]
+    pub cache_write: Option<i64>,
+    #[serde(default, rename = "totalTokens")]
+    pub total_tokens: Option<i64>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct OmpToolExecutionResult {
+    #[serde(default)]
+    pub content: Vec<OmpContentBlock>,
+}
+
+impl OmpToolExecutionResult {
+    fn text(&self) -> String {
+        let mut out = String::new();
+        for block in &self.content {
+            if let OmpContentBlock::Text { text } = block {
+                if !out.is_empty() {
+                    out.push('\n');
+                }
+                out.push_str(text);
+            }
+        }
+        out
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct OmpEventNormalizer;
+
+impl OmpEventNormalizer {
+    fn normalize(&mut self, event: OmpStreamEvent) -> Vec<NormalizedEvent> {
+        match event {
+            OmpStreamEvent::Session { id } => vec![NormalizedEvent::SessionStarted {
+                session_id: Some(id),
+            }],
+            OmpStreamEvent::MessageUpdate {
+                assistant_message_event,
+                message,
+            } => {
+                let item_id = assistant_item_id(message.response_id.as_deref());
+                match assistant_message_event {
+                    OmpAssistantMessageEvent::TextDelta { delta } if !delta.is_empty() => {
+                        vec![NormalizedEvent::AgentTextDelta { item_id, delta }]
+                    }
+                    OmpAssistantMessageEvent::ThinkingDelta {
+                        content_index,
+                        delta,
+                    } if !delta.is_empty() => {
+                        vec![NormalizedEvent::ReasoningTextDelta {
+                            item_id: reasoning_item_id(&item_id, content_index),
+                            delta,
+                        }]
+                    }
+                    OmpAssistantMessageEvent::Unknown => {
+                        eprintln!("omp: ignoring unknown assistantMessageEvent kind");
+                        Vec::new()
+                    }
+                    _ => Vec::new(),
+                }
+            }
+            OmpStreamEvent::MessageEnd { message } if message.role == "assistant" => {
+                let mut out = Vec::new();
+                if let Some(usage) = message.token_usage() {
+                    out.push(NormalizedEvent::TokenUsage { usage });
+                }
+                if message.stop_reason.as_deref() == Some("error") {
+                    out.push(NormalizedEvent::Error {
+                        message: message
+                            .error_message
+                            .unwrap_or_else(|| "omp assistant message failed".to_owned()),
+                    });
+                    return out;
+                }
+                let stop_reason = message.stop_reason.as_deref().map(normalized_stop_reason);
+                out.push(NormalizedEvent::AssistantMessage {
+                    partial: false,
+                    stop_reason,
+                    content: message.into_normalized_content(),
+                });
+                out
+            }
+            // user echoes and toolResult messages: the tool result is taken
+            // from `tool_execution_end` (which also carries `isError`), so the
+            // duplicate toolResult message would double-emit it.
+            OmpStreamEvent::MessageEnd { .. } => Vec::new(),
+            OmpStreamEvent::ToolExecutionEnd {
+                tool_call_id,
+                result,
+                is_error,
+            } => vec![NormalizedEvent::ToolResults(vec![NormalizedToolResult {
+                tool_use_id: tool_call_id,
+                content: result
+                    .as_ref()
+                    .map(OmpToolExecutionResult::text)
+                    .unwrap_or_default(),
+                is_error,
+                exit_code: None,
+            }])],
+            OmpStreamEvent::AgentEnd => vec![NormalizedEvent::Result { error: None }],
+            OmpStreamEvent::Error { message, error } => {
+                let message = message
+                    .or_else(|| error.as_ref().map(ToString::to_string))
+                    .unwrap_or_else(|| "harness error".to_string());
+                vec![NormalizedEvent::Error { message }]
+            }
+            OmpStreamEvent::AgentStart
+            | OmpStreamEvent::TurnStart
+            | OmpStreamEvent::TurnEnd
+            | OmpStreamEvent::MessageStart
+            | OmpStreamEvent::ToolExecutionStart
+            | OmpStreamEvent::ToolExecutionUpdate => Vec::new(),
+            OmpStreamEvent::Unknown => {
+                eprintln!("omp: ignoring unknown event type");
+                Vec::new()
+            }
+        }
+    }
+}
+
+impl HarnessServer for OmpHarness {
+    type Event = OmpStreamEvent;
+    type EventNormalizer = OmpEventNormalizer;
+
+    fn kind(&self) -> HarnessKind {
+        HarnessKind::Omp
+    }
+
+    fn cli_version(&self) -> &'static str {
+        "omp"
+    }
+
+    /// Empty when no explicit override exists: the model is owned by the
+    /// in-image harness config (harness/omp/config.yml modelRoles), mirroring
+    /// how claude reads harness/claude/settings.json. An empty model means
+    /// `command_for_turn` omits `--model` so the CLI falls through to the
+    /// agent config dir.
+    fn default_model(&self) -> String {
+        env::var("OMP_MODEL").unwrap_or_default()
+    }
+
+    fn default_model_provider(&self) -> &'static str {
+        "omp"
+    }
+
+    fn command_for_turn(&self, state: &ThreadState, input: &[UserInput]) -> ProcessCommand {
+        if let Some(command) = command_from_override("CENTAUR_OMP_APP_BRIDGE_COMMAND") {
+            return command;
+        }
+
+        let bin = env::var("OMP_BIN").unwrap_or_else(|_| "omp".to_string());
+        let mut command = ProcessCommand::new(bin);
+        command.args(["-p", "--mode", "json", "--auto-approve", "--session-dir"]);
+        command.arg(omp_session_dir());
+        if let Some(session_id) = &state.harness_session_id {
+            command.args(["-r", session_id]);
+        }
+        if !state.model.is_empty() {
+            command.args(["--model", &state.model]);
+        }
+        // The prompt rides argv, not stdin; `--` keeps prompts that start
+        // with a dash from being read as flags.
+        command.arg("--");
+        command.arg(prompt_text(input));
+        command
+    }
+
+    /// omp takes the prompt as a command argument and never reads stdin in
+    /// `-p` mode, so there is nothing to write (an empty write is a no-op).
+    fn stdin_for_turn(&self, _input: &[UserInput]) -> Result<Vec<u8>> {
+        Ok(Vec::new())
+    }
+
+    fn parse_stdout_line(&self, line: &str) -> Result<Self::Event> {
+        OmpStreamEvent::parse_json_line(line)
+    }
+
+    fn normalize_events(
+        &self,
+        normalizer: &mut Self::EventNormalizer,
+        event: Self::Event,
+    ) -> Result<Vec<NormalizedEvent>> {
+        Ok(normalizer.normalize(event))
+    }
+
+    /// omp's native terminal event (`agent_end`) is the last line before the
+    /// process exits, so waiting for it after the final assistant stop only
+    /// adds the process's shutdown time to every turn: complete immediately
+    /// (amp pattern). The trailing `turn_end`/`agent_end` lines die with the
+    /// per-turn process — the next turn spawns a fresh one.
+    fn terminal_assistant_stop_settle(&self) -> Option<Duration> {
+        Some(Duration::ZERO)
+    }
+
+    /// Persist the mapping in `$OMP_SESSION_DIR/thread-map.json` so it rides
+    /// the same storage as the session JSONLs it describes: a resume after
+    /// the bridge process (or its host) is replaced can still translate the
+    /// bridge id into the omp-issued one. Failures are logged, not fatal —
+    /// the in-memory mapping still covers the current process lifetime.
+    fn record_session_id(&self, thread_id: &str, session_id: &str) {
+        let dir = omp_session_dir();
+        if let Err(err) = record_thread_session(&dir, thread_id, session_id) {
+            eprintln!(
+                "omp: failed to persist session map in {}: {err}",
+                dir.display()
+            );
+        }
+    }
+
+    fn resume_session_id(&self, thread_id: &str) -> Option<String> {
+        read_thread_map(&omp_session_dir()).remove(thread_id)
+    }
+}
+
+fn assistant_item_id(raw_id: Option<&str>) -> String {
+    stable_id(raw_id.unwrap_or("assistant"), "msg")
+}
+
+fn reasoning_item_id(message_id: &str, index: usize) -> String {
+    format!("{message_id}-reasoning-{index}")
+}
+
+/// Map omp stop reasons onto the anthropic-style values the shared
+/// terminal-stop logic understands (`stop` ends the agent run, `toolUse`
+/// continues the tool loop). Unrecognized reasons pass through and never
+/// settle the turn — `agent_end` (or process exit) ends it instead.
+fn normalized_stop_reason(reason: &str) -> String {
+    match reason {
+        "stop" => "end_turn",
+        "toolUse" => "tool_use",
+        "length" => "max_tokens",
+        other => other,
+    }
+    .to_string()
+}
+
+pub(crate) fn omp_session_dir() -> PathBuf {
+    env::var_os("OMP_SESSION_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| {
+            env::var_os("HOME")
+                .map(PathBuf::from)
+                .unwrap_or_else(|| PathBuf::from("/tmp"))
+                .join(".omp-harness-sessions")
+        })
+}
+
+const THREAD_MAP_FILE: &str = "thread-map.json";
+
+/// On-disk `thread-map.json` schema: `{"version":1,"threads":{bridge_id:
+/// omp_session_id}}`. Versioned so a future shape change can migrate rather
+/// than silently misread.
+#[derive(Debug, Serialize, Deserialize)]
+struct ThreadMapFile {
+    version: u32,
+    threads: BTreeMap<String, String>,
+}
+
+/// Missing, unreadable, or corrupt maps read as empty: the map is a resume
+/// optimization, never a reason to fail a turn.
+fn read_thread_map(dir: &Path) -> BTreeMap<String, String> {
+    let Ok(bytes) = fs::read(dir.join(THREAD_MAP_FILE)) else {
+        return BTreeMap::new();
+    };
+    serde_json::from_slice::<ThreadMapFile>(&bytes)
+        .map(|file| file.threads)
+        .unwrap_or_default()
+}
+
+/// Read-modify-write with an atomic tmp+rename in the same directory, so a
+/// crash mid-write can never leave a truncated map for the next reader.
+fn record_thread_session(dir: &Path, thread_id: &str, session_id: &str) -> io::Result<()> {
+    let mut threads = read_thread_map(dir);
+    if threads.get(thread_id).map(String::as_str) == Some(session_id) {
+        return Ok(());
+    }
+    threads.insert(thread_id.to_string(), session_id.to_string());
+    fs::create_dir_all(dir)?;
+    let payload = serde_json::to_vec_pretty(&ThreadMapFile {
+        version: 1,
+        threads,
+    })
+    .map_err(io::Error::other)?;
+    let tmp = dir.join(format!("{THREAD_MAP_FILE}.tmp.{}", std::process::id()));
+    fs::write(&tmp, payload)?;
+    fs::rename(&tmp, dir.join(THREAD_MAP_FILE))
+}
+
+fn prompt_text(input: &[UserInput]) -> String {
+    let mut prompt = String::new();
+    for part in user_input_to_anthropic_content(input) {
+        if let Some(text) = part.get("text").and_then(Value::as_str) {
+            if !prompt.is_empty() {
+                prompt.push_str("\n\n");
+            }
+            prompt.push_str(text);
+        }
+    }
+    prompt
+}
+
+#[cfg(test)]
+mod tests {
+    use codex_app_server_protocol::UserInput;
+
+    use crate::{HarnessServer, NormalizedContent, NormalizedEvent};
+
+    use super::{
+        OmpEventNormalizer, OmpHarness, THREAD_MAP_FILE, read_thread_map, record_thread_session,
+    };
+
+    fn normalize(normalizer: &mut OmpEventNormalizer, line: &str) -> Vec<NormalizedEvent> {
+        let event = OmpHarness.parse_stdout_line(line).unwrap();
+        OmpHarness.normalize_events(normalizer, event).unwrap()
+    }
+
+    #[test]
+    fn thread_map_reads_empty_when_missing_or_corrupt() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(read_thread_map(dir.path()).is_empty());
+
+        std::fs::write(dir.path().join(THREAD_MAP_FILE), b"not json{").unwrap();
+        assert!(read_thread_map(dir.path()).is_empty());
+    }
+
+    #[test]
+    fn thread_map_round_trips_and_accumulates() {
+        let dir = tempfile::tempdir().unwrap();
+        // Directory creation is part of the write path: point at a child
+        // that does not exist yet.
+        let map_dir = dir.path().join("omp-sessions");
+
+        record_thread_session(&map_dir, "bridge-a", "omp-1").unwrap();
+        record_thread_session(&map_dir, "bridge-b", "omp-2").unwrap();
+        // Re-recording the same mapping is a no-op, not an error.
+        record_thread_session(&map_dir, "bridge-a", "omp-1").unwrap();
+
+        let map = read_thread_map(&map_dir);
+        assert_eq!(map.get("bridge-a").map(String::as_str), Some("omp-1"));
+        assert_eq!(map.get("bridge-b").map(String::as_str), Some("omp-2"));
+        assert_eq!(map.len(), 2);
+
+        // A remapped thread id overwrites in place.
+        record_thread_session(&map_dir, "bridge-a", "omp-3").unwrap();
+        assert_eq!(
+            read_thread_map(&map_dir)
+                .get("bridge-a")
+                .map(String::as_str),
+            Some("omp-3")
+        );
+
+        // On-disk shape matches the documented schema.
+        let raw: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(map_dir.join(THREAD_MAP_FILE)).unwrap()).unwrap();
+        assert_eq!(raw["version"], 1);
+        assert_eq!(raw["threads"]["bridge-b"], "omp-2");
+    }
+
+    #[test]
+    fn corrupt_map_is_replaced_on_next_record() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join(THREAD_MAP_FILE), b"{\"threads\":42}").unwrap();
+
+        record_thread_session(dir.path(), "bridge-a", "omp-1").unwrap();
+        assert_eq!(
+            read_thread_map(dir.path())
+                .get("bridge-a")
+                .map(String::as_str),
+            Some("omp-1")
+        );
+    }
+
+    #[test]
+    fn session_line_yields_harness_session_id() {
+        let mut normalizer = OmpEventNormalizer;
+        let events = normalize(
+            &mut normalizer,
+            r#"{"type":"session","version":3,"id":"019f3bb2-40aa-7000-b7e7-5414136e3b18","timestamp":"2026-07-07T08:29:25.547Z","cwd":"/tmp/omp-p03-test"}"#,
+        );
+        assert_eq!(events.len(), 1);
+        assert_eq!(
+            events[0].session_id(),
+            Some("019f3bb2-40aa-7000-b7e7-5414136e3b18")
+        );
+    }
+
+    #[test]
+    fn text_delta_streams_agent_text_keyed_by_response_id() {
+        let mut normalizer = OmpEventNormalizer;
+        let events = normalize(
+            &mut normalizer,
+            r#"{"type":"message_update","assistantMessageEvent":{"type":"text_delta","contentIndex":0,"delta":"ONE"},"message":{"role":"assistant","content":[{"type":"text","text":"DONE"}],"responseId":"msg_011CcnPBnPUWzpXCn7915U1v"}}"#,
+        );
+        assert!(matches!(
+            events.as_slice(),
+            [NormalizedEvent::AgentTextDelta { item_id, delta }]
+                if item_id == "msg_011CcnPBnPUWzpXCn7915U1v" && delta == "ONE"
+        ));
+    }
+
+    #[test]
+    fn assistant_message_end_emits_usage_and_tool_use() {
+        let mut normalizer = OmpEventNormalizer;
+        let events = normalize(
+            &mut normalizer,
+            r#"{"type":"message_end","message":{"role":"assistant","content":[{"type":"toolCall","id":"toolu_01CnTRcRztUD24oiuqg4wQq8","name":"bash","arguments":{"command":"echo centaur-tool-test","i":"Running test echo"}}],"provider":"anthropic","model":"claude-opus-4-8","usage":{"input":2,"output":80,"cacheRead":0,"cacheWrite":41021,"totalTokens":41103},"stopReason":"toolUse","responseId":"msg_011CcnPBYXnmZhM1otcyNfq5"}}"#,
+        );
+        assert!(matches!(
+            &events[0],
+            NormalizedEvent::TokenUsage { usage }
+                if usage.input_tokens == Some(2)
+                    && usage.output_tokens == Some(80)
+                    && usage.total_tokens == Some(41103)
+                    && usage.model.as_deref() == Some("claude-opus-4-8")
+        ));
+        assert!(matches!(
+            &events[1],
+            NormalizedEvent::AssistantMessage { partial: false, stop_reason: Some(reason), content }
+                if reason == "tool_use"
+                    && matches!(
+                        content.as_slice(),
+                        [NormalizedContent::ToolUse { raw_id, tool, .. }]
+                            if raw_id == "toolu_01CnTRcRztUD24oiuqg4wQq8" && tool == "bash"
+                    )
+        ));
+    }
+
+    #[test]
+    fn assistant_error_message_end_is_terminal_failure() {
+        let mut normalizer = OmpEventNormalizer;
+        let events = normalize(
+            &mut normalizer,
+            r#"{"type":"message_end","message":{"role":"assistant","content":[],"provider":"litellm","model":"glm-5.2-fp8","stopReason":"error","errorStatus":401,"errorId":16781312,"errorMessage":"401 LiteLLM Virtual Key expected"}}"#,
+        );
+        assert!(matches!(
+            events.as_slice(),
+            [NormalizedEvent::Error { message }]
+                if message == "401 LiteLLM Virtual Key expected"
+        ));
+    }
+
+    #[test]
+    fn tool_execution_end_maps_tool_result() {
+        let mut normalizer = OmpEventNormalizer;
+        let events = normalize(
+            &mut normalizer,
+            r#"{"type":"tool_execution_end","toolCallId":"toolu_01CnTRcRztUD24oiuqg4wQq8","toolName":"bash","result":{"content":[{"type":"text","text":"centaur-tool-test\n\n\nWall time: 0.07 seconds"}],"details":{"timeoutSeconds":300,"wallTimeMs":70.62383399999817}},"isError":false}"#,
+        );
+        assert!(matches!(
+            events.as_slice(),
+            [NormalizedEvent::ToolResults(results)]
+                if results.len() == 1
+                    && results[0].tool_use_id == "toolu_01CnTRcRztUD24oiuqg4wQq8"
+                    && results[0].content.starts_with("centaur-tool-test")
+                    && !results[0].is_error
+        ));
+    }
+
+    #[test]
+    fn final_assistant_stop_is_terminal_and_agent_end_yields_result() {
+        let mut normalizer = OmpEventNormalizer;
+        let events = normalize(
+            &mut normalizer,
+            r#"{"type":"message_end","message":{"role":"assistant","content":[{"type":"text","text":"DONE"}],"usage":{"input":2,"output":5,"cacheRead":0,"cacheWrite":41333,"totalTokens":41340},"stopReason":"stop","responseId":"msg_011CcnPBnPUWzpXCn7915U1v"}}"#,
+        );
+        let assistant = events
+            .iter()
+            .find(|event| matches!(event, NormalizedEvent::AssistantMessage { .. }))
+            .expect("assistant message");
+        assert!(assistant.is_terminal_assistant_stop());
+
+        let events = normalize(&mut normalizer, r#"{"type":"agent_end","messages":[]}"#);
+        assert!(matches!(
+            events.as_slice(),
+            [NormalizedEvent::Result { error: None }]
+        ));
+    }
+
+    #[test]
+    fn tool_result_message_end_is_ignored_to_avoid_double_emission() {
+        let mut normalizer = OmpEventNormalizer;
+        let events = normalize(
+            &mut normalizer,
+            r#"{"type":"message_end","message":{"role":"toolResult","toolCallId":"toolu_01CnTRcRztUD24oiuqg4wQq8","toolName":"bash","content":[{"type":"text","text":"centaur-tool-test"}],"isError":false}}"#,
+        );
+        assert!(events.is_empty());
+    }
+
+    #[test]
+    fn user_message_end_with_string_content_is_ignored() {
+        let mut normalizer = OmpEventNormalizer;
+        let events = normalize(
+            &mut normalizer,
+            r#"{"type":"message_end","message":{"role":"user","content":"<system-notice>workflow instructions</system-notice>"}}"#,
+        );
+        assert!(events.is_empty());
+    }
+
+    #[test]
+    fn assistant_message_end_with_string_content_emits_text() {
+        let mut normalizer = OmpEventNormalizer;
+        let events = normalize(
+            &mut normalizer,
+            r#"{"type":"message_end","message":{"role":"assistant","content":"DONE","stopReason":"stop","responseId":"msg_string_content"}}"#,
+        );
+        assert!(matches!(
+            events.as_slice(),
+            [NormalizedEvent::AssistantMessage {
+                partial: false,
+                stop_reason: Some(reason),
+                content,
+            }] if reason == "end_turn"
+                && matches!(
+                    content.as_slice(),
+                    [NormalizedContent::AgentText { item_id, text }]
+                        if item_id == "msg_string_content" && text == "DONE"
+                )
+        ));
+    }
+
+    #[test]
+    fn turn_stdin_is_empty() {
+        let bytes = OmpHarness
+            .stdin_for_turn(&[UserInput::Text {
+                text: "hello".to_string(),
+                text_elements: Vec::new(),
+            }])
+            .unwrap();
+        assert!(bytes.is_empty());
+    }
+}

--- a/crates/harness-server/src/omp_rpc.rs
+++ b/crates/harness-server/src/omp_rpc.rs
@@ -13,6 +13,17 @@
 //! Across resident lifetimes (child death / re-acquire), set
 //! `CENTAUR_OMP_SESSION_NAME` so respawn passes `--resume <name>` and the
 //! prior JSONL session is continued instead of starting an anonymous one.
+//!
+//! # Slash commands
+//! In RPC mode omp executes its builtin slash commands locally and streams
+//! their output as `command_output` frames instead of starting a model turn.
+//! The host forwards only [`OMP_SLASH_COMMAND_ALLOWLIST`] (commands with no
+//! effect beyond the current omp session) and surfaces that output as the
+//! turn's agent message; every other `/command` is answered by the host
+//! without reaching omp. The command is read from the user's own text block
+//! (the last one): api-rs prepends a chat-surface note for console and Slack
+//! threads, and forwarding that note along would hide the leading `/` from
+//! omp's parser, so an allowed command is sent to omp alone.
 
 use std::env;
 use std::io::{self, BufRead, Write};
@@ -26,7 +37,7 @@ use serde_json::{Value, json};
 
 use crate::omp::OmpStreamEvent;
 use crate::server::BlocksCommand;
-use crate::turn::CodexTurnNormalizer;
+use crate::turn::{BridgeConfig, CodexTurnNormalizer};
 use crate::util::write_value;
 use crate::{HarnessServerError, Result};
 const DEFAULT_OMP_TURN_TIMEOUT: Duration = Duration::from_secs(300);
@@ -124,6 +135,8 @@ pub enum OmpRpcFrame {
         id: Option<String>,
         agent_invoked: bool,
     },
+    /// Output of a builtin slash command omp ran locally (no model turn).
+    CommandOutput { text: String },
     /// Any other unsolicited frame the adapter does not demultiplex into a
     /// normalized event (extension_error, available_commands_update,
     /// host_tool_*, subagent_*). Forwarded verbatim to the host log.
@@ -177,6 +190,13 @@ impl OmpRpcFrame {
                     .unwrap_or(false);
                 Ok(Self::PromptResult { id, agent_invoked })
             }
+            "command_output" => Ok(Self::CommandOutput {
+                text: value
+                    .get("text")
+                    .and_then(Value::as_str)
+                    .unwrap_or_default()
+                    .to_owned(),
+            }),
             // AgentSessionEvent frames reuse the one-shot stream parser so the
             // normalized event surface is identical across paths.
             "session"
@@ -574,6 +594,195 @@ pub fn abort_command(id: &str) -> Value {
     json!({ "id": id, "type": "abort" })
 }
 
+/// Slash commands the resident host forwards to omp. omp runs its builtin
+/// slash commands locally in RPC mode, so every entry must leave no trace
+/// beyond the current omp session: no settings, plugin, MCP, SSH, or memory
+/// writes, no session rename, move, or delete, no upload. `None` admits every
+/// first argument; `Some(list)` admits only those (`""` is the bare command).
+const OMP_SLASH_COMMAND_ALLOWLIST: &[(&str, Option<&[&str]>)] = &[
+    ("changelog", None),
+    ("compact", None),
+    ("context", None),
+    ("dump", None),
+    ("export", None),
+    ("fast", None),
+    ("force", None),
+    ("fresh", None),
+    ("jobs", None),
+    ("model", None),
+    ("prewalk", None),
+    ("reload-plugins", None),
+    ("shake", None),
+    ("todo", None),
+    ("tools", None),
+    (
+        "advisor",
+        Some(&["", "toggle", "on", "off", "status", "dump"]),
+    ),
+    ("browser", Some(&["status"])),
+    (
+        "marketplace",
+        Some(&["list", "installed", "discover", "help"]),
+    ),
+    ("mcp", Some(&["list", "test", "reconnect"])),
+    ("memory", Some(&["", "view", "stats", "diagnose"])),
+    ("plugins", Some(&["", "list"])),
+    ("session", Some(&["", "info"])),
+    ("ssh", Some(&["list"])),
+    ("usage", Some(&["", "show"])),
+];
+
+/// A prompt omp would execute as a slash command rather than send to the model.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct SlashCommand<'a> {
+    name: &'a str,
+    /// First argument token, empty when the command is bare.
+    first_arg: &'a str,
+}
+
+/// Recognizes a prompt that starts with `/name`, where `name` is a bare word
+/// (letters, digits, `-`) terminated by whitespace, `:` (omp's name/argument
+/// separator), or the end of the text. Paths such as `/etc/hosts` are not
+/// commands and flow to the model unchanged.
+fn parse_slash_command(text: &str) -> Option<SlashCommand<'_>> {
+    let rest = text.trim_start().strip_prefix('/')?;
+    let name_end = rest
+        .find(|c: char| !(c.is_ascii_alphanumeric() || c == '-'))
+        .unwrap_or(rest.len());
+    let name = &rest[..name_end];
+    if !name.starts_with(|c: char| c.is_ascii_alphabetic()) {
+        return None;
+    }
+    let tail = &rest[name_end..];
+    if !(tail.is_empty() || tail.starts_with(char::is_whitespace) || tail.starts_with(':')) {
+        return None;
+    }
+    let first_arg = tail
+        .trim_start_matches(':')
+        .split_whitespace()
+        .next()
+        .unwrap_or("");
+    Some(SlashCommand { name, first_arg })
+}
+
+fn slash_command_allowed(command: &SlashCommand<'_>) -> bool {
+    let name = command.name.to_ascii_lowercase();
+    let first_arg = command.first_arg.to_ascii_lowercase();
+    OMP_SLASH_COMMAND_ALLOWLIST.iter().any(|(allowed, args)| {
+        *allowed == name && args.is_none_or(|args| args.contains(&first_arg.as_str()))
+    })
+}
+
+/// The host's reply for a slash command it refuses to forward.
+fn slash_command_rejection(command: &SlashCommand<'_>) -> String {
+    let name = command.name.to_ascii_lowercase();
+    if let Some((_, Some(args))) = OMP_SLASH_COMMAND_ALLOWLIST
+        .iter()
+        .find(|(allowed, args)| *allowed == name && args.is_some())
+    {
+        let accepted = args
+            .iter()
+            .map(|arg| {
+                if arg.is_empty() {
+                    format!("`/{name}`")
+                } else {
+                    format!("`/{name} {arg}`")
+                }
+            })
+            .collect::<Vec<_>>()
+            .join(", ");
+        return format!(
+            "`/{name} {}` is not available through Centaur because it changes state beyond this omp session. Available: {accepted}.",
+            command.first_arg
+        );
+    }
+    let mut names: Vec<&str> = OMP_SLASH_COMMAND_ALLOWLIST
+        .iter()
+        .map(|(name, _)| *name)
+        .collect();
+    names.sort_unstable();
+    let available = names
+        .iter()
+        .map(|name| format!("`/{name}`"))
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!(
+        "`/{}` is not available through Centaur. Slash commands run inside this thread's omp session, so only commands with no effect beyond it are forwarded: {available}.",
+        command.name
+    )
+}
+
+/// Drop ANSI CSI and OSC escape sequences from terminal-oriented command output.
+fn strip_ansi(text: &str) -> String {
+    let mut out = String::with_capacity(text.len());
+    let mut chars = text.chars();
+    while let Some(c) = chars.next() {
+        if c != '\u{1b}' {
+            out.push(c);
+            continue;
+        }
+        match chars.next() {
+            Some('[') => {
+                for c in chars.by_ref() {
+                    if ('\u{40}'..='\u{7e}').contains(&c) {
+                        break;
+                    }
+                }
+            }
+            Some(']') => {
+                let mut previous = '\0';
+                for c in chars.by_ref() {
+                    if c == '\u{07}' || (previous == '\u{1b}' && c == '\\') {
+                        break;
+                    }
+                    previous = c;
+                }
+            }
+            _ => {}
+        }
+    }
+    out
+}
+
+fn omp_bridge_config(thread_id: &str, turn_id: &str) -> BridgeConfig {
+    let mut config = BridgeConfig::new(thread_id.to_owned(), turn_id.to_owned());
+    config.cli_version = "omp".to_string();
+    config.model_provider = "omp".to_string();
+    config
+}
+
+/// Emit a complete turn whose only agent output is `text`, without touching
+/// the resident process. Used for slash commands the host refuses to forward.
+fn write_local_turn(
+    stdout: &mut impl Write,
+    thread_id: &str,
+    client_user_message_id: Option<String>,
+    input: Vec<codex_app_server_protocol::UserInput>,
+    text: &str,
+) -> Result<()> {
+    use crate::traits::{NormalizedContent, NormalizedEvent};
+
+    let turn_id = format!("turn-{}", uuid::Uuid::new_v4().simple());
+    let mut normalizer = CodexTurnNormalizer::new(omp_bridge_config(thread_id, &turn_id));
+    let mut notifications = normalizer.start_notifications(true)?;
+    notifications.extend(normalizer.emit_user_message(client_user_message_id, input)?);
+    notifications.extend(
+        normalizer.process_event(&NormalizedEvent::AssistantMessage {
+            partial: false,
+            stop_reason: Some("end_turn".to_string()),
+            content: vec![NormalizedContent::AgentText {
+                item_id: format!("{turn_id}-host"),
+                text: text.to_string(),
+            }],
+        })?,
+    );
+    notifications.extend(normalizer.finish_turn(None)?);
+    for notification in notifications {
+        write_value(stdout, &notification_to_wire_value(&notification)?)?;
+    }
+    Ok(())
+}
+
 /// The resident OMP blocks server. One `omp --mode rpc` process per sandbox,
 /// reused across sequential turns. Continuously drains unsolicited
 /// session/agent lifecycle frames while ordinary commands are
@@ -582,7 +791,6 @@ pub fn abort_command(id: &str) -> Value {
 pub fn run_omp_blocks_server() -> Result<()> {
     use crate::omp::OmpEventNormalizer;
     use crate::server::{BlocksState, parse_blocks_line_with_state};
-    use crate::turn::BridgeConfig;
     use crate::wire::notification_to_wire_value;
     use std::io::{self, BufRead};
     use std::sync::atomic::{AtomicBool, Ordering};
@@ -664,6 +872,41 @@ pub fn run_omp_blocks_server() -> Result<()> {
                 // after a prior turn cleared the flag.
                 turn_active.store(true, Ordering::SeqCst);
 
+                let parts = prompt_text_parts(&input);
+                let message = parts.join("\n\n");
+
+                // Detect steering: api-rs sends a user line with
+                // trace_metadata.action == "steer_active_execution" to queue
+                // additional context during an active turn. Route it as a
+                // steer command rather than a new prompt.
+                let is_steer = trace_context.metadata.get("action").and_then(Value::as_str)
+                    == Some("steer_active_execution");
+
+                // Slash commands execute inside omp itself, so refuse the ones
+                // that would outlive this session before the process is even
+                // spawned. The refusal is the turn's (or steer's) only output.
+                // The user's own text is the last block; api-rs prepends a
+                // chat-surface note for console and Slack threads.
+                let slash_command = parts.last().and_then(|text| parse_slash_command(text));
+                if let Some(command) = &slash_command
+                    && !slash_command_allowed(command)
+                {
+                    let rejection = slash_command_rejection(command);
+                    if is_steer {
+                        write_blocks_error(&mut stdout, &thread_id, "steer", &rejection)?;
+                    } else {
+                        write_local_turn(
+                            &mut stdout,
+                            &thread_id,
+                            client_user_message_id,
+                            input,
+                            &rejection,
+                        )?;
+                    }
+                    turn_active.store(false, Ordering::SeqCst);
+                    continue;
+                }
+
                 // Spawn or reuse the resident process.
                 if child.is_none() {
                     child = Some(OmpRpcChild::spawn()?);
@@ -674,15 +917,6 @@ pub fn run_omp_blocks_server() -> Result<()> {
                     )?;
                 }
                 let child = child.as_mut().unwrap();
-
-                let message = prompt_text(&input);
-
-                // Detect steering: api-rs sends a user line with
-                // trace_metadata.action == "steer_active_execution" to queue
-                // additional context during an active turn. Route it as a
-                // steer command rather than a new prompt.
-                let is_steer = trace_context.metadata.get("action").and_then(Value::as_str)
-                    == Some("steer_active_execution");
 
                 if is_steer {
                     // Steer: send the steer command and wait for its response.
@@ -706,15 +940,19 @@ pub fn run_omp_blocks_server() -> Result<()> {
                     continue;
                 }
 
-                // Prompt: send and drive the turn to completion.
+                // Prompt: send and drive the turn to completion. An allowed
+                // slash command goes to omp alone: with the chat-surface note
+                // in front of it omp's parser would never see the leading `/`.
+                let prompt = match (&slash_command, parts.last()) {
+                    (Some(_), Some(text)) => text.clone(),
+                    _ => message.clone(),
+                };
                 let id = child.next_request_id();
-                child.send_command(&prompt_command(&id, &message, None))?;
+                child.send_command(&prompt_command(&id, &prompt, None))?;
 
                 let turn_id = format!("turn-{}", uuid::Uuid::new_v4().simple());
-                let mut config = BridgeConfig::new(thread_id.clone(), turn_id.clone());
-                config.cli_version = "omp".to_string();
-                config.model_provider = "omp".to_string();
-                let mut normalizer = CodexTurnNormalizer::new(config);
+                let mut normalizer =
+                    CodexTurnNormalizer::new(omp_bridge_config(&thread_id, &turn_id));
 
                 for notification in normalizer.start_notifications(true)? {
                     write_value(&mut stdout, &notification_to_wire_value(&notification)?)?;
@@ -818,6 +1056,7 @@ fn drive_omp_steer_response(
             OmpRpcFrame::Response { .. } => {}
             OmpRpcFrame::Event(_)
             | OmpRpcFrame::PromptResult { .. }
+            | OmpRpcFrame::CommandOutput { .. }
             | OmpRpcFrame::Ready
             | OmpRpcFrame::Other(_) => {}
         }
@@ -830,7 +1069,10 @@ fn drain_ready(child: &mut OmpRpcChild) -> Result<()> {
         let frame = OmpRpcFrame::parse_json_line(&line)?;
         match frame {
             OmpRpcFrame::Ready => return Ok(()),
-            OmpRpcFrame::Event(_) | OmpRpcFrame::PromptResult { .. } | OmpRpcFrame::Other(_) => {}
+            OmpRpcFrame::Event(_)
+            | OmpRpcFrame::PromptResult { .. }
+            | OmpRpcFrame::CommandOutput { .. }
+            | OmpRpcFrame::Other(_) => {}
             OmpRpcFrame::Response { .. } => {}
         }
     }
@@ -862,7 +1104,7 @@ fn drive_omp_turn(
     turn_timeout: Duration,
 ) -> Result<TurnDriveResult> {
     use crate::omp::OmpHarness;
-    use crate::traits::{HarnessServer, NormalizedEvent};
+    use crate::traits::{HarnessServer, NormalizedContent, NormalizedEvent};
 
     let mut pending = std::collections::VecDeque::new();
     let mut terminal = false;
@@ -870,6 +1112,8 @@ fn drive_omp_turn(
     let mut aborted = false;
     let mut child_reusable = true;
     let mut prompt_error: Option<String> = None;
+    // Output of a builtin slash command omp ran locally: (item id, text so far).
+    let mut command_item: Option<(String, String)> = None;
     // Settle window: arm only after a terminal assistant stop.
     let mut settle_deadline: Option<std::time::Instant> = None;
     let absolute_deadline = std::time::Instant::now().checked_add(turn_timeout);
@@ -1023,6 +1267,24 @@ fn drive_omp_turn(
                     }
                 }
             }
+            OmpRpcFrame::CommandOutput { text } => {
+                let text = strip_ansi(&text);
+                let (item_id, buffer) = command_item
+                    .get_or_insert_with(|| (format!("{turn_id}-command"), String::new()));
+                let delta = if buffer.is_empty() || buffer.ends_with('\n') {
+                    text
+                } else {
+                    format!("\n{text}")
+                };
+                buffer.push_str(&delta);
+                let event = NormalizedEvent::AgentTextDelta {
+                    item_id: item_id.clone(),
+                    delta,
+                };
+                for notification in normalizer.process_event(&event)? {
+                    write_value(stdout, &notification_to_wire_value(&notification)?)?;
+                }
+            }
             OmpRpcFrame::PromptResult { agent_invoked, .. } if !agent_invoked => {
                 terminal = true;
             }
@@ -1033,6 +1295,18 @@ fn drive_omp_turn(
                     eprintln!("omp rpc: unsolicited {kind} frame");
                 }
             }
+        }
+    }
+
+    // Close the slash-command output item before the turn ends.
+    if let Some((item_id, text)) = command_item.take() {
+        let event = NormalizedEvent::AssistantMessage {
+            partial: false,
+            stop_reason: Some("end_turn".to_string()),
+            content: vec![NormalizedContent::AgentText { item_id, text }],
+        };
+        for notification in normalizer.process_event(&event)? {
+            write_value(stdout, &notification_to_wire_value(&notification)?)?;
         }
     }
 
@@ -1056,13 +1330,16 @@ fn drive_omp_turn(
     })
 }
 
-fn prompt_text(input: &[codex_app_server_protocol::UserInput]) -> String {
-    let parts = crate::util::user_input_to_anthropic_content(input);
-    parts
+/// The text blocks of a user line, one per content block, in order.
+fn prompt_text_parts(input: &[codex_app_server_protocol::UserInput]) -> Vec<String> {
+    crate::util::user_input_to_anthropic_content(input)
         .into_iter()
         .filter_map(|p| p.get("text").and_then(Value::as_str).map(str::to_owned))
-        .collect::<Vec<_>>()
-        .join("\n\n")
+        .collect()
+}
+
+fn prompt_text(input: &[codex_app_server_protocol::UserInput]) -> String {
+    prompt_text_parts(input).join("\n\n")
 }
 
 fn write_blocks_error(
@@ -1414,6 +1691,90 @@ done
                 Some(v) => std::env::set_var("CENTAUR_OMP_RPC_BRIDGE_COMMAND", v),
                 None => std::env::remove_var("CENTAUR_OMP_RPC_BRIDGE_COMMAND"),
             }
+        }
+    }
+
+    // --- Slash commands -----------------------------------------------------
+
+    #[test]
+    fn slash_command_parses_bare_word_names_only() {
+        assert_eq!(
+            parse_slash_command("/context"),
+            Some(SlashCommand {
+                name: "context",
+                first_arg: ""
+            })
+        );
+        assert_eq!(
+            parse_slash_command("  /usage reset now"),
+            Some(SlashCommand {
+                name: "usage",
+                first_arg: "reset"
+            })
+        );
+        assert_eq!(
+            parse_slash_command("/model:litellm/glm"),
+            Some(SlashCommand {
+                name: "model",
+                first_arg: "litellm/glm"
+            })
+        );
+        assert_eq!(parse_slash_command("/etc/hosts is empty"), None);
+        assert_eq!(parse_slash_command("/ context"), None);
+        assert_eq!(parse_slash_command("/2fast"), None);
+        assert_eq!(parse_slash_command("look at /context"), None);
+    }
+
+    #[test]
+    fn slash_command_allowlist_admits_session_scoped_commands_only() {
+        let allowed = |text: &str| slash_command_allowed(&parse_slash_command(text).unwrap());
+        assert!(allowed("/context"));
+        assert!(allowed("/compact safe"));
+        assert!(allowed("/model litellm/glm-5.2-fp8"));
+        assert!(allowed("/mcp list"));
+        assert!(allowed("/session"));
+        assert!(allowed("/Usage show"));
+        assert!(!allowed("/share"));
+        assert!(!allowed("/mcp add foo"));
+        assert!(!allowed("/session delete"));
+        assert!(!allowed("/usage reset"));
+        assert!(!allowed("/browser"));
+        assert!(!allowed("/rename x"));
+        assert!(!allowed("/move /tmp"));
+        assert!(!allowed("/new"));
+    }
+
+    #[test]
+    fn slash_command_rejection_names_the_alternatives() {
+        let unknown = slash_command_rejection(&parse_slash_command("/share").unwrap());
+        assert!(unknown.starts_with("`/share` is not available through Centaur"));
+        assert!(unknown.contains("`/context`") && unknown.contains("`/compact`"));
+        assert!(!unknown.contains("`/share`,"));
+
+        let subcommand = slash_command_rejection(&parse_slash_command("/mcp add foo").unwrap());
+        assert!(subcommand.starts_with("`/mcp add` is not available through Centaur"));
+        assert!(subcommand.contains("`/mcp list`") && subcommand.contains("`/mcp test`"));
+    }
+
+    #[test]
+    fn strip_ansi_removes_csi_and_osc_sequences() {
+        assert_eq!(
+            strip_ansi(
+                "\u{1b}[1mContext\u{1b}[0m: 12k \u{1b}]8;;https://x\u{7}link\u{1b}]8;;\u{7}"
+            ),
+            "Context: 12k link"
+        );
+        assert_eq!(strip_ansi("plain"), "plain");
+    }
+
+    #[test]
+    fn command_output_frames_are_demultiplexed() {
+        let frame =
+            OmpRpcFrame::parse_json_line(r#"{"type":"command_output","text":"Context: 12k"}"#)
+                .unwrap();
+        match frame {
+            OmpRpcFrame::CommandOutput { text } => assert_eq!(text, "Context: 12k"),
+            other => panic!("expected CommandOutput, got {other:?}"),
         }
     }
 }

--- a/crates/harness-server/src/omp_rpc.rs
+++ b/crates/harness-server/src/omp_rpc.rs
@@ -1,0 +1,1419 @@
+//! Resident OMP RPC host adapter.
+//!
+//! One `omp --mode rpc` process per Centaur session, reused across
+//! sequential turns. The process continuously drains unsolicited
+//! session/agent lifecycle frames from its stdout while ordinary
+//! commands (prompt/steer/abort) are correlated by request id. This
+//! mirrors the Codex App Server V2 resident pattern (`codex::run_codex_blocks_server`,
+//! `CodexJsonRpcChild`) but against the OMP RPC wire contract rather than the
+//! Codex JSON-RPC app-server protocol.
+//!
+//! # Process lifetime vs session resume
+//! Process reuse is within one resident host lifetime (one `OmpRpcChild`).
+//! Across resident lifetimes (child death / re-acquire), set
+//! `CENTAUR_OMP_SESSION_NAME` so respawn passes `--resume <name>` and the
+//! prior JSONL session is continued instead of starting an anonymous one.
+
+use std::env;
+use std::io::{self, BufRead, Write};
+use std::process::{Child, ChildStdin, Command as ProcessCommand, Stdio};
+use std::sync::Arc;
+use std::sync::mpsc::{self, Receiver, RecvTimeoutError};
+use std::thread;
+use std::time::Duration;
+
+use serde_json::{Value, json};
+
+use crate::omp::OmpStreamEvent;
+use crate::server::BlocksCommand;
+use crate::turn::CodexTurnNormalizer;
+use crate::util::write_value;
+use crate::{HarnessServerError, Result};
+const DEFAULT_OMP_TURN_TIMEOUT: Duration = Duration::from_secs(300);
+const OMP_TURN_TIMEOUT_GRACE: Duration = Duration::from_secs(5);
+const OMP_CONFIG_COMMAND_TIMEOUT: Duration = Duration::from_secs(5);
+const OMP_THINKING_LEVELS: [&str; 8] = [
+    "inherit", "off", "minimal", "low", "medium", "high", "xhigh", "max",
+];
+
+#[derive(Debug, PartialEq, Eq)]
+struct OmpModelSelector<'a> {
+    provider: &'a str,
+    model_id: &'a str,
+    thinking_level: Option<&'a str>,
+}
+
+fn parse_omp_model_selector(selector: &str) -> Result<OmpModelSelector<'_>> {
+    let (provider, model_selector) =
+        selector
+            .split_once('/')
+            .ok_or_else(|| HarnessServerError::InvalidBlocksInput {
+                message: format!(
+                    "OMP RPC model override must use provider/model form, got {selector:?}"
+                ),
+            })?;
+    if provider.is_empty() || model_selector.is_empty() {
+        return Err(HarnessServerError::InvalidBlocksInput {
+            message: format!(
+                "OMP RPC model override must use provider/model form, got {selector:?}"
+            ),
+        });
+    }
+
+    let (model_id, thinking_level) = match model_selector.rsplit_once(':') {
+        Some((model_id, level)) if OMP_THINKING_LEVELS.contains(&level) => (model_id, Some(level)),
+        _ => (model_selector, None),
+    };
+    if model_id.is_empty() {
+        return Err(HarnessServerError::InvalidBlocksInput {
+            message: format!("OMP RPC model override has an empty model id: {selector:?}"),
+        });
+    }
+
+    Ok(OmpModelSelector {
+        provider,
+        model_id,
+        thinking_level,
+    })
+}
+
+fn validate_omp_thinking_level(level: &str) -> Result<()> {
+    if OMP_THINKING_LEVELS.contains(&level) {
+        return Ok(());
+    }
+    Err(HarnessServerError::InvalidBlocksInput {
+        message: format!("unsupported OMP thinking level: {level:?}"),
+    })
+}
+
+fn turn_timeout_from_trace_context(trace_context: &crate::otel::TraceContext) -> Duration {
+    trace_context
+        .metadata
+        .get("max_duration_ms")
+        .and_then(Value::as_u64)
+        .filter(|duration_ms| *duration_ms > 0)
+        .map(Duration::from_millis)
+        .and_then(|duration| duration.checked_add(OMP_TURN_TIMEOUT_GRACE))
+        .unwrap_or(DEFAULT_OMP_TURN_TIMEOUT)
+}
+
+/// One frame demultiplexed from the resident `omp --mode rpc` stdout stream.
+/// The adapter distinguishes correlated command responses (matched by `id`)
+/// from unsolicited session/agent lifecycle frames.
+#[derive(Debug, Clone)]
+pub enum OmpRpcFrame {
+    /// Emitted once at startup before any command is accepted.
+    Ready,
+    /// A correlated command response. `id` echoes the request `id`; `None`
+    /// when the request had no id (or for parse/unknown-command errors).
+    Response {
+        id: Option<String>,
+        command: String,
+        success: bool,
+        data: Option<Value>,
+        error: Option<String>,
+    },
+    /// An `AgentSessionEvent` (`agent_start`, `message_update`, `agent_end`,
+    /// …). Reuses the one-shot parser so the normalized event surface is
+    /// identical across the one-shot and resident paths.
+    Event(OmpStreamEvent),
+    /// A prompt that was accepted immediately but later resolves as local-only
+    /// (no agent turn). `agent_invoked == false` is a completion signal.
+    PromptResult {
+        #[allow(dead_code)]
+        id: Option<String>,
+        agent_invoked: bool,
+    },
+    /// Any other unsolicited frame the adapter does not demultiplex into a
+    /// normalized event (extension_error, available_commands_update,
+    /// host_tool_*, subagent_*). Forwarded verbatim to the host log.
+    Other(Value),
+}
+
+impl OmpRpcFrame {
+    /// Parse one JSON line from `omp --mode rpc` stdout into a demultiplexed
+    /// frame. Unknown shapes degrade to [`OmpRpcFrame::Other`] rather than
+    /// erroring so the drain loop never blocks on a novel frame.
+    pub fn parse_json_line(line: &str) -> Result<Self> {
+        let value: Value = serde_json::from_str(line)?;
+        Self::from_value(value)
+    }
+
+    pub fn from_value(value: Value) -> Result<Self> {
+        let Some(kind) = value.get("type").and_then(Value::as_str) else {
+            return Ok(Self::Other(value));
+        };
+        match kind {
+            "ready" => Ok(Self::Ready),
+            "response" => {
+                let id = value.get("id").and_then(Value::as_str).map(str::to_owned);
+                let command = value
+                    .get("command")
+                    .and_then(Value::as_str)
+                    .unwrap_or_default()
+                    .to_owned();
+                let success = value
+                    .get("success")
+                    .and_then(Value::as_bool)
+                    .unwrap_or(false);
+                let data = value.get("data").cloned().filter(|v| !v.is_null());
+                let error = value
+                    .get("error")
+                    .and_then(Value::as_str)
+                    .map(str::to_owned);
+                Ok(Self::Response {
+                    id,
+                    command,
+                    success,
+                    data,
+                    error,
+                })
+            }
+            "prompt_result" => {
+                let id = value.get("id").and_then(Value::as_str).map(str::to_owned);
+                let agent_invoked = value
+                    .get("agentInvoked")
+                    .and_then(Value::as_bool)
+                    .unwrap_or(false);
+                Ok(Self::PromptResult { id, agent_invoked })
+            }
+            // AgentSessionEvent frames reuse the one-shot stream parser so the
+            // normalized event surface is identical across paths.
+            "session"
+            | "agent_start"
+            | "agent_end"
+            | "turn_start"
+            | "turn_end"
+            | "message_start"
+            | "message_update"
+            | "message_end"
+            | "tool_execution_start"
+            | "tool_execution_update"
+            | "tool_execution_end"
+            | "error" => Ok(Self::Event(OmpStreamEvent::parse_json_line(
+                &value.to_string(),
+            )?)),
+            _ => Ok(Self::Other(value)),
+        }
+    }
+}
+
+/// A resident `omp --mode rpc` child process. stdout is drained continuously
+/// by a background thread into an mpsc channel so unsolicited lifecycle frames
+/// never block a pending command. Command responses are correlated by `id` and
+/// handed to the waiting caller via a one-shot slot.
+pub struct OmpRpcChild {
+    child: Child,
+    stdin: Option<ChildStdin>,
+    stdout: Receiver<io::Result<String>>,
+    /// Monotonically increasing request id for commands that need correlation.
+    next_id: u64,
+}
+
+impl OmpRpcChild {
+    /// Spawn `omp --mode rpc` (or the override at `CENTAUR_OMP_RPC_BRIDGE_COMMAND`)
+    /// with piped stdio. The caller drives the ready handshake and drain loop.
+    pub fn spawn() -> Result<Self> {
+        let mut command = omp_rpc_command();
+        let mut child = command
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .map_err(|source| HarnessServerError::SpawnHarness {
+                cwd: env::current_dir().unwrap_or_default(),
+                source,
+            })?;
+
+        let stdin = child
+            .stdin
+            .take()
+            .ok_or(HarnessServerError::HarnessStdinUnavailable)?;
+        let stdout = child
+            .stdout
+            .take()
+            .ok_or(HarnessServerError::HarnessStdoutUnavailable)?;
+        let mut stderr = child
+            .stderr
+            .take()
+            .ok_or(HarnessServerError::HarnessStderrUnavailable)?;
+        thread::spawn(move || {
+            // Unlocked handle on purpose: the child outlives each turn, so
+            // holding the StderrLock for the copy's lifetime would block every
+            // eprintln! in the server until the child exits.
+            let mut parent_stderr = io::stderr();
+            let _ = io::copy(&mut stderr, &mut parent_stderr);
+        });
+
+        let (stdout_tx, stdout_rx) = mpsc::channel();
+        thread::spawn(move || {
+            let reader = io::BufReader::new(stdout);
+            for raw in reader.lines() {
+                let should_stop = raw.is_err();
+                if stdout_tx.send(raw).is_err() || should_stop {
+                    break;
+                }
+            }
+        });
+
+        Ok(Self {
+            child,
+            stdin: Some(stdin),
+            stdout: stdout_rx,
+            next_id: 1,
+        })
+    }
+
+    /// Allocate the next request id. OMP RPC accepts optional string ids; the
+    /// adapter always sends one so responses can be correlated.
+    pub fn next_request_id(&mut self) -> String {
+        let id = self.next_id.to_string();
+        self.next_id += 1;
+        id
+    }
+
+    /// Send a JSON command on stdin. The caller supplies the full command
+    /// object (including `id` and `type`).
+    pub fn send_command(&mut self, command: &Value) -> Result<()> {
+        let stdin = self
+            .stdin
+            .as_mut()
+            .ok_or(HarnessServerError::HarnessStdinUnavailable)?;
+        serde_json::to_writer(&mut *stdin, command)?;
+        stdin.write_all(b"\n")?;
+        stdin.flush()?;
+        Ok(())
+    }
+
+    /// Read the next raw stdout line. `Err` on EOF/child exit.
+    pub fn read_line(&mut self) -> Result<String> {
+        loop {
+            let line: io::Result<String> = match self.stdout.recv() {
+                Ok(line) => line,
+                Err(_) => {
+                    let status = self.child.wait()?;
+                    return Err(HarnessServerError::HarnessExited {
+                        kind: crate::traits::HarnessKind::Omp,
+                        status,
+                        stderr: String::new(),
+                    });
+                }
+            };
+            let line = line?;
+            let trimmed = line.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+            return Ok(trimmed.to_owned());
+        }
+    }
+
+    /// Try to read the next raw stdout line without blocking longer than
+    /// `timeout` wall-clock. Blank lines do not reset the budget: one absolute
+    /// deadline covers the whole call, and each recv uses only the remaining
+    /// time. `Ok(None)` on timeout; `Err` on EOF/child exit.
+    pub fn read_line_timeout(&mut self, timeout: Duration) -> Result<Option<String>> {
+        let deadline = std::time::Instant::now() + timeout;
+        loop {
+            let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+            if remaining.is_zero() {
+                return Ok(None);
+            }
+            let line: io::Result<String> = match self.stdout.recv_timeout(remaining) {
+                Ok(line) => line,
+                Err(RecvTimeoutError::Timeout) => return Ok(None),
+                Err(RecvTimeoutError::Disconnected) => {
+                    let status = self.child.wait()?;
+                    return Err(HarnessServerError::HarnessExited {
+                        kind: crate::traits::HarnessKind::Omp,
+                        status,
+                        stderr: String::new(),
+                    });
+                }
+            };
+            let line = line?;
+            let trimmed = line.trim();
+            if trimmed.is_empty() {
+                // Consume blank and continue under the same absolute deadline.
+                continue;
+            }
+            return Ok(Some(trimmed.to_owned()));
+        }
+    }
+
+    /// Wait for the process to exit and return its status. Used by clean
+    /// shutdown after stdin is closed.
+    pub fn wait(mut self) -> Result<std::process::ExitStatus> {
+        // Closing stdin tells the RPC server to drain pending side-channel
+        // requests and exit cleanly (code 0). Bounded: if the child ignores
+        // stdin EOF, kill after the timeout rather than hang forever.
+        if let Some(mut stdin) = self.stdin.take() {
+            let _ = stdin.flush();
+        }
+        let deadline = std::time::Instant::now() + Duration::from_secs(2);
+        loop {
+            match self.child.try_wait()? {
+                Some(status) => return Ok(status),
+                None if std::time::Instant::now() >= deadline => {
+                    let _ = self.child.kill();
+                    return self.child.wait().map_err(Into::into);
+                }
+                None => thread::sleep(Duration::from_millis(50)),
+            }
+        }
+    }
+}
+
+impl OmpRpcChild {}
+
+impl Drop for OmpRpcChild {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+fn omp_rpc_command() -> ProcessCommand {
+    if let Some(command) = crate::command_from_override("CENTAUR_OMP_RPC_BRIDGE_COMMAND") {
+        return command;
+    }
+    let bin = env::var("OMP_BIN").unwrap_or_else(|_| "omp".to_string());
+    let mut command = ProcessCommand::new(bin);
+    command.args([
+        "--mode",
+        "rpc",
+        "--auto-approve",
+        "--session-dir",
+        &crate::omp::omp_session_dir().display().to_string(),
+    ]);
+    // Resume prior session: read the actual session id written by the first
+    // spawn's get_state response. The release resolves --resume by JSONL
+    // filename prefix matching.
+    let session_marker = crate::omp::omp_session_dir().join(".resident_session_id");
+    if let Ok(id) = std::fs::read_to_string(&session_marker)
+        && !id.trim().is_empty()
+    {
+        command.args(["--resume", id.trim()]);
+    }
+    if let Ok(model) = env::var("OMP_MODEL")
+        && !model.is_empty()
+    {
+        command.args(["--model", &model]);
+    }
+    command
+}
+
+fn set_model_command(id: &str, provider: &str, model_id: &str) -> Value {
+    json!({
+        "id": id,
+        "type": "set_model",
+        "provider": provider,
+        "modelId": model_id,
+    })
+}
+
+fn set_thinking_level_command(id: &str, level: &str) -> Value {
+    json!({
+        "id": id,
+        "type": "set_thinking_level",
+        "level": level,
+    })
+}
+
+fn drive_omp_config_response(
+    child: &mut OmpRpcChild,
+    expected_id: &str,
+    expected_command: &str,
+) -> Result<()> {
+    let deadline = std::time::Instant::now() + OMP_CONFIG_COMMAND_TIMEOUT;
+    while std::time::Instant::now() < deadline {
+        let Some(line) = child.read_line_timeout(Duration::from_millis(100))? else {
+            continue;
+        };
+        let frame = OmpRpcFrame::parse_json_line(&line)?;
+        if let OmpRpcFrame::Response {
+            id,
+            command,
+            success,
+            error,
+            ..
+        } = frame
+            && id.as_deref() == Some(expected_id)
+            && command == expected_command
+        {
+            if success {
+                return Ok(());
+            }
+            return Err(HarnessServerError::InvalidBlocksInput {
+                message: format!(
+                    "OMP RPC {expected_command} failed: {}",
+                    error.unwrap_or_default()
+                ),
+            });
+        }
+    }
+    Err(HarnessServerError::InvalidBlocksInput {
+        message: format!("OMP RPC {expected_command} timed out"),
+    })
+}
+
+fn apply_omp_turn_configuration(
+    child: &mut OmpRpcChild,
+    model: Option<&str>,
+    reasoning: Option<&str>,
+) -> Result<()> {
+    let model_thinking_level = if let Some(selector) = model {
+        let selection = parse_omp_model_selector(selector)?;
+        let id = child.next_request_id();
+        child.send_command(&set_model_command(
+            &id,
+            selection.provider,
+            selection.model_id,
+        ))?;
+        drive_omp_config_response(child, &id, "set_model")?;
+        selection.thinking_level
+    } else {
+        None
+    };
+
+    if let Some(level) = reasoning.or(model_thinking_level) {
+        validate_omp_thinking_level(level)?;
+        let id = child.next_request_id();
+        child.send_command(&set_thinking_level_command(&id, level))?;
+        drive_omp_config_response(child, &id, "set_thinking_level")?;
+    }
+    Ok(())
+}
+
+/// After ready, drain the initial frames to find the session_info_update
+/// (emitted by the release binary on startup). This yields the actual session
+/// id and name that the release assigned, so a respawn can resume the prior
+/// session by its JSONL path rather than a display name the release cannot
+/// resolve. Frames are forwarded through the normalizer if possible.
+/// After `ready`, send `get_state` to obtain the authoritative session id.
+/// Returns `Err` if the response is missing, empty, failed, or times out.
+/// The id is persisted to `$OMP_SESSION_DIR/.resident_session_id` so a respawn
+/// can resume the prior JSONL.
+fn query_and_persist_session_state(
+    child: &mut OmpRpcChild,
+    event_normalizer: &mut crate::omp::OmpEventNormalizer,
+) -> Result<String> {
+    let id = child.next_request_id();
+    child.send_command(&json!({ "id": id, "type": "get_state" }))?;
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    while std::time::Instant::now() < deadline {
+        let Some(line) = child.read_line_timeout(Duration::from_millis(100))? else {
+            continue;
+        };
+        let frame = OmpRpcFrame::parse_json_line(&line)?;
+        match frame {
+            OmpRpcFrame::Response {
+                id: resp_id,
+                command,
+                success,
+                data,
+                error,
+            } if resp_id.as_deref() == Some(id.as_str()) && command == "get_state" => {
+                if !success {
+                    return Err(HarnessServerError::InvalidBlocksInput {
+                        message: format!("get_state failed: {}", error.unwrap_or_default()),
+                    });
+                }
+                let Some(d) = data else {
+                    return Err(HarnessServerError::InvalidBlocksInput {
+                        message: "get_state returned no data".to_string(),
+                    });
+                };
+                let Some(sid) = d.get("sessionId").and_then(Value::as_str) else {
+                    return Err(HarnessServerError::InvalidBlocksInput {
+                        message: "get_state missing sessionId".to_string(),
+                    });
+                };
+                if sid.is_empty() {
+                    return Err(HarnessServerError::InvalidBlocksInput {
+                        message: "get_state returned empty sessionId".to_string(),
+                    });
+                }
+                eprintln!("omp rpc: resident session id={sid}");
+                let dir = crate::omp::omp_session_dir();
+                std::fs::create_dir_all(&dir)?;
+                let marker = dir.join(".resident_session_id");
+                std::fs::write(&marker, sid)?;
+                return Ok(sid.to_owned());
+            }
+            OmpRpcFrame::Response { .. } => {}
+            OmpRpcFrame::Event(event) => {
+                use crate::traits::HarnessServer;
+                let _events = crate::omp::OmpHarness.normalize_events(event_normalizer, event)?;
+            }
+            _ => {}
+        }
+    }
+    Err(HarnessServerError::InvalidBlocksInput {
+        message: "get_state timed out".to_string(),
+    })
+}
+
+/// Build a `prompt` command. During active streaming, `streaming_behavior`
+/// must be `"steer"` or `"followUp"` or the prompt fails.
+pub fn prompt_command(id: &str, message: &str, streaming_behavior: Option<&str>) -> Value {
+    let mut cmd = json!({ "id": id, "type": "prompt", "message": message });
+    if let Some(behavior) = streaming_behavior {
+        cmd["streamingBehavior"] = Value::String(behavior.to_owned());
+    }
+    cmd
+}
+
+/// Build a `steer` command (queues a steering message during active streaming).
+pub fn steer_command(id: &str, message: &str) -> Value {
+    json!({ "id": id, "type": "steer", "message": message })
+}
+
+/// Build an `abort` command (interrupts the active turn).
+pub fn abort_command(id: &str) -> Value {
+    json!({ "id": id, "type": "abort" })
+}
+
+/// The resident OMP blocks server. One `omp --mode rpc` process per sandbox,
+/// reused across sequential turns. Continuously drains unsolicited
+/// session/agent lifecycle frames while ordinary commands are
+/// correlated by id. On clean stdin EOF this server waits (bounded) for the
+/// child then exits.
+pub fn run_omp_blocks_server() -> Result<()> {
+    use crate::omp::OmpEventNormalizer;
+    use crate::server::{BlocksState, parse_blocks_line_with_state};
+    use crate::turn::BridgeConfig;
+    use crate::wire::notification_to_wire_value;
+    use std::io::{self, BufRead};
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::mpsc;
+    use std::thread;
+
+    let mut stdout = io::stdout().lock();
+    let (input_tx, input_rx) = mpsc::channel::<BlocksCommand>();
+    let turn_active = Arc::new(AtomicBool::new(false));
+
+    // stdin reader: parses shared blocks commands (user/interrupt) and sends
+    // them through one channel the main loop receives on.
+    {
+        let turn_active = Arc::clone(&turn_active);
+        thread::spawn(move || {
+            let stdin = io::stdin();
+            let mut blocks_state = BlocksState::default();
+            for raw in stdin.lock().lines() {
+                let Ok(line) = raw else { break };
+                let trimmed = line.trim();
+                if trimmed.is_empty() {
+                    continue;
+                }
+                match parse_blocks_line_with_state(trimmed, &mut blocks_state) {
+                    Ok(BlocksCommand::Interrupt) if turn_active.load(Ordering::SeqCst) => {
+                        // Interrupt during an active turn: send as a control
+                        // so the turn driver can abort the resident process.
+                        if input_tx.send(BlocksCommand::Interrupt).is_err() {
+                            break;
+                        }
+                    }
+                    Ok(command @ BlocksCommand::User { .. }) => {
+                        turn_active.store(true, Ordering::SeqCst);
+                        if input_tx.send(command).is_err() {
+                            break;
+                        }
+                    }
+                    Ok(command) => {
+                        if input_tx.send(command).is_err() {
+                            break;
+                        }
+                    }
+                    Err(error) => {
+                        eprintln!("invalid OMP blocks input: {error}");
+                    }
+                }
+            }
+        });
+    }
+
+    let mut child: Option<OmpRpcChild> = None;
+    let mut event_normalizer = OmpEventNormalizer;
+    let thread_id = format!("omp-{}", uuid::Uuid::new_v4().simple());
+    let mut harness_session_id: Option<String> = None;
+
+    let mut respawn_child = false;
+    let mut outer_pending: std::collections::VecDeque<BlocksCommand> =
+        std::collections::VecDeque::new();
+    loop {
+        let input = if let Some(pending) = outer_pending.pop_front() {
+            pending
+        } else {
+            match input_rx.recv() {
+                Ok(input) => input,
+                Err(_) => break,
+            }
+        };
+        match input {
+            BlocksCommand::User {
+                input,
+                client_user_message_id,
+                model,
+                reasoning,
+                trace_context,
+                ..
+            } => {
+                // Set turn_active at actual dispatch so concurrent
+                // interrupt/steer gates work for pending Users that start
+                // after a prior turn cleared the flag.
+                turn_active.store(true, Ordering::SeqCst);
+
+                // Spawn or reuse the resident process.
+                if child.is_none() {
+                    child = Some(OmpRpcChild::spawn()?);
+                    drain_ready(child.as_mut().unwrap())?;
+                    query_and_persist_session_state(
+                        child.as_mut().unwrap(),
+                        &mut event_normalizer,
+                    )?;
+                }
+                let child = child.as_mut().unwrap();
+
+                let message = prompt_text(&input);
+
+                // Detect steering: api-rs sends a user line with
+                // trace_metadata.action == "steer_active_execution" to queue
+                // additional context during an active turn. Route it as a
+                // steer command rather than a new prompt.
+                let is_steer = trace_context.metadata.get("action").and_then(Value::as_str)
+                    == Some("steer_active_execution");
+
+                if is_steer {
+                    // Steer: send the steer command and wait for its response.
+                    // No turn lifecycle — the active turn continues.
+                    let id = child.next_request_id();
+                    child.send_command(&steer_command(&id, &message))?;
+                    drive_omp_steer_response(child, &id, &mut stdout, &thread_id)?;
+                    turn_active.store(false, Ordering::SeqCst);
+                    continue;
+                }
+                if let Err(error) =
+                    apply_omp_turn_configuration(child, model.as_deref(), reasoning.as_deref())
+                {
+                    write_blocks_error(
+                        &mut stdout,
+                        &thread_id,
+                        "turn",
+                        &format!("OMP turn configuration failed: {error}"),
+                    )?;
+                    turn_active.store(false, Ordering::SeqCst);
+                    continue;
+                }
+
+                // Prompt: send and drive the turn to completion.
+                let id = child.next_request_id();
+                child.send_command(&prompt_command(&id, &message, None))?;
+
+                let turn_id = format!("turn-{}", uuid::Uuid::new_v4().simple());
+                let mut config = BridgeConfig::new(thread_id.clone(), turn_id.clone());
+                config.cli_version = "omp".to_string();
+                config.model_provider = "omp".to_string();
+                let mut normalizer = CodexTurnNormalizer::new(config);
+
+                for notification in normalizer.start_notifications(true)? {
+                    write_value(&mut stdout, &notification_to_wire_value(&notification)?)?;
+                }
+                for notification in
+                    normalizer.emit_user_message(client_user_message_id, input.clone())?
+                {
+                    write_value(&mut stdout, &notification_to_wire_value(&notification)?)?;
+                }
+
+                let turn_timeout = turn_timeout_from_trace_context(&trace_context);
+
+                let drive_result = drive_omp_turn(
+                    child,
+                    &mut event_normalizer,
+                    &mut normalizer,
+                    &mut stdout,
+                    &mut harness_session_id,
+                    &id,
+                    &turn_id,
+                    &thread_id,
+                    &input_rx,
+                    turn_timeout,
+                )?;
+
+                turn_active.store(false, Ordering::SeqCst);
+
+                // #4: requeue pending items from the turn driver into the
+                // outer VecDeque for FIFO processing before the next recv.
+                for input in drive_result.pending {
+                    outer_pending.push_back(input);
+                }
+
+                // #6: if the child is not reusable, drop it so the next
+                // turn spawns a fresh process.
+                if !drive_result.child_reusable {
+                    // Signal outer scope to respawn. The inner 'child' is
+                    // a &mut reference; we kill via Drop by setting a flag.
+                    respawn_child = true;
+                }
+            }
+            BlocksCommand::Interrupt => {
+                // No turn is active: abort whatever the resident process may still be
+                // doing. Without a process there is nothing to abort.
+                if let Some(child) = child.as_mut() {
+                    let id = child.next_request_id();
+                    child.send_command(&abort_command(&id))?;
+                }
+            }
+            BlocksCommand::AttachmentChunk => {}
+        }
+
+        // Handle child respawn after a non-reusable turn.
+        if respawn_child {
+            if let Some(old_child) = child.take() {
+                let _ = old_child.wait();
+            }
+            respawn_child = false;
+        }
+    }
+
+    // Clean shutdown: close stdin and wait for the process to exit.
+    if let Some(child) = child.take() {
+        let _ = child.wait();
+    }
+    Ok(())
+}
+
+/// Drive a steer command to its correlated response, draining unsolicited
+/// frames (agent events) in the meantime. The steer response
+/// is an ack; the active turn continues and its events flow through the
+/// turn driver's drain loop.
+fn drive_omp_steer_response(
+    child: &mut OmpRpcChild,
+    expected_id: &str,
+    stdout: &mut impl Write,
+    thread_id: &str,
+) -> Result<()> {
+    loop {
+        let line = match child.read_line_timeout(Duration::from_secs(30))? {
+            Some(line) => line,
+            None => continue,
+        };
+        let frame = OmpRpcFrame::parse_json_line(&line)?;
+        match frame {
+            OmpRpcFrame::Response {
+                id, success, error, ..
+            } if id.as_deref() == Some(expected_id) => {
+                if !success {
+                    let msg = error.unwrap_or_else(|| "steer failed".to_owned());
+                    write_blocks_error_with_request_id(
+                        stdout,
+                        thread_id,
+                        "steer",
+                        &msg,
+                        Some(expected_id),
+                    )?;
+                }
+                return Ok(());
+            }
+            OmpRpcFrame::Response { .. } => {}
+            OmpRpcFrame::Event(_)
+            | OmpRpcFrame::PromptResult { .. }
+            | OmpRpcFrame::Ready
+            | OmpRpcFrame::Other(_) => {}
+        }
+    }
+}
+
+fn drain_ready(child: &mut OmpRpcChild) -> Result<()> {
+    loop {
+        let line = child.read_line()?;
+        let frame = OmpRpcFrame::parse_json_line(&line)?;
+        match frame {
+            OmpRpcFrame::Ready => return Ok(()),
+            OmpRpcFrame::Event(_) | OmpRpcFrame::PromptResult { .. } | OmpRpcFrame::Other(_) => {}
+            OmpRpcFrame::Response { .. } => {}
+        }
+    }
+}
+
+/// Result of driving an OMP turn. `pending` items are returned to the outer
+/// loop for FIFO processing. `child_reusable` is false when the child process
+/// is in an unrecoverable state (e.g. timeout abort without clean drain).
+struct TurnDriveResult {
+    pending: std::collections::VecDeque<BlocksCommand>,
+    child_reusable: bool,
+}
+
+#[allow(
+    clippy::too_many_arguments,
+    clippy::single_match,
+    clippy::collapsible_if
+)]
+fn drive_omp_turn(
+    child: &mut OmpRpcChild,
+    event_normalizer: &mut crate::omp::OmpEventNormalizer,
+    normalizer: &mut CodexTurnNormalizer,
+    stdout: &mut impl Write,
+    harness_session_id: &mut Option<String>,
+    expected_prompt_id: &str,
+    turn_id: &str,
+    thread_id: &str,
+    active_rx: &mpsc::Receiver<BlocksCommand>,
+    turn_timeout: Duration,
+) -> Result<TurnDriveResult> {
+    use crate::omp::OmpHarness;
+    use crate::traits::{HarnessServer, NormalizedEvent};
+
+    let mut pending = std::collections::VecDeque::new();
+    let mut terminal = false;
+    let mut failed = false;
+    let mut aborted = false;
+    let mut child_reusable = true;
+    let mut prompt_error: Option<String> = None;
+    // Settle window: arm only after a terminal assistant stop.
+    let mut settle_deadline: Option<std::time::Instant> = None;
+    let absolute_deadline = std::time::Instant::now().checked_add(turn_timeout);
+
+    while !terminal {
+        // #5: check deadlines unconditionally, regardless of frame flow.
+        let now = std::time::Instant::now();
+        if absolute_deadline.is_some_and(|deadline| now >= deadline) {
+            eprintln!("omp rpc: absolute turn timeout, terminating");
+            let abort_id = child.next_request_id();
+            child.send_command(&abort_command(&abort_id))?;
+            // #6: drain correlated abort response + agent_end (up to 2s).
+            let drain_deadline = std::time::Instant::now() + Duration::from_secs(2);
+            let mut got_abort_ack = false;
+            let mut got_terminal = false;
+            while std::time::Instant::now() < drain_deadline {
+                match child.read_line_timeout(Duration::from_millis(50))? {
+                    Some(line) => {
+                        let frame = OmpRpcFrame::parse_json_line(&line)?;
+                        match frame {
+                            OmpRpcFrame::Response { id, command, .. }
+                                if id.as_deref() == Some(abort_id.as_str())
+                                    && command == "abort" =>
+                            {
+                                got_abort_ack = true;
+                            }
+                            OmpRpcFrame::Event(event) => {
+                                let events =
+                                    OmpHarness.normalize_events(event_normalizer, event)?;
+                                for normalized in events {
+                                    // Require Result (agent_end), not Error.
+                                    if matches!(&normalized, NormalizedEvent::Result { .. }) {
+                                        got_terminal = true;
+                                    }
+                                    let _ = normalized;
+                                }
+                            }
+                            _ => {}
+                        }
+                    }
+                    None => {}
+                }
+                if got_abort_ack && got_terminal {
+                    break;
+                }
+            }
+            if !got_abort_ack || !got_terminal {
+                child_reusable = false;
+            }
+            failed = true;
+            prompt_error = Some("turn timed out".to_string());
+            break;
+        }
+        if let Some(deadline) = settle_deadline
+            && now >= deadline
+        {
+            eprintln!("omp rpc: settle window expired after terminal stop");
+            break;
+        }
+
+        // Drain concurrent controls: an interrupt aborts the turn, a steer line
+        // queues its text on the active turn, and anything else is preserved in
+        // FIFO order for the outer loop.
+        loop {
+            match active_rx.try_recv() {
+                Ok(BlocksCommand::Interrupt) => {
+                    let id = child.next_request_id();
+                    child.send_command(&abort_command(&id))?;
+                    aborted = true;
+                }
+                Ok(BlocksCommand::User {
+                    input,
+                    trace_context,
+                    ..
+                }) if trace_context.metadata.get("action").and_then(Value::as_str)
+                    == Some("steer_active_execution") =>
+                {
+                    let steer_msg = prompt_text(&input);
+                    if !steer_msg.is_empty() {
+                        let id = child.next_request_id();
+                        child.send_command(&steer_command(&id, &steer_msg))?;
+                    }
+                }
+                Ok(other) => {
+                    // Preserve unmatched input in FIFO order.
+                    pending.push_back(other);
+                }
+                Err(_) => break,
+            }
+        }
+
+        let line = match child.read_line_timeout(Duration::from_millis(50))? {
+            Some(line) => line,
+            None => continue,
+        };
+        let frame = OmpRpcFrame::parse_json_line(&line)?;
+        match frame {
+            OmpRpcFrame::Response {
+                id,
+                command: _,
+                success,
+                data,
+                error,
+            } if id.as_deref() == Some(expected_prompt_id) => {
+                if !success {
+                    // #8: preserve actual error message across scope.
+                    prompt_error = error
+                        .filter(|e| !e.is_empty())
+                        .or(Some("omp prompt failed".to_string()));
+                    write_blocks_error(
+                        stdout,
+                        thread_id,
+                        turn_id,
+                        prompt_error.as_deref().unwrap(),
+                    )?;
+                    failed = true;
+                    terminal = true;
+                    continue;
+                }
+                let agent_invoked = data
+                    .as_ref()
+                    .and_then(|d| d.get("agentInvoked").and_then(Value::as_bool))
+                    .unwrap_or(true);
+                if !agent_invoked {
+                    terminal = true;
+                }
+            }
+            OmpRpcFrame::Response { success, error, .. } => {
+                if !success {
+                    let msg = error.unwrap_or_else(|| "omp command failed".to_owned());
+                    eprintln!("omp rpc command failed: {msg}");
+                }
+            }
+            OmpRpcFrame::Event(event) => {
+                let events = OmpHarness.normalize_events(event_normalizer, event)?;
+                for normalized in events {
+                    if let Some(sid) = normalized.session_id() {
+                        *harness_session_id = Some(sid.to_string());
+                    }
+                    for notification in normalizer.process_event(&normalized)? {
+                        write_value(stdout, &notification_to_wire_value(&notification)?)?;
+                    }
+                    if normalized.is_terminal_assistant_stop() {
+                        if settle_deadline.is_none() {
+                            settle_deadline =
+                                Some(std::time::Instant::now() + Duration::from_secs(5));
+                        }
+                    }
+                    if normalized.is_terminal() {
+                        terminal = true;
+                    }
+                }
+            }
+            OmpRpcFrame::PromptResult { agent_invoked, .. } if !agent_invoked => {
+                terminal = true;
+            }
+            OmpRpcFrame::PromptResult { .. } => {}
+            OmpRpcFrame::Ready => {}
+            OmpRpcFrame::Other(value) => {
+                if let Some(kind) = value.get("type").and_then(Value::as_str) {
+                    eprintln!("omp rpc: unsolicited {kind} frame");
+                }
+            }
+        }
+    }
+
+    // #7: finish with correct status.
+    if aborted && !failed {
+        if let Some(notification) = normalizer.finish_turn_interrupted()? {
+            write_value(stdout, &notification_to_wire_value(&notification)?)?;
+        }
+    } else if failed {
+        let reason = prompt_error.unwrap_or_else(|| "omp prompt failed".to_string());
+        if let Some(notification) = normalizer.finish_turn(Some(reason))? {
+            write_value(stdout, &notification_to_wire_value(&notification)?)?;
+        }
+    } else if let Some(notification) = normalizer.finish_turn(None)? {
+        write_value(stdout, &notification_to_wire_value(&notification)?)?;
+    }
+
+    Ok(TurnDriveResult {
+        pending,
+        child_reusable,
+    })
+}
+
+fn prompt_text(input: &[codex_app_server_protocol::UserInput]) -> String {
+    let parts = crate::util::user_input_to_anthropic_content(input);
+    parts
+        .into_iter()
+        .filter_map(|p| p.get("text").and_then(Value::as_str).map(str::to_owned))
+        .collect::<Vec<_>>()
+        .join("\n\n")
+}
+
+fn write_blocks_error(
+    stdout: &mut impl Write,
+    thread_id: &str,
+    turn_id: &str,
+    message: &str,
+) -> Result<()> {
+    write_blocks_error_with_request_id(stdout, thread_id, turn_id, message, None)
+}
+
+fn write_blocks_error_with_request_id(
+    stdout: &mut impl Write,
+    thread_id: &str,
+    turn_id: &str,
+    message: &str,
+    request_id: Option<&str>,
+) -> Result<()> {
+    let mut params = serde_json::json!({
+        "error": { "message": message, "codexErrorInfo": null, "additionalDetails": null },
+        "willRetry": false,
+        "threadId": thread_id,
+        "turnId": turn_id,
+    });
+    if let Some(rid) = request_id {
+        params["request_id"] = Value::String(rid.to_owned());
+    }
+    write_value(
+        stdout,
+        &serde_json::json!({
+            "method": "error",
+            "params": params,
+        }),
+    )
+}
+
+fn notification_to_wire_value(
+    notification: &codex_app_server_protocol::ServerNotification,
+) -> Result<Value> {
+    crate::wire::notification_to_wire_value(notification)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::omp::{OmpEventNormalizer, OmpHarness};
+    use crate::traits::{HarnessServer, NormalizedEvent};
+
+    // --- Frame demultiplexing ---------------------------------------------
+
+    #[test]
+    fn ready_frame_parses() {
+        let frame = OmpRpcFrame::parse_json_line(r#"{"type":"ready"}"#).unwrap();
+        assert!(matches!(frame, OmpRpcFrame::Ready));
+    }
+
+    #[test]
+    fn response_frame_correlates_by_id() {
+        let frame = OmpRpcFrame::parse_json_line(
+            r#"{"id":"req_1","type":"response","command":"prompt","success":true,"data":{"agentInvoked":false}}"#,
+        )
+        .unwrap();
+        match frame {
+            OmpRpcFrame::Response {
+                id,
+                command,
+                success,
+                data,
+                error,
+            } => {
+                assert_eq!(id.as_deref(), Some("req_1"));
+                assert_eq!(command, "prompt");
+                assert!(success);
+                assert!(error.is_none());
+                assert_eq!(
+                    data.as_ref()
+                        .and_then(|d| d.get("agentInvoked").and_then(Value::as_bool)),
+                    Some(false)
+                );
+            }
+            other => panic!("expected Response, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn failed_response_carries_error() {
+        let frame = OmpRpcFrame::parse_json_line(
+            r#"{"id":"req_2","type":"response","command":"set_model","success":false,"error":"Model not found: provider/model"}"#,
+        )
+        .unwrap();
+        match frame {
+            OmpRpcFrame::Response { success, error, .. } => {
+                assert!(!success);
+                assert_eq!(error.as_deref(), Some("Model not found: provider/model"));
+            }
+            other => panic!("expected Response, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn response_without_id_is_still_a_response() {
+        // Unknown-command responses echo id: undefined on the wire.
+        let frame = OmpRpcFrame::parse_json_line(
+            r#"{"type":"response","command":"parse","success":false,"error":"unknown command"}"#,
+        )
+        .unwrap();
+        match frame {
+            OmpRpcFrame::Response { id, error, .. } => {
+                assert!(id.is_none());
+                assert_eq!(error.as_deref(), Some("unknown command"));
+            }
+            other => panic!("expected Response, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn agent_end_frame_routes_through_one_shot_parser() {
+        let frame = OmpRpcFrame::parse_json_line(r#"{"type":"agent_end","messages":[]}"#).unwrap();
+        match frame {
+            OmpRpcFrame::Event(event) => {
+                let mut normalizer = OmpEventNormalizer;
+                let events = OmpHarness.normalize_events(&mut normalizer, event).unwrap();
+                assert!(matches!(
+                    events.as_slice(),
+                    [NormalizedEvent::Result { error: None }]
+                ));
+            }
+            other => panic!("expected Event, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn message_update_event_normalizes_text_delta() {
+        let frame = OmpRpcFrame::parse_json_line(
+            r#"{"type":"message_update","assistantMessageEvent":{"type":"text_delta","contentIndex":0,"delta":"ONE"},"message":{"role":"assistant","content":[{"type":"text","text":"DONE"}],"responseId":"msg_011CcnPBnPUWzpXCn7915U1v"}}"#,
+        )
+        .unwrap();
+        match frame {
+            OmpRpcFrame::Event(event) => {
+                let mut normalizer = OmpEventNormalizer;
+                let events = OmpHarness.normalize_events(&mut normalizer, event).unwrap();
+                assert!(matches!(
+                    events.as_slice(),
+                    [NormalizedEvent::AgentTextDelta { item_id, delta }]
+                        if item_id == "msg_011CcnPBnPUWzpXCn7915U1v" && delta == "ONE"
+                ));
+            }
+            other => panic!("expected Event, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn prompt_result_frame_demultiplexes() {
+        let frame = OmpRpcFrame::parse_json_line(
+            r#"{"type":"prompt_result","id":"req_1","agentInvoked":false}"#,
+        )
+        .unwrap();
+        match frame {
+            OmpRpcFrame::PromptResult { id, agent_invoked } => {
+                assert_eq!(id.as_deref(), Some("req_1"));
+                assert!(!agent_invoked);
+            }
+            other => panic!("expected PromptResult, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn unknown_frame_degrades_to_other_without_erroring() {
+        let frame =
+            OmpRpcFrame::parse_json_line(r#"{"type":"available_commands_update","commands":[]}"#)
+                .unwrap();
+        assert!(matches!(frame, OmpRpcFrame::Other(_)));
+    }
+
+    #[test]
+    fn host_tool_call_frame_degrades_to_other() {
+        let frame = OmpRpcFrame::parse_json_line(
+            r#"{"type":"host_tool_call","id":"host_1","toolCallId":"toolu_123","toolName":"echo_host","arguments":{"message":"hi"}}"#,
+        )
+        .unwrap();
+        assert!(matches!(frame, OmpRpcFrame::Other(_)));
+    }
+
+    // --- Command builders -------------------------------------------------
+
+    #[test]
+    fn model_selector_extracts_provider_model_and_thinking_level() {
+        assert_eq!(
+            parse_omp_model_selector("openai-codex/gpt-5.6-sol:max").unwrap(),
+            OmpModelSelector {
+                provider: "openai-codex",
+                model_id: "gpt-5.6-sol",
+                thinking_level: Some("max"),
+            }
+        );
+        assert_eq!(
+            parse_omp_model_selector("openrouter/vendor/model:free")
+                .unwrap()
+                .model_id,
+            "vendor/model:free"
+        );
+    }
+
+    #[test]
+    fn model_configuration_commands_match_omp_rpc_contract() {
+        assert_eq!(
+            set_model_command("model-1", "openai-codex", "gpt-5.6-sol"),
+            json!({
+                "id": "model-1",
+                "type": "set_model",
+                "provider": "openai-codex",
+                "modelId": "gpt-5.6-sol",
+            })
+        );
+        assert_eq!(
+            set_thinking_level_command("thinking-1", "max"),
+            json!({
+                "id": "thinking-1",
+                "type": "set_thinking_level",
+                "level": "max",
+            })
+        );
+    }
+
+    #[test]
+    fn prompt_command_carries_id_and_optional_streaming_behavior() {
+        let cmd = prompt_command("req_1", "hello", None);
+        assert_eq!(cmd["type"], "prompt");
+        assert_eq!(cmd["id"], "req_1");
+        assert_eq!(cmd["message"], "hello");
+        assert!(cmd.get("streamingBehavior").is_none());
+
+        let cmd = prompt_command("req_1", "more", Some("steer"));
+        assert_eq!(cmd["streamingBehavior"], "steer");
+    }
+
+    #[test]
+    fn steer_command_builds() {
+        let cmd = steer_command("req_2", "also include risks");
+        assert_eq!(cmd["type"], "steer");
+        assert_eq!(cmd["id"], "req_2");
+        assert_eq!(cmd["message"], "also include risks");
+    }
+
+    #[test]
+    fn abort_command_builds() {
+        let cmd = abort_command("req_3");
+        assert_eq!(cmd["type"], "abort");
+        assert_eq!(cmd["id"], "req_3");
+    }
+
+    // --- Room state parsing and API projection ----------------------------
+
+    #[test]
+    fn configured_max_duration_extends_the_omp_turn_deadline() {
+        let trace_context = crate::otel::TraceContext {
+            metadata: std::collections::BTreeMap::from([(
+                "max_duration_ms".to_owned(),
+                json!(2_700_000),
+            )]),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            turn_timeout_from_trace_context(&trace_context),
+            Duration::from_millis(2_705_000)
+        );
+    }
+
+    #[test]
+    fn missing_invalid_or_zero_max_duration_keeps_the_default_deadline() {
+        assert_eq!(
+            turn_timeout_from_trace_context(&crate::otel::TraceContext::default()),
+            DEFAULT_OMP_TURN_TIMEOUT
+        );
+        let invalid = crate::otel::TraceContext {
+            metadata: std::collections::BTreeMap::from([(
+                "max_duration_ms".to_owned(),
+                json!("2700000"),
+            )]),
+            ..Default::default()
+        };
+        assert_eq!(
+            turn_timeout_from_trace_context(&invalid),
+            DEFAULT_OMP_TURN_TIMEOUT
+        );
+        let zero = crate::otel::TraceContext {
+            metadata: std::collections::BTreeMap::from([("max_duration_ms".to_owned(), json!(0))]),
+            ..Default::default()
+        };
+        assert_eq!(
+            turn_timeout_from_trace_context(&zero),
+            DEFAULT_OMP_TURN_TIMEOUT
+        );
+    }
+
+    #[test]
+    fn read_line_timeout_blank_stream_respects_absolute_deadline() {
+        // Bridge emits ready then continuous blank lines. A naive per-line
+        // recv_timeout reset would hang forever; absolute remaining budget
+        // must return Ok(None) within the caller's slice.
+        let bridge =
+            std::env::temp_dir().join(format!("omp-blank-bridge-{}.sh", std::process::id()));
+        std::fs::write(
+            &bridge,
+            r#"#!/bin/sh
+printf '%s\n' '{"type":"ready"}'
+# Flood blank lines forever (no non-empty frames).
+while :; do
+  printf '\n'
+done
+"#,
+        )
+        .expect("write bridge");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = std::fs::metadata(&bridge).unwrap().permissions();
+            perms.set_mode(0o755);
+            std::fs::set_permissions(&bridge, perms).unwrap();
+        }
+        let prev = std::env::var_os("CENTAUR_OMP_RPC_BRIDGE_COMMAND");
+        unsafe {
+            std::env::set_var("CENTAUR_OMP_RPC_BRIDGE_COMMAND", &bridge);
+        }
+        let mut child = OmpRpcChild::spawn().expect("spawn blank bridge");
+        drain_ready(&mut child).expect("ready");
+        let started = std::time::Instant::now();
+        let result = child
+            .read_line_timeout(Duration::from_millis(150))
+            .expect("timeout path is Ok");
+        let elapsed = started.elapsed();
+        assert!(
+            result.is_none(),
+            "blank stream must time out, got {result:?}"
+        );
+        assert!(
+            elapsed < Duration::from_millis(800),
+            "absolute deadline must bound the call, elapsed={elapsed:?}"
+        );
+        assert!(
+            elapsed >= Duration::from_millis(100),
+            "should wait near the requested slice, elapsed={elapsed:?}"
+        );
+        drop(child);
+        let _ = std::fs::remove_file(&bridge);
+        unsafe {
+            match prev {
+                Some(v) => std::env::set_var("CENTAUR_OMP_RPC_BRIDGE_COMMAND", v),
+                None => std::env::remove_var("CENTAUR_OMP_RPC_BRIDGE_COMMAND"),
+            }
+        }
+    }
+}

--- a/crates/harness-server/src/otel.rs
+++ b/crates/harness-server/src/otel.rs
@@ -1022,6 +1022,7 @@ fn harness_name(kind: HarnessKind) -> &'static str {
         HarnessKind::Codex => "codex",
         HarnessKind::ClaudeCode => "claude",
         HarnessKind::Amp => "amp",
+        HarnessKind::Omp => "omp",
     }
 }
 
@@ -1033,6 +1034,8 @@ fn gen_ai_system(kind: HarnessKind, model_provider: &str) -> &'static str {
         "openai"
     } else if provider.contains("amp") || matches!(kind, HarnessKind::Amp) {
         "amp"
+    } else if provider.contains("omp") || matches!(kind, HarnessKind::Omp) {
+        "omp"
     } else {
         "unknown"
     }

--- a/crates/harness-server/src/server.rs
+++ b/crates/harness-server/src/server.rs
@@ -30,6 +30,7 @@ use uuid::Uuid;
 use crate::amp::AmpHarness;
 use crate::claude::ClaudeCodeHarness;
 use crate::codex::CodexHarnessServer;
+use crate::omp::OmpHarness;
 use crate::otel::{TraceContext, TurnStatus as TelemetryTurnStatus, TurnTelemetry};
 use crate::traits::{
     AppServerNormalizer, AppServerRuntime, HarnessChild, HarnessKind, HarnessServer,
@@ -45,6 +46,7 @@ pub fn server_for(kind: HarnessKind) -> Box<dyn AppServerRuntime> {
         HarnessKind::Codex => Box::new(CodexHarnessServer::codex()),
         HarnessKind::ClaudeCode => Box::new(AppServerNormalizer::new(ClaudeCodeHarness)),
         HarnessKind::Amp => Box::new(AppServerNormalizer::new(AmpHarness)),
+        HarnessKind::Omp => Box::new(AppServerNormalizer::new(OmpHarness)),
     }
 }
 
@@ -56,6 +58,7 @@ pub fn run_blocks_server(kind: HarnessKind) -> Result<()> {
     match kind {
         HarnessKind::Codex => crate::codex::run_codex_blocks_server(CodexHarnessServer::codex()),
         HarnessKind::ClaudeCode => run_blocks_app_server(&ClaudeCodeHarness),
+        HarnessKind::Omp => crate::omp_rpc::run_omp_blocks_server(),
         HarnessKind::Amp => run_blocks_app_server(&AmpHarness),
     }
 }
@@ -1053,7 +1056,9 @@ fn resumed_thread_state<H: HarnessServer>(
             .clone()
             .unwrap_or_else(|| harness.default_model_provider().to_string()),
         service_tier: params.service_tier.clone().flatten(),
-        harness_session_id: Some(params.thread_id.clone()),
+        harness_session_id: harness
+            .resume_session_id(&params.thread_id)
+            .or_else(|| Some(params.thread_id.clone())),
         completed_turns: Vec::new(),
         process: None,
         thread_started_sent: false,
@@ -1289,7 +1294,7 @@ fn run_harness_turn<H: HarnessServer, W: Write>(
     request_rx: &Receiver<ActiveTurnRequest>,
     telemetry: &mut TurnTelemetry,
 ) -> Result<Option<codex_app_server_protocol::Turn>> {
-    ensure_harness_process(harness, state)?;
+    ensure_harness_process(harness, state, input)?;
     {
         let process = state
             .process
@@ -1352,6 +1357,9 @@ fn run_harness_turn<H: HarnessServer, W: Write>(
                 for normalized in normalized_events {
                     telemetry.observe_normalized(&normalized);
                     if let Some(session_id) = normalized.session_id() {
+                        if state.harness_session_id.as_deref() != Some(session_id) {
+                            harness.record_session_id(&state.id, session_id);
+                        }
                         last_session_id = Some(session_id.to_string());
                         state.harness_session_id = Some(session_id.to_string());
                     }
@@ -1444,7 +1452,11 @@ pub(crate) fn usage_span_input_value(input: &[UserInput]) -> Option<String> {
     non_empty(Some(&joined)).map(str::to_owned)
 }
 
-fn ensure_harness_process<H: HarnessServer>(harness: &H, state: &mut ThreadState) -> Result<()> {
+fn ensure_harness_process<H: HarnessServer>(
+    harness: &H,
+    state: &mut ThreadState,
+    input: &[UserInput],
+) -> Result<()> {
     if let Some(process) = state.process.as_mut() {
         if process.child.try_wait()?.is_none() {
             return Ok(());
@@ -1452,7 +1464,7 @@ fn ensure_harness_process<H: HarnessServer>(harness: &H, state: &mut ThreadState
         state.process = None;
     }
 
-    let mut command = harness.command_for_turn(state);
+    let mut command = harness.command_for_turn(state, input);
     let mut child = command
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
@@ -1641,7 +1653,6 @@ mod tests {
             Some("exe_123")
         );
     }
-
     #[test]
     fn ignores_blank_model_on_blocks_user_line() {
         let line = r#"{"type":"user","model":"  ","text":"hi"}"#;

--- a/crates/harness-server/src/traits.rs
+++ b/crates/harness-server/src/traits.rs
@@ -15,6 +15,7 @@ pub enum HarnessKind {
     Codex,
     ClaudeCode,
     Amp,
+    Omp,
 }
 
 pub struct ThreadState {
@@ -61,7 +62,11 @@ pub trait HarnessServer {
     fn cli_version(&self) -> &'static str;
     fn default_model(&self) -> String;
     fn default_model_provider(&self) -> &'static str;
-    fn command_for_turn(&self, state: &ThreadState) -> ProcessCommand;
+    /// The process to spawn for a turn. `input` is this turn's user input:
+    /// one-shot harnesses that take the prompt as a command argument (omp)
+    /// build it into the argv; stream-stdin harnesses (claude, amp) ignore it
+    /// and receive the input through `stdin_for_turn`.
+    fn command_for_turn(&self, state: &ThreadState, input: &[UserInput]) -> ProcessCommand;
     fn stdin_for_turn(&self, input: &[UserInput]) -> Result<Vec<u8>>;
     fn stdin_for_steer(&self, input: &[UserInput]) -> Result<Vec<u8>> {
         self.stdin_for_turn(input)
@@ -82,6 +87,18 @@ pub trait HarnessServer {
     /// that trailing `result` from being read as the *next* turn's terminal —
     /// while still completing when the result never comes.
     fn terminal_assistant_stop_settle(&self) -> Option<Duration> {
+        None
+    }
+
+    /// Persist the bridge-thread-id → harness-session-id mapping so a
+    /// post-restart `thread/resume` can target the id the harness actually
+    /// issued (the bridge id is minted here and unknown to the harness).
+    /// Default: no persistence — in-memory `ThreadState` is the only record.
+    fn record_session_id(&self, _thread_id: &str, _session_id: &str) {}
+
+    /// Look up a previously recorded harness session id for a bridge thread
+    /// id. `None` falls back to treating the bridge id as the session id.
+    fn resume_session_id(&self, _thread_id: &str) -> Option<String> {
         None
     }
 

--- a/crates/harness-server/tests/app_server_stdio.rs
+++ b/crates/harness-server/tests/app_server_stdio.rs
@@ -2436,13 +2436,27 @@ while IFS= read -r line; do
       ;;
     prompt)
       TURN_COUNT=$((TURN_COUNT+1))
-      printf '{{"id":"%s","type":"response","command":"prompt","success":true,"data":{{"agentInvoked":true}}}}\n' "$ID"
-      printf '%s\n' '{{"type":"agent_start"}}'
-      printf '%s\n' '{{"type":"turn_start"}}'
-      printf '%s\n' '{{"type":"message_update","assistantMessageEvent":{{"type":"text_delta","contentIndex":0,"delta":"hello from turn '"$TURN_COUNT"'"}},"message":{{"role":"assistant","content":[],"responseId":"msg-'"$TURN_COUNT"'"}}}}'
-      printf '%s\n' '{{"type":"message_end","message":{{"role":"assistant","content":[{{"type":"text","text":"hello from turn '"$TURN_COUNT"'"}}],"stopReason":"stop","responseId":"msg-'"$TURN_COUNT"'"}}}}'
-      printf '%s\n' '{{"type":"turn_end"}}'
-      printf '%s\n' '{{"type":"agent_end","messages":[]}}'
+      # Like omp, a prompt whose first token is a bare `/word` is a builtin
+      # slash command: local output, no agent turn. Paths are not commands.
+      MSG=$(printf '%s' "$line" | sed -n 's/.*"message":"\([^"]*\)".*/\1/p')
+      FIRST=${{MSG%% *}}
+      case "$FIRST" in
+        /*/*) SLASH=0 ;;
+        /*) SLASH=1 ;;
+        *) SLASH=0 ;;
+      esac
+      if [ "$SLASH" = 1 ]; then
+        printf '%s\n' '{{"type":"command_output","text":"Context: 12k of 200k tokens"}}'
+        printf '{{"id":"%s","type":"response","command":"prompt","success":true,"data":{{"agentInvoked":false}}}}\n' "$ID"
+      else
+        printf '{{"id":"%s","type":"response","command":"prompt","success":true,"data":{{"agentInvoked":true}}}}\n' "$ID"
+        printf '%s\n' '{{"type":"agent_start"}}'
+        printf '%s\n' '{{"type":"turn_start"}}'
+        printf '%s\n' '{{"type":"message_update","assistantMessageEvent":{{"type":"text_delta","contentIndex":0,"delta":"hello from turn '"$TURN_COUNT"'"}},"message":{{"role":"assistant","content":[],"responseId":"msg-'"$TURN_COUNT"'"}}}}'
+        printf '%s\n' '{{"type":"message_end","message":{{"role":"assistant","content":[{{"type":"text","text":"hello from turn '"$TURN_COUNT"'"}}],"stopReason":"stop","responseId":"msg-'"$TURN_COUNT"'"}}}}'
+        printf '%s\n' '{{"type":"turn_end"}}'
+        printf '%s\n' '{{"type":"agent_end","messages":[]}}'
+      fi
       ;;
     steer)
       printf '{{"id":"%s","type":"response","command":"steer","success":true}}\n' "$ID"
@@ -2855,6 +2869,143 @@ done
     assert!(
         interrupted,
         "valid interrupt must finish turn as interrupted"
+    );
+
+    let _ = bridge.finish_successfully();
+}
+
+#[test]
+fn resident_omp_allowlisted_slash_command_output_becomes_the_reply() {
+    let pidfile = temp_path("omp-rpc-pid-slash-ok");
+    let commands_path = format!("{}.commands", pidfile.display());
+    let _ = std::fs::remove_file(&pidfile);
+    let _ = std::fs::remove_file(&commands_path);
+    let script = fake_omp_rpc_script(&pidfile);
+    let mut bridge = spawn_omp_resident(script, &[]);
+
+    // api-rs prepends a chat-surface note as the first text block for console
+    // and Slack threads; the user's command is the last block.
+    let turn = bridge.run_blocks_user_line(
+        json!({
+            "type": "user",
+            "thread_key": "slack:C123:123.456",
+            "trace_metadata": {"source": "console", "action": "execute"},
+            "message": {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "[chat surface: Slack · channel C123 · thread 123.456.]"},
+                    {"type": "text", "text": "/context"},
+                ],
+            },
+        }),
+        Duration::from_secs(30),
+    );
+    assert_eq!(turn.terminal_status.as_deref(), Some("completed"));
+    assert!(
+        turn.text_from_deltas
+            .contains("Context: 12k of 200k tokens"),
+        "command output must stream as agent text, got {:?}",
+        turn.text_from_deltas
+    );
+    assert!(
+        turn.completed_agent_items
+            .values()
+            .any(|text| text.contains("Context: 12k of 200k tokens")),
+        "command output must complete as an agent item, got {:?}",
+        turn.completed_agent_items
+    );
+    let commands = std::fs::read_to_string(&commands_path).unwrap_or_default();
+    assert!(
+        commands.contains(r#""message":"/context""#),
+        "allowlisted command must reach omp as a prompt without the surface note: {commands}"
+    );
+    assert!(
+        !commands.contains("chat surface"),
+        "the chat-surface note must not be forwarded with a slash command: {commands}"
+    );
+
+    // The resident process is still usable for a normal turn afterwards.
+    let turn = bridge.run_blocks_user_turn("hello", Duration::from_secs(30));
+    assert_eq!(turn.terminal_status.as_deref(), Some("completed"));
+    assert!(turn.text_from_deltas.contains("hello from turn 2"));
+
+    let _ = bridge.finish_successfully();
+}
+
+#[test]
+fn resident_omp_refuses_slash_commands_with_effects_beyond_the_session() {
+    let pidfile = temp_path("omp-rpc-pid-slash-deny");
+    let commands_path = format!("{}.commands", pidfile.display());
+    let _ = std::fs::remove_file(&pidfile);
+    let _ = std::fs::remove_file(&commands_path);
+    let script = fake_omp_rpc_script(&pidfile);
+    let mut bridge = spawn_omp_resident(script, &[]);
+
+    let turn = bridge.run_blocks_user_turn("/share", Duration::from_secs(30));
+    assert_eq!(turn.terminal_status.as_deref(), Some("completed"));
+    let reply = turn
+        .completed_agent_items
+        .values()
+        .cloned()
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(
+        reply.contains("`/share` is not available through Centaur"),
+        "refusal must be the reply: {reply}"
+    );
+    assert!(
+        reply.contains("`/context`"),
+        "refusal must list alternatives: {reply}"
+    );
+    assert!(!pidfile.exists(), "a refused command must not spawn omp");
+
+    // A disallowed subcommand of an allowed command is refused the same way.
+    let turn = bridge.run_blocks_user_turn("/mcp add foo", Duration::from_secs(30));
+    let reply = turn
+        .completed_agent_items
+        .values()
+        .cloned()
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(
+        reply.contains("`/mcp add` is not available through Centaur"),
+        "subcommand refusal must be the reply: {reply}"
+    );
+    assert!(!pidfile.exists(), "a refused subcommand must not spawn omp");
+
+    // The allowed subcommand reaches omp and its output is surfaced.
+    let turn = bridge.run_blocks_user_turn("/mcp list", Duration::from_secs(30));
+    assert_eq!(turn.terminal_status.as_deref(), Some("completed"));
+    assert!(
+        turn.text_from_deltas
+            .contains("Context: 12k of 200k tokens")
+    );
+    let commands = std::fs::read_to_string(&commands_path).unwrap_or_default();
+    assert!(
+        commands.contains(r#""message":"/mcp list""#),
+        "commands: {commands}"
+    );
+    assert!(
+        !commands.contains("/share") && !commands.contains("/mcp add"),
+        "refused commands must never reach omp: {commands}"
+    );
+
+    let _ = bridge.finish_successfully();
+}
+
+#[test]
+fn resident_omp_forwards_slash_like_paths_as_prompts() {
+    let pidfile = temp_path("omp-rpc-pid-slash-path");
+    let _ = std::fs::remove_file(&pidfile);
+    let script = fake_omp_rpc_script(&pidfile);
+    let mut bridge = spawn_omp_resident(script, &[]);
+
+    let turn = bridge.run_blocks_user_turn("/etc/hosts is empty, why?", Duration::from_secs(30));
+    assert_eq!(turn.terminal_status.as_deref(), Some("completed"));
+    assert!(
+        turn.text_from_deltas.contains("hello from turn 1"),
+        "a path is a prompt, not a command: {:?}",
+        turn.text_from_deltas
     );
 
     let _ = bridge.finish_successfully();

--- a/crates/harness-server/tests/app_server_stdio.rs
+++ b/crates/harness-server/tests/app_server_stdio.rs
@@ -19,6 +19,7 @@ enum Harness {
     ClaudeCode,
     Amp,
     Codex,
+    Omp,
 }
 
 impl Harness {
@@ -27,6 +28,7 @@ impl Harness {
             Self::ClaudeCode => "claude-code",
             Self::Amp => "amp",
             Self::Codex => "codex",
+            Self::Omp => "omp",
         }
     }
 
@@ -35,6 +37,7 @@ impl Harness {
             Self::ClaudeCode => &["claude-code", "--mode", "jsonrpc"],
             Self::Amp => &["amp", "--mode", "jsonrpc"],
             Self::Codex => &["codex", "--mode", "jsonrpc"],
+            Self::Omp => &["omp", "--mode", "jsonrpc"],
         }
     }
 
@@ -43,6 +46,7 @@ impl Harness {
             Self::ClaudeCode => &["claude-code"],
             Self::Amp => &["amp"],
             Self::Codex => &["codex"],
+            Self::Omp => &["omp"],
         }
     }
 
@@ -51,6 +55,7 @@ impl Harness {
             Self::ClaudeCode => Some("CENTAUR_CLAUDE_APP_BRIDGE_COMMAND"),
             Self::Amp => Some("CENTAUR_AMP_APP_BRIDGE_COMMAND"),
             Self::Codex => None,
+            Self::Omp => Some("CENTAUR_OMP_APP_BRIDGE_COMMAND"),
         }
     }
 
@@ -66,6 +71,7 @@ impl Harness {
                 let model = std::env::var("AMP_MODE").unwrap_or_else(|_| "deep".to_string());
                 json!({ "model": model })
             }
+            Self::Omp => json!({}),
             Self::Codex => {
                 let mut params = json!({
                     "approvalPolicy": "never",
@@ -81,6 +87,32 @@ impl Harness {
             }
         }
     }
+}
+
+#[test]
+fn fake_omp_assistant_error_fails_the_app_server_turn() {
+    let fake_omp = concat!(
+        "printf '%s\\n' ",
+        "'{\"type\":\"session\",\"version\":3,\"id\":\"omp-session\"}' ",
+        "'{\"type\":\"agent_start\"}' ",
+        "'{\"type\":\"turn_start\"}' ",
+        "'{\"type\":\"message_end\",\"message\":{\"role\":\"assistant\",\"content\":[],\"provider\":\"litellm\",\"model\":\"glm-5.2-fp8\",\"stopReason\":\"error\",\"errorStatus\":401,\"errorMessage\":\"401 LiteLLM Virtual Key expected\"}}' ",
+        "'{\"type\":\"turn_end\"}' ",
+        "'{\"type\":\"agent_end\",\"messages\":[]}'"
+    );
+
+    let run = run_bridge_turn(BridgeTurnConfig {
+        harness: Harness::Omp,
+        command_override: Some(fake_omp.to_string()),
+        prompt: "say hello".to_string(),
+        timeout: Duration::from_secs(10),
+    });
+
+    assert_eq!(run.turn.terminal_status.as_deref(), Some("failed"));
+    assert_eq!(
+        run.turn.terminal_error.as_deref(),
+        Some("401 LiteLLM Virtual Key expected")
+    );
 }
 
 #[test]
@@ -1273,6 +1305,8 @@ impl BridgeProcess {
         for env_key in [
             "CENTAUR_CLAUDE_APP_BRIDGE_COMMAND",
             "CENTAUR_AMP_APP_BRIDGE_COMMAND",
+            "CENTAUR_OMP_APP_BRIDGE_COMMAND",
+            "CENTAUR_OMP_RPC_BRIDGE_COMMAND",
             "CODEX_MODEL",
             "CODEX_MODEL_PROVIDER",
             "OPENROUTER_MODEL",
@@ -1931,7 +1965,9 @@ fn run_native_anthropic(harness: Harness, prompt: &str, timeout: Duration) -> Na
             ]);
             command
         }
-        Harness::Codex => panic!("native anthropic runner does not support Codex"),
+        Harness::Codex | Harness::Omp => {
+            panic!("native anthropic runner does not support {harness:?}")
+        }
     };
     command
         .stdin(Stdio::piped())
@@ -2358,4 +2394,541 @@ fn shell_quote(path: &Path) -> String {
 
 fn shell_quote_str(raw: &str) -> String {
     format!("'{}'", raw.replace('\'', "'\\''"))
+}
+
+// ---------------------------------------------------------------------------
+// Resident OMP RPC host integration tests
+// ---------------------------------------------------------------------------
+// These tests drive the real `harness-server omp` blocks-mode binary with a
+// fake `omp --mode rpc` script (via CENTAUR_OMP_RPC_BRIDGE_COMMAND) that
+// speaks the exact OMP RPC wire protocol. They prove:
+// - process reuse across two sequential turns (same fake process)
+// - prompt/steer/interrupt normalization
+// - clean shutdown
+
+/// A fake `omp --mode rpc` script that speaks the wire protocol. It writes
+/// `ready`, responds to `prompt`/`steer`/`abort` commands, and emits agent
+/// lifecycle events. A pidfile proves process reuse across turns.
+fn fake_omp_rpc_script(pidfile: &Path) -> String {
+    let script_path = temp_path(&format!("fake-omp-rpc-{}", Uuid::new_v4().simple()));
+    let script = format!(
+        r#"#!/bin/sh
+echo $$ > '{pidfile}'
+# Session resume markers for L2 restart/resume proof.
+if [ -n "$CENTAUR_OMP_SESSION_NAME" ]; then
+  echo "$CENTAUR_OMP_SESSION_NAME" > '{pidfile}.session'
+fi
+if [ -f '{pidfile}.session' ]; then
+  cat '{pidfile}.session' > '{pidfile}.resumed'
+fi
+printf '%s\n' '{{"type":"ready"}}'
+TURN_COUNT=0
+while IFS= read -r line; do
+  printf '%s\n' "$line" >> '{pidfile}.commands'
+  CMD=$(printf '%s' "$line" | sed -n 's/.*"type":"\([^"]*\)".*/\1/p')
+  ID=$(printf '%s' "$line" | sed -n 's/.*"id":"\([^"]*\)".*/\1/p')
+  case "$CMD" in
+    set_model)
+      printf '{{"id":"%s","type":"response","command":"set_model","success":true,"data":{{"provider":"openai-codex","id":"gpt-5.6-sol"}}}}\n' "$ID"
+      ;;
+    set_thinking_level)
+      printf '{{"id":"%s","type":"response","command":"set_thinking_level","success":true}}\n' "$ID"
+      ;;
+    prompt)
+      TURN_COUNT=$((TURN_COUNT+1))
+      printf '{{"id":"%s","type":"response","command":"prompt","success":true,"data":{{"agentInvoked":true}}}}\n' "$ID"
+      printf '%s\n' '{{"type":"agent_start"}}'
+      printf '%s\n' '{{"type":"turn_start"}}'
+      printf '%s\n' '{{"type":"message_update","assistantMessageEvent":{{"type":"text_delta","contentIndex":0,"delta":"hello from turn '"$TURN_COUNT"'"}},"message":{{"role":"assistant","content":[],"responseId":"msg-'"$TURN_COUNT"'"}}}}'
+      printf '%s\n' '{{"type":"message_end","message":{{"role":"assistant","content":[{{"type":"text","text":"hello from turn '"$TURN_COUNT"'"}}],"stopReason":"stop","responseId":"msg-'"$TURN_COUNT"'"}}}}'
+      printf '%s\n' '{{"type":"turn_end"}}'
+      printf '%s\n' '{{"type":"agent_end","messages":[]}}'
+      ;;
+    steer)
+      printf '{{"id":"%s","type":"response","command":"steer","success":true}}\n' "$ID"
+      ;;
+    abort)
+      printf '{{"id":"%s","type":"response","command":"abort","success":true}}\n' "$ID"
+      printf '%s\n' '{{"type":"agent_end","messages":[]}}'
+      ;;
+    set_session_name)
+      printf '{{"id":"%s","type":"response","command":"set_session_name","success":true}}\n' "$ID"
+      ;;
+    get_state)
+      # Return the released shape: sessionId + sessionFile.
+      SESSION_ID="sess-$(cat '{pidfile}' 2>/dev/null || echo unknown)"
+      printf '{{"id":"%s","type":"response","command":"get_state","success":true,"data":{{"sessionId":"%s","sessionFile":"/tmp/%s.jsonl","sessionName":"test","isStreaming":false,"isCompacting":false,"steeringMode":"all","followUpMode":"all","interruptMode":"immediate","autoCompactionEnabled":true,"messageCount":0,"queuedMessageCount":0,"todoPhases":[],"thinkingLevel":"off"}}}}\n' "$ID" "$SESSION_ID" "$SESSION_ID"
+      ;;
+    *)
+      printf '%s' "$line" >&2
+      ;;
+  esac
+done
+"#,
+        pidfile = pidfile.display(),
+    );
+    std::fs::write(&script_path, script).expect("write fake omp script");
+    set_executable(&script_path);
+    script_path.display().to_string()
+}
+
+fn set_executable(path: &Path) {
+    let _ = std::fs::set_permissions(path, std::os::unix::fs::PermissionsExt::from_mode(0o755));
+}
+
+/// Spawn `harness-server omp` in blocks mode with a fake omp RPC bridge.
+fn spawn_omp_resident(fake_script: String, extra_envs: &[(&str, &str)]) -> BridgeProcess {
+    let bin = env!("CARGO_BIN_EXE_harness-server");
+    let mut command = Command::new(bin);
+    command
+        .args(["omp"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    for env_key in [
+        "CENTAUR_OMP_APP_BRIDGE_COMMAND",
+        "CENTAUR_OMP_RPC_BRIDGE_COMMAND",
+        "OMP_SESSION_DIR",
+    ] {
+        command.env_remove(env_key);
+    }
+    command.env("CENTAUR_OMP_RPC_BRIDGE_COMMAND", &fake_script);
+    for (key, value) in extra_envs {
+        command.env(key, value);
+    }
+    BridgeProcess::spawn_command(command)
+}
+
+#[test]
+fn resident_omp_reuses_one_process_across_two_turns() {
+    let pidfile = temp_path("omp-rpc-pid");
+    let _ = std::fs::remove_file(&pidfile);
+    let script = fake_omp_rpc_script(&pidfile);
+    let mut bridge = spawn_omp_resident(script, &[]);
+
+    let turn1 = bridge.run_blocks_user_turn("first prompt", Duration::from_secs(30));
+    let pid1 = std::fs::read_to_string(&pidfile)
+        .unwrap_or_default()
+        .trim()
+        .to_string();
+
+    let turn2 = bridge.run_blocks_user_turn("second prompt", Duration::from_secs(30));
+    let pid2 = std::fs::read_to_string(&pidfile)
+        .unwrap_or_default()
+        .trim()
+        .to_string();
+
+    let _ = bridge.finish_successfully();
+
+    // Same process: the pidfile was written once at startup and not overwritten.
+    assert_eq!(pid1, pid2, "resident process must be reused across turns");
+    assert!(!pid1.is_empty(), "pid must have been written");
+
+    // Both turns produced text.
+    assert!(
+        turn1.text_from_deltas.contains("turn 1")
+            || turn1
+                .completed_agent_items
+                .values()
+                .any(|t| t.contains("turn 1"))
+    );
+    assert!(
+        turn2.text_from_deltas.contains("turn 2")
+            || turn2
+                .completed_agent_items
+                .values()
+                .any(|t| t.contains("turn 2"))
+    );
+}
+
+#[test]
+fn resident_omp_applies_model_and_thinking_before_prompt() {
+    let pidfile = temp_path("omp-rpc-pid-model");
+    let _ = std::fs::remove_file(&pidfile);
+    let script = fake_omp_rpc_script(&pidfile);
+    let mut bridge = spawn_omp_resident(script, &[]);
+
+    let turn = bridge.run_blocks_user_line(
+        json!({
+            "type": "user",
+            "thread_key": "task:review",
+            "model": "openai-codex/gpt-5.6-sol:max",
+            "message": {
+                "role": "user",
+                "content": [{"type": "text", "text": "review this"}],
+            },
+        }),
+        Duration::from_secs(30),
+    );
+    let _ = bridge.finish_successfully();
+
+    assert!(turn.terminal_status.is_some());
+    let commands_path = PathBuf::from(format!("{}.commands", pidfile.display()));
+    let commands = std::fs::read_to_string(commands_path)
+        .expect("read fake OMP commands")
+        .lines()
+        .map(|line| serde_json::from_str::<Value>(line).expect("parse fake OMP command"))
+        .collect::<Vec<_>>();
+    assert_eq!(
+        commands
+            .iter()
+            .map(|command| command["type"].as_str().unwrap_or_default())
+            .collect::<Vec<_>>(),
+        ["get_state", "set_model", "set_thinking_level", "prompt"]
+    );
+    assert_eq!(commands[1]["provider"], "openai-codex");
+    assert_eq!(commands[1]["modelId"], "gpt-5.6-sol");
+    assert_eq!(commands[2]["level"], "max");
+}
+
+#[test]
+#[allow(clippy::useless_format)]
+fn resident_omp_drive_turn_settles_on_child_exit() {
+    // If the omp process exits without sending agent_end, drive_omp_turn
+    // must not poll forever. The settle timeout ensures the turn completes.
+    let script_path = temp_path(&format!("fake-omp-rpc-exit-{}", Uuid::new_v4().simple()));
+    let script = format!(
+        r#"#!/bin/sh
+printf '%s
+' '{{"type":"ready"}}'
+while IFS= read -r line; do
+  CMD=$(printf '%s' "$line" | sed -n 's/.*"type":"\([^"]*\)".*/\1/p')
+  ID=$(printf '%s' "$line" | sed -n 's/.*"id":"\([^"]*\)".*/\1/p')
+  case "$CMD" in
+    prompt)
+      printf '{{"id":"%s","type":"response","command":"prompt","success":true}}
+' "$ID"
+      printf '%s
+' '{{"type":"agent_start"}}'
+      # Exit WITHOUT sending agent_end — simulates a crashed/killed process.
+      exit 0
+      ;;
+    *)
+      ;;
+  esac
+done
+"#,
+    );
+    std::fs::write(&script_path, script).expect("write exit script");
+    set_executable(&script_path);
+
+    // The turn should complete (not hang forever) because the process exits
+    // and read_line_timeout returns Err on disconnect, which propagates.
+    // The adapter should handle this gracefully. The key assertion is that
+    // we reach the end of this function — the turn didn't block forever.
+    let mut bridge = spawn_omp_resident(script_path.display().to_string(), &[]);
+    // The process exits mid-turn; the adapter must settle without hanging.
+    // run_blocks_user_line will either complete or panic on process exit.
+    // Either way, the test finishes within the timeout (not forever).
+    let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        let _turn = bridge.run_blocks_user_turn("prompt", Duration::from_secs(30));
+    }));
+    // Drop the bridge — if the process already exited this is a no-op.
+    drop(bridge);
+}
+
+// ---------------------------------------------------------------------------
+// Real-binary smoke test
+// ---------------------------------------------------------------------------
+// Drives the real `omp --mode rpc` binary from the fork release
+// (v17.0.5-centaur.1) through the harness-server adapter. Ignored by default
+// because it requires the release installed at /tmp/omp-release-install.
+// Run with: cargo test --test app_server_stdio -- resident_omp_real --ignored
+
+#[test]
+fn resident_omp_session_id_resumes_across_respawn() {
+    // Fix (1): prove that get_state persists the actual session id and a
+    // second spawn passes --resume <id> via OMP_BIN (not bridge override).
+    // The fake executable records its argv and returns the session id from
+    // get_state based on its PID.
+    let session_dir = temp_path("omp-session-dir");
+    let _ = std::fs::create_dir_all(&session_dir);
+    let marker = session_dir.join(".resident_session_id");
+    let _ = std::fs::remove_file(&marker);
+    let argv_log = temp_path("omp-argv-log");
+    let _ = std::fs::remove_file(&argv_log);
+
+    // Fake omp binary: records argv, speaks the wire protocol.
+    let fake_bin = temp_path(&format!("fake-omp-bin-{}", Uuid::new_v4().simple()));
+    let script = format!(
+        r#"#!/bin/sh
+# Record argv for resume proof.
+printf '%s\n' "$*" >> '{argv_log}'
+# Write a stable PID-based session id.
+echo $$ > '{session_dir}/.pid'
+printf '%s\n' '{{"type":"ready"}}'
+while IFS= read -r line; do
+  CMD=$(printf '%s' "$line" | sed -n 's/.*"type":"\([^"]*\)".*/\1/p')
+  ID=$(printf '%s' "$line" | sed -n 's/.*"id":"\([^"]*\)".*/\1/p')
+  case "$CMD" in
+    get_state)
+      SID="sess-$$"
+      printf '{{"id":"%s","type":"response","command":"get_state","success":true,"data":{{"sessionId":"%s","sessionFile":"/tmp/%s.jsonl","sessionName":"test","isStreaming":false,"isCompacting":false,"steeringMode":"all","followUpMode":"all","interruptMode":"immediate","autoCompactionEnabled":true,"messageCount":0,"queuedMessageCount":0,"todoPhases":[],"thinkingLevel":"off"}}}}\n' "$ID" "$SID" "$SID"
+      ;;
+    prompt)
+      printf '{{"id":"%s","type":"response","command":"prompt","success":true,"data":{{"agentInvoked":true}}}}\n' "$ID"
+      printf '%s\n' '{{"type":"agent_start"}}'
+      printf '%s\n' '{{"type":"message_update","assistantMessageEvent":{{"type":"text_delta","contentIndex":0,"delta":"hi"}},"message":{{"role":"assistant","content":[],"responseId":"msg-1"}}}}'
+      printf '%s\n' '{{"type":"message_end","message":{{"role":"assistant","content":[{{"type":"text","text":"hi"}}],"stopReason":"stop","responseId":"msg-1"}}}}'
+      printf '%s\n' '{{"type":"agent_end","messages":[]}}'
+      ;;
+    *)
+      ;;
+  esac
+done
+"#,
+        argv_log = argv_log.display(),
+        session_dir = session_dir.display(),
+    );
+    std::fs::write(&fake_bin, script).expect("write fake bin");
+    set_executable(&fake_bin);
+
+    // First lifetime: spawn with OMP_BIN, no bridge override.
+    {
+        let bin = env!("CARGO_BIN_EXE_harness-server");
+        let mut command = Command::new(bin);
+        command
+            .args(["omp"])
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .env_remove("CENTAUR_OMP_RPC_BRIDGE_COMMAND")
+            .env_remove("CENTAUR_OMP_APP_BRIDGE_COMMAND")
+            .env("OMP_BIN", &fake_bin)
+            .env("OMP_SESSION_DIR", &session_dir);
+        let mut bridge = BridgeProcess::spawn_command(command);
+        let _turn = bridge.run_blocks_user_turn("first lifetime", Duration::from_secs(30));
+        let _ = bridge.finish_successfully();
+    }
+
+    // The marker must contain a session id from get_state.
+    let persisted = std::fs::read_to_string(&marker).unwrap_or_default();
+    assert!(
+        !persisted.trim().is_empty() && persisted.starts_with("sess-"),
+        "first lifetime must persist session id, got: {persisted:?}"
+    );
+
+    // Second lifetime: same OMP_BIN + session dir; must pass --resume <id>.
+    {
+        let bin = env!("CARGO_BIN_EXE_harness-server");
+        let mut command = Command::new(bin);
+        command
+            .args(["omp"])
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .env_remove("CENTAUR_OMP_RPC_BRIDGE_COMMAND")
+            .env_remove("CENTAUR_OMP_APP_BRIDGE_COMMAND")
+            .env("OMP_BIN", &fake_bin)
+            .env("OMP_SESSION_DIR", &session_dir);
+        let mut bridge = BridgeProcess::spawn_command(command);
+        let _turn = bridge.run_blocks_user_turn("second lifetime", Duration::from_secs(30));
+        let _ = bridge.finish_successfully();
+    }
+
+    // The argv log must show --resume <persisted-id> on the second spawn.
+    let argv_log_content = std::fs::read_to_string(&argv_log).unwrap_or_default();
+    let resume_flag = format!("--resume {}", persisted.trim());
+    assert!(
+        argv_log_content.contains(&resume_flag),
+        "second spawn must pass {resume_flag}, argv log: {argv_log_content}"
+    );
+}
+
+#[test]
+fn resident_omp_active_interrupt_and_steer() {
+    // Concurrent controls during an active turn: a steer queues its exact
+    // text on the turn and an interrupt finishes it as interrupted.
+    // Steer message is recorded to a temp file for exact assertion.
+    let pidfile = temp_path("omp-rpc-pid-active-ctrl");
+    let steer_log = temp_path("omp-rpc-steer-log");
+    let _ = std::fs::remove_file(&pidfile);
+    let _ = std::fs::remove_file(&steer_log);
+    let script_path = temp_path(&format!("fake-omp-hold-{}", Uuid::new_v4().simple()));
+    let script = format!(
+        r#"#!/bin/sh
+echo $$ > '{pidfile}'
+printf '%s\n' '{{"type":"ready"}}'
+while IFS= read -r line; do
+  CMD=$(printf '%s' "$line" | sed -n 's/.*"type":"\([^"]*\)".*/\1/p')
+  ID=$(printf '%s' "$line" | sed -n 's/.*"id":"\([^"]*\)".*/\1/p')
+  MSG=$(printf '%s' "$line" | sed -n 's/.*"message":"\([^"]*\)".*/\1/p')
+  case "$CMD" in
+    get_state)
+      printf '{{"id":"%s","type":"response","command":"get_state","success":true,"data":{{"sessionId":"sess-hold","sessionFile":"/tmp/sess-hold.jsonl","sessionName":"t","isStreaming":false,"isCompacting":false,"steeringMode":"all","followUpMode":"all","interruptMode":"immediate","autoCompactionEnabled":true,"messageCount":0,"queuedMessageCount":0,"todoPhases":[],"thinkingLevel":"off"}}}}\n' "$ID"
+      ;;
+    prompt)
+      printf '{{"id":"%s","type":"response","command":"prompt","success":true,"data":{{"agentInvoked":true}}}}\n' "$ID"
+      printf '%s\n' '{{"type":"agent_start"}}'
+      printf '%s\n' '{{"type":"message_update","assistantMessageEvent":{{"type":"text_delta","contentIndex":0,"delta":"working"}},"message":{{"role":"assistant","content":[],"responseId":"msg-1"}}}}'
+      # Hold open until abort.
+      ;;
+    steer)
+      printf '%s\n' "$MSG" > '{steer_log}'
+      printf '{{"id":"%s","type":"response","command":"steer","success":true}}\n' "$ID"
+      ;;
+    abort)
+      printf '{{"id":"%s","type":"response","command":"abort","success":true}}\n' "$ID"
+      printf '%s\n' '{{"type":"agent_end","messages":[]}}'
+      ;;
+    *)
+      ;;
+  esac
+done
+"#,
+        pidfile = pidfile.display(),
+        steer_log = steer_log.display(),
+    );
+    std::fs::write(&script_path, &script).expect("write hold script");
+    set_executable(&script_path);
+
+    let mut bridge = spawn_omp_resident(script_path.display().to_string(), &[]);
+
+    bridge.send(json!({
+        "type": "user",
+        "thread_key": "slack:C123:123.456",
+        "message": {
+            "role": "user",
+            "content": [{"type": "text", "text": "long running"}],
+        },
+    }));
+
+    let deadline = Instant::now() + Duration::from_secs(15);
+    let mut saw_delta = false;
+    while Instant::now() < deadline && !saw_delta {
+        let v = bridge.read_json(deadline);
+        if v.get("method").and_then(Value::as_str) == Some("item/agentMessage/delta") {
+            saw_delta = true;
+        }
+    }
+    assert!(
+        saw_delta,
+        "turn must start streaming before concurrent controls"
+    );
+
+    // Valid steer during active turn.
+    bridge.send(json!({
+        "type": "user",
+        "thread_key": "slack:C123:123.456",
+        "trace_metadata": {
+            "action": "steer_active_execution",
+        },
+        "message": {
+            "role": "user",
+            "content": [{"type": "text", "text": "also include risks"}],
+        },
+    }));
+    // Wait for steer to be processed (poll the log file).
+    let steer_deadline = Instant::now() + Duration::from_secs(5);
+    let mut steer_msg = String::new();
+    while Instant::now() < steer_deadline {
+        if let Ok(s) = std::fs::read_to_string(&steer_log)
+            && !s.trim().is_empty()
+        {
+            steer_msg = s.trim().to_string();
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    assert_eq!(
+        steer_msg, "also include risks",
+        "active steer must send exact message text, got: {steer_msg:?}"
+    );
+
+    // Valid interrupt → abort + interrupted status.
+    bridge.send(json!({
+        "type": "interrupt",
+    }));
+
+    let deadline = Instant::now() + Duration::from_secs(15);
+    let mut interrupted = false;
+    while Instant::now() < deadline {
+        let v = bridge.read_json_allowing_error(deadline);
+        if v.get("method").and_then(Value::as_str) == Some("turn/completed") {
+            let status = v.pointer("/params/turn/status").and_then(Value::as_str);
+            if status == Some("interrupted") {
+                interrupted = true;
+                break;
+            }
+        }
+    }
+    assert!(
+        interrupted,
+        "valid interrupt must finish turn as interrupted"
+    );
+
+    let _ = bridge.finish_successfully();
+}
+
+#[test]
+fn resident_omp_failed_prompt_preserves_error_message() {
+    // Fix 8: correlated prompt failure must carry the actual error text.
+    let pidfile = temp_path("omp-rpc-pid-fail");
+    let _ = std::fs::remove_file(&pidfile);
+    let script_path = temp_path(&format!("fake-omp-fail-{}", Uuid::new_v4().simple()));
+    let script = format!(
+        r#"#!/bin/sh
+echo $$ > '{pidfile}'
+printf '%s\n' '{{"type":"ready"}}'
+while IFS= read -r line; do
+  CMD=$(printf '%s' "$line" | sed -n 's/.*"type":"\([^"]*\)".*/\1/p')
+  ID=$(printf '%s' "$line" | sed -n 's/.*"id":"\([^"]*\)".*/\1/p')
+  case "$CMD" in
+    get_state)
+      printf '{{"id":"%s","type":"response","command":"get_state","success":true,"data":{{"sessionId":"sess-fail","sessionFile":"/tmp/s.jsonl","sessionName":"t","isStreaming":false,"isCompacting":false,"steeringMode":"all","followUpMode":"all","interruptMode":"immediate","autoCompactionEnabled":true,"messageCount":0,"queuedMessageCount":0,"todoPhases":[],"thinkingLevel":"off"}}}}\n' "$ID"
+      ;;
+    prompt)
+      printf '{{"id":"%s","type":"response","command":"prompt","success":false,"error":"Model not found: provider/model"}}\n' "$ID"
+      ;;
+    *)
+      ;;
+  esac
+done
+"#,
+        pidfile = pidfile.display(),
+    );
+    std::fs::write(&script_path, &script).expect("write fail script");
+    set_executable(&script_path);
+
+    let mut bridge = spawn_omp_resident(script_path.display().to_string(), &[]);
+
+    bridge.send(json!({
+        "type": "user",
+        "thread_key": "slack:C123:123.456",
+        "message": {
+            "role": "user",
+            "content": [{"type": "text", "text": "hello"}],
+        },
+    }));
+
+    let deadline = Instant::now() + Duration::from_secs(15);
+    let mut saw_actual_error = false;
+    let mut saw_failed_turn = false;
+    while Instant::now() < deadline {
+        let v = bridge.read_json_allowing_error(deadline);
+        let method = v.get("method").and_then(Value::as_str).unwrap_or_default();
+        if method == "error" {
+            let msg = v
+                .pointer("/params/error/message")
+                .and_then(Value::as_str)
+                .unwrap_or_default();
+            if msg.contains("Model not found") {
+                saw_actual_error = true;
+            }
+        }
+        if method == "turn/completed" {
+            let status = v.pointer("/params/turn/status").and_then(Value::as_str);
+            if status == Some("failed") {
+                saw_failed_turn = true;
+                break;
+            }
+        }
+    }
+    assert!(
+        saw_actual_error,
+        "must preserve actual prompt error message"
+    );
+    assert!(saw_failed_turn, "failed prompt must finish as failed");
+
+    let _ = bridge.finish_successfully();
 }

--- a/docs/pages/extend/workflows.mdx
+++ b/docs/pages/extend/workflows.mdx
@@ -211,6 +211,7 @@ SCHEDULE = {
     "type": "cron",
     "cron": "0 9 * * MON-FRI",
     "timezone": "America/New_York",
+    "allow_overlap": False,
     "input": {
         "channel": "markets",
         "topic": "overnight market structure and portfolio-relevant news",
@@ -251,10 +252,20 @@ query scopes, tenant IDs, lookback windows, and delivery settings should be
 declared in the schedule instead of inferred from wall-clock state when
 possible.
 
-For workflows that may run longer than their schedule interval, make each tick
-idempotent. Put writes and external API calls in named `ctx.step(...)` blocks,
-derive stable keys from the scheduled window, and have the handler detect
-already-processed periods before starting expensive work.
+Schedules overlap by default for backward compatibility. Set
+`allow_overlap: False` when a second run of the same workflow would duplicate
+work or race an active run. The scheduler still advances the next tick, but
+records the overlap and does not start another task while that workflow has a
+non-terminal task in its queue.
+
+Schedule dispatch is intentionally serialized within one API process because
+the active-task check and target spawn are separate database operations;
+workflow execution queues remain independently concurrent. Multi-process
+deployments need a distributed fence before relying on overlap suppression.
+
+Overlap suppression is not a substitute for idempotency. Put writes and
+external API calls in named `ctx.step(...)` blocks, derive stable keys from the
+scheduled window, and have the handler detect already-processed periods.
 
 Interval schedules are useful when exact wall-clock alignment does not matter:
 
@@ -268,6 +279,27 @@ SCHEDULE = {
 
 Use cron for calendar semantics such as "weekday at 9 AM"; use intervals for
 continuous monitors such as "check every five minutes".
+
+### Observe runs and schedules
+
+Workflow results should include a bounded semantic `outcome` such as
+`succeeded`, `noop`, `queued`, `waiting`, `blocked`, `degraded`, `dry_run`,
+`cancelled`, or `failed`. The run API persists that result.
+
+Handlers must return an object. A missing or `null` result is converted into an
+explicit terminal `failed` result rather than retried; use an explicit `failed`
+outcome for an intentional terminal business result.
+
+The Prometheus endpoint exports:
+
+- `centaur_workflow_task_attempts_total` and
+  `centaur_workflow_task_duration_seconds`, labeled by queue, workflow name,
+  and outcome;
+- `centaur_workflow_schedule_ticks_total`, labeled by schedule, workflow, and
+  tick outcome (`spawned`, `deduped`, `overlap_skipped`, or `disabled`);
+- `centaur_workflow_schedule_last_dispatch_timestamp_seconds`, which supports
+  per-schedule dispatch-freshness alerts. This detects a stalled scheduler; use
+  task outcome metrics to alert on workflow completion health.
 
 ## Expose a workflow as a webhook
 

--- a/harness/omp/config.yml
+++ b/harness/omp/config.yml
@@ -1,0 +1,26 @@
+# Baked omp (oh-my-pi) agent config. Copied to $PI_CODING_AGENT_DIR/config.yml
+# at container start by entrypoint.sh, which substitutes __OMP_LITELLM_BASE_URL__
+# (OMP_LITELLM_BASE_URL) so each deployment points omp at its own LiteLLM gateway.
+#
+# models.yml defines the gateway model STATICALLY; the model id goes on the wire
+# unchanged (discovery-based registries fuzzy-merge ids against models.dev).
+providers:
+  litellm:
+    baseUrl: __OMP_LITELLM_BASE_URL__
+    apiKey: LITELLM_API_KEY
+    auth: apiKey
+    api: openai-completions
+
+modelRoles:
+  default: "litellm/glm-5.2-fp8"
+  smol: "litellm/glm-5.2-fp8"
+  commit: "litellm/glm-5.2-fp8"
+  task: "litellm/glm-5.2-fp8"
+  # Every role stays on the gateway by default — sandboxes carry no
+  # frontier-provider keys. Point slow/plan/advisor at a frontier model only in
+  # deployments that inject its key.
+  slow: "litellm/glm-5.2-fp8"
+  plan: "litellm/glm-5.2-fp8"
+  advisor: "litellm/glm-5.2-fp8"
+
+defaultThinkingLevel: medium

--- a/harness/omp/models.yml
+++ b/harness/omp/models.yml
@@ -1,0 +1,24 @@
+# Baked omp (oh-my-pi) model-provider registry. Copied next to config.yml by
+# entrypoint.sh (same __OMP_LITELLM_BASE_URL__ substitution).
+#
+# The gateway model is defined STATICALLY, not via discovery, for two reasons:
+# (1) omp resolves model roles once per process and cold-cache discovery races
+#     that resolution (silent fallback to the built-in default provider);
+# (2) discovery fuzzy-merges gateway ids against the live models.dev catalog,
+#     where e.g. glm-5.2-fp8 collides with a differently spelled entry and gets
+#     a wire id the gateway rejects. Static definitions bypass the merge — the
+#     id goes on the wire unchanged.
+providers:
+  litellm:
+    baseUrl: __OMP_LITELLM_BASE_URL__
+    apiKey: LITELLM_API_KEY
+    api: openai-completions
+    models:
+      - id: glm-5.2-fp8
+        name: GLM 5.2 fp8 (LiteLLM gateway)
+        # Declare native tool calling explicitly: without this, discovery may
+        # mark the model tool-less and omp falls back to its in-band dialect.
+        supportsTools: true
+        reasoning: true
+        contextWindow: 1048576
+        maxTokens: 131072

--- a/services/api-rs/crates/centaur-api-integration-test/src/main.rs
+++ b/services/api-rs/crates/centaur-api-integration-test/src/main.rs
@@ -248,6 +248,7 @@ async fn test_harness_wire_values(http: &HttpClient, base_url: &str) -> Result<(
         (HarnessType::Amp, "amp"),
         (HarnessType::ClaudeCode, "claudecode"),
         (HarnessType::Nanocodex, "nanocodex"),
+        (HarnessType::Omp, "omp"),
         (HarnessType::Hermes, "hermes"),
     ];
 

--- a/services/api-rs/crates/centaur-api-server/src/args.rs
+++ b/services/api-rs/crates/centaur-api-server/src/args.rs
@@ -2003,11 +2003,19 @@ impl IronProxyHarnessArgs {
     /// so sessions restarted onto another harness still get working
     /// credentials through the proxy.
     fn fragments(&self) -> Result<Vec<ProxyFragment>, ServerError> {
-        let mut fragments = vec![self.fragment()?];
+        let mut fragments = Vec::new();
+        // Engines with no auth-mode source (amp, omp — credentials reach the
+        // sandbox as plain env, not proxy-injected) have no infra fragment to
+        // require. An explicit KUBERNETES_IRON_PROXY_HARNESS_AUTH_MODE still
+        // forces resolution (and fails loudly on an unknown pair).
+        if self.auth_mode.is_some() || harness_auth_mode_env(&self.engine).is_some() {
+            fragments.push(self.fragment()?);
+        }
         for engine in [
             HarnessType::Codex,
             HarnessType::ClaudeCode,
             HarnessType::Amp,
+            HarnessType::Omp,
         ] {
             if harness_fragment_engine_name(&engine) == harness_fragment_engine_name(&self.engine) {
                 continue;
@@ -2078,6 +2086,7 @@ fn harness_fragment_engine_name(engine: &HarnessType) -> &'static str {
         HarnessType::Amp => "amp",
         HarnessType::ClaudeCode => "claude-code",
         HarnessType::Nanocodex => "codex",
+        HarnessType::Omp => "omp",
         HarnessType::Hermes => "hermes",
     }
 }
@@ -2096,6 +2105,9 @@ fn harness_auth_mode_env(engine: &HarnessType) -> Option<String> {
         HarnessType::Codex | HarnessType::Nanocodex => env::var("CODEX_AUTH_MODE").ok(),
         HarnessType::ClaudeCode => env::var("CLAUDE_CODE_AUTH_MODE").ok(),
         HarnessType::Amp => None,
+        // omp gets its upstream key through the plain sandbox env (LiteLLM
+        // gateway), not an iron-proxy auth fragment — the amp pattern.
+        HarnessType::Omp => None,
         // Hermes resolves providers through its own credential store /
         // iron-proxy placeholder injection; no dedicated auth-mode env.
         HarnessType::Hermes => None,

--- a/services/api-rs/crates/centaur-session-cli/src/main.rs
+++ b/services/api-rs/crates/centaur-session-cli/src/main.rs
@@ -583,6 +583,7 @@ enum HarnessTypeArg {
     #[value(name = "claudecode")]
     ClaudeCode,
     Nanocodex,
+    Omp,
     Hermes,
 }
 
@@ -593,6 +594,7 @@ impl From<HarnessTypeArg> for HarnessType {
             HarnessTypeArg::Amp => Self::Amp,
             HarnessTypeArg::ClaudeCode => Self::ClaudeCode,
             HarnessTypeArg::Nanocodex => Self::Nanocodex,
+            HarnessTypeArg::Omp => Self::Omp,
             HarnessTypeArg::Hermes => Self::Hermes,
         }
     }

--- a/services/api-rs/crates/centaur-session-core/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-core/src/lib.rs
@@ -361,6 +361,7 @@ pub enum HarnessType {
     Amp,
     ClaudeCode,
     Nanocodex,
+    Omp,
     Hermes,
 }
 
@@ -865,6 +866,7 @@ mod tests {
             HarnessType::from_str("claudecode").unwrap(),
             HarnessType::ClaudeCode
         );
+        assert_eq!(HarnessType::from_str("omp").unwrap(), HarnessType::Omp);
     }
 
     #[test]
@@ -876,6 +878,10 @@ mod tests {
         assert_eq!(
             serde_json::from_value::<HarnessType>(serde_json::json!("codex")).unwrap(),
             HarnessType::Codex
+        );
+        assert_eq!(
+            serde_json::to_value(HarnessType::Omp).unwrap(),
+            serde_json::json!("omp")
         );
     }
 

--- a/services/api-rs/crates/centaur-session-runtime/Cargo.toml
+++ b/services/api-rs/crates/centaur-session-runtime/Cargo.toml
@@ -21,6 +21,7 @@ serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
+time.workspace = true
 tokio = { workspace = true, features = ["io-util", "macros", "sync", "time"] }
 tokio-util = { workspace = true, features = ["codec"] }
 tracing.workspace = true
@@ -28,7 +29,6 @@ uuid.workspace = true
 
 [dev-dependencies]
 sqlx.workspace = true
-time.workspace = true
 tokio = { workspace = true, features = ["io-util", "macros", "rt-multi-thread", "sync", "time"] }
 uuid.workspace = true
 

--- a/services/api-rs/crates/centaur-session-runtime/src/cleanup.rs
+++ b/services/api-rs/crates/centaur-session-runtime/src/cleanup.rs
@@ -76,6 +76,18 @@ impl SessionSandboxCleanupWorker {
         &mut self,
         report: &mut SessionSandboxCleanupReport,
     ) -> Result<(), SessionRuntimeError> {
+        match self.ctx.store.delete_expired_sandbox_leases().await {
+            Ok(expired_lease_count) if expired_lease_count > 0 => {
+                info!(
+                    expired_lease_count,
+                    "session sandbox cleanup worker purged expired leases"
+                );
+            }
+            Ok(_) => {}
+            Err(error) => {
+                warn!(%error, "session sandbox cleanup worker failed to purge expired leases");
+            }
+        }
         let referenced = self
             .ctx
             .store

--- a/services/api-rs/crates/centaur-session-runtime/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-runtime/src/lib.rs
@@ -42,6 +42,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use sha2::{Digest, Sha256};
 use thiserror::Error;
+use time::OffsetDateTime;
 use tokio::{
     io,
     sync::Mutex,
@@ -94,6 +95,52 @@ type SessionTitleThreadSet = Arc<DashSet<ThreadKey>>;
 type SessionTitleGenerator = Arc<
     dyn Fn(String) -> BoxFuture<'static, Result<String, SessionTitleGenerationError>> + Send + Sync,
 >;
+
+/// Durable cross-replica sandbox reference lease backed by `PgSessionStore`.
+///
+/// The renewer task periodically re-ups the lease expiry. Drop aborts the
+/// renewer; a crash or cancellation leaves a TTL-bounded DB row that the
+/// cleanup worker purges once expired. Explicit completion via `release`
+/// owner-checked-deletes the row (best-effort, logs on failure).
+#[must_use = "the sandbox reference lease must be held for the owning task's lifetime"]
+pub struct SandboxReferenceLease {
+    store: PgSessionStore,
+    sandbox_id: Arc<str>,
+    owner_id: Arc<str>,
+    renewer: Option<tokio::task::JoinHandle<()>>,
+}
+
+impl SandboxReferenceLease {
+    /// Aborts the renewer and owner-checked-deletes the lease row.
+    /// Deletion failures are warn-only and not returned.
+    pub async fn release(mut self) {
+        if let Some(renewer) = self.renewer.take() {
+            renewer.abort();
+            let _ = renewer.await;
+        }
+        if let Err(error) = self
+            .store
+            .delete_sandbox_lease(&self.sandbox_id, &self.owner_id)
+            .await
+        {
+            warn!(
+                sandbox_id = %self.sandbox_id,
+                owner_id = %self.owner_id,
+                %error,
+                "failed to delete sandbox reference lease on release; \
+                 cleanup worker will purge it once expired",
+            );
+        }
+    }
+}
+
+impl Drop for SandboxReferenceLease {
+    fn drop(&mut self) {
+        if let Some(renewer) = self.renewer.take() {
+            renewer.abort();
+        }
+    }
+}
 
 #[async_trait::async_trait]
 pub trait SessionPrincipalRegistrar: Send + Sync {
@@ -186,6 +233,15 @@ pub struct PersonaDefinition {
     pub prompt_hash: String,
     #[serde(skip_serializing)]
     pub prompt: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct PersonaSummary {
+    pub id: String,
+    pub source_root: String,
+    pub source_path: String,
+    pub source_ref: Option<String>,
+    pub prompt_hash: String,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
@@ -947,6 +1003,69 @@ impl SessionRuntime {
         }
     }
 
+    /// Acquire a durable sandbox reference shared by every api-rs replica.
+    pub async fn acquire_sandbox_reference_lease(
+        &self,
+        sandbox_id: &str,
+        owner_id: &str,
+    ) -> Result<SandboxReferenceLease, SessionRuntimeError> {
+        let sandbox_id: Arc<str> = Arc::from(sandbox_id);
+        let owner_id: Arc<str> = Arc::from(owner_id);
+        let lease_ttl = time::Duration::minutes(10);
+        let acquired = self
+            .store
+            .acquire_sandbox_lease(
+                &sandbox_id,
+                &owner_id,
+                OffsetDateTime::now_utc() + lease_ttl,
+            )
+            .await?;
+        if !acquired {
+            return Err(SessionRuntimeError::SandboxLeaseOwned {
+                sandbox_id: sandbox_id.to_string(),
+            });
+        }
+
+        let store = self.store.clone();
+        let renewer_sandbox_id = Arc::clone(&sandbox_id);
+        let renewer_owner_id = Arc::clone(&owner_id);
+        let renewer = tokio::spawn(async move {
+            loop {
+                sleep(Duration::from_secs(60)).await;
+                let expires_at = OffsetDateTime::now_utc() + lease_ttl;
+                match store
+                    .renew_sandbox_lease(&renewer_sandbox_id, &renewer_owner_id, expires_at)
+                    .await
+                {
+                    Ok(true) => {}
+                    Ok(false) => {
+                        warn!(
+                            sandbox_id = %renewer_sandbox_id,
+                            owner_id = %renewer_owner_id,
+                            "sandbox reference lease was lost; stopping renewer",
+                        );
+                        break;
+                    }
+                    Err(error) => {
+                        warn!(
+                            sandbox_id = %renewer_sandbox_id,
+                            owner_id = %renewer_owner_id,
+                            %error,
+                            "failed to renew sandbox reference lease; retrying next interval",
+                        );
+                    }
+                }
+            }
+        });
+
+        Ok(SandboxReferenceLease {
+            store: self.store.clone(),
+            sandbox_id,
+            owner_id,
+            renewer: Some(renewer),
+        })
+    }
+
     pub fn with_session_title_generator<F, Fut>(mut self, generator: F) -> Self
     where
         F: Fn(String) -> Fut + Send + Sync + 'static,
@@ -1649,6 +1768,7 @@ impl SessionRuntime {
                     )
                     .await?;
             }
+
             info!(
                 component = COMPONENT_SESSION_RUNTIME,
                 event = "session_create_or_get_completed",
@@ -2254,11 +2374,74 @@ impl SessionRuntime {
                 }
             };
 
+            // Allocation-only placeholder. An orchestrator claims a sandbox by
+            // executing with the `allocate_sandbox` marker and no input: the
+            // pod claim above is the entire purpose of the call. Left open,
+            // nothing ever completes it — the harness has no child until a
+            // User command spawns one, so not even an interrupt can end it —
+            // and max_duration fails it a minute later, leaving an
+            // `execution exceeded` row on the thread and a one-minute wait
+            // on every cold claim. Complete it here instead: the sandbox is
+            // assigned and no model turn is billed. Fenced to exactly this shape —
+            // the marker action AND no input — so no real execution can take the
+            // path.
+            if is_allocation_only_placeholder(requester_metadata.as_ref(), &input_lines) {
+                // Through the normal terminal machinery, not a bare store
+                // update: the completion event, transcript archive, lease
+                // release, activity touch, finished metric, and the idle
+                // pause the caller's own idle_timeout asked for all hang
+                // off `record_terminal_output`, and skipping them is how an
+                // abandoned allocation outlives its timeout until a sweep.
+                let terminal = record_terminal_output(
+                    &self.context(),
+                    thread_key,
+                    &sandbox_id,
+                    &execution.execution_id,
+                    TerminalOutput::Completed {
+                        reason: "allocation_only",
+                        result_text: None,
+                    },
+                )
+                .await?;
+                // `None` means another writer terminalized the row first;
+                // the in-memory `execution` still says running, and
+                // returning it would report a status the store has already
+                // replaced. Read the thread's terminal truth instead.
+                let terminal = match terminal {
+                    Some(terminal) => terminal,
+                    None => self
+                        .store
+                        .latest_execution_for_thread(thread_key)
+                        .await?
+                        .ok_or_else(|| {
+                            SessionRuntimeError::BadRequest(format!(
+                                "allocation-only execution {} disappeared from {}",
+                                execution.execution_id,
+                                thread_key.as_str(),
+                            ))
+                        })?,
+                };
+                info!(
+                    component = COMPONENT_SESSION_RUNTIME,
+                    event = "session_execute_allocation_only",
+                    thread_key = %thread_key,
+                    execution_id = %terminal.execution_id,
+                    sandbox_id = %sandbox_id,
+                    status = %terminal.status,
+                    completion_reason = "allocation_only",
+                    "allocation-only placeholder completed; sandbox claimed without a turn"
+                );
+                span.record("centaur.execution_id", terminal.execution_id.as_str());
+                span.record("execution_id", terminal.execution_id.as_str());
+                return Ok(terminal);
+            }
+
             let trace = SessionTraceContext::for_execution(
                 Some(&execution_trace_span),
                 traceparent.or_else(|| execution_traceparent(&execution).map(ToOwned::to_owned)),
                 Some(&execution.execution_id),
-            );
+            )
+            .with_max_duration_ms(max_duration_ms);
             let input_lines = input_lines_with_session_context(thread_key, &trace, &input_lines);
             if let Err(error) = write_input_lines(
                 &pipe,
@@ -3710,6 +3893,7 @@ impl SessionRuntime {
             .await;
             return Ok(OrphanAdoption::Failed);
         }
+
         if !self.claim_expired_stdout_owner(execution_id).await? {
             // Deferrals repeat on every periodic scan while another control
             // plane pumps the execution; only the first observation is worth
@@ -4294,6 +4478,7 @@ fn harness_server_subcommand(harness: &HarnessType) -> &'static str {
         HarnessType::ClaudeCode => "claude-code",
         HarnessType::Amp => "amp",
         HarnessType::Nanocodex => "nanocodex",
+        HarnessType::Omp => "omp",
         HarnessType::Hermes => "hermes",
     }
 }
@@ -5290,7 +5475,7 @@ async fn record_terminal_output(
     sandbox_id: &str,
     execution_id: &str,
     terminal: TerminalOutput,
-) -> Result<(), SessionRuntimeError> {
+) -> Result<Option<SessionExecution>, SessionRuntimeError> {
     let mut failure_class = None;
     let (terminal_execution, terminal_status) = match terminal {
         TerminalOutput::Completed {
@@ -5302,7 +5487,7 @@ async fn record_terminal_output(
                 .complete_execution_if_active_and_stdout_owner(execution_id, &ctx.stdout_owner_id)
                 .await?
             else {
-                return Ok(());
+                return Ok(None);
             };
             let mut payload = json!({
                 "execution_id": execution_id,
@@ -5334,7 +5519,7 @@ async fn record_terminal_output(
                 )
                 .await?
             else {
-                return Ok(());
+                return Ok(None);
             };
             ctx.store
                 .append_event(
@@ -5361,7 +5546,7 @@ async fn record_terminal_output(
                 )
                 .await?
             else {
-                return Ok(());
+                return Ok(None);
             };
             ctx.store
                 .append_event(
@@ -5408,12 +5593,12 @@ async fn record_terminal_output(
         spawn_idle_pause(
             ctx.clone(),
             thread_key.clone(),
-            terminal_execution.execution_id,
+            terminal_execution.execution_id.clone(),
             sandbox_id.to_owned(),
             idle_timeout,
         );
     }
-    Ok(())
+    Ok(Some(terminal_execution))
 }
 
 fn spawn_max_duration_failure(
@@ -5457,9 +5642,8 @@ fn spawn_stdout_owner_renewer(ctx: RuntimeContext, execution_id: String) {
                         execution_id,
                         stdout_owner_id = %ctx.stdout_owner_id,
                         %error,
-                        "failed to renew stdout owner lease"
+                        "failed to renew stdout owner lease; retrying"
                     );
-                    break;
                 }
             }
         }
@@ -5668,7 +5852,6 @@ fn should_pause_idle_sandbox(
         ExecutionStatus::Completed | ExecutionStatus::Failed | ExecutionStatus::Cancelled
     )
 }
-
 fn duration_millis_u64(duration: Duration) -> u64 {
     duration.as_millis().min(u128::from(u64::MAX)) as u64
 }
@@ -5979,6 +6162,7 @@ fn runtime_error_failure_class(error: &SessionRuntimeError) -> &'static str {
         SessionRuntimeError::Sandbox(SandboxError::Io { .. }) => "sandbox_io",
         SessionRuntimeError::Sandbox(SandboxError::Backend { .. }) => "sandbox_backend",
         SessionRuntimeError::Sandbox(SandboxError::InvalidSpec(_)) => "sandbox_invalid_spec",
+        SessionRuntimeError::SandboxLeaseOwned { .. } => "sandbox_lease_owned",
         SessionRuntimeError::IronControl(_) => "iron_control",
         SessionRuntimeError::WarmPool(_) => "warm_pool",
         SessionRuntimeError::CapacityExceeded { .. } => "capacity",
@@ -6434,6 +6618,10 @@ const EXECUTION_TRACEPARENT_METADATA_KEY: &str = "centaur.traceparent";
 #[derive(Clone, Debug)]
 struct SessionTraceContext {
     traceparent: Option<String>,
+    /// Trusted execution duration forwarded to the harness as a local safety
+    /// deadline. api-rs remains authoritative and records the timeout first.
+    max_duration_ms: Option<u64>,
+    /// Durable execution identity propagated to harness trace metadata.
     execution_id: Option<String>,
 }
 
@@ -6452,8 +6640,14 @@ impl SessionTraceContext {
             traceparent: execution_span
                 .and_then(centaur_telemetry::traceparent_for_span)
                 .or(persisted_traceparent),
+            max_duration_ms: None,
             execution_id: execution_id.map(ToOwned::to_owned),
         }
+    }
+
+    fn with_max_duration_ms(mut self, max_duration_ms: Option<u64>) -> Self {
+        self.max_duration_ms = max_duration_ms;
+        self
     }
 }
 
@@ -6519,6 +6713,22 @@ fn input_line_with_session_context(
         }
     }
     prepend_chat_surface_note(map, thread_key);
+    // max_duration_ms is a reserved control-plane field. Remove any caller
+    // value even when this execution has no configured maximum; otherwise the
+    // OMP harness would trust a deadline that api-rs is not enforcing.
+    if let Some(Value::Object(metadata)) = map.get_mut("trace_metadata") {
+        metadata.remove("max_duration_ms");
+    }
+    // Inject trusted execution controls into trace_metadata after the line
+    // leaves the client boundary. Client-supplied values are overwritten.
+    if let Some(max_duration_ms) = trace.max_duration_ms {
+        let mut metadata = match map.get("trace_metadata") {
+            Some(Value::Object(existing)) => existing.clone(),
+            _ => serde_json::Map::new(),
+        };
+        metadata.insert("max_duration_ms".to_owned(), json!(max_duration_ms));
+        map.insert("trace_metadata".to_owned(), Value::Object(metadata));
+    }
     merge_session_context(map, session_context_for_thread(thread_key));
     serde_json::to_string(&value).unwrap_or_else(|_| line.to_owned())
 }
@@ -6927,6 +7137,18 @@ fn validate_input_lines(lines: &[String]) -> Result<(), SessionRuntimeError> {
     Ok(())
 }
 
+/// True for the sandbox-allocation placeholder: the marker action and
+/// no input lines. A host that wants only the pod an execution claims — not
+/// a turn in it — executes exactly this shape, and [`SessionRuntime::
+/// execute_session`] completes it as soon as the sandbox is assigned.
+fn is_allocation_only_placeholder(metadata: Option<&Value>, input_lines: &[String]) -> bool {
+    input_lines.is_empty()
+        && metadata
+            .and_then(|value| value.get("action"))
+            .and_then(Value::as_str)
+            == Some("allocate_sandbox")
+}
+
 fn stdout_pump_error_message(error: &LinesCodecError) -> String {
     match error {
         LinesCodecError::MaxLineLengthExceeded => {
@@ -7212,6 +7434,8 @@ pub enum SessionRuntimeError {
     Store(#[from] SessionStoreError),
     #[error(transparent)]
     Sandbox(#[from] SandboxError),
+    #[error("sandbox {sandbox_id} reference lease is held by another owner")]
+    SandboxLeaseOwned { sandbox_id: String },
     #[error(transparent)]
     IronControl(#[from] centaur_iron_control::IronControlError),
     #[error(transparent)]
@@ -8003,6 +8227,34 @@ mod tests {
     }
 
     #[test]
+    fn execution_max_duration_is_injected_into_trusted_harness_metadata() {
+        let thread_key = ThreadKey::parse("workflow:test:repair").unwrap();
+        let trace = SessionTraceContext::new(None, None).with_max_duration_ms(Some(2_700_000));
+        let input = r#"{"type":"user","text":"repair","trace_metadata":{"max_duration_ms":1}}"#;
+
+        let value: Value =
+            serde_json::from_str(&input_line_with_session_context(&thread_key, &trace, input))
+                .unwrap();
+
+        assert_eq!(value["trace_metadata"]["max_duration_ms"], 2_700_000);
+    }
+
+    #[test]
+    fn absent_execution_max_duration_removes_client_harness_override() {
+        let thread_key = ThreadKey::parse("workflow:test:repair").unwrap();
+        let trace = SessionTraceContext::new(None, None);
+        let input = r#"{"type":"user","text":"repair","trace_metadata":{"max_duration_ms":2700000,"client_tag":"kept"}}"#;
+
+        let value: Value =
+            serde_json::from_str(&input_line_with_session_context(&thread_key, &trace, input))
+                .unwrap();
+        let metadata = value["trace_metadata"].as_object().unwrap();
+
+        assert!(!metadata.contains_key("max_duration_ms"));
+        assert_eq!(metadata["client_tag"], "kept");
+    }
+
+    #[test]
     fn execution_metadata_preserves_idle_and_max_duration() {
         let metadata =
             execution_metadata(Some(json!({"source": "test"})), Some(2_000), Some(5_000));
@@ -8079,25 +8331,25 @@ mod tests {
             &session,
             Some(&completed),
             "exe-1",
-            "asbx-1"
+            "asbx-1",
         ));
         assert!(!should_pause_idle_sandbox(
             &session,
             Some(&running),
             "exe-1",
-            "asbx-1"
+            "asbx-1",
         ));
         assert!(!should_pause_idle_sandbox(
             &session,
             Some(&newer),
             "exe-1",
-            "asbx-1"
+            "asbx-1",
         ));
         assert!(!should_pause_idle_sandbox(
             &session,
             Some(&completed),
             "exe-1",
-            "asbx-other"
+            "asbx-other",
         ));
     }
 
@@ -8420,10 +8672,12 @@ mod tests {
         let codex_spec = workload.spec(&thread_key, &HarnessType::Codex, None);
         let claude_spec = workload.spec(&thread_key, &HarnessType::ClaudeCode, None);
         let amp_spec = workload.spec(&thread_key, &HarnessType::Amp, None);
+        let omp_spec = workload.spec(&thread_key, &HarnessType::Omp, None);
 
         assert_eq!(codex_spec.args, vec!["harness-server", "codex"]);
         assert_eq!(claude_spec.args, vec!["harness-server", "claude-code"]);
         assert_eq!(amp_spec.args, vec!["harness-server", "amp"]);
+        assert_eq!(omp_spec.args, vec!["harness-server", "omp"]);
         // The image entrypoint must be preserved: only CMD is overridden.
         assert_eq!(codex_spec.command, None);
     }
@@ -8603,6 +8857,7 @@ mod tests {
         let thread_key = ThreadKey::parse("chat:C123:1780000000.000000").unwrap();
         let trace = SessionTraceContext {
             traceparent: Some("00-0123456789abcdef0123456789abcdef-0123456789abcdef-01".to_owned()),
+            max_duration_ms: None,
             execution_id: None,
         };
 
@@ -8720,6 +8975,23 @@ mod tests {
 
         assert_eq!(content.len(), 1);
         assert_eq!(content[0]["text"], "hi");
+    }
+
+    #[test]
+    fn input_line_replaces_non_object_trace_metadata_with_trusted_values() {
+        // Regression: a malicious client sends a non-object trace_metadata
+        // (e.g. null). api-rs must replace it with a fresh object carrying
+        // the trusted max_duration_ms.
+        let thread_key = ThreadKey::parse("chat:C123:1780000000.000000").unwrap();
+        let trace = SessionTraceContext::new(None, None).with_max_duration_ms(Some(99));
+
+        let line = input_line_with_session_context(
+            &thread_key,
+            &trace,
+            r#"{"type":"user","trace_metadata":null}"#,
+        );
+        let value: Value = serde_json::from_str(&line).unwrap();
+        assert_eq!(value["trace_metadata"]["max_duration_ms"], 99);
     }
 
     #[test]
@@ -10142,6 +10414,106 @@ mod adoption_tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn allocation_only_placeholder_claims_a_sandbox_and_completes() {
+        // An orchestrator's sandbox claim: execute with the marker and no
+        // input. Before the allocation-only path this execution stayed open
+        // — nothing completes a harness with no child — until max_duration
+        // failed it, leaving an `execution exceeded` row on the thread for the
+        // full minute. It must now return completed with the sandbox assigned
+        // and admit the next execution on the same thread immediately.
+        let Some(store) = test_store().await else {
+            return;
+        };
+        let _serial = TEST_LOCK.lock().await;
+        let (base_url, _requests, _server) = spawn_execute_iron_control_stub().await;
+        let thread_key =
+            ThreadKey::parse(format!("omp:test:alloc-{}", uuid::Uuid::new_v4())).unwrap();
+
+        let backend = Arc::new(MockBackend::new(SandboxStatus::Running, Vec::new()));
+        let (io, _stdout, _stdin) = mock_io();
+        backend.push_io(io).await;
+        let runtime =
+            runtime_with_registrar(&store, backend.clone(), requester_test_registrar(base_url));
+
+        runtime
+            .create_or_get_session(
+                &thread_key,
+                &HarnessType::Omp,
+                None,
+                None,
+                HarnessConflictPolicy::Reject,
+            )
+            .await
+            .expect("create session");
+
+        let claimed = runtime
+            .execute_session(
+                &thread_key,
+                ExecuteSessionInput {
+                    idempotency_key: Some(format!("alloc-{}", uuid::Uuid::new_v4())),
+                    metadata: Some(json!({"source": "orchestrator", "action": "allocate_sandbox"})),
+                    input_lines: vec![],
+                    idle_timeout_ms: Some(30_000),
+                    max_duration_ms: Some(60_000),
+                },
+            )
+            .await
+            .expect("allocation-only execute");
+
+        assert_eq!(
+            claimed.status,
+            ExecutionStatus::Completed,
+            "the placeholder completes as soon as the sandbox is assigned"
+        );
+        assert!(
+            store
+                .get_session(&thread_key)
+                .await
+                .expect("read session")
+                .sandbox_id
+                .is_some(),
+            "the pod claim is the point of the call"
+        );
+
+        // The completion went through the normal terminal machinery, so the
+        // thread carries a real `session.execution_completed` event — what
+        // the console and any event-stream consumer read — not just a row
+        // whose status quietly changed.
+        let events = store
+            .list_events_after(&thread_key, 0, Some(&claimed.execution_id), 100)
+            .await
+            .expect("list execution events");
+        let completed = events
+            .iter()
+            .find(|event| event.event_type == "session.execution_completed")
+            .expect("allocation-only completion event");
+        assert_eq!(
+            completed.payload["completion_reason"].as_str(),
+            Some("allocation_only")
+        );
+
+        // The placeholder is terminal, so a real turn on the same thread is
+        // admitted immediately — not blocked for a minute.
+        let turn = runtime
+            .execute_session(
+                &thread_key,
+                ExecuteSessionInput {
+                    idempotency_key: Some(format!("turn-{}", uuid::Uuid::new_v4())),
+                    metadata: None,
+                    input_lines: vec![r#"{"type":"user","message":{"role":"user","content":[{"type":"text","text":"hi"}]}}"#.to_owned()],
+                    idle_timeout_ms: None,
+                    max_duration_ms: None,
+                },
+            )
+            .await
+            .expect("next execution admitted after allocation-only claim");
+        store
+            .complete_execution(&turn.execution_id)
+            .await
+            .expect("complete the follow-up turn");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn channel_execute_binds_requester_and_second_user_swaps_it() {
         let Some(store) = test_store().await else {
             return;
@@ -11537,7 +11909,7 @@ mod adoption_tests {
                 .expect("claim as this control plane")
         );
 
-        runtime.handoff_owned_executions(Duration::ZERO).await;
+        let _ = runtime.handoff_owned_executions(Duration::ZERO).await;
 
         wait_for_event(&store, &thread_key, "session.stdout_owner_released").await;
         // The lease is immediately claimable by a peer control plane; without
@@ -11587,7 +11959,7 @@ mod adoption_tests {
                 .await
                 .expect("complete execution")
         });
-        runtime
+        let _ = runtime
             .handoff_owned_executions(Duration::from_secs(5))
             .await;
         let completed = completer.await.expect("completer task");
@@ -11615,7 +11987,7 @@ mod adoption_tests {
 
         // Nothing owned: the handoff returns immediately but still flips
         // the shutdown fence.
-        runtime.handoff_owned_executions(Duration::ZERO).await;
+        let _ = runtime.handoff_owned_executions(Duration::ZERO).await;
 
         let thread_key =
             ThreadKey::parse(format!("test:handoff-fence-{}", uuid::Uuid::new_v4())).unwrap();

--- a/services/api-rs/crates/centaur-session-sqlx/migrations/0055_session_harness_type_omp.sql
+++ b/services/api-rs/crates/centaur-session-sqlx/migrations/0055_session_harness_type_omp.sql
@@ -1,0 +1,7 @@
+-- Register the omp (oh-my-pi) harness. The hermes migration rebuilt the
+-- constraint without it, so extend the supported set here in a new file.
+alter table sessions
+    drop constraint sessions_harness_type_supported;
+alter table sessions
+    add constraint sessions_harness_type_supported
+    check (harness_type in ('codex', 'amp', 'claudecode', 'nanocodex', 'omp', 'hermes'));

--- a/services/api-rs/crates/centaur-session-sqlx/migrations/0056_session_sandbox_leases.sql
+++ b/services/api-rs/crates/centaur-session-sqlx/migrations/0056_session_sandbox_leases.sql
@@ -1,0 +1,10 @@
+create table if not exists session_sandbox_leases (
+    sandbox_id text primary key,
+    owner_id   text not null,
+    expires_at timestamptz not null,
+    created_at timestamptz not null default now(),
+    updated_at timestamptz not null default now()
+);
+
+create index if not exists session_sandbox_leases_expires_at_idx
+    on session_sandbox_leases (expires_at);

--- a/services/api-rs/crates/centaur-session-sqlx/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-sqlx/src/lib.rs
@@ -1094,6 +1094,21 @@ impl PgSessionStore {
         row.try_into().map(Some)
     }
 
+    /// Returns the true latest event id for a session without applying a page
+    /// limit. Lifecycle request anchors must use this rather than taking the
+    /// maximum of a bounded ascending page, which can point at an old event
+    /// once a session has more than one page of history.
+    pub async fn latest_event_id(&self, thread_key: &ThreadKey) -> Result<i64, SessionStoreError> {
+        sqlx::query_scalar::<_, Option<i64>>(
+            "select max(event_id) from session_events where thread_key = $1",
+        )
+        .bind(thread_key.as_str())
+        .fetch_one(&self.pool)
+        .await
+        .map(|latest| latest.unwrap_or(0))
+        .map_err(Into::into)
+    }
+
     pub async fn list_events_after(
         &self,
         thread_key: &ThreadKey,
@@ -1146,6 +1161,100 @@ impl PgSessionStore {
         Ok(exists)
     }
 
+    /// Acquires an absent or expired sandbox reference lease.
+    ///
+    /// A live lease is fenced: another owner cannot overwrite it. Returns
+    /// whether this caller acquired the row.
+    pub async fn acquire_sandbox_lease(
+        &self,
+        sandbox_id: &str,
+        owner_id: &str,
+        expires_at: OffsetDateTime,
+    ) -> Result<bool, SessionStoreError> {
+        let result = sqlx::query(
+            r#"
+            insert into session_sandbox_leases (sandbox_id, owner_id, expires_at)
+            values ($1, $2, $3)
+            on conflict (sandbox_id) do update
+            set owner_id = excluded.owner_id,
+                expires_at = excluded.expires_at,
+                updated_at = now()
+            where session_sandbox_leases.expires_at <= now()
+            "#,
+        )
+        .bind(sandbox_id)
+        .bind(owner_id)
+        .bind(expires_at)
+        .execute(&self.pool)
+        .await?;
+        Ok(result.rows_affected() == 1)
+    }
+
+    /// Extends a live lease held by `owner_id` without inserting or stealing.
+    ///
+    /// Returns false when the lease is missing, expired, or owned elsewhere.
+    pub async fn renew_sandbox_lease(
+        &self,
+        sandbox_id: &str,
+        owner_id: &str,
+        expires_at: OffsetDateTime,
+    ) -> Result<bool, SessionStoreError> {
+        let result = sqlx::query(
+            r#"
+            update session_sandbox_leases
+            set expires_at = $3, updated_at = now()
+            where sandbox_id = $1
+              and owner_id = $2
+              and expires_at > now()
+            "#,
+        )
+        .bind(sandbox_id)
+        .bind(owner_id)
+        .bind(expires_at)
+        .execute(&self.pool)
+        .await?;
+        Ok(result.rows_affected() == 1)
+    }
+
+    /// Deletes a sandbox reference lease owned by `owner_id`. The owner check
+    /// prevents one replica from releasing a lease another owner renewed
+    /// (and thus now owns) out from under it. A no-op (no matching row) is
+    /// not an error: a crashed renewer may have left the lease to expire, and
+    /// a best-effort release must not panic on the clean path.
+    pub async fn delete_sandbox_lease(
+        &self,
+        sandbox_id: &str,
+        owner_id: &str,
+    ) -> Result<(), SessionStoreError> {
+        sqlx::query(
+            r#"
+            delete from session_sandbox_leases
+            where sandbox_id = $1 and owner_id = $2
+            "#,
+        )
+        .bind(sandbox_id)
+        .bind(owner_id)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    /// Purges every expired sandbox reference lease. Run by the cleanup scan
+    /// before it lists referenced sandboxes so a stale lease left by a
+    /// crashed renewer cannot pin a sandbox forever. Returns the number of
+    /// rows removed so the caller can log drift.
+    pub async fn delete_expired_sandbox_leases(&self) -> Result<u64, SessionStoreError> {
+        let result = sqlx::query(
+            r#"
+            delete from session_sandbox_leases
+            where expires_at <= now()
+            "#,
+        )
+        .execute(&self.pool)
+        .await?;
+        Ok(result.rows_affected())
+    }
+
     pub async fn list_referenced_sandbox_ids(&self) -> Result<Vec<String>, SessionStoreError> {
         let rows = sqlx::query_scalar::<_, String>(
             r#"
@@ -1158,6 +1267,12 @@ impl PgSessionStore {
             select sandbox_id
             from session_warm_sandboxes
             where status in ('ready', 'claimed', 'evicting')
+
+            union
+
+            select sandbox_id
+            from session_sandbox_leases
+            where expires_at > now()
             "#,
         )
         .fetch_all(&self.pool)
@@ -2717,5 +2832,259 @@ mod tests {
                 .expect("list referenced sandboxes")
                 .contains(&sandbox_id)
         );
+    }
+
+    // ---- session sandbox leases (cross-replica durable refs) ----
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn unexpired_sandbox_lease_appears_referenced() {
+        let Some(store) = test_store().await else {
+            return;
+        };
+        let sandbox_id = format!("sbx-lease-ref-{}", Uuid::new_v4());
+        let owner_id = format!("owner-lease-ref-{}", Uuid::new_v4());
+        let expires_at = OffsetDateTime::now_utc() + TimeDuration::minutes(10);
+
+        store
+            .acquire_sandbox_lease(&sandbox_id, &owner_id, expires_at)
+            .await
+            .expect("acquire lease");
+
+        assert!(
+            store
+                .list_referenced_sandbox_ids()
+                .await
+                .expect("list referenced sandboxes")
+                .contains(&sandbox_id),
+            "an unexpired lease must keep the sandbox referenced"
+        );
+
+        store
+            .delete_sandbox_lease(&sandbox_id, &owner_id)
+            .await
+            .expect("delete lease");
+        assert!(
+            !store
+                .list_referenced_sandbox_ids()
+                .await
+                .expect("list referenced sandboxes")
+                .contains(&sandbox_id),
+            "deleting the lease must drop the reference"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn delete_sandbox_lease_rejects_wrong_owner() {
+        let Some(store) = test_store().await else {
+            return;
+        };
+        let sandbox_id = format!("sbx-lease-owner-{}", Uuid::new_v4());
+        let owner_id = format!("owner-lease-owner-{}", Uuid::new_v4());
+        let expires_at = OffsetDateTime::now_utc() + TimeDuration::minutes(10);
+
+        store
+            .acquire_sandbox_lease(&sandbox_id, &owner_id, expires_at)
+            .await
+            .expect("acquire lease");
+
+        // A different owner must not be able to release the lease.
+        store
+            .delete_sandbox_lease(&sandbox_id, "some-other-owner")
+            .await
+            .expect("delete is not an error even with a wrong owner");
+        assert!(
+            store
+                .list_referenced_sandbox_ids()
+                .await
+                .expect("list referenced sandboxes")
+                .contains(&sandbox_id),
+            "a wrong-owner delete must not release the lease"
+        );
+
+        // The holding owner can release it.
+        store
+            .delete_sandbox_lease(&sandbox_id, &owner_id)
+            .await
+            .expect("delete lease");
+        assert!(
+            !store
+                .list_referenced_sandbox_ids()
+                .await
+                .expect("list referenced sandboxes")
+                .contains(&sandbox_id),
+            "the holding owner can release the lease"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn expired_sandbox_lease_is_not_referenced_before_purge() {
+        let Some(store) = test_store().await else {
+            return;
+        };
+        let sandbox_id = format!("sbx-lease-expired-ref-{}", Uuid::new_v4());
+        let owner_id = format!("owner-lease-expired-ref-{}", Uuid::new_v4());
+        let expired_at = OffsetDateTime::now_utc() - TimeDuration::minutes(1);
+
+        store
+            .acquire_sandbox_lease(&sandbox_id, &owner_id, expired_at)
+            .await
+            .expect("acquire expired lease");
+
+        assert!(
+            !store
+                .list_referenced_sandbox_ids()
+                .await
+                .expect("list referenced sandboxes")
+                .contains(&sandbox_id),
+            "an expired lease must not keep the sandbox referenced before purge"
+        );
+
+        store
+            .delete_sandbox_lease(&sandbox_id, &owner_id)
+            .await
+            .expect("delete expired lease");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn delete_expired_sandbox_leases_purges_stale_rows() {
+        let Some(store) = test_store().await else {
+            return;
+        };
+        let sandbox_id = format!("sbx-lease-expired-{}", Uuid::new_v4());
+        let owner_id = format!("owner-lease-expired-{}", Uuid::new_v4());
+        // Insert a lease that is already expired.
+        let expired_at = OffsetDateTime::now_utc() - TimeDuration::minutes(1);
+        store
+            .acquire_sandbox_lease(&sandbox_id, &owner_id, expired_at)
+            .await
+            .expect("acquire expired lease");
+
+        let purged = store
+            .delete_expired_sandbox_leases()
+            .await
+            .expect("purge expired leases");
+        assert!(purged >= 1, "at least one expired lease must be purged");
+
+        assert!(
+            !store
+                .list_referenced_sandbox_ids()
+                .await
+                .expect("list referenced sandboxes")
+                .contains(&sandbox_id),
+            "an expired lease must not keep the sandbox referenced after purge"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn acquire_sandbox_lease_rejects_live_owner() {
+        let Some(store) = test_store().await else {
+            return;
+        };
+        let sandbox_id = format!("sbx-lease-fence-{}", Uuid::new_v4());
+        let first_owner = format!("owner-lease-first-{}", Uuid::new_v4());
+        let second_owner = format!("owner-lease-second-{}", Uuid::new_v4());
+        let expires_at = OffsetDateTime::now_utc() + TimeDuration::minutes(10);
+
+        assert!(
+            store
+                .acquire_sandbox_lease(&sandbox_id, &first_owner, expires_at)
+                .await
+                .expect("acquire first lease")
+        );
+        assert!(
+            !store
+                .acquire_sandbox_lease(&sandbox_id, &second_owner, expires_at)
+                .await
+                .expect("reject second lease"),
+            "a live lease must not be stolen by another owner"
+        );
+
+        let persisted_owner: String =
+            sqlx::query_scalar("select owner_id from session_sandbox_leases where sandbox_id = $1")
+                .bind(&sandbox_id)
+                .fetch_one(store.pool())
+                .await
+                .expect("fetch lease owner");
+        assert_eq!(persisted_owner, first_owner);
+
+        store
+            .delete_sandbox_lease(&sandbox_id, &first_owner)
+            .await
+            .expect("delete lease");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn renew_sandbox_lease_does_not_recreate_released_lease() {
+        let Some(store) = test_store().await else {
+            return;
+        };
+        let sandbox_id = format!("sbx-lease-release-race-{}", Uuid::new_v4());
+        let owner_id = format!("owner-lease-release-race-{}", Uuid::new_v4());
+        let expires_at = OffsetDateTime::now_utc() + TimeDuration::minutes(10);
+
+        assert!(
+            store
+                .acquire_sandbox_lease(&sandbox_id, &owner_id, expires_at)
+                .await
+                .expect("acquire lease")
+        );
+        store
+            .delete_sandbox_lease(&sandbox_id, &owner_id)
+            .await
+            .expect("delete lease");
+
+        assert!(
+            !store
+                .renew_sandbox_lease(&sandbox_id, &owner_id, expires_at)
+                .await
+                .expect("renew deleted lease"),
+            "renewal must not recreate a released lease"
+        );
+        let exists: bool = sqlx::query_scalar(
+            "select exists(select 1 from session_sandbox_leases where sandbox_id = $1)",
+        )
+        .bind(&sandbox_id)
+        .fetch_one(store.pool())
+        .await
+        .expect("check released lease");
+        assert!(!exists);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn renew_sandbox_lease_extends_expiry() {
+        let Some(store) = test_store().await else {
+            return;
+        };
+        let sandbox_id = format!("sbx-lease-renew-{}", Uuid::new_v4());
+        let owner_id = format!("owner-lease-renew-{}", Uuid::new_v4());
+        let soon = OffsetDateTime::now_utc() + TimeDuration::minutes(1);
+        let later = OffsetDateTime::now_utc() + TimeDuration::minutes(10);
+
+        store
+            .acquire_sandbox_lease(&sandbox_id, &owner_id, soon)
+            .await
+            .expect("acquire initial lease");
+        store
+            .renew_sandbox_lease(&sandbox_id, &owner_id, later)
+            .await
+            .expect("renew lease");
+
+        let persisted: OffsetDateTime = sqlx::query_scalar(
+            "select expires_at from session_sandbox_leases where sandbox_id = $1",
+        )
+        .bind(&sandbox_id)
+        .fetch_one(store.pool())
+        .await
+        .expect("fetch expiry");
+        // Postgres stores timestamptz at microsecond precision.
+        assert!(
+            (persisted - later).abs() < TimeDuration::milliseconds(1),
+            "renewal must update expires_at to the new value"
+        );
+
+        store
+            .delete_sandbox_lease(&sandbox_id, &owner_id)
+            .await
+            .expect("delete lease");
     }
 }

--- a/services/api-rs/crates/centaur-telemetry/src/lib.rs
+++ b/services/api-rs/crates/centaur-telemetry/src/lib.rs
@@ -1,5 +1,4 @@
 //! Shared telemetry setup for the Rust Centaur control plane.
-
 use std::{
     env, fmt as std_fmt,
     sync::{LazyLock, Mutex},
@@ -70,6 +69,11 @@ pub const WORKFLOW_QUEUE_TASKS_BY_WORKFLOW: &str = "workflow_queue_tasks_by_work
 pub const WORKFLOW_QUEUE_OLDEST_TASK_AGE_SECONDS: &str = "workflow_queue_oldest_task_age_seconds";
 pub const WORKFLOW_QUEUE_OLDEST_TASK_AGE_BY_WORKFLOW_SECONDS: &str =
     "workflow_queue_oldest_task_age_by_workflow_seconds";
+pub const WORKFLOW_TASK_ATTEMPTS_TOTAL: &str = "centaur_workflow_task_attempts_total";
+pub const WORKFLOW_TASK_DURATION_SECONDS: &str = "centaur_workflow_task_duration_seconds";
+pub const WORKFLOW_SCHEDULE_TICKS_TOTAL: &str = "centaur_workflow_schedule_ticks_total";
+pub const WORKFLOW_SCHEDULE_LAST_DISPATCH_TIMESTAMP_SECONDS: &str =
+    "centaur_workflow_schedule_last_dispatch_timestamp_seconds";
 pub const SLACK_ARCHIVE_IMPORT_RUNS_TOTAL: &str = "slack_archive_import_runs_total";
 pub const SLACK_ARCHIVE_IMPORT_DURATION_SECONDS: &str = "slack_archive_import_duration_seconds";
 pub const SLACK_ARCHIVE_IMPORT_BYTES_TOTAL: &str = "slack_archive_import_bytes_total";
@@ -124,10 +128,12 @@ const SLACK_ARCHIVE_IMPORT_BATCH_SIZE_BUCKETS: &[f64] =
     &[1.0, 10.0, 100.0, 500.0, 1_000.0, 5_000.0, 10_000.0];
 const SLACK_RETENTION_DURATION_BUCKETS: &[f64] =
     &[1.0, 5.0, 10.0, 30.0, 60.0, 120.0, 300.0, 600.0, 1_200.0];
+const WORKFLOW_TASK_DURATION_BUCKETS: &[f64] = &[
+    0.1, 1.0, 5.0, 15.0, 30.0, 60.0, 300.0, 900.0, 1_800.0, 3_600.0, 7_200.0,
+];
 
 static PROMETHEUS_HANDLE: LazyLock<Mutex<Option<PrometheusHandle>>> =
     LazyLock::new(|| Mutex::new(None));
-
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct TelemetryConfig {
     pub service_name: String,
@@ -250,6 +256,10 @@ pub fn prometheus_handle() -> Result<PrometheusHandle, TelemetryError> {
         .set_buckets_for_metric(
             Matcher::Full(SANDBOX_STARTUP_DURATION_SECONDS.to_owned()),
             SANDBOX_STARTUP_DURATION_BUCKETS,
+        )?
+        .set_buckets_for_metric(
+            Matcher::Full(WORKFLOW_TASK_DURATION_SECONDS.to_owned()),
+            WORKFLOW_TASK_DURATION_BUCKETS,
         )?
         .set_buckets_for_metric(
             Matcher::Full(SLACK_ARCHIVE_IMPORT_DURATION_SECONDS.to_owned()),
@@ -398,6 +408,55 @@ pub fn record_workflow_histogram(name: &str, labels: &[(String, String)], value:
         return;
     }
     metrics::histogram!(name.to_owned(), workflow_metric_labels(labels)).record(value);
+}
+
+pub fn record_workflow_task_finished(
+    queue: &str,
+    workflow_name: &str,
+    outcome: &str,
+    duration: Duration,
+) {
+    metrics::counter!(
+        WORKFLOW_TASK_ATTEMPTS_TOTAL,
+        "queue" => queue.to_owned(),
+        "workflow_name" => workflow_name.to_owned(),
+        "outcome" => outcome.to_owned(),
+    )
+    .increment(1);
+    metrics::histogram!(
+        WORKFLOW_TASK_DURATION_SECONDS,
+        "queue" => queue.to_owned(),
+        "workflow_name" => workflow_name.to_owned(),
+        "outcome" => outcome.to_owned(),
+    )
+    .record(duration.as_secs_f64());
+}
+
+fn schedule_tick_advances_dispatch_timestamp(outcome: &str) -> bool {
+    matches!(outcome, "spawned" | "deduped")
+}
+
+pub fn record_workflow_schedule_tick(
+    schedule_id: &str,
+    workflow_name: &str,
+    outcome: &str,
+    timestamp_seconds: f64,
+) {
+    metrics::counter!(
+        WORKFLOW_SCHEDULE_TICKS_TOTAL,
+        "schedule_id" => schedule_id.to_owned(),
+        "workflow_name" => workflow_name.to_owned(),
+        "outcome" => outcome.to_owned(),
+    )
+    .increment(1);
+    if timestamp_seconds.is_finite() && schedule_tick_advances_dispatch_timestamp(outcome) {
+        metrics::gauge!(
+            WORKFLOW_SCHEDULE_LAST_DISPATCH_TIMESTAMP_SECONDS,
+            "schedule_id" => schedule_id.to_owned(),
+            "workflow_name" => workflow_name.to_owned(),
+        )
+        .set(timestamp_seconds);
+    }
 }
 
 pub fn set_workflow_queue_tasks(queue: &str, state: &str, value: f64) {
@@ -683,6 +742,24 @@ fn describe_metrics() {
         WORKFLOW_QUEUE_OLDEST_TASK_AGE_BY_WORKFLOW_SECONDS,
         metrics::Unit::Seconds,
         "Oldest non-terminal workflow task age in seconds by queue, state, and workflow name."
+    );
+    metrics::describe_counter!(
+        WORKFLOW_TASK_ATTEMPTS_TOTAL,
+        "Terminal workflow task attempts by queue, workflow name, and semantic outcome."
+    );
+    metrics::describe_histogram!(
+        WORKFLOW_TASK_DURATION_SECONDS,
+        metrics::Unit::Seconds,
+        "Terminal workflow task duration in seconds by queue, workflow name, and semantic outcome."
+    );
+    metrics::describe_counter!(
+        WORKFLOW_SCHEDULE_TICKS_TOTAL,
+        "Workflow schedule tick decisions by schedule, workflow name, and outcome."
+    );
+    metrics::describe_gauge!(
+        WORKFLOW_SCHEDULE_LAST_DISPATCH_TIMESTAMP_SECONDS,
+        metrics::Unit::Seconds,
+        "Unix timestamp of the last workflow schedule dispatch or idempotent deduplication."
     );
     metrics::describe_counter!(
         SLACK_ARCHIVE_IMPORT_RUNS_TOTAL,
@@ -1039,6 +1116,16 @@ mod tests {
     }
 
     #[test]
+    fn schedule_dispatch_timestamp_advances_only_after_a_dispatch() {
+        assert!(schedule_tick_advances_dispatch_timestamp("spawned"));
+        assert!(schedule_tick_advances_dispatch_timestamp("deduped"));
+        assert!(!schedule_tick_advances_dispatch_timestamp(
+            "overlap_skipped"
+        ));
+        assert!(!schedule_tick_advances_dispatch_timestamp("disabled"));
+    }
+
+    #[test]
     fn prometheus_metrics_render_workflow_metrics() {
         prometheus_handle().unwrap();
         record_workflow_counter(
@@ -1097,6 +1184,24 @@ mod tests {
             "slack_sync",
             42.0,
         );
+        record_workflow_task_finished(
+            "centaur_workflows",
+            "upstream_sync",
+            "blocked",
+            Duration::from_secs(12),
+        );
+        record_workflow_schedule_tick(
+            "upstream_sync_watch_v2",
+            "upstream_sync",
+            "overlap_skipped",
+            1_784_915_200.0,
+        );
+        record_workflow_schedule_tick(
+            "upstream_sync_watch_v2",
+            "upstream_sync",
+            "spawned",
+            1_784_915_201.0,
+        );
 
         let metrics = render_metrics().unwrap();
 
@@ -1108,11 +1213,18 @@ mod tests {
         assert!(metrics.contains("workflow_queue_tasks_by_workflow{"));
         assert!(metrics.contains("workflow_queue_oldest_task_age_seconds{"));
         assert!(metrics.contains("workflow_queue_oldest_task_age_by_workflow_seconds{"));
+        assert!(metrics.contains("centaur_workflow_task_attempts_total{"));
+        assert!(metrics.contains("centaur_workflow_task_duration_seconds_count{"));
+        assert!(metrics.contains("centaur_workflow_schedule_ticks_total{"));
+        assert!(metrics.contains("centaur_workflow_schedule_last_dispatch_timestamp_seconds{"));
         assert!(metrics.contains(r#"environment="production""#));
         assert!(metrics.contains(r#"namespace="centaur-system""#));
         assert!(metrics.contains(r#"source="slack""#));
         assert!(metrics.contains(r#"queue="centaur_workflows_slack_live""#));
         assert!(metrics.contains(r#"workflow_name="slack_sync""#));
+        assert!(metrics.contains(r#"outcome="blocked""#));
+        assert!(metrics.contains(r#"outcome="overlap_skipped""#));
+        assert!(metrics.contains(r#"schedule_id="upstream_sync_watch_v2""#));
     }
 
     #[test]

--- a/services/api-rs/crates/centaur-workflows/src/lib.rs
+++ b/services/api-rs/crates/centaur-workflows/src/lib.rs
@@ -5,7 +5,7 @@ use std::{
     path::PathBuf,
     str::FromStr,
     sync::{Arc, RwLock},
-    time::Duration,
+    time::{Duration, Instant},
 };
 
 use absurd::{
@@ -65,6 +65,7 @@ const MAX_LIST_RUNS_LIMIT: i64 = 1_000;
 const WORKFLOW_REAP_REMOVED_AFTER_TICKS_ENV: &str = "WORKFLOW_REAP_REMOVED_AFTER_TICKS";
 const DEFAULT_WORKFLOW_REAP_REMOVED_AFTER_TICKS: u32 = 3;
 const ABSURD_TERMINAL_TASK_STATES: &str = "('completed', 'failed', 'cancelled')";
+const ABSURD_ACTIVE_RUN_STATES: &str = "('pending', 'running', 'sleeping')";
 
 pub fn python_workflow_event_name(event_type: &str, correlation_id: &str) -> String {
     // JSON string encoding is unambiguous even when either component contains a delimiter.
@@ -75,11 +76,10 @@ pub fn python_workflow_event_name(event_type: &str, correlation_id: &str) -> Str
     )
 }
 
-/// Per-queue worker concurrency. The defaults preserve historical behavior; each
-/// can be overridden via its env var to scale a queue independently (e.g. raise
-/// the standard queue when webhook/agent workflows back up). A value that is
-/// unset, empty, non-numeric, or zero falls back to the default (absurd also
-/// clamps zero to one, since a queue at concurrency zero would never drain).
+/// Per-workflow-queue concurrency can be overridden to scale execution queues
+/// independently. Schedule dispatch stays serialized within this API process:
+/// overlap detection and target spawn are separate database operations, so
+/// concurrent schedule workers could both pass the active-task check.
 const WORKFLOW_WORKER_CONCURRENCY_ENV: &str = "WORKFLOW_WORKER_CONCURRENCY";
 const DEFAULT_WORKFLOW_WORKER_CONCURRENCY: usize = 4;
 const WORKFLOW_ETL_WORKER_CONCURRENCY_ENV: &str = "WORKFLOW_ETL_WORKER_CONCURRENCY";
@@ -87,8 +87,7 @@ const DEFAULT_WORKFLOW_ETL_WORKER_CONCURRENCY: usize = 1;
 const WORKFLOW_ETL_BACKFILL_WORKER_CONCURRENCY_ENV: &str =
     "WORKFLOW_ETL_BACKFILL_WORKER_CONCURRENCY";
 const DEFAULT_WORKFLOW_ETL_BACKFILL_WORKER_CONCURRENCY: usize = 1;
-const WORKFLOW_SCHEDULE_WORKER_CONCURRENCY_ENV: &str = "WORKFLOW_SCHEDULE_WORKER_CONCURRENCY";
-const DEFAULT_WORKFLOW_SCHEDULE_WORKER_CONCURRENCY: usize = 1;
+const WORKFLOW_SCHEDULE_WORKER_CONCURRENCY: usize = 1;
 
 struct WorkflowTaskHeartbeatGuard {
     task: JoinHandle<()>,
@@ -481,6 +480,10 @@ struct ScheduleTickInput {
     scheduled_at: DateTime<Utc>,
 }
 
+fn default_schedule_allow_overlap() -> bool {
+    true
+}
+
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct RegisteredWorkflowSchedule {
     pub schedule_id: String,
@@ -495,6 +498,8 @@ pub struct RegisteredWorkflowSchedule {
     pub enabled: bool,
     #[serde(default)]
     pub no_delivery: bool,
+    #[serde(default = "default_schedule_allow_overlap")]
+    pub allow_overlap: bool,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -766,10 +771,7 @@ impl WorkflowRuntime {
         });
         let schedule_worker = schedule_client.start_worker(WorkerOptions {
             worker_id: Some("centaur-api-rs-workflow-schedule-worker".to_owned()),
-            concurrency: worker_concurrency(
-                WORKFLOW_SCHEDULE_WORKER_CONCURRENCY_ENV,
-                DEFAULT_WORKFLOW_SCHEDULE_WORKER_CONCURRENCY,
-            ),
+            concurrency: WORKFLOW_SCHEDULE_WORKER_CONCURRENCY,
             on_error: Some(Arc::new(|error| {
                 warn!(%error, "absurd workflow schedule worker error");
             })),
@@ -1462,6 +1464,7 @@ fn normalize_schedule(raw: Value) -> Result<RegisteredWorkflowSchedule, Workflow
     }
     let enabled = schedule_bool(object.get("enabled"), true);
     let no_delivery = schedule_bool(object.get("no_delivery"), false);
+    let allow_overlap = schedule_bool(object.get("allow_overlap"), true);
     let timezone = object
         .get("timezone")
         .and_then(Value::as_str)
@@ -1502,6 +1505,7 @@ fn normalize_schedule(raw: Value) -> Result<RegisteredWorkflowSchedule, Workflow
         input,
         enabled,
         no_delivery,
+        allow_overlap,
     })
 }
 
@@ -1839,7 +1843,17 @@ async fn discover_python_workflow_metadata() -> Result<PythonWorkflowMetadata, W
         if line.trim().is_empty() {
             continue;
         }
-        let message: Value = serde_json::from_str(&line)?;
+        // The stream can carry stray non-JSON lines (sandbox entrypoint or a
+        // tool writing to fd1 — the 2026-07-10 cold-boot "expected value at
+        // line 1 column 1" class). Skip them; valid JSON with an unknown
+        // `type` below remains a protocol error.
+        let message: Value = match serde_json::from_str(&line) {
+            Ok(message) => message,
+            Err(_) => {
+                warn!(line = %clip(&line, 200), "ignoring non-JSON workflow host stdout line");
+                continue;
+            }
+        };
         match message.get("type").and_then(Value::as_str) {
             Some("workflow.discovery") => {
                 let _ = child.wait().await;
@@ -2290,13 +2304,14 @@ async fn fetch_active_named_tasks(
     task_name: &str,
     params_name_field: &str,
 ) -> Result<Vec<(String, String)>, WorkflowRuntimeError> {
-    let (task_table, _) = absurd_queue_tables(queue_name)?;
+    let (task_table, run_table) = absurd_queue_tables(queue_name)?;
     let rows = sqlx::query(&format!(
         r#"
-        select t.task_id::text as task_id, t.params->>'{params_name_field}' as name
-        from {task_table} t
-        where t.task_name = $1
-          and t.state not in {ABSURD_TERMINAL_TASK_STATES}
+        select distinct t.task_id::text as task_id, t.params->>'{params_name_field}' as name
+        from {run_table} r
+        join {task_table} t on t.task_id = r.task_id
+        where r.state in {ABSURD_ACTIVE_RUN_STATES}
+          and t.task_name = $1
         "#,
     ))
     .bind(task_name)
@@ -2310,6 +2325,27 @@ async fn fetch_active_named_tasks(
             Some((task_id, name?))
         })
         .collect())
+}
+
+fn active_workflow_task<'a>(
+    active_tasks: &'a [(String, String)],
+    workflow_name: &str,
+) -> Option<&'a str> {
+    active_tasks
+        .iter()
+        .find(|(_, active_name)| active_name == workflow_name)
+        .map(|(task_id, _)| task_id.as_str())
+}
+
+fn overlapping_workflow_task<'a>(
+    schedule: &RegisteredWorkflowSchedule,
+    active_tasks: &'a [(String, String)],
+) -> Option<&'a str> {
+    if schedule.allow_overlap {
+        None
+    } else {
+        active_workflow_task(active_tasks, &schedule.workflow_name)
+    }
 }
 
 /// Counts consecutive reconcile passes in which each referenced name was
@@ -2365,6 +2401,12 @@ async fn run_schedule_tick(
     {
         Some(schedule) if schedule.enabled => schedule,
         Some(schedule) => {
+            centaur_telemetry::record_workflow_schedule_tick(
+                &schedule.schedule_id,
+                &schedule.workflow_name,
+                "disabled",
+                Utc::now().timestamp_millis() as f64 / 1_000.0,
+            );
             info!(
                 schedule_id = %schedule.schedule_id,
                 "skipping disabled workflow schedule tick"
@@ -2394,12 +2436,51 @@ async fn run_schedule_tick(
         schedule.schedule_id,
         input.scheduled_at.to_rfc3339()
     );
-    let target_client = match workflow_queue_class(&schedule.workflow_name) {
+    let queue_class = workflow_queue_class(&schedule.workflow_name);
+    let target_client = match queue_class {
         WorkflowQueueClass::Standard => &workflow_clients.standard,
         WorkflowQueueClass::SlackLive => &workflow_clients.slack_live,
         WorkflowQueueClass::Etl => &workflow_clients.etl,
         WorkflowQueueClass::EtlBackfill => &workflow_clients.etl_backfill,
     };
+    let next_run_at = next_schedule_time_after_tick(&schedule, input.scheduled_at, Utc::now())
+        .map_err(absurd_error)?;
+    if !schedule.allow_overlap {
+        let active_tasks = fetch_active_named_tasks(
+            target_client,
+            queue_name_for_class(queue_class),
+            WORKFLOW_TASK,
+            "workflow_name",
+        )
+        .await
+        .map_err(absurd_error)?;
+        if let Some(active_task_id) = overlapping_workflow_task(&schedule, &active_tasks) {
+            spawn_schedule_tick(&schedule_client, &schedule, next_run_at)
+                .await
+                .map_err(absurd_error)?;
+            centaur_telemetry::record_workflow_schedule_tick(
+                &schedule.schedule_id,
+                &schedule.workflow_name,
+                "overlap_skipped",
+                Utc::now().timestamp_millis() as f64 / 1_000.0,
+            );
+            info!(
+                schedule_id = %schedule.schedule_id,
+                workflow_name = %schedule.workflow_name,
+                active_task_id,
+                "skipping overlapping workflow schedule tick"
+            );
+            return Ok(json!({
+                "schedule_id": schedule.schedule_id,
+                "workflow_name": schedule.workflow_name,
+                "scheduled_at": input.scheduled_at.to_rfc3339(),
+                "skipped": true,
+                "reason": "overlap",
+                "active_task_id": active_task_id,
+                "next_run_at": next_run_at.to_rfc3339(),
+            }));
+        }
+    }
     let workflow_spawn = target_client
         .spawn(
             WORKFLOW_TASK,
@@ -2414,11 +2495,27 @@ async fn run_schedule_tick(
             },
         )
         .await?;
-    let next_run_at = next_schedule_time_after_tick(&schedule, input.scheduled_at, Utc::now())
-        .map_err(absurd_error)?;
     spawn_schedule_tick(&schedule_client, &schedule, next_run_at)
         .await
         .map_err(absurd_error)?;
+    let schedule_outcome = if workflow_spawn.created {
+        "spawned"
+    } else {
+        "deduped"
+    };
+    centaur_telemetry::record_workflow_schedule_tick(
+        &schedule.schedule_id,
+        &schedule.workflow_name,
+        schedule_outcome,
+        Utc::now().timestamp_millis() as f64 / 1_000.0,
+    );
+    info!(
+        schedule_id = %schedule.schedule_id,
+        workflow_name = %schedule.workflow_name,
+        outcome = schedule_outcome,
+        workflow_created = workflow_spawn.created,
+        "workflow schedule tick completed"
+    );
     Ok(json!({
         "schedule_id": schedule.schedule_id,
         "workflow_name": schedule.workflow_name,
@@ -2582,6 +2679,11 @@ fn next_schedule_time(
     }
 }
 
+/// UTF-8-safe truncation for logging stray host-output lines.
+fn clip(line: &str, max_chars: usize) -> String {
+    line.chars().take(max_chars).collect()
+}
+
 /// Prepends a seconds field so five-field crontab-style expressions parse with the
 /// `cron` crate. Note the crate's day-of-week numbering is Quartz-style (1 = Sunday,
 /// 7 = Saturday; 0 rejected), NOT Unix crontab — schedules should use day names
@@ -2595,6 +2697,45 @@ fn normalize_cron_expression(expr: &str) -> String {
     }
 }
 
+fn terminal_workflow_output(output: Value) -> Value {
+    if output.is_null() {
+        json!({
+            "outcome": "failed",
+            "error": "workflow completed without output",
+        })
+    } else {
+        output
+    }
+}
+
+fn workflow_output_outcome(output: &Value) -> Result<&'static str, WorkflowRuntimeError> {
+    if output.is_null() {
+        return Err(WorkflowRuntimeError::Internal(
+            "workflow completed without output".to_owned(),
+        ));
+    }
+    Ok(match output.get("outcome").and_then(Value::as_str) {
+        Some("noop") => "noop",
+        Some("queued") => "queued",
+        Some("waiting") => "waiting",
+        Some("blocked") => "blocked",
+        Some("degraded") => "degraded",
+        Some("dry_run") => "dry_run",
+        Some("cancelled") => "cancelled",
+        Some("failed") => "failed",
+        _ => "succeeded",
+    })
+}
+
+fn workflow_attempt_outcome(result: &absurd::Result<WorkflowResult>) -> Option<&'static str> {
+    match result {
+        Ok(result) => workflow_output_outcome(&result.output).ok(),
+        Err(absurd::Error::Suspend) => None,
+        Err(absurd::Error::Cancelled) => Some("cancelled"),
+        Err(_) => Some("failed"),
+    }
+}
+
 async fn run_centaur_workflow(
     input: WorkflowTaskInput,
     ctx: TaskContext,
@@ -2602,6 +2743,9 @@ async fn run_centaur_workflow(
     workflow_host_sandbox: Option<WorkflowHostSandboxRuntime>,
     workflow_clients: WorkflowQueueClients,
 ) -> absurd::Result<WorkflowResult> {
+    let workflow_name = input.workflow_name.clone();
+    let queue_name = queue_name_for_class(workflow_queue_class(&workflow_name));
+    let started_at = Instant::now();
     let mut cleanup_guard =
         WorkflowSandboxCleanupGuard::new(session_runtime.clone(), ctx.run_id().to_owned());
     let result = run_centaur_workflow_inner(
@@ -2611,7 +2755,27 @@ async fn run_centaur_workflow(
         workflow_host_sandbox,
         workflow_clients,
     )
-    .await;
+    .await
+    .map(|mut result| {
+        result.output = terminal_workflow_output(result.output);
+        result
+    });
+    if let Some(outcome) = workflow_attempt_outcome(&result) {
+        let duration = started_at.elapsed();
+        centaur_telemetry::record_workflow_task_finished(
+            queue_name,
+            &workflow_name,
+            outcome,
+            duration,
+        );
+        info!(
+            workflow_name,
+            queue = queue_name,
+            outcome,
+            duration_seconds = duration.as_secs_f64(),
+            "workflow task attempt finished"
+        );
+    }
     if let Some(reason) = workflow_cleanup_reason(&result) {
         cleanup_guard.cleanup(reason).await;
     } else {
@@ -2968,7 +3132,13 @@ async fn run_python_workflow_host_local(
         if line.trim().is_empty() {
             continue;
         }
-        let message: Value = serde_json::from_str(&line)?;
+        let message: Value = match serde_json::from_str(&line) {
+            Ok(message) => message,
+            Err(_) => {
+                warn!(line = %clip(&line, 200), "ignoring non-JSON workflow host stdout line");
+                continue;
+            }
+        };
         match message.get("type").and_then(Value::as_str) {
             Some("workflow.result") => {
                 drop(stdin);
@@ -3055,6 +3225,22 @@ async fn run_python_workflow_host_in_sandbox(
         spec = spec.env("DATABASE_URL", database_url);
     }
     let (sandbox_id, io) = sandbox.runtime.create_running_io(spec).await?;
+    let lease = match session_runtime
+        .acquire_sandbox_reference_lease(sandbox_id.as_str(), ctx.run_id())
+        .await
+    {
+        Ok(lease) => lease,
+        Err(error) => {
+            if let Err(stop_error) = sandbox.runtime.stop_sandbox(&sandbox_id).await {
+                warn!(
+                    sandbox_id = %sandbox_id.as_str(),
+                    %stop_error,
+                    "failed to stop workflow host sandbox after lease acquisition failure"
+                );
+            }
+            return Err(error.into());
+        }
+    };
     let mut stdin = io.stdin;
     let stderr_task = tokio::spawn(async move {
         let _guard = io.guard;
@@ -3079,6 +3265,7 @@ async fn run_python_workflow_host_in_sandbox(
     if let Err(error) = sandbox.runtime.stop_sandbox(&sandbox_id).await {
         warn!(sandbox_id = %sandbox_id.as_str(), %error, "failed to stop workflow host sandbox");
     }
+    lease.release().await;
     result
 }
 
@@ -3116,7 +3303,13 @@ where
         if line.trim().is_empty() {
             continue;
         }
-        let message: Value = serde_json::from_str(&line)?;
+        let message: Value = match serde_json::from_str(&line) {
+            Ok(message) => message,
+            Err(_) => {
+                warn!(line = %clip(&line, 200), "ignoring non-JSON workflow host stdout line");
+                continue;
+            }
+        };
         match message.get("type").and_then(Value::as_str) {
             Some("workflow.result") => {
                 return Ok(message.get("result").cloned().unwrap_or(Value::Null));
@@ -4715,6 +4908,35 @@ mod tests {
     }
 
     #[test]
+    fn workflow_output_outcome_preserves_semantics_and_terminalizes_empty_output() {
+        assert_eq!(
+            workflow_output_outcome(&json!({"outcome": "blocked"})).unwrap(),
+            "blocked"
+        );
+        assert_eq!(
+            workflow_output_outcome(&json!({"outcome": "unexpected"})).unwrap(),
+            "succeeded"
+        );
+        assert_eq!(
+            workflow_output_outcome(&json!({"status": "completed"})).unwrap(),
+            "succeeded"
+        );
+        assert_eq!(
+            workflow_output_outcome(&json!({"outcome": "cancelled"})).unwrap(),
+            "cancelled"
+        );
+        let terminal = terminal_workflow_output(Value::Null);
+        assert_eq!(
+            terminal,
+            json!({
+                "outcome": "failed",
+                "error": "workflow completed without output",
+            })
+        );
+        assert_eq!(workflow_output_outcome(&terminal).unwrap(), "failed");
+    }
+
+    #[test]
     fn parse_agent_principal_accepts_foreign_id_and_rejects_invalid_values() {
         assert_eq!(
             parse_agent_principal(&json!({"principal": " finance-automation "})).unwrap(),
@@ -4903,6 +5125,57 @@ mod tests {
         assert_eq!(
             schedule.input.pointer("/metadata/no_delivery"),
             Some(&json!(true))
+        );
+    }
+
+    #[test]
+    fn schedule_dispatch_is_serialized() {
+        assert_eq!(WORKFLOW_SCHEDULE_WORKER_CONCURRENCY, 1);
+    }
+
+    #[test]
+    fn schedule_overlap_is_allowed_by_default() {
+        let schedule = normalize_schedule(json!({
+            "workflow_name": "slack_sync",
+            "schedule_id": "slack_sync",
+            "interval_seconds": 60,
+        }))
+        .unwrap();
+
+        assert!(schedule.allow_overlap);
+        assert_eq!(
+            overlapping_workflow_task(
+                &schedule,
+                &[("active-task".to_owned(), "slack_sync".to_owned())],
+            ),
+            None,
+        );
+    }
+
+    #[test]
+    fn schedule_can_suppress_an_overlapping_workflow() {
+        let schedule = normalize_schedule(json!({
+            "workflow_name": "upstream_sync",
+            "schedule_id": "upstream_sync_watch_v2",
+            "cron": "*/15 * * * *",
+            "allow_overlap": false,
+        }))
+        .unwrap();
+        let active_tasks = [
+            ("other-task".to_owned(), "slack_sync".to_owned()),
+            ("sync-task".to_owned(), "upstream_sync".to_owned()),
+        ];
+
+        assert_eq!(
+            overlapping_workflow_task(&schedule, &active_tasks),
+            Some("sync-task")
+        );
+        assert_eq!(
+            overlapping_workflow_task(
+                &schedule,
+                &[("other-task".to_owned(), "slack_sync".to_owned())],
+            ),
+            None,
         );
     }
 

--- a/services/githubbot/src/session-api.ts
+++ b/services/githubbot/src/session-api.ts
@@ -26,6 +26,8 @@ import {
   traceLog,
 } from "./utils";
 
+const DEFAULT_GITHUBBOT_MAX_DURATION_MS = 45 * 60 * 1000;
+
 export class SessionApiError extends Error {
   readonly action: string;
   readonly body: string;
@@ -522,9 +524,8 @@ async function executeSession(
     ...(options.idleTimeoutMs === undefined
       ? {}
       : { idle_timeout_ms: options.idleTimeoutMs }),
-    ...(options.maxDurationMs === undefined
-      ? {}
-      : { max_duration_ms: options.maxDurationMs }),
+    max_duration_ms:
+      options.maxDurationMs ?? DEFAULT_GITHUBBOT_MAX_DURATION_MS,
   };
   const response = await fetchFn(
     apiSessionUrl(options.apiUrl, threadId, "execute"),

--- a/services/githubbot/test/session-api.test.ts
+++ b/services/githubbot/test/session-api.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, test } from "bun:test";
+import { executeSessionTurn } from "../src/session-api";
+import type {
+  ForwardSessionInput,
+  GithubbotApiMessage,
+  GithubbotOptions,
+} from "../src/types";
+
+const message: GithubbotApiMessage = {
+  attachments: [],
+  author: {
+    fullName: "Octo Cat",
+    isBot: false,
+    isMe: false,
+    userId: "123",
+    userName: "octocat",
+  },
+  id: "message-1",
+  isMention: true,
+  raw: {},
+  text: "fix the failing test",
+  threadId: "github:example/repo:1",
+  timestamp: "2026-07-24T00:00:00.000Z",
+};
+
+function input(): ForwardSessionInput {
+  return {
+    afterEventId: 0,
+    executeMessage: message,
+    messages: [],
+    onEventId: () => {},
+    openStream: false,
+    threadId: message.threadId,
+  };
+}
+
+async function captureExecuteRequest(
+  maxDurationMs?: number,
+): Promise<Record<string, unknown>> {
+  let requestBody: Record<string, unknown> | undefined;
+  const options: GithubbotOptions = {
+    apiKey: "test-api-key",
+    apiUrl: "http://centaur-api.test",
+    fetch: async (_request, init) => {
+      requestBody = JSON.parse(String(init?.body)) as Record<string, unknown>;
+      return Response.json({
+        execution_id: "execution-1",
+        ok: true,
+        status: "running",
+      });
+    },
+    maxDurationMs,
+    token: "test-github-token",
+    webhookSecret: "test-webhook-secret",
+  };
+
+  await executeSessionTurn(options, input());
+  if (!requestBody) throw new Error("execute request was not captured");
+  return requestBody;
+}
+
+describe("executeSessionTurn", () => {
+  test("allows an autonomous turn to run for 45 minutes by default", async () => {
+    const requestBody = await captureExecuteRequest();
+
+    expect(requestBody.max_duration_ms).toBe(2_700_000);
+  });
+
+  test("preserves an explicit maximum duration", async () => {
+    const requestBody = await captureExecuteRequest(60_000);
+
+    expect(requestBody.max_duration_ms).toBe(60_000);
+  });
+});

--- a/services/sandbox/Dockerfile
+++ b/services/sandbox/Dockerfile
@@ -93,6 +93,7 @@ ARG CODEX_VERSION=0.153.2
 # Hermes Agent (NousResearch) — pinned by commit SHA per the dependency policy.
 ARG HERMES_AGENT_REF=e5e2fb8b2dbe1cae85aa5ad6ce45aef376016e43
 ARG PI_CODING_AGENT_VERSION=0.67.2
+ARG OMP_VERSION=17.0.5
 ARG NUSHELL_VERSION=0.112.2
 ARG KUBECTL_VERSION=v1.34.2
 ARG KACHE_VERSION=v0.7.0
@@ -151,6 +152,7 @@ RUN --mount=type=cache,target=/root/.npm,sharing=locked \
       "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}" \
       "@openai/codex@${CODEX_VERSION}" \
       "@mariozechner/pi-coding-agent@${PI_CODING_AGENT_VERSION}" \
+      "@oh-my-pi/pi-coding-agent@${OMP_VERSION}" \
       "pnpm@${PNPM_VERSION}" \
       agent-browser@0.26.0 \
     && find /usr/lib/node_modules -type f \( -name '*.map' -o -name '*.tsbuildinfo' \) -delete \
@@ -201,7 +203,9 @@ ENV PATH="/home/agent/.cargo/bin:/home/agent/.local/bin:/home/agent/.foundry/bin
 ARG FOUNDRY_VERSION=v1.7.0
 ARG AMP_CLI_VERSION=0.0.1774529752-g94f44d
 ARG MANIM_VERSION=0.20.1
-ARG BUN_VERSION=bun-v1.3.13
+# omp (@oh-my-pi/pi-coding-agent) requires bun >= 1.3.14 (its bin shim is a
+# `#!/usr/bin/env bun` script); keep this pin at or above that.
+ARG BUN_VERSION=bun-v1.3.14
 
 # ── Agent-scoped toolchains ─────────────────────────────────────────────────
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
@@ -221,6 +225,9 @@ RUN --mount=type=cache,target=/home/agent/.cargo/registry,uid=1001,gid=1001,shar
     && kache --version
 RUN curl -LsSf https://astral.sh/uv/install.sh | sh
 RUN curl -fsSL https://bun.sh/install | bash -s "${BUN_VERSION}"
+# omp's npm bin shim runs under bun (shebang), so it can only be verified once
+# bun is on PATH — not in the root npm install layer above.
+RUN omp --version | grep -F "${OMP_VERSION}"
 RUN --mount=type=cache,target=/home/agent/.cache/uv,uid=1001,gid=1001,sharing=locked \
     uv tool install "manim==${MANIM_VERSION}" \
     && manim --version
@@ -262,7 +269,7 @@ RUN --mount=type=cache,target=/home/agent/.npm,uid=1001,gid=1001,sharing=locked 
     npx -y skills add vercel-labs/agent-browser
 # git-branch configures each writable clone with the publishing GitHub account.
 # A baked agent identity would reappear as a co-author when GitHub squash-merges its commits.
-RUN mkdir -p ~/.amp/bin ~/.config/amp ~/.codex ~/.pi/agent ~/github ~/workspace \
+RUN mkdir -p ~/.amp/bin ~/.config/amp ~/.codex ~/.pi/agent ~/.omp/agent ~/github ~/workspace \
     && git config --global init.defaultBranch main \
     && git config --global push.autoSetupRemote true \
     && git config --global core.hooksPath /opt/centaur/git-hooks \

--- a/services/sandbox/entrypoint.sh
+++ b/services/sandbox/entrypoint.sh
@@ -56,6 +56,11 @@ if [ -d "$STATE_DIR" ] && [ -w "$STATE_DIR" ]; then
     ln -s "$STATE_DIR/claude" "$HOME_DIR/.claude"
     ln -s "$STATE_DIR/uploads" "$HOME_DIR/uploads"
     ln -s "$STATE_DIR/branches" "$HOME_DIR/branches"
+    # omp session JSONLs + thread-map.json ride the state PVC so transcript
+    # continuity (and the bridge-id → omp-session-id map) survives sandbox
+    # replacement. harness-server honors OMP_SESSION_DIR directly.
+    mkdir -p "$STATE_DIR/omp-sessions"
+    export OMP_SESSION_DIR="$STATE_DIR/omp-sessions"
     export CENTAUR_PERSISTENT_STATE=1
 fi
 
@@ -382,6 +387,20 @@ cat > "$HOME_DIR/.pi/agent/settings.json" <<EOF
   "autoCompaction": true
 }
 EOF
+
+# ── omp (oh-my-pi) settings ──────────────────────────────────────────────────
+# Baked harness/omp/{config.yml,models.yml} land in $PI_CODING_AGENT_DIR with
+# the LiteLLM gateway base URL substituted (OMP_LITELLM_BASE_URL) so each
+# deployment points omp at its own gateway Service.
+export PI_CODING_AGENT_DIR="${PI_CODING_AGENT_DIR:-$HOME_DIR/.omp/agent}"
+mkdir -p "$PI_CODING_AGENT_DIR"
+OMP_LITELLM_BASE_URL="${OMP_LITELLM_BASE_URL:-http://litellm:4000/v1}"
+for omp_cfg in config.yml models.yml; do
+    if [ -f "$HARNESS_CONFIG_DIR/omp/$omp_cfg" ]; then
+        sed "s|__OMP_LITELLM_BASE_URL__|$OMP_LITELLM_BASE_URL|g" \
+            "$HARNESS_CONFIG_DIR/omp/$omp_cfg" > "$PI_CODING_AGENT_DIR/$omp_cfg"
+    fi
+done
 
 # ── Per-session workspace clone (no shared worktree metadata) ────────────────
 if [ "${CENTAUR_PERSISTENT_STATE:-0}" = "1" ]; then


### PR DESCRIPTION
here's the version with omp support we're using in production, as discussed in #962 - I cleaned it up a bit and just tested it, seems okay. most of the slash commands work as well, the advisor in omp is one of the main reasons I was keen on using it.


Note: I'm using omp's native auth-gateway and at the same time using iron-proxy for the other harnesses. So far, works just fine. Omp does it's own routing/load-balancing which is tightly integrated so I avoided getting in its way. 


@mslipper 