### PR TITLE
feat: support signed sandbox commits

### DIFF
--- a/contrib/chart/Chart.yaml
+++ b/contrib/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: centaur
 description: Helm chart for the trusted Centaur control plane
 type: application
-version: 0.1.136
+version: 0.1.137
 appVersion: "0.1.0"
 dependencies:
   - name: connect

--- a/contrib/chart/templates/apirs.yaml
+++ b/contrib/chart/templates/apirs.yaml
@@ -73,6 +73,9 @@
 {{- $companyContextEmbeddingsEnabled := dig "companyContextEmbeddings" "enabled" false $apiRsEtl -}}
 {{- $companyContextEmbeddingsModel := dig "companyContextEmbeddings" "model" "text-embedding-3-small" $apiRsEtl -}}
 {{- $companyContextEmbeddingsDimensions := dig "companyContextEmbeddings" "dimensions" 1536 $apiRsEtl -}}
+{{- if and .Values.sandbox.gitCommitSigning.enabled (not .Values.sandbox.gitCommitSigning.existingSecretName) -}}
+{{- fail "sandbox.gitCommitSigning.existingSecretName is required when commit signing is enabled" -}}
+{{- end -}}
 {{- $apiRsEtlEnv := list
   (dict "name" "SLACK_ETL_ENABLED" "value" (dig "slack" "enabled" false $apiRsEtl))
   (dict "name" "SLACK_SYNC_INTERVAL_SECONDS" "value" (dig "slack" "syncIntervalSeconds" 3600 $apiRsEtl))
@@ -389,6 +392,20 @@ spec:
 {{- if and .Values.sandbox.priorityClassName (not (hasKey .Values.apiRs.extraEnv "SESSION_SANDBOX_PRIORITY_CLASS_NAME")) }}
             - name: SESSION_SANDBOX_PRIORITY_CLASS_NAME
               value: {{ .Values.sandbox.priorityClassName | quote }}
+{{- end }}
+{{- if not (hasKey .Values.apiRs.extraEnv "SESSION_SANDBOX_GIT_COMMIT_SIGNING_ENABLED") }}
+            - name: SESSION_SANDBOX_GIT_COMMIT_SIGNING_ENABLED
+              value: {{ .Values.sandbox.gitCommitSigning.enabled | quote }}
+{{- end }}
+{{- if .Values.sandbox.gitCommitSigning.enabled }}
+{{- if not (hasKey .Values.apiRs.extraEnv "SESSION_SANDBOX_GIT_COMMIT_SIGNING_SECRET_NAME") }}
+            - name: SESSION_SANDBOX_GIT_COMMIT_SIGNING_SECRET_NAME
+              value: {{ .Values.sandbox.gitCommitSigning.existingSecretName | quote }}
+{{- end }}
+{{- if not (hasKey .Values.apiRs.extraEnv "SESSION_SANDBOX_GIT_COMMIT_SIGNING_SECRET_KEY") }}
+            - name: SESSION_SANDBOX_GIT_COMMIT_SIGNING_SECRET_KEY
+              value: {{ .Values.sandbox.gitCommitSigning.secretKey | quote }}
+{{- end }}
 {{- end }}
             # Sandboxes call back into this control plane via the in-cluster Service.
             - name: SESSION_SANDBOX_CENTAUR_API_URL

--- a/contrib/chart/values.schema.json
+++ b/contrib/chart/values.schema.json
@@ -239,6 +239,19 @@
         "serviceAccountName": { "type": "string" },
         "reposPath": { "type": "string" },
         "resources": { "type": "object" },
+        "gitCommitSigning": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "existingSecretName": { "type": "string" },
+            "secretKey": {
+              "type": "string",
+              "pattern": "^[A-Za-z0-9._-]+$"
+            }
+          },
+          "required": ["enabled", "existingSecretName", "secretKey"],
+          "additionalProperties": false
+        },
         "telemetry": {
           "type": "object",
           "properties": {

--- a/contrib/chart/values.yaml
+++ b/contrib/chart/values.yaml
@@ -355,6 +355,13 @@ sandbox:
   # mirrored into slackbotv2. This keeps Slack's model/thinking footer aligned
   # with the policy the sandbox actually runs.
   extraEnv: {}
+  # Sign every Git commit created in a sandbox with an OpenPGP key from an
+  # existing Kubernetes Secret. Disabled by default. Use a dedicated,
+  # passphrase-free signing subkey; never put private key material in values.
+  gitCommitSigning:
+    enabled: false
+    existingSecretName: ""
+    secretKey: private-key.asc
   telemetry:
     # Include user prompts, assistant responses, and bounded shell commands on
     # harness spans.

--- a/docs/pages/extend/overlay.mdx
+++ b/docs/pages/extend/overlay.mdx
@@ -145,6 +145,47 @@ with the root prompt, then appends every mounted
 Do not rely on `overlay.image.*`; repo-cache-backed overlays are the default
 delivery path.
 
+## Signed Git commits
+
+Commit signing is an explicit deployment opt-in. Keep the signing policy in the
+overlay's `services/sandbox/SYSTEM_PROMPT.md`, but keep the private key out of
+the overlay repository and Helm values. Materialize a dedicated, passphrase-free
+OpenPGP signing subkey as a Kubernetes Secret instead:
+
+```bash
+kubectl create secret generic centaur-git-signing \
+  --from-file=private-key.asc=/secure/path/centaur-signing-subkey.asc
+```
+
+An infrastructure overlay may manage the equivalent Secret through SOPS,
+External Secrets, or another secret manager. Enable the sandbox integration:
+
+```yaml
+sandbox:
+  gitCommitSigning:
+    enabled: true
+    existingSecretName: centaur-git-signing
+    secretKey: private-key.asc
+```
+
+Add the enforcement policy to the overlay prompt:
+
+```text
+All commits must be cryptographically signed. Never disable or bypass commit
+signing. If signing fails, stop and report the failure instead of committing.
+```
+
+The sandbox imports exactly one secret key at startup, verifies that it can
+sign non-interactively, and enables Git's `commit.gpgSign`. Startup fails rather
+than allowing unsigned commits when the key is missing or unusable. Register
+the corresponding public key as a signing key on the GitHub account that
+publishes Centaur's commits.
+
+Enabling this mounts the key into every sandbox created by the deployment. Use
+a dedicated, revocable signing subkey and enable it only where every sandbox
+principal is trusted with that identity. Rotate the Secret and recycle existing
+sandboxes when replacing the key.
+
 ## Verify the overlay
 
 Verify the API pod sees the ordered API-side paths:

--- a/docs/pages/reference/configuration.mdx
+++ b/docs/pages/reference/configuration.mdx
@@ -19,6 +19,7 @@ Use these as the main extension points:
 | `console.sqlExporter.*` | SQL Exporter configuration and scrape metadata for Console database metrics. |
 | `slackbot.extraEnv` | Slackbot HTTP, Slack, feedback, and cross-org behavior. |
 | `sandbox.extraEnv` | Extra variables copied into every sandbox pod through `KUBERNETES_SANDBOX_EXTRA_ENV`. |
+| `sandbox.gitCommitSigning.*` | Optional, default-off OpenPGP signing for every sandbox commit. The private key comes from an existing Kubernetes Secret. |
 | `overlays.sources` | Ordered repo-cache-backed overlay repos for tools, workflows, and skills; subdirs default to `tools`, `workflows`, and `.agents/skills`. |
 | `overlay.systemPrompt` | Small inline prompt overlay escape hatch. |
 
@@ -219,6 +220,8 @@ Kubernetes backend:
 | `KUBERNETES_AGENT_IMAGE_PULL_POLICY`, `KUBERNETES_SANDBOX_IMAGE_PULL_SECRETS` | `sandbox.image.pullPolicy`, `global.imagePullSecrets`. | Sandbox image pull behavior. |
 | `SESSION_SANDBOX_RUNTIME_CLASS_NAME` | `sandbox.runtimeClassName`. | RuntimeClass for sandbox and iron-proxy pods (e.g. gVisor). |
 | `SESSION_SANDBOX_SERVICE_ACCOUNT_NAME` | `sandbox.serviceAccountName`. | ServiceAccount for sandbox pods (session, warm, and workflow-host), e.g. for cloud workload identity (EKS IRSA). Must already exist in the namespace; iron-proxy pods are unaffected and `automountServiceAccountToken` stays `false`. Changing it drains retained sandboxes before reuse. |
+| `SESSION_SANDBOX_GIT_COMMIT_SIGNING_ENABLED` | `sandbox.gitCommitSigning.enabled`, default `false`. | Mounts the configured OpenPGP key and requires signed Git commits in every sandbox. |
+| `SESSION_SANDBOX_GIT_COMMIT_SIGNING_SECRET_NAME`, `SESSION_SANDBOX_GIT_COMMIT_SIGNING_SECRET_KEY` | `sandbox.gitCommitSigning.existingSecretName` and `secretKey`. | Select the existing Kubernetes Secret and key containing exactly one private OpenPGP signing key. |
 | `SESSION_SANDBOX_RESOURCES` | `sandbox.resources`. | Session sandbox pod resources (per-session and warm) as a JSON Kubernetes `ResourceRequirements` object. Arbitrary resource names are preserved, and malformed input fails startup. |
 | `WORKFLOW_HOST_RESOURCES` | `apiRs.workflowHostResources`. | Workflow-host sandbox pod resources as a JSON Kubernetes `ResourceRequirements` object, sized independently of session sandboxes. |
 | `KUBERNETES_IRON_PROXY_RESOURCES` | `ironProxy.resources`. | Per-sandbox iron-proxy pod resources as a JSON Kubernetes `ResourceRequirements` object. |

--- a/services/api-rs/crates/centaur-api-server/src/args.rs
+++ b/services/api-rs/crates/centaur-api-server/src/args.rs
@@ -24,8 +24,9 @@ use centaur_iron_proxy::{
     harness_auth_fragment, infra_fragment,
 };
 use centaur_sandbox_agent_k8s::{
-    AgentSandboxBackend, AgentSandboxConfig, GitHubTokenRef, IronControlSettings, IronProxyConfig,
-    OtlpEgressTarget, Toleration, ToolSource, ToolsConfig,
+    AgentSandboxBackend, AgentSandboxConfig, GIT_COMMIT_SIGNING_KEY_PATH, GitCommitSigningConfig,
+    GitHubTokenRef, IronControlSettings, IronProxyConfig, OtlpEgressTarget, Toleration, ToolSource,
+    ToolsConfig,
 };
 use centaur_sandbox_core::{Mount, MountKind, ResourceRequirements, SandboxSpec};
 use centaur_sandbox_local::LocalSandboxBackend;
@@ -716,6 +717,26 @@ struct SandboxArgs {
         env = "SESSION_SANDBOX_PRIORITY_CLASS_NAME"
     )]
     priority_class_name: Option<String>,
+    /// Enable mandatory OpenPGP commit signing in every sandbox. The private
+    /// key is mounted from an existing Secret by the Kubernetes backend.
+    #[arg(
+        long = "session-sandbox-git-commit-signing-enabled",
+        env = "SESSION_SANDBOX_GIT_COMMIT_SIGNING_ENABLED",
+        default_value_t = false,
+        action = clap::ArgAction::Set
+    )]
+    git_commit_signing_enabled: bool,
+    #[arg(
+        long = "session-sandbox-git-commit-signing-secret-name",
+        env = "SESSION_SANDBOX_GIT_COMMIT_SIGNING_SECRET_NAME"
+    )]
+    git_commit_signing_secret_name: Option<String>,
+    #[arg(
+        long = "session-sandbox-git-commit-signing-secret-key",
+        env = "SESSION_SANDBOX_GIT_COMMIT_SIGNING_SECRET_KEY",
+        default_value = "private-key.asc"
+    )]
+    git_commit_signing_secret_key: String,
     #[command(flatten)]
     tools: ToolDiscoveryArgs,
     #[command(flatten)]
@@ -831,11 +852,11 @@ impl SandboxArgs {
                     self.kube_client().await?,
                     AgentSandboxConfig::try_from(self)?,
                 );
-                let stopped = backend.drain_service_account_mismatches().await?;
+                let stopped = backend.drain_configuration_mismatches().await?;
                 if !stopped.is_empty() {
                     info!(
                         stopped_count = stopped.len(),
-                        "drained sandboxes with stale service accounts before enabling reuse"
+                        "drained sandboxes with stale immutable configuration before enabling reuse"
                     );
                 }
                 Ok(SandboxRuntime::backend_with_workload(
@@ -1144,7 +1165,45 @@ impl SandboxArgs {
             }
         }
 
+        self.apply_git_commit_signing_env(&mut envs);
+
         Ok(envs)
+    }
+
+    fn apply_git_commit_signing_env(&self, envs: &mut Vec<(String, String)>) {
+        if !self.git_commit_signing_enabled {
+            return;
+        }
+        for (name, value) in [
+            ("CENTAUR_GIT_COMMIT_SIGNING_ENABLED", "true"),
+            (
+                "CENTAUR_GIT_COMMIT_SIGNING_KEY_PATH",
+                GIT_COMMIT_SIGNING_KEY_PATH,
+            ),
+        ] {
+            envs.retain(|(existing, _)| existing != name);
+            envs.push((name.to_owned(), value.to_owned()));
+        }
+    }
+
+    fn git_commit_signing_config(&self) -> Result<Option<GitCommitSigningConfig>, ServerError> {
+        if !self.git_commit_signing_enabled {
+            return Ok(None);
+        }
+        let secret_name = clean_optional_value(self.git_commit_signing_secret_name.as_deref())
+            .ok_or_else(|| {
+                ServerError::UnsupportedConfig(
+                    "SESSION_SANDBOX_GIT_COMMIT_SIGNING_SECRET_NAME is required when commit signing is enabled"
+                        .to_owned(),
+                )
+            })?;
+        let secret_key = clean_optional_value(Some(&self.git_commit_signing_secret_key))
+            .ok_or_else(|| {
+                ServerError::UnsupportedConfig(
+                    "SESSION_SANDBOX_GIT_COMMIT_SIGNING_SECRET_KEY must not be empty".to_owned(),
+                )
+            })?;
+        Ok(Some(GitCommitSigningConfig::new(secret_name, secret_key)))
     }
 
     /// `SESSION_SANDBOX_NODE_SELECTOR` parsed as a JSON object of label
@@ -1318,6 +1377,8 @@ impl SandboxArgs {
                 }
             }
         }
+
+        self.apply_git_commit_signing_env(&mut envs);
 
         Ok(envs)
     }
@@ -1530,6 +1591,7 @@ impl TryFrom<&SandboxArgs> for AgentSandboxConfig {
             .map(str::trim)
             .filter(|name| !name.is_empty())
             .map(str::to_owned);
+        config.git_commit_signing = args.git_commit_signing_config()?;
         config.ready_timeout = Duration::from_secs(args.ready_timeout_secs);
         let mut proxy = args.iron_proxy.to_config()?;
         let mut fragments = vec![args.iron_proxy.infra_fragment()?];
@@ -2492,6 +2554,89 @@ mod tests {
         );
         assert_eq!(config.ready_timeout, Duration::from_secs(42));
         assert!(config.iron_proxy.is_some());
+        assert!(config.git_commit_signing.is_none());
+    }
+
+    #[test]
+    fn git_commit_signing_requires_a_secret_when_enabled() {
+        let args = Args::try_parse_from([
+            "centaur-api-server",
+            "--database-url",
+            "postgres://postgres:postgres@localhost/centaur",
+            "--session-sandbox-backend",
+            "agent-k8s",
+            "--session-sandbox-git-commit-signing-enabled",
+            "true",
+            "--iron-control-url",
+            "http://console.local",
+            "--iron-control-api-key",
+            "iak_test",
+        ])
+        .unwrap();
+
+        let error = AgentSandboxConfig::try_from(&args.sandbox).unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("SESSION_SANDBOX_GIT_COMMIT_SIGNING_SECRET_NAME is required")
+        );
+    }
+
+    #[test]
+    fn git_commit_signing_configures_the_key_mount_and_workload_env() {
+        let args = Args::try_parse_from([
+            "centaur-api-server",
+            "--database-url",
+            "postgres://postgres:postgres@localhost/centaur",
+            "--session-sandbox-backend",
+            "agent-k8s",
+            "--session-sandbox-workload",
+            "codex-app-server",
+            "--session-sandbox-git-commit-signing-enabled",
+            "true",
+            "--session-sandbox-git-commit-signing-secret-name",
+            "centaur-git-signing",
+            "--session-sandbox-git-commit-signing-secret-key",
+            "signing-subkey.asc",
+            "--session-sandbox-extra-env",
+            r#"[
+                {"name":"CENTAUR_GIT_COMMIT_SIGNING_ENABLED","value":"false"},
+                {"name":"CENTAUR_GIT_COMMIT_SIGNING_KEY_PATH","value":"/tmp/other-key"}
+            ]"#,
+            "--iron-control-url",
+            "http://console.local",
+            "--iron-control-api-key",
+            "iak_test",
+        ])
+        .unwrap();
+
+        let config = AgentSandboxConfig::try_from(&args.sandbox).unwrap();
+        assert_eq!(
+            config.git_commit_signing,
+            Some(GitCommitSigningConfig::new(
+                "centaur-git-signing",
+                "signing-subkey.asc"
+            ))
+        );
+        let env = args.sandbox.codex_app_server_env_template().unwrap();
+        assert!(env.iter().any(|(name, value)| {
+            name == "CENTAUR_GIT_COMMIT_SIGNING_ENABLED" && value == "true"
+        }));
+        assert!(env.iter().any(|(name, value)| {
+            name == "CENTAUR_GIT_COMMIT_SIGNING_KEY_PATH" && value == GIT_COMMIT_SIGNING_KEY_PATH
+        }));
+        assert_eq!(
+            env.iter()
+                .filter(|(name, _)| name == "CENTAUR_GIT_COMMIT_SIGNING_ENABLED")
+                .count(),
+            1
+        );
+        assert_eq!(
+            env.iter()
+                .filter(|(name, _)| name == "CENTAUR_GIT_COMMIT_SIGNING_KEY_PATH")
+                .count(),
+            1
+        );
     }
 
     #[test]

--- a/services/api-rs/crates/centaur-sandbox-agent-k8s/src/lib.rs
+++ b/services/api-rs/crates/centaur-sandbox-agent-k8s/src/lib.rs
@@ -42,6 +42,10 @@ const SANDBOX_ID_LABEL: &str = "centaur.ai/sandbox-id";
 const OBSERVABILITY_ENABLED_LABEL: &str = "centaur.ai/observability-enabled";
 const MANAGED_BY_VALUE: &str = "api-rs";
 const SANDBOX_FILES_VOLUME: &str = "sandbox-files";
+const GIT_COMMIT_SIGNING_VOLUME: &str = "git-commit-signing-key";
+const GIT_COMMIT_SIGNING_MOUNT_PATH: &str = "/var/run/secrets/centaur/git-signing";
+pub const GIT_COMMIT_SIGNING_KEY_PATH: &str =
+    "/var/run/secrets/centaur/git-signing/private-key.asc";
 // iron-control principal OID the sandbox's proxy binds to, stamped at create
 // so resume (which has only the sandbox id) can rebind without the spec or any
 // in-memory state. Survives pause and api-rs restarts.
@@ -85,6 +89,9 @@ pub struct AgentSandboxConfig {
     /// makes the kubelet/scheduler sacrifice them before the control plane
     /// under node pressure. Empty leaves the cluster default untouched.
     pub priority_class_name: Option<String>,
+    /// Optional OpenPGP key mounted from an existing Kubernetes Secret. The
+    /// sandbox entrypoint imports it and enables mandatory commit signing.
+    pub git_commit_signing: Option<GitCommitSigningConfig>,
     pub state_volume: Option<StateVolumeConfig>,
     pub iron_proxy: Option<IronProxyConfig>,
     pub iron_control: IronControlSettings,
@@ -143,6 +150,7 @@ impl AgentSandboxConfig {
             runtime_class_name: None,
             service_account_name: None,
             priority_class_name: None,
+            git_commit_signing: None,
             state_volume: None,
             iron_proxy: None,
             iron_control,
@@ -165,6 +173,26 @@ impl AgentSandboxConfig {
     pub fn tools(mut self, tools: ToolsConfig) -> Self {
         self.tools = Some(tools);
         self
+    }
+
+    pub fn git_commit_signing(mut self, config: GitCommitSigningConfig) -> Self {
+        self.git_commit_signing = Some(config);
+        self
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct GitCommitSigningConfig {
+    pub secret_name: String,
+    pub secret_key: String,
+}
+
+impl GitCommitSigningConfig {
+    pub fn new(secret_name: impl Into<String>, secret_key: impl Into<String>) -> Self {
+        Self {
+            secret_name: secret_name.into(),
+            secret_key: secret_key.into(),
+        }
     }
 }
 
@@ -266,23 +294,28 @@ impl AgentSandboxBackend {
         }
     }
 
-    /// Stop every retained sandbox whose immutable pod service account does
-    /// not match the current backend configuration. This runs before api-rs
-    /// enables session reuse or warm-pool claims, so a rollout cannot keep an
-    /// old workload identity alive or assign it to a new session.
-    pub async fn drain_service_account_mismatches(&self) -> SandboxResult<Vec<SandboxId>> {
+    /// Stop retained sandboxes whose immutable pod identity or commit-signing
+    /// key reference does not match the current backend configuration. This
+    /// runs before api-rs enables session reuse or warm-pool claims.
+    pub async fn drain_configuration_mismatches(&self) -> SandboxResult<Vec<SandboxId>> {
         let params =
             ListParams::default().labels(&format!("{MANAGED_BY_LABEL}={MANAGED_BY_VALUE}"));
         let sandboxes = self.sandboxes().list(&params).await.map_err(|err| {
-            map_kube_error("list sandboxes for service account reconciliation", err)
+            map_kube_error("list sandboxes for configuration reconciliation", err)
         })?;
         let mut stopped = Vec::new();
 
         for sandbox in sandboxes.items {
-            if sandbox_service_account_matches(
+            let service_account_matches = sandbox_service_account_matches(
                 &sandbox,
                 self.config.service_account_name.as_deref(),
-            ) {
+            );
+            let git_commit_signing_matches = sandbox_git_commit_signing_matches(
+                &sandbox,
+                &self.config.container_name,
+                self.config.git_commit_signing.as_ref(),
+            );
+            if service_account_matches && git_commit_signing_matches {
                 continue;
             }
             let Some(name) = sandbox.metadata.name.as_deref() else {
@@ -295,7 +328,9 @@ impl AgentSandboxBackend {
                 existing_service_account = ?normalized_name(
                     sandbox.spec.pod_template.spec.service_account_name.as_deref()
                 ),
-                "stopping sandbox whose service account does not match configuration"
+                service_account_matches,
+                git_commit_signing_matches,
+                "stopping sandbox whose immutable configuration is stale"
             );
             SandboxBackend::stop(self, &id).await?;
             stopped.push(id);
@@ -916,6 +951,18 @@ fn build_agent_sandbox(
             upsert_env(&mut agent_env, &name, value);
         }
     }
+    if config.git_commit_signing.is_some() {
+        upsert_env(
+            &mut agent_env,
+            "CENTAUR_GIT_COMMIT_SIGNING_ENABLED",
+            "true".to_owned(),
+        );
+        upsert_env(
+            &mut agent_env,
+            "CENTAUR_GIT_COMMIT_SIGNING_KEY_PATH",
+            GIT_COMMIT_SIGNING_KEY_PATH.to_owned(),
+        );
+    }
     insert_optional(
         &mut container,
         "env",
@@ -959,6 +1006,24 @@ fn build_agent_sandbox(
         volume_mounts.push(iron_proxy::sandbox_ca_volume_mount_json());
         volumes.push(iron_proxy::sandbox_ca_volume_json(iron_proxy));
     }
+    if let Some(signing) = &config.git_commit_signing {
+        volume_mounts.push(json!({
+            "name": GIT_COMMIT_SIGNING_VOLUME,
+            "mountPath": GIT_COMMIT_SIGNING_MOUNT_PATH,
+            "readOnly": true,
+        }));
+        volumes.push(json!({
+            "name": GIT_COMMIT_SIGNING_VOLUME,
+            "secret": {
+                "secretName": signing.secret_name,
+                "defaultMode": 0o440,
+                "items": [{
+                    "key": signing.secret_key,
+                    "path": "private-key.asc",
+                }],
+            },
+        }));
+    }
     // Tool sources are bootstrapped into an emptyDir by an init container and
     // mounted into the agent at the same path `TOOL_DIRS` points at. The mount is
     // writable so `centaur-tools refresh` can fetch and republish the tree.
@@ -1000,7 +1065,7 @@ fn build_agent_sandbox(
         "automountServiceAccountToken": false,
         "enableServiceLinks": false,
     });
-    if repo_cache_tools.is_some() {
+    if repo_cache_tools.is_some() || config.git_commit_signing.is_some() {
         pod_spec["securityContext"] = tools::pod_security_context_json();
     }
     insert_optional(
@@ -1272,6 +1337,50 @@ fn sandbox_service_account_matches(
     ) == normalized_name(configured_service_account)
 }
 
+fn sandbox_git_commit_signing_matches(
+    sandbox: &crd::Sandbox,
+    container_name: &str,
+    configured: Option<&GitCommitSigningConfig>,
+) -> bool {
+    let Ok(pod) = serde_json::to_value(&sandbox.spec.pod_template.spec) else {
+        return false;
+    };
+    let enabled = pod["containers"]
+        .as_array()
+        .and_then(|containers| {
+            containers
+                .iter()
+                .find(|container| container["name"] == container_name)
+        })
+        .and_then(|container| container["env"].as_array())
+        .is_some_and(|env| {
+            env.iter().any(|entry| {
+                entry["name"] == "CENTAUR_GIT_COMMIT_SIGNING_ENABLED" && entry["value"] == "true"
+            })
+        });
+    let signing_volume = pod["volumes"].as_array().and_then(|volumes| {
+        volumes
+            .iter()
+            .find(|volume| volume["name"] == GIT_COMMIT_SIGNING_VOLUME)
+    });
+
+    match configured {
+        None => !enabled && signing_volume.is_none(),
+        Some(config) => {
+            enabled
+                && signing_volume.is_some_and(|volume| {
+                    volume["secret"]["secretName"] == config.secret_name
+                        && volume["secret"]["items"].as_array().is_some_and(|items| {
+                            items.iter().any(|item| {
+                                item["key"] == config.secret_key
+                                    && item["path"] == "private-key.asc"
+                            })
+                        })
+                })
+        }
+    }
+}
+
 /// Override-or-append an env entry, so the agent container never emits a
 /// duplicate env name when we layer tools/overlay wiring over `spec.env`.
 fn upsert_env(env: &mut Vec<(String, String)>, name: &str, value: String) {
@@ -1447,6 +1556,65 @@ mod tests {
     }
 
     #[test]
+    fn mounts_git_commit_signing_key_only_when_configured() {
+        let spec = SandboxSpec::new("centaur-agent:latest");
+        let disabled = AgentSandboxConfig::new("centaur", test_iron_control_settings());
+        let disabled = serde_json::to_value(
+            build_agent_sandbox(&SandboxId::new("asbx-disabled"), &spec, &disabled).unwrap(),
+        )
+        .unwrap();
+        let disabled_pod = &disabled["spec"]["podTemplate"]["spec"];
+        assert!(disabled_pod["volumes"].is_null());
+        assert!(disabled_pod["securityContext"].is_null());
+        assert!(
+            disabled_pod["containers"][0]["env"]
+                .as_array()
+                .is_none_or(|env| env
+                    .iter()
+                    .all(|entry| { entry["name"] != "CENTAUR_GIT_COMMIT_SIGNING_ENABLED" }))
+        );
+
+        let enabled =
+            AgentSandboxConfig::new("centaur", test_iron_control_settings()).git_commit_signing(
+                GitCommitSigningConfig::new("centaur-git-signing", "private.asc"),
+            );
+        let enabled = serde_json::to_value(
+            build_agent_sandbox(&SandboxId::new("asbx-enabled"), &spec, &enabled).unwrap(),
+        )
+        .unwrap();
+        let pod = &enabled["spec"]["podTemplate"]["spec"];
+        assert_eq!(pod["securityContext"]["fsGroup"], 1001);
+        assert!(
+            pod["containers"][0]["env"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .any(|entry| {
+                    entry["name"] == "CENTAUR_GIT_COMMIT_SIGNING_ENABLED"
+                        && entry["value"] == "true"
+                })
+        );
+        assert!(
+            pod["containers"][0]["volumeMounts"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .any(|mount| {
+                    mount["name"] == GIT_COMMIT_SIGNING_VOLUME
+                        && mount["mountPath"] == GIT_COMMIT_SIGNING_MOUNT_PATH
+                        && mount["readOnly"] == true
+                })
+        );
+        assert!(pod["volumes"].as_array().unwrap().iter().any(|volume| {
+            volume["name"] == GIT_COMMIT_SIGNING_VOLUME
+                && volume["secret"]["secretName"] == "centaur-git-signing"
+                && volume["secret"]["defaultMode"] == 0o440
+                && volume["secret"]["items"][0]["key"] == "private.asc"
+                && volume["secret"]["items"][0]["path"] == "private-key.asc"
+        }));
+    }
+
+    #[test]
     fn renders_partial_sandbox_resources() {
         let spec = SandboxSpec::new("centaur-agent:latest").resources(
             ResourceRequirements::new()
@@ -1604,6 +1772,48 @@ mod tests {
 
         assert!(sandbox_service_account_matches(&sandbox, None));
         assert!(sandbox_service_account_matches(&sandbox, Some("  ")));
+    }
+
+    #[test]
+    fn git_commit_signing_reconciliation_detects_enable_disable_and_key_changes() {
+        let spec = SandboxSpec::new("centaur-agent:latest");
+        let disabled = AgentSandboxConfig::new("centaur", test_iron_control_settings());
+        let disabled_sandbox =
+            build_agent_sandbox(&SandboxId::new("asbx-disabled"), &spec, &disabled).unwrap();
+        let first_key = GitCommitSigningConfig::new("git-signing-v1", "private.asc");
+        let enabled = AgentSandboxConfig::new("centaur", test_iron_control_settings())
+            .git_commit_signing(first_key.clone());
+        let enabled_sandbox =
+            build_agent_sandbox(&SandboxId::new("asbx-enabled"), &spec, &enabled).unwrap();
+
+        assert!(sandbox_git_commit_signing_matches(
+            &disabled_sandbox,
+            DEFAULT_CONTAINER_NAME,
+            None
+        ));
+        assert!(!sandbox_git_commit_signing_matches(
+            &disabled_sandbox,
+            DEFAULT_CONTAINER_NAME,
+            Some(&first_key)
+        ));
+        assert!(sandbox_git_commit_signing_matches(
+            &enabled_sandbox,
+            DEFAULT_CONTAINER_NAME,
+            Some(&first_key)
+        ));
+        assert!(!sandbox_git_commit_signing_matches(
+            &enabled_sandbox,
+            DEFAULT_CONTAINER_NAME,
+            None
+        ));
+        assert!(!sandbox_git_commit_signing_matches(
+            &enabled_sandbox,
+            DEFAULT_CONTAINER_NAME,
+            Some(&GitCommitSigningConfig::new(
+                "git-signing-v2",
+                "private.asc"
+            ))
+        ));
     }
 
     #[test]

--- a/services/sandbox/Dockerfile
+++ b/services/sandbox/Dockerfile
@@ -292,6 +292,7 @@ COPY --link --chmod=755 services/sandbox/md2docx.py /usr/local/bin/md2docx
 COPY --link --chmod=755 services/workflow-python/workflow_host.py /usr/local/bin/workflow-host
 COPY --link services/workflow-python/api/ /usr/local/bin/api/
 COPY --link --chmod=755 services/sandbox/git-branch.sh /usr/local/bin/git-branch
+COPY --link --chmod=755 services/sandbox/configure_git_signing.sh /usr/local/bin/configure-git-signing
 COPY --link --chmod=755 services/sandbox/install_tool_shims.py /usr/local/bin/install-tool-shims
 COPY --link --chmod=755 services/sandbox/seed_hermes_codex_auth.py /usr/local/bin/seed-hermes-codex-auth
 COPY --link --chmod=755 services/sandbox/centaur_tool_host.py /usr/local/bin/centaur-tool-host

--- a/services/sandbox/configure_git_signing.sh
+++ b/services/sandbox/configure_git_signing.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+set -euo pipefail
+
+case "${CENTAUR_GIT_COMMIT_SIGNING_ENABLED:-false}" in
+    0|false|False|FALSE|no|No|NO|off|Off|OFF)
+        exit 0
+        ;;
+    1|true|True|TRUE|yes|Yes|YES|on|On|ON)
+        ;;
+    *)
+        echo "invalid CENTAUR_GIT_COMMIT_SIGNING_ENABLED value" >&2
+        exit 1
+        ;;
+esac
+
+key_path="${CENTAUR_GIT_COMMIT_SIGNING_KEY_PATH:-/var/run/secrets/centaur/git-signing/private-key.asc}"
+if [ ! -r "$key_path" ]; then
+    echo "git commit signing key is not readable: $key_path" >&2
+    exit 1
+fi
+
+export GNUPGHOME="${GNUPGHOME:-${HOME:?}/.gnupg}"
+install -d -m 0700 "$GNUPGHOME"
+
+if ! key_listing="$(gpg --batch --with-colons --import-options show-only --import "$key_path" 2>/dev/null)"; then
+    echo "git commit signing key is not valid OpenPGP key material" >&2
+    exit 1
+fi
+fingerprints=()
+while IFS= read -r candidate; do
+    fingerprints[${#fingerprints[@]}]="$candidate"
+done < <(
+    printf '%s\n' "$key_listing" \
+        | awk -F: '$1 == "sec" { primary = 1; next } primary && $1 == "fpr" { print $10; primary = 0 }'
+)
+unset key_listing
+
+if [ "${#fingerprints[@]}" -ne 1 ]; then
+    echo "git commit signing Secret must contain exactly one OpenPGP secret key" >&2
+    exit 1
+fi
+fingerprint="${fingerprints[0]}"
+
+if ! gpg --batch --quiet --import "$key_path" >/dev/null 2>&1; then
+    echo "failed to import git commit signing key" >&2
+    exit 1
+fi
+
+payload="$(mktemp)"
+signature="$(mktemp)"
+trap 'rm -f "$payload" "$signature"' EXIT
+printf 'centaur git signing preflight\n' > "$payload"
+if ! gpg --batch --yes --pinentry-mode loopback --passphrase '' \
+    --local-user "$fingerprint" --output "$signature" --detach-sign "$payload" \
+    >/dev/null 2>&1; then
+    echo "git commit signing key cannot sign non-interactively" >&2
+    exit 1
+fi
+
+git config --global gpg.program gpg
+git config --global user.signingKey "$fingerprint"
+git config --global commit.gpgSign true

--- a/services/sandbox/entrypoint.sh
+++ b/services/sandbox/entrypoint.sh
@@ -59,6 +59,10 @@ if [ -d "$STATE_DIR" ] && [ -w "$STATE_DIR" ]; then
     export CENTAUR_PERSISTENT_STATE=1
 fi
 
+# Optional deployment-level commit signing. The helper is a no-op unless the
+# Kubernetes backend mounted a key and explicitly enabled it.
+configure-git-signing
+
 mkdir -p "$HOME_DIR/.config/amp"
 
 # ── Write harness configs (no MCP — adds ~10s startup overhead) ───────────────

--- a/services/sandbox/test_configure_git_signing.py
+++ b/services/sandbox/test_configure_git_signing.py
@@ -1,0 +1,138 @@
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).with_name("configure_git_signing.sh")
+
+
+class ConfigureGitSigningTests(unittest.TestCase):
+    def run_script(self, root: Path, **environment: str) -> subprocess.CompletedProcess[str]:
+        env = os.environ.copy()
+        env.update(
+            {
+                "GNUPGHOME": str(root / "gnupg"),
+                "GIT_CONFIG_GLOBAL": str(root / "gitconfig"),
+                **environment,
+            }
+        )
+        return subprocess.run(
+            [str(SCRIPT)],
+            env=env,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+    def test_disabled_is_a_noop(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            result = self.run_script(root)
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertFalse((root / "gnupg").exists())
+
+    def test_enabled_requires_a_readable_key(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            result = self.run_script(
+                root,
+                CENTAUR_GIT_COMMIT_SIGNING_ENABLED="true",
+                CENTAUR_GIT_COMMIT_SIGNING_KEY_PATH=str(root / "missing.asc"),
+            )
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("not readable", result.stderr)
+
+    def test_rejects_an_invalid_enabled_value(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            result = self.run_script(
+                Path(temp), CENTAUR_GIT_COMMIT_SIGNING_ENABLED="sometimes"
+            )
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("invalid CENTAUR_GIT_COMMIT_SIGNING_ENABLED", result.stderr)
+
+    def test_imports_key_and_signs_commits(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            source_home = root / "source-gnupg"
+            source_home.mkdir(mode=0o700)
+            source_env = {**os.environ, "GNUPGHOME": str(source_home)}
+            subprocess.run(
+                [
+                    "gpg",
+                    "--batch",
+                    "--pinentry-mode",
+                    "loopback",
+                    "--passphrase",
+                    "",
+                    "--quick-generate-key",
+                    "Centaur Test <centaur-test@example.com>",
+                    "ed25519",
+                    "sign",
+                    "0",
+                ],
+                env=source_env,
+                check=True,
+                capture_output=True,
+            )
+            key_path = root / "private-key.asc"
+            with key_path.open("wb") as key_file:
+                subprocess.run(
+                    ["gpg", "--batch", "--armor", "--export-secret-keys"],
+                    env=source_env,
+                    check=True,
+                    stdout=key_file,
+                    stderr=subprocess.PIPE,
+                )
+
+            result = self.run_script(
+                root,
+                CENTAUR_GIT_COMMIT_SIGNING_ENABLED="true",
+                CENTAUR_GIT_COMMIT_SIGNING_KEY_PATH=str(key_path),
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+
+            git_env = {
+                **os.environ,
+                "GNUPGHOME": str(root / "gnupg"),
+                "GIT_CONFIG_GLOBAL": str(root / "gitconfig"),
+            }
+            repository = root / "repository"
+            subprocess.run(["git", "init", "-q", str(repository)], env=git_env, check=True)
+            subprocess.run(
+                ["git", "-C", str(repository), "config", "user.name", "Centaur Test"],
+                env=git_env,
+                check=True,
+            )
+            subprocess.run(
+                [
+                    "git",
+                    "-C",
+                    str(repository),
+                    "config",
+                    "user.email",
+                    "centaur-test@example.com",
+                ],
+                env=git_env,
+                check=True,
+            )
+            subprocess.run(
+                ["git", "-C", str(repository), "commit", "--allow-empty", "-m", "test"],
+                env=git_env,
+                check=True,
+                capture_output=True,
+            )
+            subprocess.run(
+                ["git", "-C", str(repository), "verify-commit", "HEAD"],
+                env=git_env,
+                check=True,
+                capture_output=True,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/services/sandbox/test_configure_git_signing.py
+++ b/services/sandbox/test_configure_git_signing.py
@@ -6,10 +6,71 @@ from pathlib import Path
 
 
 SCRIPT = Path(__file__).with_name("configure_git_signing.sh")
+SANDBOX_IMAGE = os.environ.get("CENTAUR_SANDBOX_TEST_IMAGE")
+
+
+def generate_key(
+    root: Path,
+    identity: str = "Centaur Test <centaur-test@example.com>",
+    passphrase: str = "",
+) -> tuple[Path, str]:
+    source_home = root / "source-gnupg"
+    source_home.mkdir(mode=0o700, exist_ok=True)
+    source_env = {**os.environ, "GNUPGHOME": str(source_home)}
+    subprocess.run(
+        [
+            "gpg",
+            "--batch",
+            "--pinentry-mode",
+            "loopback",
+            "--passphrase",
+            passphrase,
+            "--quick-generate-key",
+            identity,
+            "ed25519",
+            "sign",
+            "0",
+        ],
+        env=source_env,
+        check=True,
+        capture_output=True,
+    )
+    fingerprint = (
+        subprocess.run(
+            ["gpg", "--batch", "--with-colons", "--list-secret-keys", identity],
+            env=source_env,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        .stdout.split("fpr:::::::::", 1)[1]
+        .split(":", 1)[0]
+    )
+    key_path = root / "private-key.asc"
+    with key_path.open("wb") as key_file:
+        subprocess.run(
+            [
+                "gpg",
+                "--batch",
+                "--pinentry-mode",
+                "loopback",
+                "--passphrase",
+                passphrase,
+                "--armor",
+                "--export-secret-keys",
+            ],
+            env=source_env,
+            check=True,
+            stdout=key_file,
+            stderr=subprocess.PIPE,
+        )
+    return key_path, fingerprint
 
 
 class ConfigureGitSigningTests(unittest.TestCase):
-    def run_script(self, root: Path, **environment: str) -> subprocess.CompletedProcess[str]:
+    def run_script(
+        self, root: Path, **environment: str
+    ) -> subprocess.CompletedProcess[str]:
         env = os.environ.copy()
         env.update(
             {
@@ -55,39 +116,39 @@ class ConfigureGitSigningTests(unittest.TestCase):
             self.assertNotEqual(result.returncode, 0)
             self.assertIn("invalid CENTAUR_GIT_COMMIT_SIGNING_ENABLED", result.stderr)
 
+    def test_rejects_multiple_secret_keys(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            generate_key(root, "First Test <first@example.com>")
+            key_path, _ = generate_key(root, "Second Test <second@example.com>")
+
+            result = self.run_script(
+                root,
+                CENTAUR_GIT_COMMIT_SIGNING_ENABLED="true",
+                CENTAUR_GIT_COMMIT_SIGNING_KEY_PATH=str(key_path),
+            )
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("must contain exactly one", result.stderr)
+
+    def test_rejects_a_passphrase_protected_key(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            key_path, _ = generate_key(root, passphrase="test-passphrase")
+
+            result = self.run_script(
+                root,
+                CENTAUR_GIT_COMMIT_SIGNING_ENABLED="true",
+                CENTAUR_GIT_COMMIT_SIGNING_KEY_PATH=str(key_path),
+            )
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("cannot sign non-interactively", result.stderr)
+
     def test_imports_key_and_signs_commits(self) -> None:
         with tempfile.TemporaryDirectory() as temp:
             root = Path(temp)
-            source_home = root / "source-gnupg"
-            source_home.mkdir(mode=0o700)
-            source_env = {**os.environ, "GNUPGHOME": str(source_home)}
-            subprocess.run(
-                [
-                    "gpg",
-                    "--batch",
-                    "--pinentry-mode",
-                    "loopback",
-                    "--passphrase",
-                    "",
-                    "--quick-generate-key",
-                    "Centaur Test <centaur-test@example.com>",
-                    "ed25519",
-                    "sign",
-                    "0",
-                ],
-                env=source_env,
-                check=True,
-                capture_output=True,
-            )
-            key_path = root / "private-key.asc"
-            with key_path.open("wb") as key_file:
-                subprocess.run(
-                    ["gpg", "--batch", "--armor", "--export-secret-keys"],
-                    env=source_env,
-                    check=True,
-                    stdout=key_file,
-                    stderr=subprocess.PIPE,
-                )
+            key_path, fingerprint = generate_key(root)
 
             result = self.run_script(
                 root,
@@ -102,7 +163,9 @@ class ConfigureGitSigningTests(unittest.TestCase):
                 "GIT_CONFIG_GLOBAL": str(root / "gitconfig"),
             }
             repository = root / "repository"
-            subprocess.run(["git", "init", "-q", str(repository)], env=git_env, check=True)
+            subprocess.run(
+                ["git", "init", "-q", str(repository)], env=git_env, check=True
+            )
             subprocess.run(
                 ["git", "-C", str(repository), "config", "user.name", "Centaur Test"],
                 env=git_env,
@@ -132,6 +195,113 @@ class ConfigureGitSigningTests(unittest.TestCase):
                 check=True,
                 capture_output=True,
             )
+            self.assertEqual(
+                subprocess.run(
+                    ["git", "config", "--global", "user.signingKey"],
+                    env=git_env,
+                    check=True,
+                    capture_output=True,
+                    text=True,
+                ).stdout.strip(),
+                fingerprint,
+            )
+
+
+@unittest.skipUnless(
+    SANDBOX_IMAGE,
+    "set CENTAUR_SANDBOX_TEST_IMAGE to run the built-image integration tests",
+)
+class SandboxImageGitSigningTests(unittest.TestCase):
+    def test_built_image_leaves_commits_unsigned_by_default(self) -> None:
+        result = subprocess.run(
+            [
+                "docker",
+                "run",
+                "--rm",
+                "--env",
+                "CENTAUR_TOOLS_AUTO_RELOAD=false",
+                SANDBOX_IMAGE or "",
+                "/bin/bash",
+                "-lc",
+                """
+set -euo pipefail
+repo="$(mktemp -d)"
+git init -q "$repo"
+git -C "$repo" config user.name "Centaur Test"
+git -C "$repo" config user.email "centaur-test@example.com"
+git -C "$repo" commit --allow-empty -m "test: verify signing default" >&2
+if git -C "$repo" verify-commit HEAD >/dev/null 2>&1; then
+    echo "default commit was unexpectedly signed" >&2
+    exit 1
+fi
+""",
+            ],
+            text=True,
+            capture_output=True,
+            check=False,
+            timeout=120,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def run_image(
+        self, key_path: Path, script: str
+    ) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [
+                "docker",
+                "run",
+                "--rm",
+                "--env",
+                "CENTAUR_GIT_COMMIT_SIGNING_ENABLED=true",
+                "--env",
+                "CENTAUR_TOOLS_AUTO_RELOAD=false",
+                "--volume",
+                f"{key_path}:/var/run/secrets/centaur/git-signing/private-key.asc:ro",
+                SANDBOX_IMAGE or "",
+                "/bin/bash",
+                "-lc",
+                script,
+            ],
+            text=True,
+            capture_output=True,
+            check=False,
+            timeout=120,
+        )
+
+    def test_built_image_entrypoint_produces_a_verified_signed_commit(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            key_path, fingerprint = generate_key(Path(temp))
+            result = self.run_image(
+                key_path,
+                """
+set -euo pipefail
+repo="$(mktemp -d)"
+git init -q "$repo"
+git -C "$repo" config user.name "Centaur Test"
+git -C "$repo" config user.email "centaur-test@example.com"
+git -C "$repo" commit --allow-empty -m "test: verify signing" >&2
+git -C "$repo" verify-commit HEAD >&2
+git -C "$repo" log -1 --format=%GF
+""",
+            )
+
+            self.assertEqual(
+                result.returncode,
+                0,
+                f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}",
+            )
+            self.assertEqual(result.stdout.strip(), fingerprint)
+
+    def test_built_image_entrypoint_fails_closed_for_invalid_key(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            key_path = Path(temp) / "private-key.asc"
+            key_path.write_text("not an OpenPGP key", encoding="utf-8")
+
+            result = self.run_image(key_path, "exit 0")
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("not valid OpenPGP key material", result.stderr)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

Some repositories require cryptographically signed commits. Sandboxes need a supported signing path to satisfy those repository rules.

## Summary

- Add default-off OpenPGP commit signing backed by an existing Kubernetes Secret
- Configure and preflight signing during sandbox startup, failing closed when unusable
- Reconcile retained sandboxes when signing configuration changes
- Document overlay policy and secret provisioning

## Key design considerations

- Keep private key material out of chart values and overlay repositories
- Pin protected signing environment variables after operator overrides
- Scope the opt-in to deployments where every sandbox principal may use the signing identity