### PR TITLE
feat(githubbot): support production GitHub App deployments

### DIFF
--- a/contrib/chart/Chart.yaml
+++ b/contrib/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: centaur
 description: Helm chart for the trusted Centaur control plane
 type: application
-version: 0.1.138
+version: 0.1.139
 appVersion: "0.1.0"
 dependencies:
   - name: connect

--- a/contrib/chart/templates/githubbot.yaml
+++ b/contrib/chart/templates/githubbot.yaml
@@ -67,20 +67,37 @@ spec:
             # the deployment's default harness.
             - name: GITHUBBOT_DEFAULT_HARNESS
               value: {{ .Values.sandbox.harnessEngine | quote }}
-            # Personal access token for the bot's GitHub teammate account — kept
-            # distinct from the sandbox tool token so the bot acts as its own
-            # GitHub user (requestable as a reviewer, @-mentionable).
+{{- if eq .Values.githubbot.authMode "app" }}
+            - name: GITHUB_APP_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "centaur.secretEnvName" . }}
+                  key: {{ printf "%sGITHUB_APP_ID" .Values.secretManager.envPrefix }}
+            - name: GITHUB_APP_INSTALLATION_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "centaur.secretEnvName" . }}
+                  key: {{ printf "%sGITHUB_APP_INSTALLATION_ID" .Values.secretManager.envPrefix }}
+            - name: GITHUB_APP_PRIVATE_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "centaur.secretEnvName" . }}
+                  key: {{ printf "%sGITHUB_APP_PRIVATE_KEY" .Values.secretManager.envPrefix }}
+{{- else if eq .Values.githubbot.authMode "pat" }}
             - name: GITHUB_TOKEN
               valueFrom:
                 secretKeyRef:
                   name: {{ include "centaur.secretEnvName" . }}
                   key: {{ printf "%sGITHUBBOT_TOKEN" .Values.secretManager.envPrefix }}
+{{- else }}
+{{- fail "githubbot.authMode must be one of: app, pat" }}
+{{- end }}
             # githubbot's own webhook signing secret (the GitHub repo/org webhook).
             - name: GITHUB_WEBHOOK_SECRET
               valueFrom:
                 secretKeyRef:
                   name: {{ include "centaur.secretEnvName" . }}
-                  key: {{ printf "%sGITHUBBOT_WEBHOOK_SECRET" .Values.secretManager.envPrefix }}
+                  key: {{ printf "%s%s" .Values.secretManager.envPrefix .Values.githubbot.webhookSecretKey }}
             - name: GITHUBBOT_API_KEY
               valueFrom:
                 secretKeyRef:

--- a/contrib/chart/templates/githubbot.yaml
+++ b/contrib/chart/templates/githubbot.yaml
@@ -156,12 +156,12 @@ spec:
               name: http
           readinessProbe:
             httpGet:
-              path: /health
+              path: /readyz
               port: 3001
             timeoutSeconds: 5
           livenessProbe:
             httpGet:
-              path: /health
+              path: /livez
               port: 3001
             timeoutSeconds: 5
           securityContext:

--- a/contrib/chart/values.yaml
+++ b/contrib/chart/values.yaml
@@ -688,15 +688,17 @@ linearbot:
   extraEnv: {}
   resources: {}
 
-# Chat SDK GitHub bot — GitHub teammate (PAT) ingress. Receives issue/PR comment
+# Chat SDK GitHub bot ingress. Receives issue/PR comment
 # webhooks on /api/webhooks/github (the @chat-adapter/github adapter), answers in
 # the comment thread, and runs a review when the bot account is requested as a
 # reviewer. Forwards sessions to the api-rs control plane (:8080). Disabled by
-# default: requires the GITHUBBOT_TOKEN (PAT) and GITHUBBOT_WEBHOOK_SECRET secrets
-# (see contrib/scripts/bootstrap-k8s-secrets.sh). userName must be the bot
-# account's GitHub login so @-mention and review-request matching work.
+# default: requires either GitHub App credentials or a PAT, plus a webhook secret.
 githubbot:
   enabled: false
+  # "app" uses GITHUB_APP_ID, GITHUB_APP_INSTALLATION_ID, and
+  # GITHUB_APP_PRIVATE_KEY. "pat" preserves the legacy GITHUBBOT_TOKEN mode.
+  authMode: pat
+  webhookSecretKey: GITHUBBOT_WEBHOOK_SECRET
   replicaCount: 1
   image:
     repository: centaur-githubbot

--- a/services/githubbot/README.md
+++ b/services/githubbot/README.md
@@ -7,9 +7,9 @@ and the bot answers *in the thread* with a comment. It's built on the official
 the session logic (`session-api.ts`) and rendering are the same as the other bots; the Rust `api-rs`
 control plane is unchanged (`github:…` thread keys flow through identically).
 
-The bot acts as a **real GitHub teammate**: it authenticates with a personal access token on a
-dedicated machine-user account, so it can be `@`-mentioned, assigned, and **requested as a
-reviewer** like any other collaborator.
+The bot authenticates either as a **GitHub App installation** (preferred for least-privilege
+deployments) or with a personal access token on a dedicated machine-user account. The machine-user
+mode is required for workflows that depend on assignment or requested-reviewer identity.
 
 ## Behavior
 
@@ -113,17 +113,18 @@ sandbox. Both assume the **single replica** the chart runs (`replicaCount: 1`).
 
 ## Auth
 
-A personal access token for the bot's GitHub teammate account is required (`GITHUB_TOKEN`). As a
-normal user account it is natively mentionable, assignable, and requestable as a reviewer, and the
-token inherits that user's permissions. Scopes: **`repo`** (read PRs/issues, post and edit comments,
-add reactions) — and, when the agent pushes branches or opens PRs from its sandbox, **`workflow`**.
+Configure exactly one authentication mode:
+
+- **GitHub App (preferred):** `GITHUB_APP_ID`, `GITHUB_APP_INSTALLATION_ID`, and
+  `GITHUB_APP_PRIVATE_KEY`. Installation tokens are short-lived and inherit only the permissions and
+  repository access granted to the installation.
+- **Machine-user PAT:** `GITHUB_TOKEN`. Use this when workflows require a normal GitHub user that is
+  assignable and requestable as a reviewer. Scopes: **`repo`** and, when the sandbox changes workflow
+  files, **`workflow`**.
 
 Keep this distinct from the `GITHUB_TOKEN` used by the repo-cache / sandbox tooling — that one is the
 agent's git-operations token; this one is the bot's own identity. The chart wires githubbot's token
 from a separate `GITHUBBOT_TOKEN` secret key to avoid collision.
-
-GitHub App auth is also supported by the adapter (`GITHUB_APP_ID` / `GITHUB_PRIVATE_KEY`), but the
-PAT-teammate model is what we run.
 
 Webhook events to subscribe: **Issue comments**, **Pull request review comments**, **Issues**, **Pull
 requests**, **Pull request reviews**, **Check runs**, **Check suites**, and **Workflow runs**
@@ -133,7 +134,10 @@ requests**, **Pull request reviews**, **Check runs**, **Check suites**, and **Wo
 
 | Var | Required | Notes |
 |-----|----------|-------|
-| `GITHUB_TOKEN` | ✅ | PAT for the bot's teammate account. |
+| `GITHUB_TOKEN` | Conditional | PAT for the bot's teammate account. Mutually exclusive with GitHub App credentials. |
+| `GITHUB_APP_ID` | Conditional | GitHub App ID. Required with installation ID and private key when using App auth. |
+| `GITHUB_APP_INSTALLATION_ID` | Conditional | Fixed installation ID for the GitHub App. |
+| `GITHUB_APP_PRIVATE_KEY` | Conditional | GitHub App private key in PEM format. |
 | `GITHUB_WEBHOOK_SECRET` | ✅ | Webhook signing secret (or `GITHUBBOT_WEBHOOK_SECRET`). |
 | `GITHUB_BOT_USERNAME` | ✅ | The bot account's GitHub login — drives `@`-mention and requested-reviewer matching (or `GITHUBBOT_USER_NAME`). |
 | `GITHUBBOT_DATABASE_URL` | ✅ | Postgres for chat-SDK state (falls back to `DATABASE_URL` / `POSTGRES_URL`). |

--- a/services/githubbot/src/auth.ts
+++ b/services/githubbot/src/auth.ts
@@ -1,0 +1,37 @@
+export type GithubbotAuthInput = {
+  appId?: string;
+  installationId?: number;
+  privateKey?: string;
+  token?: string;
+};
+
+export type GithubbotAuth =
+  | { token: string }
+  | { appId: string; installationId: number; privateKey: string };
+
+/** Resolve exactly one explicit GitHub authentication mode at startup. */
+export function resolveGithubbotAuth(input: GithubbotAuthInput): GithubbotAuth {
+  const token = input.token?.trim();
+  const appId = input.appId?.trim();
+  const privateKey = input.privateKey?.trim();
+  const hasAnyAppField =
+    Boolean(appId || privateKey) || input.installationId !== undefined;
+
+  if (token && hasAnyAppField) {
+    throw new Error("Configure either GITHUB_TOKEN or GitHub App credentials, not both");
+  }
+
+  if (token) return { token };
+
+  if (!appId || input.installationId === undefined || !privateKey) {
+    throw new Error(
+      "GitHub authentication requires GITHUB_TOKEN or all of GITHUB_APP_ID, GITHUB_APP_INSTALLATION_ID, and GITHUB_APP_PRIVATE_KEY",
+    );
+  }
+
+  if (!Number.isSafeInteger(input.installationId) || input.installationId <= 0) {
+    throw new Error("GITHUB_APP_INSTALLATION_ID must be a positive integer");
+  }
+
+  return { appId, installationId: input.installationId, privateKey };
+}

--- a/services/githubbot/src/index.ts
+++ b/services/githubbot/src/index.ts
@@ -67,6 +67,7 @@ export type {
 
 const POSTGRES_CONNECT_INITIAL_DELAY_MS = 250;
 const POSTGRES_CONNECT_MAX_DELAY_MS = 10_000;
+const READINESS_TIMEOUT_MS = 2_000;
 const DEDUP_WINDOW = 200;
 
 export function createGithubbot(options: GithubbotOptions): Githubbot {
@@ -82,7 +83,10 @@ export function createGithubbot(options: GithubbotOptions): Githubbot {
     logger,
   } satisfies GitHubAdapterConfig;
   const github = createGitHubAdapter(githubConfig);
-  const state = options.state ?? createDefaultState(options, logger);
+  const defaultState = options.state ? undefined : createDefaultState(options, logger);
+  const state = options.state ?? defaultState?.state;
+  if (!state) throw new Error("githubbot state is required");
+  const checkStateReady = options.readinessCheck ?? defaultState?.checkReady;
   const chat = new Chat<{ github: typeof github }, GithubbotThreadState>({
     userName,
     adapters: { github },
@@ -148,6 +152,29 @@ export function createGithubbot(options: GithubbotOptions): Githubbot {
 
   const app = new Hono();
   app.get("/health", (c) => c.json({ ok: true, service: "githubbot" }));
+  app.get("/livez", (c) => c.json({ live: true, service: "githubbot" }));
+  app.get("/readyz", async (c) => {
+    try {
+      await checkStateReady?.();
+    } catch {
+      return c.json({ ready: false, dependency: "postgres" }, 503);
+    }
+
+    try {
+      const timeoutMs = options.readinessTimeoutMs ?? READINESS_TIMEOUT_MS;
+      const response = await (options.fetch ?? fetch)(
+        new URL("readyz", `${options.apiUrl.replace(/\/$/, "")}/`),
+        { signal: AbortSignal.timeout(timeoutMs) },
+      );
+      if (!response.ok) {
+        return c.json({ ready: false, dependency: "api-rs" }, 503);
+      }
+    } catch {
+      return c.json({ ready: false, dependency: "api-rs" }, 503);
+    }
+
+    return c.json({ ready: true, service: "githubbot" });
+  });
 
   const handleGithubWebhook = async (c: Context) => {
     const eventType = c.req.header("x-github-event") ?? "";
@@ -523,22 +550,31 @@ function verifyGithubSignature(
 function createDefaultState(
   options: GithubbotOptions,
   logger: Logger,
-): StateAdapter {
+): { checkReady: () => Promise<void>; state: StateAdapter } {
   const stateLogger = logger.child("postgres-state");
   // Own the pool so we can attach an error handler. pg.Pool emits 'error' for
   // idle clients whose connection drops (Postgres restart, or a transient blip
   // while the pod's network is still being programmed at startup). With no
   // listener, node-postgres rethrows it as an uncaught exception and the process
   // crashes/spews. Logging and swallowing lets the pool reconnect on the next query.
-  const pool = new pg.Pool({ connectionString: options.postgresUrl });
+  const pool = new pg.Pool({
+    connectionString: options.postgresUrl,
+    connectionTimeoutMillis: READINESS_TIMEOUT_MS,
+    query_timeout: READINESS_TIMEOUT_MS,
+  });
   pool.on("error", (error) => {
     stateLogger.warn("postgres pool error", { error: errorMessage(error) });
   });
-  return createPostgresState({
-    client: pool,
-    keyPrefix: options.stateKeyPrefix ?? "centaur-githubbot",
-    logger: stateLogger,
-  });
+  return {
+    checkReady: async () => {
+      await pool.query("SELECT 1");
+    },
+    state: createPostgresState({
+      client: pool,
+      keyPrefix: options.stateKeyPrefix ?? "centaur-githubbot",
+      logger: stateLogger,
+    }),
+  };
 }
 
 /**

--- a/services/githubbot/src/index.ts
+++ b/services/githubbot/src/index.ts
@@ -1,5 +1,9 @@
 import { createHmac, timingSafeEqual } from "node:crypto";
-import { createGitHubAdapter, type GitHubAdapter } from "@chat-adapter/github";
+import {
+  createGitHubAdapter,
+  type GitHubAdapter,
+  type GitHubAdapterConfig,
+} from "@chat-adapter/github";
 import { createPostgresState } from "@chat-adapter/state-pg";
 import {
   Chat,
@@ -15,6 +19,7 @@ import {
   authorAssociationFromRaw,
   isCommentAuthorAllowed,
 } from "./authorization";
+import { resolveGithubbotAuth } from "./auth";
 import { handleBodyMention } from "./body-mention";
 import { backgroundWaitUntil, requestContext, waitUntil } from "./context";
 import {
@@ -67,14 +72,16 @@ const DEDUP_WINDOW = 200;
 export function createGithubbot(options: GithubbotOptions): Githubbot {
   const userName = options.userName ?? "github-bot";
   const logger = options.logger ?? noopLogger;
-  const github = createGitHubAdapter({
-    token: options.token,
+  const auth = resolveGithubbotAuth(options);
+  const githubConfig = {
+    ...auth,
     webhookSecret: options.webhookSecret,
     userName,
     ...(options.botUserId ? { botUserId: Number(options.botUserId) } : {}),
     ...(options.githubApiUrl ? { apiUrl: options.githubApiUrl } : {}),
     logger,
-  });
+  } satisfies GitHubAdapterConfig;
+  const github = createGitHubAdapter(githubConfig);
   const state = options.state ?? createDefaultState(options, logger);
   const chat = new Chat<{ github: typeof github }, GithubbotThreadState>({
     userName,

--- a/services/githubbot/src/server.ts
+++ b/services/githubbot/src/server.ts
@@ -5,9 +5,12 @@ import { createGithubbot, type GithubbotOptions } from "./index";
 const port = numberEnv("PORT", 3001);
 const apiUrl = stringEnv("CENTAUR_API_URL", "http://127.0.0.1:8080");
 
-// Personal access token for the bot's GitHub teammate account (the bot acts as a
-// real GitHub user — it can be requested as a reviewer, @-mentioned, assigned).
-const token = requiredEnv("GITHUB_TOKEN");
+// Use exactly one authentication mode. GitHub App credentials are preferred for
+// deployments; a PAT remains available for teammate-account compatibility.
+const token = optionalEnv("GITHUB_TOKEN");
+const appId = optionalEnv("GITHUB_APP_ID");
+const installationId = optionalNumberEnv("GITHUB_APP_INSTALLATION_ID");
+const privateKey = optionalEnv("GITHUB_APP_PRIVATE_KEY");
 
 // Signing secret configured on the GitHub repo/org webhook. The adapter verifies
 // comment webhooks; githubbot verifies the pull_request (review-request) webhook.
@@ -111,6 +114,7 @@ if (!postgresUrl) {
 
 const options: GithubbotOptions = {
   apiUrl,
+  appId,
   allowedAuthorAssociations: listEnv("GITHUBBOT_ALLOWED_AUTHOR_ASSOCIATIONS"),
   apiKey: optionalEnv("GITHUBBOT_API_KEY"),
   autoMerge: boolEnv("GITHUBBOT_AUTO_MERGE", true),
@@ -129,6 +133,8 @@ const options: GithubbotOptions = {
   reviewPrompt,
   issuePrompt,
   managementPrompt,
+  installationId,
+  privateKey,
   stateKeyPrefix: optionalEnv("GITHUBBOT_STATE_KEY_PREFIX"),
   token,
   userName,
@@ -170,14 +176,6 @@ process.on("SIGINT", () => void shutdown("SIGINT"));
 function optionalEnv(name: string): string | undefined {
   const value = process.env[name]?.trim();
   return value ? value : undefined;
-}
-
-function requiredEnv(name: string): string {
-  const value = optionalEnv(name);
-  if (!value) {
-    throw new Error(`${name} is required`);
-  }
-  return value;
 }
 
 function stringEnv(name: string, fallback: string): string {

--- a/services/githubbot/src/types.ts
+++ b/services/githubbot/src/types.ts
@@ -114,6 +114,10 @@ export type GithubbotOptions = {
   mapper?: CodexAppServerToChatStreamOptions;
   maxDurationMs?: number;
   postgresUrl?: string;
+  /** Override the dependency readiness check. Primarily used by tests. */
+  readinessCheck?: () => Promise<void>;
+  /** Timeout for the api-rs readiness probe. Default 2000ms. */
+  readinessTimeoutMs?: number;
   state?: StateAdapter;
   stateKeyPrefix?: string;
   /**

--- a/services/githubbot/src/types.ts
+++ b/services/githubbot/src/types.ts
@@ -156,8 +156,14 @@ export type GithubbotOptions = {
   holdLabel?: string;
   /** Merge method for auto-merge: "merge" | "squash" | "rebase". Default "squash". */
   mergeMethod?: "merge" | "squash" | "rebase";
-  /** Personal access token for the bot's GitHub teammate account. */
-  token: string;
+  /** GitHub App ID. Configure with installationId and privateKey, or use token. */
+  appId?: string;
+  /** Fixed GitHub App installation ID for this deployment. */
+  installationId?: number;
+  /** GitHub App private key in PEM format. */
+  privateKey?: string;
+  /** Personal access token. Configure this or GitHub App credentials, not both. */
+  token?: string;
   userName?: string;
   /**
    * GitHub `author_association` values allowed to drive the conversational

--- a/services/githubbot/test/auth.test.ts
+++ b/services/githubbot/test/auth.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from "bun:test";
+import { resolveGithubbotAuth } from "../src/auth";
+
+describe("resolveGithubbotAuth", () => {
+  test("accepts a personal access token", () => {
+    expect(resolveGithubbotAuth({ token: " token " })).toEqual({ token: "token" });
+  });
+
+  test("accepts complete GitHub App credentials", () => {
+    expect(
+      resolveGithubbotAuth({
+        appId: "123",
+        installationId: 456,
+        privateKey: "private-key",
+      }),
+    ).toEqual({ appId: "123", installationId: 456, privateKey: "private-key" });
+  });
+
+  test("rejects mixed authentication modes", () => {
+    expect(() =>
+      resolveGithubbotAuth({
+        appId: "123",
+        installationId: 456,
+        privateKey: "private-key",
+        token: "token",
+      }),
+    ).toThrow("not both");
+  });
+
+  test("rejects incomplete GitHub App credentials without leaking values", () => {
+    const privateKey = "sensitive-private-key";
+    expect(() => resolveGithubbotAuth({ appId: "123", privateKey })).toThrow(
+      "all of GITHUB_APP_ID",
+    );
+    try {
+      resolveGithubbotAuth({ appId: "123", privateKey });
+    } catch (error) {
+      expect(String(error)).not.toContain(privateKey);
+    }
+  });
+
+  test("rejects missing authentication", () => {
+    expect(() => resolveGithubbotAuth({})).toThrow("GitHub authentication requires");
+  });
+
+  test("rejects an unsafe installation ID", () => {
+    expect(() =>
+      resolveGithubbotAuth({
+        appId: "123",
+        installationId: Number.MAX_SAFE_INTEGER + 1,
+        privateKey: "private-key",
+      }),
+    ).toThrow("positive integer");
+  });
+
+  test("rejects a zero installation ID", () => {
+    expect(() =>
+      resolveGithubbotAuth({
+        appId: "123",
+        installationId: 0,
+        privateKey: "private-key",
+      }),
+    ).toThrow("positive integer");
+  });
+});

--- a/services/githubbot/test/readiness.test.ts
+++ b/services/githubbot/test/readiness.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from "bun:test";
+import { createMemoryState } from "@chat-adapter/state-memory";
+import { createGithubbot, type GithubbotOptions } from "../src";
+
+function options(overrides: Partial<GithubbotOptions> = {}): GithubbotOptions {
+  return {
+    apiUrl: "http://api-rs.local",
+    connectStateOnStart: false,
+    fetch: async () => new Response("ok"),
+    readinessCheck: async () => undefined,
+    state: createMemoryState(),
+    token: "test-token",
+    userName: "test-bot",
+    webhookSecret: "test-secret",
+    ...overrides,
+  };
+}
+
+describe("githubbot health probes", () => {
+  test("liveness does not depend on external services", async () => {
+    const { app } = createGithubbot(
+      options({
+        fetch: async () => {
+          throw new Error("unavailable");
+        },
+        readinessCheck: async () => {
+          throw new Error("unavailable");
+        },
+      }),
+    );
+
+    expect((await app.request("/livez")).status).toBe(200);
+  });
+
+  test("readiness succeeds when Postgres and api-rs are ready", async () => {
+    const { app } = createGithubbot(options());
+    const response = await app.request("/readyz");
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ ready: true, service: "githubbot" });
+  });
+
+  test("readiness fails when Postgres is unavailable", async () => {
+    const { app } = createGithubbot(
+      options({
+        readinessCheck: async () => {
+          throw new Error("database unavailable");
+        },
+      }),
+    );
+    const response = await app.request("/readyz");
+
+    expect(response.status).toBe(503);
+    expect(await response.json()).toEqual({ ready: false, dependency: "postgres" });
+  });
+
+  test("readiness fails on an api-rs 5xx", async () => {
+    const { app } = createGithubbot(
+      options({ fetch: async () => new Response("unavailable", { status: 503 }) }),
+    );
+    const response = await app.request("/readyz");
+
+    expect(response.status).toBe(503);
+    expect(await response.json()).toEqual({ ready: false, dependency: "api-rs" });
+  });
+
+  test("readiness bounds an unresponsive api-rs call", async () => {
+    const { app } = createGithubbot(
+      options({
+        fetch: async (_input, init) =>
+          new Promise((_resolve, reject) => {
+            init?.signal?.addEventListener("abort", () => reject(init.signal?.reason));
+          }),
+        readinessTimeoutMs: 5,
+      }),
+    );
+    const response = await app.request("/readyz");
+
+    expect(response.status).toBe(503);
+    expect(await response.json()).toEqual({ ready: false, dependency: "api-rs" });
+  });
+});


### PR DESCRIPTION
## Summary

- add explicit single-installation GitHub App authentication to `githubbot`
- retain PAT authentication as the backward-compatible chart default
- fail fast when credentials are missing, partial, or mix both modes
- expose chart configuration for App credentials and the webhook Secret key
- split liveness from dependency-aware readiness
- fail readiness when Postgres or `api-rs` is unavailable, returns 5xx, or exceeds the bounded probe timeout

## Why

GitHub App installation tokens provide short-lived, repository-scoped credentials. The underlying Chat SDK adapter already supports this mode, but `githubbot` previously required a PAT and the Helm chart always injected `GITHUB_TOKEN`.

The chart also used the same always-successful endpoint for liveness and readiness. That could leave a webhook target healthy while its state store or control plane was unavailable.

## Validation

- `bun --cwd services/githubbot test` — 117 tests passed
- readiness coverage includes Postgres failure, `api-rs` 5xx, and timeout behavior
- `helm lint contrib/chart`
- rendered and inspected both `githubbot.authMode=app` and `githubbot.authMode=pat`
- confirmed an invalid auth mode fails Helm rendering
- `git diff --check`