### PR TITLE
feat: support channel names in Slack workflow buttons

### DIFF
--- a/docs/pages/extend/workflows.mdx
+++ b/docs/pages/extend/workflows.mdx
@@ -208,7 +208,7 @@ from api.workflow_engine import Button
 
 await ctx.slack_buttons(
     "release-review",
-    channel="C123",
+    channel="releases",
     text="Approve this release?",
     workflow="review_release",
     input={"release_id": "release-42"},
@@ -227,9 +227,10 @@ Each click starts `review_release` with the supplied input and a `click` field.
 The Rust workflow context signs the target workflow, input, action, group, and
 destination channel before posting. The invoke endpoint verifies that signature
 before creating a run. Posting a lookalike button through the agent Slack tool
-does not grant permission to start workflows. Use a Slack conversation ID for
-`channel`, such as a channel ID starting with `C` or a DM conversation ID starting
-with `D`.
+does not grant permission to start workflows. Set `channel` to a channel name
+such as `releases`, or a Slack conversation ID such as `C123` or `D123`. Names
+are resolved through the Slack tool's existing channel resolver before signing,
+so name lookup uses the same tool access as `slack.send_message`.
 
 Slackbot supplies `click` from the verified Slack interaction, and the API uses it
 instead of any `click` field in the signed input. It contains `id` (the button group ID),

--- a/services/workflow-python/api/workflow_engine.py
+++ b/services/workflow-python/api/workflow_engine.py
@@ -207,7 +207,7 @@ class WorkflowContext:
         buttons: dict[str, str | Button], input: dict[str, Any] | None = None,
         thread_ts: str | None = None,
     ) -> dict[str, Any]:
-        """Post buttons that start a workflow per click; return the Slack message."""
+        """Post workflow buttons to a channel ID or raw channel name."""
         normalized = {action: Button(button) if isinstance(button, str) else button
                       for action, button in buttons.items()}
         if (
@@ -236,10 +236,15 @@ class WorkflowContext:
                 for action, button in normalized.items()
             ]},
         ]
-        return await self.step(
-            f"{name}.post",
-            lambda: self.post_to_slack(channel, text, blocks=blocks, client_msg_id=group_id, thread_ts=thread_ts),
-        )
+        async def post() -> Any:
+            destination = channel
+            if not re.fullmatch(r"[CDG][A-Z0-9]+", destination):
+                destination = await self.call_tool("slack", "resolve_channel", {"channel": channel})
+            return await self.post_to_slack(
+                destination, text, blocks=blocks, client_msg_id=group_id, thread_ts=thread_ts,
+            )
+
+        return await self.step(f"{name}.post", post)
 
     async def update_slack(self, channel: str, message_ts: str, text: str, **kwargs: Any) -> Any:
         return await self._rpc.request({

--- a/services/workflow-python/tests/test_workflow_host.py
+++ b/services/workflow-python/tests/test_workflow_host.py
@@ -747,11 +747,14 @@ class WorkflowHostTests(unittest.TestCase):
 
     def test_slack_buttons_post_workflow_target_and_replay_message(self) -> None:
         source = '''
+from api import app
 from api.workflow_engine import Button
+# Exercise tool calls through the test RPC, independent of installed CLI shims.
+app.resolve_tool_shim = lambda: None
 WORKFLOW_NAME = "buttons"
 async def handler(inp, ctx):
     return await ctx.slack_buttons(
-        "review", channel="C1", text="Proceed?", workflow="review_release",
+        "review", channel=inp["channel"], text="Proceed?", workflow="review_release",
         input={"release_id": "release-1"},
         buttons={"approve": Button("Approve", style="primary"),
                  "reject": Button("Reject", style="danger"),
@@ -760,13 +763,14 @@ async def handler(inp, ctx):
 '''
         message = {"ok": True, "channel": "C1", "ts": "1.0"}
         group_ids = []
-        for replay in [False, True, False]:
-            with self.subTest(replay=replay), self.workflow_host(source) as proc:
+        for channel, replay in [("C1", False), ("general", True), ("general", False)]:
+            with self.subTest(channel=channel, replay=replay), self.workflow_host(source) as proc:
                 self.send_host_message(proc, {
                     "type": "workflow.start", "workflow_name": "buttons",
-                    "task_id": "task-1", "run_id": "run-1", "input": {},
+                    "task_id": "task-1", "run_id": "run-1", "input": {"channel": channel},
                 })
                 posts = 0
+                lookups = 0
                 while True:
                     request = self.read_host_message(proc)
                     kind = request["type"]
@@ -776,8 +780,15 @@ async def handler(inp, ctx):
                     if kind == "ctx.step.get":
                         self.assertEqual(request["step"], "review.post")
                         value = {"done": replay, "value": message if replay else None, "checkpoint_name": "review.post"}
+                    elif kind == "ctx.call_tool":
+                        lookups += 1
+                        self.assertEqual(request["tool"], "slack")
+                        self.assertEqual(request["method"], "resolve_channel")
+                        self.assertEqual(request["args"], {"channel": channel})
+                        value = "C1"
                     elif kind == "ctx.post_to_slack":
                         posts += 1
+                        self.assertEqual(request["channel"], "C1")
                         elements = request["args"]["blocks"][1]["elements"]
                         group_id = request["args"]["client_msg_id"]
                         group_ids.append(group_id)
@@ -801,6 +812,7 @@ async def handler(inp, ctx):
                         self.fail(f"unexpected host output: {request}")
                     self.send_host_message(proc, {"type": "ctx.response", "request_id": request["request_id"], "ok": True, "value": value})
                 self.assertEqual(posts, int(not replay))
+                self.assertEqual(lookups, int(not replay and channel == "general"))
                 proc.wait(timeout=2)
                 self.assertEqual(proc.returncode, 0)
         self.assertEqual(group_ids[0], group_ids[1])

--- a/tools/productivity/slack/client.py
+++ b/tools/productivity/slack/client.py
@@ -2568,6 +2568,11 @@ def get_user_cache(client: SlackClient | None = None) -> dict[str, str]:
     return slack_client._get_user_cache()
 
 
+def resolve_channel(channel: str) -> str:
+    """Resolve a destination using the same channel cache as send_message."""
+    return _client()._resolve_channel(channel)
+
+
 def list_bot_channels(*args, **kwargs):
     return _client().list_bot_channels(*args, **kwargs)
 

--- a/tools/productivity/slack/tests/test_client.py
+++ b/tools/productivity/slack/tests/test_client.py
@@ -3,6 +3,7 @@ import email.message
 import json
 
 import pytest
+import slack.client as slack_client
 from slack.client import SlackAuthError, SlackClient, SlackRateLimitError
 from slack_sdk.errors import SlackApiError
 
@@ -260,12 +261,13 @@ def test_resolve_channel_rejects_unknown_at_username() -> None:
         client._resolve_channel("@nobody")
 
 
-def test_resolve_channel_still_resolves_channel_names() -> None:
+def test_resolve_channel_still_resolves_channel_names(monkeypatch: pytest.MonkeyPatch) -> None:
     client, fake_web_client = _make_client()
     _restore_real_resolve_channel(client)
 
-    assert client._resolve_channel("paradigm-pulse") == "C123"
-    assert client._resolve_channel("C456DEF") == "C456DEF"
+    monkeypatch.setattr(slack_client, "_client", lambda: client)
+    assert slack_client.resolve_channel("paradigm-pulse") == "C123"
+    assert slack_client.resolve_channel("C456DEF") == "C456DEF"
     assert fake_web_client.open_calls == []
 
 


### PR DESCRIPTION
Allow `ctx.slack_buttons(channel="releases", ...)` to reuse the Slack send-message tool's existing channel resolver before signing and posting. Existing channel IDs still work, and resolution stays inside the durable posting step so completed replays skip the lookup.

All 115 workflow host and Slack tool tests pass. Local stack validation was unavailable because no Kubernetes context is configured.
