### PR TITLE
feat: add sheets batch read to gsuite tool

### DIFF
--- a/tools/productivity/gsuite/cli.py
+++ b/tools/productivity/gsuite/cli.py
@@ -1601,6 +1601,48 @@ def sheets_read_cmd(
         raise typer.Exit(1)
 
 
+@sheets_app.command("batch-read")
+def sheets_batch_read_cmd(
+    spreadsheet_id: str = typer.Argument(..., help="Spreadsheet ID (from URL)"),
+    range_notations: list[str] = typer.Option(..., "--range", "-r", help="A1 notation range"),  # noqa: B008
+    output_json: bool = typer.Option(False, "--json", "-o", help="Output as JSON"),
+):
+    """Read data from a Google Sheet, across several ranges.
+
+    Example:
+        gsuite sheets batch-read "1Abc..." --range "Sheet1!A1:D10" --range "Sheet2!A1:B5"
+        gsuite sheets batch-read "1Abc..." --range "Sheet1!A1:D10" --json
+    """
+    from .client import sheets_batch_read
+
+    try:
+        result = sheets_batch_read(spreadsheet_id, range_notations)
+
+        if output_json:
+            console.print(json.dumps(result, indent=2), markup=False, soft_wrap=True)
+            return
+
+        for value_range in result:
+            if not value_range["rows"]:
+                console.print(f"[yellow]{value_range['range']}: No data found.[/]")
+                continue
+
+            table = Table(title=f"{value_range['range']} ({len(value_range['rows'])} rows)")
+            for header in value_range["headers"]:
+                table.add_column(header, style="cyan", max_width=30)
+
+            for row in value_range["rows"][:50]:
+                values = [str(row.get(h, ""))[:30] for h in value_range["headers"]]
+                table.add_row(*values)
+
+            console.print(table)
+            if len(value_range["rows"]) > 50:
+                console.print(f"[dim]... and {len(value_range['rows']) - 50} more rows[/]")
+    except Exception as e:
+        console.print(f"[red]Error: {e}[/]")
+        raise typer.Exit(1) from e
+
+
 @sheets_app.command("update")
 def sheets_update_cmd(
     spreadsheet_id: str = typer.Argument(..., help="Spreadsheet ID (from URL)"),

--- a/tools/productivity/gsuite/client.py
+++ b/tools/productivity/gsuite/client.py
@@ -2244,6 +2244,41 @@ def sheets_read(spreadsheet_id: str, range_notation: str = "A1:Z1000") -> dict:
         .execute()
     )
 
+    return _sheets_read_result(spreadsheet_id, range_notation, result)
+
+
+def sheets_batch_read(spreadsheet_id: str, range_notations: list[str]) -> list[dict]:
+    """Read data from one Google Sheet, across several ranges.
+
+    Args:
+        spreadsheet_id: The spreadsheet ID (from URL)
+        range_notations: A1 notation range (e.g., "Sheet1!A1:D10" or "A1:Z1000")
+
+    Returns:
+        List of dicts in requested order, each with the same spreadsheet_id,
+        range, headers, rows, and raw_values fields as sheets_read.
+        The first row of each range is treated as its headers.
+    """
+    if not range_notations:
+        raise ValueError("Provide at least one range")
+
+    service = get_sheets_service()
+
+    result = (
+        service.spreadsheets()
+        .values()
+        .batchGet(spreadsheetId=spreadsheet_id, ranges=range_notations)
+        .execute()
+    )
+
+    return [
+        _sheets_read_result(spreadsheet_id, range_notation, value_range)
+        for range_notation, value_range in zip(range_notations, result["valueRanges"], strict=True)
+    ]
+
+
+def _sheets_read_result(spreadsheet_id: str, range_notation: str, result: dict) -> dict:
+    """Normalize a values response for single and batch reads."""
     values = result.get("values", [])
 
     if not values:
@@ -3540,6 +3575,15 @@ class GSuiteClient:
             Dict with spreadsheet_id, range, headers, and rows (list of dicts)
         """
         return sheets_read(spreadsheet_id, range_notation=range_notation)
+
+    def sheets_batch_read(self, spreadsheet_id: str, range_notations: list[str]) -> list[dict]:
+        """Read multiple A1 ranges from one spreadsheet in one API request.
+
+        Returns a list of dicts in requested order with the same fields as
+        sheets_read. The range list must be non-empty; the first row of each
+        range is treated as its headers.
+        """
+        return sheets_batch_read(spreadsheet_id, range_notations)
 
     def sheets_update(
         self,

--- a/tools/productivity/gsuite/test_cli.py
+++ b/tools/productivity/gsuite/test_cli.py
@@ -8,6 +8,101 @@ from gsuite.cli import app, extract_drive_file_id
 runner = CliRunner()
 
 
+def test_sheets_batch_read_passes_repeated_ranges_and_outputs_json(monkeypatch):
+    calls = []
+    expected = [{"spreadsheet_id": "sheet-123", "raw_values": [["[bold]data"]]}]
+
+    def fake_batch_read(spreadsheet_id, range_notations):
+        calls.append((spreadsheet_id, range_notations))
+        return expected
+
+    monkeypatch.setattr(client, "sheets_batch_read", fake_batch_read)
+    for json_flag in ["--json", "-o"]:
+        calls.clear()
+        result = runner.invoke(
+            app,
+            [
+                "sheets",
+                "batch-read",
+                "sheet-123",
+                "-r",
+                "Data!A1:B3",
+                "--range",
+                "Other!A1",
+                json_flag,
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert calls == [("sheet-123", ["Data!A1:B3", "Other!A1"])]
+        assert json.loads(result.stdout) == expected
+
+
+def test_sheets_batch_read_displays_each_range_by_default(monkeypatch):
+    monkeypatch.setattr(
+        client,
+        "sheets_batch_read",
+        lambda spreadsheet_id, range_notations: [
+            {"range": "Empty!A1", "headers": [], "rows": []},
+            {"range": "Data!A1:A2", "headers": ["Name"], "rows": [{"Name": "Alice"}]},
+            {"range": "Other!A1:A2", "headers": ["Name"], "rows": [{"Name": "Bob"}]},
+        ],
+    )
+    result = runner.invoke(
+        app,
+        [
+            "sheets",
+            "batch-read",
+            "sheet-123",
+            "-r",
+            "Empty!A1",
+            "-r",
+            "Data!A1:A2",
+            "-r",
+            "Other!A1:A2",
+        ],
+    )
+    assert result.exit_code == 0
+    assert "Empty!A1: No data found." in result.stdout
+    assert "Data!A1:A2" in "".join(result.stdout.split())
+    assert "Alice" in result.stdout
+    assert "Other!A1:A2" in "".join(result.stdout.split())
+    assert "Bob" in result.stdout
+
+
+def test_sheets_batch_read_requires_ranges():
+    result = runner.invoke(app, ["sheets", "batch-read", "sheet-123"])
+    assert result.exit_code == 2
+
+
+def test_sheets_batch_read_requires_range_flag():
+    result = runner.invoke(app, ["sheets", "batch-read", "sheet-123", "Data!A1"])
+    assert result.exit_code == 2
+
+
+def test_sheets_batch_read_accepts_one_range(monkeypatch):
+    calls = []
+
+    def fake_batch_read(spreadsheet_id, range_notations):
+        calls.append((spreadsheet_id, range_notations))
+        return []
+
+    monkeypatch.setattr(client, "sheets_batch_read", fake_batch_read)
+    result = runner.invoke(app, ["sheets", "batch-read", "sheet-123", "--range", "Data!A1"])
+    assert result.exit_code == 0
+    assert calls == [("sheet-123", ["Data!A1"])]
+
+
+def test_sheets_batch_read_reports_errors(monkeypatch):
+    def fake_batch_read(spreadsheet_id, range_notations):
+        raise ValueError("Invalid range")
+
+    monkeypatch.setattr(client, "sheets_batch_read", fake_batch_read)
+    result = runner.invoke(app, ["sheets", "batch-read", "sheet-123", "-r", "invalid"])
+    assert result.exit_code == 1
+    assert "Invalid range" in result.stdout
+
+
 def test_extract_drive_file_id_accepts_editor_and_drive_urls():
     assert (
         extract_drive_file_id("https://docs.google.com/document/d/doc-123/edit")

--- a/tools/productivity/gsuite/test_client.py
+++ b/tools/productivity/gsuite/test_client.py
@@ -1,6 +1,7 @@
 import base64
 import tomllib
 from pathlib import Path
+from unittest.mock import Mock
 
 import pytest
 
@@ -1003,6 +1004,74 @@ def test_gsuite_client_exposes_doc_comments(monkeypatch):
             "include_deleted": True,
         }
     ]
+
+
+def test_sheets_batch_read_uses_one_request_and_preserves_range_order(monkeypatch):
+    service = Mock()
+    values_api = service.spreadsheets.return_value.values.return_value
+    response = {
+        "valueRanges": [
+            {"range": "Data!A1:B3", "values": [["Name", "Count"], ["Alice", 2], ["Bob"]]},
+            {"range": "Empty!A1:B3"},
+            {"range": "Headers!A1:B1", "values": [["Name", "Count"]]},
+            {"range": "Data!A1:B3", "values": [["Name", "Count"], ["Alice", 2], ["Bob"]]},
+        ]
+    }
+    values_api.batchGet.return_value.execute.return_value = response
+    monkeypatch.setattr(client, "get_sheets_service", lambda: service)
+    range_notations = ["Data!A1:B3", "Empty!A1:B3", "Headers!A1:B1", "Data!A1:B3"]
+
+    result = client.GSuiteClient().sheets_batch_read(
+        "spreadsheet-123", range_notations=range_notations
+    )
+
+    values_api.batchGet.assert_called_once_with(
+        spreadsheetId="spreadsheet-123", ranges=range_notations
+    )
+    values_api.batchGet.return_value.execute.assert_called_once_with()
+    values_api.get.assert_not_called()
+    assert isinstance(result, list)
+    assert [entry["range"] for entry in result] == range_notations
+    assert result[0] == {
+        "spreadsheet_id": "spreadsheet-123",
+        "range": range_notations[0],
+        "headers": ["Name", "Count"],
+        "rows": [{"Name": "Alice", "Count": 2}, {"Name": "Bob", "Count": ""}],
+        "raw_values": response["valueRanges"][0]["values"],
+    }
+    assert result[1]["raw_values"] == []
+    assert result[1]["headers"] == []
+    assert result[1]["rows"] == []
+    assert result[2]["headers"] == ["Name", "Count"]
+    assert result[2]["rows"] == []
+    assert result[3] == result[0]
+
+    for range_notation, value_range, expected in zip(
+        range_notations, response["valueRanges"], result, strict=True
+    ):
+        values_api.get.return_value.execute.return_value = value_range
+        assert client.sheets_read("spreadsheet-123", range_notation) == expected
+
+
+def test_sheets_batch_read_rejects_empty_range_list_before_connecting(monkeypatch):
+    get_service = Mock()
+    monkeypatch.setattr(client, "get_sheets_service", get_service)
+
+    with pytest.raises(ValueError, match="Provide at least one range"):
+        client.sheets_batch_read("spreadsheet-123", range_notations=[])
+
+    get_service.assert_not_called()
+
+
+def test_sheets_batch_read_propagates_api_errors(monkeypatch):
+    service = Mock()
+    service.spreadsheets.return_value.values.return_value.batchGet.return_value.execute.side_effect = RuntimeError(
+        "Unable to read spreadsheet"
+    )
+    monkeypatch.setattr(client, "get_sheets_service", lambda: service)
+
+    with pytest.raises(RuntimeError, match="Unable to read spreadsheet"):
+        client.sheets_batch_read("spreadsheet-123", ["Data!A1"])
 
 
 def test_sheets_add_tab_uses_batch_update(monkeypatch):


### PR DESCRIPTION
# Motivation

I have a sheet with 5 tabs I want to read from. The constraints of the current `gsuite` tool means I would have to make 5 separate API requests. The underlying Google Sheets API client supports `batchGet` enabling the consumer to pass multiple ranges for one Google Sheet, reducing 5 API calls to just 1.

Exposing `batchGet` solves my problem and speeds up a skill/workflow of ours.

# Solution

Read multiple ranges from one spreadsheet in a single Sheets `values.batchGet` request. Adds `sheets_batch_read(spreadsheet_id, range_notations)` and `gsuite sheets batch-read` with repeated `--range` options, table output by default, and `--json` / `-o` output.

Returns a list in requested range order, with each entry preserving the existing `sheets_read` response shape. Single and batch reads share the same response normalization.

I tried to follow `sheets_read_cmd` and `sheets_read` patterns as much as possible.

Let me know if the tests are too sloppy or unneeded.