### PR TITLE
feat: add run command to centaur MCP tool

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -303,6 +303,9 @@ jobs:
         with:
           python-version: "3.11"
 
+      # Tool-host integration tests execute real CLIs through uvx.
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+
       - name: Sandbox Python tests
         env:
           GIT_CONFIG_GLOBAL: /dev/null

--- a/plugins/centaur/README.md
+++ b/plugins/centaur/README.md
@@ -2,6 +2,20 @@
 
 Connect Codex, Claude Code, and other MCP clients to the tools approved for your Centaur principal. Each Centaur deployment has its own MCP URL, normally ending in `/mcp`.
 
+## Running Tools
+
+Deployments with `CENTAUR_MCP_V2_ENABLED=true` expose the `centaur` MCP tool. Pass an argv array in `command` to discover and run tools:
+
+```json
+{"command": ["list"]}
+{"command": ["search", "slack messages"]}
+{"command": ["run", "slack", "--help"]}
+```
+
+`centaur run <tool> <argv>` runs the tool's CLI in your principal's sandbox using current Console policy. Use `--help` to find its commands and options, then pass each argument as a separate array element. Spaces within values are preserved. Shell expansion, pipes, and redirection are not interpreted.
+
+The result includes `stdout`, `stderr`, `exit_status`, and `timed_out` in both text and structured content. Plain-text help and JSON output are supported. Nonzero exits and timeouts set MCP `isError`. Calls have a 120-second execution timeout. Existing v1 tools with `method` and `arguments` remain available.
+
 ## Codex
 
 Add this repository as a marketplace and install the plugin:

--- a/services/api-rs/crates/centaur-api-server/src/mcp.rs
+++ b/services/api-rs/crates/centaur-api-server/src/mcp.rs
@@ -14,8 +14,8 @@ use axum::{
 };
 use base64::{Engine as _, engine::general_purpose};
 use centaur_session_runtime::{
-    SessionRuntime, ToolHostCallInput, ToolHostCallOutput, ToolHostCallPolicy, ToolHostToolFilter,
-    tool_host_thread_key,
+    SessionRuntime, ToolHostCallInput, ToolHostCallOutput, ToolHostCallPolicy, ToolHostInvocation,
+    ToolHostToolFilter, tool_host_thread_key,
 };
 use hmac::{Hmac, KeyInit, Mac};
 use serde::Deserialize;
@@ -143,7 +143,7 @@ pub(crate) async fn mcp_post(
             let policy = mcp_tool_host_call_policy(&state, &principal).await?;
             let filter = parse_sandbox_tool_filter(policy.tool_filter());
             let mut tools = mcp_builtin_tools();
-            tools.extend(mcp_centaur_tool_entries(&filter)?);
+            tools.extend(mcp_v1_tool_entries(&filter)?);
             json!({
                 "tools": tools,
             })
@@ -210,14 +210,9 @@ async fn mcp_tool_call_result(
 
     async move {
         let outcome = if let Some((tool, policy)) = tool {
-            mcp_centaur_tool_result(state, principal, tool, params.arguments, policy).await
+            mcp_v1_tool_result(state, principal, tool, params.arguments, policy).await
         } else if params.name == "centaur" {
-            mcp_dispatcher_result(state, principal, params.arguments)
-                .await
-                .map(|result| McpToolCallOutcome {
-                    result,
-                    timed_out: false,
-                })
+            mcp_v2_command_result(state, principal, params.arguments).await
         } else {
             mcp_whoami_result(principal, params.arguments).map(|result| McpToolCallOutcome {
                 result,
@@ -308,23 +303,29 @@ fn mcp_whoami_tool() -> Value {
 fn mcp_builtin_tools() -> Vec<Value> {
     let mut tools = Vec::new();
     if mcp_v2_enabled() {
-        tools.push(mcp_dispatcher_tool());
+        tools.push(mcp_v2_tool());
     }
     tools.push(mcp_whoami_tool());
     tools
 }
 
-fn mcp_dispatcher_tool() -> Value {
+fn mcp_v2_tool() -> Value {
     json!({
         "name": "centaur",
         "description": concat!(
-            "Discover Centaur services. Centaur exposes internal and third-party services ",
+            "Discover and run Centaur tools. Centaur exposes tools for internal and third-party services ",
             "(company data, Slack, Google Workspace, market data, on-chain analytics, and more) ",
             "through MCP.\n\n",
-            "Pass command as an argv array. Position 0 is a discovery verb.\n\n",
-            "Discovery verbs:\n",
-            "  [\"list\"]                          services available under your Console policy\n",
-            "  [\"search\", \"slack messages\"]      search names and descriptions, ranked\n\n",
+            "Pass command as an argv array. Position 0 is a verb.\n\n",
+            "Commands:\n",
+            "  [\"list\"]                          tools available under your Console policy\n",
+            "  [\"search\", \"slack messages\"]      search names and descriptions, ranked\n",
+            "  [\"run\", \"slack\", \"--help\"]       show a tool's CLI help\n",
+            "  [\"run\", \"<tool>\", \"<argv>\", ...] run a tool CLI in your sandbox\n\n",
+            "Use run <tool> --help to discover commands and options. Pass each argument ",
+            "as a separate token, preserving spaces within values. Arguments are passed ",
+            "literally, without shell expansion, pipes, or redirection. Run returns stdout, ",
+            "stderr, exit_status, and timed_out; nonzero exits and timeouts are tool errors.\n\n",
             "Search matches words in names and descriptions, ignoring case and punctuation. ",
             "Exact name matches rank first. Results reflect the current catalog without ",
             "refreshing MCP tool definitions, so they stay accurate even when this tool list ",
@@ -341,7 +342,7 @@ fn mcp_dispatcher_tool() -> Value {
                     "minItems": 1,
                     "description": concat!(
                         "argv array. Each element is one token; do not pre-join with spaces. ",
-                        "Examples: [\"list\"] · [\"search\", \"slack messages\"]",
+                        "Examples: [\"list\"] · [\"search\", \"slack messages\"] · [\"run\", \"slack\", \"--help\"]",
                     ),
                 },
             },
@@ -353,9 +354,10 @@ fn mcp_dispatcher_tool() -> Value {
 enum CentaurMcpCommand {
     List,
     Search(String),
+    Run { tool: String, argv: Vec<String> },
 }
 
-fn parse_centaur_command(arguments: Value) -> Result<CentaurMcpCommand, String> {
+fn parse_mcp_v2_command(arguments: Value) -> Result<CentaurMcpCommand, String> {
     let CentaurMcpArguments { command } = serde_json::from_value(arguments)
         .map_err(|error| format!("invalid centaur arguments: {error}"))?;
     if command.iter().any(|arg| arg.contains('\0')) {
@@ -369,51 +371,92 @@ fn parse_centaur_command(arguments: Value) -> Result<CentaurMcpCommand, String> 
             }
             Ok(CentaurMcpCommand::Search(query.clone()))
         }
+        [verb, tool, argv @ ..] if verb == "run" => {
+            if tool.trim().is_empty() {
+                return Err("tool must not be blank".to_owned());
+            }
+            Ok(CentaurMcpCommand::Run {
+                tool: tool.clone(),
+                argv: argv.to_vec(),
+            })
+        }
         [verb, ..] if verb == "list" => Err("list takes no arguments".to_owned()),
         [verb, ..] if verb == "search" => Err("search takes exactly one query token".to_owned()),
-        _ => Err("command must start with a supported discovery verb: list or search".to_owned()),
+        [verb, ..] if verb == "run" => Err("run requires a tool name".to_owned()),
+        _ => Err("command must start with a supported verb: list, search, or run".to_owned()),
     }
 }
 
-async fn mcp_dispatcher_result(
+async fn mcp_v2_command_result(
     state: &AppState,
     principal: &McpPrincipal,
     arguments: Value,
-) -> Result<Value, ApiError> {
-    let command = match parse_centaur_command(arguments) {
+) -> Result<McpToolCallOutcome, ApiError> {
+    let command = match parse_mcp_v2_command(arguments) {
         Ok(command) => command,
         Err(error) => {
-            return Ok(mcp_text_result(
-                format!(
-                    "{error}. Use {{\"command\":[\"list\"]}} or {{\"command\":[\"search\",\"slack messages\"]}}."
+            return Ok(McpToolCallOutcome {
+                result: mcp_text_result(
+                    format!(
+                        "{error}. Use {{\"command\":[\"list\"]}}, {{\"command\":[\"search\",\"slack messages\"]}}, or {{\"command\":[\"run\",\"<tool>\",\"--help\"]}}."
+                    ),
+                    true,
                 ),
-                true,
-            ));
+                timed_out: false,
+            });
         }
     };
-    match command {
+    let result = match command {
         CentaurMcpCommand::List => {
             record_mcp_tool_method(&Span::current(), "centaur", "list");
             let policy = mcp_tool_host_call_policy(state, principal).await?;
-            mcp_service_list_result(&parse_sandbox_tool_filter(policy.tool_filter()))
+            mcp_v2_service_list_result(&parse_sandbox_tool_filter(policy.tool_filter()))
         }
         CentaurMcpCommand::Search(query) => {
             record_mcp_tool_method(&Span::current(), "centaur", "search");
             let policy = mcp_tool_host_call_policy(state, principal).await?;
-            mcp_service_search_result(&parse_sandbox_tool_filter(policy.tool_filter()), &query)
+            mcp_v2_service_search_result(&parse_sandbox_tool_filter(policy.tool_filter()), &query)
         }
-    }
+        CentaurMcpCommand::Run {
+            tool: tool_name,
+            argv,
+        } => {
+            record_mcp_tool_method(&Span::current(), "centaur", "run");
+            let policy = mcp_tool_host_call_policy(state, principal).await?;
+            let filter = parse_sandbox_tool_filter(policy.tool_filter());
+            let Some(tool) = mcp_find_centaur_tool(&tool_name, &filter)? else {
+                return Ok(McpToolCallOutcome {
+                    result: mcp_text_result(
+                        format!(
+                            "Unknown or unavailable tool {tool_name}. Use {{\"command\":[\"list\"]}} to discover available tools."
+                        ),
+                        true,
+                    ),
+                    timed_out: false,
+                });
+            };
+            Span::current().record("tool.name", tool.name.as_str());
+            return run_mcp_v2_tool(state.runtime()?, principal, &tool, argv, policy).await;
+        }
+    }?;
+    Ok(McpToolCallOutcome {
+        result,
+        timed_out: false,
+    })
 }
 
-fn mcp_service_list_result(filter: &SandboxToolFilter) -> Result<Value, ApiError> {
-    mcp_service_summaries_result(mcp_centaur_tool_catalog(filter)?)
+fn mcp_v2_service_list_result(filter: &SandboxToolFilter) -> Result<Value, ApiError> {
+    mcp_v2_service_summaries_result(mcp_centaur_tool_catalog(filter)?)
 }
 
-fn mcp_service_search_result(filter: &SandboxToolFilter, query: &str) -> Result<Value, ApiError> {
-    mcp_service_summaries_result(search::search(mcp_centaur_tool_catalog(filter)?, query))
+fn mcp_v2_service_search_result(
+    filter: &SandboxToolFilter,
+    query: &str,
+) -> Result<Value, ApiError> {
+    mcp_v2_service_summaries_result(search::search(mcp_centaur_tool_catalog(filter)?, query))
 }
 
-fn mcp_service_summaries_result(tools: Vec<DiscoveredTool>) -> Result<Value, ApiError> {
+fn mcp_v2_service_summaries_result(tools: Vec<DiscoveredTool>) -> Result<Value, ApiError> {
     let services = tools
         .into_iter()
         .map(|tool| {
@@ -429,10 +472,10 @@ fn mcp_service_summaries_result(tools: Vec<DiscoveredTool>) -> Result<Value, Api
     Ok(result)
 }
 
-fn mcp_centaur_tool_entries(filter: &SandboxToolFilter) -> Result<Vec<Value>, ApiError> {
+fn mcp_v1_tool_entries(filter: &SandboxToolFilter) -> Result<Vec<Value>, ApiError> {
     let mut entries = Vec::new();
     for tool in mcp_centaur_tool_catalog(filter)? {
-        let methods = mcp_tool_methods(&tool);
+        let methods = mcp_v1_tool_methods(&tool);
         let signatures = methods
             .iter()
             .map(|method| method.signature.as_str())
@@ -483,7 +526,7 @@ struct McpToolMethod {
     signature: String,
 }
 
-fn mcp_tool_methods(tool: &DiscoveredTool) -> Vec<McpToolMethod> {
+fn mcp_v1_tool_methods(tool: &DiscoveredTool) -> Vec<McpToolMethod> {
     let mut methods = BTreeMap::from([("help".to_owned(), "help()".to_owned())]);
     let path = tool.project_dir.join(&tool.client_module);
     if let Ok(contents) = fs::read_to_string(&path) {
@@ -537,7 +580,7 @@ fn mcp_method_signature(name: &str, params: &str) -> String {
     format!("{name}({params})")
 }
 
-fn mcp_tool_help_result(
+fn mcp_v1_tool_help_result(
     tool: &DiscoveredTool,
     methods: &[McpToolMethod],
 ) -> Result<Value, ApiError> {
@@ -690,14 +733,14 @@ fn mcp_whoami_result(principal: &McpPrincipal, arguments: Value) -> Result<Value
     ))
 }
 
-async fn mcp_centaur_tool_result(
+async fn mcp_v1_tool_result(
     state: &AppState,
     principal: &McpPrincipal,
     tool: DiscoveredTool,
     arguments: Value,
     policy: ToolHostCallPolicy,
 ) -> Result<McpToolCallOutcome, ApiError> {
-    match prepare_mcp_centaur_tool_call(&tool, arguments)? {
+    match prepare_mcp_v1_tool_call(&tool, arguments)? {
         McpCentaurToolAction::Return { result, method } => {
             if let Some(method) = method.as_deref() {
                 record_mcp_tool_method(&Span::current(), &tool.name, method);
@@ -709,11 +752,11 @@ async fn mcp_centaur_tool_result(
         }
         McpCentaurToolAction::Run { method, arguments } => {
             record_mcp_tool_method(&Span::current(), &tool.name, &method);
-            run_tool_host_centaur_tool(
+            run_mcp_v1_tool(
                 state.runtime()?,
                 principal,
                 &tool,
-                &method,
+                method,
                 arguments,
                 policy,
             )
@@ -733,7 +776,7 @@ enum McpCentaurToolAction {
     },
 }
 
-fn prepare_mcp_centaur_tool_call(
+fn prepare_mcp_v1_tool_call(
     tool: &DiscoveredTool,
     arguments: Value,
 ) -> Result<McpCentaurToolAction, ApiError> {
@@ -743,11 +786,13 @@ fn prepare_mcp_centaur_tool_call(
         return Err(ApiError::BadRequest("method is required".to_owned()));
     }
     let method = params.method.trim().to_owned();
-    let methods = mcp_tool_methods(tool);
+    let methods = mcp_v1_tool_methods(tool);
     if method == "help" {
-        return mcp_tool_help_result(tool, &methods).map(|result| McpCentaurToolAction::Return {
-            result,
-            method: Some(method),
+        return mcp_v1_tool_help_result(tool, &methods).map(|result| {
+            McpCentaurToolAction::Return {
+                result,
+                method: Some(method),
+            }
         });
     }
     if !methods.iter().any(|candidate| candidate.name == method) {
@@ -767,7 +812,7 @@ fn prepare_mcp_centaur_tool_call(
             method: None,
         });
     }
-    let arguments = match normalize_centaur_tool_arguments(params.arguments) {
+    let arguments = match normalize_mcp_v1_tool_arguments(params.arguments) {
         Ok(arguments) => arguments,
         Err(kind) => {
             return Ok(McpCentaurToolAction::Return {
@@ -789,7 +834,7 @@ fn mcp_result_is_error(result: &Value) -> bool {
     result.get("isError").and_then(Value::as_bool) == Some(true)
 }
 
-fn normalize_centaur_tool_arguments(arguments: Value) -> Result<Value, &'static str> {
+fn normalize_mcp_v1_tool_arguments(arguments: Value) -> Result<Value, &'static str> {
     if arguments.is_null() {
         return Ok(json!({}));
     }
@@ -810,14 +855,56 @@ fn json_type_name(value: &Value) -> &'static str {
     }
 }
 
-async fn run_tool_host_centaur_tool(
+// V1 calls Python client methods and requires JSON output.
+async fn run_mcp_v1_tool(
     runtime: SessionRuntime,
     principal: &McpPrincipal,
     tool: &DiscoveredTool,
-    method: &str,
+    method: String,
     arguments: Value,
     policy: ToolHostCallPolicy,
 ) -> Result<McpToolCallOutcome, ApiError> {
+    let output = run_mcp_tool_host(
+        runtime,
+        principal,
+        tool,
+        ToolHostInvocation::V1 {
+            method: method.clone(),
+            arguments,
+        },
+        policy,
+    )
+    .await?;
+    mcp_v1_output_result(tool, &method, output)
+}
+
+// V2 runs tool CLIs and preserves both output streams and exit status.
+async fn run_mcp_v2_tool(
+    runtime: SessionRuntime,
+    principal: &McpPrincipal,
+    tool: &DiscoveredTool,
+    argv: Vec<String>,
+    policy: ToolHostCallPolicy,
+) -> Result<McpToolCallOutcome, ApiError> {
+    let output = run_mcp_tool_host(
+        runtime,
+        principal,
+        tool,
+        ToolHostInvocation::V2 { argv },
+        policy,
+    )
+    .await?;
+    mcp_v2_run_output_result(output)
+}
+
+// Both MCP versions share principal-bound sandbox execution and tracing.
+async fn run_mcp_tool_host(
+    runtime: SessionRuntime,
+    principal: &McpPrincipal,
+    tool: &DiscoveredTool,
+    invocation: ToolHostInvocation,
+    policy: ToolHostCallPolicy,
+) -> Result<ToolHostCallOutput, ApiError> {
     let output = match runtime
         .run_tool_host_call(
             ToolHostCallInput {
@@ -826,8 +913,7 @@ async fn run_tool_host_centaur_tool(
                 console_user_name: principal.console_user_name.clone(),
                 token_id: Some(principal.token_id.clone()),
                 tool_name: tool.name.clone(),
-                method: method.to_owned(),
-                arguments,
+                invocation,
                 timeout: Duration::from_secs(120),
             },
             policy,
@@ -852,6 +938,14 @@ async fn run_tool_host_centaur_tool(
         Some(&output.execution_id),
         Some(&output.sandbox_id),
     );
+    Ok(output)
+}
+
+fn mcp_v1_output_result(
+    tool: &DiscoveredTool,
+    method: &str,
+    output: ToolHostCallOutput,
+) -> Result<McpToolCallOutcome, ApiError> {
     if output.timed_out {
         return Ok(McpToolCallOutcome {
             result: mcp_text_result(
@@ -911,6 +1005,22 @@ async fn run_tool_host_centaur_tool(
             timed_out: false,
         }),
     }
+}
+
+fn mcp_v2_run_output_result(output: ToolHostCallOutput) -> Result<McpToolCallOutcome, ApiError> {
+    let is_error = output.timed_out || output.exit_status != Some(0);
+    let content = json!({
+        "stdout": output.stdout,
+        "stderr": output.stderr,
+        "exit_status": output.exit_status,
+        "timed_out": output.timed_out,
+    });
+    let mut result = mcp_text_result(serde_json::to_string_pretty(&content)?, is_error);
+    result["structuredContent"] = content;
+    Ok(McpToolCallOutcome {
+        result,
+        timed_out: output.timed_out,
+    })
 }
 
 fn tool_host_error_context(output: &ToolHostCallOutput) -> String {
@@ -1414,7 +1524,7 @@ class DemoClient:
         )
         .unwrap();
 
-        let parsed = mcp_tool_methods(&test_tool(temp.clone()));
+        let parsed = mcp_v1_tool_methods(&test_tool(temp.clone()));
         let methods = parsed
             .iter()
             .map(|method| method.name.clone())
@@ -1521,8 +1631,7 @@ def search(query, limit=20):
 
         let tool = test_tool(temp.clone());
         let (result, method) = returned_tool_action(
-            prepare_mcp_centaur_tool_call(&tool, json!({"method": "missing", "arguments": {}}))
-                .unwrap(),
+            prepare_mcp_v1_tool_call(&tool, json!({"method": "missing", "arguments": {}})).unwrap(),
         );
 
         assert_eq!(method, None);
@@ -1542,8 +1651,7 @@ def search(query, limit=20):
 
         let tool = test_tool(temp.clone());
         let (result, method) = returned_tool_action(
-            prepare_mcp_centaur_tool_call(&tool, json!({"method": "missing", "arguments": {}}))
-                .unwrap(),
+            prepare_mcp_v1_tool_call(&tool, json!({"method": "missing", "arguments": {}})).unwrap(),
         );
 
         assert_eq!(method, None);
@@ -1569,7 +1677,7 @@ def search(query, limit=20):
 
         let tool = test_tool(temp.clone());
         let (result, method) = returned_tool_action(
-            prepare_mcp_centaur_tool_call(
+            prepare_mcp_v1_tool_call(
                 &tool,
                 json!({"method": "search", "arguments": ["not", "an", "object"]}),
             )
@@ -1588,15 +1696,15 @@ def search(query, limit=20):
     #[test]
     fn mcp_tool_arguments_default_to_empty_object() {
         assert_eq!(
-            normalize_centaur_tool_arguments(Value::Null).unwrap(),
+            normalize_mcp_v1_tool_arguments(Value::Null).unwrap(),
             json!({})
         );
         assert_eq!(
-            normalize_centaur_tool_arguments(json!({"query": "hello"})).unwrap(),
+            normalize_mcp_v1_tool_arguments(json!({"query": "hello"})).unwrap(),
             json!({"query": "hello"})
         );
         assert_eq!(
-            normalize_centaur_tool_arguments(json!(["not", "object"])).unwrap_err(),
+            normalize_mcp_v1_tool_arguments(json!(["not", "object"])).unwrap_err(),
             "array"
         );
     }
@@ -1928,7 +2036,7 @@ def search(query, limit=20):
             "TOOL_DIRS",
             Box::leak(temp.display().to_string().into_boxed_str()),
         )]);
-        let result = mcp_service_list_result(&SandboxToolFilter::default()).unwrap();
+        let result = mcp_v2_service_list_result(&SandboxToolFilter::default()).unwrap();
         let expected = json!({"services": [
             {"name": "alpha", "description": "alpha service"},
             {"name": "beta", "description": "beta service"},
@@ -1938,7 +2046,8 @@ def search(query, limit=20):
         let text: Value =
             serde_json::from_str(result["content"][0]["text"].as_str().unwrap()).unwrap();
         assert_eq!(text, expected);
-        let search = mcp_service_search_result(&SandboxToolFilter::default(), "service").unwrap();
+        let search =
+            mcp_v2_service_search_result(&SandboxToolFilter::default(), "service").unwrap();
         assert_eq!(search["structuredContent"], expected);
         assert!(!mcp_result_is_error(&search));
         let text: Value =
@@ -1950,15 +2059,15 @@ def search(query, limit=20):
             blocklist: BTreeSet::new(),
         };
         assert_eq!(
-            mcp_service_list_result(&filter).unwrap()["structuredContent"],
+            mcp_v2_service_list_result(&filter).unwrap()["structuredContent"],
             json!({"services": [{"name": "alpha", "description": "alpha service"}]})
         );
         assert_eq!(
-            mcp_service_search_result(&filter, "service").unwrap()["structuredContent"],
+            mcp_v2_service_search_result(&filter, "service").unwrap()["structuredContent"],
             json!({"services": [{"name": "alpha", "description": "alpha service"}]})
         );
         assert_eq!(
-            mcp_service_search_result(&filter, "beta").unwrap()["structuredContent"],
+            mcp_v2_service_search_result(&filter, "beta").unwrap()["structuredContent"],
             json!({"services": []})
         );
         assert!(mcp_find_centaur_tool("alpha", &filter).unwrap().is_some());
@@ -1966,11 +2075,11 @@ def search(query, limit=20):
         filter.blocklist.insert("alpha".to_owned());
         assert!(mcp_find_centaur_tool("alpha", &filter).unwrap().is_none());
         assert_eq!(
-            mcp_service_list_result(&filter).unwrap()["structuredContent"],
+            mcp_v2_service_list_result(&filter).unwrap()["structuredContent"],
             json!({"services": []})
         );
         assert_eq!(
-            mcp_service_search_result(&filter, "alpha").unwrap()["structuredContent"],
+            mcp_v2_service_search_result(&filter, "alpha").unwrap()["structuredContent"],
             json!({"services": []})
         );
         fs::remove_dir_all(temp).unwrap();
@@ -1987,7 +2096,7 @@ def search(query, limit=20):
         )]);
         let filter = SandboxToolFilter::default();
         assert_eq!(
-            mcp_service_list_result(&filter).unwrap()["structuredContent"],
+            mcp_v2_service_list_result(&filter).unwrap()["structuredContent"],
             json!({"services": []})
         );
         let package_dir = temp.join("demo");
@@ -1998,20 +2107,20 @@ def search(query, limit=20):
         )
         .unwrap();
         assert_eq!(
-            mcp_service_list_result(&filter).unwrap()["structuredContent"],
+            mcp_v2_service_list_result(&filter).unwrap()["structuredContent"],
             json!({"services": [{"name": "demo", "description": null}]})
         );
         assert_eq!(
-            mcp_service_search_result(&filter, "demo").unwrap()["structuredContent"],
+            mcp_v2_service_search_result(&filter, "demo").unwrap()["structuredContent"],
             json!({"services": [{"name": "demo", "description": null}]})
         );
         fs::remove_dir_all(package_dir).unwrap();
         assert_eq!(
-            mcp_service_search_result(&filter, "demo").unwrap()["structuredContent"],
+            mcp_v2_service_search_result(&filter, "demo").unwrap()["structuredContent"],
             json!({"services": []})
         );
         assert_eq!(
-            mcp_service_list_result(&filter).unwrap()["structuredContent"],
+            mcp_v2_service_list_result(&filter).unwrap()["structuredContent"],
             json!({"services": []})
         );
         fs::remove_dir_all(temp).unwrap();
@@ -2044,12 +2153,16 @@ def search(query, limit=20):
             json!({"command": ["search", "slack", "messages"]}),
             json!({"command": ["search", ""]}),
             json!({"command": ["search", " \n\t "]}),
+            json!({"command": ["run"]}),
+            json!({"command": ["run", " \t"]}),
+            json!({"command": ["run", "slack", "nul\0byte"]}),
             json!({"command": ["service", "nul\0byte"]}),
         ] {
-            let result = mcp_dispatcher_result(&state, &principal, arguments.clone())
+            let result = mcp_v2_command_result(&state, &principal, arguments.clone())
                 .now_or_never()
                 .unwrap()
-                .unwrap();
+                .unwrap()
+                .result;
             assert!(mcp_result_is_error(&result), "arguments: {arguments}");
             assert!(
                 result["content"][0]["text"]
@@ -2063,7 +2176,7 @@ def search(query, limit=20):
     #[test]
     fn centaur_commands_parse_discovery_and_preserve_query_text() {
         assert_eq!(
-            parse_centaur_command(json!({"command": ["list"]})).unwrap(),
+            parse_mcp_v2_command(json!({"command": ["list"]})).unwrap(),
             CentaurMcpCommand::List
         );
         for query in [
@@ -2073,8 +2186,70 @@ def search(query, limit=20):
             "company_context",
         ] {
             assert_eq!(
-                parse_centaur_command(json!({"command": ["search", query]})).unwrap(),
+                parse_mcp_v2_command(json!({"command": ["search", query]})).unwrap(),
                 CentaurMcpCommand::Search(query.to_owned()),
+            );
+        }
+    }
+
+    #[test]
+    fn centaur_run_preserves_cli_arguments() {
+        for argv in [
+            vec![],
+            vec!["--help"],
+            vec![
+                "search",
+                "  café messages  ",
+                "",
+                "--limit",
+                "2",
+                "$(echo literal)",
+                "|",
+                ">",
+            ],
+        ] {
+            let mut command = vec!["run", "slack"];
+            command.extend(&argv);
+            assert_eq!(
+                parse_mcp_v2_command(json!({"command": command})).unwrap(),
+                CentaurMcpCommand::Run {
+                    tool: "slack".to_owned(),
+                    argv: argv.into_iter().map(str::to_owned).collect(),
+                },
+            );
+        }
+    }
+
+    #[test]
+    fn mcp_cli_output_preserves_streams_and_reports_exit_and_timeout() {
+        for (stdout, stderr, exit_status, timed_out, is_error) in [
+            ("Usage: demo [OPTIONS]\n", "", Some(0), false, false),
+            ("{\"ok\":true}\n", "warning\n", Some(0), false, false),
+            ("", "", Some(0), false, false),
+            ("partial\n", "invalid option\n", Some(2), false, true),
+            ("partial\n", "timed out\n", None, true, true),
+            ("", "terminated\n", None, false, true),
+        ] {
+            let outcome = mcp_v2_run_output_result(ToolHostCallOutput {
+                request_id: "request".to_owned(),
+                execution_id: "execution".to_owned(),
+                sandbox_id: "sandbox".to_owned(),
+                stdout: stdout.to_owned(),
+                stderr: stderr.to_owned(),
+                exit_status,
+                timed_out,
+            })
+            .unwrap();
+            assert_eq!(outcome.timed_out, timed_out);
+            assert_eq!(mcp_result_is_error(&outcome.result), is_error);
+            let expected = json!({"stdout": stdout, "stderr": stderr, "exit_status": exit_status, "timed_out": timed_out});
+            assert_eq!(outcome.result["structuredContent"], expected);
+            assert_eq!(
+                serde_json::from_str::<Value>(
+                    outcome.result["content"][0]["text"].as_str().unwrap()
+                )
+                .unwrap(),
+                expected
             );
         }
     }

--- a/services/api-rs/crates/centaur-session-runtime/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-runtime/src/lib.rs
@@ -386,9 +386,26 @@ pub struct ToolHostCallInput {
     pub console_user_name: Option<String>,
     pub token_id: Option<String>,
     pub tool_name: String,
-    pub method: String,
-    pub arguments: Value,
+    pub invocation: ToolHostInvocation,
     pub timeout: Duration,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(tag = "mode", rename_all = "snake_case")]
+pub enum ToolHostInvocation {
+    /// Invoke a Python client method through `centaur-tools call`.
+    V1 { method: String, arguments: Value },
+    /// Run a tool CLI through `centaur-tools run`.
+    V2 { argv: Vec<String> },
+}
+
+impl ToolHostInvocation {
+    fn method(&self) -> &str {
+        match self {
+            Self::V1 { method, .. } => method,
+            Self::V2 { .. } => "cli",
+        }
+    }
 }
 
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
@@ -511,8 +528,8 @@ struct SessionPipe {
 struct ToolHostRequest {
     id: String,
     tool: String,
-    method: String,
-    arguments: Value,
+    #[serde(flatten)]
+    invocation: ToolHostInvocation,
     principal_id: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     token_id: Option<String>,
@@ -1022,7 +1039,21 @@ impl SessionRuntime {
     ) -> Result<ToolHostCallOutput, ToolHostCallError> {
         let principal_id = input.principal_id.trim().to_owned();
         let tool_name = input.tool_name.trim().to_owned();
-        let method = input.method.trim().to_owned();
+        let invocation = match input.invocation {
+            ToolHostInvocation::V1 { method, arguments } => ToolHostInvocation::V1 {
+                method: method.trim().to_owned(),
+                arguments,
+            },
+            ToolHostInvocation::V2 { argv } => {
+                if argv.iter().any(|arg| arg.contains('\0')) {
+                    return Err(SessionRuntimeError::BadRequest(
+                        "tool host argv must not contain NUL characters".to_owned(),
+                    )
+                    .into());
+                }
+                ToolHostInvocation::V2 { argv }
+            }
+        };
         if principal_id.is_empty() {
             return Err(SessionRuntimeError::BadRequest(
                 "tool host principal_id is required".to_owned(),
@@ -1035,7 +1066,7 @@ impl SessionRuntime {
             )
             .into());
         }
-        if method.is_empty() {
+        if invocation.method().is_empty() {
             return Err(
                 SessionRuntimeError::BadRequest("tool host method is required".to_owned()).into(),
             );
@@ -1057,7 +1088,7 @@ impl SessionRuntime {
         let input = ToolHostCallInput {
             principal_id,
             tool_name,
-            method,
+            invocation,
             ..input
         };
         let call_lock = self.tool_host_call_lock(&thread_key);
@@ -1124,8 +1155,7 @@ impl SessionRuntime {
             console_user_name,
             token_id,
             tool_name,
-            method,
-            arguments,
+            invocation,
             timeout,
         } = input;
         self.create_or_get_tool_host_session(
@@ -1137,11 +1167,11 @@ impl SessionRuntime {
         .await?;
 
         let request_id = format!("mcp-call-{}", Uuid::new_v4().simple());
+        let method = invocation.method().to_owned();
         let request = ToolHostRequest {
             id: request_id.clone(),
             tool: tool_name.clone(),
-            method: method.clone(),
-            arguments,
+            invocation,
             principal_id,
             token_id,
             timeout_seconds: timeout.as_secs().max(1),
@@ -7505,6 +7535,35 @@ mod tests {
                 .unwrap()
                 .persona_id,
             "public"
+        );
+    }
+
+    #[test]
+    fn tool_host_request_serializes_cli_arguments() {
+        let request = ToolHostRequest {
+            id: "request".to_owned(),
+            tool: "demo".to_owned(),
+            invocation: ToolHostInvocation::V2 {
+                argv: vec![
+                    "search".to_owned(),
+                    " spaced query ".to_owned(),
+                    String::new(),
+                ],
+            },
+            principal_id: "prn_test".to_owned(),
+            token_id: None,
+            timeout_seconds: 120,
+        };
+        assert_eq!(
+            serde_json::to_value(request).unwrap(),
+            serde_json::json!({
+                "id": "request",
+                "tool": "demo",
+                "mode": "v2",
+                "argv": ["search", " spaced query ", ""],
+                "principal_id": "prn_test",
+                "timeout_seconds": 120,
+            })
         );
     }
 

--- a/services/sandbox/centaur_tool_host.py
+++ b/services/sandbox/centaur_tool_host.py
@@ -17,11 +17,45 @@ def _text(value: Any) -> str:
     return str(value)
 
 
+def _v1_call_command(request: dict[str, Any]) -> list[str]:
+    """V1 invokes a Python client method with JSON keyword arguments."""
+    return [
+        "centaur-tools",
+        "call",
+        str(request["tool"]),
+        str(request["method"]),
+        json.dumps(request.get("arguments", {}), separators=(",", ":")),
+    ]
+
+
+def _v2_run_command(request: dict[str, Any]) -> list[str]:
+    """V2 invokes the tool CLI with literal argv tokens."""
+    argv = request["argv"]
+    if not isinstance(argv, list):
+        raise TypeError("tool argv must be an array of strings")
+    for arg in argv:
+        if not isinstance(arg, str):
+            raise TypeError("each tool argv token must be a string")
+        if "\0" in arg:
+            raise ValueError("tool argv tokens must not contain NUL characters")
+    return ["centaur-tools", "run", str(request["tool"]), *argv]
+
+
+def _command_for_request(request: dict[str, Any]) -> list[str]:
+    # V1 requests predate the mode field and invoke Python client methods.
+    mode = request.get("mode", "v1")
+    match mode:
+        case "v1":
+            return _v1_call_command(request)
+        case "v2":
+            return _v2_run_command(request)
+        case _:
+            raise ValueError(f"unsupported tool host mode: {mode}")
+
+
 def _run_tool(request: dict[str, Any]) -> dict[str, Any]:
     request_id = request.get("id")
-    tool = request["tool"]
-    method = request["method"]
-    arguments = request.get("arguments", {})
+    command = _command_for_request(request)
     timeout_seconds = max(1, int(request.get("timeout_seconds") or 120))
 
     env = os.environ.copy()
@@ -34,13 +68,7 @@ def _run_tool(request: dict[str, Any]) -> dict[str, Any]:
 
     try:
         completed = subprocess.run(
-            [
-                "centaur-tools",
-                "call",
-                str(tool),
-                str(method),
-                json.dumps(arguments, separators=(",", ":")),
-            ],
+            command,
             check=False,
             text=True,
             capture_output=True,

--- a/services/sandbox/test_centaur_tool_host.py
+++ b/services/sandbox/test_centaur_tool_host.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+import install_tool_shims
+
+
+class ToolHostTest(unittest.TestCase):
+    """Exercise the host, generated catalog, and a real installed CLI together."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.temp = tempfile.TemporaryDirectory()
+        cls.root = Path(cls.temp.name)
+        cls.bin_dir = cls.root / "bin"
+        cls.bin_dir.mkdir()
+        project = cls.root / "demo"
+        package = project / "demo"
+        package.mkdir(parents=True)
+        (package / "__init__.py").write_text("")
+        (project / "pyproject.toml").write_text(
+            '[project]\nname = "centaur-host-test-demo"\nversion = "0.0.1"\n'
+            '[project.scripts]\ndemo = "demo.cli:main"\n'
+            '[build-system]\nrequires = ["hatchling"]\n'
+            'build-backend = "hatchling.build"\n'
+            '[tool.hatch.build.targets.wheel]\npackages = ["demo"]\n'
+        )
+        (package / "cli.py").write_text(
+            "import json, os, sys, time\n"
+            "def main():\n"
+            "    args = sys.argv[1:]\n"
+            "    if args == ['--help']:\n"
+            "        print('Usage: demo [ARGS]')\n"
+            "    elif args == ['fail']:\n"
+            "        print('partial output')\n"
+            "        print('invalid arguments', file=sys.stderr)\n"
+            "        return 2\n"
+            "    elif args == ['sleep']:\n"
+            "        print('started', flush=True)\n"
+            "        time.sleep(2)\n"
+            "    else:\n"
+            "        print(json.dumps({'argv': args, 'principal': os.environ.get('CENTAUR_MCP_PRINCIPAL_ID')}))\n"
+        )
+        index = cls.bin_dir / ".centaur-tools.json"
+        index.write_text(
+            json.dumps(
+                [
+                    {
+                        "name": "demo",
+                        "project_dir": str(project),
+                        "package": "centaur-host-test-demo",
+                        "entrypoint": "demo.cli:main",
+                        "client_module": "client.py",
+                    }
+                ]
+            )
+        )
+        install_tool_shims._write_catalog(
+            cls.bin_dir / "centaur-tools",
+            index,
+            "",
+        )
+        cls.env = {
+            **os.environ,
+            "PATH": f"{cls.bin_dir}{os.pathsep}{os.environ.get('PATH', '')}",
+            "CENTAUR_TOOL_ANALYTICS_LOG_PATH": str(cls.root / "analytics.jsonl"),
+        }
+        # Install once before exercising the host's execution timeout.
+        subprocess.run(
+            [str(cls.bin_dir / "centaur-tools"), "run", "demo", "--help"],
+            env=cls.env,
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        cls.temp.cleanup()
+
+    def requests(self, *requests: dict) -> list[dict]:
+        result = subprocess.run(
+            [sys.executable, str(Path(__file__).with_name("centaur_tool_host.py"))],
+            input="".join(json.dumps(request) + "\n" for request in requests),
+            env=self.env,
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+        ready, *events = result.stdout.splitlines()
+        self.assertEqual(ready, "__CENTAUR_TOOL_HOST_READY")
+        self.assertEqual(len(events), len(requests))
+        responses = []
+        for request, event in zip(requests, events, strict=True):
+            envelope = json.loads(event)
+            self.assertEqual(envelope["type"], "result")
+            self.assertEqual(envelope["turn_id"], request["id"])
+            responses.append(json.loads(envelope["result"]))
+        return responses
+
+    def run_request(self, argv: list[str], **kwargs) -> dict:
+        return {"id": "test", "mode": "v2", "tool": "demo", "argv": argv, **kwargs}
+
+    def test_cli_preserves_literal_arguments_and_principal(self) -> None:
+        sentinel = self.root / "shell-ran"
+        argv = [
+            "search",
+            "  café messages  ",
+            "",
+            "--limit",
+            "2",
+            f"$(touch {sentinel})",
+            ";",
+            "|",
+            ">",
+        ]
+        (response,) = self.requests(self.run_request(argv, principal_id="prn_test"))
+        self.assertEqual(response["status"], 0, response["stderr"])
+        self.assertEqual(
+            json.loads(response["stdout"]), {"argv": argv, "principal": "prn_test"}
+        )
+        self.assertFalse(response["timed_out"])
+        self.assertFalse(sentinel.exists())
+
+    def test_cli_help_no_args_failure_and_recovery(self) -> None:
+        help_result, empty, failure, recovery = self.requests(
+            self.run_request(["--help"]),
+            self.run_request([]),
+            self.run_request(["fail"]),
+            self.run_request(["--help"]),
+        )
+        self.assertEqual(help_result["status"], 0)
+        self.assertEqual(help_result["stdout"], "Usage: demo [ARGS]\n")
+        self.assertEqual(json.loads(empty["stdout"])["argv"], [])
+        self.assertEqual(failure["status"], 2)
+        self.assertEqual(failure["stdout"], "partial output\n")
+        self.assertEqual(failure["stderr"], "invalid arguments\n")
+        self.assertFalse(failure["timed_out"])
+        self.assertEqual(recovery["stdout"], help_result["stdout"])
+
+    def test_cli_timeout_preserves_partial_output(self) -> None:
+        (response,) = self.requests(self.run_request(["sleep"], timeout_seconds=1))
+        self.assertTrue(response["timed_out"])
+        self.assertIsNone(response["status"])
+        self.assertIn("started\n", response["stdout"])
+        self.assertIn("timed out after 1s", response["stderr"])
+
+    def test_catalog_rejects_unknown_tools_even_when_executable_exists(self) -> None:
+        (response,) = self.requests(self.run_request([], tool="python3"))
+        self.assertNotEqual(response["status"], 0)
+        self.assertIn("unknown tool: python3", response["stderr"])
+
+    def test_invalid_requests_fail_and_host_accepts_next_request(self) -> None:
+        for invalid in [
+            self.run_request("--help"),
+            self.run_request([1]),
+            self.run_request(["nul\0byte"]),
+            self.run_request([], mode="unknown"),
+        ]:
+            with self.subTest(request=invalid):
+                failure, recovery = self.requests(invalid, self.run_request(["--help"]))
+                self.assertEqual(failure["status"], 1)
+                self.assertEqual(recovery["status"], 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/services/sandbox/test_centaur_tool_host.py
+++ b/services/sandbox/test_centaur_tool_host.py
@@ -17,6 +17,7 @@ class ToolHostTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
         cls.temp = tempfile.TemporaryDirectory()
+        cls.addClassCleanup(cls.temp.cleanup)
         cls.root = Path(cls.temp.name)
         cls.bin_dir = cls.root / "bin"
         cls.bin_dir.mkdir()
@@ -72,20 +73,23 @@ class ToolHostTest(unittest.TestCase):
             "CENTAUR_TOOL_ANALYTICS_LOG_PATH": str(cls.root / "analytics.jsonl"),
         }
         # Install once before exercising the host's execution timeout.
-        subprocess.run(
+        install = subprocess.run(
             [str(cls.bin_dir / "centaur-tools"), "run", "demo", "--help"],
             env=cls.env,
-            check=True,
+            check=False,
             capture_output=True,
             text=True,
             timeout=60,
         )
-
-    @classmethod
-    def tearDownClass(cls) -> None:
-        cls.temp.cleanup()
+        if install.returncode != 0:
+            raise RuntimeError(
+                f"could not install test CLI:\n{install.stdout}{install.stderr}"
+            )
 
     def requests(self, *requests: dict) -> list[dict]:
+        requests = tuple(
+            {**request, "id": f"test-{index}"} for index, request in enumerate(requests)
+        )
         result = subprocess.run(
             [sys.executable, str(Path(__file__).with_name("centaur_tool_host.py"))],
             input="".join(json.dumps(request) + "\n" for request in requests),
@@ -103,7 +107,9 @@ class ToolHostTest(unittest.TestCase):
             envelope = json.loads(event)
             self.assertEqual(envelope["type"], "result")
             self.assertEqual(envelope["turn_id"], request["id"])
-            responses.append(json.loads(envelope["result"]))
+            response = json.loads(envelope["result"])
+            self.assertEqual(response["id"], request["id"])
+            responses.append(response)
         return responses
 
     def run_request(self, argv: list[str], **kwargs) -> dict:


### PR DESCRIPTION
Adds `centaur run <tool> <argv>` to the v2 MCP dispatcher, executing catalog-approved CLIs through the principal’s sandbox and returning stdout, stderr, exit status, and timeout status. Separates v1 method calls from v2 CLI execution with explicit protocol modes, preserves existing struct names, and adds focused CLI coverage and usage examples.

Rust library tests, Clippy, and the focused sandbox tests pass. Full-stack validation is pending because no Kubernetes context is configured; the broader sandbox suite also encounters four unrelated protected-branch hook failures in Git test fixtures. Rollout requires the updated API and sandbox images and recreation of existing tool-host sandboxes.
