### PR TITLE
fix: retain workflow execution startup after cancellation

### DIFF
--- a/services/api-rs/crates/centaur-workflows/src/lib.rs
+++ b/services/api-rs/crates/centaur-workflows/src/lib.rs
@@ -4318,8 +4318,11 @@ async fn run_agent_session_turn(
             }],
         )
         .await?;
+    // The workflow waiter can be dropped on cancellation. Hand startup to the
+    // durable session driver so dropping it cannot strand a running execution
+    // before sandbox binding or the execution deadline has been installed.
     let execution = session_runtime
-        .execute_session(
+        .enqueue_session_execution(
             &thread_key,
             ExecuteSessionInput {
                 idempotency_key: Some(execution_idempotency_key),


### PR DESCRIPTION
Cancelling a Python workflow while `ctx.agent_turn` is starting an explicit session can drop the inline `execute_session` future after the execution becomes running but before sandbox binding and deadline installation. That leaves an execution without the machinery that would finish or time it out.

Use the existing durable session enqueue operation. The session driver owns startup, and the workflow continues to observe the same execution through its replayable event stream. This introduces no new task or cancellation state.

Validation:

- API workspace formatting and Clippy with warnings denied passed.
- Ran the API workspace tests against disposable PostgreSQL databases. Three existing `centaur-session-runtime` EOF recovery tests time out, including when run alone; that crate is unchanged by this patch. The workflow tests and the other workspace packages passed. Absurd SDK tests passed after separating their database and waiting for TCP readiness.
- The downstream Docker product suite passed all 11 scenarios, including cancellation during startup, deadline failure, retained files, and terminal credential revocation.
- Built the API image with the repository Dockerfile and deployed it to a local Kind namespace. A stock Python workflow with dataclass input and `WorkflowContext` completed. A second workflow was cancelled while its execution was running with no sandbox bound; the native driver subsequently bound the sandbox and produced `session.execution_failed` at its configured duration limit. Harness protocol and credential authority were deterministic fixtures; the API, workflow host, PostgreSQL and Kubernetes sandbox controller were real.
