### PR TITLE
fix: allow docs creation without a Slack channel

### DIFF
--- a/tools/productivity/gsuite/cli.py
+++ b/tools/productivity/gsuite/cli.py
@@ -1510,7 +1510,9 @@ def _get_channel_member_emails_via_cli(channel: str) -> list[str]:
 @docs_app.command("create")
 def docs_create_cmd(
     title: str = typer.Argument(..., help="Document title"),
-    channel: str = typer.Option(..., "--channel", help="Slack channel to share with (required)"),
+    channel: str | None = typer.Option(
+        None, "--channel", help="Optional Slack channel to share with"
+    ),
     owner: str = typer.Option(..., "--owner", help="Email of new owner (required)"),
     content: str = typer.Option(None, "--content", "-c", help="Initial content"),
 ):
@@ -1518,7 +1520,7 @@ def docs_create_cmd(
 
     This command:
     1. Creates the document
-    2. Shares with all channel members (writer role)
+    2. Shares with all channel members when --channel is provided (writer role)
     3. Transfers ownership to the specified owner
 
     The original owner (service account) is automatically downgraded to editor
@@ -1526,6 +1528,7 @@ def docs_create_cmd(
     removes the service account's editor role permissions after 7 days.
 
     Examples:
+        gsuite docs create "Personal Notes" --owner alice@paradigm.xyz
         gsuite docs create "Meeting Notes" --channel eng-ai --owner alice@paradigm.xyz
         gsuite docs create "Doc Title" --channel ai-agent --owner bob@paradigm.xyz --content "Hello"
     """
@@ -1537,8 +1540,11 @@ def docs_create_cmd(
         console.print(f"[cyan]URL: {result['url']}[/]", soft_wrap=True)
         console.print(f"[dim]ID: {result['document_id']}[/]")
 
-        member_emails = _get_channel_member_emails_via_cli(channel)
-        console.print(f"[dim]Setting up permissions for {len(member_emails)} channel members...[/]")
+        member_emails = _get_channel_member_emails_via_cli(channel) if channel else []
+        if channel:
+            console.print(
+                f"[dim]Setting up permissions for {len(member_emails)} channel members...[/]"
+            )
 
         perm_result = drive_setup_channel_permissions(
             file_id=result["document_id"],
@@ -1546,7 +1552,10 @@ def docs_create_cmd(
             requester_email=owner,
         )
 
-        console.print(f"[green]✓ Shared with {len(perm_result['shared_with'])} channel members[/]")
+        if channel:
+            console.print(
+                f"[green]✓ Shared with {len(perm_result['shared_with'])} channel members[/]"
+            )
         console.print(f"[green]✓ Ownership transferred to {owner}[/]")
 
     except Exception as e:

--- a/tools/productivity/gsuite/test_cli.py
+++ b/tools/productivity/gsuite/test_cli.py
@@ -120,6 +120,44 @@ def test_extract_drive_file_id_accepts_editor_and_drive_urls():
     assert extract_drive_file_id("raw-file-id") == "raw-file-id"
 
 
+def test_docs_create_allows_omitting_channel(monkeypatch):
+    permission_calls: list[dict] = []
+    monkeypatch.setattr(
+        client,
+        "docs_create",
+        lambda title, content: {
+            "document_id": "doc-123",
+            "title": title,
+            "url": "https://docs.google.com/document/d/doc-123/edit",
+        },
+    )
+    monkeypatch.setattr(
+        client,
+        "drive_setup_channel_permissions",
+        lambda **kwargs: (
+            permission_calls.append(kwargs)
+            or {"shared_with": [], "new_owner": kwargs["requester_email"]}
+        ),
+    )
+
+    result = runner.invoke(
+        app,
+        ["docs", "create", "Personal Notes", "--owner", "alice@example.com"],
+    )
+
+    assert result.exit_code == 0
+    assert permission_calls == [
+        {
+            "file_id": "doc-123",
+            "channel_member_emails": [],
+            "requester_email": "alice@example.com",
+        }
+    ]
+    assert "Created document: Personal Notes" in result.output
+    assert "Shared with" not in result.output
+    assert "Ownership transferred to alice@example.com" in result.output
+
+
 def test_drive_list_full_text_flag_is_passed_to_client(monkeypatch):
     calls: list[dict] = []
 


### PR DESCRIPTION
Makes `--channel` optional for `gsuite docs create`. When omitted, Slack member lookup and sharing are skipped while ownership still transfers to the required `--owner`. Adds regression coverage for the no-channel path.