### PR TITLE
feat: add MCP sandbox artifact retrieval

### DIFF
--- a/services/api-rs/Cargo.lock
+++ b/services/api-rs/Cargo.lock
@@ -1067,7 +1067,6 @@ name = "centaur-session-runtime"
 version = "0.1.0"
 dependencies = [
  "async-trait",
- "base64 0.23.1",
  "centaur-iron-control",
  "centaur-sandbox-core",
  "centaur-sandbox-manager",

--- a/services/api-rs/Cargo.lock
+++ b/services/api-rs/Cargo.lock
@@ -1067,6 +1067,7 @@ name = "centaur-session-runtime"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "base64 0.23.1",
  "centaur-iron-control",
  "centaur-sandbox-core",
  "centaur-sandbox-manager",

--- a/services/api-rs/crates/centaur-api-server/src/args.rs
+++ b/services/api-rs/crates/centaur-api-server/src/args.rs
@@ -866,10 +866,10 @@ impl SandboxArgs {
                 self.local_workload_mode()?,
             )),
             SandboxBackendKind::AgentK8s => {
-                let backend = AgentSandboxBackend::new(
+                let backend = Arc::new(AgentSandboxBackend::new(
                     self.kube_client().await?,
                     AgentSandboxConfig::try_from(self)?,
-                );
+                ));
                 let stopped = backend.drain_service_account_mismatches().await?;
                 if !stopped.is_empty() {
                     info!(
@@ -877,10 +877,14 @@ impl SandboxArgs {
                         "drained sandboxes with stale service accounts before enabling reuse"
                     );
                 }
-                Ok(SandboxRuntime::backend_with_workload(
-                    Arc::new(backend),
-                    self.container_workload_mode()?,
-                ))
+                let artifact_backend = backend.clone();
+                Ok(
+                    SandboxRuntime::backend_with_workload(backend, self.container_workload_mode()?)
+                        .with_artifact_reader(move |id, path| {
+                            let backend = artifact_backend.clone();
+                            async move { backend.read_artifact(&id, &path).await }
+                        }),
+                )
             }
         }
     }

--- a/services/api-rs/crates/centaur-api-server/src/mcp.rs
+++ b/services/api-rs/crates/centaur-api-server/src/mcp.rs
@@ -855,7 +855,7 @@ async fn mcp_artifact_get_result(
     record_mcp_tool_method(&Span::current(), "centaur_artifact_get", "get");
     let output = state
         .runtime()?
-        .read_tool_host_file(&principal.principal_id, &args.path, MCP_ARTIFACT_MAX_BYTES)
+        .read_sandbox_artifact(&principal.principal_id, &args.path, MCP_ARTIFACT_MAX_BYTES)
         .await?;
     record_mcp_tool_correlation(&Span::current(), None, None, Some(&output.sandbox_id));
     mcp_artifact_get_output_result(&args.path, output.contents)

--- a/services/api-rs/crates/centaur-api-server/src/mcp.rs
+++ b/services/api-rs/crates/centaur-api-server/src/mcp.rs
@@ -104,11 +104,11 @@ struct CentaurToolCallArguments {
 
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
-struct CentaurDownloadFileArguments {
+struct CentaurArtifactGetArguments {
     filename: String,
 }
 
-const MCP_DOWNLOAD_MAX_BYTES: usize = 10 * 1024 * 1024;
+const MCP_ARTIFACT_MAX_BYTES: usize = 10 * 1024 * 1024;
 
 struct McpToolCallOutcome {
     result: Value,
@@ -230,8 +230,8 @@ async fn mcp_tool_call_result(
                 "centaur_tool_call" => {
                     mcp_v2_tool_call_result(state, principal, params.arguments).await
                 }
-                "centaur_download_file" => {
-                    mcp_download_file_result(state, principal, params.arguments).await
+                "centaur_artifact_get" => {
+                    mcp_artifact_get_result(state, principal, params.arguments).await
                 }
                 "centaur_whoami" => mcp_whoami_result(principal, params.arguments).map(|result| {
                     McpToolCallOutcome {
@@ -323,9 +323,9 @@ fn mcp_whoami_tool() -> Value {
     })
 }
 
-fn mcp_download_file_tool() -> Value {
+fn mcp_artifact_get_tool() -> Value {
     json!({
-        "name": "centaur_download_file",
+        "name": "centaur_artifact_get",
         "description": concat!(
             "Download a file created by a Centaur tool in the sandbox. The file must be a regular, ",
             "non-symlink direct child of /tmp/downloads and no larger than 10 MiB. Pass only its ",
@@ -384,7 +384,7 @@ fn mcp_builtin_tools() -> Vec<Value> {
     if mcp_v2_enabled() {
         tools.extend(mcp_v2_tools());
     }
-    tools.push(mcp_download_file_tool());
+    tools.push(mcp_artifact_get_tool());
     tools.push(mcp_whoami_tool());
     tools
 }
@@ -405,7 +405,7 @@ fn mcp_v2_tool_name(name: &str) -> bool {
 }
 
 fn mcp_builtin_tool_name(name: &str) -> bool {
-    mcp_v2_tool_name(name) || matches!(name, "centaur_download_file" | "centaur_whoami")
+    mcp_v2_tool_name(name) || matches!(name, "centaur_artifact_get" | "centaur_whoami")
 }
 
 fn mcp_v2_tools() -> Vec<Value> {
@@ -841,27 +841,27 @@ fn mcp_whoami_result(principal: &McpPrincipal, arguments: Value) -> Result<Value
     ))
 }
 
-async fn mcp_download_file_result(
+async fn mcp_artifact_get_result(
     state: &AppState,
     principal: &McpPrincipal,
     arguments: Value,
 ) -> Result<McpToolCallOutcome, ApiError> {
-    let args = match serde_json::from_value::<CentaurDownloadFileArguments>(arguments) {
+    let args = match serde_json::from_value::<CentaurArtifactGetArguments>(arguments) {
         Ok(args) if !args.filename.trim().is_empty() => args,
         Ok(_) => return Ok(invalid_mcp_v2_arguments("filename must not be blank")),
         Err(error) => return Ok(invalid_mcp_v2_arguments(error)),
     };
-    record_mcp_tool_method(&Span::current(), "centaur_download_file", "download");
+    record_mcp_tool_method(&Span::current(), "centaur_artifact_get", "get");
     let output = state
         .runtime()?
         .read_tool_host_file(
             &principal.principal_id,
             &args.filename,
-            MCP_DOWNLOAD_MAX_BYTES,
+            MCP_ARTIFACT_MAX_BYTES,
         )
         .await?;
     record_mcp_tool_correlation(&Span::current(), None, None, Some(&output.sandbox_id));
-    mcp_download_file_output_result(&args.filename, output.contents)
+    mcp_artifact_get_output_result(&args.filename, output.contents)
 }
 
 async fn mcp_v1_tool_result(
@@ -1175,7 +1175,7 @@ fn mcp_v2_load_output_result(
     })
 }
 
-fn mcp_download_file_output_result(
+fn mcp_artifact_get_output_result(
     filename: &str,
     contents: Vec<u8>,
 ) -> Result<McpToolCallOutcome, ApiError> {
@@ -2164,11 +2164,11 @@ def search(query, limit=20):
                         "centaur_catalog_search",
                         "centaur_catalog_load",
                         "centaur_tool_call",
-                        "centaur_download_file",
+                        "centaur_artifact_get",
                         "centaur_whoami",
                     ]
                 } else {
-                    vec!["centaur_download_file", "centaur_whoami"]
+                    vec!["centaur_artifact_get", "centaur_whoami"]
                 }
             );
 
@@ -2250,7 +2250,7 @@ def search(query, limit=20):
                 .collect::<Vec<_>>();
             assert_eq!(
                 names,
-                vec!["centaur_download_file", "centaur_whoami", "demo"]
+                vec!["centaur_artifact_get", "centaur_whoami", "demo"]
             );
         }
 
@@ -2265,7 +2265,7 @@ def search(query, limit=20):
                 "centaur_catalog_search",
                 "centaur_catalog_load",
                 "centaur_tool_call",
-                "centaur_download_file",
+                "centaur_artifact_get",
                 "centaur_whoami",
             ]
         );
@@ -2470,10 +2470,10 @@ def search(query, limit=20):
     }
 
     #[test]
-    fn mcp_download_file_returns_an_embedded_resource() {
+    fn mcp_artifact_get_returns_an_embedded_resource() {
         let contents = b"sandbox report\n";
         let outcome =
-            mcp_download_file_output_result("quarterly report.txt", contents.to_vec()).unwrap();
+            mcp_artifact_get_output_result("quarterly report.txt", contents.to_vec()).unwrap();
 
         assert!(!mcp_result_is_error(&outcome.result));
         assert_eq!(

--- a/services/api-rs/crates/centaur-api-server/src/mcp.rs
+++ b/services/api-rs/crates/centaur-api-server/src/mcp.rs
@@ -508,7 +508,7 @@ async fn mcp_v2_catalog_load_result(
     let output = run_mcp_tool_host(
         state.runtime()?,
         principal,
-        &tool.name,
+        &tool,
         ToolHostInvocation::V2 {
             argv: vec!["--help".to_owned()],
         },
@@ -995,7 +995,7 @@ async fn run_mcp_v1_tool(
     let output = run_mcp_tool_host(
         runtime,
         principal,
-        &tool.name,
+        tool,
         ToolHostInvocation::V1 {
             method: method.clone(),
             arguments,
@@ -1017,7 +1017,7 @@ async fn run_mcp_v2_tool(
     let output = run_mcp_tool_host(
         runtime,
         principal,
-        &tool.name,
+        tool,
         ToolHostInvocation::V2 { argv },
         policy,
     )
@@ -1029,7 +1029,7 @@ async fn run_mcp_v2_tool(
 async fn run_mcp_tool_host(
     runtime: SessionRuntime,
     principal: &McpPrincipal,
-    tool_name: &str,
+    tool: &DiscoveredTool,
     invocation: ToolHostInvocation,
     policy: ToolHostCallPolicy,
 ) -> Result<ToolHostCallOutput, ApiError> {
@@ -1040,7 +1040,7 @@ async fn run_mcp_tool_host(
                 console_user_email: principal.console_user_email.clone(),
                 console_user_name: principal.console_user_name.clone(),
                 token_id: Some(principal.token_id.clone()),
-                tool_name: tool_name.to_owned(),
+                tool_name: tool.name.clone(),
                 invocation,
                 timeout: Duration::from_secs(120),
             },

--- a/services/api-rs/crates/centaur-api-server/src/mcp.rs
+++ b/services/api-rs/crates/centaur-api-server/src/mcp.rs
@@ -1,7 +1,7 @@
 use std::{
     collections::{BTreeMap, BTreeSet},
     env, fs,
-    path::PathBuf,
+    path::{Path, PathBuf},
     sync::{Mutex, OnceLock},
     time::{Duration, Instant},
 };
@@ -105,7 +105,7 @@ struct CentaurToolCallArguments {
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 struct CentaurArtifactGetArguments {
-    filename: String,
+    path: String,
 }
 
 const MCP_ARTIFACT_MAX_BYTES: usize = 10 * 1024 * 1024;
@@ -327,18 +327,19 @@ fn mcp_artifact_get_tool() -> Value {
     json!({
         "name": "centaur_artifact_get",
         "description": concat!(
-            "Download a file created by a Centaur tool in the sandbox. The file must be a regular, ",
-            "non-symlink direct child of /tmp/downloads and no larger than 10 MiB. Pass only its ",
-            "filename, not a path. Returns the file as an embedded MCP resource."
+            "Retrieve a file created by a Centaur tool in the sandbox. Pass a relative path beneath ",
+            "/tmp/downloads. Subdirectories and symlinks are allowed when the opened regular file ",
+            "resolves within that directory. Files may be no larger than 10 MiB. Returns the file ",
+            "as an embedded MCP resource."
         ),
         "inputSchema": {
             "type": "object",
-            "required": ["filename"],
+            "required": ["path"],
             "properties": {
-                "filename": {
+                "path": {
                     "type": "string",
                     "minLength": 1,
-                    "description": "The direct child filename within /tmp/downloads.",
+                    "description": "A relative file path within /tmp/downloads.",
                 },
             },
             "additionalProperties": false,
@@ -847,21 +848,17 @@ async fn mcp_artifact_get_result(
     arguments: Value,
 ) -> Result<McpToolCallOutcome, ApiError> {
     let args = match serde_json::from_value::<CentaurArtifactGetArguments>(arguments) {
-        Ok(args) if !args.filename.trim().is_empty() => args,
-        Ok(_) => return Ok(invalid_mcp_v2_arguments("filename must not be blank")),
+        Ok(args) if !args.path.trim().is_empty() => args,
+        Ok(_) => return Ok(invalid_mcp_v2_arguments("path must not be blank")),
         Err(error) => return Ok(invalid_mcp_v2_arguments(error)),
     };
     record_mcp_tool_method(&Span::current(), "centaur_artifact_get", "get");
     let output = state
         .runtime()?
-        .read_tool_host_file(
-            &principal.principal_id,
-            &args.filename,
-            MCP_ARTIFACT_MAX_BYTES,
-        )
+        .read_tool_host_file(&principal.principal_id, &args.path, MCP_ARTIFACT_MAX_BYTES)
         .await?;
     record_mcp_tool_correlation(&Span::current(), None, None, Some(&output.sandbox_id));
-    mcp_artifact_get_output_result(&args.filename, output.contents)
+    mcp_artifact_get_output_result(&args.path, output.contents)
 }
 
 async fn mcp_v1_tool_result(
@@ -1176,13 +1173,23 @@ fn mcp_v2_load_output_result(
 }
 
 fn mcp_artifact_get_output_result(
-    filename: &str,
+    artifact_path: &str,
     contents: Vec<u8>,
 ) -> Result<McpToolCallOutcome, ApiError> {
     let data_base64 = general_purpose::STANDARD.encode(&contents);
 
-    let uri = format!("file:///tmp/downloads/{}", urlencoding::encode(filename));
+    let encoded_path = artifact_path
+        .split('/')
+        .map(|component| urlencoding::encode(component).into_owned())
+        .collect::<Vec<_>>()
+        .join("/");
+    let uri = format!("file:///tmp/downloads/{encoded_path}");
+    let filename = Path::new(artifact_path)
+        .file_name()
+        .and_then(|value| value.to_str())
+        .unwrap_or(artifact_path);
     let metadata = json!({
+        "path": artifact_path,
         "filename": filename,
         "mime_type": "application/octet-stream",
         "size_bytes": contents.len(),
@@ -2473,12 +2480,13 @@ def search(query, limit=20):
     fn mcp_artifact_get_returns_an_embedded_resource() {
         let contents = b"sandbox report\n";
         let outcome =
-            mcp_artifact_get_output_result("quarterly report.txt", contents.to_vec()).unwrap();
+            mcp_artifact_get_output_result("reports/quarterly report.txt", contents.to_vec())
+                .unwrap();
 
         assert!(!mcp_result_is_error(&outcome.result));
         assert_eq!(
             outcome.result["content"][0]["resource"]["uri"],
-            "file:///tmp/downloads/quarterly%20report.txt"
+            "file:///tmp/downloads/reports/quarterly%20report.txt"
         );
         assert_eq!(
             outcome.result["content"][0]["resource"]["mimeType"],
@@ -2491,6 +2499,7 @@ def search(query, limit=20):
         assert_eq!(
             outcome.result["structuredContent"],
             json!({
+                "path": "reports/quarterly report.txt",
                 "filename": "quarterly report.txt",
                 "mime_type": "application/octet-stream",
                 "size_bytes": contents.len(),

--- a/services/api-rs/crates/centaur-api-server/src/mcp.rs
+++ b/services/api-rs/crates/centaur-api-server/src/mcp.rs
@@ -102,6 +102,14 @@ struct CentaurToolCallArguments {
     argv: Vec<String>,
 }
 
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct CentaurDownloadFileArguments {
+    filename: String,
+}
+
+const MCP_DOWNLOAD_MAX_BYTES: usize = 10 * 1024 * 1024;
+
 struct McpToolCallOutcome {
     result: Value,
     timed_out: bool,
@@ -155,7 +163,7 @@ pub(crate) async fn mcp_post(
             if mcp_v2_tool_name(&params.name) && !mcp_v2_enabled() {
                 return Ok(mcp_json_error(id, -32602, "unknown tool"));
             }
-            let tool = if mcp_v2_tool_name(&params.name) || params.name == "centaur_whoami" {
+            let tool = if mcp_builtin_tool_name(&params.name) {
                 None
             } else {
                 let policy = mcp_tool_host_call_policy(&state, &principal).await?;
@@ -221,6 +229,9 @@ async fn mcp_tool_call_result(
                 }
                 "centaur_tool_call" => {
                     mcp_v2_tool_call_result(state, principal, params.arguments).await
+                }
+                "centaur_download_file" => {
+                    mcp_download_file_result(state, principal, params.arguments).await
                 }
                 "centaur_whoami" => mcp_whoami_result(principal, params.arguments).map(|result| {
                     McpToolCallOutcome {
@@ -312,6 +323,29 @@ fn mcp_whoami_tool() -> Value {
     })
 }
 
+fn mcp_download_file_tool() -> Value {
+    json!({
+        "name": "centaur_download_file",
+        "description": concat!(
+            "Download a file created by a Centaur tool in the sandbox. The file must be a regular, ",
+            "non-symlink direct child of /tmp/downloads and no larger than 10 MiB. Pass only its ",
+            "filename, not a path. Returns the file as an embedded MCP resource."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "required": ["filename"],
+            "properties": {
+                "filename": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "The direct child filename within /tmp/downloads.",
+                },
+            },
+            "additionalProperties": false,
+        },
+    })
+}
+
 fn mcp_initialize_result(params: &Value) -> Value {
     let mut result = json!({
         "protocolVersion": requested_mcp_protocol_version(params),
@@ -350,6 +384,7 @@ fn mcp_builtin_tools() -> Vec<Value> {
     if mcp_v2_enabled() {
         tools.extend(mcp_v2_tools());
     }
+    tools.push(mcp_download_file_tool());
     tools.push(mcp_whoami_tool());
     tools
 }
@@ -367,6 +402,10 @@ fn mcp_v2_tool_name(name: &str) -> bool {
         name,
         "centaur_catalog_search" | "centaur_catalog_load" | "centaur_tool_call"
     )
+}
+
+fn mcp_builtin_tool_name(name: &str) -> bool {
+    mcp_v2_tool_name(name) || matches!(name, "centaur_download_file" | "centaur_whoami")
 }
 
 fn mcp_v2_tools() -> Vec<Value> {
@@ -468,7 +507,7 @@ async fn mcp_v2_catalog_load_result(
     let output = run_mcp_tool_host(
         state.runtime()?,
         principal,
-        &tool,
+        &tool.name,
         ToolHostInvocation::V2 {
             argv: vec!["--help".to_owned()],
         },
@@ -701,10 +740,7 @@ fn mcp_centaur_tool_catalog(filter: &SandboxToolFilter) -> Result<Vec<Discovered
     Ok(tools
         .into_iter()
         // Built-in names take precedence over scripts from tool sources.
-        .filter(|tool| {
-            !matches!(tool.name.as_str(), "centaur" | "centaur_whoami")
-                && !mcp_v2_tool_name(&tool.name)
-        })
+        .filter(|tool| tool.name != "centaur" && !mcp_builtin_tool_name(&tool.name))
         .filter(|tool| filter.admits(tool))
         .collect())
 }
@@ -803,6 +839,29 @@ fn mcp_whoami_result(principal: &McpPrincipal, arguments: Value) -> Result<Value
         }))?,
         false,
     ))
+}
+
+async fn mcp_download_file_result(
+    state: &AppState,
+    principal: &McpPrincipal,
+    arguments: Value,
+) -> Result<McpToolCallOutcome, ApiError> {
+    let args = match serde_json::from_value::<CentaurDownloadFileArguments>(arguments) {
+        Ok(args) if !args.filename.trim().is_empty() => args,
+        Ok(_) => return Ok(invalid_mcp_v2_arguments("filename must not be blank")),
+        Err(error) => return Ok(invalid_mcp_v2_arguments(error)),
+    };
+    record_mcp_tool_method(&Span::current(), "centaur_download_file", "download");
+    let output = state
+        .runtime()?
+        .read_tool_host_file(
+            &principal.principal_id,
+            &args.filename,
+            MCP_DOWNLOAD_MAX_BYTES,
+        )
+        .await?;
+    record_mcp_tool_correlation(&Span::current(), None, None, Some(&output.sandbox_id));
+    mcp_download_file_output_result(&args.filename, output.contents)
 }
 
 async fn mcp_v1_tool_result(
@@ -939,7 +998,7 @@ async fn run_mcp_v1_tool(
     let output = run_mcp_tool_host(
         runtime,
         principal,
-        tool,
+        &tool.name,
         ToolHostInvocation::V1 {
             method: method.clone(),
             arguments,
@@ -961,7 +1020,7 @@ async fn run_mcp_v2_tool(
     let output = run_mcp_tool_host(
         runtime,
         principal,
-        tool,
+        &tool.name,
         ToolHostInvocation::V2 { argv },
         policy,
     )
@@ -973,7 +1032,7 @@ async fn run_mcp_v2_tool(
 async fn run_mcp_tool_host(
     runtime: SessionRuntime,
     principal: &McpPrincipal,
-    tool: &DiscoveredTool,
+    tool_name: &str,
     invocation: ToolHostInvocation,
     policy: ToolHostCallPolicy,
 ) -> Result<ToolHostCallOutput, ApiError> {
@@ -984,7 +1043,7 @@ async fn run_mcp_tool_host(
                 console_user_email: principal.console_user_email.clone(),
                 console_user_name: principal.console_user_name.clone(),
                 token_id: Some(principal.token_id.clone()),
-                tool_name: tool.name.clone(),
+                tool_name: tool_name.to_owned(),
                 invocation,
                 timeout: Duration::from_secs(120),
             },
@@ -1113,6 +1172,41 @@ fn mcp_v2_load_output_result(
     Ok(McpToolCallOutcome {
         result,
         timed_out: output.timed_out,
+    })
+}
+
+fn mcp_download_file_output_result(
+    filename: &str,
+    contents: Vec<u8>,
+) -> Result<McpToolCallOutcome, ApiError> {
+    let data_base64 = general_purpose::STANDARD.encode(&contents);
+
+    let uri = format!("file:///tmp/downloads/{}", urlencoding::encode(filename));
+    let metadata = json!({
+        "filename": filename,
+        "mime_type": "application/octet-stream",
+        "size_bytes": contents.len(),
+    });
+    Ok(McpToolCallOutcome {
+        result: json!({
+            "content": [
+                {
+                    "type": "resource",
+                    "resource": {
+                        "uri": uri,
+                        "mimeType": metadata["mime_type"],
+                        "blob": data_base64,
+                    },
+                },
+                {
+                    "type": "text",
+                    "text": serde_json::to_string_pretty(&metadata)?,
+                },
+            ],
+            "structuredContent": metadata,
+            "isError": false,
+        }),
+        timed_out: false,
     })
 }
 
@@ -2070,10 +2164,11 @@ def search(query, limit=20):
                         "centaur_catalog_search",
                         "centaur_catalog_load",
                         "centaur_tool_call",
+                        "centaur_download_file",
                         "centaur_whoami",
                     ]
                 } else {
-                    vec!["centaur_whoami"]
+                    vec!["centaur_download_file", "centaur_whoami"]
                 }
             );
 
@@ -2153,7 +2248,10 @@ def search(query, limit=20):
                 .into_iter()
                 .map(|tool| tool["name"].as_str().unwrap().to_owned())
                 .collect::<Vec<_>>();
-            assert_eq!(names, vec!["centaur_whoami", "demo"]);
+            assert_eq!(
+                names,
+                vec!["centaur_download_file", "centaur_whoami", "demo"]
+            );
         }
 
         let names = mcp_tool_entries(&filter)
@@ -2167,6 +2265,7 @@ def search(query, limit=20):
                 "centaur_catalog_search",
                 "centaur_catalog_load",
                 "centaur_tool_call",
+                "centaur_download_file",
                 "centaur_whoami",
             ]
         );
@@ -2367,6 +2466,35 @@ def search(query, limit=20):
         assert_eq!(
             outcome.result["structuredContent"]["help"],
             "Usage: demo [OPTIONS]\n"
+        );
+    }
+
+    #[test]
+    fn mcp_download_file_returns_an_embedded_resource() {
+        let contents = b"sandbox report\n";
+        let outcome =
+            mcp_download_file_output_result("quarterly report.txt", contents.to_vec()).unwrap();
+
+        assert!(!mcp_result_is_error(&outcome.result));
+        assert_eq!(
+            outcome.result["content"][0]["resource"]["uri"],
+            "file:///tmp/downloads/quarterly%20report.txt"
+        );
+        assert_eq!(
+            outcome.result["content"][0]["resource"]["mimeType"],
+            "application/octet-stream"
+        );
+        assert_eq!(
+            outcome.result["content"][0]["resource"]["blob"],
+            general_purpose::STANDARD.encode(contents)
+        );
+        assert_eq!(
+            outcome.result["structuredContent"],
+            json!({
+                "filename": "quarterly report.txt",
+                "mime_type": "application/octet-stream",
+                "size_bytes": contents.len(),
+            })
         );
     }
 

--- a/services/api-rs/crates/centaur-sandbox-agent-k8s/src/lib.rs
+++ b/services/api-rs/crates/centaur-sandbox-agent-k8s/src/lib.rs
@@ -22,7 +22,7 @@ use kube::api::{
 };
 use kube::{Api, Client, Error, Resource};
 use serde_json::{Map, Value, json};
-use tokio::io::{AsyncRead, AsyncWrite};
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite};
 use tokio::sync::Mutex;
 use tokio::time::{Instant, sleep};
 
@@ -42,6 +42,7 @@ const SANDBOX_ID_LABEL: &str = "centaur.ai/sandbox-id";
 const OBSERVABILITY_ENABLED_LABEL: &str = "centaur.ai/observability-enabled";
 const MANAGED_BY_VALUE: &str = "api-rs";
 const SANDBOX_FILES_VOLUME: &str = "sandbox-files";
+const ARTIFACT_GET_COMMAND: &str = "/usr/local/bin/centaur-artifact-get";
 // iron-control principal OID the sandbox's proxy binds to, stamped at create
 // so resume (which has only the sandbox id) can rebind without the spec or any
 // in-memory state. Survives pause and api-rs restarts.
@@ -700,6 +701,64 @@ impl SandboxBackend for AgentSandboxBackend {
         self.patch_sandbox_merge(id, sandbox_resume_patch(&capability_labels))
             .await?;
         self.wait_until_running(id).await
+    }
+}
+
+impl AgentSandboxBackend {
+    /// Read an artifact through a one-shot pod exec whose stdout is the file body.
+    pub async fn read_artifact(&self, id: &SandboxId, path: &str) -> SandboxResult<Vec<u8>> {
+        let params = AttachParams::default()
+            .container(self.config.container_name.clone())
+            .stdin(false)
+            .stdout(true)
+            .stderr(true)
+            .tty(false);
+        let mut process = self
+            .pods()
+            .exec(id.as_str(), [ARTIFACT_GET_COMMAND, path], &params)
+            .await
+            .map_err(|error| map_kube_error("exec sandbox artifact reader", error))?;
+        let mut stdout = process
+            .stdout()
+            .ok_or_else(|| SandboxError::io("artifact reader stdout was not attached"))?;
+        let mut stderr = process
+            .stderr()
+            .ok_or_else(|| SandboxError::io("artifact reader stderr was not attached"))?;
+        let status = process
+            .take_status()
+            .ok_or_else(|| SandboxError::io("artifact reader status was not attached"))?;
+
+        let mut contents = Vec::new();
+        let mut error_output = Vec::new();
+        let (stdout_result, stderr_result, status) = tokio::join!(
+            stdout.read_to_end(&mut contents),
+            stderr.read_to_end(&mut error_output),
+            status,
+        );
+        stdout_result.map_err(|error| {
+            SandboxError::io_source("read sandbox artifact command stdout", error)
+        })?;
+        stderr_result.map_err(|error| {
+            SandboxError::io_source("read sandbox artifact command stderr", error)
+        })?;
+        process.join().await.map_err(|error| {
+            SandboxError::backend_source("join sandbox artifact command", error)
+        })?;
+
+        if status.as_ref().and_then(|status| status.status.as_deref()) != Some("Success") {
+            let stderr = String::from_utf8_lossy(&error_output);
+            let detail = stderr.trim();
+            let detail = if detail.is_empty() {
+                status
+                    .and_then(|status| status.message)
+                    .unwrap_or_else(|| "artifact reader failed".to_owned())
+            } else {
+                detail.to_owned()
+            };
+            return Err(SandboxError::io(detail));
+        }
+
+        Ok(contents)
     }
 }
 

--- a/services/api-rs/crates/centaur-session-runtime/Cargo.toml
+++ b/services/api-rs/crates/centaur-session-runtime/Cargo.toml
@@ -7,6 +7,7 @@ repository.workspace = true
 
 [dependencies]
 async-trait.workspace = true
+base64.workspace = true
 centaur-iron-control.workspace = true
 centaur-sandbox-core.workspace = true
 centaur-sandbox-manager.workspace = true

--- a/services/api-rs/crates/centaur-session-runtime/Cargo.toml
+++ b/services/api-rs/crates/centaur-session-runtime/Cargo.toml
@@ -7,7 +7,6 @@ repository.workspace = true
 
 [dependencies]
 async-trait.workspace = true
-base64.workspace = true
 centaur-iron-control.workspace = true
 centaur-sandbox-core.workspace = true
 centaur-sandbox-manager.workspace = true

--- a/services/api-rs/crates/centaur-session-runtime/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-runtime/src/lib.rs
@@ -1288,24 +1288,22 @@ impl SessionRuntime {
                 .await
                 .map_err(codec_error_to_runtime)?;
         }
-        let response_json = match timeout(TOOL_HOST_FILE_READ_TIMEOUT, receiver).await {
-            Ok(Ok(Ok(response_json))) => response_json,
-            Ok(Ok(Err(error))) => {
-                return Err(SessionRuntimeError::Sandbox(SandboxError::io(error)));
-            }
-            Ok(Err(error)) => {
-                return Err(SessionRuntimeError::Sandbox(SandboxError::io_source(
-                    "receive transient tool host download response",
-                    error,
-                )));
-            }
-            Err(_) => {
-                return Err(SessionRuntimeError::Sandbox(SandboxError::io(format!(
+        let received = timeout(TOOL_HOST_FILE_READ_TIMEOUT, receiver)
+            .await
+            .map_err(|_| {
+                SessionRuntimeError::Sandbox(SandboxError::io(format!(
                     "tool host download timed out after {} seconds",
                     TOOL_HOST_FILE_READ_TIMEOUT.as_secs()
-                ))));
-            }
-        };
+                )))
+            })?;
+        let response = received.map_err(|error| {
+            SessionRuntimeError::Sandbox(SandboxError::io_source(
+                "receive transient tool host download response",
+                error,
+            ))
+        })?;
+        let response_json =
+            response.map_err(|error| SessionRuntimeError::Sandbox(SandboxError::io(error)))?;
         let response =
             serde_json::from_str::<ToolHostDownloadResponse>(&response_json).map_err(|error| {
                 SessionRuntimeError::Sandbox(SandboxError::io_source(

--- a/services/api-rs/crates/centaur-session-runtime/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-runtime/src/lib.rs
@@ -568,17 +568,11 @@ struct ToolHostResponse {
 #[derive(Deserialize)]
 struct ToolHostDownloadResponse {
     id: String,
-    status: Option<i32>,
-    #[serde(default)]
-    path: Option<String>,
-    #[serde(default)]
-    size_bytes: Option<usize>,
+    status: i32,
     #[serde(default)]
     data_base64: Option<String>,
     #[serde(default)]
     stderr: String,
-    #[serde(default)]
-    timed_out: bool,
 }
 
 struct ToolHostTransientWaiterGuard {
@@ -1173,12 +1167,6 @@ impl SessionRuntime {
                 "artifact path is required".to_owned(),
             ));
         }
-        if max_bytes == 0 {
-            return Err(SessionRuntimeError::BadRequest(
-                "download size limit must be non-zero".to_owned(),
-            ));
-        }
-
         let thread_key = tool_host_thread_key(principal_id)?;
         let call_lock = self.tool_host_call_lock(&thread_key);
         let result = {
@@ -1330,7 +1318,7 @@ impl SessionRuntime {
                 "transient tool host download response id did not match its request",
             )));
         }
-        if response.timed_out || response.status != Some(0) {
+        if response.status != 0 {
             let detail = response.stderr.trim();
             return Err(SessionRuntimeError::Sandbox(SandboxError::io(
                 if detail.is_empty() {
@@ -1338,11 +1326,6 @@ impl SessionRuntime {
                 } else {
                     format!("tool host download failed: {detail}")
                 },
-            )));
-        }
-        if response.path.as_deref() != Some(artifact_path) {
-            return Err(SessionRuntimeError::Sandbox(SandboxError::io(
-                "tool host download response path did not match its request",
             )));
         }
         let encoded = response.data_base64.ok_or_else(|| {
@@ -1356,11 +1339,6 @@ impl SessionRuntime {
                 error,
             ))
         })?;
-        if response.size_bytes != Some(contents.len()) {
-            return Err(SessionRuntimeError::Sandbox(SandboxError::io(
-                "tool host download response size did not match its file data",
-            )));
-        }
         if contents.len() > max_bytes {
             return Err(SessionRuntimeError::Sandbox(SandboxError::io(format!(
                 "sandbox download file exceeds the {max_bytes}-byte size limit"

--- a/services/api-rs/crates/centaur-session-runtime/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-runtime/src/lib.rs
@@ -12,12 +12,11 @@ use std::{
     time::{Duration, SystemTime},
 };
 
-use base64::{Engine as _, engine::general_purpose};
 use centaur_iron_control::{IronControlError, Principal, SessionRegistrar};
 use centaur_sandbox_core::{
     Mount, RepoCacheAccess, ResourceRequirements, SANDBOX_AGENT_HOME, SandboxBackend,
     SandboxCapabilities as BackendSandboxCapabilities, SandboxError, SandboxFile, SandboxId,
-    SandboxIoGuard, SandboxRead, SandboxSpec, SandboxStatus, SandboxWrite,
+    SandboxIoGuard, SandboxRead, SandboxResult, SandboxSpec, SandboxStatus, SandboxWrite,
 };
 use centaur_sandbox_manager::{
     SandboxManager, SandboxReaper, SandboxReaperConfig, WarmPoolConfig, WarmPoolError,
@@ -46,7 +45,7 @@ use sha2::{Digest, Sha256};
 use thiserror::Error;
 use tokio::{
     io,
-    sync::{Mutex, oneshot},
+    sync::Mutex,
     time::{Instant, Interval, MissedTickBehavior, interval_at, sleep, timeout},
 };
 use tokio_util::codec::{FramedRead, FramedWrite, LinesCodec, LinesCodecError};
@@ -84,18 +83,18 @@ const CENTAUR_PUBLIC_SKILL_DIRS_ENV: &str = "CENTAUR_PUBLIC_SKILL_DIRS";
 const SANDBOX_REPO_CACHE_LABEL: &str = "centaur.sandbox_repo_cache";
 const OBSERVABILITY_TOOL_BLOCKLIST: &str =
     "vlogs,vmetrics,grafana,centaur_investigator,centaur-investigator";
-const TOOL_HOST_FILE_READ_TIMEOUT: Duration = Duration::from_secs(30);
+const ARTIFACT_READ_TIMEOUT: Duration = Duration::from_secs(30);
 
 type SandboxSpecFactory = Arc<
     dyn Fn(&ThreadKey, &str, &HarnessType, Option<&PersonaContext>) -> SandboxSpec + Send + Sync,
 >;
+type SandboxArtifactReader =
+    Arc<dyn Fn(SandboxId, String) -> BoxFuture<'static, SandboxResult<Vec<u8>>> + Send + Sync>;
 type SessionInputSink = FramedWrite<SandboxWrite, LinesCodec>;
 type ExecutionSpanRegistry = Arc<Mutex<HashMap<String, Span>>>;
 type SessionPipeMap = Arc<DashMap<String, SessionPipe>>;
 type SessionPipeOpenLocks = Arc<DashMap<String, Arc<Mutex<()>>>>;
 type ToolHostCallLocks = Arc<DashMap<String, Arc<Mutex<()>>>>;
-type ToolHostTransientResult = Result<String, String>;
-type ToolHostTransientWaiters = Arc<DashMap<String, oneshot::Sender<ToolHostTransientResult>>>;
 type SessionTitleThreadSet = Arc<DashSet<ThreadKey>>;
 type SessionTitleGenerator = Arc<
     dyn Fn(String) -> BoxFuture<'static, Result<String, SessionTitleGenerationError>> + Send + Sync,
@@ -148,7 +147,6 @@ pub struct SessionRuntime {
     sandbox_pipes: SessionPipeMap,
     sandbox_pipe_open_locks: SessionPipeOpenLocks,
     tool_host_call_locks: ToolHostCallLocks,
-    tool_host_transient_waiters: ToolHostTransientWaiters,
     execution_spans: ExecutionSpanRegistry,
     iron_control: Arc<dyn SessionPrincipalRegistrar>,
     warm_pool: Option<Arc<WarmPoolManager>>,
@@ -301,6 +299,8 @@ impl PersonaRegistry {
 pub struct SandboxRuntime {
     manager: Arc<SandboxManager>,
     spec_factory: SandboxSpecFactory,
+    /// Optional out-of-band transport supplied by runtimes that can read artifacts.
+    artifact_reader: Option<SandboxArtifactReader>,
     warm_spec_factory: Option<WarmSandboxSpecFactory>,
     workload_key: Option<String>,
     /// The harness warm sandboxes boot with. A warm claim is only valid for a
@@ -444,7 +444,7 @@ pub struct ToolHostCallOutput {
 }
 
 #[derive(Debug)]
-pub struct ToolHostFileOutput {
+pub struct SandboxArtifactOutput {
     pub sandbox_id: String,
     pub contents: Vec<u8>,
 }
@@ -547,13 +547,6 @@ struct ToolHostRequest {
     timeout_seconds: u64,
 }
 
-#[derive(Serialize)]
-struct ToolHostDownloadRequest<'a> {
-    id: &'a str,
-    mode: &'static str,
-    path: &'a str,
-}
-
 #[derive(Deserialize)]
 struct ToolHostResponse {
     status: Option<i32>,
@@ -565,27 +558,6 @@ struct ToolHostResponse {
     timed_out: bool,
 }
 
-#[derive(Deserialize)]
-struct ToolHostDownloadResponse {
-    id: String,
-    status: i32,
-    #[serde(default)]
-    data_base64: Option<String>,
-    #[serde(default)]
-    stderr: String,
-}
-
-struct ToolHostTransientWaiterGuard {
-    request_id: String,
-    waiters: ToolHostTransientWaiters,
-}
-
-impl Drop for ToolHostTransientWaiterGuard {
-    fn drop(&mut self) {
-        self.waiters.remove(&self.request_id);
-    }
-}
-
 /// Shared handles threaded through background session tasks (stdout pump,
 /// terminal-output recording, max-duration failure, idle pause).
 #[derive(Clone)]
@@ -594,7 +566,6 @@ struct RuntimeContext {
     manager: Arc<SandboxManager>,
     sandbox_pipes: SessionPipeMap,
     execution_spans: ExecutionSpanRegistry,
-    tool_host_transient_waiters: ToolHostTransientWaiters,
     stdout_owner_id: String,
 }
 
@@ -993,7 +964,6 @@ impl SessionRuntime {
             sandbox_pipes: Arc::new(DashMap::new()),
             sandbox_pipe_open_locks: Arc::new(DashMap::new()),
             tool_host_call_locks: Arc::new(DashMap::new()),
-            tool_host_transient_waiters: Arc::new(DashMap::new()),
             execution_spans: Arc::new(Mutex::new(HashMap::new())),
             iron_control: Arc::new(iron_control),
             warm_pool: None,
@@ -1069,7 +1039,6 @@ impl SessionRuntime {
             manager: self.sandbox_runtime.manager.clone(),
             sandbox_pipes: self.sandbox_pipes.clone(),
             execution_spans: self.execution_spans.clone(),
-            tool_host_transient_waiters: self.tool_host_transient_waiters.clone(),
             stdout_owner_id: self.stdout_owner_id.clone(),
         }
     }
@@ -1148,14 +1117,14 @@ impl SessionRuntime {
         result
     }
 
-    /// Read a file directly from an existing principal-bound MCP tool sandbox.
+    /// Read an artifact from an existing principal-bound MCP sandbox.
     /// This operation does not create an execution, event, or durable message.
-    pub async fn read_tool_host_file(
+    pub async fn read_sandbox_artifact(
         &self,
         principal_id: &str,
         artifact_path: &str,
         max_bytes: usize,
-    ) -> Result<ToolHostFileOutput, SessionRuntimeError> {
+    ) -> Result<SandboxArtifactOutput, SessionRuntimeError> {
         let principal_id = principal_id.trim();
         if principal_id.is_empty() {
             return Err(SessionRuntimeError::BadRequest(
@@ -1168,16 +1137,66 @@ impl SessionRuntime {
             ));
         }
         let thread_key = tool_host_thread_key(principal_id)?;
-        let call_lock = self.tool_host_call_lock(&thread_key);
-        let result = {
-            let _call_guard = call_lock.lock().await;
-            self.locked_tool_host_file_read(&thread_key, principal_id, artifact_path, max_bytes)
-                .await
+        let session = match self.store.get_session(&thread_key).await {
+            Ok(session) => session,
+            Err(SessionStoreError::NotFound { .. }) => {
+                return Err(SessionRuntimeError::BadRequest(
+                    "no MCP sandbox exists for this principal".to_owned(),
+                ));
+            }
+            Err(error) => return Err(error.into()),
         };
-        drop(call_lock);
-        self.tool_host_call_locks
-            .remove_if(thread_key.as_str(), |_, lock| Arc::strong_count(lock) == 1);
-        result
+        if session.iron_control_principal.as_deref() != Some(principal_id) {
+            return Err(SessionRuntimeError::BadRequest(
+                "MCP sandbox principal does not match the requester".to_owned(),
+            ));
+        }
+        let Some(sandbox_id) = session.sandbox_id else {
+            return Err(SessionRuntimeError::BadRequest(
+                "no MCP sandbox is currently assigned to this principal".to_owned(),
+            ));
+        };
+        let id = SandboxId::new(&sandbox_id);
+        match self.sandbox_runtime.manager.status(&id).await? {
+            SandboxStatus::Running => {}
+            SandboxStatus::Suspended => self.sandbox_runtime.manager.resume(&id).await?,
+            status => {
+                return Err(SessionRuntimeError::BadRequest(format!(
+                    "MCP sandbox is not available for artifact retrieval: {status:?}"
+                )));
+            }
+        }
+        let artifact_reader = self
+            .sandbox_runtime
+            .artifact_reader
+            .as_ref()
+            .ok_or_else(|| {
+                SessionRuntimeError::BadRequest(
+                    "artifact retrieval is not supported by the configured sandbox backend"
+                        .to_owned(),
+                )
+            })?;
+        let artifact = timeout(
+            ARTIFACT_READ_TIMEOUT,
+            artifact_reader(id, artifact_path.to_owned()),
+        )
+        .await
+        .map_err(|_| {
+            SessionRuntimeError::Sandbox(SandboxError::io(format!(
+                "sandbox artifact retrieval timed out after {} seconds",
+                ARTIFACT_READ_TIMEOUT.as_secs()
+            )))
+        })?;
+        let contents = artifact?;
+        if contents.len() > max_bytes {
+            return Err(SessionRuntimeError::Sandbox(SandboxError::io(format!(
+                "sandbox artifact exceeds the {max_bytes}-byte size limit"
+            ))));
+        }
+        Ok(SandboxArtifactOutput {
+            sandbox_id,
+            contents,
+        })
     }
 
     /// Resolve the principal once and return both the tool lists from its
@@ -1215,137 +1234,6 @@ impl SessionRuntime {
             .entry(thread_key.as_str().to_owned())
             .or_insert_with(|| Arc::new(Mutex::new(())))
             .clone()
-    }
-
-    async fn locked_tool_host_file_read(
-        &self,
-        thread_key: &ThreadKey,
-        principal_id: &str,
-        artifact_path: &str,
-        max_bytes: usize,
-    ) -> Result<ToolHostFileOutput, SessionRuntimeError> {
-        let session = match self.store.get_session(thread_key).await {
-            Ok(session) => session,
-            Err(SessionStoreError::NotFound { .. }) => {
-                return Err(SessionRuntimeError::BadRequest(
-                    "no MCP tool sandbox exists for this principal".to_owned(),
-                ));
-            }
-            Err(error) => return Err(error.into()),
-        };
-        if session.iron_control_principal.as_deref() != Some(principal_id) {
-            return Err(SessionRuntimeError::BadRequest(
-                "MCP tool sandbox principal does not match the requester".to_owned(),
-            ));
-        }
-        let Some(sandbox_id) = session.sandbox_id else {
-            return Err(SessionRuntimeError::BadRequest(
-                "no MCP tool sandbox is currently assigned to this principal".to_owned(),
-            ));
-        };
-        let id = SandboxId::new(&sandbox_id);
-        match self.sandbox_runtime.manager.status(&id).await? {
-            SandboxStatus::Running => {}
-            SandboxStatus::Suspended => self.sandbox_runtime.manager.resume(&id).await?,
-            status => {
-                return Err(SessionRuntimeError::BadRequest(format!(
-                    "MCP tool sandbox is not available for download: {status:?}"
-                )));
-            }
-        }
-        let pipe = self.ensure_session_pipe(thread_key, &sandbox_id).await?;
-        let request_id = format!("mcp-artifact-{}", Uuid::new_v4().simple());
-        let input_line = serde_json::to_string(&ToolHostDownloadRequest {
-            id: &request_id,
-            mode: "download_file",
-            path: artifact_path,
-        })
-        .map_err(|error| {
-            SessionRuntimeError::Sandbox(SandboxError::io_source(
-                "encode transient tool host download request",
-                error,
-            ))
-        })?;
-        let (sender, receiver) = oneshot::channel();
-        if self
-            .tool_host_transient_waiters
-            .insert(request_id.clone(), sender)
-            .is_some()
-        {
-            self.tool_host_transient_waiters.remove(&request_id);
-            return Err(SessionRuntimeError::Sandbox(SandboxError::io(
-                "duplicate transient tool host request id",
-            )));
-        }
-        let _waiter_guard = ToolHostTransientWaiterGuard {
-            request_id: request_id.clone(),
-            waiters: self.tool_host_transient_waiters.clone(),
-        };
-        {
-            let mut stdin = pipe.stdin.lock().await;
-            stdin
-                .send(input_line)
-                .await
-                .map_err(codec_error_to_runtime)?;
-        }
-        let received = timeout(TOOL_HOST_FILE_READ_TIMEOUT, receiver)
-            .await
-            .map_err(|_| {
-                SessionRuntimeError::Sandbox(SandboxError::io(format!(
-                    "tool host download timed out after {} seconds",
-                    TOOL_HOST_FILE_READ_TIMEOUT.as_secs()
-                )))
-            })?;
-        let response = received.map_err(|error| {
-            SessionRuntimeError::Sandbox(SandboxError::io_source(
-                "receive transient tool host download response",
-                error,
-            ))
-        })?;
-        let response_json =
-            response.map_err(|error| SessionRuntimeError::Sandbox(SandboxError::io(error)))?;
-        let response =
-            serde_json::from_str::<ToolHostDownloadResponse>(&response_json).map_err(|error| {
-                SessionRuntimeError::Sandbox(SandboxError::io_source(
-                    "decode transient tool host download response",
-                    error,
-                ))
-            })?;
-        if response.id != request_id {
-            return Err(SessionRuntimeError::Sandbox(SandboxError::io(
-                "transient tool host download response id did not match its request",
-            )));
-        }
-        if response.status != 0 {
-            let detail = response.stderr.trim();
-            return Err(SessionRuntimeError::Sandbox(SandboxError::io(
-                if detail.is_empty() {
-                    "tool host download failed".to_owned()
-                } else {
-                    format!("tool host download failed: {detail}")
-                },
-            )));
-        }
-        let encoded = response.data_base64.ok_or_else(|| {
-            SessionRuntimeError::Sandbox(SandboxError::io(
-                "tool host download response did not include file data",
-            ))
-        })?;
-        let contents = general_purpose::STANDARD.decode(encoded).map_err(|error| {
-            SessionRuntimeError::Sandbox(SandboxError::io_source(
-                "decode transient tool host download data",
-                error,
-            ))
-        })?;
-        if contents.len() > max_bytes {
-            return Err(SessionRuntimeError::Sandbox(SandboxError::io(format!(
-                "sandbox download file exceeds the {max_bytes}-byte size limit"
-            ))));
-        }
-        Ok(ToolHostFileOutput {
-            sandbox_id,
-            contents,
-        })
     }
 
     async fn locked_tool_host_call(
@@ -4394,6 +4282,7 @@ impl SandboxRuntime {
         Self {
             manager: Arc::new(SandboxManager::new(backend)),
             spec_factory: Arc::new(spec_factory),
+            artifact_reader: None,
             warm_spec_factory: None,
             workload_key: None,
             warm_harness: None,
@@ -4417,10 +4306,21 @@ impl SandboxRuntime {
         Self {
             manager: Arc::new(SandboxManager::new(backend)),
             spec_factory: Arc::new(spec_factory),
+            artifact_reader: None,
             warm_spec_factory: Some(warm_spec_factory),
             workload_key: Some(workload_key),
             warm_harness: None,
         }
+    }
+
+    /// Add an artifact transport without expanding the portable sandbox backend contract.
+    pub fn with_artifact_reader<F, Fut>(mut self, reader: F) -> Self
+    where
+        F: Fn(SandboxId, String) -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = SandboxResult<Vec<u8>>> + Send + 'static,
+    {
+        self.artifact_reader = Some(Arc::new(move |id, path| reader(id, path).boxed()));
+        self
     }
 }
 
@@ -5078,11 +4978,6 @@ async fn run_stdout_pump(
             };
             line_count += 1;
             let output_value = serde_json::from_str::<Value>(&line).ok();
-            if output_value.as_ref().is_some_and(|value| {
-                dispatch_transient_tool_host_result(&ctx.tool_host_transient_waiters, value)
-            }) {
-                continue;
-            }
             if let Some(harness_thread_id) = harness_thread_id_from_output_line(&line)
                 && let Err(error) = ctx
                     .store
@@ -5211,27 +5106,6 @@ async fn run_stdout_pump(
     }
     .instrument(span)
     .await
-}
-
-fn dispatch_transient_tool_host_result(waiters: &ToolHostTransientWaiters, value: &Value) -> bool {
-    if value.get("type").and_then(Value::as_str) != Some("centaur.transient_result") {
-        return false;
-    }
-    let Some(request_id) = value.get("turn_id").and_then(Value::as_str) else {
-        return true;
-    };
-    let Some((_, waiter)) = waiters.remove(request_id) else {
-        // Late transient results are deliberately discarded rather than being
-        // attributed to whichever durable execution happens to be active.
-        return true;
-    };
-    let result = value
-        .get("result")
-        .and_then(Value::as_str)
-        .map(ToOwned::to_owned)
-        .ok_or_else(|| "transient tool host response did not include a result payload".to_owned());
-    let _ = waiter.send(result);
-    true
 }
 
 async fn record_stdout_pump_failure(
@@ -7796,49 +7670,6 @@ mod tests {
                 "timeout_seconds": 120,
             })
         );
-    }
-
-    #[test]
-    fn tool_host_download_request_serializes_as_transient_mode() {
-        let request = ToolHostDownloadRequest {
-            id: "download-1",
-            mode: "download_file",
-            path: "reports/report.pdf",
-        };
-        assert_eq!(
-            serde_json::to_value(request).unwrap(),
-            serde_json::json!({
-                "id": "download-1",
-                "mode": "download_file",
-                "path": "reports/report.pdf",
-            })
-        );
-    }
-
-    #[test]
-    fn transient_tool_host_results_are_never_routed_to_durable_output() {
-        let waiters = Arc::new(DashMap::new());
-        let (sender, mut receiver) = oneshot::channel();
-        waiters.insert("download-1".to_owned(), sender);
-        let value = json!({
-            "type": "centaur.transient_result",
-            "turn_id": "download-1",
-            "result": "{\"id\":\"download-1\",\"status\":0}",
-        });
-
-        assert!(dispatch_transient_tool_host_result(&waiters, &value));
-        assert_eq!(
-            receiver.try_recv().unwrap().unwrap(),
-            "{\"id\":\"download-1\",\"status\":0}"
-        );
-        assert!(waiters.is_empty());
-
-        // A late response remains transient even after its waiter timed out.
-        assert!(dispatch_transient_tool_host_result(&waiters, &value));
-        assert!(!dispatch_transient_tool_host_result(
-            &waiters,
-            &json!({"type": "result", "turn_id": "download-1"})
-        ));
     }
 
     #[test]

--- a/services/api-rs/crates/centaur-session-runtime/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-runtime/src/lib.rs
@@ -1266,7 +1266,7 @@ impl SessionRuntime {
             }
         }
         let pipe = self.ensure_session_pipe(thread_key, &sandbox_id).await?;
-        let request_id = format!("mcp-download-{}", Uuid::new_v4().simple());
+        let request_id = format!("mcp-artifact-{}", Uuid::new_v4().simple());
         let input_line = serde_json::to_string(&ToolHostDownloadRequest {
             id: &request_id,
             mode: "download_file",

--- a/services/api-rs/crates/centaur-session-runtime/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-runtime/src/lib.rs
@@ -12,6 +12,7 @@ use std::{
     time::{Duration, SystemTime},
 };
 
+use base64::{Engine as _, engine::general_purpose};
 use centaur_iron_control::{IronControlError, Principal, SessionRegistrar};
 use centaur_sandbox_core::{
     Mount, RepoCacheAccess, ResourceRequirements, SANDBOX_AGENT_HOME, SandboxBackend,
@@ -45,7 +46,7 @@ use sha2::{Digest, Sha256};
 use thiserror::Error;
 use tokio::{
     io,
-    sync::Mutex,
+    sync::{Mutex, oneshot},
     time::{Instant, Interval, MissedTickBehavior, interval_at, sleep, timeout},
 };
 use tokio_util::codec::{FramedRead, FramedWrite, LinesCodec, LinesCodecError};
@@ -83,6 +84,7 @@ const CENTAUR_PUBLIC_SKILL_DIRS_ENV: &str = "CENTAUR_PUBLIC_SKILL_DIRS";
 const SANDBOX_REPO_CACHE_LABEL: &str = "centaur.sandbox_repo_cache";
 const OBSERVABILITY_TOOL_BLOCKLIST: &str =
     "vlogs,vmetrics,grafana,centaur_investigator,centaur-investigator";
+const TOOL_HOST_FILE_READ_TIMEOUT: Duration = Duration::from_secs(30);
 
 type SandboxSpecFactory = Arc<
     dyn Fn(&ThreadKey, &str, &HarnessType, Option<&PersonaContext>) -> SandboxSpec + Send + Sync,
@@ -92,6 +94,8 @@ type ExecutionSpanRegistry = Arc<Mutex<HashMap<String, Span>>>;
 type SessionPipeMap = Arc<DashMap<String, SessionPipe>>;
 type SessionPipeOpenLocks = Arc<DashMap<String, Arc<Mutex<()>>>>;
 type ToolHostCallLocks = Arc<DashMap<String, Arc<Mutex<()>>>>;
+type ToolHostTransientResult = Result<String, String>;
+type ToolHostTransientWaiters = Arc<DashMap<String, oneshot::Sender<ToolHostTransientResult>>>;
 type SessionTitleThreadSet = Arc<DashSet<ThreadKey>>;
 type SessionTitleGenerator = Arc<
     dyn Fn(String) -> BoxFuture<'static, Result<String, SessionTitleGenerationError>> + Send + Sync,
@@ -144,6 +148,7 @@ pub struct SessionRuntime {
     sandbox_pipes: SessionPipeMap,
     sandbox_pipe_open_locks: SessionPipeOpenLocks,
     tool_host_call_locks: ToolHostCallLocks,
+    tool_host_transient_waiters: ToolHostTransientWaiters,
     execution_spans: ExecutionSpanRegistry,
     iron_control: Arc<dyn SessionPrincipalRegistrar>,
     warm_pool: Option<Arc<WarmPoolManager>>,
@@ -438,6 +443,12 @@ pub struct ToolHostCallOutput {
     pub timed_out: bool,
 }
 
+#[derive(Debug)]
+pub struct ToolHostFileOutput {
+    pub sandbox_id: String,
+    pub contents: Vec<u8>,
+}
+
 #[derive(Debug, Error)]
 #[error("{source}")]
 pub struct ToolHostCallError {
@@ -536,6 +547,13 @@ struct ToolHostRequest {
     timeout_seconds: u64,
 }
 
+#[derive(Serialize)]
+struct ToolHostDownloadRequest<'a> {
+    id: &'a str,
+    mode: &'static str,
+    filename: &'a str,
+}
+
 #[derive(Deserialize)]
 struct ToolHostResponse {
     status: Option<i32>,
@@ -547,6 +565,33 @@ struct ToolHostResponse {
     timed_out: bool,
 }
 
+#[derive(Deserialize)]
+struct ToolHostDownloadResponse {
+    id: String,
+    status: Option<i32>,
+    #[serde(default)]
+    filename: Option<String>,
+    #[serde(default)]
+    size_bytes: Option<usize>,
+    #[serde(default)]
+    data_base64: Option<String>,
+    #[serde(default)]
+    stderr: String,
+    #[serde(default)]
+    timed_out: bool,
+}
+
+struct ToolHostTransientWaiterGuard {
+    request_id: String,
+    waiters: ToolHostTransientWaiters,
+}
+
+impl Drop for ToolHostTransientWaiterGuard {
+    fn drop(&mut self) {
+        self.waiters.remove(&self.request_id);
+    }
+}
+
 /// Shared handles threaded through background session tasks (stdout pump,
 /// terminal-output recording, max-duration failure, idle pause).
 #[derive(Clone)]
@@ -555,6 +600,7 @@ struct RuntimeContext {
     manager: Arc<SandboxManager>,
     sandbox_pipes: SessionPipeMap,
     execution_spans: ExecutionSpanRegistry,
+    tool_host_transient_waiters: ToolHostTransientWaiters,
     stdout_owner_id: String,
 }
 
@@ -953,6 +999,7 @@ impl SessionRuntime {
             sandbox_pipes: Arc::new(DashMap::new()),
             sandbox_pipe_open_locks: Arc::new(DashMap::new()),
             tool_host_call_locks: Arc::new(DashMap::new()),
+            tool_host_transient_waiters: Arc::new(DashMap::new()),
             execution_spans: Arc::new(Mutex::new(HashMap::new())),
             iron_control: Arc::new(iron_control),
             warm_pool: None,
@@ -1028,6 +1075,7 @@ impl SessionRuntime {
             manager: self.sandbox_runtime.manager.clone(),
             sandbox_pipes: self.sandbox_pipes.clone(),
             execution_spans: self.execution_spans.clone(),
+            tool_host_transient_waiters: self.tool_host_transient_waiters.clone(),
             stdout_owner_id: self.stdout_owner_id.clone(),
         }
     }
@@ -1106,6 +1154,44 @@ impl SessionRuntime {
         result
     }
 
+    /// Read a file directly from an existing principal-bound MCP tool sandbox.
+    /// This operation does not create an execution, event, or durable message.
+    pub async fn read_tool_host_file(
+        &self,
+        principal_id: &str,
+        filename: &str,
+        max_bytes: usize,
+    ) -> Result<ToolHostFileOutput, SessionRuntimeError> {
+        let principal_id = principal_id.trim();
+        if principal_id.is_empty() {
+            return Err(SessionRuntimeError::BadRequest(
+                "tool host principal_id is required".to_owned(),
+            ));
+        }
+        if filename.is_empty() {
+            return Err(SessionRuntimeError::BadRequest(
+                "download filename is required".to_owned(),
+            ));
+        }
+        if max_bytes == 0 {
+            return Err(SessionRuntimeError::BadRequest(
+                "download size limit must be non-zero".to_owned(),
+            ));
+        }
+
+        let thread_key = tool_host_thread_key(principal_id)?;
+        let call_lock = self.tool_host_call_lock(&thread_key);
+        let result = {
+            let _call_guard = call_lock.lock().await;
+            self.locked_tool_host_file_read(&thread_key, principal_id, filename, max_bytes)
+                .await
+        };
+        drop(call_lock);
+        self.tool_host_call_locks
+            .remove_if(thread_key.as_str(), |_, lock| Arc::strong_count(lock) == 1);
+        result
+    }
+
     /// Resolve the principal once and return both the tool lists from its
     /// effective sandbox spec and the capabilities the ensuing call must use.
     pub async fn resolve_tool_host_call_policy(
@@ -1141,6 +1227,149 @@ impl SessionRuntime {
             .entry(thread_key.as_str().to_owned())
             .or_insert_with(|| Arc::new(Mutex::new(())))
             .clone()
+    }
+
+    async fn locked_tool_host_file_read(
+        &self,
+        thread_key: &ThreadKey,
+        principal_id: &str,
+        filename: &str,
+        max_bytes: usize,
+    ) -> Result<ToolHostFileOutput, SessionRuntimeError> {
+        let session = match self.store.get_session(thread_key).await {
+            Ok(session) => session,
+            Err(SessionStoreError::NotFound { .. }) => {
+                return Err(SessionRuntimeError::BadRequest(
+                    "no MCP tool sandbox exists for this principal".to_owned(),
+                ));
+            }
+            Err(error) => return Err(error.into()),
+        };
+        if session.iron_control_principal.as_deref() != Some(principal_id) {
+            return Err(SessionRuntimeError::BadRequest(
+                "MCP tool sandbox principal does not match the requester".to_owned(),
+            ));
+        }
+        let Some(sandbox_id) = session.sandbox_id else {
+            return Err(SessionRuntimeError::BadRequest(
+                "no MCP tool sandbox is currently assigned to this principal".to_owned(),
+            ));
+        };
+        let id = SandboxId::new(&sandbox_id);
+        match self.sandbox_runtime.manager.status(&id).await? {
+            SandboxStatus::Running => {}
+            SandboxStatus::Suspended => self.sandbox_runtime.manager.resume(&id).await?,
+            status => {
+                return Err(SessionRuntimeError::BadRequest(format!(
+                    "MCP tool sandbox is not available for download: {status:?}"
+                )));
+            }
+        }
+        let pipe = self.ensure_session_pipe(thread_key, &sandbox_id).await?;
+        let request_id = format!("mcp-download-{}", Uuid::new_v4().simple());
+        let input_line = serde_json::to_string(&ToolHostDownloadRequest {
+            id: &request_id,
+            mode: "download_file",
+            filename,
+        })
+        .map_err(|error| {
+            SessionRuntimeError::Sandbox(SandboxError::io_source(
+                "encode transient tool host download request",
+                error,
+            ))
+        })?;
+        let (sender, receiver) = oneshot::channel();
+        if self
+            .tool_host_transient_waiters
+            .insert(request_id.clone(), sender)
+            .is_some()
+        {
+            self.tool_host_transient_waiters.remove(&request_id);
+            return Err(SessionRuntimeError::Sandbox(SandboxError::io(
+                "duplicate transient tool host request id",
+            )));
+        }
+        let _waiter_guard = ToolHostTransientWaiterGuard {
+            request_id: request_id.clone(),
+            waiters: self.tool_host_transient_waiters.clone(),
+        };
+        {
+            let mut stdin = pipe.stdin.lock().await;
+            stdin
+                .send(input_line)
+                .await
+                .map_err(codec_error_to_runtime)?;
+        }
+        let response_json = match timeout(TOOL_HOST_FILE_READ_TIMEOUT, receiver).await {
+            Ok(Ok(Ok(response_json))) => response_json,
+            Ok(Ok(Err(error))) => {
+                return Err(SessionRuntimeError::Sandbox(SandboxError::io(error)));
+            }
+            Ok(Err(error)) => {
+                return Err(SessionRuntimeError::Sandbox(SandboxError::io_source(
+                    "receive transient tool host download response",
+                    error,
+                )));
+            }
+            Err(_) => {
+                return Err(SessionRuntimeError::Sandbox(SandboxError::io(format!(
+                    "tool host download timed out after {} seconds",
+                    TOOL_HOST_FILE_READ_TIMEOUT.as_secs()
+                ))));
+            }
+        };
+        let response =
+            serde_json::from_str::<ToolHostDownloadResponse>(&response_json).map_err(|error| {
+                SessionRuntimeError::Sandbox(SandboxError::io_source(
+                    "decode transient tool host download response",
+                    error,
+                ))
+            })?;
+        if response.id != request_id {
+            return Err(SessionRuntimeError::Sandbox(SandboxError::io(
+                "transient tool host download response id did not match its request",
+            )));
+        }
+        if response.timed_out || response.status != Some(0) {
+            let detail = response.stderr.trim();
+            return Err(SessionRuntimeError::Sandbox(SandboxError::io(
+                if detail.is_empty() {
+                    "tool host download failed".to_owned()
+                } else {
+                    format!("tool host download failed: {detail}")
+                },
+            )));
+        }
+        if response.filename.as_deref() != Some(filename) {
+            return Err(SessionRuntimeError::Sandbox(SandboxError::io(
+                "tool host download response filename did not match its request",
+            )));
+        }
+        let encoded = response.data_base64.ok_or_else(|| {
+            SessionRuntimeError::Sandbox(SandboxError::io(
+                "tool host download response did not include file data",
+            ))
+        })?;
+        let contents = general_purpose::STANDARD.decode(encoded).map_err(|error| {
+            SessionRuntimeError::Sandbox(SandboxError::io_source(
+                "decode transient tool host download data",
+                error,
+            ))
+        })?;
+        if response.size_bytes != Some(contents.len()) {
+            return Err(SessionRuntimeError::Sandbox(SandboxError::io(
+                "tool host download response size did not match its file data",
+            )));
+        }
+        if contents.len() > max_bytes {
+            return Err(SessionRuntimeError::Sandbox(SandboxError::io(format!(
+                "sandbox download file exceeds the {max_bytes}-byte size limit"
+            ))));
+        }
+        Ok(ToolHostFileOutput {
+            sandbox_id,
+            contents,
+        })
     }
 
     async fn locked_tool_host_call(
@@ -4873,6 +5102,11 @@ async fn run_stdout_pump(
             };
             line_count += 1;
             let output_value = serde_json::from_str::<Value>(&line).ok();
+            if output_value.as_ref().is_some_and(|value| {
+                dispatch_transient_tool_host_result(&ctx.tool_host_transient_waiters, value)
+            }) {
+                continue;
+            }
             if let Some(harness_thread_id) = harness_thread_id_from_output_line(&line)
                 && let Err(error) = ctx
                     .store
@@ -5001,6 +5235,27 @@ async fn run_stdout_pump(
     }
     .instrument(span)
     .await
+}
+
+fn dispatch_transient_tool_host_result(waiters: &ToolHostTransientWaiters, value: &Value) -> bool {
+    if value.get("type").and_then(Value::as_str) != Some("centaur.transient_result") {
+        return false;
+    }
+    let Some(request_id) = value.get("turn_id").and_then(Value::as_str) else {
+        return true;
+    };
+    let Some((_, waiter)) = waiters.remove(request_id) else {
+        // Late transient results are deliberately discarded rather than being
+        // attributed to whichever durable execution happens to be active.
+        return true;
+    };
+    let result = value
+        .get("result")
+        .and_then(Value::as_str)
+        .map(ToOwned::to_owned)
+        .ok_or_else(|| "transient tool host response did not include a result payload".to_owned());
+    let _ = waiter.send(result);
+    true
 }
 
 async fn record_stdout_pump_failure(
@@ -7565,6 +7820,49 @@ mod tests {
                 "timeout_seconds": 120,
             })
         );
+    }
+
+    #[test]
+    fn tool_host_download_request_serializes_as_transient_mode() {
+        let request = ToolHostDownloadRequest {
+            id: "download-1",
+            mode: "download_file",
+            filename: "report.pdf",
+        };
+        assert_eq!(
+            serde_json::to_value(request).unwrap(),
+            serde_json::json!({
+                "id": "download-1",
+                "mode": "download_file",
+                "filename": "report.pdf",
+            })
+        );
+    }
+
+    #[test]
+    fn transient_tool_host_results_are_never_routed_to_durable_output() {
+        let waiters = Arc::new(DashMap::new());
+        let (sender, mut receiver) = oneshot::channel();
+        waiters.insert("download-1".to_owned(), sender);
+        let value = json!({
+            "type": "centaur.transient_result",
+            "turn_id": "download-1",
+            "result": "{\"id\":\"download-1\",\"status\":0}",
+        });
+
+        assert!(dispatch_transient_tool_host_result(&waiters, &value));
+        assert_eq!(
+            receiver.try_recv().unwrap().unwrap(),
+            "{\"id\":\"download-1\",\"status\":0}"
+        );
+        assert!(waiters.is_empty());
+
+        // A late response remains transient even after its waiter timed out.
+        assert!(dispatch_transient_tool_host_result(&waiters, &value));
+        assert!(!dispatch_transient_tool_host_result(
+            &waiters,
+            &json!({"type": "result", "turn_id": "download-1"})
+        ));
     }
 
     #[test]

--- a/services/api-rs/crates/centaur-session-runtime/src/lib.rs
+++ b/services/api-rs/crates/centaur-session-runtime/src/lib.rs
@@ -551,7 +551,7 @@ struct ToolHostRequest {
 struct ToolHostDownloadRequest<'a> {
     id: &'a str,
     mode: &'static str,
-    filename: &'a str,
+    path: &'a str,
 }
 
 #[derive(Deserialize)]
@@ -570,7 +570,7 @@ struct ToolHostDownloadResponse {
     id: String,
     status: Option<i32>,
     #[serde(default)]
-    filename: Option<String>,
+    path: Option<String>,
     #[serde(default)]
     size_bytes: Option<usize>,
     #[serde(default)]
@@ -1159,7 +1159,7 @@ impl SessionRuntime {
     pub async fn read_tool_host_file(
         &self,
         principal_id: &str,
-        filename: &str,
+        artifact_path: &str,
         max_bytes: usize,
     ) -> Result<ToolHostFileOutput, SessionRuntimeError> {
         let principal_id = principal_id.trim();
@@ -1168,9 +1168,9 @@ impl SessionRuntime {
                 "tool host principal_id is required".to_owned(),
             ));
         }
-        if filename.is_empty() {
+        if artifact_path.is_empty() {
             return Err(SessionRuntimeError::BadRequest(
-                "download filename is required".to_owned(),
+                "artifact path is required".to_owned(),
             ));
         }
         if max_bytes == 0 {
@@ -1183,7 +1183,7 @@ impl SessionRuntime {
         let call_lock = self.tool_host_call_lock(&thread_key);
         let result = {
             let _call_guard = call_lock.lock().await;
-            self.locked_tool_host_file_read(&thread_key, principal_id, filename, max_bytes)
+            self.locked_tool_host_file_read(&thread_key, principal_id, artifact_path, max_bytes)
                 .await
         };
         drop(call_lock);
@@ -1233,7 +1233,7 @@ impl SessionRuntime {
         &self,
         thread_key: &ThreadKey,
         principal_id: &str,
-        filename: &str,
+        artifact_path: &str,
         max_bytes: usize,
     ) -> Result<ToolHostFileOutput, SessionRuntimeError> {
         let session = match self.store.get_session(thread_key).await {
@@ -1270,7 +1270,7 @@ impl SessionRuntime {
         let input_line = serde_json::to_string(&ToolHostDownloadRequest {
             id: &request_id,
             mode: "download_file",
-            filename,
+            path: artifact_path,
         })
         .map_err(|error| {
             SessionRuntimeError::Sandbox(SandboxError::io_source(
@@ -1340,9 +1340,9 @@ impl SessionRuntime {
                 },
             )));
         }
-        if response.filename.as_deref() != Some(filename) {
+        if response.path.as_deref() != Some(artifact_path) {
             return Err(SessionRuntimeError::Sandbox(SandboxError::io(
-                "tool host download response filename did not match its request",
+                "tool host download response path did not match its request",
             )));
         }
         let encoded = response.data_base64.ok_or_else(|| {
@@ -7827,14 +7827,14 @@ mod tests {
         let request = ToolHostDownloadRequest {
             id: "download-1",
             mode: "download_file",
-            filename: "report.pdf",
+            path: "reports/report.pdf",
         };
         assert_eq!(
             serde_json::to_value(request).unwrap(),
             serde_json::json!({
                 "id": "download-1",
                 "mode": "download_file",
-                "filename": "report.pdf",
+                "path": "reports/report.pdf",
             })
         );
     }

--- a/services/sandbox/Dockerfile
+++ b/services/sandbox/Dockerfile
@@ -297,6 +297,7 @@ COPY --link services/workflow-python/api/ /usr/local/bin/api/
 COPY --link --chmod=755 services/sandbox/git-branch.sh /usr/local/bin/git-branch
 COPY --link --chmod=755 services/sandbox/install_tool_shims.py /usr/local/bin/install-tool-shims
 COPY --link --chmod=755 services/sandbox/seed_hermes_codex_auth.py /usr/local/bin/seed-hermes-codex-auth
+COPY --link --chmod=755 services/sandbox/centaur_artifact_get.py /usr/local/bin/centaur-artifact-get
 COPY --link --chmod=755 services/sandbox/centaur_tool_host.py /usr/local/bin/centaur-tool-host
 COPY --link --chmod=755 services/sandbox/compose_system_prompt.py /usr/local/bin/compose-system-prompt
 COPY --link --chmod=755 services/sandbox/repo_cache_sync.py /usr/local/bin/repo-cache-sync

--- a/services/sandbox/Dockerfile
+++ b/services/sandbox/Dockerfile
@@ -284,7 +284,8 @@ RUN rm -f /etc/sudoers.d/agent
 # BuildKit's COPY --link creates parent directories without an explicit mode,
 # which can leave /etc/centaur without the execute bit for non-root users.
 # Pre-create it as 0755 so the agent user can traverse into it at runtime.
-RUN install -d -m 0755 /etc/centaur /opt/centaur
+RUN install -d -m 0755 /etc/centaur /opt/centaur \
+    && install -d -o 1001 -g 1001 -m 0700 /tmp/downloads
 COPY --link centaur_sdk/ /opt/centaur/centaur_sdk/
 COPY --link --chmod=0755 services/sandbox/git-hooks/ /opt/centaur/git-hooks/
 COPY --link --chown=1001:1001 tools/ /opt/centaur/tools/

--- a/services/sandbox/centaur_artifact_get.py
+++ b/services/sandbox/centaur_artifact_get.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import fcntl
+import os
+import stat
+import sys
+from pathlib import Path
+from typing import Any
+
+
+DOWNLOADS_ROOT = Path("/tmp/downloads")
+MAX_DOWNLOAD_BYTES = 10 * 1024 * 1024
+MACOS_F_GETPATH = 50
+
+
+def _open_file_path(file_fd: int) -> Path:
+    """Return the kernel-resolved path for an already-open file descriptor."""
+    if sys.platform.startswith("linux"):
+        return Path(os.readlink(f"/proc/self/fd/{file_fd}"))
+    if sys.platform == "darwin":
+        # F_GETPATH returns the path associated with the open descriptor on macOS.
+        path_buffer = fcntl.fcntl(file_fd, MACOS_F_GETPATH, bytes(1024))
+        path = path_buffer.split(b"\0", 1)[0]
+        return Path(os.fsdecode(path))
+    raise OSError(f"open file path lookup is unsupported on {sys.platform}")
+
+
+def _open_artifact(artifact_path: Any) -> int:
+    """Open one regular file whose resolved location is below the download root."""
+    if not isinstance(artifact_path, str) or not artifact_path:
+        raise ValueError("artifact path must be a non-empty string")
+    relative_path = Path(artifact_path)
+    if (
+        relative_path.is_absolute()
+        or relative_path == Path(".")
+        or ".." in relative_path.parts
+        or "\0" in artifact_path
+    ):
+        raise ValueError("artifact path must be relative to /tmp/downloads")
+
+    root_fd = os.open(
+        DOWNLOADS_ROOT,
+        os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW,
+    )
+    file_fd: int | None = None
+    try:
+        root_path = _open_file_path(root_fd)
+        file_fd = os.open(
+            artifact_path,
+            os.O_RDONLY | os.O_NONBLOCK,
+            dir_fd=root_fd,
+        )
+        file_stat = os.fstat(file_fd)
+        if not stat.S_ISREG(file_stat.st_mode):
+            raise ValueError("artifact must be a regular file")
+        if file_stat.st_size > MAX_DOWNLOAD_BYTES:
+            raise ValueError(
+                f"artifact exceeds the {MAX_DOWNLOAD_BYTES}-byte size limit"
+            )
+        file_path = _open_file_path(file_fd)
+        try:
+            file_path.relative_to(root_path)
+        except ValueError as error:
+            raise ValueError(
+                "artifact path resolves outside /tmp/downloads"
+            ) from error
+        return file_fd
+    except Exception:
+        if file_fd is not None:
+            os.close(file_fd)
+        raise
+    finally:
+        os.close(root_fd)
+
+
+def read_artifact(artifact_path: Any) -> bytes:
+    file_fd = _open_artifact(artifact_path)
+    with os.fdopen(file_fd, "rb") as file:
+        contents = file.read(MAX_DOWNLOAD_BYTES + 1)
+    if len(contents) > MAX_DOWNLOAD_BYTES:
+        raise ValueError(
+            f"artifact exceeds the {MAX_DOWNLOAD_BYTES}-byte size limit"
+        )
+    return contents
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print("usage: centaur-artifact-get PATH", file=sys.stderr)
+        return 2
+    try:
+        contents = read_artifact(sys.argv[1])
+    except (OSError, ValueError) as error:
+        print(f"centaur-artifact-get: {error}", file=sys.stderr)
+        return 1
+    sys.stdout.buffer.write(contents)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/sandbox/centaur_tool_host.py
+++ b/services/sandbox/centaur_tool_host.py
@@ -1,21 +1,12 @@
 #!/usr/bin/env python3
 from __future__ import annotations
 
-import base64
-import fcntl
 import json
 import os
-import stat
 import subprocess
 import sys
 import traceback
-from pathlib import Path
 from typing import Any
-
-
-DOWNLOADS_ROOT = Path("/tmp/downloads")
-MAX_DOWNLOAD_BYTES = 10 * 1024 * 1024
-MACOS_F_GETPATH = 50
 
 
 def _text(value: Any) -> str:
@@ -62,86 +53,8 @@ def _command_for_request(request: dict[str, Any]) -> list[str]:
             raise ValueError(f"unsupported tool host mode: {mode}")
 
 
-def _open_file_path(file_fd: int) -> Path:
-    """Return the kernel-resolved path for an already-open file descriptor."""
-    if sys.platform.startswith("linux"):
-        return Path(os.readlink(f"/proc/self/fd/{file_fd}"))
-    if sys.platform == "darwin":
-        # F_GETPATH returns the path associated with the open descriptor on macOS.
-        path_buffer = fcntl.fcntl(file_fd, MACOS_F_GETPATH, bytes(1024))
-        path = path_buffer.split(b"\0", 1)[0]
-        return Path(os.fsdecode(path))
-    raise OSError(f"open file path lookup is unsupported on {sys.platform}")
-
-
-def _open_download_file(artifact_path: Any) -> int:
-    """Open one regular file whose resolved location is below the download root."""
-    if not isinstance(artifact_path, str) or not artifact_path:
-        raise ValueError("artifact path must be a non-empty string")
-    relative_path = Path(artifact_path)
-    if (
-        relative_path.is_absolute()
-        or relative_path == Path(".")
-        or ".." in relative_path.parts
-        or "\0" in artifact_path
-    ):
-        raise ValueError("artifact path must be relative to /tmp/downloads")
-
-    root_flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
-    root_fd = os.open(DOWNLOADS_ROOT, root_flags)
-    file_fd: int | None = None
-    try:
-        root_path = _open_file_path(root_fd)
-        file_flags = os.O_RDONLY | os.O_NONBLOCK
-        file_fd = os.open(artifact_path, file_flags, dir_fd=root_fd)
-        file_stat = os.fstat(file_fd)
-        if not stat.S_ISREG(file_stat.st_mode):
-            raise ValueError("download target must be a regular file")
-        if file_stat.st_size > MAX_DOWNLOAD_BYTES:
-            raise ValueError(
-                f"download file exceeds the {MAX_DOWNLOAD_BYTES}-byte size limit"
-            )
-        file_path = _open_file_path(file_fd)
-        try:
-            file_path.relative_to(root_path)
-        except ValueError as error:
-            raise ValueError(
-                "artifact path resolves outside /tmp/downloads"
-            ) from error
-        return file_fd
-    except Exception:
-        if file_fd is not None:
-            os.close(file_fd)
-        raise
-    finally:
-        os.close(root_fd)
-
-
-def _read_download_file(artifact_path: Any) -> bytes:
-    file_fd = _open_download_file(artifact_path)
-    with os.fdopen(file_fd, "rb") as file:
-        contents = file.read(MAX_DOWNLOAD_BYTES + 1)
-    if len(contents) > MAX_DOWNLOAD_BYTES:
-        raise ValueError(
-            f"download file exceeds the {MAX_DOWNLOAD_BYTES}-byte size limit"
-        )
-    return contents
-
-
-def _download_file(request: dict[str, Any]) -> dict[str, Any]:
-    artifact_path = request.get("path")
-    contents = _read_download_file(artifact_path)
-    return {
-        "id": request["id"],
-        "status": 0,
-        "data_base64": base64.b64encode(contents).decode("ascii"),
-    }
-
-
 def _run_tool(request: dict[str, Any]) -> dict[str, Any]:
     request_id = request.get("id")
-    if request.get("mode") == "download_file":
-        return _download_file(request)
     command = _command_for_request(request)
     timeout_seconds = max(1, int(request.get("timeout_seconds") or 120))
 
@@ -180,11 +93,11 @@ def _run_tool(request: dict[str, Any]) -> dict[str, Any]:
         }
 
 
-def _emit_result(response: dict[str, Any], *, transient: bool = False) -> None:
+def _emit_result(response: dict[str, Any]) -> None:
     print(
         json.dumps(
             {
-                "type": "centaur.transient_result" if transient else "result",
+                "type": "result",
                 "turn_id": response.get("id"),
                 "result": json.dumps(response, separators=(",", ":")),
             },
@@ -201,11 +114,9 @@ def main() -> int:
         if not raw_line:
             continue
         request_id = None
-        transient = False
         try:
             request = json.loads(raw_line)
             request_id = request.get("id")
-            transient = request.get("mode") == "download_file"
             response = _run_tool(request)
         except Exception:
             response = {
@@ -215,7 +126,7 @@ def main() -> int:
                 "stderr": traceback.format_exc(),
                 "timed_out": False,
             }
-        _emit_result(response, transient=transient)
+        _emit_result(response)
     return 0
 
 

--- a/services/sandbox/centaur_tool_host.py
+++ b/services/sandbox/centaur_tool_host.py
@@ -87,11 +87,7 @@ def _open_download_file(artifact_path: Any) -> tuple[int, os.stat_result]:
     ):
         raise ValueError("artifact path must be relative to /tmp/downloads")
 
-    root_flags = os.O_RDONLY
-    if hasattr(os, "O_DIRECTORY"):
-        root_flags |= os.O_DIRECTORY
-    if hasattr(os, "O_NOFOLLOW"):
-        root_flags |= os.O_NOFOLLOW
+    root_flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
     root_fd = os.open(DOWNLOADS_ROOT, root_flags)
     file_fd: int | None = None
     try:

--- a/services/sandbox/centaur_tool_host.py
+++ b/services/sandbox/centaur_tool_host.py
@@ -1,12 +1,19 @@
 #!/usr/bin/env python3
 from __future__ import annotations
 
+import base64
 import json
 import os
+import stat
 import subprocess
 import sys
 import traceback
+from pathlib import Path
 from typing import Any
+
+
+DOWNLOADS_ROOT = Path("/tmp/downloads")
+MAX_DOWNLOAD_BYTES = 10 * 1024 * 1024
 
 
 def _text(value: Any) -> str:
@@ -53,8 +60,75 @@ def _command_for_request(request: dict[str, Any]) -> list[str]:
             raise ValueError(f"unsupported tool host mode: {mode}")
 
 
+def _open_download_file(filename: Any) -> tuple[int, os.stat_result]:
+    """Open one regular file directly below the sandbox download directory."""
+    if not isinstance(filename, str) or not filename:
+        raise ValueError("download filename must be a non-empty string")
+    if (
+        filename in {".", ".."}
+        or os.sep in filename
+        or (os.altsep is not None and os.altsep in filename)
+        or "\0" in filename
+    ):
+        raise ValueError("download filename must name a direct child of /tmp/downloads")
+
+    root_flags = os.O_RDONLY
+    if hasattr(os, "O_DIRECTORY"):
+        root_flags |= os.O_DIRECTORY
+    if hasattr(os, "O_NOFOLLOW"):
+        root_flags |= os.O_NOFOLLOW
+    root_fd = os.open(DOWNLOADS_ROOT, root_flags)
+    try:
+        file_flags = os.O_RDONLY
+        if hasattr(os, "O_NOFOLLOW"):
+            file_flags |= os.O_NOFOLLOW
+        file_fd = os.open(filename, file_flags, dir_fd=root_fd)
+    finally:
+        os.close(root_fd)
+
+    try:
+        file_stat = os.fstat(file_fd)
+        if not stat.S_ISREG(file_stat.st_mode):
+            raise ValueError("download target must be a regular file")
+        if file_stat.st_size > MAX_DOWNLOAD_BYTES:
+            raise ValueError(
+                f"download file exceeds the {MAX_DOWNLOAD_BYTES}-byte size limit"
+            )
+        return file_fd, file_stat
+    except Exception:
+        os.close(file_fd)
+        raise
+
+
+def _read_download_file(filename: Any) -> bytes:
+    file_fd, _ = _open_download_file(filename)
+    with os.fdopen(file_fd, "rb") as file:
+        contents = file.read(MAX_DOWNLOAD_BYTES + 1)
+    if len(contents) > MAX_DOWNLOAD_BYTES:
+        raise ValueError(
+            f"download file exceeds the {MAX_DOWNLOAD_BYTES}-byte size limit"
+        )
+    return contents
+
+
+def _download_file(request: dict[str, Any]) -> dict[str, Any]:
+    filename = request.get("filename")
+    contents = _read_download_file(filename)
+    return {
+        "id": request.get("id"),
+        "status": 0,
+        "filename": filename,
+        "size_bytes": len(contents),
+        "data_base64": base64.b64encode(contents).decode("ascii"),
+        "stderr": "",
+        "timed_out": False,
+    }
+
+
 def _run_tool(request: dict[str, Any]) -> dict[str, Any]:
     request_id = request.get("id")
+    if request.get("mode") == "download_file":
+        return _download_file(request)
     command = _command_for_request(request)
     timeout_seconds = max(1, int(request.get("timeout_seconds") or 120))
 
@@ -93,11 +167,11 @@ def _run_tool(request: dict[str, Any]) -> dict[str, Any]:
         }
 
 
-def _emit_result(response: dict[str, Any]) -> None:
+def _emit_result(response: dict[str, Any], *, transient: bool = False) -> None:
     print(
         json.dumps(
             {
-                "type": "result",
+                "type": "centaur.transient_result" if transient else "result",
                 "turn_id": response.get("id"),
                 "result": json.dumps(response, separators=(",", ":")),
             },
@@ -114,9 +188,11 @@ def main() -> int:
         if not raw_line:
             continue
         request_id = None
+        transient = False
         try:
             request = json.loads(raw_line)
             request_id = request.get("id")
+            transient = request.get("mode") == "download_file"
             response = _run_tool(request)
         except Exception:
             response = {
@@ -126,7 +202,7 @@ def main() -> int:
                 "stderr": traceback.format_exc(),
                 "timed_out": False,
             }
-        _emit_result(response)
+        _emit_result(response, transient=transient)
     return 0
 
 

--- a/services/sandbox/centaur_tool_host.py
+++ b/services/sandbox/centaur_tool_host.py
@@ -74,7 +74,7 @@ def _open_file_path(file_fd: int) -> Path:
     raise OSError(f"open file path lookup is unsupported on {sys.platform}")
 
 
-def _open_download_file(artifact_path: Any) -> tuple[int, os.stat_result]:
+def _open_download_file(artifact_path: Any) -> int:
     """Open one regular file whose resolved location is below the download root."""
     if not isinstance(artifact_path, str) or not artifact_path:
         raise ValueError("artifact path must be a non-empty string")
@@ -92,7 +92,7 @@ def _open_download_file(artifact_path: Any) -> tuple[int, os.stat_result]:
     file_fd: int | None = None
     try:
         root_path = _open_file_path(root_fd)
-        file_flags = os.O_RDONLY | getattr(os, "O_NONBLOCK", 0)
+        file_flags = os.O_RDONLY | os.O_NONBLOCK
         file_fd = os.open(artifact_path, file_flags, dir_fd=root_fd)
         file_stat = os.fstat(file_fd)
         if not stat.S_ISREG(file_stat.st_mode):
@@ -108,7 +108,7 @@ def _open_download_file(artifact_path: Any) -> tuple[int, os.stat_result]:
             raise ValueError(
                 "artifact path resolves outside /tmp/downloads"
             ) from error
-        return file_fd, file_stat
+        return file_fd
     except Exception:
         if file_fd is not None:
             os.close(file_fd)
@@ -118,7 +118,7 @@ def _open_download_file(artifact_path: Any) -> tuple[int, os.stat_result]:
 
 
 def _read_download_file(artifact_path: Any) -> bytes:
-    file_fd, _ = _open_download_file(artifact_path)
+    file_fd = _open_download_file(artifact_path)
     with os.fdopen(file_fd, "rb") as file:
         contents = file.read(MAX_DOWNLOAD_BYTES + 1)
     if len(contents) > MAX_DOWNLOAD_BYTES:
@@ -132,13 +132,9 @@ def _download_file(request: dict[str, Any]) -> dict[str, Any]:
     artifact_path = request.get("path")
     contents = _read_download_file(artifact_path)
     return {
-        "id": request.get("id"),
+        "id": request["id"],
         "status": 0,
-        "path": artifact_path,
-        "size_bytes": len(contents),
         "data_base64": base64.b64encode(contents).decode("ascii"),
-        "stderr": "",
-        "timed_out": False,
     }
 
 

--- a/services/sandbox/centaur_tool_host.py
+++ b/services/sandbox/centaur_tool_host.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import base64
+import fcntl
 import json
 import os
 import stat
@@ -14,6 +15,7 @@ from typing import Any
 
 DOWNLOADS_ROOT = Path("/tmp/downloads")
 MAX_DOWNLOAD_BYTES = 10 * 1024 * 1024
+MACOS_F_GETPATH = 50
 
 
 def _text(value: Any) -> str:
@@ -60,17 +62,30 @@ def _command_for_request(request: dict[str, Any]) -> list[str]:
             raise ValueError(f"unsupported tool host mode: {mode}")
 
 
-def _open_download_file(filename: Any) -> tuple[int, os.stat_result]:
-    """Open one regular file directly below the sandbox download directory."""
-    if not isinstance(filename, str) or not filename:
-        raise ValueError("download filename must be a non-empty string")
+def _open_file_path(file_fd: int) -> Path:
+    """Return the kernel-resolved path for an already-open file descriptor."""
+    if sys.platform.startswith("linux"):
+        return Path(os.readlink(f"/proc/self/fd/{file_fd}"))
+    if sys.platform == "darwin":
+        # F_GETPATH returns the path associated with the open descriptor on macOS.
+        path_buffer = fcntl.fcntl(file_fd, MACOS_F_GETPATH, bytes(1024))
+        path = path_buffer.split(b"\0", 1)[0]
+        return Path(os.fsdecode(path))
+    raise OSError(f"open file path lookup is unsupported on {sys.platform}")
+
+
+def _open_download_file(artifact_path: Any) -> tuple[int, os.stat_result]:
+    """Open one regular file whose resolved location is below the download root."""
+    if not isinstance(artifact_path, str) or not artifact_path:
+        raise ValueError("artifact path must be a non-empty string")
+    relative_path = Path(artifact_path)
     if (
-        filename in {".", ".."}
-        or os.sep in filename
-        or (os.altsep is not None and os.altsep in filename)
-        or "\0" in filename
+        relative_path.is_absolute()
+        or relative_path == Path(".")
+        or ".." in relative_path.parts
+        or "\0" in artifact_path
     ):
-        raise ValueError("download filename must name a direct child of /tmp/downloads")
+        raise ValueError("artifact path must be relative to /tmp/downloads")
 
     root_flags = os.O_RDONLY
     if hasattr(os, "O_DIRECTORY"):
@@ -78,15 +93,11 @@ def _open_download_file(filename: Any) -> tuple[int, os.stat_result]:
     if hasattr(os, "O_NOFOLLOW"):
         root_flags |= os.O_NOFOLLOW
     root_fd = os.open(DOWNLOADS_ROOT, root_flags)
+    file_fd: int | None = None
     try:
-        file_flags = os.O_RDONLY
-        if hasattr(os, "O_NOFOLLOW"):
-            file_flags |= os.O_NOFOLLOW
-        file_fd = os.open(filename, file_flags, dir_fd=root_fd)
-    finally:
-        os.close(root_fd)
-
-    try:
+        root_path = _open_file_path(root_fd)
+        file_flags = os.O_RDONLY | getattr(os, "O_NONBLOCK", 0)
+        file_fd = os.open(artifact_path, file_flags, dir_fd=root_fd)
         file_stat = os.fstat(file_fd)
         if not stat.S_ISREG(file_stat.st_mode):
             raise ValueError("download target must be a regular file")
@@ -94,14 +105,24 @@ def _open_download_file(filename: Any) -> tuple[int, os.stat_result]:
             raise ValueError(
                 f"download file exceeds the {MAX_DOWNLOAD_BYTES}-byte size limit"
             )
+        file_path = _open_file_path(file_fd)
+        try:
+            file_path.relative_to(root_path)
+        except ValueError as error:
+            raise ValueError(
+                "artifact path resolves outside /tmp/downloads"
+            ) from error
         return file_fd, file_stat
     except Exception:
-        os.close(file_fd)
+        if file_fd is not None:
+            os.close(file_fd)
         raise
+    finally:
+        os.close(root_fd)
 
 
-def _read_download_file(filename: Any) -> bytes:
-    file_fd, _ = _open_download_file(filename)
+def _read_download_file(artifact_path: Any) -> bytes:
+    file_fd, _ = _open_download_file(artifact_path)
     with os.fdopen(file_fd, "rb") as file:
         contents = file.read(MAX_DOWNLOAD_BYTES + 1)
     if len(contents) > MAX_DOWNLOAD_BYTES:
@@ -112,12 +133,12 @@ def _read_download_file(filename: Any) -> bytes:
 
 
 def _download_file(request: dict[str, Any]) -> dict[str, Any]:
-    filename = request.get("filename")
-    contents = _read_download_file(filename)
+    artifact_path = request.get("path")
+    contents = _read_download_file(artifact_path)
     return {
         "id": request.get("id"),
         "status": 0,
-        "filename": filename,
+        "path": artifact_path,
         "size_bytes": len(contents),
         "data_base64": base64.b64encode(contents).decode("ascii"),
         "stderr": "",

--- a/services/sandbox/test_centaur_artifact_get.py
+++ b/services/sandbox/test_centaur_artifact_get.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import centaur_artifact_get
+
+
+class ArtifactGetTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp_dir.name)
+
+    def tearDown(self) -> None:
+        self.temp_dir.cleanup()
+
+    def test_reads_file(self) -> None:
+        downloads = self.root / "downloads"
+        downloads.mkdir()
+        (downloads / "report.txt").write_bytes(b"sandbox report\n")
+
+        with mock.patch.object(centaur_artifact_get, "DOWNLOADS_ROOT", downloads):
+            self.assertEqual(
+                centaur_artifact_get.read_artifact("report.txt"),
+                b"sandbox report\n",
+            )
+
+    def test_rejects_paths_outside_downloads_root(self) -> None:
+        downloads = self.root / "restricted-downloads"
+        downloads.mkdir()
+        (self.root / "secret.txt").write_text("secret")
+
+        with mock.patch.object(centaur_artifact_get, "DOWNLOADS_ROOT", downloads):
+            for artifact_path in ["../secret.txt", "/etc/passwd"]:
+                with self.subTest(path=artifact_path):
+                    with self.assertRaisesRegex(ValueError, "relative"):
+                        centaur_artifact_get.read_artifact(artifact_path)
+
+    def test_reads_nested_paths_and_in_root_symlinks(self) -> None:
+        downloads = self.root / "nested-downloads"
+        reports = downloads / "reports"
+        reports.mkdir(parents=True)
+        (reports / "quarterly.txt").write_text("quarterly")
+        (downloads / "latest.txt").symlink_to(reports / "quarterly.txt")
+
+        with mock.patch.object(centaur_artifact_get, "DOWNLOADS_ROOT", downloads):
+            self.assertEqual(
+                centaur_artifact_get.read_artifact("reports/quarterly.txt"),
+                b"quarterly",
+            )
+            self.assertEqual(
+                centaur_artifact_get.read_artifact("latest.txt"), b"quarterly"
+            )
+
+    def test_rejects_symlinks_outside_downloads_root(self) -> None:
+        downloads = self.root / "symlink-downloads"
+        downloads.mkdir()
+        secret = self.root / "secret.txt"
+        secret.write_text("secret")
+        (downloads / "report.txt").symlink_to(secret)
+
+        with mock.patch.object(centaur_artifact_get, "DOWNLOADS_ROOT", downloads):
+            with self.assertRaisesRegex(ValueError, "resolves outside"):
+                centaur_artifact_get.read_artifact("report.txt")
+
+    def test_reads_from_validated_descriptor(self) -> None:
+        downloads = self.root / "descriptor-downloads"
+        downloads.mkdir()
+        report = downloads / "report.txt"
+        report.write_text("report")
+        secret = self.root / "secret.txt"
+        secret.write_text("secret")
+
+        with mock.patch.object(centaur_artifact_get, "DOWNLOADS_ROOT", downloads):
+            file_fd = centaur_artifact_get._open_artifact("report.txt")
+            report.unlink()
+            report.symlink_to(secret)
+            with os.fdopen(file_fd, "rb") as file:
+                self.assertEqual(file.read(), b"report")
+
+    def test_rejects_symlinked_downloads_root(self) -> None:
+        real_downloads = self.root / "real-downloads"
+        real_downloads.mkdir()
+        (real_downloads / "report.txt").write_text("report")
+        downloads_link = self.root / "downloads-link"
+        downloads_link.symlink_to(real_downloads, target_is_directory=True)
+
+        with mock.patch.object(
+            centaur_artifact_get, "DOWNLOADS_ROOT", downloads_link
+        ):
+            with self.assertRaises(OSError):
+                centaur_artifact_get.read_artifact("report.txt")
+
+    def test_rejects_oversized_files(self) -> None:
+        downloads = self.root / "size-limited-downloads"
+        downloads.mkdir()
+        (downloads / "large.bin").write_bytes(b"12345")
+
+        with (
+            mock.patch.object(centaur_artifact_get, "DOWNLOADS_ROOT", downloads),
+            mock.patch.object(centaur_artifact_get, "MAX_DOWNLOAD_BYTES", 4),
+        ):
+            with self.assertRaisesRegex(ValueError, "size limit"):
+                centaur_artifact_get.read_artifact("large.bin")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/services/sandbox/test_centaur_tool_host.py
+++ b/services/sandbox/test_centaur_tool_host.py
@@ -195,8 +195,6 @@ class ToolHostTest(unittest.TestCase):
             )
         self.assertEqual(response["id"], "download-1")
         self.assertEqual(response["status"], 0)
-        self.assertEqual(response["path"], "report.txt")
-        self.assertEqual(response["size_bytes"], len(b"sandbox report\n"))
         self.assertEqual(
             centaur_tool_host.base64.b64decode(response["data_base64"]),
             b"sandbox report\n",
@@ -257,7 +255,7 @@ class ToolHostTest(unittest.TestCase):
         secret.write_text("secret")
 
         with mock.patch.object(centaur_tool_host, "DOWNLOADS_ROOT", downloads):
-            file_fd, _ = centaur_tool_host._open_download_file("report.txt")
+            file_fd = centaur_tool_host._open_download_file("report.txt")
             report.unlink()
             report.symlink_to(secret)
             with os.fdopen(file_fd, "rb") as file:

--- a/services/sandbox/test_centaur_tool_host.py
+++ b/services/sandbox/test_centaur_tool_host.py
@@ -190,12 +190,12 @@ class ToolHostTest(unittest.TestCase):
                 {
                     "id": "download-1",
                     "mode": "download_file",
-                    "filename": "report.txt",
+                    "path": "report.txt",
                 }
             )
         self.assertEqual(response["id"], "download-1")
         self.assertEqual(response["status"], 0)
-        self.assertEqual(response["filename"], "report.txt")
+        self.assertEqual(response["path"], "report.txt")
         self.assertEqual(response["size_bytes"], len(b"sandbox report\n"))
         self.assertEqual(
             centaur_tool_host.base64.b64decode(response["data_base64"]),
@@ -216,12 +216,28 @@ class ToolHostTest(unittest.TestCase):
         (self.root / "secret.txt").write_text("secret")
 
         with mock.patch.object(centaur_tool_host, "DOWNLOADS_ROOT", downloads):
-            for filename in ["../secret.txt", "/etc/passwd", "nested/file.txt"]:
-                with self.subTest(filename=filename):
-                    with self.assertRaisesRegex(ValueError, "direct child"):
-                        centaur_tool_host._read_download_file(filename)
+            for artifact_path in ["../secret.txt", "/etc/passwd"]:
+                with self.subTest(path=artifact_path):
+                    with self.assertRaisesRegex(ValueError, "relative"):
+                        centaur_tool_host._read_download_file(artifact_path)
 
-    def test_download_file_rejects_symlinks(self) -> None:
+    def test_download_file_reads_nested_paths_and_in_root_symlinks(self) -> None:
+        downloads = self.root / "nested-downloads"
+        reports = downloads / "reports"
+        reports.mkdir(parents=True)
+        (reports / "quarterly.txt").write_text("quarterly")
+        (downloads / "latest.txt").symlink_to(reports / "quarterly.txt")
+
+        with mock.patch.object(centaur_tool_host, "DOWNLOADS_ROOT", downloads):
+            self.assertEqual(
+                centaur_tool_host._read_download_file("reports/quarterly.txt"),
+                b"quarterly",
+            )
+            self.assertEqual(
+                centaur_tool_host._read_download_file("latest.txt"), b"quarterly"
+            )
+
+    def test_download_file_rejects_symlinks_outside_downloads_root(self) -> None:
         downloads = self.root / "symlink-downloads"
         downloads.mkdir()
         secret = self.root / "secret.txt"
@@ -229,8 +245,23 @@ class ToolHostTest(unittest.TestCase):
         (downloads / "report.txt").symlink_to(secret)
 
         with mock.patch.object(centaur_tool_host, "DOWNLOADS_ROOT", downloads):
-            with self.assertRaises(OSError):
+            with self.assertRaisesRegex(ValueError, "resolves outside"):
                 centaur_tool_host._read_download_file("report.txt")
+
+    def test_download_file_reads_from_the_validated_descriptor(self) -> None:
+        downloads = self.root / "descriptor-downloads"
+        downloads.mkdir()
+        report = downloads / "report.txt"
+        report.write_text("report")
+        secret = self.root / "secret.txt"
+        secret.write_text("secret")
+
+        with mock.patch.object(centaur_tool_host, "DOWNLOADS_ROOT", downloads):
+            file_fd, _ = centaur_tool_host._open_download_file("report.txt")
+            report.unlink()
+            report.symlink_to(secret)
+            with os.fdopen(file_fd, "rb") as file:
+                self.assertEqual(file.read(), b"report")
 
     def test_download_file_rejects_symlinked_downloads_root(self) -> None:
         real_downloads = self.root / "real-downloads"

--- a/services/sandbox/test_centaur_tool_host.py
+++ b/services/sandbox/test_centaur_tool_host.py
@@ -1,13 +1,17 @@
 from __future__ import annotations
 
+import io
 import json
 import os
 import subprocess
 import sys
 import tempfile
 import unittest
+from contextlib import redirect_stdout
 from pathlib import Path
+from unittest import mock
 
+import centaur_tool_host
 import install_tool_shims
 
 
@@ -175,6 +179,83 @@ class ToolHostTest(unittest.TestCase):
                 failure, recovery = self.requests(invalid, self.run_request(["--help"]))
                 self.assertEqual(failure["status"], 1)
                 self.assertEqual(recovery["status"], 0)
+
+    def test_download_file_reads_contents(self) -> None:
+        downloads = self.root / "downloads"
+        downloads.mkdir()
+        (downloads / "report.txt").write_bytes(b"sandbox report\n")
+
+        with mock.patch.object(centaur_tool_host, "DOWNLOADS_ROOT", downloads):
+            response = centaur_tool_host._run_tool(
+                {
+                    "id": "download-1",
+                    "mode": "download_file",
+                    "filename": "report.txt",
+                }
+            )
+        self.assertEqual(response["id"], "download-1")
+        self.assertEqual(response["status"], 0)
+        self.assertEqual(response["filename"], "report.txt")
+        self.assertEqual(response["size_bytes"], len(b"sandbox report\n"))
+        self.assertEqual(
+            centaur_tool_host.base64.b64decode(response["data_base64"]),
+            b"sandbox report\n",
+        )
+
+        output = io.StringIO()
+        with redirect_stdout(output):
+            centaur_tool_host._emit_result(response, transient=True)
+        envelope = json.loads(output.getvalue())
+        self.assertEqual(envelope["type"], "centaur.transient_result")
+        self.assertEqual(envelope["turn_id"], "download-1")
+        self.assertEqual(json.loads(envelope["result"]), response)
+
+    def test_download_file_rejects_paths_outside_downloads_root(self) -> None:
+        downloads = self.root / "restricted-downloads"
+        downloads.mkdir()
+        (self.root / "secret.txt").write_text("secret")
+
+        with mock.patch.object(centaur_tool_host, "DOWNLOADS_ROOT", downloads):
+            for filename in ["../secret.txt", "/etc/passwd", "nested/file.txt"]:
+                with self.subTest(filename=filename):
+                    with self.assertRaisesRegex(ValueError, "direct child"):
+                        centaur_tool_host._read_download_file(filename)
+
+    def test_download_file_rejects_symlinks(self) -> None:
+        downloads = self.root / "symlink-downloads"
+        downloads.mkdir()
+        secret = self.root / "secret.txt"
+        secret.write_text("secret")
+        (downloads / "report.txt").symlink_to(secret)
+
+        with mock.patch.object(centaur_tool_host, "DOWNLOADS_ROOT", downloads):
+            with self.assertRaises(OSError):
+                centaur_tool_host._read_download_file("report.txt")
+
+    def test_download_file_rejects_symlinked_downloads_root(self) -> None:
+        real_downloads = self.root / "real-downloads"
+        real_downloads.mkdir()
+        (real_downloads / "report.txt").write_text("report")
+        downloads_link = self.root / "downloads-link"
+        downloads_link.symlink_to(real_downloads, target_is_directory=True)
+
+        with mock.patch.object(
+            centaur_tool_host, "DOWNLOADS_ROOT", downloads_link
+        ):
+            with self.assertRaises(OSError):
+                centaur_tool_host._read_download_file("report.txt")
+
+    def test_download_file_rejects_oversized_files(self) -> None:
+        downloads = self.root / "size-limited-downloads"
+        downloads.mkdir()
+        (downloads / "large.bin").write_bytes(b"12345")
+
+        with (
+            mock.patch.object(centaur_tool_host, "DOWNLOADS_ROOT", downloads),
+            mock.patch.object(centaur_tool_host, "MAX_DOWNLOAD_BYTES", 4),
+        ):
+            with self.assertRaisesRegex(ValueError, "size limit"):
+                centaur_tool_host._read_download_file("large.bin")
 
 
 if __name__ == "__main__":

--- a/services/sandbox/test_centaur_tool_host.py
+++ b/services/sandbox/test_centaur_tool_host.py
@@ -1,17 +1,13 @@
 from __future__ import annotations
 
-import io
 import json
 import os
 import subprocess
 import sys
 import tempfile
 import unittest
-from contextlib import redirect_stdout
 from pathlib import Path
-from unittest import mock
 
-import centaur_tool_host
 import install_tool_shims
 
 
@@ -179,113 +175,6 @@ class ToolHostTest(unittest.TestCase):
                 failure, recovery = self.requests(invalid, self.run_request(["--help"]))
                 self.assertEqual(failure["status"], 1)
                 self.assertEqual(recovery["status"], 0)
-
-    def test_download_file_reads_contents(self) -> None:
-        downloads = self.root / "downloads"
-        downloads.mkdir()
-        (downloads / "report.txt").write_bytes(b"sandbox report\n")
-
-        with mock.patch.object(centaur_tool_host, "DOWNLOADS_ROOT", downloads):
-            response = centaur_tool_host._run_tool(
-                {
-                    "id": "download-1",
-                    "mode": "download_file",
-                    "path": "report.txt",
-                }
-            )
-        self.assertEqual(response["id"], "download-1")
-        self.assertEqual(response["status"], 0)
-        self.assertEqual(
-            centaur_tool_host.base64.b64decode(response["data_base64"]),
-            b"sandbox report\n",
-        )
-
-        output = io.StringIO()
-        with redirect_stdout(output):
-            centaur_tool_host._emit_result(response, transient=True)
-        envelope = json.loads(output.getvalue())
-        self.assertEqual(envelope["type"], "centaur.transient_result")
-        self.assertEqual(envelope["turn_id"], "download-1")
-        self.assertEqual(json.loads(envelope["result"]), response)
-
-    def test_download_file_rejects_paths_outside_downloads_root(self) -> None:
-        downloads = self.root / "restricted-downloads"
-        downloads.mkdir()
-        (self.root / "secret.txt").write_text("secret")
-
-        with mock.patch.object(centaur_tool_host, "DOWNLOADS_ROOT", downloads):
-            for artifact_path in ["../secret.txt", "/etc/passwd"]:
-                with self.subTest(path=artifact_path):
-                    with self.assertRaisesRegex(ValueError, "relative"):
-                        centaur_tool_host._read_download_file(artifact_path)
-
-    def test_download_file_reads_nested_paths_and_in_root_symlinks(self) -> None:
-        downloads = self.root / "nested-downloads"
-        reports = downloads / "reports"
-        reports.mkdir(parents=True)
-        (reports / "quarterly.txt").write_text("quarterly")
-        (downloads / "latest.txt").symlink_to(reports / "quarterly.txt")
-
-        with mock.patch.object(centaur_tool_host, "DOWNLOADS_ROOT", downloads):
-            self.assertEqual(
-                centaur_tool_host._read_download_file("reports/quarterly.txt"),
-                b"quarterly",
-            )
-            self.assertEqual(
-                centaur_tool_host._read_download_file("latest.txt"), b"quarterly"
-            )
-
-    def test_download_file_rejects_symlinks_outside_downloads_root(self) -> None:
-        downloads = self.root / "symlink-downloads"
-        downloads.mkdir()
-        secret = self.root / "secret.txt"
-        secret.write_text("secret")
-        (downloads / "report.txt").symlink_to(secret)
-
-        with mock.patch.object(centaur_tool_host, "DOWNLOADS_ROOT", downloads):
-            with self.assertRaisesRegex(ValueError, "resolves outside"):
-                centaur_tool_host._read_download_file("report.txt")
-
-    def test_download_file_reads_from_the_validated_descriptor(self) -> None:
-        downloads = self.root / "descriptor-downloads"
-        downloads.mkdir()
-        report = downloads / "report.txt"
-        report.write_text("report")
-        secret = self.root / "secret.txt"
-        secret.write_text("secret")
-
-        with mock.patch.object(centaur_tool_host, "DOWNLOADS_ROOT", downloads):
-            file_fd = centaur_tool_host._open_download_file("report.txt")
-            report.unlink()
-            report.symlink_to(secret)
-            with os.fdopen(file_fd, "rb") as file:
-                self.assertEqual(file.read(), b"report")
-
-    def test_download_file_rejects_symlinked_downloads_root(self) -> None:
-        real_downloads = self.root / "real-downloads"
-        real_downloads.mkdir()
-        (real_downloads / "report.txt").write_text("report")
-        downloads_link = self.root / "downloads-link"
-        downloads_link.symlink_to(real_downloads, target_is_directory=True)
-
-        with mock.patch.object(
-            centaur_tool_host, "DOWNLOADS_ROOT", downloads_link
-        ):
-            with self.assertRaises(OSError):
-                centaur_tool_host._read_download_file("report.txt")
-
-    def test_download_file_rejects_oversized_files(self) -> None:
-        downloads = self.root / "size-limited-downloads"
-        downloads.mkdir()
-        (downloads / "large.bin").write_bytes(b"12345")
-
-        with (
-            mock.patch.object(centaur_tool_host, "DOWNLOADS_ROOT", downloads),
-            mock.patch.object(centaur_tool_host, "MAX_DOWNLOAD_BYTES", 4),
-        ):
-            with self.assertRaisesRegex(ValueError, "size limit"):
-                centaur_tool_host._read_download_file("large.bin")
-
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Adds a built-in centaur_artifact_get MCP tool for retrieving regular artifacts beneath /tmp/downloads, including nested paths and symlinks whose opened targets remain in that directory, capped at 10 MiB. Artifact retrieval uses a transient response over the existing tool-host attachment so file bytes never enter durable session messages, events, or executions, and late transient results cannot be attributed to later calls. The sandbox reader validates the kernel-resolved path of the already-open descriptor and rejects out-of-root targets, a symlinked download root, non-regular files, and oversized files.