### PR TITLE
ci: notify Paradigm sandbox after image publish

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -232,11 +232,15 @@ jobs:
         run: |
           docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAMESPACE }}/${{ matrix.image }}:${{ steps.meta.outputs.version }}
 
-      - name: Notify Paradigm sandbox
-        if: >
-          github.event_name == 'push' &&
-          github.ref == 'refs/heads/main' &&
-          matrix.image == 'centaur-agent'
+  notify-paradigm:
+    name: Notify Paradigm sandbox
+    needs: merge
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    environment: centaur-paradigm-dispatch
+    permissions: {}
+    steps:
+      - name: Dispatch sandbox update
         continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.CENTAUR_PARADIGM_DISPATCH_TOKEN }}

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -232,7 +232,7 @@ jobs:
         run: |
           docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAMESPACE }}/${{ matrix.image }}:${{ steps.meta.outputs.version }}
 
-  notify-paradigm:
+  notify-centaur-paradigm:
     name: Notify Paradigm sandbox
     needs: merge
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -233,7 +233,7 @@ jobs:
           docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAMESPACE }}/${{ matrix.image }}:${{ steps.meta.outputs.version }}
 
   notify-centaur-paradigm:
-    name: notify paradigm overlay
+    name: Notify Paradigm Overlay
     needs: merge
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -231,3 +231,28 @@ jobs:
       - name: Inspect manifest
         run: |
           docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAMESPACE }}/${{ matrix.image }}:${{ steps.meta.outputs.version }}
+
+      - name: Notify Paradigm sandbox
+        if: >
+          github.event_name == 'push' &&
+          github.ref == 'refs/heads/main' &&
+          matrix.image == 'centaur-agent'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.CENTAUR_PARADIGM_DISPATCH_TOKEN }}
+        run: |
+          if [ -z "$GH_TOKEN" ]; then
+            echo "CENTAUR_PARADIGM_DISPATCH_TOKEN is required." >&2
+            exit 1
+          fi
+
+          jq -n \
+            --arg sha "$GITHUB_SHA" \
+            '{
+              event_type: "centaur-sandbox-published",
+              client_payload: {sha: $sha}
+            }' |
+            gh api \
+              --method POST \
+              repos/paradigmxyz/centaur-paradigm/dispatches \
+              --input -

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -233,7 +233,7 @@ jobs:
           docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAMESPACE }}/${{ matrix.image }}:${{ steps.meta.outputs.version }}
 
   notify-centaur-paradigm:
-    name: Notify Paradigm sandbox
+    name: notify paradigm overlay
     needs: merge
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest


### PR DESCRIPTION
Notify the Paradigm overlay repository after the main-branch image merge completes. The dispatch runs in the protected centaur-paradigm-dispatch environment with no GITHUB_TOKEN permissions, includes the published source SHA, and remains best-effort.