### PR TITLE
feat(githubbot): skip marked CI checks without Checks API

### DIFF
--- a/services/githubbot/AGENTS.md
+++ b/services/githubbot/AGENTS.md
@@ -26,6 +26,9 @@ behavioral contract and supported webhook events are documented in `README.md`.
 - Automated merge behavior applies only to explicitly owned PRs and must honor
   draft, hold, mergeability, settled-check, attempt-limit, and human-handoff
   gates. Keep deterministic merge decisions outside the agent prompt.
+- The Actions fallback may stand in for unreadable check detail only when it
+  accounts for every context GitHub counted. An unseen check must never read as
+  green.
 - Bundled prompts remain generic and fully overrideable. Do not embed private
   review rules, repositories, user handles, or deployment behavior in defaults.
 - Unit tests must not write to real repositories, comments, branches, or PRs.

--- a/services/githubbot/README.md
+++ b/services/githubbot/README.md
@@ -75,7 +75,25 @@ management thread (`github-manage:{owner}/{repo}:{n}`); the agent does its GitHu
   exhaustion the bot comments tagging a human and stops. On the steady-state CI path it backs off if
   the failing head commit was authored by a human (it won't step on someone mid-edit) — except right
   after assignment, where being assigned is an explicit hand-off, so it fixes the PR regardless of who
-  pushed last.
+  pushed last. **`centaur-skip` checks** are excluded from that evaluation — see below.
+- **Skip a check.** Put `centaur-skip` anywhere in a job id and the bot ignores that check: it never
+  counts as red, never triggers a fix turn, and never appears in the escalation comment's "still
+  failing" list.
+
+  ```yaml
+  jobs:
+    agent-pr-rules-centaur-skip:
+  ```
+
+  The match is case-insensitive. GitHub uses the job id as the check-run name, and recomputes it
+  every run.
+- **Reading checks without the Checks API.** A fine-grained PAT has no Checks permission, so
+  `statusCheckRollup` hands it null check nodes and CI collapses to a bare pass/fail with no names —
+  and no way to spot a `centaur-skip` check. When the nodes are unreadable, githubbot rebuilds the
+  checks from the Actions API (a job *is* a check run) and trusts it only if it accounts for every
+  context GitHub counted; otherwise it keeps the old aggregate behavior rather than risk calling a
+  PR green on a check it never saw. Commit statuses and check runs from other GitHub Apps aren't
+  Actions jobs, which is exactly what that count check catches.
 - **Address review.** A submitted review (`changes_requested` / `commented`) triggers one holistic
   turn that reads all the feedback, makes a single coherent commit, replies on each thread, resolves
   what it addressed, and re-requests review.
@@ -165,6 +183,6 @@ requests**, **Pull request reviews**, **Check runs**, **Check suites**, and **Wo
 
 `bun test test` — unit tests for the override flag parser, the GitHub thread-key parsing / context
 preamble, the review-request trigger gating (incl. team requests), the issue-assignment gating, the
-v2 PR-manager decision logic (CI evaluation, assignment-based ownership, merge gating, the CI-fix
-counter / escalation, and the merge-claim release-on-failure), the author-association gate, body
-mentions, and the per-session serialization queue.
+v2 PR-manager decision logic (CI evaluation, centaur-skip checks, the Actions fallback for unreadable check detail, assignment-based ownership, merge
+gating, the CI-fix counter / escalation, and the merge-claim release-on-failure), the
+author-association gate, body mentions, and the per-session serialization queue.

--- a/services/githubbot/src/workflow-events.ts
+++ b/services/githubbot/src/workflow-events.ts
@@ -65,6 +65,16 @@ const SETTLED_CHECK_STATES = new Set([
 
 const SETTLED_STATUS_STATES = new Set(["ERROR", "FAILURE", "SUCCESS"]);
 
+const CENTAUR_SKIP_MARKER = "centaur-skip";
+
+/**
+ * A check whose job id contains `centaur-skip` is dropped from the CI evaluation:
+ * never counted as red, never fixed, never escalated.
+ */
+export function isCentaurSkipCheck(name: string | null | undefined): boolean {
+  return (name ?? "").toLowerCase().includes(CENTAUR_SKIP_MARKER);
+}
+
 export type CiCheck = { status: string; conclusion: string | null; name: string };
 export type CiStatus = { state: string; context: string };
 
@@ -225,12 +235,13 @@ export async function fetchCiEvaluation(
     );
     if (!pageNodes || readableNodes?.length !== pageNodes.length) {
       detailReadable = false;
-    } else {
-      nodes.push(...readableNodes);
     }
+    // Keep whatever *is* readable even on a partial page: the Actions fallback
+    // still needs the commit statuses, which a PAT can read.
+    if (readableNodes?.length) nodes.push(...readableNodes);
 
     const pageInfo: CiPageInfo | null | undefined = rollup.contexts?.pageInfo;
-    if (!detailReadable || !pageInfo?.hasNextPage) break;
+    if (!pageInfo?.hasNextPage) break;
     if (!pageInfo.endCursor) {
       logger.warn("githubbot_ci_rollup_pagination_failed", { ref: `${owner}/${repo}@${sha}` });
       return null;
@@ -239,7 +250,9 @@ export async function fetchCiEvaluation(
   }
 
   if (!rollupState) return null;
-  const detail = detailReadable ? evaluateCiRollupContexts(nodes) : null;
+  const detail = detailReadable
+    ? evaluateCiRollupContexts(nodes)
+    : await evaluateCiViaActions(ctx, owner, repo, sha, nodes, checkRunCounts, statusContextCounts);
   const aggregatePending = rollupState === "PENDING" || rollupState === "EXPECTED";
   const countsPending = stateCountsPending(checkRunCounts, statusContextCounts);
   let settled = rollupState === "SUCCESS";
@@ -249,18 +262,118 @@ export async function fetchCiEvaluation(
   }
   return {
     settled,
-    failed:
-      rollupState === "FAILURE" || rollupState === "ERROR" || detail?.failed === true,
+    // GitHub computes rollupState over every context, marked ones included, so
+    // OR-ing it in would undo the filter. A readable detail set is authoritative.
+    failed: detail ? detail.failed : rollupState === "FAILURE" || rollupState === "ERROR",
     failingNames: detail?.failingNames ?? [],
   };
 }
 
+/**
+ * Rebuild the check detail from the Actions API when the rollup's check nodes
+ * aren't readable. A fine-grained PAT — the type GitHub recommends — has no
+ * Checks permission at all, so `statusCheckRollup` hands it nulls and the
+ * evaluation degrades to the aggregate: no failing names, and no way to tell a
+ * `centaur-skip` check apart from a real one.
+ *
+ * An Actions job *is* a check run (same name, same conclusion), just behind the
+ * Actions permission instead. It sees fewer things though — no commit statuses,
+ * and no check runs from other GitHub Apps — so this trusts the reconstruction
+ * only when it accounts for every context GitHub counted, and otherwise returns
+ * null so the caller falls back to the aggregate rather than calling a PR green
+ * on a check it never saw.
+ */
+async function evaluateCiViaActions(
+  ctx: WorkflowEventProducerContext,
+  owner: string,
+  repo: string,
+  sha: string,
+  nodes: CiRollupContext[],
+  checkRunCounts: CiStateCount[] | null | undefined,
+  statusContextCounts: CiStateCount[] | null | undefined,
+): Promise<CiEvaluation | null> {
+  const logger = ctx.options.logger ?? noopLogger;
+  if (!checkRunCounts || !statusContextCounts) return null;
+
+  const statuses = latestCiStatuses(nodes);
+  if (statuses.length !== sumCounts(statusContextCounts)) return null;
+
+  let jobs: { name: string; status: string; conclusion: string | null }[];
+  try {
+    jobs = await fetchActionsJobs(ctx, owner, repo, sha);
+  } catch (error) {
+    logger.warn("githubbot_ci_actions_fallback_failed", { error: errorMessage(error) });
+    return null;
+  }
+  if (jobs.length !== sumCounts(checkRunCounts)) {
+    logger.warn("githubbot_ci_actions_fallback_incomplete", {
+      checkRuns: sumCounts(checkRunCounts),
+      jobs: jobs.length,
+      ref: `${owner}/${repo}@${sha}`,
+    });
+    return null;
+  }
+
+  return evaluateCi(
+    jobs
+      .filter((job) => !isCentaurSkipCheck(job.name))
+      .map((job) => ({
+        status: job.status.toLowerCase(),
+        conclusion: job.conclusion?.toLowerCase() ?? null,
+        name: job.name,
+      })),
+    statuses.map((node) => ({ state: node.state.toLowerCase(), context: node.context })),
+  );
+}
+
+/** Every job for a SHA, newest run first, deduped by name like the rollup does. */
+async function fetchActionsJobs(
+  ctx: WorkflowEventProducerContext,
+  owner: string,
+  repo: string,
+  sha: string,
+): Promise<{ name: string; status: string; conclusion: string | null }[]> {
+  const runs = await ctx.octokit.rest.actions.listWorkflowRunsForRepo({
+    head_sha: sha,
+    owner,
+    per_page: 100,
+    repo,
+  });
+  const latest = new Map<string, { name: string; status: string; conclusion: string | null }>();
+  // Descending id === newest first, so the first job seen for a name wins and a
+  // superseded re-run never overwrites it.
+  for (const run of [...runs.data.workflow_runs].sort((a, b) => b.id - a.id)) {
+    const jobs = await ctx.octokit.rest.actions.listJobsForWorkflowRun({
+      owner,
+      per_page: 100,
+      repo,
+      run_id: run.id,
+    });
+    for (const job of jobs.data.jobs) {
+      if (!latest.has(job.name)) {
+        latest.set(job.name, {
+          conclusion: job.conclusion ?? null,
+          name: job.name,
+          status: job.status,
+        });
+      }
+    }
+  }
+  return [...latest.values()];
+}
+
+function sumCounts(counts: CiStateCount[]): number {
+  return counts.reduce((total, { count }) => total + count, 0);
+}
+
 function evaluateCiRollupContexts(nodes: CiRollupContext[]): CiEvaluation {
-  const checks = latestCiChecks(nodes).map((node) => ({
-    status: node.status.toLowerCase(),
-    conclusion: node.conclusion?.toLowerCase() ?? null,
-    name: node.name,
-  }));
+  const checks = latestCiChecks(nodes)
+    .filter((node) => !isCentaurSkipCheck(node.name))
+    .map((node) => ({
+      status: node.status.toLowerCase(),
+      conclusion: node.conclusion?.toLowerCase() ?? null,
+      name: node.name,
+    }));
   const statuses = latestCiStatuses(nodes).map((node) => ({
     state: node.state.toLowerCase(),
     context: node.context,

--- a/services/githubbot/test/pr-manager.test.ts
+++ b/services/githubbot/test/pr-manager.test.ts
@@ -11,6 +11,7 @@ import { emitWorkflowEvent } from "../src/session-api";
 import {
   evaluateCi,
   fetchCiEvaluation,
+  isCentaurSkipCheck,
   type CiCheck,
 } from "../src/workflow-events";
 
@@ -100,6 +101,248 @@ describe("evaluateCi", () => {
       [{ state: "pending", context: "deploy" }],
     );
     expect(result.settled).toBe(false);
+  });
+});
+
+describe("centaur-skip checks", () => {
+  function checkRun(input: { conclusion: string; name: string }) {
+    return {
+      __typename: "CheckRun",
+      conclusion: input.conclusion,
+      name: input.name,
+      startedAt: "2026-08-01T10:00:00Z",
+      status: "COMPLETED",
+    };
+  }
+
+  // As the gate really reports it: the check name is the job id.
+  const gate = checkRun({ conclusion: "FAILURE", name: "agent-pr-rules-centaur-skip" });
+
+  function rollupCtx(rollup: {
+    state: string;
+    nodes: (Record<string, unknown> | null)[];
+    counts?: { count: number; state: string }[];
+  }) {
+    return {
+      octokit: {
+        graphql: async () => ({
+          repository: {
+            object: {
+              statusCheckRollup: {
+                state: rollup.state,
+                contexts: {
+                  nodes: rollup.nodes,
+                  pageInfo: { hasNextPage: false, endCursor: null },
+                  checkRunCountsByState: rollup.counts,
+                  statusContextCountsByState: rollup.counts ? [] : undefined,
+                },
+              },
+            },
+          },
+        }),
+        // No Actions data: the fallback finds nothing and degrades, which is
+        // what the aggregate-fallback case below asserts.
+        rest: {
+          actions: {
+            listWorkflowRunsForRepo: async () => ({ data: { workflow_runs: [] } }),
+            listJobsForWorkflowRun: async () => ({ data: { jobs: [] } }),
+          },
+        },
+      },
+      options: { logger: quietLogger },
+    } as unknown as PrManagerContext;
+  }
+
+  test("matches the marker anywhere in the name, case-insensitively", () => {
+    for (const name of [
+      "agent-pr-rules-centaur-skip",
+      "centaur-skip-approvals",
+      "Approvals (CENTAUR-SKIP)",
+    ]) {
+      expect(isCentaurSkipCheck(name)).toBe(true);
+    }
+  });
+
+  test("leaves an unmarked or absent name alone", () => {
+    for (const name of ["agent-pr-rules", "centaur", "skip", ""]) {
+      expect(isCentaurSkipCheck(name)).toBe(false);
+    }
+    expect(isCentaurSkipCheck(null)).toBe(false);
+    expect(isCentaurSkipCheck(undefined)).toBe(false);
+  });
+
+  test("a marked failure leaves CI green, despite a FAILURE aggregate", async () => {
+    // Green here is only possible if the detail wins over the FAILURE aggregate.
+    const ctx = rollupCtx({
+      state: "FAILURE",
+      nodes: [gate, checkRun({ conclusion: "SUCCESS", name: "build" })],
+    });
+    await expect(fetchCiEvaluation(ctx, "base", "repo", "abc123")).resolves.toEqual({
+      failed: false,
+      failingNames: [],
+      settled: true,
+    });
+  });
+
+  test("a real failure alongside it still fails, naming only the real one", async () => {
+    const ctx = rollupCtx({
+      state: "FAILURE",
+      nodes: [gate, checkRun({ conclusion: "FAILURE", name: "build" })],
+    });
+    await expect(fetchCiEvaluation(ctx, "base", "repo", "abc123")).resolves.toEqual({
+      failed: true,
+      failingNames: ["build"],
+      settled: true,
+    });
+  });
+
+  test("an unreadable detail set with no Actions data falls back to the aggregate", async () => {
+    // A null node means contexts are missing, not marked: aggregate is all we have.
+    const ctx = rollupCtx({
+      state: "FAILURE",
+      nodes: [null, checkRun({ conclusion: "SUCCESS", name: "build" })],
+      counts: [{ count: 2, state: "COMPLETED" }],
+    });
+    await expect(fetchCiEvaluation(ctx, "base", "repo", "abc123")).resolves.toEqual({
+      failed: true,
+      failingNames: [],
+      settled: true,
+    });
+  });
+});
+
+// A fine-grained PAT has no Checks permission, so every check node comes back
+// null and the rollup alone can't tell a marked check from a real failure.
+describe("Actions fallback when check nodes are unreadable", () => {
+  function statusCtx(context: string, state: string) {
+    return { __typename: "StatusContext", context, createdAt: "2026-08-01T10:00:00Z", state };
+  }
+  function job(name: string, conclusion: string | null, status = "completed") {
+    return { conclusion, name, status };
+  }
+  function ctxFor(input: {
+    nodes: (Record<string, unknown> | null)[];
+    checkRuns: number;
+    statuses: number;
+    actionsJobs: Record<number, ReturnType<typeof job>[]>;
+  }) {
+    const runIds = Object.keys(input.actionsJobs).map(Number);
+    return {
+      octokit: {
+        graphql: async () => ({
+          repository: {
+            object: {
+              statusCheckRollup: {
+                state: "FAILURE",
+                contexts: {
+                  nodes: input.nodes,
+                  pageInfo: { hasNextPage: false, endCursor: null },
+                  checkRunCountsByState: [{ count: input.checkRuns, state: "COMPLETED" }],
+                  statusContextCountsByState: [{ count: input.statuses, state: "SUCCESS" }],
+                },
+              },
+            },
+          },
+        }),
+        rest: {
+          actions: {
+            listWorkflowRunsForRepo: async () => ({
+              data: { workflow_runs: runIds.map((id) => ({ id })) },
+            }),
+            listJobsForWorkflowRun: async ({ run_id }: { run_id: number }) => ({
+              data: { jobs: input.actionsJobs[run_id] ?? [] },
+            }),
+          },
+        },
+      },
+      options: { logger: quietLogger },
+    } as unknown as PrManagerContext;
+  }
+
+  test("reconstructs the checks and drops the marked one", async () => {
+    // Exactly what splits-teams reports: 5 null check nodes, Vercel readable.
+    const ctx = ctxFor({
+      nodes: [null, null, null, null, null, statusCtx("Vercel", "SUCCESS")],
+      checkRuns: 5,
+      statuses: 1,
+      actionsJobs: {
+        3: [job("agent-pr-rules-centaur-skip", "failure")],
+        2: [job("assign-author", "success")],
+        1: [job("lint-and-format", "success"), job("typecheck", "success"), job("test", "success")],
+      },
+    });
+    await expect(fetchCiEvaluation(ctx, "base", "repo", "abc123")).resolves.toEqual({
+      failed: false,
+      failingNames: [],
+      settled: true,
+    });
+  });
+
+  test("still reports a real failure, and names it", async () => {
+    const ctx = ctxFor({
+      nodes: [null, null, statusCtx("Vercel", "SUCCESS")],
+      checkRuns: 2,
+      statuses: 1,
+      actionsJobs: {
+        2: [job("agent-pr-rules-centaur-skip", "failure")],
+        1: [job("typecheck", "failure")],
+      },
+    });
+    await expect(fetchCiEvaluation(ctx, "base", "repo", "abc123")).resolves.toEqual({
+      failed: true,
+      failingNames: ["typecheck"],
+      settled: true,
+    });
+  });
+
+  test("refuses to trust an incomplete reconstruction", async () => {
+    // 3 check runs counted but only 2 are Actions jobs: something else posted
+    // one (another App), and it could be the red one. Degrade, don't guess.
+    const ctx = ctxFor({
+      nodes: [null, null, null, statusCtx("Vercel", "SUCCESS")],
+      checkRuns: 3,
+      statuses: 1,
+      actionsJobs: {
+        2: [job("agent-pr-rules-centaur-skip", "failure")],
+        1: [job("typecheck", "success")],
+      },
+    });
+    await expect(fetchCiEvaluation(ctx, "base", "repo", "abc123")).resolves.toEqual({
+      failed: true,
+      failingNames: [],
+      settled: true,
+    });
+  });
+
+  test("refuses when a commit status is unreadable too", async () => {
+    // 2 statuses counted, 1 readable: a red status could be hiding.
+    const ctx = ctxFor({
+      nodes: [null, statusCtx("Vercel", "SUCCESS")],
+      checkRuns: 1,
+      statuses: 2,
+      actionsJobs: { 1: [job("agent-pr-rules-centaur-skip", "failure")] },
+    });
+    await expect(fetchCiEvaluation(ctx, "base", "repo", "abc123")).resolves.toEqual({
+      failed: true,
+      failingNames: [],
+      settled: true,
+    });
+  });
+
+  test("a superseded re-run never overwrites the newest job", async () => {
+    // Same job name in two runs; only the newest (higher id) counts, so the
+    // stale failure must not resurface.
+    const ctx = ctxFor({
+      nodes: [null, statusCtx("Vercel", "SUCCESS")],
+      checkRuns: 1,
+      statuses: 1,
+      actionsJobs: { 9: [job("typecheck", "success")], 4: [job("typecheck", "failure")] },
+    });
+    await expect(fetchCiEvaluation(ctx, "base", "repo", "abc123")).resolves.toEqual({
+      failed: false,
+      failingNames: [],
+      settled: true,
+    });
   });
 });
 


### PR DESCRIPTION
Supersedes #1589 with two follow-ups:

- document `centaur-skip` as a check-run display-name marker
- preserve same-named jobs from distinct workflows in the Actions fallback